### PR TITLE
chore: model-serving tilt opt-in for RHAII

### DIFF
--- a/distributions/base/src/ErrorBoundary.tsx
+++ b/distributions/base/src/ErrorBoundary.tsx
@@ -1,6 +1,17 @@
 import React from 'react';
 import { Alert, PageSection } from '@patternfly/react-core';
 
+const normalizeError = (value: unknown): Error => {
+  if (value instanceof Error) {
+    return value;
+  }
+  try {
+    return new Error(String(value));
+  } catch {
+    return new Error('Unknown error');
+  }
+};
+
 type ErrorBoundaryProps = {
   children?: React.ReactNode;
 };
@@ -15,12 +26,12 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    return { hasError: true, error, errorInfo: { componentStack: '' } };
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    return { hasError: true, error: normalizeError(error), errorInfo: { componentStack: '' } };
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
-    this.setState({ hasError: true, error, errorInfo });
+  componentDidCatch(error: unknown, errorInfo: React.ErrorInfo): void {
+    this.setState({ hasError: true, error: normalizeError(error), errorInfo });
     // eslint-disable-next-line no-console
     console.error('ErrorBoundary caught:', error, errorInfo);
   }

--- a/distributions/base/src/ErrorBoundary.tsx
+++ b/distributions/base/src/ErrorBoundary.tsx
@@ -27,10 +27,14 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
 
   render(): React.ReactNode {
     if (this.state.hasError) {
+      const { error } = this.state;
       return (
         <PageSection hasBodyWrapper={false}>
-          <Alert variant="danger" isInline title="Something went wrong">
-            An unexpected error occurred. Please try again or contact support.
+          <Alert variant="danger" isInline isExpandable title="Something went wrong">
+            <p>An unexpected error occurred while loading this content.</p>
+            <p>
+              <strong>{error.name}:</strong> {error.message}
+            </p>
           </Alert>
         </PageSection>
       );

--- a/distributions/base/src/NotFound.tsx
+++ b/distributions/base/src/NotFound.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { PageSection, EmptyState, EmptyStateBody } from '@patternfly/react-core';
+
+type NotFoundProps = {
+  hasRoutes?: boolean;
+};
+
+const NotFound: React.FC<NotFoundProps> = ({ hasRoutes = true }) => (
+  <PageSection hasBodyWrapper={false}>
+    <EmptyState headingLevel="h1" titleText={hasRoutes ? 'Page not found' : 'No features loaded'}>
+      <EmptyStateBody>
+        {hasRoutes
+          ? 'The requested page could not be found. Check the URL or navigate using the sidebar.'
+          : 'This is the base shell framework. Add a distribution layer to enable features.'}
+      </EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default NotFound;

--- a/distributions/base/src/ShellNav.tsx
+++ b/distributions/base/src/ShellNav.tsx
@@ -13,10 +13,14 @@ import {
   isNavExtension,
   isHrefNavItemExtension,
   isNavSectionExtension,
+  isTabRoutePageExtension,
+  isTabRouteTabExtension,
   type NavExtension,
   type HrefNavItemExtension,
   type NavSectionExtension,
   type NavItemProperties,
+  type TabRoutePageExtension,
+  type TabRouteTabExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
 import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
 
@@ -24,6 +28,7 @@ import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
 // frontend/src/app/navigation/utils.ts. Move to plugin-core when consolidating.
 const DEFAULT_GROUP = '5_default';
 
+type AnyNavExtension = NavExtension | TabRoutePageExtension;
 type NavLikeExtension = Extension<string, NavItemProperties>;
 
 const compareNavItemGroups = <T extends NavLikeExtension>(a: T, b: T): number =>
@@ -88,6 +93,31 @@ const NavHrefItem: React.FC<{ extension: LoadedExtension<HrefNavItemExtension> }
   );
 };
 
+const NavTabRouteItem: React.FC<{ extension: LoadedExtension<TabRoutePageExtension> }> = ({
+  extension: {
+    properties: { id, href, path, dataAttributes, title },
+  },
+}) => {
+  const allTabExtensions = useExtensions<TabRouteTabExtension>(isTabRouteTabExtension);
+  const tabs = React.useMemo(
+    () => allTabExtensions.filter((tab) => tab.properties.pageId === id),
+    [allTabExtensions, id],
+  );
+  const isMatch = !!useMatch(path);
+
+  if (tabs.length === 0) {
+    return null;
+  }
+
+  return (
+    <NavItem isActive={isMatch}>
+      <Link {...dataAttributes} to={href}>
+        {title}
+      </Link>
+    </NavItem>
+  );
+};
+
 const NavSectionItem: React.FC<{ extension: LoadedExtension<NavSectionExtension> }> = ({
   extension: {
     properties: { id, title },
@@ -95,10 +125,25 @@ const NavSectionItem: React.FC<{ extension: LoadedExtension<NavSectionExtension>
 }) => {
   const { pathname } = useLocation();
   const allNavExtensions = useExtensions<NavExtension>(isNavExtension);
-  const children = React.useMemo(
+  const tabRoutePageExtensions = useExtensions<TabRoutePageExtension>(isTabRoutePageExtension);
+  const tabRouteTabExtensions = useExtensions<TabRouteTabExtension>(isTabRouteTabExtension);
+
+  const tabRoutePagesWithTabs = React.useMemo(
     () =>
-      allNavExtensions.filter((e) => e.properties.section === id).toSorted(compareNavItemGroups),
-    [id, allNavExtensions],
+      tabRoutePageExtensions.filter((page) =>
+        tabRouteTabExtensions.some((tab) => tab.properties.pageId === page.properties.id),
+      ),
+    [tabRoutePageExtensions, tabRouteTabExtensions],
+  );
+
+  const allExtensions: LoadedExtension<AnyNavExtension>[] = React.useMemo(
+    () => [...allNavExtensions, ...tabRoutePagesWithTabs],
+    [allNavExtensions, tabRoutePagesWithTabs],
+  );
+
+  const children = React.useMemo(
+    () => allExtensions.filter((e) => e.properties.section === id).toSorted(compareNavItemGroups),
+    [id, allExtensions],
   );
 
   const isActive = React.useMemo(
@@ -107,6 +152,9 @@ const NavSectionItem: React.FC<{ extension: LoadedExtension<NavSectionExtension>
         if (isHrefNavItemExtension(child)) {
           const matchTarget = child.properties.path ?? child.properties.href;
           return !!matchPath(matchTarget, pathname);
+        }
+        if (isTabRoutePageExtension(child)) {
+          return !!matchPath(child.properties.path, pathname);
         }
         return false;
       }),
@@ -139,9 +187,14 @@ const NavSectionItem: React.FC<{ extension: LoadedExtension<NavSectionExtension>
   );
 };
 
-const ShellNavItem: React.FC<{ extension: LoadedExtension<NavExtension> }> = ({ extension }) => {
+const ShellNavItem: React.FC<{
+  extension: LoadedExtension<NavExtension> | LoadedExtension<TabRoutePageExtension>;
+}> = ({ extension }) => {
   if (isNavSectionExtension(extension)) {
     return <NavSectionItem extension={extension} />;
+  }
+  if (isTabRoutePageExtension(extension)) {
+    return <NavTabRouteItem extension={extension} />;
   }
   if (isHrefNavItemExtension(extension)) {
     return <NavHrefItem extension={extension} />;
@@ -151,9 +204,10 @@ const ShellNavItem: React.FC<{ extension: LoadedExtension<NavExtension> }> = ({ 
 
 const ShellNav: React.FC = () => {
   const navExtensions = useExtensions<NavExtension>(isNavExtension);
+  const tabRouteExtensions = useExtensions<TabRoutePageExtension>(isTabRoutePageExtension);
   const topLevelExtensions = React.useMemo(
-    () => getTopLevelExtensions(navExtensions),
-    [navExtensions],
+    () => getTopLevelExtensions([...navExtensions, ...tabRouteExtensions]),
+    [navExtensions, tabRouteExtensions],
   );
 
   return (

--- a/distributions/base/src/ShellRoutes.tsx
+++ b/distributions/base/src/ShellRoutes.tsx
@@ -5,7 +5,9 @@ import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core'
 import {
   isRouteExtension,
   isTabRoutePageExtension,
+  isTabRouteTabExtension,
   type TabRoutePageExtension,
+  type TabRouteTabExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
 import NotFound from './NotFound';
 import TabRoutePage from './TabRoutePage';
@@ -20,6 +22,15 @@ const fallback = (
 const ShellRoutes: React.FC = () => {
   const routeExtensions = useExtensions(isRouteExtension);
   const tabRoutePageExtensions = useExtensions<TabRoutePageExtension>(isTabRoutePageExtension);
+  const tabRouteTabExtensions = useExtensions<TabRouteTabExtension>(isTabRouteTabExtension);
+
+  const usableTabRoutePages = React.useMemo(
+    () =>
+      tabRoutePageExtensions.filter((page) =>
+        tabRouteTabExtensions.some((tab) => tab.properties.pageId === page.properties.id),
+      ),
+    [tabRoutePageExtensions, tabRouteTabExtensions],
+  );
 
   const dynamicRoutes = React.useMemo(
     () =>
@@ -43,7 +54,7 @@ const ShellRoutes: React.FC = () => {
 
   const tabRoutePages = React.useMemo(
     () =>
-      tabRoutePageExtensions.map((pageExtension) => (
+      usableTabRoutePages.map((pageExtension) => (
         <Route
           key={pageExtension.uid}
           path={pageExtension.properties.path}
@@ -54,10 +65,10 @@ const ShellRoutes: React.FC = () => {
           }
         />
       )),
-    [tabRoutePageExtensions],
+    [usableTabRoutePages],
   );
 
-  const hasRoutes = dynamicRoutes.length > 0 || tabRoutePages.length > 0;
+  const hasRoutes = dynamicRoutes.length > 0 || usableTabRoutePages.length > 0;
 
   return (
     <React.Suspense fallback={fallback}>

--- a/distributions/base/src/ShellRoutes.tsx
+++ b/distributions/base/src/ShellRoutes.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { PageSection, EmptyState, EmptyStateBody, Spinner, Bullseye } from '@patternfly/react-core';
+import { Spinner, Bullseye } from '@patternfly/react-core';
 import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core';
-import { isRouteExtension } from '@odh-dashboard/plugin-core/extension-points';
+import {
+  isRouteExtension,
+  isTabRoutePageExtension,
+  type TabRoutePageExtension,
+} from '@odh-dashboard/plugin-core/extension-points';
+import NotFound from './NotFound';
+import TabRoutePage from './TabRoutePage';
+import { ErrorBoundary } from './ErrorBoundary';
 
 const fallback = (
   <Bullseye>
@@ -10,20 +17,9 @@ const fallback = (
   </Bullseye>
 );
 
-const NotFound: React.FC<{ hasRoutes: boolean }> = ({ hasRoutes }) => (
-  <PageSection hasBodyWrapper={false}>
-    <EmptyState headingLevel="h1" titleText={hasRoutes ? 'Page not found' : 'No features loaded'}>
-      <EmptyStateBody>
-        {hasRoutes
-          ? 'The requested page could not be found. Check the URL or navigate using the sidebar.'
-          : 'This is the base shell framework. Add a distribution layer to enable features.'}
-      </EmptyStateBody>
-    </EmptyState>
-  </PageSection>
-);
-
 const ShellRoutes: React.FC = () => {
   const routeExtensions = useExtensions(isRouteExtension);
+  const tabRoutePageExtensions = useExtensions<TabRoutePageExtension>(isTabRoutePageExtension);
 
   const dynamicRoutes = React.useMemo(
     () =>
@@ -32,22 +28,43 @@ const ShellRoutes: React.FC = () => {
           key={routeExtension.uid}
           path={routeExtension.properties.path}
           element={
-            <LazyCodeRefComponent
-              key={routeExtension.uid}
-              component={routeExtension.properties.component}
-              fallback={fallback}
-            />
+            <ErrorBoundary>
+              <LazyCodeRefComponent
+                key={routeExtension.uid}
+                component={routeExtension.properties.component}
+                fallback={fallback}
+              />
+            </ErrorBoundary>
           }
         />
       )),
     [routeExtensions],
   );
 
+  const tabRoutePages = React.useMemo(
+    () =>
+      tabRoutePageExtensions.map((pageExtension) => (
+        <Route
+          key={pageExtension.uid}
+          path={pageExtension.properties.path}
+          element={
+            <ErrorBoundary>
+              <TabRoutePage extension={pageExtension} />
+            </ErrorBoundary>
+          }
+        />
+      )),
+    [tabRoutePageExtensions],
+  );
+
+  const hasRoutes = dynamicRoutes.length > 0 || tabRoutePages.length > 0;
+
   return (
     <React.Suspense fallback={fallback}>
       <Routes>
         {dynamicRoutes}
-        <Route path="*" element={<NotFound hasRoutes={dynamicRoutes.length > 0} />} />
+        {tabRoutePages}
+        <Route path="*" element={<NotFound hasRoutes={hasRoutes} />} />
       </Routes>
     </React.Suspense>
   );

--- a/distributions/base/src/TabRoutePage.tsx
+++ b/distributions/base/src/TabRoutePage.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { Content, PageSection, Spinner, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import type { LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import {
+  isTabRouteTabExtension,
+  type TabRoutePageExtension,
+  type TabRouteTabExtension,
+} from '@odh-dashboard/plugin-core/extension-points';
+import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core';
+import NotFound from './NotFound';
+import { ErrorBoundary } from './ErrorBoundary';
+
+type TabRoutePageProps = {
+  extension: LoadedExtension<TabRoutePageExtension>;
+};
+
+const tabSortComparator = (
+  a: LoadedExtension<TabRouteTabExtension>,
+  b: LoadedExtension<TabRouteTabExtension>,
+): number => {
+  const DEFAULT_GROUP = '5_default';
+  return (a.properties.group || DEFAULT_GROUP).localeCompare(b.properties.group || DEFAULT_GROUP);
+};
+
+const SESSION_STORAGE_PREFIX = 'tab-route-last-tab:';
+
+const getPersistedTab = (pageId: string): string | null => {
+  try {
+    return sessionStorage.getItem(`${SESSION_STORAGE_PREFIX}${pageId}`);
+  } catch {
+    return null;
+  }
+};
+
+const persistTab = (pageId: string, tabId: string): void => {
+  try {
+    sessionStorage.setItem(`${SESSION_STORAGE_PREFIX}${pageId}`, tabId);
+  } catch {
+    // sessionStorage may be unavailable
+  }
+};
+
+const getDefaultTab = (
+  pageId: string,
+  tabExtensions: LoadedExtension<TabRouteTabExtension>[],
+): string => {
+  const persisted = getPersistedTab(pageId);
+  if (persisted && tabExtensions.some((t) => t.properties.id === persisted)) {
+    return persisted;
+  }
+  return tabExtensions[0].properties.id;
+};
+
+type MultiTabContentProps = {
+  pageTitle: React.ReactNode;
+  tabExtensions: LoadedExtension<TabRouteTabExtension>[];
+  extension: LoadedExtension<TabRoutePageExtension>;
+  defaultTab: string;
+  tabContentFallback: React.ReactNode;
+};
+
+const MultiTabContent: React.FC<MultiTabContentProps> = ({
+  pageTitle,
+  tabExtensions,
+  extension,
+  defaultTab,
+  tabContentFallback,
+}) => {
+  const { tabId = '' } = useParams<{ tabId: string }>();
+  const navigate = useNavigate();
+
+  const activeTab = tabExtensions.find((t) => t.properties.id === tabId);
+
+  if (!activeTab) {
+    return <Navigate to={`../${defaultTab}`} replace />;
+  }
+
+  return (
+    <>
+      {pageTitle}
+      <PageSection type="tabs">
+        <Tabs
+          activeKey={tabId}
+          onSelect={(_event, tabKey) => {
+            navigate(`${extension.properties.href}/${String(tabKey)}`);
+          }}
+        >
+          {tabExtensions.map((t) => (
+            <Tab
+              key={t.properties.id}
+              eventKey={t.properties.id}
+              title={<TabTitleText>{t.properties.title}</TabTitleText>}
+              tabContentId={`tab-content-${t.properties.id}`}
+              data-testid={`tab-${t.properties.id}`}
+            />
+          ))}
+        </Tabs>
+      </PageSection>
+      {tabExtensions.map((t) => (
+        <div
+          key={t.properties.id}
+          id={`tab-content-${t.properties.id}`}
+          role="tabpanel"
+          hidden={t.properties.id !== activeTab.properties.id || undefined}
+        >
+          {t.properties.id === activeTab.properties.id && (
+            <ErrorBoundary>
+              <LazyCodeRefComponent
+                component={t.properties.component}
+                fallback={tabContentFallback}
+              />
+            </ErrorBoundary>
+          )}
+        </div>
+      ))}
+    </>
+  );
+};
+
+const TabRoutePage: React.FC<TabRoutePageProps> = ({ extension }) => {
+  const pageId = extension.properties.id;
+  const allTabExtensions = useExtensions<TabRouteTabExtension>(isTabRouteTabExtension);
+  const location = useLocation();
+
+  const tabExtensions = React.useMemo(
+    () =>
+      allTabExtensions
+        .filter((tab) => tab.properties.pageId === pageId)
+        .toSorted(tabSortComparator),
+    [allTabExtensions, pageId],
+  );
+
+  React.useEffect(() => {
+    const basePath = extension.properties.href;
+    const relativePath = location.pathname.startsWith(basePath)
+      ? location.pathname.slice(basePath.length).replace(/^\//, '')
+      : '';
+    const activeSegment = relativePath.split('/')[0];
+    if (activeSegment && tabExtensions.some((t) => t.properties.id === activeSegment)) {
+      persistTab(pageId, activeSegment);
+    }
+  }, [location.pathname, extension.properties.href, pageId, tabExtensions]);
+
+  if (tabExtensions.length === 0) {
+    return <NotFound />;
+  }
+
+  const pageTitle = (
+    <PageSection hasBodyWrapper={false}>
+      <Content component="h1" data-testid="app-tab-page-title">
+        {extension.properties.title}
+      </Content>
+    </PageSection>
+  );
+
+  const tabContentFallback = (
+    <PageSection>
+      <Spinner />
+    </PageSection>
+  );
+
+  const defaultTab = getDefaultTab(pageId, tabExtensions);
+
+  if (tabExtensions.length === 1 && !extension.properties.alwaysShowTabBar) {
+    const singleTab = tabExtensions[0];
+    return (
+      <Routes>
+        <Route
+          path={`${singleTab.properties.id}/*`}
+          element={
+            <>
+              {pageTitle}
+              <ErrorBoundary>
+                <LazyCodeRefComponent
+                  component={singleTab.properties.component}
+                  fallback={tabContentFallback}
+                />
+              </ErrorBoundary>
+            </>
+          }
+        />
+        <Route
+          path="*"
+          element={
+            <Navigate to={`${extension.properties.href}/${singleTab.properties.id}`} replace />
+          }
+        />
+      </Routes>
+    );
+  }
+
+  return (
+    <Routes>
+      <Route
+        path=":tabId/*"
+        element={
+          <MultiTabContent
+            pageTitle={pageTitle}
+            tabExtensions={tabExtensions}
+            extension={extension}
+            defaultTab={defaultTab}
+            tabContentFallback={tabContentFallback}
+          />
+        }
+      />
+      <Route
+        path="*"
+        element={<Navigate to={`${extension.properties.href}/${defaultTab}`} replace />}
+      />
+    </Routes>
+  );
+};
+
+export default TabRoutePage;

--- a/distributions/rhaii/Dockerfile
+++ b/distributions/rhaii/Dockerfile
@@ -3,6 +3,9 @@
 #
 # Build from repository root:
 #   docker build -f distributions/rhaii/Dockerfile -t rhaii-dashboard:latest .
+#
+# With model-serving enabled:
+#   docker build -f distributions/rhaii/Dockerfile --build-arg ENABLE_MODEL_SERVING=true -t rhaii-dashboard:latest .
 
 ARG NODE_BASE_IMAGE=node:22
 ARG GOLANG_BASE_IMAGE=golang:1.25
@@ -22,6 +25,13 @@ COPY frontend/src/ ./frontend/src/
 COPY packages/plugin-core/ ./packages/plugin-core/
 COPY packages/tsconfig/ ./packages/tsconfig/
 
+# Copy optional packages (always copied for npm workspace resolution;
+# only compiled into the bundle when their env flag is set)
+COPY packages/model-serving/ ./packages/model-serving/
+COPY packages/k8s-core/ ./packages/k8s-core/
+COPY packages/model-registry/ ./packages/model-registry/
+COPY packages/ui-core/ ./packages/ui-core/
+
 # Copy the base distribution (shell components + shared webpack config)
 COPY distributions/base/ ./distributions/base/
 
@@ -36,6 +46,8 @@ RUN npm ci
 
 # Build the RHAII frontend
 WORKDIR /usr/src/workspace/distributions/rhaii
+ARG ENABLE_MODEL_SERVING=false
+ENV ENABLE_MODEL_SERVING=${ENABLE_MODEL_SERVING}
 RUN npm run build
 
 # ── Stage 2: BFF Builder ─────────────────────────────────────────────────────

--- a/distributions/rhaii/config/webpack.common.js
+++ b/distributions/rhaii/config/webpack.common.js
@@ -1,18 +1,50 @@
 const path = require('path');
+const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const createWebpackCommon = require('../../base/config/webpack.common.js');
 const GenerateDistributionExtensionsPlugin = require('../../base/config/generateDistributionExtensionsPlugin');
 
 const SRC_DIR = path.resolve(__dirname, '../src');
+const REPO_ROOT = path.resolve(__dirname, '../../..');
 const TITLE = 'RHAII';
 
+const additionalIncludes = [];
+if (process.env.ENABLE_MODEL_SERVING === 'true') {
+  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/model-serving'));
+  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/k8s-core'));
+  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/model-registry'));
+  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/ui-core'));
+}
+
 module.exports = (overrides = {}) =>
-  merge(createWebpackCommon({ distributionSrcDir: SRC_DIR, title: TITLE, ...overrides }), {
-    plugins: [
-      new GenerateDistributionExtensionsPlugin({
-        configPath: path.resolve(__dirname, '../distribution.yaml'),
-        targetFile: path.join(SRC_DIR, 'distribution-extensions.ts'),
-        envOverrides: {},
-      }),
-    ],
-  });
+  merge(
+    createWebpackCommon({
+      distributionSrcDir: SRC_DIR,
+      title: TITLE,
+      additionalIncludes,
+      ...overrides,
+    }),
+    {
+      plugins: [
+        // RHAII-specific process.env overrides. Cross-distribution vars
+        // should move to the base app-shell webpack config once
+        // frontend/src/utilities/const.ts is decoupled from process.env
+        // (see docs/process-env-const-coupling.md).
+        new webpack.DefinePlugin({
+          'process.env.ODH_PRODUCT_NAME': JSON.stringify('RHAII'),
+          'process.env.BACKEND_PORT': JSON.stringify('4000'),
+        }),
+        new GenerateDistributionExtensionsPlugin({
+          configPath: path.resolve(__dirname, '../distribution.yaml'),
+          targetFile: path.join(SRC_DIR, 'distribution-extensions.ts'),
+          envOverrides: {
+            ENABLE_MODEL_SERVING: {
+              package: '@odh-dashboard/model-serving',
+              extensionsPath: './extensions',
+              featureFlags: { 'model-serving-shell': true },
+            },
+          },
+        }),
+      ],
+    },
+  );

--- a/distributions/rhaii/developing/Makefile
+++ b/distributions/rhaii/developing/Makefile
@@ -27,6 +27,11 @@ tilt-up: check-tilt setup-kind ## Start Tilt — builds, deploys, and port-forwa
 	@echo "Starting Tilt..."
 	@tilt up --port "$(TILT_PORT)"
 
+.PHONY: tilt-up-model-serving
+tilt-up-model-serving: check-tilt setup-kind ## Start Tilt with model-serving enabled (experimental)
+	@echo "Starting Tilt with model-serving package..."
+	@ENABLE_MODEL_SERVING=true tilt up --port "$(TILT_PORT)"
+
 .PHONY: tilt-down
 tilt-down: check-tilt ## Stop Tilt
 	@echo "Stopping Tilt..."

--- a/distributions/rhaii/developing/Tiltfile
+++ b/distributions/rhaii/developing/Tiltfile
@@ -4,6 +4,9 @@
 #   make tilt-up     # creates kind cluster (if needed) and starts Tilt
 #   make tilt-down   # stops Tilt
 #
+# With model-serving (experimental):
+#   make tilt-up-model-serving
+#
 # Prerequisites: docker/podman, kind, tilt
 
 analytics_settings(False)
@@ -21,12 +24,19 @@ tilt_root = os.path.dirname(os.path.abspath(__file__))
 dist_root = os.path.join(tilt_root, "..")
 repo_root = os.path.join(tilt_root, "../../..")
 
+# ── Optional packages (set env vars to "true" to enable) ─────────────────────
+
+build_args = {}
+if os.environ.get("ENABLE_MODEL_SERVING", "false") == "true":
+    build_args["ENABLE_MODEL_SERVING"] = "true"
+
 # ── RHAII Dashboard ───────────────────────────────────────────────────────────
 
 docker_build(
     "rhaii-dashboard",
     context=repo_root,
     dockerfile=os.path.join(dist_root, "Dockerfile"),
+    build_args=build_args,
     ignore=[
         "distributions/rhaii/node_modules",
         "distributions/rhaii/public",

--- a/distributions/rhaii/package.json
+++ b/distributions/rhaii/package.json
@@ -17,16 +17,24 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
+    "@odh-dashboard/k8s-core": "*",
+    "@odh-dashboard/model-serving": "*",
     "@odh-dashboard/plugin-core": "*",
     "@openshift/dynamic-plugin-sdk": "^5.0.1",
+    "@openshift/dynamic-plugin-sdk-utils": "^5.0.0",
     "@patternfly/patternfly": "^6.4.0",
+    "@patternfly/react-code-editor": "^6.4.0",
     "@patternfly/react-core": "^6.4.1",
     "@patternfly/react-icons": "^6.4.0",
     "@patternfly/react-styles": "^6.4.0",
+    "@patternfly/react-table": "^6.4.0",
+    "lodash-es": "^4.18.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router": "^7.17.0",
-    "react-router-dom": "^7.17.0"
+    "react-router-dom": "^7.17.0",
+    "yaml": "^2.9.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",

--- a/distributions/rhaii/src/extensions.ts
+++ b/distributions/rhaii/src/extensions.ts
@@ -3,6 +3,7 @@ import type {
   NavSectionExtension,
   HrefNavItemExtension,
   RouteExtension,
+  TabRoutePageExtension,
   MastheadToolbarItemExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
 
@@ -30,6 +31,25 @@ const extensions: Extension[] = [
       component: () => import('./ScaffoldPage'),
     },
   } satisfies RouteExtension,
+  {
+    type: 'app.navigation/section',
+    properties: {
+      id: 'ai-hub',
+      title: 'AI hub',
+      group: '3_ai_hub',
+    },
+  } satisfies NavSectionExtension,
+  {
+    type: 'app.tab-route/page',
+    properties: {
+      id: 'models-tab-page',
+      title: 'Models',
+      href: '/ai-hub/models',
+      path: '/ai-hub/models/*',
+      group: '1_models',
+      section: 'ai-hub',
+    },
+  } satisfies TabRoutePageExtension,
   {
     type: 'app.route',
     properties: {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-72150

---

## Description

Wire model-serving package into the RHAII distribution as an opt-in Tilt target (ENABLE_MODEL_SERVING=true). This is an incremental step toward full model-serving support in RHAII.

Base app shell (distributions/base/):
- Add tab-route page/tab extension support to ShellNav (NavTabRouteItem, AnyNavExtension type, tab-route pages rendered alongside nav extensions)
- Add TabRoutePage component with URL-driven tab selection, session- persisted tab memory, and ErrorBoundary wrapping per tab
- Extract NotFound into its own module from ShellRoutes
- Wrap all LazyCodeRefComponent renders in ErrorBoundary
- Enhance ErrorBoundary to show error details in an expandable PF Alert

RHAII distribution (distributions/rhaii/):
- Add conditional webpack includes for model-serving, k8s-core, model-registry, and ui-core packages when ENABLE_MODEL_SERVING=true
- Add DefinePlugin entries for RHAII-specific process.env overrides (ODH_PRODUCT_NAME, BACKEND_PORT)
- Add GenerateDistributionExtensionsPlugin with ENABLE_MODEL_SERVING env override mapping
- Register "AI hub" nav section and "Models" tab-route page in extensions.ts as host infrastructure for model-serving tabs
- Add model-serving and transitive dependencies to package.json
- Dockerfile: unconditionally COPY optional packages for npm workspace resolution; compile into bundle only when env flag is set
- Tiltfile/Makefile: add tilt-up-model-serving target

⚠️  This is expected to result in a broken runtime experience when model-serving pages are navigated to. The transitive import chain from model-serving through frontend/src/utilities/const.ts triggers a ReferenceError (process is not defined) because const.ts assumes dotenv-webpack is present. This work is being used to gauge progress on the model-serving modularization effort and help prioritize the remaining decoupling work (see docs/process-env-const-coupling.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an **AI hub** section with a **Models** tab page.
  * Introduced **tab-route pages** with URL-based routing and **last-open tab** persistence.
  * Added optional **model-serving** support behind a build-time enablement flag, including an experimental local startup target.

* **Bug Fixes**
  * Improved routed error handling with expandable error details.
  * Refreshed not-found/no-content screens and updated fallback behavior to account for tab-route pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->