### PR TITLE
Add YAML BFF Endpoint for Subscriptions and Policies

### DIFF
--- a/packages/maas/bff/internal/api/api_keys_handlers_test.go
+++ b/packages/maas/bff/internal/api/api_keys_handlers_test.go
@@ -354,7 +354,7 @@ var _ = Describe("APIKeysHandlers", Ordered, func() {
 			subsRepo := repositories.NewSubscriptionsRepository(testLogger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 			policiesRepo := repositories.NewPoliciesRepository(testLogger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 			modelRefsRepo := repositories.NewMaaSModelRefsRepository(testLogger, k8Factory)
-			repos, err := repositories.NewRepositories(testLogger, k8Factory, envConfig, subsRepo, policiesRepo, modelRefsRepo)
+			repos, err := repositories.NewRepositories(testLogger, k8Factory, envConfig, subsRepo, policiesRepo, modelRefsRepo, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			app := &App{

--- a/packages/maas/bff/internal/api/app.go
+++ b/packages/maas/bff/internal/api/app.go
@@ -160,18 +160,21 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 	var subscriptionsRepo repositories.SubscriptionsRepositoryInterface
 	var policiesRepo repositories.PoliciesRepositoryInterface
 	var modelRefsRepo repositories.MaaSModelRefsRepositoryInterface
+	var yamlRepo repositories.YamlRepositoryInterface
 
 	if cfg.MockK8Client {
 		subscriptionsRepo = repositories.NewMockSubscriptionsRepository(logger)
 		policiesRepo = repositories.NewMockPoliciesRepository(logger)
 		modelRefsRepo = repositories.NewMockMaaSModelRefsRepository(logger)
+		yamlRepo = repositories.NewMockYamlRepository(logger)
 	} else {
 		subscriptionsRepo = repositories.NewSubscriptionsRepository(logger, k8sFactory, cfg.MaaSSubscriptionNamespace)
 		policiesRepo = repositories.NewPoliciesRepository(logger, k8sFactory, cfg.MaaSSubscriptionNamespace)
 		modelRefsRepo = repositories.NewMaaSModelRefsRepository(logger, k8sFactory)
+		yamlRepo = repositories.NewYamlRepository(logger, k8sFactory, cfg.MaaSSubscriptionNamespace)
 	}
 
-	repos, err := repositories.NewRepositories(logger, k8sFactory, cfg, subscriptionsRepo, policiesRepo, modelRefsRepo)
+	repos, err := repositories.NewRepositories(logger, k8sFactory, cfg, subscriptionsRepo, policiesRepo, modelRefsRepo, yamlRepo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repositories: %w", err)
 	}
@@ -219,6 +222,7 @@ func (app *App) Routes() http.Handler {
 	attachSubscriptionHandlers(apiRouter, app)
 	attachPolicyHandlers(apiRouter, app)
 	attachMaaSModelRefHandlers(apiRouter, app)
+	attachYamlHandlers(apiRouter, app)
 	apiRouter.GET(constants.ApiPathPrefix+"/models", handlerWithApp(app, ListModelsHandler))
 	apiRouter.GET(constants.ModelsOverviewPath, handlerWithApp(app, ListModelsOverviewHandler))
 	apiRouter.GET(constants.IsMaasAdminPath, handlerWithApp(app, IsMaasAdminHandler))

--- a/packages/maas/bff/internal/api/app_test.go
+++ b/packages/maas/bff/internal/api/app_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Static File serving Test", func() {
 			envConfig := config.EnvConfig{
 				StaticAssetsDir: "../../static",
 			}
-			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			app := &App{
 				kubernetesClientFactory: k8Factory,

--- a/packages/maas/bff/internal/api/healthcheck_handler_test.go
+++ b/packages/maas/bff/internal/api/healthcheck_handler_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestHealthCheckHandler(t *testing.T) {
-	repos, err := repositories.NewRepositories(nil, nil, config.EnvConfig{}, nil, nil, nil)
+	repos, err := repositories.NewRepositories(nil, nil, config.EnvConfig{}, nil, nil, nil, nil)
 	assert.NoError(t, err)
 	app := App{config: config.EnvConfig{
 		Port: 4000,

--- a/packages/maas/bff/internal/api/namespaces_handler_test.go
+++ b/packages/maas/bff/internal/api/namespaces_handler_test.go
@@ -24,7 +24,7 @@ var _ = Describe("TestNamespacesHandler", func() {
 
 		BeforeAll(func() {
 			By("setting up the test app in dev mode")
-			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			testApp = App{
@@ -137,7 +137,7 @@ var _ = Describe("TestNamespacesHandler", func() {
 			By("setting up the test app in dev mode")
 			kubernetesMockedTokenClientFactory, err := k8mocks.NewTokenClientFactory(clientset, restConfig, logger)
 			Expect(err).NotTo(HaveOccurred())
-			repos, err := repositories.NewRepositories(logger, kubernetesMockedTokenClientFactory, envConfig, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, kubernetesMockedTokenClientFactory, envConfig, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			testApp = App{
 				config:                  config.EnvConfig{DevMode: true},

--- a/packages/maas/bff/internal/api/test_utils.go
+++ b/packages/maas/bff/internal/api/test_utils.go
@@ -59,8 +59,9 @@ func setupApiTest[T any](method, url string, body interface{}, k8Factory kuberne
 	subscriptionsRepo := repositories.NewSubscriptionsRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 	policiesRepo := repositories.NewPoliciesRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 	modelRefsRepo := repositories.NewMaaSModelRefsRepository(logger, k8Factory)
+	yamlRepo := repositories.NewYamlRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 
-	repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, subscriptionsRepo, policiesRepo, modelRefsRepo)
+	repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, subscriptionsRepo, policiesRepo, modelRefsRepo, yamlRepo)
 	if err != nil {
 		return empty, nil, err
 	}

--- a/packages/maas/bff/internal/api/user_handler_test.go
+++ b/packages/maas/bff/internal/api/user_handler_test.go
@@ -35,7 +35,7 @@ var _ = Describe("TestUserHandler", func() {
 
 		BeforeAll(func() {
 			By("creating the test app")
-			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			testApp = App{
 				kubernetesClientFactory: k8Factory,

--- a/packages/maas/bff/internal/api/yaml_handlers.go
+++ b/packages/maas/bff/internal/api/yaml_handlers.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+	"github.com/opendatahub-io/maas-library/bff/internal/repositories"
+)
+
+// attachYamlHandlers registers the YAML routes.
+func attachYamlHandlers(apiRouter *httprouter.Router, app *App) {
+	apiRouter.GET(constants.YamlPath, handlerWithApp(app, GetYamlHandler))
+}
+
+// GetYamlHandler handles GET /api/v1/maas-governance/yaml
+// K8s calls: GET /k8s/v1/maassubscription/:name or GET /k8s/v1/maasauthpolicy/:name
+func GetYamlHandler(app *App, w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+	name := r.URL.Query().Get("name")
+	resourceType := r.URL.Query().Get("type")
+
+	if name == "" {
+		app.badRequestResponse(w, r, errors.New("name is required"))
+		return
+	}
+	if resourceType == "" {
+		app.badRequestResponse(w, r, errors.New("type is required"))
+		return
+	}
+
+	content, err := app.repositories.Yaml.GetYaml(ctx, name, resourceType)
+	if err != nil {
+		if errors.Is(err, repositories.ErrInvalidResourceType) {
+			app.badRequestResponse(w, r, err)
+			return
+		}
+		if errors.Is(err, repositories.ErrNotFound) || k8sErrors.IsNotFound(err) {
+			app.notFoundResponse(w, r)
+			return
+		}
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	response := models.YamlResponse{Content: content}
+	if err := app.WriteJSON(w, http.StatusOK, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/packages/maas/bff/internal/api/yaml_handlers.go
+++ b/packages/maas/bff/internal/api/yaml_handlers.go
@@ -3,9 +3,11 @@ package api
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
@@ -17,19 +19,30 @@ func attachYamlHandlers(apiRouter *httprouter.Router, app *App) {
 	apiRouter.GET(constants.YamlPath, handlerWithApp(app, GetYamlHandler))
 }
 
-// GetYamlHandler handles GET /api/v1/maas-governance/yaml
+// GetYamlHandler handles GET /api/v1/yaml
 // K8s calls: GET /k8s/v1/maassubscription/:name or GET /k8s/v1/maasauthpolicy/:name
 func GetYamlHandler(app *App, w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
-	name := r.URL.Query().Get("name")
-	resourceType := r.URL.Query().Get("type")
+
+	name := strings.TrimSpace(r.URL.Query().Get("name"))
+	resourceType := strings.TrimSpace(r.URL.Query().Get("type"))
 
 	if name == "" {
 		app.badRequestResponse(w, r, errors.New("name is required"))
 		return
 	}
+	if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
+		app.badRequestResponse(w, r, errors.New("invalid name"))
+		return
+	}
 	if resourceType == "" {
 		app.badRequestResponse(w, r, errors.New("type is required"))
+		return
+	}
+	switch resourceType {
+	case constants.YamlResourceTypeSubscription, constants.YamlResourceTypeAuthorizationPolicy:
+	default:
+		app.badRequestResponse(w, r, errors.New("invalid resource type"))
 		return
 	}
 

--- a/packages/maas/bff/internal/api/yaml_handlers_test.go
+++ b/packages/maas/bff/internal/api/yaml_handlers_test.go
@@ -1,0 +1,168 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
+	"github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+var _ = Describe("YamlHandlers", Ordered, func() {
+	identity := &kubernetes.RequestIdentity{UserID: "user@example.com"}
+
+	var _ = Describe("GetYamlHandler", Ordered, func() {
+		It("returns 200 with subscription YAML for a created subscription", func() {
+			subName := fmt.Sprintf("yaml-sub-%d", GinkgoRandomSeed())
+
+			_, rs, err := setupApiTest[Envelope[*models.CreateSubscriptionResponse, None]](
+				http.MethodPost,
+				"/api/v1/new-subscription",
+				Envelope[models.CreateSubscriptionRequest, None]{
+					Data: models.CreateSubscriptionRequest{
+						Name: subName,
+						Owner: models.OwnerSpec{
+							Groups: []models.GroupReference{{Name: "premium-users"}},
+						},
+						ModelRefs: []models.ModelSubscriptionRef{
+							{
+								Name:      "granite-3-8b-instruct",
+								Namespace: "maas-models",
+								TokenRateLimits: []models.TokenRateLimit{
+									{Limit: 100000, Window: "24h"},
+								},
+							},
+						},
+						Priority: 10,
+					},
+				},
+				k8Factory,
+				identity,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+
+			actual, rs, err := setupApiTest[models.YamlResponse](
+				http.MethodGet,
+				fmt.Sprintf("%s?name=%s&type=%s", constants.YamlPath, subName, constants.YamlResourceTypeSubscription),
+				nil,
+				k8Factory,
+				identity,
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Content).To(ContainSubstring("kind: MaaSSubscription"))
+			Expect(actual.Content).To(ContainSubstring("name: " + subName))
+			Expect(actual.Content).To(ContainSubstring("apiVersion: maas.opendatahub.io/v1alpha1"))
+			Expect(actual.Content).To(ContainSubstring("granite-3-8b-instruct"))
+		})
+
+		It("returns 200 with auth policy YAML for a created subscription policy", func() {
+			subName := fmt.Sprintf("yaml-policy-sub-%d", GinkgoRandomSeed())
+			policyName := subName + "-policy"
+
+			_, rs, err := setupApiTest[Envelope[*models.CreateSubscriptionResponse, None]](
+				http.MethodPost,
+				"/api/v1/new-subscription",
+				Envelope[models.CreateSubscriptionRequest, None]{
+					Data: models.CreateSubscriptionRequest{
+						Name: subName,
+						Owner: models.OwnerSpec{
+							Groups: []models.GroupReference{{Name: "premium-users"}},
+						},
+						ModelRefs: []models.ModelSubscriptionRef{
+							{
+								Name:      "granite-3-8b-instruct",
+								Namespace: "maas-models",
+								TokenRateLimits: []models.TokenRateLimit{
+									{Limit: 100000, Window: "24h"},
+								},
+							},
+						},
+						CreateAuthPolicy: true,
+					},
+				},
+				k8Factory,
+				identity,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+
+			actual, rs, err := setupApiTest[models.YamlResponse](
+				http.MethodGet,
+				fmt.Sprintf("%s?name=%s&type=%s", constants.YamlPath, policyName, constants.YamlResourceTypeAuthorizationPolicy),
+				nil,
+				k8Factory,
+				identity,
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(actual.Content).To(ContainSubstring("kind: MaaSAuthPolicy"))
+			Expect(actual.Content).To(ContainSubstring("name: " + policyName))
+			Expect(actual.Content).To(ContainSubstring("apiVersion: maas.opendatahub.io/v1alpha1"))
+			Expect(actual.Content).To(ContainSubstring("premium-users"))
+		})
+
+		It("returns 400 for an invalid resource type", func() {
+			actual, rs, err := setupApiTest[HTTPError](
+				http.MethodGet,
+				constants.YamlPath+"?name=test-sub&type=invalid",
+				nil,
+				k8Factory,
+				identity,
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(strings.ToLower(actual.Error.Message)).To(ContainSubstring("invalid resource type"))
+		})
+
+		It("returns 400 when name is missing", func() {
+			actual, rs, err := setupApiTest[HTTPError](
+				http.MethodGet,
+				constants.YamlPath+"?type="+constants.YamlResourceTypeSubscription,
+				nil,
+				k8Factory,
+				identity,
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(actual.Error.Message).To(ContainSubstring("name is required"))
+		})
+
+		It("returns 400 when type is missing", func() {
+			actual, rs, err := setupApiTest[HTTPError](
+				http.MethodGet,
+				constants.YamlPath+"?name=test-sub",
+				nil,
+				k8Factory,
+				identity,
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(actual.Error.Message).To(ContainSubstring("type is required"))
+		})
+
+		It("returns 404 for a non-existent subscription", func() {
+			_, rs, err := setupApiTest[HTTPError](
+				http.MethodGet,
+				constants.YamlPath+"?name=non-existent-sub&type="+constants.YamlResourceTypeSubscription,
+				nil,
+				k8Factory,
+				identity,
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+	})
+})

--- a/packages/maas/bff/internal/api/yaml_handlers_test.go
+++ b/packages/maas/bff/internal/api/yaml_handlers_test.go
@@ -61,6 +61,12 @@ var _ = Describe("YamlHandlers", Ordered, func() {
 			Expect(actual.Content).To(ContainSubstring("name: " + subName))
 			Expect(actual.Content).To(ContainSubstring("apiVersion: maas.opendatahub.io/v1alpha1"))
 			Expect(actual.Content).To(ContainSubstring("granite-3-8b-instruct"))
+			Expect(actual.Content).NotTo(ContainSubstring("managedFields:"))
+			Expect(actual.Content).NotTo(ContainSubstring("resourceVersion:"))
+			Expect(actual.Content).NotTo(ContainSubstring("uid:"))
+			Expect(actual.Content).NotTo(ContainSubstring("generation:"))
+			Expect(actual.Content).NotTo(ContainSubstring("status:"))
+			Expect(actual.Content).NotTo(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
 		})
 
 		It("returns 200 with auth policy YAML for a created subscription policy", func() {
@@ -108,6 +114,12 @@ var _ = Describe("YamlHandlers", Ordered, func() {
 			Expect(actual.Content).To(ContainSubstring("name: " + policyName))
 			Expect(actual.Content).To(ContainSubstring("apiVersion: maas.opendatahub.io/v1alpha1"))
 			Expect(actual.Content).To(ContainSubstring("premium-users"))
+			Expect(actual.Content).NotTo(ContainSubstring("managedFields:"))
+			Expect(actual.Content).NotTo(ContainSubstring("resourceVersion:"))
+			Expect(actual.Content).NotTo(ContainSubstring("uid:"))
+			Expect(actual.Content).NotTo(ContainSubstring("generation:"))
+			Expect(actual.Content).NotTo(ContainSubstring("status:"))
+			Expect(actual.Content).NotTo(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
 		})
 
 		It("returns 400 for an invalid resource type", func() {
@@ -150,6 +162,32 @@ var _ = Describe("YamlHandlers", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
 			Expect(actual.Error.Message).To(ContainSubstring("type is required"))
+		})
+
+		It("returns 400 when name is invalid", func() {
+			actual, rs, err := setupApiTest[HTTPError](
+				http.MethodGet,
+				constants.YamlPath+"?name=invalid name&type="+constants.YamlResourceTypeSubscription,
+				nil,
+				k8Factory,
+				identity,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(actual.Error.Message).To(ContainSubstring("invalid name"))
+		})
+
+		It("returns 400 when type is invalid", func() {
+			actual, rs, err := setupApiTest[HTTPError](
+				http.MethodGet,
+				constants.YamlPath+"?name=test-sub&type=some-non-supported-type",
+				nil,
+				k8Factory,
+				identity,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(actual.Error.Message).To(ContainSubstring("invalid resource type"))
 		})
 
 		It("returns 404 for a non-existent subscription", func() {

--- a/packages/maas/bff/internal/constants/api_routes.go
+++ b/packages/maas/bff/internal/constants/api_routes.go
@@ -40,4 +40,7 @@ const (
 
 	// Overview routes
 	ModelsOverviewPath = ApiPathPrefix + "/overview/models"
+
+	// YAML export
+	YamlPath = ApiPathPrefix + "/maas-governance/yaml"
 )

--- a/packages/maas/bff/internal/constants/api_routes.go
+++ b/packages/maas/bff/internal/constants/api_routes.go
@@ -42,5 +42,5 @@ const (
 	ModelsOverviewPath = ApiPathPrefix + "/overview/models"
 
 	// YAML export
-	YamlPath = ApiPathPrefix + "/maas-governance/yaml"
+	YamlPath = ApiPathPrefix + "/yaml"
 )

--- a/packages/maas/bff/internal/constants/yaml.go
+++ b/packages/maas/bff/internal/constants/yaml.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	YamlResourceTypeSubscription        = "subscription"
+	YamlResourceTypeAuthorizationPolicy = "authorizationpolicy"
+)

--- a/packages/maas/bff/internal/models/yaml.go
+++ b/packages/maas/bff/internal/models/yaml.go
@@ -1,0 +1,6 @@
+package models
+
+// YamlResponse is the response body for GET /api/v1/maas-governance/yaml.
+type YamlResponse struct {
+	Content string `json:"content"`
+}

--- a/packages/maas/bff/internal/models/yaml.go
+++ b/packages/maas/bff/internal/models/yaml.go
@@ -1,6 +1,6 @@
 package models
 
-// YamlResponse is the response body for GET /api/v1/maas-governance/yaml.
+// YamlResponse is the response body for GET /api/v1/yaml.
 type YamlResponse struct {
 	Content string `json:"content"`
 }

--- a/packages/maas/bff/internal/repositories/errors.go
+++ b/packages/maas/bff/internal/repositories/errors.go
@@ -7,3 +7,6 @@ var ErrAlreadyExists = errors.New("resource already exists")
 
 // ErrNotFound is returned when a requested resource is not found.
 var ErrNotFound = errors.New("resource not found")
+
+// ErrInvalidResourceType is returned when the YAML resource type query parameter is not supported.
+var ErrInvalidResourceType = errors.New("invalid resource type")

--- a/packages/maas/bff/internal/repositories/repositories.go
+++ b/packages/maas/bff/internal/repositories/repositories.go
@@ -48,6 +48,7 @@ type Repositories struct {
 	Subscriptions SubscriptionsRepositoryInterface
 	Policies      PoliciesRepositoryInterface
 	MaaSModelRefs MaaSModelRefsRepositoryInterface
+	Yaml          YamlRepositoryInterface
 }
 
 func NewRepositories(
@@ -57,6 +58,7 @@ func NewRepositories(
 	subscriptions SubscriptionsRepositoryInterface,
 	policies PoliciesRepositoryInterface,
 	maasModelRefs MaaSModelRefsRepositoryInterface,
+	yamlRepo YamlRepositoryInterface,
 ) (*Repositories, error) {
 	apiKeysRepo, err := NewAPIKeysRepository(logger, config.MaasApiUrl)
 	if err != nil {
@@ -77,5 +79,6 @@ func NewRepositories(
 		Subscriptions: subscriptions,
 		Policies:      policies,
 		MaaSModelRefs: maasModelRefs,
+		Yaml:          yamlRepo,
 	}, nil
 }

--- a/packages/maas/bff/internal/repositories/yaml.go
+++ b/packages/maas/bff/internal/repositories/yaml.go
@@ -1,0 +1,173 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kyaml "sigs.k8s.io/yaml"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
+	"github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+// YamlRepositoryInterface defines the contract for YAML export operations.
+type YamlRepositoryInterface interface {
+	GetYaml(ctx context.Context, name, resourceType string) (string, error)
+}
+
+// YamlRepository handles YAML operations via the Kubernetes API.
+type YamlRepository struct {
+	logger     *slog.Logger
+	k8sFactory kubernetes.KubernetesClientFactory
+	namespace  string
+}
+
+// NewYamlRepository creates a new YAML repository.
+func NewYamlRepository(logger *slog.Logger, k8sFactory kubernetes.KubernetesClientFactory, namespace string) *YamlRepository {
+	return &YamlRepository{
+		logger:     logger,
+		k8sFactory: k8sFactory,
+		namespace:  namespace,
+	}
+}
+
+// GetYaml returns the YAML for a given resource name and type.
+func (r *YamlRepository) GetYaml(ctx context.Context, name, resourceType string) (string, error) {
+	r.logger.Debug("Getting YAML for resource", slog.String("name", name), slog.String("resourceType", resourceType))
+
+	gvr, err := yamlResourceTypeToGVR(resourceType)
+	if err != nil {
+		return "", err
+	}
+
+	client, err := r.k8sFactory.GetClient(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	kubeClient := client.GetDynamicClient()
+	resource, err := kubeClient.Resource(gvr).Namespace(r.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return "", fmt.Errorf("%w: %s", ErrNotFound, name)
+		}
+		return "", fmt.Errorf("failed to get resource: %w", err)
+	}
+
+	return unstructuredToYAML(resource)
+}
+
+func yamlResourceTypeToGVR(resourceType string) (schema.GroupVersionResource, error) {
+	switch resourceType {
+	case constants.YamlResourceTypeSubscription:
+		return constants.MaaSSubscriptionGvr, nil
+	case constants.YamlResourceTypeAuthorizationPolicy:
+		return constants.MaaSAuthPolicyGvr, nil
+	default:
+		return schema.GroupVersionResource{}, fmt.Errorf("%w: must be %q or %q", ErrInvalidResourceType, constants.YamlResourceTypeSubscription, constants.YamlResourceTypeAuthorizationPolicy)
+	}
+}
+
+func unstructuredToYAML(obj *unstructured.Unstructured) (string, error) {
+	clean := sanitizeResourceForYAML(obj)
+	yamlBytes, err := kyaml.Marshal(clean.Object)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal resource to YAML: %w", err)
+	}
+	return string(yamlBytes), nil
+}
+
+func setResourceStatus(obj *unstructured.Unstructured, phase, statusMessage string) {
+	status := map[string]interface{}{}
+	if phase != "" {
+		status["phase"] = phase
+	}
+	if statusMessage != "" {
+		status["conditions"] = []interface{}{
+			map[string]interface{}{
+				"type":    "Ready",
+				"status":  "True",
+				"message": statusMessage,
+			},
+		}
+	}
+	if len(status) > 0 {
+		obj.Object["status"] = status
+	}
+}
+
+func subscriptionModelToUnstructured(sub models.MaaSSubscription) *unstructured.Unstructured {
+	obj := buildSubscriptionUnstructured(
+		sub.Name,
+		sub.Namespace,
+		sub.DisplayName,
+		sub.Description,
+		sub.Owner,
+		sub.ModelRefs,
+		sub.TokenMetadata,
+		sub.Priority,
+	)
+	setResourceStatus(obj, sub.Phase, sub.StatusMessage)
+	setModelTimestamps(obj, sub.CreationTimestamp, sub.DeletionTimestamp)
+	return obj
+}
+
+func authPolicyModelToUnstructured(policy models.MaaSAuthPolicy) *unstructured.Unstructured {
+	obj := buildAuthPolicyUnstructured(
+		policy.Name,
+		policy.Namespace,
+		policy.DisplayName,
+		policy.Description,
+		policy.ModelRefs,
+		policy.Subjects.Groups,
+		policy.MeteringMetadata,
+	)
+	setResourceStatus(obj, policy.Phase, policy.StatusMessage)
+	setModelTimestamps(obj, policy.CreationTimestamp, policy.DeletionTimestamp)
+	return obj
+}
+
+func setModelTimestamps(obj *unstructured.Unstructured, creationTimestamp, deletionTimestamp *time.Time) {
+	if creationTimestamp != nil {
+		obj.SetCreationTimestamp(metav1.NewTime(*creationTimestamp))
+	}
+	if deletionTimestamp != nil {
+		obj.SetDeletionTimestamp(&metav1.Time{Time: *deletionTimestamp})
+	}
+}
+
+func sanitizeResourceForYAML(obj *unstructured.Unstructured) *unstructured.Unstructured {
+	clean := obj.DeepCopy()
+	clean.SetManagedFields(nil)
+	clean.SetResourceVersion("")
+	clean.SetUID("")
+	clean.SetGeneration(0)
+	clean.SetOwnerReferences(nil)
+
+	if metadata, ok := clean.Object["metadata"].(map[string]interface{}); ok {
+		delete(metadata, "managedFields")
+		delete(metadata, "resourceVersion")
+		delete(metadata, "uid")
+		delete(metadata, "generation")
+		delete(metadata, "ownerReferences")
+		delete(metadata, "selfLink")
+		delete(metadata, "creationTimestamp")
+		delete(metadata, "finalizers")
+		if annotations, ok := metadata["annotations"].(map[string]interface{}); ok {
+			delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
+			if len(annotations) == 0 {
+				delete(metadata, "annotations")
+			}
+		}
+	}
+	delete(clean.Object, "status")
+
+	return clean
+}

--- a/packages/maas/bff/internal/repositories/yaml.go
+++ b/packages/maas/bff/internal/repositories/yaml.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"time"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,27 +83,8 @@ func unstructuredToYAML(obj *unstructured.Unstructured) (string, error) {
 	return string(yamlBytes), nil
 }
 
-func setResourceStatus(obj *unstructured.Unstructured, phase, statusMessage string) {
-	status := map[string]interface{}{}
-	if phase != "" {
-		status["phase"] = phase
-	}
-	if statusMessage != "" {
-		status["conditions"] = []interface{}{
-			map[string]interface{}{
-				"type":    "Ready",
-				"status":  "True",
-				"message": statusMessage,
-			},
-		}
-	}
-	if len(status) > 0 {
-		obj.Object["status"] = status
-	}
-}
-
 func subscriptionModelToUnstructured(sub models.MaaSSubscription) *unstructured.Unstructured {
-	obj := buildSubscriptionUnstructured(
+	return buildSubscriptionUnstructured(
 		sub.Name,
 		sub.Namespace,
 		sub.DisplayName,
@@ -114,13 +94,10 @@ func subscriptionModelToUnstructured(sub models.MaaSSubscription) *unstructured.
 		sub.TokenMetadata,
 		sub.Priority,
 	)
-	setResourceStatus(obj, sub.Phase, sub.StatusMessage)
-	setModelTimestamps(obj, sub.CreationTimestamp, sub.DeletionTimestamp)
-	return obj
 }
 
 func authPolicyModelToUnstructured(policy models.MaaSAuthPolicy) *unstructured.Unstructured {
-	obj := buildAuthPolicyUnstructured(
+	return buildAuthPolicyUnstructured(
 		policy.Name,
 		policy.Namespace,
 		policy.DisplayName,
@@ -129,18 +106,6 @@ func authPolicyModelToUnstructured(policy models.MaaSAuthPolicy) *unstructured.U
 		policy.Subjects.Groups,
 		policy.MeteringMetadata,
 	)
-	setResourceStatus(obj, policy.Phase, policy.StatusMessage)
-	setModelTimestamps(obj, policy.CreationTimestamp, policy.DeletionTimestamp)
-	return obj
-}
-
-func setModelTimestamps(obj *unstructured.Unstructured, creationTimestamp, deletionTimestamp *time.Time) {
-	if creationTimestamp != nil {
-		obj.SetCreationTimestamp(metav1.NewTime(*creationTimestamp))
-	}
-	if deletionTimestamp != nil {
-		obj.SetDeletionTimestamp(&metav1.Time{Time: *deletionTimestamp})
-	}
 }
 
 func sanitizeResourceForYAML(obj *unstructured.Unstructured) *unstructured.Unstructured {

--- a/packages/maas/bff/internal/repositories/yaml_mock.go
+++ b/packages/maas/bff/internal/repositories/yaml_mock.go
@@ -1,0 +1,46 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/mocks"
+)
+
+// MockYamlRepository returns mock YAML for development.
+type MockYamlRepository struct {
+	logger *slog.Logger
+}
+
+// NewMockYamlRepository creates a new mock YAML repository.
+func NewMockYamlRepository(logger *slog.Logger) *MockYamlRepository {
+	return &MockYamlRepository{logger: logger}
+}
+
+// GetYaml returns realistic static YAML for known mock resources.
+func (r *MockYamlRepository) GetYaml(_ context.Context, name, resourceType string) (string, error) {
+	r.logger.Debug("Getting YAML for resource (mock)", slog.String("name", name), slog.String("resourceType", resourceType))
+
+	gvr, err := yamlResourceTypeToGVR(resourceType)
+	if err != nil {
+		return "", err
+	}
+
+	switch gvr.Resource {
+	case "maassubscriptions":
+		for _, sub := range mocks.GetMockMaaSSubscriptions() {
+			if sub.Name == name {
+				return unstructuredToYAML(subscriptionModelToUnstructured(sub))
+			}
+		}
+	case "maasauthpolicies":
+		for _, policy := range mocks.GetMockMaaSAuthPolicies() {
+			if policy.Name == name {
+				return unstructuredToYAML(authPolicyModelToUnstructured(policy))
+			}
+		}
+	}
+
+	return "", fmt.Errorf("%w: %s", ErrNotFound, name)
+}

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -1196,6 +1196,72 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/v1/maas-governance/yaml:
+    get:
+      tags:
+        - governance
+      summary: Get resource YAML
+      operationId: getResourceYaml
+      description: >
+        Fetches a MaaSSubscription or MaaSAuthPolicy by name and returns its YAML representation.
+
+        K8s calls: GET /k8s/v1/maassubscription/:name or GET /k8s/v1/maasauthpolicy/:name
+      parameters:
+        - name: name
+          in: query
+          required: true
+          description: Kubernetes resource name
+          schema:
+            type: string
+          example: premium-team-sub
+        - name: type
+          in: query
+          required: true
+          description: Resource type to fetch
+          schema:
+            type: string
+            enum:
+              - subscription
+              - authorizationpolicy
+          example: subscription
+      responses:
+        '200':
+          description: YAML content for the requested resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/YamlResponse'
+              example:
+                content: |
+                  apiVersion: maas.opendatahub.io/v1alpha1
+                  kind: MaaSSubscription
+                  metadata:
+                    name: premium-team-sub
+                    namespace: maas-system
+                  spec:
+                    priority: 10
+                    owner:
+                      groups:
+                        - name: premium-users
+        '400':
+          description: Bad Request (missing or invalid query parameters)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/v1/view-policy/{name}:
     get:
       tags:
@@ -2700,4 +2766,14 @@ components:
         - id
         - subscriptions
         - authPolicies
+
+    YamlResponse:
+      type: object
+      description: YAML export response for a MaaS governance resource.
+      properties:
+        content:
+          type: string
+          description: YAML representation of the requested Kubernetes resource.
+      required:
+        - content
 

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -1196,10 +1196,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /api/v1/maas-governance/yaml:
+  /api/v1/yaml:
     get:
       tags:
-        - governance
+        - yaml
       summary: Get resource YAML
       operationId: getResourceYaml
       description: >


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-67110](https://redhat.atlassian.net/browse/RHOAIENG-67110)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds real and mock yaml endpoints for `GET /api/v1/maas-governance/yaml?name=<resource-name>&type=<subscription|authorizationpolicy>`


Mock command:
```
cd packages/maas
make dev-bff-federated-mock
curl -s -H "kubeflow-userid: blah" \
  "http://localhost:8081/api/v1/yaml?name=premium-team-sub&type=subscription" \
  | jq -r '.content'
```
Policy command:
```
curl -s -H "kubeflow-userid: blah" \
  "http://localhost:8081/api/v1/yaml?name=premium-team-sub-policy&type=authorizationpolicy" \
  | jq -r '.content'
```


Dev mode command: (Assuming you're on the same cluster, otherwise replace sub and policy name)
```
cd packages/maas
make dev-bff-federated
curl -s -H "x-forwarded-access-token: $(oc whoami -t)" \
  "http://localhost:8081/api/v1/yaml?name=different-sub-for-testing&type=subscription" \
  | jq -r '.content'
```

Policy command:
```
curl -s -H "x-forwarded-access-token: $(oc whoami -t)" \
  "http://localhost:8081/api/v1/yaml?name=policy-test&type=authorizationpolicy" \
  | jq -r '.content'
```

You should see yaml output, something like:
```
apiVersion: maas.opendatahub.io/v1alpha1
kind: MaaSSubscription
metadata:
  annotations:
    openshift.io/display-name: Different Sub for Testing
  name: different-sub-for-testing
  namespace: models-as-a-service
spec:
  modelRefs:
  - name: facebook-opt-125m-simulated
    namespace: llm
    tokenRateLimits:
    - limit: 10000
      window: 1h
  - name: llmd-model
    namespace: sridarna
    tokenRateLimits:
    - limit: 1000
      window: 1h
    - limit: 500
      window: 2m
    - limit: 1
      window: 5s
    - limit: 2000
      window: 3h
  owner:
    groups:
    - name: cluster-admins
    - name: dedicated-admins
    - name: free-users
    - name: odh-admins
    - name: rhods-admins
    - name: special-users
    - name: tester-group
  priority: 1
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added BFF tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to view governance resources as YAML.
  * Supported YAML output for subscriptions and authorization policies, including a development-mode mock response.
  * Added a structured response format for returned YAML content.

* **Bug Fixes**
  * Improved error handling for missing or invalid request parameters.
  * Returns clearer not-found responses when a resource cannot be located.
  * Updated related tests to match the new response flow and setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->