### PR TITLE
RHOAIENG-65605: Add Labels column and search-by-label filtering to Role list view

### DIFF
--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -25,6 +25,8 @@ import CreateRoleFooter from './CreateRoleFooter';
 import CreateRoleConfirmModal from './CreateRoleConfirmModal';
 import CreateRoleYamlView from './CreateRoleYamlView';
 import assembleRole from './assembleRole';
+import { fromK8sLabels, toK8sLabels } from './labelUtils';
+import { USER_LABEL_PREFIX } from './const';
 import type { LabelEntry, RuleEntry } from './types';
 
 type ViewMode = 'form' | 'yaml';
@@ -53,16 +55,9 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
   const [description, setDescription] = React.useState(
     () => existingRole?.metadata.annotations?.['openshift.io/description'] ?? '',
   );
-  const [labels, setLabels] = React.useState<LabelEntry[]>(() => {
-    if (!existingRole?.metadata.labels) {
-      return [];
-    }
-    return Object.entries(existingRole.metadata.labels).map(([key, value]) => ({
-      id: getUniqueId('label'),
-      key,
-      value,
-    }));
-  });
+  const [labels, setLabels] = React.useState<LabelEntry[]>(() =>
+    fromK8sLabels(existingRole?.metadata.labels),
+  );
   const [rules, setRules] = React.useState<RuleEntry[]>(() => {
     if (!existingRole?.rules) {
       return [];
@@ -109,9 +104,12 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
     setSubmitError(undefined);
     const k8sName = k8sNameDescriptionData.data.k8sName.value;
     const roleDisplayName = k8sNameDescriptionData.data.name || k8sName;
-    const labelRecord = Object.fromEntries(
-      labels.filter((l) => l.key).map((l) => [l.key, l.value]),
+    const preservedLabels = Object.fromEntries(
+      Object.entries(existingRole?.metadata.labels ?? {}).filter(
+        ([key]) => !key.startsWith(USER_LABEL_PREFIX),
+      ),
     );
+    const labelRecord = { ...preservedLabels, ...toK8sLabels(labels) };
     const role = assembleRole(namespace, k8sName, roleDisplayName, description, rules, labelRecord);
     try {
       await createRole(role);
@@ -121,7 +119,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
       setSubmitError(error);
       throw error;
     }
-  }, [namespace, k8sNameDescriptionData.data, description, rules, labels, navigate]);
+  }, [namespace, k8sNameDescriptionData.data, description, rules, labels, navigate, existingRole]);
 
   const handleSubmit = React.useCallback(async () => {
     if (rules.length === 0) {

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -9,6 +9,7 @@ import {
   getUniqueId,
 } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { LABELS_FORM_DESCRIPTION } from './const';
 import type { LabelEntry } from './types';
 
 type RoleLabelsSectionProps = {
@@ -40,10 +41,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
 
   return (
     <FormGroup label="Labels" fieldId="role-labels">
-      <Content component="p">
-        Add key/value labels to organize and filter roles (for example by organization, category or
-        team).
-      </Content>
+      <Content component="p">{LABELS_FORM_DESCRIPTION}</Content>
       {labels.map((label, index) => (
         <Flex
           key={label.id}

--- a/frontend/src/pages/projects/projectRoles/RolesTable.scss
+++ b/frontend/src/pages/projects/projectRoles/RolesTable.scss
@@ -1,0 +1,3 @@
+.odh-roles-table__search {
+  width: 400px;
+}

--- a/frontend/src/pages/projects/projectRoles/RolesTable.tsx
+++ b/frontend/src/pages/projects/projectRoles/RolesTable.tsx
@@ -13,10 +13,12 @@ import { Link } from 'react-router-dom';
 import { Table, DashboardEmptyTableView } from '@odh-dashboard/ui-core';
 import type { RoleRef } from '#~/concepts/permissions/types';
 import RoleDetailsModal from '#~/pages/projects/projectPermissions/roleDetails/RoleDetailsModal';
+import { SEARCH_PLACEHOLDER } from './const';
 import type { RoleListRow } from './types';
 import { columns } from './columns';
 import RolesTableRow from './RolesTableRow';
 import PreviewYAMLModal from './PreviewYAMLModal';
+import './RolesTable.scss';
 
 type RolesTableProps = {
   rows: RoleListRow[];
@@ -48,7 +50,8 @@ const RolesTable: React.FC<RolesTableProps> = ({
     <>
       <ToolbarItem>
         <SearchInput
-          placeholder="Search by name or description"
+          className="odh-roles-table__search"
+          placeholder={SEARCH_PLACEHOLDER}
           value={searchFilter}
           onChange={(_e, value) => onSearchChange(value)}
           onClear={() => onSearchChange('')}

--- a/frontend/src/pages/projects/projectRoles/RolesTableRow.tsx
+++ b/frontend/src/pages/projects/projectRoles/RolesTableRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
-import { Button } from '@patternfly/react-core';
+import { Button, Label, LabelGroup } from '@patternfly/react-core';
 import { getRoleDescription, getRoleDisplayName } from '#~/concepts/permissions/utils';
 import RoleLabel from '#~/pages/projects/projectPermissions/components/RoleLabel';
 import type { RoleListRow } from './types';
@@ -20,10 +20,11 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({
   onEdit,
   onDuplicate,
 }) => {
-  const { roleRef, role } = row;
+  const { roleRef, role, userLabels } = row;
   const isClusterRole = roleRef.kind === 'ClusterRole';
   const displayName = getRoleDisplayName(roleRef, role);
   const description = getRoleDescription(roleRef, role);
+  const labelEntries = Object.entries(userLabels);
 
   const clusterRoleEditTooltip = 'Cluster roles cannot be edited from a project page';
   const clusterRoleDuplicateTooltip = 'Cluster roles cannot be duplicated from a project page';
@@ -59,6 +60,19 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({
         </Button>
       </Td>
       <Td dataLabel="Description">{description ?? '-'}</Td>
+      <Td dataLabel="Labels" data-testid="role-labels-cell">
+        {labelEntries.length > 0 ? (
+          <LabelGroup>
+            {labelEntries.map(([, value]) => (
+              <Label key={value} isCompact variant="outline" data-testid={`role-label-${value}`}>
+                {value}
+              </Label>
+            ))}
+          </LabelGroup>
+        ) : (
+          '-'
+        )}
+      </Td>
       <Td dataLabel="Type">
         <RoleLabel roleRef={roleRef} role={role} isCompact />
       </Td>

--- a/frontend/src/pages/projects/projectRoles/RolesTableRow.tsx
+++ b/frontend/src/pages/projects/projectRoles/RolesTableRow.tsx
@@ -63,8 +63,8 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({
       <Td dataLabel="Labels" data-testid="role-labels-cell">
         {labelEntries.length > 0 ? (
           <LabelGroup>
-            {labelEntries.map(([, value]) => (
-              <Label key={value} isCompact variant="outline" data-testid={`role-label-${value}`}>
+            {labelEntries.map(([key, value]) => (
+              <Label key={key} isCompact variant="outline" data-testid={`role-label-${key}`}>
                 {value}
               </Label>
             ))}

--- a/frontend/src/pages/projects/projectRoles/__tests__/assembleRole.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/assembleRole.spec.ts
@@ -1,4 +1,3 @@
-import { KnownLabels } from '@odh-dashboard/k8s-core';
 import assembleRole from '#~/pages/projects/projectRoles/assembleRole';
 import type { RuleEntry } from '#~/pages/projects/projectRoles/types';
 
@@ -13,7 +12,7 @@ describe('assembleRole', () => {
         name: 'my-role',
         namespace: 'test-ns',
         labels: {
-          [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+          'opendatahub.io/dashboard': 'true',
         },
         annotations: {
           'openshift.io/display-name': 'My Role',
@@ -78,7 +77,7 @@ describe('assembleRole', () => {
     const result = assembleRole('ns', 'r', 'R', '', []);
 
     expect(result.metadata.labels).toStrictEqual({
-      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+      'opendatahub.io/dashboard': 'true',
     });
   });
 
@@ -99,20 +98,23 @@ describe('assembleRole', () => {
   });
 
   it('should merge user labels with dashboard resource label', () => {
-    const userLabels = { 'app.kubernetes.io/name': 'my-app', team: 'platform' };
+    const userLabels = {
+      'labels.opendatahub.io/team': 'platform',
+      'labels.opendatahub.io/env': 'production',
+    };
     const result = assembleRole('ns', 'r', 'R', '', [], userLabels);
 
     expect(result.metadata.labels).toStrictEqual({
-      'app.kubernetes.io/name': 'my-app',
-      team: 'platform',
-      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+      'labels.opendatahub.io/team': 'platform',
+      'labels.opendatahub.io/env': 'production',
+      'opendatahub.io/dashboard': 'true',
     });
   });
 
   it('should ensure dashboard resource label overrides user label', () => {
-    const userLabels = { [KnownLabels.DASHBOARD_RESOURCE]: 'false' };
+    const userLabels = { 'opendatahub.io/dashboard': 'false' };
     const result = assembleRole('ns', 'r', 'R', '', [], userLabels);
 
-    expect(result.metadata.labels?.[KnownLabels.DASHBOARD_RESOURCE]).toBe('true');
+    expect(result.metadata.labels?.['opendatahub.io/dashboard']).toBe('true');
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
@@ -40,6 +40,14 @@ describe('toK8sLabels', () => {
     });
   });
 
+  it('should trim leading and trailing whitespace from keys', () => {
+    const entries = [{ id: 'l-1', key: '  team  ', value: 'val' }];
+
+    expect(toK8sLabels(entries)).toStrictEqual({
+      [`${USER_LABEL_PREFIX}team`]: 'val',
+    });
+  });
+
   it('should return empty object for empty array', () => {
     expect(toK8sLabels([])).toStrictEqual({});
   });

--- a/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
@@ -29,6 +29,17 @@ describe('toK8sLabels', () => {
     });
   });
 
+  it('should skip entries with whitespace-only keys', () => {
+    const entries = [
+      { id: 'l-1', key: '   ', value: 'platform' },
+      { id: 'l-2', key: 'env', value: 'production' },
+    ];
+
+    expect(toK8sLabels(entries)).toStrictEqual({
+      [`${USER_LABEL_PREFIX}env`]: 'production',
+    });
+  });
+
   it('should return empty object for empty array', () => {
     expect(toK8sLabels([])).toStrictEqual({});
   });
@@ -64,6 +75,10 @@ describe('fromK8sLabels', () => {
 
   it('should return empty array for undefined labels', () => {
     expect(fromK8sLabels(undefined)).toHaveLength(0);
+  });
+
+  it('should return empty array for null labels', () => {
+    expect(fromK8sLabels(null)).toHaveLength(0);
   });
 
   it('should return empty array for empty object', () => {
@@ -109,6 +124,10 @@ describe('getUserLabels', () => {
 
   it('should return empty object for undefined labels', () => {
     expect(getUserLabels(undefined)).toStrictEqual({});
+  });
+
+  it('should return empty object for null labels', () => {
+    expect(getUserLabels(null)).toStrictEqual({});
   });
 
   it('should return empty object for empty object', () => {

--- a/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
@@ -93,6 +93,17 @@ describe('fromK8sLabels', () => {
     expect(fromK8sLabels({})).toHaveLength(0);
   });
 
+  it('should skip labels where key is exactly the prefix with no suffix', () => {
+    const labels = {
+      [USER_LABEL_PREFIX]: 'orphan',
+      [`${USER_LABEL_PREFIX}team`]: 'platform',
+    };
+
+    const result = fromK8sLabels(labels);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('team');
+  });
+
   it('should generate unique ids for each entry', () => {
     const labels = {
       [`${USER_LABEL_PREFIX}a`]: '1',
@@ -140,5 +151,14 @@ describe('getUserLabels', () => {
 
   it('should return empty object for empty object', () => {
     expect(getUserLabels({})).toStrictEqual({});
+  });
+
+  it('should skip labels where key is exactly the prefix with no suffix', () => {
+    const labels = {
+      [USER_LABEL_PREFIX]: 'orphan',
+      [`${USER_LABEL_PREFIX}team`]: 'platform',
+    };
+
+    expect(getUserLabels(labels)).toStrictEqual({ team: 'platform' });
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
@@ -1,0 +1,117 @@
+import {
+  toK8sLabels,
+  fromK8sLabels,
+  getUserLabels,
+} from '#~/pages/projects/projectRoles/labelUtils';
+import { USER_LABEL_PREFIX } from '#~/pages/projects/projectRoles/const';
+
+describe('toK8sLabels', () => {
+  it('should prepend the prefix to each key', () => {
+    const entries = [
+      { id: 'l-1', key: 'team', value: 'platform' },
+      { id: 'l-2', key: 'env', value: 'production' },
+    ];
+
+    expect(toK8sLabels(entries)).toStrictEqual({
+      [`${USER_LABEL_PREFIX}team`]: 'platform',
+      [`${USER_LABEL_PREFIX}env`]: 'production',
+    });
+  });
+
+  it('should skip entries with empty keys', () => {
+    const entries = [
+      { id: 'l-1', key: '', value: 'platform' },
+      { id: 'l-2', key: 'env', value: 'production' },
+    ];
+
+    expect(toK8sLabels(entries)).toStrictEqual({
+      [`${USER_LABEL_PREFIX}env`]: 'production',
+    });
+  });
+
+  it('should return empty object for empty array', () => {
+    expect(toK8sLabels([])).toStrictEqual({});
+  });
+});
+
+describe('fromK8sLabels', () => {
+  it('should extract and strip prefixed labels', () => {
+    const labels = {
+      'opendatahub.io/dashboard': 'true',
+      [`${USER_LABEL_PREFIX}team`]: 'platform',
+      [`${USER_LABEL_PREFIX}env`]: 'production',
+    };
+
+    const result = fromK8sLabels(labels);
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'team', value: 'platform' }),
+        expect.objectContaining({ key: 'env', value: 'production' }),
+      ]),
+    );
+  });
+
+  it('should return empty array when no prefixed labels exist', () => {
+    const labels = {
+      'opendatahub.io/dashboard': 'true',
+      'some-other-label': 'value',
+    };
+
+    expect(fromK8sLabels(labels)).toHaveLength(0);
+  });
+
+  it('should return empty array for undefined labels', () => {
+    expect(fromK8sLabels(undefined)).toHaveLength(0);
+  });
+
+  it('should return empty array for empty object', () => {
+    expect(fromK8sLabels({})).toHaveLength(0);
+  });
+
+  it('should generate unique ids for each entry', () => {
+    const labels = {
+      [`${USER_LABEL_PREFIX}a`]: '1',
+      [`${USER_LABEL_PREFIX}b`]: '2',
+    };
+
+    const result = fromK8sLabels(labels);
+
+    expect(result[0].id).toBeDefined();
+    expect(result[1].id).toBeDefined();
+    expect(result[0].id).not.toBe(result[1].id);
+  });
+});
+
+describe('getUserLabels', () => {
+  it('should return only user-defined labels with prefix stripped', () => {
+    const labels = {
+      'opendatahub.io/dashboard': 'true',
+      [`${USER_LABEL_PREFIX}team`]: 'platform',
+      [`${USER_LABEL_PREFIX}env`]: 'production',
+      'some-other-label': 'value',
+    };
+
+    expect(getUserLabels(labels)).toStrictEqual({
+      team: 'platform',
+      env: 'production',
+    });
+  });
+
+  it('should return empty object when no user labels exist', () => {
+    const labels = {
+      'opendatahub.io/dashboard': 'true',
+    };
+
+    expect(getUserLabels(labels)).toStrictEqual({});
+  });
+
+  it('should return empty object for undefined labels', () => {
+    expect(getUserLabels(undefined)).toStrictEqual({});
+  });
+
+  it('should return empty object for empty object', () => {
+    expect(getUserLabels({})).toStrictEqual({});
+  });
+});

--- a/frontend/src/pages/projects/projectRoles/__tests__/useRoleListData.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/useRoleListData.spec.ts
@@ -1,12 +1,12 @@
 import { testHook } from '@odh-dashboard/jest-config/hooks';
-import { KnownLabels } from '@odh-dashboard/k8s-core';
 import { mockRoleK8sResource, mockClusterRoleK8sResource } from '#~/__mocks__';
 import useRoleListData from '#~/pages/projects/projectRoles/useRoleListData';
+import { USER_LABEL_PREFIX } from '#~/pages/projects/projectRoles/const';
 
 describe('useRoleListData', () => {
   const dashboardRole = mockRoleK8sResource({
     name: 'my-dashboard-role',
-    labels: { [KnownLabels.DASHBOARD_RESOURCE]: 'true' },
+    labels: { 'opendatahub.io/dashboard': 'true' },
   });
 
   const nonDashboardRole = mockRoleK8sResource({
@@ -16,7 +16,7 @@ describe('useRoleListData', () => {
 
   const dashboardClusterRole = mockClusterRoleK8sResource({
     name: 'my-dashboard-cr',
-    labels: { [KnownLabels.DASHBOARD_RESOURCE]: 'true' },
+    labels: { 'opendatahub.io/dashboard': 'true' },
   });
 
   const adminClusterRole = mockClusterRoleK8sResource({
@@ -152,5 +152,43 @@ describe('useRoleListData', () => {
     expect(renderResult).hookToHaveUpdateCount(2);
     expect(renderResult.result.current).toHaveLength(1);
     expect(renderResult.result.current[0].key).toBe('ClusterRole:admin');
+  });
+
+  describe('user labels', () => {
+    const labeledRole = mockRoleK8sResource({
+      name: 'labeled-role',
+      labels: {
+        'opendatahub.io/dashboard': 'true',
+        [`${USER_LABEL_PREFIX}team`]: 'platform',
+        [`${USER_LABEL_PREFIX}env`]: 'production',
+      },
+    });
+
+    it('should extract user labels from prefixed labels', () => {
+      const renderResult = testHook(useRoleListData)([labeledRole], [], '');
+      const rows = renderResult.result.current;
+      expect(rows[0].userLabels).toStrictEqual({
+        team: 'platform',
+        env: 'production',
+      });
+    });
+
+    it('should return empty userLabels when no prefixed labels exist', () => {
+      const renderResult = testHook(useRoleListData)([dashboardRole], [], '');
+      const rows = renderResult.result.current;
+      expect(rows[0].userLabels).toStrictEqual({});
+    });
+
+    it('should filter by label key', () => {
+      const renderResult = testHook(useRoleListData)([labeledRole, dashboardRole], [], 'team');
+      const keys = renderResult.result.current.map((r) => r.key);
+      expect(keys).toEqual(['Role:labeled-role']);
+    });
+
+    it('should filter by label value', () => {
+      const renderResult = testHook(useRoleListData)([labeledRole, dashboardRole], [], 'platform');
+      const keys = renderResult.result.current.map((r) => r.key);
+      expect(keys).toEqual(['Role:labeled-role']);
+    });
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/useRoleListData.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/useRoleListData.spec.ts
@@ -191,4 +191,37 @@ describe('useRoleListData', () => {
       expect(keys).toEqual(['Role:labeled-role']);
     });
   });
+
+  describe('type search filtering', () => {
+    it('should filter dashboard roles by "ai role"', () => {
+      const renderResult = testHook(useRoleListData)(
+        [dashboardRole],
+        [adminClusterRole],
+        'ai role',
+      );
+      const keys = renderResult.result.current.map((r) => r.key);
+      expect(keys).toContain('Role:my-dashboard-role');
+      expect(keys).toContain('ClusterRole:admin');
+    });
+
+    it('should filter default cluster roles by "openshift default role"', () => {
+      const renderResult = testHook(useRoleListData)(
+        [dashboardRole],
+        [adminClusterRole, editClusterRole, dashboardClusterRole],
+        'openshift default role',
+      );
+      const keys = renderResult.result.current.map((r) => r.key);
+      expect(keys).toEqual(['ClusterRole:admin', 'ClusterRole:edit']);
+    });
+
+    it('should filter by "cluster role"', () => {
+      const renderResult = testHook(useRoleListData)(
+        [dashboardRole],
+        [adminClusterRole, dashboardClusterRole],
+        'cluster role',
+      );
+      const keys = renderResult.result.current.map((r) => r.key);
+      expect(keys).toEqual(['ClusterRole:admin', 'ClusterRole:my-dashboard-cr']);
+    });
+  });
 });

--- a/frontend/src/pages/projects/projectRoles/columns.tsx
+++ b/frontend/src/pages/projects/projectRoles/columns.tsx
@@ -3,12 +3,8 @@ import { List, ListItem } from '@patternfly/react-core';
 import { SortableData } from '@odh-dashboard/ui-core';
 import { getRoleDescription, getRoleDisplayName } from '#~/concepts/permissions/utils';
 import { ODH_PRODUCT_NAME } from '#~/utilities/const';
+import { ROLE_NAME_HELP, DESCRIPTION_HELP, LABELS_HELP } from './const';
 import type { RoleListRow } from './types';
-
-export const ROLE_NAME_HELP = 'This is the name of the role in OpenShift.';
-
-export const DESCRIPTION_HELP =
-  "A brief summary of the role's purpose and the permissions it grants.";
 
 export const TypeHelpContent: React.FC = () => (
   <List>
@@ -31,7 +27,7 @@ export const columns: SortableData<RoleListRow>[] = [
   {
     field: 'name',
     label: 'Role name',
-    width: 35,
+    width: 25,
     sortable: (a, b) =>
       getRoleDisplayName(a.roleRef, a.role).localeCompare(getRoleDisplayName(b.roleRef, b.role)),
     info: {
@@ -42,7 +38,7 @@ export const columns: SortableData<RoleListRow>[] = [
   {
     field: 'description',
     label: 'Description',
-    width: 40,
+    width: 30,
     sortable: (a, b) =>
       (getRoleDescription(a.roleRef, a.role) ?? '').localeCompare(
         getRoleDescription(b.roleRef, b.role) ?? '',
@@ -50,6 +46,24 @@ export const columns: SortableData<RoleListRow>[] = [
     info: {
       popover: DESCRIPTION_HELP,
       ariaLabel: 'Description help',
+    },
+  },
+  {
+    field: 'labels',
+    label: 'Labels',
+    width: 20,
+    sortable: (a, b) =>
+      Object.entries(a.userLabels)
+        .map(([k, v]: [string, string]) => `${k}=${v}`)
+        .join(',')
+        .localeCompare(
+          Object.entries(b.userLabels)
+            .map(([k, v]: [string, string]) => `${k}=${v}`)
+            .join(','),
+        ),
+    info: {
+      popover: LABELS_HELP,
+      ariaLabel: 'Labels help',
     },
   },
   {

--- a/frontend/src/pages/projects/projectRoles/columns.tsx
+++ b/frontend/src/pages/projects/projectRoles/columns.tsx
@@ -54,10 +54,12 @@ export const columns: SortableData<RoleListRow>[] = [
     width: 20,
     sortable: (a, b) =>
       Object.entries(a.userLabels)
+        .toSorted(([ak], [bk]) => ak.localeCompare(bk))
         .map(([k, v]: [string, string]) => `${k}=${v}`)
         .join(',')
         .localeCompare(
           Object.entries(b.userLabels)
+            .toSorted(([ak], [bk]) => ak.localeCompare(bk))
             .map(([k, v]: [string, string]) => `${k}=${v}`)
             .join(','),
         ),

--- a/frontend/src/pages/projects/projectRoles/const.ts
+++ b/frontend/src/pages/projects/projectRoles/const.ts
@@ -1,0 +1,14 @@
+export const USER_LABEL_PREFIX = 'labels.opendatahub.io/';
+
+export const ROLE_NAME_HELP = 'This is the name of the role in OpenShift.';
+
+export const DESCRIPTION_HELP =
+  "A brief summary of the role's purpose and the permissions it grants.";
+
+export const LABELS_HELP =
+  "Labels are optional key/value pairs for organizing roles. They help you filter and find roles but don't affect permissions.";
+
+export const LABELS_FORM_DESCRIPTION =
+  'Add key/value labels to organize and filter roles (for example by organization, category or team).';
+
+export const SEARCH_PLACEHOLDER = 'Filter by name, description, label or type';

--- a/frontend/src/pages/projects/projectRoles/labelUtils.ts
+++ b/frontend/src/pages/projects/projectRoles/labelUtils.ts
@@ -4,7 +4,9 @@ import type { LabelEntry } from './types';
 
 export const toK8sLabels = (entries: LabelEntry[]): Record<string, string> =>
   Object.fromEntries(
-    entries.filter((l) => l.key.trim()).map((l) => [`${USER_LABEL_PREFIX}${l.key}`, l.value]),
+    entries
+      .filter((l) => l.key.trim())
+      .map((l) => [`${USER_LABEL_PREFIX}${l.key.trim()}`, l.value]),
   );
 
 export const fromK8sLabels = (labels?: Record<string, string> | null): LabelEntry[] =>

--- a/frontend/src/pages/projects/projectRoles/labelUtils.ts
+++ b/frontend/src/pages/projects/projectRoles/labelUtils.ts
@@ -11,7 +11,7 @@ export const toK8sLabels = (entries: LabelEntry[]): Record<string, string> =>
 
 export const fromK8sLabels = (labels?: Record<string, string> | null): LabelEntry[] =>
   Object.entries(labels ?? {})
-    .filter(([key]) => key.startsWith(USER_LABEL_PREFIX))
+    .filter(([key]) => key.startsWith(USER_LABEL_PREFIX) && key.length > USER_LABEL_PREFIX.length)
     .map(([key, value]) => ({
       id: getUniqueId('label'),
       key: key.slice(USER_LABEL_PREFIX.length),
@@ -21,6 +21,6 @@ export const fromK8sLabels = (labels?: Record<string, string> | null): LabelEntr
 export const getUserLabels = (labels?: Record<string, string> | null): Record<string, string> =>
   Object.fromEntries(
     Object.entries(labels ?? {})
-      .filter(([key]) => key.startsWith(USER_LABEL_PREFIX))
+      .filter(([key]) => key.startsWith(USER_LABEL_PREFIX) && key.length > USER_LABEL_PREFIX.length)
       .map(([key, value]) => [key.slice(USER_LABEL_PREFIX.length), value]),
   );

--- a/frontend/src/pages/projects/projectRoles/labelUtils.ts
+++ b/frontend/src/pages/projects/projectRoles/labelUtils.ts
@@ -1,0 +1,24 @@
+import { getUniqueId } from '@patternfly/react-core';
+import { USER_LABEL_PREFIX } from './const';
+import type { LabelEntry } from './types';
+
+export const toK8sLabels = (entries: LabelEntry[]): Record<string, string> =>
+  Object.fromEntries(
+    entries.filter((l) => l.key).map((l) => [`${USER_LABEL_PREFIX}${l.key}`, l.value]),
+  );
+
+export const fromK8sLabels = (labels: Record<string, string> = {}): LabelEntry[] =>
+  Object.entries(labels)
+    .filter(([key]) => key.startsWith(USER_LABEL_PREFIX))
+    .map(([key, value]) => ({
+      id: getUniqueId('label'),
+      key: key.slice(USER_LABEL_PREFIX.length),
+      value,
+    }));
+
+export const getUserLabels = (labels: Record<string, string> = {}): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(labels)
+      .filter(([key]) => key.startsWith(USER_LABEL_PREFIX))
+      .map(([key, value]) => [key.slice(USER_LABEL_PREFIX.length), value]),
+  );

--- a/frontend/src/pages/projects/projectRoles/labelUtils.ts
+++ b/frontend/src/pages/projects/projectRoles/labelUtils.ts
@@ -4,11 +4,11 @@ import type { LabelEntry } from './types';
 
 export const toK8sLabels = (entries: LabelEntry[]): Record<string, string> =>
   Object.fromEntries(
-    entries.filter((l) => l.key).map((l) => [`${USER_LABEL_PREFIX}${l.key}`, l.value]),
+    entries.filter((l) => l.key.trim()).map((l) => [`${USER_LABEL_PREFIX}${l.key}`, l.value]),
   );
 
-export const fromK8sLabels = (labels: Record<string, string> = {}): LabelEntry[] =>
-  Object.entries(labels)
+export const fromK8sLabels = (labels?: Record<string, string> | null): LabelEntry[] =>
+  Object.entries(labels ?? {})
     .filter(([key]) => key.startsWith(USER_LABEL_PREFIX))
     .map(([key, value]) => ({
       id: getUniqueId('label'),
@@ -16,9 +16,9 @@ export const fromK8sLabels = (labels: Record<string, string> = {}): LabelEntry[]
       value,
     }));
 
-export const getUserLabels = (labels: Record<string, string> = {}): Record<string, string> =>
+export const getUserLabels = (labels?: Record<string, string> | null): Record<string, string> =>
   Object.fromEntries(
-    Object.entries(labels)
+    Object.entries(labels ?? {})
       .filter(([key]) => key.startsWith(USER_LABEL_PREFIX))
       .map(([key, value]) => [key.slice(USER_LABEL_PREFIX.length), value]),
   );

--- a/frontend/src/pages/projects/projectRoles/types.ts
+++ b/frontend/src/pages/projects/projectRoles/types.ts
@@ -11,6 +11,7 @@ export type RoleListRow = {
   key: string;
   roleRef: RoleRef;
   role: RoleKind | ClusterRoleKind;
+  userLabels: Record<string, string>;
 };
 
 export type RuleEntry = ResourceRule & {

--- a/frontend/src/pages/projects/projectRoles/useRoleListData.ts
+++ b/frontend/src/pages/projects/projectRoles/useRoleListData.ts
@@ -4,9 +4,12 @@ import {
   isDashboardRole,
   getRoleDescription,
   getRoleDisplayName,
+  getRoleLabelTypeForRole,
 } from '#~/concepts/permissions/utils';
 import { DEFAULT_CLUSTER_ROLE_NAMES } from '#~/concepts/permissions/const';
-import type { RoleRef } from '#~/concepts/permissions/types';
+import { RoleLabelType, type RoleRef } from '#~/concepts/permissions/types';
+import { isDefaultRoleRef } from '#~/pages/projects/projectPermissions/utils';
+import { getUserLabels } from './labelUtils';
 import type { RoleListRow } from './types';
 
 const toRoleListRow = (role: RoleKind | ClusterRoleKind): RoleListRow => {
@@ -16,11 +19,30 @@ const toRoleListRow = (role: RoleKind | ClusterRoleKind): RoleListRow => {
     key: `${kind}:${role.metadata.name}`,
     roleRef,
     role,
+    userLabels: getUserLabels(role.metadata.labels),
   };
 };
 
 const isDefaultClusterRole = (role: ClusterRoleKind): boolean =>
   DEFAULT_CLUSTER_ROLE_NAMES.includes(role.metadata.name.toLowerCase());
+
+const getRoleTypeSearchText = (row: RoleListRow): string => {
+  const parts: string[] = [];
+  const type = getRoleLabelTypeForRole(row.role);
+  if (type === RoleLabelType.Dashboard || isDefaultRoleRef(row.roleRef)) {
+    parts.push('ai role');
+  }
+  if (type === RoleLabelType.OpenshiftDefault) {
+    parts.push('openshift default role');
+  }
+  if (type === RoleLabelType.OpenshiftCustom) {
+    parts.push('openshift custom role');
+  }
+  if (row.roleRef.kind === 'ClusterRole') {
+    parts.push('cluster role');
+  }
+  return parts.join(' ');
+};
 
 const useRoleListData = (
   roles: RoleKind[],
@@ -42,7 +64,17 @@ const useRoleListData = (
     return allRows.filter((row) => {
       const displayName = getRoleDisplayName(row.roleRef, row.role).toLowerCase();
       const description = (getRoleDescription(row.roleRef, row.role) ?? '').toLowerCase();
-      return displayName.includes(normalizedSearch) || description.includes(normalizedSearch);
+      const labelText = Object.entries(row.userLabels)
+        .map(([key, value]) => `${key} ${value}`)
+        .join(' ')
+        .toLowerCase();
+      const typeText = getRoleTypeSearchText(row);
+      return (
+        displayName.includes(normalizedSearch) ||
+        description.includes(normalizedSearch) ||
+        labelText.includes(normalizedSearch) ||
+        typeText.includes(normalizedSearch)
+      );
     });
   }, [roles, clusterRoles, searchFilter]);
 

--- a/packages/cypress/cypress/pages/projectRoles.ts
+++ b/packages/cypress/cypress/pages/projectRoles.ts
@@ -13,6 +13,10 @@ class RolesTableRow extends TableRow {
     return this.find().find('[data-label="Type"]');
   }
 
+  findLabelsCell() {
+    return this.find().findByTestId('role-labels-cell');
+  }
+
   shouldHaveName(name: string) {
     this.findNameLink().should('have.text', name);
     return this;

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
@@ -194,4 +194,41 @@ describe('Create Role submit', () => {
       );
     });
   });
+
+  it('should send labels with labels.opendatahub.io/ prefix', () => {
+    cy.interceptK8s(
+      'POST',
+      { model: RoleModel, ns: NAMESPACE },
+      mockRoleK8sResource({ name: 'labeled-role', namespace: NAMESPACE }),
+    ).as('createRole');
+
+    projectRoles.visitCreateRole(NAMESPACE);
+    projectRoles.findRoleNameInput().type('labeled-role');
+
+    projectRoles.findAddLabelButton().click();
+    projectRoles.findLabelKeyInput(0).type('team');
+    projectRoles.findLabelValueInput(0).type('platform');
+
+    projectRoles.findAddLabelButton().click();
+    projectRoles.findLabelKeyInput(1).type('env');
+    projectRoles.findLabelValueInput(1).type('production');
+
+    projectRoles.findSubmitButton().click();
+    projectRoles.findConfirmCreateButton().click();
+
+    cy.wait('@createRole').then((interception) => {
+      expect(interception.request.body.metadata.labels).to.have.property(
+        'labels.opendatahub.io/team',
+        'platform',
+      );
+      expect(interception.request.body.metadata.labels).to.have.property(
+        'labels.opendatahub.io/env',
+        'production',
+      );
+      expect(interception.request.body.metadata.labels).to.have.property(
+        'opendatahub.io/dashboard',
+        'true',
+      );
+    });
+  });
 });

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabTable.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabTable.cy.ts
@@ -108,6 +108,36 @@ describe('Roles tab table', () => {
     projectRoles.getRow('dashboard-custom').findType().contains('Cluster role').should('not.exist');
   });
 
+  describe('label rendering', () => {
+    it('should display user-defined label values as chips', () => {
+      initIntercepts({
+        roles: [
+          mockRoleK8sResource({
+            name: 'labeled-role',
+            namespace: NAMESPACE,
+            labels: {
+              'opendatahub.io/dashboard': 'true',
+              'labels.opendatahub.io/team': 'platform',
+              'labels.opendatahub.io/env': 'production',
+            },
+          }),
+        ],
+      });
+      projectRoles.visit(NAMESPACE);
+
+      const row = projectRoles.getRow('labeled-role');
+      row.findLabelsCell().findByTestId('role-label-team').should('have.text', 'platform');
+      row.findLabelsCell().findByTestId('role-label-env').should('have.text', 'production');
+    });
+
+    it('should show dash when role has no user-defined labels', () => {
+      initIntercepts();
+      projectRoles.visit(NAMESPACE);
+
+      projectRoles.getRow('dashboard-custom').findLabelsCell().should('have.text', '-');
+    });
+  });
+
   describe('search filtering', () => {
     it('should filter roles by name', () => {
       initIntercepts();


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-65605

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a **Labels** column to the project roles list view, allowing users to see and filter roles by user-defined labels.

https://github.com/user-attachments/assets/9bba069b-9e38-46ed-9ba2-9b7d86b26bcb

### Changes
- **Label prefix convention**: User-defined labels use the `labels.opendatahub.io/` prefix (e.g., `labels.opendatahub.io/team: "platform"`), distinguishing them from system labels. Users get the full 63-character allowance after the `/`.
- **Labels column**: Added a sortable Labels column to the roles table with a help popover explaining label purpose.
- **Search filtering**: Extended the search input to filter by name, description, label, or role type. Widened the search input to prevent placeholder truncation.
- **Label utilities** (`labelUtils.ts`): Centralized functions for converting between UI label entries and K8s prefixed labels (`toK8sLabels`, `fromK8sLabels`, `getUserLabels`).
- **Constants consolidation** (`const.ts`): Moved UI string constants (help text, placeholders, form descriptions) into a shared constants file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran `npx eslint` on all changed files — no errors.
- Ran `npx tsc --noEmit` — no type errors.
- Ran all affected Jest unit tests — all passing.
- Ran Cypress mock tests for role creation — all passing.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- **New unit tests** (`labelUtils.spec.ts`): 12 tests covering `toK8sLabels`, `fromK8sLabels`, and `getUserLabels` — prefix application, prefix stripping, empty/undefined inputs, non-user label filtering.
- **Updated unit tests** (`assembleRole.spec.ts`): Verifies assembled roles include prefixed labels and that the dashboard resource label cannot be overridden by user labels.
- **Updated unit tests** (`useRoleListData.spec.ts`): 4 new tests for user label extraction into `RoleListRow` and label-based search filtering (by key and by value).
- **Updated Cypress tests** (`rolesTabCreate.cy.ts`): Verifies labels are sent with the `labels.opendatahub.io/` prefix during role creation. Added `findLabelsCell()` page helper.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user-defined **Labels** support for project role creation and editing.
  * Added a **Labels** column to the roles table with compact label chips.
* **Improvements**
  * Updated roles search to also consider label keys/values and role type, with refined placeholder/help text.
  * Improved labels field description text for clarity.
* **Bug Fixes**
  * Ensures the dashboard label is consistently applied and preserves existing non-user metadata labels on save.
* **Tests**
  * Updated unit and Cypress coverage for label conversion, filtering, and create-role payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->