### PR TITLE
Update api key count label to active only

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -956,8 +956,8 @@ describe('API keys (mySubscriptions feature flag)', () => {
     subscriptionsTab.findSubscriptionsTable().should('contain.text', 'Premium Team');
     subscriptionsTab.findSubscriptionsTable().should('contain.text', 'Basic Team');
 
-    subscriptionsTab.findSubscriptionRows().eq(0).should('contain.text', '10+ keys');
-    subscriptionsTab.findSubscriptionRows().eq(1).should('contain.text', '5 keys');
+    subscriptionsTab.findSubscriptionRows().eq(0).should('contain.text', '10+ active keys');
+    subscriptionsTab.findSubscriptionRows().eq(1).should('contain.text', '5 active keys');
 
     subscriptionsTab.findSearchInput().type('Premium');
     subscriptionsTab.findSubscriptionRows().should('have.length', 1);

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -1019,7 +1019,7 @@ describe('API keys (mySubscriptions feature flag)', () => {
     apiKeysPage.findSubscriptionsTab().click();
     subscriptionsTab.findSubscriptionRows().should('have.length', 1);
     subscriptionsTab.findSubscriptionRows().eq(0).should('contain.text', 'No Keys Sub');
-    subscriptionsTab.findSubscriptionRows().eq(0).should('contain.text', '0 keys');
+    subscriptionsTab.findSubscriptionRows().eq(0).should('contain.text', '0 active keys');
   });
 
   it('should show empty state when no subscriptions exist', () => {

--- a/packages/maas/bff/internal/api/api_keys_handlers.go
+++ b/packages/maas/bff/internal/api/api_keys_handlers.go
@@ -58,7 +58,10 @@ func ListSubscriptionsPassthroughHandler(app *App, w http.ResponseWriter, r *htt
 func enrichSubscriptionsWithKeyCount(app *App, r *http.Request, subscriptions []models.SubscriptionListItem) {
 	for i := range subscriptions {
 		resp, err := app.repositories.APIKeys.SearchAPIKeys(r.Context(), models.APIKeySearchRequest{
-			Filters:    &models.APIKeySearchFilters{Subscription: subscriptions[i].SubscriptionIDHeader},
+			Filters: &models.APIKeySearchFilters{
+				Subscription: subscriptions[i].SubscriptionIDHeader,
+				Status:       []string{models.APIKeyStatusActive},
+			},
 			Pagination: &models.APIKeySearchPagination{Limit: subscriptionKeyCountCap},
 		})
 		if err != nil {

--- a/packages/maas/frontend/src/app/components/ApiKeyCountLabel.tsx
+++ b/packages/maas/frontend/src/app/components/ApiKeyCountLabel.tsx
@@ -20,7 +20,7 @@ const ApiKeyCountLabel: React.FC<ApiKeyCountLabelProps> = ({ keyCount }) => {
 
   const isCapped = keyCount >= SUBSCRIPTION_KEY_COUNT_CAP;
   const displayCount = isCapped ? `${SUBSCRIPTION_KEY_COUNT_CAP}+` : `${keyCount}`;
-  const displayUnit = !isCapped && keyCount === 1 ? 'key' : 'keys';
+  const displayUnit = !isCapped && keyCount === 1 ? 'active key' : 'active keys';
 
   return (
     <Label isCompact icon={<KeyIcon />} color={keyCount > 0 ? 'green' : 'grey'}>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-69444
## Description
Change the key count for subs to count only active keys
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Tested in the My Subscriptions page (both model and subs views)
revoked a key in one of the subs
See the key count decrease
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Updated existing cypress tests
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Corrected API key count calculations to include only active keys when displaying subscription key-count badges.
- Updated API key count badge labeling to use “active key” for singular and “active keys” for plural, including the “0 active keys” case.

**Tests**
- Adjusted UI assertions for the mySubscriptions → subscriptions tab to match the updated “active keys” badge wording and counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->