### PR TITLE
RHOAIENG-63157: Implement Form/YAML toggle and YAML preview

### DIFF
--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -108,7 +108,9 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
     setSubmitError(undefined);
     const k8sName = k8sNameDescriptionData.data.k8sName.value;
     const roleDisplayName = k8sNameDescriptionData.data.name || k8sName;
-    const labelRecord = Object.fromEntries(labels.map((l) => [l.key, l.value]));
+    const labelRecord = Object.fromEntries(
+      labels.filter((l) => l.key).map((l) => [l.key, l.value]),
+    );
     const role = assembleRole(namespace, k8sName, roleDisplayName, description, rules, labelRecord);
     try {
       await createRole(role);
@@ -195,7 +197,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
               onRulesChange={handleRulesChange}
             />
           </div>
-          <div hidden={viewMode !== 'yaml'}>
+          {viewMode === 'yaml' && (
             <CreateRoleYamlView
               namespace={namespace}
               k8sName={k8sNameDescriptionData.data.k8sName.value}
@@ -206,7 +208,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
               rules={rules}
               labels={labels}
             />
-          </div>
+          )}
         </PageSection>
         <PageSection hasBodyWrapper={false} stickyOnBreakpoint={{ default: 'bottom' }}>
           <CreateRoleFooter

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -4,8 +4,11 @@ import {
   BreadcrumbItem,
   Bullseye,
   Button,
+  Flex,
   PageSection,
   Spinner,
+  ToggleGroup,
+  ToggleGroupItem,
   getUniqueId,
 } from '@patternfly/react-core';
 import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
@@ -19,8 +22,11 @@ import { createRole } from '#~/api';
 import CreateRoleForm from './CreateRoleForm';
 import CreateRoleFooter from './CreateRoleFooter';
 import CreateRoleConfirmModal from './CreateRoleConfirmModal';
+import CreateRoleYamlView from './CreateRoleYamlView';
 import assembleRole from './assembleRole';
 import type { LabelEntry, RuleEntry } from './types';
+
+type ViewMode = 'form' | 'yaml';
 
 type CreateRolePageProps = {
   existingRole?: RoleKind;
@@ -66,6 +72,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
     }));
   });
 
+  const [viewMode, setViewMode] = React.useState<ViewMode>('form');
   const [submitError, setSubmitError] = React.useState<Error>();
   const [showNoRulesConfirm, setShowNoRulesConfirm] = React.useState(false);
 
@@ -150,24 +157,55 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
         }
         description="Create a custom role to control what users can see and do across your cluster resources. Define permissions, navigation access, and resource scopes to implement fine-grained access control."
         headerAction={
-          // TODO: Enable when template selection modal is implemented (RHOAIENG-63156)
-          <Button variant="secondary" data-testid="select-role-template-button" isDisabled>
-            Select role template
-          </Button>
+          <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }}>
+            {/* TODO: Enable when template selection modal is implemented (RHOAIENG-63156) */}
+            <Button variant="secondary" data-testid="select-role-template-button" isDisabled>
+              Select role template
+            </Button>
+            <ToggleGroup aria-label="Form or YAML view toggle" data-testid="form-yaml-toggle">
+              <ToggleGroupItem
+                text="Form"
+                buttonId="form-view-toggle"
+                data-testid="form-view-toggle"
+                isSelected={viewMode === 'form'}
+                onChange={() => setViewMode('form')}
+              />
+              <ToggleGroupItem
+                text="YAML (read-only)"
+                buttonId="yaml-view-toggle"
+                data-testid="yaml-view-toggle"
+                isSelected={viewMode === 'yaml'}
+                onChange={() => setViewMode('yaml')}
+              />
+            </ToggleGroup>
+          </Flex>
         }
         loaded
         empty={false}
       >
         <PageSection hasBodyWrapper={false} isFilled data-testid="create-role-page">
