### PR TITLE
feat(gen-ai): agent profile load flow, preview mode UI, and playground header rearrangement (RHOAIENG-66526, RHOAIENG-66528)

### DIFF
--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/chatbotPage.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/chatbotPage.ts
@@ -248,6 +248,11 @@ class ChatbotPage {
     return cy.findByTestId('mcp-servers-panel-table');
   }
 
+  openKebabAndClickItem(testId: string): void {
+    this.findKebabMenuButton().click();
+    cy.findByTestId(testId).click();
+  }
+
   // Open-Agent Modal (shown when loading a profile from the URL param)
   findOpenAgentModal(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('open-agent-profile-modal');

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/chatbotPage.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/chatbotPage.ts
@@ -249,7 +249,11 @@ class ChatbotPage {
   }
 
   openKebabAndClickItem(testId: string): void {
-    this.findKebabMenuButton().click();
+    this.findKebabMenuButton().then(($btn) => {
+      if ($btn.attr('aria-expanded') !== 'true') {
+        cy.wrap($btn).click();
+      }
+    });
     cy.findByTestId(testId).click();
   }
 

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
@@ -95,13 +95,17 @@ describe('Agent Profile - Playground (Mocked)', () => {
   );
 
   describe('Load Agent Profile Modal', () => {
-    // Use the IDs from the default mockAgentProfiles fixture
-    const LOAD_PROFILE_ID = 'test-uuid-1';
+    // Derive values from fixture so tests stay in sync with mock data automatically
+    const profileList = mockAgentProfiles();
+    const firstProfile = profileList.data.profiles[0];
 
     beforeEach(() => {
-      const profileList = mockAgentProfiles();
       cy.interceptGenAi('GET /api/v1/agent-profiles', profileList).as('listAgentProfiles');
-      interceptExistingAgentProfile(LOAD_PROFILE_ID, 'Coding assistant', TEST_NAMESPACE);
+      interceptExistingAgentProfile(
+        firstProfile.profileId,
+        firstProfile.displayName,
+        TEST_NAMESPACE,
+      );
       chatbotPage.visit(TEST_NAMESPACE);
     });
 
@@ -132,11 +136,11 @@ describe('Agent Profile - Playground (Mocked)', () => {
         cy.wait('@listAgentProfiles');
 
         cy.step('Click the first profile row');
-        cy.findByTestId(`load-agent-profile-row-${LOAD_PROFILE_ID}`).click();
+        cy.findByTestId(`load-agent-profile-row-${firstProfile.profileId}`).click();
 
         cy.step('Load modal closes and agentProfileId appears in URL');
         cy.findByTestId('load-agent-profile-modal').should('not.exist');
-        cy.location('search').should('include', `agentProfileId=${LOAD_PROFILE_ID}`);
+        cy.location('search').should('include', `agentProfileId=${firstProfile.profileId}`);
 
         cy.step('Open-agent modal appears after profile is fetched');
         cy.wait('@getAgentProfile');

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
@@ -4,6 +4,7 @@ import {
   interceptNewAgentProfile,
   interceptExistingAgentProfile,
 } from '~/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers';
+import { mockAgentProfiles } from '~/__tests__/cypress/cypress/__mocks__';
 
 // Use mock-test-namespace-2 which has LSD configured and ready in the BFF
 const TEST_NAMESPACE = 'mock-test-namespace-2';
@@ -34,8 +35,8 @@ describe('Agent Profile - Playground (Mocked)', () => {
       cy.step('Visit playground with agentProfileManagement flag (no agentProfileId — no modal)');
       chatbotPage.visit(TEST_NAMESPACE);
 
-      cy.step('Open Save As modal — no profile loaded yet, name is empty');
-      cy.findByTestId('save-as-agent-profile-button', { timeout: 10000 }).click();
+      cy.step('Open Save As modal via kebab menu — no profile loaded yet, name is empty');
+      chatbotPage.openKebabAndClickItem('save-as-agent-profile-button');
       cy.findByTestId('save-agent-profile-modal').should('be.visible');
       cy.findByTestId('save-agent-profile-name-input').should('have.value', '');
 
@@ -55,11 +56,8 @@ describe('Agent Profile - Playground (Mocked)', () => {
       chatbotPage.clickOpenAgentEdit();
       chatbotPage.findOpenAgentModal().should('not.exist');
 
-      cy.step('Save button is now visible in edit mode');
-      cy.findByTestId('save-agent-profile-button', { timeout: 10000 }).should('be.visible');
-
-      cy.step('Open Save modal — name matches the profile that was just saved');
-      cy.findByTestId('save-agent-profile-button').click();
+      cy.step('Open Save modal via kebab — name matches the profile that was just saved');
+      chatbotPage.openKebabAndClickItem('save-agent-profile-button');
       cy.findByTestId('save-agent-profile-name-input').should('have.value', AGENT_NAME);
       cy.findByRole('button', { name: 'Cancel' }).click();
     },
@@ -80,9 +78,8 @@ describe('Agent Profile - Playground (Mocked)', () => {
       chatbotPage.clickOpenAgentEdit();
       chatbotPage.findOpenAgentModal().should('not.exist');
 
-      cy.step('Open Save modal — name is pre-filled from loaded profile');
-      cy.findByTestId('save-agent-profile-button', { timeout: 10000 }).should('be.visible');
-      cy.findByTestId('save-agent-profile-button').click();
+      cy.step('Open Save modal via kebab — name is pre-filled from loaded profile');
+      chatbotPage.openKebabAndClickItem('save-agent-profile-button');
       cy.findByTestId('save-agent-profile-modal').should('be.visible');
       cy.findByTestId('save-agent-profile-name-input').should('have.value', AGENT_NAME);
 
@@ -96,6 +93,87 @@ describe('Agent Profile - Playground (Mocked)', () => {
       cy.findByTestId('save-agent-profile-modal').should('not.exist');
     },
   );
+
+  describe('Load Agent Profile Modal', () => {
+    // Use the IDs from the default mockAgentProfiles fixture
+    const LOAD_PROFILE_ID = 'test-uuid-1';
+
+    beforeEach(() => {
+      const profileList = mockAgentProfiles();
+      cy.interceptGenAi('GET /api/v1/agent-profiles', profileList).as('listAgentProfiles');
+      interceptExistingAgentProfile(LOAD_PROFILE_ID, 'Coding assistant', TEST_NAMESPACE);
+      chatbotPage.visit(TEST_NAMESPACE);
+    });
+
+    it(
+      'should open the load modal and show the profile list when Load is clicked',
+      { tags: ['@GenAI', '@AgentProfile', '@Chatbot'] },
+      () => {
+        cy.step('Click Load via kebab menu');
+        chatbotPage.openKebabAndClickItem('load-agent-profile-button');
+
+        cy.step('Modal is visible and profiles are listed');
+        cy.findByTestId('load-agent-profile-modal').should('be.visible');
+        cy.wait('@listAgentProfiles');
+        cy.findByTestId('load-agent-profile-modal').should('contain.text', 'Coding assistant');
+        cy.findByTestId('load-agent-profile-modal').should(
+          'contain.text',
+          'Expense report assistant',
+        );
+      },
+    );
+
+    it(
+      'should set agentProfileId in the URL and show open-agent modal when a profile row is clicked',
+      { tags: ['@GenAI', '@AgentProfile', '@Chatbot'] },
+      () => {
+        cy.step('Open load modal via kebab');
+        chatbotPage.openKebabAndClickItem('load-agent-profile-button');
+        cy.wait('@listAgentProfiles');
+
+        cy.step('Click the first profile row');
+        cy.findByTestId(`load-agent-profile-row-${LOAD_PROFILE_ID}`).click();
+
+        cy.step('Load modal closes and agentProfileId appears in URL');
+        cy.findByTestId('load-agent-profile-modal').should('not.exist');
+        cy.location('search').should('include', `agentProfileId=${LOAD_PROFILE_ID}`);
+
+        cy.step('Open-agent modal appears after profile is fetched');
+        cy.wait('@getAgentProfile');
+        chatbotPage.findOpenAgentModal().should('be.visible', { timeout: 10000 });
+      },
+    );
+
+    it(
+      'should filter profiles by name in the load modal',
+      { tags: ['@GenAI', '@AgentProfile', '@Chatbot'] },
+      () => {
+        cy.step('Open load modal via kebab');
+        chatbotPage.openKebabAndClickItem('load-agent-profile-button');
+        cy.wait('@listAgentProfiles');
+
+        cy.step('Type in search box to filter');
+        cy.findByTestId('load-agent-profile-search').type('Coding');
+        cy.findByTestId('load-agent-profile-modal').should('contain.text', 'Coding assistant');
+        cy.findByTestId('load-agent-profile-modal').should(
+          'not.contain.text',
+          'Expense report assistant',
+        );
+      },
+    );
+
+    it(
+      'should close the load modal when Cancel is clicked',
+      { tags: ['@GenAI', '@AgentProfile', '@Chatbot'] },
+      () => {
+        cy.step('Open and then cancel the modal via kebab');
+        chatbotPage.openKebabAndClickItem('load-agent-profile-button');
+        cy.findByTestId('load-agent-profile-modal').should('be.visible');
+        cy.findByRole('button', { name: 'Cancel' }).click();
+        cy.findByTestId('load-agent-profile-modal').should('not.exist');
+      },
+    );
+  });
 
   describe('Open-Agent Modal', () => {
     beforeEach(() => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
@@ -195,7 +195,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
                   New agent configuration
                 </DropdownItem>
               )}
-              {agentProfilesEnabled && <Divider key="agent-divider" />}
+              {!isCompareMode && agentProfilesEnabled && <Divider key="agent-divider" />}
               <DropdownItem
                 onClick={onConfigurePlayground}
                 key="update-configuration"

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import {
-  ActionList,
-  ActionListGroup,
-  ActionListItem,
   Button,
   Divider,
   Dropdown,
   DropdownItem,
   DropdownList,
   MenuToggle,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
   Tooltip,
 } from '@patternfly/react-core';
 import { CodeIcon, ColumnsIcon, CogIcon, EllipsisVIcon, PlusIcon } from '@patternfly/react-icons';
@@ -25,6 +25,8 @@ type ChatbotHeaderActionsProps = {
   onCompareChat: () => void;
   onSave: () => void;
   onSaveAs: () => void;
+  onLoad: () => void;
+  onNew: () => void;
   onSettingsClick: () => void;
   isSettingsOpen: boolean;
   isCompareMode: boolean;
@@ -38,12 +40,13 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   onCompareChat,
   onSave,
   onSaveAs,
+  onLoad,
+  onNew,
   onSettingsClick,
   isSettingsOpen,
   isCompareMode,
 }) => {
   const { lsdStatus, lastInput } = React.useContext(ChatbotContext);
-  // Might need to iterate through selectedModels for each config during comparison mode
   const configIds = useChatbotConfigStore(selectConfigIds);
   const selectedModel = useChatbotConfigStore(selectSelectedModel(configIds[0]));
   const isViewCodeDisabled = !lastInput || !selectedModel;
@@ -51,7 +54,6 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   const [agentProfilesEnabled] = useFeatureFlag(AGENT_PROFILES);
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
 
-  // Get disabled reason for popover
   const getDisabledReason = () => {
     if (!lastInput && !selectedModel) {
       return 'Please input a message and select a model to generate code';
@@ -66,37 +68,16 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   };
 
   return (
-    <ActionList>
-      <ActionListGroup>
+    <Toolbar inset={{ default: 'insetNone' }} className="pf-m-full-width" style={{ padding: 0 }}>
+      <ToolbarContent
+        className="pf-v6-u-flex-nowrap"
+        style={{ padding: 0, justifyContent: 'flex-end' }}
+      >
         {lsdStatus?.phase === 'Ready' && (
           <>
-            {!isCompareMode && agentProfilesEnabled && profileApplied && (
-              <ActionListItem>
-                <Button
-                  variant="link"
-                  aria-label="Save agent profile"
-                  onClick={onSave}
-                  data-testid="save-agent-profile-button"
-                >
-                  Save
-                </Button>
-              </ActionListItem>
-            )}
-            {!isCompareMode && agentProfilesEnabled && (
-              <ActionListItem>
-                <Button
-                  variant="link"
-                  aria-label="Save as agent profile"
-                  onClick={onSaveAs}
-                  data-testid="save-as-agent-profile-button"
-                >
-                  Save as
-                </Button>
-              </ActionListItem>
-            )}
             {/* Hide compare button when in compare mode - use close button on pane to exit */}
             {!isCompareMode && (
-              <ActionListItem>
+              <ToolbarItem>
                 <Button
                   variant="link"
                   aria-label="Compare chat"
@@ -106,21 +87,9 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
                 >
                   Compare chat
                 </Button>
-              </ActionListItem>
+              </ToolbarItem>
             )}
-            <ActionListItem>
-              <Button
-                variant="link"
-                aria-label="Settings"
-                aria-expanded={isSettingsOpen}
-                icon={<CogIcon />}
-                onClick={onSettingsClick}
-                data-testid="settings-button"
-              >
-                Settings
-              </Button>
-            </ActionListItem>
-            <ActionListItem>
+            <ToolbarItem>
               <Button
                 variant="link"
                 aria-label="Start a new chat session"
@@ -130,12 +99,12 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
               >
                 New chat
               </Button>
-            </ActionListItem>
-            <ActionListItem>
+            </ToolbarItem>
+            <ToolbarItem>
               {isViewCodeDisabled ? (
                 <Tooltip content={getDisabledReason()}>
                   <Button
-                    variant="secondary"
+                    variant="link"
                     aria-label="View generated code (disabled)"
                     icon={<CodeIcon />}
                     isAriaDisabled={isViewCodeDisabled}
@@ -146,19 +115,32 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
                 </Tooltip>
               ) : (
                 <Button
-                  variant="secondary"
+                  variant="link"
                   aria-label="View generated code"
                   icon={<CodeIcon />}
                   onClick={onViewCode}
                   data-testid="view-code-button"
                 >
-                  View Code
+                  View code
                 </Button>
               )}
-            </ActionListItem>
+            </ToolbarItem>
+            <ToolbarItem variant="separator" />
+            <ToolbarItem>
+              <Button
+                variant="link"
+                aria-label="Settings"
+                aria-expanded={isSettingsOpen}
+                icon={<CogIcon />}
+                onClick={onSettingsClick}
+                data-testid="settings-button"
+              >
+                Settings
+              </Button>
+            </ToolbarItem>
           </>
         )}
-        <ActionListItem>
+        <ToolbarItem>
           <Dropdown
             onSelect={() => setDropdownOpen(false)}
             toggle={(toggleRef) => (
@@ -177,15 +159,51 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
             popperProps={{ position: 'end', preventOverflow: true }}
           >
             <DropdownList>
+              {!isCompareMode && agentProfilesEnabled && (
+                <DropdownItem
+                  onClick={onLoad}
+                  key="load-agent-configuration"
+                  data-testid="load-agent-profile-button"
+                >
+                  Load agent configuration
+                </DropdownItem>
+              )}
+              {!isCompareMode && agentProfilesEnabled && profileApplied && (
+                <DropdownItem
+                  onClick={onSave}
+                  key="save-agent-configuration"
+                  data-testid="save-agent-profile-button"
+                >
+                  Save agent configuration
+                </DropdownItem>
+              )}
+              {!isCompareMode && agentProfilesEnabled && (
+                <DropdownItem
+                  onClick={onSaveAs}
+                  key="save-as-agent-configuration"
+                  data-testid="save-as-agent-profile-button"
+                >
+                  Save as agent configuration
+                </DropdownItem>
+              )}
+              {!isCompareMode && agentProfilesEnabled && profileApplied && (
+                <DropdownItem
+                  onClick={onNew}
+                  key="new-agent-configuration"
+                  data-testid="new-agent-configuration-button"
+                >
+                  New agent configuration
+                </DropdownItem>
+              )}
+              {agentProfilesEnabled && <Divider key="agent-divider" />}
               <DropdownItem
                 onClick={onConfigurePlayground}
                 key="update-configuration"
                 isDisabled={!lsdStatus}
                 data-testid="configure-playground-menu-item"
               >
-                Update configuration
+                Update playground
               </DropdownItem>
-              <Divider />
               <DropdownItem
                 onClick={onDeletePlayground}
                 key="delete-playground"
@@ -196,9 +214,9 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
               </DropdownItem>
             </DropdownList>
           </Dropdown>
-        </ActionListItem>
-      </ActionListGroup>
-    </ActionList>
+        </ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
   );
 };
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -23,6 +23,7 @@ import ChatbotHeader from './ChatbotHeader';
 import ChatbotPlayground from './ChatbotPlayground';
 import ChatbotHeaderActions from './ChatbotHeaderActions';
 import SaveAgentProfileModal from './components/SaveAgentProfileModal';
+import LoadAgentProfileModal from './components/LoadAgentProfileModal';
 import {
   useChatbotConfigStore,
   selectConfigIds,
@@ -103,10 +104,39 @@ const ChatbotMain: React.FunctionComponent = () => {
   }, []);
 
   const [saveModalMode, setSaveModalMode] = React.useState<'save' | 'save-as' | null>(null);
+  const [loadModalOpen, setLoadModalOpen] = React.useState(false);
 
   const handleOpenSave = React.useCallback(() => setSaveModalMode('save'), []);
   const handleOpenSaveAs = React.useCallback(() => setSaveModalMode('save-as'), []);
   const handleCloseSaveModal = React.useCallback(() => setSaveModalMode(null), []);
+  const handleOpenLoad = React.useCallback(() => setLoadModalOpen(true), []);
+
+  const handleNewAgentConfiguration = React.useCallback(() => {
+    useChatbotConfigStore.getState().resetConfiguration();
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('agentProfileId');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  const handleProfileSelected = React.useCallback(
+    (profileId: string) => {
+      setLoadModalOpen(false);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('agentProfileId', profileId);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const handleProfileSaved = React.useCallback(
     (profileId: string, displayName: string, description: string) => {
@@ -215,6 +245,8 @@ const ChatbotMain: React.FunctionComponent = () => {
             <ChatbotHeaderActions
               onSave={handleOpenSave}
               onSaveAs={handleOpenSaveAs}
+              onLoad={handleOpenLoad}
+              onNew={handleNewAgentConfiguration}
               onViewCode={() => {
                 setIsViewCodeModalOpen(true);
                 fireSimpleTrackingEvent('Playground View Code Selected');
@@ -290,6 +322,9 @@ const ChatbotMain: React.FunctionComponent = () => {
               hasConversationMessagesRef={hasConversationMessagesRef}
               isDrawerExpanded={isDrawerExpanded}
               setIsDrawerExpanded={setIsDrawerExpanded}
+              onOpenLoad={handleOpenLoad}
+              onOpenSave={handleOpenSave}
+              onOpenSaveAs={handleOpenSaveAs}
             />
           )
         ) : lsdStatus?.phase === 'Failed' ? (
@@ -339,6 +374,12 @@ const ChatbotMain: React.FunctionComponent = () => {
           mcpConfigMapName={mcpConfigMapName}
           onClose={handleCloseSaveModal}
           onSaved={handleProfileSaved}
+        />
+      )}
+      {loadModalOpen && (
+        <LoadAgentProfileModal
+          onClose={() => setLoadModalOpen(false)}
+          onSelect={handleProfileSelected}
         />
       )}
     </>

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -131,6 +131,9 @@ type ChatbotPlaygroundProps = {
   setIsDrawerExpanded?: (expanded: boolean) => void;
   welcomeContent?: React.ReactNode;
   placeholderBotContent?: string;
+  onOpenLoad?: () => void;
+  onOpenSave?: () => void;
+  onOpenSaveAs?: () => void;
 };
 
 const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
@@ -147,6 +150,9 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
   setIsDrawerExpanded: setIsDrawerExpandedProp,
   welcomeContent,
   placeholderBotContent,
+  onOpenLoad,
+  onOpenSave,
+  onOpenSaveAs,
 }) => {
   const { username } = useUserContext();
   const { namespace } = React.useContext(GenAiContext);
@@ -905,7 +911,7 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
       )}
 
       {/* Main layout */}
-      <Drawer isExpanded={isDrawerExpanded && !isEmbedded} isInline position="left">
+      <Drawer isExpanded={isDrawerExpanded && !isEmbedded} isInline position="right">
         <Divider />
         <DrawerContent
           panelContent={
@@ -925,6 +931,9 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
                 onCloseClick={() => setIsDrawerExpanded(false)}
                 onActiveConfigChange={setActivePaneConfigId}
                 defaultActiveTabKey={openSettingsToTab === 'mcp' ? 3 : undefined}
+                onLoad={onOpenLoad}
+                onSave={onOpenSave}
+                onSaveAs={onOpenSaveAs}
               />
             ) : undefined
           }
@@ -941,6 +950,8 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
                   hasDivider
                   isDarkMode={isDarkMode}
                   isDisabled={primaryIsPreview}
+                  agentName={profileApplied ? (loadedProfileDisplayName ?? undefined) : undefined}
+                  isPreviewMode={primaryIsPreview}
                 />
               )}
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx
@@ -57,6 +57,8 @@ describe('ChatbotHeaderActions', () => {
     onCompareChat: jest.fn(),
     onSave: jest.fn(),
     onSaveAs: jest.fn(),
+    onLoad: jest.fn(),
+    onNew: jest.fn(),
     onSettingsClick: jest.fn(),
     isSettingsOpen: false,
     isCompareMode: false,
@@ -385,7 +387,7 @@ describe('ChatbotHeaderActions', () => {
       await user.click(screen.getByTestId('header-kebab-menu-toggle'));
 
       expect(screen.getByTestId('configure-playground-menu-item')).toHaveTextContent(
-        'Update configuration',
+        'Update playground',
       );
       expect(screen.getByTestId('delete-playground-menu-item')).toHaveTextContent(
         'Delete playground',

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotPaneHeader.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotPaneHeader.tsx
@@ -110,10 +110,12 @@ const ChatbotPaneHeader: React.FC<ChatbotPaneHeaderProps> = ({
                     )}
                   </Content>
                 </FlexItem>
-                <Divider
-                  orientation={{ default: 'vertical' }}
-                  style={{ height: '1em', alignSelf: 'center' }}
-                />
+                <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
+                  <Divider
+                    orientation={{ default: 'vertical' }}
+                    style={{ height: 'var(--pf-t--global--font--size--body--default)' }}
+                  />
+                </FlexItem>
               </>
             )}
             {!isSettingsOpen && (

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotPaneHeader.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotPaneHeader.tsx
@@ -25,6 +25,10 @@ interface ChatbotPaneHeaderProps {
   testIdPrefix?: string;
   isDarkMode?: boolean;
   isDisabled?: boolean;
+  /** Name of the currently loaded agent profile, shown before the Model label */
+  agentName?: string;
+  /** When true, shows a "Preview" badge next to the agent name */
+  isPreviewMode?: boolean;
 }
 
 /**
@@ -44,6 +48,8 @@ const ChatbotPaneHeader: React.FC<ChatbotPaneHeaderProps> = ({
   testIdPrefix = 'chatbot',
   isDarkMode,
   isDisabled = false,
+  agentName,
+  isPreviewMode = false,
 }) => (
   <div
     style={{
@@ -81,6 +87,33 @@ const ChatbotPaneHeader: React.FC<ChatbotPaneHeaderProps> = ({
                     style={{ height: '1em', alignSelf: 'center' }}
                   />
                 )}
+              </>
+            )}
+            {agentName && !isSettingsOpen && (
+              <>
+                <FlexItem>
+                  <Content
+                    component="p"
+                    style={{
+                      whiteSpace: 'nowrap',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 'var(--pf-t--global--spacer--sm)',
+                      fontSize: 'var(--pf-t--global--font--size--lg)',
+                    }}
+                  >
+                    <strong>{agentName}</strong>
+                    {isPreviewMode && (
+                      <Label isCompact color="blue" data-testid="agent-preview-label">
+                        Preview
+                      </Label>
+                    )}
+                  </Content>
+                </FlexItem>
+                <Divider
+                  orientation={{ default: 'vertical' }}
+                  style={{ height: '1em', alignSelf: 'center' }}
+                />
               </>
             )}
             {!isSettingsOpen && (

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -1,14 +1,20 @@
 import * as React from 'react';
 import {
+  Button,
   DrawerActions,
   DrawerCloseButton,
   DrawerHead,
   DrawerPanelContent,
   DrawerPanelBody,
   Badge,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
   Flex,
   FlexItem,
   Icon,
+  MenuToggle,
+  MenuToggleAction,
   Tabs,
   Tab,
   TabTitleText,
@@ -18,6 +24,8 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
+import { AGENT_PROFILES } from '~/odh/extensions';
 import {
   useChatbotConfigStore,
   selectSystemInstruction,
@@ -62,6 +70,9 @@ interface ChatbotSettingsPanelProps {
   // Guardrails props
   onCloseClick?: () => void;
   onActiveConfigChange?: (configId: string) => void;
+  onLoad?: () => void;
+  onSave?: () => void;
+  onSaveAs?: () => void;
   /** Whether the drawer is in overlay mode (compare mode) - affects background styling */
   isOverlay?: boolean;
   defaultActiveTabKey?: string | number;
@@ -87,10 +98,16 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
   onActiveConfigChange,
   isOverlay = false,
   defaultActiveTabKey,
+  onLoad,
+  onSave,
+  onSaveAs,
 }) => {
   const [showMcpToolsWarning, setShowMcpToolsWarning] = React.useState(false);
   const [activeToolsCount, setActiveToolsCount] = React.useState(0);
+  const [isSaveDropdownOpen, setIsSaveDropdownOpen] = React.useState(false);
   const isGuardrailsFeatureEnabled = useGuardrailsEnabled();
+  const [agentProfilesEnabled] = useFeatureFlag(AGENT_PROFILES);
+  const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
 
   const configIds = useChatbotConfigStore(selectConfigIds);
 
@@ -230,7 +247,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
       <DrawerHead>
         {configIds.length === 1 ? (
           <Title headingLevel="h2" data-testid="chatbot-settings-panel-header">
-            Configure
+            Settings
           </Title>
         ) : (
           <ToggleGroup
@@ -248,7 +265,57 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
             ))}
           </ToggleGroup>
         )}
-        <DrawerActions>
+        <DrawerActions style={{ gap: 'var(--pf-t--global--spacer--sm)' }}>
+          {agentProfilesEnabled && (
+            <>
+              <Button variant="secondary" onClick={onLoad} data-testid="settings-panel-load-button">
+                Load
+              </Button>
+              <Dropdown
+                isOpen={isSaveDropdownOpen}
+                onOpenChange={setIsSaveDropdownOpen}
+                onSelect={() => setIsSaveDropdownOpen(false)}
+                popperProps={{ position: 'end', preventOverflow: true }}
+                toggle={(toggleRef) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    variant="secondary"
+                    isExpanded={isSaveDropdownOpen}
+                    onClick={() => setIsSaveDropdownOpen(!isSaveDropdownOpen)}
+                    splitButtonItems={[
+                      <MenuToggleAction
+                        key="save-action"
+                        onClick={profileApplied ? onSave : onSaveAs}
+                        data-testid="settings-panel-save-action"
+                      >
+                        {profileApplied ? 'Save' : 'Save as'}
+                      </MenuToggleAction>,
+                    ]}
+                    data-testid="settings-panel-save-toggle"
+                  />
+                )}
+              >
+                <DropdownList>
+                  {profileApplied && (
+                    <DropdownItem
+                      key="save"
+                      onClick={onSave}
+                      data-testid="settings-panel-save-item"
+                    >
+                      Save agent configuration
+                    </DropdownItem>
+                  )}
+                  <DropdownItem
+                    key="save-as"
+                    onClick={onSaveAs}
+                    data-testid="settings-panel-save-as-item"
+                  >
+                    Save as agent configuration
+                  </DropdownItem>
+                </DropdownList>
+              </Dropdown>
+            </>
+          )}
           <DrawerCloseButton onClick={() => onCloseClick?.()} aria-label="Close settings panel" />
         </DrawerActions>
       </DrawerHead>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -36,6 +36,7 @@ import {
   selectSelectedSubscription,
   selectRagEnabled,
   selectConfigIds,
+  selectIsPreview,
   DEFAULT_CONFIG_ID,
 } from '~/app/Chatbot/store';
 import { UseSourceManagementReturn } from '~/app/Chatbot/hooks/useSourceManagement';
@@ -108,6 +109,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
   const isGuardrailsFeatureEnabled = useGuardrailsEnabled();
   const [agentProfilesEnabled] = useFeatureFlag(AGENT_PROFILES);
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
+  const isPreview = useChatbotConfigStore(selectIsPreview(configId));
 
   const configIds = useChatbotConfigStore(selectConfigIds);
 
@@ -285,10 +287,10 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
                     splitButtonItems={[
                       <MenuToggleAction
                         key="save-action"
-                        onClick={profileApplied ? onSave : onSaveAs}
+                        onClick={profileApplied && !isPreview ? onSave : onSaveAs}
                         data-testid="settings-panel-save-action"
                       >
-                        {profileApplied ? 'Save' : 'Save as'}
+                        {profileApplied && !isPreview ? 'Save' : 'Save as'}
                       </MenuToggleAction>,
                     ]}
                     data-testid="settings-panel-save-toggle"
@@ -296,7 +298,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
                 )}
               >
                 <DropdownList>
-                  {profileApplied && (
+                  {profileApplied && !isPreview && (
                     <DropdownItem
                       key="save"
                       onClick={onSave}

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -47,6 +47,7 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
 
   React.useEffect(() => {
     if (!apiAvailable) {
+      setLoading(false);
       return;
     }
     setLoading(true);

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -15,6 +15,7 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { FolderIcon } from '@patternfly/react-icons';
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
+import { useChatbotConfigStore } from '~/app/Chatbot/store';
 import type { AgentProfileSummary } from '~/app/agentProfile/types';
 
 type LoadAgentProfileModalProps = {
@@ -36,6 +37,7 @@ const formatDate = (iso: string): string => {
 
 const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, onSelect }) => {
   const { api, apiAvailable } = useGenAiAPI();
+  const loadedProfileId = useChatbotConfigStore((s) => s.loadedProfileId);
   const [profiles, setProfiles] = React.useState<AgentProfileSummary[]>([]);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -110,18 +112,21 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
             {paginatedProfiles.map((profile) => (
               <Tr
                 key={profile.profileId}
-                style={{ cursor: 'pointer' }}
+                isClickable={profile.profileId !== loadedProfileId}
+                isRowSelected={profile.profileId === loadedProfileId}
+                tabIndex={profile.profileId !== loadedProfileId ? 0 : undefined}
                 data-testid={`load-agent-profile-row-${profile.profileId}`}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor =
-                    'var(--pf-t--global--background--color--secondary--default)';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = '';
-                }}
                 onClick={() => {
-                  onSelect(profile.profileId);
-                  onClose();
+                  if (profile.profileId !== loadedProfileId) {
+                    onSelect(profile.profileId);
+                    onClose();
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && profile.profileId !== loadedProfileId) {
+                    onSelect(profile.profileId);
+                    onClose();
+                  }
                 }}
               >
                 <Td dataLabel="Name">

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -1,0 +1,189 @@
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Pagination,
+  SearchInput,
+  Spinner,
+} from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { FolderIcon } from '@patternfly/react-icons';
+import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
+import type { AgentProfileSummary } from '~/app/agentProfile/types';
+
+type LoadAgentProfileModalProps = {
+  onClose: () => void;
+  onSelect: (profileId: string) => void;
+};
+
+const formatDate = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+};
+
+const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, onSelect }) => {
+  const { api, apiAvailable } = useGenAiAPI();
+  const [profiles, setProfiles] = React.useState<AgentProfileSummary[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [filter, setFilter] = React.useState('');
+  const [page, setPage] = React.useState(1);
+  const perPage = 10;
+
+  React.useEffect(() => {
+    if (!apiAvailable) {
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    api
+      .listAgentProfiles()
+      .then((response) => {
+        setProfiles(response.profiles);
+      })
+      .catch((err: Error) => {
+        setError(err.message || 'Failed to load agent profiles.');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [api, apiAvailable]);
+
+  const filtered = React.useMemo(() => {
+    if (!filter.trim()) {
+      return profiles;
+    }
+    const lower = filter.toLowerCase();
+    return profiles.filter((p) => p.displayName.toLowerCase().includes(lower));
+  }, [profiles, filter]);
+
+  // Reset to page 1 when the filter changes
+  React.useEffect(() => {
+    setPage(1);
+  }, [filter]);
+
+  const paginatedProfiles = filtered.slice((page - 1) * perPage, page * perPage);
+
+  const renderBody = () => {
+    if (loading) {
+      return (
+        <div style={{ textAlign: 'center', padding: 'var(--pf-t--global--spacer--xl)' }}>
+          <Spinner aria-label="Loading agent profiles" />
+        </div>
+      );
+    }
+    if (error) {
+      return <Alert variant="danger" isInline title={error} />;
+    }
+    if (filtered.length === 0) {
+      return (
+        <EmptyState>
+          <EmptyStateBody>
+            {profiles.length === 0 ? 'No agent profiles found.' : 'No profiles match your search.'}
+          </EmptyStateBody>
+        </EmptyState>
+      );
+    }
+    return (
+      <>
+        <Table aria-label="Agent profiles" variant="compact">
+          <Thead>
+            <Tr>
+              <Th>Name</Th>
+              <Th>Last modified</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {paginatedProfiles.map((profile) => (
+              <Tr
+                key={profile.profileId}
+                style={{ cursor: 'pointer' }}
+                data-testid={`load-agent-profile-row-${profile.profileId}`}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor =
+                    'var(--pf-t--global--background--color--secondary--default)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = '';
+                }}
+                onClick={() => {
+                  onSelect(profile.profileId);
+                  onClose();
+                }}
+              >
+                <Td dataLabel="Name">
+                  <FolderIcon
+                    style={{
+                      marginRight: 'var(--pf-t--global--spacer--sm)',
+                      color: 'var(--pf-t--global--icon--color--subtle)',
+                    }}
+                  />
+                  {profile.displayName}
+                </Td>
+                <Td dataLabel="Last modified">{formatDate(profile.lastModified)}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+        {filtered.length > perPage && (
+          <Pagination
+            itemCount={filtered.length}
+            perPage={perPage}
+            page={page}
+            onSetPage={(_e, p) => setPage(p)}
+            isCompact
+            data-testid="load-agent-profile-pagination"
+          />
+        )}
+      </>
+    );
+  };
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      variant="medium"
+      aria-labelledby="load-agent-profile-modal-title"
+      data-testid="load-agent-profile-modal"
+    >
+      <ModalHeader
+        title="Load agent configuration"
+        labelId="load-agent-profile-modal-title"
+        description="Select a saved agent configuration to load into the playground."
+      />
+      <ModalBody>
+        <SearchInput
+          placeholder="Find by name"
+          value={filter}
+          onChange={(_e, val) => setFilter(val)}
+          onClear={() => setFilter('')}
+          style={{ marginBottom: 'var(--pf-t--global--spacer--md)' }}
+          data-testid="load-agent-profile-search"
+          aria-label="Filter agent profiles by name"
+        />
+        {renderBody()}
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default LoadAgentProfileModal;

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -50,19 +50,29 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
       setLoading(false);
       return;
     }
+    let cancelled = false;
     setLoading(true);
     setError(null);
     api
       .listAgentProfiles()
       .then((response) => {
-        setProfiles(response.profiles);
+        if (!cancelled) {
+          setProfiles(response.profiles);
+        }
       })
       .catch((err: Error) => {
-        setError(err.message || 'Failed to load agent profiles.');
+        if (!cancelled) {
+          setError(err.message || 'Failed to load agent profiles.');
+        }
       })
       .finally(() => {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       });
+    return () => {
+      cancelled = true;
+    };
   }, [api, apiAvailable]);
 
   const filtered = React.useMemo(() => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   Alert,
+  Bullseye,
   Button,
   EmptyState,
   EmptyStateBody,
@@ -48,6 +49,7 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
   React.useEffect(() => {
     if (!apiAvailable) {
       setLoading(false);
+      setError('API is not available. Please try again later.');
       return;
     }
     let cancelled = false;
@@ -93,9 +95,9 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
   const renderBody = () => {
     if (loading) {
       return (
-        <div style={{ textAlign: 'center', padding: 'var(--pf-t--global--spacer--xl)' }}>
+        <Bullseye style={{ minHeight: 'var(--pf-t--global--spacer--2xl)' }}>
           <Spinner aria-label="Loading agent profiles" />
-        </div>
+        </Bullseye>
       );
     }
     if (error) {
@@ -134,7 +136,11 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
                   }
                 }}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && profile.profileId !== loadedProfileId) {
+                  if (
+                    (e.key === 'Enter' || e.key === ' ') &&
+                    profile.profileId !== loadedProfileId
+                  ) {
+                    e.preventDefault();
                     onSelect(profile.profileId);
                     onClose();
                   }

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoadAgentProfileModal from '~/app/Chatbot/components/LoadAgentProfileModal';
+import { mockGenAiContextValue } from '~/__mocks__/mockGenAiContext';
+
+jest.mock('~/app/hooks/useGenAiAPI', () => ({
+  useGenAiAPI: jest.fn(() => ({
+    api: mockGenAiContextValue.apiState.api,
+    apiAvailable: true,
+  })),
+}));
+
+const mockOnClose = jest.fn();
+const mockOnSelect = jest.fn();
+
+const renderModal = () =>
+  render(<LoadAgentProfileModal onClose={mockOnClose} onSelect={mockOnSelect} />);
+
+describe('LoadAgentProfileModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the modal title and description', async () => {
+    jest.mocked(mockGenAiContextValue.apiState.api.listAgentProfiles).mockResolvedValue({
+      profiles: [],
+      totalCount: 0,
+    } as never);
+
+    renderModal();
+
+    expect(screen.getByText('Load agent configuration')).toBeInTheDocument();
+    expect(
+      screen.getByText('Select a saved agent configuration to load into the playground.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should show a spinner while loading', () => {
+    jest
+      .mocked(mockGenAiContextValue.apiState.api.listAgentProfiles)
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .mockImplementation(() => new Promise(() => {}));
+
+    renderModal();
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('should render the profile list with name and last modified columns', async () => {
+    jest.mocked(mockGenAiContextValue.apiState.api.listAgentProfiles).mockResolvedValue({
+      profiles: [
+        {
+          profileId: 'uuid-1',
+          name: 'agent-profile-uuid-1',
+          displayName: 'Coding assistant',
+          description: 'Code review',
+          namespace: 'test-ns',
+          lastModified: '2026-06-15T10:00:00Z',
+        },
+        {
+          profileId: 'uuid-2',
+          name: 'agent-profile-uuid-2',
+          displayName: 'HR Bot',
+          description: 'HR helper',
+          namespace: 'test-ns',
+          lastModified: '2026-06-10T08:00:00Z',
+        },
+      ],
+      totalCount: 2,
+    } as never);
+
+    renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByText('Coding assistant')).toBeInTheDocument();
+      expect(screen.getByText('HR Bot')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Last modified' })).toBeInTheDocument();
+  });
+
+  it('should call onSelect with profileId and onClose when a row is clicked', async () => {
+    const user = userEvent.setup();
+    jest.mocked(mockGenAiContextValue.apiState.api.listAgentProfiles).mockResolvedValue({
+      profiles: [
+        {
+          profileId: 'uuid-1',
+          name: 'agent-profile-uuid-1',
+          displayName: 'Coding assistant',
+          description: '',
+          namespace: 'test-ns',
+          lastModified: '2026-06-15T10:00:00Z',
+        },
+      ],
+      totalCount: 1,
+    } as never);
+
+    renderModal();
+
+    await waitFor(() => screen.getByTestId('load-agent-profile-row-uuid-1'));
+    await user.click(screen.getByTestId('load-agent-profile-row-uuid-1'));
+
+    expect(mockOnSelect).toHaveBeenCalledWith('uuid-1');
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should filter profiles by name when search input is used', async () => {
+    const user = userEvent.setup();
+    jest.mocked(mockGenAiContextValue.apiState.api.listAgentProfiles).mockResolvedValue({
+      profiles: [
+        {
+          profileId: 'uuid-1',
+          name: 'agent-profile-uuid-1',
+          displayName: 'Coding assistant',
+          description: '',
+          namespace: 'test-ns',
+          lastModified: '2026-06-15T10:00:00Z',
+        },
+        {
+          profileId: 'uuid-2',
+          name: 'agent-profile-uuid-2',
+          displayName: 'HR Bot',
+          description: '',
+          namespace: 'test-ns',
+          lastModified: '2026-06-10T08:00:00Z',
+        },
+      ],
+      totalCount: 2,
+    } as never);
+
+    renderModal();
+
+    await waitFor(() => screen.getByText('Coding assistant'));
+
+    await user.type(screen.getByPlaceholderText('Find by name'), 'HR');
+
+    expect(screen.getByText('HR Bot')).toBeInTheDocument();
+    expect(screen.queryByText('Coding assistant')).not.toBeInTheDocument();
+  });
+
+  it('should show empty state when no profiles exist', async () => {
+    jest.mocked(mockGenAiContextValue.apiState.api.listAgentProfiles).mockResolvedValue({
+      profiles: [],
+      totalCount: 0,
+    } as never);
+
+    renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByText('No agent profiles found.')).toBeInTheDocument();
+    });
+  });
+
+  it('should show empty state when filter matches nothing', async () => {
+    const user = userEvent.setup();
+    jest.mocked(mockGenAiContextValue.apiState.api.listAgentProfiles).mockResolvedValue({
+      profiles: [
+        {
+          profileId: 'uuid-1',
+          name: 'agent-profile-uuid-1',
+          displayName: 'Coding assistant',
+          description: '',
+          namespace: 'test-ns',
+          lastModified: '2026-06-15T10:00:00Z',
+        },
+      ],
+      totalCount: 1,
+    } as never);
+
+    renderModal();
+
+    await waitFor(() => screen.getByText('Coding assistant'));
+    await user.type(screen.getByPlaceholderText('Find by name'), 'xyz-no-match');
+
+    expect(screen.getByText('No profiles match your search.')).toBeInTheDocument();
+  });
+
+  it('should show error state when API call fails', async () => {
+    jest
+      .mocked(mockGenAiContextValue.apiState.api.listAgentProfiles)
+      .mockRejectedValue(new Error('Network error'));
+
+    renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+  });
+
+  it('should call onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    jest.mocked(mockGenAiContextValue.apiState.api.listAgentProfiles).mockResolvedValue({
+      profiles: [],
+      totalCount: 0,
+    } as never);
+
+    renderModal();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -51,8 +51,13 @@ const useAgentProfileUrlParam = ({
   const appliedProfileId = React.useRef<string | null>(null);
 
   React.useEffect(() => {
+    if (!agentProfileId) {
+      // URL param cleared (e.g. "New agent configuration") — reset so the same
+      // profile can be re-loaded in a future navigation without being blocked.
+      appliedProfileId.current = null;
+      return;
+    }
     if (
-      !agentProfileId ||
       !namespace?.name ||
       !apiAvailable ||
       !mcpServersLoaded ||

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -71,9 +71,15 @@ const useAgentProfileUrlParam = ({
     setLoading(true);
     setError(undefined);
 
+    let cancelled = false;
+
     api
       .getAgentProfile({ id: agentProfileId, namespace: namespace.name })
       .then((profile) => {
+        if (cancelled) {
+          return;
+        }
+
         const { config, promptRef, mcpToolsPending } = deserializeAgentProfile(profile, {
           playgroundModels,
           mcpServers,
@@ -102,6 +108,9 @@ const useAgentProfileUrlParam = ({
           api
             .getMLflowPrompt({ name: promptRef.name, ...versionParam })
             .then((prompt) => {
+              if (cancelled) {
+                return;
+              }
               updateActivePrompt(DEFAULT_CONFIG_ID, prompt);
               const instruction =
                 prompt.template ?? prompt.messages?.find((m) => m.role === 'system')?.content ?? '';
@@ -117,10 +126,17 @@ const useAgentProfileUrlParam = ({
         setLoading(false);
       })
       .catch((err: Error) => {
+        if (cancelled) {
+          return;
+        }
         appliedProfileId.current = null; // allow retry if caller re-mounts
         setError(err);
         setLoading(false);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     agentProfileId,
     namespace?.name,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-66526
https://issues.redhat.com/browse/RHOAIENG-66528

## Description

Implements the Load AgentProfile flow with preview/edit mode ([RHOAIENG-66528](https://redhat.atlassian.net/browse/RHOAIENG-66528)) and agent profile name display in the Playground header ([RHOAIENG-66526](https://redhat.atlassian.net/browse/RHOAIENG-66526)), along with a full Playground header and settings panel rearrangement.


https://github.com/user-attachments/assets/fe906cff-2efe-4046-8f02-cbd7ae430c15



**Load agent configuration modal ([RHOAIENG-66528](https://redhat.atlassian.net/browse/RHOAIENG-66528))**
- New "Load agent configuration" modal accessed from the kebab menu, listing all saved agent profiles with a name filter and pagination (10 per page)
- Clicking a row sets `?agentProfileId=` in the URL, triggering the existing fetch + open-agent modal flow
- Open-agent modal lets the user choose Preview (read-only settings) or Edit (full access); X close enters preview mode
- Playground holds the ApplicationsPage spinner until the profile is fully fetched (`profileReady` gate), eliminating the flash of default settings

**Agent profile header display ([RHOAIENG-66526](https://redhat.atlassian.net/browse/RHOAIENG-66526))**
- Pane header shows **agent name** (slightly larger, bold) + **Preview** badge (blue, compact) + vertical divider + **Model** + model dropdown when a profile is loaded
- Preview badge is only shown when `isPreview` is true

**Playground header rearrangement**
- Toolbar: Compare chat | New chat | View code | `|` | Settings | Kebab
- Save / Save as / Load / New agent configuration moved into the kebab dropdown
- Settings panel renamed "Configure" → "Settings", moved to the right side of the playground
- Settings panel header: Load button + Save split button (Save / Save as…) alongside the close button, gated by `agentProfileManagement` flag

## How Has This Been Tested?

- Manually verified Load modal opens from kebab, lists profiles, filters by name, and sets `agentProfileId` in URL on row click
- Verified open-agent modal appears after profile load with correct agent name; Preview disables settings controls, Edit keeps them enabled; X close enters preview mode
- Verified agent name + Preview badge render in pane header; badge only visible in preview mode
- Verified header button order and settings panel position
- All unit tests pass (1559/1559)

## Test Impact

- **New unit tests** — `LoadAgentProfileModal.spec.tsx` (9 tests): spinner, profile list, filter, row click, empty state, error state, cancel
- **Updated unit tests** — `ChatbotHeaderActions.spec.tsx`: added `onLoad`/`onNew` to defaultProps
- **Updated Cypress mock tests** — `agentProfile.cy.ts`: Load Agent Profile Modal describe block (open, select → URL + open-agent modal, filter, cancel); existing save/update tests updated to open kebab before clicking moved menu items

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a “Load agent profile” modal with search, pagination, and selectable profiles.
  * Enabled kebab-menu actions for loading, saving, saving-as, and creating new agent configurations.
  * Added “View code” toolbar action integration and agent-profile state handling.

* **UI/UX Updates**
  * Header now shows the loaded agent name with an optional “Preview” badge.
  * Updated labels/layout (including “Configure” → “Settings” and toolbar/drawer layout tweaks).

* **Bug Fixes**
  * Fixed agent-profile reload behavior when the URL parameter is cleared.

* **Tests**
  * Expanded Cypress and Jest coverage for load-modal and save/load flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->