### PR TITLE
fix(backend): add tslib as explicit production dependency

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -55,6 +55,7 @@
     "js-yaml": "^4.2.0",
     "lodash": "^4.18.1",
     "pino": "^9.14.0",
+    "tslib": "^2.8.1",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8350,7 +8350,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9037,7 +9036,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9054,7 +9052,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9071,7 +9068,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9088,7 +9084,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9105,7 +9100,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9122,7 +9116,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9139,7 +9132,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9156,7 +9148,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9173,7 +9164,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9190,7 +9180,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9207,7 +9196,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9224,7 +9212,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13740,7 +13727,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "js-yaml": "^4.2.0",
         "lodash": "^4.18.1",
         "pino": "^9.14.0",
+        "tslib": "^2.8.1",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -8349,6 +8350,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9035,6 +9037,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9051,6 +9054,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9067,6 +9071,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9083,6 +9088,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9099,6 +9105,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9115,6 +9122,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9131,6 +9139,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9147,6 +9156,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9163,6 +9173,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9179,6 +9190,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9195,6 +9207,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9211,6 +9224,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13726,6 +13740,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-70441

## Description

`tslib` is required at runtime because the shared tsconfig (`packages/tsconfig/tsconfig.json`) sets `importHelpers: true`, which causes `tsc` to emit `require('tslib')` at the top of every compiled file instead of inlining TypeScript helpers.

### Root cause chain

**Step 1 — latent bug (PR #7958, June 15):** `prom-client` was removed from `backend/package.json`. Previously, `prom-client` provided `tslib` transitively. After this removal, the only remaining source of `tslib` in the lock file was `@kubernetes/client-node`, which declares `"tslib": "^1.9.3"`. With PatternFly 6.5 still in the lock file (also introduced in PR #7958), npm hoisted `tslib@1.14.1` to the root `node_modules/` (satisfying `@kubernetes/client-node`'s constraint), so the backend kept working.

**Step 2 — trigger (PR #8213, June 19 14:58 UTC):** ["revert frontend update to patternfly 6.5"](https://github.com/opendatahub-io/odh-dashboard/pull/8213) regenerated `package-lock.json` with PatternFly 6.4 in place. This shifted the hoisted `node_modules/tslib` from `1.14.1` to `2.8.1`. In the Docker production build, `npm install --omit=dev` prunes the dev PatternFly packages that were referencing `tslib@^2.x` — leaving `tslib@2.8.1` with no declared production consumer. Because `2.8.1` is incompatible with `@kubernetes/client-node`'s `^1.9.3` range, npm nests `tslib@1.14.1` inside `node_modules/@kubernetes/client-node/node_modules/tslib/` rather than hoisting it. Node.js module resolution from `backend/dist/server.js` walks up to `/usr/src/app/node_modules/tslib` — which is now absent — and crashes:

```
Error: Cannot find module 'tslib'
Require stack:
- /usr/src/app/backend/dist/server.js
```

This has been confirmed on the cluster — `rhods-dashboard` pods are in `CrashLoopBackOff` (84+ restarts) in `redhat-ods-applications`. All sidecar containers are healthy; only the main dashboard backend is affected. The image identified on the cluster: `registry.redhat.io/rhoai/odh-dashboard-rhel9@sha256:ba0744e4583c564ddd8a21feeee827b548b119a48e915ec97806e048211d25e2`.

### PR #8213 CI failure — merged despite failing simulator

PR #8213's own Konflux build simulator run ([`27827711310`](https://github.com/opendatahub-io/odh-dashboard/actions/runs/27827711310)) correctly detected the regression:

| Phase | Result |
|---|---|
| Phase 0: Hermetic Build Preflight | ✅ pass |
| Phase 1: Docker Build (RHOAI + ODH) | ✅ pass |
| Phase 2–3: Runtime & Module Federation | ✅ pass |
| **Phase 4: Operator Integration** | ❌ **FAIL** |

The Docker image builds fine; the crash only manifests at pod startup. Phase 4 timed out after 120 s waiting for the rollout: `kubectl rollout status deployment/odh-dashboard --timeout=120s → error: timed out waiting for the condition`. **The PR was merged with 67/72 checks passed, bypassing this failure.**

Every PR opened since June 19 15:02 UTC is failing Phase 4 for the same reason — the broken `tslib` resolution is now on `main`.

### Fix

Declare `tslib` explicitly in `backend/package.json` `dependencies` so it is always hoisted to the root `node_modules/` and accessible to the compiled backend, regardless of which transitive packages happen to pull it in (or which PatternFly version is active).

## How Has This Been Tested?

Confirmed the crash from live cluster logs (`redhat-ods-applications/rhods-dashboard-*`). The fix is a direct dependency declaration — `tslib` will be installed and hoisted by `npm install --omit=dev` during the Docker production build regardless of what other packages pull it in transitively.

Installed the early-gate image containining this fix to our odh-nightly cluster dashboard/job/dashboard-e2e-tests/1437
<img width="1118" height="704" alt="image" src="https://github.com/user-attachments/assets/ec7c9170-3773-4c34-9028-d9f31b94c5e7" />


## Test Impact

No new tests required — this is a dependency declaration fix for a missing runtime module. The existing Phase 4 Operator Integration test in `pr-build-validation.yml` (added in PR #7962) will validate that the container starts successfully once this lands and unblocks CI for all currently failing PRs.

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:

- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`