### PR TITLE
fix: re-export KnownLabels and other types from k8sTypes

### DIFF
--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -24,6 +24,25 @@ import type { DataScienceStackComponent } from '#~/concepts/areas/types';
 import { AccessMode } from '#~/pages/storageClasses/storageEnums';
 import { ImageStreamStatusTagCondition, ImageStreamStatusTagItem } from './types';
 
+// Re-export types from k8s-core that are used throughout the application
+export { KnownLabels, MetadataAnnotation, ContainerResourceAttributes };
+export type {
+  DisplayNameAnnotations,
+  K8sCondition,
+  PodSpec,
+  SupportedModelFormats,
+  SecretKind,
+  ContainerResources,
+  NodeSelector,
+  PodAffinity,
+  PodContainer,
+  Toleration,
+  Volume,
+  VolumeMount,
+  HardwareProfileBindingAnnotations,
+  AccessReviewResourceAttributes,
+};
+
 export type ModelRegistry = {
   name: string;
   displayName: string;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-69550


## Description
Re-export types that were moved to @odh-dashboard/k8s-core but are still imported from #~/k8sTypes throughout the codebase. This fixes type-check failures after PR #7855 merged with stale CI.

Root cause: PR #7855 removed exports from k8sTypes.ts, then merged using CI results from before PR #8096 (which added code importing KnownLabels).

## How Has This Been Tested?
- CI (in progress)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
