### PR TITLE
[RHOAIENG-68913] add support for existing pg_vector db in gen ai playground

### DIFF
--- a/packages/gen-ai/bff/cmd/main.go
+++ b/packages/gen-ai/bff/cmd/main.go
@@ -69,6 +69,14 @@ func main() {
 	// RBAC configuration
 	flag.BoolVar(&cfg.EnableLlamaStackRBAC, "enable-llamastack-rbac", getEnvAsBool("ENABLE_LLAMASTACK_RBAC", false), "Enable RBAC endpoint filtering on LlamaStack configurations")
 
+	// pgvector (default vector store) configuration
+	flag.StringVar(&cfg.PgvectorHost, "pgvector-host", getEnvAsString("PGVECTOR_HOST", ""), "Hostname of pgvector-enabled PostgreSQL (enables remote::pgvector as default vector_io provider)")
+	flag.IntVar(&cfg.PgvectorPort, "pgvector-port", getEnvAsInt("PGVECTOR_PORT", 5432), "PostgreSQL port for pgvector")
+	flag.StringVar(&cfg.PgvectorDB, "pgvector-db", getEnvAsString("PGVECTOR_DB", "vectordb"), "PostgreSQL database name for pgvector")
+	flag.StringVar(&cfg.PgvectorUser, "pgvector-user", getEnvAsString("PGVECTOR_USER", "vectoruser"), "PostgreSQL user for pgvector")
+	flag.StringVar(&cfg.PgvectorPasswordSecretName, "pgvector-password-secret-name", getEnvAsString("PGVECTOR_PASSWORD_SECRET_NAME", ""), "Kubernetes Secret name containing the pgvector password")
+	flag.StringVar(&cfg.PgvectorPasswordSecretKey, "pgvector-password-secret-key", getEnvAsString("PGVECTOR_PASSWORD_SECRET_KEY", "password"), "Key in the pgvector password Secret")
+
 	// BFF inter-communication configuration
 	flag.BoolVar(&cfg.MockBFFClients, "mock-bff-clients", getEnvAsBool("MOCK_BFF_CLIENTS", false), "Use mock BFF clients for inter-BFF communication")
 	flag.StringVar(&cfg.BFFMaaSServiceName, "bff-maas-service-name", getEnvAsString("BFF_MAAS_SERVICE_NAME", "odh-dashboard"), "Kubernetes service name for MaaS BFF")

--- a/packages/gen-ai/bff/cmd/main.go
+++ b/packages/gen-ai/bff/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/api"
 	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/pgvector"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -75,7 +76,7 @@ func main() {
 	flag.StringVar(&cfg.PgvectorDB, "pgvector-db", getEnvAsString("PGVECTOR_DB", "vectordb"), "PostgreSQL database name for pgvector")
 	flag.StringVar(&cfg.PgvectorUser, "pgvector-user", getEnvAsString("PGVECTOR_USER", "vectoruser"), "PostgreSQL user for pgvector")
 	flag.StringVar(&cfg.PgvectorPasswordSecretName, "pgvector-password-secret-name", getEnvAsString("PGVECTOR_PASSWORD_SECRET_NAME", ""), "Kubernetes Secret name containing the pgvector password")
-	flag.StringVar(&cfg.PgvectorPasswordSecretKey, "pgvector-password-secret-key", getEnvAsString("PGVECTOR_PASSWORD_SECRET_KEY", "password"), "Key in the pgvector password Secret")
+	flag.StringVar(&cfg.PgvectorPasswordSecretKey, "pgvector-password-secret-key", getEnvAsString("PGVECTOR_PASSWORD_SECRET_KEY", pgvector.DefaultPasswordKey), "Key in the pgvector password Secret")
 
 	// BFF inter-communication configuration
 	flag.BoolVar(&cfg.MockBFFClients, "mock-bff-clients", getEnvAsBool("MOCK_BFF_CLIENTS", false), "Use mock BFF clients for inter-BFF communication")

--- a/packages/gen-ai/bff/internal/config/environment.go
+++ b/packages/gen-ai/bff/internal/config/environment.go
@@ -127,4 +127,14 @@ type EnvConfig struct {
 	// BFFMaaSAuthTokenPrefix specifies the prefix MaaS BFF expects in the token header.
 	// Default: "" (empty for ODH's x-forwarded-access-token)
 	BFFMaaSAuthTokenPrefix string
+
+	// ─── PGVECTOR (default vector store) ─────────────────────
+	// When PgvectorHost is set, the BFF configures remote::pgvector as the
+	// default vector_io provider instead of inline::milvus.
+	PgvectorHost               string
+	PgvectorPort               int    // default: 5432
+	PgvectorDB                 string // default: "vectordb"
+	PgvectorUser               string // default: "vectoruser"
+	PgvectorPasswordSecretName string // K8s Secret name containing the password
+	PgvectorPasswordSecretKey  string // key inside the password Secret, default: "password"
 }

--- a/packages/gen-ai/bff/internal/config/environment.go
+++ b/packages/gen-ai/bff/internal/config/environment.go
@@ -128,7 +128,6 @@ type EnvConfig struct {
 	// Default: "" (empty for ODH's x-forwarded-access-token)
 	BFFMaaSAuthTokenPrefix string
 
-	// ─── PGVECTOR (default vector store) ─────────────────────
 	// When PgvectorHost is set, the BFF configures remote::pgvector as the
 	// default vector_io provider instead of inline::milvus.
 	PgvectorHost               string

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/pgvector"
 	"github.com/opendatahub-io/gen-ai/internal/models"
 	"github.com/opendatahub-io/gen-ai/internal/types"
 	"gopkg.in/yaml.v2"
@@ -554,6 +555,29 @@ func (c *LlamaStackConfig) AddInferenceProvider(provider Provider) {
 // AddVectorIOProvider adds a new vector IO provider to the config
 func (c *LlamaStackConfig) AddVectorIOProvider(provider Provider) {
 	c.Providers.VectorIO = append(c.Providers.VectorIO, provider)
+}
+
+// SetDefaultPgvectorProvider replaces the built-in vector_io provider with
+// remote::pgvector. Connection values are referenced via ${env.*} placeholders
+// that Llama Stack resolves from the OGXServer pod's environment at runtime.
+func (c *LlamaStackConfig) SetDefaultPgvectorProvider(conn pgvector.Connection) {
+	providerConfig := map[string]interface{}{
+		"host":            fmt.Sprintf("${env.%s}", pgvector.HostEnvVar),
+		"port":            conn.Port,
+		"db":              fmt.Sprintf("${env.%s:=%s}", pgvector.DBEnvVar, conn.DB),
+		"user":            fmt.Sprintf("${env.%s:=%s}", pgvector.UserEnvVar, conn.User),
+		"password":        fmt.Sprintf("${env.%s:=}", pgvector.PasswordEnvVar),
+		"distance_metric": pgvector.DefaultDistanceMetric,
+		"persistence": map[string]interface{}{
+			"namespace": fmt.Sprintf("vector_io::%s", pgvector.DefaultProviderID),
+			"backend":   "kv_default",
+		},
+	}
+
+	c.Providers.VectorIO = []Provider{
+		NewProvider(pgvector.DefaultProviderID, pgvector.ProviderType, providerConfig),
+	}
+	c.VectorStores.DefaultProviderID = pgvector.DefaultProviderID
 }
 
 // AddResponsesProvider adds a new responses provider to the config

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
@@ -563,7 +563,7 @@ func (c *LlamaStackConfig) AddVectorIOProvider(provider Provider) {
 func (c *LlamaStackConfig) SetDefaultPgvectorProvider(conn pgvector.Connection) {
 	providerConfig := map[string]interface{}{
 		"host":            fmt.Sprintf("${env.%s}", pgvector.HostEnvVar),
-		"port":            conn.Port,
+		"port":            fmt.Sprintf("${env.%s:=%d}", pgvector.PortEnvVar, conn.Port),
 		"db":              fmt.Sprintf("${env.%s:=%s}", pgvector.DBEnvVar, conn.DB),
 		"user":            fmt.Sprintf("${env.%s:=%s}", pgvector.UserEnvVar, conn.User),
 		"password":        fmt.Sprintf("${env.%s:=}", pgvector.PasswordEnvVar),

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config_test.go
@@ -1514,7 +1514,7 @@ func TestSetDefaultPgvectorProvider(t *testing.T) {
 
 		pc := config.Providers.VectorIO[0].Config
 		assert.Equal(t, "${env.PGVECTOR_HOST}", pc["host"])
-		assert.Equal(t, 5432, pc["port"])
+		assert.Equal(t, "${env.PGVECTOR_PORT:=5432}", pc["port"])
 		assert.Equal(t, "${env.PGVECTOR_DB:=mydb}", pc["db"])
 		assert.Equal(t, "${env.PGVECTOR_USER:=myuser}", pc["user"])
 		assert.Equal(t, "${env.PGVECTOR_PASSWORD:=}", pc["password"])

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/pgvector"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -1477,4 +1478,79 @@ func TestDefaultConfig_RegisteredResourcesShape(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, jsonStr, "\"models\":[]")
 	assert.Contains(t, jsonStr, "\"vector_stores\":[]")
+}
+
+func TestSetDefaultPgvectorProvider(t *testing.T) {
+	t.Run("replaces milvus with pgvector and updates default provider ID", func(t *testing.T) {
+		config := NewDefaultLlamaStackConfig()
+		require.Len(t, config.Providers.VectorIO, 1)
+		assert.Equal(t, "inline::milvus", config.Providers.VectorIO[0].ProviderType)
+		assert.Equal(t, "milvus", config.VectorStores.DefaultProviderID)
+
+		conn := pgvector.Connection{
+			Host: "pg.svc.cluster.local",
+			Port: 5432,
+			DB:   "vectordb",
+			User: "vectoruser",
+		}
+		config.SetDefaultPgvectorProvider(conn)
+
+		require.Len(t, config.Providers.VectorIO, 1, "should have exactly one vector_io provider")
+		p := config.Providers.VectorIO[0]
+		assert.Equal(t, pgvector.DefaultProviderID, p.ProviderID)
+		assert.Equal(t, pgvector.ProviderType, p.ProviderType)
+		assert.Equal(t, pgvector.DefaultProviderID, config.VectorStores.DefaultProviderID)
+	})
+
+	t.Run("provider config uses env var placeholders", func(t *testing.T) {
+		config := NewDefaultLlamaStackConfig()
+		conn := pgvector.Connection{
+			Host: "pg.svc.cluster.local",
+			Port: 5432,
+			DB:   "mydb",
+			User: "myuser",
+		}
+		config.SetDefaultPgvectorProvider(conn)
+
+		pc := config.Providers.VectorIO[0].Config
+		assert.Equal(t, "${env.PGVECTOR_HOST}", pc["host"])
+		assert.Equal(t, 5432, pc["port"])
+		assert.Equal(t, "${env.PGVECTOR_DB:=mydb}", pc["db"])
+		assert.Equal(t, "${env.PGVECTOR_USER:=myuser}", pc["user"])
+		assert.Equal(t, "${env.PGVECTOR_PASSWORD:=}", pc["password"])
+		assert.Equal(t, pgvector.DefaultDistanceMetric, pc["distance_metric"])
+
+		persistence, ok := pc["persistence"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "kv_default", persistence["backend"])
+	})
+
+	t.Run("serializes to valid YAML with pgvector provider", func(t *testing.T) {
+		config := NewDefaultLlamaStackConfig()
+		config.SetDefaultPgvectorProvider(pgvector.Connection{
+			Host: "pg.svc.cluster.local",
+			Port: 5432,
+			DB:   "vectordb",
+			User: "vectoruser",
+		})
+
+		yamlStr, err := config.ToYAML()
+		require.NoError(t, err)
+		assert.Contains(t, yamlStr, "remote::pgvector")
+		assert.NotContains(t, yamlStr, "inline::milvus")
+	})
+
+	t.Run("does not affect other providers or registered resources", func(t *testing.T) {
+		config := NewDefaultLlamaStackConfig()
+		config.AddModel(NewLLMModel("test-model", "test-provider", "Test"))
+
+		conn := pgvector.Connection{Host: "pg", Port: 5432, DB: "db", User: "user"}
+		config.SetDefaultPgvectorProvider(conn)
+
+		assert.Len(t, config.Providers.Inference, 1, "inference providers unchanged")
+		assert.Len(t, config.Providers.Responses, 1, "responses providers unchanged")
+		assert.Len(t, config.RegisteredResources.Models, 1, "registered models unchanged")
+		assert.Equal(t, "sentence-transformers", config.VectorStores.DefaultEmbeddingModel.ProviderID,
+			"default embedding model unchanged")
+	})
 }

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/pgvector/connection.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/pgvector/connection.go
@@ -1,7 +1,5 @@
 package pgvector
 
-import "fmt"
-
 const (
 	DefaultProviderID = "pgvector"
 	ProviderType      = "remote::pgvector"
@@ -9,6 +7,7 @@ const (
 	DefaultPort           = 5432
 	DefaultDB             = "vectordb"
 	DefaultUser           = "vectoruser"
+	DefaultPasswordKey    = "password"
 	DefaultDistanceMetric = "COSINE"
 
 	HostEnvVar     = "PGVECTOR_HOST"
@@ -25,19 +24,13 @@ type Connection struct {
 	Port           int
 	DB             string
 	User           string
-	Password       string
-	PasswordSecret *SecretRef // when set, password is injected via SecretKeyRef
+	PasswordSecret *SecretRef // password is injected via SecretKeyRef
 }
 
 // SecretRef identifies a key inside a Kubernetes Secret.
 type SecretRef struct {
 	Name string
 	Key  string
-}
-
-// DSN returns a PostgreSQL connection string.
-func (c *Connection) DSN() string {
-	return fmt.Sprintf("postgresql://%s:%s@%s:%d/%s", c.User, c.Password, c.Host, c.Port, c.DB)
 }
 
 // IsConfigured returns true when at least the host is set, indicating

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/pgvector/connection.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/pgvector/connection.go
@@ -1,0 +1,47 @@
+package pgvector
+
+import "fmt"
+
+const (
+	DefaultProviderID = "pgvector"
+	ProviderType      = "remote::pgvector"
+
+	DefaultPort           = 5432
+	DefaultDB             = "vectordb"
+	DefaultUser           = "vectoruser"
+	DefaultDistanceMetric = "COSINE"
+
+	HostEnvVar     = "PGVECTOR_HOST"
+	PortEnvVar     = "PGVECTOR_PORT"
+	DBEnvVar       = "PGVECTOR_DB"
+	UserEnvVar     = "PGVECTOR_USER"
+	PasswordEnvVar = "PGVECTOR_PASSWORD"
+)
+
+// Connection holds the details needed to connect an OGXServer to a
+// pgvector-enabled PostgreSQL instance.
+type Connection struct {
+	Host           string
+	Port           int
+	DB             string
+	User           string
+	Password       string
+	PasswordSecret *SecretRef // when set, password is injected via SecretKeyRef
+}
+
+// SecretRef identifies a key inside a Kubernetes Secret.
+type SecretRef struct {
+	Name string
+	Key  string
+}
+
+// DSN returns a PostgreSQL connection string.
+func (c *Connection) DSN() string {
+	return fmt.Sprintf("postgresql://%s:%s@%s:%d/%s", c.User, c.Password, c.Host, c.Port, c.DB)
+}
+
+// IsConfigured returns true when at least the host is set, indicating
+// that pgvector connection details have been provided.
+func (c *Connection) IsConfigured() bool {
+	return c.Host != ""
+}

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/pgvector/connection_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/pgvector/connection_test.go
@@ -1,0 +1,30 @@
+package pgvector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnection_IsConfigured(t *testing.T) {
+	t.Run("empty host means not configured", func(t *testing.T) {
+		c := Connection{}
+		assert.False(t, c.IsConfigured())
+	})
+
+	t.Run("host set means configured", func(t *testing.T) {
+		c := Connection{Host: "pg.svc.cluster.local"}
+		assert.True(t, c.IsConfigured())
+	})
+}
+
+func TestConnection_DSN(t *testing.T) {
+	c := Connection{
+		Host:     "pg.svc.cluster.local",
+		Port:     5432,
+		DB:       "vectordb",
+		User:     "vectoruser",
+		Password: "secret",
+	}
+	assert.Equal(t, "postgresql://vectoruser:secret@pg.svc.cluster.local:5432/vectordb", c.DSN())
+}

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/pgvector/connection_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/pgvector/connection_test.go
@@ -17,14 +17,3 @@ func TestConnection_IsConfigured(t *testing.T) {
 		assert.True(t, c.IsConfigured())
 	})
 }
-
-func TestConnection_DSN(t *testing.T) {
-	c := Connection{
-		Host:     "pg.svc.cluster.local",
-		Port:     5432,
-		DB:       "vectordb",
-		User:     "vectoruser",
-		Password: "secret",
-	}
-	assert.Equal(t, "postgresql://vectoruser:secret@pg.svc.cluster.local:5432/vectordb", c.DSN())
-}

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1580,7 +1580,11 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 	}
 
 	// Inject pgvector connection env vars when configured.
-	if conn := pgvectorConnectionFromConfig(kc.EnvConfig); conn.IsConfigured() {
+	conn, err := pgvectorConnectionFromConfig(kc.EnvConfig)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pgvector configuration: %w", err)
+	}
+	if conn.IsConfigured() {
 		envVars = append(envVars,
 			corev1.EnvVar{Name: pgvector.HostEnvVar, Value: conn.Host},
 			corev1.EnvVar{Name: pgvector.PortEnvVar, Value: strconv.Itoa(conn.Port)},
@@ -1764,14 +1768,17 @@ func ensureVLLMCompatibleURL(url string) string {
 // pgvectorConnectionFromConfig builds a pgvector.Connection from the BFF's
 // env config. Returns a zero-value Connection (IsConfigured() == false) when
 // PgvectorHost is empty.
-func pgvectorConnectionFromConfig(cfg config.EnvConfig) pgvector.Connection {
+func pgvectorConnectionFromConfig(cfg config.EnvConfig) (pgvector.Connection, error) {
 	if cfg.PgvectorHost == "" {
-		return pgvector.Connection{}
+		return pgvector.Connection{}, nil
 	}
 
 	port := cfg.PgvectorPort
 	if port == 0 {
 		port = pgvector.DefaultPort
+	}
+	if port < 1 || port > 65535 {
+		return pgvector.Connection{}, fmt.Errorf("invalid PGVECTOR_PORT %d: must be between 1 and 65535", port)
 	}
 	db := cfg.PgvectorDB
 	if db == "" {
@@ -1798,7 +1805,7 @@ func pgvectorConnectionFromConfig(cfg config.EnvConfig) pgvector.Connection {
 			Key:  key,
 		}
 	}
-	return conn
+	return conn, nil
 }
 
 // buildEmbeddingModelLookup returns a map from user-supplied embedding_model values
@@ -1835,7 +1842,11 @@ func (kc *TokenKubernetesClient) generateLlamaStackConfig(ctx context.Context, n
 	// Create a new config to build
 	config := NewDefaultLlamaStackConfig()
 
-	if conn := pgvectorConnectionFromConfig(kc.EnvConfig); conn.IsConfigured() {
+	conn, err := pgvectorConnectionFromConfig(kc.EnvConfig)
+	if err != nil {
+		return "", fmt.Errorf("invalid pgvector configuration: %w", err)
+	}
+	if conn.IsConfigured() {
 		config.SetDefaultPgvectorProvider(conn)
 		kc.Logger.Info("using remote::pgvector as default vector_io provider",
 			"host", conn.Host, "port", conn.Port, "db", conn.DB)

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -20,7 +20,6 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/pgvector"
-	"github.com/opendatahub-io/gen-ai/internal/integrations/maas"
 	"github.com/opendatahub-io/gen-ai/internal/models"
 	genaitypes "github.com/opendatahub-io/gen-ai/internal/types"
 	authnv1 "k8s.io/api/authentication/v1"

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1588,6 +1588,18 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 			corev1.EnvVar{Name: pgvector.UserEnvVar, Value: conn.User},
 		)
 		if conn.PasswordSecret != nil {
+			var secret corev1.Secret
+			if err := kc.Client.Get(ctx, types.NamespacedName{
+				Name:      conn.PasswordSecret.Name,
+				Namespace: namespace,
+			}, &secret); err != nil {
+				return nil, fmt.Errorf("pgvector password secret %q not found in namespace %s: %w",
+					conn.PasswordSecret.Name, namespace, err)
+			}
+			if _, ok := secret.Data[conn.PasswordSecret.Key]; !ok {
+				return nil, fmt.Errorf("pgvector password secret %q is missing key %q",
+					conn.PasswordSecret.Name, conn.PasswordSecret.Key)
+			}
 			envVars = append(envVars, corev1.EnvVar{
 				Name: pgvector.PasswordEnvVar,
 				ValueFrom: &corev1.EnvVarSource{
@@ -1596,11 +1608,6 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 						Key:                  conn.PasswordSecret.Key,
 					},
 				},
-			})
-		} else if conn.Password != "" {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:  pgvector.PasswordEnvVar,
-				Value: conn.Password,
 			})
 		}
 		kc.Logger.Info("injected pgvector connection env vars for OGXServer pod",
@@ -1784,7 +1791,7 @@ func pgvectorConnectionFromConfig(cfg config.EnvConfig) pgvector.Connection {
 	if cfg.PgvectorPasswordSecretName != "" {
 		key := cfg.PgvectorPasswordSecretKey
 		if key == "" {
-			key = "password"
+			key = pgvector.DefaultPasswordKey
 		}
 		conn.PasswordSecret = &pgvector.SecretRef{
 			Name: cfg.PgvectorPasswordSecretName,

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -19,6 +19,8 @@ import (
 	helper "github.com/opendatahub-io/gen-ai/internal/helpers"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/pgvector"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/maas"
 	"github.com/opendatahub-io/gen-ai/internal/models"
 	genaitypes "github.com/opendatahub-io/gen-ai/internal/types"
 	authnv1 "k8s.io/api/authentication/v1"
@@ -1577,6 +1579,34 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 		}
 	}
 
+	// Inject pgvector connection env vars when configured.
+	if conn := pgvectorConnectionFromConfig(kc.EnvConfig); conn.IsConfigured() {
+		envVars = append(envVars,
+			corev1.EnvVar{Name: pgvector.HostEnvVar, Value: conn.Host},
+			corev1.EnvVar{Name: pgvector.PortEnvVar, Value: strconv.Itoa(conn.Port)},
+			corev1.EnvVar{Name: pgvector.DBEnvVar, Value: conn.DB},
+			corev1.EnvVar{Name: pgvector.UserEnvVar, Value: conn.User},
+		)
+		if conn.PasswordSecret != nil {
+			envVars = append(envVars, corev1.EnvVar{
+				Name: pgvector.PasswordEnvVar,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: conn.PasswordSecret.Name},
+						Key:                  conn.PasswordSecret.Key,
+					},
+				},
+			})
+		} else if conn.Password != "" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  pgvector.PasswordEnvVar,
+				Value: conn.Password,
+			})
+		}
+		kc.Logger.Info("injected pgvector connection env vars for OGXServer pod",
+			"host", conn.Host, "port", conn.Port, "db", conn.DB)
+	}
+
 	// Step 5: Generate ConfigMap content first (before creating OGXServer)
 	configMapName := "llama-stack-config"
 	userAuthToken := ""
@@ -1724,6 +1754,46 @@ func ensureVLLMCompatibleURL(url string) string {
 	return url + "/v1"
 }
 
+// pgvectorConnectionFromConfig builds a pgvector.Connection from the BFF's
+// env config. Returns a zero-value Connection (IsConfigured() == false) when
+// PgvectorHost is empty.
+func pgvectorConnectionFromConfig(cfg config.EnvConfig) pgvector.Connection {
+	if cfg.PgvectorHost == "" {
+		return pgvector.Connection{}
+	}
+
+	port := cfg.PgvectorPort
+	if port == 0 {
+		port = pgvector.DefaultPort
+	}
+	db := cfg.PgvectorDB
+	if db == "" {
+		db = pgvector.DefaultDB
+	}
+	user := cfg.PgvectorUser
+	if user == "" {
+		user = pgvector.DefaultUser
+	}
+
+	conn := pgvector.Connection{
+		Host: cfg.PgvectorHost,
+		Port: port,
+		DB:   db,
+		User: user,
+	}
+	if cfg.PgvectorPasswordSecretName != "" {
+		key := cfg.PgvectorPasswordSecretKey
+		if key == "" {
+			key = "password"
+		}
+		conn.PasswordSecret = &pgvector.SecretRef{
+			Name: cfg.PgvectorPasswordSecretName,
+			Key:  key,
+		}
+	}
+	return conn
+}
+
 // buildEmbeddingModelLookup returns a map from user-supplied embedding_model values
 // as found in entries under registered_resources > vector_stores in the gen-ai-aa-vector-stores ConfigMap,
 // to the full LlamaStack model identifier (provider_id/effective_provider_model_id),
@@ -1757,6 +1827,12 @@ func buildEmbeddingModelLookup(ms []Model) map[string]string {
 func (kc *TokenKubernetesClient) generateLlamaStackConfig(ctx context.Context, namespace string, installModels []models.InstallModel, vectorStores []ValidatedVectorStore, bffClient bffclient.BFFClientInterface, userAuthToken string) (string, error) {
 	// Create a new config to build
 	config := NewDefaultLlamaStackConfig()
+
+	if conn := pgvectorConnectionFromConfig(kc.EnvConfig); conn.IsConfigured() {
+		config.SetDefaultPgvectorProvider(conn)
+		kc.Logger.Info("using remote::pgvector as default vector_io provider",
+			"host", conn.Host, "port", conn.Port, "db", conn.DB)
+	}
 
 	// Create a map of MaaS models for efficient lookup (only call ListModels once)
 	maasModelsMap := make(map[string]*models.MaaSModel)

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1613,6 +1613,9 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 					},
 				},
 			})
+		} else {
+			kc.Logger.Warn("pgvector configured without password mechanism; PostgreSQL auth may fail",
+				"host", conn.Host)
 		}
 		kc.Logger.Info("injected pgvector connection env vars for OGXServer pod",
 			"host", conn.Host, "port", conn.Port, "db", conn.DB)

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient/bffmocks"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/pgvector"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/maas/maasmocks"
 	"github.com/opendatahub-io/gen-ai/internal/models"
 	"github.com/opendatahub-io/gen-ai/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -2021,13 +2023,31 @@ func TestPgvectorConnectionFromConfig(t *testing.T) {
 		assert.Equal(t, "pg-password", conn.PasswordSecret.Key)
 	})
 
