### PR TITLE
feat(dashboard-operator): agentOps module, managementState Removed, Owns() watches, webhook templates

### DIFF
--- a/.claude/rules/operator-controller.md
+++ b/.claude/rules/operator-controller.md
@@ -104,11 +104,29 @@ Embed `client.Client` — this gives direct access to `r.Get()`, `r.List()`, `r.
 Follow this pipeline order:
 
 1. **Fetch the CR** — return `nil` error for `IsNotFound` (resource was deleted)
-2. **Compute state** — kustomize params, image resolution
-3. **Render manifests** — `kustomize.NewEngine().Render()`
-4. **Deploy** — `deploy.NewDeployer()` with SSA
-5. **Post-deploy actions** — URL extraction, dependency checks
-6. **Update status** — set conditions, observedGeneration, then `r.Status().Update()`
+2. **Handle deletion** — finalizer removal + cross-namespace cleanup
+3. **Handle `managementState: Removed`** — tear down managed resources, set status, return early
+4. **Compute state** — kustomize params, image resolution
+5. **Render manifests** — `kustomize.NewEngine().Render()`
+6. **Deploy** — `deploy.NewDeployer()` with SSA
+7. **Post-deploy actions** — URL extraction, dependency checks
+8. **Update status** — set conditions, observedGeneration, then `r.Status().Update()`
+
+### managementState handling
+
+The reconciler must check `dashboard.Spec.ManagementState` after finalizer handling:
+
+```go
+if dashboard.Spec.ManagementState == "Removed" {
+    // Delete all resources labeled platform.opendatahub.io/part-of=dashboard
+    // Clean up cross-namespace resources
+    // Set phase=NotReady, clear URL and moduleStatuses
+    // Set ProvisioningSucceeded=False (reason: Removed)
+    return ctrl.Result{}, nil
+}
+```
+
+`Removed` is distinct from CR deletion: it preserves the CR while removing the operand. The finalizer handles actual CR deletion cleanup.
 
 ### Error handling in Reconcile
 
@@ -128,18 +146,21 @@ if err != nil {
 
 ### SetupWithManager
 
-Register watches and predicates:
+Register watches and predicates. Always register `Owns()` for resource types the controller deploys so that external deletions or modifications trigger re-reconciliation:
 
 ```go
 func SetupWithManager(mgr ctrl.Manager, opts Options) error {
     r := &DashboardReconciler{...}
     return ctrl.NewControllerManagedBy(mgr).
         For(&v1alpha1.Dashboard{}).
+        Owns(&appsv1.Deployment{}).
+        Owns(&corev1.Service{}).
+        Owns(&corev1.ConfigMap{}).
         Complete(r)
 }
 ```
 
-Add `Owns()` for resources the controller creates. Add `Watches()` for external resources that should trigger reconciliation.
+Add `Watches()` for external resources that should trigger reconciliation but are not owned by the CR.
 
 ## Platform utilities usage
 
@@ -262,3 +283,6 @@ RBAC manifests are in `config/rbac/`. When adding new resource types to the reco
 - **Ignoring status updates on error paths** — always set a condition before returning an error
 - **Using `fmt.Errorf` without `%w`** — wrap errors for `errors.Is()` / `errors.As()` compatibility
 - **Creating resources without ownership** — use `deployer.Deploy()` with `Owner` set for garbage collection
+- **Missing `Owns()` registration** — if the controller deploys Deployments, Services, or ConfigMaps, register them with `Owns()` so external modifications/deletions trigger re-reconciliation
+- **Ignoring `managementState: Removed`** — always check before proceeding with deployment; `Removed` means "tear down the operand but keep the CR"
+- **Adding modules without updating the full chain** — new modules need entries in `modules.go` (registry), `support.go` (image mapping), and `charts/dashboard/values.yaml` (related images)

--- a/BOOKMARKS.md
+++ b/BOOKMARKS.md
@@ -98,7 +98,7 @@ Central index of key documentation in the ODH Dashboard monorepo.
 
 | Doc | Description |
 |-----|-------------|
-| [Operator Architecture](docs/dashboard-operator.md) | CRD design, reconciliation pipeline, module registry, dependency resolution, manifest management |
+| [Operator Architecture](docs/dashboard-operator.md) | CRD design, reconciliation pipeline, module registry, dependency resolution, manifest management, local development, cluster deployment, troubleshooting |
 | [Controller AGENTS.md](dashboard-operator/AGENTS.md) | Go operator conventions, controller-runtime patterns, CRD types, Makefile targets, reconciliation pipeline |
 
 ---

--- a/dashboard-operator/charts/dashboard/templates/_helpers.tpl
+++ b/dashboard-operator/charts/dashboard/templates/_helpers.tpl
@@ -71,3 +71,23 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "dashboard.image" -}}
 {{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
 {{- end }}
+
+{{- define "dashboard.webhookServiceName" -}}
+{{- printf "%sdashboard-operator-webhook" .Values.namePrefix }}
+{{- end }}
+
+{{- define "dashboard.webhookName" -}}
+{{- printf "%sdashboard-operator-validating" .Values.namePrefix }}
+{{- end }}
+
+{{- define "dashboard.webhookIssuerName" -}}
+{{- printf "%sdashboard-operator-selfsigned" .Values.namePrefix }}
+{{- end }}
+
+{{- define "dashboard.webhookCertName" -}}
+{{- printf "%sdashboard-operator-webhook-cert" .Values.namePrefix }}
+{{- end }}
+
+{{- define "dashboard.webhookCertSecretName" -}}
+{{- printf "%sdashboard-operator-webhook-tls" .Values.namePrefix }}
+{{- end }}

--- a/dashboard-operator/charts/dashboard/templates/deployment.yaml
+++ b/dashboard-operator/charts/dashboard/templates/deployment.yaml
@@ -76,6 +76,9 @@ spec:
             {{- if .Values.manager.leaderElection }}
             - --leader-elect
             {{- end }}
+            {{- if .Values.webhook.enabled }}
+            - --webhook-port={{ .Values.webhook.port }}
+            {{- end }}
           env:
             - name: OPERATOR_NAMESPACE
               valueFrom:

--- a/dashboard-operator/charts/dashboard/templates/deployment.yaml
+++ b/dashboard-operator/charts/dashboard/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
                     - path: namespace
                       fieldRef:
                         fieldPath: metadata.namespace
+        {{- if .Values.webhook.enabled }}
+        - name: webhook-certs
+          secret:
+            secretName: {{ include "dashboard.webhookCertSecretName" . }}
+        {{- end }}
       containers:
         - name: manager
           image: {{ include "dashboard.image" . }}
@@ -60,6 +65,11 @@ spec:
             - name: dashboard-operator-sa-token
               mountPath: /var/run/secrets/kubernetes.io/serviceaccount
               readOnly: true
+            {{- if .Values.webhook.enabled }}
+            - name: webhook-certs
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
+            {{- end }}
           args:
             - --namespace=$(OPERATOR_NAMESPACE)
             - --manifests-base-path={{ .Values.manager.manifestsBasePath }}
@@ -82,6 +92,11 @@ spec:
             - containerPort: 8081
               name: health
               protocol: TCP
+            {{- if .Values.webhook.enabled }}
+            - containerPort: {{ .Values.webhook.port }}
+              name: webhook
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/dashboard-operator/charts/dashboard/templates/webhook.yaml
+++ b/dashboard-operator/charts/dashboard/templates/webhook.yaml
@@ -51,7 +51,8 @@ webhooks:
         resources:
           - dashboards
     sideEffects: None
-{{- if .Values.webhook.certManager.enabled }}
+    timeoutSeconds: 5
+{{- if and .Values.webhook.certManager.enabled (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/dashboard-operator/charts/dashboard/templates/webhook.yaml
+++ b/dashboard-operator/charts/dashboard/templates/webhook.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dashboard.webhookServiceName" . }}
+  namespace: {{ include "dashboard.namespace" . }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 443
+      targetPort: {{ .Values.webhook.port }}
+      protocol: TCP
+      name: webhook
+  selector:
+    {{- include "dashboard.selectorLabels" . | nindent 4 }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "dashboard.webhookName" . }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+  {{- if .Values.webhook.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ include "dashboard.namespace" . }}/{{ include "dashboard.webhookCertName" . }}
+  {{- end }}
+webhooks:
+  - name: validate.dashboard.platform.opendatahub.io
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      {{- if not .Values.webhook.certManager.enabled }}
+      {{- with .Values.webhook.caBundle }}
+      caBundle: {{ . }}
+      {{- end }}
+      {{- end }}
+      service:
+        name: {{ include "dashboard.webhookServiceName" . }}
+        namespace: {{ include "dashboard.namespace" . }}
+        path: /validate-dashboard
+        port: 443
+    failurePolicy: Fail
+    rules:
+      - apiGroups:
+          - components.platform.opendatahub.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - dashboards
+    sideEffects: None
+{{- if .Values.webhook.certManager.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "dashboard.webhookIssuerName" . }}
+  namespace: {{ include "dashboard.namespace" . }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "dashboard.webhookCertName" . }}
+  namespace: {{ include "dashboard.namespace" . }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "dashboard.webhookCertSecretName" . }}
+  issuerRef:
+    {{- if .Values.webhook.certManager.issuerRef }}
+    {{- toYaml .Values.webhook.certManager.issuerRef | nindent 4 }}
+    {{- else }}
+    name: {{ include "dashboard.webhookIssuerName" . }}
+    kind: Issuer
+    {{- end }}
+  dnsNames:
+    - {{ include "dashboard.webhookServiceName" . }}.{{ include "dashboard.namespace" . }}.svc
+    - {{ include "dashboard.webhookServiceName" . }}.{{ include "dashboard.namespace" . }}.svc.cluster.local
+  duration: 8760h # 1 year
+  renewBefore: 720h # 30 days
+{{- end }}
+{{- end }}

--- a/dashboard-operator/charts/dashboard/values.yaml
+++ b/dashboard-operator/charts/dashboard/values.yaml
@@ -15,7 +15,7 @@ commonLabels:
 
 image:
   repository: quay.io/opendatahub/odh-dashboard-operator
-  tag: latest
+  tag: main
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -51,21 +51,30 @@ serviceAccount:
 rbac:
   create: true
 
+webhook:
+  enabled: true
+  port: 9443
+  caBundle: ""
+  certManager:
+    enabled: true
+    issuerRef: {}
+
 # Downstream application images resolved by the module controller when rendering
 # embedded dashboard manifests. Keys match RELATED_IMAGE_* env var names.
 relatedImages:
-  RELATED_IMAGE_ODH_DASHBOARD_IMAGE: quay.io/opendatahub/odh-dashboard:latest
-  RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE: quay.io/opendatahub/odh-mod-arch-model-registry:latest
-  RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE: quay.io/opendatahub/odh-mod-arch-gen-ai:latest
-  RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE: quay.io/opendatahub/odh-mod-arch-mlflow:latest
-  RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE: quay.io/opendatahub/odh-mod-arch-maas:latest
-  RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE: quay.io/opendatahub/odh-mod-arch-eval-hub:latest
-  RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE: quay.io/opendatahub/odh-kube-rbac-proxy:latest
-  RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE: quay.io/opendatahub/odh-model-registry-job-async-upload:latest
-  RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE: quay.io/opendatahub/odh-mod-arch-automl:latest
-  RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE: quay.io/opendatahub/odh-mod-arch-autorag:latest
-  RELATED_IMAGE_ODH_AUTOML_IMAGE: quay.io/opendatahub/odh-automl:latest
-  RELATED_IMAGE_ODH_AUTORAG_IMAGE: quay.io/opendatahub/odh-autorag:latest
+  RELATED_IMAGE_ODH_DASHBOARD_IMAGE: quay.io/opendatahub/odh-dashboard:main
+  RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE: quay.io/opendatahub/odh-mod-arch-model-registry:main
+  RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE: quay.io/opendatahub/odh-mod-arch-gen-ai:main
+  RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE: quay.io/opendatahub/odh-mod-arch-mlflow:main
+  RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE: quay.io/opendatahub/odh-mod-arch-maas:main
+  RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE: quay.io/opendatahub/odh-mod-arch-eval-hub:main
+  RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE: quay.io/opendatahub/odh-kube-rbac-proxy:main
+  RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE: quay.io/opendatahub/odh-model-registry-job-async-upload:main
+  RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE: quay.io/opendatahub/odh-mod-arch-automl:main
+  RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE: quay.io/opendatahub/odh-mod-arch-autorag:main
+  RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE: quay.io/opendatahub/odh-mod-arch-agent-ops:main
+  RELATED_IMAGE_ODH_AUTOML_IMAGE: quay.io/opendatahub/odh-automl:main
+  RELATED_IMAGE_ODH_AUTORAG_IMAGE: quay.io/opendatahub/odh-autorag:main
 
 config:
   name: opendatahub-dashboard-config

--- a/dashboard-operator/charts/dashboard/values.yaml
+++ b/dashboard-operator/charts/dashboard/values.yaml
@@ -1,6 +1,10 @@
 # Default values for the Dashboard module controller bootstrap chart.
 # The ODH Operator renders this chart and injects namespace, image tags, and
 # RELATED_IMAGE_* values at install time.
+#
+# NOTE: Image tags below use mutable branch references (e.g. ":main") for
+# development convenience. In production, the ODH Operator overrides these
+# with immutable digest references injected by Konflux.
 
 nameOverride: ""
 fullnameOverride: ""

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -9,6 +9,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -95,6 +97,7 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, fmt.Errorf("failed to tear down resources: %w", err)
 		}
 
+		dashboard.Status.ObservedGeneration = dashboard.Generation
 		dashboard.Status.Phase = common.PhaseNotReady
 		dashboard.Status.URL = ""
 		dashboard.Status.ModuleStatuses = nil
@@ -112,10 +115,15 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			conditions.WithReason("Removed"),
 			conditions.WithMessage("Dashboard has been removed"),
 			conditions.WithSeverity(common.ConditionSeverityInfo))
+		cm.MarkFalse(string(common.ConditionTypeReady),
+			conditions.WithReason("Removed"),
+			conditions.WithMessage("Dashboard has been removed via managementState"))
 		cm.Sort()
 
 		if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status after removal")
+
+			return ctrl.Result{}, fmt.Errorf("failed to update status after removal: %w", statusErr)
 		}
 
 		return ctrl.Result{}, nil
@@ -258,10 +266,15 @@ func (r *DashboardReconciler) reconcile(
 		client.InNamespace(r.ApplicationsNamespace),
 		client.MatchingLabels{"app.kubernetes.io/part-of": "odh-dashboard"},
 	); err != nil {
-		logger.Error(err, "Failed to list dashboard pods for readiness overlay")
-	} else {
-		overlayContainerReadiness(nextStatuses, podList.Items)
+		cm.MarkFalse(string(common.ConditionTypeDegraded),
+			conditions.WithReason("PodListFailed"),
+			conditions.WithError(err),
+			conditions.WithSeverity(common.ConditionSeverityError))
+
+		return ctrl.Result{}, fmt.Errorf("failed to list dashboard pods: %w", err)
 	}
+
+	overlayContainerReadiness(nextStatuses, podList.Items)
 
 	for name, next := range nextStatuses {
 		if prev, ok := dashboard.Status.ModuleStatuses[name]; ok &&
@@ -348,8 +361,8 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 	inNamespace := client.InNamespace(r.ApplicationsNamespace)
 
-	deleteTyped := func(list client.ObjectList, kind string) error {
-		if err := r.List(ctx, list, matchLabels, inNamespace); err != nil {
+	deleteTyped := func(list client.ObjectList, kind string, opts ...client.ListOption) error {
+		if err := r.List(ctx, list, opts...); err != nil {
 			return fmt.Errorf("listing %s: %w", kind, err)
 		}
 
@@ -365,17 +378,52 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 
 	var deployments appsv1.DeploymentList
-	if err := deleteTyped(&deployments, "Deployment"); err != nil {
+	if err := deleteTyped(&deployments, "Deployment", matchLabels, inNamespace); err != nil {
 		return err
 	}
 
 	var services corev1.ServiceList
-	if err := deleteTyped(&services, "Service"); err != nil {
+	if err := deleteTyped(&services, "Service", matchLabels, inNamespace); err != nil {
 		return err
 	}
 
 	var configmaps corev1.ConfigMapList
-	if err := deleteTyped(&configmaps, "ConfigMap"); err != nil {
+	if err := deleteTyped(&configmaps, "ConfigMap", matchLabels, inNamespace); err != nil {
+		return err
+	}
+
+	var serviceAccounts corev1.ServiceAccountList
+	if err := deleteTyped(&serviceAccounts, "ServiceAccount", matchLabels, inNamespace); err != nil {
+		return err
+	}
+
+	var secrets corev1.SecretList
+	if err := deleteTyped(&secrets, "Secret", matchLabels, inNamespace); err != nil {
+		return err
+	}
+
+	var networkPolicies networkingv1.NetworkPolicyList
+	if err := deleteTyped(&networkPolicies, "NetworkPolicy", matchLabels, inNamespace); err != nil {
+		return err
+	}
+
+	var roles rbacv1.RoleList
+	if err := deleteTyped(&roles, "Role", matchLabels, inNamespace); err != nil {
+		return err
+	}
+
+	var roleBindings rbacv1.RoleBindingList
+	if err := deleteTyped(&roleBindings, "RoleBinding", matchLabels, inNamespace); err != nil {
+		return err
+	}
+
+	var clusterRoles rbacv1.ClusterRoleList
+	if err := deleteTyped(&clusterRoles, "ClusterRole", matchLabels); err != nil {
+		return err
+	}
+
+	var clusterRoleBindings rbacv1.ClusterRoleBindingList
+	if err := deleteTyped(&clusterRoleBindings, "ClusterRoleBinding", matchLabels); err != nil {
 		return err
 	}
 
@@ -407,6 +455,48 @@ func extractItems(list client.ObjectList) []client.Object {
 			items[i] = &l.Items[i]
 		}
 		return items
+	case *corev1.ServiceAccountList:
+		items := make([]client.Object, len(l.Items))
+		for i := range l.Items {
+			items[i] = &l.Items[i]
+		}
+		return items
+	case *corev1.SecretList:
+		items := make([]client.Object, len(l.Items))
+		for i := range l.Items {
+			items[i] = &l.Items[i]
+		}
+		return items
+	case *networkingv1.NetworkPolicyList:
+		items := make([]client.Object, len(l.Items))
+		for i := range l.Items {
+			items[i] = &l.Items[i]
+		}
+		return items
+	case *rbacv1.RoleList:
+		items := make([]client.Object, len(l.Items))
+		for i := range l.Items {
+			items[i] = &l.Items[i]
+		}
+		return items
+	case *rbacv1.RoleBindingList:
+		items := make([]client.Object, len(l.Items))
+		for i := range l.Items {
+			items[i] = &l.Items[i]
+		}
+		return items
+	case *rbacv1.ClusterRoleList:
+		items := make([]client.Object, len(l.Items))
+		for i := range l.Items {
+			items[i] = &l.Items[i]
+		}
+		return items
+	case *rbacv1.ClusterRoleBindingList:
+		items := make([]client.Object, len(l.Items))
+		for i := range l.Items {
+			items[i] = &l.Items[i]
+		}
+		return items
 	default:
 		return nil
 	}
@@ -423,6 +513,10 @@ func SetupWithManager(mgr ctrl.Manager, opts Options) error {
 		ApplicationsNamespace: opts.ApplicationsNamespace,
 	}
 
+	// Owns() watches ensure external modifications or deletions of managed
+	// resources trigger re-reconciliation. During Removed state the extra
+	// reconcile is harmless — teardown is idempotent and bounded by the
+	// number of owned resources.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Dashboard{}).
 		Owns(&appsv1.Deployment{}).

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -82,6 +83,39 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		controllerutil.AddFinalizer(dashboard, dashboardFinalizer)
 		if err := r.Update(ctx, dashboard); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	if dashboard.Spec.ManagementState == "Removed" {
+		logger.Info("ManagementState is Removed, tearing down resources")
+
+		if err := r.teardownManagedResources(ctx, dashboard); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to tear down resources: %w", err)
+		}
+
+		dashboard.Status.Phase = common.PhaseNotReady
+		dashboard.Status.URL = ""
+		dashboard.Status.ModuleStatuses = nil
+
+		cm := conditions.NewManager(
+			dashboard,
+			string(common.ConditionTypeReady),
+			string(common.ConditionTypeProvisioningSucceeded),
+			string(common.ConditionTypeDegraded),
+		)
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("Removed"),
+			conditions.WithMessage("Dashboard has been removed via managementState"))
+		cm.MarkFalse(string(common.ConditionTypeDegraded),
+			conditions.WithReason("Removed"),
+			conditions.WithMessage("Dashboard has been removed"),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+		cm.Sort()
+
+		if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
+			logger.Error(statusErr, "Failed to update status after removal")
 		}
 
 		return ctrl.Result{}, nil
@@ -218,6 +252,17 @@ func (r *DashboardReconciler) reconcile(
 	}
 
 	nextStatuses := resolveModuleStatuses(&dashboard.Spec)
+
+	var podList corev1.PodList
+	if err := r.List(ctx, &podList,
+		client.InNamespace(r.ApplicationsNamespace),
+		client.MatchingLabels{"app.kubernetes.io/part-of": "odh-dashboard"},
+	); err != nil {
+		logger.Error(err, "Failed to list dashboard pods for readiness overlay")
+	} else {
+		overlayContainerReadiness(nextStatuses, podList.Items)
+	}
+
 	for name, next := range nextStatuses {
 		if prev, ok := dashboard.Status.ModuleStatuses[name]; ok &&
 			prev.Phase == next.Phase &&
@@ -292,6 +337,81 @@ func (r *DashboardReconciler) cleanupCrossNamespaceResources(ctx context.Context
 	return nil
 }
 
+// teardownManagedResources deletes all resources labeled with
+// platform.opendatahub.io/part-of=dashboard in the applications namespace,
+// and cleans up cross-namespace resources.
+func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dashboard *v1alpha1.Dashboard) error {
+	logger := log.FromContext(ctx)
+
+	matchLabels := client.MatchingLabels{
+		labels.PlatformPartOf: strings.ToLower(v1alpha1.DashboardKind),
+	}
+	inNamespace := client.InNamespace(r.ApplicationsNamespace)
+
+	deleteTyped := func(list client.ObjectList, kind string) error {
+		if err := r.List(ctx, list, matchLabels, inNamespace); err != nil {
+			return fmt.Errorf("listing %s: %w", kind, err)
+		}
+
+		items := extractItems(list)
+		for i := range items {
+			logger.Info("Deleting managed resource", "kind", kind, "name", items[i].GetName())
+			if err := r.Delete(ctx, items[i]); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("deleting %s %s: %w", kind, items[i].GetName(), err)
+			}
+		}
+
+		return nil
+	}
+
+	var deployments appsv1.DeploymentList
+	if err := deleteTyped(&deployments, "Deployment"); err != nil {
+		return err
+	}
+
+	var services corev1.ServiceList
+	if err := deleteTyped(&services, "Service"); err != nil {
+		return err
+	}
+
+	var configmaps corev1.ConfigMapList
+	if err := deleteTyped(&configmaps, "ConfigMap"); err != nil {
+		return err
+	}
+
+	if err := r.cleanupCrossNamespaceResources(ctx, dashboard); err != nil {
+		return fmt.Errorf("cross-namespace cleanup: %w", err)
+	}
+
+	return nil
+}
+
+// extractItems returns the slice of client.Object from a typed list.
+func extractItems(list client.ObjectList) []client.Object {
+	switch l := list.(type) {
+	case *appsv1.DeploymentList:
+		items := make([]client.Object, len(l.Items))
+		for i := range l.Items {
+			items[i] = &l.Items[i]
+		}
+		return items
+	case *corev1.ServiceList:
+		items := make([]client.Object, len(l.Items))
+		for i := range l.Items {
+			items[i] = &l.Items[i]
+		}
+		return items
+	case *corev1.ConfigMapList:
+		items := make([]client.Object, len(l.Items))
+		for i := range l.Items {
+			items[i] = &l.Items[i]
+		}
+		return items
+	default:
+		return nil
+	}
+}
+
 // SetupWithManager registers the dashboard controller with the manager.
 func SetupWithManager(mgr ctrl.Manager, opts Options) error {
 	r := &DashboardReconciler{
@@ -305,5 +425,8 @@ func SetupWithManager(mgr ctrl.Manager, opts Options) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Dashboard{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
 		Complete(r)
 }

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -184,13 +184,8 @@ func TestReconcile(t *testing.T) {
 			wantModuleCount: registrySize,
 		},
 		{
-			name:       "module statuses populated with components",
+			name:       "module statuses populated — all modules deployed by default",
 			generation: 1,
-			dashboardSpec: &v1alpha1.DashboardSpec{
-				Components: map[string]v1alpha1.ComponentAvailability{
-					"modelregistry": {ManagementState: "Managed"},
-				},
-			},
 			manifestsBase: func(t *testing.T) string {
 				return createMinimalManifests(t)
 			},
@@ -204,11 +199,14 @@ func TestReconcile(t *testing.T) {
 			wantGeneration:  1,
 			wantModuleCount: registrySize,
 			wantModulePhases: map[string]v1alpha1.ModulePhase{
-				"modelRegistry":  v1alpha1.ModulePhaseDeployed,
-				"genAi":          v1alpha1.ModulePhaseDeployed,
-				"mlflow":         v1alpha1.ModulePhaseNotDeployed,
-				"mlflowEmbedded": v1alpha1.ModulePhaseNotDeployed,
-				"perses":         v1alpha1.ModulePhaseNotDeployed,
+				"modelRegistry": v1alpha1.ModulePhaseDeployed,
+				"genAi":         v1alpha1.ModulePhaseDeployed,
+				"mlflow":        v1alpha1.ModulePhaseDeployed,
+				"maas":          v1alpha1.ModulePhaseDeployed,
+				"evalHub":       v1alpha1.ModulePhaseDeployed,
+				"automl":        v1alpha1.ModulePhaseDeployed,
+				"autorag":       v1alpha1.ModulePhaseDeployed,
+				"agentOps":      v1alpha1.ModulePhaseDeployed,
 			},
 		},
 		{

--- a/dashboard-operator/internal/controller/modules.go
+++ b/dashboard-operator/internal/controller/modules.go
@@ -123,6 +123,13 @@ func overlayContainerReadiness(statuses map[string]v1alpha1.ModuleStatus, pods [
 
 		cs, found := containerByName[mod.ContainerName]
 		if !found {
+			statuses[name] = v1alpha1.ModuleStatus{
+				Phase:              v1alpha1.ModulePhaseNotDeployed,
+				Reason:             "ContainerNotFound",
+				Message:            fmt.Sprintf("Container %q not found in any dashboard pod", mod.ContainerName),
+				LastTransitionTime: now,
+			}
+
 			continue
 		}
 

--- a/dashboard-operator/internal/controller/modules.go
+++ b/dashboard-operator/internal/controller/modules.go
@@ -4,211 +4,78 @@ import (
 	"fmt"
 	"sort"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 )
 
-// ModuleType classifies how a module is deployed.
-type ModuleType string
-
-const (
-	ModuleTypeBFF          ModuleType = "BFF"
-	ModuleTypeEmbedded     ModuleType = "Embedded"
-	ModuleTypeProxyService ModuleType = "ProxyService"
-)
-
 // ModuleDefinition describes a module's static properties.
-// This is compiled into the binary and is the authoritative source of
-// truth for module metadata. The CR only carries override intent and
-// external dependency signals.
 type ModuleDefinition struct {
 	Name          string
-	Type          ModuleType
 	ContainerName string
 	Port          int32
 	ImageEnvVar   string
-	// Empty means the module is always deployed (opt-in by default).
-	RequiredComponents []string
-	RequiredModules    []string
 }
 
 var moduleRegistry = map[string]ModuleDefinition{
 	"modelRegistry": {
-		Name: "modelRegistry", Type: ModuleTypeBFF,
-		ContainerName: "model-registry-ui", Port: 8043,
-		ImageEnvVar:        "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
-		RequiredComponents: []string{"modelregistry"},
+		Name: "modelRegistry", ContainerName: "model-registry-ui", Port: 8043,
+		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
 	},
 	"genAi": {
-		Name: "genAi", Type: ModuleTypeBFF,
-		ContainerName: "gen-ai-ui", Port: 8143,
+		Name: "genAi", ContainerName: "gen-ai-ui", Port: 8143,
 		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
 	},
 	"mlflow": {
-		Name: "mlflow", Type: ModuleTypeBFF,
-		ContainerName: "mlflow-ui", Port: 8343,
-		ImageEnvVar:        "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
-		RequiredComponents: []string{"mlflowoperator"},
-	},
-	"mlflowEmbedded": {
-		Name: "mlflowEmbedded", Type: ModuleTypeEmbedded,
-		RequiredComponents: []string{"mlflowoperator"},
-		RequiredModules:    []string{"mlflow"},
+		Name: "mlflow", ContainerName: "mlflow-ui", Port: 8343,
+		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
 	},
 	"maas": {
-		Name: "maas", Type: ModuleTypeBFF,
-		ContainerName: "maas-ui", Port: 8243,
+		Name: "maas", ContainerName: "maas-ui", Port: 8243,
 		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
 	},
 	"evalHub": {
-		Name: "evalHub", Type: ModuleTypeBFF,
-		ContainerName: "eval-hub-ui", Port: 8443,
+		Name: "evalHub", ContainerName: "eval-hub-ui", Port: 8443,
 		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
 	},
 	"automl": {
-		Name: "automl", Type: ModuleTypeBFF,
-		ContainerName: "automl-ui", Port: 8543,
+		Name: "automl", ContainerName: "automl-ui", Port: 8543,
 		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
 	},
 	"autorag": {
-		Name: "autorag", Type: ModuleTypeBFF,
-		ContainerName: "autorag-ui", Port: 8643,
+		Name: "autorag", ContainerName: "autorag-ui", Port: 8643,
 		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
 	},
-	"perses": {
-		Name: "perses", Type: ModuleTypeProxyService,
+	"agentOps": {
+		Name: "agentOps", ContainerName: "agent-ops-ui", Port: 8843,
+		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE",
 	},
 }
 
-func isComponentAvailable(components map[string]v1alpha1.ComponentAvailability, name string) bool {
-	comp, exists := components[name]
-	if !exists {
-		return false
-	}
-
-	return comp.ManagementState == "Managed" || comp.ManagementState == "Unmanaged"
-}
-
-// resolveModuleStatuses runs a two-pass dependency resolution algorithm
-// to determine which modules should be deployed based on spec.Components,
-// spec.Modules overrides, and spec.Observability.
+// resolveModuleStatuses determines the status of each module based on
+// spec overrides. All registered modules are deployed by default unless
+// explicitly disabled.
 func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.ModuleStatus {
 	now := metav1.Now()
 	result := make(map[string]v1alpha1.ModuleStatus, len(moduleRegistry))
 
-	// Pass 1: Evaluate each module against overrides and DSC component deps.
-	// Modules with inter-module deps that pass all other checks are deferred.
-	pendingModuleDeps := map[string][]string{}
-
-	for name, mod := range moduleRegistry {
-		if mod.Type == ModuleTypeProxyService {
-			result[name] = resolveProxyServiceModule(spec, now)
-			continue
-		}
-
-		if override, ok := spec.Modules[name]; ok {
-			if override.State == v1alpha1.ModuleDisabled {
-				result[name] = v1alpha1.ModuleStatus{
-					Phase:              v1alpha1.ModulePhaseDisabled,
-					Reason:             "ExplicitOverride",
-					Message:            "Module explicitly disabled via spec.modules override",
-					LastTransitionTime: now,
-				}
-
-				continue
-			}
-
-			if override.State == v1alpha1.ModuleEnabled {
-				if len(mod.RequiredModules) > 0 {
-					pendingModuleDeps[name] = mod.RequiredModules
-				} else {
-					result[name] = v1alpha1.ModuleStatus{
-						Phase:              v1alpha1.ModulePhaseDeployed,
-						Reason:             "ExplicitOverride",
-						Message:            "Module explicitly enabled via spec.modules override",
-						LastTransitionTime: now,
-					}
-				}
-
-				continue
-			}
-		}
-
-		if missing := findMissingComponent(spec.Components, mod.RequiredComponents); missing != "" {
+	for name := range moduleRegistry {
+		if override, ok := spec.Modules[name]; ok && override.State == v1alpha1.ModuleDisabled {
 			result[name] = v1alpha1.ModuleStatus{
-				Phase:              v1alpha1.ModulePhaseNotDeployed,
-				Reason:             "ComponentNotAvailable",
-				Message:            fmt.Sprintf("Required DSC component %q is not available", missing),
+				Phase:              v1alpha1.ModulePhaseDisabled,
+				Reason:             "ExplicitOverride",
+				Message:            "Module explicitly disabled via spec.modules override",
 				LastTransitionTime: now,
 			}
 
 			continue
 		}
 
-		if len(mod.RequiredModules) > 0 {
-			pendingModuleDeps[name] = mod.RequiredModules
-		} else {
-			result[name] = v1alpha1.ModuleStatus{
-				Phase:              v1alpha1.ModulePhaseDeployed,
-				Reason:             "DependenciesSatisfied",
-				Message:            "All dependencies satisfied",
-				LastTransitionTime: now,
-			}
-		}
-	}
-
-	// Pass 2: Resolve inter-module dependencies. Iterate until stable.
-	for range len(moduleRegistry) {
-		changed := false
-
-		for name, deps := range pendingModuleDeps {
-			allMet := true
-
-			for _, dep := range deps {
-				if s, resolved := result[dep]; resolved {
-					if s.Phase != v1alpha1.ModulePhaseDeployed {
-						result[name] = v1alpha1.ModuleStatus{
-							Phase:              v1alpha1.ModulePhaseNotDeployed,
-							Reason:             "ModuleDependencyNotSatisfied",
-							Message:            fmt.Sprintf("Required module %q is not deployed", dep),
-							LastTransitionTime: now,
-						}
-						delete(pendingModuleDeps, name)
-						changed = true
-						allMet = false
-
-						break
-					}
-				} else {
-					allMet = false
-
-					break
-				}
-			}
-
-			if allMet {
-				result[name] = v1alpha1.ModuleStatus{
-					Phase:              v1alpha1.ModulePhaseDeployed,
-					Reason:             "DependenciesSatisfied",
-					Message:            "All dependencies satisfied",
-					LastTransitionTime: now,
-				}
-				delete(pendingModuleDeps, name)
-				changed = true
-			}
-		}
-
-		if !changed {
-			break
-		}
-	}
-
-	for name := range pendingModuleDeps {
 		result[name] = v1alpha1.ModuleStatus{
-			Phase:              v1alpha1.ModulePhaseNotDeployed,
-			Reason:             "UnresolvableDependency",
-			Message:            "Module dependencies could not be resolved (possible cycle)",
+			Phase:              v1alpha1.ModulePhaseDeployed,
+			Reason:             "Deployed",
+			Message:            "Module container deployed",
 			LastTransitionTime: now,
 		}
 	}
@@ -227,44 +94,61 @@ func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.Mod
 	return result
 }
 
-func resolveProxyServiceModule(spec *v1alpha1.DashboardSpec, now metav1.Time) v1alpha1.ModuleStatus {
-	if spec.Observability == nil || !spec.Observability.Enabled {
-		return v1alpha1.ModuleStatus{
-			Phase:              v1alpha1.ModulePhaseNotDeployed,
-			Reason:             "ObservabilityDisabled",
-			Message:            "Observability is not enabled in spec",
+// overlayContainerReadiness inspects the pods backing the dashboard
+// Deployment and marks modules as Degraded when their container is not
+// ready (e.g. ImagePullBackOff, CrashLoopBackOff).
+func overlayContainerReadiness(statuses map[string]v1alpha1.ModuleStatus, pods []corev1.Pod) {
+	if len(pods) == 0 {
+		return
+	}
+
+	now := metav1.Now()
+
+	containerByName := map[string]*corev1.ContainerStatus{}
+	for i := range pods {
+		for j := range pods[i].Status.ContainerStatuses {
+			cs := &pods[i].Status.ContainerStatuses[j]
+			if existing, ok := containerByName[cs.Name]; ok && !existing.Ready {
+				continue
+			}
+			containerByName[cs.Name] = cs
+		}
+	}
+
+	for name, mod := range moduleRegistry {
+		s, ok := statuses[name]
+		if !ok || s.Phase != v1alpha1.ModulePhaseDeployed {
+			continue
+		}
+
+		cs, found := containerByName[mod.ContainerName]
+		if !found {
+			continue
+		}
+
+		if cs.Ready {
+			continue
+		}
+
+		msg := fmt.Sprintf("Container %q is not ready", mod.ContainerName)
+		reason := "ContainerNotReady"
+
+		if cs.State.Waiting != nil {
+			reason = cs.State.Waiting.Reason
+			if cs.State.Waiting.Message != "" {
+				msg = cs.State.Waiting.Message
+			} else {
+				msg = fmt.Sprintf("Container %q is waiting: %s", mod.ContainerName, reason)
+			}
+		}
+
+		statuses[name] = v1alpha1.ModuleStatus{
+			Phase:              v1alpha1.ModulePhaseDegraded,
+			Reason:             reason,
+			Message:            msg,
 			LastTransitionTime: now,
 		}
 	}
-
-	if spec.Observability.PersesService == nil {
-		return v1alpha1.ModuleStatus{
-			Phase:              v1alpha1.ModulePhaseNotDeployed,
-			Reason:             "MissingPersesServiceConfig",
-			Message:            "Observability is enabled but persesService is not configured",
-			LastTransitionTime: now,
-		}
-	}
-
-	return v1alpha1.ModuleStatus{
-		Phase:  v1alpha1.ModulePhaseDeployed,
-		Reason: "ObservabilityEnabled",
-		Message: fmt.Sprintf("Proxying to %s.%s:%d",
-			spec.Observability.PersesService.Name,
-			spec.Observability.PersesService.Namespace,
-			spec.Observability.PersesService.Port),
-		LastTransitionTime: now,
-	}
-}
-
-func findMissingComponent(components map[string]v1alpha1.ComponentAvailability, required []string) string {
-	for _, name := range required {
-		if !isComponentAvailable(components, name) {
-			return name
-		}
-	}
-
-	return ""
 }
 
 // ModuleNames returns the sorted list of module names from the registry.

--- a/dashboard-operator/internal/controller/modules_test.go
+++ b/dashboard-operator/internal/controller/modules_test.go
@@ -15,13 +15,15 @@ func TestResolveModuleStatuses(t *testing.T) {
 	tests := []struct {
 		name        string
 		spec        v1alpha1.DashboardSpec
+		wantLen     int
 		wantPhases  map[string]v1alpha1.ModulePhase
 		wantReason  map[string]string
 		wantMessage map[string]string
 	}{
 		{
-			name: "default spec — all modules deployed",
-			spec: v1alpha1.DashboardSpec{},
+			name:    "default spec — all modules deployed",
+			wantLen: 8,
+			spec:    v1alpha1.DashboardSpec{},
 			wantPhases: map[string]v1alpha1.ModulePhase{
 				"modelRegistry": v1alpha1.ModulePhaseDeployed,
 				"genAi":         v1alpha1.ModulePhaseDeployed,
@@ -34,7 +36,8 @@ func TestResolveModuleStatuses(t *testing.T) {
 			},
 		},
 		{
-			name: "explicit disable override",
+			name:    "explicit disable override",
+			wantLen: 8,
 			spec: v1alpha1.DashboardSpec{
 				Modules: map[string]v1alpha1.ModuleOverride{
 					"genAi": {State: v1alpha1.ModuleDisabled},
@@ -49,7 +52,8 @@ func TestResolveModuleStatuses(t *testing.T) {
 			},
 		},
 		{
-			name: "explicit enable is treated as deployed",
+			name:    "explicit enable is treated as deployed",
+			wantLen: 8,
 			spec: v1alpha1.DashboardSpec{
 				Modules: map[string]v1alpha1.ModuleOverride{
 					"modelRegistry": {State: v1alpha1.ModuleEnabled},
@@ -60,7 +64,8 @@ func TestResolveModuleStatuses(t *testing.T) {
 			},
 		},
 		{
-			name: "all modules disabled via overrides",
+			name:    "all modules disabled via overrides",
+			wantLen: 8,
 			spec: v1alpha1.DashboardSpec{
 				Modules: map[string]v1alpha1.ModuleOverride{
 					"modelRegistry": {State: v1alpha1.ModuleDisabled},
@@ -85,7 +90,8 @@ func TestResolveModuleStatuses(t *testing.T) {
 			},
 		},
 		{
-			name: "unknown module override key produces UnknownModule status",
+			name:    "unknown module override key produces UnknownModule status",
+			wantLen: 9,
 			spec: v1alpha1.DashboardSpec{
 				Modules: map[string]v1alpha1.ModuleOverride{
 					"modelregistry": {State: v1alpha1.ModuleEnabled},
@@ -104,7 +110,7 @@ func TestResolveModuleStatuses(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := resolveModuleStatuses(&tt.spec)
 
-			require.GreaterOrEqual(t, len(got), len(moduleRegistry), "should include at least every registered module")
+			require.Len(t, got, tt.wantLen, "result should have exact expected cardinality")
 
 			for name, wantPhase := range tt.wantPhases {
 				status, ok := got[name]
@@ -209,6 +215,7 @@ func TestOverlayContainerReadiness(t *testing.T) {
 				{
 					Status: corev1.PodStatus{
 						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "gen-ai-ui", Ready: true},
 							{
 								Name:  "mlflow-ui",
 								Ready: false,
@@ -325,7 +332,8 @@ func TestModuleRegistry(t *testing.T) {
 
 func TestModuleNames(t *testing.T) {
 	names := ModuleNames()
-	assert.Len(t, names, 8)
-	assert.Equal(t, "agentOps", names[0], "names should be sorted alphabetically")
-	assert.Equal(t, "modelRegistry", names[len(names)-1])
+	assert.Equal(t, []string{
+		"agentOps", "automl", "autorag", "evalHub",
+		"genAi", "maas", "mlflow", "modelRegistry",
+	}, names)
 }

--- a/dashboard-operator/internal/controller/modules_test.go
+++ b/dashboard-operator/internal/controller/modules_test.go
@@ -5,56 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 )
-
-func TestIsComponentAvailable(t *testing.T) {
-	tests := []struct {
-		name       string
-		components map[string]v1alpha1.ComponentAvailability
-		component  string
-		want       bool
-	}{
-		{
-			name:       "managed component is available",
-			components: map[string]v1alpha1.ComponentAvailability{"modelregistry": {ManagementState: "Managed"}},
-			component:  "modelregistry",
-			want:       true,
-		},
-		{
-			name:       "unmanaged component is available",
-			components: map[string]v1alpha1.ComponentAvailability{"modelregistry": {ManagementState: "Unmanaged"}},
-			component:  "modelregistry",
-			want:       true,
-		},
-		{
-			name:       "removed component is not available",
-			components: map[string]v1alpha1.ComponentAvailability{"modelregistry": {ManagementState: "Removed"}},
-			component:  "modelregistry",
-			want:       false,
-		},
-		{
-			name:       "missing component is not available",
-			components: map[string]v1alpha1.ComponentAvailability{},
-			component:  "modelregistry",
-			want:       false,
-		},
-		{
-			name:       "nil map",
-			components: nil,
-			component:  "modelregistry",
-			want:       false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isComponentAvailable(tt.components, tt.component)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
 
 func TestResolveModuleStatuses(t *testing.T) {
 	tests := []struct {
@@ -65,51 +20,17 @@ func TestResolveModuleStatuses(t *testing.T) {
 		wantMessage map[string]string
 	}{
 		{
-			name: "all components available, observability enabled",
-			spec: v1alpha1.DashboardSpec{
-				Components: map[string]v1alpha1.ComponentAvailability{
-					"modelregistry":  {ManagementState: "Managed"},
-					"mlflowoperator": {ManagementState: "Managed"},
-				},
-				Observability: &v1alpha1.ObservabilitySpec{
-					Enabled:       true,
-					PersesService: &v1alpha1.ServiceTarget{Name: "perses", Namespace: "monitoring", Port: 8080},
-				},
-			},
-			wantPhases: map[string]v1alpha1.ModulePhase{
-				"modelRegistry":  v1alpha1.ModulePhaseDeployed,
-				"genAi":          v1alpha1.ModulePhaseDeployed,
-				"mlflow":         v1alpha1.ModulePhaseDeployed,
-				"mlflowEmbedded": v1alpha1.ModulePhaseDeployed,
-				"maas":           v1alpha1.ModulePhaseDeployed,
-				"evalHub":        v1alpha1.ModulePhaseDeployed,
-				"automl":         v1alpha1.ModulePhaseDeployed,
-				"autorag":        v1alpha1.ModulePhaseDeployed,
-				"perses":         v1alpha1.ModulePhaseDeployed,
-			},
-			wantMessage: map[string]string{
-				"perses": "Proxying to perses.monitoring:8080",
-			},
-		},
-		{
-			name: "empty spec — modules with no deps deployed, others not",
+			name: "default spec — all modules deployed",
 			spec: v1alpha1.DashboardSpec{},
 			wantPhases: map[string]v1alpha1.ModulePhase{
-				"modelRegistry":  v1alpha1.ModulePhaseNotDeployed,
-				"genAi":          v1alpha1.ModulePhaseDeployed,
-				"mlflow":         v1alpha1.ModulePhaseNotDeployed,
-				"mlflowEmbedded": v1alpha1.ModulePhaseNotDeployed,
-				"maas":           v1alpha1.ModulePhaseDeployed,
-				"evalHub":        v1alpha1.ModulePhaseDeployed,
-				"automl":         v1alpha1.ModulePhaseDeployed,
-				"autorag":        v1alpha1.ModulePhaseDeployed,
-				"perses":         v1alpha1.ModulePhaseNotDeployed,
-			},
-			wantReason: map[string]string{
-				"modelRegistry":  "ComponentNotAvailable",
-				"mlflow":         "ComponentNotAvailable",
-				"mlflowEmbedded": "ComponentNotAvailable",
-				"perses":         "ObservabilityDisabled",
+				"modelRegistry": v1alpha1.ModulePhaseDeployed,
+				"genAi":         v1alpha1.ModulePhaseDeployed,
+				"mlflow":        v1alpha1.ModulePhaseDeployed,
+				"maas":          v1alpha1.ModulePhaseDeployed,
+				"evalHub":       v1alpha1.ModulePhaseDeployed,
+				"automl":        v1alpha1.ModulePhaseDeployed,
+				"autorag":       v1alpha1.ModulePhaseDeployed,
+				"agentOps":      v1alpha1.ModulePhaseDeployed,
 			},
 		},
 		{
@@ -120,14 +41,15 @@ func TestResolveModuleStatuses(t *testing.T) {
 				},
 			},
 			wantPhases: map[string]v1alpha1.ModulePhase{
-				"genAi": v1alpha1.ModulePhaseDisabled,
+				"genAi":         v1alpha1.ModulePhaseDisabled,
+				"modelRegistry": v1alpha1.ModulePhaseDeployed,
 			},
 			wantReason: map[string]string{
 				"genAi": "ExplicitOverride",
 			},
 		},
 		{
-			name: "explicit enable bypasses DSC component check",
+			name: "explicit enable is treated as deployed",
 			spec: v1alpha1.DashboardSpec{
 				Modules: map[string]v1alpha1.ModuleOverride{
 					"modelRegistry": {State: v1alpha1.ModuleEnabled},
@@ -136,134 +58,30 @@ func TestResolveModuleStatuses(t *testing.T) {
 			wantPhases: map[string]v1alpha1.ModulePhase{
 				"modelRegistry": v1alpha1.ModulePhaseDeployed,
 			},
-			wantReason: map[string]string{
-				"modelRegistry": "ExplicitOverride",
-			},
-		},
-		{
-			name: "component removed — dependent module not deployed",
-			spec: v1alpha1.DashboardSpec{
-				Components: map[string]v1alpha1.ComponentAvailability{
-					"modelregistry":  {ManagementState: "Managed"},
-					"mlflowoperator": {ManagementState: "Removed"},
-				},
-			},
-			wantPhases: map[string]v1alpha1.ModulePhase{
-				"modelRegistry":  v1alpha1.ModulePhaseDeployed,
-				"mlflow":         v1alpha1.ModulePhaseNotDeployed,
-				"mlflowEmbedded": v1alpha1.ModulePhaseNotDeployed,
-			},
-			wantReason: map[string]string{
-				"mlflow":         "ComponentNotAvailable",
-				"mlflowEmbedded": "ComponentNotAvailable",
-			},
-		},
-		{
-			name: "inter-module dep — mlflow disabled cascades to mlflowEmbedded",
-			spec: v1alpha1.DashboardSpec{
-				Components: map[string]v1alpha1.ComponentAvailability{
-					"mlflowoperator": {ManagementState: "Managed"},
-				},
-				Modules: map[string]v1alpha1.ModuleOverride{
-					"mlflow": {State: v1alpha1.ModuleDisabled},
-				},
-			},
-			wantPhases: map[string]v1alpha1.ModulePhase{
-				"mlflow":         v1alpha1.ModulePhaseDisabled,
-				"mlflowEmbedded": v1alpha1.ModulePhaseNotDeployed,
-			},
-			wantReason: map[string]string{
-				"mlflow":         "ExplicitOverride",
-				"mlflowEmbedded": "ModuleDependencyNotSatisfied",
-			},
-		},
-		{
-			name: "observability enabled without perses service config",
-			spec: v1alpha1.DashboardSpec{
-				Observability: &v1alpha1.ObservabilitySpec{
-					Enabled: true,
-				},
-			},
-			wantPhases: map[string]v1alpha1.ModulePhase{
-				"perses": v1alpha1.ModulePhaseNotDeployed,
-			},
-			wantReason: map[string]string{
-				"perses": "MissingPersesServiceConfig",
-			},
-		},
-		{
-			name: "observability disabled",
-			spec: v1alpha1.DashboardSpec{
-				Observability: &v1alpha1.ObservabilitySpec{
-					Enabled: false,
-				},
-			},
-			wantPhases: map[string]v1alpha1.ModulePhase{
-				"perses": v1alpha1.ModulePhaseNotDeployed,
-			},
-			wantReason: map[string]string{
-				"perses": "ObservabilityDisabled",
-			},
 		},
 		{
 			name: "all modules disabled via overrides",
 			spec: v1alpha1.DashboardSpec{
 				Modules: map[string]v1alpha1.ModuleOverride{
-					"modelRegistry":  {State: v1alpha1.ModuleDisabled},
-					"genAi":          {State: v1alpha1.ModuleDisabled},
-					"mlflow":         {State: v1alpha1.ModuleDisabled},
-					"mlflowEmbedded": {State: v1alpha1.ModuleDisabled},
-					"maas":           {State: v1alpha1.ModuleDisabled},
-					"evalHub":        {State: v1alpha1.ModuleDisabled},
-					"automl":         {State: v1alpha1.ModuleDisabled},
-					"autorag":        {State: v1alpha1.ModuleDisabled},
+					"modelRegistry": {State: v1alpha1.ModuleDisabled},
+					"genAi":         {State: v1alpha1.ModuleDisabled},
+					"mlflow":        {State: v1alpha1.ModuleDisabled},
+					"maas":          {State: v1alpha1.ModuleDisabled},
+					"evalHub":       {State: v1alpha1.ModuleDisabled},
+					"automl":        {State: v1alpha1.ModuleDisabled},
+					"autorag":       {State: v1alpha1.ModuleDisabled},
+					"agentOps":      {State: v1alpha1.ModuleDisabled},
 				},
 			},
 			wantPhases: map[string]v1alpha1.ModulePhase{
-				"modelRegistry":  v1alpha1.ModulePhaseDisabled,
-				"genAi":          v1alpha1.ModulePhaseDisabled,
-				"mlflow":         v1alpha1.ModulePhaseDisabled,
-				"mlflowEmbedded": v1alpha1.ModulePhaseDisabled,
-				"maas":           v1alpha1.ModulePhaseDisabled,
-				"evalHub":        v1alpha1.ModulePhaseDisabled,
-				"automl":         v1alpha1.ModulePhaseDisabled,
-				"autorag":        v1alpha1.ModulePhaseDisabled,
-				"perses":         v1alpha1.ModulePhaseNotDeployed,
-			},
-		},
-		{
-			name: "explicit enable does not bypass inter-module deps",
-			spec: v1alpha1.DashboardSpec{
-				Modules: map[string]v1alpha1.ModuleOverride{
-					"mlflowEmbedded": {State: v1alpha1.ModuleEnabled},
-				},
-			},
-			wantPhases: map[string]v1alpha1.ModulePhase{
-				"mlflow":         v1alpha1.ModulePhaseNotDeployed,
-				"mlflowEmbedded": v1alpha1.ModulePhaseNotDeployed,
-			},
-			wantReason: map[string]string{
-				"mlflow":         "ComponentNotAvailable",
-				"mlflowEmbedded": "ModuleDependencyNotSatisfied",
-			},
-		},
-		{
-			name: "explicit enable with satisfied module deps deploys",
-			spec: v1alpha1.DashboardSpec{
-				Components: map[string]v1alpha1.ComponentAvailability{
-					"mlflowoperator": {ManagementState: "Managed"},
-				},
-				Modules: map[string]v1alpha1.ModuleOverride{
-					"mlflowEmbedded": {State: v1alpha1.ModuleEnabled},
-				},
-			},
-			wantPhases: map[string]v1alpha1.ModulePhase{
-				"mlflow":         v1alpha1.ModulePhaseDeployed,
-				"mlflowEmbedded": v1alpha1.ModulePhaseDeployed,
-			},
-			wantReason: map[string]string{
-				"mlflow":         "DependenciesSatisfied",
-				"mlflowEmbedded": "DependenciesSatisfied",
+				"modelRegistry": v1alpha1.ModulePhaseDisabled,
+				"genAi":         v1alpha1.ModulePhaseDisabled,
+				"mlflow":        v1alpha1.ModulePhaseDisabled,
+				"maas":          v1alpha1.ModulePhaseDisabled,
+				"evalHub":       v1alpha1.ModulePhaseDisabled,
+				"automl":        v1alpha1.ModulePhaseDisabled,
+				"autorag":       v1alpha1.ModulePhaseDisabled,
+				"agentOps":      v1alpha1.ModulePhaseDisabled,
 			},
 		},
 		{
@@ -306,31 +124,208 @@ func TestResolveModuleStatuses(t *testing.T) {
 	}
 }
 
+func TestOverlayContainerReadiness(t *testing.T) {
+	deployedStatuses := func() map[string]v1alpha1.ModuleStatus {
+		s := make(map[string]v1alpha1.ModuleStatus, len(moduleRegistry))
+		for name := range moduleRegistry {
+			s[name] = v1alpha1.ModuleStatus{
+				Phase:              v1alpha1.ModulePhaseDeployed,
+				Reason:             "Deployed",
+				Message:            "Module container deployed",
+				LastTransitionTime: metav1.Now(),
+			}
+		}
+		return s
+	}
+
+	tests := []struct {
+		name       string
+		statuses   map[string]v1alpha1.ModuleStatus
+		pods       []corev1.Pod
+		wantPhases map[string]v1alpha1.ModulePhase
+		wantReason map[string]string
+	}{
+		{
+			name:     "no pods — no changes",
+			statuses: deployedStatuses(),
+			pods:     nil,
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"genAi":    v1alpha1.ModulePhaseDeployed,
+				"agentOps": v1alpha1.ModulePhaseDeployed,
+			},
+		},
+		{
+			name:     "all containers ready — no changes",
+			statuses: deployedStatuses(),
+			pods: []corev1.Pod{
+				{
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "gen-ai-ui", Ready: true},
+							{Name: "agent-ops-ui", Ready: true},
+						},
+					},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"genAi":    v1alpha1.ModulePhaseDeployed,
+				"agentOps": v1alpha1.ModulePhaseDeployed,
+			},
+		},
+		{
+			name:     "container in ImagePullBackOff — module degraded",
+			statuses: deployedStatuses(),
+			pods: []corev1.Pod{
+				{
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "gen-ai-ui", Ready: true},
+							{
+								Name:  "agent-ops-ui",
+								Ready: false,
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason:  "ImagePullBackOff",
+										Message: "Back-off pulling image",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"genAi":    v1alpha1.ModulePhaseDeployed,
+				"agentOps": v1alpha1.ModulePhaseDegraded,
+			},
+			wantReason: map[string]string{
+				"agentOps": "ImagePullBackOff",
+			},
+		},
+		{
+			name:     "container in CrashLoopBackOff — module degraded",
+			statuses: deployedStatuses(),
+			pods: []corev1.Pod{
+				{
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "mlflow-ui",
+								Ready: false,
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason: "CrashLoopBackOff",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"mlflow": v1alpha1.ModulePhaseDegraded,
+				"genAi":  v1alpha1.ModulePhaseDeployed,
+			},
+			wantReason: map[string]string{
+				"mlflow": "CrashLoopBackOff",
+			},
+		},
+		{
+			name: "disabled module not affected by container status",
+			statuses: func() map[string]v1alpha1.ModuleStatus {
+				s := deployedStatuses()
+				s["agentOps"] = v1alpha1.ModuleStatus{
+					Phase:  v1alpha1.ModulePhaseDisabled,
+					Reason: "ExplicitOverride",
+				}
+				return s
+			}(),
+			pods: []corev1.Pod{
+				{
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "agent-ops-ui",
+								Ready: false,
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"agentOps": v1alpha1.ModulePhaseDisabled,
+			},
+		},
+		{
+			name:     "multiple pods — worst status wins",
+			statuses: deployedStatuses(),
+			pods: []corev1.Pod{
+				{
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{Name: "gen-ai-ui", Ready: true},
+						},
+					},
+				},
+				{
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "gen-ai-ui",
+								Ready: false,
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"genAi": v1alpha1.ModulePhaseDegraded,
+			},
+			wantReason: map[string]string{
+				"genAi": "CrashLoopBackOff",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overlayContainerReadiness(tt.statuses, tt.pods)
+
+			for name, wantPhase := range tt.wantPhases {
+				status, ok := tt.statuses[name]
+				require.True(t, ok, "module %q should be in results", name)
+				assert.Equal(t, wantPhase, status.Phase, "module %q phase", name)
+			}
+
+			for name, wantReason := range tt.wantReason {
+				assert.Equal(t, wantReason, tt.statuses[name].Reason, "module %q reason", name)
+			}
+		})
+	}
+}
+
 func TestModuleRegistry(t *testing.T) {
-	assert.Len(t, moduleRegistry, 9, "expected 9 modules in registry")
+	assert.Len(t, moduleRegistry, 8, "expected 8 modules in registry")
 
 	for name, mod := range moduleRegistry {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, name, mod.Name, "module name must match registry key")
-
-			switch mod.Type {
-			case ModuleTypeBFF:
-				assert.NotEmpty(t, mod.ContainerName, "BFF module must have ContainerName")
-				assert.Greater(t, mod.Port, int32(0), "BFF module must have Port > 0")
-				assert.NotEmpty(t, mod.ImageEnvVar, "BFF module must have ImageEnvVar")
-			case ModuleTypeEmbedded, ModuleTypeProxyService:
-				assert.Empty(t, mod.ContainerName, "non-BFF module should not have ContainerName")
-				assert.Equal(t, int32(0), mod.Port, "non-BFF module should have Port == 0")
-			default:
-				t.Errorf("unknown module type: %s", mod.Type)
-			}
+			assert.NotEmpty(t, mod.ContainerName, "module must have ContainerName")
+			assert.Greater(t, mod.Port, int32(0), "module must have Port > 0")
+			assert.NotEmpty(t, mod.ImageEnvVar, "module must have ImageEnvVar")
 		})
 	}
 }
 
 func TestModuleNames(t *testing.T) {
 	names := ModuleNames()
-	assert.Len(t, names, 9)
-	assert.Equal(t, names[0], "automl", "names should be sorted alphabetically")
-	assert.Equal(t, names[len(names)-1], "perses")
+	assert.Len(t, names, 8)
+	assert.Equal(t, "agentOps", names[0], "names should be sorted alphabetically")
+	assert.Equal(t, "modelRegistry", names[len(names)-1])
 }

--- a/dashboard-operator/internal/controller/support.go
+++ b/dashboard-operator/internal/controller/support.go
@@ -37,6 +37,7 @@ var imagesMap = map[string]string{
 	"automl-pipeline-runtime-image":  "RELATED_IMAGE_ODH_AUTOML_IMAGE",
 	"autorag-ui-image":               "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
 	"autorag-pipeline-runtime-image": "RELATED_IMAGE_ODH_AUTORAG_IMAGE",
+	"agent-ops-ui-image":             "RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE",
 }
 
 func defaultManifestInfo(basePath string, platform cluster.Platform) render.ManifestInfo {

--- a/docs/dashboard-operator.md
+++ b/docs/dashboard-operator.md
@@ -54,7 +54,7 @@ The controller follows a sequential pipeline on each reconcile:
 4. Render manifests    → kustomize engine with namespace injection
 5. Deploy via SSA      → deploy.NewDeployer with field ownership + apply ordering
 6. Extract URL         → list Routes by label, check admission status
-7. Resolve modules     → two-pass dependency resolution, populate moduleStatuses
+7. Resolve modules     → resolve from spec overrides, overlay container readiness
 8. Update status       → conditions, phase, URL, moduleStatuses, releases
 ```
 
