### PR TITLE
feat(agent-ops): implement DELETE agent BFF endpoint

### DIFF
--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -166,6 +166,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
         "503":

--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -168,6 +168,8 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
       operationId: deleteAgent
       summary: Delete an agent deployment
       description: >-

--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -149,6 +149,30 @@ paths:
       operationId: getAgentRuntimeDetail
       summary: Get agent runtime detail
       description: Returns full runtime detail for a single deployed agent.
+    delete:
+      tags:
+        - AgentOperation
+      parameters:
+        - $ref: "#/components/parameters/agentNamespace"
+        - $ref: "#/components/parameters/agentName"
+      responses:
+        "204":
+          description: Agent deleted successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: deleteAgent
+      summary: Delete an agent deployment
+      description: >-
+        Removes a Sandbox CR (agents.x-k8s.io/v1beta1). The sandbox controller
+        handles pod and service cleanup.
   /api/v1/agents/runtimes/{ns}/{name}/stop:
     summary: Stop an agent deployment.
     post:

--- a/packages/agent-ops/bff/internal/api/app.go
+++ b/packages/agent-ops/bff/internal/api/app.go
@@ -240,6 +240,9 @@ func (app *App) Routes() http.Handler {
 	apiRouter.POST(AgentStartPath,
 		app.AttachNamespaceFromParam("ns",
 			app.RequireAccessToAgent(app.StartAgentHandler)))
+	apiRouter.DELETE(AgentRuntimeDetailPath,
+		app.AttachNamespaceFromParam("ns",
+			app.RequireAccessToAgent(app.DeleteAgentHandler)))
 
 	// Inter-BFF Communication routes — wire your target BFF endpoints here.
 	// Example:

--- a/packages/agent-ops/bff/internal/api/delete_handler.go
+++ b/packages/agent-ops/bff/internal/api/delete_handler.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	helper "github.com/opendatahub-io/mod-arch-library/bff/internal/helpers"
+)
+
+func (app *App) DeleteAgentHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	namespace := ps.ByName("ns")
+	name := ps.ByName("name")
+	if err := validateAgentPathParams(namespace, name); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	logger := helper.GetContextLoggerFromReq(r)
+	logger.Info("Deleting agent", slog.String("namespace", namespace), slog.String("name", name))
+
+	if err := app.repositories.AgentRuntimes.DeleteAgent(r.Context(), namespace, name); err != nil {
+		logger.Error("Failed to delete agent",
+			slog.String("namespace", namespace),
+			slog.String("name", name),
+			slog.Any("error", err))
+		app.handleAgentRepositoryError(w, r, err)
+		return
+	}
+
+	logger.Info("Agent deleted", slog.String("namespace", namespace), slog.String("name", name))
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/packages/agent-ops/bff/internal/api/delete_handler_test.go
+++ b/packages/agent-ops/bff/internal/api/delete_handler_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
+	agentsmock "github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents/mock"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/repositories"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteAgentHandler_Success(t *testing.T) {
+	app := &App{
+		repositories: testRepositoriesWithAgents(),
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, AgentRuntimeDetailPath, nil)
+	rr := httptest.NewRecorder()
+
+	app.DeleteAgentHandler(rr, req, httprouter.Params{
+		{Key: "ns", Value: "agent-ops-demo"},
+		{Key: "name", Value: "sample-support-agent"},
+	})
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+
+	detailReq := httptest.NewRequest(http.MethodGet, AgentRuntimeDetailPath, nil)
+	detailRR := httptest.NewRecorder()
+	app.GetAgentRuntimeDetailHandler(detailRR, detailReq, httprouter.Params{
+		{Key: "ns", Value: "agent-ops-demo"},
+		{Key: "name", Value: "sample-support-agent"},
+	})
+	require.Equal(t, http.StatusNotFound, detailRR.Code)
+}
+
+func TestDeleteAgentHandler_NotFound(t *testing.T) {
+	app := &App{
+		repositories: testRepositoriesWithAgents(),
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, AgentRuntimeDetailPath, nil)
+	rr := httptest.NewRecorder()
+
+	app.DeleteAgentHandler(rr, req, httprouter.Params{
+		{Key: "ns", Value: "other-ns"},
+		{Key: "name", Value: "missing-agent"},
+	})
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestDeleteAgentHandler_InvalidParams(t *testing.T) {
+	app := &App{
+		repositories: testRepositoriesWithAgents(),
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, AgentRuntimeDetailPath, nil)
+	rr := httptest.NewRecorder()
+
+	app.DeleteAgentHandler(rr, req, httprouter.Params{
+		{Key: "ns", Value: "INVALID_NS"},
+		{Key: "name", Value: "sample-support-agent"},
+	})
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestDeleteAgentHandler_Forbidden(t *testing.T) {
+	mockClient := agentsmock.NewDemoClient()
+	mockClient.DeleteAgentErr = agents.ErrForbidden
+	app := &App{
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		repositories: repositories.NewRepositories(&agentsmock.Factory{Client: mockClient}),
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, AgentRuntimeDetailPath, nil)
+	rr := httptest.NewRecorder()
+
+	app.DeleteAgentHandler(rr, req, httprouter.Params{
+		{Key: "ns", Value: "agent-ops-demo"},
+		{Key: "name", Value: "sample-support-agent"},
+	})
+
+	require.Equal(t, http.StatusForbidden, rr.Code)
+}

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -67,7 +67,10 @@ func (c *Client) DeleteAgent(ctx context.Context, namespace, name string) error 
 		return fmt.Errorf("Sandbox %q is not managed by odh-dashboard: %w", name, agents.ErrForbidden)
 	}
 
-	if err := dynamicClient.Resource(sandboxGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+	rv := cr.GetResourceVersion()
+	if err := dynamicClient.Resource(sandboxGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{ResourceVersion: &rv},
+	}); err != nil {
 		return fmt.Errorf("failed to delete Sandbox: %w", mapK8sError(err))
 	}
 

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -64,7 +64,7 @@ func (c *Client) DeleteAgent(ctx context.Context, namespace, name string) error 
 		return mapK8sError(err)
 	}
 	if cr.GetLabels()[labelManagedBy] != managedByValue {
-		return fmt.Errorf("Sandbox %q is not managed by odh-dashboard: %w", name, agents.ErrForbidden)
+		return fmt.Errorf("Sandbox %q is not managed by %s: %w", name, managedByValue, agents.ErrForbidden)
 	}
 
 	rv := cr.GetResourceVersion()

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -51,10 +51,30 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 	}, nil
 }
 
