### PR TITLE
Updating Subscription and Policy Phase Label

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -525,7 +525,7 @@ class SubscriptionTableRow extends TableRow {
   }
 
   findPhase(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().find('[data-label="Phase"]');
+    return this.find().find('[data-label="Status"]');
   }
 
   findPhaseLabel(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -978,7 +978,7 @@ class AuthPolicyTableRow extends TableRow {
   }
 
   findPhase(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().find('[data-label="Phase"]');
+    return this.find().find('[data-label="Status"]');
   }
 
   findPhaseLabel(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -134,7 +134,7 @@ describe('MaaS Auth Policies', () => {
       .findPhasePopover()
       .should(
         'contain.text',
-        'Policy failedAll critical dependencies are missing or reconiliation has failed. Access controls are not in effect.Review the policy spec and ensure referenced models exist.',
+        'Policy failedAll critical dependencies are missing or reconciliation has failed. Access controls are not in effect.Review the policy spec and ensure referenced models exist.',
       );
 
     const pendingRow = authPoliciesPage.getRow('pending-policy');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -130,7 +130,12 @@ describe('MaaS Auth Policies', () => {
     const failedRow = authPoliciesPage.getRow('failed-policy');
     failedRow.findPhase().should('contain.text', 'Failed');
     failedRow.findPhaseLabel().click();
-    failedRow.findPhasePopover().should('contain.text', 'Failed');
+    failedRow
+      .findPhasePopover()
+      .should(
+        'contain.text',
+        'Policy failedAll critical dependencies are missing or reconiliation has failed. Access controls are not in effect.Review the policy spec and ensure referenced models exist.',
+      );
 
     const pendingRow = authPoliciesPage.getRow('pending-policy');
     pendingRow.findPhase().should('contain.text', 'Pending');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -278,7 +278,7 @@ describe('View Auth Policy Page', () => {
     viewAuthPolicyPage
       .findDetailsSection()
       .should('contain.text', policyName)
-      .and('contain.text', 'Phase')
+      .and('contain.text', 'Status')
       .and('contain.text', 'Ready')
       .and('contain.text', 'Name')
       .and('contain.text', 'Resource name')

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -118,12 +118,12 @@ describe('MaaS Auth Policies', () => {
     authPoliciesPage.findRows().should('have.length', 6);
     const premiumRow = authPoliciesPage.getRow('Premium Team Policy');
     premiumRow.findName().should('contain.text', 'Premium Team Policy');
-    premiumRow.findPhase().should('contain.text', 'Active');
+    premiumRow.findPhase().should('contain.text', 'Ready');
     premiumRow.findGroups().should('contain.text', '1 Group');
     premiumRow.findModels().should('contain.text', '2 Models');
     const basicRow = authPoliciesPage.getRow('basic-team-policy');
     basicRow.findName().should('contain.text', 'basic-team-policy');
-    basicRow.findPhase().should('contain.text', 'Active');
+    basicRow.findPhase().should('contain.text', 'Ready');
     basicRow.findGroups().should('contain.text', '1 Group');
     basicRow.findModels().should('contain.text', '1 Model');
 
@@ -279,7 +279,7 @@ describe('View Auth Policy Page', () => {
       .findDetailsSection()
       .should('contain.text', policyName)
       .and('contain.text', 'Phase')
-      .and('contain.text', 'Active')
+      .and('contain.text', 'Ready')
       .and('contain.text', 'Name')
       .and('contain.text', 'Resource name')
       .and('contain.text', 'Date created');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -130,12 +130,7 @@ describe('MaaS Auth Policies', () => {
     const failedRow = authPoliciesPage.getRow('failed-policy');
     failedRow.findPhase().should('contain.text', 'Failed');
     failedRow.findPhaseLabel().click();
-    failedRow
-      .findPhasePopover()
-      .should(
-        'contain.text',
-        'Policy failedAll critical dependencies are missing or reconciliation has failed. Access controls are not in effect.Review the policy spec and ensure referenced models exist.',
-      );
+    failedRow.findPhasePopover().should('contain.text', 'Policy failed');
 
     const pendingRow = authPoliciesPage.getRow('pending-policy');
     pendingRow.findPhase().should('contain.text', 'Pending');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -110,7 +110,12 @@ describe('Subscriptions Page', () => {
     const failedRow = subscriptionsPage.getRow('failed-sub');
     failedRow.findPhase().should('contain.text', 'Failed');
     failedRow.findPhaseLabel().click();
-    failedRow.findPhasePopover().should('contain.text', 'Failed');
+    failedRow
+      .findPhasePopover()
+      .should(
+        'contain.text',
+        'Subscription failedAll critical dependencies are missing or reconiliation has failed. No models in this subscription are accessible.Review the subscription spec and model references.',
+      );
 
     const pendingRow = subscriptionsPage.getRow('pending-sub');
     pendingRow.findPhase().should('contain.text', 'Pending');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -114,7 +114,7 @@ describe('Subscriptions Page', () => {
       .findPhasePopover()
       .should(
         'contain.text',
-        'Subscription failedAll critical dependencies are missing or reconiliation has failed. No models in this subscription are accessible.Review the subscription spec and model references.',
+        'Subscription failedAll critical dependencies are missing or reconciliation has failed. No models in this subscription are accessible.Review the subscription spec and model references.',
       );
 
     const pendingRow = subscriptionsPage.getRow('pending-sub');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -212,7 +212,7 @@ describe('View Subscription Page', () => {
 
     viewSubscriptionPage
       .findDetailsSection()
-      .and('contain.text', 'Phase')
+      .and('contain.text', 'Status')
       .and('contain.text', 'Ready')
       .should('contain.text', 'Premium Team Subscription')
       .and('contain.text', 'Name')

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -87,7 +87,7 @@ describe('Subscriptions Page', () => {
     subscriptionsPage.findCreateSubscriptionButton().should('exist');
 
     const premiumRow = subscriptionsPage.getRow('Premium Team Subscription');
-    premiumRow.findPhase().should('contain.text', 'Active');
+    premiumRow.findPhase().should('contain.text', 'Ready');
     premiumRow.findName().should('contain.text', 'Premium Team Subscription');
     premiumRow.findGroups().should('contain.text', '1 Group');
     premiumRow.findModels().should('contain.text', '2 Models');
@@ -95,14 +95,14 @@ describe('Subscriptions Page', () => {
 
     const basicRow = subscriptionsPage.getRow('Basic Team Subscription');
     basicRow.findName().should('contain.text', 'Basic Team Subscription');
-    basicRow.findPhase().should('contain.text', 'Active');
+    basicRow.findPhase().should('contain.text', 'Ready');
     basicRow.findGroups().should('contain.text', '1 Group');
     basicRow.findModels().should('contain.text', '1 Model');
     basicRow.findPriority().should('contain.text', '0');
 
     const negativePriorityRow = subscriptionsPage.getRow('negative-priority-sub');
     negativePriorityRow.findName().should('contain.text', 'negative-priority-sub');
-    negativePriorityRow.findPhase().should('contain.text', 'Active');
+    negativePriorityRow.findPhase().should('contain.text', 'Ready');
     negativePriorityRow.findGroups().should('contain.text', '1 Group');
     negativePriorityRow.findModels().should('contain.text', '1 Model');
     negativePriorityRow.findPriority().should('contain.text', '-10000');
@@ -213,7 +213,7 @@ describe('View Subscription Page', () => {
     viewSubscriptionPage
       .findDetailsSection()
       .and('contain.text', 'Phase')
-      .and('contain.text', 'Active')
+      .and('contain.text', 'Ready')
       .should('contain.text', 'Premium Team Subscription')
       .and('contain.text', 'Name')
       .and('contain.text', 'Created');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -110,12 +110,7 @@ describe('Subscriptions Page', () => {
     const failedRow = subscriptionsPage.getRow('failed-sub');
     failedRow.findPhase().should('contain.text', 'Failed');
     failedRow.findPhaseLabel().click();
-    failedRow
-      .findPhasePopover()
-      .should(
-        'contain.text',
-        'Subscription failedAll critical dependencies are missing or reconciliation has failed. No models in this subscription are accessible.Review the subscription spec and model references.',
-      );
+    failedRow.findPhasePopover().should('contain.text', 'Subscription failed');
 
     const pendingRow = subscriptionsPage.getRow('pending-sub');
     pendingRow.findPhase().should('contain.text', 'Pending');

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
@@ -11,6 +11,7 @@ import { MaaSAuthPolicy } from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
 import { convertAuthPolicyToK8sResource } from '~/app/utilities/authpolicies';
 import PhaseLabel from '~/app/shared/PhaseLabel';
+import { PhaseResourceType } from '~/app/utilities/phaseLabelUtils';
 
 type AuthPoliciesTableRowProps = {
   authPolicy: MaaSAuthPolicy;
@@ -81,7 +82,11 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
         />
       </Td>
       <Td dataLabel={columns[1].label}>
-        <PhaseLabel phase={authPolicy.phase} statusMessage={authPolicy.statusMessage} />
+        <PhaseLabel
+          phase={authPolicy.phase}
+          statusMessage={authPolicy.statusMessage}
+          resourceType={PhaseResourceType.AUTHPOLICY}
+        />
       </Td>
       <Td dataLabel={columns[2].label}>{labelHelper(groupsCount, 'Group', 'Groups')}</Td>
       <Td dataLabel={columns[3].label}>{labelHelper(modelsCount, 'Model', 'Models')}</Td>

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/columns.ts
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/columns.ts
@@ -1,5 +1,6 @@
 import { SortableData } from '@odh-dashboard/internal/components/table/types';
 import { MaaSAuthPolicy } from '~/app/types/subscriptions';
+import { normalizePhase } from '~/app/utilities/phaseLabelUtils';
 
 export const authPoliciesColumns: SortableData<MaaSAuthPolicy>[] = [
   {
@@ -13,7 +14,7 @@ export const authPoliciesColumns: SortableData<MaaSAuthPolicy>[] = [
     field: 'phase',
     width: 10,
     sortable: (a: MaaSAuthPolicy, b: MaaSAuthPolicy): number =>
-      (a.phase ?? '').localeCompare(b.phase ?? ''),
+      normalizePhase(a.phase).localeCompare(normalizePhase(b.phase)),
   },
   {
     label: 'Groups',

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/columns.ts
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/columns.ts
@@ -11,7 +11,7 @@ export const authPoliciesColumns: SortableData<MaaSAuthPolicy>[] = [
   },
   {
     label: 'Status',
-    field: 'status',
+    field: 'phase',
     width: 10,
     sortable: (a: MaaSAuthPolicy, b: MaaSAuthPolicy): number =>
       normalizePhase(a.phase).localeCompare(normalizePhase(b.phase)),

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/columns.ts
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/columns.ts
@@ -10,8 +10,8 @@ export const authPoliciesColumns: SortableData<MaaSAuthPolicy>[] = [
       (a.displayName ?? a.name).localeCompare(b.displayName ?? b.name),
   },
   {
-    label: 'Phase',
-    field: 'phase',
+    label: 'Status',
+    field: 'status',
     width: 10,
     sortable: (a: MaaSAuthPolicy, b: MaaSAuthPolicy): number =>
       normalizePhase(a.phase).localeCompare(normalizePhase(b.phase)),

--- a/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { MaaSAuthPolicy } from '~/app/types/subscriptions';
 import PhaseLabel from '~/app/shared/PhaseLabel';
+import { PhaseResourceType } from '~/app/utilities/phaseLabelUtils';
 
 type PolicyDetailsSectionProps = {
   policy: MaaSAuthPolicy;
@@ -34,7 +35,11 @@ const PolicyDetailsSection: React.FC<PolicyDetailsSectionProps> = ({ policy }) =
         <DescriptionListGroup>
           <DescriptionListTerm>Phase</DescriptionListTerm>
           <DescriptionListDescription data-testid="policy-phase">
-            <PhaseLabel phase={policy.phase} statusMessage={policy.statusMessage} />
+            <PhaseLabel
+              phase={policy.phase}
+              statusMessage={policy.statusMessage}
+              resourceType={PhaseResourceType.AUTHPOLICY}
+            />
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
@@ -33,7 +33,7 @@ const PolicyDetailsSection: React.FC<PolicyDetailsSectionProps> = ({ policy }) =
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>Phase</DescriptionListTerm>
+          <DescriptionListTerm>Status</DescriptionListTerm>
           <DescriptionListDescription data-testid="policy-phase">
             <PhaseLabel
               phase={policy.phase}

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
@@ -10,6 +10,7 @@ import { MaaSSubscription } from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
 import { convertSubscriptionToK8sResource } from '~/app/utilities/subscriptions';
 import PhaseLabel from '~/app/shared/PhaseLabel';
+import { PhaseResourceType } from '~/app/utilities/phaseLabelUtils';
 import { subscriptionsColumns } from './columns';
 
 type SubscriptionTableRowProps = {
@@ -75,7 +76,11 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
         />
       </Td>
       <Td dataLabel={subscriptionsColumns[1].label}>
-        <PhaseLabel phase={subscription.phase} statusMessage={subscription.statusMessage} />
+        <PhaseLabel
+          phase={subscription.phase}
+          statusMessage={subscription.statusMessage}
+          resourceType={PhaseResourceType.SUBSCRIPTION}
+        />
       </Td>
       <Td dataLabel={subscriptionsColumns[2].label}>
         <Label color="grey">{`${subscription.owner.groups.length} Group${subscription.owner.groups.length === 1 ? '' : 's'}`}</Label>

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
@@ -10,8 +10,8 @@ export const subscriptionsColumns: SortableData<MaaSSubscription>[] = [
       (a.displayName ?? a.name).localeCompare(b.displayName ?? b.name),
   },
   {
-    label: 'Phase',
-    field: 'phase',
+    label: 'Status',
+    field: 'status',
     width: 15,
     sortable: (a: MaaSSubscription, b: MaaSSubscription): number =>
       normalizePhase(a.phase).localeCompare(normalizePhase(b.phase)),

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
@@ -1,5 +1,6 @@
 import { SortableData } from '@odh-dashboard/internal/components/table/types';
 import { MaaSSubscription } from '~/app/types/subscriptions';
+import { normalizePhase } from '~/app/utilities/phaseLabelUtils';
 
 export const subscriptionsColumns: SortableData<MaaSSubscription>[] = [
   {
@@ -13,7 +14,7 @@ export const subscriptionsColumns: SortableData<MaaSSubscription>[] = [
     field: 'phase',
     width: 15,
     sortable: (a: MaaSSubscription, b: MaaSSubscription): number =>
-      (a.phase ?? '').localeCompare(b.phase ?? ''),
+      normalizePhase(a.phase).localeCompare(normalizePhase(b.phase)),
   },
   {
     label: 'Groups',

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
@@ -11,7 +11,7 @@ export const subscriptionsColumns: SortableData<MaaSSubscription>[] = [
   },
   {
     label: 'Status',
-    field: 'status',
+    field: 'phase',
     width: 15,
     sortable: (a: MaaSSubscription, b: MaaSSubscription): number =>
       normalizePhase(a.phase).localeCompare(normalizePhase(b.phase)),

--- a/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
@@ -35,7 +35,7 @@ const SubscriptionDetailsSection: React.FC<SubscriptionDetailsSectionProps> = ({
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>Phase</DescriptionListTerm>
+          <DescriptionListTerm>Status</DescriptionListTerm>
           <DescriptionListDescription data-testid="subscription-phase">
             <PhaseLabel
               phase={subscription.phase}

--- a/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { MaaSSubscription } from '~/app/types/subscriptions';
 import PhaseLabel from '~/app/shared/PhaseLabel';
+import { PhaseResourceType } from '~/app/utilities/phaseLabelUtils';
 
 type SubscriptionDetailsSectionProps = {
   subscription: MaaSSubscription;
@@ -36,7 +37,11 @@ const SubscriptionDetailsSection: React.FC<SubscriptionDetailsSectionProps> = ({
         <DescriptionListGroup>
           <DescriptionListTerm>Phase</DescriptionListTerm>
           <DescriptionListDescription data-testid="subscription-phase">
-            <PhaseLabel phase={subscription.phase} statusMessage={subscription.statusMessage} />
+            <PhaseLabel
+              phase={subscription.phase}
+              statusMessage={subscription.statusMessage}
+              resourceType={PhaseResourceType.SUBSCRIPTION}
+            />
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
+++ b/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
@@ -4,6 +4,7 @@ import {
   normalizePhase,
   getPhaseProps,
   getPopoverContent,
+  PhaseStatus,
   PhaseResourceType,
 } from '~/app/utilities/phaseLabelUtils';
 
@@ -16,7 +17,7 @@ type PhaseLabelProps = {
 const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase, resourceType, statusMessage }) => {
   const normalized = normalizePhase(phase);
   const phaseProps = getPhaseProps(normalized);
-  const hasPopover = normalized !== 'Active' && normalized !== 'Ready' && !!statusMessage;
+  const hasPopover = normalized !== PhaseStatus.READY && !!statusMessage;
   const popoverContent = getPopoverContent(normalized, resourceType, statusMessage);
 
   const label = (

--- a/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
+++ b/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
@@ -16,7 +16,7 @@ type PhaseLabelProps = {
 const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase, resourceType, statusMessage }) => {
   const normalized = normalizePhase(phase);
   const phaseProps = getPhaseProps(normalized);
-  const hasPopover = !!statusMessage && normalized !== 'Active' && normalized !== 'Ready';
+  const hasPopover = normalized !== 'Active' && normalized !== 'Ready';
   const popoverContent = getPopoverContent(normalized, resourceType, statusMessage);
 
   const label = (

--- a/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
+++ b/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
@@ -16,7 +16,7 @@ type PhaseLabelProps = {
 const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase, resourceType, statusMessage }) => {
   const normalized = normalizePhase(phase);
   const phaseProps = getPhaseProps(normalized);
-  const hasPopover = normalized !== 'Active' && normalized !== 'Ready';
+  const hasPopover = normalized !== 'Active' && normalized !== 'Ready' && !!statusMessage;
   const popoverContent = getPopoverContent(normalized, resourceType, statusMessage);
 
   const label = (

--- a/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
+++ b/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { Label, LabelProps, Popover } from '@patternfly/react-core';
-import { CheckCircleIcon, ExclamationCircleIcon, InProgressIcon } from '@patternfly/react-icons';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  OutlinedQuestionCircleIcon,
+  ExclamationTriangleIcon,
+  PendingIcon,
+} from '@patternfly/react-icons';
 
 type PhaseLabelProps = {
   phase: string | undefined;
@@ -15,12 +21,15 @@ const getPhaseProps = (
     case 'Ready':
       return { icon: <CheckCircleIcon />, status: 'success' };
     case 'Failed':
-    case 'Unhealthy':
       return { icon: <ExclamationCircleIcon />, status: 'danger' };
+    case 'Unhealthy':
+      return { icon: <ExclamationCircleIcon />, status: 'warning' };
     case 'Pending':
-      return { icon: <InProgressIcon />, color: 'blue' };
+      return { icon: <PendingIcon />, color: 'purple' };
+    case 'Degraded':
+      return { icon: <ExclamationTriangleIcon />, status: 'warning' };
     default:
-      return { icon: undefined, color: 'grey' };
+      return { icon: <OutlinedQuestionCircleIcon />, color: 'grey' };
   }
 };
 

--- a/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
+++ b/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
@@ -1,42 +1,23 @@
 import * as React from 'react';
-import { Label, LabelProps, Popover } from '@patternfly/react-core';
+import { Label, Popover } from '@patternfly/react-core';
 import {
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  OutlinedQuestionCircleIcon,
-  ExclamationTriangleIcon,
-  PendingIcon,
-} from '@patternfly/react-icons';
+  normalizePhase,
+  getPhaseProps,
+  getPopoverContent,
+  PhaseResourceType,
+} from '~/app/utilities/phaseLabelUtils';
 
 type PhaseLabelProps = {
   phase: string | undefined;
+  resourceType: PhaseResourceType;
   statusMessage?: string;
 };
 
-const getPhaseProps = (
-  phase: string | undefined,
-): { icon: React.ReactNode; status?: LabelProps['status']; color?: LabelProps['color'] } => {
-  switch (phase) {
-    case 'Active':
-    case 'Ready':
-      return { icon: <CheckCircleIcon />, status: 'success' };
-    case 'Failed':
-      return { icon: <ExclamationCircleIcon />, status: 'danger' };
-    case 'Unhealthy':
-      return { icon: <ExclamationCircleIcon />, status: 'warning' };
-    case 'Pending':
-      return { icon: <PendingIcon />, color: 'purple' };
-    case 'Degraded':
-      return { icon: <ExclamationTriangleIcon />, status: 'warning' };
-    default:
-      return { icon: <OutlinedQuestionCircleIcon />, color: 'grey' };
-  }
-};
-
-const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase, statusMessage }) => {
-  const normalized = phase?.trim() || 'Unknown';
+const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase, resourceType, statusMessage }) => {
+  const normalized = normalizePhase(phase);
   const phaseProps = getPhaseProps(normalized);
-  const hasPopover = !!statusMessage;
+  const hasPopover = !!statusMessage && normalized !== 'Active' && normalized !== 'Ready';
+  const popoverContent = getPopoverContent(normalized, resourceType, statusMessage);
 
   const label = (
     <Label
@@ -57,8 +38,10 @@ const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase, statusMessage }) => {
   return (
     <Popover
       data-testid="phase-popover"
-      headerContent={normalized}
-      bodyContent={statusMessage}
+      headerContent={popoverContent.headerContent}
+      headerIcon={popoverContent.headerIcon}
+      bodyContent={popoverContent.bodyContent}
+      footerContent={popoverContent.footerContent}
       position="top"
     >
       {label}

--- a/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
+++ b/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
@@ -22,6 +22,15 @@ describe('PhaseLabel', () => {
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
     expect(label.textContent).toContain('Failed');
+    expect(label.className).toContain('pf-m-danger');
+  });
+
+  it('should render Degraded phase with correct text', () => {
+    render(<PhaseLabel phase="Degraded" />);
+    const label = screen.getByTestId('phase-label');
+    expect(label).not.toBeNull();
+    expect(label.textContent).toContain('Degraded');
+    expect(label.className).toContain('pf-m-warning');
   });
 
   it('should render Unhealthy phase with correct text', () => {
@@ -29,6 +38,7 @@ describe('PhaseLabel', () => {
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
     expect(label.textContent).toContain('Unhealthy');
+    expect(label.className).toContain('pf-m-warning');
   });
 
   it('should render Pending phase with correct text', () => {

--- a/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
+++ b/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
@@ -8,7 +8,7 @@ describe('PhaseLabel', () => {
     render(<PhaseLabel phase="Active" resourceType={PhaseResourceType.SUBSCRIPTION} />);
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
-    expect(label.textContent).toContain('Active');
+    expect(label.textContent).toContain('Ready');
   });
 
   it('should render Ready phase with correct text', () => {

--- a/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
+++ b/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
@@ -1,24 +1,25 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import PhaseLabel from '~/app/shared/PhaseLabel';
+import { PhaseResourceType } from '~/app/utilities/phaseLabelUtils';
 
 describe('PhaseLabel', () => {
   it('should render Active phase with correct text', () => {
-    render(<PhaseLabel phase="Active" />);
+    render(<PhaseLabel phase="Active" resourceType={PhaseResourceType.SUBSCRIPTION} />);
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
     expect(label.textContent).toContain('Active');
   });
 
   it('should render Ready phase with correct text', () => {
-    render(<PhaseLabel phase="Ready" />);
+    render(<PhaseLabel phase="Ready" resourceType={PhaseResourceType.SUBSCRIPTION} />);
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
     expect(label.textContent).toContain('Ready');
   });
 
   it('should render Failed phase with correct text', () => {
-    render(<PhaseLabel phase="Failed" />);
+    render(<PhaseLabel phase="Failed" resourceType={PhaseResourceType.SUBSCRIPTION} />);
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
     expect(label.textContent).toContain('Failed');
@@ -26,7 +27,7 @@ describe('PhaseLabel', () => {
   });
 
   it('should render Degraded phase with correct text', () => {
-    render(<PhaseLabel phase="Degraded" />);
+    render(<PhaseLabel phase="Degraded" resourceType={PhaseResourceType.SUBSCRIPTION} />);
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
     expect(label.textContent).toContain('Degraded');
@@ -34,45 +35,77 @@ describe('PhaseLabel', () => {
   });
 
   it('should render Unhealthy phase with correct text', () => {
-    render(<PhaseLabel phase="Unhealthy" />);
+    render(<PhaseLabel phase="Unhealthy" resourceType={PhaseResourceType.SUBSCRIPTION} />);
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
-    expect(label.textContent).toContain('Unhealthy');
+    expect(label.textContent).toContain('Unavailable');
     expect(label.className).toContain('pf-m-warning');
   });
 
   it('should render Pending phase with correct text', () => {
-    render(<PhaseLabel phase="Pending" />);
+    render(<PhaseLabel phase="Pending" resourceType={PhaseResourceType.SUBSCRIPTION} />);
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
     expect(label.textContent).toContain('Pending');
   });
 
   it('should render Unknown label when phase is undefined', () => {
-    render(<PhaseLabel phase={undefined} />);
+    render(<PhaseLabel phase={undefined} resourceType={PhaseResourceType.SUBSCRIPTION} />);
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
     expect(label.textContent).toContain('Unknown');
   });
 
   it('should render unrecognized phase values as-is', () => {
-    render(<PhaseLabel phase="SomethingElse" />);
+    render(<PhaseLabel phase="SomethingElse" resourceType={PhaseResourceType.SUBSCRIPTION} />);
     const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
     expect(label.textContent).toContain('SomethingElse');
   });
 
   it('should render outline variant when no statusMessage is provided', () => {
-    render(<PhaseLabel phase="Active" />);
+    render(<PhaseLabel phase="Active" resourceType={PhaseResourceType.SUBSCRIPTION} />);
     const label = screen.getByTestId('phase-label');
     expect(label.className).toContain('pf-m-outline');
     expect(screen.queryByTestId('phase-popover')).toBeNull();
   });
 
   it('should render filled variant with popover when statusMessage is provided', () => {
-    render(<PhaseLabel phase="Failed" statusMessage="Token limit exceeded." />);
+    render(
+      <PhaseLabel
+        phase="Failed"
+        resourceType={PhaseResourceType.SUBSCRIPTION}
+        statusMessage="Token limit exceeded."
+      />,
+    );
     const label = screen.getByTestId('phase-label');
     expect(label.className).not.toContain('pf-m-outline');
     expect(label.textContent).toContain('Failed');
+  });
+
+  it('should not render popover for Active phase even when statusMessage is provided', () => {
+    render(
+      <PhaseLabel
+        phase="Active"
+        resourceType={PhaseResourceType.SUBSCRIPTION}
+        statusMessage="Some message."
+      />,
+    );
+    const label = screen.getByTestId('phase-label');
+    expect(label.className).toContain('pf-m-outline');
+    expect(screen.queryByTestId('phase-popover')).toBeNull();
+  });
+
+  it('should not render popover for Ready phase even when statusMessage is provided', () => {
+    render(
+      <PhaseLabel
+        phase="Ready"
+        resourceType={PhaseResourceType.SUBSCRIPTION}
+        statusMessage="Some message."
+      />,
+    );
+    const label = screen.getByTestId('phase-label');
+    expect(label.className).toContain('pf-m-outline');
+    expect(screen.queryByTestId('phase-popover')).toBeNull();
   });
 });

--- a/packages/maas/frontend/src/app/utilities/phaseLabelUtils.tsx
+++ b/packages/maas/frontend/src/app/utilities/phaseLabelUtils.tsx
@@ -1,0 +1,218 @@
+import * as React from 'react';
+import { Icon, LabelProps } from '@patternfly/react-core';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  OutlinedQuestionCircleIcon,
+  ExclamationTriangleIcon,
+  PendingIcon,
+} from '@patternfly/react-icons';
+
+type PopoverContent = {
+  headerIcon: React.ReactNode;
+  headerContent: string;
+  bodyContent: string;
+  footerContent: string;
+};
+
+export enum PhaseResourceType {
+  SUBSCRIPTION = 'Subscription',
+  MODELREF = 'Model',
+  AUTHPOLICY = 'Policy',
+}
+
+export enum PhaseStatus {
+  ACTIVE = 'Active',
+  READY = 'Ready',
+  PENDING = 'Pending',
+  FAILED = 'Failed',
+  INVALID = 'Invalid',
+  DEGRADED = 'Degraded',
+  UNAVAILABLE = 'Unavailable',
+  UNHEALTHY = 'Unhealthy',
+  UNKNOWN = 'Unknown',
+}
+
+export const getPhaseProps = (
+  phase: string | undefined,
+): { icon: React.ReactNode; status?: LabelProps['status']; color?: LabelProps['color'] } => {
+  switch (phase) {
+    case PhaseStatus.ACTIVE:
+    case PhaseStatus.READY:
+      return { icon: <CheckCircleIcon />, status: 'success' };
+    case PhaseStatus.FAILED:
+    case PhaseStatus.INVALID:
+      return { icon: <ExclamationCircleIcon />, status: 'danger' };
+    case PhaseStatus.UNAVAILABLE:
+      return { icon: <ExclamationCircleIcon />, status: 'warning' };
+    case PhaseStatus.PENDING:
+      return { icon: <PendingIcon />, color: 'purple' };
+    case PhaseStatus.DEGRADED:
+      return { icon: <ExclamationTriangleIcon />, status: 'warning' };
+    default:
+      return { icon: <OutlinedQuestionCircleIcon />, color: 'grey' };
+  }
+};
+
+export const normalizePhase = (phase: string | undefined): string => {
+  if (phase === PhaseStatus.UNHEALTHY) {
+    return PhaseStatus.UNAVAILABLE;
+  }
+  return phase?.trim() || PhaseStatus.UNKNOWN;
+};
+
+const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverContent>>> = {
+  [PhaseResourceType.SUBSCRIPTION]: {
+    [PhaseStatus.PENDING]: {
+      headerIcon: <PendingIcon />,
+      headerContent: 'Subscription pending',
+      bodyContent:
+        'This subscription was recently created and is being reconciled. No action needed - it should become active shortly.',
+      footerContent: 'If this persists, check the controller logs.',
+    },
+    [PhaseStatus.FAILED]: {
+      headerIcon: (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      ),
+      headerContent: 'Subscription failed',
+      bodyContent:
+        'All critical dependencies are missing or reconiliation has failed. No models in this subscription are accessible.',
+      footerContent: 'Review the subscription spec and model references.',
+    },
+    [PhaseStatus.INVALID]: {
+      headerIcon: (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      ),
+      headerContent: 'Invalid subscription spec',
+      bodyContent:
+        'The resource spec contains validation errors and cannot be reconciled until corrected.',
+      footerContent:
+        'Edit the YAML to fix structural errors (malformed model refs, missing fields).',
+    },
+    [PhaseStatus.DEGRADED]: {
+      headerIcon: (
+        <Icon status="warning">
+          <ExclamationTriangleIcon />
+        </Icon>
+      ),
+      headerContent: 'Subscription degraded',
+      bodyContent:
+        'Some models may not be accessible to users. Drill into details to see affected models.',
+      footerContent:
+        'Common causes: model endpoint removed, rate limit policy not accepted by Kuadrant.',
+    },
+  },
+  [PhaseResourceType.AUTHPOLICY]: {
+    [PhaseStatus.PENDING]: {
+      headerIcon: <PendingIcon />,
+      headerContent: 'Policy pending',
+      bodyContent:
+        'This authorization policy was recently created. No AuthPolicies have been generated yet - the system is reconciling.',
+      footerContent: 'If this persists beyond a few minutes, check the controller logs.',
+    },
+    [PhaseStatus.DEGRADED]: {
+      headerIcon: (
+        <Icon status="warning">
+          <ExclamationTriangleIcon />
+        </Icon>
+      ),
+      headerContent: 'Policy degraded',
+      bodyContent:
+        'Some authorization policies are not being enforced. This may mean some model refs are missing or some Kuadrant AuthPolicies have not been accepted.',
+      footerContent:
+        'Note: "Degraded" also covers the initial state when no AuthPolicies have been generated yet. Check if this policy was recently created.',
+    },
+    [PhaseStatus.FAILED]: {
+      headerIcon: (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      ),
+      headerContent: 'Policy failed',
+      bodyContent:
+        'All critical dependencies are missing or reconiliation has failed. Access controls are not in effect.',
+      footerContent: 'Review the policy spec and ensure referenced models exist.',
+    },
+    [PhaseStatus.INVALID]: {
+      headerIcon: (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      ),
+      headerContent: 'Invalid policy spec',
+      bodyContent: 'The policy spec contains validation errors and cannot be reconciled.',
+      footerContent: 'Edit the YAML to fix structural errors.',
+    },
+  },
+  [PhaseResourceType.MODELREF]: {
+    [PhaseStatus.PENDING]: {
+      headerIcon: <PendingIcon />,
+      headerContent: 'Model pending',
+      bodyContent:
+        'This model is awaiting governance pairing (subscription + auth policy) or backend readiness. No action needed - it should become ready once dependencies are met.',
+      footerContent: 'Check that a subscription and auth policy reference this model.',
+    },
+    [PhaseStatus.UNAVAILABLE]: {
+      headerIcon: (
+        <Icon status="warning">
+          <ExclamationTriangleIcon />
+        </Icon>
+      ),
+      headerContent: 'Model unavailable',
+      bodyContent:
+        'This model has governance configured (subscription and auth policy) but the backend or routing has issues. The model cannot serve requests right now.',
+      footerContent:
+        'Check the inference gateway status and backend health. Contact your infrastructure team if the issue persists.',
+    },
+    [PhaseStatus.FAILED]: {
+      headerIcon: (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      ),
+      headerContent: 'Model failed',
+      bodyContent: 'Reconciliation has failed completely. The model cannot be used.',
+      footerContent: 'Review the model spec and check controller logs for error details.',
+    },
+    [PhaseStatus.INVALID]: {
+      headerIcon: (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      ),
+      headerContent: 'Invalid model spec',
+      bodyContent: 'The model spec contains validation errors and cannot be reconciled.',
+      footerContent: 'Edit the YAML to fix structural errors.',
+    },
+  },
+};
+
+const DEFAULT_POPOVER_CONTENT: PopoverContent = {
+  headerIcon: <OutlinedQuestionCircleIcon />,
+  headerContent: 'Unknown state',
+  bodyContent: 'The resource is in an unknown state.',
+  footerContent: 'Contact support if this persists.',
+};
+
+export const getPopoverContent = (
+  phase: string,
+  resourceType: PhaseResourceType,
+  statusMessage?: string,
+): PopoverContent => {
+  const base = POPOVER_CONTENT[resourceType][phase] ?? DEFAULT_POPOVER_CONTENT;
+  if (
+    statusMessage &&
+    resourceType === PhaseResourceType.SUBSCRIPTION &&
+    phase === PhaseStatus.DEGRADED
+  ) {
+    return {
+      ...base,
+      bodyContent: `${statusMessage}. Some models may not be accessible to users. Drill into details to see affected models.`,
+    };
+  }
+  return base;
+};

--- a/packages/maas/frontend/src/app/utilities/phaseLabelUtils.tsx
+++ b/packages/maas/frontend/src/app/utilities/phaseLabelUtils.tsx
@@ -55,10 +55,11 @@ export const getPhaseProps = (
 };
 
 export const normalizePhase = (phase: string | undefined): string => {
-  if (phase === PhaseStatus.UNHEALTHY) {
+  const normalized = phase?.trim();
+  if (normalized === PhaseStatus.UNHEALTHY) {
     return PhaseStatus.UNAVAILABLE;
   }
-  return phase?.trim() || PhaseStatus.UNKNOWN;
+  return normalized || PhaseStatus.UNKNOWN;
 };
 
 const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverContent>>> = {
@@ -78,7 +79,7 @@ const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverC
       ),
       headerContent: 'Subscription failed',
       bodyContent:
-        'All critical dependencies are missing or reconiliation has failed. No models in this subscription are accessible.',
+        'All critical dependencies are missing or reconciliation has failed. No models in this subscription are accessible.',
       footerContent: 'Review the subscription spec and model references.',
     },
     [PhaseStatus.INVALID]: {
@@ -134,7 +135,7 @@ const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverC
       ),
       headerContent: 'Policy failed',
       bodyContent:
-        'All critical dependencies are missing or reconiliation has failed. Access controls are not in effect.',
+        'All critical dependencies are missing or reconciliation has failed. Access controls are not in effect.',
       footerContent: 'Review the policy spec and ensure referenced models exist.',
     },
     [PhaseStatus.INVALID]: {

--- a/packages/maas/frontend/src/app/utilities/phaseLabelUtils.tsx
+++ b/packages/maas/frontend/src/app/utilities/phaseLabelUtils.tsx
@@ -11,13 +11,12 @@ import {
 type PopoverContent = {
   headerIcon: React.ReactNode;
   headerContent: string;
-  bodyContent: string;
-  footerContent: string;
+  bodyContent?: string;
+  footerContent?: string;
 };
 
 export enum PhaseResourceType {
   SUBSCRIPTION = 'Subscription',
-  MODELREF = 'Model',
   AUTHPOLICY = 'Policy',
 }
 
@@ -70,9 +69,6 @@ const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverC
     [PhaseStatus.PENDING]: {
       headerIcon: <PendingIcon />,
       headerContent: 'Subscription pending',
-      bodyContent:
-        'This subscription was recently created and is being reconciled. No action needed - it should become active shortly.',
-      footerContent: 'If this persists, check the controller logs.',
     },
     [PhaseStatus.FAILED]: {
       headerIcon: (
@@ -81,9 +77,6 @@ const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverC
         </Icon>
       ),
       headerContent: 'Subscription failed',
-      bodyContent:
-        'All critical dependencies are missing or reconciliation has failed. No models in this subscription are accessible.',
-      footerContent: 'Review the subscription spec and model references.',
     },
     [PhaseStatus.INVALID]: {
       headerIcon: (
@@ -92,10 +85,6 @@ const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverC
         </Icon>
       ),
       headerContent: 'Invalid subscription spec',
-      bodyContent:
-        'The resource spec contains validation errors and cannot be reconciled until corrected.',
-      footerContent:
-        'Edit the YAML to fix structural errors (malformed model refs, missing fields).',
     },
     [PhaseStatus.DEGRADED]: {
       headerIcon: (
@@ -104,19 +93,12 @@ const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverC
         </Icon>
       ),
       headerContent: 'Subscription degraded',
-      bodyContent:
-        'Some models may not be accessible to users. Drill into details to see affected models.',
-      footerContent:
-        'Common causes: model endpoint removed, rate limit policy not accepted by Kuadrant.',
     },
   },
   [PhaseResourceType.AUTHPOLICY]: {
     [PhaseStatus.PENDING]: {
       headerIcon: <PendingIcon />,
       headerContent: 'Policy pending',
-      bodyContent:
-        'This authorization policy was recently created. No AuthPolicies have been generated yet - the system is reconciling.',
-      footerContent: 'If this persists beyond a few minutes, check the controller logs.',
     },
     [PhaseStatus.DEGRADED]: {
       headerIcon: (
@@ -125,10 +107,6 @@ const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverC
         </Icon>
       ),
       headerContent: 'Policy degraded',
-      bodyContent:
-        'Some authorization policies are not being enforced. This may mean some model refs are missing or some Kuadrant AuthPolicies have not been accepted.',
-      footerContent:
-        'Note: "Degraded" also covers the initial state when no AuthPolicies have been generated yet. Check if this policy was recently created.',
     },
     [PhaseStatus.FAILED]: {
       headerIcon: (
@@ -137,9 +115,6 @@ const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverC
         </Icon>
       ),
       headerContent: 'Policy failed',
-      bodyContent:
-        'All critical dependencies are missing or reconciliation has failed. Access controls are not in effect.',
-      footerContent: 'Review the policy spec and ensure referenced models exist.',
     },
     [PhaseStatus.INVALID]: {
       headerIcon: (
@@ -148,49 +123,6 @@ const POPOVER_CONTENT: Record<PhaseResourceType, Partial<Record<string, PopoverC
         </Icon>
       ),
       headerContent: 'Invalid policy spec',
-      bodyContent: 'The policy spec contains validation errors and cannot be reconciled.',
-      footerContent: 'Edit the YAML to fix structural errors.',
-    },
-  },
-  [PhaseResourceType.MODELREF]: {
-    [PhaseStatus.PENDING]: {
-      headerIcon: <PendingIcon />,
-      headerContent: 'Model pending',
-      bodyContent:
-        'This model is awaiting governance pairing (subscription + auth policy) or backend readiness. No action needed - it should become ready once dependencies are met.',
-      footerContent: 'Check that a subscription and auth policy reference this model.',
-    },
-    [PhaseStatus.UNAVAILABLE]: {
-      headerIcon: (
-        <Icon status="warning">
-          <ExclamationTriangleIcon />
-        </Icon>
-      ),
-      headerContent: 'Model unavailable',
-      bodyContent:
-        'This model has governance configured (subscription and auth policy) but the backend or routing has issues. The model cannot serve requests right now.',
-      footerContent:
-        'Check the inference gateway status and backend health. Contact your infrastructure team if the issue persists.',
-    },
-    [PhaseStatus.FAILED]: {
-      headerIcon: (
-        <Icon status="danger">
-          <ExclamationCircleIcon />
-        </Icon>
-      ),
-      headerContent: 'Model failed',
-      bodyContent: 'Reconciliation has failed completely. The model cannot be used.',
-      footerContent: 'Review the model spec and check controller logs for error details.',
-    },
-    [PhaseStatus.INVALID]: {
-      headerIcon: (
-        <Icon status="danger">
-          <ExclamationCircleIcon />
-        </Icon>
-      ),
-      headerContent: 'Invalid model spec',
-      bodyContent: 'The model spec contains validation errors and cannot be reconciled.',
-      footerContent: 'Edit the YAML to fix structural errors.',
     },
   },
 };
@@ -199,7 +131,6 @@ const DEFAULT_POPOVER_CONTENT: PopoverContent = {
   headerIcon: <OutlinedQuestionCircleIcon />,
   headerContent: 'Unknown state',
   bodyContent: 'The resource is in an unknown state.',
-  footerContent: 'Contact support if this persists.',
 };
 
 export const getPopoverContent = (
@@ -208,15 +139,8 @@ export const getPopoverContent = (
   statusMessage?: string,
 ): PopoverContent => {
   const base = POPOVER_CONTENT[resourceType][phase] ?? DEFAULT_POPOVER_CONTENT;
-  if (
-    statusMessage &&
-    resourceType === PhaseResourceType.SUBSCRIPTION &&
-    phase === PhaseStatus.DEGRADED
-  ) {
-    return {
-      ...base,
-      bodyContent: `${statusMessage}. Some models may not be accessible to users. Drill into details to see affected models.`,
-    };
+  if (statusMessage) {
+    return { ...base, bodyContent: statusMessage };
   }
   return base;
 };

--- a/packages/maas/frontend/src/app/utilities/phaseLabelUtils.tsx
+++ b/packages/maas/frontend/src/app/utilities/phaseLabelUtils.tsx
@@ -59,6 +59,9 @@ export const normalizePhase = (phase: string | undefined): string => {
   if (normalized === PhaseStatus.UNHEALTHY) {
     return PhaseStatus.UNAVAILABLE;
   }
+  if (normalized === PhaseStatus.ACTIVE) {
+    return PhaseStatus.READY;
+  }
   return normalized || PhaseStatus.UNKNOWN;
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-65744](https://redhat.atlassian.net/browse/RHOAIENG-65744)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Some changes to the phase label for subscriptions and policies

`Degraded`: gets an icon and changes to yellow
`Unhealthy`: is changed to yellow and listed as `Unavailable` (only exists on `MaasModelRef` but they'll all use the same phase label component so I threw it in)
`Pending`: changed to purple and a new icon
`Unknown`/`default`: gets an icon
`Active`/`Ready`: turned into an outlined label (no popover) -> and `Active` is turned into `Ready`

Updated `Phase` column and view page label to `Status`

Each resource type and phase gets it's own popover header and icon, the body content is just the `StatusMessage` for now, will get updated in the next phase label update ticket

The scaffolding is there to add model refs and custom static popover messages once the UX is ready


<img width="159" height="167" alt="Screenshot 2026-06-17 at 9 00 08 AM" src="https://github.com/user-attachments/assets/2020e9a1-af9b-4320-97fb-6feb82833d95" />
<img width="138" height="228" alt="Screenshot 2026-06-17 at 9 00 15 AM" src="https://github.com/user-attachments/assets/2bf27745-1e80-42d2-8572-923ab5bb5f72" />

Popover title examples:
<img width="293" height="140" alt="Screenshot 2026-06-18 at 2 40 53 PM" src="https://github.com/user-attachments/assets/5e537fa9-cbc7-4247-9082-f8e1cf006033" />
<img width="314" height="154" alt="Screenshot 2026-06-18 at 2 40 56 PM" src="https://github.com/user-attachments/assets/1a8d6967-0ac8-46ab-8872-0fd8d86fac25" />

(Ignore the status messages on the below, I was forcing it into different states to show how the label and popover title look)
<img width="329" height="151" alt="Screenshot 2026-06-18 at 2 45 38 PM" src="https://github.com/user-attachments/assets/8efae829-1b8a-45ce-a854-8c4d3dc021da" />
<img width="243" height="158" alt="Screenshot 2026-06-18 at 2 46 21 PM" src="https://github.com/user-attachments/assets/e4cac115-c51d-4170-ba96-26f81be59cf9" />
<img width="241" height="160" alt="Screenshot 2026-06-18 at 2 46 54 PM" src="https://github.com/user-attachments/assets/892b49db-0a59-49bd-9a32-f22e49ab65b7" />


On Sub/policy view page:

<img width="301" height="200" alt="Screenshot 2026-06-17 at 9 01 39 AM" src="https://github.com/user-attachments/assets/b5752da7-7a9f-4bae-ade4-a4ad85431f14" />
<img width="245" height="173" alt="Screenshot 2026-06-17 at 9 02 02 AM" src="https://github.com/user-attachments/assets/f703c88e-bb51-44d7-b0c8-ba6640a2b80b" />



sorting updated to sort by normalized status (if the phase is technically `Active` but displays as `Ready`, we need to sort by `Ready`)

https://github.com/user-attachments/assets/d8d0dceb-4f1b-47a9-a327-87bf59daa3b7




Previous look example:
<img width="186" height="395" alt="Screenshot 2026-06-16 at 9 31 01 AM" src="https://github.com/user-attachments/assets/33ea625f-3ee0-426e-aff3-ce09bfdeb084" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- The dashboard-maas cluster has a few subs in different states but to see each one
- make a sub with 1 running and 1 non-running model to see `Degraded`
- make a sub with 1 non-running model to see `Failed`
- make a sub with 1 running model to see `Active`
- it's harder to see `Unknown` and pending so you can update this line in `PhaseLabel.tsx` to see those labels manually
```
 // const normalized = normalizePhase(phase); //comment out this line
  const normalized = 'Pending'; //write whatever status you want to see to see the label update
  const dummyStatusMessage = 'This is a dummy status message'; //to see something other than the real status message
  const phaseProps = getPhaseProps(normalized);
  const hasPopover = normalized !== 'Active' && normalized !== 'Ready' && !!dummyStatusMessage;
  const popoverContent = getPopoverContent(normalized, resourceType, dummyStatusMessage);
```
you'll also have to update the dummyStatus if you want to see a different status message in the popover, otherwise it'll print the resource's real status
then just be on the subscriptions or policies pages to see the corresponding labels


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated a couple unit tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added shared phase/status labeling with resource-aware popover content for Auth Policies and Subscriptions.

* **Bug Fixes**
  * Updated phase/status rendering to use normalized states (e.g., Active→Ready) for more consistent UI feedback.
  * Improved phase popovers so they appear only for actionable states and show expanded failure details when relevant.

* **Tests**
  * Updated UI and end-to-end checks to match revised phase text, popover behavior, and table sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->