-          <CreateRoleForm
-            nameDescriptionData={k8sNameDescriptionData}
-            description={description}
-            onDescriptionChange={handleDescriptionChange}
-            labels={labels}
-            onLabelsChange={handleLabelsChange}
-            rules={rules}
-            onRulesChange={handleRulesChange}
-          />
+          {viewMode === 'form' ? (
+            <CreateRoleForm
+              nameDescriptionData={k8sNameDescriptionData}
+              description={description}
+              onDescriptionChange={handleDescriptionChange}
+              labels={labels}
+              onLabelsChange={handleLabelsChange}
+              rules={rules}
+              onRulesChange={handleRulesChange}
+            />
+          ) : (
+            <CreateRoleYamlView
+              namespace={namespace}
+              k8sName={k8sNameDescriptionData.data.k8sName.value}
+              displayName={
+                k8sNameDescriptionData.data.name || k8sNameDescriptionData.data.k8sName.value
+              }
+              description={description}
+              rules={rules}
+              labels={labels}
+            />
+          )}
         </PageSection>
         <PageSection hasBodyWrapper={false} stickyOnBreakpoint={{ default: 'bottom' }}>
           <CreateRoleFooter

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -184,7 +184,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
         empty={false}
       >
         <PageSection hasBodyWrapper={false} isFilled data-testid="create-role-page">
-          {viewMode === 'form' ? (
+          <div hidden={viewMode !== 'form'}>
             <CreateRoleForm
               nameDescriptionData={k8sNameDescriptionData}
               description={description}
@@ -194,7 +194,8 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
               rules={rules}
               onRulesChange={handleRulesChange}
             />
-          ) : (
+          </div>
+          <div hidden={viewMode !== 'yaml'}>
             <CreateRoleYamlView
               namespace={namespace}
               k8sName={k8sNameDescriptionData.data.k8sName.value}
@@ -205,7 +206,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
               rules={rules}
               labels={labels}
             />
-          )}
+          </div>
         </PageSection>
         <PageSection hasBodyWrapper={false} stickyOnBreakpoint={{ default: 'bottom' }}>
           <CreateRoleFooter

