### PR TITLE
feat(agent-ops): Agent runtimes status polling 

### DIFF
--- a/packages/agent-ops/frontend/src/app/const.ts
+++ b/packages/agent-ops/frontend/src/app/const.ts
@@ -1,2 +1,3 @@
 /** Disables useFetchState polling when refreshRate is 0. */
 export const NO_REFRESH_INTERVAL = 0;
+export const AGENT_RUNTIMES_REFRESH_INTERVAL = 10_000;

--- a/packages/agent-ops/frontend/src/app/hooks/__tests__/useListAgentRuntimes.spec.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/__tests__/useListAgentRuntimes.spec.ts
@@ -12,6 +12,7 @@ jest.mock('~/app/utilities/const', () => ({
 
 jest.mock('~/app/const', () => ({
   NO_REFRESH_INTERVAL: 0,
+  AGENT_RUNTIMES_REFRESH_INTERVAL: 10_000,
 }));
 
 jest.mock('mod-arch-core', () => ({
@@ -88,13 +89,33 @@ describe('useListAgentRuntimes', () => {
     expect(result.current.pageSize).toBe(10);
   });
 
-  it('should pass NO_REFRESH_INTERVAL to useFetchState', () => {
+  it('should use NO_REFRESH_INTERVAL when no namespace is provided', () => {
     testHook(useListAgentRuntimes)();
 
     expect(mockUseFetchState).toHaveBeenCalledWith(
       expect.any(Function),
       { runtimes: [] },
       { refreshRate: 0 },
+    );
+  });
+
+  it('should use AGENT_RUNTIMES_REFRESH_INTERVAL when a namespace is provided', () => {
+    testHook(useListAgentRuntimes)('agent-ops-demo');
+
+    expect(mockUseFetchState).toHaveBeenCalledWith(
+      expect.any(Function),
+      { runtimes: [] },
+      { refreshRate: 10_000 },
+    );
+  });
+
+  it('should use a custom refreshInterval when provided', () => {
+    testHook(useListAgentRuntimes)('agent-ops-demo', 5_000);
+
+    expect(mockUseFetchState).toHaveBeenCalledWith(
+      expect.any(Function),
+      { runtimes: [] },
+      { refreshRate: 5_000 },
     );
   });
 

--- a/packages/agent-ops/frontend/src/app/hooks/useListAgentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useListAgentRuntimes.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useFetchState, type FetchStateCallbackPromise } from 'mod-arch-core';
 import { listAgentRuntimes } from '~/app/api/agentRuntimes';
-import { NO_REFRESH_INTERVAL } from '~/app/const';
+import { NO_REFRESH_INTERVAL, AGENT_RUNTIMES_REFRESH_INTERVAL } from '~/app/const';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -20,12 +20,12 @@ export type ListAgentRuntimesResult = {
 
 /**
  * Fetches agent runtimes for the deployments list with BFF cursor pagination.
- * Polling is added in a follow-up PR (RHOAIENG-62705); this hook loads once per
- * namespace or page change. Per-namespace RBAC is enforced by the BFF; selected
- * project scoping is applied client-side until the list API supports a namespace
- * query parameter.
+ * Polls every `refreshInterval` ms (default 10 s) when a namespace is selected;
  */
-export const useListAgentRuntimes = (namespace?: string): ListAgentRuntimesResult => {
+export const useListAgentRuntimes = (
+  namespace?: string,
+  refreshInterval = AGENT_RUNTIMES_REFRESH_INTERVAL,
+): ListAgentRuntimesResult => {
   const [page, setPage] = React.useState(1);
   const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_SIZE);
   const pageTokensRef = React.useRef<(string | undefined)[]>([]);
@@ -52,7 +52,7 @@ export const useListAgentRuntimes = (namespace?: string): ListAgentRuntimesResul
     fetchCallback,
     { runtimes: [] },
     {
-      refreshRate: NO_REFRESH_INTERVAL,
+      refreshRate: namespace ? refreshInterval : NO_REFRESH_INTERVAL,
     },
   );
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
For https://redhat.atlassian.net/browse/RHOAIENG-62705 

Adds auto-refresh polling to the agent runtimes list so deployment status updates without a manual page reload.
- Introduces `AGENT_RUNTIMES_REFRESH_INTERVAL` (10 s) in `const.ts`
- Updates `useListAgentRuntimes` to poll via `useFetchState` when a namespace is selected
- Disables polling when no namespace is provided to avoid unnecessary BFF requests
- Adds an optional `refreshInterval` parameter for tests or future overrides

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests and manually verfied on the dev tools and ensured there is new request every ~ 10 seconds 

<img width="1110" height="648" alt="image" src="https://github.com/user-attachments/assets/1db82dde-1971-4c28-9533-fa3a834838da" />

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Updated existing `useListAgentRuntimes` unit tests for the no-namespace case
- Added tests for default polling (10 s) when a namespace is provided
- Added test for custom `refreshInterval` override

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic refresh for agent runtime lists when viewing a namespace, with a default polling interval.
  * You can now override the refresh interval for this list when needed.

* **Bug Fixes**
  * Disabled refresh when no namespace is selected, reducing unnecessary background requests.
  * Updated list behavior to keep refresh timing consistent across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->