### PR TITLE
feat(agent-ops): add POST /agents/deploy BFF endpoint

### DIFF
--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -133,6 +133,48 @@ paths:
       operationId: getAgentRuntimeDetail
       summary: Get agent runtime detail
       description: Returns full runtime detail for a single deployed agent.
+  /api/v1/agents/deploy:
+    summary: Deploy a new agent runtime.
+    description: >-
+      Creates all Kubernetes resources (ServiceAccount, AgentRuntime CR, Deployment,
+      Service, and optionally an OpenShift Route) for a new agent deployment.
+    post:
+      tags:
+        - AgentOperation
+      requestBody:
+        required: true
+        description: Agent deployment specification.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeployAgentRequest"
+            example:
+              name: my-agent
+              namespace: agent-ops-demo
+              containerImage: quay.io/example/agent
+              imageTag: v1.0.0
+              protocol: a2a
+              framework: langgraph
+              createRoute: true
+              envVars:
+                - name: LOG_LEVEL
+                  value: info
+      responses:
+        "201":
+          $ref: "#/components/responses/DeployAgentResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: deployAgent
+      summary: Deploy a new agent
+      description: Creates all K8s resources for a new agent deployment.
 
 components:
   schemas:
@@ -518,6 +560,138 @@ components:
           items:
             type: string
           example: []
+    DeployAgentRequest:
+      description: Specification for deploying a new agent.
+      required:
+        - name
+        - namespace
+        - containerImage
+        - imageTag
+      type: object
+      properties:
+        name:
+          type: string
+          description: Agent name (DNS-1123 label).
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          maxLength: 63
+          example: my-agent
+        namespace:
+          type: string
+          description: Target Kubernetes namespace (DNS-1123 label).
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+          maxLength: 63
+          example: agent-ops-demo
+        containerImage:
+          type: string
+          description: Container image reference (without tag).
+          example: quay.io/example/agent
+        imageTag:
+          type: string
+          description: Container image tag.
+          example: v1.0.0
+        imagePullSecret:
+          type: string
+          description: Name of an existing image pull secret in the target namespace.
+          example: my-pull-secret
+        protocol:
+          type: string
+          description: Agent communication protocol.
+          enum: [a2a, mcp]
+          default: a2a
+          example: a2a
+        framework:
+          type: string
+          description: Agent framework identifier (valid K8s label value, max 63 chars).
+          maxLength: 63
+          example: langgraph
+        envVars:
+          type: array
+          description: Environment variables injected into the agent container.
+          items:
+            $ref: "#/components/schemas/DeployAgentEnvVar"
+        servicePorts:
+          type: array
+          description: Service port mappings. Defaults to http 8080→8000/TCP if omitted.
+          items:
+            $ref: "#/components/schemas/DeployAgentServicePort"
+        createRoute:
+          type: boolean
+          description: Whether to create an OpenShift Route for external access.
+          default: false
+          example: true
+        authBridgeEnabled:
+          type: boolean
+          description: Whether to enable kagenti AuthBridge sidecar injection.
+          default: true
+          example: true
+        authBridgeMode:
+          type: string
+          description: AuthBridge sidecar mode.
+          enum: [proxy-sidecar, envoy-sidecar, lite, waypoint]
+          example: proxy-sidecar
+        mtlsMode:
+          type: string
+          description: Mutual TLS mode for the agent.
+          enum: [disabled, permissive, strict]
+          example: disabled
+    DeployAgentEnvVar:
+      description: An environment variable for an agent container.
+      required:
+        - name
+        - value
+      type: object
+      properties:
+        name:
+          type: string
+          example: LOG_LEVEL
+        value:
+          type: string
+          example: info
+    DeployAgentServicePort:
+      description: A service port mapping for an agent.
+      required:
+        - name
+        - port
+        - targetPort
+      type: object
+      properties:
+        name:
+          type: string
+          example: http
+        port:
+          type: integer
+          minimum: 1
+          maximum: 65535
+          example: 8080
+        targetPort:
+          type: integer
+          minimum: 1
+          maximum: 65535
+          example: 8000
+        protocol:
+          type: string
+          default: TCP
+          example: TCP
+    DeployAgentResult:
+      description: Result of a successful agent deployment.
+      required:
+        - success
+        - name
+        - namespace
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        name:
+          type: string
+          example: my-agent
+        namespace:
+          type: string
+          example: agent-ops-demo
+        message:
+          type: string
+          example: Agent deployed successfully
   responses:
     HealthCheckResponse:
       description: BFF service health status
@@ -543,6 +717,12 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorEnvelope"
       description: Unauthorized
+    Conflict:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+      description: A resource with the same name already exists
     Forbidden:
       content:
         application/json:
@@ -677,6 +857,23 @@ components:
                     validSignature: true
                     linkedSkills: ["summarizer"]
       description: A response containing full agent runtime detail.
+    DeployAgentResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: "#/components/schemas/DeployAgentResult"
+          examples:
+            default:
+              value:
+                data:
+                  success: true
+                  name: my-agent
+                  namespace: agent-ops-demo
+                  message: Agent deployed successfully
+      description: A response confirming successful agent deployment.
 
 
   parameters:

--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -602,6 +602,7 @@ components:
         framework:
           type: string
           description: Agent framework identifier (valid K8s label value, max 63 chars).
+          pattern: '^[a-zA-Z0-9]([-a-zA-Z0-9_.]*[a-zA-Z0-9])?$'
           maxLength: 63
           example: langgraph
         envVars:

--- a/packages/agent-ops/bff/internal/api/agent_handlers.go
+++ b/packages/agent-ops/bff/internal/api/agent_handlers.go
@@ -33,6 +33,10 @@ func (app *App) handleAgentRepositoryError(w http.ResponseWriter, r *http.Reques
 		app.notFoundResponse(w, r)
 		return
 	}
