### PR TITLE
fix(e2e): use metrics endpoint for feature store overview card assertions

### DIFF
--- a/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
@@ -11,7 +11,10 @@ import {
 } from '../../../utils/oc_commands/featureStoreResources';
 import { retryableBefore } from '../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../utils/uuidGenerator';
-import { getAllFeatureStoreCounts } from '../../../utils/api/featureStoreRest';
+import {
+  getAllFeatureStoreCounts,
+  getMetricsResourceCounts,
+} from '../../../utils/api/featureStoreRest';
 import { featureMetricsOverview } from '../../../pages/featureStore/featureMetrics';
 import { getCustomResource } from '../../../utils/oc_commands/customResources';
 
@@ -24,6 +27,11 @@ describe('Feature Store Page Validation', () => {
   let dataSourceCount: number;
   let featureViewCount: number;
   let featureServiceCount: number;
+  let metricsFeatureCount: number;
+  let metricsEntityCount: number;
+  let metricsDatasetCount: number;
+  let metricsDataSourceCount: number;
+  let metricsFeatureServiceCount: number;
   let skipTest = false;
   const uuid = generateTestUUID();
 
@@ -65,18 +73,28 @@ describe('Feature Store Page Validation', () => {
         .then(() => {
           // Create route and fetch counts for the Feast instance
           return createRouteAndGetUrl(projectName, testData.feastInstanceName).then((routeUrl) => {
-            return getAllFeatureStoreCounts(routeUrl, testData.feastCreditScoringProject).then(
-              (feastInstanceCounts) => {
-                // Assign all counts from the returned object
-                featureCount = feastInstanceCounts.featureCount;
-                entityCount = feastInstanceCounts.entityCount;
-                datasetCount = feastInstanceCounts.datasetCount;
-                dataSourceCount = feastInstanceCounts.dataSourceCount;
-                featureViewCount = feastInstanceCounts.featureViewCount;
-                featureServiceCount = feastInstanceCounts.featureServiceCount;
+            return getMetricsResourceCounts(routeUrl, testData.feastCreditScoringProject).then(
+              (metricsCounts) => {
+                metricsFeatureCount = metricsCounts.featureCount;
+                metricsEntityCount = metricsCounts.entityCount;
+                metricsDatasetCount = metricsCounts.datasetCount;
+                metricsDataSourceCount = metricsCounts.dataSourceCount;
+                metricsFeatureServiceCount = metricsCounts.featureServiceCount;
 
-                cy.log('Counts assigned successfully:', feastInstanceCounts);
-                return cy.wrap(feastInstanceCounts);
+                return getAllFeatureStoreCounts(routeUrl, testData.feastCreditScoringProject).then(
+                  (listCounts) => {
+                    featureCount = listCounts.featureCount;
+                    entityCount = listCounts.entityCount;
+                    datasetCount = listCounts.datasetCount;
+                    dataSourceCount = listCounts.dataSourceCount;
+                    featureViewCount = listCounts.featureViewCount;
+                    featureServiceCount = listCounts.featureServiceCount;
+
+                    cy.log('Metrics counts:', metricsCounts);
+                    cy.log('List counts:', listCounts);
+                    return cy.wrap({ metricsCounts, listCounts });
+                  },
+                );
               },
             );
           });
@@ -108,11 +126,13 @@ describe('Feature Store Page Validation', () => {
       featureStoreGlobal.navigateToOverview();
       featureStoreGlobal.selectProject(testData.feastCreditScoringProject);
       cy.step(`Verify Metrics contents count is displayed correctly`);
-      featureMetricsOverview.findEntitiesCard().should('contain.text', entityCount);
-      featureMetricsOverview.findDataSourcesCard().should('contain.text', dataSourceCount);
-      featureMetricsOverview.findSavedDatasetsCard().should('contain.text', datasetCount);
-      featureMetricsOverview.findFeaturesCard().should('contain.text', featureCount);
-      featureMetricsOverview.findFeatureServicesCard().should('contain.text', featureServiceCount);
+      featureMetricsOverview.findEntitiesCard().should('contain.text', metricsEntityCount);
+      featureMetricsOverview.findDataSourcesCard().should('contain.text', metricsDataSourceCount);
+      featureMetricsOverview.findSavedDatasetsCard().should('contain.text', metricsDatasetCount);
+      featureMetricsOverview.findFeaturesCard().should('contain.text', metricsFeatureCount);
+      featureMetricsOverview
+        .findFeatureServicesCard()
+        .should('contain.text', metricsFeatureServiceCount);
 
       cy.step(`Navigate to the Feature Store Entities page`);
       featureStoreGlobal.navigateToEntities();

--- a/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
@@ -92,8 +92,8 @@ describe('Feature Store Page Validation', () => {
                     featureViewCount = listCounts.featureViewCount;
                     featureServiceCount = listCounts.featureServiceCount;
 
-                    cy.log('Metrics counts:', metricsCounts);
-                    cy.log('List counts:', listCounts);
+                    cy.log(`Metrics counts: ${JSON.stringify(metricsCounts)}`);
+                    cy.log(`List counts: ${JSON.stringify(listCounts)}`);
                     return cy.wrap({ metricsCounts, listCounts });
                   },
                 );

--- a/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
@@ -31,6 +31,7 @@ describe('Feature Store Page Validation', () => {
   let metricsEntityCount: number;
   let metricsDatasetCount: number;
   let metricsDataSourceCount: number;
+  let metricsFeatureViewCount: number;
   let metricsFeatureServiceCount: number;
   let skipTest = false;
   const uuid = generateTestUUID();
@@ -79,6 +80,7 @@ describe('Feature Store Page Validation', () => {
                 metricsEntityCount = metricsCounts.entityCount;
                 metricsDatasetCount = metricsCounts.datasetCount;
                 metricsDataSourceCount = metricsCounts.dataSourceCount;
+                metricsFeatureViewCount = metricsCounts.featureViewCount;
                 metricsFeatureServiceCount = metricsCounts.featureServiceCount;
 
                 return getAllFeatureStoreCounts(routeUrl, testData.feastCreditScoringProject).then(
@@ -130,6 +132,7 @@ describe('Feature Store Page Validation', () => {
       featureMetricsOverview.findDataSourcesCard().should('contain.text', metricsDataSourceCount);
       featureMetricsOverview.findSavedDatasetsCard().should('contain.text', metricsDatasetCount);
       featureMetricsOverview.findFeaturesCard().should('contain.text', metricsFeatureCount);
+      featureMetricsOverview.findFeatureViewsCard().should('contain.text', metricsFeatureViewCount);
       featureMetricsOverview
         .findFeatureServicesCard()
         .should('contain.text', metricsFeatureServiceCount);

--- a/packages/cypress/cypress/utils/api/featureStoreRest.ts
+++ b/packages/cypress/cypress/utils/api/featureStoreRest.ts
@@ -170,7 +170,53 @@ export const getDatasetsCount = (routeUrl: string, project: string): Cypress.Cha
 };
 
 /**
- * Fetches all Feature Store counts in a single function call
+ * Fetches resource counts from the metrics endpoint (same source the dashboard overview cards use)
+ *
+ * @param {string} routeUrl - The Feature Store route URL
+ * @param {string} project - The project name
+ * @returns {Cypress.Chainable<object>} Object containing all counts from the metrics endpoint
+ */
+export const getMetricsResourceCounts = (
+  routeUrl: string,
+  project: string,
+): Cypress.Chainable<{
+  featureCount: number;
+  entityCount: number;
+  datasetCount: number;
+  dataSourceCount: number;
+  featureViewCount: number;
+  featureServiceCount: number;
+}> => {
+  const apiUrl = `${routeUrl}/api/v1/metrics/resource_counts?project=${project}`;
+
+  return cy
+    .request({
+      method: 'GET',
+      url: apiUrl,
+      headers: { accept: 'application/json' },
+      failOnStatusCode: false,
+    })
+    .then((response) => {
+      if (response.status !== 200 || !response.body || !('counts' in response.body)) {
+        throw new Error(`Failed to get metrics resource counts: ${response.status}`);
+      }
+      const { counts } = response.body;
+      const allCounts = {
+        featureCount: counts.features,
+        entityCount: counts.entities,
+        datasetCount: counts.savedDatasets,
+        dataSourceCount: counts.dataSources,
+        featureViewCount: counts.featureViews,
+        featureServiceCount: counts.featureServices,
+      };
+
+      cy.log('Metrics resource counts fetched:', allCounts);
+      return cy.wrap(allCounts);
+    });
+};
+
+/**
+ * Fetches all Feature Store counts from individual list endpoints (for page pagination validation)
  * @param {string} routeUrl - The route URL for the API
  * @param {string} project - The project name
  * @returns {Cypress.Chainable<object>} Object containing all counts

--- a/packages/cypress/cypress/utils/api/featureStoreRest.ts
+++ b/packages/cypress/cypress/utils/api/featureStoreRest.ts
@@ -187,7 +187,9 @@ export const getMetricsResourceCounts = (
   featureViewCount: number;
   featureServiceCount: number;
 }> => {
-  const apiUrl = `${routeUrl}/api/v1/metrics/resource_counts?project=${project}`;
+  const apiUrl = `${routeUrl}/api/v1/metrics/resource_counts?project=${encodeURIComponent(
+    project,
+  )}`;
 
   return cy
     .request({

--- a/packages/cypress/cypress/utils/api/featureStoreRest.ts
+++ b/packages/cypress/cypress/utils/api/featureStoreRest.ts
@@ -203,6 +203,9 @@ export const getMetricsResourceCounts = (
         throw new Error(`Failed to get metrics resource counts: ${response.status}`);
       }
       const { counts } = response.body;
+      if (typeof counts.features !== 'number' || typeof counts.entities !== 'number') {
+        throw new Error(`Unexpected metrics response shape: ${JSON.stringify(counts)}`);
+      }
       const allCounts = {
         featureCount: counts.features,
         entityCount: counts.entities,
@@ -212,7 +215,7 @@ export const getMetricsResourceCounts = (
         featureServiceCount: counts.featureServices,
       };
 
-      cy.log('Metrics resource counts fetched:', allCounts);
+      cy.log(`Metrics resource counts fetched: ${JSON.stringify(allCounts)}`);
       return cy.wrap(allCounts);
     });
 };


### PR DESCRIPTION
## Summary
- Use `/api/v1/metrics/resource_counts` (same endpoint the dashboard UI uses) for overview metrics card assertions instead of `/api/v1/features` list endpoint which returns a different count.

## Jira
[RHOAIENG-72339](https://redhat.atlassian.net/browse/RHOAIENG-72339)

## Test plan
- [ ] Verify feature store e2e test passes on RHOAI cluster (SanitySet1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated automated Feature Store overview validation so the “Metrics” cards are verified against dedicated metrics resource-count data (entities, datasets, features, feature views, and feature services).
  * Kept navigation and subsequent page validations using the existing non-metrics/list count sources.
* **Documentation**
  * Clarified that overall resource totals are derived from list endpoints for pagination-related validation, and added documentation for metrics-specific aggregated counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->