### PR TITLE
chore: add gmenher to gen-ai approvers and reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -147,6 +147,7 @@ aliases:
     - mfleader
     - ederign
     - rhdedgar
+    - gmenher
   gen-ai-reviewers:
     - agagancarczyk
     - ikeola13
@@ -162,6 +163,7 @@ aliases:
     - rhdedgar
     - iamemilio
     - s-akhtar-baig
+    - gmenher
 
   # Notebooks
   notebooks-approvers:


### PR DESCRIPTION
Adds @gmenher to gen-ai-approvers and gen-ai-reviewers in OWNERS_ALIASES.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review ownership settings to include a new GitHub handle in the Gen AI approvers and reviewers lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->