### PR TITLE
fix(RHOAIENG-69079): use permissive Accept header for pod log fetch

### DIFF
--- a/frontend/src/api/k8s/__tests__/pods.spec.ts
+++ b/frontend/src/api/k8s/__tests__/pods.spec.ts
@@ -1,16 +1,26 @@
-import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { commonFetch, k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
 import type { PodKind } from '@odh-dashboard/k8s-core';
 import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import { mockPodK8sResource } from '#~/__mocks__/mockPodK8sResource';
-import { getPodsForKserve, getPodsForNotebook } from '#~/api/k8s/pods';
+import { getPodContainerLogText, getPodsForKserve, getPodsForNotebook } from '#~/api/k8s/pods';
 import { PodModel } from '#~/api/models';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sListResource: jest.fn(),
+  commonFetch: jest.fn(),
+  getK8sResourceURL: jest.fn((model, resource, opts) => {
+    const base = `/api/v1/namespaces/${opts.ns}/${model.plural}/${opts.name}`;
+    return opts.path ? `${base}/${opts.path}` : base;
+  }),
 }));
 
 const k8sListResourceMock = jest.mocked(k8sListResource<PodKind>);
+const commonFetchMock = jest.mocked(commonFetch);
 const namespace = 'test-project';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('getPodsForNotebook', () => {
   const notebookName = 'test';
@@ -42,6 +52,67 @@ describe('getPodsForNotebook', () => {
         queryParams: { labelSelector: `notebook-name=${notebookName}` },
       },
     });
+  });
+});
+
+describe('getPodContainerLogText', () => {
+  const podName = 'my-pod';
+  const containerName = 'step-main';
+
+  it('should fetch and return log text', async () => {
+    const logContent = 'line 1\nline 2\nline 3';
+    commonFetchMock.mockResolvedValue({
+      text: () => Promise.resolve(logContent),
+    } as Response);
+
+    const result = await getPodContainerLogText(namespace, podName, containerName);
+
+    expect(commonFetchMock).toHaveBeenCalledTimes(1);
+    expect(commonFetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(`log?container=${containerName}`),
+      { headers: { Accept: 'text/plain, application/json' } },
+      undefined,
+      true,
+    );
+    expect(result).toBe(logContent);
+  });
+
+  it('should pass tailLines when tail is specified', async () => {
+    commonFetchMock.mockResolvedValue({
+      text: () => Promise.resolve('tail log'),
+    } as Response);
+
+    await getPodContainerLogText(namespace, podName, containerName, 100);
+
+    expect(commonFetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(`log?container=${containerName}&tailLines=100`),
+      expect.any(Object),
+      undefined,
+      true,
+    );
+  });
+
+  it('should not append tailLines when tail is not specified', async () => {
+    commonFetchMock.mockResolvedValue({
+      text: () => Promise.resolve('full log'),
+    } as Response);
+
+    await getPodContainerLogText(namespace, podName, containerName);
+
+    expect(commonFetchMock).toHaveBeenCalledWith(
+      expect.not.stringContaining('tailLines'),
+      expect.any(Object),
+      undefined,
+      true,
+    );
+  });
+
+  it('should propagate fetch errors', async () => {
+    commonFetchMock.mockRejectedValue(new Error('network error'));
+
+    await expect(getPodContainerLogText(namespace, podName, containerName)).rejects.toThrow(
+      'network error',
+    );
   });
 });
 

--- a/frontend/src/api/k8s/pods.ts
+++ b/frontend/src/api/k8s/pods.ts
@@ -1,5 +1,5 @@
 import {
-  commonFetchText,
+  commonFetch,
   getK8sResourceURL,
   k8sGetResource,
   k8sListResource,
@@ -25,22 +25,25 @@ export const getPod = (namespace: string, name: string): Promise<PodKind> =>
     },
   });
 
-export const getPodContainerLogText = (
+export const getPodContainerLogText = async (
   namespace: string,
   podName: string,
   containerName: string,
   tail?: number,
-): Promise<string> =>
-  commonFetchText(
+): Promise<string> => {
+  const response = await commonFetch(
     getK8sResourceURL(PodModel, undefined, {
       name: podName,
       ns: namespace,
       path: `log?container=${containerName}${tail ? `&tailLines=${tail}` : ''}`,
     }),
-    undefined,
+    { headers: { Accept: 'text/plain, application/json' } },
     undefined,
     true,
   );
+
+  return response.text();
+};
 
 export const getPodsForKserve = (namespace: string, modelName: string): Promise<PodKind[]> =>
   k8sListResource<PodKind>({


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-69079

## Description

The KFP pipeline run Logs tab displays an HTTP 406 NotAcceptable JSON response instead of actual pod log lines. The root cause is that `getPodContainerLogText` uses `commonFetchText` from the SDK, which hardcodes `Accept: text/plain`. A layer in the RHOAI proxy chain rejects this strict content type and returns 406, even though the logs are valid plain text (confirmed via `oc logs`).

<img width="1510" height="768" alt="Screenshot 2026-06-26 at 11 19 26 AM" src="https://github.com/user-attachments/assets/e12a012f-1b28-41f7-b07f-2fc533817549" />

This PR replaces `commonFetchText` with `commonFetch` using `Accept: text/plain, application/json` — permissive enough to fix the 406 while still restricting response types (no wildcard `*/*`). No additional error handling is needed in the function itself because `appFetch` (in `SDKInitialize.tsx`) already intercepts error responses (status >= 400) and throws `K8sStatusError` for K8s Status objects.

## How Has This Been Tested?

- Ran `EXT_CLUSTER=true npm run dev` against an RHOAI cluster with a completed KFP pipeline run (`hello_logs_test`)
- Verified the Logs tab now displays log lines correctly instead of the 406 error
- Verified `oc logs` output matches dashboard log output
- All 8 unit tests pass (`npx jest frontend/src/api/k8s/__tests__/pods.spec.ts`)
- Type-check and lint pass clean

## Test Impact

Added 4 new unit tests for `getPodContainerLogText` in `frontend/src/api/k8s/__tests__/pods.spec.ts`:
- `should fetch and return log text`
- `should pass tailLines when tail is specified`
- `should not append tailLines when tail is not specified`
- `should propagate fetch errors`

Also fixed a pre-existing mock leak in the existing pod tests (missing top-level `beforeEach(clearAllMocks)`).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`