### PR TITLE
RHOAIENG-72324: Add gpuaas package skeleton with feature flag, routing, and admin gating

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -70,6 +70,7 @@ export type DashboardConfig = K8sResourceCommon & {
       promptManagement: boolean;
       mySubscriptions: boolean;
       maasSettingsIaRedesign: boolean;
+      gpuaas: boolean;
     };
     // Intentionally disjointed from the CRD, we should move away from this code-wise now; CRD later
     // groupsConfig?: {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -106,6 +106,7 @@ export const blankDashboardCR: DashboardConfig = {
       promptManagement: false,
       mySubscriptions: true,
       maasSettingsIaRedesign: false,
+      gpuaas: false,
     },
     notebookController: {
       enabled: true,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -64,6 +64,7 @@ export type MockDashboardConfigType = {
   maasSettingsIaRedesign?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
+  gpuaas?: boolean;
   globalMLflowNamespaces?: string[];
   genAiStudioConfig?: {
     aiAssetCustomEndpoints?: {
@@ -129,6 +130,7 @@ export const mockDashboardConfig = ({
   maasSettingsIaRedesign = false,
   agentOps = false,
   roleManagement = false,
+  gpuaas = false,
   hardwareProfileOrder = ['test-hardware-profile'],
   globalMLflowNamespaces = [],
   genAiStudioConfig = {
@@ -317,6 +319,7 @@ export const mockDashboardConfig = ({
       maasSettingsIaRedesign,
       agentOps,
       roleManagement,
+      gpuaas,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -85,6 +85,7 @@ export const advancedAIMLFlags = {
   disableFineTuning: true,
   disableLMEval: true,
   trainingJobs: true,
+  gpuaas: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Combined feature flags object
@@ -273,6 +274,10 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.MAAS_SETTINGS_IA_REDESIGN]: {
     featureFlags: ['maasSettingsIaRedesign'],
+  },
+  [SupportedArea.GPUAAS_INFRASTRUCTURE]: {
+    featureFlags: ['gpuaas'],
+    requiredComponents: [DataScienceStackComponent.KUEUE],
   },
 };
 

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -195,6 +195,9 @@ spec:
                     llmGatewayField:
                       type: boolean
                       description: 'When true, shows the LLM gateway configuration field on LLMd serving forms.'
+                    gpuaas:
+                      type: boolean
+                      description: 'When true, enables the GPUaaS Infrastructure page for cluster capacity and accelerator utilization monitoring.'
                   x-kubernetes-validations:
                     - rule: '!has(self.disableAcceleratorProfiles) || self.disableAcceleratorProfiles == oldSelf.disableAcceleratorProfiles'
                       message: 'DEPRECATED: spec.dashboardConfig.disableAcceleratorProfiles must be removed or left unchanged.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -36694,7 +36694,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@odh-dashboard/internal": "*",
-        "@odh-dashboard/plugin-core": "*"
+        "@odh-dashboard/k8s-core": "*",
+        "@odh-dashboard/plugin-core": "*",
+        "@odh-dashboard/ui-core": "*"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8359,7 +8359,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9046,7 +9045,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9063,7 +9061,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9080,7 +9077,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9097,7 +9093,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9114,7 +9109,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9131,7 +9125,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9148,7 +9141,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9165,7 +9157,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9182,7 +9173,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9199,7 +9189,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9216,7 +9205,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9233,7 +9221,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13749,7 +13736,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6186,6 +6186,10 @@
       "resolved": "packages/gen-ai",
       "link": true
     },
+    "node_modules/@odh-dashboard/gpuaas": {
+      "resolved": "packages/gpuaas",
+      "link": true
+    },
     "node_modules/@odh-dashboard/internal": {
       "resolved": "frontend/src",
       "link": true
@@ -8355,6 +8359,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9041,6 +9046,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9057,6 +9063,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9073,6 +9080,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9089,6 +9097,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9105,6 +9114,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9121,6 +9131,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9137,6 +9148,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9153,6 +9165,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9169,6 +9182,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9185,6 +9199,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9201,6 +9216,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9217,6 +9233,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13732,6 +13749,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -36669,6 +36687,28 @@
         "@odh-dashboard/contract-tests": "*",
         "@odh-dashboard/eslint-config": "*",
         "@odh-dashboard/tsconfig": "*"
+      }
+    },
+    "packages/gpuaas": {
+      "name": "@odh-dashboard/gpuaas",
+      "version": "0.0.0",
+      "dependencies": {
+        "@odh-dashboard/internal": "*",
+        "@odh-dashboard/k8s-core": "*",
+        "@odh-dashboard/plugin-core": "*",
+        "@odh-dashboard/ui-core": "*"
+      },
+      "devDependencies": {
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/jest-config": "*",
+        "@odh-dashboard/tsconfig": "*"
+      },
+      "peerDependencies": {
+        "@patternfly/react-core": "^6",
+        "@patternfly/react-icons": "^6",
+        "react": "^18",
+        "react-dom": "^18",
+        "react-router-dom": "^7"
       }
     },
     "packages/jest-config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36694,9 +36694,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@odh-dashboard/internal": "*",
-        "@odh-dashboard/k8s-core": "*",
-        "@odh-dashboard/plugin-core": "*",
-        "@odh-dashboard/ui-core": "*"
+        "@odh-dashboard/plugin-core": "*"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",

--- a/packages/gpuaas/.eslintrc.js
+++ b/packages/gpuaas/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@odh-dashboard/eslint-config').recommendedReactTypescript(__dirname);

--- a/packages/gpuaas/OWNERS
+++ b/packages/gpuaas/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+  - dpanshug
+  - claudialphonse78
+
+reviewers:
+  - dpanshug
+  - claudialphonse78
+
+labels:
+  - area/gpuaas

--- a/packages/gpuaas/extensions.ts
+++ b/packages/gpuaas/extensions.ts
@@ -28,7 +28,6 @@ const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
       title: 'Infrastructure',
       href: '/observe-and-monitor/infrastructure',
       path: '/observe-and-monitor/infrastructure/*',
-      group: '2_infrastructure',
       section: 'observe-and-monitor',
     },
   },

--- a/packages/gpuaas/extensions.ts
+++ b/packages/gpuaas/extensions.ts
@@ -1,0 +1,47 @@
+import type {
+  HrefNavItemExtension,
+  AreaExtension,
+  RouteExtension,
+} from '@odh-dashboard/plugin-core/extension-points';
+// Allow this import as it consists of types and enums only.
+import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
+
+const PLUGIN_GPUAAS = 'plugin-gpuaas';
+const ADMIN_USER = 'ADMIN_USER';
+
+const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
+  {
+    type: 'app.area',
+    properties: {
+      id: PLUGIN_GPUAAS,
+      reliantAreas: [SupportedArea.GPUAAS_INFRASTRUCTURE],
+      featureFlags: ['gpuaas'],
+    },
+  },
+  {
+    type: 'app.navigation/href',
+    flags: {
+      required: [PLUGIN_GPUAAS, ADMIN_USER],
+    },
+    properties: {
+      id: 'gpuaas-infrastructure',
+      title: 'Infrastructure',
+      href: '/observe-and-monitor/infrastructure',
+      path: '/observe-and-monitor/infrastructure/*',
+      group: '2_infrastructure',
+      section: 'observe-and-monitor',
+    },
+  },
+  {
+    type: 'app.route',
+    properties: {
+      path: '/observe-and-monitor/infrastructure/*',
+      component: () => import('./src/InfrastructureRoutes'),
+    },
+    flags: {
+      required: [PLUGIN_GPUAAS, ADMIN_USER],
+    },
+  },
+];
+
+export default extensions;

--- a/packages/gpuaas/jest.config.ts
+++ b/packages/gpuaas/jest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@odh-dashboard/jest-config';

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
-    "@odh-dashboard/plugin-core": "*"
+    "@odh-dashboard/k8s-core": "*",
+    "@odh-dashboard/plugin-core": "*",
+    "@odh-dashboard/ui-core": "*"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test-unit": "jest --silent",
     "type-check": "tsc --noEmit"
   },
   "exports": {

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -1,0 +1,32 @@
+{
+  "private": true,
+  "name": "@odh-dashboard/gpuaas",
+  "description": "GPU-as-a-Service infrastructure monitoring plugin for cluster capacity and accelerator utilization.",
+  "version": "0.0.0",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "type-check": "tsc --noEmit"
+  },
+  "exports": {
+    "./extensions": "./extensions.ts"
+  },
+  "dependencies": {
+    "@odh-dashboard/internal": "*",
+    "@odh-dashboard/k8s-core": "*",
+    "@odh-dashboard/plugin-core": "*",
+    "@odh-dashboard/ui-core": "*"
+  },
+  "devDependencies": {
+    "@odh-dashboard/eslint-config": "*",
+    "@odh-dashboard/jest-config": "*",
+    "@odh-dashboard/tsconfig": "*"
+  },
+  "peerDependencies": {
+    "@patternfly/react-core": "^6",
+    "@patternfly/react-icons": "^6",
+    "react": "^18",
+    "react-dom": "^18",
+    "react-router-dom": "^7"
+  }
+}

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -13,9 +13,7 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
-    "@odh-dashboard/k8s-core": "*",
-    "@odh-dashboard/plugin-core": "*",
-    "@odh-dashboard/ui-core": "*"
+    "@odh-dashboard/plugin-core": "*"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/gpuaas",
   "description": "GPU-as-a-Service infrastructure monitoring plugin for cluster capacity and accelerator utilization.",
   "version": "0.0.0",
+  "e2eCiTags": ["@GpuaasCI"],
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/gpuaas/src/InfrastructureRoutes.tsx
+++ b/packages/gpuaas/src/InfrastructureRoutes.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import InfrastructurePage from './pages/InfrastructurePage';
+
+const InfrastructureRoutes: React.FC = () => (
+  <Routes>
+    <Route index element={<InfrastructurePage />} />
+    <Route path="*" element={<Navigate to="." />} />
+  </Routes>
+);
+
+export default InfrastructureRoutes;

--- a/packages/gpuaas/src/InfrastructureRoutes.tsx
+++ b/packages/gpuaas/src/InfrastructureRoutes.tsx
@@ -5,7 +5,7 @@ import InfrastructurePage from './pages/InfrastructurePage';
 const InfrastructureRoutes: React.FC = () => (
   <Routes>
     <Route index element={<InfrastructurePage />} />
-    <Route path="*" element={<Navigate to="." />} />
+    <Route path="*" element={<Navigate to="." replace />} />
   </Routes>
 );
 

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -1,0 +1,8 @@
+export const INFRASTRUCTURE_REFRESH_INTERVAL = 30_000;
+
+export const INFRASTRUCTURE_SECTIONS = [
+  { id: 'cluster', title: 'Cluster' },
+  { id: 'hardware-usage', title: 'Hardware usage' },
+  { id: 'borrowing-lending', title: 'Borrowing & lending' },
+  { id: 'cluster-queue-utilization', title: 'Cluster queue utilization' },
+] as const;

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { Card, CardBody, CardTitle, Stack, StackItem } from '@patternfly/react-core';

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
+import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { Card, CardBody, CardTitle, Stack, StackItem } from '@patternfly/react-core';
+import { INFRASTRUCTURE_SECTIONS } from '../const';
+
+const InfrastructurePage: React.FC = () => (
+  <ApplicationsPage
+    title="Infrastructure"
+    description="Cluster capacity and accelerator utilization."
+    loaded
+    empty={false}
+    provideChildrenPadding
+  >
+    <Stack hasGutter>
+      {INFRASTRUCTURE_SECTIONS.map(({ id, title }) => (
+        <StackItem key={id}>
+          <Card data-testid={`infrastructure-${id}-section`}>
+            <CardTitle>{title}</CardTitle>
+            <CardBody />
+          </Card>
+        </StackItem>
+      ))}
+    </Stack>
+  </ApplicationsPage>
+);
+
+export default InfrastructurePage;

--- a/packages/gpuaas/tsconfig.json
+++ b/packages/gpuaas/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@odh-dashboard/tsconfig"
+}

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -280,6 +280,7 @@ export type DashboardCommonConfig = {
   maasSettingsIaRedesign?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
+  gpuaas?: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {

--- a/packages/plugin-core/src/areas/types.ts
+++ b/packages/plugin-core/src/areas/types.ts
@@ -115,6 +115,9 @@ export enum SupportedArea {
   MLFLOW = 'mlflow',
   MLFLOW_PIPELINES = 'mlflow-pipelines',
 
+  /* GPUaaS */
+  GPUAAS_INFRASTRUCTURE = 'gpuaas-infrastructure',
+
   /* Project RBAC Settings */
   PROJECT_RBAC_SETTINGS = 'project-rbac-settings',
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72324

## Description

Scaffolds the `packages/gpuaas/` bundled plugin package for the GPU-as-a-Service Infrastructure page.

<img width="1892" height="750" alt="Screenshot 2026-06-30 at 9 57 27 PM" src="https://github.com/user-attachments/assets/f86f28b0-2ee8-46a0-826b-75cddb3b2bfc" />
<img width="493" height="604" alt="Screenshot 2026-06-30 at 9 57 53 PM" src="https://github.com/user-attachments/assets/e29ca052-fdf9-4d19-9c3f-dc72205c88a0" />


## How Has This Been Tested?

- `npm run type-check` passes for `gpuaas`, `plugin-core`, `k8s-core`, and `frontend` packages
- `npm run lint` passes with zero errors/warnings on all new and modified files
- Port validation passes (no port conflicts — this is a bundled plugin with no MF ports)

## Test Impact

No new tests added. This is a package skeleton with no business logic — section content, data fetching, and interactions will be added in subsequent stories and tested at that point.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new feature flag to enable GPUaaS Infrastructure functionality.
  * Introduced an “Infrastructure” navigation item and route for cluster capacity and accelerator utilization.
  * Added the Infrastructure page layout with section cards (cluster, hardware usage, borrowing/lending, and queue utilization).

* **Bug Fixes**
  * Unknown sub-routes under Infrastructure now redirect back to the main Infrastructure view.

* **Chores**
  * Updated dashboard configuration, mocks, and CRD schema to support the new GPUaaS flag.
  * Added a new frontend package for GPUaaS with standard lint/test/type-check setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->