### PR TITLE
RHOAIENG-72103: Add existing secret option to workbench env vars form

### DIFF
--- a/frontend/src/api/k8s/__tests__/notebooks.spec.ts
+++ b/frontend/src/api/k8s/__tests__/notebooks.spec.ts
@@ -424,6 +424,118 @@ describe('assembleNotebook', () => {
       expect(result.metadata.annotations?.['opendatahub.io/mlflow-instance']).toBeUndefined();
     },
   );
+
+  it('should include env entries with secretKeyRef for existingSecretEnvVars', () => {
+    const notebookData = mockStartNotebookData({});
+    notebookData.existingSecretEnvVars = [
+      { name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' },
+      { name: 's3-credentials', key: 'AWS_SECRET_ACCESS_KEY' },
+    ];
+
+    const result = assembleNotebook(notebookData, 'test-user');
+    const container = result.spec.template.spec.containers[0];
+
+    expect(container.env).toContainEqual({
+      name: 'AWS_ACCESS_KEY_ID',
+      valueFrom: {
+        secretKeyRef: {
+          name: 's3-credentials',
+          key: 'AWS_ACCESS_KEY_ID',
+        },
+      },
+    });
+    expect(container.env).toContainEqual({
+      name: 'AWS_SECRET_ACCESS_KEY',
+      valueFrom: {
+        secretKeyRef: {
+          name: 's3-credentials',
+          key: 'AWS_SECRET_ACCESS_KEY',
+        },
+      },
+    });
+  });
+
+  it('should include env entries from multiple existing secrets', () => {
+    const notebookData = mockStartNotebookData({});
+    notebookData.existingSecretEnvVars = [
+      { name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' },
+      { name: 'db-credentials', key: 'DB_USER' },
+      { name: 'db-credentials', key: 'DB_PASSWORD' },
+    ];
+
+    const result = assembleNotebook(notebookData, 'test-user');
+    const container = result.spec.template.spec.containers[0];
+
+    expect(container.env).toContainEqual({
+      name: 'AWS_ACCESS_KEY_ID',
+      valueFrom: {
+        secretKeyRef: {
+          name: 's3-credentials',
+          key: 'AWS_ACCESS_KEY_ID',
+        },
+      },
+    });
+    expect(container.env).toContainEqual({
+      name: 'DB_USER',
+      valueFrom: {
+        secretKeyRef: {
+          name: 'db-credentials',
+          key: 'DB_USER',
+        },
+      },
+    });
+    expect(container.env).toContainEqual({
+      name: 'DB_PASSWORD',
+      valueFrom: {
+        secretKeyRef: {
+          name: 'db-credentials',
+          key: 'DB_PASSWORD',
+        },
+      },
+    });
+  });
+
+  it('should preserve static env vars (NOTEBOOK_ARGS, JUPYTER_IMAGE) when existingSecretEnvVars is present', () => {
+    const notebookData = mockStartNotebookData({});
+    notebookData.existingSecretEnvVars = [{ name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' }];
+
+    const result = assembleNotebook(notebookData, 'test-user');
+    const container = result.spec.template.spec.containers[0];
+
+    expect(container.env).toContainEqual(
+      expect.objectContaining({
+        name: 'NOTEBOOK_ARGS',
+      }),
+    );
+    expect(container.env).toContainEqual({
+      name: 'JUPYTER_IMAGE',
+      value: expect.stringContaining('docker.io/sample-repo'),
+    });
+  });
+
+  it('should handle empty existingSecretEnvVars array', () => {
+    const notebookData = mockStartNotebookData({});
+    notebookData.existingSecretEnvVars = [];
+
+    const result = assembleNotebook(notebookData, 'test-user');
+    const container = result.spec.template.spec.containers[0];
+
+    expect(container.env).toHaveLength(2);
+    expect(container.env).toContainEqual(expect.objectContaining({ name: 'NOTEBOOK_ARGS' }));
+    expect(container.env).toContainEqual(expect.objectContaining({ name: 'JUPYTER_IMAGE' }));
+  });
+
+  it('should handle undefined existingSecretEnvVars', () => {
+    const notebookData = mockStartNotebookData({});
+    notebookData.existingSecretEnvVars = undefined;
+
+    const result = assembleNotebook(notebookData, 'test-user');
+    const container = result.spec.template.spec.containers[0];
+
+    expect(container.env).toHaveLength(2);
+    expect(container.env).toContainEqual(expect.objectContaining({ name: 'NOTEBOOK_ARGS' }));
+    expect(container.env).toContainEqual(expect.objectContaining({ name: 'JUPYTER_IMAGE' }));
+  });
 });
 
 describe('createNotebook', () => {

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -44,6 +44,7 @@ export const assembleNotebook = (
     hardwareProfileOptions,
     feastData,
     mlflowEnabled,
+    existingSecretEnvVars,
   } = data;
   const {
     name: notebookName,
@@ -84,6 +85,17 @@ export const assembleNotebook = (
   const connectionsAnnotation = connections
     ?.map((connection) => `${connection.metadata.namespace}/${connection.metadata.name}`)
     .join(',');
+
+  const existingSecretEnv =
+    existingSecretEnvVars?.map(({ name, key }) => ({
+      name: key,
+      valueFrom: {
+        secretKeyRef: {
+          name,
+          key,
+        },
+      },
+    })) || [];
 
   const baseResource: NotebookKind = {
     apiVersion: 'kubeflow.org/v1',
@@ -134,6 +146,7 @@ export const assembleNotebook = (
                   name: 'JUPYTER_IMAGE',
                   value: imageUrl,
                 },
+                ...existingSecretEnv,
               ],
               envFrom,
               volumeMounts,

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -326,6 +326,14 @@ export const updateNotebook = (
   oldNotebook.spec.template.spec.volumes = [];
   container.volumeMounts = [];
 
+  // Clear old env array, keeping only static entries (NOTEBOOK_ARGS, JUPYTER_IMAGE)
+  // to prevent lodash merge from merging by array index
+  const staticEnvNames = ['NOTEBOOK_ARGS', 'JUPYTER_IMAGE'];
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  container.env = (container.env || []).filter(
+    (envVar) => envVar.name && staticEnvNames.includes(envVar.name),
+  );
+
   return k8sUpdateResource<NotebookKind>(
     applyK8sAPIOptions(
       {

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -169,6 +169,17 @@ export const getSecretsByLabel = (
     ),
   ).then((result) => result.items);
 
+export const getSecrets = (namespace: string, opts?: K8sAPIOptions): Promise<SecretKind[]> =>
+  k8sListResource<SecretKind>(
+    applyK8sAPIOptions(
+      {
+        model: SecretModel,
+        queryOptions: { ns: namespace },
+      },
+      opts,
+    ),
+  ).then((result) => result.items);
+
 export const createSecret = (data: SecretKind, opts?: K8sAPIOptions): Promise<SecretKind> =>
   k8sCreateResource<SecretKind>(
     applyK8sAPIOptions(

--- a/frontend/src/pages/projects/__tests__/types.spec.ts
+++ b/frontend/src/pages/projects/__tests__/types.spec.ts
@@ -1,0 +1,47 @@
+import { SecretCategory } from '#~/pages/projects/types';
+import { isExistingSecretCategory } from '#~/pages/projects/screens/spawner/environmentVariables/utils';
+
+describe('SecretCategory', () => {
+  it('should have EXISTING as a valid enum value', () => {
+    expect(SecretCategory.EXISTING).toBe('existing secret');
+  });
+
+  it('should include all expected enum values', () => {
+    expect(Object.values(SecretCategory)).toEqual([
+      'secret key-value',
+      'aws',
+      'secret upload',
+      'existing secret',
+    ]);
+  });
+});
+
+describe('isExistingSecretCategory', () => {
+  it('should return true for EXISTING category', () => {
+    expect(isExistingSecretCategory(SecretCategory.EXISTING)).toBe(true);
+  });
+
+  it('should return false for GENERIC category', () => {
+    expect(isExistingSecretCategory(SecretCategory.GENERIC)).toBe(false);
+  });
+
+  it('should return false for AWS category', () => {
+    expect(isExistingSecretCategory(SecretCategory.AWS)).toBe(false);
+  });
+
+  it('should return false for UPLOAD category', () => {
+    expect(isExistingSecretCategory(SecretCategory.UPLOAD)).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isExistingSecretCategory(null)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isExistingSecretCategory(undefined)).toBe(false);
+  });
+
+  it('should return false for arbitrary string', () => {
+    expect(isExistingSecretCategory('random string' as SecretCategory)).toBe(false);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -173,7 +173,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
 
     await Promise.all(restartConnectedNotebooksPromises);
 
-    const envFrom = await updateConfigMapsAndSecretsForNotebook(
+    const { envFrom, existingSecretEnvVars } = await updateConfigMapsAndSecretsForNotebook(
       projectName,
       editNotebook,
       envVariables,
@@ -182,7 +182,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     );
 
     const annotations = { ...editNotebook.metadata.annotations };
-    if (envFrom.length > 0) {
+    if (envFrom.length > 0 || existingSecretEnvVars.length > 0) {
       annotations['notebooks.opendatahub.io/notebook-restart'] = 'true';
     }
 
@@ -193,6 +193,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       volumes,
       volumeMounts,
       envFrom,
+      existingSecretEnvVars,
       connections,
       feastData,
     };

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -47,6 +47,7 @@ type SpawnerFooterProps = {
   connections: Connection[];
   canEnablePipelines: boolean;
   selectedFeatureStores?: WorkbenchFeatureStoreConfig[];
+  hasConflicts?: boolean;
 };
 
 const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
@@ -56,6 +57,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   connections = [],
   canEnablePipelines,
   selectedFeatureStores = [],
+  hasConflicts = false,
 }) => {
   const [error, setError] = React.useState<K8sStatusError>();
   const {
@@ -79,6 +81,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     createInProgress ||
     !checkRequiredFieldsForNotebookStart(startNotebookData, envVariables) ||
     !isHardwareProfileValid ||
+    hasConflicts ||
     (!isProjectScopedAvailable &&
       startNotebookData.image.imageStream?.metadata.namespace === projectName);
 

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -32,6 +32,7 @@ import { getNotebookPVCNames } from '#~/pages/projects/pvc/utils';
 import {
   createConfigMapsAndSecretsForNotebook,
   createPvcDataForNotebook,
+  extractExistingSecretEnvVars,
   updateConfigMapsAndSecretsForNotebook,
   updatePvcDataForNotebook,
 } from './service';
@@ -230,6 +231,8 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       dryRun,
     );
 
+    const existingSecretEnvVars = extractExistingSecretEnvVars(envVariables);
+
     const { volumes, volumeMounts } = pvcVolumeDetails;
     const feastData = generateFeastMetadata(selectedFeatureStores, undefined, false);
 
@@ -240,6 +243,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       envFrom: [...envFrom],
       connections,
       feastData,
+      existingSecretEnvVars,
     };
     return createNotebook(newStartData, username, canEnablePipelines, { dryRun });
   };

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -66,6 +66,8 @@ import { useDefaultStorageClass } from './storage/useDefaultStorageClass';
 import { ConnectionsFormSection } from './connections/ConnectionsFormSection';
 import { getConnectionsFromNotebook } from './connections/utils';
 import AlertWarningText from './environmentVariables/AlertWarningText';
+import { EnvVarConflictWarning } from './environmentVariables/EnvVarConflictWarning';
+import { detectEnvVarConflicts } from './environmentVariables/utils';
 import { ClusterStorageTable } from './storage/ClusterStorageTable';
 import useDefaultPvcSize from './storage/useDefaultPvcSize';
 import { defaultClusterStorage } from './storage/constants';
@@ -291,6 +293,13 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
 
   const { dashboardNamespace } = useDashboardNamespace();
 
+  const envVarConflicts = React.useMemo(
+    () => detectEnvVarConflicts(envVariables, notebookConnections),
+    [envVariables, notebookConnections],
+  );
+
+  const hasConflicts = envVarConflicts.length > 0;
+
   return (
     <ApplicationsPage
       title={existingNotebook ? `Edit ${editNotebookDisplayName}` : 'Create workbench'}
@@ -373,8 +382,17 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   deletedSecrets={deletedSecrets}
                 />
               )}
-              <EnvironmentVariables envVariables={envVariables} setEnvVariables={setEnvVariables} />
+              <EnvironmentVariables
+                envVariables={envVariables}
+                setEnvVariables={setEnvVariables}
+                namespace={currentProject.metadata.name}
+              />
             </FormSection>
+            {hasConflicts && (
+              <FormSection>
+                <EnvVarConflictWarning conflicts={envVarConflicts} />
+              </FormSection>
+            )}
             <FormSection
               title={
                 <Flex
@@ -495,6 +513,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   connections={notebookConnections}
                   canEnablePipelines={canEnablePipelines}
                   selectedFeatureStores={selectedFeatureStores}
+                  hasConflicts={hasConflicts}
                 />
               )}
             </CanEnableElyraPipelinesCheck>

--- a/frontend/src/pages/projects/screens/spawner/__tests__/service-update.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/service-update.spec.ts
@@ -1,0 +1,373 @@
+import type { ConfigMapKind, SecretKind } from '@odh-dashboard/k8s-core';
+import type { NotebookKind } from '#~/k8sTypes';
+import {
+  EnvVariable,
+  EnvironmentVariableType,
+  SecretCategory,
+  ConfigMapCategory,
+} from '#~/pages/projects/types';
+import * as api from '#~/api';
+import { updateConfigMapsAndSecretsForNotebook } from '#~/pages/projects/screens/spawner/service';
+import { fetchNotebookEnvVariables } from '#~/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables';
+
+jest.mock('#~/api', () => ({
+  ...jest.requireActual('#~/api'),
+  createSecret: jest.fn(),
+  createConfigMap: jest.fn(),
+  deleteSecret: jest.fn(),
+  deleteConfigMap: jest.fn(),
+  replaceSecret: jest.fn(),
+  replaceConfigMap: jest.fn(),
+}));
+
+jest.mock('#~/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables', () => ({
+  fetchNotebookEnvVariables: jest.fn(),
+}));
+
+const createSecretMock = jest.mocked(api.createSecret);
+const createConfigMapMock = jest.mocked(api.createConfigMap);
+const deleteSecretMock = jest.mocked(api.deleteSecret);
+const replaceSecretMock = jest.mocked(api.replaceSecret);
+const fetchNotebookEnvVariablesMock = jest.mocked(fetchNotebookEnvVariables);
+
+const mockNotebook: NotebookKind = {
+  apiVersion: 'kubeflow.org/v1',
+  kind: 'Notebook',
+  metadata: {
+    name: 'test-notebook',
+    namespace: 'test-project',
+  },
+  spec: {
+    template: {
+      spec: {
+        containers: [
+          {
+            name: 'test-notebook',
+            image: 'test-image',
+            env: [
+              {
+                name: 'NOTEBOOK_ARGS',
+                value: '--ServerApp.port=8888',
+              },
+              {
+                name: 'JUPYTER_IMAGE',
+                value: 'test-image',
+              },
+            ],
+            envFrom: [],
+          },
+        ],
+      },
+    },
+  },
+  status: {
+    readyReplicas: 0,
+  },
+};
+
+describe('updateConfigMapsAndSecretsForNotebook - EXISTING secret handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchNotebookEnvVariablesMock.mockResolvedValue([]);
+  });
+
+  it('should return both envFrom and existingSecretEnvVars when EXISTING secret is added', async () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'INLINE_KEY', value: 'inline-value' }],
+        },
+      },
+    ];
+
+    createSecretMock.mockResolvedValue({
+      kind: 'Secret',
+      metadata: { name: 'generated-secret' },
+    } as SecretKind);
+
+    const result = await updateConfigMapsAndSecretsForNotebook(
+      'test-project',
+      mockNotebook,
+      envVariables,
+      undefined,
+      false,
+    );
+
+    expect(result).toEqual({
+      envFrom: [{ secretRef: { name: 'generated-secret' } }],
+      existingSecretEnvVars: [{ name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' }],
+    });
+
+    expect(createSecretMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not create K8s Secret for EXISTING secrets', async () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [
+            { key: 'AWS_ACCESS_KEY_ID', value: '' },
+            { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+          ],
+        },
+      },
+    ];
+
+    const result = await updateConfigMapsAndSecretsForNotebook(
+      'test-project',
+      mockNotebook,
+      envVariables,
+      undefined,
+      false,
+    );
+
+    expect(createSecretMock).not.toHaveBeenCalled();
+    expect(deleteSecretMock).not.toHaveBeenCalled();
+    expect(replaceSecretMock).not.toHaveBeenCalled();
+
+    expect(result).toEqual({
+      envFrom: [],
+      existingSecretEnvVars: [
+        { name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' },
+        { name: 's3-credentials', key: 'AWS_SECRET_ACCESS_KEY' },
+      ],
+    });
+  });
+
+  it('should remove old EXISTING secret refs when they are no longer in the new env list', async () => {
+    fetchNotebookEnvVariablesMock.mockResolvedValue([
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'old-secret',
+          data: [{ key: 'OLD_KEY', value: '' }],
+        },
+        existingName: 'old-secret',
+      },
+    ]);
+
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'new-secret',
+          data: [{ key: 'NEW_KEY', value: '' }],
+        },
+      },
+    ];
+
+    const result = await updateConfigMapsAndSecretsForNotebook(
+      'test-project',
+      mockNotebook,
+      envVariables,
+      undefined,
+      false,
+    );
+
+    expect(deleteSecretMock).not.toHaveBeenCalled();
+
+    expect(result).toEqual({
+      envFrom: [],
+      existingSecretEnvVars: [{ name: 'new-secret', key: 'NEW_KEY' }],
+    });
+  });
+
+  it('should preserve inline secrets via envFrom and handle EXISTING secrets separately', async () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'INLINE_KEY', value: 'inline-value' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.CONFIG_MAP,
+        values: {
+          category: ConfigMapCategory.GENERIC,
+          data: [{ key: 'CONFIG_KEY', value: 'config-value' }],
+        },
+      },
+    ];
+
+    createSecretMock.mockResolvedValue({
+      kind: 'Secret',
+      metadata: { name: 'generated-secret' },
+    } as SecretKind);
+
+    createConfigMapMock.mockResolvedValue({
+      kind: 'ConfigMap',
+      metadata: { name: 'generated-configmap' },
+    } as ConfigMapKind);
+
+    const result = await updateConfigMapsAndSecretsForNotebook(
+      'test-project',
+      mockNotebook,
+      envVariables,
+      undefined,
+      false,
+    );
+
+    expect(result).toEqual({
+      envFrom: [
+        { secretRef: { name: 'generated-secret' } },
+        { configMapRef: { name: 'generated-configmap' } },
+      ],
+      existingSecretEnvVars: [{ name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' }],
+    });
+
+    expect(createSecretMock).toHaveBeenCalledTimes(1);
+    expect(createConfigMapMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle update from inline secret to EXISTING secret', async () => {
+    fetchNotebookEnvVariablesMock.mockResolvedValue([
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'OLD_INLINE_KEY', value: 'old-value' }],
+        },
+        existingName: 'old-inline-secret',
+      },
+    ]);
+
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'new-existing-secret',
+          data: [{ key: 'NEW_KEY', value: '' }],
+        },
+      },
+    ];
+
+    deleteSecretMock.mockResolvedValue({ status: 'Success' });
+
+    const result = await updateConfigMapsAndSecretsForNotebook(
+      'test-project',
+      mockNotebook,
+      envVariables,
+      undefined,
+      false,
+    );
+
+    expect(deleteSecretMock).toHaveBeenCalledWith('test-project', 'old-inline-secret', {
+      dryRun: false,
+    });
+
+    expect(result).toEqual({
+      envFrom: [],
+      existingSecretEnvVars: [{ name: 'new-existing-secret', key: 'NEW_KEY' }],
+    });
+  });
+
+  it('should handle updating existing workbench without any EXISTING secrets (AC8)', async () => {
+    fetchNotebookEnvVariablesMock.mockResolvedValue([
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'INLINE_KEY', value: 'inline-value' }],
+        },
+        existingName: 'existing-inline-secret',
+      },
+    ]);
+
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'INLINE_KEY', value: 'updated-value' }],
+        },
+        existingName: 'existing-inline-secret',
+      },
+    ];
+
+    replaceSecretMock.mockResolvedValue({
+      kind: 'Secret',
+      metadata: { name: 'existing-inline-secret' },
+    } as SecretKind);
+
+    const result = await updateConfigMapsAndSecretsForNotebook(
+      'test-project',
+      mockNotebook,
+      envVariables,
+      undefined,
+      false,
+    );
+
+    expect(replaceSecretMock).toHaveBeenCalledTimes(1);
+
+    expect(result).toEqual({
+      envFrom: [{ secretRef: { name: 'existing-inline-secret' } }],
+      existingSecretEnvVars: [],
+    });
+  });
+
+  it('should handle multiple EXISTING secrets', async () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'db-credentials',
+          data: [
+            { key: 'DB_USER', value: '' },
+            { key: 'DB_PASSWORD', value: '' },
+          ],
+        },
+      },
+    ];
+
+    const result = await updateConfigMapsAndSecretsForNotebook(
+      'test-project',
+      mockNotebook,
+      envVariables,
+      undefined,
+      false,
+    );
+
+    expect(result).toEqual({
+      envFrom: [],
+      existingSecretEnvVars: [
+        { name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' },
+        { name: 'db-credentials', key: 'DB_USER' },
+        { name: 'db-credentials', key: 'DB_PASSWORD' },
+      ],
+    });
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
@@ -1,0 +1,352 @@
+import type { ConfigMapKind, SecretKind } from '@odh-dashboard/k8s-core';
+import {
+  EnvVariable,
+  EnvironmentVariableType,
+  SecretCategory,
+  ConfigMapCategory,
+} from '#~/pages/projects/types';
+import * as api from '#~/api';
+import {
+  createConfigMapsAndSecretsForNotebook,
+  extractExistingSecretEnvVars,
+} from '#~/pages/projects/screens/spawner/service';
+
+jest.mock('#~/api', () => ({
+  ...jest.requireActual('#~/api'),
+  createSecret: jest.fn(),
+  createConfigMap: jest.fn(),
+}));
+
+const createSecretMock = jest.mocked(api.createSecret);
+const createConfigMapMock = jest.mocked(api.createConfigMap);
+
+describe('extractExistingSecretEnvVars', () => {
+  it('should return empty array for empty input', () => {
+    const result = extractExistingSecretEnvVars([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should extract env vars from EXISTING secret with single key', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+    ];
+
+    const result = extractExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([{ name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' }]);
+  });
+
+  it('should extract env vars from EXISTING secret with multiple keys', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [
+            { key: 'AWS_ACCESS_KEY_ID', value: '' },
+            { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+          ],
+        },
+      },
+    ];
+
+    const result = extractExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([
+      { name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' },
+      { name: 's3-credentials', key: 'AWS_SECRET_ACCESS_KEY' },
+    ]);
+  });
+
+  it('should extract env vars from multiple EXISTING secrets', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'db-credentials',
+          data: [
+            { key: 'DB_USER', value: '' },
+            { key: 'DB_PASSWORD', value: '' },
+          ],
+        },
+      },
+    ];
+
+    const result = extractExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([
+      { name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' },
+      { name: 'db-credentials', key: 'DB_USER' },
+      { name: 'db-credentials', key: 'DB_PASSWORD' },
+    ]);
+  });
+
+  it('should skip env vars without values', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: undefined,
+      },
+    ];
+
+    const result = extractExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+
+  it('should skip non-EXISTING secret categories', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'KEY', value: 'value' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.AWS,
+          data: [{ key: 'KEY', value: 'value' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.CONFIG_MAP,
+        values: {
+          category: ConfigMapCategory.GENERIC,
+          data: [{ key: 'KEY', value: 'value' }],
+        },
+      },
+    ];
+
+    const result = extractExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+
+  it('should skip EXISTING secrets without secretName', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY', value: '' }],
+        },
+      },
+    ];
+
+    const result = extractExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+
+  it('should skip EXISTING secrets with empty data array', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [],
+        },
+      },
+    ];
+
+    const result = extractExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+
+  it('should handle mixed EXISTING and non-EXISTING env vars', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'INLINE_KEY', value: 'inline-value' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.CONFIG_MAP,
+        values: {
+          category: ConfigMapCategory.GENERIC,
+          data: [{ key: 'CONFIG_KEY', value: 'config-value' }],
+        },
+      },
+    ];
+
+    const result = extractExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([{ name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' }]);
+  });
+});
+
+describe('createConfigMapsAndSecretsForNotebook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not create K8s resources for EXISTING secrets', async () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+    ];
+
+    const result = await createConfigMapsAndSecretsForNotebook('test-project', envVariables);
+
+    expect(createSecretMock).not.toHaveBeenCalled();
+    expect(createConfigMapMock).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('should create K8s resources for GENERIC secrets but not EXISTING', async () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'INLINE_KEY', value: 'inline-value' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+    ];
+
+    createSecretMock.mockResolvedValue({
+      kind: 'Secret',
+      metadata: { name: 'generated-secret', namespace: 'test-project' },
+    } as SecretKind);
+
+    const result = await createConfigMapsAndSecretsForNotebook('test-project', envVariables);
+
+    expect(createSecretMock).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      secretRef: { name: 'generated-secret' },
+    });
+  });
+
+  it('should handle multiple EXISTING secrets without creating resources', async () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'db-credentials',
+          data: [{ key: 'DB_USER', value: '' }],
+        },
+      },
+    ];
+
+    const result = await createConfigMapsAndSecretsForNotebook('test-project', envVariables);
+
+    expect(createSecretMock).not.toHaveBeenCalled();
+    expect(createConfigMapMock).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('should handle mixed EXISTING and AWS secrets', async () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.AWS,
+          data: [
+            { key: 'Name', value: 'my-aws-connection' },
+            { key: 'AWS_ACCESS_KEY_ID', value: 'inline-key' },
+            { key: 'AWS_SECRET_ACCESS_KEY', value: 'inline-secret' },
+          ],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'S3_BUCKET', value: '' }],
+        },
+      },
+    ];
+
+    createSecretMock.mockResolvedValue({
+      kind: 'Secret',
+      metadata: { name: 'aws-secret', namespace: 'test-project' },
+    } as SecretKind);
+
+    const result = await createConfigMapsAndSecretsForNotebook('test-project', envVariables);
+
+    expect(createSecretMock).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+  });
+
+  it('should handle ConfigMaps alongside EXISTING secrets', async () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.CONFIG_MAP,
+        values: {
+          category: ConfigMapCategory.GENERIC,
+          data: [{ key: 'CONFIG_KEY', value: 'config-value' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 's3-credentials',
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+    ];
+
+    createConfigMapMock.mockResolvedValue({
+      kind: 'ConfigMap',
+      metadata: { name: 'generated-config', namespace: 'test-project' },
+    } as ConfigMapKind);
+
+    const result = await createConfigMapsAndSecretsForNotebook('test-project', envVariables);
+
+    expect(createConfigMapMock).toHaveBeenCalledTimes(1);
+    expect(createSecretMock).not.toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      configMapRef: { name: 'generated-config' },
+    });
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
@@ -1,0 +1,236 @@
+import React from 'react';
+import {
+  Alert,
+  Checkbox,
+  FormGroup,
+  FormHelperText,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { TypeaheadSelectOption } from '@patternfly/react-templates';
+import { SecretKind } from '@odh-dashboard/k8s-core';
+import { getSecret } from '#~/api/k8s/secrets';
+import TypeaheadSelect from '#~/components/TypeaheadSelect';
+import IndentSection from '#~/pages/projects/components/IndentSection';
+import { EnvVariableData } from '#~/pages/projects/types';
+import { getDashboardMainContainer } from '#~/utilities/utils';
+import { useExistingSecrets } from './useExistingSecrets';
+
+type EnvExistingSecretProps = {
+  env: EnvVariableData;
+  onUpdate: (envVariableData: EnvVariableData) => void;
+  namespace: string;
+};
+
+const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, namespace }) => {
+  const [secrets, loaded, error] = useExistingSecrets(namespace, !!namespace);
+  const [selectedSecret, setSelectedSecret] = React.useState<SecretKind | null>(null);
+  const [availableKeys, setAvailableKeys] = React.useState<string[]>([]);
+  const [isLoadingKeys, setIsLoadingKeys] = React.useState(false);
+
+  const selectedSecretName = React.useMemo(() => {
+    if (env.data.length > 0) {
+      return env.data[0]?.key.split('/')[0];
+    }
+    return '';
+  }, [env.data]);
+
+  const selectedKeys = React.useMemo(() => {
+    return env.data.map((entry) => entry.key);
+  }, [env.data]);
+
+  React.useEffect(() => {
+    if (selectedSecretName && !selectedSecret) {
+      setIsLoadingKeys(true);
+      getSecret(namespace, selectedSecretName)
+        .then((secret) => {
+          setSelectedSecret(secret);
+          const keys = Object.keys(secret.data || {});
+          setAvailableKeys(keys);
+        })
+        .catch(() => {
+          setSelectedSecret(null);
+          setAvailableKeys([]);
+        })
+        .finally(() => {
+          setIsLoadingKeys(false);
+        });
+    }
+  }, [selectedSecretName, namespace, selectedSecret]);
+
+  const handleSecretSelection = React.useCallback(
+    (_event: React.MouseEvent | React.KeyboardEvent | undefined, selection: string | number) => {
+      const secretName = String(selection);
+      setIsLoadingKeys(true);
+
+      getSecret(namespace, secretName)
+        .then((secret) => {
+          setSelectedSecret(secret);
+          const keys = Object.keys(secret.data || {});
+          setAvailableKeys(keys);
+
+          // Initialize with empty selection
+          onUpdate({
+            ...env,
+            data: [],
+            allKeys: false,
+          });
+        })
+        .catch(() => {
+          setSelectedSecret(null);
+          setAvailableKeys([]);
+        })
+        .finally(() => {
+          setIsLoadingKeys(false);
+        });
+    },
+    [namespace, env, onUpdate],
+  );
+
+  const handleAllKeysChange = React.useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        // Select all keys
+        const allKeyEntries = availableKeys.map((key) => ({ key, value: '' }));
+        onUpdate({
+          ...env,
+          data: allKeyEntries,
+          allKeys: true,
+        });
+      } else {
+        // Deselect all
+        onUpdate({
+          ...env,
+          data: [],
+          allKeys: false,
+        });
+      }
+    },
+    [availableKeys, env, onUpdate],
+  );
+
+  const handleKeySelection = React.useCallback(
+    (key: string, checked: boolean) => {
+      if (checked) {
+        // Add key
+        onUpdate({
+          ...env,
+          data: [...env.data, { key, value: '' }],
+          allKeys: false,
+        });
+      } else {
+        // Remove key
+        const newData = env.data.filter((entry) => entry.key !== key);
+        onUpdate({
+          ...env,
+          data: newData,
+          allKeys: false,
+        });
+      }
+    },
+    [env, onUpdate],
+  );
+
+  if (!namespace) {
+    return (
+      <Alert variant="info" isInline title="No project context">
+        Existing secrets cannot be loaded without a project context.
+      </Alert>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="danger" isInline title="Error loading secrets">
+        {error.message}
+      </Alert>
+    );
+  }
+
+  let placeholderText: string;
+
+  if (!loaded) {
+    placeholderText = 'Loading secrets';
+  } else if (secrets.length === 0) {
+    placeholderText = 'No existing secrets available';
+  } else {
+    placeholderText = 'Select a secret';
+  }
+
+  const selectOptions: TypeaheadSelectOption[] = secrets.map((secret) => ({
+    value: secret.metadata.name,
+    content: secret.metadata.name,
+  }));
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <FormGroup isRequired label="Secret" fieldId="existing-secret-selector">
+          <TypeaheadSelect
+            selectOptions={selectOptions}
+            selected={selectedSecretName}
+            onSelect={handleSecretSelection}
+            placeholder={placeholderText}
+            noOptionsFoundMessage={(filter) => `No secret was found for "${filter}"`}
+            popperProps={{ appendTo: getDashboardMainContainer() }}
+            isDisabled={!loaded}
+            data-testid="existing-secret-typeahead"
+          />
+          <FormHelperText>
+            <Alert variant="info" title="Select an existing secret" isInline isPlain />
+          </FormHelperText>
+        </FormGroup>
+      </StackItem>
+
+      {selectedSecret && (
+        <StackItem>
+          <IndentSection>
+            <Stack hasGutter>
+              <StackItem>
+                <FormGroup label="Keys" fieldId="secret-keys">
+                  {isLoadingKeys ? (
+                    <div>Loading keys...</div>
+                  ) : (
+                    <Stack hasGutter>
+                      <StackItem>
+                        <Checkbox
+                          id="all-keys-checkbox"
+                          label="All keys"
+                          isChecked={env.allKeys || false}
+                          onChange={(_event, checked) => handleAllKeysChange(checked)}
+                          data-testid="all-keys-checkbox"
+                        />
+                      </StackItem>
+                      {!env.allKeys &&
+                        availableKeys.map((key) => (
+                          <StackItem key={key}>
+                            <Checkbox
+                              id={`key-checkbox-${key}`}
+                              label={key}
+                              isChecked={selectedKeys.includes(key)}
+                              onChange={(_event, checked) => handleKeySelection(key, checked)}
+                              data-testid={`key-checkbox-${key}`}
+                            />
+                          </StackItem>
+                        ))}
+                    </Stack>
+                  )}
+                  <FormHelperText>
+                    <Alert
+                      variant="warning"
+                      title="Secret values are never displayed. Only key names are shown."
+                      isInline
+                      isPlain
+                    />
+                  </FormHelperText>
+                </FormGroup>
+              </StackItem>
+            </Stack>
+          </IndentSection>
+        </StackItem>
+      )}
+    </Stack>
+  );
+};
+
+export default EnvExistingSecret;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
@@ -67,6 +67,7 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
         abortController.abort();
       };
     }
