### PR TITLE
feat(RHOAIENG-68466): display queue position for pending workloads via Visibility API

### DIFF
--- a/frontend/src/api/k8s/__tests__/pendingWorkloads.spec.ts
+++ b/frontend/src/api/k8s/__tests__/pendingWorkloads.spec.ts
@@ -1,0 +1,50 @@
+import { commonFetchJSON, getK8sResourceURL } from '@openshift/dynamic-plugin-sdk-utils';
+import { getPendingWorkloads } from '#~/api/k8s/pendingWorkloads';
+import { VisibilityLocalQueueModel } from '#~/api/models/kueue';
+import { PendingWorkloadsSummary } from '#~/k8sTypes';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  commonFetchJSON: jest.fn(),
+  getK8sResourceURL: jest.fn(),
+}));
+
+const commonFetchJSONMock = jest.mocked(commonFetchJSON<PendingWorkloadsSummary>);
+const getK8sResourceURLMock = jest.mocked(getK8sResourceURL);
+
+describe('getPendingWorkloads', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getK8sResourceURLMock.mockReturnValue('/mock-url');
+  });
+
+  it('should build the correct URL and return the summary from commonFetchJSON', async () => {
+    const mockSummary: PendingWorkloadsSummary = {
+      items: [
+        {
+          metadata: { name: 'wl-1', namespace: 'test-ns' },
+          priority: 100,
+          localQueueName: 'user-queue',
+          positionInClusterQueue: 0,
+          positionInLocalQueue: 0,
+        },
+      ],
+    };
+    commonFetchJSONMock.mockResolvedValue(mockSummary);
+
+    const result = await getPendingWorkloads('test-ns', 'user-queue');
+
+    expect(getK8sResourceURLMock).toHaveBeenCalledWith(VisibilityLocalQueueModel, undefined, {
+      name: 'user-queue',
+      ns: 'test-ns',
+      path: 'pendingworkloads',
+    });
+    expect(commonFetchJSONMock).toHaveBeenCalledWith('/mock-url');
+    expect(result).toStrictEqual(mockSummary);
+  });
+
+  it('should propagate errors from commonFetchJSON', async () => {
+    commonFetchJSONMock.mockRejectedValue(new Error('network error'));
+
+    await expect(getPendingWorkloads('test-ns', 'user-queue')).rejects.toThrow('network error');
+  });
+});

--- a/frontend/src/api/k8s/pendingWorkloads.ts
+++ b/frontend/src/api/k8s/pendingWorkloads.ts
@@ -1,0 +1,19 @@
+import { commonFetchJSON, getK8sResourceURL } from '@openshift/dynamic-plugin-sdk-utils';
+import { PendingWorkloadsSummary } from '#~/k8sTypes';
+import { VisibilityLocalQueueModel } from '#~/api/models/kueue';
+
+/**
+ * Fetches the list of pending workloads for a LocalQueue from the Kueue Visibility API.
+ * Endpoint: GET /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/{ns}/localqueues/{name}/pendingworkloads
+ */
+export const getPendingWorkloads = (
+  namespace: string,
+  localQueueName: string,
+): Promise<PendingWorkloadsSummary> =>
+  commonFetchJSON<PendingWorkloadsSummary>(
+    getK8sResourceURL(VisibilityLocalQueueModel, undefined, {
+      name: localQueueName,
+      ns: namespace,
+      path: 'pendingworkloads',
+    }),
+  );

--- a/frontend/src/api/models/kueue.ts
+++ b/frontend/src/api/models/kueue.ts
@@ -27,3 +27,10 @@ export const WorkloadPriorityClassModel: K8sModelCommon = {
   kind: 'WorkloadPriorityClass',
   plural: 'workloadpriorityclasses',
 };
+
+export const VisibilityLocalQueueModel: K8sModelCommon = {
+  apiVersion: 'v1beta2',
+  apiGroup: 'visibility.kueue.x-k8s.io',
+  kind: 'LocalQueue',
+  plural: 'localqueues',
+};

