### PR TITLE
RHOAIENG-71041: fix preflight skipping tag/eval for fork PRs

### DIFF
--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -195,6 +195,8 @@ jobs:
             --permission-mode acceptEdits
             --allowedTools "Bash(gh *)"
             --allowedTools "Bash(git *)"
+            --allowedTools "Bash(npm *)"
+            --allowedTools "Bash(npx *)"
             --allowedTools "Bash(bash *)"
             --allowedTools "mcp__jira__*"
             --mcp-config '{"mcpServers":{"jira":{"command":"uvx","args":["mcp-atlassian==0.21.1"],"env":{"JIRA_URL":"${{ secrets.JIRA_URL }}","JIRA_USERNAME":"${{ secrets.JIRA_USERNAME }}","JIRA_API_TOKEN":"${{ secrets.JIRA_API_TOKEN }}","READ_ONLY_MODE":"true"}}}}'
@@ -202,7 +204,7 @@ jobs:
 
       # ── Tag trace with PR context ──
       - name: Tag preflight trace
-        if: always() && env.HEAD_REPO == github.repository
+        if: always()
         continue-on-error: true
         env:
           MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
@@ -247,7 +249,7 @@ jobs:
 
       # ── Evaluate trace ──
       - name: Evaluate preflight trace
-        if: always() && env.HEAD_REPO == github.repository
+        if: always()
         continue-on-error: true
         env:
           MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-71041

## Description

The preflight workflow's "Tag preflight trace" and "Evaluate preflight trace" steps have a guard:

```yaml
if: always() && env.HEAD_REPO == github.repository
```

For fork PRs (triggered via `pull_request_target`), `HEAD_REPO` is the fork's full name (e.g., `FedeAlonso/odh-dashboard`), which never matches `github.repository` (`opendatahub-io/odh-dashboard`). This causes both steps to be **silently skipped for every fork PR**, even though the trace was successfully created during the Claude session.

The guard is unnecessary because:
- The Claude session already has full MLflow secrets access via settings env vars
- These steps only read/write to MLflow — they don't execute fork code
- The trace has already been created by the time these steps run

**Evidence:** Every `pull_request_target` run (all fork PRs) has Tag/Evaluate skipped, while every `issue_comment` run (internal branches where `HEAD_REPO == github.repository`) succeeds.

This PR also adds `npm` and `npx` to the `--allowedTools` list — without them, the preflight skill gets permission denials when trying to run lint/type-check, which contributed to the agent not posting its review comment on [PR #8255](https://github.com/opendatahub-io/odh-dashboard/pull/8255).

## How Has This Been Tested?

Verified by analyzing recent workflow runs:
- `pull_request_target` runs [28040417235](https://github.com/opendatahub-io/odh-dashboard/actions/runs/28040417235) and [28038568792](https://github.com/opendatahub-io/odh-dashboard/actions/runs/28038568792) both show Tag/Evaluate skipped with `HEAD_REPO` set to fork names
- `issue_comment` runs (e.g., [28041810245](https://github.com/opendatahub-io/odh-dashboard/actions/runs/28041810245)) show Tag/Evaluate succeeding with `HEAD_REPO: opendatahub-io/odh-dashboard`

## Test Impact

No tests applicable — this is a CI workflow configuration change. The fix removes a condition that was preventing steps from running; both steps already have `continue-on-error: true` as a safety net.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI/CD preflight workflow allowlist to permit additional Bash-based commands.
  * Adjusted the preflight tracing and evaluation steps to run unconditionally for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->