### PR TITLE
feat(automl,autorag): add Segment tracking events for key user actions

### DIFF
--- a/packages/automl/frontend/src/app/components/common/AutomlConnectionModal.tsx
+++ b/packages/automl/frontend/src/app/components/common/AutomlConnectionModal.tsx
@@ -20,6 +20,10 @@ import {
   withRequiredFields,
 } from '@odh-dashboard/internal/concepts/connectionTypes/utils';
 import { createSecret } from '@odh-dashboard/internal/api/k8s/secrets';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
+
+import { AUTOML_EVENTS } from '~/app/tracking/automlTrackingConstants';
 
 const S3_REQUIRED_ENV_VARS = ['AWS_DEFAULT_REGION', 'AWS_S3_BUCKET'];
 
@@ -200,10 +204,19 @@ const AutomlConnectionModal: React.FC<Props> = ({
 
             createSecret(assembledConnection)
               .then(async () => {
+                fireFormTrackingEvent(AUTOML_EVENTS.S3_CONNECTION_CREATED, {
+                  outcome: TrackingOutcome.submit,
+                  success: true,
+                });
                 await onSubmit(assembledConnection);
                 onClose(true);
               })
               .catch((e) => {
+                fireFormTrackingEvent(AUTOML_EVENTS.S3_CONNECTION_CREATED, {
+                  outcome: TrackingOutcome.submit,
+                  success: false,
+                  error: e instanceof Error ? e.message : 'Unknown error',
+                });
                 setSubmitError(e);
                 setIsSaving(false);
               });

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/AutomlModelDetailsModal.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/AutomlModelDetailsModal.tsx
@@ -12,10 +12,12 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { useParams } from 'react-router';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { useAutomlResultsContext } from '~/app/context/AutomlResultsContext';
 import { computeRankMap, resolveEvalMetric } from '~/app/utilities/utils';
 import { TASK_TYPE_TIMESERIES } from '~/app/utilities/const';
 import { useModelEvaluationArtifactsQuery } from '~/app/hooks/queries';
+import { AUTOML_EVENTS } from '~/app/tracking/automlTrackingConstants';
 import { getVisibleTabs, type TabDefinition } from './tabConfig';
 import AutomlModelDetailsModalHeader from './AutomlModelDetailsModalHeader';
 import './AutomlModelDetailsModal.scss';
@@ -126,7 +128,10 @@ const AutomlModelDetailsModal: React.FC<AutomlModelDetailsModalProps> = ({
             rankMap={rankMap}
             evalMetric={evalMetric}
             onSelectModel={(name) => setSelectedModelName(name)}
-            onDownload={() => setIsPrinting(true)}
+            onDownload={() => {
+              fireMiscTrackingEvent(AUTOML_EVENTS.MODEL_DETAILS_DOWNLOADED, { taskType });
+              setIsPrinting(true);
+            }}
             onSaveNotebook={
               onClickSaveNotebook
                 ? () => {

--- a/packages/automl/frontend/src/app/components/run-results/AutomlResults.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlResults.tsx
@@ -14,11 +14,13 @@ import {
 } from '@patternfly/react-core';
 import React from 'react';
 import { useParams } from 'react-router';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { useAutomlResultsContext } from '~/app/context/AutomlResultsContext';
 import { fetchS3File } from '~/app/hooks/queries';
 import PipelineTopology from '~/app/topology/PipelineTopology';
 import { useAutomlTaskTopology } from '~/app/topology/useAutomlTaskTopology';
 import { buildStageMapTopology } from '~/app/topology/buildStageMapTopology';
+import { AUTOML_EVENTS } from '~/app/tracking/automlTrackingConstants';
 import { RuntimeStateKF } from '~/app/types/pipeline';
 import type { RunDetailsKF } from '~/app/types/pipeline';
 import { downloadBlob, isRunInTerminalState } from '~/app/utilities/utils';
@@ -135,6 +137,9 @@ function AutomlResults(): React.JSX.Element {
         const safeModelName = sanitizeFilename(modelName);
         const notebookFilename = `${displayName}_${safeModelName}_notebook.ipynb`;
         downloadBlob(notebook, notebookFilename);
+        fireMiscTrackingEvent(AUTOML_EVENTS.NOTEBOOK_SAVED, {
+          taskType: parameters?.task_type ?? '',
+        });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
         setDownloadError({
@@ -143,7 +148,7 @@ function AutomlResults(): React.JSX.Element {
         });
       }
     },
-    [namespace, models, pipelineRun?.display_name],
+    [namespace, models, pipelineRun?.display_name, parameters?.task_type],
   );
 
   const isCanceled = pipelineRun?.state.toUpperCase() === RuntimeStateKF.CANCELED;

--- a/packages/automl/frontend/src/app/components/run-results/RegisterModelModal.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/RegisterModelModal.tsx
@@ -23,11 +23,14 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useMutation } from '@tanstack/react-query';
 import { useParams } from 'react-router';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
 import { useModelRegistriesQuery } from '~/app/hooks/useModelRegistriesQuery';
 import { registerModel } from '~/app/api/modelRegistry';
 import type { ModelRegistry, RegisterModelRequest } from '~/app/types';
 import { useAutomlResultsContext } from '~/app/context/AutomlResultsContext';
 import { useNotification } from '~/app/hooks/useNotification';
+import { AUTOML_EVENTS } from '~/app/tracking/automlTrackingConstants';
 
 type RegisterModelModalProps = {
   onClose: () => void;
@@ -111,6 +114,11 @@ const RegisterModelModal: React.FC<RegisterModelModalProps> = ({ onClose, modelN
       });
     },
     onSuccess: (data, variables) => {
+      fireFormTrackingEvent(AUTOML_EVENTS.MODEL_REGISTERED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        registryId: variables.registryId,
+      });
       const modelDetailsUrl = `/ai-hub/registry/${encodeURIComponent(variables.registryName)}/registered-models/${encodeURIComponent(data.registered_model_id)}/overview`;
       notification.success(`${registeredModelName.trim()} registered successfully`, undefined, [
         {
@@ -121,6 +129,11 @@ const RegisterModelModal: React.FC<RegisterModelModalProps> = ({ onClose, modelN
       onClose();
     },
     onError: (error: unknown) => {
+      fireFormTrackingEvent(AUTOML_EVENTS.MODEL_REGISTERED, {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       notification.error(
         'Failed to register model',
         error instanceof Error ? error.message : 'An unexpected error occurred',

--- a/packages/automl/frontend/src/app/hooks/useAutomlRunActions.ts
+++ b/packages/automl/frontend/src/app/hooks/useAutomlRunActions.ts
@@ -1,11 +1,14 @@
 import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
 import {
   useDeletePipelineRunMutation,
   useRetryPipelineRunMutation,
   useTerminatePipelineRunMutation,
 } from '~/app/hooks/mutations';
 import { useNotification } from '~/app/hooks/useNotification';
+import { AUTOML_EVENTS } from '~/app/tracking/automlTrackingConstants';
 
 type AutomlRunActions = {
   handleRetry: () => Promise<void>;
@@ -35,11 +38,20 @@ export const useAutomlRunActions = (
     try {
       await retryMutation.mutateAsync();
       await queryClient.invalidateQueries({ queryKey: ['pipelineRun', runId, namespace] });
+      fireFormTrackingEvent(AUTOML_EVENTS.PIPELINE_RUN_RETRIED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+      });
       notification.success(
         'Retry submitted successfully',
         'The process is asynchronous and may take some time to take effect',
       );
     } catch (error) {
+      fireFormTrackingEvent(AUTOML_EVENTS.PIPELINE_RUN_RETRIED, {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       notification.error(
         'Failed to retry run',
         error instanceof Error ? error.message : 'An unknown error occurred',
@@ -57,11 +69,20 @@ export const useAutomlRunActions = (
     try {
       await terminateMutation.mutateAsync();
       await queryClient.invalidateQueries({ queryKey: ['pipelineRun', runId, namespace] });
+      fireFormTrackingEvent(AUTOML_EVENTS.PIPELINE_RUN_STOPPED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+      });
       notification.success(
         'Stop submitted successfully',
         'The process is asynchronous and may take some time to take effect',
       );
     } catch (error) {
+      fireFormTrackingEvent(AUTOML_EVENTS.PIPELINE_RUN_STOPPED, {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       notification.error(
         'Failed to stop run',
         error instanceof Error ? error.message : 'An unknown error occurred',
@@ -79,11 +100,20 @@ export const useAutomlRunActions = (
     try {
       await deleteMutation.mutateAsync();
       await queryClient.invalidateQueries({ queryKey: ['pipelineRun', runId, namespace] });
+      fireFormTrackingEvent(AUTOML_EVENTS.PIPELINE_RUN_DELETED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+      });
       notification.success(
         'Run deleted successfully',
         'The pipeline run has been permanently removed',
       );
     } catch (error) {
+      fireFormTrackingEvent(AUTOML_EVENTS.PIPELINE_RUN_DELETED, {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       notification.error(
         'Failed to delete run',
         error instanceof Error ? error.message : 'An unknown error occurred',

--- a/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
@@ -17,6 +17,8 @@ import { ApplicationsPage } from 'mod-arch-shared';
 import React, { useCallback, useState } from 'react';
 import { FieldPath, FormProvider, useForm, useWatch } from 'react-hook-form';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
 import AutomlHeader from '~/app/components/common/AutomlHeader/AutomlHeader';
 import AutomlConfigure from '~/app/components/configure/AutomlConfigure';
 import AutomlCreate from '~/app/components/create/AutomlCreate';
@@ -26,6 +28,7 @@ import { useCreatePipelineRunMutation } from '~/app/hooks/mutations';
 import { useNotification } from '~/app/hooks/useNotification';
 import type { SecretSelection } from '~/app/components/common/SecretSelector';
 import { ConfigureSchema, createConfigureSchema } from '~/app/schemas/configure.schema';
+import { AUTOML_EVENTS } from '~/app/tracking/automlTrackingConstants';
 import { automlExperimentsPathname, automlResultsPathname } from '~/app/utilities/routes';
 
 const configureSchema = createConfigureSchema();
@@ -219,10 +222,30 @@ function AutomlConfigurePage({
 
             form.handleSubmit(
               async (data: ConfigureSchema) => {
+                const eventName = sourceRunId
+                  ? AUTOML_EVENTS.RUN_RECONFIGURED
+                  : AUTOML_EVENTS.PIPELINE_RUN_CREATED;
+                const trackingProps = {
+                  outcome: TrackingOutcome.submit,
+                  taskType: data.task_type,
+                  preset: data.preset,
+                  topN: data.top_n,
+                  evalMetric: data.eval_metric ?? '',
+                  ...(data.task_type === 'timeseries' && {
+                    predictionLength: data.prediction_length ?? 1,
+                    knownCovariatesCount: data.known_covariates_names?.length ?? 0,
+                  }),
+                };
                 try {
                   const pipelineRun = await pipelineRunsMutation.mutateAsync(data);
+                  fireFormTrackingEvent(eventName, { ...trackingProps, success: true });
                   navigate(`${automlResultsPathname}/${namespace}/${pipelineRun.run_id}`);
                 } catch (error) {
+                  fireFormTrackingEvent(eventName, {
+                    ...trackingProps,
+                    success: false,
+                    error: error instanceof Error ? error.message : 'Unknown error',
+                  });
                   notification.error(
                     'Failed to create pipeline run',
                     error instanceof Error ? error.message : '',

--- a/packages/automl/frontend/src/app/tracking/automlTrackingConstants.ts
+++ b/packages/automl/frontend/src/app/tracking/automlTrackingConstants.ts
@@ -1,0 +1,11 @@
+export const AUTOML_EVENTS = {
+  PIPELINE_RUN_CREATED: 'AutoML Pipeline Run Created',
+  PIPELINE_RUN_STOPPED: 'AutoML Pipeline Run Stopped',
+  PIPELINE_RUN_DELETED: 'AutoML Pipeline Run Deleted',
+  PIPELINE_RUN_RETRIED: 'AutoML Pipeline Run Retried',
+  MODEL_REGISTERED: 'AutoML Model Registered',
+  RUN_RECONFIGURED: 'AutoML Run Reconfigured',
+  S3_CONNECTION_CREATED: 'AutoML S3 Connection Created',
+  MODEL_DETAILS_DOWNLOADED: 'AutoML Model Details Downloaded',
+  NOTEBOOK_SAVED: 'AutoML Notebook Saved',
+} as const;

--- a/packages/autorag/frontend/src/app/components/common/OgxConnectionModal.tsx
+++ b/packages/autorag/frontend/src/app/components/common/OgxConnectionModal.tsx
@@ -19,6 +19,9 @@ import K8sNameDescriptionField, {
 import { isK8sNameDescriptionDataValid } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/utils';
 import { createSecret } from '@odh-dashboard/internal/api/k8s/secrets';
 import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
+import { AUTORAG_EVENTS } from '~/app/tracking/autoragTrackingConstants';
 
 type Props = {
   namespace: string;
@@ -72,6 +75,11 @@ const OgxConnectionModal: React.FC<Props> = ({ namespace, onClose, onSubmit }) =
     try {
       await createSecret(secret);
     } catch (e) {
+      fireFormTrackingEvent(AUTORAG_EVENTS.OGX_CONNECTION_CREATED, {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: e instanceof Error ? e.message : 'Unknown error',
+      });
       setSubmitError(e instanceof Error ? e : new Error(String(e)));
       setIsSaving(false);
       return;
@@ -79,6 +87,10 @@ const OgxConnectionModal: React.FC<Props> = ({ namespace, onClose, onSubmit }) =
 
     try {
       await onSubmit(k8sName);
+      fireFormTrackingEvent(AUTORAG_EVENTS.OGX_CONNECTION_CREATED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+      });
       onClose();
     } catch (e) {
       setSubmitError(e instanceof Error ? e : new Error(String(e)));

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
@@ -14,6 +14,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { useParams } from 'react-router';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import PipelineTopology from '~/app/topology/PipelineTopology';
 import { useAutoragTaskTopology } from '~/app/topology/useAutoragTaskTopology';
 import { buildStageMapTopology } from '~/app/topology/buildStageMapTopology';
@@ -28,6 +29,7 @@ import {
   isRunInTerminalState,
   sanitizeFilename,
 } from '~/app/utilities/utils';
+import { AUTORAG_EVENTS } from '~/app/tracking/autoragTrackingConstants';
 import AutoragLeaderboard from './AutoragLeaderboard';
 import './AutoragResults.scss';
 
@@ -135,6 +137,7 @@ function AutoragResults({ onTryPattern, onViewCode }: AutoragResultsProps): Reac
         const safePatternName = sanitizeFilename(patternName);
         const filename = `${displayName}_${safePatternName}_${notebookType}_notebook.ipynb`;
         downloadBlob(notebook, filename);
+        fireMiscTrackingEvent(AUTORAG_EVENTS.NOTEBOOK_SAVED, { patternName, notebookType });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
         setDownloadError({

--- a/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternDetailsModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternDetailsModal.tsx
@@ -16,6 +16,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import type { AutoragPattern, PatternDataBundle, ScoreType } from '~/app/types/autoragPattern';
 import { usePatternEvaluationResults } from '~/app/hooks/usePatternEvaluationResults';
 import {
@@ -24,6 +25,7 @@ import {
   formatMetricValue,
   formatPatternName,
 } from '~/app/utilities/utils';
+import { AUTORAG_EVENTS } from '~/app/tracking/autoragTrackingConstants';
 import { getVisibleTabs, OVERVIEW_KEY } from './tabConfig';
 import PatternDetailsModalHeader from './PatternDetailsModalHeader';
 import PatternComparisonSelectModal from './PatternComparisonSelectModal';
@@ -184,7 +186,12 @@ const PatternDetailsModal: React.FC<PatternDetailsModalProps> = ({
             rank={rank}
             optimizedMetric={optimizedMetric}
             onPatternChange={onPatternChange}
-            onDownload={() => setIsPrinting(true)}
+            onDownload={() => {
+              fireMiscTrackingEvent(AUTORAG_EVENTS.PATTERN_DETAILS_DOWNLOADED, {
+                patternName: data.name,
+              });
+              setIsPrinting(true);
+            }}
             onSaveNotebook={onSaveNotebook}
             onTryPattern={
               onTryPattern

--- a/packages/autorag/frontend/src/app/hooks/useAutoragRunActions.ts
+++ b/packages/autorag/frontend/src/app/hooks/useAutoragRunActions.ts
@@ -1,11 +1,14 @@
 import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
 import {
   useDeletePipelineRunMutation,
   useRetryPipelineRunMutation,
   useTerminatePipelineRunMutation,
 } from '~/app/hooks/mutations';
 import { useNotification } from '~/app/hooks/useNotification';
+import { AUTORAG_EVENTS } from '~/app/tracking/autoragTrackingConstants';
 
 type AutoragRunActions = {
   handleRetry: () => Promise<void>;
@@ -37,11 +40,20 @@ export const useAutoragRunActions = (
       await queryClient.invalidateQueries({
         queryKey: ['autorag', 'pipelineRun', runId, namespace],
       });
+      fireFormTrackingEvent(AUTORAG_EVENTS.PIPELINE_RUN_RETRIED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+      });
       notification.success(
         'Retry submitted successfully',
         'The process is asynchronous and may take some time to take effect',
       );
     } catch (error) {
+      fireFormTrackingEvent(AUTORAG_EVENTS.PIPELINE_RUN_RETRIED, {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       notification.error(
         'Failed to retry run',
         error instanceof Error ? error.message : 'An unknown error occurred',
@@ -61,11 +73,20 @@ export const useAutoragRunActions = (
       await queryClient.invalidateQueries({
         queryKey: ['autorag', 'pipelineRun', runId, namespace],
       });
+      fireFormTrackingEvent(AUTORAG_EVENTS.PIPELINE_RUN_STOPPED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+      });
       notification.success(
         'Stop submitted successfully',
         'The process is asynchronous and may take some time to take effect',
       );
     } catch (error) {
+      fireFormTrackingEvent(AUTORAG_EVENTS.PIPELINE_RUN_STOPPED, {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
       // Check if the error is because the run is already in a terminal state (case-insensitive, whole words only)
       const terminalStatePattern = /\b(FAILED|SUCCEEDED|CANCELL?ED)\b|cannot be terminated/i;
@@ -102,11 +123,20 @@ export const useAutoragRunActions = (
       await queryClient.invalidateQueries({
         queryKey: ['autorag', 'pipelineRun', runId, namespace],
       });
+      fireFormTrackingEvent(AUTORAG_EVENTS.PIPELINE_RUN_DELETED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+      });
       notification.success(
         'Run deleted successfully',
         'The pipeline run has been permanently removed',
       );
     } catch (error) {
+      fireFormTrackingEvent(AUTORAG_EVENTS.PIPELINE_RUN_DELETED, {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
       notification.error(
         'Failed to delete run',
         error instanceof Error ? error.message : 'An unknown error occurred',

--- a/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
@@ -17,6 +17,8 @@ import { ApplicationsPage } from 'mod-arch-shared';
 import React, { useCallback, useState } from 'react';
 import { FieldPath, FormProvider, useForm, useWatch } from 'react-hook-form';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
 import AutoragConfigure from '~/app/components/configure/AutoragConfigure';
 import AutoragHeader from '~/app/components/common/AutoragHeader/AutoragHeader';
 import AutoragCreate from '~/app/components/create/AutoragCreate';
@@ -27,6 +29,7 @@ import { useNotification } from '~/app/hooks/useNotification';
 import type { SecretSelection } from '~/app/components/common/SecretSelector';
 import { ConfigureSchema, createConfigureSchema } from '~/app/schemas/configure.schema';
 import { autoragExperimentsPathname, autoragResultsPathname } from '~/app/utilities/routes';
+import { AUTORAG_EVENTS } from '~/app/tracking/autoragTrackingConstants';
 
 const configureSchema = createConfigureSchema();
 const createFields = ['display_name', 'description', 'ogx_secret_name'] as const satisfies Array<
@@ -232,10 +235,28 @@ function AutoragConfigurePage({
 
             form.handleSubmit(
               async (data: ConfigureSchema) => {
+                const eventName = sourceRunId
+                  ? AUTORAG_EVENTS.RUN_RECONFIGURED
+                  : AUTORAG_EVENTS.PIPELINE_RUN_CREATED;
+                const trackingProps = {
+                  outcome: TrackingOutcome.submit,
+                  optimizationMetric: data.optimization_metric,
+                  optimizationMaxRagPatterns: data.optimization_max_rag_patterns,
+                  vectorIoProviderId: data.vector_io_provider_id,
+                  generationModels: data.generation_models.join(','),
+                  embeddingModels: data.embedding_models.join(','),
+                  hasTestData: Boolean(data.test_data_key),
+                };
                 try {
                   const pipelineRun = await pipelineRunsMutation.mutateAsync(data);
+                  fireFormTrackingEvent(eventName, { ...trackingProps, success: true });
                   navigate(`${autoragResultsPathname}/${namespace}/${pipelineRun.run_id}`);
                 } catch (error) {
+                  fireFormTrackingEvent(eventName, {
+                    ...trackingProps,
+                    success: false,
+                    error: error instanceof Error ? error.message : 'Unknown error',
+                  });
                   notification.error(
                     'Failed to create pipeline run',
                     error instanceof Error ? error.message : '',

--- a/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
@@ -14,6 +14,7 @@ import { CogIcon, OpenDrawerRightIcon, RedoIcon, StopCircleIcon } from '@pattern
 import { ApplicationsPage } from 'mod-arch-shared';
 import React from 'react';
 import { Link, useLocation, useParams } from 'react-router';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutoragHeader from '~/app/components/common/AutoragHeader/AutoragHeader';
 import InvalidPipelineRun from '~/app/components/empty-states/InvalidPipelineRun';
 import InvalidProject from '~/app/components/empty-states/InvalidProject';
@@ -40,6 +41,7 @@ import {
 } from '~/app/utilities/utils';
 import ViewCodeModal from '~/app/components/run-results/ViewCodeModal';
 import type { ResponsesTemplate } from '~/app/types/autoragPattern';
+import { AUTORAG_EVENTS } from '~/app/tracking/autoragTrackingConstants';
 
 type DrawerContentType =
   | { type: 'run-details' }
@@ -202,6 +204,7 @@ function AutoragResultsPage(): React.JSX.Element {
       if (!pattern) {
         return;
       }
+      fireMiscTrackingEvent(AUTORAG_EVENTS.PATTERN_TRIED, { patternName });
       const responsesTemplate = pattern.settings?.responses_template;
       if (!responsesTemplate) {
         return;
@@ -239,6 +242,7 @@ function AutoragResultsPage(): React.JSX.Element {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const responsesTemplate = patterns?.[patternName]?.settings?.responses_template;
       if (responsesTemplate) {
+        fireMiscTrackingEvent(AUTORAG_EVENTS.PATTERN_CODE_VIEWED, { patternName });
         setViewCodePattern({ patternName, responsesTemplate });
       }
     },

--- a/packages/autorag/frontend/src/app/tracking/autoragTrackingConstants.ts
+++ b/packages/autorag/frontend/src/app/tracking/autoragTrackingConstants.ts
@@ -1,0 +1,12 @@
+export const AUTORAG_EVENTS = {
+  PIPELINE_RUN_CREATED: 'AutoRAG Pipeline Run Created',
+  PIPELINE_RUN_STOPPED: 'AutoRAG Pipeline Run Stopped',
+  PIPELINE_RUN_DELETED: 'AutoRAG Pipeline Run Deleted',
+  PIPELINE_RUN_RETRIED: 'AutoRAG Pipeline Run Retried',
+  PATTERN_TRIED: 'AutoRAG Pattern Tried',
+  PATTERN_CODE_VIEWED: 'AutoRAG Pattern Code Viewed',
+  OGX_CONNECTION_CREATED: 'AutoRAG OGX Connection Created',
+  RUN_RECONFIGURED: 'AutoRAG Run Reconfigured',
+  PATTERN_DETAILS_DOWNLOADED: 'AutoRAG Pattern Details Downloaded',
+  NOTEBOOK_SAVED: 'AutoRAG Notebook Saved',
+} as const;


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1oSClQ9uBYyBbJVdbLaZ9eQIlDGqA71E832Lsx7aGf70/edit?usp=sharing

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds comprehensive Segment tracking events to the **automl** and **autorag** packages. Both packages previously only tracked the project dropdown selection — this PR instruments all key user actions.

### AutoML events (9 new):
- **AutoML Pipeline Run Created** — configure form submission with full config payload (task type, preset, top N, eval metric, timeseries-specific fields)
- **AutoML Run Reconfigured** — same schema, fires when reconfiguring from an existing run
- **AutoML Pipeline Run Stopped / Deleted / Retried** — run lifecycle actions via `useAutomlRunActions` hook (covers both list table and results page entry points)
- **AutoML Model Registered** — register model modal submission with registry ID
- **AutoML S3 Connection Created** — S3 connection modal submission
- **AutoML Model Details Downloaded** — download button in model details modal
- **AutoML Notebook Saved** — save notebook action from leaderboard or model details

### AutoRAG events (10 new):
- **AutoRAG Pipeline Run Created** — configure form submission with full config payload (optimization metric, max patterns, vector store, generation/embedding model IDs, test data flag)
- **AutoRAG Run Reconfigured** — same schema, fires when reconfiguring from an existing run
- **AutoRAG Pipeline Run Stopped / Deleted / Retried** — run lifecycle actions via `useAutoragRunActions` hook (covers both list table and results page entry points)
- **AutoRAG Pattern Tried** — fires from both the leaderboard "Try this pattern" action and pattern details modal (single handler in `AutoragResultsPage`)
- **AutoRAG Pattern Code Viewed** — fires from all three entry points (leaderboard, pattern details modal, playground drawer)
- **AutoRAG OGX Connection Created** — OGX connection modal submission
- **AutoRAG Pattern Details Downloaded** — download button in pattern details modal
- **AutoRAG Notebook Saved** — save notebook with pattern name and notebook type (indexing/inference)

### Implementation approach:
- Follows the eval-hub pattern: dedicated tracking constants files per package, tracking calls at the handler level
- Form events use `fireFormTrackingEvent` with `outcome`/`success`/`error` matching existing patterns (pipeline server, model serving)
- Non-form actions use `fireMiscTrackingEvent` matching eval-hub's approach
- Run actions (stop/delete/retry) tracked in shared hooks so both list table and results page entry points are covered automatically
- No S3 paths, secret names, or PII captured — only config settings and model IDs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Type-check passes for both automl and autorag frontend packages
- ESLint passes for all modified files
- Pre-commit lint-staged hook passes

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

No test changes in this PR. Tracking events are fire-and-forget calls to Segment and do not affect component behavior or rendering. In DEV_MODE, events are logged to the browser console for manual verification. Tracking-specific unit tests can be added as a follow-up (similar to eval-hub's `useStartEvaluationRunForm.tracking.spec.ts` pattern).

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for key AutoML and AutoRAG user actions, including form submissions, run actions, downloads, notebook saves, and pattern interactions.

* **Bug Fixes**
  * Improved error reporting for failed connection, registration, and pipeline creation flows so failures are captured more consistently.
  * Preserved existing success and failure notifications while adding tracking around retries, stops, and deletes.

* **Chores**
  * Introduced shared tracking event names for AutoML and AutoRAG to support consistent event reporting across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->