### PR TITLE
feat(agent-ops): deploy agent wizard steps 1–2 (Mode 1 shell)

### DIFF
--- a/packages/agent-ops/extensions.ts
+++ b/packages/agent-ops/extensions.ts
@@ -1,0 +1,12 @@
+import type { ProjectsBridgeProviderExtension } from './frontend/src/odh/extension-points';
+
+const extensions: ProjectsBridgeProviderExtension[] = [
+  {
+    type: 'agent-ops.projects/bridge-provider',
+    properties: {
+      component: () => import('./src/ProjectsBridgeProvider'),
+    },
+  },
+];
+
+export default extensions;

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
@@ -121,6 +121,7 @@ describe('Agent Deployments', () => {
       .findEmptyState()
       .should('be.visible')
       .and('contain.text', 'No agent deployments');
+    cy.findByTestId('deploy-agent-button').should('be.visible').and('be.enabled');
   });
 
   it('should show select-project state when no namespace is selected and no projects exist', () => {

--- a/packages/agent-ops/frontend/src/app/AppRoutes.tsx
+++ b/packages/agent-ops/frontend/src/app/AppRoutes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import NotFound from './components/NotFound';
+import AgentDeployWizardPage from './deployWizard/AgentDeployWizardPage';
 import AgentDeploymentListPage from './pages/AgentDeploymentListPage';
 import AgentDeploymentDetailPage from './pages/AgentDeploymentDetailPage';
 import { agentDeploymentsPath } from './utilities/routes';
@@ -9,6 +10,7 @@ const AppRoutes: React.FC = () => (
   <Routes>
     <Route path="/" element={<Navigate to={agentDeploymentsPath} replace />} />
     <Route path="/deployments" element={<AgentDeploymentListPage />} />
+    <Route path="/deployments/deploy" element={<AgentDeployWizardPage />} />
     <Route path="/deployments/:namespace" element={<AgentDeploymentListPage />} />
     <Route path="/deployments/:namespace/:agentId/*" element={<AgentDeploymentDetailPage />} />
     <Route path="*" element={<NotFound />} />

--- a/packages/agent-ops/frontend/src/app/components/AgentDetailsCard.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentDetailsCard.tsx
@@ -29,7 +29,9 @@ const getSafeExternalUrl = (value?: string): string | undefined => {
   }
   try {
     const parsed = new URL(trimmed);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.toString() : undefined;
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.toString()
+      : undefined;
   } catch {
     return undefined;
   }

--- a/packages/agent-ops/frontend/src/app/components/AgentOpsProjectSelector.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentOpsProjectSelector.tsx
@@ -20,8 +20,8 @@ const AgentOpsProjectSelector: React.FC<AgentOpsProjectSelectorProps> = ({
   const { projectNamespaces, isLoading, onProjectSelection } = useAgentOpsProjectNamespaces();
 
   const effectiveNamespaces = React.useMemo(
-    () => getEffectiveProjectNamespaces(projectNamespaces, namespace),
-    [projectNamespaces, namespace],
+    () => getEffectiveProjectNamespaces(projectNamespaces, isLoading, namespace),
+    [projectNamespaces, isLoading, namespace],
   );
 
   return (

--- a/packages/agent-ops/frontend/src/app/components/AgentOpsProjectSelector.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentOpsProjectSelector.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import ProjectSelector from '@odh-dashboard/internal/concepts/projects/ProjectSelector';
-import { useNamespaceSelector } from 'mod-arch-core';
 import { useNavigate } from 'react-router-dom';
+import {
+  getEffectiveProjectNamespaces,
+  useAgentOpsProjectNamespaces,
+} from '~/app/hooks/useAgentOpsProjectNamespaces';
 
 type AgentOpsProjectSelectorProps = {
   namespace?: string;
@@ -14,35 +17,26 @@ const AgentOpsProjectSelector: React.FC<AgentOpsProjectSelectorProps> = ({
   ...projectSelectorProps
 }) => {
   const navigate = useNavigate();
-  const { namespaces, updatePreferredNamespace, namespacesLoaded, namespacesLoadError } =
-    useNamespaceSelector();
+  const { projectNamespaces, isLoading, onProjectSelection } = useAgentOpsProjectNamespaces();
 
-  const effectiveNamespaces = React.useMemo(() => {
-    if (namespaces.length > 0) {
-      return namespaces;
-    }
-    if (namespace) {
-      return [{ name: namespace, displayName: namespace }];
-    }
-    return namespaces;
-  }, [namespaces, namespace]);
-
-  const isLoading = !namespacesLoaded && !namespacesLoadError;
+  const effectiveNamespaces = React.useMemo(
+    () => getEffectiveProjectNamespaces(projectNamespaces, namespace),
+    [projectNamespaces, namespace],
+  );
 
   return (
-    <ProjectSelector
-      {...projectSelectorProps}
-      onSelection={(projectName) => {
-        const match = projectName
-          ? (effectiveNamespaces.find((n) => n.name === projectName) ?? undefined)
-          : undefined;
-        updatePreferredNamespace(match);
-        navigate(getRedirectPath(projectName));
-      }}
-      namespace={namespace ?? ''}
-      isLoading={isLoading}
-      namespacesOverride={effectiveNamespaces}
-    />
+    <div data-testid="agent-ops-project-selector">
+      <ProjectSelector
+        {...projectSelectorProps}
+        onSelection={(projectName) => {
+          onProjectSelection(projectName);
+          navigate(getRedirectPath(projectName));
+        }}
+        namespace={namespace ?? ''}
+        isLoading={isLoading}
+        namespacesOverride={effectiveNamespaces}
+      />
+    </div>
   );
 };
 

--- a/packages/agent-ops/frontend/src/app/components/DeployAgentButton.tsx
+++ b/packages/agent-ops/frontend/src/app/components/DeployAgentButton.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Button, Tooltip } from '@patternfly/react-core';
+import { useCanDeployAgent } from '~/app/hooks/useCanDeployAgent';
+
+type DeployAgentButtonProps = {
+  namespace?: string;
+  onDeployAgent: () => void;
+};
+
+const DeployAgentButton: React.FC<DeployAgentButtonProps> = ({ namespace, onDeployAgent }) => {
+  const { canDeploy, loaded, disabledReason } = useCanDeployAgent(namespace);
+  const isDeployDisabled = !canDeploy || !loaded;
+
+  const handleDeployAgent = React.useCallback(() => {
+    if (isDeployDisabled) {
+      return;
+    }
+    onDeployAgent();
+  }, [isDeployDisabled, onDeployAgent]);
+
+  const deployButton = (
+    <Button
+      variant="primary"
+      data-testid="deploy-agent-button"
+      isAriaDisabled={isDeployDisabled}
+      onClick={handleDeployAgent}
+    >
+      Deploy agent
+    </Button>
+  );
+
+  if (isDeployDisabled) {
+    return <Tooltip content={disabledReason}>{deployButton}</Tooltip>;
+  }
+
+  return deployButton;
+};
+
+export default DeployAgentButton;

--- a/packages/agent-ops/frontend/src/app/components/ScrollLock.scss
+++ b/packages/agent-ops/frontend/src/app/components/ScrollLock.scss
@@ -1,0 +1,3 @@
+#dashboard-page-main.agent-ops-scroll-lock {
+  overflow: hidden;
+}

--- a/packages/agent-ops/frontend/src/app/components/ScrollLock.scss
+++ b/packages/agent-ops/frontend/src/app/components/ScrollLock.scss
@@ -1,3 +1,0 @@
-#dashboard-page-main.agent-ops-scroll-lock {
-  overflow: hidden;
-}

--- a/packages/agent-ops/frontend/src/app/components/ScrollLock.tsx
+++ b/packages/agent-ops/frontend/src/app/components/ScrollLock.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { getDashboardMainContainer } from '@odh-dashboard/internal/utilities/utils';
+import './ScrollLock.scss';
+
+const SCROLL_LOCK_CLASS = 'agent-ops-scroll-lock';
+
+type ScrollLockProps = {
+  children: React.ReactNode;
+};
+
+/** Locks host main scroll while a full-page agent-ops overlay (e.g. deploy wizard) is mounted. */
+const ScrollLock: React.FC<ScrollLockProps> = ({ children }) => {
+  React.useLayoutEffect(() => {
+    const scrollContainer = getDashboardMainContainer();
+    scrollContainer.classList.add(SCROLL_LOCK_CLASS);
+    return () => {
+      scrollContainer.classList.remove(SCROLL_LOCK_CLASS);
+    };
+  }, []);
+
+  return children;
+};
+
+export default ScrollLock;

--- a/packages/agent-ops/frontend/src/app/components/ScrollLock.tsx
+++ b/packages/agent-ops/frontend/src/app/components/ScrollLock.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { getDashboardMainContainer } from '@odh-dashboard/internal/utilities/utils';
-import './ScrollLock.scss';
 
-const SCROLL_LOCK_CLASS = 'agent-ops-scroll-lock';
+let lockCount = 0;
+let previousOverflow: string | undefined;
 
 type ScrollLockProps = {
   children: React.ReactNode;
@@ -12,9 +12,19 @@ type ScrollLockProps = {
 const ScrollLock: React.FC<ScrollLockProps> = ({ children }) => {
   React.useLayoutEffect(() => {
     const scrollContainer = getDashboardMainContainer();
-    scrollContainer.classList.add(SCROLL_LOCK_CLASS);
+
+    if (lockCount === 0) {
+      previousOverflow = scrollContainer.style.overflow;
+      scrollContainer.style.overflow = 'hidden';
+    }
+    lockCount += 1;
+
     return () => {
-      scrollContainer.classList.remove(SCROLL_LOCK_CLASS);
+      lockCount -= 1;
+      if (lockCount <= 0) {
+        scrollContainer.style.overflow = previousOverflow ?? '';
+        previousOverflow = undefined;
+      }
     };
   }, []);
 

--- a/packages/agent-ops/frontend/src/app/components/__tests__/ScrollLock.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/components/__tests__/ScrollLock.spec.tsx
@@ -17,6 +17,7 @@ describe('ScrollLock', () => {
   beforeEach(() => {
     scrollContainer = document.createElement('div');
     scrollContainer.id = 'dashboard-page-main';
+    scrollContainer.style.overflow = 'auto';
     document.body.appendChild(scrollContainer);
     mockGetDashboardMainContainer.mockReturnValue(scrollContainer);
   });
@@ -26,7 +27,7 @@ describe('ScrollLock', () => {
     jest.clearAllMocks();
   });
 
-  it('should add and remove the scroll lock class around child mount lifecycle', () => {
+  it('should set overflow hidden while mounted and restore on unmount', () => {
     const { unmount } = render(
       <ScrollLock>
         <span>Wizard content</span>
@@ -34,10 +35,26 @@ describe('ScrollLock', () => {
     );
 
     expect(screen.getByText('Wizard content')).toBeInTheDocument();
-    expect(scrollContainer).toHaveClass('agent-ops-scroll-lock');
+    expect(scrollContainer.style.overflow).toBe('hidden');
 
     unmount();
 
-    expect(scrollContainer).not.toHaveClass('agent-ops-scroll-lock');
+    expect(scrollContainer.style.overflow).toBe('auto');
+  });
+
+  it('should keep overflow hidden until all nested locks unmount', () => {
+    const { unmount: unmountOuter } = render(
+      <ScrollLock>
+        <ScrollLock>
+          <span>Nested wizard</span>
+        </ScrollLock>
+      </ScrollLock>,
+    );
+
+    expect(scrollContainer.style.overflow).toBe('hidden');
+
+    unmountOuter();
+
+    expect(scrollContainer.style.overflow).toBe('auto');
   });
 });

--- a/packages/agent-ops/frontend/src/app/components/__tests__/ScrollLock.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/components/__tests__/ScrollLock.spec.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import ScrollLock from '~/app/components/ScrollLock';
+
+jest.mock('@odh-dashboard/internal/utilities/utils', () => ({
+  getDashboardMainContainer: jest.fn(),
+}));
+
+const mockGetDashboardMainContainer = jest.requireMock<{
+  getDashboardMainContainer: jest.Mock<HTMLElement, []>;
+}>('@odh-dashboard/internal/utilities/utils').getDashboardMainContainer;
+
+describe('ScrollLock', () => {
+  let scrollContainer: HTMLDivElement;
+
+  beforeEach(() => {
+    scrollContainer = document.createElement('div');
+    scrollContainer.id = 'dashboard-page-main';
+    document.body.appendChild(scrollContainer);
+    mockGetDashboardMainContainer.mockReturnValue(scrollContainer);
+  });
+
+  afterEach(() => {
+    scrollContainer.remove();
+    jest.clearAllMocks();
+  });
+
+  it('should add and remove the scroll lock class around child mount lifecycle', () => {
+    const { unmount } = render(
+      <ScrollLock>
+        <span>Wizard content</span>
+      </ScrollLock>,
+    );
+
+    expect(screen.getByText('Wizard content')).toBeInTheDocument();
+    expect(scrollContainer).toHaveClass('agent-ops-scroll-lock');
+
+    unmount();
+
+    expect(scrollContainer).not.toHaveClass('agent-ops-scroll-lock');
+  });
+});

--- a/packages/agent-ops/frontend/src/app/deployWizard/AgentDeployWizard.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/AgentDeployWizard.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { Wizard, WizardStep } from '@patternfly/react-core';
+import ScrollLock from '~/app/components/ScrollLock';
+import { deployAgentWizardSteps } from './constants';
+import DeployAgentWizardFooter from './DeployAgentWizardFooter';
+import ExitDeployAgentModal from './ExitDeployAgentModal';
+import { deployAgentWizardStepSubtitles } from './wizardOptions';
+import { DeployAgentWizardStepTitle } from './types';
+import { AgentDeployWizardProvider, useAgentDeployWizardContext } from './useAgentDeployWizard';
+import { useAgentDeployWizardValidation } from './useAgentDeployWizardValidation';
+import { useExitDeployAgentWizard } from './useExitDeployAgentWizard';
+
+type AgentDeployWizardContentProps = {
+  returnRoute?: string;
+};
+
+const AgentDeployWizardContent: React.FC<AgentDeployWizardContentProps> = ({ returnRoute }) => {
+  const { formData, isDirty } = useAgentDeployWizardContext();
+  const validation = useAgentDeployWizardValidation(formData);
+  const [activeStepIndex, setActiveStepIndex] = React.useState(1);
+
+  const { isExitModalOpen, closeExitModal, handleExitConfirm, exitWizard, exitWizardOnSubmit } =
+    useExitDeployAgentWizard({
+      namespace: formData.project,
+      returnRoute,
+      isDirty,
+      isDeployFormValid: validation.isDeployFormValid,
+    });
+
+  const description =
+    deployAgentWizardStepSubtitles[
+      deployAgentWizardSteps[activeStepIndex - 1]?.name ??
+        DeployAgentWizardStepTitle.IMAGE_SELECTION
+    ];
+
+  const wizardFooter = React.useMemo(
+    () => <DeployAgentWizardFooter getIsNextDisabled={validation.isNextStepDisabled} />,
+    [validation.isNextStepDisabled],
+  );
+
+  return (
+    <ScrollLock>
+      <>
+        {isExitModalOpen && (
+          <ExitDeployAgentModal onClose={closeExitModal} onConfirm={handleExitConfirm} />
+        )}
+        <ApplicationsPage title="Deploy agent" description={description} loaded empty={false}>
+          <Wizard
+            aria-label="Deploy agent"
+            onClose={exitWizard}
+            onSave={exitWizardOnSubmit}
+            footer={wizardFooter}
+            onStepChange={(_event, currentStep) => {
+              setActiveStepIndex(currentStep.index);
+            }}
+          >
+            {deployAgentWizardSteps.map(({ name, id, Component }, index) => (
+              <WizardStep
+                key={id}
+                name={name}
+                id={id}
+                isDisabled={!validation.isStepAccessible(index + 1)}
+              >
+                <Component />
+              </WizardStep>
+            ))}
+          </Wizard>
+        </ApplicationsPage>
+      </>
+    </ScrollLock>
+  );
+};
+
+type AgentDeployWizardProps = {
+  namespace: string;
+  returnRoute?: string;
+};
+
+const AgentDeployWizard: React.FC<AgentDeployWizardProps> = ({ namespace, returnRoute }) => (
+  <AgentDeployWizardProvider key={namespace} namespace={namespace}>
+    <AgentDeployWizardContent returnRoute={returnRoute} />
+  </AgentDeployWizardProvider>
+);
+
+export default AgentDeployWizard;

--- a/packages/agent-ops/frontend/src/app/deployWizard/AgentDeployWizardPage.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/AgentDeployWizardPage.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { agentDeploymentsPath, sanitizeAgentOpsReturnRoute } from '~/app/utilities/routes';
+import AgentDeployWizard from './AgentDeployWizard';
+import { isValidAgentName } from './utils';
+import { isDeployAgentWizardLocationState, type DeployAgentWizardLocationState } from './types';
+
+const AgentDeployWizardPage: React.FC = () => {
+  const location = useLocation();
+  const wizardState: DeployAgentWizardLocationState = isDeployAgentWizardLocationState(
+    location.state,
+  )
+    ? location.state
+    : {};
+  const { namespace, returnRoute } = wizardState;
+
+  if (!namespace || !isValidAgentName(namespace)) {
+    return <Navigate to={agentDeploymentsPath} replace />;
+  }
+
+  const safeReturnRoute = sanitizeAgentOpsReturnRoute(returnRoute, namespace);
+
+  return <AgentDeployWizard namespace={namespace} returnRoute={safeReturnRoute} />;
+};
+
+export default AgentDeployWizardPage;

--- a/packages/agent-ops/frontend/src/app/deployWizard/DeployAgentWizardFooter.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/DeployAgentWizardFooter.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import {
+  ActionList,
+  ActionListGroup,
+  ActionListItem,
+  Button,
+  Tooltip,
+  useWizardContext,
+  WizardFooterWrapper,
+} from '@patternfly/react-core';
+
+type DeployAgentWizardFooterProps = {
+  submitButtonText?: string;
+  getIsNextDisabled?: (stepIndex: number) => boolean;
+};
+
+/**
+ * Wizard footer used inside PatternFly `<Wizard />`.
+ * Cancel/Back use wizard context; final-step submit is handled by Wizard `onSave` via `goToNextStep`.
+ */
+const DeployAgentWizardFooter: React.FC<DeployAgentWizardFooterProps> = ({
+  submitButtonText = 'Deploy agent',
+  getIsNextDisabled,
+}) => {
+  const { activeStep, steps, goToNextStep, goToPrevStep, close } = useWizardContext();
+  const isFinalStep = activeStep.index === steps.length;
+  const isBackDisabled = activeStep.index === 1;
+  const isNextDisabled = getIsNextDisabled?.(activeStep.index) ?? false;
+  const nextButtonLabel = isFinalStep ? submitButtonText : 'Next';
+
+  const handleBack = React.useCallback(() => {
+    if (!isBackDisabled) {
+      goToPrevStep();
+    }
+  }, [isBackDisabled, goToPrevStep]);
+
+  const handleNext = React.useCallback(() => {
+    if (!isNextDisabled) {
+      goToNextStep();
+    }
+  }, [isNextDisabled, goToNextStep]);
+
+  const backButton = (
+    <Button
+      variant="secondary"
+      onClick={handleBack}
+      isAriaDisabled={isBackDisabled}
+      data-testid="deploy-agent-wizard-back"
+    >
+      Back
+    </Button>
+  );
+
+  const nextButton = (
+    <Button
+      variant="primary"
+      onClick={handleNext}
+      isAriaDisabled={isNextDisabled}
+      data-testid={isFinalStep ? 'deploy-agent-wizard-submit' : 'deploy-agent-wizard-next'}
+    >
+      {nextButtonLabel}
+    </Button>
+  );
+
+  return (
+    <WizardFooterWrapper>
+      <ActionList>
+        <ActionListGroup>
+          <ActionListItem>
+            {isBackDisabled ? (
+              <Tooltip content="You are on the first step.">{backButton}</Tooltip>
+            ) : (
+              backButton
+            )}
+          </ActionListItem>
+          <ActionListItem>
+            {isNextDisabled ? (
+              <Tooltip content="Complete all required fields on this step before continuing.">
+                {nextButton}
+              </Tooltip>
+            ) : (
+              nextButton
+            )}
+          </ActionListItem>
+        </ActionListGroup>
+        <ActionListGroup>
+          <ActionListItem>
+            <Button variant="link" onClick={close} data-testid="deploy-agent-wizard-cancel">
+              Cancel
+            </Button>
+          </ActionListItem>
+        </ActionListGroup>
+      </ActionList>
+    </WizardFooterWrapper>
+  );
+};
+
+export default DeployAgentWizardFooter;

--- a/packages/agent-ops/frontend/src/app/deployWizard/DeployWizardSelectField.scss
+++ b/packages/agent-ops/frontend/src/app/deployWizard/DeployWizardSelectField.scss
@@ -1,0 +1,5 @@
+.deploy-agent-wizard-dropdown {
+  --deploy-agent-wizard-dropdown-max-width: 28rem;
+
+  width: min(100%, var(--deploy-agent-wizard-dropdown-max-width));
+}

--- a/packages/agent-ops/frontend/src/app/deployWizard/DeployWizardSelectField.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/DeployWizardSelectField.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import './DeployWizardSelectField.scss';
+
+/** Wrap wizard dropdowns (ProjectSelector, SimpleSelect) for consistent toggle width. */
+const DeployWizardSelectField: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="deploy-agent-wizard-dropdown">{children}</div>
+);
+
+export default DeployWizardSelectField;

--- a/packages/agent-ops/frontend/src/app/deployWizard/ExitDeployAgentModal.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/ExitDeployAgentModal.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import ContentModal from '@odh-dashboard/internal/components/modals/ContentModal';
+
+type ExitDeployAgentModalProps = {
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+const ExitDeployAgentModal: React.FC<ExitDeployAgentModalProps> = ({ onClose, onConfirm }) => (
+  <ContentModal
+    title="Discard agent deployment configuration?"
+    onClose={onClose}
+    variant="small"
+    dataTestId="exit-deploy-agent-modal"
+    contents="Your configuration details for this agent deployment are not saved. Discard your changes and leave this page, or cancel to continue editing."
+    buttonActions={[
+      {
+        label: 'Discard',
+        onClick: onConfirm,
+        variant: 'primary',
+        dataTestId: 'exit-deploy-agent-discard-button',
+      },
+      {
+        label: 'Cancel',
+        onClick: onClose,
+        variant: 'link',
+        dataTestId: 'exit-deploy-agent-cancel-button',
+      },
+    ]}
+  />
+);
+
+export default ExitDeployAgentModal;

--- a/packages/agent-ops/frontend/src/app/deployWizard/__tests__/AgentDeployWizard.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/__tests__/AgentDeployWizard.spec.tsx
@@ -1,0 +1,337 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import AgentDeployWizard from '~/app/deployWizard/AgentDeployWizard';
+import { DeployAgentWizardStepTitle } from '~/app/deployWizard/types';
+
+const mockNavigate = jest.fn();
+
+const expectWizardNextDisabled = (): void => {
+  expect(screen.getByTestId('deploy-agent-wizard-next')).toHaveAttribute('aria-disabled', 'true');
+};
+
+const expectWizardNextEnabled = (): void => {
+  expect(screen.getByTestId('deploy-agent-wizard-next')).not.toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+};
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual<typeof import('react-router-dom')>('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => ({
+  __esModule: true,
+  default: ({
+    title,
+    description,
+    children,
+  }: {
+    title: string;
+    description?: string;
+    children: React.ReactNode;
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      {description ? <p>{description}</p> : null}
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock('~/app/components/ScrollLock', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('~/app/deployWizard/ExitDeployAgentModal', () => ({
+  __esModule: true,
+  default: ({ onClose, onConfirm }: { onClose: () => void; onConfirm: () => void }) => (
+    <div data-testid="exit-deploy-agent-modal">
+      <button type="button" data-testid="exit-deploy-agent-discard-button" onClick={onConfirm}>
+        Discard
+      </button>
+      <button type="button" data-testid="exit-deploy-agent-cancel-button" onClick={onClose}>
+        Cancel
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('~/app/hooks/useAgentOpsProjectNamespaces', () => ({
+  getEffectiveProjectNamespaces: (
+    projectNamespaces: { name: string; displayName: string }[],
+    fallbackNamespace?: string,
+  ) => {
+    if (projectNamespaces.length > 0) {
+      return projectNamespaces;
+    }
+    if (fallbackNamespace) {
+      return [{ name: fallbackNamespace, displayName: fallbackNamespace }];
+    }
+    return projectNamespaces;
+  },
+  useAgentOpsProjectNamespaces: () => ({
+    projectNamespaces: [{ name: 'team1', displayName: 'team1' }],
+    isLoading: false,
+    onProjectSelection: jest.fn(),
+  }),
+}));
+
+jest.mock('@odh-dashboard/internal/concepts/projects/ProjectSelector', () => ({
+  __esModule: true,
+  default: ({
+    namespace,
+    onSelection,
+    placeholder,
+  }: {
+    namespace: string;
+    onSelection: (projectName: string) => void;
+    placeholder?: string;
+  }) => (
+    <select
+      data-testid="deploy-agent-project-select"
+      value={namespace}
+      onChange={(event) => onSelection(event.target.value)}
+    >
+      <option value="">{placeholder ?? 'Select a project'}</option>
+      <option value="team1">team1</option>
+    </select>
+  ),
+}));
+
+jest.mock('@odh-dashboard/internal/components/SimpleSelect', () => ({
+  __esModule: true,
+  default: ({
+    dataTestId,
+    value,
+    options = [],
+    onChange,
+    placeholder,
+  }: {
+    dataTestId?: string;
+    value?: string;
+    options?: { key: string; label: string }[];
+    onChange: (key: string) => void;
+    placeholder?: string;
+  }) => (
+    <select
+      data-testid={dataTestId}
+      value={value ?? ''}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      <option value="">{placeholder ?? 'Select...'}</option>
+      {options.map((option) => (
+        <option key={option.key} value={option.key}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+jest.mock('mod-arch-core', () => ({
+  ...jest.requireActual<typeof import('mod-arch-core')>('mod-arch-core'),
+  useNamespaceSelector: () => ({
+    namespaces: [{ name: 'team1', displayName: 'team1' }],
+    namespacesLoaded: true,
+    namespacesLoadError: undefined,
+    updatePreferredNamespace: jest.fn(),
+  }),
+}));
+
+const renderWizard = (props?: { namespace?: string; returnRoute?: string }) =>
+  render(
+    <MemoryRouter>
+      <AgentDeployWizard namespace={props?.namespace ?? 'team1'} returnRoute={props?.returnRoute} />
+    </MemoryRouter>,
+  );
+
+describe('AgentDeployWizard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the deploy agent title and all wizard step names', () => {
+    renderWizard();
+
+    expect(screen.getByText('Deploy agent')).toBeInTheDocument();
+    expect(
+      screen.getByText('Specify the container image and where the agent will be deployed.'),
+    ).toBeInTheDocument();
+
+    Object.values(DeployAgentWizardStepTitle).forEach((stepTitle) => {
+      expect(screen.getByRole('button', { name: stepTitle })).toBeInTheDocument();
+    });
+  });
+
+  it('disables Next on step 1 until required fields are valid', async () => {
+    renderWizard();
+
+    expectWizardNextDisabled();
+
+    await userEvent.type(
+      screen.getByTestId('deploy-agent-container-image'),
+      'quay.io/myorg/my-agent',
+    );
+
+    await waitFor(() => {
+      expectWizardNextEnabled();
+    });
+  });
+
+  it('auto-generates agent name from container image path', async () => {
+    renderWizard();
+
+    await userEvent.type(
+      screen.getByTestId('deploy-agent-container-image'),
+      'quay.io/myorg/my-agent',
+    );
+
+    expect(screen.getByTestId('deploy-agent-name')).toHaveValue('my-agent');
+  });
+
+  it('shows persistent volume size only when persistent storage is enabled', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.type(screen.getByTestId('deploy-agent-container-image'), 'quay.io/myorg/my-agent');
+    await user.click(screen.getByTestId('deploy-agent-wizard-next'));
+
+    expect(screen.queryByTestId('deploy-agent-persistent-volume-size')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('deploy-agent-enable-persistent-storage'));
+
+    expect(screen.getByTestId('deploy-agent-persistent-volume-size')).toBeInTheDocument();
+  });
+
+  it('disables Back on step 1', () => {
+    renderWizard();
+
+    expect(screen.getByTestId('deploy-agent-wizard-back')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('preserves step 1 data when navigating back from step 2', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.type(screen.getByTestId('deploy-agent-container-image'), 'quay.io/myorg/my-agent');
+    await user.click(screen.getByTestId('deploy-agent-wizard-next'));
+    await user.click(screen.getByTestId('deploy-agent-wizard-back'));
+
+    expect(screen.getByTestId('deploy-agent-container-image')).toHaveValue(
+      'quay.io/myorg/my-agent',
+    );
+    expect(screen.getByTestId('deploy-agent-name')).toHaveValue('my-agent');
+  });
+
+  it('navigates back when cancel is clicked without dirty form', async () => {
+    const user = userEvent.setup();
+
+    renderWizard();
+
+    await user.click(screen.getByTestId('deploy-agent-wizard-cancel'));
+    expect(mockNavigate).toHaveBeenCalledWith('/ai-hub/agents/deployments/team1');
+  });
+
+  it('shows exit modal when cancel is clicked with dirty form', async () => {
+    const user = userEvent.setup();
+
+    renderWizard();
+
+    await user.type(screen.getByTestId('deploy-agent-container-image'), 'quay.io/myorg/my-agent');
+    await user.click(screen.getByTestId('deploy-agent-wizard-cancel'));
+
+    expect(screen.getByTestId('exit-deploy-agent-modal')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId('exit-deploy-agent-discard-button'));
+    expect(mockNavigate).toHaveBeenCalledWith('/ai-hub/agents/deployments/team1');
+  });
+
+  it('closes exit modal on cancel without navigating', async () => {
+    const user = userEvent.setup();
+
+    renderWizard();
+
+    await user.type(screen.getByTestId('deploy-agent-container-image'), 'quay.io/myorg/my-agent');
+    await user.click(screen.getByTestId('deploy-agent-wizard-cancel'));
+    expect(screen.getByTestId('exit-deploy-agent-modal')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('exit-deploy-agent-cancel-button'));
+    expect(screen.queryByTestId('exit-deploy-agent-modal')).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.getByText('Deploy agent')).toBeInTheDocument();
+  });
+
+  it('keeps Next disabled for invalid agent name', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.type(screen.getByTestId('deploy-agent-container-image'), 'quay.io/myorg/my-agent');
+    await user.clear(screen.getByTestId('deploy-agent-name'));
+    await user.type(screen.getByTestId('deploy-agent-name'), 'Invalid_Name!');
+
+    expectWizardNextDisabled();
+  });
+
+  it('keeps Next disabled for invalid pull secret', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.type(screen.getByTestId('deploy-agent-container-image'), 'quay.io/myorg/my-agent');
+    await user.type(screen.getByTestId('deploy-agent-pull-secret'), 'bad secret');
+
+    expectWizardNextDisabled();
+  });
+
+  it('disables Next on step 2 until workload type is selected', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.type(screen.getByTestId('deploy-agent-container-image'), 'quay.io/myorg/my-agent');
+    await user.click(screen.getByTestId('deploy-agent-wizard-next'));
+
+    expectWizardNextDisabled();
+
+    await user.selectOptions(screen.getByTestId('deploy-agent-workload-type-select'), 'deployment');
+    expectWizardNextEnabled();
+  });
+
+  it('disables Next on step 2 when persistent storage size is invalid', async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.type(screen.getByTestId('deploy-agent-container-image'), 'quay.io/myorg/my-agent');
+    await user.click(screen.getByTestId('deploy-agent-wizard-next'));
+    await user.selectOptions(screen.getByTestId('deploy-agent-workload-type-select'), 'deployment');
+    await user.click(screen.getByTestId('deploy-agent-enable-persistent-storage'));
+    await user.clear(screen.getByTestId('deploy-agent-persistent-volume-size'));
+    await user.type(screen.getByTestId('deploy-agent-persistent-volume-size'), '1 GB');
+
+    expectWizardNextDisabled();
+  });
+
+  it('navigates to return route when deploy agent is submitted on the final step', async () => {
+    const user = userEvent.setup();
+
+    renderWizard({ returnRoute: '/ai-hub/agents/deployments/team1' });
+
+    await user.type(screen.getByTestId('deploy-agent-container-image'), 'quay.io/myorg/my-agent');
+    await user.click(screen.getByTestId('deploy-agent-wizard-next'));
+    await user.selectOptions(screen.getByTestId('deploy-agent-protocol-select'), 'a2a');
+    await user.selectOptions(screen.getByTestId('deploy-agent-workload-type-select'), 'deployment');
+
+    await user.click(screen.getByTestId('deploy-agent-wizard-next'));
+    await user.click(screen.getByTestId('deploy-agent-wizard-next'));
+    await user.click(screen.getByTestId('deploy-agent-wizard-next'));
+    await user.click(screen.getByTestId('deploy-agent-wizard-next'));
+    await user.click(screen.getByTestId('deploy-agent-wizard-submit'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/ai-hub/agents/deployments/team1');
+  });
+});

--- a/packages/agent-ops/frontend/src/app/deployWizard/__tests__/AgentDeployWizard.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/__tests__/AgentDeployWizard.spec.tsx
@@ -65,12 +65,13 @@ jest.mock('~/app/deployWizard/ExitDeployAgentModal', () => ({
 jest.mock('~/app/hooks/useAgentOpsProjectNamespaces', () => ({
   getEffectiveProjectNamespaces: (
     projectNamespaces: { name: string; displayName: string }[],
+    isLoading: boolean,
     fallbackNamespace?: string,
   ) => {
     if (projectNamespaces.length > 0) {
       return projectNamespaces;
     }
-    if (fallbackNamespace) {
+    if (isLoading && fallbackNamespace) {
       return [{ name: fallbackNamespace, displayName: fallbackNamespace }];
     }
     return projectNamespaces;

--- a/packages/agent-ops/frontend/src/app/deployWizard/__tests__/deployAgentWizardValidation.spec.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/__tests__/deployAgentWizardValidation.spec.ts
@@ -1,0 +1,128 @@
+import {
+  createDeployAgentWizardValidationState,
+  deployAgentWizardStepRegistry,
+  isDeployAgentWizardStepAccessible,
+  isDeployAgentWizardStepValid,
+} from '~/app/deployWizard/deployAgentWizardValidation';
+import { createInitialFormData } from '~/app/deployWizard/useAgentDeployWizard';
+
+describe('deployAgentWizardValidation', () => {
+  describe('createDeployAgentWizardValidationState', () => {
+    it('requires valid image selection on step 1', () => {
+      const state = createDeployAgentWizardValidationState(createInitialFormData('team1'));
+
+      expect(state.isImageSelectionValid).toBe(false);
+      expect(state.isDeployFormValid).toBe(false);
+    });
+
+    it('requires valid configuration on step 2', () => {
+      const state = createDeployAgentWizardValidationState({
+        ...createInitialFormData('team1'),
+        containerImage: 'quay.io/myorg/my-agent',
+        imageTag: 'latest',
+        agentName: 'my-agent',
+        workloadType: '',
+      });
+
+      expect(state.isImageSelectionValid).toBe(true);
+      expect(state.isConfigurationValid).toBe(false);
+    });
+
+    it('validates persistent volume size when enabled', () => {
+      const state = createDeployAgentWizardValidationState({
+        ...createInitialFormData('team1'),
+        containerImage: 'quay.io/myorg/my-agent',
+        imageTag: 'latest',
+        agentName: 'my-agent',
+        protocol: 'a2a',
+        workloadType: 'deployment',
+        enablePersistentStorage: true,
+        persistentVolumeSize: 'invalid',
+      });
+
+      expect(state.isConfigurationValid).toBe(false);
+    });
+  });
+
+  describe('step registry helpers', () => {
+    const completeState = createDeployAgentWizardValidationState({
+      ...createInitialFormData('team1'),
+      containerImage: 'quay.io/myorg/my-agent',
+      imageTag: 'latest',
+      agentName: 'my-agent',
+      protocol: 'a2a',
+      workloadType: 'deployment',
+    });
+
+    const imageOnlyState = createDeployAgentWizardValidationState({
+      ...createInitialFormData('team1'),
+      containerImage: 'quay.io/myorg/my-agent',
+      imageTag: 'latest',
+      agentName: 'my-agent',
+    });
+
+    it('allows step 1 navigation without prior steps', () => {
+      expect(
+        isDeployAgentWizardStepAccessible(1, imageOnlyState, deployAgentWizardStepRegistry),
+      ).toBe(true);
+    });
+
+    it('blocks step 2 until image selection is valid', () => {
+      const emptyState = createDeployAgentWizardValidationState(createInitialFormData('team1'));
+
+      expect(isDeployAgentWizardStepAccessible(2, emptyState, deployAgentWizardStepRegistry)).toBe(
+        false,
+      );
+      expect(
+        isDeployAgentWizardStepAccessible(2, imageOnlyState, deployAgentWizardStepRegistry),
+      ).toBe(true);
+    });
+
+    it('blocks step 3 until configuration is valid', () => {
+      expect(
+        isDeployAgentWizardStepAccessible(3, imageOnlyState, deployAgentWizardStepRegistry),
+      ).toBe(false);
+      expect(
+        isDeployAgentWizardStepAccessible(3, completeState, deployAgentWizardStepRegistry),
+      ).toBe(true);
+    });
+
+    it('uses per-step validators for Next button state', () => {
+      expect(isDeployAgentWizardStepValid(1, imageOnlyState, deployAgentWizardStepRegistry)).toBe(
+        true,
+      );
+      expect(isDeployAgentWizardStepValid(2, imageOnlyState, deployAgentWizardStepRegistry)).toBe(
+        false,
+      );
+      expect(isDeployAgentWizardStepValid(2, completeState, deployAgentWizardStepRegistry)).toBe(
+        true,
+      );
+      expect(isDeployAgentWizardStepValid(6, completeState, deployAgentWizardStepRegistry)).toBe(
+        true,
+      );
+    });
+
+    it('rejects out-of-range step indexes', () => {
+      expect(
+        isDeployAgentWizardStepAccessible(0, completeState, deployAgentWizardStepRegistry),
+      ).toBe(false);
+      expect(
+        isDeployAgentWizardStepAccessible(
+          deployAgentWizardStepRegistry.length + 1,
+          completeState,
+          deployAgentWizardStepRegistry,
+        ),
+      ).toBe(false);
+      expect(isDeployAgentWizardStepValid(0, completeState, deployAgentWizardStepRegistry)).toBe(
+        false,
+      );
+      expect(
+        isDeployAgentWizardStepValid(
+          deployAgentWizardStepRegistry.length + 1,
+          completeState,
+          deployAgentWizardStepRegistry,
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/agent-ops/frontend/src/app/deployWizard/__tests__/useAgentDeployWizardValidation.spec.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/__tests__/useAgentDeployWizardValidation.spec.ts
@@ -1,0 +1,54 @@
+import { renderHook } from '@testing-library/react';
+import { deployAgentWizardStepRegistry } from '~/app/deployWizard/deployAgentWizardValidation';
+import { useAgentDeployWizardValidation } from '~/app/deployWizard/useAgentDeployWizardValidation';
+import { createInitialFormData } from '~/app/deployWizard/useAgentDeployWizard';
+
+describe('useAgentDeployWizardValidation', () => {
+  it('requires valid image selection on step 1', () => {
+    const formData = createInitialFormData('team1');
+    const { result } = renderHook(() => useAgentDeployWizardValidation(formData));
+
+    expect(result.current.isImageSelectionValid).toBe(false);
+    expect(result.current.isNextStepDisabled(1)).toBe(true);
+    expect(result.current.isStepAccessible(1)).toBe(true);
+    expect(result.current.isStepAccessible(2)).toBe(false);
+  });
+
+  it('requires valid configuration on step 2', () => {
+    const formData = {
+      ...createInitialFormData('team1'),
+      containerImage: 'quay.io/myorg/my-agent',
+      imageTag: 'latest',
+      agentName: 'my-agent',
+      workloadType: '',
+    };
+    const { result } = renderHook(() => useAgentDeployWizardValidation(formData));
+
+    expect(result.current.isImageSelectionValid).toBe(true);
+    expect(result.current.isConfigurationValid).toBe(false);
+    expect(result.current.isNextStepDisabled(2)).toBe(true);
+    expect(result.current.isStepAccessible(3)).toBe(false);
+  });
+
+  it('validates persistent volume size when enabled', () => {
+    const formData = {
+      ...createInitialFormData('team1'),
+      containerImage: 'quay.io/myorg/my-agent',
+      imageTag: 'latest',
+      agentName: 'my-agent',
+      protocol: 'a2a',
+      workloadType: 'deployment',
+      enablePersistentStorage: true,
+      persistentVolumeSize: 'invalid',
+    };
+    const { result } = renderHook(() => useAgentDeployWizardValidation(formData));
+
+    expect(result.current.isConfigurationValid).toBe(false);
+  });
+
+  it('uses the shared step registry', () => {
+    expect(deployAgentWizardStepRegistry).toHaveLength(6);
+    expect(deployAgentWizardStepRegistry[0].name).toBe('Image selection');
+    expect(deployAgentWizardStepRegistry[5].name).toBe('Summary');
+  });
+});

--- a/packages/agent-ops/frontend/src/app/deployWizard/__tests__/useExitDeployAgentWizard.spec.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/__tests__/useExitDeployAgentWizard.spec.ts
@@ -1,0 +1,130 @@
+import '@testing-library/jest-dom';
+import { act, renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useExitDeployAgentWizard } from '~/app/deployWizard/useExitDeployAgentWizard';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual<typeof import('react-router-dom')>('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+describe('useExitDeployAgentWizard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('navigates to namespace deployments on cancel', () => {
+    const { result } = renderHook(
+      () =>
+        useExitDeployAgentWizard({
+          namespace: 'team1',
+          isDirty: false,
+        }),
+      { wrapper: MemoryRouter },
+    );
+
+    result.current.exitWizard();
+    expect(mockNavigate).toHaveBeenCalledWith('/ai-hub/agents/deployments/team1');
+  });
+
+  it('navigates to current namespace deployments on cancel when project changes', () => {
+    const { result } = renderHook(
+      () =>
+        useExitDeployAgentWizard({
+          namespace: 'team2',
+          isDirty: false,
+        }),
+      { wrapper: MemoryRouter },
+    );
+
+    result.current.exitWizard();
+    expect(mockNavigate).toHaveBeenCalledWith('/ai-hub/agents/deployments/team2');
+  });
+
+  it('opens exit modal when form is dirty', () => {
+    const { result } = renderHook(
+      () =>
+        useExitDeployAgentWizard({
+          namespace: 'team1',
+          isDirty: true,
+        }),
+      { wrapper: MemoryRouter },
+    );
+
+    act(() => {
+      result.current.exitWizard();
+    });
+
+    expect(result.current.isExitModalOpen).toBe(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to return route on submit when form is valid', () => {
+    const { result } = renderHook(
+      () =>
+        useExitDeployAgentWizard({
+          namespace: 'team1',
+          returnRoute: '/ai-hub/agents/deployments/team1',
+          isDeployFormValid: true,
+        }),
+      { wrapper: MemoryRouter },
+    );
+
+    result.current.exitWizardOnSubmit();
+    expect(mockNavigate).toHaveBeenCalledWith('/ai-hub/agents/deployments/team1');
+  });
+
+  it('does not navigate on submit when form is invalid', () => {
+    const { result } = renderHook(
+      () =>
+        useExitDeployAgentWizard({
+          namespace: 'team1',
+          returnRoute: '/ai-hub/agents/deployments/team1',
+          isDeployFormValid: false,
+        }),
+      { wrapper: MemoryRouter },
+    );
+
+    result.current.exitWizardOnSubmit();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to namespace deployments route for unsafe returnRoute', () => {
+    const { result } = renderHook(
+      () =>
+        useExitDeployAgentWizard({
+          namespace: 'team1',
+          returnRoute: 'https://evil.com',
+          isDeployFormValid: true,
+        }),
+      { wrapper: MemoryRouter },
+    );
+
+    result.current.exitWizardOnSubmit();
+    expect(mockNavigate).toHaveBeenCalledWith('/ai-hub/agents/deployments/team1');
+  });
+
+  it('closes exit modal without navigating', () => {
+    const { result } = renderHook(
+      () =>
+        useExitDeployAgentWizard({
+          namespace: 'team1',
+          isDirty: true,
+        }),
+      { wrapper: MemoryRouter },
+    );
+
+    act(() => {
+      result.current.exitWizard();
+    });
+    expect(result.current.isExitModalOpen).toBe(true);
+
+    act(() => {
+      result.current.closeExitModal();
+    });
+    expect(result.current.isExitModalOpen).toBe(false);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-ops/frontend/src/app/deployWizard/__tests__/useNavigateToDeployAgentWizard.spec.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/__tests__/useNavigateToDeployAgentWizard.spec.ts
@@ -1,0 +1,43 @@
+import '@testing-library/jest-dom';
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useNavigateToDeployAgentWizard } from '~/app/deployWizard/useNavigateToDeployAgentWizard';
+import { agentDeployWizardPath } from '~/app/utilities/routes';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual<typeof import('react-router-dom')>('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: '/ai-hub/agents/deployments/team1' }),
+}));
+
+describe('useNavigateToDeployAgentWizard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not navigate when namespace is missing', () => {
+    const { result } = renderHook(() => useNavigateToDeployAgentWizard(), {
+      wrapper: MemoryRouter,
+    });
+
+    result.current(undefined);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to wizard with namespace and return route', () => {
+    const { result } = renderHook(() => useNavigateToDeployAgentWizard(), {
+      wrapper: MemoryRouter,
+    });
+
+    result.current('team1');
+
+    expect(mockNavigate).toHaveBeenCalledWith(agentDeployWizardPath, {
+      state: {
+        namespace: 'team1',
+        returnRoute: '/ai-hub/agents/deployments/team1',
+      },
+    });
+  });
+});

--- a/packages/agent-ops/frontend/src/app/deployWizard/__tests__/utils.spec.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/__tests__/utils.spec.ts
@@ -1,0 +1,78 @@
+import {
+  deriveAgentNameFromImage,
+  buildFullImageReference,
+  isValidAgentName,
+  isValidK8sStorageQuantity,
+  isValidPullSecretName,
+  stripContainerImageTag,
+} from '~/app/deployWizard/utils';
+
+describe('deployWizard utils', () => {
+  describe('deriveAgentNameFromImage', () => {
+    it('derives DNS-1123 name from last image path segment', () => {
+      expect(deriveAgentNameFromImage('quay.io/myorg/my-agent')).toBe('my-agent');
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(deriveAgentNameFromImage('')).toBe('');
+    });
+  });
+
+  describe('buildFullImageReference', () => {
+    it('combines image and tag', () => {
+      expect(buildFullImageReference('quay.io/myorg/my-agent', 'latest')).toBe(
+        'quay.io/myorg/my-agent:latest',
+      );
+    });
+  });
+
+  describe('isValidK8sStorageQuantity', () => {
+    it('accepts valid quantities', () => {
+      expect(isValidK8sStorageQuantity('1Gi')).toBe(true);
+      expect(isValidK8sStorageQuantity('512Mi')).toBe(true);
+    });
+
+    it('rejects invalid quantities', () => {
+      expect(isValidK8sStorageQuantity('1 GB')).toBe(false);
+      expect(isValidK8sStorageQuantity('')).toBe(false);
+    });
+  });
+
+  describe('isValidAgentName', () => {
+    it('accepts valid DNS-1123 labels', () => {
+      expect(isValidAgentName('my-agent')).toBe(true);
+    });
+
+    it('rejects invalid names', () => {
+      expect(isValidAgentName('My_Agent!')).toBe(false);
+      expect(isValidAgentName('')).toBe(false);
+      expect(isValidAgentName('a'.repeat(64))).toBe(false);
+    });
+  });
+
+  describe('isValidPullSecretName', () => {
+    it('allows empty optional secret', () => {
+      expect(isValidPullSecretName('')).toBe(true);
+    });
+
+    it('accepts DNS subdomain names with dots', () => {
+      expect(isValidPullSecretName('pull-secret.dockerconfig')).toBe(true);
+    });
+
+    it('rejects invalid secret names', () => {
+      expect(isValidPullSecretName('bad secret')).toBe(false);
+      expect(isValidPullSecretName('My_Agent!')).toBe(false);
+    });
+  });
+
+  describe('stripContainerImageTag', () => {
+    it('removes tag from final path segment', () => {
+      expect(stripContainerImageTag('quay.io/myorg/my-agent:v1')).toBe('quay.io/myorg/my-agent');
+    });
+
+    it('preserves digest-pinned references', () => {
+      const digestImage = 'quay.io/myorg/my-agent@sha256:abcdef0123456789';
+      expect(stripContainerImageTag(digestImage)).toBe(digestImage);
+    });
+  });
+});

--- a/packages/agent-ops/frontend/src/app/deployWizard/constants.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/constants.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import {
+  deployAgentWizardStepRegistry,
+  type DeployAgentWizardStepConfig as DeployAgentWizardStepRegistryEntry,
+} from './deployAgentWizardValidation';
+import ConfigurationStep from './steps/ConfigurationStep';
+import ImageSelectionStep from './steps/ImageSelectionStep';
+import PlaceholderStep from './steps/PlaceholderStep';
+import { DeployAgentWizardStepTitle } from './types';
+
+export type DeployAgentWizardStepConfig = DeployAgentWizardStepRegistryEntry & {
+  Component: React.FC;
+};
+
+const placeholderStep = (title: DeployAgentWizardStepTitle): React.FC => {
+  const PlaceholderWizardStep: React.FC = () => <PlaceholderStep title={title} />;
+  PlaceholderWizardStep.displayName = `PlaceholderStep(${title})`;
+  return PlaceholderWizardStep;
+};
+
+const stepComponents: Record<DeployAgentWizardStepTitle, React.FC> = {
+  [DeployAgentWizardStepTitle.IMAGE_SELECTION]: ImageSelectionStep,
+  [DeployAgentWizardStepTitle.CONFIGURATION]: ConfigurationStep,
+  [DeployAgentWizardStepTitle.NETWORKING]: placeholderStep(DeployAgentWizardStepTitle.NETWORKING),
+  [DeployAgentWizardStepTitle.SECURITY_AND_IDENTITY]: placeholderStep(
+    DeployAgentWizardStepTitle.SECURITY_AND_IDENTITY,
+  ),
+  [DeployAgentWizardStepTitle.ENVIRONMENT_VARIABLES]: placeholderStep(
+    DeployAgentWizardStepTitle.ENVIRONMENT_VARIABLES,
+  ),
+  [DeployAgentWizardStepTitle.SUMMARY]: placeholderStep(DeployAgentWizardStepTitle.SUMMARY),
+};
+
+export const deployAgentWizardSteps: DeployAgentWizardStepConfig[] =
+  deployAgentWizardStepRegistry.map((step) => ({
+    ...step,
+    Component: stepComponents[step.name],
+  }));

--- a/packages/agent-ops/frontend/src/app/deployWizard/deployAgentWizardValidation.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/deployAgentWizardValidation.ts
@@ -1,0 +1,114 @@
+import type { DeployAgentWizardFormData } from './types';
+import { DeployAgentWizardStepTitle } from './types';
+import { isValidAgentName, isValidK8sStorageQuantity, isValidPullSecretName } from './utils';
+
+/** Computed validation flags shared by the step registry and submit flow. */
+export type DeployAgentWizardValidationState = {
+  isImageSelectionValid: boolean;
+  isConfigurationValid: boolean;
+  isDeployFormValid: boolean;
+};
+
+export type DeployAgentWizardStepValidator = (state: DeployAgentWizardValidationState) => boolean;
+
+export const createDeployAgentWizardValidationState = (
+  formData: DeployAgentWizardFormData,
+): DeployAgentWizardValidationState => {
+  const isImageSelectionValid =
+    formData.project.trim().length > 0 &&
+    formData.containerImage.trim().length > 0 &&
+    formData.imageTag.trim().length > 0 &&
+    formData.agentName.trim().length > 0 &&
+    isValidAgentName(formData.agentName) &&
+    isValidPullSecretName(formData.pullSecret);
+
+  const isConfigurationValid =
+    Boolean(formData.protocol && formData.workloadType) &&
+    (!formData.enablePersistentStorage || isValidK8sStorageQuantity(formData.persistentVolumeSize));
+
+  return {
+    isImageSelectionValid,
+    isConfigurationValid,
+    isDeployFormValid: isImageSelectionValid && isConfigurationValid,
+  };
+};
+
+/** Step validators keyed by title — referenced from the step registry in constants.tsx. */
+export const deployAgentWizardStepValidators = {
+  isImageSelectionStepValid: (state: DeployAgentWizardValidationState): boolean =>
+    state.isImageSelectionValid,
+  isConfigurationStepValid: (state: DeployAgentWizardValidationState): boolean =>
+    state.isConfigurationValid,
+  isPlaceholderStepValid: (): boolean => true,
+  isSummaryStepValid: (state: DeployAgentWizardValidationState): boolean => state.isDeployFormValid,
+} as const;
+
+export type DeployAgentWizardStepConfig = {
+  name: DeployAgentWizardStepTitle;
+  id: string;
+  isValid: DeployAgentWizardStepValidator;
+};
+
+/** Step metadata and validators — single source of truth for gating logic. */
+export const deployAgentWizardStepRegistry: DeployAgentWizardStepConfig[] = [
+  {
+    name: DeployAgentWizardStepTitle.IMAGE_SELECTION,
+    id: 'deploy-agent-image-selection-step',
+    isValid: deployAgentWizardStepValidators.isImageSelectionStepValid,
+  },
+  {
+    name: DeployAgentWizardStepTitle.CONFIGURATION,
+    id: 'deploy-agent-configuration-step',
+    isValid: deployAgentWizardStepValidators.isConfigurationStepValid,
+  },
+  {
+    name: DeployAgentWizardStepTitle.NETWORKING,
+    id: 'deploy-agent-networking-step',
+    isValid: deployAgentWizardStepValidators.isPlaceholderStepValid,
+  },
+  {
+    name: DeployAgentWizardStepTitle.SECURITY_AND_IDENTITY,
+    id: 'deploy-agent-security-and-identity-step',
+    isValid: deployAgentWizardStepValidators.isPlaceholderStepValid,
+  },
+  {
+    name: DeployAgentWizardStepTitle.ENVIRONMENT_VARIABLES,
+    id: 'deploy-agent-environment-variables-step',
+    isValid: deployAgentWizardStepValidators.isPlaceholderStepValid,
+  },
+  {
+    name: DeployAgentWizardStepTitle.SUMMARY,
+    id: 'deploy-agent-summary-step',
+    isValid: deployAgentWizardStepValidators.isSummaryStepValid,
+  },
+];
+
+/** Whether the user may navigate to a wizard step (all prior steps must be valid). */
+export const isDeployAgentWizardStepAccessible = (
+  stepIndex: number,
+  state: DeployAgentWizardValidationState,
+  steps: Pick<DeployAgentWizardStepConfig, 'isValid'>[] = deployAgentWizardStepRegistry,
+): boolean => {
+  if (stepIndex < 1 || stepIndex > steps.length) {
+    return false;
+  }
+
+  for (let i = 0; i < stepIndex - 1; i++) {
+    if (!steps[i]?.isValid(state)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/** Whether the active step passes validation (controls Next / Submit). */
+export const isDeployAgentWizardStepValid = (
+  stepIndex: number,
+  state: DeployAgentWizardValidationState,
+  steps: Pick<DeployAgentWizardStepConfig, 'isValid'>[] = deployAgentWizardStepRegistry,
+): boolean => {
+  if (stepIndex < 1 || stepIndex > steps.length) {
+    return false;
+  }
+  return steps[stepIndex - 1]?.isValid(state) ?? false;
+};

--- a/packages/agent-ops/frontend/src/app/deployWizard/steps/ConfigurationStep.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/steps/ConfigurationStep.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
+import FormSection from '@odh-dashboard/internal/components/pf-overrides/FormSection';
+import {
+  Checkbox,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { useAgentDeployWizardContext } from '~/app/deployWizard/useAgentDeployWizard';
+import DeployWizardSelectField from '~/app/deployWizard/DeployWizardSelectField';
+import {
+  DEPLOY_WIZARD_SELECT_MAX_MENU_HEIGHT,
+  protocolOptions,
+  workloadTypeOptions,
+} from '~/app/deployWizard/wizardOptions';
+import { isValidK8sStorageQuantity } from '~/app/deployWizard/utils';
+
+const ConfigurationStep: React.FC = () => {
+  const { formData, setFormField } = useAgentDeployWizardContext();
+
+  const pvcSizeInvalid =
+    formData.enablePersistentStorage && !isValidK8sStorageQuantity(formData.persistentVolumeSize);
+
+  return (
+    <Form>
+      <FormSection title="Configuration">
+        <FormGroup label="Protocol" isRequired fieldId="deploy-agent-protocol">
+          <DeployWizardSelectField>
+            <SimpleSelect
+              dataTestId="deploy-agent-protocol-select"
+              placeholder="Select a protocol"
+              value={formData.protocol}
+              options={protocolOptions}
+              onChange={(key) => setFormField('protocol', key)}
+              isFullWidth
+              maxMenuHeight={DEPLOY_WIZARD_SELECT_MAX_MENU_HEIGHT}
+              popperProps={{ appendTo: 'inline' }}
+              toggleProps={{ id: 'deploy-agent-protocol', 'aria-label': 'Protocol' }}
+            />
+          </DeployWizardSelectField>
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>
+                Sets protocol.kagent.io/&lt;protocol&gt; label. Example: A2A (Agent-to-Agent).
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+        <FormGroup label="Workload type" isRequired fieldId="deploy-agent-workload-type">
+          <DeployWizardSelectField>
+            <SimpleSelect
+              dataTestId="deploy-agent-workload-type-select"
+              placeholder="Select a workload type"
+              value={formData.workloadType}
+              options={workloadTypeOptions}
+              onChange={(key) => setFormField('workloadType', key)}
+              isFullWidth
+              maxMenuHeight={DEPLOY_WIZARD_SELECT_MAX_MENU_HEIGHT}
+              popperProps={{ appendTo: 'inline' }}
+              toggleProps={{ id: 'deploy-agent-workload-type', 'aria-label': 'Workload type' }}
+            />
+          </DeployWizardSelectField>
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>
+                Kubernetes-native sandbox with stable identity, persistent storage, and lifecycle
+                management (pause/resume/expire)
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+        <FormGroup fieldId="deploy-agent-enable-persistent-storage">
+          <Checkbox
+            id="deploy-agent-enable-persistent-storage"
+            data-testid="deploy-agent-enable-persistent-storage"
+            label="Enable persistent storage"
+            isChecked={formData.enablePersistentStorage}
+            onChange={(_event, checked) => setFormField('enablePersistentStorage', checked)}
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>PVC for /shared mount; emptyDir when unchecked</HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+        {formData.enablePersistentStorage && (
+          <FormGroup
+            label="Persistent volume size"
+            isRequired
+            fieldId="deploy-agent-persistent-volume-size"
+          >
+            <TextInput
+              id="deploy-agent-persistent-volume-size"
+              data-testid="deploy-agent-persistent-volume-size"
+              value={formData.persistentVolumeSize}
+              validated={pvcSizeInvalid ? ValidatedOptions.error : ValidatedOptions.default}
+              aria-invalid={pvcSizeInvalid}
+              aria-describedby={
+                pvcSizeInvalid
+                  ? 'deploy-agent-persistent-volume-size-error'
+                  : 'deploy-agent-persistent-volume-size-helper'
+              }
+              onChange={(_event, value) => setFormField('persistentVolumeSize', value)}
+              placeholder="1Gi"
+            />
+            <FormHelperText id="deploy-agent-persistent-volume-size-helper">
+              <HelperText>
+                <HelperTextItem>e.g., 1Gi</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+            {pvcSizeInvalid && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem id="deploy-agent-persistent-volume-size-error" variant="error">
+                    Enter a valid storage size (e.g., 1Gi).
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
+          </FormGroup>
+        )}
+      </FormSection>
+    </Form>
+  );
+};
+
+export default ConfigurationStep;

--- a/packages/agent-ops/frontend/src/app/deployWizard/steps/ConfigurationStep.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/steps/ConfigurationStep.tsx
@@ -46,7 +46,7 @@ const ConfigurationStep: React.FC = () => {
           <FormHelperText>
             <HelperText>
               <HelperTextItem>
-                Sets protocol.kagent.io/&lt;protocol&gt; label. Example: A2A (Agent-to-Agent).
+                Sets protocol.kagenti.io/&lt;protocol&gt; label. Example: A2A (Agent-to-Agent).
               </HelperTextItem>
             </HelperText>
           </FormHelperText>

--- a/packages/agent-ops/frontend/src/app/deployWizard/steps/ImageSelectionStep.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/steps/ImageSelectionStep.tsx
@@ -23,8 +23,8 @@ const ImageSelectionStep: React.FC = () => {
   const { projectNamespaces, isLoading, onProjectSelection } = useAgentOpsProjectNamespaces();
 
   const effectiveNamespaces = React.useMemo(
-    () => getEffectiveProjectNamespaces(projectNamespaces, formData.project),
-    [projectNamespaces, formData.project],
+    () => getEffectiveProjectNamespaces(projectNamespaces, isLoading, formData.project),
+    [projectNamespaces, isLoading, formData.project],
   );
 
   const agentNameInvalid =

--- a/packages/agent-ops/frontend/src/app/deployWizard/steps/ImageSelectionStep.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/steps/ImageSelectionStep.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import ProjectSelector from '@odh-dashboard/internal/concepts/projects/ProjectSelector';
+import {
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import FormSection from '@odh-dashboard/internal/components/pf-overrides/FormSection';
+import { useAgentDeployWizardContext } from '~/app/deployWizard/useAgentDeployWizard';
+import DeployWizardSelectField from '~/app/deployWizard/DeployWizardSelectField';
+import { isValidAgentName, isValidPullSecretName } from '~/app/deployWizard/utils';
+import {
+  getEffectiveProjectNamespaces,
+  useAgentOpsProjectNamespaces,
+} from '~/app/hooks/useAgentOpsProjectNamespaces';
+
+const ImageSelectionStep: React.FC = () => {
+  const { formData, setFormField, setAgentNameManuallyEdited } = useAgentDeployWizardContext();
+  const { projectNamespaces, isLoading, onProjectSelection } = useAgentOpsProjectNamespaces();
+
+  const effectiveNamespaces = React.useMemo(
+    () => getEffectiveProjectNamespaces(projectNamespaces, formData.project),
+    [projectNamespaces, formData.project],
+  );
+
+  const agentNameInvalid =
+    formData.agentName.trim().length > 0 && !isValidAgentName(formData.agentName);
+
+  const pullSecretInvalid =
+    formData.pullSecret.trim().length > 0 && !isValidPullSecretName(formData.pullSecret);
+
+  return (
+    <Form>
+      <FormSection title="Image selection">
+        <FormGroup label="Project" isRequired fieldId="deploy-agent-project">
+          <DeployWizardSelectField>
+            <ProjectSelector
+              namespace={formData.project}
+              onSelection={(projectName) => {
+                setFormField('project', projectName);
+                onProjectSelection(projectName);
+              }}
+              placeholder="Select a project"
+              selectorLabel="Project"
+              isFullWidth
+              isLoading={isLoading}
+              namespacesOverride={effectiveNamespaces}
+            />
+          </DeployWizardSelectField>
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>The namespace where the agent will be deployed</HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+        <FormGroup label="Container image" isRequired fieldId="deploy-agent-container-image">
+          <TextInput
+            id="deploy-agent-container-image"
+            data-testid="deploy-agent-container-image"
+            value={formData.containerImage}
+            onChange={(_event, value) => setFormField('containerImage', value)}
+            placeholder="quay.io/myorg/my-agent"
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>
+                Full image path without tag (e.g., quay.io/myorg/my-agent)
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+        <FormGroup label="Image tag" isRequired fieldId="deploy-agent-image-tag">
+          <TextInput
+            id="deploy-agent-image-tag"
+            data-testid="deploy-agent-image-tag"
+            value={formData.imageTag}
+            onChange={(_event, value) => setFormField('imageTag', value)}
+            placeholder="latest"
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>Tag to apply to the image (e.g., latest, v1.0.0)</HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+        <FormGroup label="Agent name" isRequired fieldId="deploy-agent-name">
+          <TextInput
+            id="deploy-agent-name"
+            data-testid="deploy-agent-name"
+            value={formData.agentName}
+            validated={agentNameInvalid ? ValidatedOptions.error : ValidatedOptions.default}
+            aria-invalid={agentNameInvalid}
+            aria-describedby={
+              agentNameInvalid ? 'deploy-agent-name-error' : 'deploy-agent-name-helper'
+            }
+            onChange={(_event, value) => {
+              setAgentNameManuallyEdited(true);
+              setFormField('agentName', value);
+            }}
+          />
+          <FormHelperText id="deploy-agent-name-helper">
+            <HelperText>
+              <HelperTextItem>
+                Kubernetes resource name. Auto-generated from the image name; you can edit it.
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+          {agentNameInvalid && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem id="deploy-agent-name-error" variant="error">
+                  Agent name must be a valid DNS-1123 label.
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
+        </FormGroup>
+        <FormGroup label="Pull secret" fieldId="deploy-agent-pull-secret">
+          <TextInput
+            id="deploy-agent-pull-secret"
+            data-testid="deploy-agent-pull-secret"
+            value={formData.pullSecret}
+            validated={pullSecretInvalid ? ValidatedOptions.error : ValidatedOptions.default}
+            aria-invalid={pullSecretInvalid}
+            aria-describedby={
+              pullSecretInvalid
+                ? 'deploy-agent-pull-secret-error'
+                : 'deploy-agent-pull-secret-helper'
+            }
+            onChange={(_event, value) => setFormField('pullSecret', value)}
+          />
+          <FormHelperText id="deploy-agent-pull-secret-helper">
+            <HelperText>
+              <HelperTextItem>
+                Optional secret name for pulling private container images
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+          {pullSecretInvalid && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem id="deploy-agent-pull-secret-error" variant="error">
+                  Pull secret must be a valid Kubernetes resource name.
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
+        </FormGroup>
+      </FormSection>
+    </Form>
+  );
+};
+
+export default ImageSelectionStep;

--- a/packages/agent-ops/frontend/src/app/deployWizard/steps/PlaceholderStep.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/steps/PlaceholderStep.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import {
+  Form,
+  FormGroup,
+  FormHelperText,
+  FormSection,
+  HelperText,
+  HelperTextItem,
+  Title,
+} from '@patternfly/react-core';
+
+type PlaceholderStepProps = {
+  title: string;
+};
+
+const PlaceholderStep: React.FC<PlaceholderStepProps> = ({ title }) => (
+  <Form>
+    <FormSection title={title}>
+      <FormGroup label={title} fieldId={`deploy-agent-${title.toLowerCase().replace(/\s+/g, '-')}`}>
+        <Title headingLevel="h3" size="md">
+          Coming soon
+        </Title>
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>This step will be implemented in a follow-up story.</HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+    </FormSection>
+  </Form>
+);
+
+export default PlaceholderStep;

--- a/packages/agent-ops/frontend/src/app/deployWizard/types.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/types.ts
@@ -1,0 +1,43 @@
+export enum DeployAgentWizardStepTitle {
+  IMAGE_SELECTION = 'Image selection',
+  CONFIGURATION = 'Configuration',
+  NETWORKING = 'Networking',
+  SECURITY_AND_IDENTITY = 'Security and identity',
+  ENVIRONMENT_VARIABLES = 'Environment Variables',
+  SUMMARY = 'Summary',
+}
+
+export type DeployAgentWizardFormData = {
+  project: string;
+  containerImage: string;
+  imageTag: string;
+  agentName: string;
+  pullSecret: string;
+  fullImageReference: string;
+  protocol: string;
+  workloadType: string;
+  enablePersistentStorage: boolean;
+  persistentVolumeSize: string;
+  // TODO(RHOAIENG-62719): framework — mockup summary shows LangGraph; no BFF source yet
+};
+
+export type DeployAgentWizardLocationState = {
+  namespace?: string;
+  returnRoute?: string;
+};
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === 'string';
+
+const isUnknownRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+export const isDeployAgentWizardLocationState = (
+  state: unknown,
+): state is DeployAgentWizardLocationState => {
+  if (!isUnknownRecord(state)) {
+    return false;
+  }
+
+  return isOptionalString(state.namespace) && isOptionalString(state.returnRoute);
+};

--- a/packages/agent-ops/frontend/src/app/deployWizard/useAgentDeployWizard.tsx
+++ b/packages/agent-ops/frontend/src/app/deployWizard/useAgentDeployWizard.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import {
+  DEFAULT_IMAGE_TAG,
+  DEFAULT_PERSISTENT_VOLUME_SIZE,
+  DEFAULT_PROTOCOL,
+} from './wizardOptions';
+import type { DeployAgentWizardFormData } from './types';
+import { buildFullImageReference, deriveAgentNameFromImage } from './utils';
+
+export type DeployAgentWizardFormField = keyof DeployAgentWizardFormData;
+
+type AgentDeployWizardContextValue = {
+  formData: DeployAgentWizardFormData;
+  setFormField: <K extends DeployAgentWizardFormField>(
+    field: K,
+    value: DeployAgentWizardFormData[K],
+  ) => void;
+  isDirty: boolean;
+  setAgentNameManuallyEdited: (value: boolean) => void;
+};
+
+const AgentDeployWizardContext = React.createContext<AgentDeployWizardContextValue | null>(null);
+
+export const createInitialFormData = (namespace: string): DeployAgentWizardFormData => ({
+  project: namespace,
+  containerImage: '',
+  imageTag: DEFAULT_IMAGE_TAG,
+  agentName: '',
+  pullSecret: '',
+  fullImageReference: '',
+  protocol: DEFAULT_PROTOCOL,
+  workloadType: '',
+  enablePersistentStorage: false,
+  persistentVolumeSize: DEFAULT_PERSISTENT_VOLUME_SIZE,
+});
+
+const FORM_FIELDS: DeployAgentWizardFormField[] = [
+  'project',
+  'containerImage',
+  'imageTag',
+  'agentName',
+  'pullSecret',
+  'fullImageReference',
+  'protocol',
+  'workloadType',
+  'enablePersistentStorage',
+  'persistentVolumeSize',
+];
+
+const isFormDataEqual = (
+  left: DeployAgentWizardFormData,
+  right: DeployAgentWizardFormData,
+): boolean => FORM_FIELDS.every((key) => left[key] === right[key]);
+
+type AgentDeployWizardProviderProps = {
+  namespace: string;
+  children: React.ReactNode;
+};
+
+export const AgentDeployWizardProvider: React.FC<AgentDeployWizardProviderProps> = ({
+  namespace,
+  children,
+}) => {
+  const initialFormData = React.useMemo(() => createInitialFormData(namespace), [namespace]);
+  const [formData, setFormData] = React.useState<DeployAgentWizardFormData>(initialFormData);
+  const agentNameManuallyEditedRef = React.useRef(false);
+
+  const setAgentNameManuallyEdited = React.useCallback((value: boolean) => {
+    agentNameManuallyEditedRef.current = value;
+  }, []);
+
+  const setFormField = React.useCallback(
+    <K extends DeployAgentWizardFormField>(field: K, value: DeployAgentWizardFormData[K]) => {
+      setFormData((current) => {
+        const next = { ...current, [field]: value };
+
+        if (field === 'containerImage' && typeof value === 'string') {
+          if (!agentNameManuallyEditedRef.current) {
+            next.agentName = deriveAgentNameFromImage(value);
+          }
+          next.fullImageReference = buildFullImageReference(value, current.imageTag);
+        }
+
+        if (field === 'imageTag' && typeof value === 'string') {
+          next.fullImageReference = buildFullImageReference(current.containerImage, value);
+        }
+
+        return next;
+      });
+    },
+    [],
+  );
+
+  const isDirty = !isFormDataEqual(formData, initialFormData);
+
+  const value = React.useMemo(
+    () => ({
+      formData,
+      setFormField,
+      isDirty,
+      setAgentNameManuallyEdited,
+    }),
+    [formData, setFormField, isDirty, setAgentNameManuallyEdited],
+  );
+
+  return (
+    <AgentDeployWizardContext.Provider value={value}>{children}</AgentDeployWizardContext.Provider>
+  );
+};
+
+export const useAgentDeployWizardContext = (): AgentDeployWizardContextValue => {
+  const context = React.useContext(AgentDeployWizardContext);
+  if (!context) {
+    throw new Error('useAgentDeployWizardContext must be used within AgentDeployWizardProvider');
+  }
+  return context;
+};

--- a/packages/agent-ops/frontend/src/app/deployWizard/useAgentDeployWizardValidation.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/useAgentDeployWizardValidation.ts
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import {
+  createDeployAgentWizardValidationState,
+  deployAgentWizardStepRegistry,
+  isDeployAgentWizardStepAccessible,
+  isDeployAgentWizardStepValid,
+  type DeployAgentWizardValidationState,
+} from './deployAgentWizardValidation';
+import type { DeployAgentWizardFormData } from './types';
+
+export type DeployAgentWizardValidation = DeployAgentWizardValidationState & {
+  isStepAccessible: (stepIndex: number) => boolean;
+  isCurrentStepValid: (stepIndex: number) => boolean;
+  isNextStepDisabled: (stepIndex: number) => boolean;
+};
+
+export const useAgentDeployWizardValidation = (
+  formData: DeployAgentWizardFormData,
+): DeployAgentWizardValidation => {
+  const validationState = React.useMemo(
+    () => createDeployAgentWizardValidationState(formData),
+    [formData],
+  );
+
+  const isStepAccessible = React.useCallback(
+    (stepIndex: number): boolean =>
+      isDeployAgentWizardStepAccessible(stepIndex, validationState, deployAgentWizardStepRegistry),
+    [validationState],
+  );
+
+  const isCurrentStepValid = React.useCallback(
+    (stepIndex: number): boolean =>
+      isDeployAgentWizardStepValid(stepIndex, validationState, deployAgentWizardStepRegistry),
+    [validationState],
+  );
+
+  const isNextStepDisabled = React.useCallback(
+    (stepIndex: number): boolean => !isCurrentStepValid(stepIndex),
+    [isCurrentStepValid],
+  );
+
+  return React.useMemo(
+    () => ({
+      ...validationState,
+      isStepAccessible,
+      isCurrentStepValid,
+      isNextStepDisabled,
+    }),
+    [validationState, isStepAccessible, isCurrentStepValid, isNextStepDisabled],
+  );
+};

--- a/packages/agent-ops/frontend/src/app/deployWizard/useExitDeployAgentWizard.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/useExitDeployAgentWizard.ts
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { agentOpsDeploymentsRoute, sanitizeAgentOpsReturnRoute } from '~/app/utilities/routes';
+
+type UseExitDeployAgentWizardOptions = {
+  namespace: string;
+  returnRoute?: string;
+  isDirty?: boolean;
+  isDeployFormValid?: boolean;
+};
+
+type UseExitDeployAgentWizardReturn = {
+  isExitModalOpen: boolean;
+  openExitModal: () => void;
+  closeExitModal: () => void;
+  handleExitConfirm: () => void;
+  exitWizard: () => void;
+  exitWizardOnSubmit: () => void;
+};
+
+export const useExitDeployAgentWizard = (
+  options: UseExitDeployAgentWizardOptions,
+): UseExitDeployAgentWizardReturn => {
+  const { namespace, returnRoute, isDirty = false, isDeployFormValid = false } = options;
+  const navigate = useNavigate();
+  const [isExitModalOpen, setIsExitModalOpen] = React.useState(false);
+
+  const deploymentsRoute = agentOpsDeploymentsRoute(namespace);
+  const cancelRoute = deploymentsRoute;
+  const successRoute = sanitizeAgentOpsReturnRoute(returnRoute, namespace);
+
+  const navigateToCancelRoute = React.useCallback(() => {
+    navigate(cancelRoute);
+  }, [navigate, cancelRoute]);
+
+  const openExitModal = React.useCallback(() => {
+    setIsExitModalOpen(true);
+  }, []);
+
+  const closeExitModal = React.useCallback(() => {
+    setIsExitModalOpen(false);
+  }, []);
+
+  const handleExitConfirm = React.useCallback(() => {
+    setIsExitModalOpen(false);
+    navigateToCancelRoute();
+  }, [navigateToCancelRoute]);
+
+  const exitWizard = React.useCallback(() => {
+    if (isDirty) {
+      openExitModal();
+      return;
+    }
+    navigateToCancelRoute();
+  }, [isDirty, openExitModal, navigateToCancelRoute]);
+
+  const exitWizardOnSubmit = React.useCallback(() => {
+    if (!isDeployFormValid) {
+      // eslint-disable-next-line no-console -- surfaces unexpected submit attempts during development
+      console.error('useExitDeployAgentWizard: exitWizardOnSubmit called with invalid form');
+      return;
+    }
+    // Stub: deploy logic will be implemented in a follow-up.
+    navigate(successRoute);
+  }, [isDeployFormValid, navigate, successRoute]);
+
+  return {
+    isExitModalOpen,
+    openExitModal,
+    closeExitModal,
+    handleExitConfirm,
+    exitWizard,
+    exitWizardOnSubmit,
+  };
+};

--- a/packages/agent-ops/frontend/src/app/deployWizard/useNavigateToDeployAgentWizard.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/useNavigateToDeployAgentWizard.ts
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  agentOpsDeploymentsRoute,
+  getAgentDeployWizardRoute,
+  isSafeAgentOpsInternalRoute,
+} from '~/app/utilities/routes';
+import type { DeployAgentWizardLocationState } from './types';
+
+export const useNavigateToDeployAgentWizard = (): ((namespace?: string) => void) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  return React.useCallback(
+    (namespace?: string) => {
+      if (!namespace) {
+        return;
+      }
+
+      const returnRoute = isSafeAgentOpsInternalRoute(location.pathname)
+        ? location.pathname
+        : agentOpsDeploymentsRoute(namespace);
+
+      const state: DeployAgentWizardLocationState = {
+        namespace,
+        returnRoute,
+      };
+
+      navigate(getAgentDeployWizardRoute(), { state });
+    },
+    [navigate, location.pathname],
+  );
+};

--- a/packages/agent-ops/frontend/src/app/deployWizard/utils.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/utils.ts
@@ -1,0 +1,105 @@
+const K8S_STORAGE_QUANTITY_REGEX = /^\d+(\.\d+)?(Gi|Mi|Ti|G|M|T)$/;
+const K8S_NAME_REGEX = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+const K8S_DNS_SUBDOMAIN_REGEX = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+const MAX_DNS1123_LABEL_LENGTH = 63;
+const MAX_DNS_SUBDOMAIN_LENGTH = 253;
+
+const translateImageSegmentToK8sName = (name: string): string => {
+  const translatedName = name
+    .toLowerCase()
+    .replace(/\s/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/^-*/, '')
+    .replace(/-*$/, '')
+    .replace(/[-]+/g, '-');
+
+  if (/^\d+/.test(translatedName)) {
+    return `a-${translatedName}`;
+  }
+
+  return translatedName;
+};
+
+const getImageNameFromLastSegment = (segment: string): string => {
+  const digestSeparatorIndex = segment.indexOf('@');
+  if (digestSeparatorIndex !== -1) {
+    return segment.slice(0, digestSeparatorIndex);
+  }
+
+  const tagSeparatorIndex = segment.lastIndexOf(':');
+  if (tagSeparatorIndex !== -1) {
+    return segment.slice(0, tagSeparatorIndex);
+  }
+
+  return segment;
+};
+
+const isDigestPinnedImage = (containerImage: string): boolean => {
+  const lastSegment = containerImage.split('/').pop() ?? containerImage;
+  return lastSegment.includes('@');
+};
+
+export const deriveAgentNameFromImage = (containerImage: string): string => {
+  const trimmedImage = containerImage.trim();
+  if (!trimmedImage) {
+    return '';
+  }
+
+  const lastSegment = trimmedImage.split('/').filter(Boolean).pop() ?? trimmedImage;
+
+  return translateImageSegmentToK8sName(getImageNameFromLastSegment(lastSegment));
+};
+
+export const stripContainerImageTag = (containerImage: string): string => {
+  const trimmed = containerImage.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (isDigestPinnedImage(trimmed)) {
+    return trimmed;
+  }
+
+  const parts = trimmed.split('/');
+  const lastSegment = parts[parts.length - 1];
+  const tagSeparatorIndex = lastSegment.lastIndexOf(':');
+  if (tagSeparatorIndex === -1) {
+    return trimmed;
+  }
+
+  parts[parts.length - 1] = lastSegment.slice(0, tagSeparatorIndex);
+  return parts.join('/');
+};
+
+export const buildFullImageReference = (containerImage: string, imageTag: string): string => {
+  const imageWithoutTag = stripContainerImageTag(containerImage);
+  const trimmedTag = imageTag.trim();
+
+  if (!imageWithoutTag) {
+    return '';
+  }
+
+  if (isDigestPinnedImage(imageWithoutTag)) {
+    return imageWithoutTag;
+  }
+
+  return trimmedTag ? `${imageWithoutTag}:${trimmedTag}` : imageWithoutTag;
+};
+
+export const isValidK8sStorageQuantity = (size: string): boolean =>
+  K8S_STORAGE_QUANTITY_REGEX.test(size.trim());
+
+export const isValidAgentName = (name: string): boolean => {
+  const trimmed = name.trim();
+  return (
+    trimmed.length > 0 && trimmed.length <= MAX_DNS1123_LABEL_LENGTH && K8S_NAME_REGEX.test(trimmed)
+  );
+};
+
+export const isValidPullSecretName = (name: string): boolean => {
+  const trimmed = name.trim();
+  if (trimmed === '') {
+    return true;
+  }
+  return trimmed.length <= MAX_DNS_SUBDOMAIN_LENGTH && K8S_DNS_SUBDOMAIN_REGEX.test(trimmed);
+};

--- a/packages/agent-ops/frontend/src/app/deployWizard/wizardOptions.ts
+++ b/packages/agent-ops/frontend/src/app/deployWizard/wizardOptions.ts
@@ -1,0 +1,49 @@
+import type { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect';
+import { DeployAgentWizardStepTitle } from './types';
+
+export const DEFAULT_IMAGE_TAG = 'latest';
+export const DEFAULT_PROTOCOL = 'a2a';
+export const DEFAULT_PERSISTENT_VOLUME_SIZE = '1Gi';
+/** Max toggle width for wizard dropdowns; keep in sync with DeployWizardSelectField.scss. */
+export const DEPLOY_WIZARD_SELECT_MAX_WIDTH = '28rem';
+/** Matches in-form SearchSelector / SimpleSelect menu height elsewhere in the dashboard. */
+export const DEPLOY_WIZARD_SELECT_MAX_MENU_HEIGHT = '200px';
+/** Matches in-form SimpleSelect menus (SearchSelector, AutoML configure). */
+export const deployAgentWizardStepSubtitles: Record<DeployAgentWizardStepTitle, string> = {
+  [DeployAgentWizardStepTitle.IMAGE_SELECTION]:
+    'Specify the container image and where the agent will be deployed.',
+  [DeployAgentWizardStepTitle.CONFIGURATION]:
+    'Configure protocol and workload settings for the agent.',
+  [DeployAgentWizardStepTitle.NETWORKING]: 'Configure networking settings for the agent.',
+  [DeployAgentWizardStepTitle.SECURITY_AND_IDENTITY]:
+    'Configure security and identity settings for the agent.',
+  [DeployAgentWizardStepTitle.ENVIRONMENT_VARIABLES]:
+    'Configure environment variables for the agent.',
+  [DeployAgentWizardStepTitle.SUMMARY]: 'Review your agent deployment configuration.',
+};
+
+export const protocolOptions: SimpleSelectOption[] = [
+  {
+    key: 'a2a',
+    label: 'A2A (Agent-to-Agent)',
+  },
+  {
+    key: 'mcp',
+    label: 'MCP',
+  },
+];
+
+export const workloadTypeOptions: SimpleSelectOption[] = [
+  {
+    key: 'deployment',
+    label: 'Deployment',
+  },
+  {
+    key: 'statefulset',
+    label: 'StatefulSet',
+  },
+  {
+    key: 'job',
+    label: 'Job',
+  },
+];

--- a/packages/agent-ops/frontend/src/app/hooks/__tests__/useAgentOpsProjectNamespaces.spec.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/__tests__/useAgentOpsProjectNamespaces.spec.ts
@@ -1,0 +1,25 @@
+import { getEffectiveProjectNamespaces } from '~/app/hooks/useAgentOpsProjectNamespaces';
+
+describe('getEffectiveProjectNamespaces', () => {
+  const team1 = [{ name: 'team1', displayName: 'team1' }];
+
+  it('returns project list when non-empty', () => {
+    expect(getEffectiveProjectNamespaces(team1, false, 'fallback')).toEqual(team1);
+    expect(getEffectiveProjectNamespaces(team1, true, 'fallback')).toEqual(team1);
+  });
+
+  it('synthesizes fallback namespace only while loading', () => {
+    expect(getEffectiveProjectNamespaces([], true, 'team1')).toEqual([
+      { name: 'team1', displayName: 'team1' },
+    ]);
+  });
+
+  it('returns empty list when loaded with no projects', () => {
+    expect(getEffectiveProjectNamespaces([], false, 'team1')).toEqual([]);
+  });
+
+  it('returns empty list when loaded with no fallback', () => {
+    expect(getEffectiveProjectNamespaces([], false)).toEqual([]);
+    expect(getEffectiveProjectNamespaces([], true)).toEqual([]);
+  });
+});

--- a/packages/agent-ops/frontend/src/app/hooks/__tests__/useCanDeployAgent.spec.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/__tests__/useCanDeployAgent.spec.ts
@@ -1,0 +1,39 @@
+import { useAccessReview } from '@odh-dashboard/internal/api/index';
+import { useCanDeployAgent } from '~/app/hooks/useCanDeployAgent';
+import { testHook } from '~/__tests__/unit/testUtils/hooks';
+
+jest.mock('@odh-dashboard/internal/api/index', () => ({
+  useAccessReview: jest.fn(),
+}));
+
+const mockUseAccessReview = jest.mocked(useAccessReview);
+
+describe('useCanDeployAgent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns select-project message when namespace is missing', () => {
+    mockUseAccessReview.mockReturnValue([false, false]);
+
+    const { result } = testHook(useCanDeployAgent)();
+
+    expect(result.current).toEqual({
+      canDeploy: false,
+      loaded: true,
+      disabledReason: 'Select a project to deploy an agent',
+    });
+  });
+
+  it('returns checking-access message while permissions are loading', () => {
+    mockUseAccessReview.mockReturnValue([false, false]);
+
+    const { result } = testHook(useCanDeployAgent)('team1');
+
+    expect(result.current).toEqual({
+      canDeploy: false,
+      loaded: false,
+      disabledReason: 'Checking access...',
+    });
+  });
+});

--- a/packages/agent-ops/frontend/src/app/hooks/useAgentOpsProjectNamespaces.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useAgentOpsProjectNamespaces.ts
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { isAvailableProject } from '@odh-dashboard/internal/concepts/projects/utils';
+import type { Namespace } from '@odh-dashboard/internal/types';
+import { useNamespaceSelector } from 'mod-arch-core';
+import { useProjectsBridge } from '~/odh/context/ProjectsBridgeContext';
+
+const toNamespace = (name: string, displayName?: string): Namespace => ({
+  name,
+  displayName: displayName || name,
+});
+
+/** Ensures the current namespace appears in the list while bridge/selector data is loading. */
+export const getEffectiveProjectNamespaces = (
+  projectNamespaces: Namespace[],
+  fallbackNamespace?: string,
+): Namespace[] => {
+  if (projectNamespaces.length > 0) {
+    return projectNamespaces;
+  }
+  if (fallbackNamespace) {
+    return [{ name: fallbackNamespace, displayName: fallbackNamespace }];
+  }
+  return projectNamespaces;
+};
+
+export const useAgentOpsProjectNamespaces = (): {
+  projectNamespaces: Namespace[];
+  isLoading: boolean;
+  onProjectSelection: (projectName: string) => void;
+} => {
+  const {
+    bridgeActive,
+    projects: bridgeProjects,
+    loaded: bridgeLoaded,
+    loadError: bridgeLoadError,
+    updatePreferredProject,
+  } = useProjectsBridge();
+  const { namespaces, namespacesLoaded, namespacesLoadError, updatePreferredNamespace } =
+    useNamespaceSelector();
+
+  const filteredNamespaces = React.useMemo(
+    () =>
+      namespaces
+        .filter((namespace) => isAvailableProject(namespace.name, ''))
+        .map((namespace) => toNamespace(namespace.name, namespace.displayName)),
+    [namespaces],
+  );
+
+  const bridgedNamespaces = React.useMemo(
+    () => bridgeProjects.map((project) => toNamespace(project.name, project.displayName)),
+    [bridgeProjects],
+  );
+
+  const bridgeIsLoading = bridgeActive && !bridgeLoaded && !bridgeLoadError;
+  const bridgeHasProjects = bridgeActive && bridgeLoaded && bridgeProjects.length > 0;
+
+  const projectNamespaces = bridgeHasProjects
+    ? bridgedNamespaces
+    : bridgeActive
+      ? []
+      : filteredNamespaces;
+
+  const isLoading = bridgeActive ? bridgeIsLoading : !namespacesLoaded && !namespacesLoadError;
+
+  const onProjectSelection = React.useCallback(
+    (projectName: string) => {
+      if (bridgeActive) {
+        updatePreferredProject(projectName ? { name: projectName } : null);
+        return;
+      }
+
+      const match = projectName
+        ? (namespaces.find((namespace) => namespace.name === projectName) ?? undefined)
+        : undefined;
+      updatePreferredNamespace(match);
+    },
+    [bridgeActive, namespaces, updatePreferredProject, updatePreferredNamespace],
+  );
+
+  return {
+    projectNamespaces,
+    isLoading,
+    onProjectSelection,
+  };
+};

--- a/packages/agent-ops/frontend/src/app/hooks/useAgentOpsProjectNamespaces.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useAgentOpsProjectNamespaces.ts
@@ -12,12 +12,13 @@ const toNamespace = (name: string, displayName?: string): Namespace => ({
 /** Ensures the current namespace appears in the list while bridge/selector data is loading. */
 export const getEffectiveProjectNamespaces = (
   projectNamespaces: Namespace[],
+  isLoading: boolean,
   fallbackNamespace?: string,
 ): Namespace[] => {
   if (projectNamespaces.length > 0) {
     return projectNamespaces;
   }
-  if (fallbackNamespace) {
+  if (isLoading && fallbackNamespace) {
     return [{ name: fallbackNamespace, displayName: fallbackNamespace }];
   }
   return projectNamespaces;

--- a/packages/agent-ops/frontend/src/app/hooks/useCanDeployAgent.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useCanDeployAgent.ts
@@ -1,0 +1,50 @@
+import { useAccessReview } from '@odh-dashboard/internal/api/index';
+
+type UseCanDeployAgentResult = {
+  canDeploy: boolean;
+  loaded: boolean;
+  disabledReason: string;
+};
+
+export const useCanDeployAgent = (namespace?: string): UseCanDeployAgentResult => {
+  const shouldCheck = !!namespace;
+  const [canCreateAgentRuntime, accessLoaded] = useAccessReview(
+    {
+      group: 'agent.kagenti.dev',
+      resource: 'agentruntimes',
+      verb: 'create',
+      namespace: namespace ?? '',
+    },
+    shouldCheck,
+  );
+
+  if (!namespace) {
+    return {
+      canDeploy: false,
+      loaded: true,
+      disabledReason: 'Select a project to deploy an agent',
+    };
+  }
+
+  if (!accessLoaded) {
+    return {
+      canDeploy: false,
+      loaded: false,
+      disabledReason: 'Checking access...',
+    };
+  }
+
+  if (!canCreateAgentRuntime) {
+    return {
+      canDeploy: false,
+      loaded: true,
+      disabledReason: 'You do not have permission to deploy agents in this project',
+    };
+  }
+
+  return {
+    canDeploy: true,
+    loaded: true,
+    disabledReason: '',
+  };
+};

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -17,6 +17,7 @@ import {
 import { BanIcon, CubesIcon } from '@patternfly/react-icons';
 import { useNamespaceSelector } from 'mod-arch-core';
 import AgentOpsProjectSelector from '~/app/components/AgentOpsProjectSelector';
+import { useNavigateToDeployAgentWizard } from '~/app/deployWizard/useNavigateToDeployAgentWizard';
 import { useListAgentRuntimes } from '~/app/hooks/useListAgentRuntimes';
 import { agentOpsDeploymentsRoute } from '~/app/utilities/routes';
 import AgentDeploymentsEmptyState from './AgentDeploymentsEmptyState';
@@ -27,6 +28,7 @@ const AgentDeploymentListPage: React.FC = () => {
   const { namespace } = useParams<{ namespace: string }>();
   const navigate = useNavigate();
   const { namespaces, namespacesLoaded, preferredNamespace } = useNamespaceSelector();
+  const navigateToDeployAgentWizard = useNavigateToDeployAgentWizard();
 
   const {
     runtimes,
@@ -93,7 +95,7 @@ const AgentDeploymentListPage: React.FC = () => {
       <FlexItem>
         <Content component="p">Project</Content>
       </FlexItem>
-      <FlexItem data-testid="agent-ops-project-selector">
+      <FlexItem>
         <AgentOpsProjectSelector namespace={namespace} getRedirectPath={agentOpsDeploymentsRoute} />
       </FlexItem>
       {namespace && (
@@ -137,7 +139,12 @@ const AgentDeploymentListPage: React.FC = () => {
         onPageSizeChange={setPageSize}
         onClearFilters={clearFilters}
         toolbarContent={
-          <AgentRuntimesToolbar filterText={filterText} onFilterChange={setFilterText} />
+          <AgentRuntimesToolbar
+            namespace={namespace}
+            filterText={filterText}
+            onFilterChange={setFilterText}
+            onDeployAgent={() => navigateToDeployAgentWizard(namespace)}
+          />
         }
       />
     );
@@ -163,7 +170,10 @@ const AgentDeploymentListPage: React.FC = () => {
             <EmptyStateBody>Select a project to view agent deployments.</EmptyStateBody>
           </EmptyState>
         ) : (
-          <AgentDeploymentsEmptyState />
+          <AgentDeploymentsEmptyState
+            namespace={namespace}
+            onDeployAgent={() => navigateToDeployAgentWizard(namespace)}
+          />
         )
       }
       provideChildrenPadding

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentsEmptyState.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentsEmptyState.tsx
@@ -1,8 +1,22 @@
 import * as React from 'react';
-import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
+import DeployAgentButton from '~/app/components/DeployAgentButton';
 
-const AgentDeploymentsEmptyState: React.FC = () => (
+type AgentDeploymentsEmptyStateProps = {
+  namespace?: string;
+  onDeployAgent: () => void;
+};
+
+const AgentDeploymentsEmptyState: React.FC<AgentDeploymentsEmptyStateProps> = ({
+  namespace,
+  onDeployAgent,
+}) => (
   <EmptyState
     headingLevel="h2"
     icon={CubesIcon}
@@ -13,6 +27,9 @@ const AgentDeploymentsEmptyState: React.FC = () => (
     <EmptyStateBody>
       No agents have been deployed yet. Deploy an agent to get started.
     </EmptyStateBody>
+    <EmptyStateFooter>
+      <DeployAgentButton namespace={namespace} onDeployAgent={onDeployAgent} />
+    </EmptyStateFooter>
   </EmptyState>
 );
 

--- a/packages/agent-ops/frontend/src/app/pages/__tests__/AgentDeploymentsEmptyState.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/__tests__/AgentDeploymentsEmptyState.spec.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AgentDeploymentsEmptyState from '~/app/pages/AgentDeploymentsEmptyState';
+
+const mockUseCanDeployAgent = jest.fn();
+
+jest.mock('~/app/hooks/useCanDeployAgent', () => ({
+  useCanDeployAgent: (namespace?: string) => mockUseCanDeployAgent(namespace),
+}));
+
+describe('AgentDeploymentsEmptyState', () => {
+  const onDeployAgent = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseCanDeployAgent.mockReturnValue({
+      canDeploy: true,
+      loaded: true,
+      disabledReason: '',
+    });
+  });
+
+  it('should render deploy agent button in the empty state footer', async () => {
+    const user = userEvent.setup();
+
+    render(<AgentDeploymentsEmptyState namespace="team1" onDeployAgent={onDeployAgent} />);
+
+    expect(screen.getByTestId('agent-deployments-empty-state')).toBeInTheDocument();
+    const deployButton = screen.getByTestId('deploy-agent-button');
+    expect(deployButton).toBeEnabled();
+
+    await user.click(deployButton);
+    expect(onDeployAgent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesToolbar.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesToolbar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Button, SearchInput, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { SearchInput, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import FilterToolbar from '@odh-dashboard/internal/components/FilterToolbar';
+import DeployAgentButton from '~/app/components/DeployAgentButton';
 
 export enum AgentRuntimesFilterOption {
   Name = 'name',
@@ -11,13 +12,17 @@ export const agentRuntimesFilterOptions: Record<AgentRuntimesFilterOption, strin
 };
 
 type AgentRuntimesToolbarProps = {
+  namespace?: string;
   filterText: string;
   onFilterChange: (value: string) => void;
+  onDeployAgent: () => void;
 };
 
 const AgentRuntimesToolbar: React.FC<AgentRuntimesToolbarProps> = ({
+  namespace,
   filterText,
   onFilterChange,
+  onDeployAgent,
 }) => (
   <FilterToolbar<AgentRuntimesFilterOption>
     data-testid="agent-runtimes-table-toolbar"
@@ -44,10 +49,7 @@ const AgentRuntimesToolbar: React.FC<AgentRuntimesToolbarProps> = ({
   >
     <ToolbarGroup>
       <ToolbarItem>
-        {/* Deploy agent - functionality to be implemented */}
-        <Button variant="primary" data-testid="deploy-agent-button" isDisabled>
-          Deploy agent
-        </Button>
+        <DeployAgentButton namespace={namespace} onDeployAgent={onDeployAgent} />
       </ToolbarItem>
     </ToolbarGroup>
   </FilterToolbar>

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesToolbar.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesToolbar.spec.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AgentRuntimesToolbar from '~/app/pages/agentRuntimes/AgentRuntimesToolbar';
+
+jest.mock('@odh-dashboard/internal/components/FilterToolbar', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const mockUseCanDeployAgent = jest.fn();
+
+jest.mock('~/app/hooks/useCanDeployAgent', () => ({
+  useCanDeployAgent: (namespace?: string) => mockUseCanDeployAgent(namespace),
+}));
+
+describe('AgentRuntimesToolbar', () => {
+  const onDeployAgent = jest.fn();
+  const onFilterChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseCanDeployAgent.mockImplementation((namespace?: string) => ({
+      canDeploy: !!namespace,
+      loaded: true,
+      disabledReason: namespace ? '' : 'Select a project to deploy an agent',
+    }));
+  });
+
+  it('disables deploy agent button when no namespace is selected', () => {
+    render(
+      <AgentRuntimesToolbar
+        filterText=""
+        onFilterChange={onFilterChange}
+        onDeployAgent={onDeployAgent}
+      />,
+    );
+
+    expect(screen.getByTestId('deploy-agent-button')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('calls onDeployAgent when deploy button is clicked with a namespace', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AgentRuntimesToolbar
+        namespace="team1"
+        filterText=""
+        onFilterChange={onFilterChange}
+        onDeployAgent={onDeployAgent}
+      />,
+    );
+
+    const deployButton = screen.getByTestId('deploy-agent-button');
+    expect(deployButton).toBeEnabled();
+
+    await user.click(deployButton);
+    expect(onDeployAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables deploy agent button when user lacks create permission', () => {
+    mockUseCanDeployAgent.mockReturnValue({
+      canDeploy: false,
+      loaded: true,
+      disabledReason: 'You do not have permission to deploy agents in this project',
+    });
+
+    render(
+      <AgentRuntimesToolbar
+        namespace="team1"
+        filterText=""
+        onFilterChange={onFilterChange}
+        onDeployAgent={onDeployAgent}
+      />,
+    );
+
+    expect(screen.getByTestId('deploy-agent-button')).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/routes.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/routes.spec.ts
@@ -1,0 +1,57 @@
+import {
+  agentOpsDeploymentsRoute,
+  isSafeAgentOpsInternalRoute,
+  sanitizeAgentOpsReturnRoute,
+} from '~/app/utilities/routes';
+
+describe('agent-ops routes', () => {
+  describe('isSafeAgentOpsInternalRoute', () => {
+    it('accepts valid agent-ops paths', () => {
+      expect(isSafeAgentOpsInternalRoute('/ai-hub/agents/deployments/team1')).toBe(true);
+    });
+
+    it('rejects external URLs', () => {
+      expect(isSafeAgentOpsInternalRoute('https://evil.com')).toBe(false);
+    });
+
+    it('rejects protocol-relative URLs', () => {
+      expect(isSafeAgentOpsInternalRoute('//evil.com')).toBe(false);
+    });
+
+    it('rejects path traversal segments', () => {
+      expect(isSafeAgentOpsInternalRoute('/ai-hub/agents/deployments/foo/../../other')).toBe(false);
+    });
+
+    it('rejects backslash path segments', () => {
+      expect(isSafeAgentOpsInternalRoute('/ai-hub/agents\\deployments')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(isSafeAgentOpsInternalRoute(123)).toBe(false);
+    });
+
+    it('returns false when URL parsing throws', () => {
+      const urlSpy = jest.spyOn(global, 'URL').mockImplementation(() => {
+        throw new TypeError('Invalid URL');
+      });
+
+      expect(isSafeAgentOpsInternalRoute('/ai-hub/agents/deployments/team1')).toBe(false);
+
+      urlSpy.mockRestore();
+    });
+  });
+
+  describe('sanitizeAgentOpsReturnRoute', () => {
+    it('returns safe route unchanged', () => {
+      expect(sanitizeAgentOpsReturnRoute('/ai-hub/agents/deployments/team1', 'team1')).toBe(
+        '/ai-hub/agents/deployments/team1',
+      );
+    });
+
+    it('falls back to deployments route for unsafe paths', () => {
+      expect(sanitizeAgentOpsReturnRoute('https://evil.com', 'team1')).toBe(
+        agentOpsDeploymentsRoute('team1'),
+      );
+    });
+  });
+});

--- a/packages/agent-ops/frontend/src/app/utilities/routes.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/routes.ts
@@ -4,8 +4,48 @@ export const globAgentOpsAll = `${agentOpsRootPath}/*`;
 
 export const agentDeploymentsPath = `${agentOpsRootPath}/deployments`;
 
+export const agentDeployWizardPath = `${agentDeploymentsPath}/deploy`;
+
+/** Paths registered as full-page app.route breakouts (outside the Agents tab layout). */
+export const agentOpsStandaloneRoutePaths = [
+  agentDeployWizardPath,
+  `${agentDeploymentsPath}/:namespace/:agentId/*`,
+] as const;
+
+export const getAgentDeployWizardRoute = (): string => agentDeployWizardPath;
+
 export const agentOpsDeploymentsRoute = (namespace?: string): string =>
   !namespace ? agentDeploymentsPath : `${agentDeploymentsPath}/${encodeURIComponent(namespace)}`;
 
 export const agentOpsDeploymentDetailRoute = (namespace: string, agentId: string): string =>
   `${agentDeploymentsPath}/${encodeURIComponent(namespace)}/${encodeURIComponent(agentId)}`;
+
+/** Guards in-app navigation targets passed via location.state. */
+export const isSafeAgentOpsInternalRoute = (path: unknown): boolean => {
+  if (typeof path !== 'string') {
+    return false;
+  }
+
+  if (
+    !path.startsWith('/') ||
+    path.startsWith('//') ||
+    path.includes('://') ||
+    path.includes('..') ||
+    path.includes('\\')
+  ) {
+    return false;
+  }
+
+  try {
+    const { pathname } = new URL(path, 'http://localhost');
+    return pathname === agentOpsRootPath || pathname.startsWith(`${agentOpsRootPath}/`);
+  } catch {
+    return false;
+  }
+};
+
+export const sanitizeAgentOpsReturnRoute = (
+  path: string | undefined,
+  fallbackNamespace: string,
+): string =>
+  path && isSafeAgentOpsInternalRoute(path) ? path : agentOpsDeploymentsRoute(fallbackNamespace);

--- a/packages/agent-ops/frontend/src/odh/AgentDeployWizardRoutes.tsx
+++ b/packages/agent-ops/frontend/src/odh/AgentDeployWizardRoutes.tsx
@@ -1,14 +1,17 @@
 import * as React from 'react';
+import { Route, Routes } from 'react-router-dom';
+import AgentDeployWizardPage from '~/app/deployWizard/AgentDeployWizardPage';
 import AgentOpsFederatedProviders from './AgentOpsFederatedProviders';
-import AgentDeploymentsRoutes from './AgentDeploymentsRoutes';
 import ProjectsBridgeProviderWrapper from './components/ProjectsBridgeProviderWrapper';
 
-const AgentDeploymentsWrapper: React.FC = () => (
+const AgentDeployWizardRoutes: React.FC = () => (
   <AgentOpsFederatedProviders>
     <ProjectsBridgeProviderWrapper>
-      <AgentDeploymentsRoutes />
+      <Routes>
+        <Route path="*" element={<AgentDeployWizardPage />} />
+      </Routes>
     </ProjectsBridgeProviderWrapper>
   </AgentOpsFederatedProviders>
 );
 
-export default AgentDeploymentsWrapper;
+export default AgentDeployWizardRoutes;

--- a/packages/agent-ops/frontend/src/odh/AgentDeploymentDetailRoutes.tsx
+++ b/packages/agent-ops/frontend/src/odh/AgentDeploymentDetailRoutes.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Route, Routes } from 'react-router-dom';
+import AgentDeploymentDetailPage from '~/app/pages/AgentDeploymentDetailPage';
+import AgentOpsFederatedProviders from './AgentOpsFederatedProviders';
+
+const AgentDeploymentDetailRoutes: React.FC = () => (
+  <AgentOpsFederatedProviders>
+    <Routes>
+      <Route path="*" element={<AgentDeploymentDetailPage />} />
+    </Routes>
+  </AgentOpsFederatedProviders>
+);
+
+export default AgentDeploymentDetailRoutes;

--- a/packages/agent-ops/frontend/src/odh/AgentOpsFederatedProviders.tsx
+++ b/packages/agent-ops/frontend/src/odh/AgentOpsFederatedProviders.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import {
+  BrowserStorageContextProvider,
+  DeploymentMode,
+  ModularArchConfig,
+  ModularArchContextProvider,
+  NotificationContextProvider,
+} from 'mod-arch-core';
+import { URL_PREFIX } from '~/app/utilities/const';
+
+const modularArchConfig: ModularArchConfig = {
+  deploymentMode: DeploymentMode.Federated,
+  URL_PREFIX,
+  BFF_API_VERSION: 'v1',
+};
+
+type AgentOpsFederatedProvidersProps = {
+  children: React.ReactNode;
+};
+
+const AgentOpsFederatedProviders: React.FC<AgentOpsFederatedProvidersProps> = ({ children }) => (
+  <ModularArchContextProvider config={modularArchConfig}>
+    <BrowserStorageContextProvider>
+      <NotificationContextProvider>{children}</NotificationContextProvider>
+    </BrowserStorageContextProvider>
+  </ModularArchContextProvider>
+);
+
+export default AgentOpsFederatedProviders;

--- a/packages/agent-ops/frontend/src/odh/AgentOpsWrapper.tsx
+++ b/packages/agent-ops/frontend/src/odh/AgentOpsWrapper.tsx
@@ -1,28 +1,11 @@
-import React from 'react';
-import {
-  ModularArchConfig,
-  DeploymentMode,
-  ModularArchContextProvider,
-  NotificationContextProvider,
-  BrowserStorageContextProvider,
-} from 'mod-arch-core';
-import { URL_PREFIX } from '~/app/utilities/const';
+import * as React from 'react';
 import AppRoutes from '~/app/AppRoutes';
-
-const modularArchConfig: ModularArchConfig = {
-  deploymentMode: DeploymentMode.Federated,
-  URL_PREFIX,
-  BFF_API_VERSION: 'v1',
-};
+import AgentOpsFederatedProviders from './AgentOpsFederatedProviders';
 
 const AgentOpsWrapper: React.FC = () => (
-  <ModularArchContextProvider config={modularArchConfig}>
-    <BrowserStorageContextProvider>
-      <NotificationContextProvider>
-        <AppRoutes />
-      </NotificationContextProvider>
-    </BrowserStorageContextProvider>
-  </ModularArchContextProvider>
+  <AgentOpsFederatedProviders>
+    <AppRoutes />
+  </AgentOpsFederatedProviders>
 );
 
 export default AgentOpsWrapper;

--- a/packages/agent-ops/frontend/src/odh/__tests__/AgentDeployWizardRoutes.spec.tsx
+++ b/packages/agent-ops/frontend/src/odh/__tests__/AgentDeployWizardRoutes.spec.tsx
@@ -24,12 +24,13 @@ jest.mock('~/app/components/ScrollLock', () => ({
 jest.mock('~/app/hooks/useAgentOpsProjectNamespaces', () => ({
   getEffectiveProjectNamespaces: (
     projectNamespaces: { name: string; displayName: string }[],
+    isLoading: boolean,
     fallbackNamespace?: string,
   ) => {
     if (projectNamespaces.length > 0) {
       return projectNamespaces;
     }
-    if (fallbackNamespace) {
+    if (isLoading && fallbackNamespace) {
       return [{ name: fallbackNamespace, displayName: fallbackNamespace }];
     }
     return projectNamespaces;

--- a/packages/agent-ops/frontend/src/odh/__tests__/AgentDeployWizardRoutes.spec.tsx
+++ b/packages/agent-ops/frontend/src/odh/__tests__/AgentDeployWizardRoutes.spec.tsx
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import AgentDeployWizardPage from '~/app/deployWizard/AgentDeployWizardPage';
+import AgentDeployWizardRoutes from '~/odh/AgentDeployWizardRoutes';
+import { agentDeployWizardPath } from '~/app/utilities/routes';
+
+jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => ({
+  __esModule: true,
+  default: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock('~/app/components/ScrollLock', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('~/app/hooks/useAgentOpsProjectNamespaces', () => ({
+  getEffectiveProjectNamespaces: (
+    projectNamespaces: { name: string; displayName: string }[],
+    fallbackNamespace?: string,
+  ) => {
+    if (projectNamespaces.length > 0) {
+      return projectNamespaces;
+    }
+    if (fallbackNamespace) {
+      return [{ name: fallbackNamespace, displayName: fallbackNamespace }];
+    }
+    return projectNamespaces;
+  },
+  useAgentOpsProjectNamespaces: () => ({
+    projectNamespaces: [{ name: 'aa-fede', displayName: 'aa-fede' }],
+    isLoading: false,
+    onProjectSelection: jest.fn(),
+  }),
+}));
+
+jest.mock('@odh-dashboard/internal/concepts/projects/ProjectSelector', () => ({
+  __esModule: true,
+  default: ({
+    namespace,
+    onSelection,
+    placeholder,
+  }: {
+    namespace: string;
+    onSelection: (projectName: string) => void;
+    placeholder?: string;
+  }) => (
+    <select
+      data-testid="deploy-agent-project-select"
+      value={namespace}
+      onChange={(event) => onSelection(event.target.value)}
+    >
+      <option value="">{placeholder ?? 'Select a project'}</option>
+      <option value="aa-fede">aa-fede</option>
+    </select>
+  ),
+}));
+
+jest.mock('@odh-dashboard/internal/components/SimpleSelect', () => ({
+  __esModule: true,
+  default: ({
+    dataTestId,
+    value,
+    options = [],
+    onChange,
+    placeholder,
+  }: {
+    dataTestId?: string;
+    value?: string;
+    options?: { key: string; label: string }[];
+    onChange: (key: string) => void;
+    placeholder?: string;
+  }) => (
+    <select
+      data-testid={dataTestId}
+      value={value ?? ''}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      <option value="">{placeholder ?? 'Select...'}</option>
+      {options.map((option) => (
+        <option key={option.key} value={option.key}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+jest.mock('mod-arch-core', () => ({
+  ...jest.requireActual<typeof import('mod-arch-core')>('mod-arch-core'),
+  useNamespaceSelector: () => ({
+    namespaces: [{ name: 'aa-fede', displayName: 'aa-fede' }],
+    namespacesLoaded: true,
+    namespacesLoadError: undefined,
+    updatePreferredNamespace: jest.fn(),
+  }),
+}));
+
+jest.mock('~/odh/AgentOpsFederatedProviders', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('~/odh/components/ProjectsBridgeProviderWrapper', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const wizardLocationState = {
+  namespace: 'aa-fede',
+  returnRoute: '/ai-hub/agents/deployments/aa-fede',
+};
+
+describe('AgentDeployWizardRoutes', () => {
+  it('renders the deploy wizard when mounted as a host app.route breakout', () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: agentDeployWizardPath,
+            state: wizardLocationState,
+          },
+        ]}
+      >
+        <Routes>
+          <Route path={agentDeployWizardPath} element={<AgentDeployWizardRoutes />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Deploy agent')).toBeInTheDocument();
+    expect(screen.getByTestId('deploy-agent-project-select')).toBeInTheDocument();
+  });
+
+  it('redirects to deployments when wizard state is missing', () => {
+    render(
+      <MemoryRouter initialEntries={[agentDeployWizardPath]}>
+        <Routes>
+          <Route path={agentDeployWizardPath} element={<AgentDeployWizardPage />} />
+          <Route path="/ai-hub/agents/deployments" element={<div>Deployments list</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Deployments list')).toBeInTheDocument();
+  });
+
+  it('redirects to deployments when namespace is invalid', () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: agentDeployWizardPath,
+            state: {
+              namespace: 'INVALID_NAME',
+              returnRoute: '/ai-hub/agents/deployments/INVALID_NAME',
+            },
+          },
+        ]}
+      >
+        <Routes>
+          <Route path={agentDeployWizardPath} element={<AgentDeployWizardPage />} />
+          <Route path="/ai-hub/agents/deployments" element={<div>Deployments list</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Deployments list')).toBeInTheDocument();
+  });
+});

--- a/packages/agent-ops/frontend/src/odh/__tests__/extensions.spec.ts
+++ b/packages/agent-ops/frontend/src/odh/__tests__/extensions.spec.ts
@@ -1,4 +1,5 @@
 import extensions from '~/odh/extensions';
+import { agentDeploymentsPath, agentDeployWizardPath } from '~/app/utilities/routes';
 
 const AGENT_OPS = 'agent-ops';
 
@@ -41,12 +42,20 @@ describe('agent-ops extensions', () => {
     expect(tab?.type === 'app.tab-route/tab' && tab.properties.component).toBeTruthy();
   });
 
+  it('standalone route paths match routes.ts constants', () => {
+    const paths = extensions
+      .filter((extension) => extension.type === 'app.route')
+      .map((extension) => extension.properties.path);
+    expect(paths).toContain(agentDeployWizardPath);
+    expect(paths).toContain(`${agentDeploymentsPath}/:namespace/:agentId/*`);
+  });
+
   it('should register standalone breakout routes outside the tab layout', () => {
     const routes = extensions.filter((extension) => extension.type === 'app.route');
     expect(routes).toHaveLength(2);
     expect(routes.map((route) => route.properties.path)).toEqual([
-      '/ai-hub/agents/deployments/:namespace/:agentId/*',
-      '/ai-hub/agents/deployments/deploy',
+      `${agentDeploymentsPath}/:namespace/:agentId/*`,
+      agentDeployWizardPath,
     ]);
     routes.forEach((route) => {
       expect(route).toMatchObject({

--- a/packages/agent-ops/frontend/src/odh/__tests__/extensions.spec.ts
+++ b/packages/agent-ops/frontend/src/odh/__tests__/extensions.spec.ts
@@ -3,11 +3,12 @@ import extensions from '~/odh/extensions';
 const AGENT_OPS = 'agent-ops';
 
 describe('agent-ops extensions', () => {
-  it('should register area, tab-route tab, and detail route extensions', () => {
-    expect(extensions).toHaveLength(3);
+  it('should register area, tab-route tab, and route extensions', () => {
+    expect(extensions).toHaveLength(4);
     expect(extensions.map((extension) => extension.type)).toEqual([
       'app.area',
       'app.tab-route/tab',
+      'app.route',
       'app.route',
     ]);
   });
@@ -40,17 +41,21 @@ describe('agent-ops extensions', () => {
     expect(tab?.type === 'app.tab-route/tab' && tab.properties.component).toBeTruthy();
   });
 
-  it('should register deployment detail route outside the tab layout', () => {
-    const route = extensions.find((extension) => extension.type === 'app.route');
-    expect(route).toMatchObject({
-      type: 'app.route',
-      flags: {
-        required: [AGENT_OPS],
-      },
-      properties: {
-        path: '/ai-hub/agents/deployments/:namespace/:agentId/*',
-      },
+  it('should register standalone breakout routes outside the tab layout', () => {
+    const routes = extensions.filter((extension) => extension.type === 'app.route');
+    expect(routes).toHaveLength(2);
+    expect(routes.map((route) => route.properties.path)).toEqual([
+      '/ai-hub/agents/deployments/:namespace/:agentId/*',
+      '/ai-hub/agents/deployments/deploy',
+    ]);
+    routes.forEach((route) => {
+      expect(route).toMatchObject({
+        type: 'app.route',
+        flags: {
+          required: [AGENT_OPS],
+        },
+      });
+      expect(route.properties.component).toBeTruthy();
     });
-    expect(route?.type === 'app.route' && route.properties.component).toBeTruthy();
   });
 });

--- a/packages/agent-ops/frontend/src/odh/components/ProjectsBridgeProviderWrapper.tsx
+++ b/packages/agent-ops/frontend/src/odh/components/ProjectsBridgeProviderWrapper.tsx
@@ -1,0 +1,78 @@
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import * as React from 'react';
+import type { AgentOpsProjectRef, ProjectsBridgeData } from '~/odh/extension-points';
+import { isProjectsBridgeProviderExtension } from '~/odh/extension-points';
+import { ProjectsBridgeContext } from '~/odh/context/ProjectsBridgeContext';
+
+type ProjectsBridgeProviderWrapperProps = {
+  children: React.ReactNode;
+};
+
+const EMPTY_BRIDGE_PROJECTS: AgentOpsProjectRef[] = [];
+
+const INACTIVE_BRIDGE_CONTEXT = {
+  bridgeActive: false as const,
+  projects: EMPTY_BRIDGE_PROJECTS,
+  preferredProject: null,
+  updatePreferredProject: () => undefined,
+  loaded: false,
+  loadError: null,
+};
+
+type BridgeDataSyncProps = {
+  data: ProjectsBridgeData;
+  onBridgeData: (data: ProjectsBridgeData | null) => void;
+};
+
+const BridgeDataSync: React.FC<BridgeDataSyncProps> = ({ data, onBridgeData }) => {
+  React.useEffect(() => {
+    onBridgeData(data);
+    return () => {
+      onBridgeData(null);
+    };
+  }, [data, onBridgeData]);
+
+  return null;
+};
+
+const ProjectsBridgeProviderWrapper: React.FC<ProjectsBridgeProviderWrapperProps> = ({
+  children,
+}) => {
+  const [extensions, loaded] = useResolvedExtensions(isProjectsBridgeProviderExtension);
+  const [bridgeData, setBridgeData] = React.useState<ProjectsBridgeData | null>(null);
+
+  const handleBridgeData = React.useCallback((data: ProjectsBridgeData | null) => {
+    setBridgeData(data);
+  }, []);
+
+  const contextValue = React.useMemo(() => {
+    if (bridgeData) {
+      return { ...bridgeData, bridgeActive: true as const };
+    }
+    return INACTIVE_BRIDGE_CONTEXT;
+  }, [bridgeData]);
+
+  const DataProvider =
+    loaded && extensions.length > 0 ? extensions[0].properties.component.default : null;
+
+  React.useEffect(() => {
+    if (!DataProvider) {
+      setBridgeData(null);
+    }
+  }, [DataProvider]);
+
+  return (
+    <ProjectsBridgeContext.Provider value={contextValue}>
+      {DataProvider ? (
+        <DataProvider>
+          {(data: ProjectsBridgeData) => (
+            <BridgeDataSync data={data} onBridgeData={handleBridgeData} />
+          )}
+        </DataProvider>
+      ) : null}
+      {children}
+    </ProjectsBridgeContext.Provider>
+  );
+};
+
+export default ProjectsBridgeProviderWrapper;

--- a/packages/agent-ops/frontend/src/odh/context/ProjectsBridgeContext.tsx
+++ b/packages/agent-ops/frontend/src/odh/context/ProjectsBridgeContext.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import type { AgentOpsProjectRef } from '~/odh/extension-points';
+
+type ProjectsBridgeContextType = {
+  bridgeActive: boolean;
+  projects: AgentOpsProjectRef[];
+  preferredProject: AgentOpsProjectRef | null;
+  updatePreferredProject: (project: AgentOpsProjectRef | null) => void;
+  loaded: boolean;
+  loadError: Error | null;
+};
+
+export const ProjectsBridgeContext = React.createContext<ProjectsBridgeContextType>({
+  bridgeActive: false,
+  projects: [],
+  preferredProject: null,
+  updatePreferredProject: () => undefined,
+  loaded: false,
+  loadError: null,
+});
+
+export const useProjectsBridge = (): ProjectsBridgeContextType =>
+  React.useContext(ProjectsBridgeContext);

--- a/packages/agent-ops/frontend/src/odh/extension-points/index.ts
+++ b/packages/agent-ops/frontend/src/odh/extension-points/index.ts
@@ -1,0 +1,7 @@
+export type {
+  AgentOpsProjectRef,
+  ProjectsBridgeData,
+  ProjectsBridgeProviderExtension,
+  ProjectsBridgeProviderProps,
+} from './projects-bridge';
+export { isProjectsBridgeProviderExtension } from './projects-bridge';

--- a/packages/agent-ops/frontend/src/odh/extension-points/projects-bridge.ts
+++ b/packages/agent-ops/frontend/src/odh/extension-points/projects-bridge.ts
@@ -1,0 +1,36 @@
+import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
+import type { Extension } from '@openshift/dynamic-plugin-sdk';
+import type { ReactNode } from 'react';
+
+export type AgentOpsProjectRef = {
+  name: string;
+  displayName?: string;
+};
+
+export type ProjectsBridgeData = {
+  projects: AgentOpsProjectRef[];
+  preferredProject: AgentOpsProjectRef | null;
+  updatePreferredProject: (project: AgentOpsProjectRef | null) => void;
+  loaded: boolean;
+  loadError: Error | null;
+};
+
+export type ProjectsBridgeProviderProps = {
+  children: (data: ProjectsBridgeData) => ReactNode;
+};
+
+/**
+ * Host-side bridge: reads ProjectsContext in the host bundle and passes filtered
+ * Active project data into the federated agent-ops UI.
+ */
+export type ProjectsBridgeProviderExtension = Extension<
+  'agent-ops.projects/bridge-provider',
+  {
+    component: ComponentCodeRef<ProjectsBridgeProviderProps>;
+  }
+>;
+
+export const isProjectsBridgeProviderExtension = (
+  extension: Extension,
+): extension is ProjectsBridgeProviderExtension =>
+  extension.type === 'agent-ops.projects/bridge-provider';

--- a/packages/agent-ops/frontend/src/odh/extensions.ts
+++ b/packages/agent-ops/frontend/src/odh/extensions.ts
@@ -3,7 +3,10 @@ import type {
   RouteExtension,
   TabRouteTabExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
-import { agentDeploymentsPath } from '~/app/utilities/routes';
+
+// Keep in sync with ~/app/utilities/routes.ts (value imports are disallowed in extensions.ts).
+const agentDeploymentsPath = '/ai-hub/agents/deployments';
+const agentDeployWizardPath = `${agentDeploymentsPath}/deploy`;
 
 const AGENT_OPS = 'agent-ops';
 const AGENTS_TAB_PAGE = 'agents-tab-page';
@@ -25,8 +28,20 @@ const extensions: (AreaExtension | TabRouteTabExtension | RouteExtension)[] = [
       pageId: AGENTS_TAB_PAGE,
       id: 'deployments',
       title: 'Deployments',
-      component: () => import('./AgentDeploymentsWrapper'),
+      component: () => import('./AgentDeploymentsWrapper.tsx'),
       group: '1_deployments',
+    },
+  },
+  // Full-page breakout routes share one wrapper and internal router. Keep separate
+  // app.route entries so /ai-hub/agents/deployments (tab list) is not captured.
+  {
+    type: 'app.route',
+    flags: {
+      required: [AGENT_OPS],
+    },
+    properties: {
+      path: `${agentDeploymentsPath}/:namespace/:agentId/*`,
+      component: () => import('./AgentDeploymentDetailRoutes.tsx'),
     },
   },
   {
@@ -35,8 +50,8 @@ const extensions: (AreaExtension | TabRouteTabExtension | RouteExtension)[] = [
       required: [AGENT_OPS],
     },
     properties: {
-      path: `${agentDeploymentsPath}/:namespace/:agentId/*`,
-      component: () => import('./AgentDeploymentDetailWrapper'),
+      path: agentDeployWizardPath,
+      component: () => import('./AgentDeployWizardRoutes.tsx'),
     },
   },
 ];

--- a/packages/agent-ops/package.json
+++ b/packages/agent-ops/package.json
@@ -28,6 +28,9 @@
     }
   },
   "e2eCiTags": ["@AgentOpsCI"],
+  "exports": {
+    "./extensions": "./extensions.ts"
+  },
   "bffConfig": {
     "enabled": true,
     "port": 4021,
@@ -47,6 +50,7 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
+    "@odh-dashboard/k8s-core": "*",
     "@odh-dashboard/plugin-core": "*",
     "@odh-dashboard/ui-core": "*"
   },

--- a/packages/agent-ops/package.json
+++ b/packages/agent-ops/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
-    "@odh-dashboard/k8s-core": "*",
     "@odh-dashboard/plugin-core": "*",
     "@odh-dashboard/ui-core": "*"
   },

--- a/packages/agent-ops/src/ProjectsBridgeProvider.tsx
+++ b/packages/agent-ops/src/ProjectsBridgeProvider.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import type { ProjectsBridgeData } from '../frontend/src/odh/extension-points';
+
+type ProjectsBridgeProviderProps = {
+  children: (data: ProjectsBridgeData) => React.ReactNode;
+};
+
+const ProjectsBridgeProvider: React.FC<ProjectsBridgeProviderProps> = ({ children }) => {
+  const { projects, preferredProject, updatePreferredProject, loaded, loadError } =
+    React.useContext(ProjectsContext);
+
+  const bridgeProjects = React.useMemo(
+    () =>
+      projects.map((project) => ({
+        name: project.metadata.name,
+        displayName: getDisplayNameFromK8sResource(project),
+      })),
+    [projects],
+  );
+
+  const bridgePreferred = React.useMemo(
+    () =>
+      preferredProject
+        ? {
+            name: preferredProject.metadata.name,
+            displayName: getDisplayNameFromK8sResource(preferredProject),
+          }
+        : null,
+    [preferredProject],
+  );
+
+  const bridgeUpdatePreferred = React.useCallback(
+    (ref: { name: string } | null) => {
+      if (!ref) {
+        updatePreferredProject(null);
+        return;
+      }
+      const match = projects.find((project) => project.metadata.name === ref.name) ?? null;
+      updatePreferredProject(match);
+    },
+    [projects, updatePreferredProject],
+  );
+
+  const data = React.useMemo(
+    () => ({
+      projects: bridgeProjects,
+      preferredProject: bridgePreferred,
+      updatePreferredProject: bridgeUpdatePreferred,
+      loaded,
+      loadError: loadError ?? null,
+    }),
+    [bridgeProjects, bridgePreferred, bridgeUpdatePreferred, loaded, loadError],
+  );
+
+  return <>{children(data)}</>;
+};
+
+export default ProjectsBridgeProvider;

--- a/packages/agent-ops/src/ProjectsBridgeProvider.tsx
+++ b/packages/agent-ops/src/ProjectsBridgeProvider.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
-import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import type { ProjectsBridgeData } from '../frontend/src/odh/extension-points';
+
+const getProjectDisplayName = (project: {
+  metadata: { name: string; annotations?: Record<string, string> };
+}): string => project.metadata.annotations?.['openshift.io/display-name'] || project.metadata.name;
 
 type ProjectsBridgeProviderProps = {
   children: (data: ProjectsBridgeData) => React.ReactNode;
@@ -15,7 +18,7 @@ const ProjectsBridgeProvider: React.FC<ProjectsBridgeProviderProps> = ({ childre
     () =>
       projects.map((project) => ({
         name: project.metadata.name,
-        displayName: getDisplayNameFromK8sResource(project),
+        displayName: getProjectDisplayName(project),
       })),
     [projects],
   );
@@ -25,7 +28,7 @@ const ProjectsBridgeProvider: React.FC<ProjectsBridgeProviderProps> = ({ childre
       preferredProject
         ? {
             name: preferredProject.metadata.name,
-            displayName: getDisplayNameFromK8sResource(preferredProject),
+            displayName: getProjectDisplayName(preferredProject),
           }
         : null,
     [preferredProject],


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-62718

> **Depends on [opendatahub-io/odh-dashboard#8173](https://github.com/opendatahub-io/odh-dashboard/pull/8173)** — the `POST /api/v1/agents/deploy` BFF endpoint. **Do not merge until #8173 is merged to `main`.** This PR is opened as a draft for review; merge after #8173 lands.

## Description

Adds the **Deploy Agent wizard shell** for Mode 1 (BYO image) in the agent-ops federated module — wizard steps **1 (Image selection)** and **2 (Configuration)**, with placeholder steps 3–6 for follow-up work.

<img width="1454" height="808" alt="Screenshot 2026-06-24 at 10 50 23 AM" src="https://github.com/user-attachments/assets/8bff7687-cccf-4c77-a6ca-0453bf0f6775" />

<img width="1445" height="814" alt="Screenshot 2026-06-24 at 10 51 16 AM" src="https://github.com/user-attachments/assets/2981b28a-617d-44f1-89a0-ad94deba1ca7" />


**Wizard UX**
- PatternFly `Wizard` inside `ApplicationsPage`, with exit confirmation modal and body scroll lock during the flow
- Step 1: project selector (federated projects bridge), container image, tag, protocol (`a2a` | `mcp`), workload type (`deployment` | `statefulset` | `job`)
- Step 2: agent name (auto-generated from image, editable), pull secret, optional PVC size
- Centralized step validation registry (`deployAgentWizardValidation.ts`) gates Next/Deploy and sidebar step accessibility
- Consistent dropdown widths via `DeployWizardSelectField`

**Federated integration**
- Projects bridge extension so the project dropdown matches Projects home (host `ProjectsContext`), not all cluster namespaces
- Federated breakout routes for list, detail, and deploy wizard
- Route helpers with sanitization for safe internal navigation

**Tooling**
- Align agent-ops frontend ESLint with other mod-arch BFF packages (`.eslintrc.cjs` + parent ignore pattern; ESLint 8)
- Shared `useBodyScrollLock` utility in host `frontend/`

Submit is stubbed — wiring to `POST /api/v1/agents/deploy` follows once #8173 is on `main`.

## How Has This Been Tested?

### Automated
```bash
cd packages/agent-ops/frontend && npm run test:lint && npm run test:unit
```

### Manual (federated dev)
```bash
make dev-start-federated
```
1. Navigate to **AI Hub → Agents → Deployments**
2. Select a project and click **Deploy agent**
3. Complete step 1 (image/protocol/workload) — Next enables when valid
4. Complete step 2 (name/pull secret/PVC) — verify validation messages
5. Cancel with dirty form — exit modal appears; confirm returns to deployments list
6. Verify project dropdown lists the same projects as Projects home

## Test Impact

- Jest unit tests for deploy wizard shell, validation registry, navigation/exit hooks, route sanitization, federated routes, and toolbar
- `useBodyScrollLock` unit tests in host frontend
- No Cypress specs added in this PR (follow-up)

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-step “Deploy agent” wizard with image selection, configuration, and summary steps.
  * Added deploy controls to the agent deployments list and empty state, with a new deployments-to-wizard flow.
  * Introduced dedicated wizard routing, including safer return navigation.

* **Bug Fixes**
  * Strengthened wizard input validation for image names, pull secrets, storage quantities, and required configuration.
  * Added exit confirmation when leaving the wizard with unsaved changes.
  * Disabled deploy actions when permissions or project context aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->