### PR TITLE
fix(gen-ai): set loadedResourceVersion after Save As (create) flow

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -153,6 +153,8 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
       if (mode === 'save-as' || !loadedProfileId) {
         const response = await api.createAgentProfile({ spec });
         onSaved(response.profileId, response.displayName, description.trim());
+        // Set after onSaved for the same reason as the update branch below.
+        useChatbotConfigStore.getState().setLoadedResourceVersion(response.resourceVersion);
       } else {
         // Use the stored resourceVersion directly — no intermediate GET needed.
         // The server returns 409 if the profile was modified elsewhere, or 404 if deleted.

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
@@ -144,6 +144,8 @@ describe('SaveAgentProfileModal', () => {
         );
         expect(mockOnSaved).toHaveBeenCalledWith('new-uuid', 'Test Agent', '');
         expect(mockOnClose).toHaveBeenCalledTimes(1);
+        // resourceVersion from the create response must be stored so subsequent saves work
+        expect(useChatbotConfigStore.getState().loadedResourceVersion).toBe('rv-1');
       });
     });
 


### PR DESCRIPTION
## Description

After **Save As** (create), `SaveAgentProfileModal` was not calling `setLoadedResourceVersion` with the response `resourceVersion`. The create branch went straight to `setLoadedProfileSpec` → `onClose()`, leaving `loadedResourceVersion` as `null` in the store.

This caused a bug when the user then clicked **Try in Playground** from the AI Assets page for the newly created profile:

1. `handleProfileSaved` calls `applyAgentProfile(currentConfig, newProfileId)` which resets `loadedResourceVersion → null` via `storeInitialState`
2. No subsequent `setLoadedResourceVersion` call in the create branch
3. "Try in Playground" navigates to `?agentProfileId=newProfileId` — `useAgentProfileUrlParam` sees `loadedProfileId === agentProfileId` and returns early (correct guard), leaving `loadedResourceVersion = null`
4. User opens Save modal → `updateAgentProfile({ resourceVersion: '' })` → BFF returns 400 "resourceVersion is required for update"

The update (Save) branch already called `setLoadedResourceVersion` correctly. This PR adds the same call to the create (Save As) branch.

## How Has This Been Tested?

Manually tested the full flow:
1. Load an agent configuration in the playground
2. Click Save As → create a new agent configuration
3. Navigate to AI Assets → Agent Configurations tab
4. Click **Try in Playground** for the newly created configuration
5. Click Edit in the modal
6. Click Save → verify the save succeeds and does not show "resourceVersion is required for update" error

## Test Impact

Added an assertion to the existing `should call createAgentProfile and onSaved on successful save` test in `SaveAgentProfileModal.spec.tsx` to verify `loadedResourceVersion` is set to the create response's `resourceVersion` after a Save As operation.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * After saving a profile in “Save As” mode, the app now correctly updates the saved profile version in the editor state.
  * This keeps the current profile information in sync after creating a new profile.
* **Tests**
  * Added coverage to confirm the saved profile version is updated when “Save As” completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->