### PR TITLE
Feat(RHOAIENG-68467): hp popover 

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
@@ -23,10 +23,13 @@ import {
   formatNodeSelector,
   formatIdentifierDetails,
   sortIdentifiers,
+  getLocalQueueLabel,
 } from './utils';
+import { QueueSource } from './const';
 
 type HardwareProfileDetailsPopoverProps = {
   localQueueName?: string;
+  queueSource?: QueueSource;
   priorityClass?: string;
   tolerations?: Toleration[];
   nodeSelector?: NodeSelector;
@@ -36,6 +39,7 @@ type HardwareProfileDetailsPopoverProps = {
 
 const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps> = ({
   localQueueName,
+  queueSource,
   priorityClass,
   tolerations,
   nodeSelector,
@@ -109,7 +113,9 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
             </StackItem>
           )}
           {localQueueName && (
-            <StackItem>{renderSection('Local queue', [localQueueName])}</StackItem>
+            <StackItem>
+              {renderSection(getLocalQueueLabel(queueSource), [localQueueName])}
+            </StackItem>
           )}
           {clusterQueueName && (
             <StackItem>{renderSection('Cluster queue', [clusterQueueName])}</StackItem>

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
@@ -106,12 +106,12 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
                   </StackItem>
                 ))}
             </>
-          ) : (
+          ) : !localQueueName ? (
             <StackItem>
               No matching hardware profile found, using existing settings. Default, min, and max
               values are not available.
             </StackItem>
-          )}
+          ) : null}
           {localQueueName && (
             <StackItem>
               {renderSection(getLocalQueueLabel(queueSource), [localQueueName])}

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
@@ -6,13 +6,14 @@ import type { ModelResourceType } from '@odh-dashboard/model-serving/extension-p
 import { DashboardPopupIconButton } from '@odh-dashboard/ui-core';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import { NotebookKind } from '#~/k8sTypes';
+import { KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
 import ScopedLabel from '#~/components/ScopedLabel';
 import { ScopedType } from '#~/pages/modelServing/screens/const';
 import { getHardwareProfileDisplayName } from '#~/pages/hardwareProfiles/utils';
 import { resourceTypeOf } from '#~/concepts/hardwareProfiles/utils';
 import HardwareProfileDetailsPopover from './HardwareProfileDetailsPopover';
 import HardwareProfileBindingStateLabel from './HardwareProfileBindingStateLabel';
-import { HardwareProfileBindingState } from './const';
+import { HardwareProfileBindingState, QueueSource } from './const';
 import { HardwareProfileBindingStateInfo } from './types';
 
 type HardwareProfileTableColumnProps = {
@@ -35,6 +36,7 @@ const HardwareProfileTableColumn: React.FC<HardwareProfileTableColumnProps> = ({
   const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const { bindingStateInfo, bindingStateLoaded, loadError } = bindingState;
   const hardwareProfile = bindingStateInfo?.profile;
+  const directQueueName = resource.metadata.labels?.[KUEUE_QUEUE_LABEL];
 
   if (loadError && bindingStateInfo?.state !== HardwareProfileBindingState.DELETED) {
     return (
@@ -68,13 +70,26 @@ const HardwareProfileTableColumn: React.FC<HardwareProfileTableColumnProps> = ({
       >
         {bindingStateInfo?.state !== HardwareProfileBindingState.DELETED && (
           <FlexItem>
+            {/* When a hardware profile is matched it is authoritative — directQueueName on
+                the notebook is intentionally ignored even if the HP has no kueue config. */}
             {hardwareProfile ? (
               <HardwareProfileDetailsPopover
                 hardwareProfile={hardwareProfile}
                 tolerations={hardwareProfile.spec.scheduling?.node?.tolerations}
                 nodeSelector={hardwareProfile.spec.scheduling?.node?.nodeSelector}
                 localQueueName={hardwareProfile.spec.scheduling?.kueue?.localQueueName}
+                queueSource={
+                  hardwareProfile.spec.scheduling?.kueue?.localQueueName
+                    ? QueueSource.HARDWARE_PROFILE
+                    : undefined
+                }
                 priorityClass={hardwareProfile.spec.scheduling?.kueue?.priorityClass}
+                tableView
+              />
+            ) : directQueueName ? (
+              <HardwareProfileDetailsPopover
+                localQueueName={directQueueName}
+                queueSource={QueueSource.DIRECT}
                 tableView
               />
             ) : (

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { IdentifierResourceType, SchedulingType } from '@odh-dashboard/k8s-core';
+import { QueueSource } from '#~/concepts/hardwareProfiles/const';
 import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
 import {
   ProjectDetailsContext,
@@ -85,27 +86,12 @@ describe('HardwareProfileDetailsPopover', () => {
   });
 
   describe('Custom scenario (no hardware profile)', () => {
-    it('should display informational message in popover body', async () => {
-      renderWithContext(<HardwareProfileDetailsPopover />);
-
-      await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
-
-      const details = screen.getByTestId('hardware-profile-details');
-      expect(details).toHaveTextContent(
-        'No matching hardware profile found, using existing settings. Default, min, and max values are not available.',
-      );
-    });
-
-    it('should display "View details" text in form view', () => {
+    it('should display "View details" trigger and fallback message with no resource details', async () => {
       renderWithContext(<HardwareProfileDetailsPopover />);
 
       expect(screen.getByTestId('hardware-profile-details-popover')).toHaveTextContent(
         'View details',
       );
-    });
-
-    it('should contain only the fallback message with no resource details', async () => {
-      renderWithContext(<HardwareProfileDetailsPopover />);
 
       await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
 
@@ -142,5 +128,23 @@ describe('HardwareProfileDetailsPopover', () => {
       expect(details).toHaveTextContent('Workload priority');
       expect(details).toHaveTextContent('high-priority');
     });
+
+    it.each([
+      [QueueSource.HARDWARE_PROFILE, 'test-queue', 'Local queue (via hardware profile)'],
+      [QueueSource.DIRECT, 'gitops-queue', 'Local queue (applied directly)'],
+    ])(
+      'should show correct label for queueSource "%s"',
+      async (queueSource, queueName, expectedLabel) => {
+        renderWithContext(
+          <HardwareProfileDetailsPopover localQueueName={queueName} queueSource={queueSource} />,
+        );
+
+        await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
+
+        const details = screen.getByTestId('hardware-profile-details');
+        expect(details).toHaveTextContent(expectedLabel);
+        expect(details).toHaveTextContent(queueName);
+      },
+    );
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -144,6 +144,7 @@ describe('HardwareProfileDetailsPopover', () => {
         const details = screen.getByTestId('hardware-profile-details');
         expect(details).toHaveTextContent(expectedLabel);
         expect(details).toHaveTextContent(queueName);
+        expect(details).not.toHaveTextContent('No matching hardware profile found');
       },
     );
   });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
@@ -129,6 +129,7 @@ describe('HardwareProfileTableColumn', () => {
       const details = screen.getByTestId('hardware-profile-details');
       expect(details).toHaveTextContent('Local queue (applied directly)');
       expect(details).toHaveTextContent('gitops-queue');
+      expect(details).not.toHaveTextContent('No matching hardware profile found');
     });
   });
 

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
 import {
   ProjectDetailsContext,
   ProjectDetailsContextType,
 } from '#~/pages/projects/ProjectDetailsContext';
 import { DEFAULT_LIST_FETCH_STATE } from '#~/utilities/const';
+import { NotebookKind } from '#~/k8sTypes';
+import { KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
 import HardwareProfileTableColumn from '#~/concepts/hardwareProfiles/HardwareProfileTableColumn';
 
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({
@@ -54,7 +57,7 @@ describe('HardwareProfileTableColumn', () => {
       renderWithContext(
         <HardwareProfileTableColumn
           namespace="test-project"
-          resource={mockNotebookResource as never}
+          resource={mockNotebookResource as unknown as NotebookKind}
           bindingState={{
             bindingStateInfo: {
               profile,
@@ -72,11 +75,11 @@ describe('HardwareProfileTableColumn', () => {
   });
 
   describe('Custom scenario (no hardware profile)', () => {
-    it('renders Custom text and no details popover', () => {
+    it('renders Custom text as a focusable button with no details popover', () => {
       renderWithContext(
         <HardwareProfileTableColumn
           namespace="test-project"
-          resource={mockNotebookResource as never}
+          resource={mockNotebookResource as unknown as NotebookKind}
           bindingState={{
             bindingStateInfo: {
               profile: undefined,
@@ -89,13 +92,25 @@ describe('HardwareProfileTableColumn', () => {
 
       expect(screen.getByTestId('hardware-profile-table-column')).toHaveTextContent('Custom');
       expect(screen.queryByTestId('hardware-profile-details-popover')).not.toBeInTheDocument();
+      expect(screen.getByText('Custom').closest('button')).toBeInTheDocument();
     });
 
-    it('renders Custom trigger as a focusable element', () => {
+    it('renders details popover with "applied directly" when notebook has a direct queue label and no HP', async () => {
+      const notebookWithQueueLabel = {
+        ...mockNotebookResource,
+        metadata: {
+          ...mockNotebookResource.metadata,
+          labels: {
+            ...mockNotebookResource.metadata.labels,
+            [KUEUE_QUEUE_LABEL]: 'gitops-queue',
+          },
+        },
+      };
+
       renderWithContext(
         <HardwareProfileTableColumn
           namespace="test-project"
-          resource={mockNotebookResource as never}
+          resource={notebookWithQueueLabel as unknown as NotebookKind}
           bindingState={{
             bindingStateInfo: {
               profile: undefined,
@@ -106,8 +121,14 @@ describe('HardwareProfileTableColumn', () => {
         />,
       );
 
-      const trigger = screen.getByText('Custom').closest('button');
-      expect(trigger).toBeInTheDocument();
+      expect(screen.getByTestId('hardware-profile-details-popover')).toBeInTheDocument();
+      expect(screen.queryByText('Custom')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
+
+      const details = screen.getByTestId('hardware-profile-details');
+      expect(details).toHaveTextContent('Local queue (applied directly)');
+      expect(details).toHaveTextContent('gitops-queue');
     });
   });
 
@@ -116,7 +137,7 @@ describe('HardwareProfileTableColumn', () => {
       renderWithContext(
         <HardwareProfileTableColumn
           namespace="test-project"
-          resource={mockNotebookResource as never}
+          resource={mockNotebookResource as unknown as NotebookKind}
           bindingState={{
             bindingStateInfo: null,
             bindingStateLoaded: false,

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -17,7 +17,9 @@ import {
   applyHardwareProfileConfig,
   formatIdentifierDetails,
   formatResource,
+  getLocalQueueLabel,
 } from '#~/concepts/hardwareProfiles/utils';
+import { QueueSource } from '#~/concepts/hardwareProfiles/const';
 import { UseHardwareProfileConfigResult } from '#~/concepts/hardwareProfiles/useHardwareProfileConfig';
 import { NOTEBOOK_HARDWARE_PROFILE_PATHS } from '#~/concepts/notebooks/const.ts';
 
@@ -745,5 +747,15 @@ describe('applyHardwareProfileConfig', () => {
     expect((result as any).metadata?.annotations?.['opendatahub.io/hardware-profile-name']).toBe(
       'custom-path-test',
     );
+  });
+});
+
+describe('getLocalQueueLabel', () => {
+  it.each([
+    [undefined, 'Local queue'],
+    [QueueSource.DIRECT, 'Local queue (applied directly)'],
+    [QueueSource.HARDWARE_PROFILE, 'Local queue (via hardware profile)'],
+  ])('returns correct label for queueSource %s', (source, expected) => {
+    expect(getLocalQueueLabel(source)).toBe(expected);
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/const.ts
+++ b/frontend/src/concepts/hardwareProfiles/const.ts
@@ -85,3 +85,8 @@ export const INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS: CrPathConfig = {
   tolerationsPath: 'spec.predictor.tolerations',
   nodeSelectorPath: 'spec.predictor.nodeSelector',
 };
+
+export enum QueueSource {
+  HARDWARE_PROFILE = 'hardware-profile',
+  DIRECT = 'direct',
+}

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -20,6 +20,7 @@ import {
 import {
   HardwareProfileBindingState,
   REMOVE_HARDWARE_PROFILE_ANNOTATIONS_PATCH,
+  QueueSource,
 } from '#~/concepts/hardwareProfiles/const';
 import {
   HardwarePodSpecOptions,
@@ -336,4 +337,15 @@ export const applyHardwareProfileConfig = <T extends K8sResourceCommon>(
     }
   }
   return result;
+};
+
+export const getLocalQueueLabel = (queueSource?: QueueSource): string => {
+  const commonLabel = 'Local queue';
+  if (queueSource === QueueSource.DIRECT) {
+    return `${commonLabel} (applied directly)`;
+  }
+  if (queueSource === QueueSource.HARDWARE_PROFILE) {
+    return `${commonLabel} (via hardware profile)`;
+  }
+  return commonLabel;
 };

--- a/packages/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
@@ -417,6 +417,133 @@ describe('Workbench Hardware Profiles', () => {
       });
   });
 
+  describe('Local queue label in workbench table column popover', () => {
+    beforeEach(() => {
+      asProductAdminUser();
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({ disableKueue: false, disableProjectScoped: true }),
+      );
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.WORKBENCHES]: { managementState: 'Managed' },
+            [DataScienceStackComponent.KUEUE]: { managementState: 'Managed' },
+          },
+        }),
+      );
+      cy.interceptK8sList(
+        ProjectModel,
+        mockK8sResourceList([mockProjectK8sResource({ enableKueue: true })]),
+      );
+      cy.interceptK8s(ProjectModel, mockProjectK8sResource({ enableKueue: true }));
+      cy.interceptK8sList(
+        { model: HardwareProfileModel, ns: 'test-project' },
+        mockK8sResourceList(mockProjectScopedHardwareProfiles),
+      );
+      cy.interceptK8sList(StorageClassModel, mockStorageClassList());
+      cy.interceptK8sList(PodModel, mockK8sResourceList([mockPodK8sResource({})]));
+      cy.interceptK8sList(
+        ImageStreamModel,
+        mockK8sResourceList([mockImageStreamK8sResource({ namespace: 'opendatahub' })]),
+      );
+      cy.interceptK8s(RouteModel, mockRouteK8sResource({ notebookName: 'test-notebook' }));
+      cy.interceptK8sList(SecretModel, mockK8sResourceList([mockSecretK8sResource({})]));
+      cy.interceptK8sList(
+        PVCModel,
+        mockK8sResourceList([mockPVCK8sResource({ name: 'test-storage-1' })]),
+      );
+    });
+
+    it('should show "Local queue (applied directly)" in table column popover for GitOps-managed notebook with direct queue label', () => {
+      const notebookWithDirectQueue = mockNotebookK8sResource({
+        displayName: 'Test Notebook',
+        opts: {
+          metadata: {
+            labels: {
+              'kueue.x-k8s.io/queue-name': 'direct-queue',
+            },
+          },
+        },
+      });
+
+      cy.interceptK8sList(
+        { model: HardwareProfileModel, ns: 'opendatahub' },
+        mockK8sResourceList(mockGlobalScopedHardwareProfiles),
+      );
+      cy.interceptK8sList(
+        { model: LocalQueueModel, ns: 'test-project' },
+        mockK8sResourceList([
+          mockLocalQueueK8sResource({ name: 'direct-queue', namespace: 'test-project' }),
+        ]),
+      );
+      cy.interceptK8sList(
+        { model: NotebookModel, ns: 'test-project' },
+        mockK8sResourceList([notebookWithDirectQueue]),
+      );
+
+      projectDetails.visit(projectName);
+      projectDetails.findSectionTab('workbenches').click();
+
+      hardwareProfileSection.findDetailsPopover().should('exist').click();
+      hardwareProfileSection
+        .findDetails()
+        .should('be.visible')
+        .within(() => {
+          cy.contains('Local queue (applied directly)').should('be.visible');
+          cy.contains('direct-queue').should('be.visible');
+        });
+    });
+
+    it('should show "Local queue (via hardware profile)" in table column popover when queue comes from hardware profile', () => {
+      const queueProfile = mockHardwareProfile({
+        name: 'queue-profile',
+        displayName: 'Queue Profile',
+        schedulingType: SchedulingType.QUEUE,
+        localQueueName: 'hp-queue',
+      });
+      const notebookWithHPQueue = mockNotebookK8sResource({
+        displayName: 'Test Notebook',
+        opts: {
+          metadata: {
+            annotations: {
+              'opendatahub.io/hardware-profile-name': 'queue-profile',
+              'opendatahub.io/hardware-profile-namespace': 'opendatahub',
+            },
+          },
+        },
+      });
+
+      cy.interceptK8sList(
+        { model: HardwareProfileModel, ns: 'opendatahub' },
+        mockK8sResourceList([...mockGlobalScopedHardwareProfiles, queueProfile]),
+      );
+      cy.interceptK8sList(
+        { model: LocalQueueModel, ns: 'test-project' },
+        mockK8sResourceList([
+          mockLocalQueueK8sResource({ name: 'hp-queue', namespace: 'test-project' }),
+        ]),
+      );
+      cy.interceptK8sList(
+        { model: NotebookModel, ns: 'test-project' },
+        mockK8sResourceList([notebookWithHPQueue]),
+      );
+
+      projectDetails.visit(projectName);
+      projectDetails.findSectionTab('workbenches').click();
+
+      hardwareProfileSection.findDetailsPopover().should('exist').click();
+      hardwareProfileSection
+        .findDetails()
+        .should('be.visible')
+        .within(() => {
+          cy.contains('Local queue (via hardware profile)').should('be.visible');
+          cy.contains('hp-queue').should('be.visible');
+        });
+    });
+  });
+
   describe('Edit Workbench Hardware Profiles', () => {
     it('should auto-select hardware profile from annotations', () => {
       initIntercepts();


### PR DESCRIPTION
Closes [RHOAIENG-68467](https://issues.redhat.com/browse/RHOAIENG-68467)

## Description

The hardware profile details popover in the workbenches table only showed a local queue name when
the queue was assigned through a hardware profile. If a notebook had the
`kueue.x-k8s.io/queue-name` label applied directly (for example via GitOps or kubectl), the queue
name was missing from the popover entirely.

This change adds a fallback so the popover reads the queue label directly from the notebook when
no hardware profile is matched. It also adds a source annotation to the queue section label so
users can see how the queue was assigned:

- **"Local queue (via hardware profile)"** when the queue name comes from a hardware profile's
  scheduling config
  
<img width="1266" height="738" alt="Screenshot 2026-06-23 at 1 28 56 PM" src="https://github.com/user-attachments/assets/e841989f-9459-4995-b6a5-dbde4e078055" />

- **"Local queue (applied directly)"** when the queue label was set directly on the notebook

<img width="1266" height="738" alt="Screenshot 2026-06-23 at 1 27 49 PM" src="https://github.com/user-attachments/assets/7632ad29-2195-452b-a5ec-b1893fa080bc" />



## How Has This Been Tested?

**1. Verify "via hardware profile" label**

Create or find a workbench that was assigned a hardware profile with a local queue configured.
Navigate to the project's Workbenches tab. Click the hardware profile name in the Hardware profile
column to open the details popover. The queue section should read **"Local queue (via hardware
profile)"** followed by the queue name.

**2. Verify "applied directly" label for a GitOps-managed notebook**

Apply a notebook with the queue label set directly and no hardware profile annotation:

```bash
oc apply -n <your-project> -f - <<EOF
apiVersion: kubeflow.org/v1
kind: Notebook
metadata:
  name: gitops-notebook
  namespace: <your-project>
  labels:
    app: gitops-notebook
    opendatahub.io/dashboard: 'true'
    opendatahub.io/odh-managed: 'true'
    kueue.x-k8s.io/queue-name: <local-queue-name>
  annotations:
    openshift.io/display-name: GitOps Notebook
    notebooks.opendatahub.io/inject-oauth: 'true'
    opendatahub.io/image-display-name: Minimal Python
    notebooks.opendatahub.io/last-image-selection: 's2i-minimal-notebook:py3.11-2024b'
    notebooks.opendatahub.io/last-size-selection: Small
spec:
  template:
    spec:
      containers:
        - name: gitops-notebook
          image: 'image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook:py3.11-2024b'
          resources:
            limits:
              cpu: '2'
              memory: 2Gi
            requests:
              cpu: '1'
              memory: 1Gi
EOF
```

Navigate to the project's Workbenches tab. Click **"View details"** in the Hardware profile column
for the new notebook. The popover should show **"Local queue (applied directly)"** followed by the
queue name.

**3. Verify a notebook with no queue assignment is unaffected**

A workbench with no hardware profile and no queue label should still show the **"Custom"** tooltip
in the Hardware profile column, unchanged from before.

## Test Impact

- Jest unit tests updated in `HardwareProfileDetailsPopover.spec.tsx` covering both `QueueSource`
  values using `it.each`
- Jest unit tests added in `HardwareProfileTableColumn.spec.tsx` for the GitOps direct queue label
  case
- Jest unit tests added in `utils.spec.ts` for all three `getLocalQueueLabel` execution paths
  (undefined, DIRECT, HARDWARE_PROFILE)
- Cypress mock tests added in `workbenchHardwareProfiles.cy.ts` in a dedicated describe block
  covering both the "applied directly" and "via hardware profile" table column popover cases

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not
  immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests
  for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards,
  PatternFly usage, performance considerations)

If you have UI changes:

- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

cc  @ralombar
This is just content changes and verification of whether the workbench was created via gitops and not from the dashboard so, if the razz team would pick up and convert the popover to  a modal it won't be a major change

After the PR is posted & before it merges:

- [ ] The developer has tested their solution on a cluster by using the image produced by the PR
  to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the hardware profile details popover to display the “Local queue” label with clear context for direct application vs application via a hardware profile, including corresponding labeling updates in the workbench table column flow.

* **Bug Fixes**
  * When a local queue name is available, the popover no longer shows the unrelated “No matching hardware profile found” fallback content.

* **Tests**
  * Expanded and refactored unit and Cypress coverage to verify label text and rendered queue names for both direct-queue and hardware-profile scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->