### PR TITLE
feat(agent-ops): Add project and status filters to agent deployments list

### DIFF
--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
@@ -81,6 +81,19 @@ class AgentDeploymentsPage {
     cy.findByTestId(status).click();
   }
 
+  findActiveFilterChips(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.get('[data-testid$="-filter-chip"]');
+  }
+
+  findStatusFilterChip(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('status-filter-chip');
+  }
+
+  expectSingleStatusFilterChip(label: string) {
+    this.findActiveFilterChips().should('have.length', 1);
+    this.findStatusFilterChip().should('contain.text', label);
+  }
+
   findLoadingSpinner(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByLabelText('Loading agent deployments');
   }

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
@@ -75,7 +75,7 @@ class AgentDeploymentsPage {
     return cy.findByTestId('agent-runtimes-filter-project-input');
   }
 
-  selectStatusFilter(status: 'Running' | 'Pending' | 'Failed') {
+  selectStatusFilter(status: 'Ready' | 'Pending' | 'Failed') {
     this.selectFilterOption('status');
     cy.findByTestId('agent-runtimes-filter-status').click();
     cy.findByTestId(status).click();

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
@@ -62,6 +62,25 @@ class AgentDeploymentsPage {
     return cy.findByTestId('agent-runtimes-filter-input');
   }
 
+  findFilterDropdownToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('filter-toolbar-dropdown');
+  }
+
+  selectFilterOption(option: 'name' | 'project' | 'status') {
+    this.findFilterDropdownToggle().click();
+    cy.findByTestId(`filter-toolbar-option-${option}`).click();
+  }
+
+  findProjectFilterInput(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-runtimes-filter-project-input');
+  }
+
+  selectStatusFilter(status: 'Running' | 'Pending' | 'Failed') {
+    this.selectFilterOption('status');
+    cy.findByTestId('agent-runtimes-filter-status').click();
+    cy.findByTestId(status).click();
+  }
+
   findLoadingSpinner(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByLabelText('Loading agent deployments');
   }

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
@@ -229,20 +229,25 @@ describe('Agent Deployments', () => {
     agentDeploymentsPage.findTable().should('be.visible');
 
     agentDeploymentsPage.selectStatusFilter('Pending');
+    agentDeploymentsPage.expectSingleStatusFilterChip('Pending');
     agentDeploymentsPage.findTableRows().should('have.length', 1);
     agentDeploymentsPage
       .getRow(TEST_NAMESPACE, 'pending-agent')
       .findStatusLabel()
       .should('contain.text', 'Pending');
 
+    agentDeploymentsPage.expectSingleStatusFilterChip('Pending');
     agentDeploymentsPage.selectStatusFilter('Failed');
+    agentDeploymentsPage.expectSingleStatusFilterChip('Failed');
     agentDeploymentsPage.findTableRows().should('have.length', 1);
     agentDeploymentsPage
       .getRow(TEST_NAMESPACE, 'failed-agent')
       .findStatusLabel()
       .should('contain.text', 'Failed');
 
+    agentDeploymentsPage.expectSingleStatusFilterChip('Failed');
     agentDeploymentsPage.selectStatusFilter('Running');
+    agentDeploymentsPage.expectSingleStatusFilterChip('Running');
     agentDeploymentsPage.findTableRows().should('have.length', 1);
     agentDeploymentsPage
       .getRow(TEST_NAMESPACE, 'sample-support-agent')

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
@@ -223,6 +223,46 @@ describe('Agent Deployments', () => {
     agentDeploymentsPage.findTableRows().should('have.length', 0);
   });
 
+  it('should filter deployments by status', () => {
+    initIntercepts();
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+    agentDeploymentsPage.findTable().should('be.visible');
+
+    agentDeploymentsPage.selectStatusFilter('Pending');
+    agentDeploymentsPage.findTableRows().should('have.length', 1);
+    agentDeploymentsPage
+      .getRow(TEST_NAMESPACE, 'pending-agent')
+      .findStatusLabel()
+      .should('contain.text', 'Pending');
+
+    agentDeploymentsPage.selectStatusFilter('Failed');
+    agentDeploymentsPage.findTableRows().should('have.length', 1);
+    agentDeploymentsPage
+      .getRow(TEST_NAMESPACE, 'failed-agent')
+      .findStatusLabel()
+      .should('contain.text', 'Failed');
+
+    agentDeploymentsPage.selectStatusFilter('Running');
+    agentDeploymentsPage.findTableRows().should('have.length', 1);
+    agentDeploymentsPage
+      .getRow(TEST_NAMESPACE, 'sample-support-agent')
+      .findStatusLabel()
+      .should('contain.text', 'Ready');
+  });
+
+  it('should filter deployments by project', () => {
+    initIntercepts();
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+    agentDeploymentsPage.findTable().should('be.visible');
+
+    agentDeploymentsPage.selectFilterOption('project');
+    agentDeploymentsPage.findProjectFilterInput().type(TEST_NAMESPACE);
+    agentDeploymentsPage.findTableRows().should('have.length', 4);
+
+    agentDeploymentsPage.findProjectFilterInput().clear().type('nonexistent-project');
+    agentDeploymentsPage.findTableRows().should('have.length', 0);
+  });
+
   it('should open endpoints modal from the View link', () => {
     initIntercepts();
     agentDeploymentsPage.visit(TEST_NAMESPACE);

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
@@ -246,8 +246,8 @@ describe('Agent Deployments', () => {
       .should('contain.text', 'Failed');
 
     agentDeploymentsPage.expectSingleStatusFilterChip('Failed');
-    agentDeploymentsPage.selectStatusFilter('Running');
-    agentDeploymentsPage.expectSingleStatusFilterChip('Running');
+    agentDeploymentsPage.selectStatusFilter('Ready');
+    agentDeploymentsPage.expectSingleStatusFilterChip('Ready');
     agentDeploymentsPage.findTableRows().should('have.length', 1);
     agentDeploymentsPage
       .getRow(TEST_NAMESPACE, 'sample-support-agent')

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -90,10 +90,15 @@ const AgentDeploymentListPage: React.FC = () => {
 
   const onFilterUpdate = React.useCallback(
     (key: AgentRuntimesFilterOption, value?: string | { label: string; value: string }) => {
-      setFilterData((prev) => ({
-        ...prev,
-        [key]: typeof value === 'string' ? value || undefined : value?.value ? value : undefined,
-      }));
+      setFilterData((prev) => {
+        if (typeof value === 'string') {
+          return { ...prev, [key]: value || undefined };
+        }
+        if (value?.value) {
+          return { ...prev, [key]: value };
+        }
+        return { ...prev, [key]: undefined };
+      });
     },
     [],
   );

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -20,9 +20,14 @@ import AgentOpsProjectSelector from '~/app/components/AgentOpsProjectSelector';
 import { useNavigateToDeployAgentWizard } from '~/app/deployWizard/useNavigateToDeployAgentWizard';
 import { useListAgentRuntimes } from '~/app/hooks/useListAgentRuntimes';
 import { agentOpsDeploymentsRoute } from '~/app/utilities/routes';
+import {
+  filterAgentRuntimes,
+  hasActiveAgentRuntimesFilters,
+} from '~/app/utilities/filterAgentRuntimes';
 import AgentDeploymentsEmptyState from './AgentDeploymentsEmptyState';
 import AgentRuntimesTable from './agentRuntimes/AgentRuntimesTable';
 import AgentRuntimesToolbar from './agentRuntimes/AgentRuntimesToolbar';
+import { AgentRuntimesFilterOption, emptyAgentRuntimesFilterData } from './agentRuntimes/const';
 
 const AgentDeploymentListPage: React.FC = () => {
   const { namespace } = useParams<{ namespace: string }>();
@@ -57,7 +62,8 @@ const AgentDeploymentListPage: React.FC = () => {
   const safeNamespaces = React.useMemo(
     () =>
       namespaces.filter(
-        (ns): ns is { name: string } => typeof ns.name === 'string' && ns.name.length > 0,
+        (ns): ns is { name: string; displayName?: string } =>
+          typeof ns.name === 'string' && ns.name.length > 0,
       ),
     [namespaces],
   );
@@ -74,16 +80,34 @@ const AgentDeploymentListPage: React.FC = () => {
     }
   }, [namespace, namespacesLoaded, safeNamespaces, preferredNamespace, navigate]);
 
-  const [filterText, setFilterText] = React.useState('');
-  const clearFilters = React.useCallback(() => setFilterText(''), []);
+  const [filterData, setFilterData] = React.useState(emptyAgentRuntimesFilterData);
 
-  const filteredRuntimes = React.useMemo(() => {
-    if (!filterText) {
-      return safeRuntimes;
-    }
-    const lower = filterText.toLowerCase();
-    return safeRuntimes.filter((runtime) => runtime.name.toLowerCase().includes(lower));
-  }, [safeRuntimes, filterText]);
+  const projectDisplayNames = React.useMemo(
+    () =>
+      Object.fromEntries(safeNamespaces.map((ns) => [ns.name, ns.displayName ?? ns.name] as const)),
+    [safeNamespaces],
+  );
+
+  const onFilterUpdate = React.useCallback(
+    (key: AgentRuntimesFilterOption, value?: string | { label: string; value: string }) => {
+      setFilterData((prev) => ({
+        ...prev,
+        [key]: typeof value === 'string' ? value || undefined : value?.value ? value : undefined,
+      }));
+    },
+    [],
+  );
+
+  const clearFilters = React.useCallback(() => {
+    setFilterData(emptyAgentRuntimesFilterData);
+  }, []);
+
+  const filteredRuntimes = React.useMemo(
+    () => filterAgentRuntimes(safeRuntimes, filterData, projectDisplayNames),
+    [safeRuntimes, filterData, projectDisplayNames],
+  );
+
+  const isFiltered = hasActiveAgentRuntimesFilters(filterData);
 
   const noProjectSelected = !namespace;
   const isAccessDenied = !!loadError && getGenericErrorCode(loadError) === 403;
@@ -134,15 +158,15 @@ const AgentDeploymentListPage: React.FC = () => {
         continueToken={continueToken}
         page={page}
         pageSize={pageSize}
-        isFiltered={!!filterText}
+        isFiltered={isFiltered}
         onPageChange={setPage}
         onPageSizeChange={setPageSize}
         onClearFilters={clearFilters}
         toolbarContent={
           <AgentRuntimesToolbar
             namespace={namespace}
-            filterText={filterText}
-            onFilterChange={setFilterText}
+            filterData={filterData}
+            onFilterUpdate={onFilterUpdate}
             onDeployAgent={() => navigateToDeployAgentWizard(namespace)}
           />
         }

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -27,7 +27,11 @@ import {
 import AgentDeploymentsEmptyState from './AgentDeploymentsEmptyState';
 import AgentRuntimesTable from './agentRuntimes/AgentRuntimesTable';
 import AgentRuntimesToolbar from './agentRuntimes/AgentRuntimesToolbar';
-import { AgentRuntimesFilterOption, emptyAgentRuntimesFilterData } from './agentRuntimes/const';
+import {
+  AgentRuntimeStatusFilterOption,
+  AgentRuntimesFilterOption,
+  emptyAgentRuntimesFilterData,
+} from './agentRuntimes/const';
 
 const AgentDeploymentListPage: React.FC = () => {
   const { namespace } = useParams<{ namespace: string }>();
@@ -89,7 +93,7 @@ const AgentDeploymentListPage: React.FC = () => {
   );
 
   const onFilterUpdate = React.useCallback(
-    (key: AgentRuntimesFilterOption, value?: string | { label: string; value: string }) => {
+    (key: AgentRuntimesFilterOption, value?: string | AgentRuntimeStatusFilterOption) => {
       setFilterData((prev) => {
         if (typeof value === 'string') {
           return { ...prev, [key]: value || undefined };

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -67,7 +67,9 @@ const AgentDeploymentListPage: React.FC = () => {
     () =>
       namespaces.filter(
         (ns): ns is { name: string; displayName?: string } =>
-          typeof ns.name === 'string' && ns.name.length > 0,
+          typeof ns.name === 'string' &&
+          ns.name.length > 0 &&
+          (ns.displayName === undefined || typeof ns.displayName === 'string'),
       ),
     [namespaces],
   );

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesToolbar.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesToolbar.tsx
@@ -5,6 +5,8 @@ import SimpleSelect, { SimpleSelectOption } from '@odh-dashboard/internal/compon
 import DeployAgentButton from '~/app/components/DeployAgentButton';
 import {
   agentRuntimeStatusFilterOptions,
+  AgentRuntimeStatusFilter,
+  AgentRuntimeStatusFilterOption,
   AgentRuntimesFilterData,
   AgentRuntimesFilterOption,
   agentRuntimesFilterOptions,
@@ -15,9 +17,26 @@ type AgentRuntimesToolbarProps = {
   filterData: AgentRuntimesFilterData;
   onFilterUpdate: (
     key: AgentRuntimesFilterOption,
-    value?: string | { label: string; value: string },
+    value?: string | AgentRuntimeStatusFilterOption,
   ) => void;
   onDeployAgent: () => void;
+};
+
+const adaptFilterUpdateValue = (
+  key: AgentRuntimesFilterOption,
+  value?: string | { label: string; value: string },
+): string | AgentRuntimeStatusFilterOption | undefined => {
+  if (typeof value === 'string') {
+    return value || undefined;
+  }
+  if (key !== AgentRuntimesFilterOption.Status || !value?.value) {
+    return undefined;
+  }
+  const status = value.value;
+  if (!agentRuntimeStatusFilterOptions.includes(status as AgentRuntimeStatusFilter)) {
+    return undefined;
+  }
+  return { label: status as AgentRuntimeStatusFilter, value: status as AgentRuntimeStatusFilter };
 };
 
 const statusSelectOptions: SimpleSelectOption[] = agentRuntimeStatusFilterOptions.map(
@@ -79,7 +98,9 @@ const AgentRuntimesToolbar: React.FC<AgentRuntimesToolbarProps> = ({
       ),
     }}
     filterData={filterData}
-    onFilterUpdate={onFilterUpdate}
+    onFilterUpdate={(filterType, value) =>
+      onFilterUpdate(filterType, adaptFilterUpdateValue(filterType, value))
+    }
   >
     <ToolbarGroup>
       <ToolbarItem>

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesToolbar.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesToolbar.tsx
@@ -1,35 +1,45 @@
 import * as React from 'react';
 import { SearchInput, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import FilterToolbar from '@odh-dashboard/internal/components/FilterToolbar';
+import SimpleSelect, { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect';
 import DeployAgentButton from '~/app/components/DeployAgentButton';
-
-export enum AgentRuntimesFilterOption {
-  Name = 'name',
-}
-
-export const agentRuntimesFilterOptions: Record<AgentRuntimesFilterOption, string> = {
-  [AgentRuntimesFilterOption.Name]: 'Name',
-};
+import {
+  agentRuntimeStatusFilterOptions,
+  AgentRuntimesFilterData,
+  AgentRuntimesFilterOption,
+  agentRuntimesFilterOptions,
+} from './const';
 
 type AgentRuntimesToolbarProps = {
   namespace?: string;
-  filterText: string;
-  onFilterChange: (value: string) => void;
+  filterData: AgentRuntimesFilterData;
+  onFilterUpdate: (
+    key: AgentRuntimesFilterOption,
+    value?: string | { label: string; value: string },
+  ) => void;
   onDeployAgent: () => void;
 };
 
+const statusSelectOptions: SimpleSelectOption[] = agentRuntimeStatusFilterOptions.map(
+  (status): SimpleSelectOption => ({
+    key: status,
+    label: status,
+  }),
+);
+
 const AgentRuntimesToolbar: React.FC<AgentRuntimesToolbarProps> = ({
   namespace,
-  filterText,
-  onFilterChange,
+  filterData,
+  onFilterUpdate,
   onDeployAgent,
 }) => (
   <FilterToolbar<AgentRuntimesFilterOption>
     data-testid="agent-runtimes-table-toolbar"
     filterOptions={agentRuntimesFilterOptions}
     filterOptionRenders={{
-      [AgentRuntimesFilterOption.Name]: ({ onChange, value }) => (
+      [AgentRuntimesFilterOption.Name]: ({ onChange, value, ...props }) => (
         <SearchInput
+          {...props}
           placeholder="Filter by name"
           value={value ?? ''}
           onChange={(_event, v) => onChange(v)}
@@ -38,14 +48,38 @@ const AgentRuntimesToolbar: React.FC<AgentRuntimesToolbarProps> = ({
           data-testid="agent-runtimes-filter-input"
         />
       ),
+      [AgentRuntimesFilterOption.Project]: ({ onChange, value, ...props }) => (
+        <SearchInput
+          {...props}
+          placeholder="Filter by project"
+          value={value ?? ''}
+          onChange={(_event, v) => onChange(v)}
+          onClear={() => onChange('')}
+          aria-label="Filter by project"
+          data-testid="agent-runtimes-filter-project-input"
+        />
+      ),
+      [AgentRuntimesFilterOption.Status]: ({ value, onChange }) => (
+        <SimpleSelect
+          value={value ?? ''}
+          aria-label="Filter by status"
+          placeholder="Select a status"
+          options={statusSelectOptions}
+          onChange={(selectedValue) => {
+            const selectedOption = statusSelectOptions.find(
+              (option) => option.key === selectedValue,
+            );
+            if (selectedOption) {
+              onChange(selectedValue, selectedOption.label);
+            }
+          }}
+          dataTestId="agent-runtimes-filter-status"
+          popperProps={{ maxWidth: undefined }}
+        />
+      ),
     }}
-    filterData={{
-      [AgentRuntimesFilterOption.Name]: filterText || undefined,
-    }}
-    onFilterUpdate={(_key, value) => {
-      const v = typeof value === 'string' ? value : (value?.value ?? '');
-      onFilterChange(v);
-    }}
+    filterData={filterData}
+    onFilterUpdate={onFilterUpdate}
   >
     <ToolbarGroup>
       <ToolbarItem>

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesToolbar.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesToolbar.tsx
@@ -78,8 +78,9 @@ const AgentRuntimesToolbar: React.FC<AgentRuntimesToolbarProps> = ({
           data-testid="agent-runtimes-filter-project-input"
         />
       ),
-      [AgentRuntimesFilterOption.Status]: ({ value, onChange }) => (
+      [AgentRuntimesFilterOption.Status]: ({ onChange, value, ...props }) => (
         <SimpleSelect
+          {...props}
           value={value ?? ''}
           aria-label="Filter by status"
           placeholder="Select a status"

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/const.ts
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/const.ts
@@ -5,7 +5,7 @@ export enum AgentRuntimesFilterOption {
 }
 
 export enum AgentRuntimeStatusFilter {
-  Running = 'Running',
+  Ready = 'Ready',
   Pending = 'Pending',
   Failed = 'Failed',
 }

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/const.ts
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/const.ts
@@ -1,0 +1,31 @@
+export enum AgentRuntimesFilterOption {
+  Name = 'name',
+  Project = 'project',
+  Status = 'status',
+}
+
+export enum AgentRuntimeStatusFilter {
+  Running = 'Running',
+  Pending = 'Pending',
+  Failed = 'Failed',
+}
+
+export const agentRuntimeStatusFilterOptions = Object.values(AgentRuntimeStatusFilter);
+
+export const agentRuntimesFilterOptions: Record<AgentRuntimesFilterOption, string> = {
+  [AgentRuntimesFilterOption.Name]: 'Name',
+  [AgentRuntimesFilterOption.Project]: 'Project',
+  [AgentRuntimesFilterOption.Status]: 'Status',
+};
+
+export type AgentRuntimesFilterData = {
+  [AgentRuntimesFilterOption.Name]: string | undefined;
+  [AgentRuntimesFilterOption.Project]: string | undefined;
+  [AgentRuntimesFilterOption.Status]: { label: string; value: string } | undefined;
+};
+
+export const emptyAgentRuntimesFilterData: AgentRuntimesFilterData = {
+  [AgentRuntimesFilterOption.Name]: undefined,
+  [AgentRuntimesFilterOption.Project]: undefined,
+  [AgentRuntimesFilterOption.Status]: undefined,
+};

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/const.ts
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/const.ts
@@ -18,10 +18,15 @@ export const agentRuntimesFilterOptions: Record<AgentRuntimesFilterOption, strin
   [AgentRuntimesFilterOption.Status]: 'Status',
 };
 
+export type AgentRuntimeStatusFilterOption = {
+  label: AgentRuntimeStatusFilter;
+  value: AgentRuntimeStatusFilter;
+};
+
 export type AgentRuntimesFilterData = {
   [AgentRuntimesFilterOption.Name]: string | undefined;
   [AgentRuntimesFilterOption.Project]: string | undefined;
-  [AgentRuntimesFilterOption.Status]: { label: string; value: string } | undefined;
+  [AgentRuntimesFilterOption.Status]: AgentRuntimeStatusFilterOption | undefined;
 };
 
 export const emptyAgentRuntimesFilterData: AgentRuntimesFilterData = {

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/filterAgentRuntimes.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/filterAgentRuntimes.spec.ts
@@ -1,0 +1,144 @@
+import {
+  AgentRuntimeStatusFilter,
+  AgentRuntimesFilterOption,
+  emptyAgentRuntimesFilterData,
+} from '~/app/pages/agentRuntimes/const';
+import {
+  createFailedRuntime,
+  createPendingRuntime,
+  createReadyRuntime,
+  createToolRuntime,
+} from '~/app/pages/agentRuntimes/__tests__/agentRuntimeTestUtils';
+import {
+  filterAgentRuntimes,
+  hasActiveAgentRuntimesFilters,
+} from '~/app/utilities/filterAgentRuntimes';
+
+describe('filterAgentRuntimes', () => {
+  const runtimes = [
+    createReadyRuntime(),
+    createPendingRuntime(),
+    createFailedRuntime(),
+    createToolRuntime(),
+  ];
+
+  it('returns all runtimes when no filters are active', () => {
+    expect(filterAgentRuntimes(runtimes, emptyAgentRuntimesFilterData)).toEqual(runtimes);
+  });
+
+  it('filters runtimes by name', () => {
+    expect(
+      filterAgentRuntimes(runtimes, {
+        ...emptyAgentRuntimesFilterData,
+        [AgentRuntimesFilterOption.Name]: 'pending',
+      }),
+    ).toEqual([createPendingRuntime()]);
+  });
+
+  it('filters runtimes by project', () => {
+    expect(
+      filterAgentRuntimes(
+        runtimes,
+        {
+          ...emptyAgentRuntimesFilterData,
+          [AgentRuntimesFilterOption.Project]: 'agent-ops',
+        },
+        { 'agent-ops-demo': 'Agent Ops Demo' },
+      ),
+    ).toEqual(runtimes);
+  });
+
+  it('filters runtimes by project display name', () => {
+    expect(
+      filterAgentRuntimes(
+        runtimes,
+        {
+          ...emptyAgentRuntimesFilterData,
+          [AgentRuntimesFilterOption.Project]: 'demo',
+        },
+        { 'agent-ops-demo': 'Agent Ops Demo' },
+      ),
+    ).toEqual(runtimes);
+  });
+
+  it('filters runtimes by Running status', () => {
+    expect(
+      filterAgentRuntimes(runtimes, {
+        ...emptyAgentRuntimesFilterData,
+        [AgentRuntimesFilterOption.Status]: {
+          label: AgentRuntimeStatusFilter.Running,
+          value: AgentRuntimeStatusFilter.Running,
+        },
+      }),
+    ).toEqual([createReadyRuntime()]);
+  });
+
+  it('filters runtimes by Pending status', () => {
+    expect(
+      filterAgentRuntimes(runtimes, {
+        ...emptyAgentRuntimesFilterData,
+        [AgentRuntimesFilterOption.Status]: {
+          label: AgentRuntimeStatusFilter.Pending,
+          value: AgentRuntimeStatusFilter.Pending,
+        },
+      }),
+    ).toEqual([createPendingRuntime()]);
+  });
+
+  it('filters runtimes by Failed status', () => {
+    expect(
+      filterAgentRuntimes(runtimes, {
+        ...emptyAgentRuntimesFilterData,
+        [AgentRuntimesFilterOption.Status]: {
+          label: AgentRuntimeStatusFilter.Failed,
+          value: AgentRuntimeStatusFilter.Failed,
+        },
+      }),
+    ).toEqual([createFailedRuntime()]);
+  });
+
+  it('combines name and status filters', () => {
+    expect(
+      filterAgentRuntimes(runtimes, {
+        ...emptyAgentRuntimesFilterData,
+        [AgentRuntimesFilterOption.Name]: 'agent',
+        [AgentRuntimesFilterOption.Status]: {
+          label: AgentRuntimeStatusFilter.Pending,
+          value: AgentRuntimeStatusFilter.Pending,
+        },
+      }),
+    ).toEqual([createPendingRuntime()]);
+  });
+});
+
+describe('hasActiveAgentRuntimesFilters', () => {
+  it('returns false when no filters are active', () => {
+    expect(hasActiveAgentRuntimesFilters(emptyAgentRuntimesFilterData)).toBe(false);
+  });
+
+  it('returns true when name, project, or status filters are set', () => {
+    expect(
+      hasActiveAgentRuntimesFilters({
+        ...emptyAgentRuntimesFilterData,
+        [AgentRuntimesFilterOption.Name]: 'agent',
+      }),
+    ).toBe(true);
+
+    expect(
+      hasActiveAgentRuntimesFilters({
+        ...emptyAgentRuntimesFilterData,
+        [AgentRuntimesFilterOption.Project]: 'demo',
+      }),
+    ).toBe(true);
+
+    expect(
+      hasActiveAgentRuntimesFilters({
+        ...emptyAgentRuntimesFilterData,
+        [AgentRuntimesFilterOption.Status]: {
+          label: AgentRuntimeStatusFilter.Failed,
+          value: AgentRuntimeStatusFilter.Failed,
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/filterAgentRuntimes.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/filterAgentRuntimes.spec.ts
@@ -3,6 +3,7 @@ import {
   AgentRuntimesFilterOption,
   emptyAgentRuntimesFilterData,
 } from '~/app/pages/agentRuntimes/const';
+import { mockAgentRuntime } from '~/__mocks__/mockAgentRuntime';
 import {
   createFailedRuntime,
   createPendingRuntime,
@@ -15,12 +16,23 @@ import {
 } from '~/app/utilities/filterAgentRuntimes';
 
 describe('filterAgentRuntimes', () => {
-  const runtimes = [
+  const agentOpsRuntimes = [
     createReadyRuntime(),
     createPendingRuntime(),
     createFailedRuntime(),
     createToolRuntime(),
   ];
+  const otherProjectRuntime = mockAgentRuntime({
+    name: 'other-project-agent',
+    namespace: 'other-project',
+    status: 'Stopped',
+    endpointUrl: '',
+  });
+  const runtimes = [...agentOpsRuntimes, otherProjectRuntime];
+  const projectDisplayNames = {
+    'agent-ops-demo': 'Agent Ops Demo',
+    'other-project': 'Other Project',
+  };
 
   it('returns all runtimes when no filters are active', () => {
     expect(filterAgentRuntimes(runtimes, emptyAgentRuntimesFilterData)).toEqual(runtimes);
@@ -35,7 +47,7 @@ describe('filterAgentRuntimes', () => {
     ).toEqual([createPendingRuntime()]);
   });
 
-  it('filters runtimes by project', () => {
+  it('filters runtimes by project namespace', () => {
     expect(
       filterAgentRuntimes(
         runtimes,
@@ -43,9 +55,9 @@ describe('filterAgentRuntimes', () => {
           ...emptyAgentRuntimesFilterData,
           [AgentRuntimesFilterOption.Project]: 'agent-ops',
         },
-        { 'agent-ops-demo': 'Agent Ops Demo' },
+        projectDisplayNames,
       ),
-    ).toEqual(runtimes);
+    ).toEqual(agentOpsRuntimes);
   });
 
   it('filters runtimes by project display name', () => {
@@ -56,9 +68,22 @@ describe('filterAgentRuntimes', () => {
           ...emptyAgentRuntimesFilterData,
           [AgentRuntimesFilterOption.Project]: 'demo',
         },
-        { 'agent-ops-demo': 'Agent Ops Demo' },
+        projectDisplayNames,
       ),
-    ).toEqual(runtimes);
+    ).toEqual(agentOpsRuntimes);
+  });
+
+  it('excludes runtimes that do not match the project filter', () => {
+    expect(
+      filterAgentRuntimes(
+        runtimes,
+        {
+          ...emptyAgentRuntimesFilterData,
+          [AgentRuntimesFilterOption.Project]: 'other-project',
+        },
+        projectDisplayNames,
+      ),
+    ).toEqual([otherProjectRuntime]);
   });
 
   it('filters runtimes by Running status', () => {

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/filterAgentRuntimes.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/filterAgentRuntimes.spec.ts
@@ -86,13 +86,13 @@ describe('filterAgentRuntimes', () => {
     ).toEqual([otherProjectRuntime]);
   });
 
-  it('filters runtimes by Running status', () => {
+  it('filters runtimes by Ready status', () => {
     expect(
       filterAgentRuntimes(runtimes, {
         ...emptyAgentRuntimesFilterData,
         [AgentRuntimesFilterOption.Status]: {
-          label: AgentRuntimeStatusFilter.Running,
-          value: AgentRuntimeStatusFilter.Running,
+          label: AgentRuntimeStatusFilter.Ready,
+          value: AgentRuntimeStatusFilter.Ready,
         },
       }),
     ).toEqual([createReadyRuntime()]);

--- a/packages/agent-ops/frontend/src/app/utilities/filterAgentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/filterAgentRuntimes.ts
@@ -1,0 +1,64 @@
+import {
+  AgentRuntimeStatusFilter,
+  AgentRuntimesFilterData,
+  AgentRuntimesFilterOption,
+} from '~/app/pages/agentRuntimes/const';
+import { AgentRuntime } from '~/app/types/agentRuntimes';
+import {
+  AgentRuntimeDisplayStatus,
+  mapAgentRuntimeStatus,
+} from '~/app/utilities/agentRuntimeStatus';
+
+const matchesStatusFilter = (runtimeStatus: string, filterStatus: string): boolean => {
+  const { displayStatus } = mapAgentRuntimeStatus(runtimeStatus);
+
+  switch (filterStatus) {
+    case AgentRuntimeStatusFilter.Running:
+      return displayStatus === AgentRuntimeDisplayStatus.Ready;
+    case AgentRuntimeStatusFilter.Pending:
+      return displayStatus === AgentRuntimeDisplayStatus.Pending;
+    case AgentRuntimeStatusFilter.Failed:
+      return displayStatus === AgentRuntimeDisplayStatus.Failed;
+    default:
+      return false;
+  }
+};
+
+export const filterAgentRuntimes = (
+  runtimes: AgentRuntime[],
+  filters: AgentRuntimesFilterData,
+  projectDisplayNames: Record<string, string> = {},
+): AgentRuntime[] => {
+  let result = runtimes;
+
+  const nameFilter = filters[AgentRuntimesFilterOption.Name]?.trim();
+  if (nameFilter) {
+    const lower = nameFilter.toLowerCase();
+    result = result.filter((runtime) => runtime.name.toLowerCase().includes(lower));
+  }
+
+  const projectFilter = filters[AgentRuntimesFilterOption.Project]?.trim();
+  if (projectFilter) {
+    const lower = projectFilter.toLowerCase();
+    result = result.filter((runtime) => {
+      const displayName = projectDisplayNames[runtime.namespace] ?? runtime.namespace;
+      return (
+        runtime.namespace.toLowerCase().includes(lower) || displayName.toLowerCase().includes(lower)
+      );
+    });
+  }
+
+  const statusFilter = filters[AgentRuntimesFilterOption.Status]?.value;
+  if (statusFilter) {
+    result = result.filter((runtime) => matchesStatusFilter(runtime.status, statusFilter));
+  }
+
+  return result;
+};
+
+export const hasActiveAgentRuntimesFilters = (filters: AgentRuntimesFilterData): boolean =>
+  Boolean(
+    filters[AgentRuntimesFilterOption.Name]?.trim() ||
+    filters[AgentRuntimesFilterOption.Project]?.trim() ||
+    filters[AgentRuntimesFilterOption.Status],
+  );

--- a/packages/agent-ops/frontend/src/app/utilities/filterAgentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/filterAgentRuntimes.ts
@@ -20,7 +20,7 @@ const matchesStatusFilter = (
   const { displayStatus } = mapAgentRuntimeStatus(runtimeStatus);
 
   switch (filterStatus) {
-    case AgentRuntimeStatusFilter.Running:
+    case AgentRuntimeStatusFilter.Ready:
       return displayStatus === AgentRuntimeDisplayStatus.Ready;
     case AgentRuntimeStatusFilter.Pending:
       return displayStatus === AgentRuntimeDisplayStatus.Pending;

--- a/packages/agent-ops/frontend/src/app/utilities/filterAgentRuntimes.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/filterAgentRuntimes.ts
@@ -9,7 +9,14 @@ import {
   mapAgentRuntimeStatus,
 } from '~/app/utilities/agentRuntimeStatus';
 
-const matchesStatusFilter = (runtimeStatus: string, filterStatus: string): boolean => {
+const assertNever = (value: never): never => {
+  throw new Error(`Unhandled AgentRuntimeStatusFilter: ${String(value)}`);
+};
+
+const matchesStatusFilter = (
+  runtimeStatus: string,
+  filterStatus: AgentRuntimeStatusFilter,
+): boolean => {
   const { displayStatus } = mapAgentRuntimeStatus(runtimeStatus);
 
   switch (filterStatus) {
@@ -20,7 +27,7 @@ const matchesStatusFilter = (runtimeStatus: string, filterStatus: string): boole
     case AgentRuntimeStatusFilter.Failed:
       return displayStatus === AgentRuntimeDisplayStatus.Failed;
     default:
-      return false;
+      return assertNever(filterStatus);
   }
 };
 
@@ -60,5 +67,5 @@ export const hasActiveAgentRuntimesFilters = (filters: AgentRuntimesFilterData):
   Boolean(
     filters[AgentRuntimesFilterOption.Name]?.trim() ||
     filters[AgentRuntimesFilterOption.Project]?.trim() ||
-    filters[AgentRuntimesFilterOption.Status],
+    filters[AgentRuntimesFilterOption.Status]?.value,
   );


### PR DESCRIPTION

## Description
For https://issues.redhat.com/browse/RHOAIENG-62706

Extends the Agent Ops deployments list toolbar from a single name search to full `FilterToolbar` support with three filters
- **Name** — text search on runtime name
- **Project** — text search on namespace or project display name
- **Status** — select filter for Running, Pending, or Failed 

https://github.com/user-attachments/assets/7f01b71f-25dc-4ce9-b941-0ff19b64c2d5


## How Has This Been Tested?

- Manually verified filter toolbar on the agent deployments list (name, project, status, clear filters)

## Test Impact

- Added `filterAgentRuntimes.spec.ts` — unit tests for name, project, status, combined filters, and active-filter detection
- Extended `agentDeployments.cy.ts` — Cypress tests for status and project filtering
- Extended `agentDeployments.ts` page object with filter dropdown helpers

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured filtering for agent deployments/runtimes with dedicated **Name**, **Project**, and **Status** controls, including active filter chips and consistent empty-state behavior.
* **Refactor**
  * Updated the runtimes toolbar and list page to use a unified filter model, improving filter updates and clearing.
* **Bug Fixes**
  * Ensured **Status** and **Project** filtering updates reliably and returns the correct rows as selections change.
* **Tests**
  * Added Jest coverage for runtime filtering/active-filter detection, plus Cypress scenarios for **Status** and **Project** filter workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->