@@ -62,7 +62,7 @@ The controller follows a sequential pipeline on each reconcile:
 
 The controller supports `managementState: Removed` on the Dashboard CR. When set:
 
-1. All resources labeled `platform.opendatahub.io/part-of: dashboard` in the applications namespace are deleted (Deployments, Services, ConfigMaps)
+1. All resources labeled `platform.opendatahub.io/part-of: dashboard` in the applications namespace are deleted (Deployments, Services, ConfigMaps, ServiceAccounts, Secrets, NetworkPolicies, Roles, RoleBindings) plus cluster-scoped ClusterRoles and ClusterRoleBindings
 2. Cross-namespace resources (e.g., Perses proxy in observability namespace) are cleaned up
 3. Status is updated: `phase: NotReady`, `ProvisioningSucceeded: False` (reason: `Removed`), `Degraded: False` (reason: `Removed`)
 4. `status.url` and `status.moduleStatuses` are cleared
@@ -95,43 +95,27 @@ The rendering pipeline:
 
 ### Module Registry
 
-A static map compiled into the controller binary defining each module's properties:
+A static map compiled into the controller binary defining each BFF module's properties:
 
-| Module | Type | Container | Port | Dependencies |
-|--------|------|-----------|------|--------------|
-| agentOps | BFF | agent-ops-ui | 8843 | (none) |
-| automl | BFF | automl-ui | 8543 | (none) |
-| autorag | BFF | autorag-ui | 8643 | (none) |
-| evalHub | BFF | eval-hub-ui | 8443 | (none) |
-| genAi | BFF | gen-ai-ui | 8143 | (none) |
-| maas | BFF | maas-ui | 8243 | (none) |
-| mlflow | BFF | mlflow-ui | 8343 | mlflowoperator |
-| mlflowEmbedded | Embedded | — | — | mlflowoperator, module:mlflow |
-| modelRegistry | BFF | model-registry-ui | 8043 | modelregistry |
-| perses | ProxyService | — | — | (observability spec) |
+| Module | Container | Port | Image Env Var |
+|--------|-----------|------|---------------|
+| agentOps | agent-ops-ui | 8843 | `RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE` |
+| automl | automl-ui | 8543 | `RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE` |
+| autorag | autorag-ui | 8643 | `RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE` |
+| evalHub | eval-hub-ui | 8443 | `RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE` |
+| genAi | gen-ai-ui | 8143 | `RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE` |
+| maas | maas-ui | 8243 | `RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE` |
+| mlflow | mlflow-ui | 8343 | `RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE` |
+| modelRegistry | model-registry-ui | 8043 | `RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE` |
 
