### PR TITLE
Fixed Workload usage not tracked bug

### DIFF
--- a/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
@@ -19,6 +19,8 @@ import {
   useDWProjectCurrentMetrics,
 } from '#~/api/prometheus/distributedWorkloads';
 
+const expectedCpuTotalUsageWithStatefulSet = Number('0.10201116666666666');
+
 const mockCpuUsageResults: WorkloadMetricPromQueryResponse['data']['result'] = [
   {
     metric: {
@@ -68,6 +70,13 @@ const mockCpuUsageResults: WorkloadMetricPromQueryResponse['data']['result'] = [
       owner_name: 'test-rc-3', // eslint-disable-line camelcase
     },
     value: [1711495542.368, '0.01500163333333333'],
+  },
+  {
+    metric: {
+      owner_kind: WorkloadOwnerType.StatefulSet, // eslint-disable-line camelcase
+      owner_name: 'test-notebook-0', // eslint-disable-line camelcase
+    },
+    value: [1711495542.368, '0.008'],
   },
 ];
 
@@ -121,6 +130,13 @@ const mockMemoryUsageResults: WorkloadMetricPromQueryResponse['data']['result'] 
     },
     value: [1711495542.37, '10337050'],
   },
+  {
+    metric: {
+      owner_kind: WorkloadOwnerType.StatefulSet, // eslint-disable-line camelcase
+      owner_name: 'test-notebook-0', // eslint-disable-line camelcase
+    },
+    value: [1711495542.37, '5000000'],
+  },
 ];
 
 const mockWorkloads = [
@@ -166,6 +182,12 @@ const mockWorkloads = [
     ownerKind: WorkloadOwnerType.RayCluster,
     ownerName: 'test-rc-3',
   }),
+  mockWorkloadK8sResource({
+    k8sName: 'test-notebook-wl',
+    namespace: 'test-project',
+    ownerKind: WorkloadOwnerType.StatefulSet,
+    ownerName: 'test-notebook-0',
+  }),
 ];
 
 const mockGetWorkloadCurrentUsage = (workload: WorkloadKind): WorkloadCurrentUsage => {
@@ -209,6 +231,9 @@ describe('indexWorkloadMetricByOwner', () => {
         'test-rc-2': 0.01300163333333333,
         'test-rc-3': 0.01500163333333333,
       },
+      [WorkloadOwnerType.StatefulSet]: {
+        'test-notebook-0': 0.008,
+      },
     };
     expect(indexWorkloadMetricByOwner(promResponse)).toEqual(indexedValues);
   });
