### PR TITLE
feat(agent-ops): add agent deployments list table

### DIFF
--- a/frontend/config/moduleFederation.js
+++ b/frontend/config/moduleFederation.js
@@ -170,6 +170,11 @@ module.exports = {
                 singleton: true,
                 requiredVersion: deps['@patternfly/react-core'],
               },
+              '@patternfly/react-icons': {
+                singleton: true,
+                requiredVersion: deps['@patternfly/react-icons'],
+                eager: true,
+              },
               '@openshift/dynamic-plugin-sdk': {
                 singleton: true,
                 requiredVersion: deps['@openshift/dynamic-plugin-sdk'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8355,7 +8355,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9042,7 +9041,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9059,7 +9057,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9076,7 +9073,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9093,7 +9089,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9110,7 +9105,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9127,7 +9121,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9144,7 +9137,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9161,7 +9153,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9178,7 +9169,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9195,7 +9185,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9212,7 +9201,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9229,7 +9217,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13745,7 +13732,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8355,6 +8355,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9041,6 +9042,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9057,6 +9059,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9073,6 +9076,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9089,6 +9093,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9105,6 +9110,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9121,6 +9127,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9137,6 +9144,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9153,6 +9161,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9169,6 +9178,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9185,6 +9195,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9201,6 +9212,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9217,6 +9229,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13732,6 +13745,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -36379,6 +36393,10 @@
     "packages/agent-ops": {
       "name": "@odh-dashboard/agent-ops",
       "version": "0.0.0",
+      "dependencies": {
+        "@odh-dashboard/internal": "*",
+        "@odh-dashboard/plugin-core": "*"
+      },
       "devDependencies": {
         "@odh-dashboard/contract-tests": "*",
         "@odh-dashboard/eslint-config": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8355,6 +8355,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9041,6 +9042,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9057,6 +9059,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9073,6 +9076,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9089,6 +9093,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9105,6 +9110,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9121,6 +9127,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9137,6 +9144,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9153,6 +9161,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9169,6 +9178,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9185,6 +9195,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9201,6 +9212,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9217,6 +9229,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13732,6 +13745,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -36381,7 +36395,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@odh-dashboard/internal": "*",
-        "@odh-dashboard/plugin-core": "*"
+        "@odh-dashboard/plugin-core": "*",
+        "@odh-dashboard/ui-core": "*"
       },
       "devDependencies": {
         "@odh-dashboard/contract-tests": "*",

--- a/packages/agent-ops/frontend/config/moduleFederation.js
+++ b/packages/agent-ops/frontend/config/moduleFederation.js
@@ -19,6 +19,7 @@ const moduleFederationConfig = {
     },
     '@odh-dashboard/internal': { singleton: true, requiredVersion: '*' },
     '@odh-dashboard/plugin-core': { singleton: true, requiredVersion: '*' },
+    '@odh-dashboard/ui-core': { singleton: true, requiredVersion: '*' },
   },
   exposes: {
     './extensions': './src/odh/extensions',

--- a/packages/agent-ops/frontend/config/moduleFederation.js
+++ b/packages/agent-ops/frontend/config/moduleFederation.js
@@ -13,6 +13,10 @@ const moduleFederationConfig = {
       singleton: true,
       requiredVersion: deps['@patternfly/react-core'],
     },
+    '@patternfly/react-icons': {
+      singleton: true,
+      requiredVersion: deps['@patternfly/react-icons'],
+    },
     '@odh-dashboard/internal': { singleton: true, requiredVersion: '*' },
     '@odh-dashboard/plugin-core': { singleton: true, requiredVersion: '*' },
   },

--- a/packages/agent-ops/frontend/config/webpack.common.js
+++ b/packages/agent-ops/frontend/config/webpack.common.js
@@ -244,7 +244,6 @@ module.exports = (env) => ({
     extensions: ['.js', '.ts', '.tsx', '.jsx'],
     alias: {
       '~': path.resolve(SRC_DIR),
-      '@odh-dashboard/internal': path.resolve(RELATIVE_DIRNAME, '../../../frontend/src'),
     },
     symlinks: false,
     cacheWithContext: false,

--- a/packages/agent-ops/frontend/config/webpack.common.js
+++ b/packages/agent-ops/frontend/config/webpack.common.js
@@ -244,6 +244,7 @@ module.exports = (env) => ({
     extensions: ['.js', '.ts', '.tsx', '.jsx'],
     alias: {
       '~': path.resolve(SRC_DIR),
+      '@odh-dashboard/internal': path.resolve(RELATIVE_DIRNAME, '../../../frontend/src'),
     },
     symlinks: false,
     cacheWithContext: false,

--- a/packages/agent-ops/frontend/eslint.config.mjs
+++ b/packages/agent-ops/frontend/eslint.config.mjs
@@ -270,6 +270,14 @@ export default tseslint.config(
     },
   },
 
+  // Workspace packages: disable import/no-extraneous-dependencies for @odh-dashboard packages
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    rules: {
+      'import/no-extraneous-dependencies': 'off',
+    },
+  },
+
   // TypeScript files - no type assertions in production code
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/packages/agent-ops/frontend/jest.config.js
+++ b/packages/agent-ops/frontend/jest.config.js
@@ -14,6 +14,8 @@ module.exports = {
     '^react$': '<rootDir>/../../../node_modules/react',
     '^react-dom$': '<rootDir>/../../../node_modules/react-dom',
     '@odh-dashboard/internal/(.*)': '<rootDir>/../../../frontend/src/$1',
+    // Resolve @odh-dashboard/internal's #~/ imports to main frontend src
+    '#~/(.*)': '<rootDir>/../../../frontend/src/$1',
     '~/(.*)': '<rootDir>/src/$1',
   },
   testEnvironment: 'jest-environment-jsdom',

--- a/packages/agent-ops/frontend/jest.config.js
+++ b/packages/agent-ops/frontend/jest.config.js
@@ -11,6 +11,8 @@ module.exports = {
     '\\.(css|less|sass|scss)$': '<rootDir>/config/transform.style.js',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/config/transform.file.js',
+    '^react$': '<rootDir>/../../../node_modules/react',
+    '^react-dom$': '<rootDir>/../../../node_modules/react-dom',
     '@odh-dashboard/internal/(.*)': '<rootDir>/../../../frontend/src/$1',
     '~/(.*)': '<rootDir>/src/$1',
   },

--- a/packages/agent-ops/frontend/package-lock.json
+++ b/packages/agent-ops/frontend/package-lock.json
@@ -4423,7 +4423,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
       "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -5233,7 +5232,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5248,7 +5246,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5263,7 +5260,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5278,7 +5274,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5293,7 +5288,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5308,7 +5302,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5323,7 +5316,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -5338,7 +5330,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5353,7 +5344,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5368,7 +5358,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/agent-ops/frontend/package-lock.json
+++ b/packages/agent-ops/frontend/package-lock.json
@@ -4423,6 +4423,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
       "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -5232,6 +5233,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5246,6 +5248,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5260,6 +5263,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5274,6 +5278,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5288,6 +5293,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5302,6 +5308,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5316,6 +5323,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -5330,6 +5338,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5344,6 +5353,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5358,6 +5368,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/agent-ops/frontend/src/__mocks__/mockAgentRuntime.ts
+++ b/packages/agent-ops/frontend/src/__mocks__/mockAgentRuntime.ts
@@ -1,0 +1,60 @@
+import {
+  AgentCardDetail,
+  AgentRuntime,
+  AgentRuntimeDetail,
+  AgentRuntimesList,
+} from '~/app/types/agentRuntimes';
+
+export const mockAgentRuntime = (overrides?: Partial<AgentRuntime>): AgentRuntime => ({
+  name: 'sample-support-agent',
+  namespace: 'agent-ops-demo',
+  status: 'Ready',
+  type: 'agent',
+  endpointUrl: 'http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080',
+  lastSyncTime: '2026-05-12T16:00:03.214610Z',
+  ...overrides,
+});
+
+export const mockAgentRuntimesList = (runtimes?: AgentRuntime[]): AgentRuntimesList => ({
+  runtimes: runtimes ?? [mockAgentRuntime()],
+});
+
+export const mockAgentCardDetail = (overrides?: Partial<AgentCardDetail>): AgentCardDetail => ({
+  name: 'Sample Support Agent',
+  description: 'Customer support agent that triages tickets and drafts responses.',
+  version: '1.0.0',
+  agentCardUrl:
+    'http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080/.well-known/agent-card.json',
+  externalAgentCardUrl: 'https://sample-support-agent.apps.example.com/.well-known/agent-card.json',
+  defaultInputModes: ['text/plain'],
+  defaultOutputModes: ['text/plain'],
+  capabilities: {
+    streaming: true,
+    pushNotifications: false,
+    optional: [],
+  },
+  ...overrides,
+});
+
+export const mockAgentRuntimeDetail = (
+  overrides?: Partial<AgentRuntimeDetail>,
+): AgentRuntimeDetail => {
+  const runtime = mockAgentRuntime(overrides?.runtime);
+  return {
+    name: runtime.name,
+    namespace: runtime.namespace,
+    description: 'Customer support agent that triages tickets and drafts responses.',
+    runtime,
+    workloadStatus: 'Ready',
+    serviceEndpoints: [
+      {
+        name: 'http',
+        url: runtime.endpointUrl,
+        port: 8080,
+      },
+    ],
+    podCount: 2,
+    agentCard: mockAgentCardDetail(),
+    ...overrides,
+  };
+};

--- a/packages/agent-ops/frontend/src/__mocks__/mockAgentRuntime.ts
+++ b/packages/agent-ops/frontend/src/__mocks__/mockAgentRuntime.ts
@@ -40,6 +40,7 @@ export const mockAgentRuntimeDetail = (
   overrides?: Partial<AgentRuntimeDetail>,
 ): AgentRuntimeDetail => {
   const runtime = mockAgentRuntime(overrides?.runtime);
+  const defaultAgentCard = runtime.endpointUrl.trim() === '' ? null : mockAgentCardDetail();
   return {
     name: runtime.name,
     namespace: runtime.namespace,
@@ -54,7 +55,7 @@ export const mockAgentRuntimeDetail = (
       },
     ],
     podCount: 2,
-    agentCard: mockAgentCardDetail(),
+    agentCard: defaultAgentCard,
     ...overrides,
   };
 };

--- a/packages/agent-ops/frontend/src/__mocks__/mockAgentRuntime.ts
+++ b/packages/agent-ops/frontend/src/__mocks__/mockAgentRuntime.ts
@@ -40,7 +40,8 @@ export const mockAgentRuntimeDetail = (
   overrides?: Partial<AgentRuntimeDetail>,
 ): AgentRuntimeDetail => {
   const runtime = mockAgentRuntime(overrides?.runtime);
-  const defaultAgentCard = runtime.endpointUrl.trim() === '' ? null : mockAgentCardDetail();
+  const endpointUrl = typeof runtime.endpointUrl === 'string' ? runtime.endpointUrl : '';
+  const defaultAgentCard = endpointUrl.trim() === '' ? null : mockAgentCardDetail();
   return {
     name: runtime.name,
     namespace: runtime.namespace,
@@ -50,7 +51,7 @@ export const mockAgentRuntimeDetail = (
     serviceEndpoints: [
       {
         name: 'http',
-        url: runtime.endpointUrl,
+        url: endpointUrl,
         port: 8080,
       },
     ],

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
@@ -67,7 +67,7 @@ class AgentDeploymentsPage {
   }
 
   findErrorAlert(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByText('Error loading agent deployments');
+    return cy.findByTestId('error-empty-state-body');
   }
 
   findTableRows(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
@@ -1,0 +1,97 @@
+import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
+
+class AgentDeploymentTableRow extends TableRow {
+  findName(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('agent-runtime-name');
+  }
+
+  findNamespace(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('agent-runtime-namespace');
+  }
+
+  findStatusLabel(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('agent-runtime-status-label');
+  }
+
+  findEndpointViewButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('agent-runtime-endpoint-view');
+  }
+
+  findViewDetailsAction(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findKebabAction('View details');
+  }
+
+  findRestartAction(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findKebabAction('Restart');
+  }
+
+  findStopAction(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findKebabAction('Stop');
+  }
+
+  findDeleteAction(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findKebabAction('Delete');
+  }
+}
+
+class AgentDeploymentsPage {
+  visit(namespace?: string) {
+    const url = namespace ? `/deployments/${namespace}` : '/deployments';
+    cy.visit(url);
+    this.wait();
+  }
+
+  private wait() {
+    cy.findByTestId('agent-ops-project-selector').should('exist');
+    cy.testA11y();
+  }
+
+  findTable(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-runtimes-table');
+  }
+
+  findEmptyState(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-deployments-empty-state');
+  }
+
+  findSelectProjectState(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-deployments-select-project');
+  }
+
+  findFilterInput(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-runtimes-filter-input');
+  }
+
+  findLoadingSpinner(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByLabelText('Loading agent deployments');
+  }
+
+  findErrorAlert(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByText('Error loading agent deployments');
+  }
+
+  findTableRows(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findTable().findAllByTestId(/^agent-runtime-row-/);
+  }
+
+  getRow(namespace: string, name: string): AgentDeploymentTableRow {
+    return new AgentDeploymentTableRow(() =>
+      this.findTable()
+        .findByTestId(`agent-runtime-row-${namespace}-${name}`)
+        .closest('tr')
+        .should('exist'),
+    );
+  }
+
+  findEndpointsModal(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-runtime-endpoints-modal');
+  }
+
+  findEndpointField(fieldId: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findEndpointsModal()
+      .findByTestId(`agent-runtime-endpoint-${fieldId}`)
+      .find('input[readonly]');
+  }
+}
+
+export const agentDeploymentsPage = new AgentDeploymentsPage();

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -2,10 +2,10 @@
 import type { GenericStaticResponse, RouteHandlerController } from 'cypress/types/net-stubbing';
 import type { Namespace, UserSettings } from 'mod-arch-core';
 import { mockModArchResponse } from 'mod-arch-core';
+import type { AgentRuntimesList, AgentRuntimeDetail } from '~/app/types/agentRuntimes';
 import type { RoleBindingKind } from '../../../shared/types';
 
-const MODEL_REGISTRY_API_VERSION = 'v1';
-export { MODEL_REGISTRY_API_VERSION };
+export const CLIENT_API_VERSION = 'v1';
 
 type SuccessErrorResponse = {
   success: boolean;
@@ -40,6 +40,16 @@ declare global {
           type: 'GET /api/:apiVersion/settings/role_bindings',
           options: { path: { apiVersion: string } },
           response: ApiResponse<RoleBindingKind[]>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/:apiVersion/agents/runtimes',
+          options: { path: { apiVersion: string } },
+          response: ApiResponse<AgentRuntimesList>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/:apiVersion/agents/runtimes/:namespace/:name',
+          options: { path: { apiVersion: string; namespace: string; name: string } },
+          response: ApiResponse<AgentRuntimeDetail>,
         ) => Cypress.Chainable<null>);
     }
   }

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
@@ -1,0 +1,219 @@
+import { mockNamespace } from '~/__mocks__/mockNamespace';
+import {
+  mockAgentRuntime,
+  mockAgentRuntimeDetail,
+  mockAgentRuntimesList,
+} from '~/__mocks__/mockAgentRuntime';
+import type { AgentRuntime } from '~/app/types/agentRuntimes';
+import { agentDeploymentsPage } from '~/__tests__/cypress/cypress/pages/agentDeployments';
+import { CLIENT_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+
+const TEST_NAMESPACE = 'agent-ops-demo';
+
+const mockAllRuntimes = (): AgentRuntime[] => [
+  mockAgentRuntime({
+    name: 'sample-support-agent',
+    namespace: TEST_NAMESPACE,
+    status: 'Ready',
+    type: 'agent',
+  }),
+  mockAgentRuntime({
+    name: 'pending-agent',
+    namespace: TEST_NAMESPACE,
+    status: 'Pending',
+    type: 'agent',
+    endpointUrl: '',
+  }),
+  mockAgentRuntime({
+    name: 'failed-agent',
+    namespace: TEST_NAMESPACE,
+    status: 'Failed',
+    type: 'agent',
+    endpointUrl: '',
+  }),
+  mockAgentRuntime({
+    name: 'sample-tool',
+    namespace: TEST_NAMESPACE,
+    status: 'Stopped',
+    type: 'tool',
+  }),
+];
+
+const initIntercepts = ({
+  runtimes = mockAllRuntimes(),
+  namespaces = [mockNamespace({ name: TEST_NAMESPACE })],
+}: {
+  runtimes?: AgentRuntime[];
+  namespaces?: ReturnType<typeof mockNamespace>[];
+} = {}) => {
+  cy.interceptApi(
+    'GET /api/:apiVersion/namespaces',
+    {
+      path: {
+        apiVersion: CLIENT_API_VERSION,
+      },
+    },
+    namespaces,
+  );
+
+  cy.interceptApi(
+    'GET /api/:apiVersion/agents/runtimes',
+    {
+      path: {
+        apiVersion: CLIENT_API_VERSION,
+      },
+    },
+    mockAgentRuntimesList(runtimes),
+  ).as('getAgentRuntimes');
+
+  runtimes.forEach((runtime) => {
+    cy.interceptApi(
+      'GET /api/:apiVersion/agents/runtimes/:namespace/:name',
+      {
+        path: {
+          apiVersion: CLIENT_API_VERSION,
+          namespace: runtime.namespace,
+          name: runtime.name,
+        },
+      },
+      mockAgentRuntimeDetail({
+        name: runtime.name,
+        namespace: runtime.namespace,
+        runtime,
+        agentCard:
+          runtime.endpointUrl.trim() === '' ? null : mockAgentRuntimeDetail({ runtime }).agentCard,
+      }),
+    ).as(`getAgentRuntimeDetail-${runtime.namespace}-${runtime.name}`);
+  });
+};
+
+describe('Agent Deployments', () => {
+  it('should display row data and status labels', () => {
+    initIntercepts();
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+
+    agentDeploymentsPage.findTable().should('be.visible');
+    agentDeploymentsPage.findTableRows().should('have.length', 4);
+
+    const readyRow = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'sample-support-agent');
+    readyRow.findName().should('contain.text', 'sample-support-agent');
+    readyRow.findNamespace().should('contain.text', TEST_NAMESPACE);
+    readyRow.findStatusLabel().should('contain.text', 'Ready');
+    readyRow.findEndpointViewButton().should('exist').and('not.be.disabled');
+
+    const pendingRow = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'pending-agent');
+    pendingRow.findStatusLabel().should('contain.text', 'Pending');
+    pendingRow.findEndpointViewButton().should('exist').and('not.be.disabled');
+
+    const failedRow = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'failed-agent');
+    failedRow.findStatusLabel().should('contain.text', 'Failed');
+    failedRow.findEndpointViewButton().should('exist').and('not.be.disabled');
+
+    const stoppedRow = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'sample-tool');
+    stoppedRow.findStatusLabel().should('contain.text', 'Stopped');
+  });
+
+  it('should show empty state when no agents are deployed', () => {
+    initIntercepts({ runtimes: [] });
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+
+    agentDeploymentsPage
+      .findEmptyState()
+      .should('be.visible')
+      .and('contain.text', 'No agent deployments');
+  });
+
+  it('should show select-project state when no namespace is selected and no runtimes exist', () => {
+    initIntercepts({ runtimes: [] });
+    agentDeploymentsPage.visit();
+
+    agentDeploymentsPage
+      .findSelectProjectState()
+      .should('be.visible')
+      .and('contain.text', 'Select a project');
+  });
+
+  it('should show loading spinner while runtimes are being fetched', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes`,
+      },
+      (req) => {
+        req.reply({ delay: 60000, body: { data: mockAgentRuntimesList([]) } });
+      },
+    );
+
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+    agentDeploymentsPage.findLoadingSpinner().should('exist');
+  });
+
+  it('should show error alert when runtimes fail to load', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes`,
+      },
+      {
+        statusCode: 500,
+        body: { error: 'Internal Server Error' },
+      },
+    ).as('getAgentRuntimesFailed');
+
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+    cy.wait('@getAgentRuntimesFailed');
+    agentDeploymentsPage.findErrorAlert().should('exist');
+  });
+
+  it('should filter deployments by name', () => {
+    initIntercepts();
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+    agentDeploymentsPage.findTable().should('be.visible');
+
+    agentDeploymentsPage.findFilterInput().type('pending');
+    agentDeploymentsPage.findTableRows().should('have.length', 1);
+    agentDeploymentsPage
+      .getRow(TEST_NAMESPACE, 'pending-agent')
+      .findName()
+      .should('contain.text', 'pending-agent');
+
+    agentDeploymentsPage.findFilterInput().clear().type('nonexistent-xyz');
+    agentDeploymentsPage.findTableRows().should('have.length', 0);
+  });
+
+  it('should open endpoints modal from the View link', () => {
+    initIntercepts();
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+
+    agentDeploymentsPage
+      .getRow(TEST_NAMESPACE, 'sample-support-agent')
+      .findEndpointViewButton()
+      .click();
+
+    agentDeploymentsPage.findEndpointsModal().should('be.visible');
+    agentDeploymentsPage
+      .findEndpointField('cluster-url')
+      .should('have.value', 'http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080');
+    agentDeploymentsPage
+      .findEndpointField('local-url')
+      .should(
+        'have.value',
+        'http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080/.well-known/agent-card.json',
+      );
+    agentDeploymentsPage
+      .findEndpointField('external-production-endpoint')
+      .should(
+        'have.value',
+        'https://sample-support-agent.apps.example.com/.well-known/agent-card.json',
+      );
+  });
+
+  it('should show View details row action', () => {
+    initIntercepts();
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+
+    const row = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'sample-support-agent');
+    row.findKebab().click();
+    row.findViewDetailsAction().should('be.visible');
+  });
+});

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
@@ -134,6 +134,16 @@ describe('Agent Deployments', () => {
   });
 
   it('should show loading spinner while runtimes are being fetched', () => {
+    cy.interceptApi(
+      'GET /api/:apiVersion/namespaces',
+      {
+        path: {
+          apiVersion: CLIENT_API_VERSION,
+        },
+      },
+      [mockNamespace({ name: TEST_NAMESPACE })],
+    );
+
     cy.intercept(
       {
         method: 'GET',
@@ -149,6 +159,16 @@ describe('Agent Deployments', () => {
   });
 
   it('should show error alert when runtimes fail to load', () => {
+    cy.interceptApi(
+      'GET /api/:apiVersion/namespaces',
+      {
+        path: {
+          apiVersion: CLIENT_API_VERSION,
+        },
+      },
+      [mockNamespace({ name: TEST_NAMESPACE })],
+    );
+
     cy.intercept(
       {
         method: 'GET',
@@ -158,10 +178,9 @@ describe('Agent Deployments', () => {
         statusCode: 500,
         body: { error: 'Internal Server Error' },
       },
-    ).as('getAgentRuntimesFailed');
+    );
 
     agentDeploymentsPage.visit(TEST_NAMESPACE);
-    cy.wait('@getAgentRuntimesFailed');
     agentDeploymentsPage.findErrorAlert().should('exist');
   });
 

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
@@ -123,14 +123,36 @@ describe('Agent Deployments', () => {
       .and('contain.text', 'No agent deployments');
   });
 
-  it('should show select-project state when no namespace is selected and no runtimes exist', () => {
-    initIntercepts({ runtimes: [] });
+  it('should show select-project state when no namespace is selected and no projects exist', () => {
+    initIntercepts({ runtimes: [], namespaces: [] });
     agentDeploymentsPage.visit();
 
     agentDeploymentsPage
       .findSelectProjectState()
       .should('be.visible')
       .and('contain.text', 'Select a project');
+  });
+
+  it('should redirect to the active project when no namespace is selected', () => {
+    const preferredNamespace = 'preferred-project';
+    initIntercepts({
+      runtimes: [
+        mockAgentRuntime({
+          name: 'other-agent',
+          namespace: 'other-project',
+          status: 'Ready',
+          type: 'agent',
+        }),
+      ],
+      namespaces: [
+        mockNamespace({ name: preferredNamespace }),
+        mockNamespace({ name: 'other-project' }),
+      ],
+    });
+    agentDeploymentsPage.visit();
+
+    cy.url().should('include', `/deployments/${preferredNamespace}`);
+    agentDeploymentsPage.findEmptyState().should('be.visible');
   });
 
   it('should show loading spinner while runtimes are being fetched', () => {

--- a/packages/agent-ops/frontend/src/app/api/agentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/api/agentRuntimes.ts
@@ -1,0 +1,32 @@
+import { APIOptions, handleRestFailures, isModArchResponse, restGET } from 'mod-arch-core';
+import { BFF_API_VERSION, URL_PREFIX } from '~/app/utilities/const';
+import { AgentRuntime, AgentRuntimeDetail, AgentRuntimesList } from '~/app/types/agentRuntimes';
+
+export const listAgentRuntimes =
+  (hostPath: string) =>
+  (opts: APIOptions): Promise<AgentRuntime[]> =>
+    handleRestFailures(
+      restGET(hostPath, `${URL_PREFIX}/api/${BFF_API_VERSION}/agents/runtimes`, {}, opts),
+    ).then((response) => {
+      if (isModArchResponse<AgentRuntimesList>(response)) {
+        return response.data.runtimes;
+      }
+      throw new Error('Invalid response format');
+    });
+
+export const getAgentRuntimeDetail =
+  (hostPath: string, namespace: string, name: string) =>
+  (opts: APIOptions): Promise<AgentRuntimeDetail> =>
+    handleRestFailures(
+      restGET(
+        hostPath,
+        `${URL_PREFIX}/api/${BFF_API_VERSION}/agents/runtimes/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
+        {},
+        opts,
+      ),
+    ).then((response) => {
+      if (isModArchResponse<AgentRuntimeDetail>(response)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });

--- a/packages/agent-ops/frontend/src/app/api/agentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/api/agentRuntimes.ts
@@ -2,17 +2,39 @@ import { APIOptions, handleRestFailures, isModArchResponse, restGET } from 'mod-
 import { BFF_API_VERSION, URL_PREFIX } from '~/app/utilities/const';
 import { AgentRuntime, AgentRuntimeDetail, AgentRuntimesList } from '~/app/types/agentRuntimes';
 
+export type ListAgentRuntimesParams = {
+  limit?: number;
+  continueToken?: string;
+};
+
+export type ListAgentRuntimesResult = {
+  runtimes: AgentRuntime[];
+  continueToken?: string;
+};
+
 export const listAgentRuntimes =
   (hostPath: string) =>
-  (opts: APIOptions): Promise<AgentRuntime[]> =>
-    handleRestFailures(
-      restGET(hostPath, `${URL_PREFIX}/api/${BFF_API_VERSION}/agents/runtimes`, {}, opts),
+  (opts: APIOptions, params?: ListAgentRuntimesParams): Promise<ListAgentRuntimesResult> => {
+    const queryParams: Record<string, string> = {};
+    if (params?.limit != null) {
+      queryParams.limit = String(params.limit);
+    }
+    if (params?.continueToken) {
+      queryParams.continueToken = params.continueToken;
+    }
+
+    return handleRestFailures(
+      restGET(hostPath, `${URL_PREFIX}/api/${BFF_API_VERSION}/agents/runtimes`, queryParams, opts),
     ).then((response) => {
       if (isModArchResponse<AgentRuntimesList>(response)) {
-        return response.data.runtimes;
+        return {
+          runtimes: response.data.runtimes,
+          continueToken: response.data.continueToken,
+        };
       }
       throw new Error('Invalid response format');
     });
+  };
 
 export const getAgentRuntimeDetail =
   (hostPath: string, namespace: string, name: string) =>

--- a/packages/agent-ops/frontend/src/app/components/AgentRuntimeEndpointsModal.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentRuntimeEndpointsModal.tsx
@@ -66,8 +66,8 @@ const AgentRuntimeEndpointsModal: React.FC<AgentRuntimeEndpointsModalProps> = ({
               <StackItem key={field.id}>
                 <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
                   <FlexItem>
-                    <Content component={ContentVariants.p} className="pf-v6-u-font-weight-bold">
-                      {field.label}
+                    <Content component={ContentVariants.p}>
+                      <strong>{field.label}</strong>
                     </Content>
                   </FlexItem>
                   <FlexItem>
@@ -82,7 +82,7 @@ const AgentRuntimeEndpointsModal: React.FC<AgentRuntimeEndpointsModalProps> = ({
                     </ClipboardCopy>
                   </FlexItem>
                   <FlexItem>
-                    <Content component={ContentVariants.small} className="pf-v6-u-color-text-200">
+                    <Content component={ContentVariants.small}>
                       {field.description}
                     </Content>
                   </FlexItem>

--- a/packages/agent-ops/frontend/src/app/components/AgentRuntimeEndpointsModal.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentRuntimeEndpointsModal.tsx
@@ -82,9 +82,7 @@ const AgentRuntimeEndpointsModal: React.FC<AgentRuntimeEndpointsModalProps> = ({
                     </ClipboardCopy>
                   </FlexItem>
                   <FlexItem>
-                    <Content component={ContentVariants.small}>
-                      {field.description}
-                    </Content>
+                    <Content component={ContentVariants.small}>{field.description}</Content>
                   </FlexItem>
                 </Flex>
               </StackItem>

--- a/packages/agent-ops/frontend/src/app/components/AgentRuntimeEndpointsModal.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentRuntimeEndpointsModal.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
 import {
+  Alert,
   Button,
   ClipboardCopy,
   Content,
@@ -10,6 +12,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  Spinner,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
@@ -26,11 +29,12 @@ const AgentRuntimeEndpointsModal: React.FC<AgentRuntimeEndpointsModalProps> = ({
   runtime,
   onClose,
 }) => {
-  const [detail] = useAgentRuntimeDetail(runtime.namespace, runtime.name);
+  const [detail, loaded, detailError] = useAgentRuntimeDetail(runtime.namespace, runtime.name);
+  const isAccessDenied = !!detailError && getGenericErrorCode(detailError) === 403;
 
   const endpointFields = React.useMemo(
-    () => getAgentRuntimeEndpointFields(runtime, detail),
-    [runtime, detail],
+    () => getAgentRuntimeEndpointFields(runtime, loaded && !detailError ? detail : undefined),
+    [runtime, detail, loaded, detailError],
   );
 
   return (
@@ -43,6 +47,19 @@ const AgentRuntimeEndpointsModal: React.FC<AgentRuntimeEndpointsModalProps> = ({
     >
       <ModalHeader title="Endpoints" labelId="endpoints-modal-title" />
       <ModalBody>
+        {!loaded && !detailError && <Spinner aria-label="Loading endpoints" />}
+        {detailError && (
+          <Alert
+            variant="danger"
+            isInline
+            title={isAccessDenied ? 'Access permissions needed' : 'Error loading endpoints'}
+            data-testid="agent-runtime-endpoints-error"
+          >
+            {isAccessDenied
+              ? 'You do not have permission to view endpoint details for this agent deployment.'
+              : 'Unable to load endpoint details. Please try again later.'}
+          </Alert>
+        )}
         {endpointFields.length > 0 && (
           <Stack hasGutter>
             {endpointFields.map((field) => (
@@ -65,10 +82,7 @@ const AgentRuntimeEndpointsModal: React.FC<AgentRuntimeEndpointsModalProps> = ({
                     </ClipboardCopy>
                   </FlexItem>
                   <FlexItem>
-                    <Content
-                      component={ContentVariants.small}
-                      className="pf-v6-u-color-text-subtle"
-                    >
+                    <Content component={ContentVariants.small} className="pf-v6-u-color-text-200">
                       {field.description}
                     </Content>
                   </FlexItem>

--- a/packages/agent-ops/frontend/src/app/components/AgentRuntimeEndpointsModal.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentRuntimeEndpointsModal.tsx
@@ -49,10 +49,7 @@ const AgentRuntimeEndpointsModal: React.FC<AgentRuntimeEndpointsModalProps> = ({
               <StackItem key={field.id}>
                 <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
                   <FlexItem>
-                    <Content
-                      component={ContentVariants.p}
-                      style={{ fontWeight: 'var(--pf-t--global--font--weight--body--bold)' }}
-                    >
+                    <Content component={ContentVariants.p} className="pf-v6-u-font-weight-bold">
                       {field.label}
                     </Content>
                   </FlexItem>
@@ -70,7 +67,7 @@ const AgentRuntimeEndpointsModal: React.FC<AgentRuntimeEndpointsModalProps> = ({
                   <FlexItem>
                     <Content
                       component={ContentVariants.small}
-                      style={{ color: 'var(--pf-t--global--text--color--subtle)' }}
+                      className="pf-v6-u-color-text-subtle"
                     >
                       {field.description}
                     </Content>

--- a/packages/agent-ops/frontend/src/app/components/AgentRuntimeEndpointsModal.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentRuntimeEndpointsModal.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import {
+  Button,
+  ClipboardCopy,
+  Content,
+  ContentVariants,
+  Flex,
+  FlexItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { useAgentRuntimeDetail } from '~/app/hooks/useAgentRuntimeDetail';
+import { AgentRuntime } from '~/app/types/agentRuntimes';
+import { getAgentRuntimeEndpointFields } from '~/app/utilities/agentRuntimeEndpoints';
+
+type AgentRuntimeEndpointsModalProps = {
+  runtime: AgentRuntime;
+  onClose: () => void;
+};
+
+const AgentRuntimeEndpointsModal: React.FC<AgentRuntimeEndpointsModalProps> = ({
+  runtime,
+  onClose,
+}) => {
+  const [detail] = useAgentRuntimeDetail(runtime.namespace, runtime.name);
+
+  const endpointFields = React.useMemo(
+    () => getAgentRuntimeEndpointFields(runtime, detail),
+    [runtime, detail],
+  );
+
+  return (
+    <Modal
+      variant="medium"
+      isOpen
+      onClose={onClose}
+      aria-labelledby="endpoints-modal-title"
+      data-testid="agent-runtime-endpoints-modal"
+    >
+      <ModalHeader title="Endpoints" labelId="endpoints-modal-title" />
+      <ModalBody>
+        {endpointFields.length > 0 && (
+          <Stack hasGutter>
+            {endpointFields.map((field) => (
+              <StackItem key={field.id}>
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+                  <FlexItem>
+                    <Content
+                      component={ContentVariants.p}
+                      style={{ fontWeight: 'var(--pf-t--global--font--weight--body--bold)' }}
+                    >
+                      {field.label}
+                    </Content>
+                  </FlexItem>
+                  <FlexItem>
+                    <ClipboardCopy
+                      id={field.id}
+                      isReadOnly
+                      hoverTip="Copy"
+                      clickTip="Copied"
+                      data-testid={`agent-runtime-endpoint-${field.id}`}
+                    >
+                      {field.url}
+                    </ClipboardCopy>
+                  </FlexItem>
+                  <FlexItem>
+                    <Content
+                      component={ContentVariants.small}
+                      style={{ color: 'var(--pf-t--global--text--color--subtle)' }}
+                    >
+                      {field.description}
+                    </Content>
+                  </FlexItem>
+                </Flex>
+              </StackItem>
+            ))}
+          </Stack>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="primary" onClick={onClose}>
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default AgentRuntimeEndpointsModal;

--- a/packages/agent-ops/frontend/src/app/components/AgentRuntimeStatusLabel.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentRuntimeStatusLabel.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { Label, Popover } from '@patternfly/react-core';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  OffIcon,
+  PendingIcon,
+} from '@patternfly/react-icons';
+import {
+  AgentRuntimeDisplayStatus,
+  mapAgentRuntimeStatus,
+} from '~/app/utilities/agentRuntimeStatus';
+
+type AgentRuntimeStatusLabelProps = {
+  status: string | undefined;
+  statusMessage?: string;
+};
+
+const statusIconMap: Record<AgentRuntimeDisplayStatus, React.ReactNode> = {
+  [AgentRuntimeDisplayStatus.Ready]: <CheckCircleIcon />,
+  [AgentRuntimeDisplayStatus.Stopped]: <OffIcon />,
+  [AgentRuntimeDisplayStatus.Pending]: <PendingIcon />,
+  [AgentRuntimeDisplayStatus.Failed]: <ExclamationCircleIcon />,
+};
+
+const AgentRuntimeStatusLabel: React.FC<AgentRuntimeStatusLabelProps> = ({
+  status,
+  statusMessage,
+}) => {
+  const { displayStatus, labelStatus, labelColor, labelVariant } = mapAgentRuntimeStatus(status);
+  const hasPopover = !!statusMessage;
+
+  const label = (
+    <Label
+      variant={labelVariant ?? (hasPopover ? 'filled' : 'outline')}
+      isCompact
+      isClickable={hasPopover}
+      data-testid="agent-runtime-status-label"
+      status={labelStatus}
+      color={labelColor}
+      icon={statusIconMap[displayStatus]}
+    >
+      {displayStatus}
+    </Label>
+  );
+
+  if (!hasPopover) {
+    return label;
+  }
+
+  return (
+    <Popover
+      data-testid="agent-runtime-status-popover"
+      headerContent={displayStatus}
+      bodyContent={statusMessage}
+      position="top"
+    >
+      {label}
+    </Popover>
+  );
+};
+
+export default AgentRuntimeStatusLabel;

--- a/packages/agent-ops/frontend/src/app/components/AgentRuntimeStatusLabel.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentRuntimeStatusLabel.tsx
@@ -5,6 +5,7 @@ import {
   ExclamationCircleIcon,
   OffIcon,
   PendingIcon,
+  QuestionCircleIcon,
 } from '@patternfly/react-icons';
 import {
   AgentRuntimeDisplayStatus,
@@ -21,6 +22,7 @@ const statusIconMap: Record<AgentRuntimeDisplayStatus, React.ReactNode> = {
   [AgentRuntimeDisplayStatus.Stopped]: <OffIcon />,
   [AgentRuntimeDisplayStatus.Pending]: <PendingIcon />,
   [AgentRuntimeDisplayStatus.Failed]: <ExclamationCircleIcon />,
+  [AgentRuntimeDisplayStatus.Unknown]: <QuestionCircleIcon />,
 };
 
 const AgentRuntimeStatusLabel: React.FC<AgentRuntimeStatusLabelProps> = ({

--- a/packages/agent-ops/frontend/src/app/components/__tests__/AgentRuntimeEndpointsModal.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/components/__tests__/AgentRuntimeEndpointsModal.spec.tsx
@@ -1,0 +1,89 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { AxiosError } from 'axios';
+import { mockAgentRuntimeDetail } from '~/__mocks__/mockAgentRuntime';
+import { useAgentRuntimeDetail } from '~/app/hooks/useAgentRuntimeDetail';
+import AgentRuntimeEndpointsModal from '~/app/components/AgentRuntimeEndpointsModal';
+import { createReadyRuntime } from '~/app/pages/agentRuntimes/__tests__/agentRuntimeTestUtils';
+
+jest.mock('~/app/hooks/useAgentRuntimeDetail', () => ({
+  useAgentRuntimeDetail: jest.fn(),
+}));
+
+const mockUseAgentRuntimeDetail = jest.mocked(useAgentRuntimeDetail);
+
+const createForbiddenError = () => {
+  const error = new AxiosError('Forbidden');
+  error.response = {
+    status: 403,
+    data: {},
+    statusText: 'Forbidden',
+    headers: {},
+    config: {} as never,
+  };
+  return error;
+};
+
+describe('AgentRuntimeEndpointsModal', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAgentRuntimeDetail.mockReturnValue([
+      mockAgentRuntimeDetail(),
+      true,
+      undefined,
+      jest.fn(),
+    ]);
+  });
+
+  it('should show a loading spinner while detail is loading', () => {
+    mockUseAgentRuntimeDetail.mockReturnValue([undefined, false, undefined, jest.fn()]);
+
+    render(<AgentRuntimeEndpointsModal runtime={createReadyRuntime()} onClose={onClose} />);
+
+    expect(screen.getByRole('progressbar', { name: 'Loading endpoints' })).toBeInTheDocument();
+  });
+
+  it('should show an access denied alert when detail returns 403', () => {
+    mockUseAgentRuntimeDetail.mockReturnValue([undefined, true, createForbiddenError(), jest.fn()]);
+
+    render(<AgentRuntimeEndpointsModal runtime={createReadyRuntime()} onClose={onClose} />);
+
+    expect(screen.getByTestId('agent-runtime-endpoints-error')).toHaveTextContent(
+      'Access permissions needed',
+    );
+    expect(
+      screen.getByText(
+        'You do not have permission to view endpoint details for this agent deployment.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should show a generic error alert when detail fails', () => {
+    mockUseAgentRuntimeDetail.mockReturnValue([
+      undefined,
+      true,
+      new Error('Network error'),
+      jest.fn(),
+    ]);
+
+    render(<AgentRuntimeEndpointsModal runtime={createReadyRuntime()} onClose={onClose} />);
+
+    expect(screen.getByTestId('agent-runtime-endpoints-error')).toHaveTextContent(
+      'Error loading endpoints',
+    );
+    expect(
+      screen.getByText('Unable to load endpoint details. Please try again later.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render endpoint fields when detail loads successfully', () => {
+    render(<AgentRuntimeEndpointsModal runtime={createReadyRuntime()} onClose={onClose} />);
+
+    expect(
+      screen.getByDisplayValue('http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/agent-ops/frontend/src/app/const.ts
+++ b/packages/agent-ops/frontend/src/app/const.ts
@@ -1,0 +1,2 @@
+/** Disables useFetchState polling when refreshRate is 0. */
+export const NO_REFRESH_INTERVAL = 0;

--- a/packages/agent-ops/frontend/src/app/hooks/__tests__/useListAgentRuntimes.spec.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/__tests__/useListAgentRuntimes.spec.ts
@@ -1,0 +1,251 @@
+import { act } from '@testing-library/react';
+import { useFetchState } from 'mod-arch-core';
+import { mockAgentRuntime } from '~/__mocks__/mockAgentRuntime';
+import { listAgentRuntimes } from '~/app/api/agentRuntimes';
+import { useListAgentRuntimes } from '~/app/hooks/useListAgentRuntimes';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+
+jest.mock('~/app/utilities/const', () => ({
+  URL_PREFIX: '/agent-ops',
+  BFF_API_VERSION: 'v1',
+}));
+
+jest.mock('~/app/const', () => ({
+  NO_REFRESH_INTERVAL: 0,
+}));
+
+jest.mock('mod-arch-core', () => ({
+  useFetchState: jest.fn(),
+}));
+
+jest.mock('~/app/api/agentRuntimes', () => ({
+  listAgentRuntimes: jest.fn(),
+}));
+
+const mockUseFetchState = jest.mocked(useFetchState);
+const mockListAgentRuntimes = jest.mocked(listAgentRuntimes);
+const mockListAgentRuntimesFetcher = jest.fn();
+
+const getLatestFetchCallback = () => {
+  const calls = mockUseFetchState.mock.calls;
+  const [fetchCallback] = calls[calls.length - 1] as unknown as [
+    (opts: Record<string, never>) => Promise<{ runtimes: unknown[]; continueToken?: string }>,
+  ];
+  return fetchCallback;
+};
+
+const mockLoadedState = (
+  data: { runtimes: ReturnType<typeof mockAgentRuntime>[]; continueToken?: string },
+  refresh = jest.fn(),
+) => {
+  mockUseFetchState.mockReturnValue([data, true, undefined, refresh]);
+};
+
+describe('useListAgentRuntimes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListAgentRuntimes.mockReturnValue(mockListAgentRuntimesFetcher);
+    mockListAgentRuntimesFetcher.mockResolvedValue({ runtimes: [], continueToken: undefined });
+    mockUseFetchState.mockReturnValue([
+      { runtimes: [], continueToken: undefined },
+      false,
+      undefined,
+      jest.fn(),
+    ]);
+  });
+
+  it('should filter runtimes to the selected namespace', () => {
+    mockLoadedState({
+      runtimes: [
+        mockAgentRuntime({ namespace: 'agent-ops-demo', name: 'agent-a' }),
+        mockAgentRuntime({ namespace: 'other-project', name: 'agent-b' }),
+      ],
+    });
+
+    const { result } = testHook(useListAgentRuntimes)('agent-ops-demo');
+
+    expect(result.current.runtimes).toHaveLength(1);
+    expect(result.current.runtimes[0].name).toBe('agent-a');
+  });
+
+  it('should return all runtimes when no namespace is selected', () => {
+    mockLoadedState({
+      runtimes: [
+        mockAgentRuntime({ namespace: 'agent-ops-demo', name: 'agent-a' }),
+        mockAgentRuntime({ namespace: 'other-project', name: 'agent-b' }),
+      ],
+    });
+
+    const { result } = testHook(useListAgentRuntimes)();
+
+    expect(result.current.runtimes).toHaveLength(2);
+  });
+
+  it('should initialize with page 1 and default page size', () => {
+    const { result } = testHook(useListAgentRuntimes)();
+
+    expect(result.current.page).toBe(1);
+    expect(result.current.pageSize).toBe(10);
+  });
+
+  it('should pass NO_REFRESH_INTERVAL to useFetchState', () => {
+    testHook(useListAgentRuntimes)();
+
+    expect(mockUseFetchState).toHaveBeenCalledWith(
+      expect.any(Function),
+      { runtimes: [] },
+      { refreshRate: 0 },
+    );
+  });
+
+  it('should request the first page without continueToken', async () => {
+    testHook(useListAgentRuntimes)();
+
+    await getLatestFetchCallback()({});
+
+    expect(mockListAgentRuntimes).toHaveBeenCalledWith('');
+    expect(mockListAgentRuntimesFetcher).toHaveBeenCalledWith({}, { limit: 10 });
+  });
+
+  it('should expose continueToken from fetch state', () => {
+    mockLoadedState({
+      runtimes: [mockAgentRuntime({ name: 'agent-a' })],
+      continueToken: 'next-page-token',
+    });
+
+    const { result } = testHook(useListAgentRuntimes)();
+
+    expect(result.current.continueToken).toBe('next-page-token');
+  });
+
+  it('should pass continueToken when navigating to the next page', async () => {
+    const refresh = jest.fn();
+    mockUseFetchState.mockReturnValue([
+      { runtimes: [], continueToken: undefined },
+      false,
+      undefined,
+      refresh,
+    ]);
+
+    const renderResult = testHook(useListAgentRuntimes)();
+
+    mockUseFetchState.mockReturnValue([
+      {
+        runtimes: [mockAgentRuntime({ name: 'agent-a' })],
+        continueToken: 'page-1-token',
+      },
+      true,
+      undefined,
+      refresh,
+    ]);
+
+    await act(async () => {
+      renderResult.rerender();
+    });
+
+    await act(async () => {
+      renderResult.result.current.setPage(2);
+    });
+
+    await getLatestFetchCallback()({});
+
+    expect(mockListAgentRuntimesFetcher).toHaveBeenCalledWith(
+      {},
+      { limit: 10, continueToken: 'page-1-token' },
+    );
+  });
+
+  it('should reject fetch when navigating to a page without a stored token', async () => {
+    mockLoadedState({ runtimes: [] });
+
+    const renderResult = testHook(useListAgentRuntimes)();
+
+    await act(async () => {
+      renderResult.result.current.setPage(2);
+    });
+
+    await expect(getLatestFetchCallback()({})).rejects.toThrow('No token available for page 2.');
+  });
+
+  it('should use the selected page size when requesting runtimes', async () => {
+    mockLoadedState({ runtimes: [] });
+
+    const renderResult = testHook(useListAgentRuntimes)();
+
+    await act(async () => {
+      renderResult.result.current.setPageSize(20);
+    });
+
+    await getLatestFetchCallback()({});
+
+    expect(mockListAgentRuntimesFetcher).toHaveBeenCalledWith({}, { limit: 20 });
+  });
+
+  it('should reset to page 1 when page size changes', async () => {
+    mockLoadedState({
+      runtimes: [mockAgentRuntime({ name: 'agent-a' })],
+      continueToken: 'page-1-token',
+    });
+
+    const renderResult = testHook(useListAgentRuntimes)();
+
+    await act(async () => {
+      renderResult.result.current.setPage(2);
+    });
+    expect(renderResult.result.current.page).toBe(2);
+
+    await act(async () => {
+      renderResult.result.current.setPageSize(20);
+    });
+
+    expect(renderResult.result.current.page).toBe(1);
+    expect(renderResult.result.current.pageSize).toBe(20);
+
+    await getLatestFetchCallback()({});
+
+    expect(mockListAgentRuntimesFetcher).toHaveBeenCalledWith({}, { limit: 20 });
+  });
+
+  it('should reset to page 1 when namespace changes', async () => {
+    mockLoadedState({ runtimes: [] });
+
+    const renderResult = testHook(useListAgentRuntimes)('agent-ops-demo');
+
+    await act(async () => {
+      renderResult.result.current.setPage(3);
+    });
+    expect(renderResult.result.current.page).toBe(3);
+
+    renderResult.rerender('other-project');
+
+    expect(renderResult.result.current.page).toBe(1);
+  });
+
+  it('should reset page and tokens on refresh', async () => {
+    const mockRefresh = jest.fn().mockResolvedValue(undefined);
+    mockLoadedState(
+      {
+        runtimes: [mockAgentRuntime({ name: 'agent-a' })],
+        continueToken: 'page-1-token',
+      },
+      mockRefresh,
+    );
+
+    const renderResult = testHook(useListAgentRuntimes)();
+
+    await act(async () => {
+      renderResult.result.current.setPage(2);
+    });
+
+    await act(async () => {
+      await renderResult.result.current.refresh();
+    });
+
+    expect(renderResult.result.current.page).toBe(1);
+    expect(mockRefresh).toHaveBeenCalled();
+
+    await getLatestFetchCallback()({});
+
+    expect(mockListAgentRuntimesFetcher).toHaveBeenCalledWith({}, { limit: 10 });
+  });
+});

--- a/packages/agent-ops/frontend/src/app/hooks/__tests__/useListAgentRuntimes.spec.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/__tests__/useListAgentRuntimes.spec.ts
@@ -155,6 +155,46 @@ describe('useListAgentRuntimes', () => {
     );
   });
 
+  it('should keep continueToken and allow next page when namespace filter yields an empty page', async () => {
+    const refresh = jest.fn();
+    mockUseFetchState.mockReturnValue([
+      { runtimes: [], continueToken: undefined },
+      false,
+      undefined,
+      refresh,
+    ]);
+
+    const renderResult = testHook(useListAgentRuntimes)('agent-ops-demo');
+
+    mockUseFetchState.mockReturnValue([
+      {
+        runtimes: [mockAgentRuntime({ namespace: 'other-project', name: 'agent-b' })],
+        continueToken: 'page-1-token',
+      },
+      true,
+      undefined,
+      refresh,
+    ]);
+
+    await act(async () => {
+      renderResult.rerender('agent-ops-demo');
+    });
+
+    expect(renderResult.result.current.runtimes).toHaveLength(0);
+    expect(renderResult.result.current.continueToken).toBe('page-1-token');
+
+    await act(async () => {
+      renderResult.result.current.setPage(2);
+    });
+
+    await getLatestFetchCallback()({});
+
+    expect(mockListAgentRuntimesFetcher).toHaveBeenCalledWith(
+      {},
+      { limit: 10, continueToken: 'page-1-token' },
+    );
+  });
+
   it('should reject fetch when navigating to a page without a stored token', async () => {
     mockLoadedState({ runtimes: [] });
 

--- a/packages/agent-ops/frontend/src/app/hooks/__tests__/useListAgentRuntimes.spec.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/__tests__/useListAgentRuntimes.spec.ts
@@ -27,7 +27,7 @@ const mockListAgentRuntimes = jest.mocked(listAgentRuntimes);
 const mockListAgentRuntimesFetcher = jest.fn();
 
 const getLatestFetchCallback = () => {
-  const calls = mockUseFetchState.mock.calls;
+  const { calls } = mockUseFetchState.mock;
   const [fetchCallback] = calls[calls.length - 1] as unknown as [
     (opts: Record<string, never>) => Promise<{ runtimes: unknown[]; continueToken?: string }>,
   ];

--- a/packages/agent-ops/frontend/src/app/hooks/useAgentRuntimeDetail.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useAgentRuntimeDetail.ts
@@ -1,0 +1,29 @@
+import React from 'react';
+import {
+  useFetchState,
+  type APIOptions,
+  type FetchState,
+  type FetchStateCallbackPromise,
+} from 'mod-arch-core';
+import { getAgentRuntimeDetail } from '~/app/api/agentRuntimes';
+import { NO_REFRESH_INTERVAL } from '~/app/const';
+import { AgentRuntimeDetail } from '~/app/types/agentRuntimes';
+
+export const useAgentRuntimeDetail = (
+  namespace?: string,
+  name?: string,
+): FetchState<AgentRuntimeDetail | undefined> => {
+  const callback = React.useCallback<FetchStateCallbackPromise<AgentRuntimeDetail | undefined>>(
+    (opts: APIOptions) => {
+      if (!namespace || !name) {
+        return Promise.resolve(undefined);
+      }
+      return getAgentRuntimeDetail('', namespace, name)(opts);
+    },
+    [namespace, name],
+  );
+
+  return useFetchState<AgentRuntimeDetail | undefined>(callback, undefined, {
+    refreshRate: NO_REFRESH_INTERVAL,
+  });
+};

--- a/packages/agent-ops/frontend/src/app/hooks/useListAgentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useListAgentRuntimes.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+import {
+  useFetchState,
+  type APIOptions,
+  type FetchState,
+  type FetchStateCallbackPromise,
+} from 'mod-arch-core';
+import { listAgentRuntimes } from '~/app/api/agentRuntimes';
+import { NO_REFRESH_INTERVAL } from '~/app/const';
+import { AgentRuntime } from '~/app/types/agentRuntimes';
+
+/**
+ * Fetches agent runtimes for the deployments list. Polling is added in a follow-up PR
+ * (RHOAIENG-62705); this hook loads once per namespace change.
+ */
+export const useListAgentRuntimes = (namespace?: string): FetchState<AgentRuntime[]> => {
+  const hasNamespace = !!namespace;
+
+  const callback = React.useCallback<FetchStateCallbackPromise<AgentRuntime[]>>(
+    (opts: APIOptions) =>
+      listAgentRuntimes('')(opts).then((runtimes) =>
+        hasNamespace ? runtimes.filter((runtime) => runtime.namespace === namespace) : runtimes,
+      ),
+    [hasNamespace, namespace],
+  );
+
+  return useFetchState<AgentRuntime[]>(callback, [], {
+    refreshRate: NO_REFRESH_INTERVAL,
+  });
+};

--- a/packages/agent-ops/frontend/src/app/hooks/useListAgentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useListAgentRuntimes.ts
@@ -1,30 +1,107 @@
 import React from 'react';
-import {
-  useFetchState,
-  type APIOptions,
-  type FetchState,
-  type FetchStateCallbackPromise,
-} from 'mod-arch-core';
+import { useFetchState, type FetchStateCallbackPromise } from 'mod-arch-core';
 import { listAgentRuntimes } from '~/app/api/agentRuntimes';
 import { NO_REFRESH_INTERVAL } from '~/app/const';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
 
-/**
- * Fetches agent runtimes for the deployments list. Polling is added in a follow-up PR
- * (RHOAIENG-62705); this hook loads once per namespace change.
- */
-export const useListAgentRuntimes = (namespace?: string): FetchState<AgentRuntime[]> => {
-  const hasNamespace = !!namespace;
+const DEFAULT_PAGE_SIZE = 10;
 
-  const callback = React.useCallback<FetchStateCallbackPromise<AgentRuntime[]>>(
-    (opts: APIOptions) =>
-      listAgentRuntimes('')(opts).then((runtimes) =>
-        hasNamespace ? runtimes.filter((runtime) => runtime.namespace === namespace) : runtimes,
-      ),
-    [hasNamespace, namespace],
+export type ListAgentRuntimesResult = {
+  runtimes: AgentRuntime[];
+  continueToken?: string;
+  page: number;
+  pageSize: number;
+  setPage: (page: number) => void;
+  setPageSize: (pageSize: number) => void;
+  loaded: boolean;
+  error: Error | undefined;
+  refresh: () => Promise<void>;
+};
+
+/**
+ * Fetches agent runtimes for the deployments list with BFF cursor pagination.
+ * Polling is added in a follow-up PR (RHOAIENG-62705); this hook loads once per
+ * namespace or page change. Per-namespace RBAC is enforced by the BFF; selected
+ * project scoping is applied client-side until the list API supports a namespace
+ * query parameter.
+ */
+export const useListAgentRuntimes = (namespace?: string): ListAgentRuntimesResult => {
+  const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_SIZE);
+  const pageTokensRef = React.useRef<(string | undefined)[]>([]);
+
+  const fetchCallback = React.useCallback<
+    FetchStateCallbackPromise<{ runtimes: AgentRuntime[]; continueToken?: string }>
+  >(
+    async (opts) => {
+      if (page > 1 && !pageTokensRef.current[page - 1]) {
+        throw new Error(`No token available for page ${page}.`);
+      }
+      return listAgentRuntimes('')(opts, {
+        limit: pageSize,
+        continueToken: pageTokensRef.current[page - 1],
+      });
+    },
+    [page, pageSize],
   );
 
-  return useFetchState<AgentRuntime[]>(callback, [], {
-    refreshRate: NO_REFRESH_INTERVAL,
-  });
+  const [data, loaded, error, refresh] = useFetchState<{
+    runtimes: AgentRuntime[];
+    continueToken?: string;
+  }>(
+    fetchCallback,
+    { runtimes: [] },
+    {
+      refreshRate: NO_REFRESH_INTERVAL,
+    },
+  );
+
+  React.useEffect(() => {
+    if (loaded && pageTokensRef.current[page] !== data.continueToken) {
+      const newTokens = pageTokensRef.current.slice(0, page);
+      newTokens[page] = data.continueToken;
+      pageTokensRef.current = newTokens;
+    }
+  }, [loaded, page, data.continueToken]);
+
+  React.useEffect(() => {
+    setPage(1);
+    pageTokensRef.current = [];
+  }, [namespace, pageSize]);
+
+  const setPageWrapped = React.useCallback((newPage: number) => {
+    setPage(newPage);
+  }, []);
+
+  const setPageSizeWrapped = React.useCallback((newPageSize: number) => {
+    setPageSize(newPageSize);
+    setPage(1);
+    pageTokensRef.current = [];
+  }, []);
+
+  const refreshWrapped = React.useCallback(async () => {
+    pageTokensRef.current = [];
+    setPage(1);
+    await refresh();
+  }, [refresh]);
+
+  const runtimes = React.useMemo(
+    () =>
+      namespace
+        ? data.runtimes.filter((runtime) => runtime.namespace === namespace)
+        : data.runtimes,
+    [data.runtimes, namespace],
+  );
+
+  return {
+    runtimes,
+    continueToken: data.continueToken,
+    page,
+    pageSize,
+    setPage: setPageWrapped,
+    setPageSize: setPageSizeWrapped,
+    loaded,
+    error: error ?? undefined,
+    refresh: refreshWrapped,
+  };
 };

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -6,7 +6,6 @@ import ProjectNavigatorLink from '@odh-dashboard/internal/concepts/projects/Proj
 import { IconSize } from '@odh-dashboard/internal/types';
 import {
   Alert,
-  Bullseye,
   Content,
   EmptyState,
   EmptyStateBody,
@@ -29,28 +28,36 @@ const AgentDeploymentListPage: React.FC = () => {
 
   const [runtimes, loaded, loadError] = useListAgentRuntimes(namespace);
 
+  const safeRuntimes = React.useMemo(
+    () =>
+      runtimes.filter(
+        (runtime) => typeof runtime.name === 'string' && typeof runtime.namespace === 'string',
+      ),
+    [runtimes],
+  );
+
   // When landing on /deployments with no namespace selected, auto-redirect to the first
   // namespace found in the agent runtimes list.  This way the URL always reflects the
   // active project and the project selector shows a meaningful selection on first load.
   React.useEffect(() => {
-    if (!namespace && loaded && !loadError && runtimes.length > 0) {
-      navigate(agentOpsDeploymentsRoute(runtimes[0].namespace), { replace: true });
+    if (!namespace && loaded && !loadError && safeRuntimes.length > 0) {
+      navigate(agentOpsDeploymentsRoute(safeRuntimes[0].namespace), { replace: true });
     }
-  }, [namespace, loaded, loadError, runtimes, navigate]);
+  }, [namespace, loaded, loadError, safeRuntimes, navigate]);
 
   const [filterText, setFilterText] = React.useState('');
   const clearFilters = React.useCallback(() => setFilterText(''), []);
 
   const filteredRuntimes = React.useMemo(() => {
     if (!filterText) {
-      return runtimes;
+      return safeRuntimes;
     }
     const lower = filterText.toLowerCase();
-    return runtimes.filter((r) => r.name.toLowerCase().includes(lower));
-  }, [runtimes, filterText]);
+    return safeRuntimes.filter((runtime) => runtime.name.toLowerCase().includes(lower));
+  }, [safeRuntimes, filterText]);
 
   const noProjectSelected = !namespace;
-  const isEmpty = !noProjectSelected && loaded && !loadError && runtimes.length === 0;
+  const isEmpty = !noProjectSelected && loaded && !loadError && safeRuntimes.length === 0;
 
   const headerContent = (
     <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
@@ -70,23 +77,6 @@ const AgentDeploymentListPage: React.FC = () => {
   );
 
   const tableContent = () => {
-    if (noProjectSelected) {
-      if (!loaded) {
-        return <Spinner aria-label="Loading agent deployments" />;
-      }
-      return (
-        <EmptyState
-          headingLevel="h2"
-          icon={CubesIcon}
-          titleText="Select a project"
-          variant={EmptyStateVariant.lg}
-          data-testid="agent-deployments-select-project"
-        >
-          <EmptyStateBody>Select a project to view agent deployments.</EmptyStateBody>
-        </EmptyState>
-      );
-    }
-
     if (!loaded) {
       return <Spinner aria-label="Loading agent deployments" />;
     }
@@ -94,13 +84,9 @@ const AgentDeploymentListPage: React.FC = () => {
     if (loadError) {
       return (
         <Alert variant="danger" isInline title="Error loading agent deployments">
-          {loadError.message}
+          Unable to load agent deployments. Please try again later.
         </Alert>
       );
-    }
-
-    if (isEmpty) {
-      return <AgentDeploymentsEmptyState />;
     }
 
     return (
@@ -139,7 +125,7 @@ const AgentDeploymentListPage: React.FC = () => {
       }
       provideChildrenPadding
     >
-      {noProjectSelected || isEmpty ? <Bullseye>{tableContent()}</Bullseye> : tableContent()}
+      {tableContent()}
     </ApplicationsPage>
   );
 };

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -55,7 +55,7 @@ const AgentDeploymentListPage: React.FC = () => {
   const safeNamespaces = React.useMemo(
     () =>
       namespaces.filter(
-        (ns): ns is { name: string } => typeof ns?.name === 'string' && ns.name.length > 0,
+        (ns): ns is { name: string } => typeof ns.name === 'string' && ns.name.length > 0,
       ),
     [namespaces],
   );

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -52,17 +52,25 @@ const AgentDeploymentListPage: React.FC = () => {
     [runtimes],
   );
 
+  const safeNamespaces = React.useMemo(
+    () =>
+      namespaces.filter(
+        (ns): ns is { name: string } => typeof ns?.name === 'string' && ns.name.length > 0,
+      ),
+    [namespaces],
+  );
+
   // When landing on /deployments with no namespace selected, redirect to the dashboard's
   // active project (preferred namespace) or the first accessible project.
   React.useEffect(() => {
-    if (!namespace && namespacesLoaded && namespaces.length > 0) {
+    if (!namespace && namespacesLoaded && safeNamespaces.length > 0) {
       const validPreferredNamespace = preferredNamespace
-        ? namespaces.find((n) => n.name === preferredNamespace.name)
+        ? safeNamespaces.find((n) => n.name === preferredNamespace.name)
         : undefined;
-      const redirectNamespace = validPreferredNamespace ?? namespaces[0];
+      const redirectNamespace = validPreferredNamespace ?? safeNamespaces[0];
       navigate(agentOpsDeploymentsRoute(redirectNamespace.name), { replace: true });
     }
-  }, [namespace, namespacesLoaded, namespaces, preferredNamespace, navigate]);
+  }, [namespace, namespacesLoaded, safeNamespaces, preferredNamespace, navigate]);
 
   const [filterText, setFilterText] = React.useState('');
   const clearFilters = React.useCallback(() => setFilterText(''), []);

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -15,6 +15,7 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 import { BanIcon, CubesIcon } from '@patternfly/react-icons';
+import { useNamespaceSelector } from 'mod-arch-core';
 import AgentOpsProjectSelector from '~/app/components/AgentOpsProjectSelector';
 import { useListAgentRuntimes } from '~/app/hooks/useListAgentRuntimes';
 import { agentOpsDeploymentsRoute } from '~/app/utilities/routes';
@@ -25,6 +26,7 @@ import AgentRuntimesToolbar from './agentRuntimes/AgentRuntimesToolbar';
 const AgentDeploymentListPage: React.FC = () => {
   const { namespace } = useParams<{ namespace: string }>();
   const navigate = useNavigate();
+  const { namespaces, namespacesLoaded, preferredNamespace } = useNamespaceSelector();
 
   const {
     runtimes,
@@ -50,14 +52,17 @@ const AgentDeploymentListPage: React.FC = () => {
     [runtimes],
   );
 
-  // When landing on /deployments with no namespace selected, auto-redirect to the first
-  // namespace found in the agent runtimes list.  This way the URL always reflects the
-  // active project and the project selector shows a meaningful selection on first load.
+  // When landing on /deployments with no namespace selected, redirect to the dashboard's
+  // active project (preferred namespace) or the first accessible project.
   React.useEffect(() => {
-    if (!namespace && loaded && !loadError && safeRuntimes.length > 0) {
-      navigate(agentOpsDeploymentsRoute(safeRuntimes[0].namespace), { replace: true });
+    if (!namespace && namespacesLoaded && namespaces.length > 0) {
+      const validPreferredNamespace = preferredNamespace
+        ? namespaces.find((n) => n.name === preferredNamespace.name)
+        : undefined;
+      const redirectNamespace = validPreferredNamespace ?? namespaces[0];
+      navigate(agentOpsDeploymentsRoute(redirectNamespace.name), { replace: true });
     }
-  }, [namespace, loaded, loadError, safeRuntimes, navigate]);
+  }, [namespace, namespacesLoaded, namespaces, preferredNamespace, navigate]);
 
   const [filterText, setFilterText] = React.useState('');
   const clearFilters = React.useCallback(() => setFilterText(''), []);
@@ -136,7 +141,7 @@ const AgentDeploymentListPage: React.FC = () => {
       description="View and manage agent deployments across your fleet."
       headerContent={headerContent}
       loadError={noProjectSelected || isAccessDenied ? undefined : loadError}
-      loaded={noProjectSelected ? true : loaded}
+      loaded={noProjectSelected ? namespacesLoaded : loaded}
       empty={noProjectSelected || (isEmpty && !isAccessDenied)}
       emptyStatePage={
         noProjectSelected ? (

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/ProjectIconWithSize';
 import ProjectNavigatorLink from '@odh-dashboard/internal/concepts/projects/ProjectNavigatorLink';
 import { IconSize } from '@odh-dashboard/internal/types';
 import {
+  Alert,
   Bullseye,
   Content,
   EmptyState,
@@ -12,41 +13,44 @@ import {
   EmptyStateVariant,
   Flex,
   FlexItem,
-  Stack,
-  StackItem,
-  Toolbar,
-  ToolbarContent,
+  Spinner,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 import AgentOpsProjectSelector from '~/app/components/AgentOpsProjectSelector';
+import { useListAgentRuntimes } from '~/app/hooks/useListAgentRuntimes';
 import { agentOpsDeploymentsRoute } from '~/app/utilities/routes';
 import AgentDeploymentsEmptyState from './AgentDeploymentsEmptyState';
+import AgentRuntimesTable from './agentRuntimes/AgentRuntimesTable';
 import AgentRuntimesToolbar from './agentRuntimes/AgentRuntimesToolbar';
-
-const selectProjectEmptyState = (
-  <EmptyState
-<<<<<<< HEAD
-<<<<<<< HEAD
-    headingLevel="h2"
-=======
->>>>>>> cbf3a4842 (agent list page skeleton)
-=======
-    headingLevel="h2"
->>>>>>> 806204188 (address comments)
-    icon={CubesIcon}
-    titleText="Select a project"
-    variant={EmptyStateVariant.lg}
-    data-testid="agent-deployments-select-project"
-  >
-    <EmptyStateBody>Select a project to view agent deployments.</EmptyStateBody>
-  </EmptyState>
-);
 
 const AgentDeploymentListPage: React.FC = () => {
   const { namespace } = useParams<{ namespace: string }>();
+  const navigate = useNavigate();
+
+  const [runtimes, loaded, loadError] = useListAgentRuntimes(namespace);
+
+  // When landing on /deployments with no namespace selected, auto-redirect to the first
+  // namespace found in the agent runtimes list.  This way the URL always reflects the
+  // active project and the project selector shows a meaningful selection on first load.
+  React.useEffect(() => {
+    if (!namespace && loaded && !loadError && runtimes.length > 0) {
+      navigate(agentOpsDeploymentsRoute(runtimes[0].namespace), { replace: true });
+    }
+  }, [namespace, loaded, loadError, runtimes, navigate]);
+
   const [filterText, setFilterText] = React.useState('');
+  const clearFilters = React.useCallback(() => setFilterText(''), []);
+
+  const filteredRuntimes = React.useMemo(() => {
+    if (!filterText) {
+      return runtimes;
+    }
+    const lower = filterText.toLowerCase();
+    return runtimes.filter((r) => r.name.toLowerCase().includes(lower));
+  }, [runtimes, filterText]);
 
   const noProjectSelected = !namespace;
+  const isEmpty = !noProjectSelected && loaded && !loadError && runtimes.length === 0;
 
   const headerContent = (
     <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
@@ -54,15 +58,7 @@ const AgentDeploymentListPage: React.FC = () => {
       <FlexItem>
         <Content component="p">Project</Content>
       </FlexItem>
-<<<<<<< HEAD
-<<<<<<< HEAD
       <FlexItem data-testid="agent-ops-project-selector">
-=======
-      <FlexItem>
->>>>>>> cbf3a4842 (agent list page skeleton)
-=======
-      <FlexItem data-testid="agent-ops-project-selector">
->>>>>>> 806204188 (address comments)
         <AgentOpsProjectSelector namespace={namespace} getRedirectPath={agentOpsDeploymentsRoute} />
       </FlexItem>
       {namespace && (
@@ -73,36 +69,77 @@ const AgentDeploymentListPage: React.FC = () => {
     </Flex>
   );
 
+  const tableContent = () => {
+    if (noProjectSelected) {
+      if (!loaded) {
+        return <Spinner aria-label="Loading agent deployments" />;
+      }
+      return (
+        <EmptyState
+          headingLevel="h2"
+          icon={CubesIcon}
+          titleText="Select a project"
+          variant={EmptyStateVariant.lg}
+          data-testid="agent-deployments-select-project"
+        >
+          <EmptyStateBody>Select a project to view agent deployments.</EmptyStateBody>
+        </EmptyState>
+      );
+    }
+
+    if (!loaded) {
+      return <Spinner aria-label="Loading agent deployments" />;
+    }
+
+    if (loadError) {
+      return (
+        <Alert variant="danger" isInline title="Error loading agent deployments">
+          {loadError.message}
+        </Alert>
+      );
+    }
+
+    if (isEmpty) {
+      return <AgentDeploymentsEmptyState />;
+    }
+
+    return (
+      <AgentRuntimesTable
+        runtimes={filteredRuntimes}
+        onClearFilters={clearFilters}
+        toolbarContent={
+          <AgentRuntimesToolbar filterText={filterText} onFilterChange={setFilterText} />
+        }
+      />
+    );
+  };
+
   return (
     <ApplicationsPage
-      noTitle
+      noTitle // rendered inside a TabRoutePage which provides the title and tabs
       description="View and manage agent deployments across your fleet."
       headerContent={headerContent}
-      loaded
-      empty={false}
+      loadError={noProjectSelected ? undefined : loadError}
+      loaded={noProjectSelected ? true : loaded}
+      empty={noProjectSelected || isEmpty}
+      emptyStatePage={
+        noProjectSelected ? (
+          <EmptyState
+            headingLevel="h2"
+            icon={CubesIcon}
+            titleText="Select a project"
+            variant={EmptyStateVariant.lg}
+            data-testid="agent-deployments-select-project"
+          >
+            <EmptyStateBody>Select a project to view agent deployments.</EmptyStateBody>
+          </EmptyState>
+        ) : (
+          <AgentDeploymentsEmptyState />
+        )
+      }
       provideChildrenPadding
-      removeChildrenTopPadding
     >
-      {noProjectSelected ? (
-        <Bullseye>{selectProjectEmptyState}</Bullseye>
-      ) : (
-        <Stack hasGutter>
-          <StackItem>
-<<<<<<< HEAD
-            <Toolbar inset={{ default: 'insetNone' }}>
-=======
-            <Toolbar inset={{ default: 'insetNone' }} className="pf-v6-u-w-100">
->>>>>>> cbf3a4842 (agent list page skeleton)
-              <ToolbarContent>
-                <AgentRuntimesToolbar filterText={filterText} onFilterChange={setFilterText} />
-              </ToolbarContent>
-            </Toolbar>
-          </StackItem>
-          <StackItem>
-            <AgentDeploymentsEmptyState />
-          </StackItem>
-        </Stack>
-      )}
+      {noProjectSelected || isEmpty ? <Bullseye>{tableContent()}</Bullseye> : tableContent()}
     </ApplicationsPage>
   );
 };

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
 import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/ProjectIconWithSize';
 import ProjectNavigatorLink from '@odh-dashboard/internal/concepts/projects/ProjectNavigatorLink';
 import { IconSize } from '@odh-dashboard/internal/types';
@@ -14,7 +15,7 @@ import {
   FlexItem,
   Spinner,
 } from '@patternfly/react-core';
-import { CubesIcon } from '@patternfly/react-icons';
+import { BanIcon, CubesIcon } from '@patternfly/react-icons';
 import AgentOpsProjectSelector from '~/app/components/AgentOpsProjectSelector';
 import { useListAgentRuntimes } from '~/app/hooks/useListAgentRuntimes';
 import { agentOpsDeploymentsRoute } from '~/app/utilities/routes';
@@ -31,7 +32,12 @@ const AgentDeploymentListPage: React.FC = () => {
   const safeRuntimes = React.useMemo(
     () =>
       runtimes.filter(
-        (runtime) => typeof runtime.name === 'string' && typeof runtime.namespace === 'string',
+        (runtime) =>
+          typeof runtime.name === 'string' &&
+          runtime.name !== '' &&
+          typeof runtime.namespace === 'string' &&
+          runtime.namespace !== '' &&
+          typeof runtime.status === 'string',
       ),
     [runtimes],
   );
@@ -57,6 +63,7 @@ const AgentDeploymentListPage: React.FC = () => {
   }, [safeRuntimes, filterText]);
 
   const noProjectSelected = !namespace;
+  const isAccessDenied = !!loadError && getGenericErrorCode(loadError) === 403;
   const isEmpty = !noProjectSelected && loaded && !loadError && safeRuntimes.length === 0;
 
   const headerContent = (
@@ -76,9 +83,25 @@ const AgentDeploymentListPage: React.FC = () => {
     </Flex>
   );
 
+  const accessDeniedState = (
+    <EmptyState
+      headingLevel="h2"
+      icon={BanIcon}
+      titleText="Access permissions needed"
+      variant={EmptyStateVariant.lg}
+      data-testid="agent-deployments-access-denied"
+    >
+      <EmptyStateBody>You do not have permission to view agent deployments.</EmptyStateBody>
+    </EmptyState>
+  );
+
   const tableContent = () => {
     if (!loaded) {
       return <Spinner aria-label="Loading agent deployments" />;
+    }
+
+    if (isAccessDenied) {
+      return accessDeniedState;
     }
 
     if (loadError) {
@@ -105,9 +128,9 @@ const AgentDeploymentListPage: React.FC = () => {
       noTitle // rendered inside a TabRoutePage which provides the title and tabs
       description="View and manage agent deployments across your fleet."
       headerContent={headerContent}
-      loadError={noProjectSelected ? undefined : loadError}
+      loadError={noProjectSelected || isAccessDenied ? undefined : loadError}
       loaded={noProjectSelected ? true : loaded}
-      empty={noProjectSelected || isEmpty}
+      empty={noProjectSelected || (isEmpty && !isAccessDenied)}
       emptyStatePage={
         noProjectSelected ? (
           <EmptyState

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -26,9 +26,13 @@ import AgentRuntimesToolbar from './agentRuntimes/AgentRuntimesToolbar';
 const selectProjectEmptyState = (
   <EmptyState
 <<<<<<< HEAD
+<<<<<<< HEAD
     headingLevel="h2"
 =======
 >>>>>>> cbf3a4842 (agent list page skeleton)
+=======
+    headingLevel="h2"
+>>>>>>> 806204188 (address comments)
     icon={CubesIcon}
     titleText="Select a project"
     variant={EmptyStateVariant.lg}
@@ -51,10 +55,14 @@ const AgentDeploymentListPage: React.FC = () => {
         <Content component="p">Project</Content>
       </FlexItem>
 <<<<<<< HEAD
+<<<<<<< HEAD
       <FlexItem data-testid="agent-ops-project-selector">
 =======
       <FlexItem>
 >>>>>>> cbf3a4842 (agent list page skeleton)
+=======
+      <FlexItem data-testid="agent-ops-project-selector">
+>>>>>>> 806204188 (address comments)
         <AgentOpsProjectSelector namespace={namespace} getRedirectPath={agentOpsDeploymentsRoute} />
       </FlexItem>
       {namespace && (

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -25,7 +25,10 @@ import AgentRuntimesToolbar from './agentRuntimes/AgentRuntimesToolbar';
 
 const selectProjectEmptyState = (
   <EmptyState
+<<<<<<< HEAD
     headingLevel="h2"
+=======
+>>>>>>> cbf3a4842 (agent list page skeleton)
     icon={CubesIcon}
     titleText="Select a project"
     variant={EmptyStateVariant.lg}
@@ -47,7 +50,11 @@ const AgentDeploymentListPage: React.FC = () => {
       <FlexItem>
         <Content component="p">Project</Content>
       </FlexItem>
+<<<<<<< HEAD
       <FlexItem data-testid="agent-ops-project-selector">
+=======
+      <FlexItem>
+>>>>>>> cbf3a4842 (agent list page skeleton)
         <AgentOpsProjectSelector namespace={namespace} getRedirectPath={agentOpsDeploymentsRoute} />
       </FlexItem>
       {namespace && (
@@ -73,7 +80,11 @@ const AgentDeploymentListPage: React.FC = () => {
       ) : (
         <Stack hasGutter>
           <StackItem>
+<<<<<<< HEAD
             <Toolbar inset={{ default: 'insetNone' }}>
+=======
+            <Toolbar inset={{ default: 'insetNone' }} className="pf-v6-u-w-100">
+>>>>>>> cbf3a4842 (agent list page skeleton)
               <ToolbarContent>
                 <AgentRuntimesToolbar filterText={filterText} onFilterChange={setFilterText} />
               </ToolbarContent>

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -6,7 +6,6 @@ import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/P
 import ProjectNavigatorLink from '@odh-dashboard/internal/concepts/projects/ProjectNavigatorLink';
 import { IconSize } from '@odh-dashboard/internal/types';
 import {
-  Alert,
   Content,
   EmptyState,
   EmptyStateBody,
@@ -27,7 +26,16 @@ const AgentDeploymentListPage: React.FC = () => {
   const { namespace } = useParams<{ namespace: string }>();
   const navigate = useNavigate();
 
-  const [runtimes, loaded, loadError] = useListAgentRuntimes(namespace);
+  const {
+    runtimes,
+    continueToken,
+    page,
+    pageSize,
+    setPage,
+    setPageSize,
+    loaded,
+    error: loadError,
+  } = useListAgentRuntimes(namespace);
 
   const safeRuntimes = React.useMemo(
     () =>
@@ -104,17 +112,16 @@ const AgentDeploymentListPage: React.FC = () => {
       return accessDeniedState;
     }
 
-    if (loadError) {
-      return (
-        <Alert variant="danger" isInline title="Error loading agent deployments">
-          Unable to load agent deployments. Please try again later.
-        </Alert>
-      );
-    }
-
     return (
       <AgentRuntimesTable
         runtimes={filteredRuntimes}
+        loaded={loaded}
+        continueToken={continueToken}
+        page={page}
+        pageSize={pageSize}
+        isFiltered={!!filterText}
+        onPageChange={setPage}
+        onPageSizeChange={setPageSize}
         onClearFilters={clearFilters}
         toolbarContent={
           <AgentRuntimesToolbar filterText={filterText} onFilterChange={setFilterText} />

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentsEmptyState.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentsEmptyState.tsx
@@ -4,7 +4,10 @@ import { CubesIcon } from '@patternfly/react-icons';
 
 const AgentDeploymentsEmptyState: React.FC = () => (
   <EmptyState
+<<<<<<< HEAD
     headingLevel="h2"
+=======
+>>>>>>> cbf3a4842 (agent list page skeleton)
     icon={CubesIcon}
     titleText="No agent deployments"
     variant={EmptyStateVariant.lg}

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentsEmptyState.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentsEmptyState.tsx
@@ -4,10 +4,7 @@ import { CubesIcon } from '@patternfly/react-icons';
 
 const AgentDeploymentsEmptyState: React.FC = () => (
   <EmptyState
-<<<<<<< HEAD
     headingLevel="h2"
-=======
->>>>>>> cbf3a4842 (agent list page skeleton)
     icon={CubesIcon}
     titleText="No agent deployments"
     variant={EmptyStateVariant.lg}

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
@@ -1,37 +1,116 @@
 import * as React from 'react';
-import Table from '@odh-dashboard/internal/components/table/Table';
+import TableBase from '@odh-dashboard/internal/components/table/TableBase';
 import DashboardEmptyTableView from '@odh-dashboard/internal/concepts/dashboard/DashboardEmptyTableView';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
 import { getAgentRuntimeRowKey } from '~/app/utilities/agentRuntimes';
 import { agentRuntimesColumns } from './columns';
 import AgentRuntimesTableRow from './AgentRuntimesTableRow';
 
+const perPageOptions = [
+  { title: '5', value: 5 },
+  { title: '10', value: 10 },
+  { title: '20', value: 20 },
+  { title: '50', value: 50 },
+];
+
 type AgentRuntimesTableProps = {
   runtimes: AgentRuntime[];
+  loaded: boolean;
+  continueToken?: string;
+  page: number;
+  pageSize: number;
+  isFiltered?: boolean;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
   onClearFilters: () => void;
   toolbarContent?: React.ReactElement;
 };
 
+const getItemCount = (
+  runtimesLength: number,
+  page: number,
+  pageSize: number,
+  continueToken: string | undefined,
+  isFiltered: boolean,
+): number => {
+  if (isFiltered) {
+    return runtimesLength;
+  }
+  if (continueToken) {
+    // Lower bound so next-page navigation stays enabled when more results exist.
+    return page * pageSize + 1;
+  }
+  return (page - 1) * pageSize + runtimesLength;
+};
+
 const AgentRuntimesTable: React.FC<AgentRuntimesTableProps> = ({
   runtimes,
+  loaded,
+  continueToken,
+  page,
+  pageSize,
+  isFiltered = false,
+  onPageChange,
+  onPageSizeChange,
   onClearFilters,
   toolbarContent,
-}) => (
-  <Table
-    data-testid="agent-runtimes-table"
-    data={runtimes}
-    columns={agentRuntimesColumns}
-    enablePagination
-    rowRenderer={(runtime: AgentRuntime) => (
-      <AgentRuntimesTableRow
-        key={getAgentRuntimeRowKey(runtime.namespace, runtime.name)}
-        runtime={runtime}
-      />
-    )}
-    emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
-    toolbarContent={toolbarContent}
-    onClearFilters={onClearFilters}
-  />
-);
+}) => {
+  const itemCount = getItemCount(runtimes.length, page, pageSize, continueToken, isFiltered);
+
+  const onNextPageClick = React.useCallback(
+    (_: React.SyntheticEvent<HTMLButtonElement>, nextPage: number) => {
+      if (!isFiltered && continueToken) {
+        onPageChange(nextPage);
+      }
+    },
+    [continueToken, isFiltered, onPageChange],
+  );
+
+  const onPrevPageClick = React.useCallback(
+    (_: React.SyntheticEvent<HTMLButtonElement>, prevPage: number) => {
+      if (!isFiltered) {
+        onPageChange(prevPage);
+      }
+    },
+    [isFiltered, onPageChange],
+  );
+
+  return (
+    <TableBase
+      data-testid="agent-runtimes-table"
+      loading={!loaded}
+      data={runtimes}
+      columns={agentRuntimesColumns}
+      enablePagination={loaded && (runtimes.length > 0 || page > 1) ? 'compact' : false}
+      page={page}
+      perPage={pageSize}
+      itemCount={itemCount}
+      perPageOptions={perPageOptions}
+      onNextClick={onNextPageClick}
+      onPreviousClick={onPrevPageClick}
+      onSetPage={(_, newPage) => {
+        if (isFiltered) {
+          return;
+        }
+        if (newPage < page || !loaded) {
+          onPageChange(newPage);
+        }
+      }}
+      onPerPageSelect={(_, newSize, newPage) => {
+        onPageSizeChange(newSize);
+        onPageChange(newPage);
+      }}
+      rowRenderer={(runtime: AgentRuntime) => (
+        <AgentRuntimesTableRow
+          key={getAgentRuntimeRowKey(runtime.namespace, runtime.name)}
+          runtime={runtime}
+        />
+      )}
+      emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
+      toolbarContent={toolbarContent}
+      onClearFilters={onClearFilters}
+    />
+  );
+};
 
 export default AgentRuntimesTable;

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import TableBase from '@odh-dashboard/internal/components/table/TableBase';
+import { TableBase } from '@odh-dashboard/internal/components/table';
 import DashboardEmptyTableView from '@odh-dashboard/internal/concepts/dashboard/DashboardEmptyTableView';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
 import { getAgentRuntimeRowKey } from '~/app/utilities/agentRuntimes';

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import Table from '@odh-dashboard/internal/components/table/Table';
+import DashboardEmptyTableView from '@odh-dashboard/internal/concepts/dashboard/DashboardEmptyTableView';
+import { AgentRuntime } from '~/app/types/agentRuntimes';
+import { agentRuntimesColumns } from './columns';
+import AgentRuntimesTableRow from './AgentRuntimesTableRow';
+
+type AgentRuntimesTableProps = {
+  runtimes: AgentRuntime[];
+  onClearFilters: () => void;
+  toolbarContent?: React.ReactElement;
+};
+
+const AgentRuntimesTable: React.FC<AgentRuntimesTableProps> = ({
+  runtimes,
+  onClearFilters,
+  toolbarContent,
+}) => (
+  <Table
+    data-testid="agent-runtimes-table"
+    data={runtimes}
+    columns={agentRuntimesColumns}
+    enablePagination
+    rowRenderer={(runtime: AgentRuntime) => (
+      <AgentRuntimesTableRow key={`${runtime.namespace}/${runtime.name}`} runtime={runtime} />
+    )}
+    emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
+    toolbarContent={toolbarContent}
+    onClearFilters={onClearFilters}
+  />
+);
+
+export default AgentRuntimesTable;

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { TableBase } from '@odh-dashboard/internal/components/table';
-import DashboardEmptyTableView from '@odh-dashboard/internal/concepts/dashboard/DashboardEmptyTableView';
+import { DashboardEmptyTableView, TableBase } from '@odh-dashboard/ui-core';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
 import { getAgentRuntimeRowKey } from '~/app/utilities/agentRuntimes';
 import { agentRuntimesColumns } from './columns';

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Table from '@odh-dashboard/internal/components/table/Table';
 import DashboardEmptyTableView from '@odh-dashboard/internal/concepts/dashboard/DashboardEmptyTableView';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
+import { getAgentRuntimeRowKey } from '~/app/utilities/agentRuntimes';
 import { agentRuntimesColumns } from './columns';
 import AgentRuntimesTableRow from './AgentRuntimesTableRow';
 
@@ -22,7 +23,10 @@ const AgentRuntimesTable: React.FC<AgentRuntimesTableProps> = ({
     columns={agentRuntimesColumns}
     enablePagination
     rowRenderer={(runtime: AgentRuntime) => (
-      <AgentRuntimesTableRow key={`${runtime.namespace}/${runtime.name}`} runtime={runtime} />
+      <AgentRuntimesTableRow
+        key={getAgentRuntimeRowKey(runtime.namespace, runtime.name)}
+        runtime={runtime}
+      />
     )}
     emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
     toolbarContent={toolbarContent}

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
@@ -34,39 +34,41 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({ runtime }
   );
 
   return (
-    <Tr data-testid={`agent-runtime-row-${runtime.namespace}-${runtime.name}`}>
-      <Td dataLabel={agentRuntimesColumns[0].label} data-testid="agent-runtime-name">
-        <Link to={detailRoute}>
-          <Truncate content={runtime.name} />
-        </Link>
-      </Td>
-      <Td dataLabel={agentRuntimesColumns[1].label} data-testid="agent-runtime-namespace">
-        {runtime.namespace}
-      </Td>
-      <Td dataLabel={agentRuntimesColumns[2].label} data-testid="agent-runtime-endpoint">
-        <Button
-          variant="link"
-          isInline
-          isDisabled={!hasEndpoints}
-          onClick={() => setIsEndpointsModalOpen(true)}
-          data-testid="agent-runtime-endpoint-view"
-        >
-          View
-        </Button>
-      </Td>
-      <Td dataLabel={agentRuntimesColumns[3].label} data-testid="agent-runtime-status">
-        <AgentRuntimeStatusLabel status={runtime.status} />
-      </Td>
-      <Td isActionCell data-testid="agent-runtime-actions">
-        <ActionsColumn items={actions} />
-      </Td>
+    <>
+      <Tr data-testid={`agent-runtime-row-${runtime.namespace}-${runtime.name}`}>
+        <Td dataLabel={agentRuntimesColumns[0].label} data-testid="agent-runtime-name">
+          <Link to={detailRoute}>
+            <Truncate content={runtime.name} />
+          </Link>
+        </Td>
+        <Td dataLabel={agentRuntimesColumns[1].label} data-testid="agent-runtime-namespace">
+          {runtime.namespace}
+        </Td>
+        <Td dataLabel={agentRuntimesColumns[2].label} data-testid="agent-runtime-endpoint">
+          <Button
+            variant="link"
+            isInline
+            isDisabled={!hasEndpoints}
+            onClick={() => setIsEndpointsModalOpen(true)}
+            data-testid="agent-runtime-endpoint-view"
+          >
+            View
+          </Button>
+        </Td>
+        <Td dataLabel={agentRuntimesColumns[3].label} data-testid="agent-runtime-status">
+          <AgentRuntimeStatusLabel status={runtime.status} />
+        </Td>
+        <Td isActionCell data-testid="agent-runtime-actions">
+          <ActionsColumn items={actions} />
+        </Td>
+      </Tr>
       {isEndpointsModalOpen && (
         <AgentRuntimeEndpointsModal
           runtime={runtime}
           onClose={() => setIsEndpointsModalOpen(false)}
         />
       )}
-    </Tr>
+    </>
   );
 };
 

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
 import AgentRuntimeStatusLabel from '~/app/components/AgentRuntimeStatusLabel';
 import AgentRuntimeEndpointsModal from '~/app/components/AgentRuntimeEndpointsModal';
+import { getAgentRuntimeEndpointFields } from '~/app/utilities/agentRuntimeEndpoints';
 import { agentOpsDeploymentDetailRoute } from '~/app/utilities/routes';
 import { agentRuntimesColumns } from './columns';
 
@@ -16,6 +17,11 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({ runtime }
   const [isEndpointsModalOpen, setIsEndpointsModalOpen] = React.useState(false);
   const navigate = useNavigate();
   const detailRoute = agentOpsDeploymentDetailRoute(runtime.namespace, runtime.name);
+
+  const hasEndpoints = React.useMemo(
+    () => getAgentRuntimeEndpointFields(runtime).length > 0,
+    [runtime],
+  );
 
   const actions: IAction[] = React.useMemo(
     () => [
@@ -41,6 +47,7 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({ runtime }
         <Button
           variant="link"
           isInline
+          isDisabled={!hasEndpoints}
           onClick={() => setIsEndpointsModalOpen(true)}
           data-testid="agent-runtime-endpoint-view"
         >

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
@@ -39,9 +39,10 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({ runtime }
       </Td>
       <Td dataLabel={agentRuntimesColumns[2].label} data-testid="agent-runtime-endpoint">
         <Button
-          variant="link"
+          variant="plain"
           isInline
-          style={{ textDecoration: 'none' }}
+          hasNoPadding
+          className="pf-v6-u-text-color-brand"
           onClick={() => setIsEndpointsModalOpen(true)}
           data-testid="agent-runtime-endpoint-view"
         >

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
+import { Button, Truncate } from '@patternfly/react-core';
+import { Link, useNavigate } from 'react-router-dom';
+import { AgentRuntime } from '~/app/types/agentRuntimes';
+import AgentRuntimeStatusLabel from '~/app/components/AgentRuntimeStatusLabel';
+import AgentRuntimeEndpointsModal from '~/app/components/AgentRuntimeEndpointsModal';
+import { agentOpsDeploymentDetailRoute } from '~/app/utilities/routes';
+import { agentRuntimesColumns } from './columns';
+
+type AgentRuntimesTableRowProps = {
+  runtime: AgentRuntime;
+};
+
+const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({ runtime }) => {
+  const [isEndpointsModalOpen, setIsEndpointsModalOpen] = React.useState(false);
+  const navigate = useNavigate();
+  const detailRoute = agentOpsDeploymentDetailRoute(runtime.namespace, runtime.name);
+
+  const actions: IAction[] = React.useMemo(
+    () => [
+      {
+        title: 'View details',
+        onClick: () => navigate(detailRoute),
+      },
+    ],
+    [navigate, detailRoute],
+  );
+
+  return (
+    <Tr data-testid={`agent-runtime-row-${runtime.namespace}-${runtime.name}`}>
+      <Td dataLabel={agentRuntimesColumns[0].label} data-testid="agent-runtime-name">
+        <Link to={detailRoute}>
+          <Truncate content={runtime.name} />
+        </Link>
+      </Td>
+      <Td dataLabel={agentRuntimesColumns[1].label} data-testid="agent-runtime-namespace">
+        {runtime.namespace}
+      </Td>
+      <Td dataLabel={agentRuntimesColumns[2].label} data-testid="agent-runtime-endpoint">
+        <Button
+          variant="link"
+          isInline
+          style={{ textDecoration: 'none' }}
+          onClick={() => setIsEndpointsModalOpen(true)}
+          data-testid="agent-runtime-endpoint-view"
+        >
+          View
+        </Button>
+      </Td>
+      <Td dataLabel={agentRuntimesColumns[3].label} data-testid="agent-runtime-status">
+        <AgentRuntimeStatusLabel status={runtime.status} />
+      </Td>
+      <Td isActionCell data-testid="agent-runtime-actions">
+        <ActionsColumn items={actions} />
+      </Td>
+      {isEndpointsModalOpen && (
+        <AgentRuntimeEndpointsModal
+          runtime={runtime}
+          onClose={() => setIsEndpointsModalOpen(false)}
+        />
+      )}
+    </Tr>
+  );
+};
+
+export default AgentRuntimesTableRow;

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
@@ -39,10 +39,8 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({ runtime }
       </Td>
       <Td dataLabel={agentRuntimesColumns[2].label} data-testid="agent-runtime-endpoint">
         <Button
-          variant="plain"
+          variant="link"
           isInline
-          hasNoPadding
-          className="pf-v6-u-text-color-brand"
           onClick={() => setIsEndpointsModalOpen(true)}
           data-testid="agent-runtime-endpoint-view"
         >

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesToolbar.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesToolbar.tsx
@@ -44,6 +44,7 @@ const AgentRuntimesToolbar: React.FC<AgentRuntimesToolbarProps> = ({
   >
     <ToolbarGroup>
       <ToolbarItem>
+        {/* Deploy agent - functionality to be implemented */}
         <Button variant="primary" data-testid="deploy-agent-button" isDisabled>
           Deploy agent
         </Button>

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTable.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTable.spec.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AgentRuntimesTable from '~/app/pages/agentRuntimes/AgentRuntimesTable';
+import {
+  createFailedRuntime,
+  createMockAgentRuntime,
+  createPendingRuntime,
+  createReadyRuntime,
+} from './agentRuntimeTestUtils';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>{children}</MemoryRouter>
+);
+
+describe('AgentRuntimesTable', () => {
+  const onClearFilters = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render all runtime rows', () => {
+    render(
+      <AgentRuntimesTable
+        runtimes={[createReadyRuntime(), createPendingRuntime(), createFailedRuntime()]}
+        onClearFilters={onClearFilters}
+      />,
+      { wrapper },
+    );
+
+    expect(
+      screen.getByTestId('agent-runtime-row-agent-ops-demo-sample-support-agent'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('agent-runtime-row-agent-ops-demo-pending-agent'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('agent-runtime-row-agent-ops-demo-failed-agent')).toBeInTheDocument();
+  });
+
+  it('should render column headers', () => {
+    render(
+      <AgentRuntimesTable runtimes={[createMockAgentRuntime()]} onClearFilters={onClearFilters} />,
+      { wrapper },
+    );
+
+    expect(screen.getByRole('columnheader', { name: /^Name$/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /^Project$/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /^Endpoints$/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /^Status$/i })).toBeInTheDocument();
+  });
+
+  it('should show empty table view when runtimes list is empty', () => {
+    render(<AgentRuntimesTable runtimes={[]} onClearFilters={onClearFilters} />, { wrapper });
+
+    expect(
+      screen.queryByTestId('agent-runtime-row-agent-ops-demo-sample-support-agent'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-empty-table-state')).toBeInTheDocument();
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+    expect(screen.getByText('Adjust your filters and try again.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /clear all filters/i })).toBeInTheDocument();
+  });
+});

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTable.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTable.spec.tsx
@@ -14,6 +14,14 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
   <MemoryRouter>{children}</MemoryRouter>
 );
 
+const defaultPaginationProps = {
+  loaded: true,
+  page: 1,
+  pageSize: 10,
+  onPageChange: jest.fn(),
+  onPageSizeChange: jest.fn(),
+};
+
 describe('AgentRuntimesTable', () => {
   const onClearFilters = jest.fn();
 
@@ -26,6 +34,7 @@ describe('AgentRuntimesTable', () => {
       <AgentRuntimesTable
         runtimes={[createReadyRuntime(), createPendingRuntime(), createFailedRuntime()]}
         onClearFilters={onClearFilters}
+        {...defaultPaginationProps}
       />,
       { wrapper },
     );
@@ -41,7 +50,11 @@ describe('AgentRuntimesTable', () => {
 
   it('should render column headers', () => {
     render(
-      <AgentRuntimesTable runtimes={[createMockAgentRuntime()]} onClearFilters={onClearFilters} />,
+      <AgentRuntimesTable
+        runtimes={[createMockAgentRuntime()]}
+        onClearFilters={onClearFilters}
+        {...defaultPaginationProps}
+      />,
       { wrapper },
     );
 
@@ -52,7 +65,14 @@ describe('AgentRuntimesTable', () => {
   });
 
   it('should show empty table view when runtimes list is empty', () => {
-    render(<AgentRuntimesTable runtimes={[]} onClearFilters={onClearFilters} />, { wrapper });
+    render(
+      <AgentRuntimesTable
+        runtimes={[]}
+        onClearFilters={onClearFilters}
+        {...defaultPaginationProps}
+      />,
+      { wrapper },
+    );
 
     expect(
       screen.queryByTestId('agent-runtime-row-agent-ops-demo-sample-support-agent'),

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
@@ -1,0 +1,83 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Table as PfTable, Tbody } from '@patternfly/react-table';
+import { MemoryRouter } from 'react-router-dom';
+import { mockAgentRuntimeDetail } from '~/__mocks__/mockAgentRuntime';
+import { AgentRuntime } from '~/app/types/agentRuntimes';
+import { useAgentRuntimeDetail } from '~/app/hooks/useAgentRuntimeDetail';
+import AgentRuntimesTableRow from '~/app/pages/agentRuntimes/AgentRuntimesTableRow';
+import { createMockAgentRuntime, createReadyRuntime } from './agentRuntimeTestUtils';
+
+jest.mock('~/app/hooks/useAgentRuntimeDetail', () => ({
+  useAgentRuntimeDetail: jest.fn(),
+}));
+
+const mockUseAgentRuntimeDetail = jest.mocked(useAgentRuntimeDetail);
+
+const renderRow = (runtime: AgentRuntime) =>
+  render(
+    <MemoryRouter>
+      <PfTable>
+        <Tbody>
+          <AgentRuntimesTableRow runtime={runtime} />
+        </Tbody>
+      </PfTable>
+    </MemoryRouter>,
+  );
+
+describe('AgentRuntimesTableRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAgentRuntimeDetail.mockReturnValue([
+      mockAgentRuntimeDetail(),
+      true,
+      undefined,
+      jest.fn(),
+    ]);
+  });
+
+  it('should render name and namespace columns', () => {
+    renderRow(createMockAgentRuntime());
+    expect(screen.getByTestId('agent-runtime-name')).toHaveTextContent('sample-support-agent');
+    expect(screen.getByTestId('agent-runtime-namespace')).toHaveTextContent('agent-ops-demo');
+  });
+
+  it('should wire status label from runtime status', () => {
+    renderRow(createReadyRuntime());
+    expect(screen.getByTestId('agent-runtime-status-label')).toBeInTheDocument();
+  });
+
+  it('should open endpoints modal when View is clicked', async () => {
+    const user = userEvent.setup();
+    renderRow(createReadyRuntime());
+
+    await user.click(screen.getByTestId('agent-runtime-endpoint-view'));
+    expect(screen.getByTestId('agent-runtime-endpoints-modal')).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue('http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue(
+        'http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080/.well-known/agent-card.json',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue(
+        'https://sample-support-agent.apps.example.com/.well-known/agent-card.json',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should show View details row action', async () => {
+    const user = userEvent.setup();
+    renderRow(createReadyRuntime());
+
+    await user.click(screen.getByRole('button', { name: 'Kebab toggle' }));
+    expect(screen.getByRole('menuitem', { name: 'View details' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Restart' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+});

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
@@ -8,7 +8,11 @@ import { mockAgentRuntimeDetail } from '~/__mocks__/mockAgentRuntime';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
 import { useAgentRuntimeDetail } from '~/app/hooks/useAgentRuntimeDetail';
 import AgentRuntimesTableRow from '~/app/pages/agentRuntimes/AgentRuntimesTableRow';
-import { createMockAgentRuntime, createReadyRuntime } from './agentRuntimeTestUtils';
+import {
+  createFailedRuntime,
+  createMockAgentRuntime,
+  createReadyRuntime,
+} from './agentRuntimeTestUtils';
 
 jest.mock('~/app/hooks/useAgentRuntimeDetail', () => ({
   useAgentRuntimeDetail: jest.fn(),
@@ -47,6 +51,11 @@ describe('AgentRuntimesTableRow', () => {
   it('should wire status label from runtime status', () => {
     renderRow(createReadyRuntime());
     expect(screen.getByTestId('agent-runtime-status-label')).toBeInTheDocument();
+  });
+
+  it('should disable View when runtime has no endpoints', () => {
+    renderRow(createFailedRuntime());
+    expect(screen.getByTestId('agent-runtime-endpoint-view')).toBeDisabled();
   });
 
   it('should open endpoints modal when View is clicked', async () => {

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/agentRuntimeTestUtils.ts
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/agentRuntimeTestUtils.ts
@@ -1,0 +1,26 @@
+import { mockAgentRuntime } from '~/__mocks__/mockAgentRuntime';
+import { AgentRuntime } from '~/app/types/agentRuntimes';
+
+export { mockAgentRuntime as createMockAgentRuntime };
+
+export const createReadyRuntime = (): AgentRuntime => mockAgentRuntime({ status: 'Ready' });
+
+export const createPendingRuntime = (): AgentRuntime =>
+  mockAgentRuntime({
+    name: 'pending-agent',
+    status: 'Pending',
+  });
+
+export const createFailedRuntime = (): AgentRuntime =>
+  mockAgentRuntime({
+    name: 'failed-agent',
+    status: 'Failed',
+    endpointUrl: '',
+  });
+
+export const createToolRuntime = (): AgentRuntime =>
+  mockAgentRuntime({
+    name: 'sample-tool',
+    status: 'Stopped',
+    type: 'tool',
+  });

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/columns.ts
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/columns.ts
@@ -1,4 +1,4 @@
-import { kebabTableColumn, SortableData } from '@odh-dashboard/internal/components/table';
+import { kebabTableColumn, SortableData } from '@odh-dashboard/ui-core';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
 import { getAgentRuntimeStatusSortWeight } from '~/app/utilities/agentRuntimeStatus';
 

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/columns.ts
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/columns.ts
@@ -1,5 +1,4 @@
-import { SortableData } from '@odh-dashboard/internal/components/table/types';
-import { kebabTableColumn } from '@odh-dashboard/internal/components/table/const';
+import { kebabTableColumn, SortableData } from '@odh-dashboard/internal/components/table';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
 import { getAgentRuntimeStatusSortWeight } from '~/app/utilities/agentRuntimeStatus';
 

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/columns.ts
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/columns.ts
@@ -1,0 +1,31 @@
+import { SortableData } from '@odh-dashboard/internal/components/table/types';
+import { kebabTableColumn } from '@odh-dashboard/internal/components/table/const';
+import { AgentRuntime } from '~/app/types/agentRuntimes';
+import { getAgentRuntimeStatusSortWeight } from '~/app/utilities/agentRuntimeStatus';
+
+export const agentRuntimesColumns: SortableData<AgentRuntime>[] = [
+  {
+    label: 'Name',
+    field: 'name',
+    sortable: (a, b) => a.name.localeCompare(b.name),
+  },
+  {
+    label: 'Project',
+    field: 'namespace',
+    width: 15,
+    sortable: (a, b) => a.namespace.localeCompare(b.namespace),
+  },
+  {
+    label: 'Endpoints',
+    field: 'endpointUrl',
+    sortable: false,
+  },
+  {
+    label: 'Status',
+    field: 'status',
+    width: 15,
+    sortable: (a, b) =>
+      getAgentRuntimeStatusSortWeight(a.status) - getAgentRuntimeStatusSortWeight(b.status),
+  },
+  kebabTableColumn(),
+];

--- a/packages/agent-ops/frontend/src/app/types/agentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/types/agentRuntimes.ts
@@ -1,0 +1,53 @@
+export type AgentRuntime = {
+  name: string;
+  namespace: string;
+  status: string;
+  type: string;
+  endpointUrl: string;
+  lastSyncTime: string;
+};
+
+export type AgentRuntimesList = {
+  runtimes: AgentRuntime[];
+};
+
+export type AgentServiceEndpoint = {
+  name: string;
+  url: string;
+  port: number;
+};
+
+export type AgentCardCapabilities = {
+  streaming: boolean;
+  pushNotifications: boolean;
+  optional: string[];
+};
+
+export type AgentCardDetail = {
+  name: string;
+  description?: string;
+  version?: string;
+  agentCardUrl?: string;
+  externalAgentCardUrl?: string;
+  defaultInputModes: string[];
+  defaultOutputModes: string[];
+  capabilities: AgentCardCapabilities;
+};
+
+export type AgentRuntimeDetail = {
+  name: string;
+  namespace: string;
+  description: string;
+  runtime: AgentRuntime;
+  workloadStatus: string;
+  serviceEndpoints: AgentServiceEndpoint[];
+  podCount: number;
+  agentCard?: AgentCardDetail | null;
+};
+
+export type AgentRuntimeEndpointField = {
+  id: string;
+  label: string;
+  description: string;
+  url: string;
+};

--- a/packages/agent-ops/frontend/src/app/types/agentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/types/agentRuntimes.ts
@@ -9,6 +9,7 @@ export type AgentRuntime = {
 
 export type AgentRuntimesList = {
   runtimes: AgentRuntime[];
+  continueToken?: string;
 };
 
 export type AgentServiceEndpoint = {

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/agentRuntimeEndpoints.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/agentRuntimeEndpoints.spec.ts
@@ -1,0 +1,59 @@
+import {
+  AGENT_RUNTIME_ENDPOINT_DESCRIPTIONS,
+  getAgentRuntimeEndpointFields,
+} from '~/app/utilities/agentRuntimeEndpoints';
+import { mockAgentRuntime, mockAgentRuntimeDetail } from '~/__mocks__/mockAgentRuntime';
+
+describe('getAgentRuntimeEndpointFields', () => {
+  it('should map BFF detail fields to cluster, local, and external endpoint labels', () => {
+    const runtime = mockAgentRuntime();
+    const fields = getAgentRuntimeEndpointFields(runtime, mockAgentRuntimeDetail());
+
+    expect(fields).toHaveLength(3);
+    expect(fields[0]).toMatchObject({
+      id: 'cluster-url',
+      label: 'Cluster URL',
+      description: AGENT_RUNTIME_ENDPOINT_DESCRIPTIONS.clusterUrl,
+      url: 'http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080',
+    });
+    expect(fields[1]).toMatchObject({
+      id: 'local-url',
+      label: 'Local URL',
+      description: AGENT_RUNTIME_ENDPOINT_DESCRIPTIONS.localUrl,
+      url: 'http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080/.well-known/agent-card.json',
+    });
+    expect(fields[2]).toMatchObject({
+      id: 'external-production-endpoint',
+      label: 'External production endpoint',
+      description: AGENT_RUNTIME_ENDPOINT_DESCRIPTIONS.externalProductionEndpoint,
+      url: 'https://sample-support-agent.apps.example.com/.well-known/agent-card.json',
+    });
+  });
+
+  it('should show cluster URL from list runtime before detail is loaded', () => {
+    const runtime = mockAgentRuntime();
+    const fields = getAgentRuntimeEndpointFields(runtime);
+
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toMatchObject({
+      id: 'cluster-url',
+      label: 'Cluster URL',
+      url: runtime.endpointUrl,
+    });
+  });
+
+  it('should omit empty endpoint values', () => {
+    const fields = getAgentRuntimeEndpointFields(
+      mockAgentRuntime({ endpointUrl: '' }),
+      mockAgentRuntimeDetail({
+        runtime: {
+          ...mockAgentRuntimeDetail().runtime,
+          endpointUrl: '',
+        },
+        agentCard: null,
+      }),
+    );
+
+    expect(fields).toEqual([]);
+  });
+});

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/agentRuntimeEndpoints.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/agentRuntimeEndpoints.spec.ts
@@ -5,6 +5,18 @@ import {
 import { mockAgentRuntime, mockAgentRuntimeDetail } from '~/__mocks__/mockAgentRuntime';
 
 describe('getAgentRuntimeEndpointFields', () => {
+  it('should not throw when detail.runtime is missing', () => {
+    const runtime = mockAgentRuntime();
+    const fields = getAgentRuntimeEndpointFields(runtime, { agentCard: null } as never);
+
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toMatchObject({
+      id: 'cluster-url',
+      label: 'Cluster URL',
+      url: runtime.endpointUrl,
+    });
+  });
+
   it('should map BFF detail fields to cluster, local, and external endpoint labels', () => {
     const runtime = mockAgentRuntime();
     const fields = getAgentRuntimeEndpointFields(runtime, mockAgentRuntimeDetail());

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/agentRuntimeStatus.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/agentRuntimeStatus.spec.ts
@@ -1,0 +1,61 @@
+import {
+  AgentRuntimeDisplayStatus,
+  getAgentRuntimeStatusSortWeight,
+  mapAgentRuntimeStatus,
+} from '~/app/utilities/agentRuntimeStatus';
+
+describe('mapAgentRuntimeStatus', () => {
+  it.each([
+    ['Ready', AgentRuntimeDisplayStatus.Ready, 'success', undefined],
+    ['ready', AgentRuntimeDisplayStatus.Ready, 'success', undefined],
+    ['Running', AgentRuntimeDisplayStatus.Ready, 'success', undefined],
+    ['running', AgentRuntimeDisplayStatus.Ready, 'success', undefined],
+    ['Pending', AgentRuntimeDisplayStatus.Pending, undefined, 'purple'],
+    ['pending', AgentRuntimeDisplayStatus.Pending, undefined, 'purple'],
+    ['Failed', AgentRuntimeDisplayStatus.Failed, 'danger', undefined],
+    ['failed', AgentRuntimeDisplayStatus.Failed, 'danger', undefined],
+    ['Stopped', AgentRuntimeDisplayStatus.Stopped, undefined, 'grey'],
+    ['stopped', AgentRuntimeDisplayStatus.Stopped, undefined, 'grey'],
+  ] as const)('should map %s to %s', (status, displayStatus, labelStatus, labelColor) => {
+    const result = mapAgentRuntimeStatus(status);
+    expect(result.displayStatus).toBe(displayStatus);
+    expect(result.labelStatus).toBe(labelStatus);
+    expect(result.labelColor).toBe(labelColor);
+  });
+
+  it('should map failed status to filled danger label', () => {
+    expect(mapAgentRuntimeStatus('failed')).toEqual({
+      displayStatus: AgentRuntimeDisplayStatus.Failed,
+      labelStatus: 'danger',
+      labelVariant: 'filled',
+    });
+  });
+
+  it('should map unknown status to Stopped with grey label', () => {
+    const result = mapAgentRuntimeStatus('unknown');
+    expect(result).toEqual({
+      displayStatus: AgentRuntimeDisplayStatus.Stopped,
+      labelColor: 'grey',
+    });
+  });
+
+  it('should map undefined status to Stopped with grey label', () => {
+    const result = mapAgentRuntimeStatus(undefined);
+    expect(result).toEqual({
+      displayStatus: AgentRuntimeDisplayStatus.Stopped,
+      labelColor: 'grey',
+    });
+  });
+});
+
+describe('getAgentRuntimeStatusSortWeight', () => {
+  it.each([
+    ['Ready', 0],
+    ['Pending', 1],
+    ['Stopped', 2],
+    ['Failed', 3],
+    ['unknown', 2],
+  ] as const)('should return sort weight %i for %s', (status, weight) => {
+    expect(getAgentRuntimeStatusSortWeight(status)).toBe(weight);
+  });
+});

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/agentRuntimeStatus.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/agentRuntimeStatus.spec.ts
@@ -31,18 +31,18 @@ describe('mapAgentRuntimeStatus', () => {
     });
   });
 
-  it('should map unknown status to Stopped with grey label', () => {
+  it('should map unknown status to Unknown with grey label', () => {
     const result = mapAgentRuntimeStatus('unknown');
     expect(result).toEqual({
-      displayStatus: AgentRuntimeDisplayStatus.Stopped,
+      displayStatus: AgentRuntimeDisplayStatus.Unknown,
       labelColor: 'grey',
     });
   });
 
-  it('should map undefined status to Stopped with grey label', () => {
+  it('should map undefined status to Unknown with grey label', () => {
     const result = mapAgentRuntimeStatus(undefined);
     expect(result).toEqual({
-      displayStatus: AgentRuntimeDisplayStatus.Stopped,
+      displayStatus: AgentRuntimeDisplayStatus.Unknown,
       labelColor: 'grey',
     });
   });
@@ -54,7 +54,7 @@ describe('getAgentRuntimeStatusSortWeight', () => {
     ['Pending', 1],
     ['Stopped', 2],
     ['Failed', 3],
-    ['unknown', 2],
+    ['unknown', 4],
   ] as const)('should return sort weight %i for %s', (status, weight) => {
     expect(getAgentRuntimeStatusSortWeight(status)).toBe(weight);
   });

--- a/packages/agent-ops/frontend/src/app/utilities/agentRuntimeEndpoints.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/agentRuntimeEndpoints.ts
@@ -1,0 +1,55 @@
+import {
+  AgentRuntime,
+  AgentRuntimeDetail,
+  AgentRuntimeEndpointField,
+} from '~/app/types/agentRuntimes';
+
+const trimUrl = (url?: string): string => url?.trim() ?? '';
+
+export const AGENT_RUNTIME_ENDPOINT_DESCRIPTIONS = {
+  clusterUrl:
+    'Kubernetes cluster endpoint automatically created when the agent is deployed. Use this URL for in-cluster invocation from other workloads.',
+  localUrl:
+    'Endpoint for local Kind clusters during development. Available only when enabled at deploy time.',
+  externalProductionEndpoint:
+    'OpenShift Route exposed outside the cluster for production access. Available only when enabled at deploy time.',
+} as const;
+
+export const getAgentRuntimeEndpointFields = (
+  runtime?: AgentRuntime,
+  detail?: AgentRuntimeDetail,
+): AgentRuntimeEndpointField[] => {
+  const fields: AgentRuntimeEndpointField[] = [];
+
+  const clusterUrl = trimUrl(detail?.runtime.endpointUrl ?? runtime?.endpointUrl);
+  if (clusterUrl) {
+    fields.push({
+      id: 'cluster-url',
+      label: 'Cluster URL',
+      description: AGENT_RUNTIME_ENDPOINT_DESCRIPTIONS.clusterUrl,
+      url: clusterUrl,
+    });
+  }
+
+  const localUrl = trimUrl(detail?.agentCard?.agentCardUrl);
+  if (localUrl) {
+    fields.push({
+      id: 'local-url',
+      label: 'Local URL',
+      description: AGENT_RUNTIME_ENDPOINT_DESCRIPTIONS.localUrl,
+      url: localUrl,
+    });
+  }
+
+  const externalUrl = trimUrl(detail?.agentCard?.externalAgentCardUrl);
+  if (externalUrl) {
+    fields.push({
+      id: 'external-production-endpoint',
+      label: 'External production endpoint',
+      description: AGENT_RUNTIME_ENDPOINT_DESCRIPTIONS.externalProductionEndpoint,
+      url: externalUrl,
+    });
+  }
+
+  return fields;
+};

--- a/packages/agent-ops/frontend/src/app/utilities/agentRuntimeEndpoints.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/agentRuntimeEndpoints.ts
@@ -21,7 +21,11 @@ export const getAgentRuntimeEndpointFields = (
 ): AgentRuntimeEndpointField[] => {
   const fields: AgentRuntimeEndpointField[] = [];
 
-  const clusterUrl = trimUrl(detail?.runtime.endpointUrl ?? runtime?.endpointUrl);
+  const detailRuntime = detail?.runtime;
+  const clusterUrl = trimUrl(
+    (detailRuntime && 'endpointUrl' in detailRuntime ? detailRuntime.endpointUrl : undefined) ??
+      runtime?.endpointUrl,
+  );
   if (clusterUrl) {
     fields.push({
       id: 'cluster-url',

--- a/packages/agent-ops/frontend/src/app/utilities/agentRuntimeStatus.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/agentRuntimeStatus.ts
@@ -1,0 +1,56 @@
+import { LabelProps } from '@patternfly/react-core';
+
+export enum AgentRuntimeApiStatus {
+  Ready = 'ready',
+  Running = 'running',
+  Stopped = 'stopped',
+  Pending = 'pending',
+  Failed = 'failed',
+}
+
+export enum AgentRuntimeDisplayStatus {
+  Ready = 'Ready',
+  Stopped = 'Stopped',
+  Pending = 'Pending',
+  Failed = 'Failed',
+}
+
+export type AgentRuntimeStatusMapping = {
+  displayStatus: AgentRuntimeDisplayStatus;
+  labelStatus?: LabelProps['status'];
+  labelColor?: LabelProps['color'];
+  labelVariant?: LabelProps['variant'];
+};
+
+const STATUS_SORT_WEIGHTS: Record<AgentRuntimeDisplayStatus, number> = {
+  [AgentRuntimeDisplayStatus.Ready]: 0,
+  [AgentRuntimeDisplayStatus.Pending]: 1,
+  [AgentRuntimeDisplayStatus.Stopped]: 2,
+  [AgentRuntimeDisplayStatus.Failed]: 3,
+};
+
+const normalizeAgentRuntimeStatus = (status: string | undefined): string =>
+  status?.trim().toLowerCase() ?? '';
+
+export const mapAgentRuntimeStatus = (status: string | undefined): AgentRuntimeStatusMapping => {
+  switch (normalizeAgentRuntimeStatus(status)) {
+    case AgentRuntimeApiStatus.Ready:
+    case AgentRuntimeApiStatus.Running:
+      return { displayStatus: AgentRuntimeDisplayStatus.Ready, labelStatus: 'success' };
+    case AgentRuntimeApiStatus.Stopped:
+      return { displayStatus: AgentRuntimeDisplayStatus.Stopped, labelColor: 'grey' };
+    case AgentRuntimeApiStatus.Pending:
+      return { displayStatus: AgentRuntimeDisplayStatus.Pending, labelColor: 'purple' };
+    case AgentRuntimeApiStatus.Failed:
+      return {
+        displayStatus: AgentRuntimeDisplayStatus.Failed,
+        labelStatus: 'danger',
+        labelVariant: 'filled',
+      };
+    default:
+      return { displayStatus: AgentRuntimeDisplayStatus.Stopped, labelColor: 'grey' };
+  }
+};
+
+export const getAgentRuntimeStatusSortWeight = (status: string | undefined): number =>
+  STATUS_SORT_WEIGHTS[mapAgentRuntimeStatus(status).displayStatus];

--- a/packages/agent-ops/frontend/src/app/utilities/agentRuntimeStatus.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/agentRuntimeStatus.ts
@@ -13,6 +13,7 @@ export enum AgentRuntimeDisplayStatus {
   Stopped = 'Stopped',
   Pending = 'Pending',
   Failed = 'Failed',
+  Unknown = 'Unknown',
 }
 
 export type AgentRuntimeStatusMapping = {
@@ -27,6 +28,7 @@ const STATUS_SORT_WEIGHTS: Record<AgentRuntimeDisplayStatus, number> = {
   [AgentRuntimeDisplayStatus.Pending]: 1,
   [AgentRuntimeDisplayStatus.Stopped]: 2,
   [AgentRuntimeDisplayStatus.Failed]: 3,
+  [AgentRuntimeDisplayStatus.Unknown]: 4,
 };
 
 const normalizeAgentRuntimeStatus = (status: string | undefined): string =>
@@ -48,7 +50,7 @@ export const mapAgentRuntimeStatus = (status: string | undefined): AgentRuntimeS
         labelVariant: 'filled',
       };
     default:
-      return { displayStatus: AgentRuntimeDisplayStatus.Stopped, labelColor: 'grey' };
+      return { displayStatus: AgentRuntimeDisplayStatus.Unknown, labelColor: 'grey' };
   }
 };
 

--- a/packages/agent-ops/frontend/src/app/utilities/agentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/agentRuntimes.ts
@@ -1,0 +1,2 @@
+export const getAgentRuntimeRowKey = (namespace: string, name: string): string =>
+  `${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`;

--- a/packages/agent-ops/package.json
+++ b/packages/agent-ops/package.json
@@ -47,7 +47,8 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
-    "@odh-dashboard/plugin-core": "*"
+    "@odh-dashboard/plugin-core": "*",
+    "@odh-dashboard/ui-core": "*"
   },
   "devDependencies": {
     "@odh-dashboard/contract-tests": "*",

--- a/packages/agent-ops/package.json
+++ b/packages/agent-ops/package.json
@@ -45,6 +45,10 @@
     "cypress:server:dev": "cd frontend && DEPLOYMENT_MODE=federated PORT=9111 PROXY_PORT=4021 npm run start:dev",
     "cypress:server:wait": "wait-on -i 1000 http://localhost:9111"
   },
+  "dependencies": {
+    "@odh-dashboard/internal": "*",
+    "@odh-dashboard/plugin-core": "*"
+  },
   "devDependencies": {
     "@odh-dashboard/contract-tests": "*",
     "@odh-dashboard/eslint-config": "*",


### PR DESCRIPTION

## Description
Closes [RHOAIENG-62704](https://redhat.atlassian.net/browse/RHOAIENG-62704)

This PR adds the agent runtimes table and functionality in the agent deployments list page. 

<img width="1015" height="523" alt="image" src="https://github.com/user-attachments/assets/6ec59576-277f-4589-a21b-a3a8511cfcdc" />

**Included**
- Agent table: Name, Project, Endpoints (View modal), Status, kebab actions
- `AgentRuntimeStatusLabel` with phase mapping (Ready / Pending / Failed / Stopped)
- `AgentRuntimeEndpointsModal` (cluster URL, local agent card, external endpoint)
- Row action: View details (Restart/Stop/Delete deferred)
- One-shot list fetch via `useListAgentRuntimes` (no polling yet)
- API client for list + detail endpoints
- Unit tests: table, row, status mapping, endpoint fields
- Cypress mock tests: table rows, status labels, empty/loading/error states, filter, endpoints modal, kebab


## How Has This Been Tested?

- Unit: `cd packages/agent-ops/frontend && npm run test:unit -- --testPathPatterns="agentRuntime|AgentRuntimes"`
- Lint/type-check on `packages/agent-ops/frontend`
- Manual: enable `agentOps` flag, navigate to AI Hub → Agents → Ensured the UI is right

## Request review criteria:

Self-checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Agent Runtimes UI: a sortable, paginated table with **View details** and an **Endpoints** modal that shows read-only endpoint URLs with copy support.
  * Improved runtime status badges, including **Unknown**, with optional popover status messaging.
  * Updated Agent Deployments UI with improved loading/empty/error handling, access-denied messaging, automatic namespace selection, and name filtering.

* **Tests**
  * Added Cypress end-to-end and Jest/React component/hook tests for the new and updated experiences.

* **Chores**
  * Updated test and lint configurations, plus Module Federation sharing for UI icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->