-// DeleteAgent removes all Kubernetes resources associated with an agent deployment.
+// DeleteAgent removes a Sandbox CR (agents.x-k8s.io/v1beta1).
+// The sandbox controller handles pod and service cleanup.
 func (c *Client) DeleteAgent(ctx context.Context, namespace, name string) error {
-	_ = ctx
-	return &agents.UnavailableError{Message: fmt.Sprintf("delete not yet implemented for agent %s/%s", namespace, name)}
+	dynamicClient, err := c.k8sClient.DynamicClient()
+	if err != nil {
+		return fmt.Errorf("failed to get dynamic client: %w", err)
+	}
+
+	cr, err := dynamicClient.Resource(sandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mapK8sError(err)
+	}
+	if cr.GetLabels()[labelManagedBy] != managedByValue {
+		return fmt.Errorf("Sandbox %q is not managed by odh-dashboard: %w", name, agents.ErrForbidden)
+	}
+
+	if err := dynamicClient.Resource(sandboxGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete Sandbox: %w", mapK8sError(err))
+	}
+
+	c.logger.Info("Deleted Sandbox CR",
+		slog.String("name", name),
+		slog.String("namespace", namespace))
+	return nil
 }
 
 // StopAgent patches the Sandbox CR operatingMode to Suspended.

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
@@ -187,6 +187,65 @@ func TestDeployAgent_AlreadyExistsUnmanaged(t *testing.T) {
 	assert.ErrorIs(t, err, agents.ErrAlreadyExists)
 }
 
