### PR TITLE
feat(gen-ai): agent config guard features (RHOAIENG-66531, RHOAIENG-66532, RHOAIENG-66533)

### DIFF
--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/helpers/agentProfiles/agentProfilePlaygroundHelpers.ts
@@ -27,7 +27,23 @@ export const setupPlaygroundBase = (namespace: string): void => {
   cy.interceptGenAi('GET /api/v1/user', { data: { username: 'test-user' } });
   cy.interceptGenAi('GET /api/v1/config', { data: { isCustomLSD: false } });
   cy.interceptGenAi('GET /api/v1/lsd/status', { query: { namespace } }, mockStatus('Ready'));
-  cy.interceptGenAi('GET /api/v1/lsd/models', { query: { namespace } }, mockEmptyList());
+  // Include the model used in makeProfileResponse so validation warnings don't fire
+  // and the Edit button stays enabled in tests that expect it to be clickable.
+  cy.interceptGenAi(
+    'GET /api/v1/lsd/models',
+    { query: { namespace } },
+    {
+      data: [
+        {
+          id: 'meta-llama/llama-3.1-8b-instruct',
+          providerModelId: 'meta-llama/llama-3.1-8b-instruct',
+          providerId: 'meta-llama',
+          modelType: 'llm',
+          metadata: {},
+        },
+      ],
+    },
+  );
   cy.interceptGenAi('GET /api/v1/aaa/models', { query: { namespace } }, mockEmptyList());
   cy.interceptGenAi('GET /api/v1/maas/models', { query: { namespace } }, mockEmptyList());
   cy.interceptGenAi(

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -85,7 +85,6 @@ const ChatbotMain: React.FunctionComponent = () => {
   const { loading: profileLoading, error: profileLoadError } = useAgentProfileUrlParam({
     mcpServers,
     mcpServersLoaded,
-    playgroundModelsLoaded: Boolean(modelsLoaded) || Boolean(modelsError),
   });
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
   const loadedProfileId = useChatbotConfigStore((s) => s.loadedProfileId);

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -82,16 +82,18 @@ const ChatbotMain: React.FunctionComponent = () => {
   const agentProfileId = searchParams.get('agentProfileId');
 
   // Load agent profile from URL param — lives here so the ApplicationsPage spinner covers the fetch
-  const { error: profileLoadError } = useAgentProfileUrlParam({
+  const { loading: profileLoading, error: profileLoadError } = useAgentProfileUrlParam({
     mcpServers,
     mcpServersLoaded,
     playgroundModelsLoaded: Boolean(modelsLoaded) || Boolean(modelsError),
   });
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
   const loadedProfileId = useChatbotConfigStore((s) => s.loadedProfileId);
-  // Ready when: no profile to load, fetch errored (show error state), or profile applied for this ID
+  // Ready when: no profile to load, fetch errored, or profile fully applied (async assets settled)
   const profileReady =
-    !agentProfileId || !!profileLoadError || (profileApplied && loadedProfileId === agentProfileId);
+    !agentProfileId ||
+    !!profileLoadError ||
+    (profileApplied && loadedProfileId === agentProfileId && !profileLoading);
   const configIds = useChatbotConfigStore(selectConfigIds);
   const isCompareMode = configIds.length > 1;
   const primaryConfigId = configIds[0] || DEFAULT_CONFIG_ID;

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -19,6 +19,9 @@ import DeletePlaygroundModal from '~/app/Chatbot/components/DeletePlaygroundModa
 import ChatModal from '~/app/Chatbot/components/ChatModal';
 import useFetchMCPServers from '~/app/hooks/useFetchMCPServers';
 import useAgentProfileUrlParam from '~/app/agentProfile/useAgentProfileUrlParam';
+import useIsProfileDirty from '~/app/agentProfile/useIsProfileDirty';
+import SafeNavigationBlocker from '~/app/components/SafeNavigationBlocker';
+import { useSafeBrowserUnloadBlocker } from '~/app/hooks/useSafeBrowserUnloadBlocker';
 import ChatbotHeader from './ChatbotHeader';
 import ChatbotPlayground from './ChatbotPlayground';
 import ChatbotHeaderActions from './ChatbotHeaderActions';
@@ -92,6 +95,9 @@ const ChatbotMain: React.FunctionComponent = () => {
   const configIds = useChatbotConfigStore(selectConfigIds);
   const isCompareMode = configIds.length > 1;
   const primaryConfigId = configIds[0] || DEFAULT_CONFIG_ID;
+
+  const isProfileDirty = useIsProfileDirty(primaryConfigId);
+  useSafeBrowserUnloadBlocker(isProfileDirty);
   const selectedModel = useChatbotConfigStore(selectSelectedModel(primaryConfigId));
 
   // Check if there are any models available (either AI assets or MaaS models)
@@ -386,6 +392,7 @@ const ChatbotMain: React.FunctionComponent = () => {
           onSelect={handleProfileSelected}
         />
       )}
+      {isProfileDirty && <SafeNavigationBlocker hasUnsavedChanges={isProfileDirty} />}
     </>
   );
 };

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -266,27 +266,33 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
   const loadedProfileId = useChatbotConfigStore((s) => s.loadedProfileId);
   const loadedProfileDisplayName = useChatbotConfigStore((s) => s.loadedProfileDisplayName);
+  const loadedProfileWarnings = useChatbotConfigStore((s) => s.loadedProfileWarnings);
   const [showOpenAgentModal, setShowOpenAgentModal] = React.useState(false);
   const modalShownForProfileRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
-    let isDismissed = false;
-    try {
-      isDismissed = !!localStorage.getItem(OPEN_AGENT_MODAL_DISMISSED_KEY);
-    } catch {
-      // SecurityError in private browsing — treat as not dismissed
-    }
     if (
-      profileApplied &&
-      loadedProfileId &&
-      loadedProfileId === agentProfileIdParam &&
-      modalShownForProfileRef.current !== loadedProfileId &&
-      !isDismissed
+      !profileApplied ||
+      !loadedProfileId ||
+      loadedProfileId !== agentProfileIdParam ||
+      modalShownForProfileRef.current === loadedProfileId
     ) {
+      return;
+    }
+    const hasWarnings = !!loadedProfileWarnings?.length;
+    let isDismissed = false;
+    if (!hasWarnings) {
+      try {
+        isDismissed = !!localStorage.getItem(OPEN_AGENT_MODAL_DISMISSED_KEY);
+      } catch {
+        // SecurityError in private browsing — treat as not dismissed
+      }
+    }
+    if (!isDismissed) {
       modalShownForProfileRef.current = loadedProfileId;
       setShowOpenAgentModal(true);
     }
-  }, [profileApplied, loadedProfileId, agentProfileIdParam]);
+  }, [profileApplied, loadedProfileId, agentProfileIdParam, loadedProfileWarnings]);
 
   const handleOpenAgentPreview = React.useCallback(() => {
     useChatbotConfigStore.getState().updatePreviewMode(DEFAULT_CONFIG_ID, true);
@@ -952,6 +958,8 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
                   isDisabled={primaryIsPreview}
                   agentName={profileApplied ? (loadedProfileDisplayName ?? undefined) : undefined}
                   isPreviewMode={primaryIsPreview}
+                  onExitPreview={primaryIsPreview ? handleOpenAgentEdit : undefined}
+                  hasValidationWarnings={!!loadedProfileWarnings?.length}
                 />
               )}
 
@@ -1075,6 +1083,7 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
       {showOpenAgentModal && (
         <OpenAgentProfileModal
           displayName={loadedProfileDisplayName ?? 'Agent'}
+          validationWarnings={loadedProfileWarnings ?? undefined}
           onPreview={handleOpenAgentPreview}
           onEdit={handleOpenAgentEdit}
           onCancel={handleOpenAgentCancel}

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotPaneHeader.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotPaneHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button, Divider, Flex, FlexItem, Label, Spinner, Content } from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
+import { PencilAltIcon, TimesIcon } from '@patternfly/react-icons';
 import { ChatbotHeaderMain } from '@patternfly/chatbot';
 import { ResponseMetrics } from '~/app/types';
 import { formatDuration } from '~/app/Chatbot/ChatbotMessagesMetrics';
@@ -29,6 +29,10 @@ interface ChatbotPaneHeaderProps {
   agentName?: string;
   /** When true, shows a "Preview" badge next to the agent name */
   isPreviewMode?: boolean;
+  /** Called when the user clicks the edit icon to exit preview mode */
+  onExitPreview?: () => void;
+  /** When true, the edit icon is disabled (e.g. validation warnings prevent editing) */
+  hasValidationWarnings?: boolean;
 }
 
 /**
@@ -50,6 +54,8 @@ const ChatbotPaneHeader: React.FC<ChatbotPaneHeaderProps> = ({
   isDisabled = false,
   agentName,
   isPreviewMode = false,
+  onExitPreview,
+  hasValidationWarnings = false,
 }) => (
   <div
     style={{
@@ -104,9 +110,21 @@ const ChatbotPaneHeader: React.FC<ChatbotPaneHeaderProps> = ({
                   >
                     <strong>{agentName}</strong>
                     {isPreviewMode && (
-                      <Label isCompact color="blue" data-testid="agent-preview-label">
-                        Preview
-                      </Label>
+                      <>
+                        <Label isCompact color="blue" data-testid="agent-preview-label">
+                          Preview
+                        </Label>
+                        {onExitPreview && (
+                          <Button
+                            variant="plain"
+                            aria-label="Edit agent configuration"
+                            icon={<PencilAltIcon />}
+                            isDisabled={hasValidationWarnings}
+                            onClick={onExitPreview}
+                            data-testid="agent-exit-preview-button"
+                          />
+                        )}
+                      </>
                     )}
                   </Content>
                 </FlexItem>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -56,6 +56,7 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
   const config = useChatbotConfigStore((s) => s.configurations[DEFAULT_CONFIG_ID]);
   const loadedProfileId = useChatbotConfigStore((s) => s.loadedProfileId);
   const loadedProfileDisplayName = useChatbotConfigStore((s) => s.loadedProfileDisplayName);
+  const loadedResourceVersion = useChatbotConfigStore((s) => s.loadedResourceVersion);
   const loadedProfileDescription = useChatbotConfigStore((s) => s.loadedProfileDescription);
 
   const { data: externalVectorStores = [] } = useFetchAAEVectorStores();
@@ -67,6 +68,7 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
   );
   const [isSaving, setIsSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const [conflictError, setConflictError] = React.useState<'modified' | 'deleted' | null>(null);
 
   const llamaModel = React.useMemo(
     () => playgroundModels.find((m) => m.id === config?.selectedModel),
@@ -152,19 +154,35 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
         const response = await api.createAgentProfile({ spec });
         onSaved(response.profileId, response.displayName, description.trim());
       } else {
-        const currentProfile = await api.getAgentProfile({ id: loadedProfileId });
+        // Use the stored resourceVersion directly — no intermediate GET needed.
+        // The server returns 409 if the profile was modified elsewhere, or 404 if deleted.
         const response = await api.updateAgentProfile({
           id: loadedProfileId,
           spec,
-          resourceVersion: currentProfile.metadata.resourceVersion,
+          resourceVersion: loadedResourceVersion ?? '',
         });
         onSaved(loadedProfileId, response.displayName, description.trim());
+        // Set after onSaved: applyAgentProfile (called inside onSaved) resets the store
+        // from storeInitialState, which would clear anything set before it.
+        useChatbotConfigStore.getState().setLoadedResourceVersion(response.resourceVersion);
       }
       // Update the dirty-detection baseline to the spec that was just persisted.
       // Any subsequent config changes will now be detected as unsaved.
       useChatbotConfigStore.getState().setLoadedProfileSpec(spec);
       onClose();
     } catch (err) {
+      if (err instanceof Error && 'code' in err) {
+        if (err.code === 'conflict') {
+          setConflictError('modified');
+          setIsSaving(false);
+          return;
+        }
+        if (err.code === 'not_found' || err.code === '404') {
+          setConflictError('deleted');
+          setIsSaving(false);
+          return;
+        }
+      }
       setError(err instanceof Error ? err.message : 'An unexpected error occurred.');
       setIsSaving(false);
     }
@@ -256,6 +274,26 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
               data-testid="save-agent-profile-description-input"
             />
           </FormGroup>
+          {error && (
+            <HelperText>
+              <HelperTextItem variant="error">{error}</HelperTextItem>
+            </HelperText>
+          )}
+          {conflictError && (
+            <Alert
+              variant="warning"
+              isInline
+              title={
+                conflictError === 'deleted'
+                  ? 'This agent configuration could not be found'
+                  : 'This agent configuration was modified elsewhere'
+              }
+              data-testid="save-conflict-alert"
+            >
+              Your changes cannot be saved directly. Use Save As to create a new agent configuration
+              with your changes.
+            </Alert>
+          )}
           <Divider />
           {/* Agent configuration details */}
           <Title headingLevel="h3" size="md">
