### PR TITLE
test: add missing Konflux pipeline for k8s-core (build simulator demo)

### DIFF
--- a/.tekton/odh-mod-arch-k8s-core-pull-request.yaml
+++ b/.tekton/odh-mod-arch-k8s-core-pull-request.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "packages/k8s-core/**".pathChanged()
+      || ".tekton/odh-mod-arch-k8s-core-pull-request.yaml".pathChanged() || "Dockerfile.workspace".pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-mod-arch-k8s-core-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mod-arch-k8s-core-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-mod-arch-k8s-core:odh-pr
+  - name: dockerfile
+    value: packages/k8s-core/Dockerfile.workspace
+  - name: path-context
+    value: .
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-k8s-core
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Context

PR #7855 introduced the new `packages/k8s-core` package but shipped without a corresponding `.tekton` pipeline file. Because Pipelines as Code (PAC) only fires when a matching `*-pull-request.yaml` with a `pathChanged()` expression exists, the Konflux build simulator **never ran** for `k8s-core` on that PR.

## What this PR does

Adds `.tekton/odh-mod-arch-k8s-core-pull-request.yaml` following the exact same pattern as every other modular-architecture package (gen-ai, mlflow, autorag, eval-hub, etc.).

The pipeline references `packages/k8s-core/Dockerfile.workspace` — a file that **does not exist**, because `k8s-core` is a pure TypeScript types-only package with no container image. The Konflux build simulator should therefore:

1. ✅ **Trigger** (the `.tekton` file is new → `pathChanged()` fires)
2. ❌ **Fail** (no `Dockerfile.workspace` in `packages/k8s-core`)

This is a **draft / demo PR** to demonstrate the gap. It should be closed without merging once the build failure is confirmed.

> **DO NOT MERGE** — this is a test/demo PR only.

Made with [Cursor](https://cursor.com)