### PR TITLE
Rearrange generative deployment methods

### DIFF
--- a/frontend/src/__mocks__/mockLLMInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockLLMInferenceServiceK8sResource.ts
@@ -25,6 +25,7 @@ type MockLLMInferenceServiceConfigType = {
   isMaaS?: boolean;
   secretName?: string;
   gatewayRefs?: { name: string; namespace: string }[];
+  isLLMd?: boolean;
 };
 
 export const mockLLMInferenceServiceK8sResource = ({
@@ -46,6 +47,7 @@ export const mockLLMInferenceServiceK8sResource = ({
   isMaaS = false,
   secretName,
   gatewayRefs,
+  isLLMd = true,
 }: MockLLMInferenceServiceConfigType): LLMInferenceServiceKind => ({
   apiVersion: 'serving.kserve.io/v1alpha1',
   kind: 'LLMInferenceService',
@@ -86,7 +88,7 @@ export const mockLLMInferenceServiceK8sResource = ({
           : {}),
       },
       route: {},
-      scheduler: {},
+      ...(isLLMd && { scheduler: {} }),
     },
     template: {
       containers: [

--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -8,6 +8,11 @@ import { DeleteModal } from './components/DeleteModal';
 import { DashboardCodeEditor } from './components/DashboardCodeEditor';
 import { mixin } from '../utils/mixin';
 
+type DeploymentMethodKey =
+  | 'legacy'
+  | 'llm-inference-service-simple-vllm'
+  | 'llm-inference-service-llmd';
+
 class ModelServingToolbar extends Contextual<HTMLElement> {
   findToggleButton(id: string) {
     return this.find().pfSwitch(id).click();
@@ -1417,13 +1422,17 @@ class ModelServingWizard extends Wizard {
     return cy.findByTestId('deployment-method-select');
   }
 
-  findDeploymentMethodSelectOption(name: string) {
-    return this.findDeploymentMethodSelect().findSelectOption(new RegExp(`^${name}`));
+  findDeploymentMethodSelectOption(testId: DeploymentMethodKey) {
+    this.findDeploymentMethodSelect().then(($el) => {
+      if ($el.attr('aria-expanded') === 'false') {
+        cy.wrap($el).click();
+      }
+    });
+    return cy.findByTestId(testId);
   }
 
-  selectDeploymentMethodByKey(key: string) {
-    this.findDeploymentMethodSelect().click();
-    return cy.findByTestId(key).click();
+  selectDeploymentMethodByKey(key: DeploymentMethodKey) {
+    this.findDeploymentMethodSelectOption(key).click();
   }
 
   findYAMLEditFallbackAlert() {

--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -1413,8 +1413,17 @@ class ModelServingWizard extends Wizard {
     return cy.findByTestId('switch-to-manual-yaml-editor');
   }
 
-  findLegacyModeCheckbox() {
-    return cy.findByTestId('legacy-mode-checkbox');
+  findDeploymentMethodSelect() {
+    return cy.findByTestId('deployment-method-select');
+  }
+
+  findDeploymentMethodSelectOption(name: string) {
+    return this.findDeploymentMethodSelect().findSelectOption(new RegExp(`^${name}`));
+  }
+
+  selectDeploymentMethodByKey(key: string) {
+    this.findDeploymentMethodSelect().click();
+    return cy.findByTestId(key).click();
   }
 
   findYAMLEditFallbackAlert() {

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployLLMDServing.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployLLMDServing.cy.ts
@@ -134,9 +134,7 @@ describe('A user can deploy an LLMD model', () => {
         });
       modelServingWizard.selectPotentiallyDisabledProfile(hardwareProfileResourceName);
 
-      modelServingWizard
-        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
-        .click();
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
 
       cy.step('Verify YAML Viewer');
       // Stub clipboard API AFTER page load (window changes on navigation)

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployLLMDServing.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployLLMDServing.cy.ts
@@ -120,9 +120,6 @@ describe('A user can deploy an LLMD model', () => {
         .type(`${modelName}${testData.connectionNameSuffix}`);
       modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
 
-      cy.step('Verify legacy deployment checkbox appears and is unchecked');
-      modelServingWizard.findLegacyModeCheckbox().should('exist').should('not.be.checked');
-
       modelServingWizard.findNextButton().should('be.enabled').click();
 
       cy.step('Select Model deployment');
@@ -136,6 +133,10 @@ describe('A user can deploy an LLMD model', () => {
           resourceName = val as string;
         });
       modelServingWizard.selectPotentiallyDisabledProfile(hardwareProfileResourceName);
+
+      modelServingWizard
+        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
+        .click();
 
       cy.step('Verify YAML Viewer');
       // Stub clipboard API AFTER page load (window changes on navigation)

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -110,11 +110,6 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
         .clear()
         .type(`${modelName}${testData.connectionNameSuffix}`);
       modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
-
-      cy.step('Verify legacy deployment checkbox appears and check it');
-      modelServingWizard.findLegacyModeCheckbox().should('exist').should('not.be.checked');
-      modelServingWizard.findLegacyModeCheckbox().click();
-      modelServingWizard.findLegacyModeCheckbox().should('be.checked');
       modelServingWizard.findNextButton().should('be.enabled').click();
 
       cy.step('Step 2: Model deployment');
@@ -127,6 +122,7 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
         .then((val) => {
           resourceName = val as string;
         });
+      modelServingWizard.findDeploymentMethodSelectOption('Legacy deployment').click();
       modelServingWizard.selectPotentiallyDisabledProfile(hardwareProfileResourceName);
       modelServingWizard.selectServingRuntimeOption(servingRuntime);
       modelServingWizard.findNextButton().click();

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -122,7 +122,7 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
         .then((val) => {
           resourceName = val as string;
         });
-      modelServingWizard.findDeploymentMethodSelectOption('Legacy deployment').click();
+      modelServingWizard.selectDeploymentMethodByKey('legacy');
       modelServingWizard.selectPotentiallyDisabledProfile(hardwareProfileResourceName);
       modelServingWizard.selectServingRuntimeOption(servingRuntime);
       modelServingWizard.findNextButton().click();

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testVLLMOnMaaS.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testVLLMOnMaaS.cy.ts
@@ -127,9 +127,7 @@ describe('A user can deploy a model via vLLM on MaaS (LLMInferenceServiceConfig)
         .then((val) => {
           resourceName = val as string;
         });
-      modelServingWizard
-        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
-        .click();
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-simple-vllm');
       modelServingWizard.selectPotentiallyDisabledProfile(hardwareProfileResourceName);
       modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
       modelServingWizard

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testVLLMOnMaaS.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testVLLMOnMaaS.cy.ts
@@ -115,9 +115,6 @@ describe('A user can deploy a model via vLLM on MaaS (LLMInferenceServiceConfig)
         .clear()
         .type(`${modelName}${testData.connectionNameSuffix}`);
       modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
-
-      cy.step('Verify legacy checkbox is unchecked (non-legacy MaaS path)');
-      modelServingWizard.findLegacyModeCheckbox().should('exist').should('not.be.checked');
       modelServingWizard.findNextButton().should('be.enabled').click();
 
       cy.step('Step 2: Model deployment - select vLLM CPU LLMInferenceServiceConfig');
@@ -130,6 +127,9 @@ describe('A user can deploy a model via vLLM on MaaS (LLMInferenceServiceConfig)
         .then((val) => {
           resourceName = val as string;
         });
+      modelServingWizard
+        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
+        .click();
       modelServingWizard.selectPotentiallyDisabledProfile(hardwareProfileResourceName);
       modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
       modelServingWizard

--- a/packages/cypress/cypress/tests/e2e/modelsAsAService/testMaaSSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelsAsAService/testMaaSSubscriptions.cy.ts
@@ -218,9 +218,7 @@ describe('A model can be deployed and accessed with a MaaS subscription and API 
           resourceName = String(val ?? '');
         });
       modelServingWizard.selectPotentiallyDisabledProfile(hardwareProfileResourceName);
-      modelServingWizard
-        .findDeploymentMethodSelectOption('LLM inference service deployment')
-        .click();
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-simple-vllm');
       modelServingWizard.findModelServerManualSelectRadio().click();
       modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
       modelServingWizard

--- a/packages/cypress/cypress/tests/e2e/modelsAsAService/testMaaSSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelsAsAService/testMaaSSubscriptions.cy.ts
@@ -218,6 +218,9 @@ describe('A model can be deployed and accessed with a MaaS subscription and API 
           resourceName = String(val ?? '');
         });
       modelServingWizard.selectPotentiallyDisabledProfile(hardwareProfileResourceName);
+      modelServingWizard
+        .findDeploymentMethodSelectOption('LLM inference service deployment')
+        .click();
       modelServingWizard.findModelServerManualSelectRadio().click();
       modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
       modelServingWizard

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -376,8 +376,6 @@ describe('Model Serving Deploy Wizard', () => {
       .should('exist')
       .click();
     modelServingWizard.findSaveConnectionCheckbox().should('not.exist');
-
-    modelServingWizard.findLegacyModeCheckbox().should('exist').click();
     modelServingWizard.findNextButton().should('be.enabled').click();
 
     // Step 2: Model deployment
@@ -386,6 +384,7 @@ describe('Model Serving Deploy Wizard', () => {
     modelServingWizard.findNextButton().should('be.disabled');
     modelServingWizard.findModelDeploymentNameInput().type('test-model');
     modelServingWizard.findModelDeploymentDescriptionInput().type('test-description');
+    modelServingWizard.findDeploymentMethodSelectOption('Legacy deployment').click();
     hardwareProfileSection.findSelect().should('contain.text', 'Small');
 
     // Generative has no model format select (they are all vLLM)
@@ -1481,13 +1480,16 @@ describe('Model Serving Deploy Wizard', () => {
       .should('have.text', ModelTypeLabel.GENERATIVE)
       .should('be.disabled');
 
-    modelServingWizardEdit.findLegacyModeCheckbox().should('be.checked').should('be.disabled');
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
 
     // Step 2: Model deployment
     modelServingWizardEdit
       .findModelDeploymentDescriptionInput()
       .should('contain.text', 'test-description');
+    modelServingWizardEdit
+      .findDeploymentMethodSelect()
+      .should('be.disabled')
+      .should('contain.text', 'Legacy deployment');
     modelServingWizardEdit.findModelDeploymentStep().should('be.enabled');
     modelServingWizardEdit.findNextButton().should('be.enabled');
 
@@ -1659,6 +1661,7 @@ describe('Model Serving Deploy Wizard', () => {
     modelServingWizard.findAdvancedOptionsStep().should('be.disabled');
     modelServingWizard.findNextButton().should('be.disabled');
     modelServingWizard.findModelDeploymentNameInput().type('test-model');
+    modelServingWizardEdit.findDeploymentMethodSelectOption('Legacy deployment').click();
     hardwareProfileSection.findSelect().should('contain.text', 'Small');
 
     modelServingWizard.findModelFormatSelect().should('not.exist');
@@ -1820,10 +1823,8 @@ describe('Model Serving Deploy Wizard', () => {
       modelServingWizard.findSaveConnectionCheckbox().click();
       modelServingWizard.findNextButton().should('be.enabled').click();
       modelServingWizard.findModelDeploymentNameInput().type('test-model');
-      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
-      modelServingWizard
-        .findGlobalScopedTemplateOption('Distributed inference with llm-d')
-        .should('exist')
+      modelServingWizardEdit
+        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
         .click();
 
       // Verify yaml preview contents (use .contains() command, not .should('contain.text'),
@@ -1874,10 +1875,8 @@ describe('Model Serving Deploy Wizard', () => {
 
       // Step 2: Model deployment - set name and choose the LLMd runtime
       modelServingWizard.findModelDeploymentNameInput().type('test-model');
-      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
-      modelServingWizard
-        .findGlobalScopedTemplateOption('Distributed inference with llm-d')
-        .should('exist')
+      modelServingWizardEdit
+        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
         .click();
       modelServingWizard.findNextButton().should('be.enabled').click();
 
@@ -2158,6 +2157,7 @@ describe('Model Serving Deploy Wizard', () => {
       modelServingWizard.findNextButton().click();
 
       // Step 6: Verify selection is cleared when model type changes
+      modelServingWizardEdit.findDeploymentMethodSelectOption('Legacy deployment').click();
       modelServingWizard
         .findServingRuntimeTemplateSearchSelector()
         .should('contain.text', 'Select one');

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -384,7 +384,7 @@ describe('Model Serving Deploy Wizard', () => {
     modelServingWizard.findNextButton().should('be.disabled');
     modelServingWizard.findModelDeploymentNameInput().type('test-model');
     modelServingWizard.findModelDeploymentDescriptionInput().type('test-description');
-    modelServingWizard.findDeploymentMethodSelectOption('Legacy deployment').click();
+    modelServingWizard.selectDeploymentMethodByKey('legacy');
     hardwareProfileSection.findSelect().should('contain.text', 'Small');
 
     // Generative has no model format select (they are all vLLM)
@@ -1661,7 +1661,7 @@ describe('Model Serving Deploy Wizard', () => {
     modelServingWizard.findAdvancedOptionsStep().should('be.disabled');
     modelServingWizard.findNextButton().should('be.disabled');
     modelServingWizard.findModelDeploymentNameInput().type('test-model');
-    modelServingWizardEdit.findDeploymentMethodSelectOption('Legacy deployment').click();
+    modelServingWizard.selectDeploymentMethodByKey('legacy');
     hardwareProfileSection.findSelect().should('contain.text', 'Small');
 
     modelServingWizard.findModelFormatSelect().should('not.exist');
@@ -1823,9 +1823,7 @@ describe('Model Serving Deploy Wizard', () => {
       modelServingWizard.findSaveConnectionCheckbox().click();
       modelServingWizard.findNextButton().should('be.enabled').click();
       modelServingWizard.findModelDeploymentNameInput().type('test-model');
-      modelServingWizardEdit
-        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
-        .click();
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
 
       // Verify yaml preview contents (use .contains() command, not .should('contain.text'),
       // because cy.contains() normalizes &nbsp; to regular spaces while the assertion does not)
@@ -1875,9 +1873,7 @@ describe('Model Serving Deploy Wizard', () => {
 
       // Step 2: Model deployment - set name and choose the LLMd runtime
       modelServingWizard.findModelDeploymentNameInput().type('test-model');
-      modelServingWizardEdit
-        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
-        .click();
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       modelServingWizard.findNextButton().should('be.enabled').click();
 
       // Step 3: Advanced options
@@ -2157,7 +2153,7 @@ describe('Model Serving Deploy Wizard', () => {
       modelServingWizard.findNextButton().click();
 
       // Step 6: Verify selection is cleared when model type changes
-      modelServingWizardEdit.findDeploymentMethodSelectOption('Legacy deployment').click();
+      modelServingWizard.selectDeploymentMethodByKey('legacy');
       modelServingWizard
         .findServingRuntimeTemplateSearchSelector()
         .should('contain.text', 'Select one');

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
@@ -297,14 +297,11 @@ describe('Model Serving LLMD', () => {
       modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
       modelServingWizard.findNextButton().click();
 
-      cy.step('Verify LLMD runtime option is not displayed');
-      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
+      cy.step('Verify LLMD deployment method option is not displayed');
       modelServingWizard
-        .findGlobalScopedTemplateOption('Distributed inference with llm-d')
-        .should('not.exist');
-
-      //Just to close the runtime template search selector
-      modelServingWizard.findModelDeploymentNameInput().click();
+        .findDeploymentMethodSelect()
+        .should('exist')
+        .should('not.contain.text', 'LLM inference service deployment with llm-d');
       modelServingWizard.findCancelButton().click();
       modelServingWizard.findDiscardButton().click();
 
@@ -326,10 +323,9 @@ describe('Model Serving LLMD', () => {
       modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
       modelServingWizard.findNextButton().click();
 
-      cy.step('Verify LLMD runtime option is displayed when LLMD is enabled');
-      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
+      cy.step('Verify LLMD deployment method option is displayed when LLMD is enabled');
       modelServingWizard
-        .findGlobalScopedTemplateOption('Distributed inference with llm-d')
+        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
         .should('exist');
     });
 
@@ -403,12 +399,11 @@ describe('Model Serving LLMD', () => {
       modelServingWizard.findModelDeploymentNameInput().type('test-llmd-model');
       modelServingWizard.findModelDeploymentDescriptionInput().type('test-llmd-description');
 
-      hardwareProfileSection.findSelect().should('contain.text', 'Small');
-      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
       modelServingWizard
-        .findGlobalScopedTemplateOption('Distributed inference with llm-d')
-        .should('exist')
+        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
         .click();
+
+      hardwareProfileSection.findSelect().should('contain.text', 'Small');
 
       modelServingWizard.findNumReplicasInputField().should('have.value', '1');
       modelServingWizard.findNumReplicasPlusButton().click();
@@ -555,7 +550,6 @@ describe('Model Serving LLMD', () => {
       modelServingWizardEdit.findNextButton().should('be.enabled').click();
 
       // Step 2: Model deployment
-      modelServingWizardEdit.findNextButton().should('be.disabled');
       modelServingWizardEdit.findModelDeploymentNameInput().clear().type('test-llmd-model-2');
       modelServingWizardEdit.findModelDeploymentDescriptionInput().type('test-llmd-description-2');
 
@@ -565,9 +559,9 @@ describe('Model Serving LLMD', () => {
         'Large Profile Compatible CPU: Default = 4 Cores, Max = 8 Cores; Memory: Default = 8 GiB, Max = 16 GiB',
       );
       modelServingWizardEdit
-        .findServingRuntimeTemplateSearchSelector()
+        .findDeploymentMethodSelect()
         .should('be.disabled')
-        .should('contain.text', 'Distributed inference with llm-d');
+        .should('contain.text', 'LLM inference service deployment with llm-d');
 
       modelServingWizardEdit.findNumReplicasInputField().should('have.value', '2');
       modelServingWizardEdit.findNumReplicasPlusButton().click();
@@ -710,10 +704,8 @@ describe('Model Serving LLMD', () => {
 
       // Step 2: Model deployment
       modelServingWizard.findModelDeploymentNameInput().type('test-gateway-model');
-      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
       modelServingWizard
-        .findGlobalScopedTemplateOption('Distributed inference with llm-d')
-        .should('exist')
+        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
         .click();
       modelServingWizard.findNextButton().should('be.enabled').click();
 
@@ -848,6 +840,7 @@ describe('Model Serving LLMD', () => {
             displayName: 'GPU vLLM Deployment',
             baseRefs: [{ name: 'test-vllm-gpu' }],
             modelType: ServingRuntimeModelType.GENERATIVE,
+            isLLMd: false, // remove the spec.router.scheduler
           }),
         ],
       });
@@ -1048,11 +1041,12 @@ describe('Model Serving LLMD', () => {
       // Step 2: Model deployment
       modelServingWizard.findModelDeploymentNameInput().type(deploymentName);
 
-      // Open template dropdown and verify all deployment configuration options are available
+      // Select the vLLM deployment method to activate the model server field
+      modelServingWizard.findDeploymentMethodSelect().should('not.be.disabled');
+      modelServingWizard.selectDeploymentMethodByKey('inference-service-simple-vllm');
+
+      // Open template dropdown and verify LLMInferenceServiceConfig options are available
       modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
-      modelServingWizard
-        .findGlobalScopedTemplateOption('Distributed inference with llm-d')
-        .should('exist');
       modelServingWizard
         .findGlobalScopedTemplateOption('vLLM on Gaudi LLMInferenceServiceConfig')
         .should('exist');
@@ -1142,8 +1136,10 @@ describe('Model Serving LLMD', () => {
       modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
       modelServingWizard.findNextButton().should('be.enabled').click();
 
-      // Step 2: Model deployment — open the config dropdown
+      // Step 2: Model deployment — select vLLM deployment method, then open the config dropdown
       modelServingWizard.findModelDeploymentNameInput().type('test-disabled-config');
+      modelServingWizard.findDeploymentMethodSelect().should('not.be.disabled');
+      modelServingWizard.selectDeploymentMethodByKey('inference-service-simple-vllm');
       modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
 
       // Enabled config should be visible
@@ -1155,11 +1151,6 @@ describe('Model Serving LLMD', () => {
       modelServingWizard
         .findGlobalScopedTemplateOption('vLLM on Gaudi LLMInferenceServiceConfig')
         .should('not.exist');
-
-      // The default llm-d option should still be available
-      modelServingWizard
-        .findGlobalScopedTemplateOption('Distributed inference with llm-d')
-        .should('exist');
     });
 
     it('Edit existing LLMInferenceService preserves LLMInferenceServiceConfig and baseRef', () => {

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
@@ -300,8 +300,8 @@ describe('Model Serving LLMD', () => {
       cy.step('Verify LLMD deployment method option is not displayed');
       modelServingWizard
         .findDeploymentMethodSelect()
-        .should('exist')
-        .should('not.contain.text', 'LLM inference service deployment with llm-d');
+        .should('be.disabled')
+        .should('contain.text', 'Legacy deployment');
       modelServingWizard.findCancelButton().click();
       modelServingWizard.findDiscardButton().click();
 
@@ -325,7 +325,7 @@ describe('Model Serving LLMD', () => {
 
       cy.step('Verify LLMD deployment method option is displayed when LLMD is enabled');
       modelServingWizard
-        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
+        .findDeploymentMethodSelectOption('llm-inference-service-llmd')
         .should('exist');
     });
 
@@ -399,9 +399,7 @@ describe('Model Serving LLMD', () => {
       modelServingWizard.findModelDeploymentNameInput().type('test-llmd-model');
       modelServingWizard.findModelDeploymentDescriptionInput().type('test-llmd-description');
 
-      modelServingWizard
-        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
-        .click();
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
 
       hardwareProfileSection.findSelect().should('contain.text', 'Small');
 
@@ -704,9 +702,7 @@ describe('Model Serving LLMD', () => {
 
       // Step 2: Model deployment
       modelServingWizard.findModelDeploymentNameInput().type('test-gateway-model');
-      modelServingWizard
-        .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
-        .click();
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       modelServingWizard.findNextButton().should('be.enabled').click();
 
       // Step 3: Advanced Options — gateway select should be visible
@@ -1043,7 +1039,7 @@ describe('Model Serving LLMD', () => {
 
       // Select the vLLM deployment method to activate the model server field
       modelServingWizard.findDeploymentMethodSelect().should('not.be.disabled');
-      modelServingWizard.selectDeploymentMethodByKey('inference-service-simple-vllm');
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-simple-vllm');
 
       // Open template dropdown and verify LLMInferenceServiceConfig options are available
       modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
@@ -1139,7 +1135,7 @@ describe('Model Serving LLMD', () => {
       // Step 2: Model deployment — select vLLM deployment method, then open the config dropdown
       modelServingWizard.findModelDeploymentNameInput().type('test-disabled-config');
       modelServingWizard.findDeploymentMethodSelect().should('not.be.disabled');
-      modelServingWizard.selectDeploymentMethodByKey('inference-service-simple-vllm');
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-simple-vllm');
       modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
 
       // Enabled config should be visible

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
@@ -171,8 +171,9 @@ describe('MaaS Deployment Wizard', () => {
     modelServingWizard
       .findModelDeploymentDescriptionInput()
       .type('Test LLM Inference Service Description');
-    modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
-    modelServingWizard.findGlobalScopedTemplateOption('Distributed inference with llm-d').click();
+    modelServingWizardEdit
+      .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
+      .click();
     modelServingWizard.findNextButton().click();
 
     // Focus on MaaS feature testing
@@ -399,8 +400,9 @@ describe('MaaS Deployment Wizard', () => {
     modelServingWizard
       .findModelDeploymentDescriptionInput()
       .type('Test LLM Inference Service Description');
-    modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
-    modelServingWizard.findGlobalScopedTemplateOption('Distributed inference with llm-d').click();
+    modelServingWizardEdit
+      .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
+      .click();
     modelServingWizard.findNextButton().click();
 
     // Focus on MaaS feature testing

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
@@ -171,9 +171,7 @@ describe('MaaS Deployment Wizard', () => {
     modelServingWizard
       .findModelDeploymentDescriptionInput()
       .type('Test LLM Inference Service Description');
-    modelServingWizardEdit
-      .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
-      .click();
+    modelServingWizardEdit.selectDeploymentMethodByKey('llm-inference-service-llmd');
     modelServingWizard.findNextButton().click();
 
     // Focus on MaaS feature testing
@@ -400,9 +398,7 @@ describe('MaaS Deployment Wizard', () => {
     modelServingWizard
       .findModelDeploymentDescriptionInput()
       .type('Test LLM Inference Service Description');
-    modelServingWizardEdit
-      .findDeploymentMethodSelectOption('LLM inference service deployment with llm-d')
-      .click();
+    modelServingWizardEdit.selectDeploymentMethodByKey('llm-inference-service-llmd');
     modelServingWizard.findNextButton().click();
 
     // Focus on MaaS feature testing

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -27,6 +27,7 @@ import {
   DataScienceStackComponent,
   SupportedArea,
 } from '@odh-dashboard/internal/concepts/areas/index';
+import type { DeploymentMethodFieldData } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/DeploymentMethodSelectField';
 import type { TimeoutFieldValue } from './src/wizardFields/timeout/TimeoutField';
 import type { KServeServingRuntimeFieldType } from './src/wizardFields/servingRuntime/KServeServingRuntimeField';
 import type { KServeDeployment } from './src/deployments';
@@ -65,6 +66,39 @@ const kserveTimeoutFieldExtension: WizardFieldExtension<
   },
 };
 
+const timeoutExtractorExtension: WizardFieldExtractorExtension<
+  TimeoutFieldValue,
+  KServeDeployment
+> = {
+  type: 'model-serving.deployment/wizard-field-extractor',
+  properties: {
+    fieldId: 'kserve/timeout',
+    platform: KSERVE_ID,
+    extract: () =>
+      import('./src/wizardFields/timeout/timeoutApplyExtract').then(
+        (m) => m.extractTimeoutFieldData,
+      ),
+  },
+  flags: {
+    required: [SupportedArea.K_SERVE],
+  },
+};
+
+const deploymentMethodExtractorExtension: WizardFieldExtractorExtension<
+  DeploymentMethodFieldData,
+  KServeDeployment
+> = {
+  type: 'model-serving.deployment/wizard-field-extractor',
+  properties: {
+    fieldId: 'deploymentMethod',
+    platform: KSERVE_ID,
+    extract: () => import('./src/deployUtils').then((m) => m.extractDeploymentMethod),
+  },
+  flags: {
+    required: [SupportedArea.K_SERVE],
+  },
+};
+
 const extensions: (
   | AreaExtension
   | ModelServingPlatformExtension<KServeDeployment>
@@ -81,6 +115,7 @@ const extensions: (
   | WizardFieldExtension<WizardField<TimeoutFieldValue, undefined>, KServeDeployment>
   | WizardFieldApplyExtension<TimeoutFieldValue, KServeDeployment>
   | WizardFieldExtractorExtension<TimeoutFieldValue, KServeDeployment>
+  | WizardFieldExtractorExtension<DeploymentMethodFieldData, KServeDeployment>
   | DeploymentWizardFieldOverrideExtension<KServeDeployment>
 )[] = [
   {
@@ -247,20 +282,8 @@ const extensions: (
       required: [SupportedArea.K_SERVE],
     },
   },
-  {
-    type: 'model-serving.deployment/wizard-field-extractor',
-    properties: {
-      fieldId: 'kserve/timeout',
-      platform: KSERVE_ID,
-      extract: () =>
-        import('./src/wizardFields/timeout/timeoutApplyExtract').then(
-          (m) => m.extractTimeoutFieldData,
-        ),
-    },
-    flags: {
-      required: [SupportedArea.K_SERVE],
-    },
-  },
+  timeoutExtractorExtension,
+  deploymentMethodExtractorExtension,
   {
     type: 'model-serving.deployment/wizard-field-override',
     properties: {
@@ -272,6 +295,19 @@ const extensions: (
     },
     flags: {
       required: [KSERVE_ID],
+    },
+  },
+  {
+    type: 'model-serving.deployment/wizard-field-override',
+    properties: {
+      platform: KSERVE_ID,
+      field: () =>
+        import('./src/wizardFields/deploymentMethodField').then(
+          (m) => m.legacyDeploymentMethodOverride,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.K_SERVE],
     },
   },
 ];

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -52,6 +52,8 @@ import {
   deploymentStrategyRolling,
   deploymentStrategyRecreate,
 } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/DeploymentStrategyField';
+import type { DeploymentMethodFieldData } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/DeploymentMethodSelectField';
+import { LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY } from './wizardFields/deploymentMethodField';
 import type { CreatingInferenceServiceObject } from './deployModel';
 import type { KServeDeployment } from './deployments';
 
@@ -391,7 +393,6 @@ export const extractModelType = (deployment: {
 
   return {
     type: modelType,
-    legacyVLLM: modelType === ServingRuntimeModelType.GENERATIVE,
   };
 };
 
@@ -445,3 +446,7 @@ export const applyDeploymentStrategy = (
   }
   return result;
 };
+
+export const extractDeploymentMethod = (): DeploymentMethodFieldData => ({
+  method: LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY,
+});

--- a/packages/kserve/src/wizardFields/deploymentMethodField.ts
+++ b/packages/kserve/src/wizardFields/deploymentMethodField.ts
@@ -1,0 +1,17 @@
+import type { DeploymentMethodFieldOverride } from '@odh-dashboard/model-serving/types/form-data';
+
+export const LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY = 'legacy';
+
+export const legacyDeploymentMethodOverride: DeploymentMethodFieldOverride = {
+  id: 'deploymentMethod',
+  type: 'modifier',
+  isActive: () => true,
+  options: [
+    {
+      key: LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY,
+      label: 'Legacy deployment',
+      description:
+        'Deploy a model using a serving runtime and inference server. This deployment method does not support Models as a Service.',
+    },
+  ],
+};

--- a/packages/kserve/src/wizardFields/servingRuntime/KServeServingRuntimeField.tsx
+++ b/packages/kserve/src/wizardFields/servingRuntime/KServeServingRuntimeField.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import { z } from 'zod';
 import type { WizardField, WizardFormData } from '@odh-dashboard/model-serving/types/form-data';
-import { isModelServerTemplateFieldOverride } from '@odh-dashboard/model-serving/components/deploymentWizard/types';
-import { useWizardFieldOverrides } from '@odh-dashboard/model-serving/components/deploymentWizard/dynamicFormUtils';
 import ModelServerTemplateSelectField, {
   type ModelServerOption,
   type ModelServerSelectFieldData,
   modelServerSelectFieldSchema,
   getAcceleratorIdentifierFromHardwareProfile,
 } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/ModelServerTemplateSelectField';
-import { useModelServingClusterSettings } from '@odh-dashboard/model-serving/concepts/useModelServingClusterSettings';
 import type { ModelTypeFieldData } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/ModelTypeSelectField';
 import type {
   HardwareProfileKind,
@@ -26,6 +23,7 @@ import {
 } from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils';
 import { isCompatibleWithIdentifier } from '@odh-dashboard/internal/pages/projects/screens/spawner/spawnerUtils';
 import { useProfileIdentifiers } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
+import { LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY } from '../deploymentMethodField';
 
 // Types
 
@@ -35,6 +33,7 @@ type KServeServingRuntimeDependencies = {
   hardwareProfile?: HardwareProfileKind;
   modelType?: ModelTypeFieldData;
   vLLMDeploymentOnMaaS?: boolean;
+  deploymentMethod?: string;
 };
 
 export type KServeServingRuntimeExternalData = {
@@ -57,11 +56,7 @@ export type KServeServingRuntimeFieldType = WizardField<
  *
  * Activation logic:
  * - PREDICTIVE models: Always active (use traditional KServe serving runtimes)
- * - GENERATIVE models with LLMInferenceServiceConfig flow available (vLLMDeploymentOnMaaS=true):
- *   - Active ONLY if legacyVLLM=true (user opted for legacy vLLM deployment path)
- *   - Inactive if legacyVLLM=false (uses LLMInferenceServiceConfig-based deployment instead)
- * - GENERATIVE models without LLMInferenceServiceConfig flow (vLLMDeploymentOnMaaS=false):
- *   - Always active (LLMInferenceServiceConfig not available, must use KServe serving runtime)
+ * - GENERATIVE models: Active only when the legacy deployment method is selected
  *
  * @param wizardState Current wizard form state
  * @returns true if the KServe serving runtime field should be shown
@@ -70,7 +65,7 @@ export const isKServeServingRuntimeFieldActive = (
   wizardState: RecursivePartial<WizardFormData['state']>,
 ): boolean => {
   const modelType = wizardState.modelType?.data;
-  const vLLMDeploymentOnMaaSEnabled = wizardState.devFeatureFlags?.vLLMDeploymentOnMaaS;
+  const deploymentMethodOption = wizardState.deploymentMethod?.method;
 
   // Predictive models always use KServe serving runtimes
   if (modelType?.type === ServingRuntimeModelType.PREDICTIVE) {
@@ -78,85 +73,14 @@ export const isKServeServingRuntimeFieldActive = (
   }
 
   // Generative models with LLMInferenceServiceConfig flow enabled: only show if using legacy vLLM
-  if (vLLMDeploymentOnMaaSEnabled === true) {
-    if (modelType?.type === ServingRuntimeModelType.GENERATIVE && modelType.legacyVLLM === true) {
-      return true;
-    }
-  }
-
-  // Generative models without LLMInferenceServiceConfig flow: always show (no alternative)
-  if (!vLLMDeploymentOnMaaSEnabled) {
-    if (modelType?.type === ServingRuntimeModelType.GENERATIVE) {
-      return true;
-    }
+  if (
+    modelType?.type === ServingRuntimeModelType.GENERATIVE &&
+    deploymentMethodOption === LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY
+  ) {
+    return true;
   }
 
   return false;
-};
-
-// External data hook
-
-/**
- * External data hook for KServe serving runtime field.
- * Fetches wizard field overrides from extensions and computes suggestions.
- *
- * @param dependencies Dependencies needed to resolve overrides and suggestions
- * @returns External data object with extraOptions, suggestion, loaded state, and optional error
- */
-export const useKServeServingRuntimeExternalData = (
-  dependencies?: KServeServingRuntimeDependencies,
-): {
-  data: KServeServingRuntimeExternalData;
-  loaded: boolean;
-  loadError?: Error;
-} => {
-  const {
-    data: modelServingClusterSettings,
-    loaded: modelServingClusterSettingsLoaded,
-    error: modelServingClusterSettingsError,
-  } = useModelServingClusterSettings();
-
-  const formData = React.useMemo(
-    () => ({
-      modelType: { data: dependencies?.modelType },
-      devFeatureFlags: { vLLMDeploymentOnMaaS: dependencies?.vLLMDeploymentOnMaaS },
-    }),
-    [dependencies?.modelType, dependencies?.vLLMDeploymentOnMaaS],
-  );
-
-  const modelServerOverrides = useWizardFieldOverrides(
-    isModelServerTemplateFieldOverride,
-    formData,
-  );
-
-  return React.useMemo(() => {
-    try {
-      const extraOptions = modelServerOverrides.flatMap((override) => override.extraOptions ?? []);
-      const suggestion = modelServerOverrides.reduce<ModelServerOption | undefined>(
-        (acc, override) => acc ?? override.suggestion?.(modelServingClusterSettings),
-        undefined,
-      );
-
-      return {
-        data: { extraOptions, suggestion },
-        loaded: modelServingClusterSettingsLoaded,
-        loadError: modelServingClusterSettingsError,
-      };
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Error loading KServe serving runtime external data:', error);
-      return {
-        data: { extraOptions: [], suggestion: undefined },
-        loaded: modelServingClusterSettingsLoaded,
-        loadError: error instanceof Error ? error : new Error(String(error)),
-      };
-    }
-  }, [
-    modelServerOverrides,
-    modelServingClusterSettings,
-    modelServingClusterSettingsLoaded,
-    modelServingClusterSettingsError,
-  ]);
 };
 
 const computeSuggestion = (
@@ -263,6 +187,7 @@ export const KServeServingRuntimeFieldWizardField: KServeServingRuntimeFieldType
       hardwareProfile: formData.hardwareProfileConfig.formData.selectedProfile,
       modelType: formData.modelType.data,
       vLLMDeploymentOnMaaS: formData.devFeatureFlags?.vLLMDeploymentOnMaaS,
+      deploymentMethod: formData.deploymentMethod?.method,
     }),
     setFieldData: (value: KServeServingRuntimeFieldValue) => value,
     getInitialFieldData: (
@@ -305,25 +230,12 @@ export const KServeServingRuntimeFieldWizardField: KServeServingRuntimeFieldType
       data: modelServerSelectFieldSchema,
     }),
   },
-  /**
-   * Determines when the field should reset to its initial value.
-   *
-   * The serving runtime selection is reset ONLY when the model type changes
-   * (predictive ↔ generative), because different model types use different
-   * serving runtime templates.
-   *
-   * The field does NOT reset on modelFormat or hardwareProfile changes.
-   * While these affect which templates are compatible and which gets suggested,
-   * they don't fundamentally change the available template set, so we preserve
-   * the user's selection if they already made one.
-   *
-   * @param prevDependencies Previous dependency values
-   * @param newDependencies New dependency values
-   * @returns true if the field should reset, false to preserve current value
-   */
   shouldResetOnDependencyChange: (prevDependencies, newDependencies) => {
-    return prevDependencies.modelType?.type !== newDependencies.modelType?.type;
+    return (
+      prevDependencies.modelType?.type !== newDependencies.modelType?.type ||
+      prevDependencies.deploymentMethod !== newDependencies.deploymentMethod
+    );
   },
   component: KServeServingRuntimeField,
-  externalDataHook: useKServeServingRuntimeExternalData,
+  // externalDataHook: NOT NEEDED - the ServingRuntime Templates currently are from the model format field
 };

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -92,6 +92,38 @@ const gatewaySelectExtractorExtension: WizardFieldExtractorExtension<
   },
 };
 
+const deploymentMethodExtractorExtensionLllmdOnly: WizardFieldExtractorExtension<
+  { method: string },
+  LLMdDeployment
+> = {
+  type: 'model-serving.deployment/wizard-field-extractor',
+  properties: {
+    fieldId: 'deploymentMethod',
+    platform: LLMD_SERVING_ID,
+    extract: () =>
+      import('../src/deployments/model').then((m) => m.extractDeploymentMethodAlwaysLlmd),
+  },
+  flags: {
+    required: [LLMD_SERVING_ID],
+    disallowed: [SupportedArea.VLLM_ON_MAAS],
+  },
+};
+const deploymentMethodExtractorExtensionvLLMOnMaaS: WizardFieldExtractorExtension<
+  { method: string },
+  LLMdDeployment
+> = {
+  type: 'model-serving.deployment/wizard-field-extractor',
+  properties: {
+    fieldId: 'deploymentMethod',
+    platform: LLMD_SERVING_ID,
+    extract: () =>
+      import('../src/deployments/model').then((m) => m.extractDeploymentMethodvLLMOnMaaS),
+  },
+  flags: {
+    required: [LLMD_SERVING_ID, SupportedArea.VLLM_ON_MAAS],
+  },
+};
+
 const extensions: (
   | AreaExtension
   | ModelServingPlatformWatchDeploymentsExtension<LLMdDeployment>
@@ -107,6 +139,7 @@ const extensions: (
   | WizardFieldExtension<GatewaySelectFieldType, LLMdDeployment>
   | WizardFieldApplyExtension<GatewaySelectFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<GatewaySelectFieldData, LLMdDeployment>
+  | WizardFieldExtractorExtension<{ method: string }, LLMdDeployment>
 )[] = [
   {
     type: 'app.area',
@@ -265,10 +298,38 @@ const extensions: (
       required: [LLMD_SERVING_ID],
     },
   },
+  {
+    type: 'model-serving.deployment/wizard-field-override',
+    properties: {
+      platform: LLMD_SERVING_ID,
+      field: () =>
+        import('../src/wizardFields/deploymentMethodField').then(
+          (m) => m.vllmDeploymentMethodOverride,
+        ),
+    },
+    flags: {
+      required: [LLMD_SERVING_ID, SupportedArea.VLLM_ON_MAAS],
+    },
+  },
+  {
+    type: 'model-serving.deployment/wizard-field-override',
+    properties: {
+      platform: LLMD_SERVING_ID,
+      field: () =>
+        import('../src/wizardFields/deploymentMethodField').then(
+          (m) => m.llmdDeploymentMethodOverride,
+        ),
+    },
+    flags: {
+      required: [LLMD_SERVING_ID],
+    },
+  },
   llmConfigOptionsFieldExtension,
   gatewaySelectFieldExtension,
   gatewaySelectApplyExtension,
   gatewaySelectExtractorExtension,
+  deploymentMethodExtractorExtensionLllmdOnly,
+  deploymentMethodExtractorExtensionvLLMOnMaaS,
   {
     type: 'model-serving.deployments-table/start-stop-action',
     properties: {

--- a/packages/llmd-serving/src/__tests__/formUtils.spec.ts
+++ b/packages/llmd-serving/src/__tests__/formUtils.spec.ts
@@ -1,20 +1,23 @@
 import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
-import { isGenerativeNonLegacy, isLLMInferenceServiceActive } from '../formUtils';
-import { LLMD_OPTION } from '../deployments/server';
+import { isSimpleLLMInferenceService, isLLMInferenceServiceActive } from '../formUtils';
+import {
+  LLMD_DEPLOYMENT_METHOD_KEY,
+  SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY,
+} from '../wizardFields/deploymentMethodField';
 
 describe('isLLMInferenceServiceActive', () => {
-  it('returns true when the llm-d option is selected by name', () => {
+  it('returns true when the simple vLLM deployment method is selected', () => {
     expect(
       isLLMInferenceServiceActive({
-        modelServer: { data: { selection: { name: LLMD_OPTION.name } } },
+        deploymentMethod: { method: SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY },
       }),
     ).toBe(true);
   });
 
-  it('returns true when an LLMInferenceServiceConfig template is selected', () => {
+  it('returns true when the llm-d deployment method is selected', () => {
     expect(
       isLLMInferenceServiceActive({
-        modelServer: { data: { selection: { template: { kind: 'LLMInferenceServiceConfig' } } } },
+        deploymentMethod: { method: LLMD_DEPLOYMENT_METHOD_KEY },
       }),
     ).toBe(true);
   });
@@ -25,53 +28,61 @@ describe('isLLMInferenceServiceActive', () => {
     ).toBe(true);
   });
 
-  it('returns false when a different serving runtime is selected', () => {
+  it('returns false when a different deployment method is selected', () => {
     expect(
       isLLMInferenceServiceActive({
-        modelServer: { data: { selection: { name: 'other-runtime' } } },
+        deploymentMethod: { method: 'other-method' },
       }),
     ).toBe(false);
   });
 
-  it('returns false when no model server selection or resource is provided', () => {
+  it('returns false when no deployment method or resource is provided', () => {
     expect(isLLMInferenceServiceActive({})).toBe(false);
   });
 });
 
-describe('isGenerativeNonLegacy', () => {
-  it('returns true for GENERATIVE model type with legacyVLLM false and vLLMDeploymentOnMaaS enabled', () => {
+describe('isSimpleLLMInferenceService', () => {
+  it('returns true for GENERATIVE model type with simple vLLM deployment method and vLLMDeploymentOnMaaS enabled', () => {
     expect(
-      isGenerativeNonLegacy({
-        modelType: { data: { type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false } },
+      isSimpleLLMInferenceService({
+        modelType: { data: { type: ServingRuntimeModelType.GENERATIVE } },
+        deploymentMethod: { method: SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY },
         devFeatureFlags: { vLLMDeploymentOnMaaS: true },
       }),
     ).toBe(true);
   });
 
-  it('returns false for GENERATIVE model type with legacyVLLM false when vLLMDeploymentOnMaaS is disabled', () => {
+  it('returns false for GENERATIVE model type with simple vLLM deployment method when vLLMDeploymentOnMaaS is disabled', () => {
     expect(
-      isGenerativeNonLegacy({
-        modelType: { data: { type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false } },
+      isSimpleLLMInferenceService({
+        modelType: { data: { type: ServingRuntimeModelType.GENERATIVE } },
+        deploymentMethod: { method: SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY },
         devFeatureFlags: { vLLMDeploymentOnMaaS: false },
       }),
     ).toBe(false);
   });
 
-  it('returns false for GENERATIVE model type with legacyVLLM true', () => {
+  it('returns false for GENERATIVE model type with llm-d deployment method', () => {
     expect(
-      isGenerativeNonLegacy({
-        modelType: { data: { type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: true } },
+      isSimpleLLMInferenceService({
+        modelType: { data: { type: ServingRuntimeModelType.GENERATIVE } },
+        deploymentMethod: { method: LLMD_DEPLOYMENT_METHOD_KEY },
+        devFeatureFlags: { vLLMDeploymentOnMaaS: true },
       }),
     ).toBe(false);
   });
 
   it('returns false for PREDICTIVE model type', () => {
     expect(
-      isGenerativeNonLegacy({ modelType: { data: { type: ServingRuntimeModelType.PREDICTIVE } } }),
+      isSimpleLLMInferenceService({
+        modelType: { data: { type: ServingRuntimeModelType.PREDICTIVE } },
+        deploymentMethod: { method: SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY },
+        devFeatureFlags: { vLLMDeploymentOnMaaS: true },
+      }),
     ).toBe(false);
   });
 
   it('returns false when modelType is not set', () => {
-    expect(isGenerativeNonLegacy({})).toBe(false);
+    expect(isSimpleLLMInferenceService({})).toBe(false);
   });
 });

--- a/packages/llmd-serving/src/deployments/model.ts
+++ b/packages/llmd-serving/src/deployments/model.ts
@@ -18,6 +18,11 @@ import {
 } from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
 import type { LLMdContainer, LLMInferenceServiceKind, LLMdDeployment } from '../types';
 import { VLLM_ADDITIONAL_ARGS } from '../types';
+import {
+  LLMD_DEPLOYMENT_METHOD_KEY,
+  SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY,
+} from '../wizardFields/deploymentMethodField';
+import { isLLMd } from '../formUtils';
 
 export const applyModelLocation = (
   llmdInferenceService: LLMInferenceServiceKind,
@@ -76,7 +81,6 @@ export const extractModelFormat = (): SupportedModelFormats | null => {
 
 export const extractModelType = (): ModelTypeFieldData => ({
   type: ServingRuntimeModelType.GENERATIVE,
-  legacyVLLM: false,
 });
 
 /**
@@ -275,3 +279,13 @@ export const applyTokenAuthentication = (
   result.metadata.annotations = annotations;
   return result;
 };
+
+export const extractDeploymentMethodAlwaysLlmd = (): { method: string } => ({
+  method: LLMD_DEPLOYMENT_METHOD_KEY,
+});
+
+export const extractDeploymentMethodvLLMOnMaaS = (
+  llmdDeployment: LLMdDeployment,
+): { method: string } => ({
+  method: isLLMd(llmdDeployment) ? LLMD_DEPLOYMENT_METHOD_KEY : SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY,
+});

--- a/packages/llmd-serving/src/formUtils.ts
+++ b/packages/llmd-serving/src/formUtils.ts
@@ -2,7 +2,11 @@ import { type RecursivePartial } from '@odh-dashboard/internal/typeHelpers';
 import { WizardFormData } from '@odh-dashboard/model-serving/types/form-data';
 import { ModelResourceType } from '@odh-dashboard/model-serving/extension-points';
 import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
-import { LLMD_OPTION } from './deployments/server';
+import {
+  LLMD_DEPLOYMENT_METHOD_KEY,
+  SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY,
+} from './wizardFields/deploymentMethodField';
+import { LLMdDeployment } from './types';
 
 /**
  * @returns `true` if "LLM-d" selected or an LLMInferenceServiceConfig selected
@@ -13,9 +17,11 @@ export const isLLMInferenceServiceActive = (
     model?: ModelResourceType;
   },
 ): boolean => {
+  const deploymentMethodOption = wizardState.deploymentMethod?.method;
+
   const isLLMOptionSelected =
-    wizardState.modelServer?.data?.selection?.name === LLMD_OPTION.name ||
-    wizardState.modelServer?.data?.selection?.template?.kind === 'LLMInferenceServiceConfig';
+    deploymentMethodOption === SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY ||
+    deploymentMethodOption === LLMD_DEPLOYMENT_METHOD_KEY;
   const isLLMInferenceService = resources?.model?.kind === 'LLMInferenceService';
 
   return isLLMOptionSelected || isLLMInferenceService;
@@ -23,20 +29,28 @@ export const isLLMInferenceServiceActive = (
 
 /**
  *
- * @returns `true` if Generative is selected and legacyVLLM is false (only possible with vLLM on MaaS enabled)
+ * @returns `true` if Generative is selected and the simple vLLM deployment method is chosen (only possible with vLLM on MaaS enabled)
  */
-export const isGenerativeNonLegacy = (
+export const isSimpleLLMInferenceService = (
   wizardState: RecursivePartial<WizardFormData['state']>,
 ): boolean => {
   const modelType = wizardState.modelType?.data;
+  const deploymentMethodOption = wizardState.deploymentMethod?.method;
   const vLLMDeploymentOnMaaSEnabled = wizardState.devFeatureFlags?.vLLMDeploymentOnMaaS;
 
   if (
     vLLMDeploymentOnMaaSEnabled &&
     modelType?.type === ServingRuntimeModelType.GENERATIVE &&
-    !modelType.legacyVLLM
+    deploymentMethodOption === SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY
   ) {
     return true;
   }
   return false;
+};
+
+/**
+ * @returns `true` if the `spec.router.scheduler` exists
+ */
+export const isLLMd = (deployment: LLMdDeployment): boolean => {
+  return !!deployment.model.spec.router && 'scheduler' in deployment.model.spec.router;
 };

--- a/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
+++ b/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
@@ -10,17 +10,14 @@ import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/p
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
 import type { HardwareProfileKind } from '@odh-dashboard/k8s-core';
 import { isCompatibleWithIdentifier } from '@odh-dashboard/internal/pages/projects/screens/spawner/spawnerUtils';
-import { useModelServingClusterSettings } from '@odh-dashboard/model-serving/concepts/useModelServingClusterSettings';
 import { useFetchLLMInferenceServiceConfigs } from '../api/LLMInferenceServiceConfigs';
 import { LLMInferenceServiceConfigKind } from '../types';
-import { LLMD_OPTION } from '../deployments/server';
-import { isGenerativeNonLegacy } from '../formUtils';
+import { isSimpleLLMInferenceService } from '../formUtils';
 
 // External data hook
 
 export type LLMConfigOptionsData = {
   configs: LLMInferenceServiceConfigKind[];
-  isLlmdSuggested: boolean;
 };
 
 export const useLLMConfigOptions = (): {
@@ -28,13 +25,6 @@ export const useLLMConfigOptions = (): {
   loaded: boolean;
   loadError?: Error;
 } => {
-  const {
-    data: modelServingClusterSettings,
-    loaded: modelServingClusterSettingsLoaded,
-    error: modelServingClusterSettingsError,
-  } = useModelServingClusterSettings();
-  const isLLMdDefault = modelServingClusterSettings?.isLLMdDefault ?? false;
-
   const { dashboardNamespace } = useDashboardNamespace();
   const {
     data: llmInferenceServiceConfigs,
@@ -54,19 +44,11 @@ export const useLLMConfigOptions = (): {
     () => ({
       data: {
         configs: llmEnabledConfigs,
-        isLlmdSuggested: isLLMdDefault,
       },
-      loaded: modelServingClusterSettingsLoaded && loaded,
-      loadError: modelServingClusterSettingsError || error,
-    }),
-    [
-      llmEnabledConfigs,
       loaded,
-      error,
-      isLLMdDefault,
-      modelServingClusterSettingsLoaded,
-      modelServingClusterSettingsError,
-    ],
+      loadError: error,
+    }),
+    [llmEnabledConfigs, loaded, error],
   );
 };
 
@@ -94,7 +76,6 @@ const getOptions = (
   hardwareProfile?: HardwareProfileKind,
 ): ModelServerOption[] => {
   const result: ModelServerOption[] = [];
-  result.push(LLMD_OPTION);
   result.push(
     ...(externalData?.configs.map((config) =>
       getOptionFromLLMInferenceServiceConfig(config, hardwareProfile),
@@ -143,7 +124,7 @@ export const LLMConfigOptionsFieldWizardField: LLMConfigOptionsFieldType = {
   step: 'modelDeployment',
   type: 'replacement',
   stateKey: 'modelServer',
-  isActive: isGenerativeNonLegacy,
+  isActive: isSimpleLLMInferenceService,
   reducerFunctions: {
     resolveDependencies: (formData) => ({
       hardwareProfile: formData.hardwareProfileConfig.formData.selectedProfile,
@@ -157,18 +138,9 @@ export const LLMConfigOptionsFieldWizardField: LLMConfigOptionsFieldType = {
       if (existingFieldData) {
         return existingFieldData;
       }
-      // if llmd is default
+
       const options = getOptions(externalData, dependencies?.hardwareProfile);
 
-      if (externalData?.isLlmdSuggested) {
-        return {
-          data: {
-            selection: LLMD_OPTION,
-            autoSelect: true,
-            suggestion: LLMD_OPTION,
-          },
-        };
-      }
       // if there is only one matching hardware profile, select it
       const matchingHardwareProfileOption = options.filter(
         (option) => option.compatibleWithHardwareProfile,

--- a/packages/llmd-serving/src/wizardFields/__tests__/LlmConfigOptionsField.spec.ts
+++ b/packages/llmd-serving/src/wizardFields/__tests__/LlmConfigOptionsField.spec.ts
@@ -1,17 +1,12 @@
 import { testHook } from '@odh-dashboard/jest-config/hooks';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
-import * as clusterSettingsModule from '@odh-dashboard/model-serving/concepts/useModelServingClusterSettings';
 import * as projectSelectors from '@odh-dashboard/internal/redux/selectors/project';
 import * as llmConfigsApi from '../../api/LLMInferenceServiceConfigs';
 import { useLLMConfigOptions } from '../LlmConfigOptionsField';
 
-jest.mock('@odh-dashboard/model-serving/concepts/useModelServingClusterSettings');
 jest.mock('@odh-dashboard/internal/redux/selectors/project');
 jest.mock('../../api/LLMInferenceServiceConfigs');
 
-const mockUseModelServingClusterSettings = jest.mocked(
-  clusterSettingsModule.useModelServingClusterSettings,
-);
 const mockUseDashboardNamespace = jest.mocked(projectSelectors.useDashboardNamespace);
 const mockUseFetchLLMInferenceServiceConfigs = jest.mocked(
   llmConfigsApi.useFetchLLMInferenceServiceConfigs,
@@ -20,12 +15,6 @@ const mockUseFetchLLMInferenceServiceConfigs = jest.mocked(
 describe('useLLMConfigOptions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseModelServingClusterSettings.mockReturnValue({
-      data: { isLLMdDefault: false },
-      loaded: true,
-      error: undefined,
-      refresh: jest.fn(),
-    });
     mockUseDashboardNamespace.mockReturnValue({ dashboardNamespace: 'opendatahub' });
     mockUseFetchLLMInferenceServiceConfigs.mockReturnValue({
       data: [],
@@ -109,32 +98,6 @@ describe('useLLMConfigOptions', () => {
     expect(renderResult.result.current.loaded).toBe(true);
   });
 
-  it('should reflect isLlmdSuggested from cluster settings', () => {
-    mockUseModelServingClusterSettings.mockReturnValue({
-      data: { isLLMdDefault: true },
-      loaded: true,
-      error: undefined,
-      refresh: jest.fn(),
-    });
-
-    const renderResult = testHook(useLLMConfigOptions)();
-
-    expect(renderResult.result.current.data.isLlmdSuggested).toBe(true);
-  });
-
-  it('should report loaded as false when cluster settings are not loaded', () => {
-    mockUseModelServingClusterSettings.mockReturnValue({
-      data: undefined,
-      loaded: false,
-      error: undefined,
-      refresh: jest.fn(),
-    });
-
-    const renderResult = testHook(useLLMConfigOptions)();
-
-    expect(renderResult.result.current.loaded).toBe(false);
-  });
-
   it('should report loaded as false when configs are not loaded', () => {
     mockUseFetchLLMInferenceServiceConfigs.mockReturnValue({
       data: [],
@@ -146,20 +109,6 @@ describe('useLLMConfigOptions', () => {
     const renderResult = testHook(useLLMConfigOptions)();
 
     expect(renderResult.result.current.loaded).toBe(false);
-  });
-
-  it('should propagate load errors from cluster settings', () => {
-    const settingsError = new Error('Failed to fetch cluster settings');
-    mockUseModelServingClusterSettings.mockReturnValue({
-      data: undefined,
-      loaded: false,
-      error: settingsError,
-      refresh: jest.fn(),
-    });
-
-    const renderResult = testHook(useLLMConfigOptions)();
-
-    expect(renderResult.result.current.loadError).toBe(settingsError);
   });
 
   it('should propagate load errors from config fetch', () => {
@@ -180,7 +129,6 @@ describe('useLLMConfigOptions', () => {
     const configNoAnnotations = mockLLMInferenceServiceConfigK8sResource({
       name: 'no-annotation-config',
     });
-    // Remove the disabled annotation explicitly — the mock doesn't add it by default
     mockUseFetchLLMInferenceServiceConfigs.mockReturnValue({
       data: [configNoAnnotations],
       loaded: true,

--- a/packages/llmd-serving/src/wizardFields/deploymentMethodField.ts
+++ b/packages/llmd-serving/src/wizardFields/deploymentMethodField.ts
@@ -2,7 +2,7 @@ import type { DeploymentMethodFieldOverride } from '@odh-dashboard/model-serving
 
 // Keys
 
-export const SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY = 'inference-service-simple-vllm';
+export const SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY = 'llm-inference-service-simple-vllm';
 export const LLMD_DEPLOYMENT_METHOD_KEY = 'llm-inference-service-llmd';
 
 // Simple vLLM

--- a/packages/llmd-serving/src/wizardFields/deploymentMethodField.ts
+++ b/packages/llmd-serving/src/wizardFields/deploymentMethodField.ts
@@ -1,0 +1,39 @@
+import type { DeploymentMethodFieldOverride } from '@odh-dashboard/model-serving/types/form-data';
+
+// Keys
+
+export const SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY = 'inference-service-simple-vllm';
+export const LLMD_DEPLOYMENT_METHOD_KEY = 'llm-inference-service-llmd';
+
+// Simple vLLM
+
+const SIMPLE_VLLM_OPTION = {
+  key: SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY,
+  label: 'LLM inference service deployment',
+  description:
+    'Deploy an LLM using a preconfigured LLMInferenceService and vLLM accelerator configuration.',
+};
+
+export const vllmDeploymentMethodOverride: DeploymentMethodFieldOverride = {
+  id: 'deploymentMethod',
+  type: 'modifier',
+  isActive: () => true,
+  options: [SIMPLE_VLLM_OPTION],
+};
+
+// LLM-d
+
+const LLMD_OPTION = {
+  key: LLMD_DEPLOYMENT_METHOD_KEY,
+  label: 'LLM inference service deployment with llm-d',
+  description:
+    'Deploy an LLM using an LLMInferenceService with additional capabilities such as distributed inference, prefill-decode disaggregation and advanced routing.',
+};
+
+export const llmdDeploymentMethodOverride: DeploymentMethodFieldOverride = {
+  id: 'deploymentMethod',
+  type: 'modifier',
+  isActive: () => true,
+  options: [LLMD_OPTION],
+  suggestion: (clusterSettings) => (clusterSettings?.isLLMdDefault ? LLMD_OPTION : undefined),
+};

--- a/packages/model-serving/extensions/odh.ts
+++ b/packages/model-serving/extensions/odh.ts
@@ -8,11 +8,26 @@ import type {
 // Allow this import as it consists of types and enums only.
 // eslint-disable-next-line no-restricted-syntax
 import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
+import type { WizardFieldExtension } from '@odh-dashboard/model-serving/extension-points/deployment-wizard';
+import type { DeploymentMethodSelectFieldType } from '../src/components/deploymentWizard/fields/DeploymentMethodSelectField';
 
 const createRedirectComponent = (args: { from: string; to: string }) => () =>
   import('@odh-dashboard/internal/utilities/v2Redirect').then((module) => ({
     default: () => module.buildV2RedirectElement(args),
   }));
+
+const deploymentMethodFieldExtension: WizardFieldExtension<DeploymentMethodSelectFieldType> = {
+  type: 'model-serving.deployment/wizard-field',
+  properties: {
+    field: () =>
+      import('../src/components/deploymentWizard/fields/DeploymentMethodSelectField').then(
+        (m) => m.DeploymentMethodSelectFieldWizardField,
+      ),
+  },
+  flags: {
+    required: [SupportedArea.MODEL_SERVING],
+  },
+};
 
 const extensions: (
   | AreaExtension
@@ -20,6 +35,7 @@ const extensions: (
   | RouteExtension
   | OverviewSectionExtension
   | TabRouteTabExtension
+  | WizardFieldExtension<DeploymentMethodSelectFieldType>
 )[] = [
   {
     type: 'app.area',
@@ -102,6 +118,7 @@ const extensions: (
       required: [SupportedArea.MODEL_SERVING],
     },
   },
+  deploymentMethodFieldExtension,
 ];
 
 export default extensions;

--- a/packages/model-serving/modelRegistry/useNavigateToDeploymentWizardWithData.ts
+++ b/packages/model-serving/modelRegistry/useNavigateToDeploymentWizardWithData.ts
@@ -54,7 +54,6 @@ export const useNavigateToDeploymentWizardWithData = (
       },
       modelTypeField: {
         type: deployPrefillData.modelType ?? ServingRuntimeModelType.GENERATIVE,
-        legacyVLLM: false,
       },
       k8sNameDesc: {
         name: deployPrefillData.modelName,

--- a/packages/model-serving/src/__tests__/mockUtils.ts
+++ b/packages/model-serving/src/__tests__/mockUtils.ts
@@ -138,7 +138,7 @@ export const mockDeploymentWizardState = (
           setProjectName: jest.fn(),
         },
         modelType: {
-          data: { type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false },
+          data: { type: ServingRuntimeModelType.GENERATIVE },
           setData: jest.fn(),
           externalData: { data: { extraOptions: [] as SimpleSelectOption[], forced: false } },
         },

--- a/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
@@ -9,13 +9,13 @@ import {
 
 export const useWizardFieldOverrides = <T extends DeploymentWizardFieldOverride>(
   predicate: (field: DeploymentWizardFieldOverride) => field is T,
-  formData: RecursivePartial<WizardFormData['state']>,
+  formData?: RecursivePartial<WizardFormData['state']>,
 ): T[] => {
   const [extensions] = useResolvedExtensions(isDeploymentWizardFieldOverrideExtension);
 
   return React.useMemo(() => {
     const active = extensions
-      .filter((ext) => ext.properties.field.isActive(formData))
+      .filter((ext) => ext.properties.field.isActive(formData ?? {}))
       .toSorted((a, b) => a.uid.localeCompare(b.uid))
       .map((ext) => ext.properties.field)
       .filter(predicate);

--- a/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { FormGroup } from '@patternfly/react-core';
+import { z } from 'zod';
+import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
+import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
+import type { RecursivePartial } from '@odh-dashboard/internal/typeHelpers';
+import { useModelServingClusterSettings } from '../../../concepts/useModelServingClusterSettings';
+import {
+  type DeploymentMethodOption,
+  type WizardField,
+  type WizardFormData,
+  isDeploymentMethodFieldOverride,
+} from '../types';
+import { useWizardFieldOverrides } from '../dynamicFormUtils';
+
+// Schema
+
+export const deploymentMethodSelectFieldSchema = z.object({
+  method: z.string().min(1),
+});
+
+export type DeploymentMethodFieldData = z.infer<typeof deploymentMethodSelectFieldSchema>;
+
+// External data
+
+export type DeploymentMethodExternalData = {
+  options: DeploymentMethodOption[];
+  suggestion?: DeploymentMethodOption;
+};
+
+export const useDeploymentMethodExternalData = (): {
+  data: DeploymentMethodExternalData;
+  loaded: boolean;
+  loadError?: Error;
+} => {
+  const {
+    data: modelServingClusterSettings,
+    loaded: clusterSettingsLoaded,
+    error: clusterSettingsError,
+  } = useModelServingClusterSettings();
+
+  const overrides = useWizardFieldOverrides(isDeploymentMethodFieldOverride);
+
+  return React.useMemo(() => {
+    const options = overrides.flatMap((override) => override.options);
+    const suggestion = overrides.reduce<DeploymentMethodOption | undefined>(
+      (acc, override) => acc ?? override.suggestion?.(modelServingClusterSettings),
+      undefined,
+    );
+
+    return {
+      data: { options, suggestion },
+      loaded: clusterSettingsLoaded,
+      loadError: clusterSettingsError,
+    };
+  }, [overrides, modelServingClusterSettings, clusterSettingsLoaded, clusterSettingsError]);
+};
+
+// isActive
+
+export const isDeploymentMethodFieldActive = (
+  wizardState: RecursivePartial<WizardFormData['state']>,
+): boolean => {
+  const modelType = wizardState.modelType?.data;
+  return modelType?.type === ServingRuntimeModelType.GENERATIVE;
+};
+
+// Component
+
+export type DeploymentMethodSelectFieldType = WizardField<
+  DeploymentMethodFieldData,
+  DeploymentMethodExternalData
+>;
+
+const DeploymentMethodSelectField: DeploymentMethodSelectFieldType['component'] = ({
+  value,
+  onChange,
+  externalData,
+  isEditing,
+}) => {
+  const options = React.useMemo(
+    () =>
+      (externalData?.data.options ?? []).map((opt) => ({
+        key: opt.key,
+        label: opt.label,
+        description: opt.description,
+      })),
+    [externalData?.data.options],
+  );
+
+  return (
+    <FormGroup fieldId="deployment-method-select" label="Deployment method" isRequired>
+      <SimpleSelect
+        options={options}
+        onChange={(key) => {
+          onChange({ method: key });
+        }}
+        placeholder="Select deployment method"
+        value={value?.method}
+        isFullWidth
+        dataTestId="deployment-method-select"
+        isDisabled={isEditing}
+      />
+    </FormGroup>
+  );
+};
+
+// WizardField definition
+
+export const DeploymentMethodSelectFieldWizardField: DeploymentMethodSelectFieldType = {
+  id: 'deploymentMethod',
+  parentId: 'modelDeployment',
+  step: 'modelDeployment',
+  type: 'addition',
+  isActive: isDeploymentMethodFieldActive,
+  reducerFunctions: {
+    setFieldData: (value: DeploymentMethodFieldData) => value,
+    getInitialFieldData: (
+      existingFieldData?: DeploymentMethodFieldData,
+      externalData?: DeploymentMethodExternalData,
+    ): DeploymentMethodFieldData => {
+      if (existingFieldData?.method) {
+        return existingFieldData;
+      }
+      if (externalData?.suggestion) {
+        return { method: externalData.suggestion.key };
+      }
+      if (externalData?.options.length === 1) {
+        return { method: externalData.options[0].key };
+      }
+      return { method: '' };
+    },
+    validationSchema: deploymentMethodSelectFieldSchema,
+  },
+  component: DeploymentMethodSelectField,
+  externalDataHook: useDeploymentMethodExternalData,
+};

--- a/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
@@ -42,7 +42,9 @@ export const useDeploymentMethodExternalData = (): {
   const overrides = useWizardFieldOverrides(isDeploymentMethodFieldOverride);
 
   return React.useMemo(() => {
-    const options = overrides.flatMap((override) => override.options);
+    const options = overrides
+      .flatMap((override) => override.options)
+      .toSorted((a, b) => b.label.localeCompare(a.label));
     const suggestion = overrides.reduce<DeploymentMethodOption | undefined>(
       (acc, override) => acc ?? override.suggestion?.(modelServingClusterSettings),
       undefined,

--- a/packages/model-serving/src/components/deploymentWizard/fields/DeploymentStrategyField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/DeploymentStrategyField.tsx
@@ -3,6 +3,7 @@ import { Radio, Stack, StackItem } from '@patternfly/react-core';
 import { z } from 'zod';
 import type { ModelTypeField } from './ModelTypeSelectField';
 import type { ModelServerSelectField } from './ModelServerTemplateSelectField';
+import { DeploymentMethodFieldData } from './DeploymentMethodSelectField';
 import { isDeploymentStrategyFieldOverride } from '../types';
 import { useWizardFieldOverrides } from '../dynamicFormUtils';
 import { useModelServingClusterSettings } from '../../../concepts/useModelServingClusterSettings';
@@ -30,6 +31,7 @@ export const useDeploymentStrategyField = (
   existingData?: DeploymentStrategyFieldData,
   modelType?: ModelTypeField,
   modelServer?: ModelServerSelectField,
+  deploymentMethod?: DeploymentMethodFieldData,
 ): DeploymentStrategyFieldHook => {
   const { data: modelServingClusterSettings } = useModelServingClusterSettings();
   const deploymentStrategyFieldOverrides = useWizardFieldOverrides(
@@ -37,6 +39,7 @@ export const useDeploymentStrategyField = (
     {
       modelType,
       modelServer,
+      deploymentMethod,
     },
   );
 

--- a/packages/model-serving/src/components/deploymentWizard/fields/ExternalRouteField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ExternalRouteField.tsx
@@ -3,6 +3,7 @@ import { Checkbox, Stack, StackItem } from '@patternfly/react-core';
 import { z } from 'zod';
 import type { ModelServerSelectField } from './ModelServerTemplateSelectField';
 import type { ModelTypeField } from './ModelTypeSelectField';
+import { DeploymentMethodFieldData } from './DeploymentMethodSelectField';
 import { isExternalRouteFieldOverride } from '../types';
 import { useWizardFieldOverrides } from '../dynamicFormUtils';
 
@@ -26,10 +27,12 @@ export const useExternalRouteField = (
   existingData?: ExternalRouteFieldData,
   modelType?: ModelTypeField,
   modelServer?: ModelServerSelectField,
+  deploymentMethod?: DeploymentMethodFieldData,
 ): ExternalRouteFieldHook => {
   const externalRouteOverrides = useWizardFieldOverrides(isExternalRouteFieldOverride, {
     modelType: { data: modelType?.data },
     modelServer: { data: modelServer?.data },
+    deploymentMethod,
   });
   const isVisible = React.useMemo(() => {
     return externalRouteOverrides.length > 0

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { Checkbox, FormGroup } from '@patternfly/react-core';
+import { FormGroup } from '@patternfly/react-core';
 import { z, type ZodIssue } from 'zod';
 import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
 import { FieldValidationProps } from '@odh-dashboard/internal/hooks/useZodFormValidation';
 import { ZodErrorHelperText } from '@odh-dashboard/internal/components/ZodErrorFormHelperText';
 import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
-import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/internal/concepts/areas';
 import {
   isModelTypeFieldOverride,
   ModelLocationData,
@@ -17,7 +16,6 @@ import { useWizardFieldOverrides } from '../dynamicFormUtils';
 // Schema
 export const modelTypeSelectFieldSchema = z.object({
   type: z.string(),
-  legacyVLLM: z.boolean(),
 });
 
 export type ModelTypeFieldData = z.infer<typeof modelTypeSelectFieldSchema>;
@@ -37,14 +35,12 @@ export type ModelTypeField = {
 export const useModelTypeField = (
   existingData?: ModelTypeFieldData,
   modelLocationData?: ModelLocationData,
-  vLLMDeploymentOnMaaSEnabled?: boolean,
 ): ModelTypeField => {
   const overrideFormData = React.useMemo(
     () => ({
       modelLocationData: { data: modelLocationData },
-      devFeatureFlags: { vLLMDeploymentOnMaaS: vLLMDeploymentOnMaaSEnabled },
     }),
-    [modelLocationData, vLLMDeploymentOnMaaSEnabled],
+    [modelLocationData],
   );
   const modelTypeOverrides = useWizardFieldOverrides(isModelTypeFieldOverride, overrideFormData);
 
@@ -54,8 +50,7 @@ export const useModelTypeField = (
 
   const forcedOverride = modelTypeOverrides.find((o) => o.forced);
   const modelType = React.useMemo(
-    () =>
-      forcedOverride ? { type: forcedOverride.extraOption.key, legacyVLLM: false } : modelTypeState,
+    () => (forcedOverride ? { type: forcedOverride.extraOption.key } : modelTypeState),
     [forcedOverride, modelTypeState],
   );
 
@@ -94,8 +89,6 @@ export const ModelTypeSelectField: React.FC<ModelTypeSelectFieldProps> = ({
   isEditing,
   externalData,
 }) => {
-  const isVLLMOnMaaSEnabled = useIsAreaAvailable(SupportedArea.VLLM_ON_MAAS).status;
-
   const options = React.useMemo(() => {
     return [
       {
@@ -118,7 +111,6 @@ export const ModelTypeSelectField: React.FC<ModelTypeSelectFieldProps> = ({
           onChange={(key) => {
             setModelType?.({
               type: key,
-              legacyVLLM: key === ServingRuntimeModelType.GENERATIVE && !isVLLMOnMaaSEnabled,
             });
           }}
           onBlur={validationProps?.onBlur}
@@ -130,17 +122,6 @@ export const ModelTypeSelectField: React.FC<ModelTypeSelectFieldProps> = ({
         />
         <ZodErrorHelperText zodIssue={validationIssues} />
       </FormGroup>
-      {isVLLMOnMaaSEnabled && modelType?.type === ServingRuntimeModelType.GENERATIVE && (
-        <Checkbox
-          id="legacy-mode-checkbox"
-          data-testid="legacy-mode-checkbox"
-          label={<span className="pf-v6-c-form__label-text">Use legacy deployment method</span>}
-          description="Deploy this model using a serving runtime and inference server. This deployment method does not support MaaS."
-          isChecked={modelType.legacyVLLM}
-          onChange={(_e, checked) => setModelType?.({ ...modelType, legacyVLLM: checked })}
-          isDisabled={isEditing || isDisabled || externalData.data.forced}
-        />
-      )}
     </>
   );
 };

--- a/packages/model-serving/src/components/deploymentWizard/fields/TokenAuthenticationField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/TokenAuthenticationField.tsx
@@ -20,6 +20,7 @@ import * as _ from 'lodash-es';
 import { z } from 'zod';
 import type { ModelServerSelectField } from './ModelServerTemplateSelectField';
 import type { ModelTypeField } from './ModelTypeSelectField';
+import { DeploymentMethodFieldData } from './DeploymentMethodSelectField';
 import { isTokenAuthFieldOverride } from '../types';
 import { useWizardFieldOverrides } from '../dynamicFormUtils';
 import { showAuthWarning } from '../hooks/useAuthWarning';
@@ -55,11 +56,13 @@ export const useTokenAuthenticationField = (
   existingData?: TokenAuthenticationFieldData,
   modelType?: ModelTypeField,
   modelServer?: ModelServerSelectField,
+  deploymentMethod?: DeploymentMethodFieldData,
   canCreateRoleBindings?: boolean,
 ): TokenAuthenticationFieldHook => {
   const tokenAuthOverrides = useWizardFieldOverrides(isTokenAuthFieldOverride, {
     modelType: { data: modelType?.data },
     modelServer: { data: modelServer?.data },
+    deploymentMethod,
   });
   const shouldAutoCheck = React.useMemo(() => {
     return tokenAuthOverrides.some((override) => override.initialValue);

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelAvailabilityFields.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelAvailabilityFields.test.tsx
@@ -205,7 +205,6 @@ describe('AvailableAiAssetsFields', () => {
       const { result } = renderHook(() =>
         useModelAvailabilityFields(undefined, {
           type: ServingRuntimeModelType.GENERATIVE,
-
         }),
       );
       expect(result.current.showField).toBe(true);
@@ -214,7 +213,6 @@ describe('AvailableAiAssetsFields', () => {
       const { result } = renderHook(() =>
         useModelAvailabilityFields(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-
         }),
       );
       expect(result.current.showField).toBe(false);

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelAvailabilityFields.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelAvailabilityFields.test.tsx
@@ -205,7 +205,7 @@ describe('AvailableAiAssetsFields', () => {
       const { result } = renderHook(() =>
         useModelAvailabilityFields(undefined, {
           type: ServingRuntimeModelType.GENERATIVE,
-          legacyVLLM: false,
+
         }),
       );
       expect(result.current.showField).toBe(true);
@@ -214,7 +214,7 @@ describe('AvailableAiAssetsFields', () => {
       const { result } = renderHook(() =>
         useModelAvailabilityFields(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-          legacyVLLM: false,
+
         }),
       );
       expect(result.current.showField).toBe(false);
@@ -225,7 +225,7 @@ describe('AvailableAiAssetsFields', () => {
           useModelAvailabilityFields({ saveAsAiAsset: true, useCase: 'test' }, modelType),
         {
           initialProps: {
-            modelType: { type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false },
+            modelType: { type: ServingRuntimeModelType.GENERATIVE },
           },
         },
       );
@@ -237,7 +237,7 @@ describe('AvailableAiAssetsFields', () => {
 
       // Change to predictive model type
       rerender({
-        modelType: { type: ServingRuntimeModelType.PREDICTIVE, legacyVLLM: false },
+        modelType: { type: ServingRuntimeModelType.PREDICTIVE },
       });
 
       // Data should be reset and field should be hidden

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelFormatField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelFormatField.test.tsx
@@ -73,7 +73,6 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-
         }),
       );
 
@@ -86,7 +85,6 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.GENERATIVE,
-
         }),
       );
 
@@ -99,7 +97,6 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.GENERATIVE,
-
         }),
       );
 
@@ -114,7 +111,6 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-
         }),
       );
 
@@ -133,7 +129,6 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-
         }),
       );
 
@@ -148,7 +143,6 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-
         }),
       );
 
@@ -166,7 +160,6 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-
         }),
       );
 
@@ -212,7 +205,6 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-
         }),
       );
 

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelFormatField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelFormatField.test.tsx
@@ -73,7 +73,7 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-          legacyVLLM: false,
+
         }),
       );
 
@@ -86,7 +86,7 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.GENERATIVE,
-          legacyVLLM: false,
+
         }),
       );
 
@@ -99,7 +99,7 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.GENERATIVE,
-          legacyVLLM: false,
+
         }),
       );
 
@@ -114,7 +114,7 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-          legacyVLLM: false,
+
         }),
       );
 
@@ -133,7 +133,7 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-          legacyVLLM: false,
+
         }),
       );
 
@@ -148,7 +148,7 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-          legacyVLLM: false,
+
         }),
       );
 
@@ -166,7 +166,7 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-          legacyVLLM: false,
+
         }),
       );
 
@@ -212,7 +212,7 @@ describe('ModelFormatField', () => {
       const { result } = renderHook(() =>
         useModelFormatField(undefined, {
           type: ServingRuntimeModelType.PREDICTIVE,
-          legacyVLLM: false,
+
         }),
       );
 

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
@@ -1,8 +1,6 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent, renderHook } from '@testing-library/react';
 import { type ZodIssue } from 'zod';
-import { useIsAreaAvailable } from '@odh-dashboard/internal/concepts/areas';
-import type { IsAreaAvailableStatus } from '@odh-dashboard/internal/concepts/areas/types';
 import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
 import { mockExtensions } from '../../../../__tests__/mockUtils';
 import {
@@ -13,62 +11,29 @@ import {
 import { ModelTypeLabel } from '../../types';
 
 jest.mock('@odh-dashboard/plugin-core');
-jest.mock('@odh-dashboard/internal/concepts/areas', () => ({
-  ...jest.requireActual('@odh-dashboard/internal/concepts/areas'),
-  useIsAreaAvailable: jest.fn(),
-}));
-
-const mockUseIsAreaAvailable = jest.mocked(useIsAreaAvailable);
-
-const mockAreaAvailabilityStatus = (status: boolean): IsAreaAvailableStatus => ({
-  status,
-  devFlags: null,
-  featureFlags: null,
-  reliantAreas: null,
-  requiredCapabilities: null,
-  requiredComponents: null,
-  customCondition: () => false,
-});
 
 describe('ModelTypeSelectField', () => {
   beforeEach(() => {
     mockExtensions([]);
-    mockUseIsAreaAvailable.mockReturnValue(mockAreaAvailabilityStatus(false));
   });
   describe('Schema validation', () => {
     it('should validate predictive', () => {
       const result = modelTypeSelectFieldSchema.safeParse({
         type: ServingRuntimeModelType.PREDICTIVE,
-        legacyVLLM: false,
       });
       expect(result.success).toBe(true);
       expect(result.data).toEqual({
         type: ServingRuntimeModelType.PREDICTIVE,
-        legacyVLLM: false,
       });
     });
 
     it('should validate generative-model', () => {
       const result = modelTypeSelectFieldSchema.safeParse({
         type: ServingRuntimeModelType.GENERATIVE,
-        legacyVLLM: false,
       });
       expect(result.success).toBe(true);
       expect(result.data).toEqual({
         type: ServingRuntimeModelType.GENERATIVE,
-        legacyVLLM: false,
-      });
-    });
-
-    it('should validate generative with legacyVLLM true', () => {
-      const result = modelTypeSelectFieldSchema.safeParse({
-        type: ServingRuntimeModelType.GENERATIVE,
-        legacyVLLM: true,
-      });
-      expect(result.success).toBe(true);
-      expect(result.data).toEqual({
-        type: ServingRuntimeModelType.GENERATIVE,
-        legacyVLLM: true,
       });
     });
 
@@ -91,22 +56,20 @@ describe('ModelTypeSelectField', () => {
 
     it('should initialize with existing data', () => {
       const { result } = renderHook(() =>
-        useModelTypeField({ type: ServingRuntimeModelType.PREDICTIVE, legacyVLLM: false }),
+        useModelTypeField({ type: ServingRuntimeModelType.PREDICTIVE }),
       );
       expect(result.current.data).toEqual({
         type: ServingRuntimeModelType.PREDICTIVE,
-        legacyVLLM: false,
       });
     });
 
     it('should update model type', () => {
       const { result } = renderHook(() => useModelTypeField());
       act(() => {
-        result.current.setData({ type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false });
+        result.current.setData({ type: ServingRuntimeModelType.GENERATIVE });
       });
       expect(result.current.data).toEqual({
         type: ServingRuntimeModelType.GENERATIVE,
-        legacyVLLM: false,
       });
     });
   });
@@ -127,7 +90,7 @@ describe('ModelTypeSelectField', () => {
     it('should render with selected value', () => {
       render(
         <ModelTypeSelectField
-          modelType={{ type: ServingRuntimeModelType.PREDICTIVE, legacyVLLM: false }}
+          modelType={{ type: ServingRuntimeModelType.PREDICTIVE }}
           externalData={{ data: { extraOptions: [], forced: false } }}
         />,
       );
@@ -153,7 +116,6 @@ describe('ModelTypeSelectField', () => {
 
       expect(mockSetModelType).toHaveBeenCalledWith({
         type: ServingRuntimeModelType.GENERATIVE,
-        legacyVLLM: true,
       });
     });
 
@@ -205,17 +167,6 @@ describe('ModelTypeSelectField', () => {
     it('should disable model type select when forced', () => {
       render(<ModelTypeSelectField externalData={{ data: { extraOptions: [], forced: true } }} />);
       expect(screen.getByRole('button', { name: 'Options menu' })).toHaveClass('pf-m-disabled');
-    });
-
-    it('should disable legacy checkbox when forced', () => {
-      mockUseIsAreaAvailable.mockReturnValue(mockAreaAvailabilityStatus(true));
-      render(
-        <ModelTypeSelectField
-          modelType={{ type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false }}
-          externalData={{ data: { extraOptions: [], forced: true } }}
-        />,
-      );
-      expect(screen.getByTestId('legacy-mode-checkbox')).toBeDisabled();
     });
   });
 });

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -50,6 +50,12 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
           nameLabel="Model deployment name"
           nameHelperTextAbove="Name this deployment. This name is also used for the inference service created when the model is deployed."
         />
+        <GenericFieldRenderer
+          fieldId="deploymentMethod"
+          wizardState={wizardState}
+          externalData={externalData}
+          isEditing={wizardState.initialData?.isEditing}
+        />
         <ModelServingHardwareProfileSection
           project={projectName}
           hardwareProfileConfig={wizardState.state.hardwareProfileConfig}

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
@@ -70,7 +70,7 @@ describe('ModelSourceStep', () => {
   describe('Schema validation', () => {
     it('should validate complete data', () => {
       const validData: ModelSourceStepData = {
-        modelType: { type: ServingRuntimeModelType.PREDICTIVE, legacyVLLM: false },
+        modelType: { type: ServingRuntimeModelType.PREDICTIVE },
         modelLocationData: {
           type: ModelLocationType.PVC,
           fieldValues: {
@@ -182,7 +182,7 @@ describe('ModelSourceStep', () => {
             projectName: 'test-project',
           },
           modelType: {
-            data: { type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false },
+            data: { type: ServingRuntimeModelType.GENERATIVE },
           },
           createConnectionData: {
             data: {

--- a/packages/model-serving/src/components/deploymentWizard/types.ts
+++ b/packages/model-serving/src/components/deploymentWizard/types.ts
@@ -33,6 +33,7 @@ import {
 import { useProjectSection } from './fields/ProjectSection';
 import { NIMModelLocationKey } from './fields/modelLocationFields/NIMModelLocation';
 import { getStateKey } from './dynamicFormUtils';
+import { DeploymentMethodFieldData } from './fields/DeploymentMethodSelectField';
 import type { ModelServingClusterSettings } from '../../concepts/useModelServingClusterSettings';
 
 export enum ConnectionTypeRefs {
@@ -147,6 +148,7 @@ export type WizardFormData = {
     project: ReturnType<typeof useProjectSection>;
     modelType: ReturnType<typeof useModelTypeField>;
     k8sNameDesc: ReturnType<typeof useK8sNameDescriptionFieldData>;
+    deploymentMethod?: DeploymentMethodFieldData;
     hardwareProfileConfig: ReturnType<typeof useHardwareProfileConfig>;
     modelFormatState: ReturnType<typeof useModelFormatField>;
     modelLocationData: ReturnType<typeof useModelLocationData>;
@@ -203,7 +205,8 @@ export type DeploymentWizardFieldId =
   | 'modelAvailability'
   | 'externalRoute'
   | 'tokenAuth'
-  | 'deploymentStrategy';
+  | 'deploymentStrategy'
+  | 'deploymentMethod';
 
 export type DeploymentWizardFieldBase<ID extends DeploymentWizardFieldId | string> = {
   id: ID;
@@ -342,7 +345,8 @@ export type DeploymentWizardFieldOverride =
   | ModelAvailabilityFieldOverride
   | ExternalRouteFieldOverride
   | TokenAuthFieldOverride
-  | DeploymentStrategyFieldOverride;
+  | DeploymentStrategyFieldOverride
+  | DeploymentMethodFieldOverride;
 
 export const isModelTypeFieldOverride = (
   field: DeploymentWizardFieldOverride,
@@ -378,4 +382,19 @@ export const isDeploymentStrategyFieldOverride = (
   field: DeploymentWizardFieldOverride,
 ): field is DeploymentStrategyFieldOverride => {
   return field.id === 'deploymentStrategy';
+};
+
+export type DeploymentMethodOption = SimpleSelectOption & {
+  description: string;
+};
+export type DeploymentMethodFieldOverride = DeploymentWizardFieldBase<'deploymentMethod'> & {
+  options: DeploymentMethodOption[];
+  suggestion?: (
+    clusterSettings: ModelServingClusterSettings | null | undefined,
+  ) => DeploymentMethodOption | undefined;
+};
+export const isDeploymentMethodFieldOverride = (
+  field: DeploymentWizardFieldOverride,
+): field is DeploymentMethodFieldOverride => {
+  return field.id === 'deploymentMethod';
 };

--- a/packages/model-serving/src/components/deploymentWizard/types.ts
+++ b/packages/model-serving/src/components/deploymentWizard/types.ts
@@ -10,7 +10,7 @@ import {
 import type { ProjectKind, SecretKind, SupportedModelFormats } from '@odh-dashboard/k8s-core';
 import type { LabeledConnection } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import type { RecursivePartial } from '@odh-dashboard/internal/typeHelpers';
-import { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect.js';
+import type { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect';
 import type {
   ModelServerOption,
   ModelServerSelectField,
@@ -33,7 +33,7 @@ import {
 import { useProjectSection } from './fields/ProjectSection';
 import { NIMModelLocationKey } from './fields/modelLocationFields/NIMModelLocation';
 import { getStateKey } from './dynamicFormUtils';
-import { DeploymentMethodFieldData } from './fields/DeploymentMethodSelectField';
+import type { DeploymentMethodFieldData } from './fields/DeploymentMethodSelectField';
 import type { ModelServingClusterSettings } from '../../concepts/useModelServingClusterSettings';
 
 export enum ConnectionTypeRefs {

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
@@ -87,11 +87,7 @@ export const useModelDeploymentWizard = (
     initialData?.createConnectionData,
     modelLocationData.data,
   );
-  const modelType = useModelTypeField(
-    initialData?.modelTypeField,
-    modelLocationData.data,
-    vLLMDeploymentOnMaaSEnabled,
-  );
+  const modelType = useModelTypeField(initialData?.modelTypeField, modelLocationData.data);
 
   // loaded state
   const modelSourceLoaded = React.useMemo(() => {
@@ -130,12 +126,14 @@ export const useModelDeploymentWizard = (
     initialData?.externalRoute ?? undefined,
     modelType,
     formState.modelServer,
+    formState.deploymentMethod,
   );
 
   const tokenAuthentication = useTokenAuthenticationField(
     initialData?.tokenAuthentication ?? undefined,
     modelType,
     formState.modelServer,
+    formState.deploymentMethod,
     canCreateRoleBindings,
   );
 
@@ -147,6 +145,7 @@ export const useModelDeploymentWizard = (
     initialData?.deploymentStrategy ?? undefined,
     modelType,
     formState.modelServer,
+    formState.deploymentMethod,
   );
 
   // Step 4: Summary

--- a/packages/nim-serving/src/pages/deploymentWizard/__tests__/extractNIMFormData.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/__tests__/extractNIMFormData.spec.ts
@@ -170,7 +170,7 @@ describe('extractNIMRuntimeArgs', () => {
 
 describe('extractNIMModelType', () => {
   it('should always return NVIDIA NIM model type', () => {
-    expect(extractNIMModelType()).toEqual({ type: NIM_MODEL_TYPE, legacyVLLM: false });
+    expect(extractNIMModelType()).toEqual({ type: NIM_MODEL_TYPE });
   });
 });
 

--- a/packages/nim-serving/src/pages/deploymentWizard/extractNIMFormData.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/extractNIMFormData.ts
@@ -79,7 +79,6 @@ export const extractNIMModelAvailabilityData = (): {
 
 export const extractNIMModelType = (): ModelTypeFieldData => ({
   type: NIM_MODEL_TYPE,
-  legacyVLLM: false,
 });
 
 export const extractNIMModelServerTemplate = (): null => null;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://redhat.atlassian.net/browse/RHOAIENG-70687

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Basically removes the legacy checkbox for generative and adds the "Deployment method" dropdown to choose between 3 options, LLM-d (if enabled), vLLM llmInferenceService (with the vLLMOnMaaS) feature flag, or the legacy generative

No selection for generative:
<img width="1188" height="771" alt="image" src="https://github.com/user-attachments/assets/3638a318-7328-45dd-9143-c1a1d2d1a236" />

LLM-d selected:
<img width="938" height="639" alt="image" src="https://github.com/user-attachments/assets/23b91cf6-7aa5-4110-bc2d-dd80b74364fc" />

vLLM on MaaS option:
<img width="952" height="678" alt="image" src="https://github.com/user-attachments/assets/16e48cbd-b8db-4c06-a491-4a767510c547" />

Legacy
<img width="953" height="653" alt="image" src="https://github.com/user-attachments/assets/66b5621e-c764-49e6-a10c-4036eab0b838" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A few scenarioes:
KServe on, llm-d off, vLLMOnMaaS off
1. Deploy a new model
2. Select generative
3. Only the Legacy deployment option is visible and autoselected
4. It shows the "Deployment Resource" for vLLM ServingRuntime Templates like before

KServe on, llm-d on, vLLMOnMaaS off
1. Deploy a new model
2. Select generative
3. Select the LLMd option
4. No "Deployment Resource" is shown 

KServe on, llm-d on, admin setting use llm-d as default is on, vLLMOnMaaS off
1. Deploy a new model
2. Select generative
3. The LLMd option is already selected
4. No "Deployment Resource" is shown 

KServe on, llm-d on, vLLMOnMaaSOff
1. Deploy a new model
2. Select generative
3. Select the LLMInferenceService option (not llm-d) 
5. The "Deployment Resource" is shown and shows the LLMInferenceServiceConfigs

Edit works for the above 3

Predictive still shows the predictive "Deployment Resource"

All subsequent platform specific fields still show up and work

Yaml still shows up when LLMInferenceServices are being used

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Fix a lot of cypress mock and e2e tests to use the new flow

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change. @vconzola 

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deployment method selector to the model deployment wizard to drive legacy vs LLM inference service flows.
  * Introduced deployment-method handling across KServe and LLMD deployment wizards, including llm-d and simple vLLM options.

* **Bug Fixes**
  * Updated deployment flows to consistently use the selected deployment method (replacing legacy checkbox-driven behavior).
  * Fixed wizard initialization/activation logic so the correct options and defaults appear for each chosen method.

* **Tests**
  * Updated Cypress end-to-end and mock wizard flows to select/verify the deployment method instead of the legacy checkbox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->