--- a/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import {
+  Button,
+  Content,
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  Title,
+  Tooltip,
+} from '@patternfly/react-core';
+import { Language } from '@patternfly/react-code-editor';
+import { CompressArrowsAltIcon } from '@patternfly/react-icons/dist/esm/icons/compress-arrows-alt-icon';
+import { ExpandArrowsAltIcon } from '@patternfly/react-icons/dist/esm/icons/expand-arrows-alt-icon';
+import YAML from 'yaml';
+import DashboardCodeEditor from '#~/concepts/dashboard/codeEditor/DashboardCodeEditor';
+import assembleRole from './assembleRole';
+import type { LabelEntry, RuleEntry } from './types';
+
+type CreateRoleYamlViewProps = {
+  namespace: string;
+  k8sName: string;
+  displayName: string;
+  description: string;
+  rules: RuleEntry[];
+  labels: LabelEntry[];
+};
+
+const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
+  namespace,
+  k8sName,
+  displayName,
+  description,
+  rules,
+  labels,
+}) => {
+  const [isFullScreen, setIsFullScreen] = React.useState(false);
+  const editorContainerRef = React.useRef<HTMLDivElement>(null);
+
+  const labelRecord = React.useMemo(
+    () => Object.fromEntries(labels.filter((l) => l.key).map((l) => [l.key, l.value])),
+    [labels],
+  );
+
+  const yamlContent = React.useMemo(() => {
+    const role = assembleRole(
+      namespace,
+      k8sName,
+      displayName || k8sName,
+      description,
+      rules,
+      labelRecord,
+    );
+    return YAML.stringify(role);
+  }, [namespace, k8sName, displayName, description, rules, labelRecord]);
+
+  React.useEffect(() => {
+    const handleFullScreenChange = () => {
+      setIsFullScreen(!!document.fullscreenElement);
+    };
+    document.addEventListener('fullscreenchange', handleFullScreenChange);
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullScreenChange);
+    };
+  }, []);
+
+  const onFullScreenToggle = () => {
+    if (!isFullScreen) {
+      editorContainerRef.current?.requestFullscreen();
+    } else if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+  };
+
+  const customControls = (
+    <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+      <FlexItem>
+        <Tooltip content={isFullScreen ? 'Exit full screen' : 'Full screen'}>
+          <Button
+            variant="plain"
+            aria-label={isFullScreen ? 'Exit full screen' : 'Full screen'}
+            data-testid="yaml-fullscreen-toggle"
+            onClick={onFullScreenToggle}
+            icon={isFullScreen ? <CompressArrowsAltIcon /> : <ExpandArrowsAltIcon />}
+          />
+        </Tooltip>
+      </FlexItem>
+      <FlexItem>
+        <Content component="small">YAML (read-only)</Content>
+      </FlexItem>
+    </Flex>
+  );
+
+  return (
+    <Stack hasGutter data-testid="create-role-yaml-view">
+      <StackItem>
+        <Title headingLevel="h2" size="md" data-testid="yaml-view-title">
+          Role configuration YAML
+        </Title>
+      </StackItem>
+      <StackItem>
+        <Content component="p" data-testid="yaml-view-description">
+          View the live, read-only YAML for this role. This preview automatically updates to reflect
+          changes you make in <strong>Form</strong> view.
+        </Content>
+      </StackItem>
+      <StackItem isFilled>
+        <div
+          ref={editorContainerRef}
+          data-testid="yaml-editor-container"
+          style={{ background: 'var(--pf-t--global--background--color--primary--default)' }}
+        >
+          <DashboardCodeEditor
+            code={yamlContent}
+            isReadOnly
+            isLanguageLabelVisible
+            isCopyEnabled
+            isDownloadEnabled
+            downloadFileName={`${k8sName || 'untitled-role'}.yaml`}
+            language={Language.yaml}
+            codeEditorHeight={isFullScreen ? '100vh' : '500px'}
+            testId="yaml-code-editor"
+            customControls={customControls}
+          />
+        </div>
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default CreateRoleYamlView;

--- a/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
@@ -10,8 +10,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { Language } from '@patternfly/react-code-editor';
-import { CompressArrowsAltIcon } from '@patternfly/react-icons/dist/esm/icons/compress-arrows-alt-icon';
-import { ExpandArrowsAltIcon } from '@patternfly/react-icons/dist/esm/icons/expand-arrows-alt-icon';
+import { CompressArrowsAltIcon, ExpandArrowsAltIcon } from '@patternfly/react-icons';
 import YAML from 'yaml';
 import DashboardCodeEditor from '#~/concepts/dashboard/codeEditor/DashboardCodeEditor';
 import assembleRole from './assembleRole';
@@ -56,7 +55,7 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
 
   React.useEffect(() => {
     const handleFullScreenChange = () => {
-      setIsFullScreen(!!document.fullscreenElement);
+      setIsFullScreen(document.fullscreenElement === editorContainerRef.current);
     };
     document.addEventListener('fullscreenchange', handleFullScreenChange);
     return () => {
@@ -67,7 +66,7 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
   const onFullScreenToggle = () => {
     if (!isFullScreen) {
       editorContainerRef.current?.requestFullscreen();
-    } else if (document.fullscreenElement) {
+    } else if (document.fullscreenElement === editorContainerRef.current) {
       document.exitFullscreen();
     }
   };
@@ -105,6 +104,7 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
         </Content>
       </StackItem>
       <StackItem isFilled>
+        {/* PF gap: no pf-v6-u-background-color-100 equivalent in v6 — remove when added */}
         <div
           ref={editorContainerRef}
           data-testid="yaml-editor-container"
@@ -118,7 +118,8 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
             isDownloadEnabled
             downloadFileName={`${k8sName || 'untitled-role'}.yaml`}
             language={Language.yaml}
-            codeEditorHeight={isFullScreen ? '100vh' : '500px'}
+            height={isFullScreen ? '100%' : undefined}
+            codeEditorHeight={isFullScreen ? 'calc(100vh - 66px)' : '500px'}
             testId="yaml-code-editor"
             customControls={customControls}
           />

--- a/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
@@ -54,12 +54,16 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
   }, [namespace, k8sName, displayName, description, rules, labelRecord]);
 
   React.useEffect(() => {
+    const container = editorContainerRef.current;
     const handleFullScreenChange = () => {
-      setIsFullScreen(document.fullscreenElement === editorContainerRef.current);
+      setIsFullScreen(document.fullscreenElement === container);
     };
     document.addEventListener('fullscreenchange', handleFullScreenChange);
     return () => {
       document.removeEventListener('fullscreenchange', handleFullScreenChange);
+      if (document.fullscreenElement === container) {
+        document.exitFullscreen();
+      }
     };
   }, []);
 
@@ -74,7 +78,7 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
   const customControls = (
     <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
       <FlexItem>
-        <Tooltip content={isFullScreen ? 'Exit full screen' : 'Full screen'}>
+        <Tooltip content={isFullScreen ? 'Exit full screen' : 'Full screen'} aria="none">
           <Button
             variant="plain"
             aria-label={isFullScreen ? 'Exit full screen' : 'Full screen'}

--- a/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleYamlView.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleYamlView.spec.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import YAML from 'yaml';
+import { KnownLabels } from '#~/k8sTypes';
+import CreateRoleYamlView from '#~/pages/projects/projectRoles/CreateRoleYamlView';
+import type { RuleEntry } from '#~/pages/projects/projectRoles/types';
+
+jest.mock('#~/concepts/dashboard/codeEditor/DashboardCodeEditor', () => {
+  const MockEditor: React.FC<{
+    code: string;
+    testId?: string;
+    isReadOnly?: boolean;
+    customControls?: React.ReactNode;
+  }> = ({ code, testId, isReadOnly, customControls }) => (
+    <div data-testid={testId} data-readonly={isReadOnly}>
+      <pre>{code}</pre>
+      {customControls}
+    </div>
+  );
+  MockEditor.displayName = 'DashboardCodeEditor';
+  return { __esModule: true, default: MockEditor };
+});
+
+describe('CreateRoleYamlView', () => {
+  const defaultProps = {
+    namespace: 'test-ns',
+    k8sName: 'my-role',
+    displayName: 'My Role',
+    description: 'A test role',
+    rules: [] as RuleEntry[],
+    labels: [],
+  };
+
+  it('should render the title and description', () => {
+    render(<CreateRoleYamlView {...defaultProps} />);
+
+    expect(screen.getByTestId('yaml-view-title')).toHaveTextContent('Role configuration YAML');
+    expect(screen.getByTestId('yaml-view-description')).toBeInTheDocument();
+    expect(screen.getByText(/View the live, read-only YAML for this role/)).toBeInTheDocument();
+  });
+
+  it('should render a valid Kubernetes Role YAML', () => {
+    render(<CreateRoleYamlView {...defaultProps} />);
+
+    const editorContent = screen.getByTestId('yaml-code-editor').querySelector('pre')?.textContent;
+    const parsed = YAML.parse(editorContent ?? '');
+
+    expect(parsed).toMatchObject({
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'Role',
+      metadata: {
+        name: 'my-role',
+        namespace: 'test-ns',
+        labels: {
+          [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        },
+        annotations: {
+          'openshift.io/display-name': 'My Role',
+          'openshift.io/description': 'A test role',
+        },
+      },
+      rules: [],
+    });
+  });
+
+  it('should reflect rules in YAML output', () => {
+    const rules: RuleEntry[] = [
+      {
+        id: 'rule-1',
+        verbs: ['get', 'list'],
+        apiGroups: [''],
+        resources: ['pods'],
+      },
+    ];
+
+    render(<CreateRoleYamlView {...defaultProps} rules={rules} />);
+
+    const editorContent = screen.getByTestId('yaml-code-editor').querySelector('pre')?.textContent;
+    const parsed = YAML.parse(editorContent ?? '');
+
+    expect(parsed.rules).toStrictEqual([
+      { verbs: ['get', 'list'], apiGroups: [''], resources: ['pods'] },
+    ]);
+  });
+
+  it('should reflect labels in YAML output', () => {
+    const labels = [
+      { id: 'l1', key: 'team', value: 'platform' },
+      { id: 'l2', key: 'env', value: 'prod' },
+    ];
+
+    render(<CreateRoleYamlView {...defaultProps} labels={labels} />);
+
+    const editorContent = screen.getByTestId('yaml-code-editor').querySelector('pre')?.textContent;
+    const parsed = YAML.parse(editorContent ?? '');
+
+    expect(parsed.metadata.labels).toMatchObject({
+      team: 'platform',
+      env: 'prod',
+      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+    });
+  });
+
+  it('should show empty name when k8sName is empty', () => {
+    render(<CreateRoleYamlView {...defaultProps} k8sName="" displayName="" />);
+
+    const editorContent = screen.getByTestId('yaml-code-editor').querySelector('pre')?.textContent;
+    const parsed = YAML.parse(editorContent ?? '');
+
+    expect(parsed.metadata.name).toBe('');
+  });
+
+  it('should render the full-screen toggle button', () => {
+    render(<CreateRoleYamlView {...defaultProps} />);
+
+    expect(screen.getByTestId('yaml-fullscreen-toggle')).toBeInTheDocument();
+  });
+
+  it('should filter out labels with empty keys', () => {
+    const labels = [
+      { id: 'l1', key: '', value: 'ignored' },
+      { id: 'l2', key: 'valid', value: 'kept' },
+    ];
+
+    render(<CreateRoleYamlView {...defaultProps} labels={labels} />);
+
+    const editorContent = screen.getByTestId('yaml-code-editor').querySelector('pre')?.textContent;
+    const parsed = YAML.parse(editorContent ?? '');
+
+    expect(parsed.metadata.labels).toMatchObject({
+      valid: 'kept',
+      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+    });
+    expect(Object.keys(parsed.metadata.labels)).not.toContain('');
+  });
+});

--- a/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleYamlView.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleYamlView.spec.tsx
@@ -42,6 +42,8 @@ describe('CreateRoleYamlView', () => {
   it('should render a valid Kubernetes Role YAML', () => {
     render(<CreateRoleYamlView {...defaultProps} />);
 
+    expect(screen.getByTestId('yaml-code-editor')).toHaveAttribute('data-readonly', 'true');
+
     const editorContent = screen.getByTestId('yaml-code-editor').querySelector('pre')?.textContent;
     const parsed = YAML.parse(editorContent ?? '');
 

--- a/packages/cypress/cypress/pages/projectRoles.ts
+++ b/packages/cypress/cypress/pages/projectRoles.ts
@@ -154,6 +154,10 @@ class ProjectRolesTab {
     return cy.findByTestId('yaml-code-editor');
   }
 
+  findYamlEditorContainer() {
+    return cy.findByTestId('yaml-editor-container');
+  }
+
   findYamlFullscreenToggle() {
     return cy.findByTestId('yaml-fullscreen-toggle');
   }

--- a/packages/cypress/cypress/pages/projectRoles.ts
+++ b/packages/cypress/cypress/pages/projectRoles.ts
@@ -126,6 +126,38 @@ class ProjectRolesTab {
     return cy.findByTestId('dashboard-empty-table-state');
   }
 
+  findFormYamlToggle() {
+    return cy.findByTestId('form-yaml-toggle');
+  }
+
+  findFormViewToggle() {
+    return cy.findByTestId('form-view-toggle');
+  }
+
+  findYamlViewToggle() {
+    return cy.findByTestId('yaml-view-toggle');
+  }
+
+  findYamlView() {
+    return cy.findByTestId('create-role-yaml-view');
+  }
+
+  findYamlViewTitle() {
+    return cy.findByTestId('yaml-view-title');
+  }
+
+  findYamlViewDescription() {
+    return cy.findByTestId('yaml-view-description');
+  }
+
+  findYamlCodeEditor() {
+    return cy.findByTestId('yaml-code-editor');
+  }
+
+  findYamlFullscreenToggle() {
+    return cy.findByTestId('yaml-fullscreen-toggle');
+  }
+
   findPreviewYAMLModal() {
     return cy.findByTestId('preview-yaml-modal');
   }

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabYamlToggle.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabYamlToggle.cy.ts
@@ -44,7 +44,7 @@ describe('Create Role - Form/YAML toggle', () => {
   });
 
   it('should have Form selected by default', () => {
-    projectRoles.findFormViewToggle().should('have.class', 'pf-m-selected');
+    projectRoles.findFormViewToggle().find('button').should('have.class', 'pf-m-selected');
     projectRoles.findCreateRoleForm().should('exist');
   });
 
@@ -74,12 +74,11 @@ describe('Create Role - Form/YAML toggle', () => {
     projectRoles.findRoleNameInput().type('test-role');
     projectRoles.findYamlViewToggle().click();
 
-    projectRoles
-      .findYamlCodeEditor()
-      .should('contain.text', 'apiVersion: rbac.authorization.k8s.io/v1');
-    projectRoles.findYamlCodeEditor().should('contain.text', 'kind: Role');
-    projectRoles.findYamlCodeEditor().should('contain.text', 'name: test-role');
-    projectRoles.findYamlCodeEditor().should('contain.text', `namespace: ${NAMESPACE}`);
+    projectRoles.findYamlCodeEditor().should('exist');
+    cy.findByTestId('yaml-editor-container').contains('rbac.authorization.k8s.io/v1');
+    cy.findByTestId('yaml-editor-container').contains('Role');
+    cy.findByTestId('yaml-editor-container').contains('test-role');
+    cy.findByTestId('yaml-editor-container').contains(NAMESPACE);
   });
 
   it('should reflect description in YAML', () => {
@@ -87,9 +86,7 @@ describe('Create Role - Form/YAML toggle', () => {
     projectRoles.findDescriptionTextarea().type('My role description');
     projectRoles.findYamlViewToggle().click();
 
-    projectRoles
-      .findYamlCodeEditor()
-      .should('contain.text', 'openshift.io/description: My role description');
+    cy.findByTestId('yaml-editor-container').contains('My role description');
   });
 
   it('should switch back to Form view and preserve data', () => {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabYamlToggle.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabYamlToggle.cy.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the Form/YAML toggle on the Create Role page: toggle visibility,
+ * switching between views, YAML content verification, and data preservation.
+ */
+import {
+  mockDashboardConfig,
+  mockK8sResourceList,
+  mockProjectK8sResource,
+} from '@odh-dashboard/internal/__mocks__';
+import {
+  ClusterRoleModel,
+  ProjectModel,
+  RoleBindingModel,
+  RoleModel,
+} from '../../../../utils/models';
+import { asProjectAdminUser } from '../../../../utils/mockUsers';
+import { projectRoles } from '../../../../pages/projectRoles';
+
+const NAMESPACE = 'test-project';
+
+const initIntercepts = () => {
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ roleManagement: true }));
+  cy.interceptK8s(ProjectModel, mockProjectK8sResource({ k8sName: NAMESPACE }));
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ k8sName: NAMESPACE })]),
+  );
+  cy.interceptK8sList({ model: RoleModel, ns: NAMESPACE }, mockK8sResourceList([]));
+  cy.interceptK8sList(ClusterRoleModel, mockK8sResourceList([]));
+  cy.interceptK8sList({ model: RoleBindingModel, ns: NAMESPACE }, mockK8sResourceList([]));
+};
+
+describe('Create Role - Form/YAML toggle', () => {
+  beforeEach(() => {
+    asProjectAdminUser();
+    initIntercepts();
+    projectRoles.visitCreateRole(NAMESPACE);
+  });
+
+  it('should display the Form/YAML toggle group', () => {
+    projectRoles.findFormYamlToggle().should('exist');
+    projectRoles.findFormViewToggle().should('exist');
+    projectRoles.findYamlViewToggle().should('exist');
+  });
+
+  it('should have Form selected by default', () => {
+    projectRoles.findFormViewToggle().should('have.class', 'pf-m-selected');
+    projectRoles.findCreateRoleForm().should('exist');
+  });
+
+  it('should switch to YAML view when YAML toggle is clicked', () => {
+    projectRoles.findYamlViewToggle().click();
+
+    projectRoles.findYamlView().should('exist');
+    projectRoles.findCreateRoleForm().should('not.exist');
+  });
+
+  it('should display title and description in YAML view', () => {
+    projectRoles.findYamlViewToggle().click();
+
+    projectRoles.findYamlViewTitle().should('have.text', 'Role configuration YAML');
+    projectRoles
+      .findYamlViewDescription()
+      .should('contain.text', 'View the live, read-only YAML for this role');
+  });
+
+  it('should display code editor with YAML content', () => {
+    projectRoles.findYamlViewToggle().click();
+
+    projectRoles.findYamlCodeEditor().should('exist');
+  });
+
+  it('should display a valid Role manifest in YAML view', () => {
+    projectRoles.findRoleNameInput().type('test-role');
+    projectRoles.findYamlViewToggle().click();
+
+    projectRoles
+      .findYamlCodeEditor()
+      .should('contain.text', 'apiVersion: rbac.authorization.k8s.io/v1');
+    projectRoles.findYamlCodeEditor().should('contain.text', 'kind: Role');
+    projectRoles.findYamlCodeEditor().should('contain.text', 'name: test-role');
+    projectRoles.findYamlCodeEditor().should('contain.text', `namespace: ${NAMESPACE}`);
+  });
+
+  it('should reflect description in YAML', () => {
+    projectRoles.findRoleNameInput().type('test-role');
+    projectRoles.findDescriptionTextarea().type('My role description');
+    projectRoles.findYamlViewToggle().click();
+
+    projectRoles
+      .findYamlCodeEditor()
+      .should('contain.text', 'openshift.io/description: My role description');
+  });
+
+  it('should switch back to Form view and preserve data', () => {
+    projectRoles.findRoleNameInput().type('preserved-role');
+    projectRoles.findDescriptionTextarea().type('Preserved description');
+
+    projectRoles.findYamlViewToggle().click();
+    projectRoles.findYamlView().should('exist');
+
+    projectRoles.findFormViewToggle().click();
+    projectRoles.findCreateRoleForm().should('exist');
+
+    projectRoles.findRoleNameInput().should('have.value', 'preserved-role');
+    projectRoles.findDescriptionTextarea().should('have.value', 'Preserved description');
+  });
+
+  it('should keep footer visible in YAML view', () => {
+    projectRoles.findYamlViewToggle().click();
+
+    projectRoles.findSubmitButton().should('exist');
+    projectRoles.findCancelButton().should('exist');
+  });
+
+  it('should display full-screen toggle button in YAML view', () => {
+    projectRoles.findYamlViewToggle().click();
+
+    projectRoles.findYamlFullscreenToggle().should('exist');
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabYamlToggle.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabYamlToggle.cy.ts
@@ -44,15 +44,15 @@ describe('Create Role - Form/YAML toggle', () => {
   });
 
   it('should have Form selected by default', () => {
-    projectRoles.findFormViewToggle().find('button').should('have.class', 'pf-m-selected');
+    projectRoles.findFormViewToggle().find('button').should('have.attr', 'aria-pressed', 'true');
     projectRoles.findCreateRoleForm().should('exist');
   });
 
   it('should switch to YAML view when YAML toggle is clicked', () => {
     projectRoles.findYamlViewToggle().click();
 
-    projectRoles.findYamlView().should('exist');
-    projectRoles.findCreateRoleForm().should('not.exist');
+    projectRoles.findYamlView().should('be.visible');
+    projectRoles.findCreateRoleForm().should('not.be.visible');
   });
 
   it('should display title and description in YAML view', () => {
@@ -94,10 +94,10 @@ describe('Create Role - Form/YAML toggle', () => {
     projectRoles.findDescriptionTextarea().type('Preserved description');
 
     projectRoles.findYamlViewToggle().click();
-    projectRoles.findYamlView().should('exist');
+    projectRoles.findYamlView().should('be.visible');
 
     projectRoles.findFormViewToggle().click();
-    projectRoles.findCreateRoleForm().should('exist');
+    projectRoles.findCreateRoleForm().should('be.visible');
 
     projectRoles.findRoleNameInput().should('have.value', 'preserved-role');
     projectRoles.findDescriptionTextarea().should('have.value', 'Preserved description');

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabYamlToggle.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabYamlToggle.cy.ts
@@ -51,8 +51,9 @@ describe('Create Role - Form/YAML toggle', () => {
   it('should switch to YAML view when YAML toggle is clicked', () => {
     projectRoles.findYamlViewToggle().click();
 
-    projectRoles.findYamlView().should('be.visible');
+    projectRoles.findYamlView().should('exist');
     projectRoles.findCreateRoleForm().should('not.be.visible');
+    cy.testA11y();
   });
 
   it('should display title and description in YAML view', () => {
@@ -75,10 +76,10 @@ describe('Create Role - Form/YAML toggle', () => {
     projectRoles.findYamlViewToggle().click();
 
     projectRoles.findYamlCodeEditor().should('exist');
-    cy.findByTestId('yaml-editor-container').contains('rbac.authorization.k8s.io/v1');
-    cy.findByTestId('yaml-editor-container').contains('Role');
-    cy.findByTestId('yaml-editor-container').contains('test-role');
-    cy.findByTestId('yaml-editor-container').contains(NAMESPACE);
+    projectRoles.findYamlEditorContainer().contains('rbac.authorization.k8s.io/v1');
+    projectRoles.findYamlEditorContainer().contains('Role');
+    projectRoles.findYamlEditorContainer().contains('test-role');
+    projectRoles.findYamlEditorContainer().contains(NAMESPACE);
   });
 
   it('should reflect description in YAML', () => {
@@ -86,7 +87,17 @@ describe('Create Role - Form/YAML toggle', () => {
     projectRoles.findDescriptionTextarea().type('My role description');
     projectRoles.findYamlViewToggle().click();
 
-    cy.findByTestId('yaml-editor-container').contains('My role description');
+    projectRoles.findYamlEditorContainer().contains('My role description');
+  });
+
+  it('should reflect rules in YAML', () => {
+    projectRoles.findRoleNameInput().type('test-role');
+    projectRoles.findAddRuleButton().click();
+    projectRoles.findVerbCheckbox('get').click();
+    projectRoles.findRuleSaveButton().click();
+    projectRoles.findYamlViewToggle().click();
+
+    projectRoles.findYamlEditorContainer().contains('get');
   });
 
   it('should switch back to Form view and preserve data', () => {
@@ -94,7 +105,7 @@ describe('Create Role - Form/YAML toggle', () => {
     projectRoles.findDescriptionTextarea().type('Preserved description');
 
     projectRoles.findYamlViewToggle().click();
-    projectRoles.findYamlView().should('be.visible');
+    projectRoles.findYamlView().should('exist');
 
     projectRoles.findFormViewToggle().click();
     projectRoles.findCreateRoleForm().should('be.visible');

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabYamlToggle.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabYamlToggle.cy.ts
@@ -93,11 +93,19 @@ describe('Create Role - Form/YAML toggle', () => {
   it('should reflect rules in YAML', () => {
     projectRoles.findRoleNameInput().type('test-role');
     projectRoles.findAddRuleButton().click();
+    projectRoles.findAddRuleModal().should('exist');
+    projectRoles.findRuleApiGroupsToggle().click();
+    projectRoles.findRuleApiGroupsToggle().parent().find('input').type('apps');
+    cy.contains('Use custom API group "apps"').click();
+    projectRoles.findRuleResourceTypesToggle().click();
+    projectRoles.findRuleResourceTypesToggle().parent().find('input').type('deployments');
+    cy.contains('Use custom resource type "deployments"').click();
     projectRoles.findVerbCheckbox('get').click();
     projectRoles.findRuleSaveButton().click();
     projectRoles.findYamlViewToggle().click();
 
     projectRoles.findYamlEditorContainer().contains('get');
+    projectRoles.findYamlEditorContainer().contains('deployments');
   });
 
   it('should switch back to Form view and preserve data', () => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-63157

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Implements the Form/YAML toggle on the Create Custom Role page.

https://github.com/user-attachments/assets/531a688e-8cc6-4661-b55f-0806a024858a

This adds a `ToggleGroup` in the page header (next to "Select role template") that allows users to switch between the interactive form view and a read-only YAML preview showing the Kubernetes Role manifest generated from the current form state.

**Key behaviors:**
- "Form" is selected by default, showing the existing interactive form
- Switching to "YAML (read-only)" displays a live YAML preview of the Role manifest
- YAML reflects all form state in real-time: metadata (name, labels, annotations) and rules
- Switching back to "Form" preserves all entered data
- The YAML view is strictly read-only — no editing capability
- The footer (Create role / Cancel) remains visible in both views

**YAML view includes:**
- A title ("Role configuration YAML") and description matching the form view's layout pattern
- A `DashboardCodeEditor` with copy, download, and full-screen toolbar actions
- A "YAML (read-only)" label in the toolbar and the language label on the right

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Verified toggle renders and switches between Form and YAML views
- Confirmed YAML output matches expected Kubernetes Role manifest structure
- Verified form data (name, description, labels, rules) is preserved across toggle switches
- Verified toolbar actions (copy, download, full-screen) are present and functional
- Confirmed footer remains visible in both views
- Ran ESLint with zero errors across all modified/new files
- Ran all projectRoles unit tests (47 tests passing)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
**Unit tests added:**
- `CreateRoleYamlView.spec.tsx` — 7 tests covering:
  - Title and description rendering
  - Valid Kubernetes Role YAML output
  - Rules reflected in YAML
  - Labels reflected in YAML
  - Empty name behavior
  - Full-screen toggle button rendered
  - Labels with empty keys filtered out
  
**Cypress mock tests added:**
- `rolesTabYamlToggle.cy.ts` — 9 tests covering:
  - Toggle group visibility
  - Form selected by default
  - Switching to YAML view
  - Title and description in YAML view
  - Code editor presence
  - Valid Role manifest content
  - Description reflected in YAML
  - Data preservation on toggle back to Form
  - Footer visible in YAML view
  - Full-screen toggle button presence

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added Form/YAML switching for creating roles, with YAML shown as a live, read-only preview.
  * YAML preview includes copy/download and fullscreen support, updating as role details change.
  * Submitting role definitions now omits any labels with empty keys.
* **Tests**
  * Added Jest coverage validating generated Role YAML (structure, required dashboard label/annotations, rules/labels serialization, and empty-key filtering).
  * Added Cypress coverage for toggle behavior, YAML rendering, fullscreen control, and input preservation when switching views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->