### PR TITLE
Fix inactive state in revoke modal

### DIFF
--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/AdminRevokeAllApiKeysModal.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/AdminRevokeAllApiKeysModal.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   Alert,
   Button,
-  capitalize,
   Form,
   FormGroup,
   FormHelperText,
@@ -10,7 +9,6 @@ import {
   HelperTextItem,
   InputGroup,
   InputGroupItem,
-  Label,
   Modal,
   ModalBody,
   ModalFooter,
@@ -21,12 +19,13 @@ import {
   TextInput,
   Title,
 } from '@patternfly/react-core';
-import { CheckCircleIcon, MinusCircleIcon, SearchIcon } from '@patternfly/react-icons';
+import { SearchIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { searchApiKeys, bulkRevokeApiKeys } from '~/app/api/api-keys';
 import { useNotification } from '~/app/hooks/useNotification';
 import { isKeyInactive } from '~/app/utilities/apiKeys';
 import type { APIKey, SubscriptionDetail } from '~/app/types/api-key';
+import ApiKeyStatusLabel from '~/app/pages/keys-and-subs/apiKeys/ApiKeyStatusLabel';
 
 const formatDate = (dateString: string): string => {
   const date = new Date(dateString);
@@ -206,19 +205,7 @@ const AdminRevokeAllApiKeysModal: React.FC<AdminRevokeAllApiKeysModalProps> = ({
                           <Tr key={key.id}>
                             <Td dataLabel="Name">{key.name}</Td>
                             <Td dataLabel="Status">
-                              {inactive ? (
-                                <Label variant="filled" icon={<MinusCircleIcon />}>
-                                  {capitalize('inactive')}
-                                </Label>
-                              ) : (
-                                <Label
-                                  variant="outline"
-                                  status="success"
-                                  icon={<CheckCircleIcon />}
-                                >
-                                  {capitalize(key.status)}
-                                </Label>
-                              )}
+                              <ApiKeyStatusLabel status={inactive ? 'inactive' : key.status} />
                             </Td>
                             <Td dataLabel="Last used">
                               {key.lastUsedAt ? formatDate(key.lastUsedAt) : 'Never'}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/AdminRevokeAllApiKeysModal.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/AdminRevokeAllApiKeysModal.tsx
@@ -21,7 +21,7 @@ import {
   TextInput,
   Title,
 } from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, MinusCircleIcon, SearchIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { searchApiKeys, bulkRevokeApiKeys } from '~/app/api/api-keys';
 import { useNotification } from '~/app/hooks/useNotification';
@@ -207,9 +207,17 @@ const AdminRevokeAllApiKeysModal: React.FC<AdminRevokeAllApiKeysModalProps> = ({
                             <Td dataLabel="Name">{key.name}</Td>
                             <Td dataLabel="Status">
                               {inactive ? (
-                                <Label variant="filled">{capitalize('inactive')}</Label>
+                                <Label variant="filled" icon={<MinusCircleIcon />}>
+                                  {capitalize('inactive')}
+                                </Label>
                               ) : (
-                                <Label color="green">{capitalize(key.status)}</Label>
+                                <Label
+                                  variant="outline"
+                                  status="success"
+                                  icon={<CheckCircleIcon />}
+                                >
+                                  {capitalize(key.status)}
+                                </Label>
                               )}
                             </Td>
                             <Td dataLabel="Last used">

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/AdminRevokeAllApiKeysModal.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/AdminRevokeAllApiKeysModal.tsx
@@ -25,7 +25,8 @@ import { SearchIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { searchApiKeys, bulkRevokeApiKeys } from '~/app/api/api-keys';
 import { useNotification } from '~/app/hooks/useNotification';
-import type { APIKey } from '~/app/types/api-key';
+import { isKeyInactive } from '~/app/utilities/apiKeys';
+import type { APIKey, SubscriptionDetail } from '~/app/types/api-key';
 
 const formatDate = (dateString: string): string => {
   const date = new Date(dateString);
@@ -45,6 +46,9 @@ const AdminRevokeAllApiKeysModal: React.FC<AdminRevokeAllApiKeysModalProps> = ({
   const [username, setUsername] = React.useState('');
   const [searchedUsername, setSearchedUsername] = React.useState('');
   const [apiKeys, setApiKeys] = React.useState<APIKey[]>([]);
+  const [subscriptionDetails, setSubscriptionDetails] = React.useState<
+    Record<string, SubscriptionDetail> | undefined
+  >();
   const [searching, setSearching] = React.useState(false);
   const [searchError, setSearchError] = React.useState<Error | undefined>();
   const [revoking, setRevoking] = React.useState(false);
@@ -68,9 +72,11 @@ const AdminRevokeAllApiKeysModal: React.FC<AdminRevokeAllApiKeysModalProps> = ({
     try {
       const response = await searchApiKeys()({}, { filters: { username: trimmed } });
       setApiKeys(response.data);
+      setSubscriptionDetails(response.subscriptionDetails);
     } catch (err) {
       setSearchError(err instanceof Error ? err : new Error('Failed to search API keys'));
       setApiKeys([]);
+      setSubscriptionDetails(undefined);
     } finally {
       setSearching(false);
     }
@@ -194,20 +200,27 @@ const AdminRevokeAllApiKeysModal: React.FC<AdminRevokeAllApiKeysModalProps> = ({
                       </Tr>
                     </Thead>
                     <Tbody>
-                      {activeKeys.map((key) => (
-                        <Tr key={key.id}>
-                          <Td dataLabel="Name">{key.name}</Td>
-                          <Td dataLabel="Status">
-                            <Label color="green">{capitalize(key.status)}</Label>
-                          </Td>
-                          <Td dataLabel="Last used">
-                            {key.lastUsedAt ? formatDate(key.lastUsedAt) : 'Never'}
-                          </Td>
-                          <Td dataLabel="Expiration">
-                            {key.expirationDate ? formatDate(key.expirationDate) : 'Never'}
-                          </Td>
-                        </Tr>
-                      ))}
+                      {activeKeys.map((key) => {
+                        const inactive = isKeyInactive(key, subscriptionDetails);
+                        return (
+                          <Tr key={key.id}>
+                            <Td dataLabel="Name">{key.name}</Td>
+                            <Td dataLabel="Status">
+                              {inactive ? (
+                                <Label variant="filled">{capitalize('inactive')}</Label>
+                              ) : (
+                                <Label color="green">{capitalize(key.status)}</Label>
+                              )}
+                            </Td>
+                            <Td dataLabel="Last used">
+                              {key.lastUsedAt ? formatDate(key.lastUsedAt) : 'Never'}
+                            </Td>
+                            <Td dataLabel="Expiration">
+                              {key.expirationDate ? formatDate(key.expirationDate) : 'Never'}
+                            </Td>
+                          </Tr>
+                        );
+                      })}
                     </Tbody>
                   </Table>
                 </StackItem>

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeyStatusLabel.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeyStatusLabel.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { capitalize, Label, Popover } from '@patternfly/react-core';
+import type { LabelProps } from '@patternfly/react-core';
+import {
+  BanIcon,
+  CheckCircleIcon,
+  MinusCircleIcon,
+  OutlinedClockIcon,
+  OutlinedQuestionCircleIcon,
+} from '@patternfly/react-icons';
+import type { APIKeyDisplayStatus } from '~/app/types/api-key';
+
+const getApiKeyStatusProps = (
+  status: APIKeyDisplayStatus,
+): { icon: React.ReactNode; status?: LabelProps['status']; variant?: LabelProps['variant'] } => {
+  switch (status) {
+    case 'active':
+      return { icon: <CheckCircleIcon />, status: 'success' };
+    case 'inactive':
+      return { icon: <MinusCircleIcon />, variant: 'filled' };
+    case 'expired':
+      return { icon: <OutlinedClockIcon /> };
+    case 'revoked':
+      return { icon: <BanIcon />, status: 'danger' };
+    default:
+      return { icon: <OutlinedQuestionCircleIcon /> };
+  }
+};
+
+type ApiKeyStatusLabelProps = {
+  status: APIKeyDisplayStatus;
+  showInactivePopover?: boolean;
+};
+
+const ApiKeyStatusLabel: React.FC<ApiKeyStatusLabelProps> = ({
+  status,
+  showInactivePopover = false,
+}) => {
+  const { variant, ...labelProps } = getApiKeyStatusProps(status);
+  const label = (
+    <Label variant={variant ?? 'outline'} {...labelProps}>
+      {capitalize(status)}
+    </Label>
+  );
+
+  if (showInactivePopover && status === 'inactive') {
+    return (
+      <Popover
+        headerContent="Subscription unavailable"
+        bodyContent="The subscription this key was created for has been deleted or is not ready. The key itself has not been revoked, but it cannot authenticate requests until the subscription is restored."
+      >
+        <span style={{ cursor: 'pointer' }}>{label}</span>
+      </Popover>
+    );
+  }
+
+  return label;
+};
+
+export default ApiKeyStatusLabel;

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTableRow.tsx
@@ -1,35 +1,10 @@
 import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
-import { capitalize, Label, Popover } from '@patternfly/react-core';
-import type { LabelProps } from '@patternfly/react-core';
-import {
-  BanIcon,
-  CheckCircleIcon,
-  MinusCircleIcon,
-  OutlinedClockIcon,
-  OutlinedQuestionCircleIcon,
-} from '@patternfly/react-icons';
 import TableRowTitleDescription from '@odh-dashboard/internal/components/table/TableRowTitleDescription';
 import { APIKey, APIKeyDisplayStatus, SubscriptionDetail } from '~/app/types/api-key';
+import ApiKeyStatusLabel from '~/app/pages/keys-and-subs/apiKeys/ApiKeyStatusLabel';
 import { ApiKeyColumn } from './columns';
 import SubscriptionCell from './SubscriptionCell';
-
-const getApiKeyStatusProps = (
-  status: APIKeyDisplayStatus,
-): { icon: React.ReactNode; status?: LabelProps['status']; variant?: LabelProps['variant'] } => {
-  switch (status) {
-    case 'active':
-      return { icon: <CheckCircleIcon />, status: 'success' };
-    case 'inactive':
-      return { icon: <MinusCircleIcon />, variant: 'filled' };
-    case 'expired':
-      return { icon: <OutlinedClockIcon /> };
-    case 'revoked':
-      return { icon: <BanIcon />, status: 'danger' };
-    default:
-      return { icon: <OutlinedQuestionCircleIcon /> };
-  }
-};
 
 const formatDate = (dateString?: string, fallback = '—'): string => {
   if (!dateString) {
@@ -68,25 +43,7 @@ const cellRenderers: Record<string, CellRenderer> = {
 
   status: ({ apiKey, isInactive }) => {
     const displayStatus = getDisplayStatus(apiKey, isInactive);
-    const { variant, ...labelProps } = getApiKeyStatusProps(displayStatus);
-    const label = (
-      <Label variant={variant ?? 'outline'} {...labelProps}>
-        {capitalize(displayStatus)}
-      </Label>
-    );
-
-    if (displayStatus !== 'inactive') {
-      return label;
-    }
-
-    return (
-      <Popover
-        headerContent="Subscription unavailable"
-        bodyContent="The subscription this key was created for has been deleted or is not ready. The key itself has not been revoked, but it cannot authenticate requests until the subscription is restored."
-      >
-        <span style={{ cursor: 'pointer' }}>{label}</span>
-      </Popover>
-    );
+    return <ApiKeyStatusLabel status={displayStatus} showInactivePopover />;
   },
 
   subscription: ({ apiKey, subscriptionDetail }) => (


### PR DESCRIPTION
Closes: https://redhat.atlassian.net/browse/RHOAIENG-64755

## Description
Updates the revoke api keys modal to properly show inactive keys state

## How Has This Been Tested?
Tested locally. Go to revoke an api key with an inactive status. The modal should display the status properly 

## Test Impact
No tests changed

## Screenshots

<img width="851" height="473" alt="Screenshot 2026-06-26 at 4 26 20 PM" src="https://github.com/user-attachments/assets/f1d3566d-b3ab-4678-8424-f1178f9c8b82" />


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key status display by using subscription metadata to accurately mark keys as inactive when the related subscription is unavailable.
  * Updated search behavior so any previously loaded subscription context is cleared when a search fails.
* **New Features**
  * Added a shared API key status label with an optional informational popover for inactive keys, providing clearer context about why a key is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->