--- a/frontend/src/concepts/kueue/types.ts
+++ b/frontend/src/concepts/kueue/types.ts
@@ -18,6 +18,8 @@ export type KueueWorkloadStatusWithMessage = {
   message?: string;
   timestamp?: string;
   queueName?: string;
+  workloadName?: string;
+  queuePosition?: number;
   requeueInfo?: {
     count: number;
     requeueAt?: string;

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -187,15 +187,23 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
         color = RegularColor.var;
     }
 
-    const kueueTitle = showKueueMessage
-      ? kueueStatus.status === KueueWorkloadStatus.Requeued
-        ? getRequeuedMessage(kueueStatus)
-        : getHumanReadableKueueMessage(
-            kueueStatus.status,
-            kueueStatus.message,
-            kueueStatus.queueName,
-          )
-      : null;
+    let kueueTitle: string | null = null;
+    if (showKueueMessage) {
+      const message =
+        kueueStatus.status === KueueWorkloadStatus.Requeued
+          ? getRequeuedMessage(kueueStatus)
+          : getHumanReadableKueueMessage(
+              kueueStatus.status,
+              kueueStatus.message,
+              kueueStatus.queueName,
+            );
+      kueueTitle =
+        kueueStatus.queuePosition != null &&
+        (kueueStatus.status === KueueWorkloadStatus.Queued ||
+          kueueStatus.status === KueueWorkloadStatus.Inadmissible)
+          ? `${message} (position ${kueueStatus.queuePosition})`
+          : message;
+    }
     const workbenchTitle =
       notebookStatus?.currentEvent ||
       (isStarting

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1052,6 +1052,24 @@ export type WorkloadPriorityClassKind = K8sResourceCommon & {
   description?: string;
 };
 
+// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#visibility-kueue-x-k8s-io-v1beta2-PendingWorkload
+export type PendingWorkload = {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp?: string;
+  };
+  priority: number;
+  priorityClassName?: string;
+  localQueueName: string;
+  positionInClusterQueue: number;
+  positionInLocalQueue: number;
+};
+
+export type PendingWorkloadsSummary = {
+  items: PendingWorkload[];
+};
+
 export type SelfSubjectAccessReviewKind = K8sResourceCommon & {
   spec: {
     resourceAttributes?: AccessReviewResourceAttributes;

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -42,6 +42,7 @@ import useProjectKueueInfo from './useProjectKueueInfo';
 import { NotebookState } from './notebook/types';
 import useProjectNotebookStates from './notebook/useProjectNotebookStates';
 import { useKueueStatusForNotebooks } from './notebook/useKueueStatusForNotebooks';
+import { useQueuePositions } from './notebook/useQueuePositions';
 import useProjectPvcs from './screens/detail/storage/useProjectPvcs';
 import useProjectSharing from './projectSharing/useProjectSharing';
 import useConnections from './screens/detail/connections/useConnections';
@@ -93,11 +94,23 @@ const ProjectDetailsContextProvider: React.FC = () => {
   const project = projects.find(byName(namespace)) ?? null;
   useSyncPreferredProject(project);
   const notebooks = useProjectNotebookStates(namespace, { refreshRate: POLL_INTERVAL });
-  const { kueueStatusByNotebookName, isLoading: isKueueLoading } = useKueueStatusForNotebooks(
-    notebooks.data,
-    project ?? undefined,
-  );
+  const { kueueStatusByNotebookName: rawKueueStatus, isLoading: isKueueLoading } =
+    useKueueStatusForNotebooks(notebooks.data, project ?? undefined);
   const isKueueLoaded = !isKueueLoading;
+  const queuePositions = useQueuePositions(namespace, rawKueueStatus);
+  const kueueStatusByNotebookName = React.useMemo(() => {
+    if (Object.keys(queuePositions).length === 0) {
+      return rawKueueStatus;
+    }
+    const result: Record<string, KueueWorkloadStatusWithMessage | null> = {};
+    for (const [name, status] of Object.entries(rawKueueStatus)) {
+      result[name] =
+        status && name in queuePositions
+          ? { ...status, queuePosition: queuePositions[name] }
+          : status;
+    }
+    return result;
+  }, [rawKueueStatus, queuePositions]);
 
   const pvcs = useProjectPvcs(namespace, { refreshRate: POLL_INTERVAL });
   const connections = useConnections(namespace, { refreshRate: POLL_INTERVAL });

--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -67,11 +67,19 @@ export const getStatusSubtitle = ({
     if (kueueStatus.status === KueueWorkloadStatus.Requeued) {
       return getRequeuedMessage(kueueStatus);
     }
-    return getHumanReadableKueueMessage(
+    const message = getHumanReadableKueueMessage(
       kueueStatus.status,
       kueueStatus.message,
       kueueStatus.queueName,
     );
+    if (
+      kueueStatus.queuePosition != null &&
+      (kueueStatus.status === KueueWorkloadStatus.Queued ||
+        kueueStatus.status === KueueWorkloadStatus.Inadmissible)
+    ) {
+      return `${message} (position ${kueueStatus.queuePosition})`;
+    }
+    return message;
   }
   if (isStarting) {
     return notebookStatus?.currentEvent || 'Waiting for server request to start...';

--- a/frontend/src/pages/projects/notebook/__tests__/NotebookStateStatus.spec.ts
+++ b/frontend/src/pages/projects/notebook/__tests__/NotebookStateStatus.spec.ts
@@ -227,6 +227,63 @@ describe('getStatusSubtitle', () => {
         }),
       ).toBeNull();
     });
+
+    it.each([
+      [
+        KueueWorkloadStatus.Queued,
+        'insufficient unused quota',
+        3,
+        'Waiting for quota in test-queue (position 3)',
+      ],
+      [
+        KueueWorkloadStatus.Inadmissible,
+        'queue not found',
+        1,
+        'Queue test-queue does not exist (position 1)',
+      ],
+    ])(
+      'should append queue position for %s status when position is available',
+      (status, message, position, expected) => {
+        expect(
+          getStatusSubtitle({
+            isStarting: false,
+            isStopping: false,
+            notebookStatus: null,
+            kueueStatus: { status, message, queueName: 'test-queue', queuePosition: position },
+          }),
+        ).toBe(expected);
+      },
+    );
+
+    it('should not append position for non-pending statuses even if queuePosition is set', () => {
+      expect(
+        getStatusSubtitle({
+          isStarting: false,
+          isStopping: false,
+          notebookStatus: null,
+          kueueStatus: {
+            status: KueueWorkloadStatus.Failed,
+            message: 'error occurred',
+            queueName: 'test-queue',
+            queuePosition: 5,
+          },
+        }),
+      ).toBe('error occurred');
+    });
+
+    it('should not append position when queuePosition is undefined', () => {
+      expect(
+        getStatusSubtitle({
+          isStarting: false,
+          isStopping: false,
+          notebookStatus: null,
+          kueueStatus: {
+            status: KueueWorkloadStatus.Queued,
+            queueName: 'test-queue',
+          },
+        }),
+      ).toBe('Waiting for quota in test-queue');
+    });
   });
 
   describe('isStarting', () => {

--- a/frontend/src/pages/projects/notebook/__tests__/useKueueStatusForNotebooks.spec.ts
+++ b/frontend/src/pages/projects/notebook/__tests__/useKueueStatusForNotebooks.spec.ts
@@ -158,6 +158,24 @@ describe('useKueueStatusForNotebooks', () => {
     );
   });
 
+  it('includes workloadName in status entry', () => {
+    const wl = mockWorkloadK8sResource({
+      k8sName: 'wl-named',
+      namespace: 'test-project',
+      ownerName: 'my-notebook',
+      mockStatus: WorkloadStatusType.Pending,
+    });
+    if (wl.metadata) {
+      wl.metadata.labels = { ...wl.metadata.labels, 'kueue.x-k8s.io/job-name': 'my-notebook' };
+    }
+    useWatchWorkloadsMock.mockReturnValue([[wl], true, undefined]);
+    const states = [notebookState('my-notebook')];
+    const { result } = testHook(useKueueStatusForNotebooks)(states, project);
+    expect(result.current.kueueStatusByNotebookName['my-notebook']).toEqual(
+      expect.objectContaining({ workloadName: 'wl-named' }),
+    );
+  });
+
   it('returns null for notebook with no matching workload', () => {
     const wl = mockWorkloadK8sResource({
       k8sName: 'wl-other',

--- a/frontend/src/pages/projects/notebook/__tests__/useQueuePositions.spec.ts
+++ b/frontend/src/pages/projects/notebook/__tests__/useQueuePositions.spec.ts
@@ -1,0 +1,182 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { getPendingWorkloads } from '#~/api/k8s/pendingWorkloads';
+import { KueueWorkloadStatus, KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
+import { useQueuePositions } from '#~/pages/projects/notebook/useQueuePositions';
+import { PendingWorkload } from '#~/k8sTypes';
+
+jest.mock('#~/api/k8s/pendingWorkloads', () => ({
+  getPendingWorkloads: jest.fn(),
+}));
+
+const getPendingWorkloadsMock = jest.mocked(getPendingWorkloads);
+
+function makeStatus(
+  status: KueueWorkloadStatus,
+  queueName?: string,
+  workloadName?: string,
+): KueueWorkloadStatusWithMessage {
+  return { status, queueName, workloadName };
+}
+
+function mockPendingWorkload(
+  name: string,
+  namespace: string,
+  positionInLocalQueue: number,
+  positionInClusterQueue = positionInLocalQueue,
+): PendingWorkload {
+  return {
+    metadata: { name, namespace },
+    priority: 0,
+    localQueueName: 'user-queue',
+    positionInClusterQueue,
+    positionInLocalQueue,
+  };
+}
+
+describe('useQueuePositions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each<[string, string | undefined, Record<string, KueueWorkloadStatusWithMessage | null>]>([
+    [
+      'namespace is undefined',
+      undefined,
+      { nb1: makeStatus(KueueWorkloadStatus.Queued, 'user-queue', 'wl-1') },
+    ],
+    [
+      'status is not pending',
+      'test-ns',
+      {
+        nb1: makeStatus(KueueWorkloadStatus.Running, 'user-queue', 'wl-1'),
+        nb2: null as KueueWorkloadStatusWithMessage | null,
+      },
+    ],
+    [
+      'queueName is missing',
+      'test-ns',
+      { nb1: makeStatus(KueueWorkloadStatus.Queued, undefined, 'wl-1') },
+    ],
+    [
+      'workloadName is missing',
+      'test-ns',
+      { nb1: makeStatus(KueueWorkloadStatus.Queued, 'user-queue', undefined) },
+    ],
+  ])('should return empty map and not fetch when %s', (_, ns, statusMap) => {
+    const renderResult = testHook(useQueuePositions)(ns, statusMap);
+    expect(renderResult).hookToStrictEqual({});
+    expect(getPendingWorkloadsMock).not.toHaveBeenCalled();
+  });
+
+  it('should fetch positions for Queued workloads', async () => {
+    getPendingWorkloadsMock.mockResolvedValue({
+      items: [mockPendingWorkload('wl-1', 'test-ns', 0)],
+    });
+
+    const statusMap = {
+      nb1: makeStatus(KueueWorkloadStatus.Queued, 'user-queue', 'wl-1'),
+    };
+    const renderResult = testHook(useQueuePositions)('test-ns', statusMap);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(getPendingWorkloadsMock).toHaveBeenCalledWith('test-ns', 'user-queue');
+    expect(renderResult).hookToStrictEqual({ nb1: 1 });
+  });
+
+  it('should fetch positions for Inadmissible workloads', async () => {
+    getPendingWorkloadsMock.mockResolvedValue({
+      items: [mockPendingWorkload('wl-inadm', 'test-ns', 1, 2)],
+    });
+
+    const statusMap = {
+      nb1: makeStatus(KueueWorkloadStatus.Inadmissible, 'user-queue', 'wl-inadm'),
+    };
+    const renderResult = testHook(useQueuePositions)('test-ns', statusMap);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual({ nb1: 2 });
+  });
+
+  it('should return 1-indexed positions', async () => {
+    getPendingWorkloadsMock.mockResolvedValue({
+      items: [mockPendingWorkload('wl-1', 'test-ns', 0), mockPendingWorkload('wl-2', 'test-ns', 1)],
+    });
+
+    const statusMap = {
+      nb1: makeStatus(KueueWorkloadStatus.Queued, 'user-queue', 'wl-1'),
+      nb2: makeStatus(KueueWorkloadStatus.Queued, 'user-queue', 'wl-2'),
+    };
+    const renderResult = testHook(useQueuePositions)('test-ns', statusMap);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual({ nb1: 1, nb2: 2 });
+  });
+
+  it('should batch requests by queue name', async () => {
+    getPendingWorkloadsMock.mockImplementation(async (_ns, queueName) => {
+      if (queueName === 'queue-a') {
+        return { items: [mockPendingWorkload('wl-1', 'test-ns', 0)] };
+      }
+      return { items: [mockPendingWorkload('wl-2', 'test-ns', 0)] };
+    });
+
+    const statusMap = {
+      nb1: makeStatus(KueueWorkloadStatus.Queued, 'queue-a', 'wl-1'),
+      nb2: makeStatus(KueueWorkloadStatus.Queued, 'queue-b', 'wl-2'),
+    };
+    const renderResult = testHook(useQueuePositions)('test-ns', statusMap);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(getPendingWorkloadsMock).toHaveBeenCalledTimes(2);
+    expect(getPendingWorkloadsMock).toHaveBeenCalledWith('test-ns', 'queue-a');
+    expect(getPendingWorkloadsMock).toHaveBeenCalledWith('test-ns', 'queue-b');
+    expect(renderResult).hookToStrictEqual({ nb1: 1, nb2: 1 });
+  });
+
+  it.each([
+    [
+      '403 errors (no RBAC)',
+      Object.assign(new Error('Forbidden'), { statusObject: { code: 403 } }),
+    ],
+    ['non-403 errors', new Error('network error')],
+  ])('should silently handle %s and return empty map', async (_, error) => {
+    getPendingWorkloadsMock.mockRejectedValue(error);
+    const statusMap = {
+      nb1: makeStatus(KueueWorkloadStatus.Queued, 'user-queue', 'wl-1'),
+    };
+    const renderResult = testHook(useQueuePositions)('test-ns', statusMap);
+    await renderResult.waitForNextUpdate();
+    expect(renderResult).hookToStrictEqual({});
+  });
+
+  it('should omit position when workload is not found in pending list', async () => {
+    getPendingWorkloadsMock.mockResolvedValue({
+      items: [mockPendingWorkload('other-wl', 'test-ns', 0)],
+    });
+
+    const statusMap = {
+      nb1: makeStatus(KueueWorkloadStatus.Queued, 'user-queue', 'wl-not-found'),
+    };
+    const renderResult = testHook(useQueuePositions)('test-ns', statusMap);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual({});
+  });
+
+  it('should not fetch for non-pending statuses', () => {
+    const statusMap = {
+      nb1: makeStatus(KueueWorkloadStatus.Running, 'user-queue', 'wl-1'),
+      nb2: makeStatus(KueueWorkloadStatus.Admitted, 'user-queue', 'wl-2'),
+      nb3: makeStatus(KueueWorkloadStatus.Failed, 'user-queue', 'wl-3'),
+      nb4: makeStatus(KueueWorkloadStatus.Complete, 'user-queue', 'wl-4'),
+    };
+    testHook(useQueuePositions)('test-ns', statusMap);
+
+    expect(getPendingWorkloadsMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/projects/notebook/useKueueStatusForNotebooks.ts
+++ b/frontend/src/pages/projects/notebook/useKueueStatusForNotebooks.ts
@@ -48,6 +48,7 @@ export const useKueueStatusForNotebooks = (
       statusMap[name] = {
         ...statusWithMessage,
         queueName: notebook?.metadata.labels?.[KUEUE_QUEUE_LABEL],
+        workloadName: workload.metadata?.name,
       };
     }
     return statusMap;

--- a/frontend/src/pages/projects/notebook/useQueuePositions.ts
+++ b/frontend/src/pages/projects/notebook/useQueuePositions.ts
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { KueueWorkloadStatus, type KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
+import { getPendingWorkloads } from '#~/api/k8s/pendingWorkloads';
+import { useDeepCompareMemoize } from '#~/utilities/useDeepCompareMemoize';
+
+const PENDING_STATUSES: KueueWorkloadStatus[] = [
+  KueueWorkloadStatus.Queued,
+  KueueWorkloadStatus.Inadmissible,
+];
+
+const REFRESH_INTERVAL = 30_000;
+
+type QueuedEntry = {
+  notebookName: string;
+  queueName: string;
+  workloadName: string;
+};
+
+/**
+ * Fetches queue positions from the Kueue Visibility API for pending workloads.
+ * Returns a map of notebook name → 1-indexed position in the local queue.
+ *
+ * Handles 403 gracefully: when the user lacks RBAC for the Visibility API,
+ * positions are silently omitted (no error, empty map).
+ */
+export const useQueuePositions = (
+  namespace: string | undefined,
+  kueueStatusByNotebookName: Record<string, KueueWorkloadStatusWithMessage | null>,
+): Record<string, number> => {
+  const [positions, setPositions] = React.useState<Record<string, number>>({});
+
+  const queuedEntries: QueuedEntry[] = React.useMemo(() => {
+    const entries: QueuedEntry[] = [];
+    for (const [notebookName, status] of Object.entries(kueueStatusByNotebookName)) {
+      if (
+        status &&
+        PENDING_STATUSES.includes(status.status) &&
+        status.queueName &&
+        status.workloadName
+      ) {
+        entries.push({
+          notebookName,
+          queueName: status.queueName,
+          workloadName: status.workloadName,
+        });
+      }
+    }
+    return entries;
+  }, [kueueStatusByNotebookName]);
+
+  const stableEntries = useDeepCompareMemoize(queuedEntries);
+
+  React.useEffect(() => {
+    if (!namespace || stableEntries.length === 0) {
+      setPositions({});
+      return undefined;
+    }
+
+    let cancelled = false;
+    let latestRequestId = 0;
+
+    const fetchPositions = async (): Promise<void> => {
+      const requestId = ++latestRequestId;
+      const byQueue = new Map<string, QueuedEntry[]>();
+      for (const entry of stableEntries) {
+        const list = byQueue.get(entry.queueName) ?? [];
+        list.push(entry);
+        byQueue.set(entry.queueName, list);
+      }
+
+      const newPositions: Record<string, number> = {};
+
+      await Promise.all(
+        Array.from(byQueue.entries()).map(async ([queueName, entries]) => {
+          try {
+            const summary = await getPendingWorkloads(namespace, queueName);
+            for (const entry of entries) {
+              const found = summary.items.find((pw) => pw.metadata.name === entry.workloadName);
+              if (found != null) {
+                newPositions[entry.notebookName] = found.positionInLocalQueue + 1;
+              }
+            }
+          } catch {
+            // Silently omit positions on any error (403 = no RBAC, others = optional data)
+          }
+        }),
+      );
+
+      if (!cancelled && requestId === latestRequestId) {
+        setPositions(newPositions);
+      }
+    };
+
+    fetchPositions();
+    const intervalId = setInterval(fetchPositions, REFRESH_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [namespace, stableEntries]);
+
+  return positions;
+};

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -2796,5 +2796,49 @@ describe('Workbench page', () => {
         .findHaveNotebookStatusText()
         .should('have.text', 'Inadmissible');
     });
+
+    it('displays queue position in subtitle for Queued workload when Visibility API is available', () => {
+      initKueueWorkloadStatus(WorkloadStatusType.Pending);
+      cy.intercept(
+        'GET',
+        '/api/k8s/apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/test-project/localqueues/test-queue/pendingworkloads',
+        {
+          kind: 'PendingWorkloadsSummary',
+          apiVersion: 'visibility.kueue.x-k8s.io/v1beta2',
+          metadata: {},
+          items: [
+            {
+              metadata: {
+                name: 'workload-test-notebook',
+                namespace: 'test-project',
+              },
+              priority: 0,
+              localQueueName: 'test-queue',
+              positionInClusterQueue: 2,
+              positionInLocalQueue: 2,
+            },
+          ],
+        },
+      ).as('pendingWorkloads');
+      workbenchPage.visit('test-project');
+      cy.wait('@pendingWorkloads');
+      workbenchPage.getNotebookRow('Test Notebook').find().should('contain.text', 'position 3');
+    });
+
+    it('displays subtitle without position when Visibility API returns 403', () => {
+      initKueueWorkloadStatus(WorkloadStatusType.Pending);
+      cy.intercept(
+        'GET',
+        '/api/k8s/apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/test-project/localqueues/test-queue/pendingworkloads',
+        { statusCode: 403, body: { kind: 'Status', code: 403, message: 'Forbidden' } },
+      ).as('pendingWorkloads403');
+      workbenchPage.visit('test-project');
+      cy.wait('@pendingWorkloads403');
+      workbenchPage
+        .getNotebookRow('Test Notebook')
+        .find()
+        .should('contain.text', 'Waiting for')
+        .and('not.contain.text', 'position');
+    });
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-68466

## Description

Integrates the Kueue Visibility API (`visibility.kueue.x-k8s.io/v1beta2`) to display queue position for pending workloads. When a workbench is in **Queued** or **Inadmissible** state, the status subtitle shows the position in the local queue (e.g. `Waiting for quota in default (position 3)`). Position is shown in both the workbench table and the status modal.

<img width="652" height="701" alt="Screenshot 2026-06-30 at 5 26 21 PM" src="https://github.com/user-attachments/assets/003a1c85-da57-48e6-967f-cbd0cf30d54d" />

<img width="1407" height="204" alt="Screenshot 2026-06-30 at 5 26 17 PM" src="https://github.com/user-attachments/assets/9714580e-b08c-4f14-89fb-8f1bad4e7477" />


## How Has This Been Tested?

In tangerine cluster

1. stop the cluster queue briefly and start a new workbench so it gets stuck in "Queued":
```oc patch clusterqueue default --type merge -p '{"spec":{"stopPolicy":"HoldAndDrain"}}'```

2. Then create a new workbench in the dashboard UI in kueue-phase2-dev. It will stay in Queued state and should show Waiting for quota in default (position N).

3. When done testing, re-enable the queue:
```oc patch clusterqueue default --type merge -p '{"spec":{"stopPolicy":null}}'```

## Test Impact
Added unit test

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our [Best Practices](/docs/best-practices.md)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@kywalker-rh @ralombar 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notebook and workbench Kueue statuses now display queue position details when available.
  * Pending queue information is now surfaced alongside notebook status to improve progress visibility.
* **Bug Fixes**
  * Queued and inadmissible subtitles now consistently include “position <n>” when position data exists.
  * If queue-position data can’t be retrieved (including permission errors), the status display degrades gracefully without position.
* **Tests**
  * Added unit and UI coverage for queue position formatting and error/omitted-position scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->