@@ -229,7 +254,7 @@ describe('getTopResourceConsumingWorkloads', () => {
   it('sorts the top 5 workloads and sums remaining as "other" when there are more than 6', () => {
     expect(getTopResourceConsumingWorkloads(mockWorkloads, mockGetWorkloadCurrentUsage)).toEqual({
       cpuCoresUsed: {
-        totalUsage: 0.09401116666666666,
+        totalUsage: expectedCpuTotalUsageWithStatefulSet,
         topWorkloads: [
           { workload: mockWorkloads[3], usage: 0.04300163333333333 },
           { workload: mockWorkloads[6], usage: 0.01500163333333333 },
@@ -237,10 +262,10 @@ describe('getTopResourceConsumingWorkloads', () => {
           { workload: mockWorkloads[2], usage: 0.0120015 },
           { workload: mockWorkloads[4], usage: 0.01100163333333333 },
         ],
-        otherUsage: 0.00000313333333333,
+        otherUsage: 0.00800313333333333,
       },
       memoryBytesUsed: {
-        totalUsage: 169396710,
+        totalUsage: 174396710,
         topWorkloads: [
           { workload: mockWorkloads[3], usage: 82493440 },
           { workload: mockWorkloads[4], usage: 42493440 },
@@ -248,7 +273,7 @@ describe('getTopResourceConsumingWorkloads', () => {
           { workload: mockWorkloads[2], usage: 9349344 },
           { workload: mockWorkloads[1], usage: 8249344 },
         ],
-        otherUsage: 16474092,
+        otherUsage: 21474092,
       },
     } satisfies TopWorkloadsByUsage);
   });
@@ -362,11 +387,11 @@ describe('useDWProjectCurrentMetrics', () => {
     expect(mockAxios).toHaveBeenCalledTimes(2);
     expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/query', {
       query:
-        'namespace=test-project&query=sum by(owner_name, owner_kind)  (kube_pod_owner{owner_kind=~"RayCluster|Job", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)',
+        'namespace=test-project&query=sum by(owner_name, owner_kind)  (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)',
     });
     expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/query', {
       query:
-        'namespace=test-project&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)',
+        'namespace=test-project&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)',
     });
     expect(renderResult).hookToHaveUpdateCount(1);
 
@@ -387,6 +412,9 @@ describe('useDWProjectCurrentMetrics', () => {
               'test-rc-2': 0.01300163333333333,
               'test-rc-3': 0.01500163333333333,
             },
+            [WorkloadOwnerType.StatefulSet]: {
+              'test-notebook-0': 0.008,
+            },
           },
           error: undefined,
           loaded: true,
@@ -404,6 +432,9 @@ describe('useDWProjectCurrentMetrics', () => {
               'test-rc-1': 42493440,
               'test-rc-2': 8237036,
               'test-rc-3': 10337050,
+            },
+            [WorkloadOwnerType.StatefulSet]: {
+              'test-notebook-0': 5000000,
             },
           },
           error: undefined,
@@ -424,8 +455,8 @@ describe('useDWProjectCurrentMetrics', () => {
             { workload: mockWorkloads[2], usage: 0.0120015 },
             { workload: mockWorkloads[4], usage: 0.01100163333333333 },
           ],
-          otherUsage: 0.00000313333333333,
-          totalUsage: 0.09401116666666666,
+          otherUsage: 0.00800313333333333,
+          totalUsage: expectedCpuTotalUsageWithStatefulSet,
         },
         memoryBytesUsed: {
           topWorkloads: [
@@ -435,8 +466,8 @@ describe('useDWProjectCurrentMetrics', () => {
             { workload: mockWorkloads[2], usage: 9349344 },
             { workload: mockWorkloads[1], usage: 8249344 },
           ],
-          otherUsage: 16474092,
-          totalUsage: 169396710,
+          otherUsage: 21474092,
+          totalUsage: 174396710,
         },
       },
     };
@@ -541,6 +572,10 @@ describe('useDWProjectCurrentMetrics', () => {
     expect(getWorkloadCurrentUsage(mockWorkloads[6])).toEqual({
       cpuCoresUsed: 0.01500163333333333,
       memoryBytesUsed: 10337050,
+    } satisfies WorkloadCurrentUsage);
+    expect(getWorkloadCurrentUsage(mockWorkloads[7])).toEqual({
+      cpuCoresUsed: 0.008,
+      memoryBytesUsed: 5000000,
     } satisfies WorkloadCurrentUsage);
   });
 });

--- a/frontend/src/api/prometheus/distributedWorkloads.ts
+++ b/frontend/src/api/prometheus/distributedWorkloads.ts
@@ -14,6 +14,7 @@ export type WorkloadMetricIndexedByOwner = Record<
 export const EMPTY_WORKLOAD_METRIC_INDEXED_BY_OWNER: WorkloadMetricIndexedByOwner = {
   [WorkloadOwnerType.RayCluster]: {},
   [WorkloadOwnerType.Job]: {},
+  [WorkloadOwnerType.StatefulSet]: {},
 };
 
 export type WorkloadMetricPromQueryResponse = PrometheusQueryResponse<{
@@ -134,8 +135,8 @@ export const DEFAULT_DW_PROJECT_CURRENT_METRICS: DWProjectCurrentMetrics = {
 const getDWProjectCurrentMetricsQueries = (
   namespace: string,
 ): Record<DWProjectCurrentMetricType, string> => ({
-  cpuCoresUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind)  (kube_pod_owner{owner_kind=~"RayCluster|Job", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)`,
-  memoryBytesUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)`,
+  cpuCoresUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind)  (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)`,
+  memoryBytesUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)`,
 });
 
 export const useDWProjectCurrentMetrics = (

--- a/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
@@ -130,6 +130,19 @@ describe('getWorkloadOwner', () => {
     });
   });
 
+  it('returns the name of a statefulset found in ownerReferences of a workload if present', () => {
+    const mockWorkload = mockWorkloadK8sResource({
+      k8sName: 'test-workload',
+      namespace: 'test-project',
+      ownerKind: WorkloadOwnerType.StatefulSet,
+      ownerName: 'test-notebook-0',
+    });
+    expect(getWorkloadOwner(mockWorkload)).toStrictEqual({
+      kind: 'StatefulSet',
+      name: 'test-notebook-0',
+    });
+  });
+
   it('returns undefined if there is no job in ownerReferences', () => {
     const mockWorkload = mockWorkloadK8sResource({
       k8sName: 'test-workload',

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -974,6 +974,7 @@ export type WorkloadPodSet = {
 export enum WorkloadOwnerType {
   RayCluster = 'RayCluster',
   Job = 'Job',
+  StatefulSet = 'StatefulSet',
 }
 
 // https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Workload

--- a/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -103,6 +103,13 @@ const initIntercepts = ({
       mockStatus: WorkloadStatusType.Complete,
       podSets: [mockPodset, mockPodset],
     }),
+    mockWorkloadK8sResource({
+      k8sName: 'test-workload-notebook',
+      ownerKind: WorkloadOwnerType.StatefulSet,
+      ownerName: 'test-notebook-0',
+      mockStatus: WorkloadStatusType.Running,
+      podSets: [mockPodset],
+    }),
   ],
 }: HandlersProps) => {
   cy.interceptOdh(
@@ -161,6 +168,9 @@ const initIntercepts = ({
             'test-workload-spinning-down-both-rc': 0.2,
             'test-workload-spinning-down-cpu-only-rc': 0.2,
           },
+          [WorkloadOwnerType.StatefulSet]: {
+            'test-notebook-0': 1.5,
+          },
         }),
       });
     } else if (req.body.query.includes('container_memory_working_set_bytes')) {
@@ -174,6 +184,9 @@ const initIntercepts = ({
           [WorkloadOwnerType.RayCluster]: {
             'test-workload-spinning-down-both-rc': 104857600, // 100 MiB
             'test-workload-spinning-down-cpu-only-rc': 0,
+          },
+          [WorkloadOwnerType.StatefulSet]: {
+            'test-notebook-0': 524288000, // 500 MiB
           },
         }),
       });
@@ -349,6 +362,20 @@ describe('Project Metrics tab', () => {
       globalDistributedWorkloads
         .findWorkloadResourceMetricsTable()
         .findByText('test-workload-running')
+        .closest('tr')
+        .within(() => {
+          cy.get('td[data-label="CPU usage (cores)"]').should('not.contain.text', '-');
+          cy.get('td[data-label="Memory usage (GiB)"]').should('not.contain.text', '-');
+        });
+    });
+
+    it('Should render usage bars on a StatefulSet workload', () => {
+      initIntercepts({});
+      globalDistributedWorkloads.visit();
+      cy.findByLabelText('Project metrics tab').click();
+      globalDistributedWorkloads
+        .findWorkloadResourceMetricsTable()
+        .findByText('test-workload-notebook')
         .closest('tr')
         .within(() => {
           cy.get('td[data-label="CPU usage (cores)"]').should('not.contain.text', '-');


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-69284


## Description
 Project metrics tab showed 0 CPU/memory and empty Top 5 list even when workloads were running.
 
 Root cause - 
 Prometheus queries only matched RayCluster|Job owners. Other workloads sit under StatefulSet, which never got fetched or mapped.
 
 
# Screenshots 
 
# BEFORE
<img width="2528" height="1192" alt="SCR-20260626-qolm" src="https://github.com/user-attachments/assets/0bcf9593-402e-4b69-adc2-eb06e0a156e8" />

<img width="2535" height="1271" alt="SCR-20260626-qomt" src="https://github.com/user-attachments/assets/c1f789f7-d91e-4371-a28a-8aea47fd29ce" />


# AFTER

<img width="2528" height="1188" alt="SCR-20260626-qmma" src="https://github.com/user-attachments/assets/ac0e7eeb-5f20-415a-a46c-ccd2e974a368" />

<img width="2531" height="1292" alt="SCR-20260626-qmnk" src="https://github.com/user-attachments/assets/8a2621ae-5af6-4592-a8e9-739e7dcbe075" />


## How Has This Been Tested?
- Jest: distributedWorkloads.spec.ts, utils.spec.ts
- npm run test:type-check --prefix frontend

## Test Impact
- Updated prom query + indexing tests in distributedWorkloads.spec.ts
-  StatefulSet owner test in utils.spec.ts



## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for StatefulSet workloads in distributed workload metrics and ownership detection.
  * The metrics view now includes StatefulSet usage in CPU and memory calculations.

* **Bug Fixes**
  * Updated workload usage totals and “other” values to account for StatefulSet entries.
  * Expanded UI coverage so StatefulSet workload rows display usage data instead of blanks.

* **Tests**
  * Added and updated test coverage for StatefulSet ownership, metric aggregation, and workload usage display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->