### PR TITLE
update mod-arch and use new prop in TruncatedText

### DIFF
--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
@@ -140,6 +140,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
       <TruncatedText
         content={model.description || ''}
         maxLines={4}
+        tooltipPosition="left"
         data-testid="model-catalog-card-description"
       />
     );
@@ -154,6 +155,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
             <TruncatedText
               content={model.description || ''}
               maxLines={4}
+              tooltipPosition="left"
               data-testid="model-catalog-card-description"
             />
           </StackItem>
@@ -196,6 +198,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
         <TruncatedText
           content={model.description || ''}
           maxLines={4}
+          tooltipPosition="left"
           data-testid="model-catalog-card-description"
         />
       );
@@ -344,6 +347,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
     <TruncatedText
       content={model.description || ''}
       maxLines={4}
+      tooltipPosition="left"
       data-testid="model-catalog-card-description"
     />
   );


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-56639

## Description
The `TruncatedText` component from `mod-arch-shared` renders a PatternFly `<Tooltip>` on hover when description text is truncated in model catalog cards. This tooltip appears directly above the text, overlapping the model title link in the card header and intercepting user clicks — preventing navigation to the model detail page.

**Root cause**: The midstream was using [mod-arch-shared@1.12.0](mailto:mod-arch-shared@1.12.0) which lacked the `tooltipPosition` prop. The upstream fix (kubeflow/hub#2792) added `tooltipPosition="left"` to reposition the tooltip, but this prop was only available starting from [mod-arch-shared@1.19.0](mailto:mod-arch-shared@1.19.0).

**Fix**: Updated mod-arch-core, mod-arch-kubeflow, and mod-arch-shared to `~1.19.0` and added `tooltipPosition="left"` to all 4 `TruncatedText` instances in `ModelCatalogCardBody.tsx`. This repositions the tooltip to the left side of the card, eliminating the collision with the title link.

Before the changes:
<img width="426" height="420" alt="image" src="https://github.com/user-attachments/assets/e3373c74-9d91-48b5-8f8e-40bdded1c326" />

After changes:
<img width="859" height="306" alt="image" src="https://github.com/user-attachments/assets/111b4915-121d-4a1c-9acc-cb82ae2c6280" />


Related upstream PR: kubeflow/hub#2792
Related mod-arch-library PR: opendatahub-io/mod-arch-library#235

## How Has This Been Tested?
- TypeScript compilation: no new errors introduced
- Verified [mod-arch-shared@1.19.0](mailto:mod-arch-shared@1.19.0) exports `tooltipPosition` prop on `TruncatedText`
- Manual verification pending on cluster

## Test Impact
No new tests required — this is a prop addition to existing components. The tooltip behavior is visual and tested via manual QA. Existing Cypress tests cover the model catalog card rendering.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our Best Practices

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
```