### PR TITLE
Update subscription search placeholder text

### DIFF
--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsToolbar.tsx
@@ -28,8 +28,9 @@ const SubscriptionsToolbar: React.FC<SubscriptionsToolbarProps> = ({
       <ToolbarGroup>
         <ToolbarItem>
           <SearchInput
-            aria-label="Search subscriptions"
-            placeholder="Search..."
+            aria-label="Filter by subscription or model name"
+            placeholder="Filter by subscription or model name"
+            style={{ minWidth: '350px' }}
             data-testid="subscriptions-search-input"
             value={searchValue}
             onChange={(_event, value) => onSearchChange(value)}


### PR DESCRIPTION
Closes: [RHOAIENG-69441](https://redhat.atlassian.net/browse/RHOAIENG-69441)

## Description
Implements changes from https://github.com/opendatahub-io/odh-dashboard/pull/8154
Updates the placeholder text in the search bar for the API subscriptions tab

## How Has This Been Tested?
Tested locally

## Test Impact
No tests changed

## Screenshots
<img width="804" height="620" alt="Screenshot 2026-06-17 at 10 49 21 AM" src="https://github.com/user-attachments/assets/a13001a4-300e-4623-bf68-89b55dda1a24" />

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated filter input labels in the subscriptions toolbar for improved clarity. The filter now displays "Filter by subscription or model name" to better reflect its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->