### PR TITLE
feat: Display "Template removed" label on ServingRuntimes with missing templates

### DIFF
--- a/frontend/src/__mocks__/mockLegacyNimResource.ts
+++ b/frontend/src/__mocks__/mockLegacyNimResource.ts
@@ -108,7 +108,7 @@ export const mockNimServingRuntime = (): ServingRuntimeKind => {
 
 export const mockNimServingRuntimeTemplate = (): TemplateKind => {
   const templateMock = mockServingRuntimeTemplateK8sResource({
-    name: 'mock-nvidia-nim-serving-template',
+    name: 'nvidia-nim-runtime',
     displayName: 'NVIDIA NIM',
     platforms: [ServingRuntimePlatform.SINGLE],
     apiProtocol: ServingRuntimeAPIProtocol.REST,

--- a/frontend/src/__mocks__/mockNimAccount.ts
+++ b/frontend/src/__mocks__/mockNimAccount.ts
@@ -17,7 +17,7 @@ export const mockNimAccount = ({
   uid = 'test-uid',
   apiKeySecretName = 'mock-nvidia-nim-access',
   nimConfigName = 'mock-nvidia-nim-images-data',
-  runtimeTemplateName = 'mock-nvidia-nim-serving-template',
+  runtimeTemplateName = 'nvidia-nim-runtime',
   nimPullSecretName = 'mock-nvidia-nim-image-pull',
   conditions = [
     {

--- a/frontend/src/pages/modelServing/screens/ServingRuntimeTemplateStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/ServingRuntimeTemplateStatus.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Alert, Label, Popover } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { ServingRuntimeTemplateStatusLabel } from './const';
+
+const ServingRuntimeTemplateStatus: React.FC = () => {
+  const [isPopoverVisible, setIsPopoverVisible] = React.useState(false);
+
+  return (
+    <Popover
+      isVisible={isPopoverVisible}
+      shouldOpen={() => setIsPopoverVisible(true)}
+      shouldClose={() => setIsPopoverVisible(false)}
+      headerContent={<Alert variant="warning" isInline isPlain title="Template removed" />}
+      bodyContent={
+        <p>
+          The serving runtime template used to create this deployment is no longer available. The
+          deployment will continue to run, but you cannot create new deployments using this
+          template.
+        </p>
+      }
+    >
+      <Label
+        data-testid="serving-runtime-template-status-label"
+        status="warning"
+        icon={<ExclamationTriangleIcon />}
+        isCompact
+      >
+        {ServingRuntimeTemplateStatusLabel.TEMPLATE_REMOVED}
+      </Label>
+    </Popover>
+  );
+};
+
+export default ServingRuntimeTemplateStatus;

--- a/frontend/src/pages/modelServing/screens/__tests__/ServingRuntimeTemplateStatus.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/__tests__/ServingRuntimeTemplateStatus.spec.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ServingRuntimeTemplateStatus from '#~/pages/modelServing/screens/ServingRuntimeTemplateStatus';
+
+describe('ServingRuntimeTemplateStatus', () => {
+  it('should render "Template removed" label', () => {
+    render(<ServingRuntimeTemplateStatus />);
+    expect(screen.getByTestId('serving-runtime-template-status-label')).toBeVisible();
+    expect(screen.getByText('Template removed')).toBeVisible();
+  });
+
+  it('should render with warning status styling', () => {
+    render(<ServingRuntimeTemplateStatus />);
+    const label = screen.getByTestId('serving-runtime-template-status-label');
+    expect(label).toHaveClass('pf-m-warning');
+  });
+});

--- a/frontend/src/pages/modelServing/screens/const.ts
+++ b/frontend/src/pages/modelServing/screens/const.ts
@@ -32,3 +32,7 @@ export enum ServingRuntimeVersionStatusLabel {
   LATEST = 'Latest',
   OUTDATED = 'Outdated',
 }
+
+export enum ServingRuntimeTemplateStatusLabel {
+  TEMPLATE_REMOVED = 'Template removed',
+}

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
@@ -11,6 +11,7 @@ import {
   ServingRuntimeVersionStatusLabel,
 } from '#~/pages/modelServing/screens/const';
 import ServingRuntimeVersionLabel from '#~/pages/modelServing/screens/ServingRuntimeVersionLabel';
+import ServingRuntimeTemplateStatus from '#~/pages/modelServing/screens/ServingRuntimeTemplateStatus';
 import ScopedLabel from '#~/components/ScopedLabel';
 import { useTemplateByName } from '#~/pages/modelServing/customServingRuntimes/useTemplateByName';
 import ServingRuntimeVersionStatus from '#~/pages/modelServing/screens/ServingRuntimeVersionStatus';
@@ -40,6 +41,8 @@ const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime }) => 
     return undefined;
   }, [template, templateLoaded, templateError, servingRuntime]);
 
+  const isTemplateRemoved = templateLoaded && !templateError && !template && !!templateName;
+
   return (
     <>
       {servingRuntime ? (
@@ -60,6 +63,7 @@ const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime }) => 
                   templateVersion={getServingRuntimeVersion(template) || ''}
                 />
               )}
+              {isTemplateRemoved && <ServingRuntimeTemplateStatus />}
               {isProjectScopedAvailable &&
                 servingRuntime.metadata.annotations?.['opendatahub.io/serving-runtime-scope'] ===
                   SERVING_RUNTIME_SCOPE.Project && (

--- a/frontend/src/pages/modelServing/screens/global/__tests__/InferenceServiceServingRuntime.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/global/__tests__/InferenceServiceServingRuntime.spec.tsx
@@ -59,4 +59,15 @@ describe('InferenceServiceServingRuntime', () => {
 
     await findByText('Outdated');
   });
+
+  it('should show "Template removed" label when template is not found', async () => {
+    const mockServingRuntime = mockServingRuntimeK8sResource({});
+    useTemplateByNameMock.mockReturnValue([undefined, true, undefined]);
+
+    const { findByText } = render(
+      <InferenceServiceServingRuntime servingRuntime={mockServingRuntime} />,
+    );
+
+    await findByText('Template removed');
+  });
 });

--- a/packages/llmd-serving/src/components/ServingDetails.tsx
+++ b/packages/llmd-serving/src/components/ServingDetails.tsx
@@ -6,6 +6,7 @@ import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/
 import ServingRuntimeVersionLabel from '@odh-dashboard/internal/pages/modelServing/screens/ServingRuntimeVersionLabel';
 import { getServingRuntimeVersionStatus } from '@odh-dashboard/internal/pages/modelServing/utils';
 import ServingRuntimeVersionStatus from '@odh-dashboard/internal/pages/modelServing/screens/ServingRuntimeVersionStatus';
+import ServingRuntimeTemplateStatus from '@odh-dashboard/internal/pages/modelServing/screens/ServingRuntimeTemplateStatus';
 import { ServingRuntimeVersionStatusLabel } from '@odh-dashboard/internal/pages/modelServing/screens/const';
 import type { LLMdDeployment, LLMInferenceServiceConfigKind } from '../types';
 import { useFetchLLMInferenceServiceConfigs } from '../api/LLMInferenceServiceConfigs';
@@ -36,6 +37,9 @@ const LLMInferenceServiceServingDetails: React.FC<Props> = ({ deployment, data }
   const parentConfigVersion =
     parentConfig?.metadata.annotations?.['opendatahub.io/runtime-version'];
   const childConfigVersion = server?.metadata.annotations?.['opendatahub.io/runtime-version'];
+  const templateName = server?.metadata.annotations?.['opendatahub.io/template-name'];
+
+  const isTemplateRemoved = !parentConfig && !!templateName && !!llmInferenceServiceConfigs;
 
   const versionStatus =
     parentConfigVersion && childConfigVersion
@@ -57,6 +61,7 @@ const LLMInferenceServiceServingDetails: React.FC<Props> = ({ deployment, data }
               templateVersion={parentConfigVersion || ''}
             />
           )}
+          {isTemplateRemoved && <ServingRuntimeTemplateStatus />}
         </LabelGroup>
       </StackItem>
     </Stack>


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-49796

## Description

When a ServingRuntime was originally created from a template that has since been removed (e.g., during upgrades where templates like Caikit-TGIS or Caikit-Standalone are dropped), there was no indication in the UI that the underlying template is no longer available.

This PR adds a "Template removed" warning label on ServingRuntimes whose referenced template no longer exists in the cluster. The label follows the same pattern as the existing "Outdated" label (PatternFly `Label` with warning status, `ExclamationTriangleIcon`, and a `Popover` with explanatory text).

**Detection logic:** When the template lookup completes successfully but returns no match, while the runtime's `opendatahub.io/template-name` annotation references a template name, the label is shown. This is mutually exclusive with the version status labels (Outdated/Latest) since those require a template to compare against.

## How Has This Been Tested?

- Manually tested on a live cluster (ODH Dashboard local dev connected to OpenShift) by modifying a ServingRuntime's `opendatahub.io/template-name` annotation to reference a non-existent template — confirmed the "Template removed" label appears in the deployments table.
Before 
<img width="1599" height="435" alt="Screenshot 2026-06-15 at 2 37 39 PM" src="https://github.com/user-attachments/assets/f31604fd-59a7-440a-955b-c7eab41d2bf2" />
After
<img width="1575" height="405" alt="Screenshot 2026-06-15 at 2 39 05 PM" src="https://github.com/user-attachments/assets/fe8f0a69-6136-4b20-aaab-4114b759929b" />

- Unit tests pass (7/7) covering both the new component and the integration with `InferenceServiceServingRuntime`.
- Type-checking and linting pass for both `frontend/` and `packages/llmd-serving/`.

## Test Impact

- **Added:** `frontend/src/pages/modelServing/screens/__tests__/ServingRuntimeTemplateStatus.spec.tsx` — unit tests for the new component (renders label text, verifies warning status)
- **Updated:** `frontend/src/pages/modelServing/screens/global/__tests__/InferenceServiceServingRuntime.spec.tsx` — added test case for "Template removed" scenario (template not found but runtime has template-name annotation)

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a warning status indicator to inform users when a serving runtime template is unavailable for creating new deployments, while existing deployments continue running.

* **Tests**
  * Added React Testing Library coverage to verify the indicator renders expected text and warning styling.
  * Added integration test coverage to confirm the indicator appears in the relevant serving runtime UI when the template is missing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->