### PR TITLE
fix(gen-ai): reset MCP panel state on config switch in compare mode

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/MCPTabContent.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/MCPTabContent.tsx
@@ -46,6 +46,7 @@ const MCPTabContent: React.FunctionComponent<MCPTabContentProps> = ({
       titleTestId="mcp-servers-section-title"
     >
       <MCPServersPanel
+        key={configId}
         configId={configId}
         servers={mcpServers}
         serversLoaded={mcpServersLoaded}

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/MCPTabContent.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/MCPTabContent.spec.tsx
@@ -141,4 +141,20 @@ describe('MCPTabContent', () => {
 
     expect(screen.getByTestId('config-id')).toHaveTextContent('test-config');
   });
+
+  it('remounts MCPServersPanel when configId changes', () => {
+    const { rerender } = render(<MCPTabContent {...defaultProps} configId="config-a" />);
+
+    const panelBefore = screen.getByTestId('mcp-servers-panel');
+    expect(screen.getByTestId('config-id')).toHaveTextContent('config-a');
+
+    rerender(<MCPTabContent {...defaultProps} configId="config-b" />);
+
+    const panelAfter = screen.getByTestId('mcp-servers-panel');
+    expect(screen.getByTestId('config-id')).toHaveTextContent('config-b');
+
+    // key={configId} causes React to unmount and remount the component,
+    // producing a different DOM node instance
+    expect(panelBefore).not.toBe(panelAfter);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes MCP server selections bleeding across panels in compare mode.

**Root cause:** `useServerSelection` hook uses a `useRef` gate for one-time initialization. When `configId` changes (switching between compare mode panels), the hook never re-processes the initial selection for the new config, causing stale selections from the previous panel to persist.

**Fix:** Add `key={configId}` to `MCPServersPanel` so React remounts it cleanly on config switch. This is the [standard React pattern](https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes) for resetting component state when an identity prop changes.

## Changes

- `packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/MCPTabContent.tsx`: Added `key={configId}` prop to `MCPServersPanel`

## Verification

- All 1529 unit tests pass (105 suites)
- Manually verified in compare mode: each panel maintains independent MCP server selections
- Confirmed via DevTools Network tab that each panel sends its correct `mcp_servers` array in the request payload (Chat 1 → Alpha, Chat 2 → Beta)

## Test plan

- [x] Unit tests pass (`npx jest` — 1529/1529)
- [x] Visual verification: selections don't bleed across panels
- [x] Functional verification: request payloads carry correct per-panel MCP server config

Ref: [RHOAIENG-58728](https://redhat.atlassian.net/browse/RHOAIENG-58728)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings panels now properly refresh when switching between different configurations.

* **Tests**
  * Added verification tests for configuration panel refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->