### PR TITLE
docs(agent-ops): add OpenAPI spec for delete/stop/start endpoints

### DIFF
--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -148,6 +148,87 @@ paths:
       operationId: getAgentRuntimeDetail
       summary: Get agent runtime detail
       description: Returns full runtime detail for a single deployed agent.
+    delete:
+      tags:
+        - AgentOperation
+      parameters:
+        - $ref: "#/components/parameters/agentNamespace"
+        - $ref: "#/components/parameters/agentName"
+      responses:
+        "204":
+          description: Agent deployment deleted successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: deleteAgent
+      summary: Delete an agent deployment
+      description: >-
+        Removes all Kubernetes resources associated with an agent deployment.
+        Deletes the AgentRuntime CR (cascading to Deployment, Service, Route via
+        OwnerReferences) and the ServiceAccount.
+  /api/v1/agents/runtimes/{ns}/{name}/stop:
+    summary: Stop an agent deployment.
+    description: >-
+      Scales the agent Deployment to zero replicas.
+    post:
+      tags:
+        - AgentOperation
+      parameters:
+        - $ref: "#/components/parameters/agentNamespace"
+        - $ref: "#/components/parameters/agentName"
+      responses:
+        "200":
+          $ref: "#/components/responses/LifecycleResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: stopAgent
+      summary: Stop an agent
+      description: >-
+        Scales the agent Deployment to zero replicas. The original replica count
+        is stored as an annotation for later restoration via the start endpoint.
+  /api/v1/agents/runtimes/{ns}/{name}/start:
+    summary: Start an agent deployment.
+    description: >-
+      Scales the agent Deployment back to its original replica count.
+    post:
+      tags:
+        - AgentOperation
+      parameters:
+        - $ref: "#/components/parameters/agentNamespace"
+        - $ref: "#/components/parameters/agentName"
+      responses:
+        "200":
+          $ref: "#/components/responses/LifecycleResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: startAgent
+      summary: Start an agent
+      description: >-
+        Scales the agent Deployment back to its original replica count (read from
+        the annotation set by stop, defaults to 1 if not found).
   /api/v1/agents/deploy:
     summary: Deploy a new agent runtime.
     description: >-
@@ -708,6 +789,26 @@ components:
         message:
           type: string
           example: Agent deployed successfully
+    LifecycleResult:
+      description: Result of a lifecycle operation (stop/start).
+      required:
+        - name
+        - namespace
+        - message
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the agent.
+          example: my-agent
+        namespace:
+          type: string
+          description: Namespace of the agent.
+          example: agent-ops-demo
+        message:
+          type: string
+          description: Human-readable result message.
+          example: Agent stopped successfully
   responses:
     HealthCheckResponse:
       description: BFF service health status
@@ -890,7 +991,25 @@ components:
                   namespace: agent-ops-demo
                   message: Agent deployed successfully
       description: A response confirming successful agent deployment.
-
+    LifecycleResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: "#/components/schemas/LifecycleResult"
+          examples:
+            stopped:
+              summary: Agent stopped
+              value:
+                data:
+                  name: my-agent
+                  namespace: agent-ops-demo
+                  message: Agent stopped successfully
+      description: Confirms a lifecycle operation completed successfully.
 
   parameters:
     agentNamespace:


### PR DESCRIPTION
## Summary
- Add `DELETE /api/v1/agents/runtimes/{ns}/{name}` — deletes all K8s resources for an agent deployment (204 no-content response)
- Add `POST /api/v1/agents/runtimes/{ns}/{name}/stop` — scales agent Deployment to zero replicas, storing original count as annotation
- Add `POST /api/v1/agents/runtimes/{ns}/{name}/start` — restores agent Deployment to its original replica count
- Add `LifecycleResult` schema (name, namespace, message) and `LifecycleResponse` envelope used by stop/start

All new operations reuse existing `agentNamespace`/`agentName` path parameters and standard error responses (`400`, `401`, `403`, `404`, `500`).

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-62716

## Test plan
- [ ] YAML validates: `python3 -c "import yaml; yaml.safe_load(open('packages/agent-ops/api/openapi/agent-ops.yaml'))"`
- [ ] All `$ref` targets resolve (76 refs, 0 broken)
- [ ] Spec renders correctly in Swagger/Redoc viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deleting agent runtimes.
  * Added start and stop actions for agent runtimes.
  * Standardized success responses for agent lifecycle actions with clearer status details.

* **Bug Fixes**
  * Improved API consistency by using shared error handling across lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->