### PR TITLE
RHOAIENG-62252: Add model capabilities selection to custom endpoint modal

### DIFF
--- a/packages/gen-ai/bff/internal/api/external_models_handler.go
+++ b/packages/gen-ai/bff/internal/api/external_models_handler.go
@@ -79,6 +79,7 @@ func (app *App) CreateExternalModelHandler(w http.ResponseWriter, r *http.Reques
 			app.badRequestResponse(w, r, fmt.Errorf("embedding_dimension must be a positive number"))
 			return
 		}
+		req.Capabilities = nil
 	}
 
 	// Get Kubernetes client

--- a/packages/gen-ai/bff/internal/api/external_models_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/external_models_handler_test.go
@@ -453,6 +453,48 @@ var _ = Describe("CreateExternalModelHandler", func() {
 		assert.NotContains(t, caps, "made-up", "unknown capabilities should be filtered out")
 		assert.Len(t, caps, 2, "should only contain text-generation and vision")
 	})
+
+	It("should strip capabilities for embedding models", func() {
+		t := GinkgoT()
+
+		embDim := 768
+		requestBody := models.ExternalModelRequest{
+			ModelID:            "bge-large-en",
+			ModelDisplayName:   "BGE Large EN",
+			BaseURL:            "https://api.example.com/v1",
+			SecretValue:        "sk-test-key",
+			ModelType:          models.ModelTypeEmbedding,
+			EmbeddingDimension: &embDim,
+			Capabilities:       []string{"vision"},
+		}
+
+		bodyBytes, err := json.Marshal(requestBody)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "/gen-ai/api/v1/models/external", bytes.NewReader(bodyBytes))
+		assert.NoError(t, err)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "mock-test-namespace-1")
+		ctx = context.WithValue(ctx, constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		app.CreateExternalModelHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusCreated, rr.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		data := response["data"].(map[string]interface{})
+		caps, ok := data["capabilities"].([]interface{})
+		assert.True(t, ok, "capabilities should be an array")
+		assert.NotContains(t, caps, "vision", "user-supplied capabilities should be stripped for embedding models")
+	})
 })
 
 var _ = Describe("DeleteExternalModelHandler", func() {

--- a/packages/gen-ai/bff/internal/api/external_models_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/external_models_handler_test.go
@@ -329,6 +329,130 @@ var _ = Describe("CreateExternalModelHandler", func() {
 
 		assert.Contains(t, messageStr, "missing RequestIdentity in context")
 	})
+
+	It("should include capabilities in response when provided in request", func() {
+		t := GinkgoT()
+
+		requestBody := models.ExternalModelRequest{
+			ModelID:          "qwen2.5-vl-7b",
+			ModelDisplayName: "Qwen 2.5 VL 7B",
+			BaseURL:          "https://api.example.com/v1",
+			SecretValue:      "sk-test-key",
+			ModelType:        models.ModelTypeLLM,
+			Capabilities:     []string{"vision"},
+		}
+
+		bodyBytes, err := json.Marshal(requestBody)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "/gen-ai/api/v1/models/external", bytes.NewReader(bodyBytes))
+		assert.NoError(t, err)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "mock-test-namespace-1")
+		ctx = context.WithValue(ctx, constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		app.CreateExternalModelHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusCreated, rr.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		data := response["data"].(map[string]interface{})
+		caps, ok := data["capabilities"].([]interface{})
+		assert.True(t, ok, "capabilities should be an array")
+		assert.Contains(t, caps, "text-generation", "text-generation should always be present")
+		assert.Contains(t, caps, "vision", "vision should be included when requested")
+	})
+
+	It("should return default capabilities when none are provided in request", func() {
+		t := GinkgoT()
+
+		requestBody := models.ExternalModelRequest{
+			ModelID:          "gpt-4o-default-caps",
+			ModelDisplayName: "GPT-4o Default Caps",
+			BaseURL:          "https://api.example.com/v1",
+			SecretValue:      "sk-test-key",
+			ModelType:        models.ModelTypeLLM,
+		}
+
+		bodyBytes, err := json.Marshal(requestBody)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "/gen-ai/api/v1/models/external", bytes.NewReader(bodyBytes))
+		assert.NoError(t, err)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "mock-test-namespace-1")
+		ctx = context.WithValue(ctx, constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		app.CreateExternalModelHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusCreated, rr.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		data := response["data"].(map[string]interface{})
+		caps, ok := data["capabilities"].([]interface{})
+		assert.True(t, ok, "capabilities should be an array")
+		assert.Equal(t, []interface{}{"text-generation"}, caps, "default should be text-generation only")
+	})
+
+	It("should filter out unknown capabilities and keep valid ones", func() {
+		t := GinkgoT()
+
+		requestBody := models.ExternalModelRequest{
+			ModelID:          "model-unknown-caps",
+			ModelDisplayName: "Model Unknown Caps",
+			BaseURL:          "https://api.example.com/v1",
+			SecretValue:      "sk-test-key",
+			ModelType:        models.ModelTypeLLM,
+			Capabilities:     []string{"vision", "unknown-capability", "made-up"},
+		}
+
+		bodyBytes, err := json.Marshal(requestBody)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "/gen-ai/api/v1/models/external", bytes.NewReader(bodyBytes))
+		assert.NoError(t, err)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "mock-test-namespace-1")
+		ctx = context.WithValue(ctx, constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		app.CreateExternalModelHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusCreated, rr.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		data := response["data"].(map[string]interface{})
+		caps, ok := data["capabilities"].([]interface{})
+		assert.True(t, ok, "capabilities should be an array")
+		assert.Contains(t, caps, "text-generation")
+		assert.Contains(t, caps, "vision")
+		assert.NotContains(t, caps, "unknown-capability", "unknown capabilities should be filtered out")
+		assert.NotContains(t, caps, "made-up", "unknown capabilities should be filtered out")
+		assert.Len(t, caps, 2, "should only contain text-generation and vision")
+	})
 })
 
 var _ = Describe("DeleteExternalModelHandler", func() {

--- a/packages/gen-ai/bff/internal/constants/capabilities.go
+++ b/packages/gen-ai/bff/internal/constants/capabilities.go
@@ -28,3 +28,36 @@ var defaultCapabilities = []string{CapabilityTextGeneration}
 func DefaultCapabilities() []string {
 	return append([]string{}, defaultCapabilities...)
 }
+
+// BuildCapabilities filters the input through the allowlist and ensures
+// text-generation is always present. Returns nil when input is empty so
+// the YAML field is omitted and the read-path default applies.
+func BuildCapabilities(input []string) []string {
+	if len(input) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool, len(input))
+	hasTextGen := false
+	result := make([]string, 0, len(input)+1)
+	for _, cap := range input {
+		if !IsAllowedCapability(cap) || seen[cap] {
+			continue
+		}
+		seen[cap] = true
+		if cap == CapabilityTextGeneration {
+			hasTextGen = true
+		}
+		result = append(result, cap)
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	if !hasTextGen {
+		result = append([]string{CapabilityTextGeneration}, result...)
+	}
+
+	return result
+}

--- a/packages/gen-ai/bff/internal/constants/capabilities_test.go
+++ b/packages/gen-ai/bff/internal/constants/capabilities_test.go
@@ -1,0 +1,78 @@
+package constants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildCapabilities(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "nil input returns nil",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty input returns nil",
+			input:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "vision only prepends text-generation",
+			input:    []string{"vision"},
+			expected: []string{"text-generation", "vision"},
+		},
+		{
+			name:     "audio-transcription only prepends text-generation",
+			input:    []string{"audio-transcription"},
+			expected: []string{"text-generation", "audio-transcription"},
+		},
+		{
+			name:     "both capabilities prepends text-generation",
+			input:    []string{"vision", "audio-transcription"},
+			expected: []string{"text-generation", "vision", "audio-transcription"},
+		},
+		{
+			name:     "text-generation included does not duplicate",
+			input:    []string{"text-generation", "vision"},
+			expected: []string{"text-generation", "vision"},
+		},
+		{
+			name:     "unknown capability is filtered out",
+			input:    []string{"vision", "unknown-cap"},
+			expected: []string{"text-generation", "vision"},
+		},
+		{
+			name:     "all unknown capabilities returns nil",
+			input:    []string{"unknown-1", "unknown-2"},
+			expected: nil,
+		},
+		{
+			name:     "text-generation alone is preserved",
+			input:    []string{"text-generation"},
+			expected: []string{"text-generation"},
+		},
+		{
+			name:     "duplicate capabilities are deduplicated",
+			input:    []string{"vision", "vision", "audio-transcription"},
+			expected: []string{"text-generation", "vision", "audio-transcription"},
+		},
+		{
+			name:     "all duplicates of same capability reduces to one",
+			input:    []string{"vision", "vision", "vision"},
+			expected: []string{"text-generation", "vision"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildCapabilities(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1354,19 +1354,14 @@ func (kc *TokenKubernetesClient) GetAAModelsFromExternalModels(ctx context.Conte
 			useCases = model.Metadata.CustomGenAI.UseCases
 		}
 
-		caps := constants.DefaultCapabilities()
-		if len(model.Metadata.Capabilities) > 0 {
-			filtered := make([]string, 0, len(model.Metadata.Capabilities))
-			for _, c := range model.Metadata.Capabilities {
-				if constants.IsAllowedCapability(c) {
-					filtered = append(filtered, c)
-				} else {
-					kc.Logger.Warn("unknown external model capability dropped", "modelID", model.ModelID, "capability", c)
-				}
+		for _, c := range model.Metadata.Capabilities {
+			if !constants.IsAllowedCapability(c) {
+				kc.Logger.Warn("unknown external model capability dropped", "modelID", model.ModelID, "capability", c)
 			}
-			if len(filtered) > 0 {
-				caps = filtered
-			}
+		}
+		caps := constants.BuildCapabilities(model.Metadata.Capabilities)
+		if caps == nil {
+			caps = constants.DefaultCapabilities()
 		}
 		aaModel := models.AAModel{
 			ModelName:          model.ModelID,
@@ -2664,6 +2659,7 @@ func (kc *TokenKubernetesClient) CreateOrUpdateExternalModelConfigMap(ctx contex
 		Metadata: models.RegisteredModelMetadata{
 			DisplayName:        req.ModelDisplayName,
 			EmbeddingDimension: req.EmbeddingDimension,
+			Capabilities:       constants.BuildCapabilities(req.Capabilities),
 		},
 	}
 

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -1151,7 +1151,7 @@ registered_resources:
 		result, err := kc.GetAAModelsFromExternalModels(context.Background(), identity, "test-ns")
 		require.NoError(t, err)
 		require.Len(t, result, 1)
-		assert.Equal(t, []string{"audio-transcription", "vision"}, result[0].Capabilities)
+		assert.Equal(t, []string{"text-generation", "audio-transcription", "vision"}, result[0].Capabilities)
 	})
 }
 

--- a/packages/gen-ai/bff/internal/models/external_models.go
+++ b/packages/gen-ai/bff/internal/models/external_models.go
@@ -9,6 +9,7 @@ type ExternalModelRequest struct {
 	UseCases           string        `json:"use_cases,omitempty"`
 	ModelType          ModelTypeEnum `json:"model_type"`
 	EmbeddingDimension *int          `json:"embedding_dimension,omitempty"`
+	Capabilities       []string      `json:"capabilities,omitempty"`
 }
 
 // VerifyExternalModelRequest represents a request to verify an external model

--- a/packages/gen-ai/bff/internal/repositories/external_models.go
+++ b/packages/gen-ai/bff/internal/repositories/external_models.go
@@ -59,6 +59,10 @@ func (r *ExternalModelsRepository) CreateExternalModel(
 	}
 
 	// Return AAModel structure for consistent API response
+	caps := constants.BuildCapabilities(req.Capabilities)
+	if caps == nil {
+		caps = constants.DefaultCapabilities()
+	}
 	return &models.AAModel{
 		ModelName:       req.ModelID,
 		ModelID:         req.ModelID,
@@ -73,7 +77,7 @@ func (r *ExternalModelsRepository) CreateExternalModel(
 		SAToken:         models.SAToken{},
 		ModelSourceType: models.ModelSourceTypeCustomEndpoint,
 		ModelType:       req.ModelType,
-		Capabilities:    constants.DefaultCapabilities(),
+		Capabilities:    caps,
 	}, nil
 }
 

--- a/packages/gen-ai/bff/openapi/src/gen-ai.yaml
+++ b/packages/gen-ai/bff/openapi/src/gen-ai.yaml
@@ -3007,6 +3007,17 @@ components:
           type: integer
           example: 1536
           description: Output vector size for embedding models (required for embedding models)
+        capabilities:
+          type: array
+          items:
+            type: string
+            enum:
+              - vision
+              - audio-transcription
+          description: >-
+            Optional model capabilities beyond text generation.
+            text-generation is always included implicitly by the BFF.
+          example: ["vision"]
 
     # Verify External Model Request Schema
     # Uses oneOf to enforce conditional requirements based on model_type

--- a/packages/gen-ai/frontend/jest.config.js
+++ b/packages/gen-ai/frontend/jest.config.js
@@ -19,6 +19,11 @@ module.exports = {
     '\\.(css|less|sass|scss)$': '<rootDir>/config/transform.style.js',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/config/transform.file.js',
+    // Single React instance when testing components that use @odh-dashboard/internal
+    '^react$': '<rootDir>/../../../node_modules/react',
+    '^react-dom$': '<rootDir>/../../../node_modules/react-dom',
+    // Resolve @odh-dashboard/internal directly to main frontend src
+    '^@odh-dashboard/internal(.*)$': '<rootDir>/../../../frontend/src$1',
     '#~/(.*)': '<rootDir>/../../../frontend/src/$1',
     '~/(.*)': '<rootDir>/src/$1',
   },

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/CreateExternalEndpointModal.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/CreateExternalEndpointModal.tsx
@@ -22,6 +22,10 @@ import {
 } from '@patternfly/react-core';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import {
+  MultiSelection,
+  type SelectionOptions,
+} from '@odh-dashboard/internal/components/MultiSelection';
+import {
   AIModel,
   ExternalModelRequest,
   ExternalModelResponse,
@@ -33,6 +37,11 @@ import useGenAiDashboardConfig from '~/app/hooks/useGenAiDashboardConfig';
 
 const MODEL_TYPE_LLM = 'llm' as const;
 const MODEL_TYPE_EMBEDDING = 'embedding' as const;
+
+const CAPABILITY_OPTIONS: SelectionOptions[] = [
+  { id: 'vision', name: 'Vision (image input)' },
+  { id: 'audio-transcription', name: 'Audio Transcription (ASR)' },
+];
 
 type CreateExternalEndpointModalProps = {
   isOpen: boolean;
@@ -86,6 +95,9 @@ const CreateExternalEndpointModal: React.FC<CreateExternalEndpointModalProps> = 
   const [token, setToken] = React.useState('');
   const [useCases, setUseCases] = React.useState('');
   const [embeddingDimension, setEmbeddingDimension] = React.useState('');
+  const [capabilities, setCapabilities] = React.useState<SelectionOptions[]>(
+    CAPABILITY_OPTIONS.map((opt) => ({ ...opt, selected: false })),
+  );
 
   // Dropdown states
   const [isModelTypeOpen, setIsModelTypeOpen] = React.useState(false);
@@ -121,6 +133,7 @@ const CreateExternalEndpointModal: React.FC<CreateExternalEndpointModalProps> = 
       setToken('');
       setUseCases('');
       setEmbeddingDimension('');
+      setCapabilities(CAPABILITY_OPTIONS.map((opt) => ({ ...opt, selected: false })));
       setTouched({
         modelId: false,
         displayName: false,
@@ -273,6 +286,7 @@ const CreateExternalEndpointModal: React.FC<CreateExternalEndpointModalProps> = 
     const trackingModelType = modelType === MODEL_TYPE_EMBEDDING ? 'embedding' : 'inference';
     const wasVerified = verificationResult !== null;
     const hasUseCase = useCases.trim() !== '';
+    const selectedCapabilities = capabilities.filter((c) => c.selected).map((c) => String(c.id));
 
     try {
       const request: ExternalModelRequest = {
@@ -286,6 +300,10 @@ const CreateExternalEndpointModal: React.FC<CreateExternalEndpointModalProps> = 
           embeddingDimension.trim() && {
             embedding_dimension: parseInt(embeddingDimension.trim(), 10),
           }),
+        ...(modelType === MODEL_TYPE_LLM &&
+          selectedCapabilities.length > 0 && {
+            capabilities: selectedCapabilities,
+          }),
       };
 
       await onSubmit(request);
@@ -295,6 +313,7 @@ const CreateExternalEndpointModal: React.FC<CreateExternalEndpointModalProps> = 
         modelType: trackingModelType,
         wasVerified,
         hasUseCase,
+        hasCapabilities: selectedCapabilities.length > 0,
       });
       onSuccess();
       onClose();
@@ -306,6 +325,7 @@ const CreateExternalEndpointModal: React.FC<CreateExternalEndpointModalProps> = 
         modelType: trackingModelType,
         wasVerified,
         hasUseCase,
+        hasCapabilities: selectedCapabilities.length > 0,
       });
     } finally {
       setIsSubmitting(false);
@@ -319,6 +339,7 @@ const CreateExternalEndpointModal: React.FC<CreateExternalEndpointModalProps> = 
     modelType,
     useCases,
     embeddingDimension,
+    capabilities,
     verificationResult,
     onSubmit,
     onSuccess,
@@ -420,6 +441,27 @@ const CreateExternalEndpointModal: React.FC<CreateExternalEndpointModalProps> = 
               </HelperText>
             </FormHelperText>
           </FormGroup>
+
+          {modelType === MODEL_TYPE_LLM && (
+            <FormGroup label="Model capabilities" fieldId="model-capabilities">
+              <MultiSelection
+                ariaLabel="Select model capabilities"
+                value={capabilities}
+                setValue={setCapabilities}
+                placeholder="Select capabilities"
+                isDisabled={isVerifying || isSubmitting}
+                toggleTestId="create-external-model-capabilities-select"
+              />
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem>
+                    Optional. Select additional capabilities this model supports. All models support
+                    text generation by default.
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            </FormGroup>
+          )}
 
           <FormGroup label="Model ID" isRequired fieldId="model-id">
             <TextInput

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/CreateExternalEndpointModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/CreateExternalEndpointModal.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import * as React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CreateExternalEndpointModal from '~/app/AIAssets/components/CreateExternalEndpointModal';
 import {
@@ -253,6 +253,182 @@ describe('CreateExternalEndpointModal', () => {
       await user.click(cancelButton);
 
       expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Model Capabilities', () => {
+    it('should show capabilities field when model type is LLM (default)', () => {
+      render(<CreateExternalEndpointModal {...defaultProps} />);
+
+      expect(screen.getByTestId('create-external-model-capabilities-select')).toBeInTheDocument();
+      expect(screen.getByText('Model capabilities')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Optional. Select additional capabilities this model supports. All models support text generation by default.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should hide capabilities field when model type is Embedding', async () => {
+      const user = userEvent.setup();
+      render(<CreateExternalEndpointModal {...defaultProps} />);
+
+      // Switch to embedding model type
+      await user.click(screen.getByTestId('create-external-model-type-select'));
+      await user.click(screen.getByText('Embedding model'));
+
+      expect(
+        screen.queryByTestId('create-external-model-capabilities-select'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Model capabilities')).not.toBeInTheDocument();
+    });
+
+    it('should submit without capabilities when none are selected', async () => {
+      const user = userEvent.setup();
+      render(<CreateExternalEndpointModal {...defaultProps} />);
+
+      fillInput(screen.getByTestId('create-external-model-id-input'), 'gpt-4o');
+      fillInput(screen.getByTestId('create-external-model-display-name-input'), 'My GPT-4o');
+      fillInput(
+        screen.getByTestId('create-external-model-url-input'),
+        'https://model.svc.cluster.local/v1',
+      );
+      fillInput(screen.getByTestId('create-external-model-token-input'), 'sk-test-token');
+
+      await user.click(screen.getByRole('button', { name: /^Create$/i }));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledWith(
+          expect.not.objectContaining({ capabilities: expect.anything() }),
+        );
+      });
+    });
+
+    it('should submit with capabilities when selected', async () => {
+      const user = userEvent.setup();
+      render(<CreateExternalEndpointModal {...defaultProps} />);
+
+      fillInput(screen.getByTestId('create-external-model-id-input'), 'qwen-vl-7b');
+      fillInput(screen.getByTestId('create-external-model-display-name-input'), 'Qwen VL 7B');
+      fillInput(
+        screen.getByTestId('create-external-model-url-input'),
+        'https://model.svc.cluster.local/v1',
+      );
+      fillInput(screen.getByTestId('create-external-model-token-input'), 'sk-test-token');
+
+      // Open capabilities dropdown and select Vision
+      const capToggle = screen.getByTestId('create-external-model-capabilities-select');
+      await user.click(within(capToggle).getByRole('combobox'));
+      await user.click(await screen.findByText('Vision (image input)'));
+
+      await user.click(screen.getByRole('button', { name: /^Create$/i }));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ capabilities: ['vision'] }),
+        );
+      });
+    });
+
+    it('should reset capabilities when modal is reopened', () => {
+      const { rerender } = render(<CreateExternalEndpointModal {...defaultProps} isOpen={false} />);
+
+      rerender(<CreateExternalEndpointModal {...defaultProps} isOpen />);
+
+      const capabilitiesToggle = screen.getByTestId('create-external-model-capabilities-select');
+      expect(capabilitiesToggle).toBeInTheDocument();
+      // No labels should be visible (no selections); placeholder is in the input element
+      expect(screen.queryAllByLabelText('Current selections')[0]?.children.length ?? 0).toBe(0);
+    });
+
+    it('should disable capabilities select during verification', async () => {
+      const user = userEvent.setup();
+      let resolveVerify: (v: { success: boolean; message: string }) => void;
+      mockOnVerify.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveVerify = resolve;
+          }),
+      );
+
+      render(<CreateExternalEndpointModal {...defaultProps} />);
+
+      fillInput(screen.getByTestId('create-external-model-id-input'), 'gpt-4o');
+      fillInput(screen.getByTestId('create-external-model-display-name-input'), 'My GPT-4o');
+      fillInput(
+        screen.getByTestId('create-external-model-url-input'),
+        'https://model.svc.cluster.local/v1',
+      );
+      fillInput(screen.getByTestId('create-external-model-token-input'), 'sk-test-token');
+
+      await user.click(screen.getByTestId('create-external-model-verify-button'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('create-external-model-capabilities-select')).toHaveAttribute(
+          'disabled',
+        );
+      });
+
+      // Resolve to clean up
+      resolveVerify!({ success: true, message: 'ok' });
+    });
+
+    it('should submit with multiple capabilities when both are selected', async () => {
+      const user = userEvent.setup();
+      render(<CreateExternalEndpointModal {...defaultProps} />);
+
+      fillInput(screen.getByTestId('create-external-model-id-input'), 'multi-model');
+      fillInput(screen.getByTestId('create-external-model-display-name-input'), 'Multi-Cap Model');
+      fillInput(
+        screen.getByTestId('create-external-model-url-input'),
+        'https://model.svc.cluster.local/v1',
+      );
+      fillInput(screen.getByTestId('create-external-model-token-input'), 'sk-test-token');
+
+      // Select both capabilities (PF multi-select keeps dropdown open between selections)
+      const capToggle2 = screen.getByTestId('create-external-model-capabilities-select');
+      await user.click(within(capToggle2).getByRole('combobox'));
+      await user.click(await screen.findByText('Vision (image input)'));
+      await user.click(await screen.findByText('Audio Transcription (ASR)'));
+
+      await user.click(screen.getByRole('button', { name: /^Create$/i }));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            capabilities: expect.arrayContaining(['vision', 'audio-transcription']),
+          }),
+        );
+      });
+    });
+
+    it('should not include capabilities for embedding model submission', async () => {
+      const user = userEvent.setup();
+      render(<CreateExternalEndpointModal {...defaultProps} />);
+
+      // Switch to embedding model type
+      await user.click(screen.getByTestId('create-external-model-type-select'));
+      await user.click(screen.getByText('Embedding model'));
+
+      fillInput(screen.getByTestId('create-external-model-id-input'), 'embed-model');
+      fillInput(screen.getByTestId('create-external-model-display-name-input'), 'Embed Model');
+      fillInput(
+        screen.getByTestId('create-external-model-url-input'),
+        'https://model.svc.cluster.local/v1',
+      );
+      fillInput(screen.getByTestId('create-external-model-token-input'), 'sk-test-token');
+      fillInput(screen.getByTestId('create-external-model-embedding-dimension-input'), '768');
+
+      await user.click(screen.getByRole('button', { name: /^Create$/i }));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledWith(
+          expect.not.objectContaining({ capabilities: expect.anything() }),
+        );
+        expect(mockOnSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ model_type: 'embedding' }),
+        );
+      });
     });
   });
 });

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -399,6 +399,7 @@ export type ExternalModelRequest = {
   model_type: 'llm' | 'embedding';
   use_cases?: string;
   embedding_dimension?: number;
+  capabilities?: string[];
 };
 
 export type ExternalModelResponse = AAModelResponse;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62252

