### PR TITLE
fix(owners): add platform-reviewers to docs and manifests filters

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -35,6 +35,8 @@ filters:
       - area/backend
 
   'docs/.*':
+    reviewers:
+      - platform-reviewers
     labels:
       - area/docs
 
@@ -47,6 +49,8 @@ filters:
       - area/components
 
   'manifests/.*':
+    reviewers:
+      - platform-reviewers
     labels:
       - area/manifests
 


### PR DESCRIPTION
## Description

Platform PRs (e.g. `dashboard-operator/` changes) often touch `docs/` and `manifests/` as well. The `docs/.*` and `manifests/.*` OWNERS filters only defined `labels` — no `reviewers`. Since the root catchall (`'.*'`) also omits `reviewers`, **no one** could `/lgtm` a PR touching those paths unless they were a general approver.

This meant platform-reviewers like `liday-rh` could not `/lgtm` PRs like #8133, even though all the substantive code was in `dashboard-operator/` where they have review rights.

This PR adds `platform-reviewers` as reviewers to the `docs/.*` and `manifests/.*` filters so platform reviewers can `/lgtm` PRs that span those directories.

## How Has This Been Tested?

Verified the OWNERS file syntax is valid YAML. Confirmed the filter entries match the existing pattern used by other sections (e.g., `dashboard-operator/.*`).

## Test Impact

No code changes — OWNERS-only. No tests applicable.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review process configuration for documentation and manifest paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->