### PR TITLE
feat(spawner): reference existing Kubernetes Secrets as environment variables (RHOAIENG-60680)

### DIFF
--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -37,6 +37,7 @@ export const assembleNotebook = (
     projectName,
     notebookData,
     envFrom,
+    secretKeyRefEnvVars,
     image,
     volumes: formVolumes,
     volumeMounts: formVolumeMounts,
@@ -134,6 +135,7 @@ export const assembleNotebook = (
                   name: 'JUPYTER_IMAGE',
                   value: imageUrl,
                 },
+                ...(secretKeyRefEnvVars ?? []),
               ],
               envFrom,
               volumeMounts,
@@ -312,6 +314,10 @@ export const updateNotebook = (
   // merging them by array index, which creates corrupted volumes with multiple types
   oldNotebook.spec.template.spec.volumes = [];
   container.volumeMounts = [];
+
+  // Clear old env array so the assembled notebook's env (including secretKeyRef entries)
+  // replaces rather than merges by index
+  container.env = [];
 
   return k8sUpdateResource<NotebookKind>(
     applyK8sAPIOptions(

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -172,7 +172,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
 
     await Promise.all(restartConnectedNotebooksPromises);
 
-    const envFrom = await updateConfigMapsAndSecretsForNotebook(
+    const { envFrom, secretKeyRefEnvVars } = await updateConfigMapsAndSecretsForNotebook(
       projectName,
       editNotebook,
       envVariables,
@@ -181,7 +181,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     );
 
     const annotations = { ...editNotebook.metadata.annotations };
-    if (envFrom.length > 0) {
+    if (envFrom.length > 0 || secretKeyRefEnvVars.length > 0) {
       annotations['notebooks.opendatahub.io/notebook-restart'] = 'true';
     }
 
@@ -192,6 +192,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       volumes,
       volumeMounts,
       envFrom,
+      secretKeyRefEnvVars,
       connections,
       feastData,
     };

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -32,6 +32,7 @@ import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import {
   createConfigMapsAndSecretsForNotebook,
   createPvcDataForNotebook,
+  getSecretKeyRefEnvVars,
   updateConfigMapsAndSecretsForNotebook,
   updatePvcDataForNotebook,
 } from './service';
@@ -239,6 +240,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       volumes,
       volumeMounts,
       envFrom: [...envFrom],
+      secretKeyRefEnvVars: getSecretKeyRefEnvVars(envVariables),
       connections,
       feastData,
     };

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -351,7 +351,11 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   deletedSecrets={deletedSecrets}
                 />
               )}
-              <EnvironmentVariables envVariables={envVariables} setEnvVariables={setEnvVariables} />
+              <EnvironmentVariables
+                envVariables={envVariables}
+                setEnvVariables={setEnvVariables}
+                namespace={currentProject.metadata.name}
+              />
             </FormSection>
             <FormSection
               title={

--- a/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
@@ -1,0 +1,157 @@
+import {
+  EnvironmentVariableType,
+  EnvVariable,
+  SecretCategory,
+  ConfigMapCategory,
+} from '#~/pages/projects/types';
+import { getSecretKeyRefEnvVars } from '#~/src/pages/projects/screens/spawner/service';
+
+describe('getSecretKeyRefEnvVars', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return empty array when no env variables provided', () => {
+    const result = getSecretKeyRefEnvVars([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when no EXISTING category env vars exist', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'test-secret',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'KEY', value: 'VALUE' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.CONFIG_MAP,
+        existingName: 'test-cm',
+        values: {
+          category: ConfigMapCategory.GENERIC,
+          data: [{ key: 'KEY', value: 'VALUE' }],
+        },
+      },
+    ];
+    const result = getSecretKeyRefEnvVars(envVars);
+    expect(result).toEqual([]);
+  });
+
+  it('should generate secretKeyRef entries for a single secret with one key', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [{ secretName: 'db-credentials', selectedKeys: ['DB_PASSWORD'] }],
+      },
+    ];
+    const result = getSecretKeyRefEnvVars(envVars);
+    expect(result).toEqual([
+      {
+        name: 'DB_PASSWORD',
+        valueFrom: { secretKeyRef: { name: 'db-credentials', key: 'DB_PASSWORD' } },
+      },
+    ]);
+  });
+
+  it('should generate secretKeyRef entries for a single secret with multiple keys', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [
+          {
+            secretName: 'aws-credentials',
+            selectedKeys: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
+          },
+        ],
+      },
+    ];
+    const result = getSecretKeyRefEnvVars(envVars);
+    expect(result).toEqual([
+      {
+        name: 'AWS_ACCESS_KEY_ID',
+        valueFrom: { secretKeyRef: { name: 'aws-credentials', key: 'AWS_ACCESS_KEY_ID' } },
+      },
+      {
+        name: 'AWS_SECRET_ACCESS_KEY',
+        valueFrom: {
+          secretKeyRef: { name: 'aws-credentials', key: 'AWS_SECRET_ACCESS_KEY' },
+        },
+      },
+    ]);
+  });
+
+  it('should generate secretKeyRef entries for multiple secrets', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [
+          { secretName: 'db-credentials', selectedKeys: ['DB_PASSWORD'] },
+          { secretName: 'api-secret', selectedKeys: ['API_KEY'] },
+        ],
+      },
+    ];
+    const result = getSecretKeyRefEnvVars(envVars);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      name: 'DB_PASSWORD',
+      valueFrom: { secretKeyRef: { name: 'db-credentials', key: 'DB_PASSWORD' } },
+    });
+    expect(result).toContainEqual({
+      name: 'API_KEY',
+      valueFrom: { secretKeyRef: { name: 'api-secret', key: 'API_KEY' } },
+    });
+  });
+
+  it('should handle env variables with undefined existingSecretRefs', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+      },
+    ];
+    const result = getSecretKeyRefEnvVars(envVars);
+    expect(result).toEqual([]);
+  });
+
+  it('should handle empty selectedKeys array', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [{ secretName: 'empty-secret', selectedKeys: [] }],
+      },
+    ];
+    const result = getSecretKeyRefEnvVars(envVars);
+    expect(result).toEqual([]);
+  });
+
+  it('should ignore non-EXISTING category env vars while processing EXISTING ones', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'test-secret',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'KEY', value: 'VALUE' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [{ secretName: 'my-secret', selectedKeys: ['MY_KEY'] }],
+      },
+    ];
+    const result = getSecretKeyRefEnvVars(envVars);
+    expect(result).toEqual([
+      {
+        name: 'MY_KEY',
+        valueFrom: { secretKeyRef: { name: 'my-secret', key: 'MY_KEY' } },
+      },
+    ]);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
@@ -4,7 +4,7 @@ import {
   SecretCategory,
   ConfigMapCategory,
 } from '#~/pages/projects/types';
