### PR TITLE
feat(gen-ai): migrate agentProfileManagement dev flag to agentConfigManagement CRD field

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -64,6 +64,7 @@ export type DashboardConfig = K8sResourceCommon & {
       projectRBAC: boolean;
       deploymentWizardYAMLViewer: boolean;
       externalVectorStores: boolean;
+      agentConfigManagement: boolean;
       vLLMDeploymentOnMaaS: boolean;
       llmGatewayField: boolean;
       promptManagement: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -100,6 +100,7 @@ export const blankDashboardCR: DashboardConfig = {
       projectRBAC: true,
       deploymentWizardYAMLViewer: false,
       externalVectorStores: false,
+      agentConfigManagement: false,
       vLLMDeploymentOnMaaS: false,
       llmGatewayField: false,
       promptManagement: false,

--- a/distributions/core-bff/bff/internal/models/dashboard_config.go
+++ b/distributions/core-bff/bff/internal/models/dashboard_config.go
@@ -85,6 +85,7 @@ type DashboardFeatureFlags struct {
 	ProjectRBAC                  bool `json:"projectRBAC"`
 	DeploymentWizardYAMLViewer   bool `json:"deploymentWizardYAMLViewer"`
 	ExternalVectorStores         bool `json:"externalVectorStores"`
+	AgentConfigManagement        bool `json:"agentConfigManagement"`
 	VLLMDeploymentOnMaaS         bool `json:"vLLMDeploymentOnMaaS"`
 	LlmGatewayField              bool `json:"llmGatewayField"`
 	PromptManagement             bool `json:"promptManagement"`

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -44,6 +44,7 @@ export type MockDashboardConfigType = {
   modelAsService?: boolean;
   maasAuthPolicies?: boolean;
   externalVectorStores?: boolean;
+  agentConfigManagement?: boolean;
   aiAssetCustomEndpoints?: boolean;
   trainingJobs?: boolean;
   observabilityDashboard?: boolean;
@@ -118,6 +119,7 @@ export const mockDashboardConfig = ({
   disableLLMd = false,
   deploymentWizardYAMLViewer = false,
   externalVectorStores = false,
+  agentConfigManagement = false,
   vLLMDeploymentOnMaaS = false,
   llmGatewayField = false,
   promptManagement = false,
@@ -304,6 +306,7 @@ export const mockDashboardConfig = ({
       disableLLMd,
       deploymentWizardYAMLViewer,
       externalVectorStores,
+      agentConfigManagement,
       vLLMDeploymentOnMaaS,
       llmGatewayField,
       promptManagement,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -15,6 +15,7 @@ export const techPreviewFlags = {
   observabilityDashboard: false,
   deploymentWizardYAMLViewer: false,
   externalVectorStores: false,
+  agentConfigManagement: false,
   vLLMDeploymentOnMaaS: false,
   llmGatewayField: false,
   promptManagement: false,
@@ -29,7 +30,6 @@ export const devTemporaryFeatureFlags = {
   nimWizard: false,
   agentOps: false,
   roleManagement: false,
-  agentProfileManagement: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Group 1: Core Dashboard Features

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -159,6 +159,9 @@ spec:
                     externalVectorStores:
                       type: boolean
                       description: 'When true, enables external vector store integration for RAG workflows.'
+                    agentConfigManagement:
+                      type: boolean
+                      description: 'When true, enables agent configuration management features in the Gen AI Studio.'
                     mlflow:
                       type: boolean
                       description: 'DEPRECATED: MLflow is now always enabled when the operator component is present. This field will be removed in a future version.'

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers.ts
@@ -194,8 +194,8 @@ export const interceptMLflowPrompt = (
   }).as('registerPrompt');
 };
 
-/** URL for a playground page with the agentProfileManagement flag enabled. */
+/** URL for a playground page, optionally with an agentProfileId query param. */
 export const playgroundUrl = (namespace: string, agentProfileId?: string): string => {
-  const base = `/gen-ai-studio/playground/${namespace}?agentProfileManagement=true`;
-  return agentProfileId ? `${base}&agentProfileId=${agentProfileId}` : base;
+  const base = `/gen-ai-studio/playground/${namespace}`;
+  return agentProfileId ? `${base}?agentProfileId=${agentProfileId}` : base;
 };

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/agentProfiles.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/agentProfiles.cy.ts
@@ -2,12 +2,11 @@ import { aiAssetsPage } from '~/__tests__/cypress/cypress/pages/aiAssetsPage';
 import { setupAgentProfilesIntercepts } from '~/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilesTestHelpers';
 
 const TEST_NAMESPACE = 'mock-test-namespace-2';
-const AGENT_PROFILE_PARAMS = { agentProfileManagement: 'true' };
 
 describe('AI Assets - Agent Profiles', () => {
   beforeEach(() => {
     setupAgentProfilesIntercepts({ namespace: TEST_NAMESPACE });
-    aiAssetsPage.visit(TEST_NAMESPACE, AGENT_PROFILE_PARAMS);
+    aiAssetsPage.visit(TEST_NAMESPACE);
     aiAssetsPage.switchToAgentProfilesTab();
     cy.wait('@listAgentProfiles');
   });

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/agentProfiles.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/agentProfiles.cy.ts
@@ -124,7 +124,7 @@ describe('AI Assets - Agent Profiles', () => {
 describe('AI Assets - Agent Profiles (empty state)', () => {
   beforeEach(() => {
     setupAgentProfilesIntercepts({ namespace: TEST_NAMESPACE, empty: true });
-    aiAssetsPage.visit(TEST_NAMESPACE, AGENT_PROFILE_PARAMS);
+    aiAssetsPage.visit(TEST_NAMESPACE);
     aiAssetsPage.switchToAgentProfilesTab();
     cy.wait('@listAgentProfiles');
   });

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/agentProfile.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { chatbotPage } from '~/__tests__/cypress/cypress/pages/chatbotPage';
 import {
   interceptNewAgentProfile,
@@ -17,13 +16,8 @@ const DISMISSED_KEY = 'gen-ai-agent-open-modal-dismissed';
 
 describe('Agent Profile - Playground (Mocked)', () => {
   beforeEach(() => {
-    Cypress.env('_featureFlagParams', 'agentProfileManagement=true');
     // Ensure the open-agent modal always appears by clearing the dismissed preference
     cy.clearLocalStorage(DISMISSED_KEY);
-  });
-
-  afterEach(() => {
-    Cypress.env('_featureFlagParams', '');
   });
 
   it(
@@ -32,7 +26,7 @@ describe('Agent Profile - Playground (Mocked)', () => {
     () => {
       interceptNewAgentProfile(NEW_PROFILE_ID, AGENT_NAME, TEST_NAMESPACE);
 
-      cy.step('Visit playground with agentProfileManagement flag (no agentProfileId — no modal)');
+      cy.step('Visit playground (no agentProfileId — no modal)');
       chatbotPage.visit(TEST_NAMESPACE);
 
       cy.step('Open Save As modal via kebab menu — no profile loaded yet, name is empty');

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
@@ -51,7 +51,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   const selectedModel = useChatbotConfigStore(selectSelectedModel(configIds[0]));
   const isViewCodeDisabled = !lastInput || !selectedModel;
   const [isDropdownOpen, setDropdownOpen] = React.useState(false);
-  const [agentProfilesEnabled] = useFeatureFlag(AGENT_CONFIG_MANAGEMENT);
+  const [agentConfigManagementEnabled] = useFeatureFlag(AGENT_CONFIG_MANAGEMENT);
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
 
   const getDisabledReason = () => {
@@ -159,7 +159,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
             popperProps={{ position: 'end', preventOverflow: true }}
           >
             <DropdownList>
-              {!isCompareMode && agentProfilesEnabled && (
+              {!isCompareMode && agentConfigManagementEnabled && (
                 <DropdownItem
                   onClick={onLoad}
                   key="load-agent-configuration"
@@ -168,7 +168,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
                   Load agent configuration
                 </DropdownItem>
               )}
-              {!isCompareMode && agentProfilesEnabled && profileApplied && (
+              {!isCompareMode && agentConfigManagementEnabled && profileApplied && (
                 <DropdownItem
                   onClick={onSave}
                   key="save-agent-configuration"
@@ -177,7 +177,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
                   Save agent configuration
                 </DropdownItem>
               )}
-              {!isCompareMode && agentProfilesEnabled && (
+              {!isCompareMode && agentConfigManagementEnabled && (
                 <DropdownItem
                   onClick={onSaveAs}
                   key="save-as-agent-configuration"
@@ -186,7 +186,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
                   Save as agent configuration
                 </DropdownItem>
               )}
-              {!isCompareMode && agentProfilesEnabled && profileApplied && (
+              {!isCompareMode && agentConfigManagementEnabled && profileApplied && (
                 <DropdownItem
                   onClick={onNew}
                   key="new-agent-configuration"
@@ -195,7 +195,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
                   New agent configuration
                 </DropdownItem>
               )}
-              {!isCompareMode && agentProfilesEnabled && <Divider key="agent-divider" />}
+              {!isCompareMode && agentConfigManagementEnabled && <Divider key="agent-divider" />}
               <DropdownItem
                 onClick={onConfigurePlayground}
                 key="update-configuration"

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
@@ -14,7 +14,7 @@ import {
 import { CodeIcon, ColumnsIcon, CogIcon, EllipsisVIcon, PlusIcon } from '@patternfly/react-icons';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
-import { AGENT_PROFILES } from '~/odh/extensions';
+import { AGENT_CONFIG_MANAGEMENT } from '~/odh/extensions';
 import { useChatbotConfigStore, selectSelectedModel, selectConfigIds } from './store';
 
 type ChatbotHeaderActionsProps = {
@@ -51,7 +51,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   const selectedModel = useChatbotConfigStore(selectSelectedModel(configIds[0]));
   const isViewCodeDisabled = !lastInput || !selectedModel;
   const [isDropdownOpen, setDropdownOpen] = React.useState(false);
-  const [agentProfilesEnabled] = useFeatureFlag(AGENT_PROFILES);
+  const [agentProfilesEnabled] = useFeatureFlag(AGENT_CONFIG_MANAGEMENT);
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
 
   const getDisabledReason = () => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -107,7 +107,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
   const [activeToolsCount, setActiveToolsCount] = React.useState(0);
   const [isSaveDropdownOpen, setIsSaveDropdownOpen] = React.useState(false);
   const isGuardrailsFeatureEnabled = useGuardrailsEnabled();
-  const [agentProfilesEnabled] = useFeatureFlag(AGENT_CONFIG_MANAGEMENT);
+  const [agentConfigManagementEnabled] = useFeatureFlag(AGENT_CONFIG_MANAGEMENT);
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
   const isPreview = useChatbotConfigStore(selectIsPreview(configId));
 
@@ -268,7 +268,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
           </ToggleGroup>
         )}
         <DrawerActions style={{ gap: 'var(--pf-t--global--spacer--sm)' }}>
-          {agentProfilesEnabled && (
+          {agentConfigManagementEnabled && (
             <>
               <Button variant="secondary" onClick={onLoad} data-testid="settings-panel-load-button">
                 Load

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -25,7 +25,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
-import { AGENT_PROFILES } from '~/odh/extensions';
+import { AGENT_CONFIG_MANAGEMENT } from '~/odh/extensions';
 import {
   useChatbotConfigStore,
   selectSystemInstruction,
@@ -107,7 +107,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
   const [activeToolsCount, setActiveToolsCount] = React.useState(0);
   const [isSaveDropdownOpen, setIsSaveDropdownOpen] = React.useState(false);
   const isGuardrailsFeatureEnabled = useGuardrailsEnabled();
-  const [agentProfilesEnabled] = useFeatureFlag(AGENT_PROFILES);
+  const [agentProfilesEnabled] = useFeatureFlag(AGENT_CONFIG_MANAGEMENT);
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
   const isPreview = useChatbotConfigStore(selectIsPreview(configId));
 

--- a/packages/gen-ai/frontend/src/odh/PluginStoreContextProvider.tsx
+++ b/packages/gen-ai/frontend/src/odh/PluginStoreContextProvider.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { PluginStoreProvider } from '@openshift/dynamic-plugin-sdk';
 import { PluginStore } from '@odh-dashboard/plugin-core';
 import extensions, {
-  AGENT_PROFILES,
+  AGENT_CONFIG_MANAGEMENT,
   AI_ASSET_CUSTOM_ENDPOINTS,
   CHAT_PLAYGROUND,
   EXTERNAL_VECTOR_STORES,
@@ -25,7 +25,7 @@ export const PluginStoreContextProvider: React.FC<React.PropsWithChildren> = ({ 
       [PROMPT_MANAGEMENT]: true,
       [EXTERNAL_VECTOR_STORES]: true,
       [AI_ASSET_CUSTOM_ENDPOINTS]: true,
-      [AGENT_PROFILES]: false,
+      [AGENT_CONFIG_MANAGEMENT]: true,
     };
 
     const params = new URLSearchParams(window.location.search);

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -24,7 +24,7 @@ export const GUARDRAILS = 'guardrails';
 export const PROMPT_MANAGEMENT = 'promptManagement';
 export const AI_ASSET_CUSTOM_ENDPOINTS = 'aiAssetCustomEndpoints';
 export const EXTERNAL_VECTOR_STORES = 'externalVectorStores';
-export const AGENT_PROFILES = 'agentProfileManagement';
+export const AGENT_CONFIG_MANAGEMENT = 'agentConfigManagement';
 const MODELS_AS_SERVICE_READY = 'ModelsAsServiceReady';
 
 const extensions: (
@@ -90,9 +90,9 @@ const extensions: (
   {
     type: 'app.area',
     properties: {
-      id: AGENT_PROFILES,
+      id: AGENT_CONFIG_MANAGEMENT,
       reliantAreas: [PLUGIN_GEN_AI],
-      featureFlags: [AGENT_PROFILES],
+      featureFlags: [AGENT_CONFIG_MANAGEMENT],
     },
   },
   {
@@ -194,11 +194,11 @@ const extensions: (
   {
     type: 'gen-ai.ai-assets/tab',
     flags: {
-      required: [PLUGIN_GEN_AI, AGENT_PROFILES],
+      required: [PLUGIN_GEN_AI, AGENT_CONFIG_MANAGEMENT],
     },
     properties: {
       id: 'agentprofile',
-      title: 'Agent profiles',
+      title: 'Agent configurations',
       component: () => import('../app/AIAssets/AIAssetsAgentProfilesTab').then((m) => m.default),
     },
   },

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -269,6 +269,7 @@ export type DashboardCommonConfig = {
   disableLLMd?: boolean;
   deploymentWizardYAMLViewer?: boolean;
   externalVectorStores?: boolean;
+  agentConfigManagement?: boolean;
   vLLMDeploymentOnMaaS?: boolean;
   llmGatewayField?: boolean;
   promptManagement?: boolean;
@@ -277,7 +278,6 @@ export type DashboardCommonConfig = {
   maasSettingsIaRedesign?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
-  agentProfileManagement?: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-70793

## Description

Replaces the URL-based dev feature flag `agentProfileManagement` with a proper `agentConfigManagement` boolean field in the `OdhDashboardConfig` CRD, following the same pattern as `externalVectorStores`.

Changes across the full stack:

- **CRD** (`odhdashboardconfigs.opendatahub.io.crd.yaml`) — added `agentConfigManagement: boolean` field
- **k8s-core types** (`k8sTypes.ts`) — added `agentConfigManagement?: boolean` to `DashboardCommonConfig`, removed `agentProfileManagement`
- **Backend** (`types.ts`, `constants.ts`) — added `agentConfigManagement` with default `false`
- **Frontend area flags** (`concepts/areas/const.ts`) — moved `agentConfigManagement: false` into `techPreviewFlags`, removed `agentProfileManagement` from `devTemporaryFeatureFlags`
- **Mock config** (`mockDashboardConfig.ts`) — threaded through `agentConfigManagement`
- **gen-ai extensions** (`extensions.ts`) — renamed constant `AGENT_PROFILES` → `AGENT_CONFIG_MANAGEMENT`, value `'agentProfileManagement'` → `'agentConfigManagement'`; updated tab title to "Agent configurations"
- **gen-ai plugin store** (`PluginStoreContextProvider.tsx`) — updated to `AGENT_CONFIG_MANAGEMENT`, default `true`
- **gen-ai components** (`ChatbotHeaderActions.tsx`, `ChatbotSettingsPanel.tsx`) — updated import/usage
- **core-bff Go model** (`dashboard_config.go`) — added `AgentConfigManagement bool`
- **Cypress tests** — removed `agentProfileManagement=true` URL param from test setup and playground URL helper; flag is on by default so no override needed

## How Has This Been Tested?

- Verified lint passes (lint-staged on commit)
- Manually traced through the full flag flow from CRD → backend → frontend area → plugin store → components

## Test Impact

Existing Cypress mock tests for agent profiles updated to remove the URL flag override. No new tests needed — this is a rename/migration with no behavior change.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `agentConfigManagement` feature flag to dashboard configuration (backend, CRD schema, and frontend mocks/defaults), defaulting to disabled.
* **Refactor**
  * Updated agent-related feature flag naming and gating in the Gen AI Studio UI to use `agentConfigManagement` instead of the previous agent profile flag.
* **Tests**
  * Adjusted Cypress setup and helper URL/query behavior to match the new feature-flag and URL parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->