### PR TITLE
chore(e2e): cherry-pick MLflow selector fix and Feast workaround for v3.4

### DIFF
--- a/packages/cypress/cypress/fixtures/resources/yaml/feast.yaml
+++ b/packages/cypress/cypress/fixtures/resources/yaml/feast.yaml
@@ -28,6 +28,7 @@ metadata:
 spec:
   feastProject: credit_scoring_local
   services:
+    runFeastApplyOnInit: false
     onlineStore:
       persistence:
         store:

--- a/packages/cypress/cypress/pages/mlflowExperiments.ts
+++ b/packages/cypress/cypress/pages/mlflowExperiments.ts
@@ -143,20 +143,22 @@ class MlflowExperiments {
     return cy.findByTestId('overflow-menu-trigger');
   }
 
-  findRenameAction() {
-    return cy.findByTestId('rename');
+  findEditExperimentAction() {
+    return cy.findByTestId('mlflow.experiment_page.managementMenu.edit-experiment');
   }
 
   findDeleteAction() {
-    return cy.findByTestId('delete');
+    return cy.findByTestId('mlflow.experiment_page.managementMenu.delete');
   }
 
-  findRenameInput() {
-    return this.findCreateExperimentModal().find('input').first();
+  findEditExperimentNameInput() {
+    return cy.findByRole('dialog', { name: 'Edit experiment' }).find('input').first();
   }
 
-  findRenameSubmitButton() {
-    return this.findCreateExperimentModal().findByRole('button', { name: 'Save' });
+  findEditExperimentSubmitButton() {
+    return cy
+      .findByRole('dialog', { name: 'Edit experiment' })
+      .findByRole('button', { name: 'Save' });
   }
 
   findDeleteConfirmModal() {

--- a/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
@@ -185,7 +185,7 @@ describe('Verify MLflow Experiments page', () => {
       mlflowExperiments.findExperimentInTable(experimentName).should('be.visible');
 
       // =======================================================================
-      // Rename experiment
+      // Edit experiment (rename)
       // =======================================================================
 
       cy.step('Click experiment to open detail page');
@@ -194,14 +194,18 @@ describe('Verify MLflow Experiments page', () => {
       cy.step('Open overflow menu on detail page');
       mlflowExperiments.findOverflowMenuTrigger().click();
 
-      cy.step('Click rename action');
-      mlflowExperiments.findRenameAction().click();
+      cy.step('Click edit experiment action');
+      mlflowExperiments.findEditExperimentAction().click();
 
       cy.step('Clear and type new name');
-      mlflowExperiments.findRenameInput().should('be.visible').clear().type(renamedExperimentName);
+      mlflowExperiments
+        .findEditExperimentNameInput()
+        .should('be.visible')
+        .clear()
+        .type(renamedExperimentName);
 
-      cy.step('Submit rename');
-      mlflowExperiments.findRenameSubmitButton().click();
+      cy.step('Submit edit experiment');
+      mlflowExperiments.findEditExperimentSubmitButton().click();
       mlflowExperiments.findExperimentDetailHeading(renamedExperimentName).should('be.visible');
       uiExperimentName = renamedExperimentName;
 


### PR DESCRIPTION
## Summary

Cherry-picks and workarounds for two known E2E test failures on `v3.4.0-fixes`:

- **MLflow Experiments**: Cherry-pick of #8255 — updates test selectors to match upstream MLflow v3.13.0 which renamed "Rename experiment" to "Edit experiment". Without this, the rename/edit section of `testMlflowExperiments.cy.ts` fails on mismatched `data-testid` values and dialog selectors.
- **Feature Store (Feast)**: Adds `runFeastApplyOnInit: false` under `services` in `feast.yaml` fixture as a workaround for [RHOAIENG-71247](https://issues.redhat.com/browse/RHOAIENG-71247). The permanent fix is tracked for 3.5.

## Changes

| File | Change |
|------|--------|
| `packages/cypress/cypress/pages/mlflowExperiments.ts` | `findRenameAction` → `findEditExperimentAction`, `findRenameInput` → `findEditExperimentNameInput`, `findRenameSubmitButton` → `findEditExperimentSubmitButton`, updated `data-testid` selectors, scoped dialog queries |
| `packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts` | Updated test steps to use new edit experiment page object methods |
| `packages/cypress/cypress/fixtures/resources/yaml/feast.yaml` | Added `runFeastApplyOnInit: false` under `spec.services` |

## Context

Both failures were observed in [Jenkins build #1531](https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/components/job/dashboard/job/dashboard-e2e-tests/1531/) (2 of 129 tests failing):
- Feature Store: `Timed out retrying — expected '<h1>' to have text 'Feature store overview', but the text was ''`
- MLflow: `Unable to find an accessible element with the role "heading" and name "e2e-test-experiment-..."`

## Test plan

- [ ] Verify MLflow experiments E2E test passes on a cluster with MLflow v3.13.0+
- [ ] Verify Feature Store E2E test passes with `runFeastApplyOnInit: false` workaround

[RHOAIENG-71247]: https://redhat.atlassian.net/browse/RHOAIENG-71247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