-	t.Run("password secret key defaults to 'password'", func(t *testing.T) {
+	t.Run("password secret key defaults to DefaultPasswordKey", func(t *testing.T) {
 		cfg := config.EnvConfig{
 			PgvectorHost:               "pg.svc",
 			PgvectorPasswordSecretName: "pg-creds",
 		}
 		conn := pgvectorConnectionFromConfig(cfg)
 		require.NotNil(t, conn.PasswordSecret)
-		assert.Equal(t, "password", conn.PasswordSecret.Key)
+		assert.Equal(t, pgvector.DefaultPasswordKey, conn.PasswordSecret.Key)
+	})
+
+	t.Run("negative port uses default", func(t *testing.T) {
+		cfg := config.EnvConfig{
+			PgvectorHost: "pg.svc",
+			PgvectorPort: -1,
+		}
+		conn := pgvectorConnectionFromConfig(cfg)
+		assert.Equal(t, -1, conn.Port, "validation is not applied at factory level; port is passed through")
+	})
+
+	t.Run("secret key without secret name does not set PasswordSecret", func(t *testing.T) {
+		cfg := config.EnvConfig{
+			PgvectorHost:              "pg.svc",
+			PgvectorPasswordSecretKey: "my-key",
+		}
+		conn := pgvectorConnectionFromConfig(cfg)
+		assert.Nil(t, conn.PasswordSecret, "key alone without name should not create a SecretRef")
 	})
 }

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -1980,7 +1980,8 @@ func TestGetAAModelsFromInferenceServiceCapabilities(t *testing.T) {
 func TestPgvectorConnectionFromConfig(t *testing.T) {
 	t.Run("empty host returns unconfigured connection", func(t *testing.T) {
 		cfg := config.EnvConfig{}
-		conn := pgvectorConnectionFromConfig(cfg)
+		conn, err := pgvectorConnectionFromConfig(cfg)
+		require.NoError(t, err)
 		assert.False(t, conn.IsConfigured())
 	})
 
@@ -1988,7 +1989,8 @@ func TestPgvectorConnectionFromConfig(t *testing.T) {
 		cfg := config.EnvConfig{
 			PgvectorHost: "pg.svc.cluster.local",
 		}
-		conn := pgvectorConnectionFromConfig(cfg)
+		conn, err := pgvectorConnectionFromConfig(cfg)
+		require.NoError(t, err)
 		assert.True(t, conn.IsConfigured())
 		assert.Equal(t, "pg.svc.cluster.local", conn.Host)
 		assert.Equal(t, 5432, conn.Port)
@@ -2004,7 +2006,8 @@ func TestPgvectorConnectionFromConfig(t *testing.T) {
 			PgvectorDB:   "mydb",
 			PgvectorUser: "myuser",
 		}
-		conn := pgvectorConnectionFromConfig(cfg)
+		conn, err := pgvectorConnectionFromConfig(cfg)
+		require.NoError(t, err)
 		assert.Equal(t, "custom-host", conn.Host)
 		assert.Equal(t, 5433, conn.Port)
 		assert.Equal(t, "mydb", conn.DB)
@@ -2017,7 +2020,8 @@ func TestPgvectorConnectionFromConfig(t *testing.T) {
 			PgvectorPasswordSecretName: "pg-creds",
 			PgvectorPasswordSecretKey:  "pg-password",
 		}
-		conn := pgvectorConnectionFromConfig(cfg)
+		conn, err := pgvectorConnectionFromConfig(cfg)
+		require.NoError(t, err)
 		require.NotNil(t, conn.PasswordSecret)
 		assert.Equal(t, "pg-creds", conn.PasswordSecret.Name)
 		assert.Equal(t, "pg-password", conn.PasswordSecret.Key)
@@ -2028,18 +2032,30 @@ func TestPgvectorConnectionFromConfig(t *testing.T) {
 			PgvectorHost:               "pg.svc",
 			PgvectorPasswordSecretName: "pg-creds",
 		}
-		conn := pgvectorConnectionFromConfig(cfg)
+		conn, err := pgvectorConnectionFromConfig(cfg)
+		require.NoError(t, err)
 		require.NotNil(t, conn.PasswordSecret)
 		assert.Equal(t, pgvector.DefaultPasswordKey, conn.PasswordSecret.Key)
 	})
 
-	t.Run("negative port uses default", func(t *testing.T) {
+	t.Run("negative port returns error", func(t *testing.T) {
 		cfg := config.EnvConfig{
 			PgvectorHost: "pg.svc",
 			PgvectorPort: -1,
 		}
-		conn := pgvectorConnectionFromConfig(cfg)
-		assert.Equal(t, -1, conn.Port, "validation is not applied at factory level; port is passed through")
+		_, err := pgvectorConnectionFromConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid PGVECTOR_PORT")
+	})
+
+	t.Run("port exceeding 65535 returns error", func(t *testing.T) {
+		cfg := config.EnvConfig{
+			PgvectorHost: "pg.svc",
+			PgvectorPort: 70000,
+		}
+		_, err := pgvectorConnectionFromConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid PGVECTOR_PORT")
 	})
 
 	t.Run("secret key without secret name does not set PasswordSecret", func(t *testing.T) {
@@ -2047,7 +2063,8 @@ func TestPgvectorConnectionFromConfig(t *testing.T) {
 			PgvectorHost:              "pg.svc",
 			PgvectorPasswordSecretKey: "my-key",
 		}
-		conn := pgvectorConnectionFromConfig(cfg)
+		conn, err := pgvectorConnectionFromConfig(cfg)
+		require.NoError(t, err)
 		assert.Nil(t, conn.PasswordSecret, "key alone without name should not create a SecretRef")
 	})
 }

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -1974,3 +1974,60 @@ func TestGetAAModelsFromInferenceServiceCapabilities(t *testing.T) {
 		assert.Equal(t, []string{constants.CapabilityAudioTranscription}, result[0].Capabilities)
 	})
 }
+
+func TestPgvectorConnectionFromConfig(t *testing.T) {
+	t.Run("empty host returns unconfigured connection", func(t *testing.T) {
+		cfg := config.EnvConfig{}
+		conn := pgvectorConnectionFromConfig(cfg)
+		assert.False(t, conn.IsConfigured())
+	})
+
+	t.Run("host set returns configured connection with defaults", func(t *testing.T) {
+		cfg := config.EnvConfig{
+			PgvectorHost: "pg.svc.cluster.local",
+		}
+		conn := pgvectorConnectionFromConfig(cfg)
+		assert.True(t, conn.IsConfigured())
+		assert.Equal(t, "pg.svc.cluster.local", conn.Host)
+		assert.Equal(t, 5432, conn.Port)
+		assert.Equal(t, "vectordb", conn.DB)
+		assert.Equal(t, "vectoruser", conn.User)
+		assert.Nil(t, conn.PasswordSecret)
+	})
+
+	t.Run("custom values override defaults", func(t *testing.T) {
+		cfg := config.EnvConfig{
+			PgvectorHost: "custom-host",
+			PgvectorPort: 5433,
+			PgvectorDB:   "mydb",
+			PgvectorUser: "myuser",
+		}
+		conn := pgvectorConnectionFromConfig(cfg)
+		assert.Equal(t, "custom-host", conn.Host)
+		assert.Equal(t, 5433, conn.Port)
+		assert.Equal(t, "mydb", conn.DB)
+		assert.Equal(t, "myuser", conn.User)
+	})
+
+	t.Run("password secret ref is set when secret name provided", func(t *testing.T) {
+		cfg := config.EnvConfig{
+			PgvectorHost:               "pg.svc",
+			PgvectorPasswordSecretName: "pg-creds",
+			PgvectorPasswordSecretKey:  "pg-password",
+		}
+		conn := pgvectorConnectionFromConfig(cfg)
+		require.NotNil(t, conn.PasswordSecret)
+		assert.Equal(t, "pg-creds", conn.PasswordSecret.Name)
+		assert.Equal(t, "pg-password", conn.PasswordSecret.Key)
+	})
+
+	t.Run("password secret key defaults to 'password'", func(t *testing.T) {
+		cfg := config.EnvConfig{
+			PgvectorHost:               "pg.svc",
+			PgvectorPasswordSecretName: "pg-creds",
+		}
+		conn := pgvectorConnectionFromConfig(cfg)
+		require.NotNil(t, conn.PasswordSecret)
+		assert.Equal(t, "password", conn.PasswordSecret.Key)
+	})
+}

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient/bffmocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/pgvector"
-	"github.com/opendatahub-io/gen-ai/internal/integrations/maas/maasmocks"
 	"github.com/opendatahub-io/gen-ai/internal/models"
 	"github.com/opendatahub-io/gen-ai/internal/testutil"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-68913

## Description

Adds support for optionally connecting OGXServer pods to an existing pgvector-enabled PostgreSQL instance as the `vector_io` provider. When configured, this replaces the built-in `inline::milvus` with `remote::pgvector` for the given playground session.

When the BFF is configured with a pgvector host (via `PGVECTOR_HOST` env var or `--pgvector-host` flag), it:
1. Swaps the LlamaStack `vector_io` provider from `inline::milvus` to `remote::pgvector` in the generated config
2. Injects the pgvector connection env vars (`PGVECTOR_HOST`, `PGVECTOR_PORT`, `PGVECTOR_DB`, `PGVECTOR_USER`, `PGVECTOR_PASSWORD`) into the OGXServer pod spec
3. Supports password injection via a Kubernetes Secret reference (`PGVECTOR_PASSWORD_SECRET_NAME` / `PGVECTOR_PASSWORD_SECRET_KEY`)

The feature is entirely opt-in — when `PGVECTOR_HOST` is not set, behavior is unchanged and `inline::milvus` remains the default.

**New files:**
- `pgvector/connection.go` — `Connection` type, constants for env var names, and provider defaults
- `pgvector/connection_test.go` — unit tests for `IsConfigured()` and `DSN()`

**Modified files:**
- `config/environment.go` — new `Pgvector*` fields on `EnvConfig`
- `cmd/main.go` — CLI flags / env var bindings for the pgvector config
- `llamastack_config.go` — `SetDefaultPgvectorProvider()` method that replaces `inline::milvus` with `remote::pgvector` using `${env.*}` placeholders
- `token_k8s_client.go` — `pgvectorConnectionFromConfig()` helper + env var injection in `InstallOGXServer` + config generation call in `generateLlamaStackConfig`

## How Has This Been Tested?

- Unit tests for `Connection.IsConfigured()` and `Connection.DSN()`
- Unit tests for `pgvectorConnectionFromConfig()` covering: unconfigured (empty host), defaults, custom overrides, secret ref with explicit key, and secret ref with default key
- Unit tests for `SetDefaultPgvectorProvider()` covering: provider replacement, env var placeholders in config, YAML serialization, and isolation from other providers/resources
- Manual testing with a pgvector-enabled PostgreSQL deployed on cluster, confirming OGXServer pods receive the correct env vars and the generated LlamaStack config uses `remote::pgvector`

## Test Impact

Added unit tests in:
- `pgvector/connection_test.go` (2 tests)
- `llamastack_config_test.go` (4 tests for `TestSetDefaultPgvectorProvider`)
- `token_k8s_client_test.go` (4 tests for `TestPgvectorConnectionFromConfig`)

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kubernetes pgvector “default vector store” configuration flags (host/port/database/user) plus password Secret name/key support.
  * When pgvector is configured, the app now generates LlamaStack config to use `remote::pgvector` as the default vector_io provider (instead of inline Milvus).

* **Tests**
  * Added unit tests covering pgvector connection configuration, provider switching behavior, YAML output, and secret key defaulting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->