## Description

Adds a model capabilities multi-select field to the Create Custom Endpoint modal in Gen AI Studio. Users can tag LLM endpoints with additional capabilities (`vision`, `audio-transcription`) beyond the implicit `text-generation` default. 

<img width="809" height="857" alt="image" src="https://github.com/user-attachments/assets/2bb60e7c-6d66-4df4-b347-67982ec93ae5" />


### Frontend — UI form

- **New `MultiSelection` field**: Appears after the Model type dropdown, visible only for LLM model type (hidden for Embedding models)
- **Fixed options**: `Vision (image input)` and `Audio Transcription (ASR)` — maps to `vision` and `audio-transcription` capability IDs
- **Submission**: Selected capability IDs sent as `capabilities: string[]` in the `ExternalModelRequest` payload; omitted when no capabilities are selected
- **State management**: Capabilities reset when modal reopens; field disabled during verification and submission
- **Jest config**: Added `moduleNameMapper` entries for `react`, `react-dom`, and `@odh-dashboard/internal` to resolve the real `MultiSelection` component from main frontend source (follows pattern from `automl` and `autorag` packages), eliminating the need for hand-crafted component mocks

### BFF — capabilities processing

- **`BuildCapabilities` helper** (new in `constants/capabilities.go`): Filters input through the allowlist, deduplicates, and ensures `text-generation` is always prepended if absent. Returns `nil` for empty/all-invalid input so the YAML field omits and the read-path default applies
- **Write path** (`token_k8s_client.go`): Populates `newModel.Metadata.Capabilities` via `BuildCapabilities(req.Capabilities)`
- **Read path** (`token_k8s_client.go`): Refactored to use `BuildCapabilities` with fallback to `DefaultCapabilities()` for consistency with write path
- **API response** (`repositories/external_models.go`): Uses `BuildCapabilities` when constructing the `AAModel` response, falls back to `DefaultCapabilities()` if nil
- **Server-side validation** (`external_models_handler.go`): Strips `req.Capabilities` for embedding models before processing
- **OpenAPI schema** (`gen-ai.yaml`): Added `capabilities` array field to `ExternalModelRequest` with enum values `vision` and `audio-transcription`
- **Model struct** (`external_models.go`): Added `Capabilities []string` field to `ExternalModelRequest`
- **Frontend type** (`types.ts`): Added `capabilities?: string[]` to `ExternalModelRequest`