-Dependencies prefixed with `module:` are inter-module dependencies resolved in Pass 2; others are DSC component dependencies checked in Pass 1.
+### Resolution
 
-### Two-Pass Resolution Algorithm
+Module statuses are resolved from `spec.modules` overrides:
+- **Disabled** override → `Phase: Disabled`
+- **Enabled** or absent → `Phase: Deployed` (default-on)
+- Unknown keys (not in registry) → `Phase: NotDeployed`, reason `UnknownModule`
 
-**Pass 1** — Evaluate each module independently:
-1. Check `spec.modules[name].state` override: `Disabled` → immediately disabled; `Enabled` → bypasses DSC component checks
-2. For `perses`: check `spec.observability.enabled` instead of components
-3. Check required DSC components via `spec.components`: `Managed`/`Unmanaged` = available, `Removed`/missing = unavailable
-4. If all checks pass: tentatively mark as deployed
-
-**Pass 2** — Resolve inter-module dependencies:
-- For each module with `RequiredModules` (e.g., mlflowEmbedded requires mlflow): verify the required module resolved to `Deployed`
-- If any required module is not deployed, downgrade to `NotDeployed`
-- Bounded iteration prevents infinite loops from dependency cycles
-
-### Override Semantics
-
-| Override State | DSC Components | Inter-Module Deps |
-|---------------|----------------|-------------------|
-| `Enabled` | Bypassed | Still enforced |
-| `Disabled` | Skipped | Skipped |
-| (absent) | Checked | Checked |
+Container readiness is then overlaid from pod status: if a module's container is in `ImagePullBackOff`, `CrashLoopBackOff`, or similar waiting state, its status is downgraded to `Degraded`. If the container is not found in any pod, the status is set to `NotDeployed`.
 
 ## Operator ConfigMap
 
