### PR TITLE
feat(gen-ai): rename 'Agent profile' to 'Agent configuration' + disable compare mode with agents (RHOAIENG-70792, RHOAIENG-68514)

### DIFF
--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/agentProfiles.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/agentProfiles.cy.ts
@@ -136,7 +136,7 @@ describe('AI Assets - Agent Profiles (empty state)', () => {
     () => {
       cy.step('Verify empty state is shown');
       cy.findByTestId('empty-state').should('be.visible');
-      cy.findByText('No agent profiles').should('be.visible');
+      cy.findByText('No agent configurations').should('be.visible');
     },
   );
 });

--- a/packages/gen-ai/frontend/src/app/AIAssets/AIAssetsAgentProfilesTab.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/AIAssetsAgentProfilesTab.tsx
@@ -31,8 +31,8 @@ const AIAssetsAgentProfilesTab: React.FC = () => {
   if (error) {
     return (
       <NoData
-        title="Unable to load agent profiles"
-        description="There was a problem loading agent profiles. Try refreshing the page or contact your cluster administrator."
+        title="Unable to load agent configurations"
+        description="There was a problem loading agent configurations. Try refreshing the page or contact your cluster administrator."
       />
     );
   }
@@ -40,8 +40,8 @@ const AIAssetsAgentProfilesTab: React.FC = () => {
   if (profiles.length === 0) {
     return (
       <NoData
-        title="No agent profiles"
-        description="Save a playground configuration as an agent profile to see it listed here."
+        title="No agent configurations"
+        description="Save a playground configuration as an agent configuration to see it listed here."
       />
     );
   }

--- a/packages/gen-ai/frontend/src/app/AIAssets/__tests__/AIAssetsAgentProfilesTab.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/__tests__/AIAssetsAgentProfilesTab.spec.tsx
@@ -69,7 +69,7 @@ describe('AIAssetsAgentProfilesTab', () => {
     });
 
     renderTab();
-    expect(screen.getByText('Unable to load agent profiles')).toBeInTheDocument();
+    expect(screen.getByText('Unable to load agent configurations')).toBeInTheDocument();
   });
 
   it('should render empty state when no profiles exist', () => {
@@ -81,7 +81,7 @@ describe('AIAssetsAgentProfilesTab', () => {
     });
 
     renderTab();
-    expect(screen.getByText('No agent profiles')).toBeInTheDocument();
+    expect(screen.getByText('No agent configurations')).toBeInTheDocument();
   });
 
   it('should render the profiles table when profiles exist', () => {

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/agentprofiles/DeleteAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/agentprofiles/DeleteAgentProfileModal.tsx
@@ -46,15 +46,15 @@ const DeleteAgentProfileModal: React.FC<DeleteAgentProfileModalProps> = ({
       data-testid="delete-agent-profile-modal"
     >
       <ModalHeader
-        title="Delete agent profile?"
+        title="Delete agent configuration?"
         labelId="delete-agent-profile-modal-title"
         titleIconVariant="warning"
       />
       <ModalBody>
         <Content>
           <p>
-            The <strong>{profile.displayName}</strong> agent profile will be permanently deleted.
-            This action cannot be undone.
+            The <strong>{profile.displayName}</strong> agent configuration will be permanently
+            deleted. This action cannot be undone.
           </p>
           {error && (
             <HelperText>

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/agentprofiles/EditAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/agentprofiles/EditAgentProfileModal.tsx
@@ -51,7 +51,7 @@ const EditAgentProfileModal: React.FC<EditAgentProfileModalProps> = ({
       })
       .catch(() => {
         if (!controller.signal.aborted) {
-          setError('Failed to load agent profile. Please close and try again.');
+          setError('Failed to load agent configuration. Please close and try again.');
         }
       })
       .finally(() => {
@@ -98,7 +98,7 @@ const EditAgentProfileModal: React.FC<EditAgentProfileModalProps> = ({
       aria-labelledby="edit-agent-profile-modal-title"
       data-testid="edit-agent-profile-modal"
     >
-      <ModalHeader title="Edit agent profile" labelId="edit-agent-profile-modal-title" />
+      <ModalHeader title="Edit agent configuration" labelId="edit-agent-profile-modal-title" />
       <ModalBody>
         <Form id="edit-agent-profile-form" onSubmit={handleSubmit}>
           <FormGroup label="Name" isRequired fieldId="agent-profile-name">

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/agentprofiles/__tests__/DeleteAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/agentprofiles/__tests__/DeleteAgentProfileModal.spec.tsx
@@ -28,7 +28,7 @@ describe('DeleteAgentProfileModal', () => {
     );
 
     expect(screen.getByTestId('delete-agent-profile-modal')).toBeInTheDocument();
-    expect(screen.getByText('Delete agent profile?')).toBeInTheDocument();
+    expect(screen.getByText('Delete agent configuration?')).toBeInTheDocument();
     expect(screen.getByText('My Agent')).toBeInTheDocument();
     expect(screen.getByText(/will be permanently/)).toBeInTheDocument();
   });

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/agentprofiles/__tests__/EditAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/agentprofiles/__tests__/EditAgentProfileModal.spec.tsx
@@ -51,7 +51,7 @@ describe('EditAgentProfileModal', () => {
     renderModal();
 
     expect(screen.getByTestId('edit-agent-profile-modal')).toBeInTheDocument();
-    expect(screen.getByText('Edit agent profile')).toBeInTheDocument();
+    expect(screen.getByText('Edit agent configuration')).toBeInTheDocument();
     expect(screen.getByTestId('edit-agent-profile-name')).toHaveValue('My Agent');
     expect(screen.getByTestId('edit-agent-profile-description')).toHaveValue('My description');
   });

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
@@ -78,15 +78,29 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
             {/* Hide compare button when in compare mode - use close button on pane to exit */}
             {!isCompareMode && (
               <ToolbarItem>
-                <Button
-                  variant="link"
-                  aria-label="Compare chat"
-                  icon={<ColumnsIcon />}
-                  onClick={onCompareChat}
-                  data-testid="compare-chat-button"
-                >
-                  Compare chat
-                </Button>
+                {profileApplied ? (
+                  <Tooltip content="Comparison mode is not available when an agent configuration is loaded.">
+                    <Button
+                      variant="link"
+                      aria-label="Compare chat (disabled)"
+                      icon={<ColumnsIcon />}
+                      isAriaDisabled
+                      data-testid="compare-chat-button"
+                    >
+                      Compare chat
+                    </Button>
+                  </Tooltip>
+                ) : (
+                  <Button
+                    variant="link"
+                    aria-label="Compare chat"
+                    icon={<ColumnsIcon />}
+                    onClick={onCompareChat}
+                    data-testid="compare-chat-button"
+                  >
+                    Compare chat
+                  </Button>
+                )}
               </ToolbarItem>
             )}
             <ToolbarItem>
@@ -159,43 +173,47 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
             popperProps={{ position: 'end', preventOverflow: true }}
           >
             <DropdownList>
-              {!isCompareMode && agentProfilesEnabled && (
+              {agentProfilesEnabled && (
                 <DropdownItem
-                  onClick={onLoad}
+                  onClick={!isCompareMode ? onLoad : undefined}
+                  isAriaDisabled={isCompareMode}
                   key="load-agent-configuration"
                   data-testid="load-agent-profile-button"
                 >
                   Load agent configuration
                 </DropdownItem>
               )}
-              {!isCompareMode && agentProfilesEnabled && profileApplied && (
+              {agentProfilesEnabled && profileApplied && (
                 <DropdownItem
-                  onClick={onSave}
+                  onClick={!isCompareMode ? onSave : undefined}
+                  isAriaDisabled={isCompareMode}
                   key="save-agent-configuration"
                   data-testid="save-agent-profile-button"
                 >
                   Save agent configuration
                 </DropdownItem>
               )}
-              {!isCompareMode && agentProfilesEnabled && (
+              {agentProfilesEnabled && (
                 <DropdownItem
-                  onClick={onSaveAs}
+                  onClick={!isCompareMode ? onSaveAs : undefined}
+                  isAriaDisabled={isCompareMode}
                   key="save-as-agent-configuration"
                   data-testid="save-as-agent-profile-button"
                 >
                   Save as agent configuration
                 </DropdownItem>
               )}
-              {!isCompareMode && agentProfilesEnabled && profileApplied && (
+              {agentProfilesEnabled && profileApplied && (
                 <DropdownItem
-                  onClick={onNew}
+                  onClick={!isCompareMode ? onNew : undefined}
+                  isAriaDisabled={isCompareMode}
                   key="new-agent-configuration"
                   data-testid="new-agent-configuration-button"
                 >
                   New agent configuration
                 </DropdownItem>
               )}
-              {!isCompareMode && agentProfilesEnabled && <Divider key="agent-divider" />}
+              {agentProfilesEnabled && <Divider key="agent-divider" />}
               <DropdownItem
                 onClick={onConfigurePlayground}
                 key="update-configuration"

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -112,6 +112,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
   const isPreview = useChatbotConfigStore(selectIsPreview(configId));
 
   const configIds = useChatbotConfigStore(selectConfigIds);
+  const isCompareMode = configIds.length > 1;
 
   // Consume store directly using configId (controlled by parent)
   const systemInstruction = useChatbotConfigStore(selectSystemInstruction(configId));
@@ -270,7 +271,12 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
         <DrawerActions style={{ gap: 'var(--pf-t--global--spacer--sm)' }}>
           {agentProfilesEnabled && (
             <>
-              <Button variant="secondary" onClick={onLoad} data-testid="settings-panel-load-button">
+              <Button
+                variant="secondary"
+                onClick={onLoad}
+                isDisabled={isCompareMode}
+                data-testid="settings-panel-load-button"
+              >
                 Load
               </Button>
               <Dropdown
@@ -283,6 +289,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
                     ref={toggleRef}
                     variant="secondary"
                     isExpanded={isSaveDropdownOpen}
+                    isDisabled={isCompareMode}
                     onClick={() => setIsSaveDropdownOpen(!isSaveDropdownOpen)}
                     splitButtonItems={[
                       <MenuToggleAction

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/LoadAgentProfileModal.tsx
@@ -64,7 +64,7 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
       })
       .catch((err: Error) => {
         if (!cancelled) {
-          setError(err.message || 'Failed to load agent profiles.');
+          setError(err.message || 'Failed to load agent configurations.');
         }
       })
       .finally(() => {
@@ -96,7 +96,7 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
     if (loading) {
       return (
         <Bullseye style={{ minHeight: 'var(--pf-t--global--spacer--2xl)' }}>
-          <Spinner aria-label="Loading agent profiles" />
+          <Spinner aria-label="Loading agent configurations" />
         </Bullseye>
       );
     }
@@ -107,14 +107,16 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
       return (
         <EmptyState>
           <EmptyStateBody>
-            {profiles.length === 0 ? 'No agent profiles found.' : 'No profiles match your search.'}
+            {profiles.length === 0
+              ? 'No agent configurations found.'
+              : 'No configurations match your search.'}
           </EmptyStateBody>
         </EmptyState>
       );
     }
     return (
       <>
-        <Table aria-label="Agent profiles" variant="compact">
+        <Table aria-label="Agent configurations" variant="compact">
           <Thead>
             <Tr>
               <Th>Name</Th>
@@ -195,7 +197,7 @@ const LoadAgentProfileModal: React.FC<LoadAgentProfileModalProps> = ({ onClose, 
           onClear={() => setFilter('')}
           style={{ marginBottom: 'var(--pf-t--global--spacer--md)' }}
           data-testid="load-agent-profile-search"
-          aria-label="Filter agent profiles by name"
+          aria-label="Filter agent configurations by name"
         />
         {renderBody()}
       </ModalBody>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -155,7 +155,7 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
     }
   };
 
-  const title = mode === 'save' ? 'Save agent profile' : 'Save as agent profile';
+  const title = mode === 'save' ? 'Save agent configuration' : 'Save as agent configuration';
   const nameError = nameTouched && !name.trim();
   const isSaveDisabled = isSaving || !name.trim();
 
@@ -205,7 +205,7 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
       <ModalHeader
         title={title}
         labelId="save-agent-profile-modal-title"
-        description="Save your model, prompt, knowledge, and MCP servers as a reusable agent profile."
+        description="Save your model, prompt, knowledge, and MCP servers as a reusable agent configuration."
       />
       <ModalBody>
         <Form id="save-agent-profile-form" onSubmit={handleSubmit}>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/LoadAgentProfileModal.spec.tsx
@@ -149,7 +149,7 @@ describe('LoadAgentProfileModal', () => {
     renderModal();
 
     await waitFor(() => {
-      expect(screen.getByText('No agent profiles found.')).toBeInTheDocument();
+      expect(screen.getByText('No agent configurations found.')).toBeInTheDocument();
     });
   });
 
@@ -174,7 +174,7 @@ describe('LoadAgentProfileModal', () => {
     await waitFor(() => screen.getByText('Coding assistant'));
     await user.type(screen.getByPlaceholderText('Find by name'), 'xyz-no-match');
 
-    expect(screen.getByText('No profiles match your search.')).toBeInTheDocument();
+    expect(screen.getByText('No configurations match your search.')).toBeInTheDocument();
   });
 
   it('should show error state when API call fails', async () => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
@@ -113,7 +113,7 @@ describe('SaveAgentProfileModal', () => {
   describe('Save As mode', () => {
     it('should render with empty name field', () => {
       renderModal('save-as');
-      expect(screen.getByText('Save as agent profile')).toBeInTheDocument();
+      expect(screen.getByText('Save as agent configuration')).toBeInTheDocument();
       expect(screen.getByTestId('save-agent-profile-name-input')).toHaveValue('');
     });
 
@@ -181,7 +181,7 @@ describe('SaveAgentProfileModal', () => {
         loadedProfileDescription: null,
       });
       renderModal('save');
-      expect(screen.getByText('Save agent profile')).toBeInTheDocument();
+      expect(screen.getByText('Save agent configuration')).toBeInTheDocument();
       expect(screen.getByTestId('save-agent-profile-name-input')).toHaveValue('My Agent');
     });
 

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -198,7 +198,7 @@ const extensions: (
     },
     properties: {
       id: 'agentprofile',
-      title: 'Agent profiles',
+      title: 'Agent configurations',
       component: () => import('../app/AIAssets/AIAssetsAgentProfilesTab').then((m) => m.default),
     },
   },


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-70792
https://issues.redhat.com/browse/RHOAIENG-68514

## Description

**Rename 'Agent profile' → 'Agent configuration' ([RHOAIENG-70792](https://redhat.atlassian.net/browse/RHOAIENG-70792))**

Updates all user-facing strings to use 'agent configuration' instead of 'agent profile' for consistent naming across the UI:
- `SaveAgentProfileModal`: modal titles, description
- `LoadAgentProfileModal`: spinner, error, empty states, table aria-label, search aria-label
- `AIAssetsAgentProfilesTab`: error state title/description, empty state title/description
- `DeleteAgentProfileModal`: modal title, confirmation text
- `EditAgentProfileModal`: modal title, error message

**Disable comparison mode when agent is loaded ([RHOAIENG-68514](https://redhat.atlassian.net/browse/RHOAIENG-68514))**

Enforces that agent configuration actions are unavailable in comparison mode, and comparison mode is unavailable when an agent is loaded:

- **Compare chat button**: `isAriaDisabled` with tooltip `"Comparison mode is not available when an agent configuration is loaded."` when `profileApplied` is true
- **Kebab menu agent actions** (Load, Save, Save as, New agent configuration): always visible but `isAriaDisabled` in compare mode — users see them grayed out rather than disappearing
- **Settings panel Load + Save split button**: `isDisabled` when `configIds.length > 1` (compare mode)

## How Has This Been Tested?

- Manually verified string replacements render correctly across all affected modals and tabs
- Manually verified Compare chat button shows tooltip and is non-interactive when agent is loaded
- Manually verified agent actions in kebab and settings panel are grayed out in compare mode
- All unit tests pass (1569/1569)

## Test Impact

No new tests added — these are purely UI string changes and disable-state wiring with no new logic branches.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compare chat button is now disabled when an agent configuration is loaded with an explanatory tooltip.
  * Configuration load and save actions are disabled during chat comparison mode while menu structure remains visible.

* **Style**
  * Updated UI terminology from "agent profile" to "agent configuration" throughout the application.
  * Revised empty-state messages and accessibility labels for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->