### PR TITLE
Feat(RHOAIENG-68463):Add banner for Kueue enabled project

### DIFF
--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -151,13 +151,19 @@ const ProjectDetails: React.FC = () => {
           </Alert>
         </Flex>
       )}
-      {isKueueManaged && (
+      {isKueueManaged && !isKueueAlertDismissed && (
         <Flex direction={{ default: 'column' }} className="pf-v6-u-px-lg">
           <Alert
             data-testid="kueue-managed-alert-project-details"
             variant="info"
             isInline
             title="This project uses Kueue for workload scheduling"
+            actionClose={
+              <AlertActionCloseButton
+                data-testid="kueue-managed-alert-close"
+                onClose={handleKueueAlertClose}
+              />
+            }
           />
         </Flex>
       )}

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -75,7 +75,10 @@ const ProjectDetails: React.FC = () => {
 
   useCheckLogoutParams();
 
-  const { isKueueDisabled } = useKueueConfiguration(currentProject);
+  const { isKueueDisabled, isProjectKueueEnabled, isKueueFeatureEnabled } =
+    useKueueConfiguration(currentProject);
+
+  const isKueueManaged = isProjectKueueEnabled && isKueueFeatureEnabled;
 
   const [isKueueAlertDismissed, setIsKueueAlertDismissed] = React.useState(false);
 
@@ -146,6 +149,16 @@ const ProjectDetails: React.FC = () => {
               </Button>
             </Popover>
           </Alert>
+        </Flex>
+      )}
+      {isKueueManaged && (
+        <Flex direction={{ default: 'column' }} className="pf-v6-u-px-lg">
+          <Alert
+            data-testid="kueue-managed-alert-project-details"
+            variant="info"
+            isInline
+            title="This project uses Kueue for workload scheduling"
+          />
         </Flex>
       )}
 

--- a/frontend/src/pages/projects/screens/detail/__tests__/ProjectDetails.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/__tests__/ProjectDetails.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import ProjectDetails from '#~/pages/projects/screens/detail/ProjectDetails';
@@ -121,6 +121,21 @@ describe('ProjectDetails', () => {
       renderProjectDetails();
 
       expect(screen.getByTestId('kueue-disabled-alert-project-details')).toBeInTheDocument();
+      expect(screen.queryByTestId('kueue-managed-alert-project-details')).not.toBeInTheDocument();
+    });
+
+    it('should hide the managed indicator when the close button is clicked', () => {
+      mockUseKueueConfiguration.mockReturnValue({
+        isKueueDisabled: false,
+        isKueueFeatureEnabled: true,
+        isProjectKueueEnabled: true,
+        kueueFilteringState: KueueFilteringState.ONLY_KUEUE_PROFILES,
+      });
+
+      renderProjectDetails();
+
+      expect(screen.getByTestId('kueue-managed-alert-project-details')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('kueue-managed-alert-close'));
       expect(screen.queryByTestId('kueue-managed-alert-project-details')).not.toBeInTheDocument();
     });
 

--- a/frontend/src/pages/projects/screens/detail/__tests__/ProjectDetails.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/__tests__/ProjectDetails.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
+import { useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import ProjectDetails from '#~/pages/projects/screens/detail/ProjectDetails';
 import {
   ProjectDetailsContext,
@@ -11,7 +12,6 @@ import {
   useKueueConfiguration,
   KueueFilteringState,
 } from '#~/concepts/hardwareProfiles/kueueUtils';
-import { useIsAreaAvailable } from '#~/concepts/areas';
 import { useDeploymentsTab } from '#~/concepts/projects/projectDetails/useDeploymentsTab';
 import {
   useProjectPermissionsTabVisible,
@@ -31,8 +31,8 @@ jest.mock('#~/concepts/hardwareProfiles/kueueUtils', () => ({
   useKueueConfiguration: jest.fn(),
 }));
 
-jest.mock('#~/concepts/areas', () => ({
-  ...jest.requireActual('#~/concepts/areas'),
+jest.mock('@odh-dashboard/plugin-core/areas', () => ({
+  ...jest.requireActual('@odh-dashboard/plugin-core/areas'),
   useIsAreaAvailable: jest.fn(),
 }));
 

--- a/frontend/src/pages/projects/screens/detail/__tests__/ProjectDetails.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/__tests__/ProjectDetails.spec.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import ProjectDetails from '#~/pages/projects/screens/detail/ProjectDetails';
+import {
+  ProjectDetailsContext,
+  type ProjectDetailsContextType,
+} from '#~/pages/projects/ProjectDetailsContext';
+import {
+  useKueueConfiguration,
+  KueueFilteringState,
+} from '#~/concepts/hardwareProfiles/kueueUtils';
+import { useIsAreaAvailable } from '#~/concepts/areas';
+import { useDeploymentsTab } from '#~/concepts/projects/projectDetails/useDeploymentsTab';
+import {
+  useProjectPermissionsTabVisible,
+  useProjectRolesTabVisible,
+} from '#~/concepts/projects/accessChecks';
+import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
+
+jest.mock('#~/pages/ApplicationsPage', () =>
+  // eslint-disable-next-line react/display-name
+  ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+);
+
+jest.mock('#~/pages/projects/components/GenericHorizontalBar', () => () => null);
+
+jest.mock('#~/concepts/hardwareProfiles/kueueUtils', () => ({
+  ...jest.requireActual('#~/concepts/hardwareProfiles/kueueUtils'),
+  useKueueConfiguration: jest.fn(),
+}));
+
+jest.mock('#~/concepts/areas', () => ({
+  ...jest.requireActual('#~/concepts/areas'),
+  useIsAreaAvailable: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/plugin-core', () => ({
+  useExtensions: jest.fn().mockReturnValue([]),
+  isProjectDetailsSettingsCardExtension: jest.fn(),
+}));
+
+jest.mock('#~/concepts/projects/projectDetails/useDeploymentsTab', () => ({
+  useDeploymentsTab: jest.fn(),
+}));
+
+jest.mock('#~/concepts/projects/accessChecks', () => ({
+  useProjectPermissionsTabVisible: jest.fn(),
+  useProjectRolesTabVisible: jest.fn(),
+}));
+
+jest.mock('#~/pages/projects/screens/detail/useCheckLogoutParams', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('#~/pages/projects/screens/detail/ProjectActions', () => () => null);
+
+const mockUseKueueConfiguration = jest.mocked(useKueueConfiguration);
+const mockUseIsAreaAvailable = jest.mocked(useIsAreaAvailable);
+const mockUseDeploymentsTab = jest.mocked(useDeploymentsTab);
+const mockUseProjectPermissionsTabVisible = jest.mocked(useProjectPermissionsTabVisible);
+const mockUseProjectRolesTabVisible = jest.mocked(useProjectRolesTabVisible);
+
+const mockProject = mockProjectK8sResource({ k8sName: 'test-project' });
+
+const defaultAreaAvailability = {
+  status: false,
+  devFlags: {},
+  featureFlags: {},
+  reliantAreas: {},
+  requiredComponents: {},
+  requiredCapabilities: {},
+  customCondition: () => false,
+};
+
+const renderProjectDetails = () =>
+  render(
+    <MemoryRouter>
+      <ProjectDetailsContext.Provider
+        value={{ currentProject: mockProject } as ProjectDetailsContextType}
+      >
+        <ProjectDetails />
+      </ProjectDetailsContext.Provider>
+    </MemoryRouter>,
+  );
+
+describe('ProjectDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseIsAreaAvailable.mockReturnValue(defaultAreaAvailability);
+    mockUseDeploymentsTab.mockReturnValue([]);
+    mockUseProjectPermissionsTabVisible.mockReturnValue([false, true]);
+    mockUseProjectRolesTabVisible.mockReturnValue([false, true]);
+  });
+
+  describe('Kueue managed indicator', () => {
+    it('should show positive Kueue indicator when project is Kueue-managed and feature is enabled', () => {
+      mockUseKueueConfiguration.mockReturnValue({
+        isKueueDisabled: false,
+        isKueueFeatureEnabled: true,
+        isProjectKueueEnabled: true,
+        kueueFilteringState: KueueFilteringState.ONLY_KUEUE_PROFILES,
+      });
+
+      renderProjectDetails();
+
+      expect(screen.getByTestId('kueue-managed-alert-project-details')).toBeInTheDocument();
+      expect(screen.queryByTestId('kueue-disabled-alert-project-details')).not.toBeInTheDocument();
+    });
+
+    it('should show disabled alert and not the managed indicator when Kueue feature is disabled', () => {
+      mockUseKueueConfiguration.mockReturnValue({
+        isKueueDisabled: true,
+        isKueueFeatureEnabled: false,
+        isProjectKueueEnabled: true,
+        kueueFilteringState: KueueFilteringState.NO_PROFILES,
+      });
+
+      renderProjectDetails();
+
+      expect(screen.getByTestId('kueue-disabled-alert-project-details')).toBeInTheDocument();
+      expect(screen.queryByTestId('kueue-managed-alert-project-details')).not.toBeInTheDocument();
+    });
+
+    it('should show neither indicator when project is not Kueue-managed', () => {
+      mockUseKueueConfiguration.mockReturnValue({
+        isKueueDisabled: false,
+        isKueueFeatureEnabled: true,
+        isProjectKueueEnabled: false,
+        kueueFilteringState: KueueFilteringState.ONLY_NON_KUEUE_PROFILES,
+      });
+
+      renderProjectDetails();
+
+      expect(screen.queryByTestId('kueue-managed-alert-project-details')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('kueue-disabled-alert-project-details')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
@@ -619,4 +619,28 @@ describe('Project Details', () => {
       cy.findByTestId('deploy-button').should('have.attr', 'aria-disabled', 'true');
     });
   });
+
+  describe('Kueue managed project', () => {
+    beforeEach(() => {
+      initIntercepts({ disableKueue: false });
+    });
+
+    it('should show positive Kueue indicator when project is Kueue-managed and feature is enabled', () => {
+      const kueueManagedProject = mockProjectK8sResource({ enableKueue: true });
+      cy.interceptK8s(ProjectModel, kueueManagedProject);
+      cy.interceptK8sList(ProjectModel, mockK8sResourceList([kueueManagedProject]));
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.KUEUE]: { managementState: 'Managed' },
+          },
+        }),
+      );
+
+      projectDetails.visit('test-project');
+      cy.findByTestId('kueue-managed-alert-project-details').should('be.visible');
+      cy.findByTestId('kueue-disabled-alert-project-details').should('not.exist');
+    });
+  });
 });


### PR DESCRIPTION
Closes [RHOAIENG-68463](https://issues.redhat.com/browse/RHOAIENG-68463)
## Description

When a project has the `kueue.openshift.io/managed=true` label and Kueue is enabled on the cluster, there was no visual indicator of this on the project details page. 
This PR adds a simple inline info banner ,"This project uses Kueue for workload scheduling" ,so users know their project's workload scheduling is managed by Kueue.

The banner is mutually exclusive with the existing "Kueue is disabled" warning you'll never see both at the same time.

<img width="2522" height="1622" alt="image" src="https://github.com/user-attachments/assets/379769c6-8e38-4714-8f3f-41ba5cf4b58e" />

## How Has This Been Tested?

Added unit tests (Jest) and a Cypress mocked test covering:
- Banner shows when the project has the Kueue label and Kueue is enabled
- "Kueue disabled" warning shows instead when Kueue is globally off
- Neither banner shows for a non-Kueue project

## Test Impact

- Added `ProjectDetails.spec.tsx` with 3 unit tests
- Added a new Cypress mocked test in `projectDetails.cy.ts`

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new dismissible informational alert on the Project Details page when the project is Kueue-managed for workload scheduling.

* **Bug Fixes**
  * Updated the alert logic to accurately display the correct Kueue message based on project management status and feature availability.

* **Tests**
  * Added unit tests covering managed, disabled, and no-alert scenarios, including alert dismissal.
  * Added a Cypress test to verify the managed alert visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->