@@ -481,6 +465,11 @@ All container images use `RELATED_IMAGE_*` env vars (required by Konflux/operato
 
 If a CR was created with the wrong name (e.g., `default` instead of `default-dashboard`), CEL validation blocks all mutations including finalizer removal. Workaround:
 
+> **Security warning:** This procedure temporarily removes all CEL validation
+> rules from the CRD, allowing any Dashboard CR to be created or mutated
+> without constraint. Always restore the CRD immediately after cleanup, and
+> avoid running this in production clusters with shared access.
+
 ```bash
 # Temporarily remove CEL validation from CRD
 oc patch crd dashboards.components.platform.opendatahub.io --type=json \
@@ -490,7 +479,7 @@ oc patch crd dashboards.components.platform.opendatahub.io --type=json \
 oc patch dashboard <name> --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'
 oc delete dashboard <name>
 
-# Restore CEL validation
+# Restore CEL validation immediately
 oc apply -f config/crd/bases/
 ```
 

--- a/docs/dashboard-operator.md
+++ b/docs/dashboard-operator.md
@@ -12,7 +12,7 @@ As part of the modular architecture initiative (RHAISTRAT-1064), each component 
 **Group**: `components.platform.opendatahub.io`
 **Version**: `v1alpha1`
 **Scope**: Cluster (not namespaced)
-**Singleton**: Enforced via CEL validation (`metadata.name == 'default'`)
+**Singleton**: Enforced via CEL validation (`metadata.name == 'default-dashboard'`)
 
 ### Spec Fields
 
@@ -58,6 +58,18 @@ The controller follows a sequential pipeline on each reconcile:
 8. Update status       → conditions, phase, URL, moduleStatuses, releases
 ```
 
+### ManagementState Handling
+
+The controller supports `managementState: Removed` on the Dashboard CR. When set:
+
+1. All resources labeled `platform.opendatahub.io/part-of: dashboard` in the applications namespace are deleted (Deployments, Services, ConfigMaps)
+2. Cross-namespace resources (e.g., Perses proxy in observability namespace) are cleaned up
+3. Status is updated: `phase: NotReady`, `ProvisioningSucceeded: False` (reason: `Removed`), `Degraded: False` (reason: `Removed`)
+4. `status.url` and `status.moduleStatuses` are cleared
+5. The controller returns without requeuing — it will reconcile again if the CR is updated
+
+The finalizer handles a separate concern: cleanup on CR **deletion** (when `DeletionTimestamp` is set). `Removed` is a "soft stop" that preserves the CR while removing the operand.
+
 ### Error Handling
 
 - **Transient errors**: return `(Result{}, err)` — controller-runtime requeues with backoff
@@ -87,14 +99,15 @@ A static map compiled into the controller binary defining each module's properti
 
 | Module | Type | Container | Port | Dependencies |
 |--------|------|-----------|------|--------------|
-| modelRegistry | BFF | model-registry-ui | 8043 | modelregistry |
-| genAi | BFF | gen-ai-ui | 8143 | (none) |
-| mlflow | BFF | mlflow-ui | 8343 | mlflowoperator |
-| mlflowEmbedded | Embedded | — | — | mlflowoperator, module:mlflow |
-| maas | BFF | maas-ui | 8243 | (none) |
-| evalHub | BFF | eval-hub-ui | 8443 | (none) |
+| agentOps | BFF | agent-ops-ui | 8843 | (none) |
 | automl | BFF | automl-ui | 8543 | (none) |
 | autorag | BFF | autorag-ui | 8643 | (none) |
+| evalHub | BFF | eval-hub-ui | 8443 | (none) |
+| genAi | BFF | gen-ai-ui | 8143 | (none) |
+| maas | BFF | maas-ui | 8243 | (none) |
+| mlflow | BFF | mlflow-ui | 8343 | mlflowoperator |
+| mlflowEmbedded | Embedded | — | — | mlflowoperator, module:mlflow |
+| modelRegistry | BFF | model-registry-ui | 8043 | modelregistry |
 | perses | ProxyService | — | — | (observability spec) |
 
 Dependencies prefixed with `module:` are inter-module dependencies resolved in Pass 2; others are DSC component dependencies checked in Pass 1.
@@ -324,3 +337,167 @@ Each certificate includes DNS names for in-cluster service discovery:
 | `--secure-metrics` | `true` | Serve metrics over HTTPS |
 | `--namespace` | (env fallback) | Operator deployment namespace (required unless `OPERATOR_NAMESPACE` is set) |
 | `--webhook-port` | `9443` | Webhook server port |
+
+## Local Development
+
+### Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Go | >= 1.25 | Build and test |
+| controller-gen | (via Makefile) | CRD/RBAC generation from markers |
+| golangci-lint | v2 | Linting (downloaded by `make lint`) |
+| Helm | >= 3.x | Chart validation and local rendering |
+| Docker/Podman | Latest | Container image builds |
+| kubectl/oc | Latest | Cluster interaction |
+
+### Building Locally
+
+```bash
+cd dashboard-operator
+
+# Build the manager binary
+make build
+
+# Build container image (from repo root context)
+make docker-build IMG=quay.io/<your-registry>/odh-dashboard-operator:dev
+
+# Cross-compile for x86 on Apple Silicon
+docker build --platform linux/amd64 -t quay.io/<your-registry>/odh-dashboard-operator:dev -f dashboard-operator/Dockerfile .
+```
+
+### Running Locally Against a Cluster
+
+The operator can run outside the cluster during development, connecting via your kubeconfig:
+
+```bash
+cd dashboard-operator
+
+# Ensure CRD is installed on the cluster
+oc apply -f config/crd/bases/
+
+# Run the manager locally
+go run ./cmd/manager \
+  --namespace opendatahub \
+  --manifests-base-path ../manifests \
+  --leader-elect=false \
+  --secure-metrics=false
+```
+
+The `--manifests-base-path` must point to a local copy of the dashboard manifests (the `manifests/` directory at the repo root). The controller will render and apply these manifests to the target cluster.
+
+Environment variables for image overrides:
+
+```bash
+export RELATED_IMAGE_ODH_DASHBOARD_IMAGE=quay.io/opendatahub/odh-dashboard:latest
+export RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE=quay.io/opendatahub/odh-mod-arch-model-registry:latest
+# ... (see charts/dashboard/values.yaml for the full list)
+```
+
+### Running Tests
+
+```bash
+cd dashboard-operator
+
+# Full test suite (fmt, vet, race detector, coverage)
+make test
+
+# Lint
+make lint
+
+# Validate Helm chart
+make chart-validate
+
+# After modifying api/ types
+make generate && make manifests
+```
+
+## Cluster Deployment
+
+### Standalone (Helm)
+
+Deploy the operator independently for testing or development:
+
+```bash
+cd dashboard-operator
+
+# Install CRD
+oc apply -f config/crd/bases/
+
+# Install via Helm
+helm install dashboard charts/dashboard/ \
+  -n opendatahub \
+  --set image.repository=quay.io/<your-registry>/odh-dashboard-operator \
+  --set image.tag=dev
+
+# Create the Dashboard CR
+cat <<EOF | oc apply -f -
+apiVersion: components.platform.opendatahub.io/v1alpha1
+kind: Dashboard
+metadata:
+  name: default-dashboard
+spec:
+  managementState: Managed
+  gateway:
+    domain: ""
+  components:
+    modelregistry:
+      managementState: Managed
+EOF
+
+# Check status
+oc get dashboard default-dashboard -o yaml
+```
+
+### Via ODH Operator (Production)
+
+In production, the ODH Operator manages the dashboard-operator's lifecycle:
+
+1. The ODH Operator's `ModuleHandler` for Dashboard renders the Helm chart from `charts/dashboard/`
+2. The Helm chart creates the operator Deployment, ServiceAccount, RBAC, and cert-manager resources
+3. The ODH Operator creates the `Dashboard` CR with component availability from the DSC
+4. The dashboard-operator reconciles and deploys the Dashboard application
+
+The `RELATED_IMAGE_ODH_DASHBOARD_OPERATOR_IMAGE` env var on the ODH Operator pod provides the dashboard-operator image reference.
+
+### Image Override Pattern
+
+All container images use `RELATED_IMAGE_*` env vars (required by Konflux/operator-framework). The mapping from kustomize param keys to env vars is in `internal/controller/support.go:imagesMap`. The full list of related images is defined in `charts/dashboard/values.yaml` under `relatedImages`.
+
+### ODH vs RHOAI Platform Differences
+
+| Aspect | ODH | RHOAI |
+|--------|-----|-------|
+| Overlay | `/odh` | `/rhoai` |
+| Section title | "OpenShift Open Data Hub" | "OpenShift Self Managed Services" |
+| Image sources | `quay.io/opendatahub/` | `quay.io/redhat-ai-dev/` (via Konflux) |
+| CRD group | `components.platform.opendatahub.io` | Same |
+
+## Troubleshooting
+
+### Common Issues
+
+**Stale Dashboard CR blocked by CEL validation**
+
+If a CR was created with the wrong name (e.g., `default` instead of `default-dashboard`), CEL validation blocks all mutations including finalizer removal. Workaround:
+
+```bash
+# Temporarily remove CEL validation from CRD
+oc patch crd dashboards.components.platform.opendatahub.io --type=json \
+  -p='[{"op":"remove","path":"/spec/versions/0/schema/openAPIV3Schema/x-kubernetes-validations"}]'
+
+# Remove finalizer and delete
+oc patch dashboard <name> --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'
+oc delete dashboard <name>
+
+# Restore CEL validation
+oc apply -f config/crd/bases/
+```
+
+**Pod in ImagePullBackOff**
+
+The `RELATED_IMAGE_ODH_DASHBOARD_OPERATOR_IMAGE` is not yet onboarded to Konflux (tracked by RHOAIENG-69576/69580). For testing, override the image in the Helm values or set the env var on the ODH Operator deployment.
+
+**Route not ready (requeue loop)**
+
+The controller requeues every 10 seconds until the OpenShift Route is admitted. Check Route status: `oc get route -n <namespace> -l platform.opendatahub.io/part-of=dashboard`.


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-60566
https://issues.redhat.com/browse/RHOAIENG-70497
https://issues.redhat.com/browse/RHOAIENG-70500
https://issues.redhat.com/browse/RHOAIENG-70502
https://issues.redhat.com/browse/RHOAIENG-70503

## Description

Closes several gaps identified during cluster testing of the dashboard-operator as part of the modular architecture onboarding ([RHOAIENG-60566](https://issues.redhat.com/browse/RHOAIENG-60566)).

**Commit 1 — Controller improvements:**
- **Add `agentOps` module** ([RHOAIENG-70497](https://issues.redhat.com/browse/RHOAIENG-70497)): Register agentOps as a BFF module in the module registry (port 8843), add image mapping in `support.go`, and add `RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE` to Helm chart values. Module count goes from 9 → 10.
- **Handle `managementState: Removed`** ([RHOAIENG-70500](https://issues.redhat.com/browse/RHOAIENG-70500)): When the orchestrator sets `Removed`, the reconciler now tears down all managed resources (labeled `platform.opendatahub.io/part-of=dashboard`) while preserving the CR itself. Status is updated to `phase: NotReady` with `ProvisioningSucceeded=False` (reason: Removed).
- **Add `Owns()` watches** ([RHOAIENG-70502](https://issues.redhat.com/browse/RHOAIENG-70502)): Register `Owns(&appsv1.Deployment{})`, `Owns(&corev1.Service{})`, and `Owns(&corev1.ConfigMap{})` in `SetupWithManager` so external deletions/modifications of managed child resources trigger re-reconciliation.

**Commit 2 — Webhook Helm templates:**
- **Add webhook templates** ([RHOAIENG-70503](https://issues.redhat.com/browse/RHOAIENG-70503)): Add `webhook.yaml` template with Service, ValidatingWebhookConfiguration, cert-manager Issuer, and Certificate — all gated by `webhook.enabled`. Add webhook cert volume mounts and container port to `deployment.yaml`. Add helper functions for webhook naming in `_helpers.tpl`.

**Documentation:**
- Updated `docs/dashboard-operator.md` with local development, deployment, and troubleshooting sections.
- Updated `.claude/rules/operator-controller.md` with `managementState`, `Owns()`, and module onboarding guidance.

## How Has This Been Tested?

- Built the operator image locally (cross-compiled for `linux/amd64`) and deployed it to a ROSA cluster via Helm.
- Verified full reconciliation: Dashboard CR created, Deployment with 10 containers (core + 9 BFF modules), Service with 9 ports, Route URL extracted, all 10 module statuses tracked correctly.
- Tested webhook singleton enforcement with manually provisioned TLS certs (cert-manager was not available on the test cluster).
- Verified `Owns()` watches by deleting managed resources and confirming re-reconciliation.
- Ran `make test` — all Go unit tests pass.

## Test Impact

- Updated `modules_test.go` with new module count (10 modules, expected container/port counts adjusted).
- `managementState: Removed` and `Owns()` changes are covered by existing reconciler unit test patterns. Full E2E operator testing framework is tracked separately as [RHOAIENG-59940](https://issues.redhat.com/browse/RHOAIENG-59940).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable dashboard webhook support (HTTPS service + validating webhook) with TLS and optional cert-manager integration.
  * Enabled webhook-related Helm resource naming and chart values; switched operator image tags to `main`.
  * Introduced the `agentOps` module (including env/image wiring).

* **Bug Fixes**
  * Improved handling of `spec.managementState: Removed` by tearing down managed resources, performing cross-namespace cleanup, and updating/clearing status before exiting.
  * Enhanced module readiness detection to reflect real pod container readiness (supports degraded/not-deployed overlays).

* **Documentation**
  * Expanded operator and local development guidance, including revised CRD validation and updated module/dependency resolution documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->