### PR TITLE
fix(autorag): replace OpenAI SDK with direct OGX API calls in code snippets

### DIFF
--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/playgroundSnippets.spec.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/playgroundSnippets.spec.ts
@@ -77,9 +77,12 @@ describe('generateNodeSnippet', () => {
     expect(result).toContain('test-model');
   });
 
-  it('should contain import OpenAI', () => {
+  it('should use fetch to call the OGX Responses API directly', () => {
     const result = generateNodeSnippet(mockParams);
-    expect(result).toContain('import OpenAI');
+    expect(result).toContain('await fetch(');
+    expect(result).toContain('/v1/responses');
+    expect(result).not.toContain('openai');
+    expect(result).not.toContain('OpenAI');
   });
 
   it('should contain the secret name and namespace', () => {
@@ -135,9 +138,12 @@ describe('generatePythonSnippet', () => {
     expect(result).toContain('test-model');
   });
 
-  it('should contain from openai import OpenAI', () => {
+  it('should use requests to call the OGX Responses API directly', () => {
     const result = generatePythonSnippet(mockParams);
-    expect(result).toContain('from openai import OpenAI');
+    expect(result).toContain('requests.post');
+    expect(result).toContain('/v1/responses');
+    expect(result).not.toContain('from openai');
+    expect(result).not.toContain('openai_client');
   });
 
   it('should contain the secret name and namespace', () => {

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/playgroundSnippets.spec.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/playgroundSnippets.spec.ts
@@ -157,6 +157,7 @@ describe('generatePythonSnippet', () => {
     const result = generatePythonSnippet(mockParams);
     expect(result).toContain('timeout=30');
     expect(result).toContain('raise_for_status()');
+    expect(result).toContain('result.get("output", result)');
   });
 
   it('should contain the secret name and namespace', () => {

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/playgroundSnippets.spec.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/playgroundSnippets.spec.ts
@@ -85,6 +85,13 @@ describe('generateNodeSnippet', () => {
     expect(result).not.toContain('OpenAI');
   });
 
+  it('should include request timeout and error handling', () => {
+    const result = generateNodeSnippet(mockParams);
+    expect(result).toContain('AbortSignal.timeout(');
+    expect(result).toContain('response.ok');
+    expect(result).toContain('result.output ?? result');
+  });
+
   it('should contain the secret name and namespace', () => {
     const result = generateNodeSnippet(mockParams);
     expect(result).toContain('my-secret');
@@ -144,6 +151,12 @@ describe('generatePythonSnippet', () => {
     expect(result).toContain('/v1/responses');
     expect(result).not.toContain('from openai');
     expect(result).not.toContain('openai_client');
+  });
+
+  it('should include request timeout and error handling', () => {
+    const result = generatePythonSnippet(mockParams);
+    expect(result).toContain('timeout=30');
+    expect(result).toContain('raise_for_status()');
   });
 
   it('should contain the secret name and namespace', () => {

--- a/packages/autorag/frontend/src/app/components/run-results/playgroundSnippets.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/playgroundSnippets.ts
@@ -56,10 +56,16 @@ const response = await fetch(\`\${baseURL}/v1/responses\`, {
     "Authorization": \`Bearer \${apiKey}\`,
   },
   body: JSON.stringify(payload),
+  signal: AbortSignal.timeout(30_000),
 });
 
+if (!response.ok) {
+  const errorBody = await response.text();
+  throw new Error(\`Request failed (\${response.status}): \${errorBody}\`);
+}
+
 const result = await response.json();
-console.log(result.output);`;
+console.log(result.output ?? result);`;
 };
 
 export const generateGoSnippet = ({ template, secretName, namespace }: SnippetParams): string => {
@@ -204,8 +210,10 @@ response = requests.post(
         "Authorization": f"Bearer {api_key}",
     },
     json=payload,
+    timeout=30,
 )
+response.raise_for_status()
 
 result = response.json()
-print(result.get("output"))`;
+print(result.get("output", result))`;
 };

--- a/packages/autorag/frontend/src/app/components/run-results/playgroundSnippets.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/playgroundSnippets.ts
@@ -24,7 +24,7 @@ export const generateNodeSnippet = ({ template, secretName, namespace }: Snippet
     .split('\n')
     .map((line, i) => (i === 0 ? line : `  ${line}`))
     .join('\n');
-  return `// Prerequisites: npm install @kubernetes/client-node
+  return `// Prerequisites: Node.js 18+, npm install @kubernetes/client-node
 // Save as .mjs or add "type": "module" to package.json
 import * as k8s from "@kubernetes/client-node";
 
@@ -85,6 +85,7 @@ export const generateGoSnippet = ({ template, secretName, namespace }: SnippetPa
     '\t"fmt"',
     '\t"io"',
     '\t"net/http"',
+    '\t"time"',
     '',
     '\tmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"',
     '\t"k8s.io/client-go/kubernetes"',
@@ -127,13 +128,17 @@ export const generateGoSnippet = ({ template, secretName, namespace }: SnippetPa
     '\treq.Header.Set("Content-Type", "application/json")',
     '\treq.Header.Set("Authorization", "Bearer "+apiKey)',
     '',
-    '\tresp, err := http.DefaultClient.Do(req)',
+    '\tclient := &http.Client{Timeout: 30 * time.Second}',
+    '\tresp, err := client.Do(req)',
     '\tif err != nil {',
     '\t\tpanic(err)',
     '\t}',
     '\tdefer resp.Body.Close()',
     '',
     '\tbody, _ := io.ReadAll(resp.Body)',
+    '\tif resp.StatusCode < 200 || resp.StatusCode >= 300 {',
+    '\t\tpanic(fmt.Sprintf("request failed (%d): %s", resp.StatusCode, string(body)))',
+    '\t}',
     '\tfmt.Println(string(body))',
     '}',
   ];

--- a/packages/autorag/frontend/src/app/components/run-results/playgroundSnippets.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/playgroundSnippets.ts
@@ -24,9 +24,8 @@ export const generateNodeSnippet = ({ template, secretName, namespace }: Snippet
     .split('\n')
     .map((line, i) => (i === 0 ? line : `  ${line}`))
     .join('\n');
-  return `// Prerequisites: npm install openai @kubernetes/client-node
+  return `// Prerequisites: npm install @kubernetes/client-node
 // Save as .mjs or add "type": "module" to package.json
-import OpenAI from "openai";
 import * as k8s from "@kubernetes/client-node";
 
 // Loads kubeconfig from the default location (~/.kube/config or KUBECONFIG env var).
@@ -46,16 +45,21 @@ const decode = (key) => Buffer.from(secret.data[key], "base64").toString();
 const baseURL = decode("OGX_CLIENT_BASE_URL");
 const apiKey = decode("OGX_CLIENT_API_KEY");
 
-// Initialize the OpenAI client pointing to the OGX endpoint
-const client = new OpenAI({
-  baseURL: \`\${baseURL}/v1\`,
-  apiKey,
-});
+// Build the JSON request body
+const payload = ${body};
 
 // Send a request to the Responses API
-const response = await client.responses.create(${body});
+const response = await fetch(\`\${baseURL}/v1/responses\`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": \`Bearer \${apiKey}\`,
+  },
+  body: JSON.stringify(payload),
+});
 
-console.log(response.output);`;
+const result = await response.json();
+console.log(result.output);`;
 };
 
 export const generateGoSnippet = ({ template, secretName, namespace }: SnippetParams): string => {
@@ -172,10 +176,10 @@ export const generatePythonSnippet = ({
   namespace,
 }: SnippetParams): string => {
   const params = jsonToPython(template, 0);
-  return `# Prerequisites: pip install openai kubernetes
+  return `# Prerequisites: pip install kubernetes requests
 import base64
+import requests
 from kubernetes import client, config
-from openai import OpenAI
 
 # Loads kubeconfig from the default location (~/.kube/config or KUBECONFIG env var).
 # Ensure you are logged in to the cluster (e.g. via "oc login") before running this script.
@@ -189,16 +193,19 @@ secret = v1.read_namespaced_secret("${secretName}", "${namespace}")
 base_url = base64.b64decode(secret.data["OGX_CLIENT_BASE_URL"]).decode()
 api_key = base64.b64decode(secret.data["OGX_CLIENT_API_KEY"]).decode()
 
-# Initialize the OpenAI client pointing to the OGX endpoint
-openai_client = OpenAI(
-    base_url=f"{base_url}/v1",
-    api_key=api_key,
-)
+# Build the request payload
+payload = ${params}
 
 # Send a request to the Responses API
-params = ${params}
+response = requests.post(
+    f"{base_url}/v1/responses",
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    },
+    json=payload,
+)
 
-response = openai_client.responses.create(**params)
-
-print(response.output)`;
+result = response.json()
+print(result.get("output"))`;
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-70364

## Description

Replaces the OpenAI SDK with direct HTTP calls in the Node.js and Python playground code snippets (View Code modal) so that the payload sent when trying out a RAG pattern matches what the backend sends during experiments.

**Node.js snippet:**
- Removed `openai` dependency; now uses native `fetch()` to POST to `/v1/responses`
- Prerequisite changed from `npm install openai @kubernetes/client-node` to `npm install @kubernetes/client-node`

<details>

<summary>NodeJS generated code block</summary>

```javascript
// Prerequisites: npm install @kubernetes/client-node
// Save as .mjs or add "type": "module" to package.json
import * as k8s from "@kubernetes/client-node";

// Loads kubeconfig from the default location (~/.kube/config or KUBECONFIG env var).
// Ensure you are logged in to the cluster (e.g. via "oc login") before running this script.
const kc = new k8s.KubeConfig();
kc.loadFromDefault();
const k8sApi = kc.makeApiClient(k8s.CoreV1Api);

// Fetch the OGX credentials from the Kubernetes secret
const secret = await k8sApi.readNamespacedSecret({
  name: "ogx",
  namespace: "nick-test-managed-pipelines",
});

// Secret values are base64-encoded; decode them to get the raw strings
const decode = (key) => Buffer.from(secret.data[key], "base64").toString();
const baseURL = decode("OGX_CLIENT_BASE_URL");
const apiKey = decode("OGX_CLIENT_API_KEY");

// Build the JSON request body
const payload = {
    "model": "vllm-inference/meta-llama/Llama-3.1-8B-Instruct",
    "stream": false,
    "store": false,
    "input": [
      {
        "type": "message",
        "role": "user",
        "content": [
          {
            "type": "input_text",
            "text": "<user_query_placeholder>"
          }
        ]
      }
    ],
    "instructions": "You are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.\nIf a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don’t know the answer to a question, please don’t share false information.\n",
    "tools": [
      {
        "type": "file_search",
        "vector_store_ids": [
          "vs_5ec3553f-a34e-4a52-8072-727f3c63ad4a"
        ]
      }
    ],
    "include": [
      "file_search_call.results"
    ]
  };

// Send a request to the Responses API
const response = await fetch(`${baseURL}/v1/responses`, {
  method: "POST",
  headers: {
    "Content-Type": "application/json",
    "Authorization": `Bearer ${apiKey}`,
  },
  body: JSON.stringify(payload),
});

const result = await response.json();
console.log(result.output);
```

</details>

@claude ran the snippet and verfied:
> The snippet works end-to-end. Got a 200 response with file search results and a generated answer. The snippet successfully:
> 
> Fetched K8s secret credentials
> Called the OGX /v1/responses endpoint directly via fetch (no OpenAI SDK)
> Received file search results and an LLM-generated response

**Python snippet:**
- Removed `openai` dependency; now uses `requests.post()` to POST to `/v1/responses`
- Prerequisite changed from `pip install openai kubernetes` to `pip install kubernetes requests`

<details>

<summary>Python generated code block</summary>

```python
# Prerequisites: pip install kubernetes requests
import base64
import requests
from kubernetes import client, config

# Loads kubeconfig from the default location (~/.kube/config or KUBECONFIG env var).
# Ensure you are logged in to the cluster (e.g. via "oc login") before running this script.
config.load_config()
v1 = client.CoreV1Api()

# Fetch the OGX credentials from the Kubernetes secret
secret = v1.read_namespaced_secret("ogx", "nick-test-managed-pipelines")

# Secret values are base64-encoded; decode them to get the raw strings
base_url = base64.b64decode(secret.data["OGX_CLIENT_BASE_URL"]).decode()
api_key = base64.b64decode(secret.data["OGX_CLIENT_API_KEY"]).decode()

# Build the request payload
payload = {
    "model": "vllm-inference/meta-llama/Llama-3.1-8B-Instruct",
    "stream": False,
    "store": False,
    "input": [
        {
            "type": "message",
            "role": "user",
            "content": [
                {
                    "type": "input_text",
                    "text": "<user_query_placeholder>",
                },
            ],
        },
    ],
    "instructions": "You are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.\nIf a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don’t know the answer to a question, please don’t share false information.\n",
    "tools": [
        {
            "type": "file_search",
            "vector_store_ids": [
                "vs_5ec3553f-a34e-4a52-8072-727f3c63ad4a",
            ],
        },
    ],
    "include": [
        "file_search_call.results",
    ],
}

# Send a request to the Responses API
response = requests.post(
    f"{base_url}/v1/responses",
    headers={
        "Content-Type": "application/json",
        "Authorization": f"Bearer {api_key}",
    },
    json=payload,
)

result = response.json()
print(result.get("output"))
```

</details>

@claude 
> Python snippet works — 200 with file search results and LLM response. Both snippets verified against your live cluster.

**curl and Go snippets** already used direct HTTP calls — no changes needed.

## How Has This Been Tested?

- Both the Node.js and Python generated snippets were executed against a live cluster (`nick-test-managed-pipelines` namespace) and returned successful 200 responses from the OGX Responses API.
- Unit tests updated and passing (`playgroundSnippets.spec.ts`).

## Test Impact

- Updated `playgroundSnippets.spec.ts`:
  - Node.js tests now assert `fetch()` usage and absence of OpenAI references.
  - Python tests now assert `requests.post` usage and absence of OpenAI references.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Node.js and Python playground snippets to call the Responses API via standard HTTP requests (with timeouts and basic error handling).
  * Updated the Go playground snippet to use an explicit HTTP client with timeout and non-2xx response checking.

* **Bug Fixes**
  * Removed OpenAI SDK/client references from generated snippets, ensuring examples match the current API approach and output handling.

* **Tests**
  * Strengthened snippet-generation tests to verify the generated code includes timeout, response/error handling, and no OpenAI-related identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->