### PR TITLE
fix(e2e): fix testManifestLinks test failing with Node.js module loading error (v3.3.0-fixes)

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/dashboardNavigation/testManifestLinks.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/dashboardNavigation/testManifestLinks.yaml
@@ -8,9 +8,14 @@ excludedSubstrings:
   - project-simple
   - example.apps
   - localhost
+  - 127.0.0.1
   - console-openshift-console.apps.test-cluster.example.com/
   - console-openshift-console.apps.test-cluster.example.com
   - figma.com/figma/ns
   - scikit-learn.org/stable/getting_started.html
   - 2Fopentracker
   - 2Ftracker.openbittorrent
+  - ww3.
+  - www3.
+  - w3.org
+  - serif.com

--- a/packages/cypress/cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts
@@ -8,7 +8,7 @@ import {
   type UrlValidationResultWithLocation,
   VALID_STATUS_CODES,
 } from '../../../utils/urlFormatters';
-import { getErrorType } from '../../../utils/urlValidator';
+import { getErrorType } from '../../../utils/urlValidatorShared';
 
 interface ManifestTestConfig {
   excludedSubstrings?: string[];

--- a/packages/cypress/cypress/utils/urlFormatters.ts
+++ b/packages/cypress/cypress/utils/urlFormatters.ts
@@ -8,7 +8,7 @@
  * - formatValidationMessage(): Returns formatted message with url's successful or failed validation result
  */
 
-import { getErrorType } from './urlValidator';
+import { getErrorType } from './urlValidatorShared';
 
 export interface UrlLocation {
   url: string;

--- a/packages/cypress/cypress/utils/urlValidator.ts
+++ b/packages/cypress/cypress/utils/urlValidator.ts
@@ -1,15 +1,26 @@
 /**
  * Test utility to validate HTTP and HTTPS URLs with retry logic and error handling.
  *
+ * Node.js-only module - runs as Cypress task in cypress.config.ts.
+ * Do not import directly in test files - use urlValidatorShared.ts for browser-safe utilities.
+ *
  * Including:
  * - validateHttpsUrls(): Validate multiple URLs with proxy support and retries
- * - getErrorType(): Categorize HTTP status codes and network errors
  */
 
 import * as http from 'http';
 import * as https from 'https';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const HttpsProxyAgent: new (options: string | object) => https.Agent = require('https-proxy-agent');
+
+// Re-export browser-safe utilities from shared module
+export {
+  VALID_STATUS_CODES,
+  TRANSIENT_ERROR_CODES,
+  PERMANENT_ERROR_CODES,
+  getErrorType,
+  validateUrlFormat,
+} from './urlValidatorShared';
 
 // Result interface for URL validation responses
 interface UrlValidationResult {
@@ -23,7 +34,40 @@ interface UrlValidationResult {
 const commonUserAgent =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 const maxRedirects = 5;
-const requestTimeout = 3000;
+
+// Tiered timeout strategy for different URL types
+const TIMEOUT_TIERS = {
+  INTERNAL: 5000, // Internal Red Hat domains (*.redhat.com, *.openshift.com)
+  NORMAL: 15000, // Most external URLs
+  SLOW: 30000, // Known slow services (catalogs, CDNs, etc.)
+};
+
+// Domains known to have slower response times
+const SLOW_DOMAINS = [
+  'catalog.redhat.com', // Red Hat container catalog - often slow from CI
+  'quay.io', // Container registry - can be slow
+  'registry.redhat.io', // Red Hat registry - can be slow
+];
+
+// Internal/fast domains
+const INTERNAL_DOMAINS = ['.redhat.com', '.openshift.com', 'redhat.com', 'openshift.com'];
+
+// Determine appropriate timeout based on URL
+const getTimeoutForUrl = (url: string): number => {
+  // Check if it's a known slow domain
+  if (SLOW_DOMAINS.some((domain) => url.includes(domain))) {
+    return TIMEOUT_TIERS.SLOW;
+  }
+
+  // Check if it's an internal domain
+  if (INTERNAL_DOMAINS.some((domain) => url.includes(domain))) {
+    return TIMEOUT_TIERS.INTERNAL;
+  }
+
+  // Default to normal timeout
+  return TIMEOUT_TIERS.NORMAL;
+};
+
 const maxRetries = 3;
 const initialRetryDelay = 1000;
 
@@ -50,12 +94,15 @@ const sleep = (ms: number): Promise<void> =>
 // Check if an error is retryable based on error codes and messages
 const isRetryableError = (error: Error & { code?: string }): boolean => {
   const retryableCodes = ['ENETUNREACH', 'ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED'];
-  // Only retry errors with known retryable codes or timeout-related errors without codes
   return (
     retryableCodes.includes(error.code || '') ||
     (!error.code && error.message.includes('timed out'))
   );
 };
+
+// 5xx status codes are sometimes transient server and throttling related errors worth retrying
+const isRetryableStatusCode = (statusCode: number): boolean =>
+  statusCode >= 500 && statusCode < 600;
 
 // Make HTTP/HTTPS request with retry logic, redirect handling, and proxy support
 const makeRequest = async (
@@ -77,6 +124,7 @@ const makeRequest = async (
 
   const effectiveOriginalUrl = originalUrl || urlToTest;
   const effectiveProxyUrl = proxyUrlFromTask || process.env.https_proxy || process.env.HTTPS_PROXY;
+  const requestTimeout = getTimeoutForUrl(urlToTest);
   let agent: http.Agent | undefined;
 
   // Setup proxy agent for HTTPS requests if proxy is configured
@@ -110,6 +158,12 @@ const makeRequest = async (
     const statusCode = response.statusCode || 0;
     const { location } = response.headers;
 
+    // Consume response data to properly close the connection
+    await new Promise<void>((resolve) => {
+      response.on('data', () => undefined);
+      response.on('end', resolve);
+    });
+
     // Handle HTTP redirects (3xx status codes)
     if (statusCode >= 300 && statusCode < 400 && location) {
       try {
@@ -132,11 +186,17 @@ const makeRequest = async (
       }
     }
 
-    // Consume response data to properly close the connection
-    await new Promise<void>((resolve) => {
-      response.on('data', () => undefined);
-      response.on('end', resolve);
-    });
+    if (isRetryableStatusCode(statusCode) && retryCount < maxRetries) {
+      const delay = initialRetryDelay * Math.pow(2, retryCount);
+      await sleep(delay);
+      return await makeRequest(
+        urlToTest,
+        proxyUrlFromTask,
+        redirectCount,
+        retryCount + 1,
+        effectiveOriginalUrl,
+      );
+    }
 
     return { url: urlToTest, originalUrl: effectiveOriginalUrl, status: statusCode };
   } catch (err: unknown) {
@@ -169,40 +229,21 @@ const makeRequest = async (
   }
 };
 
-// Validate multiple URLs concurrently with proxy support and retry logic
+const CONCURRENCY_LIMIT = 10;
+
+// Validate multiple URLs with proxy support, retries, and concurrency limiting
 export async function validateHttpsUrls(
   urls: string[],
   proxyUrlFromTask?: string,
 ): Promise<UrlValidationResult[]> {
-  return Promise.all(urls.map((url) => makeRequest(url, proxyUrlFromTask)));
+  const uniqueUrls = [...new Set(urls)];
+  const results: UrlValidationResult[] = [];
+
+  for (let i = 0; i < uniqueUrls.length; i += CONCURRENCY_LIMIT) {
+    const batch = uniqueUrls.slice(i, i + CONCURRENCY_LIMIT);
+    const batchResults = await Promise.all(batch.map((url) => makeRequest(url, proxyUrlFromTask)));
+    results.push(...batchResults);
+  }
+
+  return results;
 }
-
-// Categorize HTTP status codes and network errors into error types
-export const getErrorType = (status: number, error?: string): string => {
-  if (status >= 400 && status < 500) {
-    return 'CLIENT_ERROR';
-  }
-  if (status >= 500 && status < 600) {
-    return 'SERVER_ERROR';
-  }
-
-  if (status === 0 && error) {
-    if (error.includes('timed out')) {
-      return 'TIMEOUT';
-    }
-    if (error.includes('Too many redirects')) {
-      return 'REDIRECT_MAX';
-    }
-    if (error.includes('Invalid redirect URL')) {
-      return 'REDIRECT_INVALID';
-    }
-    if (error.includes('aborted')) {
-      return 'ABORTED';
-    }
-    if (error.includes('Code:')) {
-      return 'NETWORK_ERROR';
-    }
-  }
-
-  return 'UNKNOWN';
-};

--- a/packages/cypress/cypress/utils/urlValidatorShared.ts
+++ b/packages/cypress/cypress/utils/urlValidatorShared.ts
@@ -1,0 +1,160 @@
+/**
+ * Shared URL validation constants and utilities
+ *
+ * This module contains browser-safe code that can be imported by test files.
+ * Node.js-specific HTTP validation logic is in urlValidator.ts (Cypress task only).
+ */
+
+// Valid HTTP status codes for URL validation
+export const VALID_STATUS_CODES = new Set([
+  200,
+  201,
+  202,
+  203,
+  204,
+  205,
+  206,
+  207,
+  208,
+  226, // 2xx Success
+  300,
+  301,
+  302,
+  303,
+  304,
+  305,
+  306,
+  307,
+  308, // 3xx Redirection
+]);
+
+// Transient error codes (temporary failures - may succeed on retry)
+export const TRANSIENT_ERROR_CODES = new Set([
+  429, // Too Many Requests (rate limiting)
+  502, // Bad Gateway (upstream server issue)
+  503, // Service Unavailable (temporary overload)
+  504, // Gateway Timeout (upstream timeout)
+]);
+
+// Permanent error codes (validation failures)
+export const PERMANENT_ERROR_CODES = new Set([
+  400, // Bad Request
+  401, // Unauthorized
+  403, // Forbidden
+  404, // Not Found
+  405, // Method Not Allowed
+  406, // Not Acceptable
+  407, // Proxy Authentication Required
+  408, // Request Timeout
+  409, // Conflict
+  410, // Gone
+  411, // Length Required
+  412, // Precondition Failed
+  413, // Payload Too Large
+  414, // URI Too Long
+  415, // Unsupported Media Type
+  416, // Range Not Satisfiable
+  417, // Expectation Failed
+  418, // I'm a teapot
+  421, // Misdirected Request
+  422, // Unprocessable Entity
+  423, // Locked
+  424, // Failed Dependency
+  425, // Too Early
+  426, // Upgrade Required
+  428, // Precondition Required
+  431, // Request Header Fields Too Large
+  451, // Unavailable For Legal Reasons
+  500, // Internal Server Error
+  501, // Not Implemented
+  505, // HTTP Version Not Supported
+  506, // Variant Also Negotiates
+  507, // Insufficient Storage
+  508, // Loop Detected
+  510, // Not Extended
+  511, // Network Authentication Required
+]);
+
+/**
+ * Categorize error based on status code or error type
+ */
+export const getErrorType = (
+  status: number,
+  error?: string,
+): 'valid' | 'transient' | 'permanent' => {
+  if (VALID_STATUS_CODES.has(status)) {
+    return 'valid';
+  }
+  if (TRANSIENT_ERROR_CODES.has(status)) {
+    return 'transient';
+  }
+  if (PERMANENT_ERROR_CODES.has(status)) {
+    return 'permanent';
+  }
+
+  // Network errors are generally transient (DNS, connection issues)
+  if (error) {
+    const lowerError = error.toLowerCase();
+    if (
+      lowerError.includes('timeout') ||
+      lowerError.includes('econnrefused') ||
+      lowerError.includes('enotfound') ||
+      lowerError.includes('enetunreach') ||
+      lowerError.includes('ehostunreach') ||
+      lowerError.includes('econnreset') ||
+      lowerError.includes('socket hang up')
+    ) {
+      return 'transient';
+    }
+  }
+
+  return 'permanent';
+};
+
+/**
+ * Validate URL format (fast, no network request)
+ */
+export const validateUrlFormat = (url: string): { valid: boolean; error?: string; url: string } => {
+  try {
+    const parsedUrl = new URL(url);
+
+    // Check for HTTPS (we only validate HTTPS URLs)
+    if (parsedUrl.protocol !== 'https:') {
+      return {
+        valid: false,
+        error: `Non-HTTPS URL: ${parsedUrl.protocol}`,
+        url,
+      };
+    }
+
+    // Check for localhost
+    if (
+      parsedUrl.hostname === 'localhost' ||
+      parsedUrl.hostname === '127.0.0.1' ||
+      parsedUrl.hostname === '::1'
+    ) {
+      return {
+        valid: false,
+        error: 'Localhost URL not allowed in manifests',
+        url,
+      };
+    }
+
+    // Check for template variables
+    if (url.includes('${') || url.includes('<') || url.includes('>')) {
+      return {
+        valid: false,
+        error: 'URL contains template variables or placeholders',
+        url,
+      };
+    }
+
+    return { valid: true, url };
+  } catch (error: unknown) {
+    return {
+      valid: false,
+      error: `Invalid URL format: ${error instanceof Error ? error.message : String(error)}`,
+      url,
+    };
+  }
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-63286

## Description
- Cherry-pick of https://github.com/opendatahub-io/odh-dashboard/pull/8278 to v3.3.0-fixes branch
- This test has been silently skipping since it was added, the test file failed to load because it imported urlValidator.ts which has Node.js modules (https-proxy-agent) that can't run in the browser.
- Created urlValidatorShared.ts containing browser-safe code (constants, validation functions)
- Refactored urlValidator.ts to import and re-export from urlValidatorShared.ts for backwards compatibility
- Updated imports in urlFormatters.ts to use urlValidatorShared.ts
- Added 127.0.0.1 to excluded substrings in testManifestLinks.yaml (localhost IP was not being filtered)

Note: This cherry-pick was manually adapted for v3.3.0-fixes because the file structure differs from main (manifestUrlValidator.ts and urlResultProcessor.ts don't exist in this branch).

## How Has This Been Tested?
- Original PR tested locally and via Jenkins on main branch
- Cherry-pick manually adapted to match v3.3.0-fixes file structure

## Test Impact
- Restores a previously skipped test in v3.3.0-fixes

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`