### PR TITLE
Rhoaieng 66124/delete modal should show display name

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -779,6 +779,15 @@ class DeleteSubscriptionModal extends DeleteModal {
   findSubmitButton(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().findByRole('button', { name: /Delete/, hidden: true });
   }
+
+  findConfirmationMessage(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('delete-modal-confirmation-message');
+  }
+
+  shouldShowResourceName(name: string): this {
+    this.findConfirmationMessage().find('strong').should('have.text', name);
+    return this;
+  }
 }
 class ViewSubscriptionPage {
   visit(name: string): void {
@@ -1008,6 +1017,15 @@ class DeleteAuthPolicyModal extends DeleteModal {
 
   findSubmitButton(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().findByRole('button', { name: /Delete/, hidden: true });
+  }
+
+  findConfirmationMessage(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('delete-modal-confirmation-message');
+  }
+
+  shouldShowResourceName(name: string): this {
+    this.findConfirmationMessage().find('strong').should('have.text', name);
+    return this;
   }
 }
 

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -116,8 +116,8 @@ describe('MaaS Auth Policies', () => {
     authPoliciesPage.findTitle().should('contain.text', 'Authorization policies');
     authPoliciesPage.findTable().should('exist');
     authPoliciesPage.findRows().should('have.length', 6);
-    const premiumRow = authPoliciesPage.getRow('premium-team-policy');
-    premiumRow.findName().should('contain.text', 'premium-team-policy');
+    const premiumRow = authPoliciesPage.getRow('Premium Team Policy');
+    premiumRow.findName().should('contain.text', 'Premium Team Policy');
     premiumRow.findPhase().should('contain.text', 'Active');
     premiumRow.findGroups().should('contain.text', '1 Group');
     premiumRow.findModels().should('contain.text', '2 Models');
@@ -142,9 +142,9 @@ describe('MaaS Auth Policies', () => {
     authPoliciesPage.findKeywordFilterInput().type('premium');
     authPoliciesPage.findRows().should('have.length', 1);
     authPoliciesPage
-      .getRow('premium-team-policy')
+      .getRow('Premium Team Policy')
       .findName()
-      .should('contain.text', 'premium-team-policy');
+      .should('contain.text', 'Premium Team Policy');
 
     authPoliciesPage.clearAllFilters();
     authPoliciesPage.findRows().should('have.length', 6);
@@ -173,8 +173,10 @@ describe('MaaS Auth Policies', () => {
       { path: { name: 'premium-team-policy' } },
       { data: { message: "MaaSAuthPolicy 'premium-team-policy' deleted successfully" } },
     ).as('deleteAuthPolicy');
-    authPoliciesPage.getRow('premium-team-policy').findKebabAction('Delete').click();
-    deleteAuthPolicyModal.findInput().type('premium-team-policy');
+    authPoliciesPage.getRow('Premium Team Policy').findKebabAction('Delete').click();
+    deleteAuthPolicyModal.shouldShowResourceName('Premium Team Policy');
+    deleteAuthPolicyModal.findInput().type('Premium Team Policy');
+    deleteAuthPolicyModal.findSubmitButton().should('be.enabled');
     deleteAuthPolicyModal.findSubmitButton().click();
     cy.wait('@deleteAuthPolicy').then((response) => {
       expect(response.response?.body).to.deep.equal({
@@ -249,6 +251,7 @@ describe('Auth policy create and edit pages', () => {
 
 describe('View Auth Policy Page', () => {
   const policyName = 'premium-team-policy';
+  const policyDisplayName = 'Premium Team Policy';
 
   beforeEach(() => {
     setupAuthPoliciesCommon();
@@ -262,10 +265,10 @@ describe('View Auth Policy Page', () => {
   it('should display the page content with title, breadcrumb, details, groups, and models', () => {
     cy.interceptOdh('GET /maas/api/v1/all-policies', { data: mockAuthPolicies() });
     authPoliciesPage.visit();
-    authPoliciesPage.getRow(policyName).findKebabAction('View details').click();
+    authPoliciesPage.getRow(policyDisplayName).findKebabAction('View details').click();
     cy.url().should('include', `/maas/auth-policies/view/${policyName}`);
 
-    viewAuthPolicyPage.findTitle().should('contain.text', `${policyName} Display`);
+    viewAuthPolicyPage.findTitle().should('contain.text', policyDisplayName);
 
     viewAuthPolicyPage
       .findDetailsSection()

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -167,8 +167,9 @@ describe('Subscriptions Page', () => {
     ).as('deleteSubscription');
 
     subscriptionsPage.getRow('Premium Team Subscription').findKebabAction('Delete').click();
-    deleteSubscriptionModal.findInput().type('premium-team-sub');
-
+    deleteSubscriptionModal.shouldShowResourceName('Premium Team Subscription');
+    deleteSubscriptionModal.findInput().type('Premium Team Subscription');
+    deleteSubscriptionModal.findSubmitButton().should('be.enabled');
     cy.interceptOdh('GET /maas/api/v1/all-subscriptions', {
       data: mockSubscriptions().filter((subscription) => subscription.name !== 'premium-team-sub'),
     }).as('getSubscriptions');

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -448,6 +448,7 @@ export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
   },
   {
     name: 'premium-team-policy',
+    displayName: 'Premium Team Policy',
     namespace: 'maas-system',
     phase: 'Active',
     statusMessage: 'successfully reconciled',
@@ -477,7 +478,7 @@ export const mockPolicyInfo = (name = 'premium-team-policy'): PolicyInfoResponse
   return {
     policy: {
       ...policy,
-      displayName: `${resolvedName} Display`,
+      displayName: policy.displayName ?? `${resolvedName} Display`,
       description: `Description for ${resolvedName}`,
       creationTimestamp: '2025-03-01T10:00:00Z',
     },

--- a/packages/maas/frontend/src/app/pages/auth-policies/DeleteAuthPolicyModal.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/DeleteAuthPolicyModal.tsx
@@ -31,7 +31,7 @@ const DeleteAuthPolicyModal: React.FC<DeleteAuthPolicyModalProps> = ({ authPolic
       error={error}
     >
       <Stack hasGutter>
-        <StackItem>
+        <StackItem data-testid="delete-modal-confirmation-message">
           Are you sure you want to delete the Policy{' '}
           <strong>{authPolicy.displayName || authPolicy.name}</strong>?
         </StackItem>

--- a/packages/maas/frontend/src/app/pages/auth-policies/DeleteAuthPolicyModal.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/DeleteAuthPolicyModal.tsx
@@ -25,14 +25,15 @@ const DeleteAuthPolicyModal: React.FC<DeleteAuthPolicyModalProps> = ({ authPolic
         await deleteAuthPolicyCallback(authPolicy.name);
         onClose(true);
       }}
-      deleteName={authPolicy.name}
+      deleteName={authPolicy.displayName || authPolicy.name}
       genericLabel
       testId="delete-auth-policy-modal"
       error={error}
     >
       <Stack hasGutter>
         <StackItem>
-          Are you sure you want to delete the Policy <strong>{authPolicy.name}</strong>?
+          Are you sure you want to delete the Policy{' '}
+          <strong>{authPolicy.displayName || authPolicy.name}</strong>?
         </StackItem>
       </Stack>
     </DeleteModal>

--- a/packages/maas/frontend/src/app/pages/subscriptions/DeleteSubscriptionModal.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/DeleteSubscriptionModal.tsx
@@ -30,14 +30,15 @@ const DeleteSubscriptionModal: React.FC<DeleteSubscriptionModalProps> = ({
         onClose(true);
       }}
       submitButtonLabel="Delete"
-      deleteName={subscription.name}
+      deleteName={subscription.displayName || subscription.name}
       error={error}
       genericLabel
       data-testid="delete-subscription-modal"
     >
       <Stack hasGutter>
         <StackItem>
-          Are you sure you want to delete the Subscription <strong>{subscription.name}</strong>?
+          Are you sure you want to delete the Subscription{' '}
+          <strong>{subscription.displayName || subscription.name}</strong>?
         </StackItem>
       </Stack>
     </DeleteModal>

--- a/packages/maas/frontend/src/app/pages/subscriptions/DeleteSubscriptionModal.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/DeleteSubscriptionModal.tsx
@@ -33,10 +33,10 @@ const DeleteSubscriptionModal: React.FC<DeleteSubscriptionModalProps> = ({
       deleteName={subscription.displayName || subscription.name}
       error={error}
       genericLabel
-      data-testid="delete-subscription-modal"
+      testId="delete-subscription-modal"
     >
       <Stack hasGutter>
-        <StackItem>
+        <StackItem data-testid="delete-modal-confirmation-message">
           Are you sure you want to delete the Subscription{' '}
           <strong>{subscription.displayName || subscription.name}</strong>?
         </StackItem>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
closes https://redhat.atlassian.net/browse/RHOAIENG-66124
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Update the Delete Modal for Subscriptions and Authorization policies to show the display name instead of resource when available.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
**Created Subscription with display name different from resource name** 
<img width="576" height="223" alt="delete_subscription_1" src="https://github.com/user-attachments/assets/b50493f9-0ea7-4094-9db4-3307da9c3bcc" />
Delete subscription modal show display name and submit is enabled when display name is entered.
<img width="655" height="387" alt="deleet_sub_3" src="https://github.com/user-attachments/assets/96638eef-15d8-4cf6-a338-9696f434687c" />
<img width="579" height="357" alt="delete_sub_2" src="https://github.com/user-attachments/assets/7184cc2a-145b-40f3-962d-26016838dc3b" />

**Same for Authorization policies:**
<img width="630" height="299" alt="delete_policy_1" src="https://github.com/user-attachments/assets/b9c8b1ef-05c8-416a-9f1b-f24867eb5dd7" />
<img width="644" height="405" alt="delete_policy_2" src="https://github.com/user-attachments/assets/2395d071-3c00-4f35-b34a-4d06b412d06e" />

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added cypress mock tests.
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Delete confirmation dialogs now display human-friendly resource names instead of technical identifiers for Auth Policies and Subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->