### PR TITLE
chore: add preflight checks for Dockerfile downstream sync

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -199,6 +199,8 @@ Run whichever the user picks. If a reviewer fails (e.g. CR CLI not installed or 
 
 Read [references/checks.md](references/checks.md) for the full list of checks and how to run each one in each context (PR synced, PR not synced, no PR).
 
+**Downstream Dockerfile Sync** — only evaluate this check when `Dockerfile.workspace` files appear in the changed-files list from Step 1. If no Dockerfile.workspace files were changed, report ➖ and move on — do not run any diff commands for this check.
+
 Statuses:
 - ✅ passed · ❌ failed · ⚠️ warning · ⏭️ covered by CI (same commit) · ➖ not applicable
 

--- a/.claude/skills/preflight/references/checks.md
+++ b/.claude/skills/preflight/references/checks.md
@@ -152,3 +152,53 @@ Checks that the PR description follows the template.
 6. If PR touches `.tsx`/`.css`/`.scss` files, check for image/gif links → ⚠️ if missing
 
 Empty Description → ❌. Other missing sections → ⚠️.
+
+## Downstream Dockerfile Sync
+
+Checks whether Dockerfile.workspace changes require corresponding updates to downstream `Dockerfile.konflux.*` files (in `red-hat-data-services/odh-dashboard`).
+
+**Background:** Downstream Konflux Dockerfiles are structurally derived from the upstream `Dockerfile.workspace` files but diverge in three ways: (1) base image tags are SHA-pinned, (2) Go toolchain versions are normalized with SHA pins, (3) Red Hat metadata (`LABEL`, `USER` directives) is appended. Changes to the upstream "skeleton" — COPY commands, base image versions, Go versions, build stages, RUN commands — must be manually replicated downstream or builds break.
+
+**Gate:** Only evaluate when the diff includes files matching `**/Dockerfile.workspace`. If no Dockerfile.workspace files are in the changed-files list from Step 1, report ➖ and skip — do not run any commands for this check.
+
+| Context | How to check |
+|---|---|
+| PR (any) | Filter `gh pr diff "$pr_number"` to Dockerfile.workspace hunks (see below), then parse for change classes. If `gh pr diff` fails with `too_large`, fall back to `git diff origin/$base_branch -- '**/Dockerfile.workspace'` locally. |
+| No PR | `git diff origin/$base_branch -- '**/Dockerfile.workspace'` — parse for change classes below |
+
+**Filtering `gh pr diff` to Dockerfile.workspace hunks** — `gh pr diff` does not support pathspec arguments. Pipe through awk to extract only Dockerfile.workspace sections:
+
+```bash
+gh pr diff "$pr_number" | awk '
+  /^diff --git.*Dockerfile\.workspace/ { capture=1 }
+  /^diff --git/ && !/Dockerfile\.workspace/ { capture=0 }
+  capture { print }
+'
+```
+
+### Change classes to detect
+
+Parse the diff for each class of change that requires downstream replication:
+
+**1. New package COPY lines (High risk — breaks builds)**
+Lines matching `^+COPY.*packages/`. Extract the package directory name (e.g., `packages/k8s-core/`). Cross-reference against removed lines (`^-COPY.*packages/`) to find net-new dependencies. This is the class that caused the 2026-06-18 Konflux outage.
+
+**2. Base image version changes (Medium risk — breaks builds)**
+Lines matching `^[+-]ARG (NODE_BASE_IMAGE|GOLANG_BASE_IMAGE|DISTROLESS_BASE_IMAGE)=`. If the image tag version changed (e.g., `nodejs-22` → `nodejs-24`, or `go-toolset:1.24` → `go-toolset:1.26`), downstream SHA pins must be updated to match the new version.
+
+**3. Structural changes (Medium risk — may break builds)**
+Any other added/removed `RUN`, `FROM`, `ENV`, `ARG`, `WORKDIR`, `EXPOSE`, or `ENTRYPOINT` lines that alter the build flow. These may need to be carried over to the downstream Dockerfile.
+
+### Status mapping
+
+| Scenario | Status |
+|---|---|
+| No Dockerfile.workspace in diff | ➖ "no Dockerfile changes" |
+| Changes detected but only comments, whitespace, or no actionable diff | ✅ "no downstream-impacting changes" |
+| New package COPY lines found | ⚠️ "new package COPY: `<list>` — add to downstream `Dockerfile.konflux.*` in `red-hat-data-services/odh-dashboard`" |
+| Base image version changed | ⚠️ "base image version changed: `<details>` — update downstream SHA pins" |
+| Structural changes found | ⚠️ "Dockerfile structure changed — review downstream `Dockerfile.konflux.*` for needed updates" |
+
+Multiple classes can trigger simultaneously — combine into a single ⚠️ listing all findings.
+
+**No `--fix` behavior.** This check is advisory only — the fix requires a PR in the downstream repo (`red-hat-data-services/odh-dashboard`). Step 4 should skip this check entirely.

--- a/.claude/skills/preflight/references/ci-comment-template.md
+++ b/.claude/skills/preflight/references/ci-comment-template.md
@@ -34,6 +34,7 @@ The review `body` field contains the full preflight report. Format:
 | Jira | ❌ | No Jira key found |
 | Test Coverage | ⚠️ | No test files added |
 | PR Body | ⚠️ | Minimal — missing template sections |
+| Downstream Sync | ⚠️ | New package COPY: `k8s-core`; Go version bump `1.24`→`1.26`. Update downstream `Dockerfile.konflux.*` |
 | Review | 🟡 3 minor · 🧹 2 nits | See inline comments + nits below |
 
 </details>


### PR DESCRIPTION
## Description

On 2026-06-18 a new package (k8s-core) was added upstream with Dockerfile.workspace COPY commands, but the corresponding downstream Dockerfile.konflux.* files in red-hat-data-services/odh-dashboard were not updated, breaking all Konflux builds for two days.

Add a "Downstream Dockerfile Sync" check to the /preflight skill that warns when Dockerfile.workspace changes may need downstream replication. The check is gated behind a changed-files filter so it only runs (and only costs tokens) when Dockerfile.workspace files appear in the diff.

Three change classes are detected:

1. New package COPY lines (high risk) — the class that caused the outage. Parses added vs removed COPY lines to find net-new package dependencies that must be added to downstream Dockerfiles.

2. Base image version changes (medium risk) — detects ARG changes to NODE_BASE_IMAGE, GOLANG_BASE_IMAGE, or DISTROLESS_BASE_IMAGE. Since downstream pins these to SHA digests, a version bump upstream requires new SHA pins downstream.

3. Structural changes (medium risk) — detects added/removed RUN, FROM, ENV, ARG, WORKDIR, EXPOSE, or ENTRYPOINT lines that may need to be carried over.

All findings report as warnings (never failures) since the fix requires a cross-repo PR. The check explicitly has no --fix behavior.

Implementation notes:
- gh pr diff does not support pathspec args, so an awk state machine filters the diff to Dockerfile.workspace hunks
- For large PRs where gh pr diff fails with too_large, falls back to local git diff with pathspec
- Verified against PR #7855 (the k8s-core incident) and PR #7980 (Go version bumps) to confirm correct detection

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new preflight check to detect when container configuration changes require corresponding updates in downstream services.

* **Documentation**
  * Added comprehensive reference documentation for the downstream sync check, including detection rules and status indicators.
  * Updated CI report template to display downstream sync warnings with required change details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->