+func TestDeleteAgent_Success(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+
+	managed := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": sandboxGVR.Group + "/" + sandboxGVR.Version,
+		"kind":       "Sandbox",
+		"metadata": map[string]any{
+			"name":      "my-agent",
+			"namespace": ns,
+			"labels": map[string]any{
+				labelManagedBy: managedByValue,
+			},
+		},
+	}}
+	_, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Create(context.Background(), managed, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	err = client.DeleteAgent(context.Background(), ns, "my-agent")
+	require.NoError(t, err)
+
+	_, err = dynamicClient.Resource(sandboxGVR).Namespace(ns).Get(context.Background(), "my-agent", metav1.GetOptions{})
+	assert.True(t, err != nil, "Sandbox should be gone after delete")
+}
+
+func TestDeleteAgent_NotFound(t *testing.T) {
+	client, _ := newDeployTestClient(t)
+
+	err := client.DeleteAgent(context.Background(), "test-ns", "missing-agent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrNotFound)
+}
+
+func TestDeleteAgent_Unmanaged(t *testing.T) {
+	ns := "test-ns"
+	client, dynamicClient := newDeployTestClient(t)
+
+	unmanaged := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": sandboxGVR.Group + "/" + sandboxGVR.Version,
+		"kind":       "Sandbox",
+		"metadata": map[string]any{
+			"name":      "foreign-agent",
+			"namespace": ns,
+			"labels": map[string]any{
+				labelManagedBy: "some-other-tool",
+			},
+		},
+	}}
+	_, err := dynamicClient.Resource(sandboxGVR).Namespace(ns).Create(context.Background(), unmanaged, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	err = client.DeleteAgent(context.Background(), ns, "foreign-agent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrForbidden)
+
+	_, err = dynamicClient.Resource(sandboxGVR).Namespace(ns).Get(context.Background(), "foreign-agent", metav1.GetOptions{})
+	assert.NoError(t, err, "Unmanaged sandbox should not be deleted")
+}
+
 func TestDeployAgent_FullParams(t *testing.T) {
 	ns := "test-ns"
 	client, _ := newDeployTestClient(t,

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/k8s_errors.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/k8s_errors.go
@@ -18,6 +18,8 @@ func mapK8sError(err error) error {
 		return agents.ErrAlreadyExists
 	case apierrors.IsConflict(err):
 		return agents.ErrConflict
+	case apierrors.IsServiceUnavailable(err), apierrors.IsServerTimeout(err):
+		return &agents.UnavailableError{Message: err.Error()}
 	default:
 		return err
 	}

--- a/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
@@ -25,6 +25,7 @@ type Client struct {
 	DeployAgentErr          error
 	StopAgentErr            error
 	StartAgentErr           error
+	DeleteAgentErr          error
 }
 
 // NewClient returns a mock client with no data. CanListAgentsInNamespace defaults to allowed.
@@ -129,7 +130,26 @@ func (c *Client) DeployAgent(ctx context.Context, params *agents.DeployAgentPara
 // DeleteAgent implements agents.Client.
 func (c *Client) DeleteAgent(ctx context.Context, namespace, name string) error {
 	_ = ctx
-	return agents.ErrUnavailable
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.DeleteAgentErr != nil {
+		return c.DeleteAgentErr
+	}
+	key := detailKey(namespace, name)
+	if _, ok := c.Details[key]; !ok {
+		return agents.ErrNotFound
+	}
+	delete(c.Details, key)
+	if agentList, ok := c.Agents[namespace]; ok {
+		filtered := make([]agents.AgentSummary, 0, len(agentList))
+		for _, a := range agentList {
+			if a.Name != name {
+				filtered = append(filtered, a)
+			}
+		}
+		c.Agents[namespace] = filtered
+	}
+	return nil
 }
 
 // StopAgent implements agents.Client.

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
@@ -126,6 +126,15 @@ func (r *AgentRuntimesRepository) StartAgent(ctx context.Context, namespace, nam
 	return translateAgentError(client.StartAgent(ctx, namespace, name))
 }
 
+// DeleteAgent removes a deployed agent via the agent data source.
+func (r *AgentRuntimesRepository) DeleteAgent(ctx context.Context, namespace, name string) error {
+	client, err := r.agentSourceFactory.GetClient(ctx)
+	if err != nil {
+		return translateAgentError(err)
+	}
+	return translateAgentError(client.DeleteAgent(ctx, namespace, name))
+}
+
 func translateAgentError(err error) error {
 	if err == nil {
 		return nil

--- a/packages/agent-ops/bff/openapi/src/agent-ops.yaml
+++ b/packages/agent-ops/bff/openapi/src/agent-ops.yaml
@@ -149,6 +149,34 @@ paths:
       operationId: getAgentRuntimeDetail
       summary: Get agent runtime detail
       description: Returns full runtime detail for a single deployed agent.
+    delete:
+      tags:
+        - AgentOperation
+      parameters:
+        - $ref: "#/components/parameters/agentNamespace"
+        - $ref: "#/components/parameters/agentName"
+      responses:
+        "204":
+          description: Agent deleted successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      operationId: deleteAgent
+      summary: Delete an agent deployment
+      description: >-
+        Removes a Sandbox CR (agents.x-k8s.io/v1beta1). The sandbox controller
+        handles pod and service cleanup.
   /api/v1/agents/runtimes/{ns}/{name}/stop:
     summary: Stop an agent deployment.
     post:


### PR DESCRIPTION
## Description

DELETE `/api/v1/agents/runtimes/:ns/:name` — removes a Sandbox CR (`agents.x-k8s.io/v1beta1`). The sandbox controller handles pod and service cleanup. Single resource delete, no cascade chain.

- Verifies managed-by label before deleting (403 if not managed)
- Returns 404 if CR doesn't exist
- OpenAPI spec updated

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-62714

## How Has This Been Tested?

- `delete_handler_test.go`: 4 tests (success + verify removal, not-found, bad-params, forbidden)
- `go test ./...` passes

## Test Impact

- New: `delete_handler_test.go` (4 tests)

## Request review criteria

- [x] The developer has manually tested the changes and verified that they work
- [x] Unit tests added
- [x] OpenAPI spec updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `DELETE /api/v1/agents/runtimes/{ns}/{name}` to remove an agent runtime (returns `204 No Content` on success).
  * Updated the OpenAPI spec with the new `deleteAgent` operation and documented responses.
* **Bug Fixes**
  * Deletion now removes the underlying Sandbox custom resource, enforcing managed-by ownership and using a safer delete precondition.
  * Enhanced error handling for service-unavailable and server-timeout conditions.
* **Tests**
  * Added API handler tests for success, not found, invalid parameters, and forbidden access.
  * Added Kubernetes integration tests covering success, unmanaged/forbidden, and missing resource cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->