### PR TITLE
fix(operator): bump Go to 1.26 and harden Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,6 @@ tests/
 **/__tests__/
 scripts/
 !scripts/prepare-production-manifest.js
-manifests/
 
 # Local .env images
 **/.env.development

--- a/dashboard-operator/Dockerfile
+++ b/dashboard-operator/Dockerfile
@@ -12,7 +12,7 @@ COPY dashboard-operator/cmd/ cmd/
 COPY dashboard-operator/api/ api/
 COPY dashboard-operator/internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -o /tmp/manager ./cmd/manager
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -ldflags="-s -w" -o /tmp/manager ./cmd/manager
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 

--- a/dashboard-operator/Dockerfile
+++ b/dashboard-operator/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /usr/src/app
 
@@ -9,7 +12,7 @@ COPY dashboard-operator/cmd/ cmd/
 COPY dashboard-operator/api/ api/
 COPY dashboard-operator/internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o /tmp/manager ./cmd/manager
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -o /tmp/manager ./cmd/manager
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
@@ -17,7 +20,6 @@ WORKDIR /
 
 COPY --from=builder /tmp/manager .
 COPY manifests/ /opt/manifests/dashboard/
-RUN chmod -R g+w /opt/manifests/dashboard/
 
 USER 65532:65532
 

--- a/dashboard-operator/go.mod
+++ b/dashboard-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/odh-dashboard/dashboard-operator
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/opendatahub-io/odh-platform-utilities v0.0.0-20260506180717-e15e712db78d


### PR DESCRIPTION
## Description

Bumps the dashboard-operator Go version to 1.26 and applies several hardening improvements to the Dockerfile:

1. **Go 1.26 bump** — Aligns with the rest of the Go modules in the monorepo (`automl`, `eval-hub`, `autorag`, `maas`, `mlflow` BFFs are already on 1.26).
2. **Cross-architecture support** — Adds `TARGETOS`/`TARGETARCH` build args with `GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH}`, matching the pattern used in other Konflux Dockerfiles (e.g., `agent-ops`). This ensures correct binaries if multi-arch builds are ever enabled.
3. **Smaller binary** — Adds `-ldflags="-s -w"` to strip debug symbols and DWARF information.
4. **Security hardening** — Removes `chmod -R g+w` on the manifests directory. The operator only reads manifests at runtime; `COPY` already preserves readable permissions. Granting group-write to read-only data is an unnecessary attack surface.
5. **Fix `.dockerignore` for operator builds** — Removes `manifests/` from the root `.dockerignore`. The operator Dockerfile needs `COPY manifests/ /opt/manifests/dashboard/`, but when the Tekton build task copies the Dockerfile to a temp location, it falls back to the root `.dockerignore` instead of the operator-specific `Dockerfile.dockerignore`, causing the build to fail with "no items matching glob".

## How Has This Been Tested?

- Verified `go mod tidy` produces no changes
- Verified `CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o /tmp/manager ./cmd/manager` compiles successfully with Go 1.26
- Verified `manifests/` directory exists at repo root and is no longer excluded by `.dockerignore`

## Test Impact

No test changes needed — this is a build/infrastructure change. The operator's existing unit tests continue to pass with Go 1.26.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the Go toolchain to 1.26 for improved build compatibility.
  * Enhanced the Docker build to support cross-platform builds using configurable target OS/architecture.
  * Updated the Docker packaging to ensure the `manifests/` directory is included in images (and removed the previous recursive permission adjustment for that content).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->