+    return undefined;
   }, [selectedSecretName, namespace, selectedSecret]);
 
   const handleSecretSelection = React.useCallback(

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
@@ -4,6 +4,7 @@ import {
   Checkbox,
   FormGroup,
   FormHelperText,
+  Spinner,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
@@ -27,13 +28,9 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
   const [selectedSecret, setSelectedSecret] = React.useState<SecretKind | null>(null);
   const [availableKeys, setAvailableKeys] = React.useState<string[]>([]);
   const [isLoadingKeys, setIsLoadingKeys] = React.useState(false);
+  const [keyLoadError, setKeyLoadError] = React.useState<string | null>(null);
 
-  const selectedSecretName = React.useMemo(() => {
-    if (env.data.length > 0) {
-      return env.data[0]?.key.split('/')[0];
-    }
-    return '';
-  }, [env.data]);
+  const selectedSecretName = env.secretName || '';
 
   const selectedKeys = React.useMemo(() => {
     return env.data.map((entry) => entry.key);
@@ -42,19 +39,33 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
   React.useEffect(() => {
     if (selectedSecretName && !selectedSecret) {
       setIsLoadingKeys(true);
+      setKeyLoadError(null);
+      const abortController = new AbortController();
+
       getSecret(namespace, selectedSecretName)
         .then((secret) => {
-          setSelectedSecret(secret);
-          const keys = Object.keys(secret.data || {});
-          setAvailableKeys(keys);
+          if (!abortController.signal.aborted) {
+            setSelectedSecret(secret);
+            const keys = Object.keys(secret.data || {});
+            setAvailableKeys(keys);
+          }
         })
-        .catch(() => {
-          setSelectedSecret(null);
-          setAvailableKeys([]);
+        .catch((err) => {
+          if (!abortController.signal.aborted) {
+            setSelectedSecret(null);
+            setAvailableKeys([]);
+            setKeyLoadError(err.message || 'Failed to load secret keys');
+          }
         })
         .finally(() => {
-          setIsLoadingKeys(false);
+          if (!abortController.signal.aborted) {
+            setIsLoadingKeys(false);
+          }
         });
+
+      return () => {
+        abortController.abort();
+      };
     }
   }, [selectedSecretName, namespace, selectedSecret]);
 
@@ -62,6 +73,7 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
     (_event: React.MouseEvent | React.KeyboardEvent | undefined, selection: string | number) => {
       const secretName = String(selection);
       setIsLoadingKeys(true);
+      setKeyLoadError(null);
 
       getSecret(namespace, secretName)
         .then((secret) => {
@@ -74,11 +86,13 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
             ...env,
             data: [],
             allKeys: false,
+            secretName,
           });
         })
-        .catch(() => {
+        .catch((err) => {
           setSelectedSecret(null);
           setAvailableKeys([]);
+          setKeyLoadError(err.message || 'Failed to load secret keys');
         })
         .finally(() => {
           setIsLoadingKeys(false);
@@ -186,10 +200,17 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
         <StackItem>
           <IndentSection>
             <Stack hasGutter>
+              {keyLoadError && (
+                <StackItem>
+                  <Alert variant="danger" isInline title="Error loading keys">
+                    {keyLoadError}
+                  </Alert>
+                </StackItem>
+              )}
               <StackItem>
                 <FormGroup label="Keys" fieldId="secret-keys">
                   {isLoadingKeys ? (
-                    <div>Loading keys...</div>
+                    <Spinner size="md" aria-label="Loading secret keys" />
                   ) : (
                     <Stack hasGutter>
                       <StackItem>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
@@ -29,8 +29,13 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
   const [availableKeys, setAvailableKeys] = React.useState<string[]>([]);
   const [isLoadingKeys, setIsLoadingKeys] = React.useState(false);
   const [keyLoadError, setKeyLoadError] = React.useState<string | null>(null);
+  const envRef = React.useRef(env);
 
   const selectedSecretName = env.secretName || '';
+
+  React.useEffect(() => {
+    envRef.current = env;
+  }, [env]);
 
   const selectedKeys = React.useMemo(() => {
     return env.data.map((entry) => entry.key);
@@ -68,7 +73,8 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
       };
     }
     return undefined;
-  }, [selectedSecretName, namespace, selectedSecret]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- selectedSecret is read-only state gate
+  }, [selectedSecretName, namespace]);
 
   const handleSecretSelection = React.useCallback(
     (_event: React.MouseEvent | React.KeyboardEvent | undefined, selection: string | number) => {
@@ -84,7 +90,7 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
 
           // Initialize with empty selection
           onUpdate({
-            ...env,
+            ...envRef.current,
             data: [],
             allKeys: false,
             secretName,
@@ -99,7 +105,7 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
           setIsLoadingKeys(false);
         });
     },
-    [namespace, env, onUpdate],
+    [namespace, onUpdate],
   );
 
   const handleAllKeysChange = React.useCallback(
@@ -108,20 +114,20 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
         // Select all keys
         const allKeyEntries = availableKeys.map((key) => ({ key, value: '' }));
         onUpdate({
-          ...env,
+          ...envRef.current,
           data: allKeyEntries,
           allKeys: true,
         });
       } else {
         // Deselect all
         onUpdate({
-          ...env,
+          ...envRef.current,
           data: [],
           allKeys: false,
         });
       }
     },
-    [availableKeys, env, onUpdate],
+    [availableKeys, onUpdate],
   );
 
   const handleKeySelection = React.useCallback(
@@ -129,21 +135,21 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ env, onUpdate, na
       if (checked) {
         // Add key
         onUpdate({
-          ...env,
-          data: [...env.data, { key, value: '' }],
+          ...envRef.current,
+          data: [...envRef.current.data, { key, value: '' }],
           allKeys: false,
         });
       } else {
         // Remove key
-        const newData = env.data.filter((entry) => entry.key !== key);
+        const newData = envRef.current.data.filter((entry) => entry.key !== key);
         onUpdate({
-          ...env,
+          ...envRef.current,
           data: newData,
           allKeys: false,
         });
       }
     },
-    [env, onUpdate],
+    [onUpdate],
   );
 
   if (!namespace) {

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -10,7 +10,7 @@ import EnvExistingSecret from './EnvExistingSecret';
 type EnvSecretProps = {
   env?: EnvVariableData;
   onUpdate: (envVariableData: EnvVariableData) => void;
-  namespace?: string;
+  namespace: string;
 };
 
 const DEFAULT_ENV: EnvVariableData = {
@@ -18,7 +18,7 @@ const DEFAULT_ENV: EnvVariableData = {
   data: [],
 };
 
-const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate, namespace = '' }) => (
+const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate, namespace }) => (
   <EnvDataTypeField
     selection={env.category || ''}
     onSelection={(value) =>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -5,10 +5,12 @@ import EnvDataTypeField from './EnvDataTypeField';
 import GenericKeyValuePairField from './GenericKeyValuePairField';
 import { EMPTY_KEY_VALUE_PAIR } from './const';
 import EnvUploadField from './EnvUploadField';
+import EnvExistingSecret from './EnvExistingSecret';
 
 type EnvSecretProps = {
   env?: EnvVariableData;
   onUpdate: (envVariableData: EnvVariableData) => void;
+  namespace?: string;
 };
 
 const DEFAULT_ENV: EnvVariableData = {
@@ -16,7 +18,7 @@ const DEFAULT_ENV: EnvVariableData = {
   data: [],
 };
 
-const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) => (
+const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate, namespace = '' }) => (
   <EnvDataTypeField
     selection={env.category || ''}
     onSelection={(value) =>
@@ -42,6 +44,10 @@ const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) =>
             translateValue={(value) => atob(value)}
           />
         ),
+      },
+      [SecretCategory.EXISTING]: {
+        label: 'Existing secret',
+        render: <EnvExistingSecret env={env} onUpdate={onUpdate} namespace={namespace} />,
       },
     }}
   />

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -11,12 +11,14 @@ type EnvTypeSelectFieldProps = {
   envVariable: EnvVariable;
   onUpdate: (envVariable: EnvVariable) => void;
   onRemove: () => void;
+  namespace: string;
 };
 
 const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
   envVariable,
   onUpdate,
   onRemove,
+  namespace,
 }) => (
   <FormGroup isRequired label="Variable type" fieldId="environment-variable-type-select">
     <Split data-testid="environment-variable-field">
@@ -51,6 +53,7 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                 <EnvTypeSwitch
                   env={envVariable}
                   onUpdate={(envValue) => onUpdate({ ...envVariable, values: envValue })}
+                  namespace={namespace}
                 />
               </IndentSection>
             </StackItem>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
@@ -6,14 +6,15 @@ import EnvSecret from './EnvSecret';
 type EnvTypeSwitchProps = {
   env: EnvVariable;
   onUpdate: (envVariableData: EnvVariableData) => void;
+  namespace: string;
 };
 
-const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate }) => {
+const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate, namespace }) => {
   switch (env.type) {
     case EnvironmentVariableType.CONFIG_MAP:
       return <EnvConfigMap env={env.values} onUpdate={onUpdate} />;
     case EnvironmentVariableType.SECRET:
-      return <EnvSecret env={env.values} onUpdate={onUpdate} />;
+      return <EnvSecret env={env.values} onUpdate={onUpdate} namespace={namespace} />;
     default:
       return null;
   }

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning.tsx
@@ -19,7 +19,7 @@ export const EnvVarConflictWarning: React.FC<Props> = ({ conflicts }) => {
       Environment variables from multiple sources conflict. When environment variables conflict,
       only one of the values is used in the workbench.
       <ExpandableSection
-        toggleText={showConflicts ? 'Show conflicts' : 'Show conflicts'}
+        toggleText={showConflicts ? 'Hide conflicts' : 'Show conflicts'}
         onToggle={() => setShowConflicts((prev) => !prev)}
         isExpanded={showConflicts}
         isIndented

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Alert, ExpandableSection, List, ListItem } from '@patternfly/react-core';
+import { EnvVarConflict } from './utils';
+
+type Props = {
+  conflicts: EnvVarConflict[];
+};
+
+export const EnvVarConflictWarning: React.FC<Props> = ({ conflicts }) => {
+  const [showConflicts, setShowConflicts] = React.useState(false);
+
+  return (
+    <Alert
+      variant="danger"
+      isInline
+      title="Environment variables conflict"
+      data-testid="envvar-conflict-warning"
+    >
+      Environment variables from multiple sources conflict. When environment variables conflict,
+      only one of the values is used in the workbench.
+      <ExpandableSection
+        toggleText={showConflicts ? 'Show conflicts' : 'Show conflicts'}
+        onToggle={() => setShowConflicts((prev) => !prev)}
+        isExpanded={showConflicts}
+        isIndented
+      >
+        {conflicts.map((conflict, conflictIndex) => (
+          <div key={conflictIndex} data-testid={`envvar-conflict-${conflictIndex}`}>
+            <b>{conflict.source1}</b> and <b>{conflict.source2}</b> contain the following
+            conflicting variables:
+            <List>
+              {conflict.keys.map((key, keyIndex) => (
+                <ListItem key={keyIndex}>
+                  <b>{key}</b>
+                </ListItem>
+              ))}
+            </List>
+            <br />
+          </div>
+        ))}
+      </ExpandableSection>
+    </Alert>
+  );
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvironmentVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvironmentVariables.tsx
@@ -7,10 +7,12 @@ import EnvTypeSelectField from './EnvTypeSelectField';
 type EnvironmentVariablesProps = {
   envVariables: EnvVariable[];
   setEnvVariables: (envVars: EnvVariable[]) => void;
+  namespace: string;
 };
 const EnvironmentVariables: React.FC<EnvironmentVariablesProps> = ({
   envVariables,
   setEnvVariables,
+  namespace,
 }) => (
   <>
     {envVariables.map((envVariable, i) => (
@@ -27,6 +29,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesProps> = ({
           onRemove={() =>
             setEnvVariables(envVariables.filter((v, filterIndex) => filterIndex !== i))
           }
+          namespace={namespace}
         />
         {i !== envVariables.length - 1 && <Divider />}
       </React.Fragment>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
@@ -1,0 +1,266 @@
+import React, { act } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SecretKind } from '@odh-dashboard/k8s-core';
+import { getSecret } from '#~/api/k8s/secrets';
+import { EnvVariableData } from '#~/pages/projects/types';
+import EnvExistingSecret from '#~/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret';
+import { useExistingSecrets } from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+
+jest.mock('../useExistingSecrets');
+jest.mock('#~/api/k8s/secrets');
+
+const mockUseExistingSecrets = jest.mocked(useExistingSecrets);
+const mockGetSecret = jest.mocked(getSecret);
+
+const createMockSecret = (name: string, data: Record<string, string>): SecretKind => ({
+  apiVersion: 'v1',
+  kind: 'Secret',
+  metadata: {
+    name,
+    namespace: 'test-namespace',
+  },
+  type: 'Opaque',
+  data: Object.fromEntries(Object.keys(data).map((k) => [k, btoa(data[k])])),
+});
+
+describe('EnvExistingSecret', () => {
+  const mockOnUpdate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show message when namespace is not provided', () => {
+    mockUseExistingSecrets.mockReturnValue([[], false, undefined, jest.fn()]);
+
+    render(
+      <EnvExistingSecret env={{ category: null, data: [] }} onUpdate={mockOnUpdate} namespace="" />,
+    );
+
+    expect(
+      screen.getByText(/existing secrets cannot be loaded without a project context/i),
+    ).toBeInTheDocument();
+  });
+
+  it('should render typeahead with loading state', () => {
+    mockUseExistingSecrets.mockReturnValue([[], false, undefined, jest.fn()]);
+
+    render(
+      <EnvExistingSecret
+        env={{ category: null, data: [] }}
+        onUpdate={mockOnUpdate}
+        namespace="test-namespace"
+      />,
+    );
+
+    expect(screen.getByPlaceholderText(/loading secrets/i)).toBeInTheDocument();
+  });
+
+  it('should render typeahead with available secrets', () => {
+    const mockSecrets = [
+      createMockSecret('secret-one', { key1: 'val1' }),
+      createMockSecret('secret-two', { key2: 'val2' }),
+    ];
+
+    mockUseExistingSecrets.mockReturnValue([mockSecrets, true, undefined, jest.fn()]);
+
+    render(
+      <EnvExistingSecret
+        env={{ category: null, data: [] }}
+        onUpdate={mockOnUpdate}
+        namespace="test-namespace"
+      />,
+    );
+
+    expect(screen.getByPlaceholderText(/select a secret/i)).toBeInTheDocument();
+  });
+
+  it('should display error when secrets fail to load', () => {
+    const error = new Error('Failed to load');
+    mockUseExistingSecrets.mockReturnValue([[], false, error, jest.fn()]);
+
+    render(
+      <EnvExistingSecret
+        env={{ category: null, data: [] }}
+        onUpdate={mockOnUpdate}
+        namespace="test-namespace"
+      />,
+    );
+
+    expect(screen.getByText(/error loading secrets/i)).toBeInTheDocument();
+    expect(screen.getByText('Failed to load')).toBeInTheDocument();
+  });
+
+  it('should show no secrets available when list is empty', () => {
+    mockUseExistingSecrets.mockReturnValue([[], true, undefined, jest.fn()]);
+
+    render(
+      <EnvExistingSecret
+        env={{ category: null, data: [] }}
+        onUpdate={mockOnUpdate}
+        namespace="test-namespace"
+      />,
+    );
+
+    expect(screen.getByPlaceholderText(/no existing secrets available/i)).toBeInTheDocument();
+  });
+
+  it('should load secret keys when a secret is selected', async () => {
+    const mockSecrets = [createMockSecret('secret-one', { key1: 'val1', key2: 'val2' })];
+    const mockSecretDetail = createMockSecret('secret-one', { key1: 'val1', key2: 'val2' });
+
+    mockUseExistingSecrets.mockReturnValue([mockSecrets, true, undefined, jest.fn()]);
+    mockGetSecret.mockResolvedValue(mockSecretDetail);
+
+    render(
+      <EnvExistingSecret
+        env={{ category: null, data: [] }}
+        onUpdate={mockOnUpdate}
+        namespace="test-namespace"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/select a secret/i);
+    fireEvent.click(input);
+
+    const option = await screen.findByText('secret-one');
+    fireEvent.click(option);
+
+    await waitFor(() => {
+      expect(mockGetSecret).toHaveBeenCalledWith('test-namespace', 'secret-one');
+    });
+  });
+
+  it('should display key selection checkboxes after secret is selected', async () => {
+    const mockSecrets = [createMockSecret('secret-one', { key1: 'val1', key2: 'val2' })];
+    const mockSecretDetail = createMockSecret('secret-one', { key1: 'val1', key2: 'val2' });
+
+    mockUseExistingSecrets.mockReturnValue([mockSecrets, true, undefined, jest.fn()]);
+    mockGetSecret.mockResolvedValue(mockSecretDetail);
+
+    const { rerender } = render(
+      <EnvExistingSecret
+        env={{ category: null, data: [] }}
+        onUpdate={mockOnUpdate}
+        namespace="test-namespace"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/select a secret/i);
+    fireEvent.click(input);
+
+    const option = await screen.findByText('secret-one');
+    await act(async () => {
+      fireEvent.click(option);
+    });
+
+    await waitFor(() => {
+      expect(mockGetSecret).toHaveBeenCalled();
+    });
+
+    // After selection, the component should call onUpdate with selected secret
+    expect(mockOnUpdate).toHaveBeenCalled();
+
+    // Re-render with updated env including the selected secret
+    const updatedEnv: EnvVariableData = {
+      category: null,
+      data: [],
+    };
+
+    rerender(
+      <EnvExistingSecret env={updatedEnv} onUpdate={mockOnUpdate} namespace="test-namespace" />,
+    );
+
+    // Should show key checkboxes (this will be tested in component implementation)
+  });
+
+  it('should show all keys checkbox', async () => {
+    const mockSecrets = [createMockSecret('secret-one', { key1: 'val1', key2: 'val2' })];
+    const mockSecretDetail = createMockSecret('secret-one', { key1: 'val1', key2: 'val2' });
+
+    mockUseExistingSecrets.mockReturnValue([mockSecrets, true, undefined, jest.fn()]);
+    mockGetSecret.mockResolvedValue(mockSecretDetail);
+
+    render(
+      <EnvExistingSecret
+        env={{ category: null, data: [] }}
+        onUpdate={mockOnUpdate}
+        namespace="test-namespace"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/select a secret/i);
+    fireEvent.click(input);
+
+    const option = await screen.findByText('secret-one');
+    await act(async () => {
+      fireEvent.click(option);
+    });
+
+    await waitFor(() => {
+      expect(mockGetSecret).toHaveBeenCalled();
+    });
+  });
+
+  it('should update form state when individual keys are selected', async () => {
+    const mockSecrets = [createMockSecret('secret-one', { key1: 'val1', key2: 'val2' })];
+    const mockSecretDetail = createMockSecret('secret-one', { key1: 'val1', key2: 'val2' });
+
+    mockUseExistingSecrets.mockReturnValue([mockSecrets, true, undefined, jest.fn()]);
+    mockGetSecret.mockResolvedValue(mockSecretDetail);
+
+    render(
+      <EnvExistingSecret
+        env={{ category: null, data: [] }}
+        onUpdate={mockOnUpdate}
+        namespace="test-namespace"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/select a secret/i);
+    fireEvent.click(input);
+
+    const option = await screen.findByText('secret-one');
+    await act(async () => {
+      fireEvent.click(option);
+    });
+
+    await waitFor(() => {
+      expect(mockGetSecret).toHaveBeenCalled();
+    });
+
+    // Verify that onUpdate was called with appropriate data structure
+    expect(mockOnUpdate).toHaveBeenCalled();
+  });
+
+  it('should never display secret values', async () => {
+    const mockSecrets = [createMockSecret('secret-one', { key1: 'secret-value' })];
+    const mockSecretDetail = createMockSecret('secret-one', { key1: 'secret-value' });
+
+    mockUseExistingSecrets.mockReturnValue([mockSecrets, true, undefined, jest.fn()]);
+    mockGetSecret.mockResolvedValue(mockSecretDetail);
+
+    const { container } = render(
+      <EnvExistingSecret
+        env={{ category: null, data: [] }}
+        onUpdate={mockOnUpdate}
+        namespace="test-namespace"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/select a secret/i);
+    fireEvent.click(input);
+
+    const option = await screen.findByText('secret-one');
+    await act(async () => {
+      fireEvent.click(option);
+    });
+
+    await waitFor(() => {
+      expect(mockGetSecret).toHaveBeenCalled();
+    });
+
+    // Should never show "secret-value" in the DOM
+    expect(container.textContent).not.toContain('secret-value');
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvVarConflictWarning.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvVarConflictWarning.spec.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EnvVarConflictWarning } from '#~/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning';
+
+describe('EnvVarConflictWarning', () => {
+  it('should render alert with conflict message', () => {
+    const conflicts = [
+      {
+        source1: 'Inline secret',
+        source2: 'secret1',
+        keys: ['KEY1', 'KEY2'],
+      },
+    ];
+
+    render(<EnvVarConflictWarning conflicts={conflicts} />);
+
+    expect(screen.getByTestId('envvar-conflict-warning')).toBeInTheDocument();
+    expect(screen.getByText('Environment variables conflict')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Environment variables from multiple sources conflict/),
+    ).toBeInTheDocument();
+  });
+
+  it('should show expandable section with conflict details', () => {
+    const conflicts = [
+      {
+        source1: 'Inline secret',
+        source2: 'secret1',
+        keys: ['KEY1'],
+      },
+    ];
+
+    render(<EnvVarConflictWarning conflicts={conflicts} />);
+
+    const toggleButton = screen.getByRole('button', { name: /show conflicts/i });
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByTestId('envvar-conflict-0')).toBeInTheDocument();
+    expect(screen.getByText('Inline secret')).toBeInTheDocument();
+    expect(screen.getByText('secret1')).toBeInTheDocument();
+    expect(screen.getByText('KEY1')).toBeInTheDocument();
+  });
+
+  it('should render multiple conflicts', () => {
+    const conflicts = [
+      {
+        source1: 'Inline secret',
+        source2: 'secret1',
+        keys: ['KEY1'],
+      },
+      {
+        source1: 'secret1',
+        source2: 'secret2',
+        keys: ['KEY2'],
+      },
+    ];
+
+    render(<EnvVarConflictWarning conflicts={conflicts} />);
+
+    const toggleButton = screen.getByRole('button', { name: /show conflicts/i });
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByTestId('envvar-conflict-0')).toBeInTheDocument();
+    expect(screen.getByTestId('envvar-conflict-1')).toBeInTheDocument();
+  });
+
+  it('should render multiple conflicting keys in a single conflict', () => {
+    const conflicts = [
+      {
+        source1: 'Inline secret',
+        source2: 'secret1',
+        keys: ['KEY1', 'KEY2', 'KEY3'],
+      },
+    ];
+
+    render(<EnvVarConflictWarning conflicts={conflicts} />);
+
+    const toggleButton = screen.getByRole('button', { name: /show conflicts/i });
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByText('KEY1')).toBeInTheDocument();
+    expect(screen.getByText('KEY2')).toBeInTheDocument();
+    expect(screen.getByText('KEY3')).toBeInTheDocument();
+  });
+
+  it('should toggle expandable section on click', () => {
+    const conflicts = [
+      {
+        source1: 'Inline secret',
+        source2: 'secret1',
+        keys: ['KEY1'],
+      },
+    ];
+
+    render(<EnvVarConflictWarning conflicts={conflicts} />);
+
+    const toggleButton = screen.getByRole('button', { name: /show conflicts/i });
+
+    expect(screen.queryByTestId('envvar-conflict-0')).not.toBeVisible();
+
+    fireEvent.click(toggleButton);
+    expect(screen.getByTestId('envvar-conflict-0')).toBeVisible();
+
+    fireEvent.click(toggleButton);
+    expect(screen.queryByTestId('envvar-conflict-0')).not.toBeVisible();
+  });
+
+  it('should use danger variant', () => {
+    const conflicts = [
+      {
+        source1: 'Inline secret',
+        source2: 'secret1',
+        keys: ['KEY1'],
+      },
+    ];
+
+    const { container } = render(<EnvVarConflictWarning conflicts={conflicts} />);
+
+    const alert = container.querySelector('.pf-v6-c-alert.pf-m-danger');
+    expect(alert).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
@@ -1,0 +1,200 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { getSecrets } from '#~/api/k8s/secrets';
+import { isConnection } from '#~/concepts/connectionTypes/utils';
+import { mockSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
+import { useExistingSecrets } from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+import { NotReadyError } from '#~/utilities/useFetch';
+
+jest.mock('#~/api/k8s/secrets', () => ({
+  getSecrets: jest.fn(),
+}));
+
+jest.mock('#~/concepts/connectionTypes/utils', () => ({
+  isConnection: jest.fn(),
+}));
+
+jest.mock('#~/utilities/useFetchState', () => ({
+  ...jest.requireActual('#~/utilities/useFetchState'),
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockGetSecrets = jest.mocked(getSecrets);
+const mockIsConnection = jest.mocked(isConnection);
+const mockUseFetchState = jest.mocked(require('#~/utilities/useFetchState').default);
+
+describe('useExistingSecrets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseFetchState.mockReturnValue([[], false, undefined, jest.fn()]);
+  });
+
+  it('should not fire API call when enabled is false', () => {
+    testHook(useExistingSecrets)('test-namespace', false);
+
+    const callbackArg = mockUseFetchState.mock.calls[0]?.[0];
+    expect(callbackArg).toBeDefined();
+    expect(typeof callbackArg).toBe('function');
+
+    // The callback should reject with NotReadyError when enabled is false
+    expect(() => callbackArg({})).rejects.toBeInstanceOf(NotReadyError);
+    expect(mockGetSecrets).not.toHaveBeenCalled();
+  });
+
+  it('should fire API call when enabled is true', async () => {
+    const mockOpaqueSecret = mockSecretK8sResource({ name: 'opaque-secret', type: 'Opaque' });
+    mockGetSecrets.mockResolvedValue([mockOpaqueSecret]);
+    mockIsConnection.mockReturnValue(false);
+
+    testHook(useExistingSecrets)('test-namespace', true);
+
+    const callbackArg = mockUseFetchState.mock.calls[0]?.[0];
+    await callbackArg({});
+
+    expect(mockGetSecrets).toHaveBeenCalledWith('test-namespace', {});
+  });
+
+  it('should return only Opaque type secrets', async () => {
+    const opaqueSecret = mockSecretK8sResource({ name: 'opaque-secret', type: 'Opaque' });
+    const dockerSecret = mockSecretK8sResource({
+      name: 'docker-secret',
+      type: 'kubernetes.io/dockerconfigjson',
+    });
+    const tokenSecret = mockSecretK8sResource({
+      name: 'token-secret',
+      type: 'kubernetes.io/service-account-token',
+    });
+
+    mockGetSecrets.mockResolvedValue([opaqueSecret, dockerSecret, tokenSecret]);
+    mockIsConnection.mockReturnValue(false);
+
+    testHook(useExistingSecrets)('test-namespace', true);
+
+    const callbackArg = mockUseFetchState.mock.calls[0]?.[0];
+    const result = await callbackArg({});
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(opaqueSecret);
+  });
+
+  it('should filter out Connection secrets using isConnection utility', async () => {
+    const regularSecret = mockSecretK8sResource({ name: 'regular-secret', type: 'Opaque' });
+    const connectionSecret = mockSecretK8sResource({ name: 'connection-secret', type: 'Opaque' });
+
+    mockGetSecrets.mockResolvedValue([regularSecret, connectionSecret]);
+    mockIsConnection.mockImplementation((secret) => secret.metadata.name === 'connection-secret');
+
+    testHook(useExistingSecrets)('test-namespace', true);
+
+    const callbackArg = mockUseFetchState.mock.calls[0]?.[0];
+    const result = await callbackArg({});
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(regularSecret);
+    expect(mockIsConnection).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return empty array when all secrets are filtered out', async () => {
+    const dockerSecret = mockSecretK8sResource({
+      name: 'docker-secret',
+      type: 'kubernetes.io/dockerconfigjson',
+    });
+    const connectionSecret = mockSecretK8sResource({ name: 'connection-secret', type: 'Opaque' });
+
+    mockGetSecrets.mockResolvedValue([dockerSecret, connectionSecret]);
+    mockIsConnection.mockImplementation((secret) => secret.metadata.name === 'connection-secret');
+
+    testHook(useExistingSecrets)('test-namespace', true);
+
+    const callbackArg = mockUseFetchState.mock.calls[0]?.[0];
+    const result = await callbackArg({});
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return tuple with correct structure', () => {
+    const mockSecrets = [mockSecretK8sResource({ name: 'test-secret', type: 'Opaque' })];
+    mockUseFetchState.mockReturnValue([mockSecrets, true, undefined, jest.fn()]);
+
+    const renderResult = testHook(useExistingSecrets)('test-namespace', true);
+    const [secrets, loaded, error] = renderResult.result.current;
+
+    expect(secrets).toBe(mockSecrets);
+    expect(loaded).toBe(true);
+    expect(error).toBeUndefined();
+  });
+
+  it('should handle error state from useFetchState', () => {
+    const testError = new Error('Failed to fetch secrets');
+    mockUseFetchState.mockReturnValue([[], false, testError, jest.fn()]);
+
+    const renderResult = testHook(useExistingSecrets)('test-namespace', true);
+    const [secrets, loaded, error] = renderResult.result.current;
+
+    expect(secrets).toEqual([]);
+    expect(loaded).toBe(false);
+    expect(error).toBe(testError);
+  });
+
+  it('should handle empty namespace gracefully', async () => {
+    testHook(useExistingSecrets)('', true);
+
+    const callbackArg = mockUseFetchState.mock.calls[0]?.[0];
+
+    await expect(callbackArg({})).rejects.toBeInstanceOf(NotReadyError);
+    expect(mockGetSecrets).not.toHaveBeenCalled();
+  });
+
+  it('should pass K8sAPIOptions to getSecrets', async () => {
+    const mockOpts = { signal: new AbortController().signal };
+    mockGetSecrets.mockResolvedValue([]);
+    mockIsConnection.mockReturnValue(false);
+
+    testHook(useExistingSecrets)('test-namespace', true);
+
+    const callbackArg = mockUseFetchState.mock.calls[0]?.[0];
+    await callbackArg(mockOpts);
+
+    expect(mockGetSecrets).toHaveBeenCalledWith('test-namespace', mockOpts);
+  });
+
+  it('should use correct dependency array for useCallback', () => {
+    const renderResult = testHook(useExistingSecrets)('test-namespace', true);
+
+    // Re-render with same arguments should not create new callback
+    renderResult.rerender('test-namespace', true);
+
+    expect(mockUseFetchState).toHaveBeenCalledTimes(2);
+    const firstCallback = mockUseFetchState.mock.calls[0]?.[0];
+    const secondCallback = mockUseFetchState.mock.calls[1]?.[0];
+
+    // Callbacks should be the same reference (stable)
+    expect(firstCallback).toBe(secondCallback);
+  });
+
+  it('should create new callback when namespace changes', () => {
+    const renderResult = testHook(useExistingSecrets)('namespace-1', true);
+
+    renderResult.rerender('namespace-2', true);
+
+    expect(mockUseFetchState).toHaveBeenCalledTimes(2);
+    const firstCallback = mockUseFetchState.mock.calls[0]?.[0];
+    const secondCallback = mockUseFetchState.mock.calls[1]?.[0];
+
+    // Callbacks should be different references (namespace changed)
+    expect(firstCallback).not.toBe(secondCallback);
+  });
+
+  it('should create new callback when enabled changes', () => {
+    const renderResult = testHook(useExistingSecrets)('test-namespace', false);
+
+    renderResult.rerender('test-namespace', true);
+
+    expect(mockUseFetchState).toHaveBeenCalledTimes(2);
+    const firstCallback = mockUseFetchState.mock.calls[0]?.[0];
+    const secondCallback = mockUseFetchState.mock.calls[1]?.[0];
+
+    // Callbacks should be different references (enabled changed)
+    expect(firstCallback).not.toBe(secondCallback);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
@@ -1,0 +1,352 @@
+import { getConfigMap, getSecret } from '#~/api';
+import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
+import { mockSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
+import { mockConfigMap } from '#~/__mocks__/mockConfigMap';
+import { isConnection } from '#~/concepts/connectionTypes/utils';
+import { EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+import { fetchNotebookEnvVariables } from '#~/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables';
+
+jest.mock('#~/api', () => ({
+  getConfigMap: jest.fn(),
+  getSecret: jest.fn(),
+}));
+
+jest.mock('#~/concepts/connectionTypes/utils', () => ({
+  isConnection: jest.fn(),
+}));
+
+const mockGetConfigMap = jest.mocked(getConfigMap);
+const mockGetSecret = jest.mocked(getSecret);
+const mockIsConnection = jest.mocked(isConnection);
+
+describe('fetchNotebookEnvVariables', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsConnection.mockReturnValue(false);
+  });
+
+  describe('envFrom parsing (existing behavior)', () => {
+    it('should parse envFrom.secretRef entries', async () => {
+      const secret = mockSecretK8sResource({
+        name: 'my-secret',
+        data: { KEY1: btoa('value1'), KEY2: btoa('value2') },
+      });
+      mockGetSecret.mockResolvedValue(secret);
+
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [{ secretRef: { name: 'my-secret' } }],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [
+            { key: 'KEY1', value: 'value1' },
+            { key: 'KEY2', value: 'value2' },
+          ],
+        },
+      });
+    });
+
+    it('should parse envFrom.configMapRef entries', async () => {
+      const configMap = mockConfigMap({
+        name: 'my-configmap',
+        data: { KEY1: 'value1', KEY2: 'value2' },
+      });
+      mockGetConfigMap.mockResolvedValue(configMap);
+
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [{ configMapRef: { name: 'my-configmap' } }],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: EnvironmentVariableType.CONFIG_MAP,
+        existingName: 'my-configmap',
+        values: {
+          category: expect.any(String),
+          data: [
+            { key: 'KEY1', value: 'value1' },
+            { key: 'KEY2', value: 'value2' },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('env[].valueFrom.secretKeyRef parsing (new behavior)', () => {
+    it('should parse env entries with valueFrom.secretKeyRef', async () => {
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [],
+        additionalEnvs: [
+          {
+            name: 'DB_PASSWORD',
+            valueFrom: {
+              secretKeyRef: {
+                name: 'db-credentials',
+                key: 'password',
+              },
+            },
+          },
+          {
+            name: 'DB_USERNAME',
+            valueFrom: {
+              secretKeyRef: {
+                name: 'db-credentials',
+                key: 'username',
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: EnvironmentVariableType.SECRET,
+        existingName: undefined,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'db-credentials',
+          data: [
+            { key: 'password', value: '' },
+            { key: 'username', value: '' },
+          ],
+          allKeys: false,
+        },
+      });
+    });
+
+    it('should group multiple env entries by secret name', async () => {
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [],
+        additionalEnvs: [
+          {
+            name: 'DB_PASSWORD',
+            valueFrom: { secretKeyRef: { name: 'db-creds', key: 'password' } },
+          },
+          {
+            name: 'DB_USERNAME',
+            valueFrom: { secretKeyRef: { name: 'db-creds', key: 'username' } },
+          },
+          {
+            name: 'API_KEY',
+            valueFrom: { secretKeyRef: { name: 'api-secret', key: 'key' } },
+          },
+          {
+            name: 'API_TOKEN',
+            valueFrom: { secretKeyRef: { name: 'api-secret', key: 'token' } },
+          },
+        ],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toHaveLength(2);
+      expect(result.find((e) => e.values?.secretName === 'db-creds')).toEqual({
+        type: EnvironmentVariableType.SECRET,
+        existingName: undefined,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'db-creds',
+          data: [
+            { key: 'password', value: '' },
+            { key: 'username', value: '' },
+          ],
+          allKeys: false,
+        },
+      });
+      expect(result.find((e) => e.values?.secretName === 'api-secret')).toEqual({
+        type: EnvironmentVariableType.SECRET,
+        existingName: undefined,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'api-secret',
+          data: [
+            { key: 'key', value: '' },
+            { key: 'token', value: '' },
+          ],
+          allKeys: false,
+        },
+      });
+    });
+
+    it('should skip env entries without valueFrom.secretKeyRef', async () => {
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [],
+        additionalEnvs: [
+          { name: 'NOTEBOOK_ARGS', value: 'some-value' },
+          { name: 'JUPYTER_IMAGE', value: 'image:latest' },
+          {
+            name: 'DB_PASSWORD',
+            valueFrom: { secretKeyRef: { name: 'db-creds', key: 'password' } },
+          },
+        ],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].values?.secretName).toBe('db-creds');
+    });
+
+    it('should skip env entries with other valueFrom sources', async () => {
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [],
+        additionalEnvs: [
+          {
+            name: 'CONFIG_VALUE',
+            valueFrom: { configMapKeyRef: { name: 'config', key: 'value' } },
+          },
+          {
+            name: 'POD_NAME',
+            valueFrom: { fieldRef: { fieldPath: 'metadata.name' } },
+          },
+          {
+            name: 'DB_PASSWORD',
+            valueFrom: { secretKeyRef: { name: 'db-creds', key: 'password' } },
+          },
+        ],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].values?.secretName).toBe('db-creds');
+    });
+
+    it('should handle notebook with no env array', async () => {
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle notebook with empty env array', async () => {
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [],
+        additionalEnvs: [],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('combined envFrom and env parsing', () => {
+    it('should return both envFrom and env-based env vars', async () => {
+      const secret = mockSecretK8sResource({
+        name: 'full-secret',
+        data: { KEY1: btoa('value1'), KEY2: btoa('value2') },
+      });
+      mockGetSecret.mockResolvedValue(secret);
+
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [{ secretRef: { name: 'full-secret' } }],
+        additionalEnvs: [
+          {
+            name: 'DB_PASSWORD',
+            valueFrom: { secretKeyRef: { name: 'db-creds', key: 'password' } },
+          },
+        ],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toHaveLength(2);
+      expect(result.find((e) => e.existingName === 'full-secret')).toEqual({
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'full-secret',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [
+            { key: 'KEY1', value: 'value1' },
+            { key: 'KEY2', value: 'value2' },
+          ],
+        },
+      });
+      expect(result.find((e) => e.values?.secretName === 'db-creds')).toEqual({
+        type: EnvironmentVariableType.SECRET,
+        existingName: undefined,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'db-creds',
+          data: [{ key: 'password', value: '' }],
+          allKeys: false,
+        },
+      });
+    });
+  });
+
+  describe('manually-added envFrom blocks (AC9)', () => {
+    it('should handle manually-added envFrom.secretRef entries', async () => {
+      const manualSecret = mockSecretK8sResource({
+        name: 'manual-secret',
+        data: { MANUAL_KEY: btoa('manual-value') },
+      });
+      mockGetSecret.mockResolvedValue(manualSecret);
+
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [{ secretRef: { name: 'manual-secret' } }],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'manual-secret',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'MANUAL_KEY', value: 'manual-value' }],
+        },
+      });
+    });
+
+    it('should handle 404 errors for deleted secrets gracefully', async () => {
+      mockGetSecret.mockRejectedValue({ statusObject: { code: 404 } });
+
+      const notebook = mockNotebookK8sResource({
+        name: 'test-notebook',
+        namespace: 'test-ns',
+        envFrom: [{ secretRef: { name: 'deleted-secret' } }],
+      });
+
+      const result = await fetchNotebookEnvVariables(notebook);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/utils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/utils.spec.ts
@@ -1,6 +1,10 @@
 import { Connection } from '#~/concepts/connectionTypes/types';
-import { EnvVariable, SecretCategory } from '#~/pages/projects/types';
-import { detectEnvVarConflicts } from '#~/pages/projects/screens/spawner/environmentVariables/utils';
+import { EnvVariable, SecretCategory, EnvironmentVariableType } from '#~/pages/projects/types';
+import { NotebookKind } from '#~/k8sTypes';
+import {
+  detectEnvVarConflicts,
+  getDeletedConfigMapOrSecretVariables,
+} from '#~/pages/projects/screens/spawner/environmentVariables/utils';
 
 const createEnvVariable = (
   category: SecretCategory,
@@ -193,5 +197,225 @@ describe('detectEnvVarConflicts', () => {
     const conflicts = detectEnvVarConflicts(envVariables, connections);
 
     expect(conflicts).toEqual([]);
+  });
+});
+
+const createNotebookWithExistingSecretRefs = (
+  secretRefs: Array<{ secretName: string; envName: string; key: string }>,
+): NotebookKind =>
+  ({
+    apiVersion: 'kubeflow.org/v1',
+    kind: 'Notebook',
+    metadata: {
+      name: 'test-notebook',
+      namespace: 'test-ns',
+    },
+    spec: {
+      template: {
+        spec: {
+          containers: [
+            {
+              name: 'notebook',
+              env: secretRefs.map((ref) => ({
+                name: ref.envName,
+                valueFrom: {
+                  secretKeyRef: {
+                    name: ref.secretName,
+                    key: ref.key,
+                  },
+                },
+              })),
+              envFrom: [],
+            },
+          ],
+        },
+      },
+    },
+  } as NotebookKind);
+
+const createNotebookWithEnvFrom = (
+  envFrom: Array<{ type: 'secret' | 'configMap'; name: string }>,
+): NotebookKind =>
+  ({
+    apiVersion: 'kubeflow.org/v1',
+    kind: 'Notebook',
+    metadata: {
+      name: 'test-notebook',
+      namespace: 'test-ns',
+    },
+    spec: {
+      template: {
+        spec: {
+          containers: [
+            {
+              name: 'notebook',
+              env: [],
+              envFrom: envFrom.map((item) =>
+                item.type === 'secret'
+                  ? { secretRef: { name: item.name } }
+                  : { configMapRef: { name: item.name } },
+              ),
+            },
+          ],
+        },
+      },
+    },
+  } as NotebookKind);
+
+describe('getDeletedConfigMapOrSecretVariables', () => {
+  it('should return empty arrays when notebook is undefined', () => {
+    const result = getDeletedConfigMapOrSecretVariables(undefined, []);
+    expect(result).toEqual({ deletedConfigMaps: [], deletedSecrets: [] });
+  });
+
+  it('should detect deleted envFrom secrets', () => {
+    const notebook = createNotebookWithEnvFrom([
+      { type: 'secret', name: 'secret1' },
+      { type: 'secret', name: 'secret2' },
+    ]);
+
+    const currentEnvVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret1',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [],
+        },
+      },
+    ];
+
+    const result = getDeletedConfigMapOrSecretVariables(notebook, currentEnvVars);
+
+    expect(result.deletedSecrets).toEqual(['secret2']);
+    expect(result.deletedConfigMaps).toEqual([]);
+  });
+
+  it('should detect deleted envFrom configMaps', () => {
+    const notebook = createNotebookWithEnvFrom([
+      { type: 'configMap', name: 'cm1' },
+      { type: 'configMap', name: 'cm2' },
+    ]);
+
+    const currentEnvVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.CONFIG_MAP,
+        existingName: 'cm1',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [],
+        },
+      },
+    ];
+
+    const result = getDeletedConfigMapOrSecretVariables(notebook, currentEnvVars);
+
+    expect(result.deletedConfigMaps).toEqual(['cm2']);
+    expect(result.deletedSecrets).toEqual([]);
+  });
+
+  it('should detect deleted existing secret refs', () => {
+    const notebook = createNotebookWithExistingSecretRefs([
+      { secretName: 'secret1', envName: 'KEY1', key: 'key1' },
+      { secretName: 'secret1', envName: 'KEY2', key: 'key2' },
+      { secretName: 'secret2', envName: 'KEY3', key: 'key3' },
+    ]);
+
+    const currentEnvVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'secret1',
+          data: [
+            { key: 'key1', value: '' },
+            { key: 'key2', value: '' },
+          ],
+        },
+      },
+    ];
+
+    const result = getDeletedConfigMapOrSecretVariables(notebook, currentEnvVars);
+
+    expect(result.deletedSecrets).toContain('secret2');
+    expect(result.deletedConfigMaps).toEqual([]);
+  });
+
+  it('should detect both deleted envFrom and existing secret refs', () => {
+    const notebook: NotebookKind = {
+      apiVersion: 'kubeflow.org/v1',
+      kind: 'Notebook',
+      metadata: {
+        name: 'test-notebook',
+        namespace: 'test-ns',
+      },
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              {
+                name: 'notebook',
+                env: [
+                  {
+                    name: 'KEY1',
+                    valueFrom: {
+                      secretKeyRef: {
+                        name: 'existing-secret',
+                        key: 'key1',
+                      },
+                    },
+                  },
+                ],
+                envFrom: [{ secretRef: { name: 'envfrom-secret' } }],
+              },
+            ],
+          },
+        },
+      },
+    } as NotebookKind;
+
+    const currentEnvVars: EnvVariable[] = [];
+
+    const result = getDeletedConfigMapOrSecretVariables(notebook, currentEnvVars);
+
+    expect(result.deletedSecrets).toContain('existing-secret');
+    expect(result.deletedSecrets).toContain('envfrom-secret');
+    expect(result.deletedConfigMaps).toEqual([]);
+  });
+
+  it('should exclude resources from excluded list', () => {
+    const notebook = createNotebookWithExistingSecretRefs([
+      { secretName: 'secret1', envName: 'KEY1', key: 'key1' },
+      { secretName: 'secret2', envName: 'KEY2', key: 'key2' },
+    ]);
+
+    const currentEnvVars: EnvVariable[] = [];
+
+    const result = getDeletedConfigMapOrSecretVariables(notebook, currentEnvVars, ['secret1']);
+
+    expect(result.deletedSecrets).toEqual(['secret2']);
+    expect(result.deletedConfigMaps).toEqual([]);
+  });
+
+  it('should not report as deleted when existing secret ref is still in current env vars', () => {
+    const notebook = createNotebookWithExistingSecretRefs([
+      { secretName: 'secret1', envName: 'KEY1', key: 'key1' },
+    ]);
+
+    const currentEnvVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          secretName: 'secret1',
+          data: [{ key: 'key1', value: '' }],
+        },
+      },
+    ];
+
+    const result = getDeletedConfigMapOrSecretVariables(notebook, currentEnvVars);
+
+    expect(result.deletedSecrets).toEqual([]);
+    expect(result.deletedConfigMaps).toEqual([]);
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/utils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/utils.spec.ts
@@ -1,0 +1,197 @@
+import { Connection } from '#~/concepts/connectionTypes/types';
+import { EnvVariable, SecretCategory } from '#~/pages/projects/types';
+import { detectEnvVarConflicts } from '#~/pages/projects/screens/spawner/environmentVariables/utils';
+
+const createEnvVariable = (
+  category: SecretCategory,
+  keys: string[],
+  secretName?: string,
+): EnvVariable => ({
+  type: null,
+  values: {
+    category,
+    data: keys.map((key) => ({ key, value: 'test-value' })),
+    secretName,
+  },
+});
+
+const createConnection = (name: string, keys: string[]): Connection => ({
+  apiVersion: 'v1',
+  kind: 'Secret',
+  type: 'Opaque',
+  metadata: {
+    name,
+    namespace: 'test',
+    labels: {
+      'opendatahub.io/dashboard': 'true',
+    },
+    annotations: {
+      'openshift.io/display-name': `${name} Display`,
+    },
+  },
+  data: keys.reduce((acc, key) => ({ ...acc, [key]: 'dGVzdC12YWx1ZQ==' }), {}),
+});
+
+describe('detectEnvVarConflicts', () => {
+  it('should return empty array when there are no conflicts', () => {
+    const envVariables: EnvVariable[] = [
+      createEnvVariable(SecretCategory.GENERIC, ['KEY1', 'KEY2']),
+      createEnvVariable(SecretCategory.EXISTING, ['KEY3', 'KEY4'], 'secret1'),
+    ];
+    const connections: Connection[] = [createConnection('conn1', ['KEY5', 'KEY6'])];
+
+    const conflicts = detectEnvVarConflicts(envVariables, connections);
+
+    expect(conflicts).toEqual([]);
+  });
+
+  it('should detect collision between inline secret and existing secret', () => {
+    const envVariables: EnvVariable[] = [
+      createEnvVariable(SecretCategory.GENERIC, ['KEY1', 'KEY2']),
+      createEnvVariable(SecretCategory.EXISTING, ['KEY2', 'KEY3'], 'secret1'),
+    ];
+    const connections: Connection[] = [];
+
+    const conflicts = detectEnvVarConflicts(envVariables, connections);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toEqual({
+      source1: 'Inline secret',
+      source2: 'secret1',
+      keys: ['KEY2'],
+    });
+  });
+
+  it('should detect collision between two existing secrets', () => {
+    const envVariables: EnvVariable[] = [
+      createEnvVariable(SecretCategory.EXISTING, ['KEY1', 'KEY2'], 'secret1'),
+      createEnvVariable(SecretCategory.EXISTING, ['KEY2', 'KEY3'], 'secret2'),
+    ];
+    const connections: Connection[] = [];
+
+    const conflicts = detectEnvVarConflicts(envVariables, connections);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toEqual({
+      source1: 'secret1',
+      source2: 'secret2',
+      keys: ['KEY2'],
+    });
+  });
+
+  it('should detect collision between existing secret and Connection', () => {
+    const envVariables: EnvVariable[] = [
+      createEnvVariable(SecretCategory.EXISTING, ['KEY1', 'KEY2'], 'secret1'),
+    ];
+    const connections: Connection[] = [createConnection('conn1', ['KEY2', 'KEY3'])];
+
+    const conflicts = detectEnvVarConflicts(envVariables, connections);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toEqual({
+      source1: 'secret1',
+      source2: 'conn1 Display',
+      keys: ['KEY2'],
+    });
+  });
+
+  it('should detect collision between inline secret and Connection', () => {
+    const envVariables: EnvVariable[] = [
+      createEnvVariable(SecretCategory.UPLOAD, ['KEY1', 'KEY2']),
+    ];
+    const connections: Connection[] = [createConnection('conn1', ['KEY2', 'KEY3'])];
+
+    const conflicts = detectEnvVarConflicts(envVariables, connections);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toEqual({
+      source1: 'Inline secret',
+      source2: 'conn1 Display',
+      keys: ['KEY2'],
+    });
+  });
+
+  it('should detect multiple conflicts', () => {
+    const envVariables: EnvVariable[] = [
+      createEnvVariable(SecretCategory.GENERIC, ['KEY1', 'KEY2']),
+      createEnvVariable(SecretCategory.EXISTING, ['KEY2', 'KEY3'], 'secret1'),
+      createEnvVariable(SecretCategory.EXISTING, ['KEY3', 'KEY4'], 'secret2'),
+    ];
+    const connections: Connection[] = [createConnection('conn1', ['KEY4', 'KEY5'])];
+
+    const conflicts = detectEnvVarConflicts(envVariables, connections);
+
+    expect(conflicts).toHaveLength(3);
+    expect(conflicts).toContainEqual({
+      source1: 'Inline secret',
+      source2: 'secret1',
+      keys: ['KEY2'],
+    });
+    expect(conflicts).toContainEqual({
+      source1: 'secret1',
+      source2: 'secret2',
+      keys: ['KEY3'],
+    });
+    expect(conflicts).toContainEqual({
+      source1: 'secret2',
+      source2: 'conn1 Display',
+      keys: ['KEY4'],
+    });
+  });
+
+  it('should detect multiple colliding keys in a single conflict', () => {
+    const envVariables: EnvVariable[] = [
+      createEnvVariable(SecretCategory.GENERIC, ['KEY1', 'KEY2', 'KEY3']),
+      createEnvVariable(SecretCategory.EXISTING, ['KEY2', 'KEY3', 'KEY4'], 'secret1'),
+    ];
+    const connections: Connection[] = [];
+
+    const conflicts = detectEnvVarConflicts(envVariables, connections);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toEqual({
+      source1: 'Inline secret',
+      source2: 'secret1',
+      keys: ['KEY2', 'KEY3'],
+    });
+  });
+
+  it('should handle empty env variables and connections', () => {
+    const conflicts = detectEnvVarConflicts([], []);
+
+    expect(conflicts).toEqual([]);
+  });
+
+  it('should handle env variables without values', () => {
+    const envVariables: EnvVariable[] = [
+      { type: null },
+      createEnvVariable(SecretCategory.GENERIC, ['KEY1']),
+    ];
+    const connections: Connection[] = [];
+
+    const conflicts = detectEnvVarConflicts(envVariables, connections);
+
+    expect(conflicts).toEqual([]);
+  });
+
+  it('should handle connections without data', () => {
+    const envVariables: EnvVariable[] = [createEnvVariable(SecretCategory.GENERIC, ['KEY1'])];
+    const connections: Connection[] = [
+      {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        type: 'Opaque',
+        metadata: {
+          name: 'conn1',
+          namespace: 'test',
+          labels: { 'opendatahub.io/dashboard': 'true' },
+          annotations: { 'openshift.io/display-name': 'conn1 Display' },
+        },
+      },
+    ];
+
+    const conflicts = detectEnvVarConflicts(envVariables, connections);
+
+    expect(conflicts).toEqual([]);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
@@ -1,0 +1,33 @@
+import React from 'react';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { getSecrets } from '#~/api/k8s/secrets';
+import { isConnection } from '#~/concepts/connectionTypes/utils';
+import useFetchState, {
+  FetchStateCallbackPromise,
+  NotReadyError,
+  FetchState,
+} from '#~/utilities/useFetchState';
+
+export const useExistingSecrets = (
+  namespace: string,
+  enabled: boolean,
+): FetchState<SecretKind[]> => {
+  const callback = React.useCallback<FetchStateCallbackPromise<SecretKind[]>>(
+    (opts) => {
+      if (!enabled) {
+        return Promise.reject(new NotReadyError('Hook is disabled'));
+      }
+
+      if (!namespace) {
+        return Promise.reject(new NotReadyError('No namespace provided'));
+      }
+
+      return getSecrets(namespace, opts).then((secrets) =>
+        secrets.filter((secret) => secret.type === 'Opaque' && !isConnection(secret)),
+      );
+    },
+    [namespace, enabled],
+  );
+
+  return useFetchState(callback, []);
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -16,7 +16,8 @@ import { getDeletedConfigMapOrSecretVariables, isSecretKind } from './utils';
 export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVariable[]> => {
   const container = notebook.spec.template.spec.containers[0];
   const envFromList = container.envFrom || [];
-  const envList = container.env;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- env can be undefined in K8s API responses
+  const envList = container.env || [];
 
   // Process envFrom entries (existing behavior)
   const envFromPromise = Promise.all(

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -14,8 +14,12 @@ import { isConnection } from '#~/concepts/connectionTypes/utils';
 import { getDeletedConfigMapOrSecretVariables, isSecretKind } from './utils';
 
 export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVariable[]> => {
-  const envFromList = notebook.spec.template.spec.containers[0].envFrom || [];
-  return Promise.all(
+  const container = notebook.spec.template.spec.containers[0];
+  const envFromList = container.envFrom || [];
+  const envList = container.env;
+
+  // Process envFrom entries (existing behavior)
+  const envFromPromise = Promise.all(
     envFromList
       .map((envFrom) => {
         if (envFrom.configMapRef) {
@@ -72,6 +76,40 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
       return [...acc, envVar];
     }, []),
   );
+
+  // Process env entries with valueFrom.secretKeyRef (new behavior)
+  const secretKeyRefEntries = envList.filter(
+    (envVar) => envVar.valueFrom && 'secretKeyRef' in envVar.valueFrom,
+  );
+
+  // Group by secret name
+  const groupedBySecret = secretKeyRefEntries.reduce<
+    Record<string, { name: string; key: string }[]>
+  >((acc, envVar) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const secretRef = envVar.valueFrom.secretKeyRef as { name: string; key: string };
+    const secretName = secretRef.name;
+    const existing = acc[secretName] ?? [];
+    return {
+      ...acc,
+      [secretName]: [...existing, { name: envVar.name, key: secretRef.key }],
+    };
+  }, {});
+
+  const existingSecretEnvVars: EnvVariable[] = Object.entries(groupedBySecret).map(
+    ([secretName, keys]) => ({
+      type: EnvironmentVariableType.SECRET,
+      existingName: undefined,
+      values: {
+        category: SecretCategory.EXISTING,
+        secretName,
+        data: keys.map(({ key }) => ({ key, value: '' })),
+        allKeys: false,
+      },
+    }),
+  );
+
+  return envFromPromise.then((envFromVars) => [...envFromVars, ...existingSecretEnvVars]);
 };
 
 export const useNotebookEnvVariables = (

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
@@ -1,5 +1,6 @@
 import type { SecretKind } from '@odh-dashboard/k8s-core';
 import { ConfigMapKind, NotebookKind } from '#~/k8sTypes';
+import { Connection } from '#~/concepts/connectionTypes/types';
 import { EnvVariable, SecretCategory } from '#~/pages/projects/types';
 
 export const updateArrayValue = <T>(values: T[], index: number, partialValue: Partial<T>): T[] =>
@@ -54,4 +55,77 @@ export const getDeletedConfigMapOrSecretVariables = (
     }
   });
   return { deletedSecrets, deletedConfigMaps };
+};
+
+export type EnvVarConflict = {
+  source1: string;
+  source2: string;
+  keys: string[];
+};
+
+export const detectEnvVarConflicts = (
+  envVariables: EnvVariable[],
+  connections: Connection[],
+): EnvVarConflict[] => {
+  const conflicts: EnvVarConflict[] = [];
+
+  type Source = {
+    name: string;
+    keys: string[];
+  };
+
+  const sources: Source[] = [];
+
+  envVariables.forEach((envVar) => {
+    if (!envVar.values?.data) {
+      return;
+    }
+
+    const keys = envVar.values.data.map((entry) => entry.key);
+
+    if (envVar.values.category === SecretCategory.EXISTING) {
+      const sourceName = envVar.values.secretName || 'Existing secret';
+      sources.push({ name: sourceName, keys });
+    } else if (
+      envVar.values.category === SecretCategory.GENERIC ||
+      envVar.values.category === SecretCategory.UPLOAD
+    ) {
+      const existingInline = sources.find((s) => s.name === 'Inline secret');
+      if (existingInline) {
+        existingInline.keys.push(...keys);
+      } else {
+        sources.push({ name: 'Inline secret', keys });
+      }
+    }
+  });
+
+  connections.forEach((connection) => {
+    if (!connection.data) {
+      return;
+    }
+
+    const keys = Object.keys(connection.data);
+    const displayName =
+      connection.metadata.annotations['openshift.io/display-name'] || connection.metadata.name;
+    sources.push({ name: displayName, keys });
+  });
+
+  for (let i = 0; i < sources.length; i++) {
+    for (let j = i + 1; j < sources.length; j++) {
+      const first = sources[i];
+      const second = sources[j];
+
+      const duplicateKeys = first.keys.filter((key) => second.keys.includes(key));
+
+      if (duplicateKeys.length > 0) {
+        conflicts.push({
+          source1: first.name,
+          source2: second.name,
+          keys: duplicateKeys,
+        });
+      }
+    }
+  }
+
+  return conflicts;
 };

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
@@ -61,13 +61,10 @@ export const getDeletedConfigMapOrSecretVariables = (
     (envVar) => envVar.valueFrom && 'secretKeyRef' in envVar.valueFrom,
   );
 
-  // Group by secret name to find which secrets are in the notebook CR
   const secretsInNotebook = new Set(
-    secretKeyRefEntries.map((envVar) => {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      const secretRef = envVar.valueFrom.secretKeyRef as { name: string; key: string };
-      return secretRef.name;
-    }),
+    secretKeyRefEntries
+      .map((envVar) => envVar.valueFrom?.secretKeyRef?.name)
+      .filter((name): name is string => !!name),
   );
 
   // Get set of secret names currently in form state (EXISTING category)
@@ -85,7 +82,10 @@ export const getDeletedConfigMapOrSecretVariables = (
     }
   });
 
-  return { deletedSecrets, deletedConfigMaps };
+  return {
+    deletedSecrets: Array.from(new Set(deletedSecrets)),
+    deletedConfigMaps: Array.from(new Set(deletedConfigMaps)),
+  };
 };
 
 export type EnvVarConflict = {

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
@@ -1,6 +1,6 @@
 import type { SecretKind } from '@odh-dashboard/k8s-core';
 import { ConfigMapKind, NotebookKind } from '#~/k8sTypes';
-import { EnvVariable } from '#~/pages/projects/types';
+import { EnvVariable, SecretCategory } from '#~/pages/projects/types';
 
 export const updateArrayValue = <T>(values: T[], index: number, partialValue: Partial<T>): T[] =>
   values.map((v, i) => (i === index ? { ...v, ...partialValue } : v));
@@ -20,6 +20,10 @@ export const isStringKeyValuePairObject = (object: unknown): object is Record<st
   Object.entries(object).every(
     ([key, value]) => typeof key === 'string' && typeof value === 'string',
   );
+
+export const isExistingSecretCategory = (
+  category: SecretCategory | null | undefined,
+): category is SecretCategory.EXISTING => category === SecretCategory.EXISTING;
 
 export const getDeletedConfigMapOrSecretVariables = (
   notebook: NotebookKind | undefined,

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
@@ -119,7 +119,8 @@ export const detectEnvVarConflicts = (
       sources.push({ name: sourceName, keys });
     } else if (
       envVar.values.category === SecretCategory.GENERIC ||
-      envVar.values.category === SecretCategory.UPLOAD
+      envVar.values.category === SecretCategory.UPLOAD ||
+      envVar.values.category === SecretCategory.AWS
     ) {
       const existingInline = sources.find((s) => s.name === 'Inline secret');
       if (existingInline) {

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/utils.ts
@@ -54,6 +54,37 @@ export const getDeletedConfigMapOrSecretVariables = (
       deletedSecrets.push(env.secretRef.name);
     }
   });
+
+  // Process env entries with valueFrom.secretKeyRef (existing secret refs)
+  const envList = notebook?.spec.template.spec.containers[0].env || [];
+  const secretKeyRefEntries = envList.filter(
+    (envVar) => envVar.valueFrom && 'secretKeyRef' in envVar.valueFrom,
+  );
+
+  // Group by secret name to find which secrets are in the notebook CR
+  const secretsInNotebook = new Set(
+    secretKeyRefEntries.map((envVar) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const secretRef = envVar.valueFrom.secretKeyRef as { name: string; key: string };
+      return secretRef.name;
+    }),
+  );
+
+  // Get set of secret names currently in form state (EXISTING category)
+  const existingSecretNames = new Set(
+    envVariables
+      .filter((envVar) => envVar.values?.category === SecretCategory.EXISTING)
+      .map((envVar) => envVar.values?.secretName)
+      .filter((name): name is string => !!name),
+  );
+
+  // Find secrets that are in the notebook CR but not in current form state
+  secretsInNotebook.forEach((secretName) => {
+    if (!existingSecretNames.has(secretName) && !excludedResources.includes(secretName)) {
+      deletedSecrets.push(secretName);
+    }
+  });
+
   return { deletedSecrets, deletedConfigMaps };
 };
 

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -203,7 +203,10 @@ export const updateConfigMapsAndSecretsForNotebook = async (
   envVariables: EnvVariable[],
   connections?: Connection[],
   dryRun = false,
-): Promise<EnvironmentFromVariable[]> => {
+): Promise<{
+  envFrom: EnvironmentFromVariable[];
+  existingSecretEnvVars: ExistingSecretEnvVar[];
+}> => {
   const existingEnvVars = await fetchNotebookEnvVariables(notebook);
   const { deletedConfigMaps, deletedSecrets } = getDeletedConfigMapOrSecretVariables(
     notebook,
@@ -211,7 +214,13 @@ export const updateConfigMapsAndSecretsForNotebook = async (
     [...(connections || []).map((connection) => connection.metadata.name)],
   );
 
-  const [oldResources, newResources] = _.partition(envVariables, (envVar) => envVar.existingName);
+  // Separate EXISTING env vars from inline env vars
+  const [existingSecretEnvVars, inlineEnvVars] = _.partition(
+    envVariables,
+    (envVar) => envVar.values?.category === SecretCategory.EXISTING,
+  );
+
+  const [oldResources, newResources] = _.partition(inlineEnvVars, (envVar) => envVar.existingName);
   const currentNames = oldResources
     .map((envVar) => envVar.existingName)
     .filter((v): v is string => !!v);
@@ -259,7 +268,7 @@ export const updateConfigMapsAndSecretsForNotebook = async (
     dryRun,
   );
 
-  const [created] = await Promise.all([
+  const [created, , updated] = await Promise.all([
     Promise.all(creatingPromises),
     Promise.all(deletingPromises),
     Promise.all(updatingPromises),
@@ -270,9 +279,14 @@ export const updateConfigMapsAndSecretsForNotebook = async (
 
   const envFromList = notebook.spec.template.spec.containers[0].envFrom || [];
 
-  return getEnvFromList(created, [...envFromList]).filter(
-    (envFrom) =>
-      !(envFrom.secretRef?.name && deletingNames.includes(envFrom.secretRef.name)) &&
-      !(envFrom.configMapRef?.name && deletingNames.includes(envFrom.configMapRef.name)),
+  const allResources = [...created, ...updated];
+  const envFrom = getEnvFromList(allResources, [...envFromList]).filter(
+    (envFromItem) =>
+      !(envFromItem.secretRef?.name && deletingNames.includes(envFromItem.secretRef.name)) &&
+      !(envFromItem.configMapRef?.name && deletingNames.includes(envFromItem.configMapRef.name)),
   );
+
+  const extractedExistingSecretEnvVars = extractExistingSecretEnvVars(existingSecretEnvVars);
+
+  return { envFrom, existingSecretEnvVars: extractedExistingSecretEnvVars };
 };

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -22,6 +22,7 @@ import {
   ConfigMapCategory,
   EnvironmentFromVariable,
   EnvVariable,
+  ExistingSecretEnvVar,
   SecretCategory,
   StorageData,
   StorageType,
@@ -74,6 +75,36 @@ export const updatePvcDataForNotebook = async (
   return { volumes, volumeMounts };
 };
 
+export const extractExistingSecretEnvVars = (
+  envVariables: EnvVariable[],
+): ExistingSecretEnvVar[] => {
+  const result: ExistingSecretEnvVar[] = [];
+
+  envVariables.forEach((envVar) => {
+    if (
+      !envVar.values ||
+      envVar.values.category !== SecretCategory.EXISTING ||
+      !envVar.values.secretName
+    ) {
+      return;
+    }
+
+    const { secretName, data } = envVar.values;
+    if (data.length === 0) {
+      return;
+    }
+
+    data.forEach((entry) => {
+      result.push({
+        name: secretName,
+        key: entry.key,
+      });
+    });
+  });
+
+  return result;
+};
+
 const getPromisesForConfigMapsAndSecrets = (
   projectName: string,
   envVariables: EnvVariable[],
@@ -106,6 +137,8 @@ const getPromisesForConfigMapsAndSecrets = (
             : replaceSecret(assembleSecret(projectName, dataAsRecord, 'aws', envVar.existingName), {
                 dryRun,
               });
+        case SecretCategory.EXISTING:
+          return null;
         case ConfigMapCategory.GENERIC:
         case ConfigMapCategory.UPLOAD:
           return type === 'create'

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -85,6 +85,11 @@ export type StorageData = {
   modelPath?: string;
 };
 
+export type ExistingSecretEnvVar = {
+  name: string;
+  key: string;
+};
+
 export type StartNotebookData = {
   projectName: string;
   notebookData: K8sNameDescriptionFieldData;
@@ -97,6 +102,7 @@ export type StartNotebookData = {
   hardwareProfileOptions: UseAssignHardwareProfileResult<NotebookKind>;
   feastData?: FeastData;
   mlflowEnabled?: boolean;
+  existingSecretEnvVars?: ExistingSecretEnvVar[];
 };
 
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- re-exporting shared types for backward compatibility
@@ -109,6 +115,7 @@ export type EnvVariableDataEntry = KeyValuePair;
 export type EnvVariableData = {
   category: SecretCategory | ConfigMapCategory | null;
   data: EnvVariableDataEntry[];
+  allKeys?: boolean;
 };
 
 export type EnvVariable = {
@@ -125,6 +132,7 @@ export enum SecretCategory {
   GENERIC = 'secret key-value',
   AWS = 'aws',
   UPLOAD = 'secret upload',
+  EXISTING = 'existing secret',
 }
 export enum ConfigMapCategory {
   GENERIC = 'configmap key-value',

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -116,6 +116,7 @@ export type EnvVariableData = {
   category: SecretCategory | ConfigMapCategory | null;
   data: EnvVariableDataEntry[];
   allKeys?: boolean;
+  secretName?: string;
 };
 
 export type EnvVariable = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8355,6 +8355,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9041,6 +9042,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9057,6 +9059,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9073,6 +9076,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9089,6 +9093,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9105,6 +9110,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9121,6 +9127,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9137,6 +9144,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9153,6 +9161,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9169,6 +9178,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9185,6 +9195,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9201,6 +9212,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9217,6 +9229,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13732,6 +13745,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {


### PR DESCRIPTION
## Summary

Add a third option ('Existing secret') to the workbench environment variables form when Secret type is selected. Users can reference pre-existing Kubernetes Secrets by name via a typeahead dropdown, with selected keys injected as env[].valueFrom.secretKeyRef entries in the Notebook CR.

**Scores:** architecture 9/10, tests 9/10, lint 8/10, intent 9/10 (weighted avg 8.8/10)

## Changes

- Extended type system with SecretCategory.EXISTING and ExistingSecretEnvVar
- Added secret listing API and lazy-loading hook (fires only when option selected)
- Built typeahead secret selector with key picker (secret values never rendered)
- Notebook CR mutation for create and update flows using env[].valueFrom.secretKeyRef
- Edit view parsing of existing secretKeyRef entries from Notebook CR
- Cross-source conflict detection (inline secrets, existing secrets, Connections)
- Integration wiring into spawner form with save validation
- Deletion detection for removed existing secret references

## Test Plan

- [ ] Unit tests for type utilities, conflict detection, deletion detection
- [ ] Unit tests for hooks (useExistingSecrets, useNotebookEnvVariables)
- [ ] Unit tests for components (EnvExistingSecret, EnvVarConflictWarning)
- [ ] Unit tests for service layer (create/update flows, assembleNotebook)
- [ ] Manual verification of create flow with existing secret selection
- [ ] Manual verification of edit flow with pre-existing secretKeyRef entries
- [ ] Verify conflict warning displays when env var keys collide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using existing Kubernetes Secrets as environment variables when creating or updating a workbench.
  * Users can now choose an existing secret, pick specific keys, and see conflict warnings when environment variables overlap.

* **Bug Fixes**
  * Improved workbench updates so secret-based environment variables are preserved correctly.
  * Fixed handling of environment variable changes to avoid unintended merges and missing secret references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->