### PR TITLE
RHOAIENG-58995: Move playground chat scrollbar to panel edge

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -14,6 +14,7 @@ import {
 import { Chatbot, ChatbotContent, ChatbotDisplayMode } from '@patternfly/chatbot';
 // Imported here (not just App.tsx) so the CSS is bundled when loaded via Module Federation
 import '@patternfly/chatbot/dist/css/main.css';
+import '~/app/app.css';
 import { useLocation } from 'react-router-dom';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import DashboardModalFooter from '@odh-dashboard/internal/concepts/dashboard/DashboardModalFooter';

--- a/packages/gen-ai/frontend/src/app/Chatbot/EmbeddableChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/EmbeddableChatbotPlayground.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 // load this component via Module Federation without going through App.tsx,
 // which is where the chatbot stylesheet is normally imported.
 import '@patternfly/chatbot/dist/css/main.css';
+import '~/app/app.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   ModularArchConfig,

--- a/packages/gen-ai/frontend/src/app/app.css
+++ b/packages/gen-ai/frontend/src/app/app.css
@@ -65,3 +65,21 @@ body,
   padding: var(--pf-t--global--spacer--xs);
 }
 
+/*
+ * Push the scrollbar to the outer edge of the chatbot panel.
+ * Remove the max-width from the scroll container (messagebox) so the
+ * scrollbar sits at the full panel width, then constrain each message
+ * child to the readable width instead.
+ */
+@media screen and (min-width: 64rem) {
+  .pf-chatbot--embedded .pf-chatbot__messagebox {
+    max-width: unset;
+    align-items: center;
+  }
+
+  .pf-chatbot--embedded .pf-chatbot__messagebox > * {
+    max-width: 60rem;
+    width: 100%;
+  }
+}
+


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-58995

## Description
Move the scrollbar from the edge of the max-width message column to the outer edge of the chatbot panel. This keeps the 60rem readable width for text but lets users scroll from the whitespace, reducing visual crowding.

The max-width constraint is shifted from the messagebox scroll container (`.pf-chatbot__messagebox`) down to its direct children, so the scrollbar tracks the full panel width while messages remain centered at 60rem.

Also imports `app.css` in the federated entry points (`ChatbotPlayground.tsx`, `EmbeddableChatbotPlayground.tsx`) so the override applies when loaded via Module Federation.

## How Has This Been Tested?
- Manually verified on localhost:4010 (main dashboard via Module Federation)
- Manually verified on localhost:9102 (gen-ai standalone)
- Confirmed scrollbar appears at panel edge with whitespace between text and scrollbar

## Test Impact
CSS-only change with no logic changes. No new tests needed — existing Cypress tests cover chatbot rendering.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our Best Practices

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster

Made with [Cursor](https://cursor.com)