### PR TITLE
feat(llmd-serving): add data layer for topology and routing config management

### DIFF
--- a/frontend/src/__mocks__/mockLLMInferenceServiceConfigK8sResource.ts
+++ b/frontend/src/__mocks__/mockLLMInferenceServiceConfigK8sResource.ts
@@ -8,7 +8,7 @@ type MockLLMInferenceServiceConfigType = {
   name?: string;
   namespace?: string;
   displayName?: string;
-  configType?: string;
+  configType?: TopologyType | 'router' | 'accelerator';
   topologyType?: TopologyType;
   routingType?: RoutingType;
   supportedTopologies?: TopologyType[];
@@ -51,13 +51,13 @@ export const mockLLMInferenceServiceConfigK8sResource = ({
       ...(templateName ? { 'opendatahub.io/template-name': templateName } : {}),
       ...(disabled ? { 'opendatahub.io/disabled': 'true' as const } : {}),
       ...(routingType ? { 'opendatahub.io/routing-type': routingType } : {}),
+      ...(supportedTopologies
+        ? { 'opendatahub.io/supported-topologies': JSON.stringify(supportedTopologies) }
+        : {}),
       ...(preInstalled ? { 'serving.kserve.io/well-known-config': 'true' as const } : {}),
     },
     labels: {
       'opendatahub.io/config-type': topologyType ?? configType,
-      ...(supportedTopologies
-        ? { 'opendatahub.io/supported-topologies': JSON.stringify(supportedTopologies) }
-        : {}),
       ...(!preInstalled ? { 'opendatahub.io/dashboard': 'true' as const } : {}),
     },
     ...(preInstalled

--- a/frontend/src/__mocks__/mockLLMInferenceServiceConfigK8sResource.ts
+++ b/frontend/src/__mocks__/mockLLMInferenceServiceConfigK8sResource.ts
@@ -1,16 +1,24 @@
-import { type LLMInferenceServiceConfigKind } from '@odh-dashboard/llmd-serving/types';
+import {
+  type LLMInferenceServiceConfigKind,
+  type TopologyType,
+  type RoutingType,
+} from '@odh-dashboard/llmd-serving/types';
 
 type MockLLMInferenceServiceConfigType = {
   name?: string;
   namespace?: string;
   displayName?: string;
-  configType?: 'accelerator' | string;
+  configType?: string;
+  topologyType?: TopologyType;
+  routingType?: RoutingType;
+  supportedTopologies?: TopologyType[];
   recommendedAccelerators?: string;
   runtimeVersion?: string;
   modelUri?: string;
   modelName?: string;
   templateName?: string;
   disabled?: boolean;
+  preInstalled?: boolean;
 };
 
 export const mockLLMInferenceServiceConfigK8sResource = ({
@@ -18,14 +26,18 @@ export const mockLLMInferenceServiceConfigK8sResource = ({
   namespace = 'opendatahub',
   displayName = 'Test vLLM Config',
   configType = 'accelerator',
+  topologyType,
+  routingType,
+  supportedTopologies,
   recommendedAccelerators,
   runtimeVersion = 'v0.9.1',
   modelUri = 'hf://test/model',
   modelName = 'test-model',
   templateName,
   disabled,
+  preInstalled,
 }: MockLLMInferenceServiceConfigType): LLMInferenceServiceConfigKind => ({
-  apiVersion: 'serving.kserve.io/v1alpha1',
+  apiVersion: 'serving.kserve.io/v1alpha2',
   kind: 'LLMInferenceServiceConfig',
   metadata: {
     name,
@@ -38,10 +50,28 @@ export const mockLLMInferenceServiceConfigK8sResource = ({
         : {}),
       ...(templateName ? { 'opendatahub.io/template-name': templateName } : {}),
       ...(disabled ? { 'opendatahub.io/disabled': 'true' as const } : {}),
+      ...(routingType ? { 'opendatahub.io/routing-type': routingType } : {}),
+      ...(preInstalled ? { 'serving.kserve.io/well-known-config': 'true' as const } : {}),
     },
     labels: {
-      'opendatahub.io/config-type': configType,
+      'opendatahub.io/config-type': topologyType ?? configType,
+      ...(supportedTopologies
+        ? { 'opendatahub.io/supported-topologies': JSON.stringify(supportedTopologies) }
+        : {}),
+      ...(!preInstalled ? { 'opendatahub.io/dashboard': 'true' as const } : {}),
     },
+    ...(preInstalled
+      ? {
+          ownerReferences: [
+            {
+              apiVersion: 'operator.kserve.io/v1alpha1',
+              kind: 'KServe',
+              name: 'default',
+              uid: 'test-uid-kserve',
+            },
+          ],
+        }
+      : {}),
   },
   spec: {
     model: {

--- a/frontend/src/__mocks__/mockLLMInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockLLMInferenceServiceK8sResource.ts
@@ -47,7 +47,7 @@ export const mockLLMInferenceServiceK8sResource = ({
   secretName,
   gatewayRefs,
 }: MockLLMInferenceServiceConfigType): LLMInferenceServiceKind => ({
-  apiVersion: 'serving.kserve.io/v1alpha1',
+  apiVersion: 'serving.kserve.io/v1alpha2',
   kind: 'LLMInferenceService',
   metadata: {
     annotations: {

--- a/frontend/src/api/models/kserve.ts
+++ b/frontend/src/api/models/kserve.ts
@@ -15,14 +15,14 @@ export const InferenceServiceModel: K8sModelCommon = {
 };
 
 export const LLMInferenceServiceModel: K8sModelCommon = {
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1alpha2',
   apiGroup: 'serving.kserve.io',
   kind: 'LLMInferenceService',
   plural: 'llminferenceservices',
 };
 
 export const LLMInferenceServiceConfigModel: K8sModelCommon = {
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1alpha2',
   apiGroup: 'serving.kserve.io',
   kind: 'LLMInferenceServiceConfig',
   plural: 'llminferenceserviceconfigs',

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -17,6 +17,7 @@ export const techPreviewFlags = {
   externalVectorStores: false,
   vLLMDeploymentOnMaaS: false,
   llmGatewayField: false,
+  llmdTopologyConfigs: false,
   promptManagement: false,
   mySubscriptions: true,
   maasSettingsIaRedesign: false,
@@ -247,6 +248,10 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.VLLM_ON_MAAS]: {
     featureFlags: ['vLLMDeploymentOnMaaS'],
+    reliantAreas: [SupportedArea.LLMD_SERVING],
+  },
+  [SupportedArea.LLMD_TOPOLOGY_CONFIGS]: {
+    featureFlags: ['llmdTopologyConfigs'],
     reliantAreas: [SupportedArea.LLMD_SERVING],
   },
   [SupportedArea.LLMD_GATEWAY_FIELD]: {

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -65,6 +65,7 @@ export enum SupportedArea {
   MODEL_AS_SERVICE = 'model-as-service',
   MAAS_AUTH_POLICIES = 'maas-auth-policies',
   LLMD_SERVING = 'llmd-serving',
+  LLMD_TOPOLOGY_CONFIGS = 'llmd-topology-configs',
   YAML_VIEWER = 'yaml-viewer',
   VLLM_ON_MAAS = 'vllm-on-maas',
   LLMD_GATEWAY_FIELD = 'llmd-gateway-field',

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -1830,7 +1830,7 @@ describe('Model Serving Deploy Wizard', () => {
       // because cy.contains() normalizes &nbsp; to regular spaces while the assertion does not)
       modelServingWizard.findYAMLViewerToggle('YAML').should('exist').click();
       const yamlEditor = modelServingWizard.findYAMLCodeEditor();
-      yamlEditor.containsText('apiVersion: serving.kserve.io/v1alpha1');
+      yamlEditor.containsText('apiVersion: serving.kserve.io/v1alpha2');
       yamlEditor.containsText('kind: LLMInferenceService');
       yamlEditor.containsText('name: test-model');
     });
@@ -1909,7 +1909,7 @@ describe('Model Serving Deploy Wizard', () => {
       cy.wait('@createLLMInferenceService').then((interception) => {
         expect(interception.request.url).to.include('?dryRun=All');
         expect(interception.request.body.kind).to.equal('LLMInferenceService');
-        expect(interception.request.body.apiVersion).to.equal('serving.kserve.io/v1alpha1');
+        expect(interception.request.body.apiVersion).to.equal('serving.kserve.io/v1alpha2');
         expect(interception.request.body.metadata.name).to.equal('yaml-edited-model');
         expect(interception.request.body.metadata.namespace).to.equal('test-project');
       });
@@ -1990,7 +1990,7 @@ describe('Model Serving Deploy Wizard', () => {
 
       // Set a valid LLMInferenceService YAML
       const yamlContent = [
-        'apiVersion: serving.kserve.io/v1alpha1',
+        'apiVersion: serving.kserve.io/v1alpha2',
         'kind: LLMInferenceService',
         'metadata:',
         '  name: yaml-only-model',
@@ -2009,7 +2009,7 @@ describe('Model Serving Deploy Wizard', () => {
       cy.wait('@createLLMInferenceService').then((interception) => {
         expect(interception.request.url).to.include('?dryRun=All');
         expect(interception.request.body.kind).to.equal('LLMInferenceService');
-        expect(interception.request.body.apiVersion).to.equal('serving.kserve.io/v1alpha1');
+        expect(interception.request.body.apiVersion).to.equal('serving.kserve.io/v1alpha2');
         expect(interception.request.body.metadata.name).to.equal('yaml-only-model');
         expect(interception.request.body.metadata.namespace).to.equal('test-project');
         expect(interception.request.body.spec.model.uri).to.equal('hf://test/model');

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
@@ -635,7 +635,7 @@ describe('Model Serving LLMD', () => {
       });
       cy.intercept(
         'PATCH',
-        '/api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/test-project/llminferenceservices/test-llmd-model',
+        '/api/k8s/apis/serving.kserve.io/v1alpha2/namespaces/test-project/llminferenceservices/test-llmd-model',
         (req) => {
           req.reply({
             statusCode: 200,
@@ -645,7 +645,7 @@ describe('Model Serving LLMD', () => {
       ).as('startLLMInferenceService1');
       cy.intercept(
         'PATCH',
-        '/api/k8s/apis/serving.kserve.io/v1alpha1/namespaces/test-project/llminferenceservices/test-llmd-model-2',
+        '/api/k8s/apis/serving.kserve.io/v1alpha2/namespaces/test-project/llminferenceservices/test-llmd-model-2',
         (req) => {
           req.reply({
             statusCode: 200,

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -267,6 +267,7 @@ export type DashboardCommonConfig = {
   projectRBAC?: boolean;
   observabilityDashboard?: boolean;
   disableLLMd?: boolean;
+  llmdTopologyConfigs?: boolean;
   deploymentWizardYAMLViewer?: boolean;
   externalVectorStores?: boolean;
   vLLMDeploymentOnMaaS?: boolean;

--- a/packages/llmd-serving/docs/overview.md
+++ b/packages/llmd-serving/docs/overview.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-- The `llmd-serving` package implements LLM-d (LLM-dedicated) serving: KServe-backed extension to `model-serving` that creates and manages `LLMInferenceService` resources (`serving.kserve.io/v1alpha1`).
+- The `llmd-serving` package implements LLM-d (LLM-dedicated) serving: KServe-backed extension to `model-serving` that creates and manages `LLMInferenceService` resources (`serving.kserve.io/v1alpha2`).
 - For generative models that need LLM-d scheduling, gateway routing, and token-auth wiring rather than generic KServe or ModelMesh paths.
 
 ## Design Intent
@@ -10,13 +10,13 @@
 - **No BFF**: CRUD for `LLMInferenceService` in `src/api/` uses the OpenShift dynamic plugin SDK from the browser with the main dashboard's in-cluster credentials.
 - **Extension points**: `extensions/extensions.ts` registers `model-serving.platform/watch-deployments`, `model-serving.deployment/deploy`, `model-serving.deployment/form-data`, `model-serving.deployment/wizard-field`, and `model-serving.deployments-table/start-stop-action`; host `model-serving` orchestrates; this package supplies LLM-d-specific behavior only.
 - **No Webpack remote**: Dashboard loads via monorepo exports (e.g. `./extensions`, `./types`, test helpers under `./__tests__/utils`).
-- **API**: Group `serving.kserve.io`, resource `llminferenceservices`, version `v1alpha1`; shapes in `src/types.ts` as `LLMInferenceServiceKind`.
+- **API**: Group `serving.kserve.io`, resource `llminferenceservices`, version `v1alpha2`; shapes in `src/types.ts` as `LLMInferenceServiceKind`.
 
 ## Key Concepts
 
 | Term | Definition |
 |------|-----------|
-| **LLMInferenceService** | CR `serving.kserve.io/v1alpha1` / `llminferenceservices`; deployed LLM-d model. |
+| **LLMInferenceService** | CR `serving.kserve.io/v1alpha2` / `llminferenceservices`; deployed LLM-d model. |
 | **LLMdDeployment** | `Deployment<LLMInferenceServiceKind>` with `modelServingPlatformId = 'llmd-serving'`. |
 | **LLMdContainer** | Container in `spec.template.containers`; vLLM args via `VLLM_ADDITIONAL_ARGS`. |
 | **Router** | `spec.router` with `gateway`, `route`, `scheduler`; LLM-d routing layer. |
@@ -33,7 +33,7 @@
 | `@odh-dashboard/model-serving` | Package | Extension-point interfaces this package implements |
 | `@odh-dashboard/kserve` | Package | Shared KServe utilities and types |
 | `@odh-dashboard/internal` | Package | Hardware profiles, k8s types, flags / areas |
-| `LLMInferenceService` CRD | Kubernetes API | Group `serving.kserve.io`, `v1alpha1` |
+| `LLMInferenceService` CRD | Kubernetes API | Group `serving.kserve.io`, `v1alpha2` |
 | Main ODH Dashboard | Host application | Loads extensions; model-serving wizard and table |
 
 ## Known Issues / Gotchas

--- a/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
@@ -13,9 +13,9 @@ import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
 import {
   LLMInferenceServiceConfigModel,
+  TopologyType,
   CONFIG_TYPE_LABEL,
   CONFIG_TYPE_ROUTER,
-  type TopologyType,
   type LLMInferenceServiceConfigKind,
 } from '../types';
 
@@ -128,6 +128,9 @@ export const useWatchLLMInferenceServiceConfigs = (
 
 // --- Topology Configuration APIs ---
 
+const TOPOLOGY_TYPE_VALUES = Object.values(TopologyType);
+const TOPOLOGY_LABEL_SELECTOR = `${CONFIG_TYPE_LABEL} in (${TOPOLOGY_TYPE_VALUES.join(',')})`;
+
 export const listTopologyConfigs = async (
   namespace: string,
   topologyType: TopologyType,
@@ -143,23 +146,17 @@ export const listTopologyConfigs = async (
   });
 };
 
-/**
- * Fetches all configs and filters client-side because topology types use distinct label values
- * (e.g., workload-single-node, workload-multi-node-data-parallel) that can't be matched
- * with a single server-side label selector.
- */
 export const listAllTopologyConfigs = async (
   namespace: string,
 ): Promise<LLMInferenceServiceConfigKind[]> => {
-  const results = await k8sListResourceItems<LLMInferenceServiceConfigKind>({
+  return k8sListResourceItems<LLMInferenceServiceConfigKind>({
     model: LLMInferenceServiceConfigModel,
     queryOptions: {
       ns: namespace,
+      queryParams: {
+        labelSelector: TOPOLOGY_LABEL_SELECTOR,
+      },
     },
-  });
-  return results.filter((config) => {
-    const configType = config.metadata.labels?.[CONFIG_TYPE_LABEL];
-    return configType && configType !== CONFIG_TYPE_ROUTER && configType !== 'accelerator';
   });
 };
 
@@ -182,6 +179,15 @@ export const useWatchTopologyConfigs = (
       isList: true,
       groupVersionKind: groupVersionKind(LLMInferenceServiceConfigModel),
       namespace,
+      selector: {
+        matchExpressions: [
+          {
+            key: CONFIG_TYPE_LABEL,
+            operator: 'In',
+            values: TOPOLOGY_TYPE_VALUES,
+          },
+        ],
+      },
     },
     LLMInferenceServiceConfigModel,
     opts,

--- a/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
@@ -11,7 +11,13 @@ import { createPatchesFromDiff, groupVersionKind } from '@odh-dashboard/internal
 import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
 import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
-import { LLMInferenceServiceConfigModel, type LLMInferenceServiceConfigKind } from '../types';
+import {
+  LLMInferenceServiceConfigModel,
+  CONFIG_TYPE_LABEL,
+  CONFIG_TYPE_ROUTER,
+  type TopologyType,
+  type LLMInferenceServiceConfigKind,
+} from '../types';
 
 export const createLLMInferenceServiceConfig = (
   llmInferenceServiceConfig: LLMInferenceServiceConfigKind,
@@ -114,6 +120,114 @@ export const useWatchLLMInferenceServiceConfigs = (
       isList: true,
       groupVersionKind: groupVersionKind(LLMInferenceServiceConfigModel),
       namespace,
+    },
+    LLMInferenceServiceConfigModel,
+    opts,
+  );
+};
+
+// --- Topology Configuration APIs ---
+
+export const listTopologyConfigs = async (
+  namespace: string,
+  topologyType: TopologyType,
+): Promise<LLMInferenceServiceConfigKind[]> => {
+  return k8sListResourceItems<LLMInferenceServiceConfigKind>({
+    model: LLMInferenceServiceConfigModel,
+    queryOptions: {
+      ns: namespace,
+      queryParams: {
+        labelSelector: `${CONFIG_TYPE_LABEL}=${topologyType}`,
+      },
+    },
+  });
+};
+
+/**
+ * Fetches all configs and filters client-side because topology types use distinct label values
+ * (e.g., workload-single-node, workload-multi-node-data-parallel) that can't be matched
+ * with a single server-side label selector.
+ */
+export const listAllTopologyConfigs = async (
+  namespace: string,
+): Promise<LLMInferenceServiceConfigKind[]> => {
+  const results = await k8sListResourceItems<LLMInferenceServiceConfigKind>({
+    model: LLMInferenceServiceConfigModel,
+    queryOptions: {
+      ns: namespace,
+    },
+  });
+  return results.filter((config) => {
+    const configType = config.metadata.labels?.[CONFIG_TYPE_LABEL];
+    return configType && configType !== CONFIG_TYPE_ROUTER && configType !== 'accelerator';
+  });
+};
+
+export const useFetchTopologyConfigs = (
+  namespace: string,
+): FetchStateObject<LLMInferenceServiceConfigKind[]> => {
+  const fetchCallbackPromise = React.useCallback(async () => {
+    return listAllTopologyConfigs(namespace);
+  }, [namespace]);
+
+  return useFetch(fetchCallbackPromise, []);
+};
+
+export const useWatchTopologyConfigs = (
+  namespace: string,
+  opts?: K8sAPIOptions,
+): CustomWatchK8sResult<LLMInferenceServiceConfigKind[]> => {
+  return useK8sWatchResourceList<LLMInferenceServiceConfigKind[]>(
+    {
+      isList: true,
+      groupVersionKind: groupVersionKind(LLMInferenceServiceConfigModel),
+      namespace,
+    },
+    LLMInferenceServiceConfigModel,
+    opts,
+  );
+};
+
+// --- Router Configuration APIs ---
+
+export const listRouterConfigs = async (
+  namespace: string,
+): Promise<LLMInferenceServiceConfigKind[]> => {
+  return k8sListResourceItems<LLMInferenceServiceConfigKind>({
+    model: LLMInferenceServiceConfigModel,
+    queryOptions: {
+      ns: namespace,
+      queryParams: {
+        labelSelector: `${CONFIG_TYPE_LABEL}=${CONFIG_TYPE_ROUTER}`,
+      },
+    },
+  });
+};
+
+export const useFetchRouterConfigs = (
+  namespace: string,
+): FetchStateObject<LLMInferenceServiceConfigKind[]> => {
+  const fetchCallbackPromise = React.useCallback(async () => {
+    return listRouterConfigs(namespace);
+  }, [namespace]);
+
+  return useFetch(fetchCallbackPromise, []);
+};
+
+export const useWatchRouterConfigs = (
+  namespace: string,
+  opts?: K8sAPIOptions,
+): CustomWatchK8sResult<LLMInferenceServiceConfigKind[]> => {
+  return useK8sWatchResourceList<LLMInferenceServiceConfigKind[]>(
+    {
+      isList: true,
+      groupVersionKind: groupVersionKind(LLMInferenceServiceConfigModel),
+      namespace,
+      selector: {
+        matchLabels: {
+          [CONFIG_TYPE_LABEL]: CONFIG_TYPE_ROUTER,
+        },
+      },
     },
     LLMInferenceServiceConfigModel,
     opts,

--- a/packages/llmd-serving/src/deployments/deploy.ts
+++ b/packages/llmd-serving/src/deployments/deploy.ts
@@ -47,7 +47,7 @@ export const BaseLLMInferenceService = (
   annotations?: Record<string, string>,
 ): LLMInferenceServiceKind => {
   return {
-    apiVersion: 'serving.kserve.io/v1alpha1',
+    apiVersion: 'serving.kserve.io/v1alpha2',
     kind: 'LLMInferenceService',
     metadata: {
       name: name ?? '',

--- a/packages/llmd-serving/src/types.ts
+++ b/packages/llmd-serving/src/types.ts
@@ -45,7 +45,7 @@ export const CONFIG_TYPE_ROUTER = 'router';
 const WELL_KNOWN_ANNOTATION = 'serving.kserve.io/well-known-config';
 const DISABLED_ANNOTATION = 'opendatahub.io/disabled';
 const ROUTING_TYPE_ANNOTATION = 'opendatahub.io/routing-type';
-const SUPPORTED_TOPOLOGIES_LABEL = 'opendatahub.io/supported-topologies';
+const SUPPORTED_TOPOLOGIES_ANNOTATION = 'opendatahub.io/supported-topologies';
 export const DASHBOARD_RESOURCE_LABEL = 'opendatahub.io/dashboard';
 
 export type LLMdContainer = { name: string; args?: string[] } & Partial<PodContainer>;
@@ -125,11 +125,11 @@ export type LLMInferenceServiceConfigKind = K8sResourceCommon & {
       'opendatahub.io/template-name'?: string;
       'opendatahub.io/disabled'?: 'true' | 'false';
       'opendatahub.io/routing-type'?: RoutingType;
+      'opendatahub.io/supported-topologies'?: string;
       'serving.kserve.io/well-known-config'?: 'true' | 'false';
     };
     labels?: {
-      'opendatahub.io/config-type'?: string;
-      'opendatahub.io/supported-topologies'?: string;
+      'opendatahub.io/config-type'?: TopologyType | 'router' | 'accelerator';
       'opendatahub.io/dashboard'?: 'true' | 'false';
     };
   };
@@ -206,7 +206,7 @@ export const getConfigRoutingType = (
 export const getConfigSupportedTopologies = (
   config: LLMInferenceServiceConfigKind,
 ): TopologyType[] => {
-  const raw = config.metadata.labels?.[SUPPORTED_TOPOLOGIES_LABEL];
+  const raw = config.metadata.annotations?.[SUPPORTED_TOPOLOGIES_ANNOTATION];
   if (!raw) {
     return [];
   }

--- a/packages/llmd-serving/src/types.ts
+++ b/packages/llmd-serving/src/types.ts
@@ -10,6 +10,44 @@ import { LLMD_SERVING_ID } from '../extensions/extensions';
 
 export const MAAS_ENDPOINT_LABEL = 'opendatahub.io/maas-endpoint';
 
+// --- Topology and Routing Config Enums ---
+
+export enum TopologyType {
+  SINGLE_NODE = 'workload-single-node',
+  MULTI_NODE = 'workload-multi-node-data-parallel',
+  SINGLE_NODE_DISAGGREGATED = 'workload-single-node-pd',
+  MULTI_NODE_DISAGGREGATED = 'workload-multi-node-data-parallel-pd',
+}
+
+export const TopologyTypeLabels: Record<TopologyType, string> = {
+  [TopologyType.SINGLE_NODE]: 'Single node',
+  [TopologyType.MULTI_NODE]: 'Multi-node',
+  [TopologyType.SINGLE_NODE_DISAGGREGATED]: 'Single node disaggregated',
+  [TopologyType.MULTI_NODE_DISAGGREGATED]: 'Multi-node disaggregated',
+};
+
+export enum RoutingType {
+  SCHEDULER = 'scheduler',
+  HTTP_ROUTE = 'http-route',
+  SCHEDULER_AND_HTTP_ROUTE = 'scheduler-and-http-route',
+}
+
+export const RoutingTypeLabels: Record<RoutingType, string> = {
+  [RoutingType.SCHEDULER]: 'Scheduler',
+  [RoutingType.HTTP_ROUTE]: 'HTTPRoute',
+  [RoutingType.SCHEDULER_AND_HTTP_ROUTE]: 'Scheduler + HTTPRoute',
+};
+
+// --- Label/Annotation Constants (dashboard-owned, abstracted for easy refactor) ---
+
+export const CONFIG_TYPE_LABEL = 'opendatahub.io/config-type';
+export const CONFIG_TYPE_ROUTER = 'router';
+const WELL_KNOWN_ANNOTATION = 'serving.kserve.io/well-known-config';
+const DISABLED_ANNOTATION = 'opendatahub.io/disabled';
+const ROUTING_TYPE_ANNOTATION = 'opendatahub.io/routing-type';
+const SUPPORTED_TOPOLOGIES_LABEL = 'opendatahub.io/supported-topologies';
+export const DASHBOARD_RESOURCE_LABEL = 'opendatahub.io/dashboard';
+
 export type LLMdContainer = { name: string; args?: string[] } & Partial<PodContainer>;
 
 // Shared by both LLMInferenceService and LLMInferenceServiceConfig
@@ -86,9 +124,13 @@ export type LLMInferenceServiceConfigKind = K8sResourceCommon & {
       'opendatahub.io/runtime-version'?: string;
       'opendatahub.io/template-name'?: string;
       'opendatahub.io/disabled'?: 'true' | 'false';
+      'opendatahub.io/routing-type'?: RoutingType;
+      'serving.kserve.io/well-known-config'?: 'true' | 'false';
     };
     labels?: {
-      'opendatahub.io/config-type'?: 'accelerator' | string;
+      'opendatahub.io/config-type'?: string;
+      'opendatahub.io/supported-topologies'?: string;
+      'opendatahub.io/dashboard'?: 'true' | 'false';
     };
   };
   spec?: LLMInferenceServiceSpec;
@@ -103,14 +145,14 @@ export const isLLMdDeployment = (deployment: Deployment): deployment is LLMdDepl
   deployment.modelServingPlatformId === LLMD_SERVING_ID;
 
 export const LLMInferenceServiceModel: K8sModelCommon = {
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1alpha2',
   apiGroup: 'serving.kserve.io',
   kind: 'LLMInferenceService',
   plural: 'llminferenceservices',
 };
 
 export const LLMInferenceServiceConfigModel: K8sModelCommon = {
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1alpha2',
   apiGroup: 'serving.kserve.io',
   kind: 'LLMInferenceServiceConfig',
   plural: 'llminferenceserviceconfigs',
@@ -122,3 +164,75 @@ export enum LLMInferenceServiceReadyConditionReason {
   MINIMUM_REPLICAS_UNAVAILABLE = 'MinimumReplicasUnavailable',
   PROGRESSING = 'Progressing',
 }
+
+// --- Config Type Helpers (abstracted so label names can be updated in one place) ---
+
+const topologyTypeValues: string[] = Object.values(TopologyType);
+const isTopologyTypeValue = (value: string): value is TopologyType =>
+  topologyTypeValues.includes(value);
+
+const routingTypeValues: string[] = Object.values(RoutingType);
+const isRoutingTypeValue = (value: string): value is RoutingType =>
+  routingTypeValues.includes(value);
+
+export const isTopologyConfig = (config: LLMInferenceServiceConfigKind): boolean => {
+  const configType = config.metadata.labels?.[CONFIG_TYPE_LABEL];
+  return !!configType && isTopologyTypeValue(configType);
+};
+
+export const isRouterConfig = (config: LLMInferenceServiceConfigKind): boolean =>
+  config.metadata.labels?.[CONFIG_TYPE_LABEL] === CONFIG_TYPE_ROUTER;
+
+export const getConfigTopologyType = (
+  config: LLMInferenceServiceConfigKind,
+): TopologyType | undefined => {
+  const configType = config.metadata.labels?.[CONFIG_TYPE_LABEL];
+  if (configType && isTopologyTypeValue(configType)) {
+    return configType;
+  }
+  return undefined;
+};
+
+export const getConfigRoutingType = (
+  config: LLMInferenceServiceConfigKind,
+): RoutingType | undefined => {
+  const value = config.metadata.annotations?.[ROUTING_TYPE_ANNOTATION];
+  if (value && isRoutingTypeValue(value)) {
+    return value;
+  }
+  return undefined;
+};
+
+export const getConfigSupportedTopologies = (
+  config: LLMInferenceServiceConfigKind,
+): TopologyType[] => {
+  const raw = config.metadata.labels?.[SUPPORTED_TOPOLOGIES_LABEL];
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((t): t is TopologyType => typeof t === 'string' && isTopologyTypeValue(t));
+  } catch {
+    return [];
+  }
+};
+
+const hasKserveOwnership = (resource: K8sResourceCommon): boolean =>
+  resource.metadata?.ownerReferences?.some(
+    (ref) => ref.kind === 'KServe' || ref.apiVersion.startsWith('operator.kserve.io/'),
+  ) ?? false;
+
+export const isConfigPreInstalled = (config: LLMInferenceServiceConfigKind): boolean => {
+  const hasWellKnownAnnotation = config.metadata.annotations?.[WELL_KNOWN_ANNOTATION] === 'true';
+  const hasKserveOwnerRef = hasKserveOwnership(config);
+  const hasDashboardLabel = config.metadata.labels?.[DASHBOARD_RESOURCE_LABEL] === 'true';
+
+  return (hasWellKnownAnnotation || hasKserveOwnerRef) && !hasDashboardLabel;
+};
+
+export const isConfigEnabled = (config: LLMInferenceServiceConfigKind): boolean =>
+  config.metadata.annotations?.[DISABLED_ANNOTATION] !== 'true';

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
@@ -61,7 +61,7 @@ export const useModelDeploymentSubmit = (
         if (
           viewMode === 'yaml-edit' &&
           (resources.model?.kind !== 'LLMInferenceService' ||
-            !resources.model.apiVersion.startsWith('serving.kserve.io/'))
+            resources.model.apiVersion !== 'serving.kserve.io/v1alpha2')
         ) {
           throw new Error(
             'Invalid YAML: Kind must be LLMInferenceService and apiVersion must be serving.kserve.io/v1alpha2',

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
@@ -61,10 +61,10 @@ export const useModelDeploymentSubmit = (
         if (
           viewMode === 'yaml-edit' &&
           (resources.model?.kind !== 'LLMInferenceService' ||
-            resources.model.apiVersion !== 'serving.kserve.io/v1alpha1')
+            !resources.model.apiVersion.startsWith('serving.kserve.io/'))
         ) {
           throw new Error(
-            'Invalid YAML: Kind must be LLMInferenceService and apiVersion must be serving.kserve.io/v1alpha1',
+            'Invalid YAML: Kind must be LLMInferenceService and apiVersion must be serving.kserve.io/v1alpha2',
           );
         }
         if (

--- a/packages/model-serving/src/components/deploymentWizard/yaml/__tests__/useYamlResourcesResult.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/yaml/__tests__/useYamlResourcesResult.spec.ts
@@ -15,7 +15,7 @@ jest.mock('../../useWizardFieldApply');
 const mockUseWizardFieldApply = jest.mocked(useWizardFieldApply);
 
 const mockModel: ModelResourceType = {
-  apiVersion: 'serving.kserve.io/v1alpha1',
+  apiVersion: 'serving.kserve.io/v1alpha2',
   kind: 'LLMInferenceService',
   metadata: {
     name: 'test-model',
@@ -26,7 +26,7 @@ const mockModel: ModelResourceType = {
 const mockDeployment: Deployment = {
   modelServingPlatformId: 'test-platform',
   model: {
-    apiVersion: 'serving.kserve.io/v1alpha1',
+    apiVersion: 'serving.kserve.io/v1alpha2',
     kind: 'LLMInferenceService',
     metadata: {
       name: 'test-model',
@@ -65,7 +65,7 @@ describe('useFormYamlResources', () => {
 
   it('should include formResources server in resources when in editor mode', () => {
     const mockServer: DeploymentAssemblyResources['server'] = {
-      apiVersion: 'serving.kserve.io/v1alpha1',
+      apiVersion: 'serving.kserve.io/v1alpha2',
       kind: 'LLMInferenceServiceConfig',
       metadata: {
         name: 'test-server',


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-70580

## Description

Adds the data layer foundation for the llm-d topology and routing configuration feature (Story 1 of the LLMISConfig Topology epic).

This is a pure infrastructure change with no UI rendering — subsequent stories will build wizard fields and admin pages on top of this.

## How Has This Been Tested?
<img width="1235" height="659" alt="Screenshot 2026-06-23 at 12 35 33 PM" src="https://github.com/user-attachments/assets/7153d392-315e-41d1-998f-48ccd325a765" />


- TypeScript type-check passes for `packages/k8s-core` and `packages/llmd-serving`
- ESLint + Prettier pass for all 7 modified files
- No regressions in existing code (pre-existing unrelated errors remain unchanged)
- Manual verification that the new feature flag defaults to `false` and the area wiring is correct

## Test Impact

No new unit or Cypress tests in this PR. This story establishes types and API hooks that will be exercised by mocked Cypress tests in Stories 2-5. The mock factory extension enables those future tests to create topology/routing config fixtures.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added topology- and router-specific list/watch support for LLMInferenceService configs.
  * Introduced **LLMD topology configs** feature flag and gated navigation area (off by default).

* **Updates**
  * Upgraded KServe **LLMInferenceService** CR API version to **serving.kserve.io/v1alpha2** across deployment and YAML flows.
  * Improved config metadata/labels to support topology, routing type, supported topologies, and pre-installed state.

* **Tests**
  * Updated Cypress and YAML resource expectations for **v1alpha2**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->