@@ -404,12 +442,6 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
               title="Playground guardrails will not be saved with this profile"
             />
           </FormGroup>
-
-          {error && (
-            <HelperText>
-              <HelperTextItem variant="error">{error}</HelperTextItem>
-            </HelperText>
-          )}
         </Form>
       </ModalBody>
       <ModalFooter>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -160,6 +160,9 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
         });
         onSaved(loadedProfileId, response.displayName, description.trim());
       }
+      // Update the dirty-detection baseline to the spec that was just persisted.
+      // Any subsequent config changes will now be detected as unsaved.
+      useChatbotConfigStore.getState().setLoadedProfileSpec(spec);
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unexpected error occurred.');

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
@@ -82,6 +82,7 @@ describe('SaveAgentProfileModal', () => {
       loadedProfileId: null,
       loadedProfileDisplayName: null,
       loadedProfileDescription: null,
+      loadedResourceVersion: null,
     });
     jest.mocked(mockGenAiContextValue.apiState.api.createAgentProfile).mockResolvedValue({
       profileId: 'new-uuid',
@@ -200,7 +201,7 @@ describe('SaveAgentProfileModal', () => {
       );
     });
 
-    it('should call getAgentProfile then updateAgentProfile on submit', async () => {
+    it('should call updateAgentProfile with stored resourceVersion on submit', async () => {
       useChatbotConfigStore.setState({
         configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
         configIds: [DEFAULT_CONFIG_ID],
@@ -208,6 +209,7 @@ describe('SaveAgentProfileModal', () => {
         loadedProfileId: 'existing-uuid',
         loadedProfileDisplayName: 'My Agent',
         loadedProfileDescription: null,
+        loadedResourceVersion: 'rv-stored',
       });
       const user = userEvent.setup();
       renderModal('save');
@@ -215,23 +217,24 @@ describe('SaveAgentProfileModal', () => {
       await user.click(screen.getByTestId('save-agent-profile-submit-button'));
 
       await waitFor(() => {
-        expect(mockGenAiContextValue.apiState.api.getAgentProfile).toHaveBeenCalledWith({
-          id: 'existing-uuid',
-        });
+        expect(mockGenAiContextValue.apiState.api.getAgentProfile).not.toHaveBeenCalled();
         expect(mockGenAiContextValue.apiState.api.updateAgentProfile).toHaveBeenCalledWith(
           expect.objectContaining({
             id: 'existing-uuid',
-            resourceVersion: 'rv-1',
+            resourceVersion: 'rv-stored',
           }),
         );
         expect(mockOnSaved).toHaveBeenCalledWith('existing-uuid', 'My Agent', '');
       });
     });
 
-    it('should show error when getAgentProfile rejects', async () => {
+    it('should show conflict alert when updateAgentProfile returns 409', async () => {
+      const conflictError = Object.assign(new Error('object has been modified'), {
+        code: 'conflict',
+      });
       jest
-        .mocked(mockGenAiContextValue.apiState.api.getAgentProfile)
-        .mockRejectedValue(new Error('Profile not found'));
+        .mocked(mockGenAiContextValue.apiState.api.updateAgentProfile)
+        .mockRejectedValue(conflictError);
       useChatbotConfigStore.setState({
         configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
         configIds: [DEFAULT_CONFIG_ID],
@@ -239,6 +242,7 @@ describe('SaveAgentProfileModal', () => {
         loadedProfileId: 'existing-uuid',
         loadedProfileDisplayName: 'My Agent',
         loadedProfileDescription: null,
+        loadedResourceVersion: 'rv-stale',
       });
       const user = userEvent.setup();
       renderModal('save');
@@ -246,7 +250,34 @@ describe('SaveAgentProfileModal', () => {
       await user.click(screen.getByTestId('save-agent-profile-submit-button'));
 
       await waitFor(() => {
-        expect(screen.getByText('Profile not found')).toBeInTheDocument();
+        expect(screen.getByTestId('save-conflict-alert')).toBeInTheDocument();
+      });
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it('should show conflict alert when updateAgentProfile returns 404', async () => {
+      const notFoundError = Object.assign(new Error('the requested resource could not be found'), {
+        code: '404',
+      });
+      jest
+        .mocked(mockGenAiContextValue.apiState.api.updateAgentProfile)
+        .mockRejectedValue(notFoundError);
+      useChatbotConfigStore.setState({
+        configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
+        configIds: [DEFAULT_CONFIG_ID],
+        profileApplied: true,
+        loadedProfileId: 'existing-uuid',
+        loadedProfileDisplayName: 'My Agent',
+        loadedProfileDescription: null,
+        loadedResourceVersion: 'rv-stored',
+      });
+      const user = userEvent.setup();
+      renderModal('save');
+
+      await user.click(screen.getByTestId('save-agent-profile-submit-button'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('save-conflict-alert')).toBeInTheDocument();
       });
       expect(mockOnClose).not.toHaveBeenCalled();
     });

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/__tests__/useChatbotConfigStore.test.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/__tests__/useChatbotConfigStore.test.ts
@@ -1415,4 +1415,36 @@ describe('useChatbotConfigStore', () => {
       expect(useChatbotConfigStore.getState().loadedProfileSpec).toBeNull();
     });
   });
+
+  describe('setLoadedProfileWarnings', () => {
+    it('should store warnings', () => {
+      act(() => {
+        useChatbotConfigStore
+          .getState()
+          .setLoadedProfileWarnings(['Model "x" is no longer available.']);
+      });
+
+      expect(useChatbotConfigStore.getState().loadedProfileWarnings).toEqual([
+        'Model "x" is no longer available.',
+      ]);
+    });
+
+    it('should clear warnings when called with null', () => {
+      act(() => {
+        useChatbotConfigStore.getState().setLoadedProfileWarnings(['some warning']);
+        useChatbotConfigStore.getState().setLoadedProfileWarnings(null);
+      });
+
+      expect(useChatbotConfigStore.getState().loadedProfileWarnings).toBeNull();
+    });
+
+    it('should be cleared by resetConfiguration', () => {
+      act(() => {
+        useChatbotConfigStore.getState().setLoadedProfileWarnings(['some warning']);
+        useChatbotConfigStore.getState().resetConfiguration();
+      });
+
+      expect(useChatbotConfigStore.getState().loadedProfileWarnings).toBeNull();
+    });
+  });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/__tests__/useChatbotConfigStore.test.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/__tests__/useChatbotConfigStore.test.ts
@@ -1370,4 +1370,49 @@ describe('useChatbotConfigStore', () => {
       expect(newConfig?.isAsrModelEnabled).toBe(true);
     });
   });
+
+  describe('setLoadedProfileSpec', () => {
+    it('should store the spec', () => {
+      const spec = {
+        displayName: 'My Agent',
+        model: { id: 'llama-3', uri: 'http://llama.svc' },
+        temperature: 0.7,
+        stream: true,
+      };
+
+      act(() => {
+        useChatbotConfigStore.getState().setLoadedProfileSpec(spec);
+      });
+
+      expect(useChatbotConfigStore.getState().loadedProfileSpec).toEqual(spec);
+    });
+
+    it('should clear the spec when called with null', () => {
+      act(() => {
+        useChatbotConfigStore.getState().setLoadedProfileSpec({
+          displayName: 'A',
+          model: { id: 'x', uri: '' },
+          temperature: 0.1,
+          stream: false,
+        });
+        useChatbotConfigStore.getState().setLoadedProfileSpec(null);
+      });
+
+      expect(useChatbotConfigStore.getState().loadedProfileSpec).toBeNull();
+    });
+
+    it('should be cleared by resetConfiguration', () => {
+      act(() => {
+        useChatbotConfigStore.getState().setLoadedProfileSpec({
+          displayName: 'A',
+          model: { id: 'x', uri: '' },
+          temperature: 0.1,
+          stream: false,
+        });
+        useChatbotConfigStore.getState().resetConfiguration();
+      });
+
+      expect(useChatbotConfigStore.getState().loadedProfileSpec).toBeNull();
+    });
+  });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/selectors.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/selectors.ts
@@ -1,4 +1,5 @@
 import { MLflowPromptVersion } from '~/app/types';
+import { AgentProfileSpec } from '~/app/agentProfile/types';
 import { ChatbotConfigStore, DEFAULT_CONFIGURATION, McpToolSelectionsMap } from './types';
 
 // Field-specific selectors
@@ -121,3 +122,6 @@ export const selectIsPreview =
 
 // Configuration management selectors
 export const selectConfigIds = (state: ChatbotConfigStore): string[] => state.configIds;
+
+export const selectLoadedProfileSpec = (state: ChatbotConfigStore): AgentProfileSpec | null =>
+  state.loadedProfileSpec;

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_SYSTEM_INSTRUCTIONS } from '~/app/Chatbot/const';
 import { MLflowPromptVersion } from '~/app/types';
+import { AgentProfileSpec } from '~/app/agentProfile/types';
 
 /**
  * MCP tool selections map structure:
@@ -93,6 +94,12 @@ export interface ChatbotConfigStoreState {
   loadedProfileDisplayName: string | null;
   /** description of the currently loaded AgentProfile, for pre-filling the Save modal. */
   loadedProfileDescription: string | null;
+  /**
+   * The AgentProfileSpec that was last saved or loaded, used for dirty detection.
+   * Set by setLoadedProfileSpec() after a profile load or successful save.
+   * Cleared by resetConfiguration() when the user starts a new configuration.
+   */
+  loadedProfileSpec: AgentProfileSpec | null;
 }
 
 /**
@@ -150,6 +157,14 @@ export interface ChatbotConfigStoreActions {
   resetDirtyPrompt: (id: string) => void;
   clearPromptState: (id: string, newDirtyPrompt: MLflowPromptVersion | null) => void;
   updateVariableValues: (id: string, values: Record<string, string>) => void;
+
+  /**
+   * Store the AgentProfileSpec snapshot for dirty detection.
+   * Call after a profile is loaded (with the API response spec) or after a successful
+   * save (with the spec that was just written), so the dirty check baseline is always
+   * "the last thing that was persisted."
+   */
+  setLoadedProfileSpec: (spec: AgentProfileSpec | null) => void;
 
   // Configuration management
   resetConfiguration: (initialValues?: Partial<ChatbotConfiguration>) => void;

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
@@ -101,6 +101,12 @@ export interface ChatbotConfigStoreState {
    */
   loadedProfileSpec: AgentProfileSpec | null;
   /**
+   * The Kubernetes resourceVersion of the currently loaded AgentProfile.
+   * Used for optimistic concurrency: the PUT request includes this value so the server
+   * can reject the write if the profile was modified elsewhere (409 Conflict).
+   */
+  loadedResourceVersion: string | null;
+  /**
    * Validation warnings produced during profile deserialization (e.g. model not found,
    * MCP server unresolvable). Non-null when a profile is loaded with missing resources.
    * Drives the warning alert and disabled Edit in OpenAgentProfileModal.
@@ -171,6 +177,7 @@ export interface ChatbotConfigStoreActions {
    * "the last thing that was persisted."
    */
   setLoadedProfileSpec: (spec: AgentProfileSpec | null) => void;
+  setLoadedResourceVersion: (resourceVersion: string | null) => void;
   setLoadedProfileWarnings: (warnings: string[] | null) => void;
 
   // Configuration management

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
@@ -100,6 +100,12 @@ export interface ChatbotConfigStoreState {
    * Cleared by resetConfiguration() when the user starts a new configuration.
    */
   loadedProfileSpec: AgentProfileSpec | null;
+  /**
+   * Validation warnings produced during profile deserialization (e.g. model not found,
+   * MCP server unresolvable). Non-null when a profile is loaded with missing resources.
+   * Drives the warning alert and disabled Edit in OpenAgentProfileModal.
+   */
+  loadedProfileWarnings: string[] | null;
 }
 
 /**
@@ -165,6 +171,7 @@ export interface ChatbotConfigStoreActions {
    * "the last thing that was persisted."
    */
   setLoadedProfileSpec: (spec: AgentProfileSpec | null) => void;
+  setLoadedProfileWarnings: (warnings: string[] | null) => void;
 
   // Configuration management
   resetConfiguration: (initialValues?: Partial<ChatbotConfiguration>) => void;

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
@@ -155,6 +155,7 @@ export const createChatbotConfigStore = (
     loadedProfileId: null,
     loadedProfileDisplayName: null,
     loadedProfileDescription: null,
+    loadedProfileSpec: null,
   };
 
   return create<ChatbotConfigStore>()(
@@ -628,6 +629,10 @@ const createStoreActions = (
       false,
       'updateHasVisionImage',
     );
+  },
+
+  setLoadedProfileSpec: (spec) => {
+    set(() => ({ loadedProfileSpec: spec }), false, 'setLoadedProfileSpec');
   },
 
   // Configuration management

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
@@ -156,6 +156,7 @@ export const createChatbotConfigStore = (
     loadedProfileDisplayName: null,
     loadedProfileDescription: null,
     loadedProfileSpec: null,
+    loadedProfileWarnings: null,
   };
 
   return create<ChatbotConfigStore>()(
@@ -633,6 +634,10 @@ const createStoreActions = (
 
   setLoadedProfileSpec: (spec) => {
     set(() => ({ loadedProfileSpec: spec }), false, 'setLoadedProfileSpec');
+  },
+
+  setLoadedProfileWarnings: (warnings) => {
+    set(() => ({ loadedProfileWarnings: warnings }), false, 'setLoadedProfileWarnings');
   },
 
   // Configuration management

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
@@ -157,6 +157,7 @@ export const createChatbotConfigStore = (
     loadedProfileDescription: null,
     loadedProfileSpec: null,
     loadedProfileWarnings: null,
+    loadedResourceVersion: null,
   };
 
   return create<ChatbotConfigStore>()(
@@ -638,6 +639,10 @@ const createStoreActions = (
 
   setLoadedProfileWarnings: (warnings) => {
     set(() => ({ loadedProfileWarnings: warnings }), false, 'setLoadedProfileWarnings');
+  },
+
+  setLoadedResourceVersion: (resourceVersion) => {
+    set(() => ({ loadedResourceVersion: resourceVersion }), false, 'setLoadedResourceVersion');
   },
 
   // Configuration management

--- a/packages/gen-ai/frontend/src/app/agentProfile/OpenAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/agentProfile/OpenAgentProfileModal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Alert,
   Button,
   Checkbox,
   Content,
@@ -13,6 +14,7 @@ export const OPEN_AGENT_MODAL_DISMISSED_KEY = 'gen-ai-agent-open-modal-dismissed
 
 type OpenAgentProfileModalProps = {
   displayName: string;
+  validationWarnings?: string[];
   onPreview: () => void;
   onEdit: () => void;
   onCancel: () => void;
@@ -20,14 +22,16 @@ type OpenAgentProfileModalProps = {
 
 const OpenAgentProfileModal: React.FC<OpenAgentProfileModalProps> = ({
   displayName,
+  validationWarnings,
   onPreview,
   onEdit,
   onCancel,
 }) => {
   const [doNotShow, setDoNotShow] = React.useState(false);
+  const hasWarnings = !!validationWarnings?.length;
 
   const persist = () => {
-    if (doNotShow) {
+    if (doNotShow && !hasWarnings) {
       try {
         localStorage.setItem(OPEN_AGENT_MODAL_DISMISSED_KEY, 'true');
       } catch {
@@ -46,6 +50,21 @@ const OpenAgentProfileModal: React.FC<OpenAgentProfileModalProps> = ({
     >
       <ModalHeader title="Open this agent?" labelId="open-agent-profile-modal-title" />
       <ModalBody>
+        {hasWarnings && (
+          <Alert
+            variant="warning"
+            isInline
+            title="Some resources from this agent configuration are no longer available"
+            className="pf-v6-u-mb-md"
+            data-testid="open-agent-profile-warning-alert"
+          >
+            <ul>
+              {validationWarnings.map((w) => (
+                <li key={w}>{w}</li>
+              ))}
+            </ul>
+          </Alert>
+        )}
         <Content>
           <Content component="p">
             You are opening <strong>{displayName}</strong>. Preview keeps agent configuration
@@ -53,12 +72,14 @@ const OpenAgentProfileModal: React.FC<OpenAgentProfileModalProps> = ({
             changes.
           </Content>
         </Content>
-        <Checkbox
-          id="open-agent-do-not-show"
-          label="Don't show this message again"
-          isChecked={doNotShow}
-          onChange={(_e, checked) => setDoNotShow(checked)}
-        />
+        {!hasWarnings && (
+          <Checkbox
+            id="open-agent-do-not-show"
+            label="Don't show this message again"
+            isChecked={doNotShow}
+            onChange={(_e, checked) => setDoNotShow(checked)}
+          />
+        )}
       </ModalBody>
       <ModalFooter>
         <Button
@@ -73,6 +94,7 @@ const OpenAgentProfileModal: React.FC<OpenAgentProfileModalProps> = ({
         </Button>
         <Button
           variant="primary"
+          isDisabled={hasWarnings}
           data-testid="open-agent-profile-edit-button"
           onClick={() => {
             persist();

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/OpenAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/OpenAgentProfileModal.spec.tsx
@@ -134,4 +134,57 @@ describe('OpenAgentProfileModal', () => {
       expect(localStorage.getItem(OPEN_AGENT_MODAL_DISMISSED_KEY)).toBeNull();
     });
   });
+
+  describe('validation warnings', () => {
+    const warnings = [
+      'Model "fake-model" is no longer available.',
+      'MCP server "gone-server" is no longer available.',
+    ];
+
+    it('should render the warning alert listing each warning', () => {
+      render(<OpenAgentProfileModal {...defaultProps} validationWarnings={warnings} />);
+
+      expect(screen.getByTestId('open-agent-profile-warning-alert')).toBeInTheDocument();
+      expect(screen.getByText('Model "fake-model" is no longer available.')).toBeInTheDocument();
+      expect(
+        screen.getByText('MCP server "gone-server" is no longer available.'),
+      ).toBeInTheDocument();
+    });
+
+    it('should disable the Edit button when warnings are present', () => {
+      render(<OpenAgentProfileModal {...defaultProps} validationWarnings={warnings} />);
+
+      expect(screen.getByTestId('open-agent-profile-edit-button')).toBeDisabled();
+    });
+
+    it('should hide the "Don\'t show this message again" checkbox when warnings are present', () => {
+      render(<OpenAgentProfileModal {...defaultProps} validationWarnings={warnings} />);
+
+      expect(
+        screen.queryByRole('checkbox', { name: /don't show this message again/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not write to localStorage even if Preview is clicked when warnings are present', async () => {
+      const user = userEvent.setup();
+      render(<OpenAgentProfileModal {...defaultProps} validationWarnings={warnings} />);
+
+      await user.click(screen.getByTestId('open-agent-profile-preview-button'));
+
+      expect(localStorage.getItem(OPEN_AGENT_MODAL_DISMISSED_KEY)).toBeNull();
+    });
+
+    it('should not render the warning alert when validationWarnings is empty', () => {
+      render(<OpenAgentProfileModal {...defaultProps} validationWarnings={[]} />);
+
+      expect(screen.queryByTestId('open-agent-profile-warning-alert')).not.toBeInTheDocument();
+      expect(screen.getByTestId('open-agent-profile-edit-button')).not.toBeDisabled();
+    });
+
+    it('should not render the warning alert when validationWarnings is undefined', () => {
+      render(<OpenAgentProfileModal {...defaultProps} />);
+
+      expect(screen.queryByTestId('open-agent-profile-warning-alert')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/useIsProfileDirty.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/useIsProfileDirty.spec.ts
@@ -7,6 +7,8 @@ import { DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
 import useIsProfileDirty from '~/app/agentProfile/useIsProfileDirty';
 import type { AgentProfileSpec } from '~/app/agentProfile/types';
 
+import useFetchMCPServers from '~/app/hooks/useFetchMCPServers';
+
 jest.mock('~/app/hooks/useFetchMCPServers', () => ({
   __esModule: true,
   default: jest.fn(() => ({ data: [], configMapName: null, loaded: true })),
@@ -128,37 +130,37 @@ describe('useIsProfileDirty', () => {
     expect(result.current).toBe(false);
   });
 
-  it('should return false when mcpServers in snapshot are in different order', () => {
-    const serverA = {
-      serverRef: { kind: 'ConfigMap', name: 'mcp-cm', key: 'server-a' },
-      allowedTools: ['tool1', 'tool2'],
-    };
-    const serverB = {
-      serverRef: { kind: 'ConfigMap', name: 'mcp-cm', key: 'server-b' },
-      allowedTools: ['tool3'],
-    };
+  it('should return false when mcpServers in snapshot are in different order than serialized config', () => {
+    // Give useFetchMCPServers real servers so serializeToAgentProfileSpec produces mcpServers.
+    jest.mocked(useFetchMCPServers).mockReturnValueOnce({
+      data: [
+        { name: 'server-a', url: 'http://server-a' },
+        { name: 'server-b', url: 'http://server-b' },
+      ] as never,
+      configMapName: 'gen-ai-aa-mcp-servers',
+      loaded: true,
+    });
 
+    // Config selects servers in [A, B] order — serialized spec will have [A, B].
+    // Snapshot has them in [B, A] order. normalizeSpec sorts both → equal → not dirty.
     useChatbotConfigStore.setState({
       profileApplied: true,
-      loadedProfileSpec: makeMatchingSpec({ mcpServers: [serverB, serverA] }),
+      loadedProfileSpec: makeMatchingSpec({
+        mcpServers: [
+          { serverRef: { kind: 'ConfigMap', name: 'gen-ai-aa-mcp-servers', key: 'server-b' } },
+          { serverRef: { kind: 'ConfigMap', name: 'gen-ai-aa-mcp-servers', key: 'server-a' } },
+        ],
+      }),
       configurations: {
         [DEFAULT_CONFIG_ID]: {
           ...DEFAULT_CONFIGURATION,
-          selectedMcpServerIds: ['server-a-url', 'server-b-url'],
+          selectedMcpServerIds: ['http://server-a', 'http://server-b'],
         },
       },
     });
 
-    // With no mcpServers data in useFetchMCPServers, the serialized config produces no mcpServers.
-    // This test verifies the order-sorting logic by using the snapshot's own comparison.
-    // Snapshot with [B, A] and [A, B] would normalize to same result.
-    const snapshotReversed = makeMatchingSpec({ mcpServers: [serverA, serverB] });
-    useChatbotConfigStore.setState({ loadedProfileSpec: snapshotReversed });
-
     const { result } = renderHook(() => useIsProfileDirty(DEFAULT_CONFIG_ID), { wrapper });
-    // Config has no MCP servers (empty mcpServers from useFetchMCPServers mock) so spec produces
-    // no mcpServers; snapshot also has mcpServers defined — they differ.
-    expect(result.current).toBe(true);
+    expect(result.current).toBe(false);
   });
 
   it('should return false when config is undefined', () => {

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/useIsProfileDirty.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/useIsProfileDirty.spec.ts
@@ -1,0 +1,174 @@
+/* eslint-disable camelcase */
+import * as React from 'react';
+import { renderHook } from '@testing-library/react';
+import { ChatbotContext } from '~/app/context/ChatbotContext';
+import { useChatbotConfigStore, DEFAULT_CONFIG_ID } from '~/app/Chatbot/store';
+import { DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
+import useIsProfileDirty from '~/app/agentProfile/useIsProfileDirty';
+import type { AgentProfileSpec } from '~/app/agentProfile/types';
+
+jest.mock('~/app/hooks/useFetchMCPServers', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ data: [], configMapName: null, loaded: true })),
+}));
+
+const emptyChatbotContext = {
+  models: [],
+  modelsLoaded: true,
+  modelsError: undefined,
+  aiModels: [],
+  aiModelsLoaded: true,
+  aiModelsError: undefined,
+  maasModels: [],
+  maasModelsLoaded: true,
+  maasModelsError: undefined,
+  lsdStatus: null,
+  lsdStatusLoaded: true,
+  lsdStatusError: undefined,
+  refresh: jest.fn(),
+  lastInput: '',
+  setLastInput: jest.fn(),
+};
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) =>
+  React.createElement(ChatbotContext.Provider, { value: emptyChatbotContext as never }, children);
+
+/** Minimal AgentProfileSpec that matches DEFAULT_CONFIGURATION with no model context. */
+const makeMatchingSpec = (overrides: Partial<AgentProfileSpec> = {}): AgentProfileSpec => ({
+  displayName: 'Test Agent',
+  model: { id: DEFAULT_CONFIGURATION.selectedModel, uri: '' },
+  temperature: DEFAULT_CONFIGURATION.temperature,
+  stream: DEFAULT_CONFIGURATION.isStreamingEnabled,
+  ...overrides,
+});
+
+const resetStore = () =>
+  useChatbotConfigStore.setState({
+    configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
+    configIds: [DEFAULT_CONFIG_ID],
+    profileApplied: false,
+    loadedProfileId: null,
+    loadedProfileDisplayName: null,
+    loadedProfileDescription: null,
+    loadedProfileSpec: null,
+  });
+
+describe('useIsProfileDirty', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStore();
+  });
+
+  it('should return false when no profile is loaded', () => {
+    useChatbotConfigStore.setState({ profileApplied: false, loadedProfileSpec: null });
+
+    const { result } = renderHook(() => useIsProfileDirty(DEFAULT_CONFIG_ID), { wrapper });
+    expect(result.current).toBe(false);
+  });
+
+  it('should return false when loadedProfileSpec is null', () => {
+    useChatbotConfigStore.setState({ profileApplied: true, loadedProfileSpec: null });
+
+    const { result } = renderHook(() => useIsProfileDirty(DEFAULT_CONFIG_ID), { wrapper });
+    expect(result.current).toBe(false);
+  });
+
+  it('should return false when config matches the snapshot', () => {
+    useChatbotConfigStore.setState({
+      profileApplied: true,
+      loadedProfileSpec: makeMatchingSpec(),
+    });
+
+    const { result } = renderHook(() => useIsProfileDirty(DEFAULT_CONFIG_ID), { wrapper });
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true when temperature differs from snapshot', () => {
+    useChatbotConfigStore.setState({
+      profileApplied: true,
+      loadedProfileSpec: makeMatchingSpec({ temperature: 0.9 }),
+    });
+
+    const { result } = renderHook(() => useIsProfileDirty(DEFAULT_CONFIG_ID), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it('should return true when model ID differs from snapshot', () => {
+    useChatbotConfigStore.setState({
+      profileApplied: true,
+      loadedProfileSpec: makeMatchingSpec({ model: { id: 'different-model', uri: '' } }),
+    });
+
+    const { result } = renderHook(() => useIsProfileDirty(DEFAULT_CONFIG_ID), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it('should return true when streaming setting differs from snapshot', () => {
+    useChatbotConfigStore.setState({
+      profileApplied: true,
+      loadedProfileSpec: makeMatchingSpec({ stream: !DEFAULT_CONFIGURATION.isStreamingEnabled }),
+    });
+
+    const { result } = renderHook(() => useIsProfileDirty(DEFAULT_CONFIG_ID), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it('should ignore displayName, description, and guardrails fields in snapshot', () => {
+    useChatbotConfigStore.setState({
+      profileApplied: true,
+      loadedProfileSpec: makeMatchingSpec({
+        description: 'some description',
+        guardrails: [
+          { provider: 'test', guardrailRef: { kind: 'ConfigMap', name: 'g', key: 'k' } },
+        ],
+      }),
+    });
+
+    const { result } = renderHook(() => useIsProfileDirty(DEFAULT_CONFIG_ID), { wrapper });
+    expect(result.current).toBe(false);
+  });
+
+  it('should return false when mcpServers in snapshot are in different order', () => {
+    const serverA = {
+      serverRef: { kind: 'ConfigMap', name: 'mcp-cm', key: 'server-a' },
+      allowedTools: ['tool1', 'tool2'],
+    };
+    const serverB = {
+      serverRef: { kind: 'ConfigMap', name: 'mcp-cm', key: 'server-b' },
+      allowedTools: ['tool3'],
+    };
+
+    useChatbotConfigStore.setState({
+      profileApplied: true,
+      loadedProfileSpec: makeMatchingSpec({ mcpServers: [serverB, serverA] }),
+      configurations: {
+        [DEFAULT_CONFIG_ID]: {
+          ...DEFAULT_CONFIGURATION,
+          selectedMcpServerIds: ['server-a-url', 'server-b-url'],
+        },
+      },
+    });
+
+    // With no mcpServers data in useFetchMCPServers, the serialized config produces no mcpServers.
+    // This test verifies the order-sorting logic by using the snapshot's own comparison.
+    // Snapshot with [B, A] and [A, B] would normalize to same result.
+    const snapshotReversed = makeMatchingSpec({ mcpServers: [serverA, serverB] });
+    useChatbotConfigStore.setState({ loadedProfileSpec: snapshotReversed });
+
+    const { result } = renderHook(() => useIsProfileDirty(DEFAULT_CONFIG_ID), { wrapper });
+    // Config has no MCP servers (empty mcpServers from useFetchMCPServers mock) so spec produces
+    // no mcpServers; snapshot also has mcpServers defined — they differ.
+    expect(result.current).toBe(true);
+  });
+
+  it('should return false when config is undefined', () => {
+    useChatbotConfigStore.setState({
+      profileApplied: true,
+      loadedProfileSpec: makeMatchingSpec(),
+      configurations: {},
+    });
+
+    const { result } = renderHook(() => useIsProfileDirty(DEFAULT_CONFIG_ID), { wrapper });
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/useIsProfileDirty.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/useIsProfileDirty.spec.ts
@@ -139,6 +139,7 @@ describe('useIsProfileDirty', () => {
       ] as never,
       configMapName: 'gen-ai-aa-mcp-servers',
       loaded: true,
+      error: undefined,
     });
 
     // Config selects servers in [A, B] order — serialized spec will have [A, B].

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/validateAgentProfile.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/validateAgentProfile.spec.ts
@@ -189,6 +189,18 @@ describe('validateAgentProfileAsync', () => {
       expect(result.warnings).toHaveLength(0);
     });
 
+    it('should not warn and leave resolvedPrompt undefined when getMLflowPrompt resolves null', async () => {
+      const api = makeApi({ getMLflowPrompt: jest.fn().mockResolvedValue(null) });
+      const profile = makeProfile({
+        prompt: { name: 'my-prompt', source: 'mlflow', version: '1' },
+      });
+
+      const result = await validateAgentProfileAsync(profile, api);
+
+      expect(result.resolvedPrompt).toBeFalsy();
+      expect(result.warnings).toHaveLength(0);
+    });
+
     it('should warn when getMLflowPrompt rejects', async () => {
       const api = makeApi({ getMLflowPrompt: jest.fn().mockRejectedValue(new Error('404')) });
       const profile = makeProfile({

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/validateAgentProfile.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/validateAgentProfile.spec.ts
@@ -1,0 +1,277 @@
+/* eslint-disable camelcase */
+import {
+  buildValidationWarnings,
+  validateAgentProfileAsync,
+} from '~/app/agentProfile/validateAgentProfile';
+import type { AgentProfile } from '~/app/agentProfile/types';
+import type {
+  LlamaModel,
+  AIModel,
+  GenAiAPIs,
+  ExternalVectorStoreSummary,
+  VectorStore,
+} from '~/app/types';
+
+const makeProfile = (overrides: Partial<AgentProfile['spec']> = {}): AgentProfile => ({
+  apiVersion: 'genai.redhat.com/v1alpha1',
+  kind: 'AgentProfile',
+  metadata: { name: 'test-uuid', resourceVersion: '1' },
+  spec: {
+    displayName: 'Test Agent',
+    model: { id: 'llama-3-70b', uri: 'http://llama.svc/v1', sourceType: 'namespace' },
+    ...overrides,
+  },
+});
+
+const makeLlamaModel = (modelId: string): LlamaModel => ({
+  id: `vllm/${modelId}`,
+  modelId,
+  object: 'model',
+  created: 0,
+  owned_by: '',
+});
+
+const makeAIModel = (model_id: string): AIModel =>
+  ({
+    model_id,
+    model_name: model_id,
+    model_source_type: 'namespace',
+    internalEndpoint: 'http://endpoint',
+  }) as AIModel;
+
+const makeApi = (overrides: Partial<GenAiAPIs> = {}): GenAiAPIs =>
+  ({
+    getMLflowPrompt: jest.fn().mockResolvedValue(null),
+    getAAVectorStores: jest.fn().mockResolvedValue([]),
+    listVectorStores: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  }) as unknown as GenAiAPIs;
+
+const baseContext = {
+  playgroundModels: [makeLlamaModel('llama-3-70b')],
+  aiModels: [] as AIModel[],
+  mcpServers: [],
+};
+
+// ---------------------------------------------------------------------------
+// buildValidationWarnings
+// ---------------------------------------------------------------------------
+
+describe('buildValidationWarnings', () => {
+  it('should return no warnings when all resources resolve', () => {
+    expect(buildValidationWarnings(makeProfile(), baseContext)).toHaveLength(0);
+  });
+
+  describe('model', () => {
+    it('should warn when model is not in playgroundModels', () => {
+      const warnings = buildValidationWarnings(makeProfile(), {
+        ...baseContext,
+        playgroundModels: [],
+      });
+      expect(warnings).toContain('Model "llama-3-70b" is no longer available.');
+    });
+
+    it('should not warn when model is present', () => {
+      expect(
+        buildValidationWarnings(makeProfile(), baseContext).some((w) => w.includes('Model')),
+      ).toBe(false);
+    });
+  });
+
+  describe('ASR model', () => {
+    it('should warn when ASR model is not in aiModels', () => {
+      const profile = makeProfile({ asr: { model: { id: 'whisper-v3', uri: '' } } });
+      const warnings = buildValidationWarnings(profile, { ...baseContext, aiModels: [] });
+      expect(warnings).toContain('Transcription model "whisper-v3" is no longer available.');
+    });
+
+    it('should not warn when ASR model is present', () => {
+      const profile = makeProfile({ asr: { model: { id: 'whisper-v3', uri: '' } } });
+      const warnings = buildValidationWarnings(profile, {
+        ...baseContext,
+        aiModels: [makeAIModel('whisper-v3')],
+      });
+      expect(warnings.some((w) => w.includes('Transcription'))).toBe(false);
+    });
+
+    it('should not warn when spec has no ASR section', () => {
+      expect(
+        buildValidationWarnings(makeProfile(), baseContext).some((w) =>
+          w.includes('Transcription'),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('MCP servers', () => {
+    it('should warn when MCP server key is not in available servers', () => {
+      const profile = makeProfile({
+        mcpServers: [
+          {
+            serverRef: { kind: 'ConfigMap', name: 'gen-ai-aa-mcp-servers', key: 'my-server' },
+          },
+        ],
+      });
+      const warnings = buildValidationWarnings(profile, { ...baseContext, mcpServers: [] });
+      expect(warnings).toContain('MCP server "my-server" is no longer available.');
+    });
+
+    it('should not warn when MCP server key resolves', () => {
+      const profile = makeProfile({
+        mcpServers: [
+          {
+            serverRef: { kind: 'ConfigMap', name: 'gen-ai-aa-mcp-servers', key: 'my-server' },
+          },
+        ],
+      });
+      const warnings = buildValidationWarnings(profile, {
+        ...baseContext,
+        mcpServers: [{ name: 'my-server', url: 'http://mcp.svc' } as never],
+      });
+      expect(warnings.some((w) => w.includes('MCP'))).toBe(false);
+    });
+  });
+
+  it('should return multiple warnings when several resources are missing', () => {
+    const profile = makeProfile({
+      asr: { model: { id: 'whisper-v3', uri: '' } },
+      mcpServers: [
+        {
+          serverRef: { kind: 'ConfigMap', name: 'gen-ai-aa-mcp-servers', key: 'gone-server' },
+        },
+      ],
+    });
+    expect(
+      buildValidationWarnings(profile, { playgroundModels: [], aiModels: [], mcpServers: [] }),
+    ).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateAgentProfileAsync
+// ---------------------------------------------------------------------------
+
+describe('validateAgentProfileAsync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return no warnings and no resolved data when profile has no async resources', async () => {
+    const result = await validateAgentProfileAsync(makeProfile(), makeApi());
+    expect(result.warnings).toHaveLength(0);
+    expect(result.resolvedPrompt).toBeUndefined();
+  });
+
+  it('should not call vector store APIs when profile has no vector stores', async () => {
+    const api = makeApi();
+    await validateAgentProfileAsync(makeProfile(), api);
+    expect(api.getAAVectorStores).not.toHaveBeenCalled();
+    expect(api.listVectorStores).not.toHaveBeenCalled();
+  });
+
+  it('should not call prompt API when profile has no prompt', async () => {
+    const api = makeApi();
+    await validateAgentProfileAsync(makeProfile(), api);
+    expect(api.getMLflowPrompt).not.toHaveBeenCalled();
+  });
+
+  describe('prompt', () => {
+    it('should return resolvedPrompt when getMLflowPrompt succeeds', async () => {
+      const mockPrompt = { name: 'my-prompt', version: 1, template: 'Hello' };
+      const api = makeApi({ getMLflowPrompt: jest.fn().mockResolvedValue(mockPrompt) });
+      const profile = makeProfile({
+        prompt: { name: 'my-prompt', source: 'mlflow', version: '1' },
+      });
+
+      const result = await validateAgentProfileAsync(profile, api);
+
+      expect(result.resolvedPrompt).toEqual(mockPrompt);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('should warn when getMLflowPrompt rejects', async () => {
+      const api = makeApi({ getMLflowPrompt: jest.fn().mockRejectedValue(new Error('404')) });
+      const profile = makeProfile({
+        prompt: { name: 'gone-prompt', source: 'mlflow', version: '1' },
+      });
+
+      const result = await validateAgentProfileAsync(profile, api);
+
+      expect(result.resolvedPrompt).toBeUndefined();
+      expect(result.warnings).toContain('Prompt "gone-prompt" is no longer available.');
+    });
+  });
+
+  describe('external (ConfigMap-backed) vector stores', () => {
+    const externalStore: ExternalVectorStoreSummary = {
+      vector_store_id: 'my-store',
+      vector_store_name: 'My Store',
+      provider_id: 'chroma',
+      provider_type: 'inline',
+      embedding_model: 'all-minilm',
+      embedding_dimension: 384,
+    };
+
+    it('should return resolvedAAVectorStores and no warning when store is found', async () => {
+      const api = makeApi({ getAAVectorStores: jest.fn().mockResolvedValue([externalStore]) });
+      const profile = makeProfile({
+        vectorStores: {
+          stores: [
+            { storeRef: { kind: 'ConfigMap', name: 'gen-ai-aa-vector-stores', key: 'my-store' } },
+          ],
+        },
+      });
+
+      const result = await validateAgentProfileAsync(profile, api);
+
+      expect(result.resolvedAAVectorStores).toEqual([externalStore]);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('should warn when external store key is not in AA stores list', async () => {
+      const api = makeApi({ getAAVectorStores: jest.fn().mockResolvedValue([]) });
+      const profile = makeProfile({
+        vectorStores: {
+          stores: [
+            {
+              storeRef: { kind: 'ConfigMap', name: 'gen-ai-aa-vector-stores', key: 'gone-store' },
+            },
+          ],
+        },
+      });
+
+      const result = await validateAgentProfileAsync(profile, api);
+
+      expect(result.warnings).toContain('Vector store "gone-store" is no longer available.');
+    });
+  });
+
+  describe('inline (Llama Stack) vector stores', () => {
+    const llamaStore: VectorStore = {
+      id: 'vs_abc123',
+      created_at: 0,
+      last_active_at: 0,
+      file_counts: { in_progress: 0, completed: 0, failed: 0, cancelled: 0, total: 0 },
+      metadata: { provider_id: 'chroma' },
+    } as VectorStore;
+
+    it('should return resolvedLlamaVectorStores and no warning when store is found', async () => {
+      const api = makeApi({ listVectorStores: jest.fn().mockResolvedValue([llamaStore]) });
+      const profile = makeProfile({ vectorStores: { stores: [{ id: 'vs_abc123' }] } });
+
+      const result = await validateAgentProfileAsync(profile, api);
+
+      expect(result.resolvedLlamaVectorStores).toEqual([llamaStore]);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('should warn when inline store ID is not in Llama Stack stores', async () => {
+      const api = makeApi({ listVectorStores: jest.fn().mockResolvedValue([]) });
+      const profile = makeProfile({ vectorStores: { stores: [{ id: 'vs_gone' }] } });
+
+      const result = await validateAgentProfileAsync(profile, api);
+
+      expect(result.warnings).toContain('Vector store "vs_gone" is no longer available.');
+    });
+  });
+});

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/validateAgentProfile.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/validateAgentProfile.spec.ts
@@ -189,7 +189,7 @@ describe('validateAgentProfileAsync', () => {
       expect(result.warnings).toHaveLength(0);
     });
 
-    it('should not warn and leave resolvedPrompt undefined when getMLflowPrompt resolves null', async () => {
+    it('should warn when getMLflowPrompt resolves null (prompt not found)', async () => {
       const api = makeApi({ getMLflowPrompt: jest.fn().mockResolvedValue(null) });
       const profile = makeProfile({
         prompt: { name: 'my-prompt', source: 'mlflow', version: '1' },
@@ -198,7 +198,7 @@ describe('validateAgentProfileAsync', () => {
       const result = await validateAgentProfileAsync(profile, api);
 
       expect(result.resolvedPrompt).toBeFalsy();
-      expect(result.warnings).toHaveLength(0);
+      expect(result.warnings).toContain('Prompt "my-prompt" is no longer available.');
     });
 
     it('should warn when getMLflowPrompt rejects', async () => {

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -6,6 +6,7 @@ import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
 import { MCPServerFromAPI } from '~/app/types/mcp';
 import { DEFAULT_CONFIG_ID, useChatbotConfigStore } from '~/app/Chatbot/store';
 import { deserializeAgentProfile } from './deserialize';
+import { buildValidationWarnings, validateAgentProfileAsync } from './validateAgentProfile';
 
 const AGENT_PROFILE_ID_PARAM = 'agentProfileId';
 
@@ -37,18 +38,20 @@ const useAgentProfileUrlParam = ({
   const agentProfileId = searchParams.get(AGENT_PROFILE_ID_PARAM);
 
   const { namespace } = React.useContext(GenAiContext);
-  const { models: playgroundModels } = React.useContext(ChatbotContext);
+  const { models: playgroundModels, aiModels } = React.useContext(ChatbotContext);
   const { api, apiAvailable } = useGenAiAPI();
 
   // Refs for values used only inside the fetch callback — keep them current without
   // adding to the effect dep array, which would cancel in-flight fetches on every render.
   const playgroundModelsRef = React.useRef(playgroundModels);
   playgroundModelsRef.current = playgroundModels;
+  const aiModelsRef = React.useRef(aiModels);
+  aiModelsRef.current = aiModels;
   const mcpServersRef = React.useRef(mcpServers);
   mcpServersRef.current = mcpServers;
-
   const applyAgentProfile = useChatbotConfigStore((s) => s.applyAgentProfile);
   const setLoadedProfileSpec = useChatbotConfigStore((s) => s.setLoadedProfileSpec);
+  const setLoadedProfileWarnings = useChatbotConfigStore((s) => s.setLoadedProfileWarnings);
   const updateActivePrompt = useChatbotConfigStore((s) => s.updateActivePrompt);
   const updateSystemInstruction = useChatbotConfigStore((s) => s.updateSystemInstruction);
   const saveToolSelections = useChatbotConfigStore((s) => s.saveToolSelections);
@@ -87,12 +90,13 @@ const useAgentProfileUrlParam = ({
 
     api
       .getAgentProfile({ id: agentProfileId, namespace: namespace.name })
-      .then((profile) => {
+      .then(async (profile) => {
         if (cancelled) {
+          setLoading(false);
           return;
         }
 
-        const { config, promptRef, mcpToolsPending } = deserializeAgentProfile(profile, {
+        const { config, mcpToolsPending } = deserializeAgentProfile(profile, {
           playgroundModels: playgroundModelsRef.current,
           mcpServers: mcpServersRef.current,
         });
@@ -104,49 +108,51 @@ const useAgentProfileUrlParam = ({
           profile.spec.description,
         );
 
+        // Sync warnings are set immediately so the OpenAgentProfileModal can show
+        // the alert (and bypass localStorage) as soon as the profile is applied.
+        const syncWarnings = buildValidationWarnings(profile, {
+          playgroundModels: playgroundModelsRef.current,
+          aiModels: aiModelsRef.current,
+          mcpServers: mcpServersRef.current,
+        });
+        setLoadedProfileWarnings(syncWarnings.length > 0 ? syncWarnings : null);
+
         // Restore MCP tool selections — mcpServers is guaranteed loaded at this point.
-        // mcpToolsPending is now keyed by server URL (same canonical format as
-        // selectedMcpServerIds), so no secondary name→URL lookup is needed here.
         if (mcpToolsPending) {
           for (const [serverUrl, tools] of Object.entries(mcpToolsPending)) {
             saveToolSelections(DEFAULT_CONFIG_ID, namespace.name, serverUrl, tools);
           }
         }
 
-        // Load the MLflow prompt asynchronously — doesn't block the profile load.
-        // setLoadedProfileSpec is deferred until after the prompt lands so the dirty
-        // check doesn't fire a false positive while activePrompt is still null.
-        if (promptRef) {
-          const versionParam =
-            promptRef.version !== undefined ? { version: String(promptRef.version) } : {};
-          api
-            .getMLflowPrompt({ name: promptRef.name, ...versionParam })
-            .then((prompt) => {
-              // Check the store instead of `cancelled`: StrictMode cleanup sets cancelled=true
-              // even after applyAgentProfile has committed, causing the prompt to be discarded.
-              if (useChatbotConfigStore.getState().loadedProfileId !== agentProfileId) {
-                return;
-              }
-              updateActivePrompt(DEFAULT_CONFIG_ID, prompt);
-              const instruction =
-                prompt.template ?? prompt.messages?.find((m) => m.role === 'system')?.content ?? '';
-              updateSystemInstruction(DEFAULT_CONFIG_ID, instruction);
-              setLoadedProfileSpec(profile.spec);
-            })
-            .catch((promptErr) => {
-              // Prompt load failure is non-fatal — the rest of the profile is already applied.
-              // Still set the snapshot so the dirty guard works for the non-prompt fields.
-              if (useChatbotConfigStore.getState().loadedProfileId !== agentProfileId) {
-                return;
-              }
-              // eslint-disable-next-line no-console
-              console.error('[useAgentProfileUrlParam] Failed to load MLflow prompt', promptErr);
-              setLoadedProfileSpec(profile.spec);
-            });
-        } else {
-          // No prompt to load — set the dirty-detection baseline immediately.
-          setLoadedProfileSpec(profile.spec);
+        // Async validation: prompt availability, vector store existence.
+        // setLoadedProfileSpec and final loadedProfileWarnings are written after this
+        // settles so the dirty check and warning alert have complete data.
+        const asyncOutcome = await Promise.allSettled([validateAgentProfileAsync(profile, api)]);
+
+        // Bail out if a different profile has been loaded in the meantime (StrictMode /
+        // rapid navigation). cancelled is intentionally NOT used here — see applyAgentProfile.
+        if (useChatbotConfigStore.getState().loadedProfileId !== agentProfileId) {
+          return;
         }
+
+        const asyncResult = asyncOutcome[0].status === 'fulfilled' ? asyncOutcome[0].value : null;
+
+        // Apply the resolved prompt returned by validation (no separate fetch needed).
+        if (asyncResult?.resolvedPrompt) {
+          const { resolvedPrompt } = asyncResult;
+          updateActivePrompt(DEFAULT_CONFIG_ID, resolvedPrompt);
+          const instruction =
+            resolvedPrompt.template ??
+            resolvedPrompt.messages?.find((m) => m.role === 'system')?.content ??
+            '';
+          updateSystemInstruction(DEFAULT_CONFIG_ID, instruction);
+        }
+
+        // Merge sync + async warnings and update the store once.
+        const asyncWarnings = asyncResult?.warnings ?? [];
+        const allWarnings = [...syncWarnings, ...asyncWarnings];
+        setLoadedProfileWarnings(allWarnings.length > 0 ? allWarnings : null);
+        setLoadedProfileSpec(profile.spec);
 
         setLoading(false);
       })
@@ -175,6 +181,7 @@ const useAgentProfileUrlParam = ({
     api,
     applyAgentProfile,
     setLoadedProfileSpec,
+    setLoadedProfileWarnings,
     updateActivePrompt,
     updateSystemInstruction,
     saveToolSelections,

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -48,6 +48,7 @@ const useAgentProfileUrlParam = ({
   mcpServersRef.current = mcpServers;
 
   const applyAgentProfile = useChatbotConfigStore((s) => s.applyAgentProfile);
+  const setLoadedProfileSpec = useChatbotConfigStore((s) => s.setLoadedProfileSpec);
   const updateActivePrompt = useChatbotConfigStore((s) => s.updateActivePrompt);
   const updateSystemInstruction = useChatbotConfigStore((s) => s.updateSystemInstruction);
   const saveToolSelections = useChatbotConfigStore((s) => s.saveToolSelections);
@@ -112,26 +113,39 @@ const useAgentProfileUrlParam = ({
           }
         }
 
-        // Load the MLflow prompt asynchronously — doesn't block the profile load
+        // Load the MLflow prompt asynchronously — doesn't block the profile load.
+        // setLoadedProfileSpec is deferred until after the prompt lands so the dirty
+        // check doesn't fire a false positive while activePrompt is still null.
         if (promptRef) {
           const versionParam =
             promptRef.version !== undefined ? { version: String(promptRef.version) } : {};
           api
             .getMLflowPrompt({ name: promptRef.name, ...versionParam })
             .then((prompt) => {
-              if (cancelled) {
+              // Check the store instead of `cancelled`: StrictMode cleanup sets cancelled=true
+              // even after applyAgentProfile has committed, causing the prompt to be discarded.
+              if (useChatbotConfigStore.getState().loadedProfileId !== agentProfileId) {
                 return;
               }
               updateActivePrompt(DEFAULT_CONFIG_ID, prompt);
               const instruction =
                 prompt.template ?? prompt.messages?.find((m) => m.role === 'system')?.content ?? '';
               updateSystemInstruction(DEFAULT_CONFIG_ID, instruction);
+              setLoadedProfileSpec(profile.spec);
             })
             .catch((promptErr) => {
-              // Prompt load failure is non-fatal — the rest of the profile is already applied
+              // Prompt load failure is non-fatal — the rest of the profile is already applied.
+              // Still set the snapshot so the dirty guard works for the non-prompt fields.
+              if (useChatbotConfigStore.getState().loadedProfileId !== agentProfileId) {
+                return;
+              }
               // eslint-disable-next-line no-console
               console.error('[useAgentProfileUrlParam] Failed to load MLflow prompt', promptErr);
+              setLoadedProfileSpec(profile.spec);
             });
+        } else {
+          // No prompt to load — set the dirty-detection baseline immediately.
+          setLoadedProfileSpec(profile.spec);
         }
 
         setLoading(false);
@@ -160,6 +174,7 @@ const useAgentProfileUrlParam = ({
     loadedProfileId,
     api,
     applyAgentProfile,
+    setLoadedProfileSpec,
     updateActivePrompt,
     updateSystemInstruction,
     saveToolSelections,

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -117,7 +117,11 @@ const useAgentProfileUrlParam = ({
           aiModels: aiModelsRef.current,
           mcpServers: mcpServersRef.current,
         });
-        setLoadedProfileWarnings(syncWarnings.length > 0 ? syncWarnings : null);
+        // Guard matches the check used for the async writes below — only commit warnings
+        // if this profile is still the active one (rapid navigation / Save As can change it).
+        if (useChatbotConfigStore.getState().loadedProfileId === agentProfileId) {
+          setLoadedProfileWarnings(syncWarnings.length > 0 ? syncWarnings : null);
+        }
 
         // Restore MCP tool selections — mcpServers is guaranteed loaded at this point.
         if (mcpToolsPending) {

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -52,6 +52,7 @@ const useAgentProfileUrlParam = ({
   const applyAgentProfile = useChatbotConfigStore((s) => s.applyAgentProfile);
   const setLoadedProfileSpec = useChatbotConfigStore((s) => s.setLoadedProfileSpec);
   const setLoadedProfileWarnings = useChatbotConfigStore((s) => s.setLoadedProfileWarnings);
+  const setLoadedResourceVersion = useChatbotConfigStore((s) => s.setLoadedResourceVersion);
   const updateActivePrompt = useChatbotConfigStore((s) => s.updateActivePrompt);
   const updateSystemInstruction = useChatbotConfigStore((s) => s.updateSystemInstruction);
   const saveToolSelections = useChatbotConfigStore((s) => s.saveToolSelections);
@@ -107,6 +108,7 @@ const useAgentProfileUrlParam = ({
           profile.spec.displayName,
           profile.spec.description,
         );
+        setLoadedResourceVersion(profile.metadata.resourceVersion);
 
         // Sync warnings are set immediately so the OpenAgentProfileModal can show
         // the alert (and bypass localStorage) as soon as the profile is applied.
@@ -182,6 +184,7 @@ const useAgentProfileUrlParam = ({
     applyAgentProfile,
     setLoadedProfileSpec,
     setLoadedProfileWarnings,
+    setLoadedResourceVersion,
     updateActivePrompt,
     updateSystemInstruction,
     saveToolSelections,

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -27,18 +27,15 @@ type UseAgentProfileUrlParamResult = {
 const useAgentProfileUrlParam = ({
   mcpServers,
   mcpServersLoaded,
-  playgroundModelsLoaded,
 }: {
   mcpServers: MCPServerFromAPI[];
   mcpServersLoaded: boolean;
-  /** Wait for playground models before deserializing so selectedModel is always a full Llama Stack ID */
-  playgroundModelsLoaded: boolean;
 }): UseAgentProfileUrlParamResult => {
   const [searchParams] = useSearchParams();
   const agentProfileId = searchParams.get(AGENT_PROFILE_ID_PARAM);
 
   const { namespace } = React.useContext(GenAiContext);
-  const { models: playgroundModels, aiModels } = React.useContext(ChatbotContext);
+  const { models: playgroundModels, modelsLoaded, aiModels } = React.useContext(ChatbotContext);
   const { api, apiAvailable } = useGenAiAPI();
 
   // Refs for values used only inside the fetch callback — keep them current without
@@ -76,7 +73,7 @@ const useAgentProfileUrlParam = ({
       !namespace?.name ||
       !apiAvailable ||
       !mcpServersLoaded ||
-      !playgroundModelsLoaded ||
+      !modelsLoaded ||
       appliedProfileId.current === agentProfileId ||
       loadedProfileId === agentProfileId
     ) {
@@ -180,7 +177,7 @@ const useAgentProfileUrlParam = ({
     namespace?.name,
     apiAvailable,
     mcpServersLoaded,
-    playgroundModelsLoaded,
+    modelsLoaded,
     loadedProfileId,
     api,
     applyAgentProfile,

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -133,7 +133,7 @@ const useAgentProfileUrlParam = ({
         // Async validation: prompt availability, vector store existence.
         // setLoadedProfileSpec and final loadedProfileWarnings are written after this
         // settles so the dirty check and warning alert have complete data.
-        const asyncOutcome = await Promise.allSettled([validateAgentProfileAsync(profile, api)]);
+        const asyncResult = await validateAgentProfileAsync(profile, api);
 
         // Bail out if a different profile has been loaded in the meantime (StrictMode /
         // rapid navigation). cancelled is intentionally NOT used here — see applyAgentProfile.
@@ -141,10 +141,8 @@ const useAgentProfileUrlParam = ({
           return;
         }
 
-        const asyncResult = asyncOutcome[0].status === 'fulfilled' ? asyncOutcome[0].value : null;
-
         // Apply the resolved prompt returned by validation (no separate fetch needed).
-        if (asyncResult?.resolvedPrompt) {
+        if (asyncResult.resolvedPrompt) {
           const { resolvedPrompt } = asyncResult;
           updateActivePrompt(DEFAULT_CONFIG_ID, resolvedPrompt);
           const instruction =
@@ -155,7 +153,7 @@ const useAgentProfileUrlParam = ({
         }
 
         // Merge sync + async warnings and update the store once.
-        const asyncWarnings = asyncResult?.warnings ?? [];
+        const asyncWarnings = asyncResult.warnings;
         const allWarnings = [...syncWarnings, ...asyncWarnings];
         setLoadedProfileWarnings(allWarnings.length > 0 ? allWarnings : null);
         setLoadedProfileSpec(profile.spec);

--- a/packages/gen-ai/frontend/src/app/agentProfile/useIsProfileDirty.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useIsProfileDirty.ts
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { ChatbotContext } from '~/app/context/ChatbotContext';
+import { useChatbotConfigStore } from '~/app/Chatbot/store';
+import useFetchMCPServers from '~/app/hooks/useFetchMCPServers';
+import { convertMaaSModelToAIModel, isPlaygroundModelMatchForAIModel } from '~/app/utilities/utils';
+import { serializeToAgentProfileSpec } from './serialize';
+import type { AgentProfileSpec } from './types';
+
+const MCP_CONFIG_MAP_NAME_FALLBACK = 'gen-ai-aa-mcp-servers';
+
+/** JSON.stringify with recursively sorted object keys so insertion order doesn't affect equality. */
+const stableStringify = (val: unknown): string =>
+  JSON.stringify(val, (_key, v) => {
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      return Object.fromEntries(Object.entries(v).toSorted(([a], [b]) => a.localeCompare(b)));
+    }
+    return v;
+  });
+
+const EXCLUDED_SPEC_KEYS = new Set(['displayName', 'description', 'guardrails']);
+
+/**
+ * Strips fields not written by serializeToAgentProfileSpec (displayName, description,
+ * guardrails) and sorts mcpServers/allowedTools for stable comparison.
+ * New fields added to AgentProfileSpec are included automatically.
+ */
+const normalizeSpec = (spec: AgentProfileSpec) => ({
+  ...Object.fromEntries(Object.entries(spec).filter(([k]) => !EXCLUDED_SPEC_KEYS.has(k))),
+  mcpServers: spec.mcpServers
+    ? spec.mcpServers
+        .toSorted((a, b) =>
+          (a.serverRef.key ?? a.serverRef.name).localeCompare(b.serverRef.key ?? b.serverRef.name),
+        )
+        .map((s) => ({
+          ...s,
+          allowedTools: s.allowedTools ? [...s.allowedTools].toSorted() : undefined,
+        }))
+    : undefined,
+});
+
+/**
+ * Returns true when the current playground configuration differs from the last
+ * saved/loaded agent profile spec.
+ *
+ * The comparison is serialization-based: the current config is serialized to an
+ * AgentProfileSpec using the same path as the save flow, then compared against the
+ * stored snapshot. This means "dirty" is defined as "saving now would produce a
+ * different profile" — the same fields, the same normalization.
+ *
+ * Only meaningful when a profile is loaded (profileApplied === true). Returns false
+ * when no profile is active or no snapshot is stored.
+ */
+const useIsProfileDirty = (configId: string): boolean => {
+  const { aiModels, maasModels, models: playgroundModels } = React.useContext(ChatbotContext);
+  const { data: mcpServers = [], configMapName: mcpConfigMapName } = useFetchMCPServers();
+
+  const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
+  const loadedProfileSpec = useChatbotConfigStore((s) => s.loadedProfileSpec);
+  const config = useChatbotConfigStore((s) => s.configurations[configId]);
+
+  const allAIModels = React.useMemo(
+    () => [...aiModels, ...maasModels.map(convertMaaSModelToAIModel)],
+    [aiModels, maasModels],
+  );
+
+  const aiModel = React.useMemo(() => {
+    const llamaModel = playgroundModels.find((m) => m.id === config?.selectedModel);
+    return llamaModel
+      ? allAIModels.find((ai) => isPlaygroundModelMatchForAIModel(llamaModel, ai))
+      : undefined;
+  }, [playgroundModels, config?.selectedModel, allAIModels]);
+
+  const asrModel = React.useMemo(
+    () =>
+      config?.isAsrModelEnabled && config.selectedAsrModel
+        ? aiModels.find((ai) => ai.model_id === config.selectedAsrModel)
+        : undefined,
+    [config?.isAsrModelEnabled, config?.selectedAsrModel, aiModels],
+  );
+
+  return React.useMemo(() => {
+    if (!profileApplied || !loadedProfileSpec || !config) {
+      return false;
+    }
+
+    const currentSpec = serializeToAgentProfileSpec(config, '', undefined, {
+      model: aiModel,
+      asrModel,
+      mcpServers,
+      mcpConfigMapName: mcpConfigMapName ?? MCP_CONFIG_MAP_NAME_FALLBACK,
+    });
+
+    // eslint-disable-next-line no-console
+    console.log('[useIsProfileDirty] current:', normalizeSpec(currentSpec));
+    // eslint-disable-next-line no-console
+    console.log('[useIsProfileDirty] snapshot:', normalizeSpec(loadedProfileSpec));
+
+    return (
+      stableStringify(normalizeSpec(currentSpec)) !==
+      stableStringify(normalizeSpec(loadedProfileSpec))
+    );
+  }, [profileApplied, loadedProfileSpec, config, aiModel, asrModel, mcpServers, mcpConfigMapName]);
+};
+
+export default useIsProfileDirty;

--- a/packages/gen-ai/frontend/src/app/agentProfile/useIsProfileDirty.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useIsProfileDirty.ts
@@ -90,11 +90,6 @@ const useIsProfileDirty = (configId: string): boolean => {
       mcpConfigMapName: mcpConfigMapName ?? MCP_CONFIG_MAP_NAME_FALLBACK,
     });
 
-    // eslint-disable-next-line no-console
-    console.log('[useIsProfileDirty] current:', normalizeSpec(currentSpec));
-    // eslint-disable-next-line no-console
-    console.log('[useIsProfileDirty] snapshot:', normalizeSpec(loadedProfileSpec));
-
     return (
       stableStringify(normalizeSpec(currentSpec)) !==
       stableStringify(normalizeSpec(loadedProfileSpec))

--- a/packages/gen-ai/frontend/src/app/agentProfile/useIsProfileDirty.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useIsProfileDirty.ts
@@ -17,7 +17,9 @@ const stableStringify = (val: unknown): string =>
     return v;
   });
 
-const EXCLUDED_SPEC_KEYS = new Set(['displayName', 'description', 'guardrails']);
+// Fields excluded from dirty comparison: either not written by serializeToAgentProfileSpec
+// (maxOutputTokens is in AgentProfileSpec but never serialized from config) or metadata-only.
+const EXCLUDED_SPEC_KEYS = new Set(['displayName', 'description', 'guardrails', 'maxOutputTokens']);
 
 /**
  * Strips fields not written by serializeToAgentProfileSpec (displayName, description,

--- a/packages/gen-ai/frontend/src/app/agentProfile/validateAgentProfile.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/validateAgentProfile.ts
@@ -1,0 +1,119 @@
+import {
+  AIModel,
+  LlamaModel,
+  MLflowPromptVersion,
+  ExternalVectorStoreSummary,
+  VectorStore,
+} from '~/app/types';
+import type { GenAiAPIs } from '~/app/types';
+import { MCPServerFromAPI } from '~/app/types/mcp';
+import { AgentProfile } from './types';
+
+export type AgentProfileValidationContext = {
+  playgroundModels: LlamaModel[];
+  aiModels: AIModel[];
+  mcpServers?: MCPServerFromAPI[];
+};
+
+export type AsyncValidationResult = {
+  warnings: string[];
+  /** The fetched MLflow prompt — present when the profile has a prompt ref and the fetch succeeded. */
+  resolvedPrompt?: MLflowPromptVersion;
+  /** AA (ConfigMap-backed) vector stores fetched during validation. */
+  resolvedAAVectorStores?: ExternalVectorStoreSummary[];
+  /** Llama Stack inline vector stores fetched during validation. */
+  resolvedLlamaVectorStores?: VectorStore[];
+};
+
+/**
+ * Synchronous validation: checks resources resolvable without API calls.
+ * Run immediately after deserialization; results drive the modal warning alert.
+ */
+export const buildValidationWarnings = (
+  profile: AgentProfile,
+  { playgroundModels, aiModels, mcpServers = [] }: AgentProfileValidationContext,
+): string[] => {
+  const { spec } = profile;
+  const warnings: string[] = [];
+
+  // Model: warn when the AI Asset model_id couldn't be matched to a running Llama Stack model.
+  if (!playgroundModels.find((m) => m.modelId === spec.model.id)) {
+    warnings.push(`Model "${spec.model.id}" is no longer available.`);
+  }
+
+  // ASR model: warn when the transcription model is no longer in the AI Assets list.
+  if (spec.asr?.model?.id && !aiModels.find((m) => m.model_id === spec.asr!.model!.id)) {
+    warnings.push(`Transcription model "${spec.asr.model.id}" is no longer available.`);
+  }
+
+  // MCP servers: warn for any server key that couldn't be resolved to a known server.
+  spec.mcpServers?.forEach((s) => {
+    const key = s.serverRef.key ?? s.serverRef.name;
+    if (!mcpServers.find((ms) => ms.name === key)) {
+      warnings.push(`MCP server "${key}" is no longer available.`);
+    }
+  });
+
+  return warnings;
+};
+
+/**
+ * Async validation: fetches resources that require API calls, checks their availability,
+ * and returns both warnings and the fetched data so callers don't need to re-fetch.
+ */
+export const validateAgentProfileAsync: (
+  profile: AgentProfile,
+  api: GenAiAPIs,
+) => Promise<AsyncValidationResult> = async (profile, api) => {
+  const { spec } = profile;
+  const warnings: string[] = [];
+  const result: AsyncValidationResult = { warnings };
+
+  const stores = spec.vectorStores?.stores ?? [];
+  const externalKeys = stores.filter((s) => s.storeRef).map((s) => s.storeRef!.key);
+  const inlineIds = stores.filter((s) => s.id).map((s) => s.id!);
+
+  const [promptOutcome, aaOutcome, llamaOutcome] = await Promise.allSettled([
+    spec.prompt
+      ? api.getMLflowPrompt({
+          name: spec.prompt.name,
+          ...(spec.prompt.version !== undefined ? { version: spec.prompt.version } : {}),
+        })
+      : Promise.resolve(null),
+    externalKeys.length > 0 ? api.getAAVectorStores() : Promise.resolve(null),
+    inlineIds.length > 0 ? api.listVectorStores({}) : Promise.resolve(null),
+  ]);
+
+  // Prompt
+  if (spec.prompt) {
+    if (promptOutcome.status === 'fulfilled' && promptOutcome.value) {
+      result.resolvedPrompt = promptOutcome.value;
+    } else if (promptOutcome.status === 'rejected') {
+      warnings.push(`Prompt "${spec.prompt.name}" is no longer available.`);
+    }
+  }
+
+  // External (ConfigMap-backed) vector stores
+  if (aaOutcome.status === 'fulfilled' && aaOutcome.value !== null) {
+    const aaStores = Array.isArray(aaOutcome.value) ? aaOutcome.value : [];
+    result.resolvedAAVectorStores = aaStores;
+    externalKeys.forEach((key) => {
+      if (!aaStores.find((s) => s.vector_store_id === key)) {
+        warnings.push(`Vector store "${key}" is no longer available.`);
+      }
+    });
+  }
+
+  // Inline (Llama Stack) vector stores
+  if (llamaOutcome.status === 'fulfilled' && llamaOutcome.value !== null) {
+    const llamaStores = Array.isArray(llamaOutcome.value) ? llamaOutcome.value : [];
+    result.resolvedLlamaVectorStores = llamaStores;
+    inlineIds.forEach((id) => {
+      if (!llamaStores.find((s) => s.id === id)) {
+        warnings.push(`Vector store "${id}" is no longer available.`);
+      }
+    });
+  }
+
+  return result;
+};

--- a/packages/gen-ai/frontend/src/app/agentProfile/validateAgentProfile.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/validateAgentProfile.ts
@@ -70,7 +70,7 @@ export const validateAgentProfileAsync: (
   const result: AsyncValidationResult = { warnings };
 
   const stores = spec.vectorStores?.stores ?? [];
-  const externalKeys = stores.filter((s) => s.storeRef).map((s) => s.storeRef!.key);
+  const externalKeys = stores.filter((s) => s.storeRef?.key).map((s) => s.storeRef!.key);
   const inlineIds = stores.filter((s) => s.id).map((s) => s.id!);
 
   const [promptOutcome, aaOutcome, llamaOutcome] = await Promise.allSettled([

--- a/packages/gen-ai/frontend/src/app/agentProfile/validateAgentProfile.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/validateAgentProfile.ts
@@ -88,7 +88,8 @@ export const validateAgentProfileAsync: (
   if (spec.prompt) {
     if (promptOutcome.status === 'fulfilled' && promptOutcome.value) {
       result.resolvedPrompt = promptOutcome.value;
-    } else if (promptOutcome.status === 'rejected') {
+    } else {
+      // Covers both rejected promises and fulfilled-with-null (prompt not found).
       warnings.push(`Prompt "${spec.prompt.name}" is no longer available.`);
     }
   }

--- a/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
+++ b/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
@@ -1148,6 +1148,9 @@ export const deleteAgentProfile =
     ).then(() => undefined);
   };
 
+// Custom implementation that bypasses handleRestFailures so the raw error code is
+// preserved in the thrown error. Callers can inspect err.code to distinguish
+// 409 Conflict ('conflict') from 404 Not Found ('not_found') and other faults.
 export const updateAgentProfile =
   (
     hostPath: string,
@@ -1162,16 +1165,14 @@ export const updateAgentProfile =
       return Promise.reject(new Error('id parameter is required'));
     }
     const path = `/agent-profiles/${encodeURIComponent(id)}`;
-    return handleRestFailures(
-      restUPDATE<AgentProfileUpdateResponse>(
-        hostPath,
-        path,
-        { spec, resourceVersion },
-        baseQueryParams,
-        opts,
-      ),
-    ).then((response) => {
-      if (isModArchResponse<AgentProfileUpdateResponse>(response)) {
+    return restUPDATE<{
+      data?: AgentProfileUpdateResponse;
+      error?: { code: string; message: string };
+    }>(hostPath, path, { spec, resourceVersion }, baseQueryParams, opts).then((response) => {
+      if (response.error) {
+        throw Object.assign(new Error(response.error.message), { code: response.error.code });
+      }
+      if (response.data) {
         return response.data;
       }
       throw new Error('Invalid response format');


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-66531
https://issues.redhat.com/browse/RHOAIENG-66532
https://issues.redhat.com/browse/RHOAIENG-66533

## Description

Three related agent configuration guard features for the Gen AI Playground:

### [RHOAIENG-66532](https://redhat.atlassian.net/browse/RHOAIENG-66532) — Unsaved change guard
Adds serialization-based dirty detection for loaded agent configurations. The current config is serialized to `AgentProfileSpec` and compared against a stored snapshot taken at load/save time. When dirty, navigation away from the Playground (sidebar click or browser refresh/close) shows a "Discard unsaved changes?" warning. The snapshot is deferred until the MLflow prompt finishes loading to avoid false positives during the async load window. Also fixes a StrictMode bug where `profileLoading` could get stuck `true` after Save As.


https://github.com/user-attachments/assets/f0193c5e-58fe-47e8-86e9-80347ea75d45



### [RHOAIENG-66531](https://redhat.atlassian.net/browse/RHOAIENG-66531) — Validation warnings on AgentProfile load
Detects missing resources during profile load (model, ASR model, MCP servers, MLflow prompt, vector stores) and surfaces them as a warning alert in the `OpenAgentProfileModal`. When warnings are present:
- Edit button is disabled
- "Do not show again" checkbox is hidden
- The modal bypasses the localStorage dismiss flag
- An edit icon button next to the Preview label in the header is disabled

Sync checks (model, ASR model, MCP server name resolution) fire immediately. Async checks (MLflow prompt, vector store existence) run in parallel with the prompt fetch using `Promise.allSettled`.


https://github.com/user-attachments/assets/51fd0c4e-a756-41a3-804d-5d3d9e697044




### [RHOAIENG-66533](https://redhat.atlassian.net/browse/RHOAIENG-66533) — Optimistic concurrency conflict UI
Stores `loadedResourceVersion` when a profile is loaded and uses it directly in the PUT request (no pre-flight GET). If the profile was modified elsewhere the server returns 409 (`conflict`); if deleted, 404. Both surface an inline warning alert in the Save modal between the description field and the agent configuration details divider. `updateAgentProfile` in the service layer bypasses `handleRestFailures` to preserve the error code for detection, matching the existing `initNemoGuardrails` pattern.


https://github.com/user-attachments/assets/d74089bd-0e20-4e62-8f2b-8b04dee8c42f



## How Has This Been Tested?

Manually tested the following scenarios on a local cluster:
1. **Dirty guard**: Load an agent config, modify the model, click a sidebar nav link → "Discard unsaved changes?" modal appears. Refresh browser tab → native browser alert fires.
2. **Validation warnings**: Load the profile `bd1d920a-0469-4f51-848b-01ed29877460` (fake model, prompt, vector store, MCP server) → warning alert in modal, Edit disabled.
3. **Prompt-only warning**: Load profile `1732a7f2-0075-4a78-9139-b7063b430583` (real model, fake prompt) → no sync warnings, prompt warning appears after MLflow fetch fails.
4. **Conflict UI**: Open Save modal for a loaded profile, delete it in another tab, click Save → "This agent configuration could not be found" alert appears between description and divider.

## Test Impact

- `useIsProfileDirty.spec.ts` (new) — 8 tests covering sync dirty detection
- `validateAgentProfile.spec.ts` (new) — 20 tests covering sync and async resource validation
- `OpenAgentProfileModal.spec.tsx` — 6 new tests for warning alert UI
- `SaveAgentProfileModal.spec.tsx` — 3 new tests: stored RV in PUT, 409 conflict alert, 404 not-found alert
- `useChatbotConfigStore.test.ts` — new actions: `setLoadedProfileSpec`, `setLoadedProfileWarnings`, `setLoadedResourceVersion`

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent profile validation warnings in the open/edit flow, including inline alert display and disabled edit when warnings exist.
  * Enhanced chat “Preview” mode with an explicit exit/edit action.

* **Bug Fixes**
  * Prevented accidental loss of unsaved profile changes by blocking unsafe navigation and browser unload.
  * Improved “Open agent” dialog behavior for warning-bearing profiles.
  * Improved saving for existing profiles with clearer alerts for conflicts (modified) and missing/deleted profiles.

* **Tests**
  * Expanded unit test coverage for profile dirtiness, validation warnings, modal behavior, and store loaded-profile state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->