### PR TITLE
fix(gen-ai): replace compress icon with clear selection button in loa…

### DIFF
--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/promptManagementPage.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/promptManagementPage.ts
@@ -53,8 +53,8 @@ class PromptDrawer {
     return cy.findByTestId('prompt-drawer-template');
   }
 
-  findCloseButton(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('prompt-drawer-close');
+  findClearSelectionButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('prompt-drawer-clear-selection');
   }
 
   findLoading(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/__tests__/promptDrawer.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/__tests__/promptDrawer.spec.tsx
@@ -107,9 +107,9 @@ describe('PromptDrawer', () => {
     );
   });
 
-  it('should render close button in drawer', () => {
+  it('should render clear selection button in drawer', () => {
     render(<PromptDrawer {...defaultProps} selectedVersion={2} />);
 
-    expect(screen.getByRole('button', { name: 'Close drawer' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear selection' })).toBeInTheDocument();
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/promptDrawer.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/promptDrawer.tsx
@@ -24,8 +24,9 @@ import {
   TimestampFormat,
   LabelGroup,
   Label,
+  Tooltip,
 } from '@patternfly/react-core';
-import { CompressAltIcon } from '@patternfly/react-icons';
+import { TimesIcon } from '@patternfly/react-icons';
 import { MLflowPromptVersion } from '~/app/types';
 
 const VersionSelect: React.FC<{
@@ -120,14 +121,16 @@ export default function PromptDrawer({
         <DrawerHead>
           <Title headingLevel="h2">{name}</Title>
           <DrawerActions>
-            <Button
-              data-testid="prompt-drawer-close"
-              variant="plain"
-              aria-label="Close drawer"
-              onClick={onClose}
-            >
-              <CompressAltIcon />
-            </Button>
+            <Tooltip content="Clear selection">
+              <Button
+                data-testid="prompt-drawer-clear-selection"
+                variant="plain"
+                aria-label="Clear selection"
+                onClick={onClose}
+              >
+                <TimesIcon />
+              </Button>
+            </Tooltip>
           </DrawerActions>
         </DrawerHead>
         <Flex


### PR DESCRIPTION
…d prompt drawer
https://issues.redhat.com/browse/RHOAIENG-58425

<img width="1167" height="730" alt="prompt" src="https://github.com/user-attachments/assets/5ceec0e8-0bc9-4b87-9244-7bbdc382199a" />


## Description

In the Playground **Load prompt** modal, the inline control used to deselect/clear the currently selected prompt was using a `CompressAltIcon` (compress/minimize icon). This icon reads as generic panel chrome and users could not identify it as a "clear selection" affordance.

**Changes:**
- Replaced `CompressAltIcon` with `TimesIcon` (×) — universally recognized as a close/dismiss/clear action
- Wrapped the button in a PatternFly `Tooltip` with the label **"Clear selection"** so the intent is explicit on hover
- Updated `aria-label` from `"Close drawer"` to `"Clear selection"` for accurate accessibility semantics

**Before:** A compress/minimize icon with no tooltip — easily missed or misread as a panel collapse control  
**After:** A × icon with a "Clear selection" tooltip — the action is self-explanatory at a glance

<!-- Screenshots/gifs showing before/after would go here -->

## How Has This Been Tested?
Tested on the cluster

## Test Impact

Updated the existing unit test in `promptDrawer.spec.tsx`:
- Renamed test from `"should render close button in drawer"` → `"should render clear selection button in drawer"`
- Updated `aria-label` assertion from `"Close drawer"` → `"Clear selection"` to match the new button

No new test cases were required — the existing test coverage for the drawer close button remains intact.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the prompt drawer's close button with a new icon and "Clear selection" tooltip to enhance clarity on the button's function.

* **Tests**
  * Updated test cases to reflect changes in the prompt drawer control button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->