### PR TITLE
feat(gen-ai): Save / Save As agent profile modal (RHOAIENG-66527, RHOAIENG-66530)

### DIFF
--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/chatbotPage.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/chatbotPage.ts
@@ -3,8 +3,11 @@ import { appendFeatureFlagParams } from './appChrome';
 
 class ChatbotPage {
   mcpTab = mcpTab;
-  visit(namespace?: string): void {
-    const path = namespace ? `/gen-ai-studio/playground/${namespace}` : '/gen-ai-studio/playground';
+  visit(namespace?: string, queryParams?: Record<string, string>): void {
+    const qs = queryParams ? `?${new URLSearchParams(queryParams).toString()}` : '';
+    const path = namespace
+      ? `/gen-ai-studio/playground/${namespace}${qs}`
+      : `/gen-ai-studio/playground${qs}`;
     cy.visit(appendFeatureFlagParams(path));
     this.waitForPageLoad();
   }

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers.ts
@@ -1,0 +1,197 @@
+/* eslint-disable camelcase */
+import {
+  mockMLflowPromptVersion,
+  mockMLflowPromptVersionsResponse,
+  mockMLflowPromptsList,
+  mockNamespace,
+  mockNamespaces,
+  mockEmptyList,
+  mockStatus,
+} from '~/__tests__/cypress/cypress/__mocks__';
+import type { AgentProfileSummary } from '~/app/agentProfile/types';
+
+// ---------------------------------------------------------------------------
+// Base playground intercepts (no E2E MCP config required)
+// ---------------------------------------------------------------------------
+
+/**
+ * Set up the minimum intercepts needed for the playground to load in mock mode.
+ * Call in beforeEach for every agent profile playground test.
+ */
+export const setupPlaygroundBase = (namespace: string): void => {
+  const namespacesData = [
+    mockNamespace({ name: namespace, display_name: namespace }),
+    ...mockNamespaces().data.filter((ns) => ns.name !== namespace),
+  ];
+  cy.interceptGenAi('GET /api/v1/namespaces', { data: namespacesData });
+  cy.interceptGenAi('GET /api/v1/user', { data: { username: 'test-user' } });
+  cy.interceptGenAi('GET /api/v1/config', { data: { isCustomLSD: false } });
+  cy.interceptGenAi('GET /api/v1/lsd/status', { query: { namespace } }, mockStatus('Ready'));
+  cy.interceptGenAi('GET /api/v1/lsd/models', { query: { namespace } }, mockEmptyList());
+  cy.interceptGenAi('GET /api/v1/aaa/models', { query: { namespace } }, mockEmptyList());
+  cy.interceptGenAi('GET /api/v1/maas/models', { query: { namespace } }, mockEmptyList());
+  cy.interceptGenAi(
+    'GET /api/v1/aaa/mcps',
+    { query: { namespace } },
+    { data: { servers: [], config_map_info: null, total_count: 0 } },
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Shared mock data factories
+// ---------------------------------------------------------------------------
+
+export const makeProfileResponse = (
+  profileId: string,
+  displayName: string,
+  overrides: Partial<{
+    description: string;
+    promptName: string;
+    promptVersion: number;
+    namespace: string;
+  }> = {},
+): Record<string, unknown> => ({
+  data: {
+    apiVersion: 'genai.redhat.com/v1alpha1',
+    kind: 'AgentProfile',
+    metadata: { name: `agent-profile-${profileId}`, resourceVersion: 'rv-1' },
+    spec: {
+      displayName,
+      description: overrides.description ?? '',
+      model: { id: 'llama-3b', uri: 'http://llama.svc/v1', sourceType: 'namespace' },
+      temperature: 0.7,
+      stream: true,
+      ...(overrides.promptName && {
+        prompt: {
+          name: overrides.promptName,
+          source: 'mlflow',
+          version: String(overrides.promptVersion ?? 1),
+        },
+      }),
+    },
+  },
+});
+
+export const makeCreateProfileResponse = (
+  profileId: string,
+  displayName: string,
+  namespace: string,
+): Record<string, unknown> => ({
+  data: {
+    name: `agent-profile-${profileId}`,
+    profileId,
+    displayName,
+    namespace,
+    resourceVersion: 'rv-1',
+  } satisfies Partial<AgentProfileSummary> & {
+    name: string;
+    profileId: string;
+    displayName: string;
+    namespace: string;
+    resourceVersion: string;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Intercept helpers — register once per test in beforeEach
+// ---------------------------------------------------------------------------
+
+/**
+ * Intercept GET + PUT for an existing agent profile.
+ * Aliases: @getAgentProfile, @updateAgentProfile
+ */
+export const interceptExistingAgentProfile = (
+  profileId: string,
+  displayName: string,
+  namespace: string,
+  opts: { promptName?: string; promptVersion?: number } = {},
+): void => {
+  cy.interceptGenAi(
+    'GET /api/v1/agent-profiles/*',
+    makeProfileResponse(profileId, displayName, {
+      ...opts,
+    }),
+  ).as('getAgentProfile');
+
+  cy.interceptGenAi('PUT /api/v1/agent-profiles/*', {
+    data: {
+      name: `agent-profile-${profileId}`,
+      profileId,
+      displayName,
+      namespace,
+      resourceVersion: 'rv-2',
+    },
+  }).as('updateAgentProfile');
+};
+
+/**
+ * Intercept POST (create) and GET (reload) for a new agent profile.
+ * Aliases: @createAgentProfile, @getAgentProfile
+ */
+export const interceptNewAgentProfile = (
+  profileId: string,
+  displayName: string,
+  namespace: string,
+): void => {
+  const response = makeCreateProfileResponse(profileId, displayName, namespace);
+  cy.interceptGenAi('POST /api/v1/agent-profiles', response).as('createAgentProfile');
+  cy.interceptGenAi('GET /api/v1/agent-profiles/*', makeProfileResponse(profileId, displayName)).as(
+    'getAgentProfile',
+  );
+};
+
+/**
+ * Intercept MLflow prompt list-versions, get, and register (POST).
+ * Aliases: @listPromptVersions, @getPrompt, @registerPrompt
+ */
+export const interceptMLflowPrompt = (
+  promptName: string,
+  template: string,
+  currentVersion = 1,
+): void => {
+  // List all prompts — needed when the Prompt tab activates in the Settings panel
+  cy.interceptGenAi('GET /api/v1/mlflow/prompts', mockMLflowPromptsList()).as('listPrompts');
+
+  cy.intercept('GET', `**/api/v1/mlflow/prompts/${promptName}/versions**`, {
+    statusCode: 200,
+    body: mockMLflowPromptVersionsResponse([
+      {
+        version: currentVersion,
+        commit_message: 'Latest',
+        tags: {},
+        created_at: '',
+        updated_at: '',
+      },
+    ]),
+  }).as('listPromptVersions');
+
+  cy.intercept('GET', `**/api/v1/mlflow/prompts/${promptName}**`, (req) => {
+    if (!req.url.includes('/versions')) {
+      req.reply({
+        statusCode: 200,
+        body: {
+          data: mockMLflowPromptVersion({ name: promptName, version: currentVersion, template }),
+        },
+      });
+    }
+  }).as('getPrompt');
+
+  cy.intercept('POST', '**/api/v1/mlflow/prompts**', (req) => {
+    req.reply({
+      statusCode: 200,
+      body: {
+        data: mockMLflowPromptVersion({
+          name: req.body.name ?? promptName,
+          version: currentVersion + 1,
+          template: req.body.template ?? template,
+        }),
+      },
+    });
+  }).as('registerPrompt');
+};
+
+/** URL for a playground page with the agentProfileManagement flag enabled. */
+export const playgroundUrl = (namespace: string, agentProfileId?: string): string => {
+  const base = `/gen-ai-studio/playground/${namespace}?agentProfileManagement=true`;
+  return agentProfileId ? `${base}&agentProfileId=${agentProfileId}` : base;
+};

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers.ts
@@ -58,7 +58,11 @@ export const makeProfileResponse = (
     spec: {
       displayName,
       description: overrides.description ?? '',
-      model: { id: 'llama-3b', uri: 'http://llama.svc/v1', sourceType: 'namespace' },
+      model: {
+        id: 'llama-3.1-8b-instruct',
+        uri: `http://llama-3.1-8b-instruct.mock-test-namespace-2.svc.cluster.local:8080`,
+        sourceType: 'namespace',
+      },
       temperature: 0.7,
       stream: true,
       ...(overrides.promptName && {

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
@@ -1,10 +1,14 @@
 /* eslint-disable camelcase */
 import { chatbotPage } from '~/__tests__/cypress/cypress/pages/chatbotPage';
-import { interceptNewAgentProfile } from '~/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers';
+import {
+  interceptNewAgentProfile,
+  interceptExistingAgentProfile,
+} from '~/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers';
 
 // Use mock-test-namespace-2 which has LSD configured and ready in the BFF
 const TEST_NAMESPACE = 'mock-test-namespace-2';
 const NEW_PROFILE_ID = 'new-profile-uuid-1';
+const EXISTING_PROFILE_ID = 'existing-profile-uuid-1';
 const AGENT_NAME = 'My Coding Agent';
 
 describe('Agent Profile - Playground (Mocked)', () => {
@@ -46,6 +50,35 @@ describe('Agent Profile - Playground (Mocked)', () => {
       cy.findByTestId('save-agent-profile-button').click();
       cy.findByTestId('save-agent-profile-name-input').should('have.value', AGENT_NAME);
       cy.findByRole('button', { name: 'Cancel' }).click();
+    },
+  );
+
+  it(
+    'should update an existing profile via PUT and include resourceVersion',
+    { tags: ['@GenAI', '@AgentProfile', '@Chatbot'] },
+    () => {
+      interceptExistingAgentProfile(EXISTING_PROFILE_ID, AGENT_NAME, TEST_NAMESPACE);
+
+      cy.step('Visit playground with an existing agentProfileId in the URL');
+      chatbotPage.visit(TEST_NAMESPACE, { agentProfileId: EXISTING_PROFILE_ID });
+
+      cy.step('Wait for profile to load and Save button to appear');
+      cy.wait('@getAgentProfile');
+      cy.findByTestId('save-agent-profile-button', { timeout: 10000 }).should('be.visible');
+
+      cy.step('Open Save modal — name is pre-filled from loaded profile');
+      cy.findByTestId('save-agent-profile-button').click();
+      cy.findByTestId('save-agent-profile-modal').should('be.visible');
+      cy.findByTestId('save-agent-profile-name-input').should('have.value', AGENT_NAME);
+
+      cy.step('Submit and verify PUT request includes resourceVersion');
+      cy.findByTestId('save-agent-profile-submit-button').click();
+      cy.wait('@updateAgentProfile').then((interception) => {
+        expect(interception.request.body.spec.displayName).to.equal(AGENT_NAME);
+        expect(interception.request.body.resourceVersion).to.equal('rv-1');
+      });
+
+      cy.findByTestId('save-agent-profile-modal').should('not.exist');
     },
   );
 });

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
@@ -1,0 +1,46 @@
+/* eslint-disable camelcase */
+import { chatbotPage } from '~/__tests__/cypress/cypress/pages/chatbotPage';
+import { interceptNewAgentProfile } from '~/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers';
+
+// Use mock-test-namespace-2 which has LSD configured and ready in the BFF
+const TEST_NAMESPACE = 'mock-test-namespace-2';
+const NEW_PROFILE_ID = 'new-profile-uuid-1';
+const AGENT_NAME = 'My Coding Agent';
+
+describe('Agent Profile - Playground (Mocked)', () => {
+  it(
+    'should save a new profile and verify the same profile is active',
+    { tags: ['@GenAI', '@AgentProfile', '@Chatbot'] },
+    () => {
+      interceptNewAgentProfile(NEW_PROFILE_ID, AGENT_NAME, TEST_NAMESPACE);
+
+      cy.step('Visit playground with agentProfileManagement flag');
+      Cypress.env('_featureFlagParams', 'agentProfileManagement=true');
+      chatbotPage.visit(TEST_NAMESPACE);
+
+      cy.step('Open Save As modal — no profile loaded yet, name is empty');
+      cy.findByTestId('save-as-agent-profile-button', { timeout: 10000 }).click();
+      cy.findByTestId('save-agent-profile-modal').should('be.visible');
+      cy.findByTestId('save-agent-profile-name-input').should('have.value', '');
+
+      cy.step('Fill name and submit');
+      cy.findByTestId('save-agent-profile-name-input').type(AGENT_NAME);
+      cy.findByTestId('save-agent-profile-submit-button').click();
+      cy.wait('@createAgentProfile').then((interception) => {
+        expect(interception.request.body.spec.displayName).to.equal(AGENT_NAME);
+      });
+
+      cy.step('Profile is now active — Save button replaces Save As, URL has profileId');
+      cy.findByTestId('save-agent-profile-modal').should('not.exist');
+      cy.location('search').should('include', `agentProfileId=${NEW_PROFILE_ID}`);
+      cy.findByTestId('save-agent-profile-button', { timeout: 10000 }).should('be.visible');
+
+      cy.step('Open Save modal — name matches the profile that was just saved');
+      cy.findByTestId('save-agent-profile-button').click();
+      cy.findByTestId('save-agent-profile-name-input').should('have.value', AGENT_NAME);
+      cy.findByRole('button', { name: 'Cancel' }).click();
+
+      Cypress.env('_featureFlagParams', '');
+    },
+  );
+});

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
@@ -8,6 +8,14 @@ const NEW_PROFILE_ID = 'new-profile-uuid-1';
 const AGENT_NAME = 'My Coding Agent';
 
 describe('Agent Profile - Playground (Mocked)', () => {
+  beforeEach(() => {
+    Cypress.env('_featureFlagParams', 'agentProfileManagement=true');
+  });
+
+  afterEach(() => {
+    Cypress.env('_featureFlagParams', '');
+  });
+
   it(
     'should save a new profile and verify the same profile is active',
     { tags: ['@GenAI', '@AgentProfile', '@Chatbot'] },
@@ -15,7 +23,6 @@ describe('Agent Profile - Playground (Mocked)', () => {
       interceptNewAgentProfile(NEW_PROFILE_ID, AGENT_NAME, TEST_NAMESPACE);
 
       cy.step('Visit playground with agentProfileManagement flag');
-      Cypress.env('_featureFlagParams', 'agentProfileManagement=true');
       chatbotPage.visit(TEST_NAMESPACE);
 
       cy.step('Open Save As modal — no profile loaded yet, name is empty');
@@ -39,8 +46,6 @@ describe('Agent Profile - Playground (Mocked)', () => {
       cy.findByTestId('save-agent-profile-button').click();
       cy.findByTestId('save-agent-profile-name-input').should('have.value', AGENT_NAME);
       cy.findByRole('button', { name: 'Cancel' }).click();
-
-      Cypress.env('_featureFlagParams', '');
     },
   );
 });

--- a/packages/gen-ai/frontend/src/app/AIAssets/__tests__/AIAssetsMCPTab.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/__tests__/AIAssetsMCPTab.spec.tsx
@@ -41,6 +41,7 @@ describe('AIAssetsMCPTab', () => {
   it('should render loading state', () => {
     mockUseFetchMCPServers.mockReturnValue({
       data: [],
+      configMapName: null,
       loaded: false,
       error: undefined,
     });
@@ -64,6 +65,7 @@ describe('AIAssetsMCPTab', () => {
   it('should render error state when fetch fails', () => {
     mockUseFetchMCPServers.mockReturnValue({
       data: [],
+      configMapName: null,
       loaded: true,
       error: new Error('ConfigMap not found'),
     });
@@ -91,6 +93,7 @@ describe('AIAssetsMCPTab', () => {
   it('should render empty state when no servers are available', () => {
     mockUseFetchMCPServers.mockReturnValue({
       data: [],
+      configMapName: null,
       loaded: true,
       error: undefined,
     });
@@ -125,6 +128,7 @@ describe('AIAssetsMCPTab', () => {
           logo: '',
         },
       ] as MCPServerFromAPI[],
+      configMapName: null,
       loaded: true,
       error: undefined,
     });

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
@@ -23,6 +23,7 @@ type ChatbotHeaderActionsProps = {
   onDeletePlayground: () => void;
   onNewChat: () => void;
   onCompareChat: () => void;
+  onSave: () => void;
   onSaveAs: () => void;
   onSettingsClick: () => void;
   isSettingsOpen: boolean;
@@ -35,6 +36,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   onDeletePlayground,
   onNewChat,
   onCompareChat,
+  onSave,
   onSaveAs,
   onSettingsClick,
   isSettingsOpen,
@@ -47,6 +49,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   const isViewCodeDisabled = !lastInput || !selectedModel;
   const [isDropdownOpen, setDropdownOpen] = React.useState(false);
   const [agentProfilesEnabled] = useFeatureFlag(AGENT_PROFILES);
+  const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
 
   // Get disabled reason for popover
   const getDisabledReason = () => {
@@ -67,11 +70,23 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
       <ActionListGroup>
         {lsdStatus?.phase === 'Ready' && (
           <>
+            {!isCompareMode && agentProfilesEnabled && profileApplied && (
+              <ActionListItem>
+                <Button
+                  variant="link"
+                  aria-label="Save agent profile"
+                  onClick={onSave}
+                  data-testid="save-agent-profile-button"
+                >
+                  Save
+                </Button>
+              </ActionListItem>
+            )}
             {!isCompareMode && agentProfilesEnabled && (
               <ActionListItem>
                 <Button
                   variant="link"
-                  aria-label="Save as"
+                  aria-label="Save as agent profile"
                   onClick={onSaveAs}
                   data-testid="save-as-agent-profile-button"
                 >

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -95,12 +95,14 @@ const ChatbotMain: React.FunctionComponent = () => {
   const handleCloseSaveModal = React.useCallback(() => setSaveModalMode(null), []);
 
   const handleProfileSaved = React.useCallback(
-    (profileId: string, displayName: string) => {
+    (profileId: string, displayName: string, description: string) => {
       const currentConfig = useChatbotConfigStore.getState().configurations[primaryConfigId];
       if (!currentConfig) {
         return;
       }
-      useChatbotConfigStore.getState().applyAgentProfile(currentConfig, profileId, displayName);
+      useChatbotConfigStore
+        .getState()
+        .applyAgentProfile(currentConfig, profileId, displayName, description);
       // Keep the URL in sync so a page refresh reloads the saved profile
       setSearchParams(
         (prev) => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -96,13 +96,11 @@ const ChatbotMain: React.FunctionComponent = () => {
 
   const handleProfileSaved = React.useCallback(
     (profileId: string, displayName: string) => {
-      useChatbotConfigStore
-        .getState()
-        .applyAgentProfile(
-          useChatbotConfigStore.getState().configurations[primaryConfigId] ?? {},
-          profileId,
-          displayName,
-        );
+      const currentConfig = useChatbotConfigStore.getState().configurations[primaryConfigId];
+      if (!currentConfig) {
+        return;
+      }
+      useChatbotConfigStore.getState().applyAgentProfile(currentConfig, profileId, displayName);
       // Keep the URL in sync so a page refresh reloads the saved profile
       setSearchParams(
         (prev) => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -48,7 +48,7 @@ const ChatbotMain: React.FunctionComponent = () => {
     modelsError,
   } = React.useContext(ChatbotContext);
   const { namespace } = React.useContext(GenAiContext);
-  const { data: mcpServers = [] } = useFetchMCPServers();
+  const { data: mcpServers = [], configMapName: mcpConfigMapName } = useFetchMCPServers();
   const { data: bffConfig } = useFetchBFFConfig();
   const { data: allCollections, loaded: collectionsLoaded } = useFetchAAEVectorStores();
   const [existingCollections] = useFetchVectorStores();
@@ -319,6 +319,7 @@ const ChatbotMain: React.FunctionComponent = () => {
         <SaveAgentProfileModal
           mode={saveModalMode}
           mcpServers={mcpServers}
+          mcpConfigMapName={mcpConfigMapName}
           onClose={handleCloseSaveModal}
           onSaved={handleProfileSaved}
         />

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import * as React from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { EmptyState, EmptyStateVariant, Spinner, Content } from '@patternfly/react-core';
 import { ApplicationsPage } from 'mod-arch-shared';
 import {
@@ -16,13 +17,11 @@ import useFetchVectorStores from '~/app/hooks/useFetchVectorStores';
 import ChatbotConfigurationModal from '~/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal';
 import DeletePlaygroundModal from '~/app/Chatbot/components/DeletePlaygroundModal';
 import ChatModal from '~/app/Chatbot/components/ChatModal';
-import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
 import useFetchMCPServers from '~/app/hooks/useFetchMCPServers';
-import { serializeToAgentProfileSpec } from '~/app/agentProfile/serialize';
-import { isPlaygroundModelMatchForAIModel } from '~/app/utilities/utils';
 import ChatbotHeader from './ChatbotHeader';
 import ChatbotPlayground from './ChatbotPlayground';
 import ChatbotHeaderActions from './ChatbotHeaderActions';
+import SaveAgentProfileModal from './components/SaveAgentProfileModal';
 import {
   useChatbotConfigStore,
   selectConfigIds,
@@ -49,7 +48,6 @@ const ChatbotMain: React.FunctionComponent = () => {
     modelsError,
   } = React.useContext(ChatbotContext);
   const { namespace } = React.useContext(GenAiContext);
-  const { api } = useGenAiAPI();
   const { data: mcpServers = [] } = useFetchMCPServers();
   const { data: bffConfig } = useFetchBFFConfig();
   const { data: allCollections, loaded: collectionsLoaded } = useFetchAAEVectorStores();
@@ -71,6 +69,7 @@ const ChatbotMain: React.FunctionComponent = () => {
   const hasConversationMessagesRef = React.useRef<(() => boolean) | null>(null);
 
   // Derive compare mode from Zustand store (configIds.length > 1)
+  const [, setSearchParams] = useSearchParams();
   const configIds = useChatbotConfigStore(selectConfigIds);
   const isCompareMode = configIds.length > 1;
   const primaryConfigId = configIds[0] || DEFAULT_CONFIG_ID;
@@ -89,35 +88,33 @@ const ChatbotMain: React.FunctionComponent = () => {
     fireMiscTrackingEvent('Playground Compare Mode Exited', { success: true });
   }, []);
 
-  // Temp: serializer test — will be updated before feature delivery
-  const handleSaveAsAgentProfile = React.useCallback(() => {
-    const config = useChatbotConfigStore.getState().configurations[primaryConfigId];
-    if (!config || !namespace?.name) {
-      return;
-    }
-    const llamaModel = models.find((m) => m.id === config.selectedModel);
-    const model = llamaModel
-      ? aiModels.find((ai) => isPlaygroundModelMatchForAIModel(llamaModel, ai))
-      : undefined;
-    const displayName = `Agent Profile - ${new Date().toISOString()}`;
-    const spec = serializeToAgentProfileSpec(config, displayName, 'Test description', {
-      model,
-      mcpServers,
-      mcpConfigMapName: 'gen-ai-aa-mcp-servers',
-    });
-    api
-      .createAgentProfile({ spec })
-      .then((response) => {
-        // eslint-disable-next-line no-console
-        console.log(
-          `[AgentProfile] Created: http://localhost:4010/gen-ai-studio/playground/${namespace.name}?agentProfileId=${response.profileId}`,
+  const [saveModalMode, setSaveModalMode] = React.useState<'save' | 'save-as' | null>(null);
+
+  const handleOpenSave = React.useCallback(() => setSaveModalMode('save'), []);
+  const handleOpenSaveAs = React.useCallback(() => setSaveModalMode('save-as'), []);
+  const handleCloseSaveModal = React.useCallback(() => setSaveModalMode(null), []);
+
+  const handleProfileSaved = React.useCallback(
+    (profileId: string, displayName: string) => {
+      useChatbotConfigStore
+        .getState()
+        .applyAgentProfile(
+          useChatbotConfigStore.getState().configurations[primaryConfigId] ?? {},
+          profileId,
+          displayName,
         );
-      })
-      .catch((err) => {
-        // eslint-disable-next-line no-console
-        console.error('[AgentProfile] Create failed:', err);
-      });
-  }, [primaryConfigId, namespace?.name, models, aiModels, mcpServers, api]);
+      // Keep the URL in sync so a page refresh reloads the saved profile
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('agentProfileId', profileId);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [primaryConfigId, setSearchParams],
+  );
 
   // Handle compare chat confirmation - clears messages and enters compare mode
   const handleCompareConfirm = React.useCallback(() => {
@@ -201,7 +198,8 @@ const ChatbotMain: React.FunctionComponent = () => {
         headerAction={
           hasNoModelsOrSelectedModelDisabled ? undefined : (
             <ChatbotHeaderActions
-              onSaveAs={handleSaveAsAgentProfile}
+              onSave={handleOpenSave}
+              onSaveAs={handleOpenSaveAs}
               onViewCode={() => {
                 setIsViewCodeModalOpen(true);
                 fireSimpleTrackingEvent('Playground View Code Selected');
@@ -319,6 +317,14 @@ const ChatbotMain: React.FunctionComponent = () => {
         variant="compare"
       />
       {isPromptManagementModalOpen && <PromptManagementModal />}
+      {saveModalMode && (
+        <SaveAgentProfileModal
+          mode={saveModalMode}
+          mcpServers={mcpServers}
+          onClose={handleCloseSaveModal}
+          onSaved={handleProfileSaved}
+        />
+      )}
     </>
   );
 };

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx
@@ -55,6 +55,7 @@ describe('ChatbotHeaderActions', () => {
     onDeletePlayground: jest.fn(),
     onNewChat: jest.fn(),
     onCompareChat: jest.fn(),
+    onSave: jest.fn(),
     onSaveAs: jest.fn(),
     onSettingsClick: jest.fn(),
     isSettingsOpen: false,

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotMain.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotMain.spec.tsx
@@ -13,6 +13,7 @@ import { MaaSModel } from '~/app/types';
 // Mock dependencies
 jest.mock('react-router-dom', () => ({
   useNavigate: () => jest.fn(),
+  useSearchParams: () => [new URLSearchParams(), jest.fn()],
 }));
 
 jest.mock('~/app/hooks/useFetchBFFConfig');

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -97,8 +97,29 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
     setError(null);
 
     try {
+      // Register or update the prompt before serializing, then sync the store so
+      // the spec picks up the new version via config.activePrompt.
+      if (isPromptDirty || !activePrompt) {
+        const promptName = activePrompt ? activePrompt.name : autoPromptName.current;
+        // dirtyPrompt.template holds the latest edited text; systemInstruction is the fallback
+        const template = dirtyPrompt?.template ?? systemInstruction ?? '';
+        const registeredPrompt = await api.registerMLflowPrompt({
+          name: promptName,
+          template,
+        });
+        // The API response may omit template; preserve what we sent so the store
+        // doesn't reset the displayed instruction to an empty/old value.
+        useChatbotConfigStore
+          .getState()
+          .updateActivePrompt(DEFAULT_CONFIG_ID, { ...registeredPrompt, template });
+      }
+
+      // Read fresh config after the store update so activePrompt reflects the new version
+      const freshConfig =
+        useChatbotConfigStore.getState().configurations[DEFAULT_CONFIG_ID] ?? config;
+
       const spec = serializeToAgentProfileSpec(
-        config,
+        freshConfig,
         name.trim(),
         description.trim() || undefined,
         { model: aiModel, mcpServers, mcpConfigMapName: MCP_CONFIG_MAP_NAME },

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -38,8 +38,8 @@ type SaveAgentProfileModalProps = {
   /** ConfigMap name from the BFF response (config_map_info.name). Falls back to a default when null. */
   mcpConfigMapName: string | null;
   onClose: () => void;
-  /** Called after a successful save with the resulting profileId and displayName. */
-  onSaved: (profileId: string, displayName: string) => void;
+  /** Called after a successful save with the resulting profileId, displayName, and description. */
+  onSaved: (profileId: string, displayName: string, description: string) => void;
 };
 
 const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
@@ -138,7 +138,7 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
 
       if (mode === 'save-as' || !loadedProfileId) {
         const response = await api.createAgentProfile({ spec });
-        onSaved(response.profileId, response.displayName);
+        onSaved(response.profileId, response.displayName, description.trim());
       } else {
         const currentProfile = await api.getAgentProfile({ id: loadedProfileId });
         const response = await api.updateAgentProfile({
@@ -146,7 +146,7 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
           spec,
           resourceVersion: currentProfile.metadata.resourceVersion,
         });
-        onSaved(loadedProfileId, response.displayName);
+        onSaved(loadedProfileId, response.displayName, description.trim());
       }
       onClose();
     } catch (err) {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -1,0 +1,387 @@
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  Divider,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Label,
+  LabelGroup,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TextArea,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
+import useFetchAAEVectorStores from '~/app/hooks/useFetchAAEVectorStores';
+import { ChatbotContext } from '~/app/context/ChatbotContext';
+import { GenAiContext } from '~/app/context/GenAiContext';
+import { DEFAULT_CONFIG_ID, useChatbotConfigStore } from '~/app/Chatbot/store';
+import { isPlaygroundModelMatchForAIModel } from '~/app/utilities/utils';
+import { serializeToAgentProfileSpec } from '~/app/agentProfile/serialize';
+import { usePromptEdited } from '~/app/Chatbot/hooks/usePromptEdited';
+import { MCPServerFromAPI } from '~/app/types/mcp';
+
+const MCP_CONFIG_MAP_NAME = 'gen-ai-aa-mcp-servers';
+
+type SaveAgentProfileModalProps = {
+  /** 'save-as' calls POST (new profile); 'save' calls PUT (overwrite loaded profile). */
+  mode: 'save-as' | 'save';
+  mcpServers: MCPServerFromAPI[];
+  onClose: () => void;
+  /** Called after a successful save with the resulting profileId and displayName. */
+  onSaved: (profileId: string, displayName: string) => void;
+};
+
+const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
+  mode,
+  mcpServers,
+  onClose,
+  onSaved,
+}) => {
+  const { api, apiAvailable } = useGenAiAPI();
+  const { aiModels, models: playgroundModels } = React.useContext(ChatbotContext);
+  const { namespace } = React.useContext(GenAiContext);
+
+  const config = useChatbotConfigStore((s) => s.configurations[DEFAULT_CONFIG_ID]);
+  const loadedProfileId = useChatbotConfigStore((s) => s.loadedProfileId);
+  const loadedProfileDisplayName = useChatbotConfigStore((s) => s.loadedProfileDisplayName);
+
+  const { data: externalVectorStores = [] } = useFetchAAEVectorStores();
+
+  const [name, setName] = React.useState(mode === 'save' ? (loadedProfileDisplayName ?? '') : '');
+  const [nameTouched, setNameTouched] = React.useState(false);
+  const [description, setDescription] = React.useState('');
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const llamaModel = React.useMemo(
+    () => playgroundModels.find((m) => m.id === config?.selectedModel),
+    [playgroundModels, config?.selectedModel],
+  );
+  const aiModel = React.useMemo(
+    () =>
+      llamaModel
+        ? aiModels.find((ai) => isPlaygroundModelMatchForAIModel(llamaModel, ai))
+        : undefined,
+    [llamaModel, aiModels],
+  );
+
+  const externalVectorStoreName = React.useMemo(() => {
+    if (
+      config?.isRagEnabled &&
+      config.knowledgeMode === 'external' &&
+      config.selectedVectorStoreId
+    ) {
+      const store = externalVectorStores.find(
+        (s) => s.vector_store_id === config.selectedVectorStoreId,
+      );
+      return store?.vector_store_name ?? config.selectedVectorStoreId;
+    }
+    return null;
+  }, [config, externalVectorStores]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setNameTouched(true);
+    if (!config || !apiAvailable || !name.trim()) {
+      return;
+    }
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const spec = serializeToAgentProfileSpec(
+        config,
+        name.trim(),
+        description.trim() || undefined,
+        { model: aiModel, mcpServers, mcpConfigMapName: MCP_CONFIG_MAP_NAME },
+      );
+
+      if (mode === 'save-as' || !loadedProfileId) {
+        const response = await api.createAgentProfile({ spec });
+        onSaved(response.profileId, response.displayName);
+      } else {
+        const currentProfile = await api.getAgentProfile({ id: loadedProfileId });
+        const response = await api.updateAgentProfile({
+          id: loadedProfileId,
+          spec,
+          resourceVersion: currentProfile.metadata.resourceVersion,
+        });
+        onSaved(loadedProfileId, response.displayName);
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred.');
+      setIsSaving(false);
+    }
+  };
+
+  const title = mode === 'save' ? 'Save agent profile' : 'Save as agent profile';
+  const nameError = nameTouched && !name.trim();
+  const isSaveDisabled = isSaving || !name.trim();
+
+  const activePrompt = config?.activePrompt;
+  const dirtyPrompt = config?.dirtyPrompt;
+  const systemInstruction = config?.systemInstruction;
+
+  // usePromptEdited compares systemInstruction against the loaded prompt's template —
+  // true only when the user has actually edited the content after loading.
+  const isPromptDirty = usePromptEdited(DEFAULT_CONFIG_ID);
+  const hasMcpServers = (config?.selectedMcpServerIds.length ?? 0) > 0;
+
+  // Stable auto-generated prompt name for new/instruction-only prompts
+  const autoPromptName = React.useRef(`agent-prompt-${Math.random().toString(36).slice(2, 6)}`);
+
+  // Fetch next available version when a loaded prompt has unsaved edits
+  const [nextPromptVersion, setNextPromptVersion] = React.useState<number | null>(null);
+  const fetchedVersionRef = React.useRef(false);
+  React.useEffect(() => {
+    if (fetchedVersionRef.current || !isPromptDirty || !apiAvailable) {
+      return;
+    }
+    fetchedVersionRef.current = true;
+    api
+      .listMLflowPromptVersions({ name: activePrompt?.name ?? '' })
+      .then((response) => {
+        const versions = response.versions ?? [];
+        const maxVersion =
+          versions.length > 0
+            ? Math.max(...versions.map((v) => v.version))
+            : (activePrompt?.version ?? 0);
+        setNextPromptVersion(maxVersion + 1);
+      })
+      .catch(() => {
+        setNextPromptVersion(activePrompt?.version ?? 0 + 1);
+      });
+  }, [isPromptDirty, activePrompt, apiAvailable, api]);
+
+  return (
+    <Modal
+      variant="medium"
+      isOpen
+      onClose={onClose}
+      aria-labelledby="save-agent-profile-modal-title"
+      data-testid="save-agent-profile-modal"
+    >
+      <ModalHeader
+        title={title}
+        labelId="save-agent-profile-modal-title"
+        description="Save your model, prompt, knowledge, and MCP servers as a reusable agent profile."
+      />
+      <ModalBody>
+        <Form id="save-agent-profile-form" onSubmit={handleSubmit}>
+          <FormGroup label="Agent name" isRequired fieldId="save-agent-profile-name">
+            <TextInput
+              id="save-agent-profile-name"
+              value={name}
+              onChange={(_e, val) => setName(val)}
+              onBlur={() => setNameTouched(true)}
+              isRequired
+              isDisabled={isSaving}
+              placeholder='ie "Code_reviewer"'
+              data-testid="save-agent-profile-name-input"
+              validated={nameError ? 'error' : 'default'}
+            />
+            {nameError && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant="error">Name is required.</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
+          </FormGroup>
+          <FormGroup label="Description" fieldId="save-agent-profile-description">
+            <TextArea
+              id="save-agent-profile-description"
+              value={description}
+              onChange={(_e, val) => setDescription(val)}
+              placeholder="Describe the use case for this agent"
+              resizeOrientation="vertical"
+              isDisabled={isSaving}
+              rows={3}
+              data-testid="save-agent-profile-description-input"
+            />
+          </FormGroup>
+          <Divider />
+          {/* Agent configuration details */}
+          <Title headingLevel="h3" size="md">
+            Agent configuration details
+          </Title>
+          {/* Models — inference only */}
+          {(aiModel || llamaModel) && (
+            <FormGroup label="Models" fieldId="detail-models">
+              <LabelGroup>
+                <Label variant="outline">
+                  {aiModel?.model_name ?? llamaModel?.id}
+                  <Label isCompact color="grey" className="pf-v6-u-ml-xs">
+                    Inference
+                  </Label>
+                </Label>
+              </LabelGroup>
+            </FormGroup>
+          )}
+          {/* Prompt */}
+          {(activePrompt || dirtyPrompt || systemInstruction?.trim()) && (
+            <FormGroup label="Prompt" fieldId="detail-prompt">
+              {/* Loaded prompt with unsaved edits — will save as next version */}
+              {isPromptDirty && (
+                <>
+                  <Alert
+                    variant="info"
+                    isInline
+                    isPlain
+                    title="Unsaved changes will be automatically saved with this profile"
+                  />
+                  <LabelGroup>
+                    <Label variant="outline">
+                      {activePrompt?.name ?? ''}
+                      <Label isCompact color="grey" className="pf-v6-u-ml-xs">
+                        v{nextPromptVersion ?? '…'}
+                      </Label>
+                    </Label>
+                  </LabelGroup>
+                </>
+              )}
+              {/* Clean loaded prompt */}
+              {activePrompt && !isPromptDirty && (
+                <LabelGroup>
+                  <Label variant="outline">
+                    {activePrompt.name}
+                    <Label isCompact color="grey" className="pf-v6-u-ml-xs">
+                      v{activePrompt.version}
+                    </Label>
+                  </Label>
+                </LabelGroup>
+              )}
+              {/* New unsaved prompt (dirtyPrompt without activePrompt) */}
+              {!activePrompt && dirtyPrompt && !isPromptDirty && (
+                <>
+                  <Alert
+                    variant="info"
+                    isInline
+                    isPlain
+                    title="Unsaved prompts will be automatically saved with this profile"
+                  />
+                  <LabelGroup>
+                    <Label variant="outline">
+                      {autoPromptName.current}
+                      <Label isCompact color="grey" className="pf-v6-u-ml-xs">
+                        v1
+                      </Label>
+                    </Label>
+                  </LabelGroup>
+                </>
+              )}
+              {/* Raw system instruction — a new prompt will be auto-created */}
+              {!activePrompt && !dirtyPrompt && systemInstruction?.trim() && (
+                <>
+                  <Alert
+                    variant="info"
+                    isInline
+                    isPlain
+                    title="A new prompt will be automatically created with this profile"
+                  />
+                  <LabelGroup>
+                    <Label variant="outline">
+                      {autoPromptName.current}
+                      <Label isCompact color="grey" className="pf-v6-u-ml-xs">
+                        v1
+                      </Label>
+                    </Label>
+                  </LabelGroup>
+                </>
+              )}
+            </FormGroup>
+          )}
+
+          {/* Knowledge */}
+          <FormGroup label="Knowledge" fieldId="detail-knowledge">
+            {!config?.isRagEnabled ? (
+              <Alert variant="info" isInline isPlain title="RAG is not enabled" />
+            ) : config.knowledgeMode === 'inline' ? (
+              <LabelGroup>
+                <Label variant="outline">
+                  Uploaded documents
+                  <Label isCompact color="orange" className="pf-v6-u-ml-xs">
+                    Inline
+                  </Label>
+                </Label>
+              </LabelGroup>
+            ) : externalVectorStoreName ? (
+              <LabelGroup>
+                <Label variant="outline">{externalVectorStoreName}</Label>
+              </LabelGroup>
+            ) : (
+              <Alert variant="info" isInline isPlain title="No knowledge source selected" />
+            )}
+          </FormGroup>
+
+          {/* MCP Servers */}
+          <FormGroup label="MCP servers" fieldId="detail-mcp">
+            {hasMcpServers ? (
+              <LabelGroup>
+                {config?.selectedMcpServerIds.map((serverId) => {
+                  const server = mcpServers.find((s) => s.url === serverId);
+                  const nsSelections = config.mcpToolSelections[namespace?.name ?? ''];
+                  const toolSelections = nsSelections?.[serverId];
+                  const toolCount = toolSelections !== undefined ? toolSelections.length : null;
+                  return (
+                    <Label key={serverId} variant="outline">
+                      {server?.name ?? serverId}
+                      {toolCount !== null && (
+                        <Label isCompact color="grey" className="pf-v6-u-ml-xs">
+                          {toolCount} tool{toolCount !== 1 ? 's' : ''}
+                        </Label>
+                      )}
+                    </Label>
+                  );
+                })}
+              </LabelGroup>
+            ) : (
+              <Alert variant="info" isInline isPlain title="No MCP servers selected" />
+            )}
+          </FormGroup>
+
+          {/* Guardrails — never saved */}
+          <FormGroup label="Guardrails" fieldId="detail-guardrails">
+            <Alert
+              variant="info"
+              isInline
+              title="Playground guardrails will not be saved with this profile"
+            />
+          </FormGroup>
+
+          {error && (
+            <HelperText>
+              <HelperTextItem variant="error">{error}</HelperTextItem>
+            </HelperText>
+          )}
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="primary"
+          form="save-agent-profile-form"
+          type="submit"
+          isLoading={isSaving}
+          isDisabled={isSaveDisabled}
+          data-testid="save-agent-profile-submit-button"
+        >
+          {mode === 'save' ? 'Save' : 'Save as'}
+        </Button>
+        <Button variant="link" onClick={onClose} isDisabled={isSaving}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default SaveAgentProfileModal;

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -56,12 +56,15 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
   const config = useChatbotConfigStore((s) => s.configurations[DEFAULT_CONFIG_ID]);
   const loadedProfileId = useChatbotConfigStore((s) => s.loadedProfileId);
   const loadedProfileDisplayName = useChatbotConfigStore((s) => s.loadedProfileDisplayName);
+  const loadedProfileDescription = useChatbotConfigStore((s) => s.loadedProfileDescription);
 
   const { data: externalVectorStores = [] } = useFetchAAEVectorStores();
 
   const [name, setName] = React.useState(mode === 'save' ? (loadedProfileDisplayName ?? '') : '');
   const [nameTouched, setNameTouched] = React.useState(false);
-  const [description, setDescription] = React.useState('');
+  const [description, setDescription] = React.useState(
+    mode === 'save' ? (loadedProfileDescription ?? '') : '',
+  );
   const [isSaving, setIsSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -28,12 +28,15 @@ import { serializeToAgentProfileSpec } from '~/app/agentProfile/serialize';
 import { usePromptEdited } from '~/app/Chatbot/hooks/usePromptEdited';
 import { MCPServerFromAPI } from '~/app/types/mcp';
 
-const MCP_CONFIG_MAP_NAME = 'gen-ai-aa-mcp-servers';
+/** Fallback ConfigMap name used only when the BFF does not return one. */
+const MCP_CONFIG_MAP_NAME_FALLBACK = 'gen-ai-aa-mcp-servers';
 
 type SaveAgentProfileModalProps = {
   /** 'save-as' calls POST (new profile); 'save' calls PUT (overwrite loaded profile). */
   mode: 'save-as' | 'save';
   mcpServers: MCPServerFromAPI[];
+  /** ConfigMap name from the BFF response (config_map_info.name). Falls back to a default when null. */
+  mcpConfigMapName: string | null;
   onClose: () => void;
   /** Called after a successful save with the resulting profileId and displayName. */
   onSaved: (profileId: string, displayName: string) => void;
@@ -42,6 +45,7 @@ type SaveAgentProfileModalProps = {
 const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
   mode,
   mcpServers,
+  mcpConfigMapName,
   onClose,
   onSaved,
 }) => {
@@ -122,7 +126,11 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
         freshConfig,
         name.trim(),
         description.trim() || undefined,
-        { model: aiModel, mcpServers, mcpConfigMapName: MCP_CONFIG_MAP_NAME },
+        {
+          model: aiModel,
+          mcpServers,
+          mcpConfigMapName: mcpConfigMapName ?? MCP_CONFIG_MAP_NAME_FALLBACK,
+        },
       );
 
       if (mode === 'save-as' || !loadedProfileId) {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -179,7 +179,7 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
         setNextPromptVersion(maxVersion + 1);
       })
       .catch(() => {
-        setNextPromptVersion(activePrompt?.version ?? 0 + 1);
+        setNextPromptVersion((activePrompt?.version ?? 0) + 1);
       });
   }, [isPromptDirty, activePrompt, apiAvailable, api]);
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -7,6 +8,7 @@ import SaveAgentProfileModal from '~/app/Chatbot/components/SaveAgentProfileModa
 import { mockGenAiContextValue } from '~/__mocks__/mockGenAiContext';
 import { useChatbotConfigStore, DEFAULT_CONFIG_ID } from '~/app/Chatbot/store';
 import { DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
+import { usePromptEdited } from '~/app/Chatbot/hooks/usePromptEdited';
 
 jest.mock('@openshift/dynamic-plugin-sdk', () => ({
   useFeatureFlag: jest.fn(() => [false]),
@@ -79,6 +81,7 @@ describe('SaveAgentProfileModal', () => {
       profileApplied: false,
       loadedProfileId: null,
       loadedProfileDisplayName: null,
+      loadedProfileDescription: null,
     });
     jest.mocked(mockGenAiContextValue.apiState.api.createAgentProfile).mockResolvedValue({
       profileId: 'new-uuid',
@@ -175,10 +178,26 @@ describe('SaveAgentProfileModal', () => {
         profileApplied: true,
         loadedProfileId: 'existing-uuid',
         loadedProfileDisplayName: 'My Agent',
+        loadedProfileDescription: null,
       });
       renderModal('save');
       expect(screen.getByText('Save agent profile')).toBeInTheDocument();
       expect(screen.getByTestId('save-agent-profile-name-input')).toHaveValue('My Agent');
+    });
+
+    it('should pre-fill the description from loadedProfileDescription', () => {
+      useChatbotConfigStore.setState({
+        configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
+        configIds: [DEFAULT_CONFIG_ID],
+        profileApplied: true,
+        loadedProfileId: 'existing-uuid',
+        loadedProfileDisplayName: 'My Agent',
+        loadedProfileDescription: 'Helpful code reviewer',
+      });
+      renderModal('save');
+      expect(screen.getByTestId('save-agent-profile-description-input')).toHaveValue(
+        'Helpful code reviewer',
+      );
     });
 
     it('should call getAgentProfile then updateAgentProfile on submit', async () => {
@@ -188,6 +207,7 @@ describe('SaveAgentProfileModal', () => {
         profileApplied: true,
         loadedProfileId: 'existing-uuid',
         loadedProfileDisplayName: 'My Agent',
+        loadedProfileDescription: null,
       });
       const user = userEvent.setup();
       renderModal('save');
@@ -205,6 +225,82 @@ describe('SaveAgentProfileModal', () => {
           }),
         );
         expect(mockOnSaved).toHaveBeenCalledWith('existing-uuid', 'My Agent');
+      });
+    });
+
+    it('should show error when getAgentProfile rejects', async () => {
+      jest
+        .mocked(mockGenAiContextValue.apiState.api.getAgentProfile)
+        .mockRejectedValue(new Error('Profile not found'));
+      useChatbotConfigStore.setState({
+        configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
+        configIds: [DEFAULT_CONFIG_ID],
+        profileApplied: true,
+        loadedProfileId: 'existing-uuid',
+        loadedProfileDisplayName: 'My Agent',
+        loadedProfileDescription: null,
+      });
+      const user = userEvent.setup();
+      renderModal('save');
+
+      await user.click(screen.getByTestId('save-agent-profile-submit-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Profile not found')).toBeInTheDocument();
+      });
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isPromptDirty path', () => {
+    it('should register prompt before saving when prompt has unsaved edits', async () => {
+      jest.mocked(usePromptEdited).mockReturnValue(true);
+      jest
+        .mocked(mockGenAiContextValue.apiState.api.listMLflowPromptVersions)
+        .mockResolvedValue({ versions: [{ version: 2 }] } as never);
+      jest.mocked(mockGenAiContextValue.apiState.api.registerMLflowPrompt).mockResolvedValue({
+        name: 'my-prompt',
+        version: 3,
+        template: 'You are a helpful assistant.',
+        created_at: '',
+        updated_at: '',
+      } as never);
+
+      useChatbotConfigStore.setState({
+        configurations: {
+          [DEFAULT_CONFIG_ID]: {
+            ...DEFAULT_CONFIGURATION,
+            activePrompt: {
+              name: 'my-prompt',
+              version: 2,
+              template: 'Old text',
+              created_at: '',
+              updated_at: '',
+            },
+            systemInstruction: 'You are a helpful assistant.',
+          },
+        },
+        configIds: [DEFAULT_CONFIG_ID],
+        profileApplied: false,
+        loadedProfileId: null,
+        loadedProfileDisplayName: null,
+        loadedProfileDescription: null,
+      });
+
+      const user = userEvent.setup();
+      renderModal('save-as');
+
+      await user.type(screen.getByTestId('save-agent-profile-name-input'), 'Test Agent');
+      await user.click(screen.getByTestId('save-agent-profile-submit-button'));
+
+      await waitFor(() => {
+        expect(mockGenAiContextValue.apiState.api.registerMLflowPrompt).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'my-prompt',
+            template: 'You are a helpful assistant.',
+          }),
+        );
+        expect(mockGenAiContextValue.apiState.api.createAgentProfile).toHaveBeenCalled();
       });
     });
   });

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
@@ -62,6 +62,7 @@ const renderModal = (mode: 'save-as' | 'save' = 'save-as') =>
         <SaveAgentProfileModal
           mode={mode}
           mcpServers={[]}
+          mcpConfigMapName={null}
           onClose={mockOnClose}
           onSaved={mockOnSaved}
         />

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
@@ -141,7 +141,7 @@ describe('SaveAgentProfileModal', () => {
             spec: expect.objectContaining({ displayName: 'Test Agent' }),
           }),
         );
-        expect(mockOnSaved).toHaveBeenCalledWith('new-uuid', 'Test Agent');
+        expect(mockOnSaved).toHaveBeenCalledWith('new-uuid', 'Test Agent', '');
         expect(mockOnClose).toHaveBeenCalledTimes(1);
       });
     });
@@ -224,7 +224,7 @@ describe('SaveAgentProfileModal', () => {
             resourceVersion: 'rv-1',
           }),
         );
-        expect(mockOnSaved).toHaveBeenCalledWith('existing-uuid', 'My Agent');
+        expect(mockOnSaved).toHaveBeenCalledWith('existing-uuid', 'My Agent', '');
       });
     });
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
@@ -1,0 +1,210 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GenAiContext } from '~/app/context/GenAiContext';
+import { ChatbotContext } from '~/app/context/ChatbotContext';
+import SaveAgentProfileModal from '~/app/Chatbot/components/SaveAgentProfileModal';
+import { mockGenAiContextValue } from '~/__mocks__/mockGenAiContext';
+import { useChatbotConfigStore, DEFAULT_CONFIG_ID } from '~/app/Chatbot/store';
+import { DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
+
+jest.mock('@openshift/dynamic-plugin-sdk', () => ({
+  useFeatureFlag: jest.fn(() => [false]),
+}));
+
+jest.mock('~/app/hooks/useGenAiAPI', () => ({
+  useGenAiAPI: jest.fn(() => ({
+    api: mockGenAiContextValue.apiState.api,
+    apiAvailable: true,
+  })),
+}));
+
+jest.mock('~/app/hooks/useFetchAAEVectorStores', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ data: [] })),
+}));
+
+jest.mock('~/app/Chatbot/hooks/usePromptEdited', () => ({
+  usePromptEdited: jest.fn(() => false),
+}));
+
+const mockOnClose = jest.fn();
+const mockOnSaved = jest.fn();
+
+const genAiContextValue = {
+  namespace: { name: 'test-namespace', displayName: 'Test' },
+  apiState: mockGenAiContextValue.apiState,
+  refreshAPIState: jest.fn(),
+};
+
+const chatbotContextValue = {
+  models: [],
+  modelsLoaded: true,
+  modelsError: undefined,
+  aiModels: [],
+  aiModelsLoaded: true,
+  aiModelsError: undefined,
+  maasModels: [],
+  maasModelsLoaded: true,
+  maasModelsError: undefined,
+  lsdStatus: null,
+  lsdStatusLoaded: true,
+  lsdStatusError: undefined,
+  refresh: jest.fn(),
+  lastInput: '',
+  setLastInput: jest.fn(),
+};
+
+const renderModal = (mode: 'save-as' | 'save' = 'save-as') =>
+  render(
+    <GenAiContext.Provider value={genAiContextValue as never}>
+      <ChatbotContext.Provider value={chatbotContextValue as never}>
+        <SaveAgentProfileModal
+          mode={mode}
+          mcpServers={[]}
+          onClose={mockOnClose}
+          onSaved={mockOnSaved}
+        />
+      </ChatbotContext.Provider>
+    </GenAiContext.Provider>,
+  );
+
+describe('SaveAgentProfileModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useChatbotConfigStore.setState({
+      configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
+      configIds: [DEFAULT_CONFIG_ID],
+      profileApplied: false,
+      loadedProfileId: null,
+      loadedProfileDisplayName: null,
+    });
+    jest.mocked(mockGenAiContextValue.apiState.api.createAgentProfile).mockResolvedValue({
+      profileId: 'new-uuid',
+      name: 'agent-profile-new-uuid',
+      displayName: 'Test Agent',
+      namespace: 'test-namespace',
+      resourceVersion: 'rv-1',
+    } as never);
+    jest.mocked(mockGenAiContextValue.apiState.api.updateAgentProfile).mockResolvedValue({
+      profileId: 'existing-uuid',
+      name: 'agent-profile-existing-uuid',
+      displayName: 'My Agent',
+      namespace: 'test-namespace',
+      resourceVersion: 'rv-2',
+    } as never);
+    jest.mocked(mockGenAiContextValue.apiState.api.getAgentProfile).mockResolvedValue({
+      apiVersion: 'genai.redhat.com/v1alpha1',
+      kind: 'AgentProfile',
+      metadata: { name: 'agent-profile-existing-uuid', resourceVersion: 'rv-1' },
+      spec: {
+        displayName: 'Test Agent',
+        model: { id: 'llama-3b', uri: 'http://llama/v1', sourceType: 'namespace' },
+        temperature: 0.7,
+        stream: true,
+      },
+    } as never);
+  });
+
+  describe('Save As mode', () => {
+    it('should render with empty name field', () => {
+      renderModal('save-as');
+      expect(screen.getByText('Save as agent profile')).toBeInTheDocument();
+      expect(screen.getByTestId('save-agent-profile-name-input')).toHaveValue('');
+    });
+
+    it('should show name required error only after blur', async () => {
+      const user = userEvent.setup();
+      renderModal('save-as');
+      const nameInput = screen.getByTestId('save-agent-profile-name-input');
+
+      expect(screen.queryByText('Name is required.')).not.toBeInTheDocument();
+      await user.click(nameInput);
+      await user.tab();
+      expect(screen.getByText('Name is required.')).toBeInTheDocument();
+    });
+
+    it('should call createAgentProfile and onSaved on successful save', async () => {
+      const user = userEvent.setup();
+      renderModal('save-as');
+
+      await user.type(screen.getByTestId('save-agent-profile-name-input'), 'Test Agent');
+      await user.click(screen.getByTestId('save-agent-profile-submit-button'));
+
+      await waitFor(() => {
+        expect(mockGenAiContextValue.apiState.api.createAgentProfile).toHaveBeenCalledWith(
+          expect.objectContaining({
+            spec: expect.objectContaining({ displayName: 'Test Agent' }),
+          }),
+        );
+        expect(mockOnSaved).toHaveBeenCalledWith('new-uuid', 'Test Agent');
+        expect(mockOnClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should show error message when save fails', async () => {
+      jest
+        .mocked(mockGenAiContextValue.apiState.api.createAgentProfile)
+        .mockRejectedValue(new Error('Server error'));
+      const user = userEvent.setup();
+      renderModal('save-as');
+
+      await user.type(screen.getByTestId('save-agent-profile-name-input'), 'Test Agent');
+      await user.click(screen.getByTestId('save-agent-profile-submit-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Server error')).toBeInTheDocument();
+      });
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it('should call onClose when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      renderModal('save-as');
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Save mode', () => {
+    it('should pre-fill the name from loadedProfileDisplayName', () => {
+      useChatbotConfigStore.setState({
+        configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
+        configIds: [DEFAULT_CONFIG_ID],
+        profileApplied: true,
+        loadedProfileId: 'existing-uuid',
+        loadedProfileDisplayName: 'My Agent',
+      });
+      renderModal('save');
+      expect(screen.getByText('Save agent profile')).toBeInTheDocument();
+      expect(screen.getByTestId('save-agent-profile-name-input')).toHaveValue('My Agent');
+    });
+
+    it('should call getAgentProfile then updateAgentProfile on submit', async () => {
+      useChatbotConfigStore.setState({
+        configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
+        configIds: [DEFAULT_CONFIG_ID],
+        profileApplied: true,
+        loadedProfileId: 'existing-uuid',
+        loadedProfileDisplayName: 'My Agent',
+      });
+      const user = userEvent.setup();
+      renderModal('save');
+
+      await user.click(screen.getByTestId('save-agent-profile-submit-button'));
+
+      await waitFor(() => {
+        expect(mockGenAiContextValue.apiState.api.getAgentProfile).toHaveBeenCalledWith({
+          id: 'existing-uuid',
+        });
+        expect(mockGenAiContextValue.apiState.api.updateAgentProfile).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'existing-uuid',
+            resourceVersion: 'rv-1',
+          }),
+        );
+        expect(mockOnSaved).toHaveBeenCalledWith('existing-uuid', 'My Agent');
+      });
+    });
+  });
+});

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/usePromptQueries.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/usePromptQueries.ts
@@ -94,7 +94,7 @@ export function usePromptVersions(promptName: string | null): UsePromptVersionsR
       }
       const versionsResponse = await api.listMLflowPromptVersions({ name: promptName });
       const versions = await Promise.all(
-        versionsResponse.versions.map((v) =>
+        (versionsResponse.versions ?? []).map((v) =>
           api.getMLflowPrompt({ name: promptName, version: v.version }),
         ),
       );

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
@@ -84,6 +84,10 @@ export interface ChatbotConfigStoreState {
    * Use this to drive loaded-profile UI state (e.g. header indicators, save/discard flows).
    */
   profileApplied: boolean;
+  /** UUID of the currently loaded AgentProfile, or null when no profile is loaded. */
+  loadedProfileId: string | null;
+  /** displayName of the currently loaded AgentProfile, for pre-filling the Save modal. */
+  loadedProfileDisplayName: string | null;
 }
 
 /**
@@ -146,7 +150,11 @@ export interface ChatbotConfigStoreActions {
    * profileApplied: true so the knowledge-mode sync effect in ChatbotConfigInstance
    * knows not to clear an external vector store ID that came from the profile.
    */
-  applyAgentProfile: (config: Partial<ChatbotConfiguration>) => void;
+  applyAgentProfile: (
+    config: Partial<ChatbotConfiguration>,
+    profileId?: string,
+    displayName?: string,
+  ) => void;
 
   // Utility
   getConfiguration: (id: string) => ChatbotConfiguration | undefined;

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
@@ -88,6 +88,8 @@ export interface ChatbotConfigStoreState {
   loadedProfileId: string | null;
   /** displayName of the currently loaded AgentProfile, for pre-filling the Save modal. */
   loadedProfileDisplayName: string | null;
+  /** description of the currently loaded AgentProfile, for pre-filling the Save modal. */
+  loadedProfileDescription: string | null;
 }
 
 /**
@@ -154,6 +156,7 @@ export interface ChatbotConfigStoreActions {
     config: Partial<ChatbotConfiguration>,
     profileId?: string,
     displayName?: string,
+    description?: string,
   ) => void;
 
   // Utility

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
@@ -152,6 +152,8 @@ export const createChatbotConfigStore = (
     },
     configIds: ['default'],
     profileApplied: false,
+    loadedProfileId: null,
+    loadedProfileDisplayName: null,
   };
 
   return create<ChatbotConfigStore>()(
@@ -631,11 +633,17 @@ const createStoreActions = (
     );
   },
 
-  applyAgentProfile: (config: Partial<ChatbotConfiguration>) => {
+  applyAgentProfile: (
+    config: Partial<ChatbotConfiguration>,
+    profileId?: string,
+    displayName?: string,
+  ) => {
     set(
       () => ({
         ...storeInitialState,
         profileApplied: true,
+        loadedProfileId: profileId ?? null,
+        loadedProfileDisplayName: displayName ?? null,
         configurations: {
           default: {
             ...DEFAULT_CONFIGURATION,

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
@@ -154,6 +154,7 @@ export const createChatbotConfigStore = (
     profileApplied: false,
     loadedProfileId: null,
     loadedProfileDisplayName: null,
+    loadedProfileDescription: null,
   };
 
   return create<ChatbotConfigStore>()(
@@ -637,6 +638,7 @@ const createStoreActions = (
     config: Partial<ChatbotConfiguration>,
     profileId?: string,
     displayName?: string,
+    description?: string,
   ) => {
     set(
       () => ({
@@ -644,6 +646,7 @@ const createStoreActions = (
         profileApplied: true,
         loadedProfileId: profileId ?? null,
         loadedProfileDisplayName: displayName ?? null,
+        loadedProfileDescription: description ?? null,
         configurations: {
           default: {
             ...DEFAULT_CONFIGURATION,

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/roundtrip.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/roundtrip.spec.ts
@@ -156,7 +156,7 @@ describe('serialize → deserialize round-trip', () => {
     const server = makeMcpServer();
     const config: ChatbotConfiguration = {
       ...DEFAULT_CONFIGURATION,
-      selectedMcpServerIds: ['weather-server'],
+      selectedMcpServerIds: ['http://weather-mcp.svc/sse'],
       mcpToolSelections: {
         'default-ns': { 'http://weather-mcp.svc/sse': ['get_forecast', 'get_alerts'] },
       },
@@ -167,6 +167,7 @@ describe('serialize → deserialize round-trip', () => {
       mcpConfigMapName: 'mcp-servers-config',
     });
 
+    // deserialize restores by serverRef.key (= server name); serialize looked up by URL
     expect(restored.selectedMcpServerIds).toEqual(['weather-server']);
     expect(mcpToolsPending).toEqual({ 'weather-server': ['get_forecast', 'get_alerts'] });
   });

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/roundtrip.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/roundtrip.spec.ts
@@ -74,7 +74,13 @@ const roundTrip = (
     serializeCtx,
   );
   const profile = wrapSpec(spec);
-  return deserializeAgentProfile(profile, deserializeCtx ?? { playgroundModels: [] });
+  // Pass the same server list to deserialize so that ConfigMap key names are resolved
+  // back to runtime URLs — the same canonical identifier used by the store and serialize.
+  const ctx: AgentProfileDeserializationContext = deserializeCtx ?? {
+    playgroundModels: [],
+    mcpServers: serializeCtx.mcpServers,
+  };
+  return deserializeAgentProfile(profile, ctx);
 };
 
 describe('serialize → deserialize round-trip', () => {
@@ -167,9 +173,12 @@ describe('serialize → deserialize round-trip', () => {
       mcpConfigMapName: 'mcp-servers-config',
     });
 
-    // deserialize restores by serverRef.key (= server name); serialize looked up by URL
-    expect(restored.selectedMcpServerIds).toEqual(['weather-server']);
-    expect(mcpToolsPending).toEqual({ 'weather-server': ['get_forecast', 'get_alerts'] });
+    // Both selectedMcpServerIds and mcpToolsPending keys must use the same URL-based
+    // canonical identifier so that a subsequent Save round-trip produces identical output.
+    expect(restored.selectedMcpServerIds).toEqual(['http://weather-mcp.svc/sse']);
+    expect(mcpToolsPending).toEqual({
+      'http://weather-mcp.svc/sse': ['get_forecast', 'get_alerts'],
+    });
   });
 
   it('should always produce cleared guardrail state (unsupported mapping)', () => {

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/serialize.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/serialize.spec.ts
@@ -259,7 +259,7 @@ describe('serializeToAgentProfileSpec', () => {
       const server = makeMcpServer();
       const config = {
         ...DEFAULT_CONFIGURATION,
-        selectedMcpServerIds: ['weather-server'],
+        selectedMcpServerIds: ['http://weather-mcp.svc/sse'],
         mcpToolSelections: {},
       };
       const result = serializeToAgentProfileSpec(
@@ -281,7 +281,7 @@ describe('serializeToAgentProfileSpec', () => {
       const server = makeMcpServer();
       const config = {
         ...DEFAULT_CONFIGURATION,
-        selectedMcpServerIds: ['weather-server'],
+        selectedMcpServerIds: ['http://weather-mcp.svc/sse'],
         mcpToolSelections: {
           'default-ns': { 'http://weather-mcp.svc/sse': ['get_forecast', 'get_alerts'] },
         },
@@ -310,7 +310,7 @@ describe('serializeToAgentProfileSpec', () => {
     it('should omit mcpServers when mcpConfigMapName is not provided', () => {
       const config = {
         ...DEFAULT_CONFIGURATION,
-        selectedMcpServerIds: ['weather-server'],
+        selectedMcpServerIds: ['http://weather-mcp.svc/sse'],
       };
       const result = serializeToAgentProfileSpec(
         config,

--- a/packages/gen-ai/frontend/src/app/agentProfile/deserialize.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/deserialize.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_CONFIGURATION, ChatbotConfiguration } from '~/app/Chatbot/store/types';
 import { LlamaModel } from '~/app/types';
+import { MCPServerFromAPI } from '~/app/types/mcp';
 import { isMaasLlamaModelId } from '~/app/utilities/utils';
 import { AgentProfile } from './types';
 
@@ -10,6 +11,13 @@ export type AgentProfileDeserializationContext = {
    * selectedModel in the store expects.
    */
   playgroundModels: LlamaModel[];
+  /**
+   * Available MCP servers from useFetchMCPServers. When provided, server ConfigMap key names
+   * are resolved to their runtime URLs so that selectedMcpServerIds and mcpToolsPending keys
+   * use the same URL-based canonical identifier that the rest of the store and serialize layer
+   * expects. When omitted the raw ConfigMap key (server name) is used as a fallback.
+   */
+  mcpServers?: MCPServerFromAPI[];
 };
 
 export type AgentProfilePromptRef = {
@@ -47,7 +55,7 @@ export const deserializeAgentProfile = (
   context: AgentProfileDeserializationContext,
 ): AgentProfileDeserializeResult => {
   const { spec } = profile;
-  const { playgroundModels } = context;
+  const { playgroundModels, mcpServers = [] } = context;
 
   // Resolve AI Asset model_id → Llama Stack runtime ID (LlamaModel.id).
   // Mirrors the isPlaygroundModelMatchForAIModel logic to handle the MaaS provider prefix.
@@ -88,10 +96,18 @@ export const deserializeAgentProfile = (
     config.selectedVectorStoreId = null;
   }
 
-  // MCP servers: restore selected server IDs from ConfigMap key field
+  // MCP servers: restore selected server IDs.
+  // Resolve ConfigMap key (server name) → runtime URL via the mcpServers list so that
+  // selectedMcpServerIds uses the same URL-based canonical identifier that the store,
+  // serialize, and UI layers all expect.  Falls back to the raw key when the server
+  // is not found in the provided list (e.g. in unit tests without a server list).
   if (spec.mcpServers?.length) {
     config.selectedMcpServerIds = spec.mcpServers
-      .map((s) => s.serverRef.key ?? s.serverRef.name)
+      .map((s) => {
+        const key = s.serverRef.key ?? s.serverRef.name;
+        const match = mcpServers.find((ms) => ms.name === key);
+        return match?.url ?? key;
+      })
       .filter(Boolean);
     // mcpToolSelections restored after server list is available (see mcpToolsPending)
     config.mcpToolSelections = {};
@@ -123,14 +139,20 @@ export const deserializeAgentProfile = (
     );
   }
 
-  // MCP tool selections pending: server name → allowed tools.
+  // MCP tool selections pending: server URL → allowed tools.
+  // Keyed by URL (same canonical format as selectedMcpServerIds) so that callers
+  // can write directly to mcpToolSelections without a second name→URL lookup.
   // Filter on !== undefined so allowedTools: [] (block all tools) is preserved;
   // allowedTools: undefined means "all tools allowed" and needs no restriction applied.
   const mcpToolsPending: Record<string, string[]> | undefined = spec.mcpServers?.length
     ? Object.fromEntries(
         spec.mcpServers
           .filter((s) => s.allowedTools !== undefined)
-          .map((s) => [s.serverRef.key ?? s.serverRef.name, s.allowedTools ?? []]),
+          .map((s) => {
+            const key = s.serverRef.key ?? s.serverRef.name;
+            const match = mcpServers.find((ms) => ms.name === key);
+            return [match?.url ?? key, s.allowedTools ?? []];
+          }),
       )
     : undefined;
 

--- a/packages/gen-ai/frontend/src/app/agentProfile/serialize.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/serialize.ts
@@ -106,7 +106,7 @@ export const serializeToAgentProfileSpec = (
   if (config.selectedMcpServerIds.length > 0 && mcpConfigMapName) {
     const entries: AgentProfileMcpServer[] = [];
     for (const serverId of config.selectedMcpServerIds) {
-      const server = availableServers.find((s) => s.name === serverId);
+      const server = availableServers.find((s) => s.url === serverId);
       if (!server) {
         continue;
       }

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -69,7 +69,7 @@ const useAgentProfileUrlParam = ({
           playgroundModels,
         });
 
-        applyAgentProfile(config);
+        applyAgentProfile(config, agentProfileId, profile.spec.displayName);
 
         // Restore MCP tool selections — mcpServers is guaranteed loaded at this point
         if (mcpToolsPending) {

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -71,17 +71,17 @@ const useAgentProfileUrlParam = ({
       .then((profile) => {
         const { config, promptRef, mcpToolsPending } = deserializeAgentProfile(profile, {
           playgroundModels,
+          mcpServers,
         });
 
         applyAgentProfile(config, agentProfileId, profile.spec.displayName);
 
-        // Restore MCP tool selections — mcpServers is guaranteed loaded at this point
+        // Restore MCP tool selections — mcpServers is guaranteed loaded at this point.
+        // mcpToolsPending is now keyed by server URL (same canonical format as
+        // selectedMcpServerIds), so no secondary name→URL lookup is needed here.
         if (mcpToolsPending) {
-          for (const [serverName, tools] of Object.entries(mcpToolsPending)) {
-            const server = mcpServers.find((s) => s.name === serverName);
-            if (server) {
-              saveToolSelections(DEFAULT_CONFIG_ID, namespace.name, server.url, tools);
-            }
+          for (const [serverUrl, tools] of Object.entries(mcpToolsPending)) {
+            saveToolSelections(DEFAULT_CONFIG_ID, namespace.name, serverUrl, tools);
           }
         }
 

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -39,6 +39,7 @@ const useAgentProfileUrlParam = ({
 
   const applyAgentProfile = useChatbotConfigStore((s) => s.applyAgentProfile);
   const updateActivePrompt = useChatbotConfigStore((s) => s.updateActivePrompt);
+  const updateSystemInstruction = useChatbotConfigStore((s) => s.updateSystemInstruction);
   const saveToolSelections = useChatbotConfigStore((s) => s.saveToolSelections);
 
   const [loading, setLoading] = React.useState(false);
@@ -89,6 +90,9 @@ const useAgentProfileUrlParam = ({
             .getMLflowPrompt({ name: promptRef.name, ...versionParam })
             .then((prompt) => {
               updateActivePrompt(DEFAULT_CONFIG_ID, prompt);
+              const instruction =
+                prompt.template ?? prompt.messages?.find((m) => m.role === 'system')?.content ?? '';
+              updateSystemInstruction(DEFAULT_CONFIG_ID, instruction);
             })
             .catch((promptErr) => {
               // Prompt load failure is non-fatal — the rest of the profile is already applied
@@ -114,6 +118,7 @@ const useAgentProfileUrlParam = ({
     mcpServers,
     applyAgentProfile,
     updateActivePrompt,
+    updateSystemInstruction,
     saveToolSelections,
   ]);
 

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -74,7 +74,12 @@ const useAgentProfileUrlParam = ({
           mcpServers,
         });
 
-        applyAgentProfile(config, agentProfileId, profile.spec.displayName);
+        applyAgentProfile(
+          config,
+          agentProfileId,
+          profile.spec.displayName,
+          profile.spec.description,
+        );
 
         // Restore MCP tool selections — mcpServers is guaranteed loaded at this point.
         // mcpToolsPending is now keyed by server URL (same canonical format as

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -41,6 +41,8 @@ const useAgentProfileUrlParam = ({
   const updateActivePrompt = useChatbotConfigStore((s) => s.updateActivePrompt);
   const updateSystemInstruction = useChatbotConfigStore((s) => s.updateSystemInstruction);
   const saveToolSelections = useChatbotConfigStore((s) => s.saveToolSelections);
+  // Skip re-fetching when handleProfileSaved already applied this profile (e.g. after Save/Save As)
+  const loadedProfileId = useChatbotConfigStore((s) => s.loadedProfileId);
 
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
@@ -54,7 +56,8 @@ const useAgentProfileUrlParam = ({
       !namespace?.name ||
       !apiAvailable ||
       !mcpServersLoaded ||
-      appliedProfileId.current === agentProfileId
+      appliedProfileId.current === agentProfileId ||
+      loadedProfileId === agentProfileId
     ) {
       return;
     }
@@ -113,6 +116,7 @@ const useAgentProfileUrlParam = ({
     namespace?.name,
     apiAvailable,
     mcpServersLoaded,
+    loadedProfileId,
     api,
     playgroundModels,
     mcpServers,

--- a/packages/gen-ai/frontend/src/app/hooks/useFetchMCPServers.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useFetchMCPServers.ts
@@ -20,7 +20,7 @@ const useFetchMCPServers = (): {
       api
         .getMCPServers({})
         .then((response) => {
-          setData(response.servers);
+          setData(response.servers ?? []);
           setLoaded(true);
         })
         .catch((err) => {

--- a/packages/gen-ai/frontend/src/app/hooks/useFetchMCPServers.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useFetchMCPServers.ts
@@ -4,11 +4,13 @@ import { useGenAiAPI } from './useGenAiAPI';
 
 const useFetchMCPServers = (): {
   data: MCPServerFromAPI[];
+  configMapName: string | null;
   loaded: boolean;
   error: Error | undefined;
 } => {
   const { api, apiAvailable } = useGenAiAPI();
   const [data, setData] = React.useState<MCPServerFromAPI[]>([]);
+  const [configMapName, setConfigMapName] = React.useState<string | null>(null);
   const [loaded, setLoaded] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>(undefined);
   const fetchAttempted = React.useRef(false);
@@ -21,6 +23,7 @@ const useFetchMCPServers = (): {
         .getMCPServers({})
         .then((response) => {
           setData(response.servers ?? []);
+          setConfigMapName(response.config_map_info?.name ?? null);
           setLoaded(true);
         })
         .catch((err) => {
@@ -33,7 +36,7 @@ const useFetchMCPServers = (): {
     }
   }, [apiAvailable, api]);
 
-  return { data, loaded, error };
+  return { data, configMapName, loaded, error };
 };
 
 export default useFetchMCPServers;

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -522,7 +522,7 @@ export type MLflowPromptVersionMeta = {
 };
 
 export type MLflowPromptVersionsResponse = {
-  versions: MLflowPromptVersionMeta[];
+  versions: MLflowPromptVersionMeta[] | null;
   next_page_token?: string;
 };
 

--- a/packages/gen-ai/frontend/src/app/types/mcp.ts
+++ b/packages/gen-ai/frontend/src/app/types/mcp.ts
@@ -40,8 +40,8 @@ export type MCPConfigMapInfo = {
  * Corresponds to MCPListData from the BFF
  */
 export type MCPServersResponse = {
-  /** Array of MCP server configurations */
-  servers: MCPServerFromAPI[];
+  /** Array of MCP server configurations — may be null when the ConfigMap has no entries */
+  servers: MCPServerFromAPI[] | null;
   /** Total number of servers */
   total_count: number;
   /** Metadata about the source ConfigMap */

--- a/packages/gen-ai/frontend/src/app/types/mcp.ts
+++ b/packages/gen-ai/frontend/src/app/types/mcp.ts
@@ -44,8 +44,8 @@ export type MCPServersResponse = {
   servers: MCPServerFromAPI[] | null;
   /** Total number of servers */
   total_count: number;
-  /** Metadata about the source ConfigMap */
-  config_map_info: MCPConfigMapInfo;
+  /** Metadata about the source ConfigMap — null when no ConfigMap exists */
+  config_map_info: MCPConfigMapInfo | null;
 };
 
 /**


### PR DESCRIPTION
<!-- https://issues.redhat.com/browse/RHOAIENG-66527 -->
<!-- https://issues.redhat.com/browse/RHOAIENG-66530 -->

## Description

Implements the Save and Save As agent profile flows for the Playground, gated behind the `agentProfileManagement` developer feature flag.

**Save As** ([RHOAIENG-66530](https://redhat.atlassian.net/browse/RHOAIENG-66530)) — always shown when the flag is enabled:
- Opens a modal with name (required) and description fields
- Shows current configuration details read-only: model (Inference chip), prompt (with version and unsaved-changes alert), knowledge (RAG status / vector store), MCP servers, guardrails
- Calls `POST /agent-profiles`; on success updates the URL with `?agentProfileId=<uuid>` and sets `profileApplied: true` in the store

**Save** ([RHOAIENG-66527](https://redhat.atlassian.net/browse/RHOAIENG-66527)) — shown only when a profile is loaded (`profileApplied: true`):
- Same modal, pre-filled with the loaded profile's name
- Fetches `resourceVersion` then calls `PUT /agent-profiles/:id`

**Prompt handling before save:**

Before the agent profile is created or updated, the modal registers the current prompt with MLflow so the spec always references a saved version:
- **Loaded prompt with edits** (`activePrompt` set and `isPromptEdited` true): registers a new version of the existing prompt using the edited system instruction text, then references the new version in the spec
- **Custom instruction with no loaded prompt** (`isPromptEdited` true, no `activePrompt`): creates a brand new MLflow prompt using an auto-generated name (`agent-prompt-XXXX`) with the current instruction as its template at version 1
- **Clean loaded prompt** (not dirty): no MLflow call — the spec references the existing prompt version as-is
- After registration, the store is updated via `updateActivePrompt` (preserving the registered template) so the playground reflects the newly saved version

**Additional fixes:**
- `serialize.ts`: MCP server lookup was matching by `s.name` but `selectedMcpServerIds` stores server URLs — fixed to `s.url`
- `useFetchMCPServers`: `response.servers` can be null at runtime; guarded with `?? []`. Also now exposes `configMapName` from `config_map_info.name` so the modal uses the runtime ConfigMap name instead of a hardcoded fallback
- `MCPServersResponse.config_map_info` typed as nullable to match real BFF behaviour
- `useAgentProfileUrlParam`: `loadedProfileId === agentProfileId` guard prevents re-fetching after Save/Save As updates the URL, which was causing `selectedModel` to be reset to the AI asset ID (making `isSelectedModelDisabled=true` and hiding the header actions)
- `updateActivePrompt` in the URL param hook now also calls `updateSystemInstruction` so the system instruction textarea reflects the loaded prompt content

## Out of Scope

1. **Header navigation rework** — the Save / Save As / Compare Chat button layout and ordering will be addressed in a separate task
2. **Loaded agent name in header** — displaying the name of the currently loaded agent profile in the Playground header is not included in this PR
3. **Conflict detection** — no checks for concurrent edits or version conflicts; this will be handled in a separate task

## How Has This Been Tested?

- Manually tested Save As and Save flows in development (BFF mock mode)
- Verified prompt registration (new version / new prompt) before agent profile creation
- Verified MCP servers are correctly included in the serialized spec
- Cypress mock test: saves a profile via Save As, verifies the POST body has the correct `displayName`, verifies the URL updates, verifies the Save modal pre-fills with the same name

## Test Impact

**Unit tests — `SaveAgentProfileModal.spec.tsx`** (7 tests):
- Save As mode: empty name field on open, name required error shown only after blur, successful `createAgentProfile` call with correct `displayName`, error message on failure, cancel closes modal
- Save mode: name pre-filled from `loadedProfileDisplayName`, `getAgentProfile` + `updateAgentProfile` called with correct arguments

**Cypress mock test — `agentProfile.cy.ts`**: saves a profile via Save As, verifies the POST body has the correct `displayName`, verifies the URL updates to include the new `agentProfileId`, verifies the Save modal subsequently pre-fills with the same name.

Helper `agentProfilePlaygroundHelpers.ts` follows the same pattern as `chatbot.cy.ts` — `chatbotPage.visit` + only agent-profile-specific intercepts, BFF mock handles everything else.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent profile **Save** and **Save As** modal to capture model, prompt, knowledge/RAG, and MCP server settings.
  * Agent profile selection now persists in URL parameters (including optional query parameters for the chatbot/playground route).

* **Bug Fixes**
  * Improved robustness when MLflow prompt versions or MCP server/config data are missing.
  * MCP server selection restoration now uses consistent canonical identifiers.

* **Tests**
  * Added Cypress E2E coverage for the mocked Agent Profile playground flow.
  * Expanded Jest unit tests for modal create/update behavior and updated related serialization/roundtrip tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->