### Files changed

| Area | Files | Summary |
|------|-------|---------|
| BFF constants | `capabilities.go`, `capabilities_test.go` (new) | `BuildCapabilities` helper + 10 table-driven unit tests |
| BFF handler | `external_models_handler.go`, `external_models_handler_test.go` | Embedding model capability stripping + 3 integration tests |
| BFF K8s client | `token_k8s_client.go`, `token_k8s_client_test.go` | Write/read path using `BuildCapabilities` |
| BFF models/repo | `external_models.go` (models), `external_models.go` (repo) | `Capabilities` field + response construction |
| OpenAPI | `gen-ai.yaml` | `capabilities` array on `ExternalModelRequest` |
| Frontend component | `CreateExternalEndpointModal.tsx` | `MultiSelection` field, conditional on LLM type |
| Frontend tests | `CreateExternalEndpointModal.spec.tsx` | 8 new tests for capability selection/submission |
| Frontend config | `jest.config.js` | `moduleNameMapper` for single React instance |
| Frontend type | `types.ts` | `capabilities` field on `ExternalModelRequest` |

## How Has This Been Tested?

1. **BFF unit tests**: `BuildCapabilities` covered with 10 table-driven tests — valid capabilities, `text-generation` prepending, unknown filtering, deduplication, empty/nil input
2. **BFF integration tests**: 3 new Ginkgo tests for `CreateExternalModelHandler` — capabilities inclusion, default when omitted, unknown capability filtering
3. **Frontend unit tests**: 8 new tests for capability field — visibility for LLM/Embedding, submission with/without capabilities, multi-select, reset on reopen, disabled during verification, embedding model exclusion
4. **Full test suite**: `npm test` from `packages/gen-ai/frontend/` — **106 suites, 1558 tests, all pass**
5. **Lint**: ESLint passes with 0 errors, 0 warnings (pre-commit hook verified)

## Test Impact

**New tests:**
- `capabilities_test.go` — 10 tests (78 lines)
- `external_models_handler_test.go` — 3 tests (+124 lines)
- `CreateExternalEndpointModal.spec.tsx` — 8 tests (+178 lines)

**Updated:**
- `token_k8s_client_test.go` — updated expected capabilities for consistency

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “Model capabilities” selector for external **LLM** endpoint creation (vision, audio-transcription). **Text-generation** is included automatically.
* **Behavior Changes**
  * For **embedding** models, provided capabilities are ignored/stripped.
* **API/Documentation**
  * External model requests now support an optional `capabilities` field.
* **Tests**
  * Added and updated backend and frontend tests to validate capability inclusion, filtering, defaults, and UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->