-import { getSecretKeyRefEnvVars } from '#~/src/pages/projects/screens/spawner/service';
+import { getSecretKeyRefEnvVars } from '#~/pages/projects/screens/spawner/service';
 
 describe('getSecretKeyRefEnvVars', () => {
   beforeEach(() => {

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Alert,
   Badge,
   Button,
   Content,
@@ -27,6 +28,7 @@ import { TimesIcon } from '@patternfly/react-icons';
 import { ExistingSecretRef, ExistingSecretMetadata } from '#~/pages/projects/types';
 import { useExistingSecrets } from './useExistingSecrets';
 import ExistingSecretKeyPicker from './ExistingSecretKeyPicker';
+import { detectExistingSecretKeyCollisions, getCollidingKeySet } from './existingSecretCollisions';
 
 type EnvExistingSecretFieldProps = {
   namespace: string;
@@ -114,6 +116,13 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
     },
     [isOpen],
   );
+
+  const collisions = React.useMemo(
+    () => detectExistingSecretKeyCollisions(existingSecretRefs),
+    [existingSecretRefs],
+  );
+
+  const collidingKeySet = React.useMemo(() => getCollidingKeySet(collisions), [collisions]);
 
   // RBAC: user cannot list secrets
   if (loaded && !canList) {
@@ -273,12 +282,37 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
           </SelectList>
         </Select>
       </StackItem>
+      {collisions.length > 0 ? (
+        <StackItem>
+          <Alert
+            variant="warning"
+            isInline
+            isPlain
+            title={
+              collisions.length === 1
+                ? `${collisions[0].key} is defined in both ${collisions[0].sources.join(' and ')}.`
+                : 'Key name collisions across attached secrets'
+            }
+            data-testid="env-collision-warning"
+          >
+            {collisions.length > 1
+              ? collisions.map((c) => (
+                  <div key={c.key}>
+                    <strong>{c.key}</strong> is defined in both {c.sources.join(' and ')}.
+                  </div>
+                ))
+              : null}
+            <p>Choose one and deselect the duplicate key to resolve the collision.</p>
+          </Alert>
+        </StackItem>
+      ) : null}
       {existingSecretRefs.length > 0 ? (
         <StackItem>
           <ExistingSecretKeyPicker
             selectedRefs={existingSecretRefs}
             availableSecrets={secrets}
             onUpdate={onUpdate}
+            collidingKeys={collidingKeySet}
           />
         </StackItem>
       ) : null}

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
@@ -10,10 +10,7 @@ import {
   MenuToggle,
   MenuToggleElement,
   Popover,
-  /**
-   * The Select component is used to build a typeahead multi-select for existing secrets
-   */
-  // eslint-disable-next-line no-restricted-imports
+  // eslint-disable-next-line no-restricted-imports -- typeahead multi-select requires Select directly
   Select,
   SelectList,
   SelectOption,
@@ -63,6 +60,12 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
   const [isOpen, setIsOpen] = React.useState(false);
   const [searchText, setSearchText] = React.useState('');
   const textInputRef = React.useRef<HTMLInputElement>();
+
+  React.useEffect(() => {
+    if (isOpen) {
+      requestAnimationFrame(() => textInputRef.current?.focus());
+    }
+  }, [isOpen]);
 
   const selectedSecretNames = React.useMemo(
     () => new Set(existingSecretRefs.map((ref) => ref.secretName)),
@@ -216,10 +219,7 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
             <MenuToggle
               ref={toggleRef}
               variant="typeahead"
-              onClick={() => {
-                setIsOpen(!isOpen);
-                setTimeout(() => textInputRef.current?.focus(), 100);
-              }}
+              onClick={() => setIsOpen(!isOpen)}
               isExpanded={isOpen}
               isFullWidth
               data-testid="env-existing-secret-toggle"

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
@@ -26,6 +26,7 @@ import {
 import { TimesIcon } from '@patternfly/react-icons';
 import { ExistingSecretRef, ExistingSecretMetadata } from '#~/pages/projects/types';
 import { useExistingSecrets } from './useExistingSecrets';
+import ExistingSecretKeyPicker from './ExistingSecretKeyPicker';
 
 type EnvExistingSecretFieldProps = {
   namespace: string;
@@ -272,6 +273,15 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
           </SelectList>
         </Select>
       </StackItem>
+      {existingSecretRefs.length > 0 ? (
+        <StackItem>
+          <ExistingSecretKeyPicker
+            selectedRefs={existingSecretRefs}
+            availableSecrets={secrets}
+            onUpdate={onUpdate}
+          />
+        </StackItem>
+      ) : null}
     </Stack>
   );
 };

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
@@ -1,0 +1,279 @@
+import * as React from 'react';
+import {
+  Badge,
+  Button,
+  Content,
+  ContentVariants,
+  FormGroup,
+  FormGroupLabelHelp,
+  MenuToggle,
+  MenuToggleElement,
+  Popover,
+  /**
+   * The Select component is used to build a typeahead multi-select for existing secrets
+   */
+  // eslint-disable-next-line no-restricted-imports
+  Select,
+  SelectList,
+  SelectOption,
+  Spinner,
+  Stack,
+  StackItem,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+import { ExistingSecretRef, ExistingSecretMetadata } from '#~/pages/projects/types';
+import { useExistingSecrets } from './useExistingSecrets';
+
+type EnvExistingSecretFieldProps = {
+  namespace: string;
+  existingSecretRefs: ExistingSecretRef[];
+  onUpdate: (refs: ExistingSecretRef[]) => void;
+};
+
+const MAX_KEY_PREVIEW_LENGTH = 60;
+
+const getKeyPreview = (keys: string[]): string => {
+  if (keys.length === 0) {
+    return '';
+  }
+  const preview = keys.join(', ');
+  if (preview.length <= MAX_KEY_PREVIEW_LENGTH) {
+    return preview;
+  }
+  return `${preview.substring(0, MAX_KEY_PREVIEW_LENGTH)}...`;
+};
+
+const DESCRIPTION_TEXT =
+  'Attach an available secret from this project. Use Existing Secrets to attach secrets ' +
+  'managed by your platform team or provisioned through external tools. For reusable ' +
+  'credentials like S3 or database connections, use the Connections section.';
+
+const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
+  namespace,
+  existingSecretRefs,
+  onUpdate,
+}) => {
+  const { secrets, loaded, canList, error } = useExistingSecrets(namespace);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [searchText, setSearchText] = React.useState('');
+  const textInputRef = React.useRef<HTMLInputElement>();
+
+  const selectedSecretNames = React.useMemo(
+    () => new Set(existingSecretRefs.map((ref) => ref.secretName)),
+    [existingSecretRefs],
+  );
+
+  const filteredSecrets = React.useMemo(
+    () =>
+      searchText
+        ? secrets.filter((s) => s.name.toLowerCase().includes(searchText.toLowerCase()))
+        : secrets,
+    [secrets, searchText],
+  );
+
+  const handleSelect = React.useCallback(
+    (_event: React.MouseEvent | undefined, value: string | number | undefined) => {
+      const secretName = String(value);
+      if (selectedSecretNames.has(secretName)) {
+        onUpdate(existingSecretRefs.filter((ref) => ref.secretName !== secretName));
+      } else {
+        const secret = secrets.find((s) => s.name === secretName);
+        if (secret) {
+          onUpdate([
+            ...existingSecretRefs,
+            { secretName: secret.name, selectedKeys: [...secret.keys] },
+          ]);
+        }
+      }
+    },
+    [selectedSecretNames, existingSecretRefs, onUpdate, secrets],
+  );
+
+  const handleClearSearch = React.useCallback(() => {
+    setSearchText('');
+    textInputRef.current?.focus();
+  }, []);
+
+  const handleOpenChange = React.useCallback((open: boolean) => {
+    setIsOpen(open);
+    if (!open) {
+      setSearchText('');
+    }
+  }, []);
+
+  const handleTextInputChange = React.useCallback(
+    (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+      setSearchText(value);
+      if (!isOpen) {
+        setIsOpen(true);
+      }
+    },
+    [isOpen],
+  );
+
+  // RBAC: user cannot list secrets
+  if (loaded && !canList) {
+    return (
+      <FormGroup
+        label="Existing secrets"
+        data-testid="env-existing-secret-field"
+        labelHelp={
+          <Popover
+            headerContent="Access permissions needed"
+            bodyContent="To list existing secrets, ask your administrator to grant 'secrets list' access for this project, or use the Key / value option to create a new secret."
+          >
+            <FormGroupLabelHelp
+              aria-label="More info about access permissions"
+              data-testid="env-existing-secret-rbac-popover"
+            />
+          </Popover>
+        }
+      >
+        <Content component={ContentVariants.small} data-testid="env-existing-secret-rbac-message">
+          You do not have permission to list secrets in this project.
+        </Content>
+      </FormGroup>
+    );
+  }
+
+  // Loading state
+  if (!loaded) {
+    return (
+      <FormGroup label="Existing secrets" data-testid="env-existing-secret-field">
+        <Spinner size="md" data-testid="env-existing-secret-loading" />
+      </FormGroup>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <FormGroup label="Existing secrets" data-testid="env-existing-secret-field">
+        <Content component={ContentVariants.small} data-testid="env-existing-secret-error">
+          Unable to load secrets: {error.message}
+        </Content>
+      </FormGroup>
+    );
+  }
+
+  const hasSecrets = secrets.length > 0;
+
+  // Empty namespace state
+  if (!hasSecrets) {
+    return (
+      <FormGroup
+        label="Existing secrets"
+        data-testid="env-existing-secret-field"
+        labelHelp={
+          <Popover
+            headerContent="No available secrets in this project"
+            bodyContent="Your project may already have secrets, but they may be managed by Connections or created by other workbenches. New secrets can be added by your platform team using tools like External Secrets Operator, or you can create one using the Key / value option above."
+          >
+            <FormGroupLabelHelp
+              aria-label="More info about existing secrets"
+              data-testid="env-existing-secret-empty-popover"
+            />
+          </Popover>
+        }
+      >
+        <Content component={ContentVariants.small} data-testid="env-existing-secret-empty-message">
+          No third-party secrets available in this project.
+        </Content>
+      </FormGroup>
+    );
+  }
+
+  const selectedCount = existingSecretRefs.length;
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Content component={ContentVariants.small} data-testid="env-existing-secret-description">
+          {DESCRIPTION_TEXT}
+        </Content>
+      </StackItem>
+      <StackItem data-testid="env-existing-secret-field">
+        <Select
+          isOpen={isOpen}
+          selected={Array.from(selectedSecretNames)}
+          isScrollable
+          onSelect={handleSelect}
+          onOpenChange={handleOpenChange}
+          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            <MenuToggle
+              ref={toggleRef}
+              variant="typeahead"
+              onClick={() => {
+                setIsOpen(!isOpen);
+                setTimeout(() => textInputRef.current?.focus(), 100);
+              }}
+              isExpanded={isOpen}
+              isFullWidth
+              data-testid="env-existing-secret-toggle"
+            >
+              <TextInputGroup isPlain>
+                <TextInputGroupMain
+                  value={searchText}
+                  onClick={() => {
+                    setIsOpen(!isOpen);
+                  }}
+                  onChange={handleTextInputChange}
+                  autoComplete="off"
+                  innerRef={textInputRef}
+                  placeholder="Search secrets"
+                  role="combobox"
+                  isExpanded={isOpen}
+                  data-testid="env-existing-secret-search"
+                />
+                <TextInputGroupUtilities>
+                  {selectedCount > 0 ? (
+                    <Badge isRead data-testid="env-existing-secret-badge">
+                      {selectedCount} selected
+                    </Badge>
+                  ) : null}
+                  {searchText ? (
+                    <Button
+                      variant="plain"
+                      onClick={handleClearSearch}
+                      aria-label="Clear search"
+                      icon={<TimesIcon />}
+                      data-testid="env-existing-secret-clear-search"
+                    />
+                  ) : null}
+                </TextInputGroupUtilities>
+              </TextInputGroup>
+            </MenuToggle>
+          )}
+        >
+          <SelectList data-testid="env-existing-secret-list">
+            {filteredSecrets.length === 0 ? (
+              <SelectOption isDisabled data-testid="env-existing-secret-no-results">
+                No results found
+              </SelectOption>
+            ) : (
+              filteredSecrets.map((secret: ExistingSecretMetadata) => (
+                <SelectOption
+                  key={secret.name}
+                  value={secret.name}
+                  hasCheckbox
+                  isSelected={selectedSecretNames.has(secret.name)}
+                  description={`${secret.keys.length} key${
+                    secret.keys.length !== 1 ? 's' : ''
+                  }: ${getKeyPreview(secret.keys)}`}
+                  data-testid={`env-existing-secret-option-${secret.name}`}
+                >
+                  {secret.name}
+                </SelectOption>
+              ))
+            )}
+          </SelectList>
+        </Select>
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default EnvExistingSecretField;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -1,14 +1,23 @@
 import * as React from 'react';
-import { EnvironmentVariableType, EnvVariableData, SecretCategory } from '#~/pages/projects/types';
+import {
+  EnvironmentVariableType,
+  EnvVariableData,
+  ExistingSecretRef,
+  SecretCategory,
+} from '#~/pages/projects/types';
 import { asEnumMember } from '#~/utilities/utils';
 import EnvDataTypeField from './EnvDataTypeField';
 import GenericKeyValuePairField from './GenericKeyValuePairField';
 import { EMPTY_KEY_VALUE_PAIR } from './const';
 import EnvUploadField from './EnvUploadField';
+import EnvExistingSecretField from './EnvExistingSecretField';
 
 type EnvSecretProps = {
   env?: EnvVariableData;
   onUpdate: (envVariableData: EnvVariableData) => void;
+  namespace: string;
+  existingSecretRefs?: ExistingSecretRef[];
+  onExistingSecretRefsUpdate?: (refs: ExistingSecretRef[]) => void;
 };
 
 const DEFAULT_ENV: EnvVariableData = {
@@ -16,7 +25,13 @@ const DEFAULT_ENV: EnvVariableData = {
   data: [],
 };
 
-const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) => (
+const EnvSecret: React.FC<EnvSecretProps> = ({
+  env = DEFAULT_ENV,
+  onUpdate,
+  namespace,
+  existingSecretRefs = [],
+  onExistingSecretRefsUpdate,
+}) => (
   <EnvDataTypeField
     selection={env.category || ''}
     onSelection={(value) =>
@@ -40,6 +55,16 @@ const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) =>
             envVarType={EnvironmentVariableType.SECRET}
             onUpdate={(newEnvData) => onUpdate({ ...env, data: newEnvData })}
             translateValue={(value) => atob(value)}
+          />
+        ),
+      },
+      [SecretCategory.EXISTING]: {
+        label: 'Existing secret',
+        render: (
+          <EnvExistingSecretField
+            namespace={namespace}
+            existingSecretRefs={existingSecretRefs}
+            onUpdate={(refs) => onExistingSecretRefsUpdate?.(refs)}
           />
         ),
       },

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -11,12 +11,14 @@ type EnvTypeSelectFieldProps = {
   envVariable: EnvVariable;
   onUpdate: (envVariable: EnvVariable) => void;
   onRemove: () => void;
+  namespace: string;
 };
 
 const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
   envVariable,
   onUpdate,
   onRemove,
+  namespace,
 }) => (
   <FormGroup isRequired label="Variable type" fieldId="environment-variable-type-select">
     <Split data-testid="environment-variable-field">
@@ -51,6 +53,10 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                 <EnvTypeSwitch
                   env={envVariable}
                   onUpdate={(envValue) => onUpdate({ ...envVariable, values: envValue })}
+                  namespace={namespace}
+                  onExistingSecretRefsUpdate={(refs) =>
+                    onUpdate({ ...envVariable, existingSecretRefs: refs })
+                  }
                 />
               </IndentSection>
             </StackItem>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
@@ -1,19 +1,39 @@
 import * as React from 'react';
-import { EnvironmentVariableType, EnvVariable, EnvVariableData } from '#~/pages/projects/types';
+import {
+  EnvironmentVariableType,
+  EnvVariable,
+  EnvVariableData,
+  ExistingSecretRef,
+} from '#~/pages/projects/types';
 import EnvConfigMap from './EnvConfigMap';
 import EnvSecret from './EnvSecret';
 
 type EnvTypeSwitchProps = {
   env: EnvVariable;
   onUpdate: (envVariableData: EnvVariableData) => void;
+  namespace: string;
+  onExistingSecretRefsUpdate: (refs: ExistingSecretRef[]) => void;
 };
 
-const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate }) => {
+const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({
+  env,
+  onUpdate,
+  namespace,
+  onExistingSecretRefsUpdate,
+}) => {
   switch (env.type) {
     case EnvironmentVariableType.CONFIG_MAP:
       return <EnvConfigMap env={env.values} onUpdate={onUpdate} />;
     case EnvironmentVariableType.SECRET:
-      return <EnvSecret env={env.values} onUpdate={onUpdate} />;
+      return (
+        <EnvSecret
+          env={env.values}
+          onUpdate={onUpdate}
+          namespace={namespace}
+          existingSecretRefs={env.existingSecretRefs}
+          onExistingSecretRefsUpdate={onExistingSecretRefsUpdate}
+        />
+      );
     default:
       return null;
   }

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvironmentVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvironmentVariables.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Button, Divider } from '@patternfly/react-core';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Button, Divider, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { InfoCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { EnvVariable } from '#~/pages/projects/types';
 import EnvTypeSelectField from './EnvTypeSelectField';
 
@@ -34,6 +34,14 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesProps> = ({
         {i !== envVariables.length - 1 && <Divider />}
       </React.Fragment>
     ))}
+    {envVariables.length > 0 ? (
+      <HelperText data-testid="env-rotation-hint">
+        <HelperTextItem variant="indeterminate" icon={<InfoCircleIcon />}>
+          Environment variables are set at workbench start. If secret values change (e.g.,
+          credential rotation), restart the workbench to pick up new values.
+        </HelperTextItem>
+      </HelperText>
+    ) : null}
     <Button
       variant="link"
       data-testid="add-variable-button"

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvironmentVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvironmentVariables.tsx
@@ -7,10 +7,12 @@ import EnvTypeSelectField from './EnvTypeSelectField';
 type EnvironmentVariablesProps = {
   envVariables: EnvVariable[];
   setEnvVariables: (envVars: EnvVariable[]) => void;
+  namespace: string;
 };
 const EnvironmentVariables: React.FC<EnvironmentVariablesProps> = ({
   envVariables,
   setEnvVariables,
+  namespace,
 }) => (
   <>
     {envVariables.map((envVariable, i) => (
@@ -27,6 +29,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesProps> = ({
           onRemove={() =>
             setEnvVariables(envVariables.filter((v, filterIndex) => filterIndex !== i))
           }
+          namespace={namespace}
         />
         {i !== envVariables.length - 1 && <Divider />}
       </React.Fragment>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretKeyPicker.scss
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretKeyPicker.scss
@@ -1,0 +1,3 @@
+.odh-existing-secret-key-picker__section {
+  border-left: 2px solid var(--pf-t--global--border--color--default);
+}

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretKeyPicker.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretKeyPicker.tsx
@@ -1,0 +1,183 @@
+import * as React from 'react';
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Content,
+  ExpandableSection,
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  TextInput,
+} from '@patternfly/react-core';
+import { ExistingSecretMetadata, ExistingSecretRef } from '#~/pages/projects/types';
+import './ExistingSecretKeyPicker.scss';
+
+const FILTER_THRESHOLD = 10;
+
+type ExistingSecretKeyPickerProps = {
+  selectedRefs: ExistingSecretRef[];
+  availableSecrets: ExistingSecretMetadata[];
+  onUpdate: (updatedRefs: ExistingSecretRef[]) => void;
+};
+
+type SecretKeySectionProps = {
+  secretRef: ExistingSecretRef;
+  allKeys: string[];
+  onKeysChange: (selectedKeys: string[]) => void;
+};
+
+const SecretKeySection: React.FC<SecretKeySectionProps> = ({
+  secretRef,
+  allKeys,
+  onKeysChange,
+}) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [filter, setFilter] = React.useState('');
+
+  const { selectedKeys } = secretRef;
+  const totalKeys = allKeys.length;
+  const allSelected = selectedKeys.length === totalKeys;
+
+  const visibleKeys = React.useMemo(
+    () =>
+      filter ? allKeys.filter((k) => k.toLowerCase().includes(filter.toLowerCase())) : allKeys,
+    [allKeys, filter],
+  );
+
+  const selectedSet = React.useMemo(() => new Set(selectedKeys), [selectedKeys]);
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      onKeysChange([]);
+    } else {
+      onKeysChange([...allKeys]);
+    }
+  };
+
+  const toggleKey = (key: string, checked: boolean) => {
+    if (checked) {
+      onKeysChange([...selectedKeys, key]);
+    } else {
+      onKeysChange(selectedKeys.filter((k) => k !== key));
+    }
+  };
+
+  const entryId = secretRef.secretName.replace(/[^a-zA-Z0-9-_]/g, '-');
+
+  return (
+    <div
+      className="odh-existing-secret-key-picker__section pf-v6-u-pl-md pf-v6-u-ml-sm"
+      data-testid={`secret-key-section-${secretRef.secretName}`}
+    >
+      <ExpandableSection
+        toggleContent={
+          <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+            <FlexItem>
+              <strong>{secretRef.secretName}</strong>
+            </FlexItem>
+            <FlexItem>
+              <Badge isRead data-testid={`key-count-badge-${secretRef.secretName}`}>
+                {selectedKeys.length} of {totalKeys} keys
+              </Badge>
+            </FlexItem>
+          </Flex>
+        }
+        isExpanded={isExpanded}
+        onToggle={(_event, expanded) => setIsExpanded(expanded)}
+        data-testid={`expandable-section-${secretRef.secretName}`}
+      >
+        <Stack hasGutter>
+          <StackItem>
+            <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+              <FlexItem>
+                <Button
+                  variant="link"
+                  isInline
+                  onClick={toggleSelectAll}
+                  data-testid={`toggle-select-all-${secretRef.secretName}`}
+                >
+                  {allSelected ? 'Deselect all' : 'Select all'}
+                </Button>
+              </FlexItem>
+              <FlexItem>
+                <Content component="small" className="pf-v6-u-color-200">
+                  {selectedKeys.length} of {totalKeys} keys selected
+                </Content>
+              </FlexItem>
+            </Flex>
+          </StackItem>
+          {totalKeys > FILTER_THRESHOLD ? (
+            <StackItem>
+              <TextInput
+                type="search"
+                placeholder="Filter keys"
+                value={filter}
+                onChange={(_event, value) => setFilter(value)}
+                aria-label={`Filter keys for ${secretRef.secretName}`}
+                data-testid={`key-filter-${secretRef.secretName}`}
+              />
+            </StackItem>
+          ) : null}
+          {visibleKeys.map((k) => (
+            <StackItem key={k}>
+              <Checkbox
+                id={`key-${entryId}-${k}`}
+                label={k}
+                isChecked={selectedSet.has(k)}
+                onChange={(_event, checked) => toggleKey(k, checked)}
+                data-testid={`key-checkbox-${secretRef.secretName}-${k}`}
+              />
+            </StackItem>
+          ))}
+        </Stack>
+      </ExpandableSection>
+    </div>
+  );
+};
+
+const ExistingSecretKeyPicker: React.FC<ExistingSecretKeyPickerProps> = ({
+  selectedRefs,
+  availableSecrets,
+  onUpdate,
+}) => {
+  const secretMap = React.useMemo(() => {
+    const map = new Map<string, ExistingSecretMetadata>();
+    availableSecrets.forEach((s) => map.set(s.name, s));
+    return map;
+  }, [availableSecrets]);
+
+  const handleKeysChange = React.useCallback(
+    (secretName: string, newKeys: string[]) => {
+      onUpdate(
+        selectedRefs.map((ref) =>
+          ref.secretName === secretName ? { ...ref, selectedKeys: newKeys } : ref,
+        ),
+      );
+    },
+    [selectedRefs, onUpdate],
+  );
+
+  return (
+    <Stack hasGutter data-testid="existing-secret-key-picker">
+      {selectedRefs.map((ref) => {
+        const secretMeta = secretMap.get(ref.secretName);
+        if (!secretMeta) {
+          return null;
+        }
+        return (
+          <StackItem key={ref.secretName}>
+            <SecretKeySection
+              secretRef={ref}
+              allKeys={secretMeta.keys}
+              onKeysChange={(newKeys) => handleKeysChange(ref.secretName, newKeys)}
+            />
+          </StackItem>
+        );
+      })}
+    </Stack>
+  );
+};
+
+export default ExistingSecretKeyPicker;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretKeyPicker.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretKeyPicker.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Alert,
   Badge,
   Button,
   Checkbox,
@@ -7,10 +8,13 @@ import {
   ExpandableSection,
   Flex,
   FlexItem,
+  Icon,
   Stack,
   StackItem,
   TextInput,
+  Tooltip,
 } from '@patternfly/react-core';
+import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { ExistingSecretMetadata, ExistingSecretRef } from '#~/pages/projects/types';
 import './ExistingSecretKeyPicker.scss';
 
@@ -20,25 +24,37 @@ type ExistingSecretKeyPickerProps = {
   selectedRefs: ExistingSecretRef[];
   availableSecrets: ExistingSecretMetadata[];
   onUpdate: (updatedRefs: ExistingSecretRef[]) => void;
+  collidingKeys?: Set<string>;
 };
 
 type SecretKeySectionProps = {
   secretRef: ExistingSecretRef;
   allKeys: string[];
+  isDeleted: boolean;
+  missingKeys: string[];
+  collidingKeys: Set<string>;
   onKeysChange: (selectedKeys: string[]) => void;
+  onRemoveRef: () => void;
+  onRemoveMissingKeys: (keys: string[]) => void;
 };
 
 const SecretKeySection: React.FC<SecretKeySectionProps> = ({
   secretRef,
   allKeys,
+  isDeleted,
+  missingKeys,
+  collidingKeys,
   onKeysChange,
+  onRemoveRef,
+  onRemoveMissingKeys,
 }) => {
-  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [isExpanded, setIsExpanded] = React.useState(isDeleted || missingKeys.length > 0);
   const [filter, setFilter] = React.useState('');
 
   const { selectedKeys } = secretRef;
   const totalKeys = allKeys.length;
-  const allSelected = selectedKeys.length === totalKeys;
+  const allSelected = !isDeleted && selectedKeys.length === totalKeys;
+  const hasMissingKeys = missingKeys.length > 0;
 
   const visibleKeys = React.useMemo(
     () =>
@@ -66,71 +82,176 @@ const SecretKeySection: React.FC<SecretKeySectionProps> = ({
 
   const entryId = secretRef.secretName.replace(/[^a-zA-Z0-9-_]/g, '-');
 
+  const toggleContent = (
+    <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+      <FlexItem>
+        <strong>{secretRef.secretName}</strong>
+      </FlexItem>
+      {isDeleted ? (
+        <FlexItem>
+          <Tooltip content="This secret was not found.">
+            <Icon isInline status="danger" data-testid={`deleted-icon-${secretRef.secretName}`}>
+              <ExclamationCircleIcon />
+            </Icon>
+          </Tooltip>
+        </FlexItem>
+      ) : null}
+      {!isDeleted && hasMissingKeys ? (
+        <FlexItem>
+          <Tooltip content="Missing keys detected">
+            <Icon
+              isInline
+              status="warning"
+              data-testid={`missing-keys-icon-${secretRef.secretName}`}
+            >
+              <ExclamationTriangleIcon />
+            </Icon>
+          </Tooltip>
+        </FlexItem>
+      ) : null}
+      {!isDeleted ? (
+        <FlexItem>
+          <Badge isRead data-testid={`key-count-badge-${secretRef.secretName}`}>
+            {selectedKeys.length} of {totalKeys} keys
+          </Badge>
+        </FlexItem>
+      ) : null}
+    </Flex>
+  );
+
   return (
     <div
       className="odh-existing-secret-key-picker__section pf-v6-u-pl-md pf-v6-u-ml-sm"
       data-testid={`secret-key-section-${secretRef.secretName}`}
     >
       <ExpandableSection
-        toggleContent={
-          <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
-            <FlexItem>
-              <strong>{secretRef.secretName}</strong>
-            </FlexItem>
-            <FlexItem>
-              <Badge isRead data-testid={`key-count-badge-${secretRef.secretName}`}>
-                {selectedKeys.length} of {totalKeys} keys
-              </Badge>
-            </FlexItem>
-          </Flex>
-        }
+        toggleContent={toggleContent}
         isExpanded={isExpanded}
         onToggle={(_event, expanded) => setIsExpanded(expanded)}
         data-testid={`expandable-section-${secretRef.secretName}`}
       >
         <Stack hasGutter>
-          <StackItem>
-            <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
-              <FlexItem>
-                <Button
-                  variant="link"
-                  isInline
-                  onClick={toggleSelectAll}
-                  data-testid={`toggle-select-all-${secretRef.secretName}`}
-                >
-                  {allSelected ? 'Deselect all' : 'Select all'}
-                </Button>
-              </FlexItem>
-              <FlexItem>
-                <Content component="small" className="pf-v6-u-color-200">
-                  {selectedKeys.length} of {totalKeys} keys selected
-                </Content>
-              </FlexItem>
-            </Flex>
-          </StackItem>
-          {totalKeys > FILTER_THRESHOLD ? (
+          {isDeleted ? (
             <StackItem>
-              <TextInput
-                type="search"
-                placeholder="Filter keys"
-                value={filter}
-                onChange={(_event, value) => setFilter(value)}
-                aria-label={`Filter keys for ${secretRef.secretName}`}
-                data-testid={`key-filter-${secretRef.secretName}`}
+              <Alert
+                variant="danger"
+                isInline
+                isPlain
+                title="This secret was not found. This workbench cannot start until the missing secret is restored or removed."
+                actionLinks={
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={onRemoveRef}
+                    data-testid={`remove-deleted-ref-${secretRef.secretName}`}
+                  >
+                    Remove this reference
+                  </Button>
+                }
+                data-testid={`env-deleted-secret-alert-${secretRef.secretName}`}
               />
             </StackItem>
           ) : null}
-          {visibleKeys.map((k) => (
-            <StackItem key={k}>
-              <Checkbox
-                id={`key-${entryId}-${k}`}
-                label={k}
-                isChecked={selectedSet.has(k)}
-                onChange={(_event, checked) => toggleKey(k, checked)}
-                data-testid={`key-checkbox-${secretRef.secretName}-${k}`}
-              />
+          {!isDeleted && hasMissingKeys ? (
+            <StackItem>
+              <Alert
+                variant="warning"
+                isInline
+                isPlain
+                title={`${missingKeys.length} previously selected key${
+                  missingKeys.length > 1 ? 's were' : ' was'
+                } not found in this secret`}
+                actionLinks={
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={() => onRemoveMissingKeys(missingKeys)}
+                    data-testid={`remove-missing-keys-${secretRef.secretName}`}
+                  >
+                    Remove missing keys
+                  </Button>
+                }
+                data-testid={`env-missing-keys-alert-${secretRef.secretName}`}
+              >
+                <p>
+                  Missing: {missingKeys.join(', ')}. These keys may have been renamed or removed.
+                  Remove missing keys to prevent the workbench from failing to start.
+                </p>
+              </Alert>
             </StackItem>
-          ))}
+          ) : null}
+          {!isDeleted ? (
+            <>
+              <StackItem>
+                <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+                  <FlexItem>
+                    <Button
+                      variant="link"
+                      isInline
+                      onClick={toggleSelectAll}
+                      data-testid={`toggle-select-all-${secretRef.secretName}`}
+                    >
+                      {allSelected ? 'Deselect all' : 'Select all'}
+                    </Button>
+                  </FlexItem>
+                  <FlexItem>
+                    <Content component="small" className="pf-v6-u-color-200">
+                      {selectedKeys.length} of {totalKeys} keys selected
+                    </Content>
+                  </FlexItem>
+                </Flex>
+              </StackItem>
+              {totalKeys > FILTER_THRESHOLD ? (
+                <StackItem>
+                  <TextInput
+                    type="search"
+                    placeholder="Filter keys"
+                    value={filter}
+                    onChange={(_event, value) => setFilter(value)}
+                    aria-label={`Filter keys for ${secretRef.secretName}`}
+                    data-testid={`key-filter-${secretRef.secretName}`}
+                  />
+                </StackItem>
+              ) : null}
+              {visibleKeys.map((k) => {
+                const isColliding = collidingKeys.has(k);
+                return (
+                  <StackItem key={k}>
+                    <Checkbox
+                      id={`key-${entryId}-${k}`}
+                      label={
+                        isColliding ? (
+                          <Flex
+                            gap={{ default: 'gapSm' }}
+                            alignItems={{ default: 'alignItemsCenter' }}
+                            display={{ default: 'inlineFlex' }}
+                          >
+                            <FlexItem>{k}</FlexItem>
+                            <FlexItem>
+                              <Tooltip content="This key is defined in multiple secrets">
+                                <Icon
+                                  isInline
+                                  status="warning"
+                                  data-testid={`collision-icon-${secretRef.secretName}-${k}`}
+                                >
+                                  <ExclamationTriangleIcon />
+                                </Icon>
+                              </Tooltip>
+                            </FlexItem>
+                          </Flex>
+                        ) : (
+                          k
+                        )
+                      }
+                      isChecked={selectedSet.has(k)}
+                      onChange={(_event, checked) => toggleKey(k, checked)}
+                      data-testid={`key-checkbox-${secretRef.secretName}-${k}`}
+                    />
+                  </StackItem>
+                );
+              })}
+            </>
+          ) : null}
         </Stack>
       </ExpandableSection>
     </div>
@@ -141,6 +262,7 @@ const ExistingSecretKeyPicker: React.FC<ExistingSecretKeyPickerProps> = ({
   selectedRefs,
   availableSecrets,
   onUpdate,
+  collidingKeys = new Set<string>(),
 }) => {
   const secretMap = React.useMemo(() => {
     const map = new Map<string, ExistingSecretMetadata>();
@@ -159,19 +281,49 @@ const ExistingSecretKeyPicker: React.FC<ExistingSecretKeyPickerProps> = ({
     [selectedRefs, onUpdate],
   );
 
+  const handleRemoveRef = React.useCallback(
+    (secretName: string) => {
+      onUpdate(selectedRefs.filter((ref) => ref.secretName !== secretName));
+    },
+    [selectedRefs, onUpdate],
+  );
+
+  const handleRemoveMissingKeys = React.useCallback(
+    (secretName: string, missingKeysList: string[]) => {
+      const missingSet = new Set(missingKeysList);
+      onUpdate(
+        selectedRefs.map((ref) =>
+          ref.secretName === secretName
+            ? { ...ref, selectedKeys: ref.selectedKeys.filter((k) => !missingSet.has(k)) }
+            : ref,
+        ),
+      );
+    },
+    [selectedRefs, onUpdate],
+  );
+
   return (
     <Stack hasGutter data-testid="existing-secret-key-picker">
       {selectedRefs.map((ref) => {
         const secretMeta = secretMap.get(ref.secretName);
-        if (!secretMeta) {
-          return null;
-        }
+        const isDeleted = !secretMeta;
+        const allKeys = secretMeta?.keys ?? [];
+
+        // Detect missing keys: keys in selectedKeys that are not in the secret's actual keys
+        const actualKeySet = new Set(allKeys);
+        const missingKeys = ref.selectedKeys.filter((k) => !actualKeySet.has(k));
+
         return (
           <StackItem key={ref.secretName}>
             <SecretKeySection
               secretRef={ref}
-              allKeys={secretMeta.keys}
+              allKeys={allKeys}
+              isDeleted={isDeleted}
+              missingKeys={missingKeys}
+              collidingKeys={collidingKeys}
               onKeysChange={(newKeys) => handleKeysChange(ref.secretName, newKeys)}
+              onRemoveRef={() => handleRemoveRef(ref.secretName)}
+              onRemoveMissingKeys={(keys) => handleRemoveMissingKeys(ref.secretName, keys)}
             />
           </StackItem>
         );

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ExistingSecretRef, ExistingSecretMetadata } from '#~/pages/projects/types';
-import EnvExistingSecretField from '#~/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField';
-import { useExistingSecrets } from '#~/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+import EnvExistingSecretField from '#~/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField';
+import { useExistingSecrets } from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
 
 jest.mock('../useExistingSecrets');
 

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
@@ -236,8 +236,9 @@ describe('EnvExistingSecretField', () => {
         expect(screen.getByTestId('env-existing-secret-option-db-credentials')).toBeInTheDocument();
       });
 
-      // Click the option text to deselect
-      await user.click(screen.getByText('db-credentials'));
+      // Click the option in the dropdown to deselect
+      const option = screen.getByTestId('env-existing-secret-option-db-credentials');
+      await user.click(within(option).getByText('db-credentials'));
 
       expect(onUpdate).toHaveBeenCalledWith([]);
     });
@@ -335,6 +336,110 @@ describe('EnvExistingSecretField', () => {
       );
 
       expect(mockUseExistingSecrets).toHaveBeenCalledWith('my-project');
+    });
+  });
+
+  describe('collision warning', () => {
+    beforeEach(() => {
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: mockSecrets,
+        loaded: true,
+        canList: true,
+      });
+    });
+
+    it('should not show collision warning when no collisions exist', () => {
+      const existingRefs: ExistingSecretRef[] = [
+        { secretName: 'db-credentials', selectedKeys: ['username'] },
+        { secretName: 'api-key-secret', selectedKeys: ['api-key'] },
+      ];
+
+      render(
+        <EnvExistingSecretField
+          namespace="test-ns"
+          existingSecretRefs={existingRefs}
+          onUpdate={jest.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('env-collision-warning')).not.toBeInTheDocument();
+    });
+
+    it('should show singular collision warning for one key collision', () => {
+      const collidingSecrets: ExistingSecretMetadata[] = [
+        { name: 'secret-a', keys: ['SHARED_KEY', 'key-a'] },
+        { name: 'secret-b', keys: ['SHARED_KEY', 'key-b'] },
+      ];
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: collidingSecrets,
+        loaded: true,
+        canList: true,
+      });
+      const existingRefs: ExistingSecretRef[] = [
+        { secretName: 'secret-a', selectedKeys: ['SHARED_KEY', 'key-a'] },
+        { secretName: 'secret-b', selectedKeys: ['SHARED_KEY', 'key-b'] },
+      ];
+
+      render(
+        <EnvExistingSecretField
+          namespace="test-ns"
+          existingSecretRefs={existingRefs}
+          onUpdate={jest.fn()}
+        />,
+      );
+
+      const alert = screen.getByTestId('env-collision-warning');
+      expect(alert).toBeInTheDocument();
+      expect(alert).toHaveTextContent('SHARED_KEY is defined in both secret-a and secret-b.');
+      expect(alert).toHaveTextContent(
+        'Choose one and deselect the duplicate key to resolve the collision.',
+      );
+    });
+
+    it('should show plural collision warning for multiple key collisions', () => {
+      const collidingSecrets: ExistingSecretMetadata[] = [
+        { name: 'secret-a', keys: ['KEY_1', 'KEY_2', 'unique-a'] },
+        { name: 'secret-b', keys: ['KEY_1', 'KEY_2', 'unique-b'] },
+      ];
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: collidingSecrets,
+        loaded: true,
+        canList: true,
+      });
+      const existingRefs: ExistingSecretRef[] = [
+        { secretName: 'secret-a', selectedKeys: ['KEY_1', 'KEY_2', 'unique-a'] },
+        { secretName: 'secret-b', selectedKeys: ['KEY_1', 'KEY_2', 'unique-b'] },
+      ];
+
+      render(
+        <EnvExistingSecretField
+          namespace="test-ns"
+          existingSecretRefs={existingRefs}
+          onUpdate={jest.fn()}
+        />,
+      );
+
+      const alert = screen.getByTestId('env-collision-warning');
+      expect(alert).toBeInTheDocument();
+      expect(alert).toHaveTextContent('Key name collisions across attached secrets');
+      expect(alert).toHaveTextContent('KEY_1 is defined in both secret-a and secret-b.');
+      expect(alert).toHaveTextContent('KEY_2 is defined in both secret-a and secret-b.');
+    });
+
+    it('should not show collision warning when only one secret is selected', () => {
+      const existingRefs: ExistingSecretRef[] = [
+        { secretName: 'db-credentials', selectedKeys: ['username', 'password', 'host'] },
+      ];
+
+      render(
+        <EnvExistingSecretField
+          namespace="test-ns"
+          existingSecretRefs={existingRefs}
+          onUpdate={jest.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('env-collision-warning')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
@@ -1,0 +1,340 @@
+import * as React from 'react';
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ExistingSecretRef, ExistingSecretMetadata } from '#~/pages/projects/types';
+import EnvExistingSecretField from '#~/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField';
+import { useExistingSecrets } from '#~/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+
+jest.mock('../useExistingSecrets');
+
+const mockUseExistingSecrets = jest.mocked(useExistingSecrets);
+
+const mockSecrets: ExistingSecretMetadata[] = [
+  { name: 'db-credentials', keys: ['username', 'password', 'host'] },
+  { name: 'api-key-secret', keys: ['api-key'] },
+  { name: 'tls-cert', keys: ['cert', 'key'] },
+];
+
+describe('EnvExistingSecretField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('loading state', () => {
+    it('should show loading spinner when secrets are not loaded', () => {
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: [],
+        loaded: false,
+        canList: true,
+      });
+
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      expect(screen.getByTestId('env-existing-secret-loading')).toBeInTheDocument();
+    });
+  });
+
+  describe('RBAC disabled state', () => {
+    it('should show RBAC message when user cannot list secrets', () => {
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: [],
+        loaded: true,
+        canList: false,
+      });
+
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      expect(screen.getByTestId('env-existing-secret-rbac-message')).toBeInTheDocument();
+      expect(screen.getByTestId('env-existing-secret-rbac-message')).toHaveTextContent(
+        'You do not have permission to list secrets in this project.',
+      );
+    });
+
+    it('should show RBAC popover trigger', () => {
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: [],
+        loaded: true,
+        canList: false,
+      });
+
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      expect(screen.getByTestId('env-existing-secret-rbac-popover')).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('should show error message when loading fails', () => {
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: [],
+        loaded: true,
+        canList: true,
+        error: new Error('Network error'),
+      });
+
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      expect(screen.getByTestId('env-existing-secret-error')).toBeInTheDocument();
+      expect(screen.getByTestId('env-existing-secret-error')).toHaveTextContent(
+        'Unable to load secrets: Network error',
+      );
+    });
+  });
+
+  describe('empty state', () => {
+    it('should show empty message when no secrets exist', () => {
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: [],
+        loaded: true,
+        canList: true,
+      });
+
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      expect(screen.getByTestId('env-existing-secret-empty-message')).toBeInTheDocument();
+      expect(screen.getByTestId('env-existing-secret-empty-message')).toHaveTextContent(
+        'No third-party secrets available in this project.',
+      );
+    });
+
+    it('should show empty state popover trigger', () => {
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: [],
+        loaded: true,
+        canList: true,
+      });
+
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      expect(screen.getByTestId('env-existing-secret-empty-popover')).toBeInTheDocument();
+    });
+  });
+
+  describe('with available secrets', () => {
+    beforeEach(() => {
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: mockSecrets,
+        loaded: true,
+        canList: true,
+      });
+    });
+
+    it('should render description text', () => {
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      expect(screen.getByTestId('env-existing-secret-description')).toHaveTextContent(
+        'Attach an available secret from this project',
+      );
+    });
+
+    it('should render the dropdown toggle', () => {
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      expect(screen.getByTestId('env-existing-secret-toggle')).toBeInTheDocument();
+    });
+
+    it('should show search input with placeholder', () => {
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      expect(screen.getByTestId('env-existing-secret-search')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Search secrets')).toBeInTheDocument();
+    });
+
+    it('should show secret options when dropdown is opened', async () => {
+      const user = userEvent.setup();
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      await user.click(screen.getByTestId('env-existing-secret-search'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('env-existing-secret-option-db-credentials')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('env-existing-secret-option-api-key-secret')).toBeInTheDocument();
+      expect(screen.getByTestId('env-existing-secret-option-tls-cert')).toBeInTheDocument();
+    });
+
+    it('should display key count and preview in option descriptions', async () => {
+      const user = userEvent.setup();
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      await user.click(screen.getByTestId('env-existing-secret-search'));
+
+      await waitFor(() => {
+        expect(screen.getByText('3 keys: username, password, host')).toBeInTheDocument();
+      });
+      expect(screen.getByText('1 key: api-key')).toBeInTheDocument();
+      expect(screen.getByText('2 keys: cert, key')).toBeInTheDocument();
+    });
+
+    it('should call onUpdate when a secret is selected', async () => {
+      const user = userEvent.setup();
+      const onUpdate = jest.fn();
+
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={onUpdate} />,
+      );
+
+      // Open dropdown
+      await user.click(screen.getByTestId('env-existing-secret-search'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('env-existing-secret-option-db-credentials')).toBeInTheDocument();
+      });
+
+      // Click the option text to trigger PF Select's onSelect
+      await user.click(screen.getByText('db-credentials'));
+
+      expect(onUpdate).toHaveBeenCalledWith([
+        {
+          secretName: 'db-credentials',
+          selectedKeys: ['username', 'password', 'host'],
+        },
+      ]);
+    });
+
+    it('should call onUpdate to remove a secret when it is deselected', async () => {
+      const user = userEvent.setup();
+      const existingRefs: ExistingSecretRef[] = [
+        { secretName: 'db-credentials', selectedKeys: ['username', 'password', 'host'] },
+      ];
+      const onUpdate = jest.fn();
+
+      render(
+        <EnvExistingSecretField
+          namespace="test-ns"
+          existingSecretRefs={existingRefs}
+          onUpdate={onUpdate}
+        />,
+      );
+
+      // Open dropdown
+      await user.click(screen.getByTestId('env-existing-secret-search'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('env-existing-secret-option-db-credentials')).toBeInTheDocument();
+      });
+
+      // Click the option text to deselect
+      await user.click(screen.getByText('db-credentials'));
+
+      expect(onUpdate).toHaveBeenCalledWith([]);
+    });
+
+    it('should show "N selected" badge when secrets are chosen', () => {
+      const existingRefs: ExistingSecretRef[] = [
+        { secretName: 'db-credentials', selectedKeys: ['username', 'password', 'host'] },
+        { secretName: 'api-key-secret', selectedKeys: ['api-key'] },
+      ];
+
+      render(
+        <EnvExistingSecretField
+          namespace="test-ns"
+          existingSecretRefs={existingRefs}
+          onUpdate={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('env-existing-secret-badge')).toHaveTextContent('2 selected');
+    });
+
+    it('should not show badge when no secrets are selected', () => {
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      expect(screen.queryByTestId('env-existing-secret-badge')).not.toBeInTheDocument();
+    });
+
+    it('should filter secrets by search text', async () => {
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      // Target the actual input element inside the TextInputGroupMain
+      const inputEl = screen.getByRole('combobox');
+      fireEvent.change(inputEl, { target: { value: 'db' } });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('env-existing-secret-option-db-credentials')).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByTestId('env-existing-secret-option-api-key-secret'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('env-existing-secret-option-tls-cert')).not.toBeInTheDocument();
+    });
+
+    it('should show no results when search matches nothing', async () => {
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      const inputEl = screen.getByRole('combobox');
+      fireEvent.change(inputEl, { target: { value: 'nonexistent' } });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('env-existing-secret-no-results')).toBeInTheDocument();
+      });
+    });
+
+    it('should never display secret values in the DOM', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <EnvExistingSecretField namespace="test-ns" existingSecretRefs={[]} onUpdate={jest.fn()} />,
+      );
+
+      await user.click(screen.getByTestId('env-existing-secret-search'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('env-existing-secret-option-db-credentials')).toBeInTheDocument();
+      });
+
+      // The component renders only secret names and key names, never actual values
+      const listEl = screen.getByTestId('env-existing-secret-list');
+      expect(within(listEl).getByText('db-credentials')).toBeInTheDocument();
+      expect(within(listEl).getByText(/username/)).toBeInTheDocument();
+    });
+  });
+
+  describe('namespace propagation', () => {
+    it('should call useExistingSecrets with the provided namespace', () => {
+      mockUseExistingSecrets.mockReturnValue({
+        secrets: [],
+        loaded: true,
+        canList: true,
+      });
+
+      render(
+        <EnvExistingSecretField
+          namespace="my-project"
+          existingSecretRefs={[]}
+          onUpdate={jest.fn()}
+        />,
+      );
+
+      expect(mockUseExistingSecrets).toHaveBeenCalledWith('my-project');
+    });
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretKeyPicker.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretKeyPicker.spec.tsx
@@ -1,0 +1,265 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExistingSecretMetadata, ExistingSecretRef } from '#~/pages/projects/types';
+import ExistingSecretKeyPicker from '#~/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretKeyPicker';
+
+describe('ExistingSecretKeyPicker', () => {
+  const availableSecrets: ExistingSecretMetadata[] = [
+    { name: 'db-secret', keys: ['username', 'password', 'host'] },
+    { name: 'api-secret', keys: ['api-key', 'api-url'] },
+  ];
+
+  const expandSection = (secretName: string) => {
+    const section = screen.getByTestId(`expandable-section-${secretName}`);
+    const button = section.querySelector('button');
+    if (button) {
+      fireEvent.click(button);
+    }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render expandable sections for each selected secret', () => {
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+      { secretName: 'api-secret', selectedKeys: ['api-key', 'api-url'] },
+    ];
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={availableSecrets}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expect(screen.getByTestId('secret-key-section-db-secret')).toBeInTheDocument();
+    expect(screen.getByTestId('secret-key-section-api-secret')).toBeInTheDocument();
+  });
+
+  it('should show correct "N of M keys" badge', () => {
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'db-secret', selectedKeys: ['username'] },
+    ];
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={availableSecrets}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expect(screen.getByTestId('key-count-badge-db-secret')).toHaveTextContent('1 of 3 keys');
+  });
+
+  it('should show all keys badge when all are selected', () => {
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+    ];
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={availableSecrets}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expect(screen.getByTestId('key-count-badge-db-secret')).toHaveTextContent('3 of 3 keys');
+  });
+
+  it('should toggle select all to deselect all when all keys are selected', () => {
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+    ];
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={availableSecrets}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expandSection('db-secret');
+    fireEvent.click(screen.getByTestId('toggle-select-all-db-secret'));
+
+    expect(onUpdate).toHaveBeenCalledWith([{ secretName: 'db-secret', selectedKeys: [] }]);
+  });
+
+  it('should toggle select all to select all when not all keys are selected', () => {
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'db-secret', selectedKeys: ['username'] },
+    ];
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={availableSecrets}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expandSection('db-secret');
+    fireEvent.click(screen.getByTestId('toggle-select-all-db-secret'));
+
+    expect(onUpdate).toHaveBeenCalledWith([
+      { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+    ]);
+  });
+
+  it('should toggle individual key selection', () => {
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'db-secret', selectedKeys: ['username'] },
+    ];
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={availableSecrets}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expandSection('db-secret');
+    fireEvent.click(screen.getByTestId('key-checkbox-db-secret-password'));
+
+    expect(onUpdate).toHaveBeenCalledWith([
+      { secretName: 'db-secret', selectedKeys: ['username', 'password'] },
+    ]);
+  });
+
+  it('should uncheck an individual key', () => {
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'db-secret', selectedKeys: ['username', 'password'] },
+    ];
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={availableSecrets}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expandSection('db-secret');
+    fireEvent.click(screen.getByTestId('key-checkbox-db-secret-username'));
+
+    expect(onUpdate).toHaveBeenCalledWith([
+      { secretName: 'db-secret', selectedKeys: ['password'] },
+    ]);
+  });
+
+  it('should not show filter input when secret has 10 or fewer keys', () => {
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+    ];
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={availableSecrets}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expandSection('db-secret');
+
+    expect(screen.queryByTestId('key-filter-db-secret')).not.toBeInTheDocument();
+  });
+
+  it('should show filter input when secret has more than 10 keys', () => {
+    const manyKeys = Array.from({ length: 12 }, (_, i) => `key-${i}`);
+    const largeSecret: ExistingSecretMetadata[] = [{ name: 'large-secret', keys: manyKeys }];
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'large-secret', selectedKeys: manyKeys },
+    ];
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={largeSecret}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expandSection('large-secret');
+
+    expect(screen.getByTestId('key-filter-large-secret')).toBeInTheDocument();
+  });
+
+  it('should filter visible keys when filter is typed', () => {
+    const manyKeys = Array.from({ length: 12 }, (_, i) => `key-${i}`);
+    const largeSecret: ExistingSecretMetadata[] = [{ name: 'large-secret', keys: manyKeys }];
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'large-secret', selectedKeys: manyKeys },
+    ];
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={largeSecret}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expandSection('large-secret');
+
+    const filterInput = screen.getByTestId('key-filter-large-secret');
+    fireEvent.change(filterInput, { target: { value: 'key-1' } });
+
+    // Should show key-1, key-10, key-11 (matching 'key-1')
+    expect(screen.getByTestId('key-checkbox-large-secret-key-1')).toBeInTheDocument();
+    expect(screen.getByTestId('key-checkbox-large-secret-key-10')).toBeInTheDocument();
+    expect(screen.getByTestId('key-checkbox-large-secret-key-11')).toBeInTheDocument();
+    // key-2 should not be visible
+    expect(screen.queryByTestId('key-checkbox-large-secret-key-2')).not.toBeInTheDocument();
+  });
+
+  it('should not render anything for a secret not in availableSecrets', () => {
+    const selectedRefs: ExistingSecretRef[] = [
+      { secretName: 'nonexistent-secret', selectedKeys: [] },
+    ];
+    const onUpdate = jest.fn();
+
+    const { container } = render(
+      <ExistingSecretKeyPicker
+        selectedRefs={selectedRefs}
+        availableSecrets={availableSecrets}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-testid="secret-key-section-nonexistent-secret"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render nothing when no selectedRefs', () => {
+    const onUpdate = jest.fn();
+
+    render(
+      <ExistingSecretKeyPicker
+        selectedRefs={[]}
+        availableSecrets={availableSecrets}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    expect(screen.queryByTestId('secret-key-section-db-secret')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('secret-key-section-api-secret')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretKeyPicker.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretKeyPicker.spec.tsx
@@ -229,13 +229,13 @@ describe('ExistingSecretKeyPicker', () => {
     expect(screen.queryByTestId('key-checkbox-large-secret-key-2')).not.toBeInTheDocument();
   });
 
-  it('should not render anything for a secret not in availableSecrets', () => {
+  it('should show deleted secret alert for a secret not in availableSecrets', () => {
     const selectedRefs: ExistingSecretRef[] = [
       { secretName: 'nonexistent-secret', selectedKeys: [] },
     ];
     const onUpdate = jest.fn();
 
-    const { container } = render(
+    render(
       <ExistingSecretKeyPicker
         selectedRefs={selectedRefs}
         availableSecrets={availableSecrets}
@@ -243,9 +243,8 @@ describe('ExistingSecretKeyPicker', () => {
       />,
     );
 
-    expect(
-      container.querySelector('[data-testid="secret-key-section-nonexistent-secret"]'),
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('secret-key-section-nonexistent-secret')).toBeInTheDocument();
+    expect(screen.getByTestId('env-deleted-secret-alert-nonexistent-secret')).toBeInTheDocument();
   });
 
   it('should render nothing when no selectedRefs', () => {
@@ -261,5 +260,218 @@ describe('ExistingSecretKeyPicker', () => {
 
     expect(screen.queryByTestId('secret-key-section-db-secret')).not.toBeInTheDocument();
     expect(screen.queryByTestId('secret-key-section-api-secret')).not.toBeInTheDocument();
+  });
+
+  describe('deleted secret detection', () => {
+    it('should show danger alert when a referenced secret is not in availableSecrets', () => {
+      const selectedRefs: ExistingSecretRef[] = [
+        { secretName: 'deleted-secret', selectedKeys: ['old-key'] },
+      ];
+      const onUpdate = jest.fn();
+
+      render(
+        <ExistingSecretKeyPicker
+          selectedRefs={selectedRefs}
+          availableSecrets={availableSecrets}
+          onUpdate={onUpdate}
+        />,
+      );
+
+      expect(screen.getByTestId('secret-key-section-deleted-secret')).toBeInTheDocument();
+      expect(screen.getByTestId('env-deleted-secret-alert-deleted-secret')).toBeInTheDocument();
+      expect(screen.getByTestId('deleted-icon-deleted-secret')).toBeInTheDocument();
+    });
+
+    it('should not show key count badge for deleted secret', () => {
+      const selectedRefs: ExistingSecretRef[] = [
+        { secretName: 'deleted-secret', selectedKeys: ['old-key'] },
+      ];
+      const onUpdate = jest.fn();
+
+      render(
+        <ExistingSecretKeyPicker
+          selectedRefs={selectedRefs}
+          availableSecrets={availableSecrets}
+          onUpdate={onUpdate}
+        />,
+      );
+
+      expect(screen.queryByTestId('key-count-badge-deleted-secret')).not.toBeInTheDocument();
+    });
+
+    it('should remove the deleted ref when "Remove this reference" is clicked', () => {
+      const selectedRefs: ExistingSecretRef[] = [
+        { secretName: 'deleted-secret', selectedKeys: ['old-key'] },
+        { secretName: 'db-secret', selectedKeys: ['username'] },
+      ];
+      const onUpdate = jest.fn();
+
+      render(
+        <ExistingSecretKeyPicker
+          selectedRefs={selectedRefs}
+          availableSecrets={availableSecrets}
+          onUpdate={onUpdate}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('remove-deleted-ref-deleted-secret'));
+
+      expect(onUpdate).toHaveBeenCalledWith([
+        { secretName: 'db-secret', selectedKeys: ['username'] },
+      ]);
+    });
+  });
+
+  describe('missing keys detection', () => {
+    it('should show warning alert when selected keys are not in the secret', () => {
+      const secretsWithFewerKeys: ExistingSecretMetadata[] = [
+        { name: 'db-secret', keys: ['username', 'host'] },
+      ];
+      const selectedRefs: ExistingSecretRef[] = [
+        { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+      ];
+      const onUpdate = jest.fn();
+
+      render(
+        <ExistingSecretKeyPicker
+          selectedRefs={selectedRefs}
+          availableSecrets={secretsWithFewerKeys}
+          onUpdate={onUpdate}
+        />,
+      );
+
+      expect(screen.getByTestId('env-missing-keys-alert-db-secret')).toBeInTheDocument();
+      expect(screen.getByTestId('missing-keys-icon-db-secret')).toBeInTheDocument();
+    });
+
+    it('should show singular message for one missing key', () => {
+      const secretsWithFewerKeys: ExistingSecretMetadata[] = [
+        { name: 'db-secret', keys: ['username', 'host'] },
+      ];
+      const selectedRefs: ExistingSecretRef[] = [
+        { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+      ];
+      const onUpdate = jest.fn();
+
+      render(
+        <ExistingSecretKeyPicker
+          selectedRefs={selectedRefs}
+          availableSecrets={secretsWithFewerKeys}
+          onUpdate={onUpdate}
+        />,
+      );
+
+      const alert = screen.getByTestId('env-missing-keys-alert-db-secret');
+      expect(alert).toHaveTextContent('1 previously selected key was not found in this secret');
+      expect(alert).toHaveTextContent('Missing: password');
+    });
+
+    it('should show plural message for multiple missing keys', () => {
+      const secretsWithFewerKeys: ExistingSecretMetadata[] = [
+        { name: 'db-secret', keys: ['host'] },
+      ];
+      const selectedRefs: ExistingSecretRef[] = [
+        { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+      ];
+      const onUpdate = jest.fn();
+
+      render(
+        <ExistingSecretKeyPicker
+          selectedRefs={selectedRefs}
+          availableSecrets={secretsWithFewerKeys}
+          onUpdate={onUpdate}
+        />,
+      );
+
+      const alert = screen.getByTestId('env-missing-keys-alert-db-secret');
+      expect(alert).toHaveTextContent('2 previously selected keys were not found in this secret');
+      expect(alert).toHaveTextContent('Missing: username, password');
+    });
+
+    it('should remove missing keys when "Remove missing keys" is clicked', () => {
+      const secretsWithFewerKeys: ExistingSecretMetadata[] = [
+        { name: 'db-secret', keys: ['username', 'host'] },
+      ];
+      const selectedRefs: ExistingSecretRef[] = [
+        { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+      ];
+      const onUpdate = jest.fn();
+
+      render(
+        <ExistingSecretKeyPicker
+          selectedRefs={selectedRefs}
+          availableSecrets={secretsWithFewerKeys}
+          onUpdate={onUpdate}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('remove-missing-keys-db-secret'));
+
+      expect(onUpdate).toHaveBeenCalledWith([
+        { secretName: 'db-secret', selectedKeys: ['username', 'host'] },
+      ]);
+    });
+
+    it('should not show missing keys warning when all selected keys exist', () => {
+      const selectedRefs: ExistingSecretRef[] = [
+        { secretName: 'db-secret', selectedKeys: ['username', 'password'] },
+      ];
+      const onUpdate = jest.fn();
+
+      render(
+        <ExistingSecretKeyPicker
+          selectedRefs={selectedRefs}
+          availableSecrets={availableSecrets}
+          onUpdate={onUpdate}
+        />,
+      );
+
+      expect(screen.queryByTestId('env-missing-keys-alert-db-secret')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('missing-keys-icon-db-secret')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('collision icons', () => {
+    it('should show collision warning icon on colliding keys', () => {
+      const selectedRefs: ExistingSecretRef[] = [
+        { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+      ];
+      const onUpdate = jest.fn();
+      const collidingKeys = new Set(['username']);
+
+      render(
+        <ExistingSecretKeyPicker
+          selectedRefs={selectedRefs}
+          availableSecrets={availableSecrets}
+          onUpdate={onUpdate}
+          collidingKeys={collidingKeys}
+        />,
+      );
+
+      expandSection('db-secret');
+
+      expect(screen.getByTestId('collision-icon-db-secret-username')).toBeInTheDocument();
+      expect(screen.queryByTestId('collision-icon-db-secret-password')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('collision-icon-db-secret-host')).not.toBeInTheDocument();
+    });
+
+    it('should not show collision icons when collidingKeys is not provided', () => {
+      const selectedRefs: ExistingSecretRef[] = [
+        { secretName: 'db-secret', selectedKeys: ['username', 'password', 'host'] },
+      ];
+      const onUpdate = jest.fn();
+
+      render(
+        <ExistingSecretKeyPicker
+          selectedRefs={selectedRefs}
+          availableSecrets={availableSecrets}
+          onUpdate={onUpdate}
+        />,
+      );
+
+      expandSection('db-secret');
+
+      expect(screen.queryByTestId('collision-icon-db-secret-username')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretKeyPicker.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretKeyPicker.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ExistingSecretMetadata, ExistingSecretRef } from '#~/pages/projects/types';
-import ExistingSecretKeyPicker from '#~/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretKeyPicker';
+import ExistingSecretKeyPicker from '#~/pages/projects/screens/spawner/environmentVariables/ExistingSecretKeyPicker';
 
 describe('ExistingSecretKeyPicker', () => {
   const availableSecrets: ExistingSecretMetadata[] = [

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretCollisions.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretCollisions.spec.ts
@@ -1,0 +1,85 @@
+import { ExistingSecretRef } from '#~/pages/projects/types';
+import {
+  detectExistingSecretKeyCollisions,
+  getCollidingKeySet,
+} from '#~/src/pages/projects/screens/spawner/environmentVariables/existingSecretCollisions';
+
+describe('detectExistingSecretKeyCollisions', () => {
+  it('should return empty array when no refs are provided', () => {
+    expect(detectExistingSecretKeyCollisions([])).toEqual([]);
+  });
+
+  it('should return empty array when a single secret is selected', () => {
+    const refs: ExistingSecretRef[] = [{ secretName: 'secret-a', selectedKeys: ['key1', 'key2'] }];
+    expect(detectExistingSecretKeyCollisions(refs)).toEqual([]);
+  });
+
+  it('should return empty array when no keys overlap across secrets', () => {
+    const refs: ExistingSecretRef[] = [
+      { secretName: 'secret-a', selectedKeys: ['key1', 'key2'] },
+      { secretName: 'secret-b', selectedKeys: ['key3', 'key4'] },
+    ];
+    expect(detectExistingSecretKeyCollisions(refs)).toEqual([]);
+  });
+
+  it('should detect a single collision between two secrets', () => {
+    const refs: ExistingSecretRef[] = [
+      { secretName: 'aws-training-creds', selectedKeys: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET'] },
+      { secretName: 's3-readonly', selectedKeys: ['AWS_ACCESS_KEY_ID', 'BUCKET_NAME'] },
+    ];
+    const collisions = detectExistingSecretKeyCollisions(refs);
+    expect(collisions).toEqual([
+      { key: 'AWS_ACCESS_KEY_ID', sources: ['aws-training-creds', 's3-readonly'] },
+    ]);
+  });
+
+  it('should detect multiple collisions across secrets', () => {
+    const refs: ExistingSecretRef[] = [
+      { secretName: 'secret-a', selectedKeys: ['DB_HOST', 'DB_PORT', 'DB_USER'] },
+      { secretName: 'secret-b', selectedKeys: ['DB_HOST', 'DB_USER', 'DB_NAME'] },
+    ];
+    const collisions = detectExistingSecretKeyCollisions(refs);
+    expect(collisions).toHaveLength(2);
+    expect(collisions).toEqual(
+      expect.arrayContaining([
+        { key: 'DB_HOST', sources: ['secret-a', 'secret-b'] },
+        { key: 'DB_USER', sources: ['secret-a', 'secret-b'] },
+      ]),
+    );
+  });
+
+  it('should detect collisions across three secrets', () => {
+    const refs: ExistingSecretRef[] = [
+      { secretName: 'secret-a', selectedKeys: ['SHARED_KEY'] },
+      { secretName: 'secret-b', selectedKeys: ['SHARED_KEY'] },
+      { secretName: 'secret-c', selectedKeys: ['SHARED_KEY'] },
+    ];
+    const collisions = detectExistingSecretKeyCollisions(refs);
+    expect(collisions).toEqual([
+      { key: 'SHARED_KEY', sources: ['secret-a', 'secret-b', 'secret-c'] },
+    ]);
+  });
+
+  it('should return empty array when secrets have no selected keys', () => {
+    const refs: ExistingSecretRef[] = [
+      { secretName: 'secret-a', selectedKeys: [] },
+      { secretName: 'secret-b', selectedKeys: [] },
+    ];
+    expect(detectExistingSecretKeyCollisions(refs)).toEqual([]);
+  });
+});
+
+describe('getCollidingKeySet', () => {
+  it('should return empty set when no collisions', () => {
+    expect(getCollidingKeySet([])).toEqual(new Set());
+  });
+
+  it('should return set of colliding key names', () => {
+    const collisions = [
+      { key: 'DB_HOST', sources: ['secret-a', 'secret-b'] },
+      { key: 'DB_USER', sources: ['secret-a', 'secret-b'] },
+    ];
+    const result = getCollidingKeySet(collisions);
+    expect(result).toEqual(new Set(['DB_HOST', 'DB_USER']));
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretCollisions.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretCollisions.spec.ts
@@ -2,7 +2,7 @@ import { ExistingSecretRef } from '#~/pages/projects/types';
 import {
   detectExistingSecretKeyCollisions,
   getCollidingKeySet,
-} from '#~/src/pages/projects/screens/spawner/environmentVariables/existingSecretCollisions';
+} from '#~/pages/projects/screens/spawner/environmentVariables/existingSecretCollisions';
 
 describe('detectExistingSecretKeyCollisions', () => {
   it('should return empty array when no refs are provided', () => {

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/getSecretKeyRefEnvVars.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/getSecretKeyRefEnvVars.spec.ts
@@ -1,0 +1,117 @@
+import { EnvVariable, EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+import { getSecretKeyRefEnvVars } from '#~/src/pages/projects/screens/spawner/service';
+
+describe('getSecretKeyRefEnvVars', () => {
+  it('should return empty array for empty input', () => {
+    expect(getSecretKeyRefEnvVars([])).toEqual([]);
+  });
+
+  it('should return empty array when no EXISTING category vars', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.GENERIC, data: [{ key: 'foo', value: 'bar' }] },
+      },
+    ];
+    expect(getSecretKeyRefEnvVars(envVars)).toEqual([]);
+  });
+
+  it('should generate secretKeyRef entries from existing secret refs', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [{ secretName: 'my-secret', selectedKeys: ['username', 'password'] }],
+      },
+    ];
+
+    const result = getSecretKeyRefEnvVars(envVars);
+
+    expect(result).toEqual([
+      {
+        name: 'username',
+        valueFrom: { secretKeyRef: { name: 'my-secret', key: 'username' } },
+      },
+      {
+        name: 'password',
+        valueFrom: { secretKeyRef: { name: 'my-secret', key: 'password' } },
+      },
+    ]);
+  });
+
+  it('should handle multiple secrets with multiple keys', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [
+          { secretName: 'db-secret', selectedKeys: ['host', 'port'] },
+          { secretName: 'api-secret', selectedKeys: ['api-key'] },
+        ],
+      },
+    ];
+
+    const result = getSecretKeyRefEnvVars(envVars);
+
+    expect(result).toEqual([
+      {
+        name: 'host',
+        valueFrom: { secretKeyRef: { name: 'db-secret', key: 'host' } },
+      },
+      {
+        name: 'port',
+        valueFrom: { secretKeyRef: { name: 'db-secret', key: 'port' } },
+      },
+      {
+        name: 'api-key',
+        valueFrom: { secretKeyRef: { name: 'api-secret', key: 'api-key' } },
+      },
+    ]);
+  });
+
+  it('should handle EXISTING category with no existingSecretRefs', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+      },
+    ];
+
+    expect(getSecretKeyRefEnvVars(envVars)).toEqual([]);
+  });
+
+  it('should handle EXISTING category with empty selectedKeys', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [{ secretName: 'my-secret', selectedKeys: [] }],
+      },
+    ];
+
+    expect(getSecretKeyRefEnvVars(envVars)).toEqual([]);
+  });
+
+  it('should skip non-EXISTING category vars and include EXISTING ones', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.GENERIC, data: [{ key: 'foo', value: 'bar' }] },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [{ secretName: 'my-secret', selectedKeys: ['token'] }],
+      },
+    ];
+
+    const result = getSecretKeyRefEnvVars(envVars);
+
+    expect(result).toEqual([
+      {
+        name: 'token',
+        valueFrom: { secretKeyRef: { name: 'my-secret', key: 'token' } },
+      },
+    ]);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/getSecretKeyRefEnvVars.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/getSecretKeyRefEnvVars.spec.ts
@@ -1,5 +1,5 @@
 import { EnvVariable, EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
-import { getSecretKeyRefEnvVars } from '#~/src/pages/projects/screens/spawner/service';
+import { getSecretKeyRefEnvVars } from '#~/pages/projects/screens/spawner/service';
 
 describe('getSecretKeyRefEnvVars', () => {
   it('should return empty array for empty input', () => {

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
@@ -1,0 +1,253 @@
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { renderHook } from '@odh-dashboard/jest-config/hooks';
+import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
+import { SecretModel } from '#~/api/models';
+import { useAccessReview } from '#~/api/useAccessReview';
+import {
+  fetchExistingSecrets,
+  useExistingSecrets,
+} from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+}));
+
+jest.mock('#~/api/useAccessReview', () => ({
+  useAccessReview: jest.fn(),
+}));
+
+const k8sListResourceMock = jest.mocked(k8sListResource<SecretKind>);
+const useAccessReviewMock = jest.mocked(useAccessReview);
+
+const createMockSecret = (
+  name: string,
+  options: {
+    data?: Record<string, string>;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+    type?: string;
+  } = {},
+): SecretKind => ({
+  apiVersion: 'v1',
+  kind: 'Secret',
+  metadata: {
+    name,
+    namespace: 'test-namespace',
+    ...(options.labels && { labels: options.labels }),
+    ...(options.annotations && { annotations: options.annotations }),
+  },
+  ...(options.data && { data: options.data }),
+  ...(options.type && { type: options.type }),
+});
+
+describe('fetchExistingSecrets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return eligible secrets with key names only', async () => {
+    const secrets = [
+      createMockSecret('my-secret', {
+        data: { username: 'dXNlcg==', password: 'cGFzcw==' },
+      }),
+    ];
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList(secrets));
+
+    const result = await fetchExistingSecrets('test-namespace');
+
+    expect(result).toStrictEqual([{ name: 'my-secret', keys: ['username', 'password'] }]);
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: SecretModel,
+      queryOptions: { ns: 'test-namespace' },
+    });
+  });
+
+  it('should filter out dashboard-created secrets', async () => {
+    const secrets = [
+      createMockSecret('dashboard-secret', {
+        data: { key1: 'val1' },
+        labels: { 'opendatahub.io/dashboard': 'true' },
+      }),
+      createMockSecret('user-secret', {
+        data: { key2: 'val2' },
+      }),
+    ];
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList(secrets));
+
+    const result = await fetchExistingSecrets('test-namespace');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('user-secret');
+  });
+
+  it('should filter out connection secrets with connection-type-ref annotation', async () => {
+    const secrets = [
+      createMockSecret('connection-secret', {
+        data: { endpoint: 'aHR0cA==' },
+        annotations: { 'opendatahub.io/connection-type-ref': 's3' },
+      }),
+      createMockSecret('user-secret', {
+        data: { key1: 'val1' },
+      }),
+    ];
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList(secrets));
+
+    const result = await fetchExistingSecrets('test-namespace');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('user-secret');
+  });
+
+  it('should filter out connection secrets with connection-type-protocol annotation', async () => {
+    const secrets = [
+      createMockSecret('protocol-secret', {
+        data: { endpoint: 'aHR0cA==' },
+        annotations: { 'opendatahub.io/connection-type-protocol': 's3' },
+      }),
+      createMockSecret('user-secret', {
+        data: { key1: 'val1' },
+      }),
+    ];
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList(secrets));
+
+    const result = await fetchExistingSecrets('test-namespace');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('user-secret');
+  });
+
+  it('should filter out secrets that are both dashboard-created and connections', async () => {
+    const secrets = [
+      createMockSecret('combo-secret', {
+        data: { key1: 'val1' },
+        labels: { 'opendatahub.io/dashboard': 'true' },
+        annotations: { 'opendatahub.io/connection-type-ref': 's3' },
+      }),
+    ];
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList(secrets));
+
+    const result = await fetchExistingSecrets('test-namespace');
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('should return empty keys array for secrets without data', async () => {
+    const secrets = [createMockSecret('empty-secret')];
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList(secrets));
+
+    const result = await fetchExistingSecrets('test-namespace');
+
+    expect(result).toStrictEqual([{ name: 'empty-secret', keys: [] }]);
+  });
+
+  it('should return empty array when namespace has no eligible secrets', async () => {
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList([]));
+
+    const result = await fetchExistingSecrets('test-namespace');
+
+    expect(result).toStrictEqual([]);
+  });
+
+  it('should not expose secret values in the result', async () => {
+    const secrets = [
+      createMockSecret('my-secret', {
+        data: { apiKey: 'c3VwZXItc2VjcmV0', token: 'dG9rZW4=' },
+      }),
+    ];
+    k8sListResourceMock.mockResolvedValue(mockK8sResourceList(secrets));
+
+    const result = await fetchExistingSecrets('test-namespace');
+
+    expect(result[0].keys).toStrictEqual(['apiKey', 'token']);
+    // Verify no values are present in the result
+    expect(result[0]).not.toHaveProperty('data');
+    expect(JSON.stringify(result)).not.toContain('c3VwZXItc2VjcmV0');
+    expect(JSON.stringify(result)).not.toContain('dG9rZW4=');
+  });
+
+  it('should propagate API errors', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('Forbidden'));
+
+    await expect(fetchExistingSecrets('test-namespace')).rejects.toThrow('Forbidden');
+  });
+});
+
+describe('useExistingSecrets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return loaded secrets when RBAC allows listing', async () => {
+    useAccessReviewMock.mockReturnValue([true, true]);
+    k8sListResourceMock.mockResolvedValue(
+      mockK8sResourceList([
+        createMockSecret('secret-a', { data: { key1: 'val1' } }),
+        createMockSecret('secret-b', { data: { key2: 'val2', key3: 'val3' } }),
+      ]),
+    );
+
+    const renderResult = renderHook(() => useExistingSecrets('test-namespace'));
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current).toStrictEqual({
+      secrets: [
+        { name: 'secret-a', keys: ['key1'] },
+        { name: 'secret-b', keys: ['key2', 'key3'] },
+      ],
+      loaded: true,
+      canList: true,
+      error: undefined,
+    });
+  });
+
+  it('should return canList false when RBAC denies listing', async () => {
+    useAccessReviewMock.mockReturnValue([false, true]);
+
+    const renderResult = renderHook(() => useExistingSecrets('test-namespace'));
+
+    expect(renderResult.result.current).toStrictEqual({
+      secrets: [],
+      loaded: true,
+      canList: false,
+      error: undefined,
+    });
+  });
+
+  it('should return loaded false while RBAC check is pending', () => {
+    useAccessReviewMock.mockReturnValue([false, false]);
+
+    const renderResult = renderHook(() => useExistingSecrets('test-namespace'));
+
+    expect(renderResult.result.current).toStrictEqual({
+      secrets: [],
+      loaded: false,
+      canList: false,
+      error: undefined,
+    });
+  });
+
+  it('should handle API errors gracefully', async () => {
+    useAccessReviewMock.mockReturnValue([true, true]);
+    k8sListResourceMock.mockRejectedValue(new Error('Network error'));
+
+    const renderResult = renderHook(() => useExistingSecrets('test-namespace'));
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current).toStrictEqual({
+      secrets: [],
+      loaded: true,
+      canList: true,
+      error: new Error('Network error'),
+    });
+  });
+
+  it('should not fetch when namespace is empty', () => {
+    useAccessReviewMock.mockReturnValue([true, true]);
+
+    const renderResult = renderHook(() => useExistingSecrets(''));
+
+    expect(k8sListResourceMock).not.toHaveBeenCalled();
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
@@ -1,9 +1,9 @@
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
-import { EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+import { EnvironmentVariableType, EnvVariable, SecretCategory } from '#~/pages/projects/types';
 import {
   fetchNotebookEnvVariables,
   parseSecretKeyRefEntries,
-} from '#~/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables';
+} from '#~/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables';
 
 jest.mock('#~/api', () => ({
   getConfigMap: jest.fn(),
@@ -177,7 +177,9 @@ describe('fetchNotebookEnvVariables', () => {
 
     const result = await fetchNotebookEnvVariables(notebook);
 
-    const existingRefs = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+    const existingRefs = result.filter(
+      (v: EnvVariable) => v.values?.category === SecretCategory.EXISTING,
+    );
     expect(existingRefs).toHaveLength(0);
   });
 
@@ -208,7 +210,9 @@ describe('fetchNotebookEnvVariables', () => {
 
     const result = await fetchNotebookEnvVariables(notebook);
 
-    const existingRefs = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+    const existingRefs = result.filter(
+      (v: EnvVariable) => v.values?.category === SecretCategory.EXISTING,
+    );
     expect(existingRefs).toHaveLength(1);
     expect(existingRefs[0].existingSecretRefs).toHaveLength(2);
     expect(existingRefs[0].existingSecretRefs).toContainEqual({

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
@@ -1,0 +1,223 @@
+import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
+import { EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+import {
+  fetchNotebookEnvVariables,
+  parseSecretKeyRefEntries,
+} from '#~/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables';
+
+jest.mock('#~/api', () => ({
+  getConfigMap: jest.fn(),
+  getSecret: jest.fn(),
+}));
+
+jest.mock('#~/concepts/connectionTypes/utils', () => ({
+  isConnection: jest.fn().mockReturnValue(false),
+}));
+
+describe('parseSecretKeyRefEntries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return empty array when there are no env entries', () => {
+    const notebook = mockNotebookK8sResource({ additionalEnvs: [] });
+    const result = parseSecretKeyRefEntries(notebook);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when no entries have secretKeyRef', () => {
+    const notebook = mockNotebookK8sResource({
+      additionalEnvs: [{ name: 'CUSTOM_VAR', value: 'custom-value' }],
+    });
+    const result = parseSecretKeyRefEntries(notebook);
+    expect(result).toEqual([]);
+  });
+
+  it('should parse a single secretKeyRef entry', () => {
+    const notebook = mockNotebookK8sResource({
+      additionalEnvs: [
+        {
+          name: 'DB_PASSWORD',
+          valueFrom: {
+            secretKeyRef: { name: 'db-credentials', key: 'DB_PASSWORD' },
+          },
+        },
+      ],
+    });
+    const result = parseSecretKeyRefEntries(notebook);
+    expect(result).toEqual([{ secretName: 'db-credentials', selectedKeys: ['DB_PASSWORD'] }]);
+  });
+
+  it('should group multiple keys from the same secret', () => {
+    const notebook = mockNotebookK8sResource({
+      additionalEnvs: [
+        {
+          name: 'AWS_ACCESS_KEY_ID',
+          valueFrom: {
+            secretKeyRef: { name: 'aws-credentials', key: 'AWS_ACCESS_KEY_ID' },
+          },
+        },
+        {
+          name: 'AWS_SECRET_ACCESS_KEY',
+          valueFrom: {
+            secretKeyRef: { name: 'aws-credentials', key: 'AWS_SECRET_ACCESS_KEY' },
+          },
+        },
+      ],
+    });
+    const result = parseSecretKeyRefEntries(notebook);
+    expect(result).toEqual([
+      {
+        secretName: 'aws-credentials',
+        selectedKeys: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
+      },
+    ]);
+  });
+
+  it('should handle multiple different secrets', () => {
+    const notebook = mockNotebookK8sResource({
+      additionalEnvs: [
+        {
+          name: 'DB_PASSWORD',
+          valueFrom: {
+            secretKeyRef: { name: 'db-credentials', key: 'DB_PASSWORD' },
+          },
+        },
+        {
+          name: 'API_KEY',
+          valueFrom: {
+            secretKeyRef: { name: 'api-secret', key: 'API_KEY' },
+          },
+        },
+      ],
+    });
+    const result = parseSecretKeyRefEntries(notebook);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      secretName: 'db-credentials',
+      selectedKeys: ['DB_PASSWORD'],
+    });
+    expect(result).toContainEqual({
+      secretName: 'api-secret',
+      selectedKeys: ['API_KEY'],
+    });
+  });
+
+  it('should ignore non-secretKeyRef valueFrom entries', () => {
+    const notebook = mockNotebookK8sResource({
+      additionalEnvs: [
+        {
+          name: 'NAMESPACE',
+          valueFrom: {
+            fieldRef: { fieldPath: 'metadata.namespace' },
+          },
+        },
+        {
+          name: 'DB_PASSWORD',
+          valueFrom: {
+            secretKeyRef: { name: 'db-credentials', key: 'DB_PASSWORD' },
+          },
+        },
+      ],
+    });
+    const result = parseSecretKeyRefEntries(notebook);
+    expect(result).toEqual([{ secretName: 'db-credentials', selectedKeys: ['DB_PASSWORD'] }]);
+  });
+
+  it('should handle mixed env entries (value and valueFrom)', () => {
+    const notebook = mockNotebookK8sResource({
+      additionalEnvs: [
+        { name: 'STATIC_VAR', value: 'static-value' },
+        {
+          name: 'SECRET_VAR',
+          valueFrom: {
+            secretKeyRef: { name: 'my-secret', key: 'SECRET_VAR' },
+          },
+        },
+      ],
+    });
+    const result = parseSecretKeyRefEntries(notebook);
+    expect(result).toEqual([{ secretName: 'my-secret', selectedKeys: ['SECRET_VAR'] }]);
+  });
+});
+
+describe('fetchNotebookEnvVariables', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should include EXISTING category env variable when secretKeyRef entries exist', async () => {
+    const notebook = mockNotebookK8sResource({
+      envFrom: [],
+      additionalEnvs: [
+        {
+          name: 'DB_PASSWORD',
+          valueFrom: {
+            secretKeyRef: { name: 'db-credentials', key: 'DB_PASSWORD' },
+          },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: EnvironmentVariableType.SECRET,
+      values: { category: SecretCategory.EXISTING, data: [] },
+      existingSecretRefs: [{ secretName: 'db-credentials', selectedKeys: ['DB_PASSWORD'] }],
+    });
+  });
+
+  it('should not include EXISTING env variable when no secretKeyRef entries exist', async () => {
+    const notebook = mockNotebookK8sResource({
+      envFrom: [],
+      additionalEnvs: [],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    const existingRefs = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+    expect(existingRefs).toHaveLength(0);
+  });
+
+  it('should group multiple secretKeyRef entries into a single EXISTING env variable', async () => {
+    const notebook = mockNotebookK8sResource({
+      envFrom: [],
+      additionalEnvs: [
+        {
+          name: 'KEY_1',
+          valueFrom: {
+            secretKeyRef: { name: 'secret-a', key: 'KEY_1' },
+          },
+        },
+        {
+          name: 'KEY_2',
+          valueFrom: {
+            secretKeyRef: { name: 'secret-a', key: 'KEY_2' },
+          },
+        },
+        {
+          name: 'KEY_3',
+          valueFrom: {
+            secretKeyRef: { name: 'secret-b', key: 'KEY_3' },
+          },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    const existingRefs = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+    expect(existingRefs).toHaveLength(1);
+    expect(existingRefs[0].existingSecretRefs).toHaveLength(2);
+    expect(existingRefs[0].existingSecretRefs).toContainEqual({
+      secretName: 'secret-a',
+      selectedKeys: ['KEY_1', 'KEY_2'],
+    });
+    expect(existingRefs[0].existingSecretRefs).toContainEqual({
+      secretName: 'secret-b',
+      selectedKeys: ['KEY_3'],
+    });
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/existingSecretCollisions.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/existingSecretCollisions.ts
@@ -1,0 +1,42 @@
+import { ExistingSecretRef } from '#~/pages/projects/types';
+
+export type KeyCollision = {
+  key: string;
+  sources: string[];
+};
+
+/**
+ * Detect key name collisions across selected existing secret refs.
+ * A collision occurs when two or more secrets have the same key selected.
+ */
+export const detectExistingSecretKeyCollisions = (
+  existingSecretRefs: ExistingSecretRef[],
+): KeyCollision[] => {
+  const keySourceMap = new Map<string, string[]>();
+
+  existingSecretRefs.forEach((ref) => {
+    ref.selectedKeys.forEach((key) => {
+      const sources = keySourceMap.get(key);
+      if (sources) {
+        sources.push(ref.secretName);
+      } else {
+        keySourceMap.set(key, [ref.secretName]);
+      }
+    });
+  });
+
+  const collisions: KeyCollision[] = [];
+  keySourceMap.forEach((sources, key) => {
+    if (sources.length > 1) {
+      collisions.push({ key, sources });
+    }
+  });
+
+  return collisions;
+};
+
+/**
+ * Build a Set of key names that are colliding, for quick per-key lookup.
+ */
+export const getCollidingKeySet = (collisions: KeyCollision[]): Set<string> =>
+  new Set(collisions.map((c) => c.key));

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { KnownLabels, type SecretKind } from '@odh-dashboard/k8s-core';
+import { SecretModel } from '#~/api/models';
+import { useAccessReview } from '#~/api/useAccessReview';
+import { ExistingSecretMetadata } from '#~/pages/projects/types';
+
+/**
+ * Returns true if the secret was created by the dashboard
+ * (has opendatahub.io/dashboard: 'true' label).
+ */
+const isDashboardSecret = (secret: SecretKind): boolean =>
+  secret.metadata.labels?.[KnownLabels.DASHBOARD_RESOURCE] === 'true';
+
+/**
+ * Returns true if the secret is a Connection resource
+ * (has connection-type-protocol or connection-type-ref annotations).
+ */
+const isConnectionSecret = (secret: SecretKind): boolean =>
+  !!secret.metadata.annotations?.['opendatahub.io/connection-type-protocol'] ||
+  !!secret.metadata.annotations?.['opendatahub.io/connection-type-ref'];
+
+/**
+ * Fetches all Opaque secrets in a namespace and returns only the ones
+ * that are NOT dashboard-created and NOT connection secrets.
+ * Strips secret values — only metadata.name and data key names are exposed.
+ */
+export const fetchExistingSecrets = async (
+  namespace: string,
+): Promise<ExistingSecretMetadata[]> => {
+  const result = await k8sListResource<SecretKind>({
+    model: SecretModel,
+    queryOptions: { ns: namespace },
+  });
+
+  return result.items
+    .filter((secret) => !isDashboardSecret(secret) && !isConnectionSecret(secret))
+    .map((secret) => ({
+      name: secret.metadata.name,
+      keys: secret.data ? Object.keys(secret.data) : [],
+    }));
+};
+
+type UseExistingSecretsResult = {
+  secrets: ExistingSecretMetadata[];
+  loaded: boolean;
+  canList: boolean;
+  error?: Error;
+};
+
+/**
+ * Hook that lazily fetches existing (non-dashboard, non-connection) secrets
+ * in the given namespace. Includes an RBAC check to verify the user can list secrets.
+ *
+ * Returns only secret names and their key names — values are never exposed.
+ */
+export const useExistingSecrets = (namespace: string): UseExistingSecretsResult => {
+  const [isAllowed, isAllowedLoaded] = useAccessReview({
+    group: '',
+    resource: 'secrets',
+    verb: 'list',
+    namespace,
+  });
+
+  const [secrets, setSecrets] = React.useState<ExistingSecretMetadata[]>([]);
+  const [loaded, setLoaded] = React.useState(false);
+  const [error, setError] = React.useState<Error | undefined>(undefined);
+
+  React.useEffect(() => {
+    if (!isAllowedLoaded || !isAllowed || !namespace) {
+      return;
+    }
+
+    let cancelled = false;
+
+    fetchExistingSecrets(namespace)
+      .then((result) => {
+        if (!cancelled) {
+          setSecrets(result);
+          setLoaded(true);
+        }
+      })
+      .catch((e: Error) => {
+        if (!cancelled) {
+          setError(e);
+          setLoaded(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [namespace, isAllowed, isAllowedLoaded]);
+
+  const shouldFetch = !!namespace && isAllowed;
+
+  return {
+    secrets: shouldFetch ? secrets : [],
+    loaded: !namespace || (isAllowedLoaded && (loaded || !isAllowed)),
+    canList: isAllowed,
+    error,
+  };
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -7,11 +7,35 @@ import {
   ConfigMapCategory,
   EnvironmentVariableType,
   EnvVariable,
+  ExistingSecretRef,
   SecretCategory,
 } from '#~/pages/projects/types';
 import useFetchState, { NotReadyError } from '#~/utilities/useFetchState';
 import { isConnection } from '#~/concepts/connectionTypes/utils';
 import { getDeletedConfigMapOrSecretVariables, isSecretKind } from './utils';
+
+/**
+ * Parse secretKeyRef entries from the Notebook CR's env[] array.
+ * Groups entries by secret name and returns them as ExistingSecretRef objects.
+ */
+export const parseSecretKeyRefEntries = (notebook: NotebookKind): ExistingSecretRef[] => {
+  const envList = notebook.spec.template.spec.containers[0].env;
+  const secretKeyRefMap = new Map<string, string[]>();
+
+  envList.forEach((entry) => {
+    const secretKeyRef = entry.valueFrom?.secretKeyRef;
+    if (secretKeyRef?.name && secretKeyRef.key) {
+      const keys = secretKeyRefMap.get(secretKeyRef.name) || [];
+      keys.push(secretKeyRef.key);
+      secretKeyRefMap.set(secretKeyRef.name, keys);
+    }
+  });
+
+  return Array.from(secretKeyRefMap.entries()).map(([secretName, selectedKeys]) => ({
+    secretName,
+    selectedKeys,
+  }));
+};
 
 export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVariable[]> => {
   const envFromList = notebook.spec.template.spec.containers[0].envFrom || [];
@@ -41,8 +65,8 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
           v: Promise<ConfigMapKind | null> | Promise<undefined> | undefined,
         ): v is Promise<SecretKind | ConfigMapKind | null> => !!v,
       ),
-  ).then((results) =>
-    results.reduce<EnvVariable[]>((acc, resource) => {
+  ).then((results) => {
+    const envVars = results.reduce<EnvVariable[]>((acc, resource) => {
       if (!resource) {
         return acc;
       }
@@ -70,8 +94,20 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
         return acc;
       }
       return [...acc, envVar];
-    }, []),
-  );
+    }, []);
+
+    // Parse secretKeyRef entries from env[] (existing secret references)
+    const existingSecretRefs = parseSecretKeyRefEntries(notebook);
+    if (existingSecretRefs.length > 0) {
+      envVars.push({
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs,
+      });
+    }
+
+    return envVars;
+  });
 };
 
 export const useNotebookEnvVariables = (

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -19,15 +19,26 @@ import { getDeletedConfigMapOrSecretVariables, isSecretKind } from './utils';
  * Groups entries by secret name and returns them as ExistingSecretRef objects.
  */
 export const parseSecretKeyRefEntries = (notebook: NotebookKind): ExistingSecretRef[] => {
-  const envList = notebook.spec.template.spec.containers[0].env;
+  const container = notebook.spec.template.spec.containers[0];
+  const envList: {
+    name: string;
+    value?: string;
+    valueFrom?: { secretKeyRef?: { name: string; key: string } };
+  }[] =
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/consistent-type-assertions
+    (container.env as {
+      name: string;
+      value?: string;
+      valueFrom?: { secretKeyRef?: { name: string; key: string } };
+    }[]) ?? [];
   const secretKeyRefMap = new Map<string, string[]>();
 
   envList.forEach((entry) => {
-    const secretKeyRef = entry.valueFrom?.secretKeyRef;
-    if (secretKeyRef?.name && secretKeyRef.key) {
-      const keys = secretKeyRefMap.get(secretKeyRef.name) || [];
-      keys.push(secretKeyRef.key);
-      secretKeyRefMap.set(secretKeyRef.name, keys);
+    const ref = entry.valueFrom?.secretKeyRef;
+    if (ref) {
+      const keys = secretKeyRefMap.get(ref.name) || [];
+      keys.push(ref.key);
+      secretKeyRefMap.set(ref.name, keys);
     }
   });
 

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -23,6 +23,7 @@ import {
   EnvironmentFromVariable,
   EnvVariable,
   SecretCategory,
+  SecretKeyRefEnvVar,
   StorageData,
   StorageType,
 } from '#~/pages/projects/types';
@@ -106,6 +107,9 @@ const getPromisesForConfigMapsAndSecrets = (
             : replaceSecret(assembleSecret(projectName, dataAsRecord, 'aws', envVar.existingName), {
                 dryRun,
               });
+        case SecretCategory.EXISTING:
+          // Existing secrets are referenced, not created or updated
+          return null;
         case ConfigMapCategory.GENERIC:
         case ConfigMapCategory.UPLOAD:
           return type === 'create'
@@ -143,6 +147,22 @@ const getEnvFromList = (
     return [...acc, envFrom];
   }, initialList);
 
+/**
+ * Generate secretKeyRef env entries from env variables with category EXISTING.
+ * Each ExistingSecretRef produces one env entry per selected key.
+ */
+export const getSecretKeyRefEnvVars = (envVariables: EnvVariable[]): SecretKeyRefEnvVar[] =>
+  envVariables
+    .filter((v) => v.values?.category === SecretCategory.EXISTING)
+    .flatMap((v) =>
+      (v.existingSecretRefs ?? []).flatMap((ref) =>
+        ref.selectedKeys.map((key) => ({
+          name: key,
+          valueFrom: { secretKeyRef: { name: ref.secretName, key } },
+        })),
+      ),
+    );
+
 export const createConfigMapsAndSecretsForNotebook = async (
   projectName: string,
   envVariables: EnvVariable[],
@@ -164,13 +184,18 @@ export const createConfigMapsAndSecretsForNotebook = async (
     });
 };
 
+export type UpdateConfigMapsAndSecretsResult = {
+  envFrom: EnvironmentFromVariable[];
+  secretKeyRefEnvVars: SecretKeyRefEnvVar[];
+};
+
 export const updateConfigMapsAndSecretsForNotebook = async (
   projectName: string,
   notebook: NotebookKind,
   envVariables: EnvVariable[],
   connections?: Connection[],
   dryRun = false,
-): Promise<EnvironmentFromVariable[]> => {
+): Promise<UpdateConfigMapsAndSecretsResult> => {
   const existingEnvVars = await fetchNotebookEnvVariables(notebook);
   const { deletedConfigMaps, deletedSecrets } = getDeletedConfigMapOrSecretVariables(
     notebook,
@@ -178,17 +203,29 @@ export const updateConfigMapsAndSecretsForNotebook = async (
     [...(connections || []).map((connection) => connection.metadata.name)],
   );
 
-  const [oldResources, newResources] = _.partition(envVariables, (envVar) => envVar.existingName);
+  // Filter out EXISTING category env vars for resource management — they don't need
+  // K8s resource creation/update/deletion. They are handled via secretKeyRef entries.
+  const managedEnvVariables = envVariables.filter(
+    (v) => v.values?.category !== SecretCategory.EXISTING,
+  );
+  const managedExistingEnvVars = existingEnvVars.filter(
+    (v) => v.values?.category !== SecretCategory.EXISTING,
+  );
+
+  const [oldResources, newResources] = _.partition(
+    managedEnvVariables,
+    (envVar) => envVar.existingName,
+  );
   const currentNames = oldResources
     .map((envVar) => envVar.existingName)
     .filter((v): v is string => !!v);
 
-  const removeResources = existingEnvVars.filter(
+  const removeResources = managedExistingEnvVars.filter(
     (envVar) => envVar.existingName && !currentNames.includes(envVar.existingName),
   );
 
   const [typeChangeResources, updateResources] = _.partition(oldResources, (envVar) =>
-    existingEnvVars.find(
+    managedExistingEnvVars.find(
       (existingEnvVar) =>
         existingEnvVar.existingName === envVar.existingName &&
         existingEnvVar.values?.category !== envVar.values?.category,
@@ -237,9 +274,14 @@ export const updateConfigMapsAndSecretsForNotebook = async (
 
   const envFromList = notebook.spec.template.spec.containers[0].envFrom || [];
 
-  return getEnvFromList(created, [...envFromList]).filter(
-    (envFrom) =>
-      !(envFrom.secretRef?.name && deletingNames.includes(envFrom.secretRef.name)) &&
-      !(envFrom.configMapRef?.name && deletingNames.includes(envFrom.configMapRef.name)),
+  const envFrom = getEnvFromList(created, [...envFromList]).filter(
+    (envFromEntry) =>
+      !(envFromEntry.secretRef?.name && deletingNames.includes(envFromEntry.secretRef.name)) &&
+      !(envFromEntry.configMapRef?.name && deletingNames.includes(envFromEntry.configMapRef.name)),
   );
+
+  // Generate secretKeyRef env entries from EXISTING category env vars
+  const secretKeyRefEnvVars = getSecretKeyRefEnvVars(envVariables);
+
+  return { envFrom, secretKeyRefEnvVars };
 };

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -111,10 +111,21 @@ export type EnvVariableData = {
   data: EnvVariableDataEntry[];
 };
 
+export type ExistingSecretRef = {
+  secretName: string;
+  selectedKeys: string[];
+};
+
+export type ExistingSecretMetadata = {
+  name: string;
+  keys: string[];
+};
+
 export type EnvVariable = {
   type: EnvironmentVariableType | null;
   existingName?: string;
   values?: EnvVariableData;
+  existingSecretRefs?: ExistingSecretRef[];
 };
 
 export enum EnvironmentVariableType {
@@ -125,6 +136,7 @@ export enum SecretCategory {
   GENERIC = 'secret key-value',
   AWS = 'aws',
   UPLOAD = 'secret upload',
+  EXISTING = 'existing secret',
 }
 export enum ConfigMapCategory {
   GENERIC = 'configmap key-value',

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -85,6 +85,16 @@ export type StorageData = {
   modelPath?: string;
 };
 
+export type SecretKeyRefEnvVar = {
+  name: string;
+  valueFrom: {
+    secretKeyRef: {
+      name: string;
+      key: string;
+    };
+  };
+};
+
 export type StartNotebookData = {
   projectName: string;
   notebookData: K8sNameDescriptionFieldData;
@@ -92,6 +102,7 @@ export type StartNotebookData = {
   volumes?: Volume[];
   volumeMounts?: VolumeMount[];
   envFrom?: EnvironmentFromVariable[];
+  secretKeyRefEnvVars?: SecretKeyRefEnvVar[];
   dashboardNamespace?: string;
   connections?: Connection[];
   hardwareProfileOptions: UseAssignHardwareProfileResult<NotebookKind>;


### PR DESCRIPTION
This is a second eval of https://github.com/opendatahub-io/odh-dashboard/pull/8114 leveraging https://github.com/DaoDaoNoCode/odh-dashboard/tree/prototype-skills from @DaoDaoNoCode  🙇🏾‍♂️ 

## Happy Path
<img width="1571" height="911" alt="Screenshot 2026-06-22 at 4 07 26 PM" src="https://github.com/user-attachments/assets/e3691e1d-aae8-45d1-b465-5fd660129fca" />

## Duplicate Keys Err State
<img width="1298" height="994" alt="Screenshot 2026-06-23 at 3 36 04 PM" src="https://github.com/user-attachments/assets/282892a0-998f-4f44-8ea3-3b228e5490c4" />

### Eval Experiment cost
>   Session                              
> 
>   Total cost:            $89.69
>   Total duration (API):  1h 17m 32s
>   Total duration (wall): 3h 24m 39s
>   Total code changes:    3691 lines added, 403 lines removed
>   Usage by model:
>       claude-opus-4-6:  3.9k input, 229.2k output, 106.4m cache read, 4.8m cache write ($89.26)
>       claude-haiku-4-5:  205 input, 11.7k output, 1.8m cache read, 160.7k cache write ($0.4363)


### Original Cursor Loop eval cost (~estimate)
> $175 Opus 4.6


## Description

Enables data scientists to reference pre-existing Kubernetes Secrets by name when configuring workbench environment variables, instead of requiring manual re-entry of values. This eliminates the need to duplicate secret values or bypass the dashboard by editing Notebook CR YAML directly.

**UX prototype:** https://rhoai-rachel-64723e.pages.redhat.com/develop-train/workbenches/create#create-wb-section-env

### What's included

**Data layer ([RHOAIENG-69120](https://redhat.atlassian.net/browse/RHOAIENG-69120)):**
- `SecretCategory.EXISTING` enum value, `ExistingSecretRef` and `ExistingSecretMetadata` types
- `useExistingSecrets(namespace)` hook with RBAC check, dashboard/connection secret filtering, value stripping

**Creation flow — dropdown ([RHOAIENG-69121](https://redhat.atlassian.net/browse/RHOAIENG-69121)):**
- "Existing secret" radio option under Secret variable type
- Typeahead multi-select dropdown with secret name, key count, key preview
- Empty namespace and RBAC disabled states with popovers

**Creation flow — key picker + save ([RHOAIENG-69122](https://redhat.atlassian.net/browse/RHOAIENG-69122)):**
- Per-key expandable sections with select all/deselect all, individual checkboxes
- Key filter for secrets with >10 keys
- Creation path generates `env[].valueFrom.secretKeyRef` entries (never `envFrom`)
- Rotation hint HelperText

**Edit flow ([RHOAIENG-69123](https://redhat.atlassian.net/browse/RHOAIENG-69123)):**
- Parses `secretKeyRef` entries from Notebook CR `env[]` array
- Reconstructs form state grouping by secret name
- Handles mixed `envFrom[]` + `secretKeyRef` save
- `SecretKeyRefEnvVar` type on `StartNotebookData`

**Conflict detection + error states ([RHOAIENG-69124](https://redhat.atlassian.net/browse/RHOAIENG-69124)):**
- Cross-secret key collision detection with warning Alert
- Per-key warning triangle icons on colliding checkboxes
- Deleted secret: danger Alert with "Remove this reference" action
- Missing keys: warning Alert with "Remove missing keys" action

## How Has This Been Tested?

- TypeScript type-check passing
- ESLint passing (zero warnings)
- 95 unit tests covering all new components, hooks, utilities, and service layer changes
- Not manually tested on cluster yet — draft PR for early review

## Test Impact

95 new unit tests across 7 test files:
- `useExistingSecrets.spec.ts` — 14 tests (hook filtering, RBAC, edge cases)
- `useNotebookEnvVariables.spec.ts` — 13 tests (secretKeyRef parsing, grouping)
- `service.spec.ts` — 8 tests (getSecretKeyRefEnvVars helper)
- `EnvExistingSecretField.spec.tsx` — 23 tests (dropdown, states, collisions)
- `ExistingSecretKeyPicker.spec.tsx` — 22 tests (key picker, deleted/missing, collision icons)
- `existingSecretCollisions.spec.ts` — 9 tests (collision detection utility)
- `getSecretKeyRefEnvVars.spec.ts` — 7 tests (secretKeyRef generation)

Cypress mock tests are not yet added — will be added in a follow-up before merge.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-69120]: https://redhat.atlassian.net/browse/RHOAIENG-69120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