### PR TITLE
fix(agent-ops): scope runtimes list by namespace, add auth checks & scrub query params from logs

### DIFF
--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -112,6 +112,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
       operationId: listAgentRuntimes

--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -79,6 +79,17 @@ paths:
       tags:
         - AgentOperation
       parameters:
+        - name: namespace
+          in: query
+          required: false
+          description: >-
+            Kubernetes namespace to scope results to. When provided, only agents
+            from this namespace are returned. When omitted, agents from all
+            enabled namespaces are returned.
+          schema:
+            type: string
+            pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+            maxLength: 63
         - name: limit
           in: query
           required: false
@@ -97,6 +108,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/AgentRuntimesResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "500":

--- a/packages/agent-ops/bff/internal/api/agent_handlers.go
+++ b/packages/agent-ops/bff/internal/api/agent_handlers.go
@@ -56,7 +56,7 @@ func (app *App) handleAgentRepositoryError(w http.ResponseWriter, r *http.Reques
 		app.logger.Warn("Agent repository access forbidden",
 			"error", err.Error(),
 			"method", r.Method,
-			"uri", r.URL.RequestURI())
+			"path", r.URL.Path)
 		app.forbiddenResponse(w, r, "user does not have permission to access the requested agent")
 		return
 	}

--- a/packages/agent-ops/bff/internal/api/agent_runtimes_handler.go
+++ b/packages/agent-ops/bff/internal/api/agent_runtimes_handler.go
@@ -24,7 +24,7 @@ func parseListAgentRuntimesOptions(r *http.Request) (models.ListAgentRuntimesOpt
 
 	if ns := opts.Namespace; ns != "" {
 		if !isValidDNS1123Label(ns) {
-			return models.ListAgentRuntimesOptions{}, fmt.Errorf("namespace must be a valid RFC 1123 label (lowercase alphanumeric and hyphens, max 63 chars)")
+			return models.ListAgentRuntimesOptions{}, fmt.Errorf("invalid namespace %q: must match RFC 1123 label format (lowercase alphanumeric and hyphens, max 63 chars)", ns)
 		}
 	}
 

--- a/packages/agent-ops/bff/internal/api/agent_runtimes_handler.go
+++ b/packages/agent-ops/bff/internal/api/agent_runtimes_handler.go
@@ -22,6 +22,12 @@ func parseListAgentRuntimesOptions(r *http.Request) (models.ListAgentRuntimesOpt
 		ContinueToken: r.URL.Query().Get("continueToken"),
 	}
 
+	if ns := opts.Namespace; ns != "" {
+		if !isValidDNS1123Label(ns) {
+			return models.ListAgentRuntimesOptions{}, fmt.Errorf("namespace must be a valid RFC 1123 label (lowercase alphanumeric and hyphens, max 63 chars)")
+		}
+	}
+
 	limitValue := r.URL.Query().Get("limit")
 	if limitValue == "" {
 		return opts, nil

--- a/packages/agent-ops/bff/internal/api/agent_runtimes_handler.go
+++ b/packages/agent-ops/bff/internal/api/agent_runtimes_handler.go
@@ -17,6 +17,7 @@ type AgentRuntimesEnvelope Envelope[*models.AgentRuntimesResponse, None]
 
 func parseListAgentRuntimesOptions(r *http.Request) (models.ListAgentRuntimesOptions, error) {
 	opts := models.ListAgentRuntimesOptions{
+		Namespace:     r.URL.Query().Get("namespace"),
 		Limit:         repositories.DefaultAgentRuntimesLimit,
 		ContinueToken: r.URL.Query().Get("continueToken"),
 	}

--- a/packages/agent-ops/bff/internal/api/agent_runtimes_handler_test.go
+++ b/packages/agent-ops/bff/internal/api/agent_runtimes_handler_test.go
@@ -63,3 +63,46 @@ func TestListAgentRuntimesHandler(t *testing.T) {
 	assert.Equal(t, "agent", runtime.Type)
 	assert.Equal(t, "http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080", runtime.EndpointURL)
 }
+
+func TestListAgentRuntimesHandler_WithNamespace(t *testing.T) {
+	app := &App{
+		repositories: testRepositoriesWithAgents(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, AgentRuntimesPath+"?namespace=agent-ops-demo", nil)
+	rr := httptest.NewRecorder()
+
+	app.ListAgentRuntimesHandler(rr, req, httprouter.Params{})
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body, err := io.ReadAll(rr.Body)
+	require.NoError(t, err)
+
+	var envelope AgentRuntimesEnvelope
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	require.NotNil(t, envelope.Data)
+	require.Len(t, envelope.Data.Runtimes, 1)
+	assert.Equal(t, "agent-ops-demo", envelope.Data.Runtimes[0].Namespace)
+}
+
+func TestListAgentRuntimesHandler_WithNamespaceNoResults(t *testing.T) {
+	app := &App{
+		repositories: testRepositoriesWithAgents(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, AgentRuntimesPath+"?namespace=nonexistent-ns", nil)
+	rr := httptest.NewRecorder()
+
+	app.ListAgentRuntimesHandler(rr, req, httprouter.Params{})
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body, err := io.ReadAll(rr.Body)
+	require.NoError(t, err)
+
+	var envelope AgentRuntimesEnvelope
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	require.NotNil(t, envelope.Data)
+	assert.Empty(t, envelope.Data.Runtimes)
+}

--- a/packages/agent-ops/bff/internal/api/agent_runtimes_handler_test.go
+++ b/packages/agent-ops/bff/internal/api/agent_runtimes_handler_test.go
@@ -24,6 +24,18 @@ func TestListAgentRuntimesHandler_InvalidLimit(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
+func TestListAgentRuntimesHandler_WithInvalidNamespace(t *testing.T) {
+	app := &App{
+		repositories: testRepositoriesWithAgents(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, AgentRuntimesPath+"?namespace=INVALID_NS", nil)
+	rr := httptest.NewRecorder()
+	app.ListAgentRuntimesHandler(rr, req, httprouter.Params{})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
 func TestListAgentRuntimesHandler_InvalidContinueToken(t *testing.T) {
 	app := &App{
 		repositories: testRepositoriesWithAgents(),

--- a/packages/agent-ops/bff/internal/api/agent_runtimes_handler_test.go
+++ b/packages/agent-ops/bff/internal/api/agent_runtimes_handler_test.go
@@ -1,13 +1,17 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
+	agentsmock "github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents/mock"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/repositories"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -117,4 +121,28 @@ func TestListAgentRuntimesHandler_WithNamespaceNoResults(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &envelope))
 	require.NotNil(t, envelope.Data)
 	assert.Empty(t, envelope.Data.Runtimes)
+}
+
+func TestListAgentRuntimesHandler_ForbiddenNamespaceDoesNotLeakQueryParams(t *testing.T) {
+	mockClient := agentsmock.NewClient()
+	mockClient.CanListAgentsInNSResult = false
+	repos := repositories.NewRepositories(&agentsmock.Factory{Client: mockClient})
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	app := &App{
+		repositories: repos,
+		logger:       logger,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, AgentRuntimesPath+"?namespace=secret-ns&continueToken=sensitive-token", nil)
+	rr := httptest.NewRecorder()
+
+	app.ListAgentRuntimesHandler(rr, req, httprouter.Params{})
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+
+	logOutput := buf.String()
+	assert.NotContains(t, logOutput, "sensitive-token")
+	assert.NotContains(t, logOutput, "continueToken")
 }

--- a/packages/agent-ops/bff/internal/api/errors.go
+++ b/packages/agent-ops/bff/internal/api/errors.go
@@ -30,10 +30,10 @@ type ErrorPayload struct {
 func (app *App) LogError(r *http.Request, err error) {
 	var (
 		method = r.Method
-		uri    = r.URL.RequestURI()
+		path   = r.URL.Path
 	)
 
-	app.logger.Error(err.Error(), "method", method, "uri", uri)
+	app.logger.Error(err.Error(), "method", method, "path", path)
 }
 
 func (app *App) badRequestResponse(w http.ResponseWriter, r *http.Request, err error) {
@@ -42,14 +42,14 @@ func (app *App) badRequestResponse(w http.ResponseWriter, r *http.Request, err e
 }
 
 func (app *App) forbiddenResponse(w http.ResponseWriter, r *http.Request, message string) {
-	app.logger.Warn("Access forbidden", "message", message, "method", r.Method, "uri", r.URL.RequestURI())
+	app.logger.Warn("Access forbidden", "message", message, "method", r.Method, "path", r.URL.Path)
 
 	httpError := &HTTPError{StatusCode: http.StatusForbidden, Error: ErrorPayload{Code: ErrCodeForbidden, Message: "Access forbidden"}}
 	app.errorResponse(w, r, httpError)
 }
 
 func (app *App) unauthorizedResponse(w http.ResponseWriter, r *http.Request, err error) {
-	app.logger.Warn("Unauthorized request", "error", err.Error(), "method", r.Method, "uri", r.URL.RequestURI())
+	app.logger.Warn("Unauthorized request", "error", err.Error(), "method", r.Method, "path", r.URL.Path)
 
 	httpError := &HTTPError{StatusCode: http.StatusUnauthorized, Error: ErrorPayload{Code: ErrCodeUnauthorized, Message: "Authentication required"}}
 	app.errorResponse(w, r, httpError)

--- a/packages/agent-ops/bff/internal/integrations/agents/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/client.go
@@ -5,6 +5,7 @@ import "context"
 // Client loads agent runtime data from Kubernetes workloads or mocks.
 type Client interface {
 	ListNamespaces(ctx context.Context, enabledOnly bool) ([]string, error)
+	CanListAgentsInNamespace(ctx context.Context, namespace string) (bool, error)
 	ListAgents(ctx context.Context, namespace string) (*AgentList, error)
 	GetAgent(ctx context.Context, namespace, name string) (*AgentDetail, error)
 

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client.go
@@ -52,6 +52,11 @@ func (c *Client) ListNamespaces(ctx context.Context, enabledOnly bool) ([]string
 	return result, nil
 }
 
+// CanListAgentsInNamespace checks whether the caller has permission to list agent workloads in the given namespace.
+func (c *Client) CanListAgentsInNamespace(ctx context.Context, namespace string) (bool, error) {
+	return c.k8sClient.CanListAgentsInNamespace(ctx, c.identity, namespace)
+}
+
 // ListAgents returns labeled agent workloads in a namespace.
 func (c *Client) ListAgents(ctx context.Context, namespace string) (*agents.AgentList, error) {
 	summaries, err := c.listAgentSummaries(ctx, namespace)

--- a/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
@@ -17,17 +17,20 @@ type Client struct {
 	Agents     map[string][]agents.AgentSummary
 	Details    map[string]agents.AgentDetail
 
-	ListNamespacesErr error
-	ListAgentsErr     error
-	GetAgentErr       error
-	DeployAgentErr    error
+	ListNamespacesErr         error
+	CanListAgentsInNSResult   bool
+	CanListAgentsInNSErr      error
+	ListAgentsErr             error
+	GetAgentErr               error
+	DeployAgentErr            error
 }
 
-// NewClient returns a mock client with no data.
+// NewClient returns a mock client with no data. CanListAgentsInNamespace defaults to allowed.
 func NewClient() *Client {
 	return &Client{
-		Agents:  map[string][]agents.AgentSummary{},
-		Details: map[string]agents.AgentDetail{},
+		Agents:                  map[string][]agents.AgentSummary{},
+		Details:                 map[string]agents.AgentDetail{},
+		CanListAgentsInNSResult: true,
 	}
 }
 
@@ -45,6 +48,18 @@ func (c *Client) ListNamespaces(ctx context.Context, enabledOnly bool) ([]string
 		return nil, c.ListNamespacesErr
 	}
 	return append([]string(nil), c.Namespaces...), nil
+}
+
+// CanListAgentsInNamespace implements agents.Client.
+func (c *Client) CanListAgentsInNamespace(ctx context.Context, namespace string) (bool, error) {
+	_ = ctx
+	_ = namespace
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.CanListAgentsInNSErr != nil {
+		return false, c.CanListAgentsInNSErr
+	}
+	return c.CanListAgentsInNSResult, nil
 }
 
 // ListAgents implements agents.Client.

--- a/packages/agent-ops/bff/internal/models/agent_runtime.go
+++ b/packages/agent-ops/bff/internal/models/agent_runtime.go
@@ -18,8 +18,9 @@ type AgentRuntimesResponse struct {
 	ContinueToken *string        `json:"continueToken,omitempty"`
 }
 
-// ListAgentRuntimesOptions controls pagination for runtime list queries.
+// ListAgentRuntimesOptions controls pagination and filtering for runtime list queries.
 type ListAgentRuntimesOptions struct {
+	Namespace     string
 	Limit         int
 	ContinueToken string
 }

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
@@ -35,6 +35,10 @@ func (r *AgentRuntimesRepository) ListAgentRuntimes(ctx context.Context, opts mo
 
 	var namespaces []string
 	if opts.Namespace != "" {
+		allowed, err := client.CanListAgentsInNamespace(ctx, opts.Namespace)
+		if err != nil || !allowed {
+			return nil, bfferrors.ErrForbidden
+		}
 		namespaces = []string{opts.Namespace}
 	} else {
 		namespaces, err = client.ListNamespaces(ctx, true)

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
@@ -25,16 +25,22 @@ func NewAgentRuntimesRepository(agentSourceFactory agents.ClientFactory) *AgentR
 	return &AgentRuntimesRepository{agentSourceFactory: agentSourceFactory}
 }
 
-// ListAgentRuntimes returns deployed agent runtimes across enabled namespaces.
+// ListAgentRuntimes returns deployed agent runtimes. When opts.Namespace is set,
+// only agents from that namespace are returned; otherwise all enabled namespaces are queried.
 func (r *AgentRuntimesRepository) ListAgentRuntimes(ctx context.Context, opts models.ListAgentRuntimesOptions) (*models.AgentRuntimesResponse, error) {
 	client, err := r.agentSourceFactory.GetClient(ctx)
 	if err != nil {
 		return nil, translateAgentError(err)
 	}
 
-	namespaces, err := client.ListNamespaces(ctx, true)
-	if err != nil {
-		return nil, translateAgentError(err)
+	var namespaces []string
+	if opts.Namespace != "" {
+		namespaces = []string{opts.Namespace}
+	} else {
+		namespaces, err = client.ListNamespaces(ctx, true)
+		if err != nil {
+			return nil, translateAgentError(err)
+		}
 	}
 
 	runtimes := make([]models.AgentRuntime, 0)

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
@@ -47,6 +47,9 @@ func (r *AgentRuntimesRepository) ListAgentRuntimes(ctx context.Context, opts mo
 	for _, namespace := range namespaces {
 		list, err := client.ListAgents(ctx, namespace)
 		if err != nil {
+			if opts.Namespace != "" {
+				return nil, translateAgentError(err)
+			}
 			slog.Warn("failed to list agents in namespace, skipping",
 				slog.String("namespace", namespace),
 				slog.Any("error", err))

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
@@ -94,6 +94,17 @@ func TestListAgentRuntimesScopedByNamespace(t *testing.T) {
 		assert.Equal(t, "ns-a", result.Runtimes[0].Namespace)
 	})
 
+	t.Run("with namespace propagates ListAgents error", func(t *testing.T) {
+		clientWithErr := agentsmock.NewClient()
+		clientWithErr.ListAgentsErr = errors.New("upstream failure")
+		repo := NewAgentRuntimesRepository(&agentsmock.Factory{Client: clientWithErr})
+		_, err := repo.ListAgentRuntimes(context.Background(), models.ListAgentRuntimesOptions{
+			Namespace: "ns-a",
+			Limit:     DefaultAgentRuntimesLimit,
+		})
+		require.Error(t, err)
+	})
+
 	t.Run("with namespace skips ListNamespaces call", func(t *testing.T) {
 		clientWithNsErr := agentsmock.NewClient()
 		clientWithNsErr.ListNamespacesErr = errors.New("should not be called")

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
@@ -125,6 +125,18 @@ func TestListAgentRuntimesScopedByNamespace(t *testing.T) {
 		assert.True(t, errors.Is(err, bfferrors.ErrForbidden))
 	})
 
+	t.Run("with namespace returns forbidden when access check errors", func(t *testing.T) {
+		errClient := agentsmock.NewClient()
+		errClient.CanListAgentsInNSErr = errors.New("sar failed")
+		repo := NewAgentRuntimesRepository(&agentsmock.Factory{Client: errClient})
+		_, err := repo.ListAgentRuntimes(context.Background(), models.ListAgentRuntimesOptions{
+			Namespace: "ns-a",
+			Limit:     DefaultAgentRuntimesLimit,
+		})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, bfferrors.ErrForbidden))
+	})
+
 	t.Run("with namespace skips ListNamespaces call", func(t *testing.T) {
 		clientWithNsErr := agentsmock.NewClient()
 		clientWithNsErr.ListNamespacesErr = errors.New("should not be called")

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
@@ -44,6 +44,10 @@ func (nilAgentDetailClient) ListNamespaces(context.Context, bool) ([]string, err
 	return nil, nil
 }
 
+func (nilAgentDetailClient) CanListAgentsInNamespace(context.Context, string) (bool, error) {
+	return true, nil
+}
+
 func (nilAgentDetailClient) ListAgents(context.Context, string) (*agents.AgentList, error) {
 	return nil, nil
 }
@@ -103,6 +107,22 @@ func TestListAgentRuntimesScopedByNamespace(t *testing.T) {
 			Limit:     DefaultAgentRuntimesLimit,
 		})
 		require.Error(t, err)
+	})
+
+	t.Run("with namespace returns forbidden when access denied", func(t *testing.T) {
+		forbiddenClient := agentsmock.NewClient()
+		forbiddenClient.CanListAgentsInNSResult = false
+		forbiddenClient.Agents = map[string][]agents.AgentSummary{
+			"ns-a": {{Name: "agent-1", Namespace: "ns-a", Status: "Ready", ResourceType: "agent",
+				EndpointURL: "http://agent-1.ns-a.svc:8080", CreatedAt: "2026-06-01T00:00:00Z"}},
+		}
+		repo := NewAgentRuntimesRepository(&agentsmock.Factory{Client: forbiddenClient})
+		_, err := repo.ListAgentRuntimes(context.Background(), models.ListAgentRuntimesOptions{
+			Namespace: "ns-a",
+			Limit:     DefaultAgentRuntimesLimit,
+		})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, bfferrors.ErrForbidden))
 	})
 
 	t.Run("with namespace skips ListNamespaces call", func(t *testing.T) {

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
@@ -60,6 +60,56 @@ func (nilAgentDetailClient) DeleteAgent(context.Context, string, string) error {
 func (nilAgentDetailClient) StopAgent(context.Context, string, string) error   { return nil }
 func (nilAgentDetailClient) StartAgent(context.Context, string, string) error  { return nil }
 
+func TestListAgentRuntimesScopedByNamespace(t *testing.T) {
+	client := agentsmock.NewClient()
+	client.Namespaces = []string{"ns-a", "ns-b"}
+	client.Agents = map[string][]agents.AgentSummary{
+		"ns-a": {
+			{Name: "agent-1", Namespace: "ns-a", Status: "Ready", ResourceType: "agent",
+				EndpointURL: "http://agent-1.ns-a.svc:8080", CreatedAt: "2026-06-01T00:00:00Z"},
+		},
+		"ns-b": {
+			{Name: "agent-2", Namespace: "ns-b", Status: "Ready", ResourceType: "agent",
+				EndpointURL: "http://agent-2.ns-b.svc:8080", CreatedAt: "2026-06-01T00:00:00Z"},
+		},
+	}
+	repo := NewAgentRuntimesRepository(&agentsmock.Factory{Client: client})
+
+	t.Run("without namespace returns all", func(t *testing.T) {
+		result, err := repo.ListAgentRuntimes(context.Background(), models.ListAgentRuntimesOptions{
+			Limit: DefaultAgentRuntimesLimit,
+		})
+		require.NoError(t, err)
+		require.Len(t, result.Runtimes, 2)
+	})
+
+	t.Run("with namespace returns only that namespace", func(t *testing.T) {
+		result, err := repo.ListAgentRuntimes(context.Background(), models.ListAgentRuntimesOptions{
+			Namespace: "ns-a",
+			Limit:     DefaultAgentRuntimesLimit,
+		})
+		require.NoError(t, err)
+		require.Len(t, result.Runtimes, 1)
+		assert.Equal(t, "agent-1", result.Runtimes[0].Name)
+		assert.Equal(t, "ns-a", result.Runtimes[0].Namespace)
+	})
+
+	t.Run("with namespace skips ListNamespaces call", func(t *testing.T) {
+		clientWithNsErr := agentsmock.NewClient()
+		clientWithNsErr.ListNamespacesErr = errors.New("should not be called")
+		clientWithNsErr.Agents = map[string][]agents.AgentSummary{
+			"ns-a": {{Name: "agent-1", Namespace: "ns-a", Status: "Ready", ResourceType: "agent",
+				EndpointURL: "http://agent-1.ns-a.svc:8080", CreatedAt: "2026-06-01T00:00:00Z"}},
+		}
+		repo := NewAgentRuntimesRepository(&agentsmock.Factory{Client: clientWithNsErr})
+		result, err := repo.ListAgentRuntimes(context.Background(), models.ListAgentRuntimesOptions{
+			Namespace: "ns-a",
+			Limit:     DefaultAgentRuntimesLimit,
+		})
+		require.NoError(t, err)
+		require.Len(t, result.Runtimes, 1)
+	})
+}
 func TestPaginateAgentRuntimes(t *testing.T) {
 	runtimes := []models.AgentRuntime{
 		{Name: "agent-b", Namespace: "ns-a"},


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-70967

## Description

Rebased version of #8252 onto current `main` (resolved merge conflicts from deploy/stop/start agent additions).

The `GET /api/v1/agents/runtimes` endpoint previously iterated through all accessible namespaces for every request, even though the frontend only needs agents from a single selected namespace. This caused wasted Kubernetes API calls and broken cursor-based pagination when results were filtered client-side.

Changes across 5 commits:
- Add an optional `namespace` query parameter to scope the runtimes list to a single namespace
- Add `CanListAgentsInNamespace` SAR check to prevent unauthorized namespace access (403 Forbidden)
- Add namespace validation with descriptive error messages
- Replace `r.URL.RequestURI()` with `r.URL.Path` in error response helpers to prevent sensitive query parameters (continueToken, namespace) from leaking into logs
- Backward compatible: when `namespace` is omitted, existing cross-namespace behavior is preserved

## How Has This Been Tested?

Go unit tests pass locally after rebase (`go test ./...` — all packages OK). No TypeScript/JavaScript changes in this PR.

## Test Impact

- `TestListAgentRuntimesHandler_WithNamespace` and `TestListAgentRuntimesHandler_WithNamespaceNoResults` handler tests
- `TestListAgentRuntimesScopedByNamespace` repository test with sub-tests: scoped, unscoped, ListNamespaces-bypass, forbidden access, and auth-error fail-closed
- Test verifying forbidden path does not leak query parameters

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent runtime listing now supports an optional namespace filter, allowing results to be scoped to a specific namespace.
  * Namespace values are validated to match standard naming rules before requests are processed.

* **Bug Fixes**
  * Improved handling of forbidden and unauthorized responses, including clearer request-path logging.
  * Expanded error coverage for the agent runtimes endpoint with additional documented response cases.

* **Tests**
  * Added coverage for namespace filtering, invalid namespace input, empty results, and forbidden-access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->