### PR TITLE
Area-gate project-scoped navigation in model-serving for RHAII

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/useNavigateToDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useNavigateToDeploymentWizard.ts
@@ -57,16 +57,18 @@ export const useNavigateToDeploymentWizard = (
 ): ((projectName?: string, initialDataOnNavigate?: InitialWizardFormData | null) => void) => {
   const navigate: NavigateFunction = useNavigate();
   const isYAMLViewerEnabled = useIsAreaAvailable(SupportedArea.YAML_VIEWER).status;
+  // Projects routes don't exist in project-less distributions (e.g. RHAII)
+  const hasProjects = useIsAreaAvailable(SupportedArea.DS_PROJECTS_VIEW).status;
 
   // Load hooks needed for the deployment wizard
   const { formData, loaded, error } = useExtractFormDataFromDeployment(deployment);
   const location = useLocation();
   let returnRoute = returnRouteValue ?? location.pathname;
-  if (returnRoute.includes('projects')) {
+  if (hasProjects && returnRoute.includes('projects')) {
     returnRoute += '?section=model-server';
   }
   let cancelReturnRoute = cancelReturnRouteValue ?? location.pathname;
-  if (cancelReturnRoute.includes('projects')) {
+  if (hasProjects && cancelReturnRoute.includes('projects')) {
     cancelReturnRoute += '?section=model-server';
   }
 

--- a/packages/model-serving/src/components/metrics/DeploymentMetricsLink.tsx
+++ b/packages/model-serving/src/components/metrics/DeploymentMetricsLink.tsx
@@ -1,20 +1,30 @@
 import React from 'react';
 import { Link, useLocation, matchPath } from 'react-router-dom';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
+import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/internal/concepts/areas';
 import type { Deployment } from '../../../extension-points';
 
-const getMetricsUrl = (currentPath: string, deployment: Deployment) => {
+// Projects routes don't exist in project-less distributions (e.g. RHAII)
+const getMetricsUrl = (currentPath: string, deployment: Deployment, hasProjects: boolean) => {
   if (matchPath('/ai-hub/models/deployments/*', currentPath)) {
     return `/ai-hub/models/deployments/${deployment.model.metadata.namespace}/metrics/${deployment.model.metadata.name}`;
   }
-  return `/projects/${deployment.model.metadata.namespace}/metrics/model/${deployment.model.metadata.name}`;
+  if (hasProjects) {
+    return `/projects/${deployment.model.metadata.namespace}/metrics/model/${deployment.model.metadata.name}`;
+  }
+  return undefined;
 };
 
 export const DeploymentMetricsLink: React.FC<{
   deployment: Deployment;
 }> = ({ deployment, ...props }) => {
   const currentPath = useLocation().pathname;
-  const metricsUrl = getMetricsUrl(currentPath, deployment);
+  const hasProjects = useIsAreaAvailable(SupportedArea.DS_PROJECTS_VIEW).status;
+  const metricsUrl = getMetricsUrl(currentPath, deployment, hasProjects);
+
+  if (!metricsUrl) {
+    return <span>{getDisplayNameFromK8sResource(deployment.model)}</span>;
+  }
 
   return (
     <Link


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-69372

## Description

Model-serving hardcodes links to `/projects/*` routes. In RHAII (which has no projects package), these would be dead links. This PR gates them behind `DS_PROJECTS_VIEW` so they only render when projects exists.

**No change to RHOAI behavior** — `DS_PROJECTS_VIEW` is always `true` there. We're just adding explicit guards for distributions where it's not.

**2 files changed (~15 lines):**
- `useNavigateToDeploymentWizard.ts` — only appends `?section=model-server` to return route when projects is available
- `DeploymentMetricsLink.tsx` — renders plain text instead of a dead `/projects/` link when projects is unavailable

**Why not the other 2 sites?** `DeployedModelsSection.tsx` is served via `app.project-details/overview-section` — it only mounts when projects exist. Structurally safe, no gate needed.

<img width="1512" height="826" alt="Screenshot 2026-06-16 at 1 26 37 PM" src="https://github.com/user-attachments/assets/9599c66a-9b4e-4f4f-b4a7-db0455260f98" />
<img width="1512" height="824" alt="Screenshot 2026-06-16 at 1 26 44 PM" src="https://github.com/user-attachments/assets/6f4fa001-aed2-4b3f-99c8-660f26a88ec6" />
<img width="1512" height="828" alt="Screenshot 2026-06-16 at 1 26 51 PM" src="https://github.com/user-attachments/assets/34bb6b15-8b99-47f7-9178-cb01e81f4444" />


## How Has This Been Tested?

- ESLint passes with zero warnings
- Verified locally against RHOAI cluster — all navigation works identically (gates are `true`)
- RHAII end-to-end deferred: model-serving isn't integrated there yet

## Test Impact

No existing tests cover these files. Change is additive — wraps existing conditionals with a boolean that's always `true` in RHOAI. Tests will be added when model-serving integrates into RHAII.

## Request review criteria:

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our [Best Practices](/docs/best-practices.md)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment wizard navigation to correctly adapt route parameters based on whether the projects feature area is available, preventing incorrect parameter appending.
  * Improved metrics link rendering to gracefully handle scenarios where the projects feature area is unavailable, displaying plain text instead of a clickable link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->