+	if errors.Is(err, bfferrors.ErrAlreadyExists) {
+		app.conflictResponse(w, r, err)
+		return
+	}
 	if errors.Is(err, bfferrors.ErrForbidden) {
 		app.logger.Warn("Agent repository access forbidden",
 			"error", err.Error(),

--- a/packages/agent-ops/bff/internal/api/agent_handlers.go
+++ b/packages/agent-ops/bff/internal/api/agent_handlers.go
@@ -10,12 +10,23 @@ import (
 )
 
 var dns1123LabelRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+var labelValueRegex = regexp.MustCompile(`^[a-zA-Z0-9]([-a-zA-Z0-9_.]*[a-zA-Z0-9])?$`)
 
 func isValidDNS1123Label(label string) bool {
 	if len(label) == 0 || len(label) > 63 {
 		return false
 	}
 	return dns1123LabelRegex.MatchString(label)
+}
+
+func isValidLabelValue(value string) bool {
+	if len(value) > 63 {
+		return false
+	}
+	if value == "" {
+		return true
+	}
+	return labelValueRegex.MatchString(value)
 }
 
 func validateAgentPathParams(namespace, name string) error {
@@ -34,6 +45,10 @@ func (app *App) handleAgentRepositoryError(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if errors.Is(err, bfferrors.ErrAlreadyExists) {
+		app.logger.Warn("Agent deployment conflict",
+			"error", err.Error(),
+			"method", r.Method,
+			"uri", r.URL.RequestURI())
 		app.conflictResponse(w, r, err)
 		return
 	}

--- a/packages/agent-ops/bff/internal/api/app.go
+++ b/packages/agent-ops/bff/internal/api/app.go
@@ -38,6 +38,7 @@ const (
 	NamespacePath          = ApiPathPrefix + "/namespaces"
 	AgentRuntimesPath      = ApiPathPrefix + "/agents/runtimes"
 	AgentRuntimeDetailPath = ApiPathPrefix + "/agents/runtimes/:ns/:name"
+	AgentDeployPath        = ApiPathPrefix + "/agents/deploy"
 )
 
 var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
@@ -222,6 +223,7 @@ func (app *App) Routes() http.Handler {
 	apiRouter.GET(AgentRuntimeDetailPath,
 		app.AttachNamespaceFromParam("ns",
 			app.RequireAccessToAgent(app.GetAgentRuntimeDetailHandler)))
+	apiRouter.POST(AgentDeployPath, app.RequireAuthenticatedForAgents(app.DeployAgentHandler))
 
 	// Inter-BFF Communication routes — wire your target BFF endpoints here.
 	// Example:

--- a/packages/agent-ops/bff/internal/api/deploy_handler.go
+++ b/packages/agent-ops/bff/internal/api/deploy_handler.go
@@ -16,6 +16,7 @@ type DeployAgentEnvelope Envelope[*models.DeployAgentResponse, None]
 
 // DeployAgentHandler handles POST /api/v1/agents/deploy.
 func (app *App) DeployAgentHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
 	logger := helper.GetContextLoggerFromReq(r)
 	logger.Info("Deploying agent", slog.String("method", r.Method), slog.String("path", r.URL.Path))
 
@@ -33,24 +34,23 @@ func (app *App) DeployAgentHandler(w http.ResponseWriter, r *http.Request, _ htt
 	}
 
 	// RBAC: verify the caller can create all agent resources in the target namespace
-	identityVal := r.Context().Value(constants.RequestIdentityKey)
-	if identityVal == nil {
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+	if !ok || identity == nil {
 		app.forbiddenResponse(w, r, "missing request identity")
 		return
 	}
-	identity, ok := identityVal.(*k8s.RequestIdentity)
-	if !ok || identity == nil {
-		app.forbiddenResponse(w, r, "invalid request identity")
+
+	if app.kubernetesClientFactory == nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("kubernetes client factory not available"))
 		return
 	}
-
-	k8sClient, err := app.kubernetesClientFactory.GetClient(r.Context())
+	k8sClient, err := app.kubernetesClientFactory.GetClient(ctx)
 	if err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("failed to get kubernetes client: %w", err))
 		return
 	}
 
-	canDeploy, err := k8sClient.CanDeployAgentInNamespace(r.Context(), identity, req.Namespace)
+	canDeploy, err := k8sClient.CanDeployAgentInNamespace(ctx, identity, req.Namespace, req.CreateRoute)
 	if err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("RBAC check failed: %w", err))
 		return
@@ -62,7 +62,7 @@ func (app *App) DeployAgentHandler(w http.ResponseWriter, r *http.Request, _ htt
 
 	params := mapDeployRequestToParams(&req)
 
-	result, err := app.repositories.AgentRuntimes.DeployAgent(r.Context(), params)
+	result, err := app.repositories.AgentRuntimes.DeployAgent(ctx, params)
 	if err != nil {
 		logger.Error("Failed to deploy agent",
 			slog.String("method", r.Method),

--- a/packages/agent-ops/bff/internal/api/deploy_handler.go
+++ b/packages/agent-ops/bff/internal/api/deploy_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/config"
 	"github.com/opendatahub-io/mod-arch-library/bff/internal/constants"
 	helper "github.com/opendatahub-io/mod-arch-library/bff/internal/helpers"
 	k8s "github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/kubernetes"
@@ -33,31 +34,30 @@ func (app *App) DeployAgentHandler(w http.ResponseWriter, r *http.Request, _ htt
 		return
 	}
 
-	// RBAC: verify the caller can create all agent resources in the target namespace
-	identity, ok := ctx.Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
-	if !ok || identity == nil {
-		app.forbiddenResponse(w, r, "missing request identity")
-		return
-	}
+	// RBAC: verify the caller can create all agent resources in the target namespace.
+	// Skip when auth is disabled (local dev / mock mode) — matches RequireAccessToService pattern.
+	if app.config.AuthMethod != config.AuthMethodDisabled {
+		identity, ok := ctx.Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+		if !ok || identity == nil {
+			app.forbiddenResponse(w, r, "missing request identity")
+			return
+		}
 
-	if app.kubernetesClientFactory == nil {
-		app.serverErrorResponse(w, r, fmt.Errorf("kubernetes client factory not available"))
-		return
-	}
-	k8sClient, err := app.kubernetesClientFactory.GetClient(ctx)
-	if err != nil {
-		app.serverErrorResponse(w, r, fmt.Errorf("failed to get kubernetes client: %w", err))
-		return
-	}
+		k8sClient, err := app.kubernetesClientFactory.GetClient(ctx)
+		if err != nil {
+			app.serverErrorResponse(w, r, fmt.Errorf("failed to get kubernetes client: %w", err))
+			return
+		}
 
-	canDeploy, err := k8sClient.CanDeployAgentInNamespace(ctx, identity, req.Namespace, req.CreateRoute)
-	if err != nil {
-		app.serverErrorResponse(w, r, fmt.Errorf("RBAC check failed: %w", err))
-		return
-	}
-	if !canDeploy {
-		app.forbiddenResponse(w, r, fmt.Sprintf("user does not have permission to deploy agents in namespace %q", req.Namespace))
-		return
+		canDeploy, err := k8sClient.CanDeployAgentInNamespace(ctx, identity, req.Namespace, req.CreateRoute)
+		if err != nil {
+			app.serverErrorResponse(w, r, fmt.Errorf("RBAC check failed: %w", err))
+			return
+		}
+		if !canDeploy {
+			app.forbiddenResponse(w, r, fmt.Sprintf("user does not have permission to deploy agents in namespace %q", req.Namespace))
+			return
+		}
 	}
 
 	params := mapDeployRequestToParams(&req)

--- a/packages/agent-ops/bff/internal/api/deploy_handler.go
+++ b/packages/agent-ops/bff/internal/api/deploy_handler.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/constants"
+	helper "github.com/opendatahub-io/mod-arch-library/bff/internal/helpers"
+	k8s "github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/models"
+)
+
+type DeployAgentEnvelope Envelope[*models.DeployAgentResponse, None]
+
+// DeployAgentHandler handles POST /api/v1/agents/deploy.
+func (app *App) DeployAgentHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	logger := helper.GetContextLoggerFromReq(r)
+	logger.Info("Deploying agent", slog.String("method", r.Method), slog.String("path", r.URL.Path))
+
+	var req models.DeployAgentRequest
+	if err := app.ReadJSON(w, r, &req); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	applyDeployDefaults(&req)
+
+	if err := validateDeployRequest(&req); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	// RBAC: verify the caller can create all agent resources in the target namespace
+	identityVal := r.Context().Value(constants.RequestIdentityKey)
+	if identityVal == nil {
+		app.forbiddenResponse(w, r, "missing request identity")
+		return
+	}
+	identity, ok := identityVal.(*k8s.RequestIdentity)
+	if !ok || identity == nil {
+		app.forbiddenResponse(w, r, "invalid request identity")
+		return
+	}
+
+	k8sClient, err := app.kubernetesClientFactory.GetClient(r.Context())
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to get kubernetes client: %w", err))
+		return
+	}
+
+	canDeploy, err := k8sClient.CanDeployAgentInNamespace(r.Context(), identity, req.Namespace)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("RBAC check failed: %w", err))
+		return
+	}
+	if !canDeploy {
+		app.forbiddenResponse(w, r, fmt.Sprintf("user does not have permission to deploy agents in namespace %q", req.Namespace))
+		return
+	}
+
+	params := mapDeployRequestToParams(&req)
+
+	result, err := app.repositories.AgentRuntimes.DeployAgent(r.Context(), params)
+	if err != nil {
+		logger.Error("Failed to deploy agent",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Any("error", err))
+		app.handleAgentRepositoryError(w, r, err)
+		return
+	}
+
+	logger.Info("Agent deployed successfully",
+		slog.String("name", result.Name),
+		slog.String("namespace", result.Namespace))
+
+	envelope := DeployAgentEnvelope{
+		Data: result,
+	}
+
+	if err := app.WriteJSON(w, http.StatusCreated, envelope, nil); err != nil {
+		logger.Error("Failed to write JSON response",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", http.StatusCreated),
+			slog.Any("error", err))
+	}
+}

--- a/packages/agent-ops/bff/internal/api/deploy_handler_test.go
+++ b/packages/agent-ops/bff/internal/api/deploy_handler_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/config"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func deployApp() *App {
+	return &App{
+		config:       config.EnvConfig{AuthMethod: config.AuthMethodDisabled},
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		repositories: testRepositoriesWithAgents(),
+	}
+}
+
+func deployRequest(t *testing.T, body any) *http.Request {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	return httptest.NewRequest(http.MethodPost, AgentDeployPath, bytes.NewReader(b))
+}
+
+func TestDeployAgentHandler_Success(t *testing.T) {
+	app := deployApp()
+	req := deployRequest(t, models.DeployAgentRequest{
+		Name:           "my-agent",
+		Namespace:      "default",
+		ContainerImage: "quay.io/example/agent",
+		ImageTag:       "latest",
+	})
+	rr := httptest.NewRecorder()
+
+	app.DeployAgentHandler(rr, req, httprouter.Params{})
+
+	require.Equal(t, http.StatusCreated, rr.Code)
+
+	var envelope DeployAgentEnvelope
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&envelope))
+	require.NotNil(t, envelope.Data)
+	assert.Equal(t, "my-agent", envelope.Data.Name)
+	assert.Equal(t, "default", envelope.Data.Namespace)
+}
+
+func TestDeployAgentHandler_BadJSON(t *testing.T) {
+	app := deployApp()
+	req := httptest.NewRequest(http.MethodPost, AgentDeployPath, bytes.NewReader([]byte("not json")))
+	rr := httptest.NewRecorder()
+
+	app.DeployAgentHandler(rr, req, httprouter.Params{})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestDeployAgentHandler_MissingContainerImage(t *testing.T) {
+	app := deployApp()
+	req := deployRequest(t, models.DeployAgentRequest{
+		Name:      "my-agent",
+		Namespace: "default",
+		ImageTag:  "latest",
+	})
+	rr := httptest.NewRecorder()
+
+	app.DeployAgentHandler(rr, req, httprouter.Params{})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestDeployAgentHandler_InvalidNamespace(t *testing.T) {
+	app := deployApp()
+	req := deployRequest(t, models.DeployAgentRequest{
+		Name:           "my-agent",
+		Namespace:      "INVALID_NS",
+		ContainerImage: "quay.io/example/agent",
+		ImageTag:       "latest",
+	})
+	rr := httptest.NewRecorder()
+
+	app.DeployAgentHandler(rr, req, httprouter.Params{})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestDeployAgentHandler_InvalidProtocol(t *testing.T) {
+	app := deployApp()
+	req := deployRequest(t, models.DeployAgentRequest{
+		Name:           "my-agent",
+		Namespace:      "default",
+		ContainerImage: "quay.io/example/agent",
+		ImageTag:       "latest",
+		Protocol:       "grpc",
+	})
+	rr := httptest.NewRecorder()
+
+	app.DeployAgentHandler(rr, req, httprouter.Params{})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestDeployAgentHandler_Duplicate(t *testing.T) {
+	app := deployApp()
+	body := models.DeployAgentRequest{
+		Name:           "dup-agent",
+		Namespace:      "default",
+		ContainerImage: "quay.io/example/agent",
+		ImageTag:       "latest",
+	}
+
+	req1 := deployRequest(t, body)
+	rr1 := httptest.NewRecorder()
+	app.DeployAgentHandler(rr1, req1, httprouter.Params{})
+	require.Equal(t, http.StatusCreated, rr1.Code)
+
+	req2 := deployRequest(t, body)
+	rr2 := httptest.NewRecorder()
+	app.DeployAgentHandler(rr2, req2, httprouter.Params{})
+	assert.Equal(t, http.StatusConflict, rr2.Code)
+}
+
+func TestDeployAgentHandler_AuthDisabledSkipsRBAC(t *testing.T) {
+	app := deployApp()
+	req := deployRequest(t, models.DeployAgentRequest{
+		Name:           "auth-test-agent",
+		Namespace:      "default",
+		ContainerImage: "quay.io/example/agent",
+		ImageTag:       "latest",
+	})
+	rr := httptest.NewRecorder()
+
+	app.DeployAgentHandler(rr, req, httprouter.Params{})
+
+	require.Equal(t, http.StatusCreated, rr.Code)
+}

--- a/packages/agent-ops/bff/internal/api/deploy_validation.go
+++ b/packages/agent-ops/bff/internal/api/deploy_validation.go
@@ -2,10 +2,14 @@ package api
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
 	"github.com/opendatahub-io/mod-arch-library/bff/internal/models"
 )
+
+var envVarNameRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 var validProtocols = map[string]bool{
 	"a2a": true,
@@ -49,6 +53,15 @@ func validateDeployRequest(req *models.DeployAgentRequest) error {
 	}
 	if req.MTLSMode != "" && !validMTLSModes[req.MTLSMode] {
 		return fmt.Errorf("invalid mtlsMode %q: must be one of disabled, permissive, strict", req.MTLSMode)
+	}
+	for i, e := range req.EnvVars {
+		name := strings.TrimSpace(e.Name)
+		if name == "" {
+			return fmt.Errorf("envVars[%d].name must not be empty", i)
+		}
+		if !envVarNameRegex.MatchString(name) {
+			return fmt.Errorf("envVars[%d].name %q is not a valid C_IDENTIFIER", i, name)
+		}
 	}
 	for i, p := range req.ServicePorts {
 		if p.Port < 1 || p.Port > 65535 {

--- a/packages/agent-ops/bff/internal/api/deploy_validation.go
+++ b/packages/agent-ops/bff/internal/api/deploy_validation.go
@@ -38,6 +38,9 @@ func validateDeployRequest(req *models.DeployAgentRequest) error {
 	if req.ImageTag == "" {
 		return fmt.Errorf("imageTag is required")
 	}
+	if req.Framework != "" && !isValidLabelValue(req.Framework) {
+		return fmt.Errorf("invalid framework %q: must be a valid Kubernetes label value (max 63 chars, alphanumeric, '-', '_', or '.')", req.Framework)
+	}
 	if req.Protocol != "" && !validProtocols[req.Protocol] {
 		return fmt.Errorf("invalid protocol %q: must be one of a2a, mcp", req.Protocol)
 	}

--- a/packages/agent-ops/bff/internal/api/deploy_validation.go
+++ b/packages/agent-ops/bff/internal/api/deploy_validation.go
@@ -55,12 +55,14 @@ func validateDeployRequest(req *models.DeployAgentRequest) error {
 		return fmt.Errorf("invalid mtlsMode %q: must be one of disabled, permissive, strict", req.MTLSMode)
 	}
 	for i, e := range req.EnvVars {
-		name := strings.TrimSpace(e.Name)
-		if name == "" {
+		if strings.TrimSpace(e.Name) != e.Name {
+			return fmt.Errorf("envVars[%d].name must not have leading/trailing whitespace", i)
+		}
+		if e.Name == "" {
 			return fmt.Errorf("envVars[%d].name must not be empty", i)
 		}
-		if !envVarNameRegex.MatchString(name) {
-			return fmt.Errorf("envVars[%d].name %q is not a valid C_IDENTIFIER", i, name)
+		if !envVarNameRegex.MatchString(e.Name) {
+			return fmt.Errorf("envVars[%d].name %q is not a valid C_IDENTIFIER", i, e.Name)
 		}
 	}
 	for i, p := range req.ServicePorts {

--- a/packages/agent-ops/bff/internal/api/deploy_validation.go
+++ b/packages/agent-ops/bff/internal/api/deploy_validation.go
@@ -29,6 +29,13 @@ var validMTLSModes = map[string]bool{
 	"strict":     true,
 }
 
+var validServicePortProtocols = map[string]bool{
+	"TCP":  true,
+	"UDP":  true,
+	"SCTP": true,
+	"":     true,
+}
+
 func validateDeployRequest(req *models.DeployAgentRequest) error {
 	if !isValidDNS1123Label(req.Name) {
 		return fmt.Errorf("invalid agent name %q", req.Name)
@@ -38,6 +45,9 @@ func validateDeployRequest(req *models.DeployAgentRequest) error {
 	}
 	if req.ContainerImage == "" {
 		return fmt.Errorf("containerImage is required")
+	}
+	if strings.Contains(req.ContainerImage, ":") {
+		return fmt.Errorf("containerImage must not include a tag — use imageTag instead")
 	}
 	if req.ImageTag == "" {
 		return fmt.Errorf("imageTag is required")
@@ -71,6 +81,9 @@ func validateDeployRequest(req *models.DeployAgentRequest) error {
 		}
 		if p.TargetPort < 1 || p.TargetPort > 65535 {
 			return fmt.Errorf("servicePorts[%d].targetPort must be between 1 and 65535", i)
+		}
+		if !validServicePortProtocols[p.Protocol] {
+			return fmt.Errorf("servicePorts[%d].protocol %q must be one of TCP, UDP, SCTP", i, p.Protocol)
 		}
 	}
 	return nil

--- a/packages/agent-ops/bff/internal/api/deploy_validation.go
+++ b/packages/agent-ops/bff/internal/api/deploy_validation.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/models"
+)
+
+var validProtocols = map[string]bool{
+	"a2a": true,
+	"mcp": true,
+}
+
+var validAuthBridgeModes = map[string]bool{
+	"proxy-sidecar": true,
+	"envoy-sidecar": true,
+	"lite":          true,
+	"waypoint":      true,
+}
+
+var validMTLSModes = map[string]bool{
+	"disabled":   true,
+	"permissive": true,
+	"strict":     true,
+}
+
+func validateDeployRequest(req *models.DeployAgentRequest) error {
+	if !isValidDNS1123Label(req.Name) {
+		return fmt.Errorf("invalid agent name %q", req.Name)
+	}
+	if !isValidDNS1123Label(req.Namespace) {
+		return fmt.Errorf("invalid namespace %q", req.Namespace)
+	}
+	if req.ContainerImage == "" {
+		return fmt.Errorf("containerImage is required")
+	}
+	if req.ImageTag == "" {
+		return fmt.Errorf("imageTag is required")
+	}
+	if req.Protocol != "" && !validProtocols[req.Protocol] {
+		return fmt.Errorf("invalid protocol %q: must be one of a2a, mcp", req.Protocol)
+	}
+	if req.AuthBridgeMode != "" && !validAuthBridgeModes[req.AuthBridgeMode] {
+		return fmt.Errorf("invalid authBridgeMode %q: must be one of proxy-sidecar, envoy-sidecar, lite, waypoint", req.AuthBridgeMode)
+	}
+	if req.MTLSMode != "" && !validMTLSModes[req.MTLSMode] {
+		return fmt.Errorf("invalid mtlsMode %q: must be one of disabled, permissive, strict", req.MTLSMode)
+	}
+	for i, p := range req.ServicePorts {
+		if p.Port < 1 || p.Port > 65535 {
+			return fmt.Errorf("servicePorts[%d].port must be between 1 and 65535", i)
+		}
+		if p.TargetPort < 1 || p.TargetPort > 65535 {
+			return fmt.Errorf("servicePorts[%d].targetPort must be between 1 and 65535", i)
+		}
+	}
+	return nil
+}
+
+func applyDeployDefaults(req *models.DeployAgentRequest) {
+	if req.Protocol == "" {
+		req.Protocol = "a2a"
+	}
+	if req.AuthBridgeEnabled == nil {
+		enabled := true
+		req.AuthBridgeEnabled = &enabled
+	}
+	if len(req.ServicePorts) == 0 {
+		req.ServicePorts = []models.ServicePort{
+			{Name: "http", Port: 8080, TargetPort: 8000, Protocol: "TCP"},
+		}
+	}
+}
+
+func mapDeployRequestToParams(req *models.DeployAgentRequest) *agents.DeployAgentParams {
+	params := &agents.DeployAgentParams{
+		Name:            req.Name,
+		Namespace:       req.Namespace,
+		ContainerImage:  req.ContainerImage,
+		ImageTag:        req.ImageTag,
+		ImagePullSecret: req.ImagePullSecret,
+		Protocol:        req.Protocol,
+		Framework:       req.Framework,
+		CreateRoute:     req.CreateRoute,
+		AuthBridgeMode:  req.AuthBridgeMode,
+		MTLSMode:        req.MTLSMode,
+	}
+	if req.AuthBridgeEnabled != nil {
+		params.AuthBridgeEnabled = *req.AuthBridgeEnabled
+	}
+	for _, e := range req.EnvVars {
+		params.EnvVars = append(params.EnvVars, agents.AgentEnvVar{
+			Name:  e.Name,
+			Value: e.Value,
+		})
+	}
+	for _, p := range req.ServicePorts {
+		params.ServicePorts = append(params.ServicePorts, agents.AgentServicePortSpec{
+			Name:       p.Name,
+			Port:       p.Port,
+			TargetPort: p.TargetPort,
+			Protocol:   p.Protocol,
+		})
+	}
+	return params
+}

--- a/packages/agent-ops/bff/internal/api/deploy_validation_test.go
+++ b/packages/agent-ops/bff/internal/api/deploy_validation_test.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validDeployRequest() *models.DeployAgentRequest {
+	return &models.DeployAgentRequest{
+		Name:           "my-agent",
+		Namespace:      "default",
+		ContainerImage: "quay.io/example/agent",
+		ImageTag:       "latest",
+		Protocol:       "a2a",
+	}
+}
+
+func TestValidateDeployRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(r *models.DeployAgentRequest)
+		wantErr string
+	}{
+		{
+			name:   "valid minimal request",
+			modify: func(r *models.DeployAgentRequest) {},
+		},
+		{
+			name:    "empty name",
+			modify:  func(r *models.DeployAgentRequest) { r.Name = "" },
+			wantErr: "invalid agent name",
+		},
+		{
+			name:    "uppercase name",
+			modify:  func(r *models.DeployAgentRequest) { r.Name = "MyAgent" },
+			wantErr: "invalid agent name",
+		},
+		{
+			name:    "name too long",
+			modify:  func(r *models.DeployAgentRequest) { r.Name = "a234567890123456789012345678901234567890123456789012345678901234" },
+			wantErr: "invalid agent name",
+		},
+		{
+			name:    "empty namespace",
+			modify:  func(r *models.DeployAgentRequest) { r.Namespace = "" },
+			wantErr: "invalid namespace",
+		},
+		{
+			name:    "uppercase namespace",
+			modify:  func(r *models.DeployAgentRequest) { r.Namespace = "INVALID" },
+			wantErr: "invalid namespace",
+		},
+		{
+			name:    "empty containerImage",
+			modify:  func(r *models.DeployAgentRequest) { r.ContainerImage = "" },
+			wantErr: "containerImage is required",
+		},
+		{
+			name:    "empty imageTag",
+			modify:  func(r *models.DeployAgentRequest) { r.ImageTag = "" },
+			wantErr: "imageTag is required",
+		},
+		{
+			name:    "invalid protocol",
+			modify:  func(r *models.DeployAgentRequest) { r.Protocol = "grpc" },
+			wantErr: "invalid protocol",
+		},
+		{
+			name:   "valid protocol mcp",
+			modify: func(r *models.DeployAgentRequest) { r.Protocol = "mcp" },
+		},
+		{
+			name:    "invalid authBridgeMode",
+			modify:  func(r *models.DeployAgentRequest) { r.AuthBridgeMode = "invalid" },
+			wantErr: "invalid authBridgeMode",
+		},
+		{
+			name:   "valid authBridgeMode",
+			modify: func(r *models.DeployAgentRequest) { r.AuthBridgeMode = "proxy-sidecar" },
+		},
+		{
+			name:    "invalid mtlsMode",
+			modify:  func(r *models.DeployAgentRequest) { r.MTLSMode = "invalid" },
+			wantErr: "invalid mtlsMode",
+		},
+		{
+			name:   "valid mtlsMode",
+			modify: func(r *models.DeployAgentRequest) { r.MTLSMode = "strict" },
+		},
+		{
+			name:    "framework too long",
+			modify:  func(r *models.DeployAgentRequest) { r.Framework = "a234567890123456789012345678901234567890123456789012345678901234" },
+			wantErr: "invalid framework",
+		},
+		{
+			name:    "framework invalid chars",
+			modify:  func(r *models.DeployAgentRequest) { r.Framework = "has spaces" },
+			wantErr: "invalid framework",
+		},
+		{
+			name:   "valid framework",
+			modify: func(r *models.DeployAgentRequest) { r.Framework = "langgraph" },
+		},
+		{
+			name: "empty env var name",
+			modify: func(r *models.DeployAgentRequest) {
+				r.EnvVars = []models.EnvVar{{Name: "", Value: "val"}}
+			},
+			wantErr: "envVars[0].name must not be empty",
+		},
+		{
+			name: "env var name with whitespace",
+			modify: func(r *models.DeployAgentRequest) {
+				r.EnvVars = []models.EnvVar{{Name: " FOO ", Value: "val"}}
+			},
+			wantErr: "whitespace",
+		},
+		{
+			name: "env var name starts with digit",
+			modify: func(r *models.DeployAgentRequest) {
+				r.EnvVars = []models.EnvVar{{Name: "1BAD", Value: "val"}}
+			},
+			wantErr: "C_IDENTIFIER",
+		},
+		{
+			name: "valid env var",
+			modify: func(r *models.DeployAgentRequest) {
+				r.EnvVars = []models.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}}
+			},
+		},
+		{
+			name: "port zero",
+			modify: func(r *models.DeployAgentRequest) {
+				r.ServicePorts = []models.ServicePort{{Name: "http", Port: 0, TargetPort: 8000}}
+			},
+			wantErr: "port must be between",
+		},
+		{
+			name: "port too high",
+			modify: func(r *models.DeployAgentRequest) {
+				r.ServicePorts = []models.ServicePort{{Name: "http", Port: 8080, TargetPort: 65536}}
+			},
+			wantErr: "targetPort must be between",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validDeployRequest()
+			tt.modify(req)
+			err := validateDeployRequest(req)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestApplyDeployDefaults(t *testing.T) {
+	t.Run("applies defaults to empty request", func(t *testing.T) {
+		req := &models.DeployAgentRequest{}
+		applyDeployDefaults(req)
+
+		assert.Equal(t, "a2a", req.Protocol)
+		require.NotNil(t, req.AuthBridgeEnabled)
+		assert.True(t, *req.AuthBridgeEnabled)
+		require.Len(t, req.ServicePorts, 1)
+		assert.Equal(t, int32(8080), req.ServicePorts[0].Port)
+		assert.Equal(t, int32(8000), req.ServicePorts[0].TargetPort)
+	})
+
+	t.Run("does not overwrite existing protocol", func(t *testing.T) {
+		req := &models.DeployAgentRequest{Protocol: "mcp"}
+		applyDeployDefaults(req)
+		assert.Equal(t, "mcp", req.Protocol)
+	})
+
+	t.Run("does not overwrite existing service ports", func(t *testing.T) {
+		req := &models.DeployAgentRequest{
+			ServicePorts: []models.ServicePort{{Name: "grpc", Port: 50051, TargetPort: 50051}},
+		}
+		applyDeployDefaults(req)
+		require.Len(t, req.ServicePorts, 1)
+		assert.Equal(t, int32(50051), req.ServicePorts[0].Port)
+	})
+}
+
+func TestMapDeployRequestToParams(t *testing.T) {
+	enabled := true
+	req := &models.DeployAgentRequest{
+		Name:              "my-agent",
+		Namespace:         "default",
+		ContainerImage:    "quay.io/example/agent",
+		ImageTag:          "v1.0.0",
+		Protocol:          "a2a",
+		Framework:         "langgraph",
+		CreateRoute:       true,
+		AuthBridgeEnabled: &enabled,
+		EnvVars:           []models.EnvVar{{Name: "KEY", Value: "val"}},
+		ServicePorts:      []models.ServicePort{{Name: "http", Port: 8080, TargetPort: 8000, Protocol: "TCP"}},
+	}
+
+	params := mapDeployRequestToParams(req)
+
+	assert.Equal(t, "my-agent", params.Name)
+	assert.Equal(t, "default", params.Namespace)
+	assert.Equal(t, "quay.io/example/agent", params.ContainerImage)
+	assert.Equal(t, "v1.0.0", params.ImageTag)
+	assert.Equal(t, "a2a", params.Protocol)
+	assert.Equal(t, "langgraph", params.Framework)
+	assert.True(t, params.CreateRoute)
+	assert.True(t, params.AuthBridgeEnabled)
+	require.Len(t, params.EnvVars, 1)
+	assert.Equal(t, "KEY", params.EnvVars[0].Name)
+	require.Len(t, params.ServicePorts, 1)
+	assert.Equal(t, int32(8080), params.ServicePorts[0].Port)
+}

--- a/packages/agent-ops/bff/internal/api/errors.go
+++ b/packages/agent-ops/bff/internal/api/errors.go
@@ -13,6 +13,7 @@ const (
 	ErrCodeMethodNotAllowed    = "METHOD_NOT_ALLOWED"
 	ErrCodeInternalServerError = "INTERNAL_SERVER_ERROR"
 	ErrCodeServiceUnavailable  = "SERVICE_UNAVAILABLE"
+	ErrCodeConflict            = "CONFLICT"
 	ErrCodeNotImplemented      = "NOT_IMPLEMENTED"
 )
 
@@ -73,6 +74,13 @@ func (app *App) serviceUnavailableResponse(w http.ResponseWriter, r *http.Reques
 	app.LogError(r, err)
 
 	httpError := &HTTPError{StatusCode: http.StatusServiceUnavailable, Error: ErrorPayload{Code: ErrCodeServiceUnavailable, Message: "the service is currently unavailable"}}
+	app.errorResponse(w, r, httpError)
+}
+
+func (app *App) conflictResponse(w http.ResponseWriter, r *http.Request, err error) {
+	app.LogError(r, err)
+
+	httpError := &HTTPError{StatusCode: http.StatusConflict, Error: ErrorPayload{Code: ErrCodeConflict, Message: "the resource already exists"}}
 	app.errorResponse(w, r, httpError)
 }
 

--- a/packages/agent-ops/bff/internal/api/middleware_test.go
+++ b/packages/agent-ops/bff/internal/api/middleware_test.go
@@ -50,6 +50,10 @@ func (c *rbacTestK8sClient) CanGetAgentInNamespace(context.Context, *k8s.Request
 	return c.getAllowed, c.err
 }
 
+func (c *rbacTestK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
+	return c.allowed, c.err
+}
+
 func (c *rbacTestK8sClient) CanAccessAgentCardEnrichment(context.Context, *k8s.RequestIdentity, string, string) (k8s.AgentCardEnrichmentAccess, error) {
 	if c.err != nil {
 		return k8s.AgentCardEnrichmentAccess{}, c.err

--- a/packages/agent-ops/bff/internal/api/middleware_test.go
+++ b/packages/agent-ops/bff/internal/api/middleware_test.go
@@ -50,7 +50,7 @@ func (c *rbacTestK8sClient) CanGetAgentInNamespace(context.Context, *k8s.Request
 	return c.getAllowed, c.err
 }
 
-func (c *rbacTestK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
+func (c *rbacTestK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string, bool) (bool, error) {
 	return c.allowed, c.err
 }
 

--- a/packages/agent-ops/bff/internal/errors/errors.go
+++ b/packages/agent-ops/bff/internal/errors/errors.go
@@ -10,3 +10,6 @@ var ErrForbidden = errors.New("resource access forbidden")
 
 // ErrUpstreamUnavailable is returned when the agent monitoring backend cannot reach the agent workload.
 var ErrUpstreamUnavailable = errors.New("upstream service unavailable")
+
+// ErrAlreadyExists is returned when attempting to create a resource that already exists.
+var ErrAlreadyExists = errors.New("resource already exists")

--- a/packages/agent-ops/bff/internal/integrations/agents/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/client.go
@@ -7,6 +7,11 @@ type Client interface {
 	ListNamespaces(ctx context.Context, enabledOnly bool) ([]string, error)
 	ListAgents(ctx context.Context, namespace string) (*AgentList, error)
 	GetAgent(ctx context.Context, namespace, name string) (*AgentDetail, error)
+
+	DeployAgent(ctx context.Context, params *DeployAgentParams) (*DeployAgentResult, error)
+	DeleteAgent(ctx context.Context, namespace, name string) error
+	StopAgent(ctx context.Context, namespace, name string) error
+	StartAgent(ctx context.Context, namespace, name string) error
 }
 
 // ClientFactory creates a Client for the current request (e.g. with caller identity from context).

--- a/packages/agent-ops/bff/internal/integrations/agents/deploy_types.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/deploy_types.go
@@ -1,0 +1,34 @@
+package agents
+
+type DeployAgentParams struct {
+	Name              string
+	Namespace         string
+	ContainerImage    string
+	ImageTag          string
+	ImagePullSecret   string
+	Protocol          string
+	Framework         string
+	EnvVars           []AgentEnvVar
+	ServicePorts      []AgentServicePortSpec
+	CreateRoute       bool
+	AuthBridgeEnabled bool
+	AuthBridgeMode    string
+	MTLSMode          string
+}
+
+type DeployAgentResult struct {
+	Name      string
+	Namespace string
+}
+
+type AgentEnvVar struct {
+	Name  string
+	Value string
+}
+
+type AgentServicePortSpec struct {
+	Name       string
+	Port       int32
+	TargetPort int32
+	Protocol   string
+}

--- a/packages/agent-ops/bff/internal/integrations/agents/errors.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/errors.go
@@ -12,6 +12,10 @@ var (
 	ErrForbidden = errors.New("agent access forbidden")
 	// ErrUnavailable indicates agent data could not be loaded (e.g. workload unreachable).
 	ErrUnavailable = errors.New("agent data unavailable")
+	// ErrAlreadyExists indicates the agent already exists in the namespace.
+	ErrAlreadyExists = errors.New("agent already exists")
+	// ErrConflict indicates the agent is in a state that conflicts with the requested operation.
+	ErrConflict = errors.New("agent state conflict")
 )
 
 // UnavailableError provides context for ErrUnavailable.

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client_test.go
@@ -55,6 +55,10 @@ func (c *permissiveK8sClient) CanGetAgentInNamespace(context.Context, *k8s.Reque
 	return true, nil
 }
 
+func (c *permissiveK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
+	return true, nil
+}
+
 func (c *permissiveK8sClient) CanAccessAgentCardEnrichment(context.Context, *k8s.RequestIdentity, string, string) (k8s.AgentCardEnrichmentAccess, error) {
 	return k8s.AgentCardEnrichmentAccess{
 		AgentRuntime: true,
@@ -233,6 +237,10 @@ func (c *failingNamespacesK8sClient) CanListAgentsInNamespace(context.Context, *
 
 func (c *failingNamespacesK8sClient) CanGetAgentInNamespace(context.Context, *k8s.RequestIdentity, string, string) (bool, error) {
 	return true, nil
+}
+
+func (c *failingNamespacesK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
+	return false, nil
 }
 
 func (c *failingNamespacesK8sClient) CanAccessAgentCardEnrichment(context.Context, *k8s.RequestIdentity, string, string) (k8s.AgentCardEnrichmentAccess, error) {

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client_test.go
@@ -55,7 +55,7 @@ func (c *permissiveK8sClient) CanGetAgentInNamespace(context.Context, *k8s.Reque
 	return true, nil
 }
 
-func (c *permissiveK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
+func (c *permissiveK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string, bool) (bool, error) {
 	return true, nil
 }
 
@@ -239,7 +239,7 @@ func (c *failingNamespacesK8sClient) CanGetAgentInNamespace(context.Context, *k8
 	return true, nil
 }
 
-func (c *failingNamespacesK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
+func (c *failingNamespacesK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string, bool) (bool, error) {
 	return false, nil
 }
 

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // DeployAgent creates all Kubernetes resources for a new agent deployment.
@@ -57,16 +58,24 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 
 	// 2. AgentRuntime CR
 	agentRuntime := buildAgentRuntimeCR(params)
-	_, err = dynamicClient.Resource(agentRuntimeGVR).Namespace(params.Namespace).Create(ctx, agentRuntime, metav1.CreateOptions{})
+	var crUID types.UID
+	createdCR, err := dynamicClient.Resource(agentRuntimeGVR).Namespace(params.Namespace).Create(ctx, agentRuntime, metav1.CreateOptions{})
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			rollback()
 			return nil, fmt.Errorf("failed to create AgentRuntime: %w", mapK8sError(err))
 		}
+		existingCR, getErr := dynamicClient.Resource(agentRuntimeGVR).Namespace(params.Namespace).Get(ctx, params.Name, metav1.GetOptions{})
+		if getErr != nil {
+			rollback()
+			return nil, fmt.Errorf("failed to get existing AgentRuntime: %w", mapK8sError(getErr))
+		}
+		crUID = existingCR.GetUID()
 		c.logger.Debug("AgentRuntime already exists, reusing",
 			slog.String("name", params.Name),
 			slog.String("namespace", params.Namespace))
 	} else {
+		crUID = createdCR.GetUID()
 		cleanups = append(cleanups, func() {
 			if delErr := dynamicClient.Resource(agentRuntimeGVR).Namespace(params.Namespace).Delete(rollbackCtx, params.Name, metav1.DeleteOptions{}); delErr != nil {
 				c.logger.Warn("rollback: failed to delete AgentRuntime",
@@ -76,8 +85,15 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 		})
 	}
 
+	ownerRef := metav1.OwnerReference{
+		APIVersion: agentRuntimeGVR.Group + "/" + agentRuntimeGVR.Version,
+		Kind:       "AgentRuntime",
+		Name:       params.Name,
+		UID:        crUID,
+	}
+
 	// 3. Deployment
-	deployment := buildDeployment(params)
+	deployment := buildDeployment(params, ownerRef)
 	_, err = clientset.AppsV1().Deployments(params.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	if err != nil {
 		rollback()
@@ -92,7 +108,7 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 	})
 
 	// 4. Service
-	svc := buildService(params)
+	svc := buildService(params, ownerRef)
 	_, err = clientset.CoreV1().Services(params.Namespace).Create(ctx, svc, metav1.CreateOptions{})
 	if err != nil {
 		rollback()
@@ -113,7 +129,7 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 			svcPort = params.ServicePorts[0].Port
 		}
 
-		route := buildRoute(params.Name, params.Namespace, svcPort)
+		route := buildRoute(params.Name, params.Namespace, svcPort, ownerRef)
 		_, err = dynamicClient.Resource(openshiftRouteGVR).Namespace(params.Namespace).Create(ctx, route, metav1.CreateOptions{})
 		if err != nil {
 			rollback()

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -62,14 +62,15 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 		c.logger.Debug("AgentRuntime already exists, reusing",
 			slog.String("name", params.Name),
 			slog.String("namespace", params.Namespace))
+	} else {
+		cleanups = append(cleanups, func() {
+			if delErr := dynamicClient.Resource(agentRuntimeGVR).Namespace(params.Namespace).Delete(rollbackCtx, params.Name, metav1.DeleteOptions{}); delErr != nil {
+				c.logger.Warn("rollback: failed to delete AgentRuntime",
+					slog.String("name", params.Name),
+					slog.Any("error", delErr))
+			}
+		})
 	}
-	cleanups = append(cleanups, func() {
-		if delErr := dynamicClient.Resource(agentRuntimeGVR).Namespace(params.Namespace).Delete(rollbackCtx, params.Name, metav1.DeleteOptions{}); delErr != nil {
-			c.logger.Warn("rollback: failed to delete AgentRuntime",
-				slog.String("name", params.Name),
-				slog.Any("error", delErr))
-		}
-	})
 
 	// 3. Deployment
 	deployment := buildDeployment(params)

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -40,7 +40,10 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 			return nil, fmt.Errorf("failed to create ServiceAccount: %w", mapK8sError(err))
 		}
 		existingSA, getErr := clientset.CoreV1().ServiceAccounts(params.Namespace).Get(ctx, params.Name, metav1.GetOptions{})
-		if getErr != nil || existingSA.Labels[labelManagedBy] != managedByValue {
+		if getErr != nil {
+			return nil, fmt.Errorf("failed to verify existing ServiceAccount %q: %w", params.Name, mapK8sError(getErr))
+		}
+		if existingSA.Labels[labelManagedBy] != managedByValue {
 			return nil, fmt.Errorf("ServiceAccount %q already exists and is not managed by odh-dashboard", params.Name)
 		}
 		c.logger.Debug("ServiceAccount already exists, reusing",

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -38,6 +38,10 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 		if !apierrors.IsAlreadyExists(err) {
 			return nil, fmt.Errorf("failed to create ServiceAccount: %w", mapK8sError(err))
 		}
+		existingSA, getErr := clientset.CoreV1().ServiceAccounts(params.Namespace).Get(ctx, params.Name, metav1.GetOptions{})
+		if getErr != nil || existingSA.Labels[labelManagedBy] != managedByValue {
+			return nil, fmt.Errorf("ServiceAccount %q already exists and is not managed by odh-dashboard", params.Name)
+		}
 		c.logger.Debug("ServiceAccount already exists, reusing",
 			slog.String("name", params.Name),
 			slog.String("namespace", params.Namespace))
@@ -115,6 +119,13 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 			rollback()
 			return nil, fmt.Errorf("failed to create Route: %w", mapK8sError(err))
 		}
+		cleanups = append(cleanups, func() {
+			if delErr := dynamicClient.Resource(openshiftRouteGVR).Namespace(params.Namespace).Delete(rollbackCtx, params.Name, metav1.DeleteOptions{}); delErr != nil {
+				c.logger.Warn("rollback: failed to delete Route",
+					slog.String("name", params.Name),
+					slog.Any("error", delErr))
+			}
+		})
 	}
 
 	return &agents.DeployAgentResult{

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -70,6 +70,10 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 			rollback()
 			return nil, fmt.Errorf("failed to get existing AgentRuntime: %w", mapK8sError(getErr))
 		}
+		if existingCR.GetLabels()[labelManagedBy] != managedByValue {
+			rollback()
+			return nil, fmt.Errorf("AgentRuntime %q already exists and is not managed by odh-dashboard", params.Name)
+		}
 		crUID = existingCR.GetUID()
 		c.logger.Debug("AgentRuntime already exists, reusing",
 			slog.String("name", params.Name),
@@ -90,6 +94,7 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 		Kind:       "AgentRuntime",
 		Name:       params.Name,
 		UID:        crUID,
+		Controller: boolPtr(true),
 	}
 
 	// 3. Deployment

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -55,8 +55,13 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 	agentRuntime := buildAgentRuntimeCR(params)
 	_, err = dynamicClient.Resource(agentRuntimeGVR).Namespace(params.Namespace).Create(ctx, agentRuntime, metav1.CreateOptions{})
 	if err != nil {
-		rollback()
-		return nil, fmt.Errorf("failed to create AgentRuntime: %w", mapK8sError(err))
+		if !apierrors.IsAlreadyExists(err) {
+			rollback()
+			return nil, fmt.Errorf("failed to create AgentRuntime: %w", mapK8sError(err))
+		}
+		c.logger.Debug("AgentRuntime already exists, reusing",
+			slog.String("name", params.Name),
+			slog.String("namespace", params.Namespace))
 	}
 	cleanups = append(cleanups, func() {
 		if delErr := dynamicClient.Resource(agentRuntimeGVR).Namespace(params.Namespace).Delete(rollbackCtx, params.Name, metav1.DeleteOptions{}); delErr != nil {

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -1,0 +1,136 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DeployAgent creates all Kubernetes resources for a new agent deployment.
+// Resources are created in order: ServiceAccount, AgentRuntime CR, Deployment, Service, Route (optional).
+// On failure, previously created resources are cleaned up via a closure-based rollback stack.
+func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentParams) (*agents.DeployAgentResult, error) {
+	if params == nil {
+		return nil, fmt.Errorf("deploy params must not be nil")
+	}
+
+	clientset := c.k8sClient.KubernetesClientset()
+	dynamicClient, err := c.k8sClient.DynamicClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dynamic client: %w", err)
+	}
+
+	rollbackCtx := context.Background()
+	var cleanups []func()
+	rollback := func() {
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			cleanups[i]()
+		}
+	}
+	// 1. ServiceAccount
+	sa := buildServiceAccount(params.Name, params.Namespace)
+	_, err = clientset.CoreV1().ServiceAccounts(params.Namespace).Create(ctx, sa, metav1.CreateOptions{})
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("failed to create ServiceAccount: %w", mapK8sError(err))
+		}
+		c.logger.Debug("ServiceAccount already exists, reusing",
+			slog.String("name", params.Name),
+			slog.String("namespace", params.Namespace))
+	} else {
+		cleanups = append(cleanups, func() {
+			if delErr := clientset.CoreV1().ServiceAccounts(params.Namespace).Delete(rollbackCtx, params.Name, metav1.DeleteOptions{}); delErr != nil {
+				c.logger.Warn("rollback: failed to delete ServiceAccount",
+					slog.String("name", params.Name),
+					slog.Any("error", delErr))
+			}
+		})
+	}
+
+	// 2. AgentRuntime CR
+	agentRuntime := buildAgentRuntimeCR(params)
+	_, err = dynamicClient.Resource(agentRuntimeGVR).Namespace(params.Namespace).Create(ctx, agentRuntime, metav1.CreateOptions{})
+	if err != nil {
+		rollback()
+		return nil, fmt.Errorf("failed to create AgentRuntime: %w", mapK8sError(err))
+	}
+	cleanups = append(cleanups, func() {
+		if delErr := dynamicClient.Resource(agentRuntimeGVR).Namespace(params.Namespace).Delete(rollbackCtx, params.Name, metav1.DeleteOptions{}); delErr != nil {
+			c.logger.Warn("rollback: failed to delete AgentRuntime",
+				slog.String("name", params.Name),
+				slog.Any("error", delErr))
+		}
+	})
+
+	// 3. Deployment
+	deployment := buildDeployment(params)
+	_, err = clientset.AppsV1().Deployments(params.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil {
+		rollback()
+		return nil, fmt.Errorf("failed to create Deployment: %w", mapK8sError(err))
+	}
+	cleanups = append(cleanups, func() {
+		if delErr := clientset.AppsV1().Deployments(params.Namespace).Delete(rollbackCtx, params.Name, metav1.DeleteOptions{}); delErr != nil {
+			c.logger.Warn("rollback: failed to delete Deployment",
+				slog.String("name", params.Name),
+				slog.Any("error", delErr))
+		}
+	})
+
+	// 4. Service
+	svc := buildService(params)
+	_, err = clientset.CoreV1().Services(params.Namespace).Create(ctx, svc, metav1.CreateOptions{})
+	if err != nil {
+		rollback()
+		return nil, fmt.Errorf("failed to create Service: %w", mapK8sError(err))
+	}
+	cleanups = append(cleanups, func() {
+		if delErr := clientset.CoreV1().Services(params.Namespace).Delete(rollbackCtx, params.Name, metav1.DeleteOptions{}); delErr != nil {
+			c.logger.Warn("rollback: failed to delete Service",
+				slog.String("name", params.Name),
+				slog.Any("error", delErr))
+		}
+	})
+
+	// 5. Route (optional)
+	if params.CreateRoute {
+		svcPort := defaultSvcPort
+		if len(params.ServicePorts) > 0 && params.ServicePorts[0].Port > 0 {
+			svcPort = params.ServicePorts[0].Port
+		}
+
+		route := buildRoute(params.Name, params.Namespace, svcPort)
+		_, err = dynamicClient.Resource(openshiftRouteGVR).Namespace(params.Namespace).Create(ctx, route, metav1.CreateOptions{})
+		if err != nil {
+			rollback()
+			return nil, fmt.Errorf("failed to create Route: %w", mapK8sError(err))
+		}
+	}
+
+	return &agents.DeployAgentResult{
+		Name:      params.Name,
+		Namespace: params.Namespace,
+	}, nil
+}
+
+// DeleteAgent removes all Kubernetes resources associated with an agent deployment.
+func (c *Client) DeleteAgent(ctx context.Context, namespace, name string) error {
+	_ = ctx
+	return &agents.UnavailableError{Message: fmt.Sprintf("delete not yet implemented for agent %s/%s", namespace, name)}
+}
+
+// StopAgent scales down the agent workload to zero replicas.
+func (c *Client) StopAgent(ctx context.Context, namespace, name string) error {
+	_ = ctx
+	return &agents.UnavailableError{Message: fmt.Sprintf("stop not yet implemented for agent %s/%s", namespace, name)}
+}
+
+// StartAgent scales the agent workload back up.
+func (c *Client) StartAgent(ctx context.Context, namespace, name string) error {
+	_ = ctx
+	return &agents.UnavailableError{Message: fmt.Sprintf("start not yet implemented for agent %s/%s", namespace, name)}
+}

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
@@ -159,6 +159,28 @@ func TestDeployAgent_ServiceAccountAlreadyExists(t *testing.T) {
 	assert.Equal(t, "my-agent", result.Name)
 }
 
+func TestDeployAgent_ServiceAccountUnmanaged(t *testing.T) {
+	ns := "test-ns"
+	client := newDeployTestClient(t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-agent",
+				Namespace: ns,
+			},
+		},
+	)
+
+	_, err := client.DeployAgent(context.Background(), &agents.DeployAgentParams{
+		Name:           "my-agent",
+		Namespace:      ns,
+		ContainerImage: "quay.io/example/agent",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not managed by odh-dashboard")
+}
+
 func TestDeployAgent_FullParams(t *testing.T) {
 	ns := "test-ns"
 	client := newDeployTestClient(t,

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
@@ -196,7 +196,7 @@ func TestDeployAgent_FullParams(t *testing.T) {
 		Protocol:          "a2a",
 		Framework:         "langgraph",
 		AuthBridgeEnabled: true,
-		AuthBridgeMode:    "token",
+		AuthBridgeMode:    "proxy-sidecar",
 		MTLSMode:          "strict",
 		CreateRoute:       true,
 		EnvVars: []agents.AgentEnvVar{

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
@@ -49,7 +49,7 @@ func (c *deployTestK8sClient) CanGetAgentInNamespace(context.Context, *k8s.Reque
 	return true, nil
 }
 
-func (c *deployTestK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
+func (c *deployTestK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string, bool) (bool, error) {
 	return true, nil
 }
 

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
@@ -141,6 +141,9 @@ func TestDeployAgent_ServiceAccountAlreadyExists(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-agent",
 				Namespace: ns,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "odh-dashboard",
+				},
 			},
 		},
 	)

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
@@ -1,0 +1,189 @@
+package kubernetes
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
+	k8s "github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/kubernetes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type deployTestK8sClient struct {
+	clientset     *fake.Clientset
+	dynamicClient *fakedynamic.FakeDynamicClient
+}
+
+func (c *deployTestK8sClient) GetNamespaces(context.Context, *k8s.RequestIdentity) ([]corev1.Namespace, error) {
+	return nil, nil
+}
+
+func (c *deployTestK8sClient) IsClusterAdmin(*k8s.RequestIdentity) (bool, error) {
+	return true, nil
+}
+
+func (c *deployTestK8sClient) GetUser(*k8s.RequestIdentity) (string, error) {
+	return "test-user", nil
+}
+
+func (c *deployTestK8sClient) CanListServicesInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
+	return true, nil
+}
+
+func (c *deployTestK8sClient) CanListAgentsInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
+	return true, nil
+}
+
+func (c *deployTestK8sClient) CanGetAgentInNamespace(context.Context, *k8s.RequestIdentity, string, string) (bool, error) {
+	return true, nil
+}
+
+func (c *deployTestK8sClient) CanDeployAgentInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
+	return true, nil
+}
+
+func (c *deployTestK8sClient) CanAccessAgentCardEnrichment(context.Context, *k8s.RequestIdentity, string, string) (k8s.AgentCardEnrichmentAccess, error) {
+	return k8s.AgentCardEnrichmentAccess{}, nil
+}
+
+func (c *deployTestK8sClient) KubernetesClientset() kubernetes.Interface {
+	return c.clientset
+}
+
+func (c *deployTestK8sClient) DynamicClient() (dynamic.Interface, error) {
+	return c.dynamicClient, nil
+}
+
+func newDeployTestClient(t *testing.T, objects ...runtime.Object) *Client {
+	t.Helper()
+
+	clientset := fake.NewClientset(objects...)
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		agentRuntimeGVR:   "AgentRuntimeList",
+		openshiftRouteGVR: "RouteList",
+	}
+	dynamicClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+
+	return &Client{
+		k8sClient: &deployTestK8sClient{
+			clientset:     clientset,
+			dynamicClient: dynamicClient,
+		},
+		identity: &k8s.RequestIdentity{UserID: "test-user"},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func TestDeployAgent_Success(t *testing.T) {
+	ns := "test-ns"
+	client := newDeployTestClient(t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+	)
+
+	result, err := client.DeployAgent(context.Background(), &agents.DeployAgentParams{
+		Name:           "my-agent",
+		Namespace:      ns,
+		ContainerImage: "quay.io/example/agent",
+		ImageTag:       "latest",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "my-agent", result.Name)
+	assert.Equal(t, ns, result.Namespace)
+}
+
+func TestDeployAgent_WithRoute(t *testing.T) {
+	ns := "test-ns"
+	client := newDeployTestClient(t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+	)
+
+	result, err := client.DeployAgent(context.Background(), &agents.DeployAgentParams{
+		Name:           "my-agent",
+		Namespace:      ns,
+		ContainerImage: "quay.io/example/agent",
+		CreateRoute:    true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "my-agent", result.Name)
+}
+
+func TestDeployAgent_NilParams(t *testing.T) {
+	client := newDeployTestClient(t)
+
+	result, err := client.DeployAgent(context.Background(), nil)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "must not be nil")
+}
+
+func TestDeployAgent_ServiceAccountAlreadyExists(t *testing.T) {
+	ns := "test-ns"
+	client := newDeployTestClient(t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-agent",
+				Namespace: ns,
+			},
+		},
+	)
+
+	result, err := client.DeployAgent(context.Background(), &agents.DeployAgentParams{
+		Name:           "my-agent",
+		Namespace:      ns,
+		ContainerImage: "quay.io/example/agent",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "my-agent", result.Name)
+}
+
+func TestDeployAgent_FullParams(t *testing.T) {
+	ns := "test-ns"
+	client := newDeployTestClient(t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+	)
+
+	result, err := client.DeployAgent(context.Background(), &agents.DeployAgentParams{
+		Name:              "full-agent",
+		Namespace:         ns,
+		ContainerImage:    "quay.io/example/full-agent",
+		ImageTag:          "v2.0.0",
+		ImagePullSecret:   "my-pull-secret",
+		Protocol:          "a2a",
+		Framework:         "langgraph",
+		AuthBridgeEnabled: true,
+		AuthBridgeMode:    "token",
+		MTLSMode:          "strict",
+		CreateRoute:       true,
+		EnvVars: []agents.AgentEnvVar{
+			{Name: "LOG_LEVEL", Value: "debug"},
+		},
+		ServicePorts: []agents.AgentServicePortSpec{
+			{Name: "http", Port: 9090, TargetPort: 9000, Protocol: "TCP"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "full-agent", result.Name)
+	assert.Equal(t, ns, result.Namespace)
+}

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/k8s_errors.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/k8s_errors.go
@@ -1,0 +1,24 @@
+package kubernetes
+
+import (
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func mapK8sError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case apierrors.IsNotFound(err):
+		return agents.ErrNotFound
+	case apierrors.IsForbidden(err):
+		return agents.ErrForbidden
+	case apierrors.IsAlreadyExists(err):
+		return agents.ErrAlreadyExists
+	case apierrors.IsConflict(err):
+		return agents.ErrConflict
+	default:
+		return err
+	}
+}

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -300,7 +300,8 @@ func buildEnvVars(params *agents.DeployAgentParams) []corev1.EnvVar {
 		svcPort = params.ServicePorts[0].Port
 	}
 
-	defaults := map[string]string{
+	defaultKeys := []string{"AGENT_ENDPOINT", "HOST", "PORT", "UV_CACHE_DIR"}
+	defaultValues := map[string]string{
 		"AGENT_ENDPOINT": agentEndpointURL(params.Name, params.Namespace, svcPort),
 		"PORT":           fmt.Sprintf("%d", defaultPort),
 		"HOST":           "0.0.0.0",
@@ -313,9 +314,9 @@ func buildEnvVars(params *agents.DeployAgentParams) []corev1.EnvVar {
 	}
 
 	var result []corev1.EnvVar
-	for name, value := range defaults {
+	for _, name := range defaultKeys {
 		if !seen[name] {
-			result = append(result, corev1.EnvVar{Name: name, Value: value})
+			result = append(result, corev1.EnvVar{Name: name, Value: defaultValues[name]})
 		}
 	}
 

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -230,6 +230,7 @@ func buildRoute(name, namespace string, port int32, ownerRef metav1.OwnerReferen
 						"kind":       ownerRef.Kind,
 						"name":       ownerRef.Name,
 						"uid":        string(ownerRef.UID),
+						"controller": true,
 					},
 				},
 			},

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -49,7 +49,7 @@ func buildServiceAccount(name, namespace string) *corev1.ServiceAccount {
 	}
 }
 
-func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
+func buildDeployment(params *agents.DeployAgentParams, ownerRef metav1.OwnerReference) *appsv1.Deployment {
 	labels := buildDeploymentLabels(params)
 
 	image := params.ContainerImage
@@ -118,10 +118,11 @@ func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        params.Name,
-			Namespace:   params.Namespace,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:            params.Name,
+			Namespace:       params.Namespace,
+			Labels:          labels,
+			Annotations:     annotations,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -150,7 +151,7 @@ func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
 	}
 }
 
-func buildService(params *agents.DeployAgentParams) *corev1.Service {
+func buildService(params *agents.DeployAgentParams, ownerRef metav1.OwnerReference) *corev1.Service {
 	ports := buildServicePorts(params)
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -158,9 +159,10 @@ func buildService(params *agents.DeployAgentParams) *corev1.Service {
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      params.Name,
-			Namespace: params.Namespace,
-			Labels:    buildServiceLabels(params),
+			Name:            params.Name,
+			Namespace:       params.Namespace,
+			Labels:          buildServiceLabels(params),
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
@@ -207,7 +209,7 @@ func buildAgentRuntimeCR(params *agents.DeployAgentParams) *unstructured.Unstruc
 	return obj
 }
 
-func buildRoute(name, namespace string, port int32) *unstructured.Unstructured {
+func buildRoute(name, namespace string, port int32, ownerRef metav1.OwnerReference) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": openshiftRouteGVR.Group + "/" + openshiftRouteGVR.Version,
@@ -218,6 +220,14 @@ func buildRoute(name, namespace string, port int32) *unstructured.Unstructured {
 				"labels": map[string]any{
 					labelManagedBy: managedByValue,
 					labelAppName:   name,
+				},
+				"ownerReferences": []any{
+					map[string]any{
+						"apiVersion": ownerRef.APIVersion,
+						"kind":       ownerRef.Kind,
+						"name":       ownerRef.Name,
+						"uid":        string(ownerRef.UID),
+					},
 				},
 			},
 			"spec": map[string]any{

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -2,27 +2,34 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
-	labelInject      = "kagenti.io/inject"
-	labelFramework   = "kagenti.io/framework"
-	labelManagedBy   = "app.kubernetes.io/managed-by"
-	labelAppName     = "app.kubernetes.io/name"
-	labelComponent   = "app.kubernetes.io/component"
-	managedByValue   = "odh-dashboard"
-	componentValue   = "agent"
-	containerName    = "agent"
-	defaultPort      int32 = 8000
-	defaultSvcPort   int32 = 8080
-	injectEnabled    = "enabled"
+	labelInject    = "kagenti.io/inject"
+	labelFramework = "kagenti.io/framework"
+	labelManagedBy = "app.kubernetes.io/managed-by"
+	labelAppName   = "app.kubernetes.io/name"
+	labelComponent = "app.kubernetes.io/component"
+
+	annotationDescription = "kagenti.io/description"
+
+	managedByValue = "odh-dashboard"
+	componentValue = "agent"
+	containerName  = "agent"
+	injectEnabled  = "enabled"
+	injectDisabled = "disabled"
+
+	defaultPort    int32 = 8000
+	defaultSvcPort int32 = 8080
 )
 
 func buildServiceAccount(name, namespace string) *corev1.ServiceAccount {
@@ -60,7 +67,7 @@ func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
 	container := corev1.Container{
 		Name:            containerName,
 		Image:           image,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		ImagePullPolicy: corev1.PullAlways,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "http",
@@ -69,9 +76,20 @@ func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
 			},
 		},
 		Env: envVars,
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "cache", MountPath: "/app/.cache"},
 			{Name: "shared-data", MountPath: "/shared"},
+			{Name: "marvin", MountPath: "/.marvin"},
 		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: boolPtr(false),
@@ -90,15 +108,20 @@ func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
 
 	replicas := int32(1)
 
+	annotations := map[string]string{
+		annotationDescription: fmt.Sprintf("Agent '%s' deployed from dashboard.", params.Name),
+	}
+
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      params.Name,
-			Namespace: params.Namespace,
-			Labels:    labels,
+			Name:        params.Name,
+			Namespace:   params.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -119,6 +142,7 @@ func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
 					Volumes: []corev1.Volume{
 						{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 						{Name: "shared-data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{Name: "marvin", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 					},
 				},
 			},
@@ -136,11 +160,7 @@ func buildService(params *agents.DeployAgentParams) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      params.Name,
 			Namespace: params.Namespace,
-			Labels: map[string]string{
-				agents.LabelAgentType:    agents.AgentTypeAgent,
-								labelAppName:             params.Name,
-				agents.LabelProtocolPrefix + params.Protocol: "true",
-			},
+			Labels:    buildServiceLabels(params),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
@@ -219,7 +239,8 @@ func buildRoute(name, namespace string, port int32) *unstructured.Unstructured {
 
 func selectorLabels(name string) map[string]string {
 	return map[string]string{
-		labelAppName: name,
+		agents.LabelAgentType: agents.AgentTypeAgent,
+		labelAppName:          name,
 	}
 }
 
@@ -228,15 +249,38 @@ func buildDeploymentLabels(params *agents.DeployAgentParams) map[string]string {
 		agents.LabelAgentType:    agents.AgentTypeAgent,
 		agents.LabelWorkloadType: agents.WorkloadTypeDeployment,
 		labelAppName:             params.Name,
+		labelManagedBy:           managedByValue,
 		labelComponent:           componentValue,
 	}
 
 	if params.AuthBridgeEnabled {
 		labels[labelInject] = injectEnabled
+	} else {
+		labels[labelInject] = injectDisabled
 	}
 
 	if params.Protocol != "" {
-		labels[agents.LabelProtocolPrefix+params.Protocol] = "true"
+		labels[agents.LabelProtocolPrefix+params.Protocol] = ""
+	}
+
+	if params.Framework != "" {
+		labels[labelFramework] = params.Framework
+	}
+
+	return labels
+}
+
+func buildServiceLabels(params *agents.DeployAgentParams) map[string]string {
+	labels := map[string]string{
+		agents.LabelAgentType:    agents.AgentTypeAgent,
+		agents.LabelWorkloadType: agents.WorkloadTypeDeployment,
+		labelAppName:             params.Name,
+		labelManagedBy:           managedByValue,
+		labelComponent:           componentValue,
+	}
+
+	if params.Protocol != "" {
+		labels[agents.LabelProtocolPrefix+params.Protocol] = ""
 	}
 
 	if params.Framework != "" {
@@ -256,8 +300,23 @@ func buildEnvVars(params *agents.DeployAgentParams) []corev1.EnvVar {
 		svcPort = params.ServicePorts[0].Port
 	}
 
-	result := []corev1.EnvVar{
-		{Name: "AGENT_ENDPOINT", Value: agentEndpointURL(params.Name, params.Namespace, svcPort)},
+	defaults := map[string]string{
+		"AGENT_ENDPOINT": agentEndpointURL(params.Name, params.Namespace, svcPort),
+		"PORT":           fmt.Sprintf("%d", defaultPort),
+		"HOST":           "0.0.0.0",
+		"UV_CACHE_DIR":   "/app/.cache/uv",
+	}
+
+	seen := make(map[string]bool)
+	for _, ev := range params.EnvVars {
+		seen[strings.TrimSpace(ev.Name)] = true
+	}
+
+	var result []corev1.EnvVar
+	for name, value := range defaults {
+		if !seen[name] {
+			result = append(result, corev1.EnvVar{Name: name, Value: value})
+		}
 	}
 
 	for _, ev := range params.EnvVars {

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -1,0 +1,276 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	labelInject      = "kagenti.io/inject"
+	labelFramework   = "kagenti.io/framework"
+	labelManagedBy   = "app.kubernetes.io/managed-by"
+	labelAppName     = "app.kubernetes.io/name"
+	managedByValue   = "odh-dashboard"
+	defaultPort      int32 = 8000
+	defaultSvcPort   int32 = 8080
+	injectEnabled    = "enabled"
+)
+
+func buildServiceAccount(name, namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				labelManagedBy: managedByValue,
+				labelAppName:   name,
+			},
+		},
+	}
+}
+
+func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
+	labels := buildDeploymentLabels(params)
+
+	image := params.ContainerImage
+	if params.ImageTag != "" {
+		image = fmt.Sprintf("%s:%s", image, params.ImageTag)
+	}
+
+	containerPort := defaultPort
+	if len(params.ServicePorts) > 0 && params.ServicePorts[0].TargetPort > 0 {
+		containerPort = params.ServicePorts[0].TargetPort
+	}
+
+	container := corev1.Container{
+		Name:  params.Name,
+		Image: image,
+		Ports: []corev1.ContainerPort{
+			{
+				ContainerPort: containerPort,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+		Env: buildEnvVars(params.EnvVars),
+		SecurityContext: &corev1.SecurityContext{
+			RunAsNonRoot:             boolPtr(true),
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		},
+	}
+
+	var imagePullSecrets []corev1.LocalObjectReference
+	if params.ImagePullSecret != "" {
+		imagePullSecrets = []corev1.LocalObjectReference{
+			{Name: params.ImagePullSecret},
+		}
+	}
+
+	replicas := int32(1)
+
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      params.Name,
+			Namespace: params.Namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					labelAppName: params.Name,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: params.Name,
+					Containers:         []corev1.Container{container},
+					ImagePullSecrets:   imagePullSecrets,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: boolPtr(true),
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildService(params *agents.DeployAgentParams) *corev1.Service {
+	ports := buildServicePorts(params)
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      params.Name,
+			Namespace: params.Namespace,
+			Labels: map[string]string{
+				labelManagedBy: managedByValue,
+				labelAppName:   params.Name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				labelAppName: params.Name,
+			},
+			Ports: ports,
+		},
+	}
+}
+
+func buildAgentRuntimeCR(params *agents.DeployAgentParams) *unstructured.Unstructured {
+	spec := map[string]any{
+		"type": "agent",
+		"targetRef": map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"name":       params.Name,
+		},
+	}
+
+	if params.AuthBridgeMode != "" {
+		spec["authBridgeMode"] = params.AuthBridgeMode
+	}
+	if params.MTLSMode != "" {
+		spec["mtlsMode"] = params.MTLSMode
+	}
+
+	labels := map[string]any{
+		labelManagedBy: managedByValue,
+		labelAppName:   params.Name,
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": agentRuntimeGVR.Group + "/" + agentRuntimeGVR.Version,
+			"kind":       "AgentRuntime",
+			"metadata": map[string]any{
+				"name":      params.Name,
+				"namespace": params.Namespace,
+				"labels":    labels,
+			},
+			"spec": spec,
+		},
+	}
+	return obj
+}
+
+func buildRoute(name, namespace string, port int32) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": openshiftRouteGVR.Group + "/" + openshiftRouteGVR.Version,
+			"kind":       "Route",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+				"labels": map[string]any{
+					labelManagedBy: managedByValue,
+					labelAppName:   name,
+				},
+			},
+			"spec": map[string]any{
+				"to": map[string]any{
+					"kind": "Service",
+					"name": name,
+				},
+				"port": map[string]any{
+					"targetPort": fmt.Sprintf("%d", port),
+				},
+				"tls": map[string]any{
+					"termination":                   "edge",
+					"insecureEdgeTerminationPolicy": "Redirect",
+				},
+			},
+		},
+	}
+}
+
+func buildDeploymentLabels(params *agents.DeployAgentParams) map[string]string {
+	labels := map[string]string{
+		agents.LabelAgentType:    agents.AgentTypeAgent,
+		agents.LabelWorkloadType: agents.WorkloadTypeDeployment,
+		labelAppName:             params.Name,
+		labelManagedBy:           managedByValue,
+	}
+
+	if params.AuthBridgeEnabled {
+		labels[labelInject] = injectEnabled
+	}
+
+	if params.Protocol != "" {
+		labels[agents.LabelProtocolPrefix+params.Protocol] = ""
+	}
+
+	if params.Framework != "" {
+		labels[labelFramework] = params.Framework
+	}
+
+	return labels
+}
+
+func buildEnvVars(envVars []agents.AgentEnvVar) []corev1.EnvVar {
+	if len(envVars) == 0 {
+		return nil
+	}
+	result := make([]corev1.EnvVar, 0, len(envVars))
+	for _, ev := range envVars {
+		result = append(result, corev1.EnvVar{
+			Name:  ev.Name,
+			Value: ev.Value,
+		})
+	}
+	return result
+}
+
+func buildServicePorts(params *agents.DeployAgentParams) []corev1.ServicePort {
+	if len(params.ServicePorts) > 0 {
+		ports := make([]corev1.ServicePort, 0, len(params.ServicePorts))
+		for _, sp := range params.ServicePorts {
+			protocol := corev1.ProtocolTCP
+			if sp.Protocol != "" {
+				protocol = corev1.Protocol(sp.Protocol)
+			}
+			ports = append(ports, corev1.ServicePort{
+				Name:       sp.Name,
+				Port:       sp.Port,
+				TargetPort: intstr.FromInt32(sp.TargetPort),
+				Protocol:   protocol,
+			})
+		}
+		return ports
+	}
+
+	return []corev1.ServicePort{
+		{
+			Name:       "http",
+			Port:       defaultSvcPort,
+			TargetPort: intstr.FromInt32(defaultPort),
+			Protocol:   corev1.ProtocolTCP,
+		},
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -138,8 +138,7 @@ func buildService(params *agents.DeployAgentParams) *corev1.Service {
 			Namespace: params.Namespace,
 			Labels: map[string]string{
 				agents.LabelAgentType:    agents.AgentTypeAgent,
-				labelManagedBy:           managedByValue,
-				labelAppName:             params.Name,
+								labelAppName:             params.Name,
 				agents.LabelProtocolPrefix + params.Protocol: "true",
 			},
 		},
@@ -229,7 +228,6 @@ func buildDeploymentLabels(params *agents.DeployAgentParams) map[string]string {
 		agents.LabelAgentType:    agents.AgentTypeAgent,
 		agents.LabelWorkloadType: agents.WorkloadTypeDeployment,
 		labelAppName:             params.Name,
-		labelManagedBy:           managedByValue,
 		labelComponent:           componentValue,
 	}
 

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -220,8 +220,7 @@ func buildRoute(name, namespace string, port int32) *unstructured.Unstructured {
 
 func selectorLabels(name string) map[string]string {
 	return map[string]string{
-		agents.LabelAgentType: agents.AgentTypeAgent,
-		labelAppName:          name,
+		labelAppName: name,
 	}
 }
 

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -16,7 +16,10 @@ const (
 	labelFramework   = "kagenti.io/framework"
 	labelManagedBy   = "app.kubernetes.io/managed-by"
 	labelAppName     = "app.kubernetes.io/name"
+	labelComponent   = "app.kubernetes.io/component"
 	managedByValue   = "odh-dashboard"
+	componentValue   = "agent"
+	containerName    = "agent"
 	defaultPort      int32 = 8000
 	defaultSvcPort   int32 = 8080
 	injectEnabled    = "enabled"
@@ -52,18 +55,25 @@ func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
 		containerPort = params.ServicePorts[0].TargetPort
 	}
 
+	envVars := buildEnvVars(params)
+
 	container := corev1.Container{
-		Name:  params.Name,
-		Image: image,
+		Name:            containerName,
+		Image:           image,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			{
+				Name:          "http",
 				ContainerPort: containerPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		Env: buildEnvVars(params.EnvVars),
+		Env: envVars,
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "cache", MountPath: "/app/.cache"},
+			{Name: "shared-data", MountPath: "/shared"},
+		},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsNonRoot:             boolPtr(true),
 			AllowPrivilegeEscalation: boolPtr(false),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
@@ -93,9 +103,7 @@ func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					labelAppName: params.Name,
-				},
+				MatchLabels: selectorLabels(params.Name),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -107,6 +115,10 @@ func buildDeployment(params *agents.DeployAgentParams) *appsv1.Deployment {
 					ImagePullSecrets:   imagePullSecrets,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: boolPtr(true),
+					},
+					Volumes: []corev1.Volume{
+						{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{Name: "shared-data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 					},
 				},
 			},
@@ -125,16 +137,16 @@ func buildService(params *agents.DeployAgentParams) *corev1.Service {
 			Name:      params.Name,
 			Namespace: params.Namespace,
 			Labels: map[string]string{
-				labelManagedBy: managedByValue,
-				labelAppName:   params.Name,
+				agents.LabelAgentType:    agents.AgentTypeAgent,
+				labelManagedBy:           managedByValue,
+				labelAppName:             params.Name,
+				agents.LabelProtocolPrefix + params.Protocol: "true",
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Selector: map[string]string{
-				labelAppName: params.Name,
-			},
-			Ports: ports,
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: selectorLabels(params.Name),
+			Ports:    ports,
 		},
 	}
 }
@@ -206,12 +218,20 @@ func buildRoute(name, namespace string, port int32) *unstructured.Unstructured {
 	}
 }
 
+func selectorLabels(name string) map[string]string {
+	return map[string]string{
+		agents.LabelAgentType: agents.AgentTypeAgent,
+		labelAppName:          name,
+	}
+}
+
 func buildDeploymentLabels(params *agents.DeployAgentParams) map[string]string {
 	labels := map[string]string{
 		agents.LabelAgentType:    agents.AgentTypeAgent,
 		agents.LabelWorkloadType: agents.WorkloadTypeDeployment,
 		labelAppName:             params.Name,
 		labelManagedBy:           managedByValue,
+		labelComponent:           componentValue,
 	}
 
 	if params.AuthBridgeEnabled {
@@ -219,7 +239,7 @@ func buildDeploymentLabels(params *agents.DeployAgentParams) map[string]string {
 	}
 
 	if params.Protocol != "" {
-		labels[agents.LabelProtocolPrefix+params.Protocol] = ""
+		labels[agents.LabelProtocolPrefix+params.Protocol] = "true"
 	}
 
 	if params.Framework != "" {
@@ -229,12 +249,21 @@ func buildDeploymentLabels(params *agents.DeployAgentParams) map[string]string {
 	return labels
 }
 
-func buildEnvVars(envVars []agents.AgentEnvVar) []corev1.EnvVar {
-	if len(envVars) == 0 {
-		return nil
+func agentEndpointURL(name, namespace string, port int32) string {
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/", name, namespace, port)
+}
+
+func buildEnvVars(params *agents.DeployAgentParams) []corev1.EnvVar {
+	svcPort := defaultSvcPort
+	if len(params.ServicePorts) > 0 && params.ServicePorts[0].Port > 0 {
+		svcPort = params.ServicePorts[0].Port
 	}
-	result := make([]corev1.EnvVar, 0, len(envVars))
-	for _, ev := range envVars {
+
+	result := []corev1.EnvVar{
+		{Name: "AGENT_ENDPOINT", Value: agentEndpointURL(params.Name, params.Namespace, svcPort)},
+	}
+
+	for _, ev := range params.EnvVars {
 		result = append(result, corev1.EnvVar{
 			Name:  ev.Name,
 			Value: ev.Value,

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -299,11 +299,15 @@ func buildEnvVars(params *agents.DeployAgentParams) []corev1.EnvVar {
 	if len(params.ServicePorts) > 0 && params.ServicePorts[0].Port > 0 {
 		svcPort = params.ServicePorts[0].Port
 	}
+	containerPort := defaultPort
+	if len(params.ServicePorts) > 0 && params.ServicePorts[0].TargetPort > 0 {
+		containerPort = params.ServicePorts[0].TargetPort
+	}
 
 	defaultKeys := []string{"AGENT_ENDPOINT", "HOST", "PORT", "UV_CACHE_DIR"}
 	defaultValues := map[string]string{
 		"AGENT_ENDPOINT": agentEndpointURL(params.Name, params.Namespace, svcPort),
-		"PORT":           fmt.Sprintf("%d", defaultPort),
+		"PORT":           fmt.Sprintf("%d", containerPort),
 		"HOST":           "0.0.0.0",
 		"UV_CACHE_DIR":   "/app/.cache/uv",
 	}

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests.go
@@ -96,6 +96,9 @@ func buildDeployment(params *agents.DeployAgentParams, ownerRef metav1.OwnerRefe
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 		},
 	}
 

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
@@ -78,7 +78,7 @@ func TestBuildDeployment(t *testing.T) {
 				Framework:      "langgraph",
 			},
 			wantLabels: map[string]string{
-				agents.LabelProtocolPrefix + "a2a": "true",
+				agents.LabelProtocolPrefix + "a2a": "",
 				labelFramework:                     "langgraph",
 			},
 			wantPort: defaultPort,
@@ -161,13 +161,16 @@ func TestBuildDeploymentEnvVars(t *testing.T) {
 	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 
 	envVars := deployment.Spec.Template.Spec.Containers[0].Env
-	require.Len(t, envVars, 3)
-	assert.Equal(t, "AGENT_ENDPOINT", envVars[0].Name)
-	assert.Equal(t, "http://my-agent.test-ns.svc.cluster.local:8080/", envVars[0].Value)
-	assert.Equal(t, "API_KEY", envVars[1].Name)
-	assert.Equal(t, "secret", envVars[1].Value)
-	assert.Equal(t, "LOG_LEVEL", envVars[2].Name)
-	assert.Equal(t, "debug", envVars[2].Value)
+	envMap := make(map[string]string)
+	for _, ev := range envVars {
+		envMap[ev.Name] = ev.Value
+	}
+	assert.Equal(t, "http://my-agent.test-ns.svc.cluster.local:8080/", envMap["AGENT_ENDPOINT"])
+	assert.Equal(t, "8000", envMap["PORT"])
+	assert.Equal(t, "0.0.0.0", envMap["HOST"])
+	assert.Equal(t, "/app/.cache/uv", envMap["UV_CACHE_DIR"])
+	assert.Equal(t, "secret", envMap["API_KEY"])
+	assert.Equal(t, "debug", envMap["LOG_LEVEL"])
 }
 
 func TestBuildService(t *testing.T) {

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
@@ -38,7 +38,6 @@ func TestBuildDeployment(t *testing.T) {
 				agents.LabelAgentType:    agents.AgentTypeAgent,
 				agents.LabelWorkloadType: agents.WorkloadTypeDeployment,
 				labelAppName:             "my-agent",
-				labelManagedBy:           managedByValue,
 				labelComponent:           componentValue,
 			},
 			wantImage:       "quay.io/example/agent",

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
@@ -7,7 +7,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
+
+var testOwnerRef = metav1.OwnerReference{
+	APIVersion: "agent.kagenti.dev/v1alpha1",
+	Kind:       "AgentRuntime",
+	Name:       "my-agent",
+	UID:        types.UID("test-uid-1234"),
+}
 
 func TestBuildServiceAccount(t *testing.T) {
 	sa := buildServiceAccount("my-agent", "test-ns")
@@ -110,7 +119,7 @@ func TestBuildDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			deployment := buildDeployment(tt.params)
+			deployment := buildDeployment(tt.params, testOwnerRef)
 			require.NotNil(t, deployment)
 
 			assert.Equal(t, tt.params.Name, deployment.Name)
@@ -156,7 +165,7 @@ func TestBuildDeploymentEnvVars(t *testing.T) {
 		},
 	}
 
-	deployment := buildDeployment(params)
+	deployment := buildDeployment(params, testOwnerRef)
 	require.NotNil(t, deployment)
 	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 
@@ -209,7 +218,7 @@ func TestBuildService(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := buildService(tt.params)
+			svc := buildService(tt.params, testOwnerRef)
 			require.NotNil(t, svc)
 
 			assert.Equal(t, tt.params.Name, svc.Name)
@@ -301,7 +310,7 @@ func TestBuildAgentRuntimeCR(t *testing.T) {
 }
 
 func TestBuildRoute(t *testing.T) {
-	route := buildRoute("my-agent", "test-ns", 8080)
+	route := buildRoute("my-agent", "test-ns", 8080, testOwnerRef)
 	require.NotNil(t, route)
 
 	assert.Equal(t, "Route", route.GetKind())

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
@@ -1,0 +1,318 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestBuildServiceAccount(t *testing.T) {
+	sa := buildServiceAccount("my-agent", "test-ns")
+	require.NotNil(t, sa)
+	assert.Equal(t, "my-agent", sa.Name)
+	assert.Equal(t, "test-ns", sa.Namespace)
+	assert.Equal(t, managedByValue, sa.Labels[labelManagedBy])
+	assert.Equal(t, "my-agent", sa.Labels[labelAppName])
+}
+
+func TestBuildDeployment(t *testing.T) {
+	tests := []struct {
+		name            string
+		params          *agents.DeployAgentParams
+		wantLabels      map[string]string
+		wantImage       string
+		wantPort        int32
+		wantPullSecrets int
+	}{
+		{
+			name: "minimal params",
+			params: &agents.DeployAgentParams{
+				Name:           "my-agent",
+				Namespace:      "test-ns",
+				ContainerImage: "quay.io/example/agent",
+			},
+			wantLabels: map[string]string{
+				agents.LabelAgentType:    agents.AgentTypeAgent,
+				agents.LabelWorkloadType: agents.WorkloadTypeDeployment,
+				labelAppName:             "my-agent",
+				labelManagedBy:           managedByValue,
+			},
+			wantImage:       "quay.io/example/agent",
+			wantPort:        defaultPort,
+			wantPullSecrets: 0,
+		},
+		{
+			name: "with image tag",
+			params: &agents.DeployAgentParams{
+				Name:           "my-agent",
+				Namespace:      "test-ns",
+				ContainerImage: "quay.io/example/agent",
+				ImageTag:       "v1.0.0",
+			},
+			wantImage: "quay.io/example/agent:v1.0.0",
+			wantPort:  defaultPort,
+		},
+		{
+			name: "with auth bridge enabled",
+			params: &agents.DeployAgentParams{
+				Name:              "my-agent",
+				Namespace:         "test-ns",
+				ContainerImage:    "quay.io/example/agent",
+				AuthBridgeEnabled: true,
+			},
+			wantLabels: map[string]string{
+				labelInject: injectEnabled,
+			},
+			wantPort: defaultPort,
+		},
+		{
+			name: "with protocol and framework labels",
+			params: &agents.DeployAgentParams{
+				Name:           "my-agent",
+				Namespace:      "test-ns",
+				ContainerImage: "quay.io/example/agent",
+				Protocol:       "a2a",
+				Framework:      "langgraph",
+			},
+			wantLabels: map[string]string{
+				agents.LabelProtocolPrefix + "a2a": "",
+				labelFramework:                     "langgraph",
+			},
+			wantPort: defaultPort,
+		},
+		{
+			name: "with custom service ports",
+			params: &agents.DeployAgentParams{
+				Name:           "my-agent",
+				Namespace:      "test-ns",
+				ContainerImage: "quay.io/example/agent",
+				ServicePorts: []agents.AgentServicePortSpec{
+					{Name: "http", Port: 9090, TargetPort: 9000, Protocol: "TCP"},
+				},
+			},
+			wantPort: 9000,
+		},
+		{
+			name: "with image pull secret",
+			params: &agents.DeployAgentParams{
+				Name:            "my-agent",
+				Namespace:       "test-ns",
+				ContainerImage:  "quay.io/example/agent",
+				ImagePullSecret: "my-registry-secret",
+			},
+			wantPort:        defaultPort,
+			wantPullSecrets: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployment := buildDeployment(tt.params)
+			require.NotNil(t, deployment)
+
+			assert.Equal(t, tt.params.Name, deployment.Name)
+			assert.Equal(t, tt.params.Namespace, deployment.Namespace)
+
+			if tt.wantImage != "" {
+				require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+				assert.Equal(t, tt.wantImage, deployment.Spec.Template.Spec.Containers[0].Image)
+			}
+
+			if tt.wantPort > 0 {
+				require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+				require.Len(t, deployment.Spec.Template.Spec.Containers[0].Ports, 1)
+				assert.Equal(t, tt.wantPort, deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+			}
+
+			for key, val := range tt.wantLabels {
+				assert.Equal(t, val, deployment.Labels[key], "label %s", key)
+			}
+
+			assert.Len(t, deployment.Spec.Template.Spec.ImagePullSecrets, tt.wantPullSecrets)
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+			require.NotNil(t, container.SecurityContext)
+			assert.True(t, *container.SecurityContext.RunAsNonRoot)
+			assert.False(t, *container.SecurityContext.AllowPrivilegeEscalation)
+			assert.Contains(t, container.SecurityContext.Capabilities.Drop, corev1.Capability("ALL"))
+		})
+	}
+}
+
+func TestBuildDeploymentEnvVars(t *testing.T) {
+	params := &agents.DeployAgentParams{
+		Name:           "my-agent",
+		Namespace:      "test-ns",
+		ContainerImage: "quay.io/example/agent",
+		EnvVars: []agents.AgentEnvVar{
+			{Name: "API_KEY", Value: "secret"},
+			{Name: "LOG_LEVEL", Value: "debug"},
+		},
+	}
+
+	deployment := buildDeployment(params)
+	require.NotNil(t, deployment)
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+
+	envVars := deployment.Spec.Template.Spec.Containers[0].Env
+	require.Len(t, envVars, 2)
+	assert.Equal(t, "API_KEY", envVars[0].Name)
+	assert.Equal(t, "secret", envVars[0].Value)
+	assert.Equal(t, "LOG_LEVEL", envVars[1].Name)
+	assert.Equal(t, "debug", envVars[1].Value)
+}
+
+func TestBuildService(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     *agents.DeployAgentParams
+		wantPorts  int
+		wantPort   int32
+		wantTarget int32
+	}{
+		{
+			name: "default ports",
+			params: &agents.DeployAgentParams{
+				Name:           "my-agent",
+				Namespace:      "test-ns",
+				ContainerImage: "quay.io/example/agent",
+			},
+			wantPorts:  1,
+			wantPort:   defaultSvcPort,
+			wantTarget: defaultPort,
+		},
+		{
+			name: "custom ports",
+			params: &agents.DeployAgentParams{
+				Name:           "my-agent",
+				Namespace:      "test-ns",
+				ContainerImage: "quay.io/example/agent",
+				ServicePorts: []agents.AgentServicePortSpec{
+					{Name: "grpc", Port: 50051, TargetPort: 50051, Protocol: "TCP"},
+					{Name: "http", Port: 8080, TargetPort: 8000, Protocol: "TCP"},
+				},
+			},
+			wantPorts: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := buildService(tt.params)
+			require.NotNil(t, svc)
+
+			assert.Equal(t, tt.params.Name, svc.Name)
+			assert.Equal(t, tt.params.Namespace, svc.Namespace)
+			assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
+			assert.Equal(t, tt.params.Name, svc.Spec.Selector[labelAppName])
+			assert.Len(t, svc.Spec.Ports, tt.wantPorts)
+
+			if tt.wantPort > 0 {
+				assert.Equal(t, tt.wantPort, svc.Spec.Ports[0].Port)
+			}
+			if tt.wantTarget > 0 {
+				assert.Equal(t, tt.wantTarget, svc.Spec.Ports[0].TargetPort.IntVal)
+			}
+		})
+	}
+}
+
+func TestBuildAgentRuntimeCR(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         *agents.DeployAgentParams
+		wantAuthBridge bool
+		wantMTLS       bool
+	}{
+		{
+			name: "minimal",
+			params: &agents.DeployAgentParams{
+				Name:           "my-agent",
+				Namespace:      "test-ns",
+				ContainerImage: "quay.io/example/agent",
+			},
+		},
+		{
+			name: "with auth bridge mode",
+			params: &agents.DeployAgentParams{
+				Name:           "my-agent",
+				Namespace:      "test-ns",
+				ContainerImage: "quay.io/example/agent",
+				AuthBridgeMode: "token",
+			},
+			wantAuthBridge: true,
+		},
+		{
+			name: "with mTLS mode",
+			params: &agents.DeployAgentParams{
+				Name:           "my-agent",
+				Namespace:      "test-ns",
+				ContainerImage: "quay.io/example/agent",
+				MTLSMode:       "strict",
+			},
+			wantMTLS: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := buildAgentRuntimeCR(tt.params)
+			require.NotNil(t, obj)
+
+			assert.Equal(t, "AgentRuntime", obj.GetKind())
+			assert.Equal(t, agentRuntimeGVR.Group+"/"+agentRuntimeGVR.Version, obj.GetAPIVersion())
+			assert.Equal(t, tt.params.Name, obj.GetName())
+			assert.Equal(t, tt.params.Namespace, obj.GetNamespace())
+
+			spec, ok := obj.Object["spec"].(map[string]any)
+			require.True(t, ok)
+
+			targetRef, ok := spec["targetRef"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "Deployment", targetRef["kind"])
+			assert.Equal(t, tt.params.Name, targetRef["name"])
+
+			if tt.wantAuthBridge {
+				assert.Equal(t, tt.params.AuthBridgeMode, spec["authBridgeMode"])
+			} else {
+				_, exists := spec["authBridgeMode"]
+				assert.False(t, exists)
+			}
+
+			if tt.wantMTLS {
+				assert.Equal(t, tt.params.MTLSMode, spec["mtlsMode"])
+			} else {
+				_, exists := spec["mtlsMode"]
+				assert.False(t, exists)
+			}
+		})
+	}
+}
+
+func TestBuildRoute(t *testing.T) {
+	route := buildRoute("my-agent", "test-ns", 8080)
+	require.NotNil(t, route)
+
+	assert.Equal(t, "Route", route.GetKind())
+	assert.Equal(t, "my-agent", route.GetName())
+	assert.Equal(t, "test-ns", route.GetNamespace())
+
+	spec, ok := route.Object["spec"].(map[string]any)
+	require.True(t, ok)
+
+	to, ok := spec["to"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Service", to["kind"])
+	assert.Equal(t, "my-agent", to["name"])
+
+	port, ok := spec["port"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "8080", port["targetPort"])
+
+	tls, ok := spec["tls"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "edge", tls["termination"])
+}

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
@@ -39,6 +39,7 @@ func TestBuildDeployment(t *testing.T) {
 				agents.LabelWorkloadType: agents.WorkloadTypeDeployment,
 				labelAppName:             "my-agent",
 				labelManagedBy:           managedByValue,
+				labelComponent:           componentValue,
 			},
 			wantImage:       "quay.io/example/agent",
 			wantPort:        defaultPort,
@@ -78,7 +79,7 @@ func TestBuildDeployment(t *testing.T) {
 				Framework:      "langgraph",
 			},
 			wantLabels: map[string]string{
-				agents.LabelProtocolPrefix + "a2a": "",
+				agents.LabelProtocolPrefix + "a2a": "true",
 				labelFramework:                     "langgraph",
 			},
 			wantPort: defaultPort,
@@ -134,10 +135,13 @@ func TestBuildDeployment(t *testing.T) {
 			assert.Len(t, deployment.Spec.Template.Spec.ImagePullSecrets, tt.wantPullSecrets)
 
 			container := deployment.Spec.Template.Spec.Containers[0]
+			assert.Equal(t, containerName, container.Name)
 			require.NotNil(t, container.SecurityContext)
-			assert.True(t, *container.SecurityContext.RunAsNonRoot)
 			assert.False(t, *container.SecurityContext.AllowPrivilegeEscalation)
 			assert.Contains(t, container.SecurityContext.Capabilities.Drop, corev1.Capability("ALL"))
+
+			require.NotNil(t, deployment.Spec.Template.Spec.SecurityContext)
+			assert.True(t, *deployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot)
 		})
 	}
 }
@@ -158,11 +162,13 @@ func TestBuildDeploymentEnvVars(t *testing.T) {
 	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 
 	envVars := deployment.Spec.Template.Spec.Containers[0].Env
-	require.Len(t, envVars, 2)
-	assert.Equal(t, "API_KEY", envVars[0].Name)
-	assert.Equal(t, "secret", envVars[0].Value)
-	assert.Equal(t, "LOG_LEVEL", envVars[1].Name)
-	assert.Equal(t, "debug", envVars[1].Value)
+	require.Len(t, envVars, 3)
+	assert.Equal(t, "AGENT_ENDPOINT", envVars[0].Name)
+	assert.Equal(t, "http://my-agent.test-ns.svc.cluster.local:8080/", envVars[0].Value)
+	assert.Equal(t, "API_KEY", envVars[1].Name)
+	assert.Equal(t, "secret", envVars[1].Value)
+	assert.Equal(t, "LOG_LEVEL", envVars[2].Name)
+	assert.Equal(t, "debug", envVars[2].Value)
 }
 
 func TestBuildService(t *testing.T) {

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/manifests_test.go
@@ -142,6 +142,10 @@ func TestBuildDeployment(t *testing.T) {
 
 			assert.Len(t, deployment.Spec.Template.Spec.ImagePullSecrets, tt.wantPullSecrets)
 
+			require.Len(t, deployment.OwnerReferences, 1)
+			assert.Equal(t, "AgentRuntime", deployment.OwnerReferences[0].Kind)
+			assert.Equal(t, testOwnerRef.UID, deployment.OwnerReferences[0].UID)
+
 			container := deployment.Spec.Template.Spec.Containers[0]
 			assert.Equal(t, containerName, container.Name)
 			require.NotNil(t, container.SecurityContext)
@@ -223,6 +227,8 @@ func TestBuildService(t *testing.T) {
 
 			assert.Equal(t, tt.params.Name, svc.Name)
 			assert.Equal(t, tt.params.Namespace, svc.Namespace)
+			require.Len(t, svc.OwnerReferences, 1)
+			assert.Equal(t, "AgentRuntime", svc.OwnerReferences[0].Kind)
 			assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
 			assert.Equal(t, tt.params.Name, svc.Spec.Selector[labelAppName])
 			assert.Len(t, svc.Spec.Ports, tt.wantPorts)
@@ -316,6 +322,15 @@ func TestBuildRoute(t *testing.T) {
 	assert.Equal(t, "Route", route.GetKind())
 	assert.Equal(t, "my-agent", route.GetName())
 	assert.Equal(t, "test-ns", route.GetNamespace())
+
+	metadata, ok := route.Object["metadata"].(map[string]any)
+	require.True(t, ok)
+	ownerRefs, ok := metadata["ownerReferences"].([]any)
+	require.True(t, ok)
+	require.Len(t, ownerRefs, 1)
+	ownerRefMap, ok := ownerRefs[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "AgentRuntime", ownerRefMap["kind"])
 
 	spec, ok := route.Object["spec"].(map[string]any)
 	require.True(t, ok)

--- a/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"sync"
 
@@ -79,8 +80,14 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 	_ = ctx
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if params == nil {
+		return nil, fmt.Errorf("deploy params must not be nil")
+	}
 	if c.DeployAgentErr != nil {
 		return nil, c.DeployAgentErr
+	}
+	if c.Details == nil {
+		c.Details = make(map[string]agents.AgentDetail)
 	}
 	key := detailKey(params.Namespace, params.Name)
 	if _, ok := c.Details[key]; ok {

--- a/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
@@ -19,6 +19,7 @@ type Client struct {
 	ListNamespacesErr error
 	ListAgentsErr     error
 	GetAgentErr       error
+	DeployAgentErr    error
 }
 
 // NewClient returns a mock client with no data.
@@ -71,6 +72,42 @@ func (c *Client) GetAgent(ctx context.Context, namespace, name string) (*agents.
 	}
 	copy := cloneAgentDetail(detail)
 	return &copy, nil
+}
+
+// DeployAgent implements agents.Client.
+func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentParams) (*agents.DeployAgentResult, error) {
+	_ = ctx
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.DeployAgentErr != nil {
+		return nil, c.DeployAgentErr
+	}
+	key := detailKey(params.Namespace, params.Name)
+	if _, ok := c.Details[key]; ok {
+		return nil, agents.ErrAlreadyExists
+	}
+	return &agents.DeployAgentResult{
+		Name:      params.Name,
+		Namespace: params.Namespace,
+	}, nil
+}
+
+// DeleteAgent implements agents.Client.
+func (c *Client) DeleteAgent(ctx context.Context, namespace, name string) error {
+	_ = ctx
+	return agents.ErrUnavailable
+}
+
+// StopAgent implements agents.Client.
+func (c *Client) StopAgent(ctx context.Context, namespace, name string) error {
+	_ = ctx
+	return agents.ErrUnavailable
+}
+
+// StartAgent implements agents.Client.
+func (c *Client) StartAgent(ctx context.Context, namespace, name string) error {
+	_ = ctx
+	return agents.ErrUnavailable
 }
 
 // cloneAgentDetail returns a defensive copy of detail. Spec and Status use maps.Clone

--- a/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
@@ -86,6 +86,16 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 	if _, ok := c.Details[key]; ok {
 		return nil, agents.ErrAlreadyExists
 	}
+	c.Details[key] = agents.AgentDetail{
+		Metadata: agents.AgentMetadata{
+			Name:      params.Name,
+			Namespace: params.Namespace,
+			Labels: map[string]string{
+				"kagenti.io/type": "agent",
+			},
+		},
+		WorkloadType: "Deployment",
+	}
 	return &agents.DeployAgentResult{
 		Name:      params.Name,
 		Namespace: params.Namespace,

--- a/packages/agent-ops/bff/internal/integrations/kubernetes/agent_rbac.go
+++ b/packages/agent-ops/bff/internal/integrations/kubernetes/agent_rbac.go
@@ -53,6 +53,43 @@ func (kc *TokenKubernetesClient) CanGetAgentInNamespace(ctx context.Context, _ *
 	return kc.selfSubjectAccessReview(ctx, namespace, name, "services", "get")
 }
 
+var agentDeployResources = []struct {
+	group    string
+	resource string
+}{
+	{"", "serviceaccounts"},
+	{"apps", "deployments"},
+	{"", "services"},
+	{"agent.kagenti.dev", "agentruntimes"},
+	{"route.openshift.io", "routes"},
+}
+
+func (kc *InternalKubernetesClient) CanDeployAgentInNamespace(ctx context.Context, identity *RequestIdentity, namespace string) (bool, error) {
+	for _, r := range agentDeployResources {
+		allowed, err := kc.subjectAccessReviewGroup(ctx, identity, namespace, "", r.group, r.resource, "create")
+		if err != nil {
+			return false, err
+		}
+		if !allowed {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (kc *TokenKubernetesClient) CanDeployAgentInNamespace(ctx context.Context, _ *RequestIdentity, namespace string) (bool, error) {
+	for _, r := range agentDeployResources {
+		allowed, err := kc.selfSubjectAccessReviewGroup(ctx, namespace, "", r.group, r.resource, "create")
+		if err != nil {
+			return false, err
+		}
+		if !allowed {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 func (kc *InternalKubernetesClient) anySubjectAccessReview(
 	ctx context.Context,
 	identity *RequestIdentity,

--- a/packages/agent-ops/bff/internal/integrations/kubernetes/agent_rbac.go
+++ b/packages/agent-ops/bff/internal/integrations/kubernetes/agent_rbac.go
@@ -53,31 +53,30 @@ func (kc *TokenKubernetesClient) CanGetAgentInNamespace(ctx context.Context, _ *
 	return kc.selfSubjectAccessReview(ctx, namespace, name, "services", "get")
 }
 
-var agentDeployBaseResources = []struct {
+type deployResourceCheck struct {
 	group    string
 	resource string
-}{
-	{"", "serviceaccounts"},
-	{"apps", "deployments"},
-	{"", "services"},
-	{"agent.kagenti.dev", "agentruntimes"},
+	verb     string
 }
 
-var agentDeployRouteResource = struct {
-	group    string
-	resource string
-}{"route.openshift.io", "routes"}
+var agentDeployChecks = []deployResourceCheck{
+	{"", "serviceaccounts", "create"},
+	{"", "serviceaccounts", "get"},
+	{"apps", "deployments", "create"},
+	{"", "services", "create"},
+	{"agent.kagenti.dev", "agentruntimes", "create"},
+	{"agent.kagenti.dev", "agentruntimes", "get"},
+}
+
+var agentDeployRouteCheck = deployResourceCheck{"route.openshift.io", "routes", "create"}
 
 func (kc *InternalKubernetesClient) CanDeployAgentInNamespace(ctx context.Context, identity *RequestIdentity, namespace string, createRoute bool) (bool, error) {
-	resources := agentDeployBaseResources
+	checks := agentDeployChecks
 	if createRoute {
-		resources = append(append([]struct {
-			group    string
-			resource string
-		}{}, resources...), agentDeployRouteResource)
+		checks = append(append([]deployResourceCheck{}, checks...), agentDeployRouteCheck)
 	}
-	for _, r := range resources {
-		allowed, err := kc.subjectAccessReviewGroup(ctx, identity, namespace, "", r.group, r.resource, "create")
+	for _, r := range checks {
+		allowed, err := kc.subjectAccessReviewGroup(ctx, identity, namespace, "", r.group, r.resource, r.verb)
 		if err != nil {
 			return false, err
 		}
@@ -89,15 +88,12 @@ func (kc *InternalKubernetesClient) CanDeployAgentInNamespace(ctx context.Contex
 }
 
 func (kc *TokenKubernetesClient) CanDeployAgentInNamespace(ctx context.Context, _ *RequestIdentity, namespace string, createRoute bool) (bool, error) {
-	resources := agentDeployBaseResources
+	checks := agentDeployChecks
 	if createRoute {
-		resources = append(append([]struct {
-			group    string
-			resource string
-		}{}, resources...), agentDeployRouteResource)
+		checks = append(append([]deployResourceCheck{}, checks...), agentDeployRouteCheck)
 	}
-	for _, r := range resources {
-		allowed, err := kc.selfSubjectAccessReviewGroup(ctx, namespace, "", r.group, r.resource, "create")
+	for _, r := range checks {
+		allowed, err := kc.selfSubjectAccessReviewGroup(ctx, namespace, "", r.group, r.resource, r.verb)
 		if err != nil {
 			return false, err
 		}

--- a/packages/agent-ops/bff/internal/integrations/kubernetes/agent_rbac.go
+++ b/packages/agent-ops/bff/internal/integrations/kubernetes/agent_rbac.go
@@ -53,7 +53,7 @@ func (kc *TokenKubernetesClient) CanGetAgentInNamespace(ctx context.Context, _ *
 	return kc.selfSubjectAccessReview(ctx, namespace, name, "services", "get")
 }
 
-var agentDeployResources = []struct {
+var agentDeployBaseResources = []struct {
 	group    string
 	resource string
 }{
@@ -61,11 +61,22 @@ var agentDeployResources = []struct {
 	{"apps", "deployments"},
 	{"", "services"},
 	{"agent.kagenti.dev", "agentruntimes"},
-	{"route.openshift.io", "routes"},
 }
 
-func (kc *InternalKubernetesClient) CanDeployAgentInNamespace(ctx context.Context, identity *RequestIdentity, namespace string) (bool, error) {
-	for _, r := range agentDeployResources {
+var agentDeployRouteResource = struct {
+	group    string
+	resource string
+}{"route.openshift.io", "routes"}
+
+func (kc *InternalKubernetesClient) CanDeployAgentInNamespace(ctx context.Context, identity *RequestIdentity, namespace string, createRoute bool) (bool, error) {
+	resources := agentDeployBaseResources
+	if createRoute {
+		resources = append(append([]struct {
+			group    string
+			resource string
+		}{}, resources...), agentDeployRouteResource)
+	}
+	for _, r := range resources {
 		allowed, err := kc.subjectAccessReviewGroup(ctx, identity, namespace, "", r.group, r.resource, "create")
 		if err != nil {
 			return false, err
@@ -77,8 +88,15 @@ func (kc *InternalKubernetesClient) CanDeployAgentInNamespace(ctx context.Contex
 	return true, nil
 }
 
-func (kc *TokenKubernetesClient) CanDeployAgentInNamespace(ctx context.Context, _ *RequestIdentity, namespace string) (bool, error) {
-	for _, r := range agentDeployResources {
+func (kc *TokenKubernetesClient) CanDeployAgentInNamespace(ctx context.Context, _ *RequestIdentity, namespace string, createRoute bool) (bool, error) {
+	resources := agentDeployBaseResources
+	if createRoute {
+		resources = append(append([]struct {
+			group    string
+			resource string
+		}{}, resources...), agentDeployRouteResource)
+	}
+	for _, r := range resources {
 		allowed, err := kc.selfSubjectAccessReviewGroup(ctx, namespace, "", r.group, r.resource, "create")
 		if err != nil {
 			return false, err

--- a/packages/agent-ops/bff/internal/integrations/kubernetes/client.go
+++ b/packages/agent-ops/bff/internal/integrations/kubernetes/client.go
@@ -24,6 +24,9 @@ type KubernetesClientInterface interface {
 	// CanGetAgentInNamespace checks whether the user can get an agent workload
 	// (deployment, statefulset, or job) and its service in the namespace.
 	CanGetAgentInNamespace(ctx context.Context, identity *RequestIdentity, namespace, name string) (bool, error)
+	// CanDeployAgentInNamespace checks whether the user can create all resources
+	// required for an agent deployment (serviceaccounts, deployments, services, agentruntimes).
+	CanDeployAgentInNamespace(ctx context.Context, identity *RequestIdentity, namespace string) (bool, error)
 	// CanAccessAgentCardEnrichment checks SAR/SSAR for optional card enrichment sources.
 	CanAccessAgentCardEnrichment(ctx context.Context, identity *RequestIdentity, namespace, agentRuntimeName string) (AgentCardEnrichmentAccess, error)
 	// KubernetesClientset exposes the underlying clientset for workload reads.

--- a/packages/agent-ops/bff/internal/integrations/kubernetes/client.go
+++ b/packages/agent-ops/bff/internal/integrations/kubernetes/client.go
@@ -25,8 +25,9 @@ type KubernetesClientInterface interface {
 	// (deployment, statefulset, or job) and its service in the namespace.
 	CanGetAgentInNamespace(ctx context.Context, identity *RequestIdentity, namespace, name string) (bool, error)
 	// CanDeployAgentInNamespace checks whether the user can create all resources
-	// required for an agent deployment (serviceaccounts, deployments, services, agentruntimes).
-	CanDeployAgentInNamespace(ctx context.Context, identity *RequestIdentity, namespace string) (bool, error)
+	// required for an agent deployment (serviceaccounts, deployments, services, agentruntimes,
+	// and routes when createRoute is true).
+	CanDeployAgentInNamespace(ctx context.Context, identity *RequestIdentity, namespace string, createRoute bool) (bool, error)
 	// CanAccessAgentCardEnrichment checks SAR/SSAR for optional card enrichment sources.
 	CanAccessAgentCardEnrichment(ctx context.Context, identity *RequestIdentity, namespace, agentRuntimeName string) (AgentCardEnrichmentAccess, error)
 	// KubernetesClientset exposes the underlying clientset for workload reads.

--- a/packages/agent-ops/bff/internal/models/deploy.go
+++ b/packages/agent-ops/bff/internal/models/deploy.go
@@ -1,0 +1,43 @@
+package models
+
+type EnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type ServicePort struct {
+	Name       string `json:"name"`
+	Port       int32  `json:"port"`
+	TargetPort int32  `json:"targetPort"`
+	Protocol   string `json:"protocol,omitempty"`
+}
+
+type DeployAgentRequest struct {
+	Name              string        `json:"name"`
+	Namespace         string        `json:"namespace"`
+	ContainerImage    string        `json:"containerImage"`
+	ImageTag          string        `json:"imageTag"`
+	ImagePullSecret   string        `json:"imagePullSecret,omitempty"`
+	Protocol          string        `json:"protocol,omitempty"`
+	Framework         string        `json:"framework,omitempty"`
+	EnvVars           []EnvVar      `json:"envVars,omitempty"`
+	ServicePorts      []ServicePort `json:"servicePorts,omitempty"`
+	CreateRoute       bool          `json:"createRoute,omitempty"`
+	AuthBridgeEnabled *bool         `json:"authBridgeEnabled,omitempty"`
+	AuthBridgeMode    string        `json:"authBridgeMode,omitempty"`
+	MTLSMode          string        `json:"mtlsMode,omitempty"`
+}
+
+type DeployAgentResponse struct {
+	Success   bool   `json:"success"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Message   string `json:"message"`
+}
+
+type AgentLifecycleResponse struct {
+	Success   bool   `json:"success"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Message   string `json:"message"`
+}

--- a/packages/agent-ops/bff/internal/models/deploy.go
+++ b/packages/agent-ops/bff/internal/models/deploy.go
@@ -34,10 +34,3 @@ type DeployAgentResponse struct {
 	Namespace string `json:"namespace"`
 	Message   string `json:"message"`
 }
-
-type AgentLifecycleResponse struct {
-	Success   bool   `json:"success"`
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-	Message   string `json:"message"`
-}

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
@@ -108,6 +108,10 @@ func translateAgentError(err error) error {
 		return bfferrors.ErrAlreadyExists
 	}
 
+	if errors.Is(err, agents.ErrConflict) {
+		return bfferrors.ErrAlreadyExists
+	}
+
 	if errors.Is(err, agents.ErrForbidden) {
 		return bfferrors.ErrForbidden
 	}

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
@@ -75,6 +75,26 @@ func (r *AgentRuntimesRepository) GetAgentRuntimeDetail(ctx context.Context, nam
 	return mapper.AgentDetailToRuntimeDetail(detail), nil
 }
 
+// DeployAgent deploys a new agent via the agent data source.
+func (r *AgentRuntimesRepository) DeployAgent(ctx context.Context, params *agents.DeployAgentParams) (*models.DeployAgentResponse, error) {
+	client, err := r.agentSourceFactory.GetClient(ctx)
+	if err != nil {
+		return nil, translateAgentError(err)
+	}
+
+	result, err := client.DeployAgent(ctx, params)
+	if err != nil {
+		return nil, translateAgentError(err)
+	}
+
+	return &models.DeployAgentResponse{
+		Success:   true,
+		Name:      result.Name,
+		Namespace: result.Namespace,
+		Message:   "Agent deployed successfully",
+	}, nil
+}
+
 func translateAgentError(err error) error {
 	if err == nil {
 		return nil
@@ -82,6 +102,10 @@ func translateAgentError(err error) error {
 
 	if errors.Is(err, agents.ErrNotFound) {
 		return bfferrors.ErrNotFound
+	}
+
+	if errors.Is(err, agents.ErrAlreadyExists) {
+		return bfferrors.ErrAlreadyExists
 	}
 
 	if errors.Is(err, agents.ErrForbidden) {

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
@@ -52,6 +52,14 @@ func (nilAgentDetailClient) GetAgent(context.Context, string, string) (*agents.A
 	return nil, nil
 }
 
+func (nilAgentDetailClient) DeployAgent(context.Context, *agents.DeployAgentParams) (*agents.DeployAgentResult, error) {
+	return nil, nil
+}
+
+func (nilAgentDetailClient) DeleteAgent(context.Context, string, string) error { return nil }
+func (nilAgentDetailClient) StopAgent(context.Context, string, string) error   { return nil }
+func (nilAgentDetailClient) StartAgent(context.Context, string, string) error  { return nil }
+
 func TestPaginateAgentRuntimes(t *testing.T) {
 	runtimes := []models.AgentRuntime{
 		{Name: "agent-b", Namespace: "ns-a"},

--- a/packages/agent-ops/contract-tests/__tests__/testAgentOpsContract.test.ts
+++ b/packages/agent-ops/contract-tests/__tests__/testAgentOpsContract.test.ts
@@ -74,4 +74,58 @@ describe('Agent Ops API Contract Tests', () => {
       });
     });
   });
+
+  describe('Deploy Agent Endpoint', () => {
+    it('should deploy an agent with minimal params', async () => {
+      const result = await apiClient.post('/api/v1/agents/deploy', {
+        name: 'contract-test-agent',
+        namespace: 'default',
+        containerImage: 'quay.io/example/agent',
+        imageTag: 'latest',
+      });
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/DeployAgentResponse/content/application~1json/schema',
+        status: 201,
+      });
+    });
+
+    it('should return 400 for missing required fields', async () => {
+      const result = await apiClient.post('/api/v1/agents/deploy', {
+        name: 'bad-agent',
+        namespace: 'default',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(400);
+      }
+    });
+
+    it('should return 400 for an invalid namespace', async () => {
+      const result = await apiClient.post('/api/v1/agents/deploy', {
+        name: 'bad-agent',
+        namespace: 'INVALID_NS',
+        containerImage: 'quay.io/example/agent',
+        imageTag: 'latest',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(400);
+      }
+    });
+
+    it('should return 409 for duplicate deployment', async () => {
+      const body = {
+        name: 'dup-agent',
+        namespace: 'default',
+        containerImage: 'quay.io/example/agent',
+        imageTag: 'latest',
+      };
+      await apiClient.post('/api/v1/agents/deploy', body);
+      const result = await apiClient.post('/api/v1/agents/deploy', body);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.status).toBe(409);
+      }
+    });
+  });
 });

--- a/packages/agent-ops/contract-tests/__tests__/testAgentOpsContract.test.ts
+++ b/packages/agent-ops/contract-tests/__tests__/testAgentOpsContract.test.ts
@@ -120,7 +120,8 @@ describe('Agent Ops API Contract Tests', () => {
         containerImage: 'quay.io/example/agent',
         imageTag: 'latest',
       };
-      await apiClient.post('/api/v1/agents/deploy', body);
+      const firstResult = await apiClient.post('/api/v1/agents/deploy', body);
+      expect(firstResult.success).toBe(true);
       const result = await apiClient.post('/api/v1/agents/deploy', body);
       expect(result.success).toBe(false);
       if (!result.success) {

--- a/packages/agent-ops/package.json
+++ b/packages/agent-ops/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "install:module": "npm install --prefix frontend",
-    "test:contract": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client --mock-http-client --auth-method=internal' odh-ct-bff-consumer --bff-dir bff",
+    "test:contract": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client --mock-agent-client --mock-http-client --auth-method=internal' odh-ct-bff-consumer --bff-dir bff",
     "test:contract:cluster": "cross-env AGENT_OPS_CONTRACT_CLUSTER=true BFF_MOCK_FLAGS='--mock-k8s-client=false --mock-http-client=false --deployment-mode=federated --auth-method=user_token --auth-token-header=x-forwarded-access-token --auth-token-prefix= --insecure-skip-verify=true' odh-ct-bff-consumer --bff-dir bff",
     "cypress:server:build": "cd frontend && DIST_DIR=./public-cypress DEPLOYMENT_MODE=federated npm run build",
     "cypress:server:build:coverage": "COVERAGE=true npm run cypress:server:build",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62713

## Description

Implements the `POST /api/v1/agents/deploy` BFF endpoint that creates all Kubernetes resources needed for a new agent deployment. This is the backend for the Mode 1 (BYO image) deploy wizard in the 3.5 agent catalog feature.

The BFF creates resources directly via K8s API (no kagenti-backend dependency):
1. **ServiceAccount** — for SPIFFE identity derivation
2. **AgentRuntime CR** (`agent.kagenti.dev/v1alpha1`) — triggers operator sidecar injection
3. **Deployment** — user's container image with kagenti labels and OpenShift security context
4. **Service** — ClusterIP pointing at Deployment pods
5. **OpenShift Route** — optional, TLS edge termination

Key features:
- Manifest output aligned with kagenti backend (`agents.py`) — same labels, env vars, volumes, selectors, resource limits
- Closure-based rollback stack for partial failure cleanup
- RBAC pre-check via `CanDeployAgentInNamespace` (SAR/SSAR for all 5 resource types)
- Request validation (DNS1123 names, enum fields for protocol/authBridgeMode/mtlsMode, port ranges)
- Default env vars auto-injected: `AGENT_ENDPOINT`, `PORT`, `HOST`, `UV_CACHE_DIR`
- AgentRuntime and ServiceAccount AlreadyExists handled gracefully (idempotent retries)

Lifecycle endpoints (delete, stop, start) are tracked separately in [RHOAIENG-69644](https://issues.redhat.com/browse/RHOAIENG-69644).

## How Has This Been Tested?

### Automated
- `go build ./...` — compiles cleanly
- `go test ./...` — all test suites pass (manifest builders, deploy orchestration, handler, RBAC)
- `go vet ./...` — no issues

### Manual — against live cluster (`ui-razzmatazz`)

**Prerequisites:**
- Cluster with kagenti operator installed
- A namespace with `kagenti-enabled: "true"` label (e.g., `team1`)
- `oc` CLI logged in

**1. Start the BFF locally:**
```bash
cd packages/agent-ops/bff

go run ./cmd \
  --port=4000 \
  --auth-method=user_token \
  --auth-token-header=Authorization \
  --auth-token-prefix="Bearer " \
  --mock-k8s-client=false \
  --mock-agent-client=false \
  --dev-mode=true \
  --deployment-mode=standalone \
  --log-level=info \
  --insecure-skip-verify=true
```

**2. Get your OCP token:**
```bash
TOKEN=$(oc whoami -t)
```

**3. Deploy an agent (using kagenti weather_service example image):**
```bash
curl -s -X POST \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "test-agent",
    "namespace": "team1",
    "containerImage": "ghcr.io/kagenti/agent-examples/weather_service",
    "imageTag": "v0.1.0-alpha.1",
    "protocol": "a2a",
    "framework": "LangGraph",
    "createRoute": false,
    "envVars": [
      {"name": "LLM_API_BASE", "value": "http://host.docker.internal:11434/v1"},
      {"name": "LLM_API_KEY", "value": "dummy"},
      {"name": "LLM_MODEL", "value": "llama3.2:3b-instruct-fp16"}
    ]
  }' \
  http://localhost:4000/api/v1/agents/deploy | jq .
```

**4. Verify resources were created:**
```bash
oc get sa,deploy,svc,agentruntime -n team1 -l app.kubernetes.io/name=test-agent
```

**5. Test error cases:**
```bash
# Duplicate deploy (expect 409)
curl -s -w "\n%{http_code}" -X POST -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"test-agent","namespace":"team1","containerImage":"img","imageTag":"v1"}' \
  http://localhost:4000/api/v1/agents/deploy

# Bad request - empty name (expect 400)
curl -s -w "\n%{http_code}" -X POST -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"","namespace":"team1","containerImage":"img","imageTag":"v1"}' \
  http://localhost:4000/api/v1/agents/deploy

# No auth token (expect 401)
curl -s -w "\n%{http_code}" -X POST \
  -H "Content-Type: application/json" \
  -d '{"name":"x","namespace":"team1","containerImage":"img","imageTag":"v1"}' \
  http://localhost:4000/api/v1/agents/deploy
```

**6. Cleanup:**
```bash
oc delete agentruntime test-agent -n team1
oc delete svc test-agent -n team1
oc delete deploy test-agent -n team1
oc delete sa test-agent -n team1
```

## Test Impact

- Added `manifests_test.go` — table-driven tests for all manifest builder functions (labels, selectors, security context, defaults, custom ports/env vars, resource limits)
- Added `deploy_test.go` — tests for the deploy orchestration with fake K8s clientset (success, with-route, nil-params, SA-already-exists, full-params)
- Updated existing test files (`client_test.go`, `middleware_test.go`, `agent_runtimes_test.go`) for interface compliance

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an agent deployment endpoint (`POST /api/v1/agents/deploy`) with support for environment variables, service port mappings, auth/MTLS settings, and optional route creation.
  * Added deploy request validation and sensible defaults.
  * Updated OpenAPI documentation and expanded contract tests for the new endpoint.

* **Bug Fixes**
  * Duplicate deployment attempts now consistently return **409 Conflict** with the expected conflict payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->