### PR TITLE
feat(agent-ops): implement stop/start agent BFF endpoints

### DIFF
--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -149,6 +149,60 @@ paths:
       operationId: getAgentRuntimeDetail
       summary: Get agent runtime detail
       description: Returns full runtime detail for a single deployed agent.
+  /api/v1/agents/runtimes/{ns}/{name}/stop:
+    summary: Stop an agent deployment.
+    post:
+      tags:
+        - AgentOperation
+      parameters:
+        - $ref: "#/components/parameters/agentNamespace"
+        - $ref: "#/components/parameters/agentName"
+      responses:
+        "200":
+          $ref: "#/components/responses/LifecycleResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: stopAgent
+      summary: Stop an agent
+      description: >-
+        Patches the Sandbox CR operatingMode to Suspended. Returns 409 if already stopped.
+  /api/v1/agents/runtimes/{ns}/{name}/start:
+    summary: Start an agent deployment.
+    post:
+      tags:
+        - AgentOperation
+      parameters:
+        - $ref: "#/components/parameters/agentNamespace"
+        - $ref: "#/components/parameters/agentName"
+      responses:
+        "200":
+          $ref: "#/components/responses/LifecycleResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: startAgent
+      summary: Start an agent
+      description: >-
+        Patches the Sandbox CR operatingMode to Running. Returns 409 if already running.
   /api/v1/agents/deploy:
     summary: Deploy a new agent runtime.
     description: >-
@@ -714,6 +768,32 @@ components:
         message:
           type: string
           example: Agent deployed successfully
+    LifecycleResult:
+      description: Result of a lifecycle operation (stop/start).
+      required:
+        - success
+        - name
+        - namespace
+        - action
+        - message
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        name:
+          type: string
+          example: my-agent
+        namespace:
+          type: string
+          example: agent-ops-demo
+        action:
+          type: string
+          enum: [stop, start]
+          example: stop
+        message:
+          type: string
+          example: Agent stop completed successfully
   responses:
     HealthCheckResponse:
       description: BFF service health status
@@ -896,7 +976,36 @@ components:
                   namespace: agent-ops-demo
                   message: Agent deployed successfully
       description: A response confirming successful agent deployment.
-
+    LifecycleResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: "#/components/schemas/LifecycleResult"
+          examples:
+            stopped:
+              summary: Agent stopped
+              value:
+                data:
+                  success: true
+                  name: my-agent
+                  namespace: agent-ops-demo
+                  action: stop
+                  message: Agent stop completed successfully
+            started:
+              summary: Agent started
+              value:
+                data:
+                  success: true
+                  name: my-agent
+                  namespace: agent-ops-demo
+                  action: start
+                  message: Agent start completed successfully
+      description: Confirms a lifecycle operation completed successfully.
 
   parameters:
     agentNamespace:

--- a/packages/agent-ops/api/openapi/agent-ops.yaml
+++ b/packages/agent-ops/api/openapi/agent-ops.yaml
@@ -824,7 +824,7 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorEnvelope"
-      description: A resource with the same name already exists
+      description: The request conflicts with the current state of the resource
     Forbidden:
       content:
         application/json:

--- a/packages/agent-ops/bff/internal/api/agent_handlers.go
+++ b/packages/agent-ops/bff/internal/api/agent_handlers.go
@@ -45,7 +45,15 @@ func (app *App) handleAgentRepositoryError(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if errors.Is(err, bfferrors.ErrAlreadyExists) {
-		app.logger.Warn("Agent deployment conflict",
+		app.logger.Warn("Agent already exists",
+			"error", err.Error(),
+			"method", r.Method,
+			"uri", r.URL.RequestURI())
+		app.conflictResponse(w, r, err)
+		return
+	}
+	if errors.Is(err, bfferrors.ErrConflict) {
+		app.logger.Warn("Agent state conflict",
 			"error", err.Error(),
 			"method", r.Method,
 			"uri", r.URL.RequestURI())

--- a/packages/agent-ops/bff/internal/api/agent_lifecycle_handler.go
+++ b/packages/agent-ops/bff/internal/api/agent_lifecycle_handler.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	helper "github.com/opendatahub-io/mod-arch-library/bff/internal/helpers"
+)
+
+type LifecycleActionResponseBody struct {
+	Success   bool   `json:"success"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Action    string `json:"action"`
+	Message   string `json:"message"`
+}
+
+type LifecycleActionEnvelope Envelope[*LifecycleActionResponseBody, None]
+
+func (app *App) StopAgentHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	app.handleLifecycleAction(w, r, ps, "stop", app.repositories.AgentRuntimes.StopAgent)
+}
+
+func (app *App) StartAgentHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	app.handleLifecycleAction(w, r, ps, "start", app.repositories.AgentRuntimes.StartAgent)
+}
+
+func (app *App) handleLifecycleAction(
+	w http.ResponseWriter,
+	r *http.Request,
+	ps httprouter.Params,
+	action string,
+	repoFn func(ctx context.Context, namespace, name string) error,
+) {
+	namespace := ps.ByName("ns")
+	name := ps.ByName("name")
+	if err := validateAgentPathParams(namespace, name); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	logger := helper.GetContextLoggerFromReq(r)
+	logger.Info(fmt.Sprintf("Agent %s requested", action),
+		slog.String("namespace", namespace),
+		slog.String("name", name))
+
+	if err := repoFn(r.Context(), namespace, name); err != nil {
+		logger.Error(fmt.Sprintf("Failed to %s agent", action),
+			slog.String("namespace", namespace),
+			slog.String("name", name),
+			slog.Any("error", err))
+		app.handleAgentRepositoryError(w, r, err)
+		return
+	}
+
+	envelope := LifecycleActionEnvelope{
+		Data: &LifecycleActionResponseBody{
+			Success:   true,
+			Name:      name,
+			Namespace: namespace,
+			Action:    action,
+			Message:   fmt.Sprintf("Agent %s completed successfully", action),
+		},
+	}
+	if err := app.WriteJSON(w, http.StatusOK, envelope, nil); err != nil {
+		logger.Error("Failed to write response", slog.Any("error", err))
+	}
+}

--- a/packages/agent-ops/bff/internal/api/agent_lifecycle_handler_test.go
+++ b/packages/agent-ops/bff/internal/api/agent_lifecycle_handler_test.go
@@ -122,3 +122,37 @@ func TestStartAgentHandler_InvalidParams(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
+
+func TestStopAgentHandler_Conflict(t *testing.T) {
+	app := lifecycleApp()
+	params := httprouter.Params{
+		{Key: "ns", Value: "agent-ops-demo"},
+		{Key: "name", Value: "sample-support-agent"},
+	}
+
+	// First stop succeeds
+	req := httptest.NewRequest(http.MethodPost, AgentStopPath, nil)
+	rr := httptest.NewRecorder()
+	app.StopAgentHandler(rr, req, params)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Second stop returns 409
+	req = httptest.NewRequest(http.MethodPost, AgentStopPath, nil)
+	rr = httptest.NewRecorder()
+	app.StopAgentHandler(rr, req, params)
+	require.Equal(t, http.StatusConflict, rr.Code)
+}
+
+func TestStartAgentHandler_Conflict(t *testing.T) {
+	app := lifecycleApp()
+	params := httprouter.Params{
+		{Key: "ns", Value: "agent-ops-demo"},
+		{Key: "name", Value: "sample-support-agent"},
+	}
+
+	// Agent starts in running state — start should return 409
+	req := httptest.NewRequest(http.MethodPost, AgentStartPath, nil)
+	rr := httptest.NewRecorder()
+	app.StartAgentHandler(rr, req, params)
+	require.Equal(t, http.StatusConflict, rr.Code)
+}

--- a/packages/agent-ops/bff/internal/api/agent_lifecycle_handler_test.go
+++ b/packages/agent-ops/bff/internal/api/agent_lifecycle_handler_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func lifecycleApp() *App {
+	return &App{
+		config:       config.EnvConfig{AuthMethod: config.AuthMethodDisabled},
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		repositories: testRepositoriesWithAgents(),
+	}
+}
+
+func TestStopAgentHandler_Success(t *testing.T) {
+	app := lifecycleApp()
+	req := httptest.NewRequest(http.MethodPost, AgentStopPath, nil)
+	rr := httptest.NewRecorder()
+
+	app.StopAgentHandler(rr, req, httprouter.Params{
+		{Key: "ns", Value: "agent-ops-demo"},
+		{Key: "name", Value: "sample-support-agent"},
+	})
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var envelope LifecycleActionEnvelope
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&envelope))
+	require.NotNil(t, envelope.Data)
+	assert.True(t, envelope.Data.Success)
+	assert.Equal(t, "stop", envelope.Data.Action)
+	assert.Equal(t, "sample-support-agent", envelope.Data.Name)
+}
+
+func TestStopAgentHandler_NotFound(t *testing.T) {
+	app := lifecycleApp()
+	req := httptest.NewRequest(http.MethodPost, AgentStopPath, nil)
+	rr := httptest.NewRecorder()
+
+	app.StopAgentHandler(rr, req, httprouter.Params{
+		{Key: "ns", Value: "other-ns"},
+		{Key: "name", Value: "missing-agent"},
+	})
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestStopAgentHandler_InvalidParams(t *testing.T) {
+	app := lifecycleApp()
+	req := httptest.NewRequest(http.MethodPost, AgentStopPath, nil)
+	rr := httptest.NewRecorder()
+
+	app.StopAgentHandler(rr, req, httprouter.Params{
+		{Key: "ns", Value: "INVALID_NS"},
+		{Key: "name", Value: "sample-support-agent"},
+	})
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestStartAgentHandler_Success(t *testing.T) {
+	app := lifecycleApp()
+
+	// Stop first so start has something to do
+	stopReq := httptest.NewRequest(http.MethodPost, AgentStopPath, nil)
+	stopRR := httptest.NewRecorder()
+	app.StopAgentHandler(stopRR, stopReq, httprouter.Params{
+		{Key: "ns", Value: "agent-ops-demo"},
+		{Key: "name", Value: "sample-support-agent"},
+	})
+	require.Equal(t, http.StatusOK, stopRR.Code)
+
+	req := httptest.NewRequest(http.MethodPost, AgentStartPath, nil)
+	rr := httptest.NewRecorder()
+
+	app.StartAgentHandler(rr, req, httprouter.Params{
+		{Key: "ns", Value: "agent-ops-demo"},
+		{Key: "name", Value: "sample-support-agent"},
+	})
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var envelope LifecycleActionEnvelope
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&envelope))
+	require.NotNil(t, envelope.Data)
+	assert.True(t, envelope.Data.Success)
+	assert.Equal(t, "start", envelope.Data.Action)
+}
+
+func TestStartAgentHandler_NotFound(t *testing.T) {
+	app := lifecycleApp()
+	req := httptest.NewRequest(http.MethodPost, AgentStartPath, nil)
+	rr := httptest.NewRecorder()
+
+	app.StartAgentHandler(rr, req, httprouter.Params{
+		{Key: "ns", Value: "other-ns"},
+		{Key: "name", Value: "missing-agent"},
+	})
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestStartAgentHandler_InvalidParams(t *testing.T) {
+	app := lifecycleApp()
+	req := httptest.NewRequest(http.MethodPost, AgentStartPath, nil)
+	rr := httptest.NewRecorder()
+
+	app.StartAgentHandler(rr, req, httprouter.Params{
+		{Key: "ns", Value: "agent-ops-demo"},
+		{Key: "name", Value: "INVALID_NAME"},
+	})
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/packages/agent-ops/bff/internal/api/app.go
+++ b/packages/agent-ops/bff/internal/api/app.go
@@ -39,6 +39,8 @@ const (
 	AgentRuntimesPath      = ApiPathPrefix + "/agents/runtimes"
 	AgentRuntimeDetailPath = ApiPathPrefix + "/agents/runtimes/:ns/:name"
 	AgentDeployPath        = ApiPathPrefix + "/agents/deploy"
+	AgentStopPath          = AgentRuntimeDetailPath + "/stop"
+	AgentStartPath         = AgentRuntimeDetailPath + "/start"
 )
 
 var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
@@ -232,6 +234,12 @@ func (app *App) Routes() http.Handler {
 		app.AttachNamespaceFromParam("ns",
 			app.RequireAccessToAgent(app.GetAgentRuntimeDetailHandler)))
 	apiRouter.POST(AgentDeployPath, app.RequireAuthenticatedForAgents(app.DeployAgentHandler))
+	apiRouter.POST(AgentStopPath,
+		app.AttachNamespaceFromParam("ns",
+			app.RequireAccessToAgent(app.StopAgentHandler)))
+	apiRouter.POST(AgentStartPath,
+		app.AttachNamespaceFromParam("ns",
+			app.RequireAccessToAgent(app.StartAgentHandler)))
 
 	// Inter-BFF Communication routes — wire your target BFF endpoints here.
 	// Example:

--- a/packages/agent-ops/bff/internal/errors/errors.go
+++ b/packages/agent-ops/bff/internal/errors/errors.go
@@ -13,3 +13,6 @@ var ErrUpstreamUnavailable = errors.New("upstream service unavailable")
 
 // ErrAlreadyExists is returned when attempting to create a resource that already exists.
 var ErrAlreadyExists = errors.New("resource already exists")
+
+// ErrConflict is returned when a request conflicts with the current state of the resource.
+var ErrConflict = errors.New("resource state conflict")

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"log/slog"
 
+	"strings"
+
 	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/agents"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // DeployAgent creates a Sandbox CR for the agent.
@@ -53,14 +57,70 @@ func (c *Client) DeleteAgent(ctx context.Context, namespace, name string) error 
 	return &agents.UnavailableError{Message: fmt.Sprintf("delete not yet implemented for agent %s/%s", namespace, name)}
 }
 
-// StopAgent scales down the agent workload to zero replicas.
+// StopAgent patches the Sandbox CR operatingMode to Suspended.
 func (c *Client) StopAgent(ctx context.Context, namespace, name string) error {
-	_ = ctx
-	return &agents.UnavailableError{Message: fmt.Sprintf("stop not yet implemented for agent %s/%s", namespace, name)}
+	dynamicClient, err := c.k8sClient.DynamicClient()
+	if err != nil {
+		return fmt.Errorf("failed to get dynamic client: %w", err)
+	}
+
+	cr, err := dynamicClient.Resource(sandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mapK8sError(err)
+	}
+	if cr.GetLabels()[labelManagedBy] != managedByValue {
+		return fmt.Errorf("Sandbox %q is not managed by odh-dashboard: %w", name, agents.ErrForbidden)
+	}
+
+	operatingMode, _, _ := unstructured.NestedString(cr.Object, "spec", "operatingMode")
+	if strings.EqualFold(operatingMode, "Suspended") {
+		return fmt.Errorf("agent %s/%s is already stopped: %w", namespace, name, agents.ErrConflict)
+	}
+
+	patch := []byte(`{"spec":{"operatingMode":"Suspended"}}`)
+	_, err = dynamicClient.Resource(sandboxGVR).Namespace(namespace).Patch(
+		ctx, name, types.MergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to stop agent: %w", mapK8sError(err))
+	}
+
+	c.logger.Info("Agent stopped (operatingMode: Suspended)",
+		slog.String("name", name),
+		slog.String("namespace", namespace))
+	return nil
 }
 
-// StartAgent scales the agent workload back up.
+// StartAgent patches the Sandbox CR operatingMode to Running.
 func (c *Client) StartAgent(ctx context.Context, namespace, name string) error {
-	_ = ctx
-	return &agents.UnavailableError{Message: fmt.Sprintf("start not yet implemented for agent %s/%s", namespace, name)}
+	dynamicClient, err := c.k8sClient.DynamicClient()
+	if err != nil {
+		return fmt.Errorf("failed to get dynamic client: %w", err)
+	}
+
+	cr, err := dynamicClient.Resource(sandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mapK8sError(err)
+	}
+	if cr.GetLabels()[labelManagedBy] != managedByValue {
+		return fmt.Errorf("Sandbox %q is not managed by odh-dashboard: %w", name, agents.ErrForbidden)
+	}
+
+	operatingMode, _, _ := unstructured.NestedString(cr.Object, "spec", "operatingMode")
+	if operatingMode == "" || strings.EqualFold(operatingMode, "Running") {
+		return fmt.Errorf("agent %s/%s is already running: %w", namespace, name, agents.ErrConflict)
+	}
+
+	patch := []byte(`{"spec":{"operatingMode":"Running"}}`)
+	_, err = dynamicClient.Resource(sandboxGVR).Namespace(namespace).Patch(
+		ctx, name, types.MergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to start agent: %w", mapK8sError(err))
+	}
+
+	c.logger.Info("Agent started (operatingMode: Running)",
+		slog.String("name", name),
+		slog.String("namespace", namespace))
+	return nil
 }

--- a/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
@@ -23,6 +23,8 @@ type Client struct {
 	ListAgentsErr           error
 	GetAgentErr             error
 	DeployAgentErr          error
+	StopAgentErr            error
+	StartAgentErr           error
 }
 
 // NewClient returns a mock client with no data. CanListAgentsInNamespace defaults to allowed.
@@ -133,13 +135,43 @@ func (c *Client) DeleteAgent(ctx context.Context, namespace, name string) error 
 // StopAgent implements agents.Client.
 func (c *Client) StopAgent(ctx context.Context, namespace, name string) error {
 	_ = ctx
-	return agents.ErrUnavailable
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.StopAgentErr != nil {
+		return c.StopAgentErr
+	}
+	key := detailKey(namespace, name)
+	detail, ok := c.Details[key]
+	if !ok {
+		return agents.ErrNotFound
+	}
+	if detail.ReadyStatus == "Stopped" {
+		return agents.ErrConflict
+	}
+	detail.ReadyStatus = "Stopped"
+	c.Details[key] = detail
+	return nil
 }
 
 // StartAgent implements agents.Client.
 func (c *Client) StartAgent(ctx context.Context, namespace, name string) error {
 	_ = ctx
-	return agents.ErrUnavailable
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.StartAgentErr != nil {
+		return c.StartAgentErr
+	}
+	key := detailKey(namespace, name)
+	detail, ok := c.Details[key]
+	if !ok {
+		return agents.ErrNotFound
+	}
+	if detail.ReadyStatus != "Stopped" {
+		return agents.ErrConflict
+	}
+	detail.ReadyStatus = "Ready"
+	c.Details[key] = detail
+	return nil
 }
 
 // cloneAgentDetail returns a defensive copy of detail. Spec and Status use maps.Clone

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
@@ -140,7 +140,7 @@ func translateAgentError(err error) error {
 	}
 
 	if errors.Is(err, agents.ErrConflict) {
-		return bfferrors.ErrAlreadyExists
+		return bfferrors.ErrConflict
 	}
 
 	if errors.Is(err, agents.ErrForbidden) {

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes.go
@@ -108,6 +108,24 @@ func (r *AgentRuntimesRepository) DeployAgent(ctx context.Context, params *agent
 	}, nil
 }
 
+// StopAgent stops a deployed agent via the agent data source.
+func (r *AgentRuntimesRepository) StopAgent(ctx context.Context, namespace, name string) error {
+	client, err := r.agentSourceFactory.GetClient(ctx)
+	if err != nil {
+		return translateAgentError(err)
+	}
+	return translateAgentError(client.StopAgent(ctx, namespace, name))
+}
+
+// StartAgent starts a stopped agent via the agent data source.
+func (r *AgentRuntimesRepository) StartAgent(ctx context.Context, namespace, name string) error {
+	client, err := r.agentSourceFactory.GetClient(ctx)
+	if err != nil {
+		return translateAgentError(err)
+	}
+	return translateAgentError(client.StartAgent(ctx, namespace, name))
+}
+
 func translateAgentError(err error) error {
 	if err == nil {
 		return nil

--- a/packages/agent-ops/bff/openapi/src/agent-ops.yaml
+++ b/packages/agent-ops/bff/openapi/src/agent-ops.yaml
@@ -149,6 +149,60 @@ paths:
       operationId: getAgentRuntimeDetail
       summary: Get agent runtime detail
       description: Returns full runtime detail for a single deployed agent.
+  /api/v1/agents/runtimes/{ns}/{name}/stop:
+    summary: Stop an agent deployment.
+    post:
+      tags:
+        - AgentOperation
+      parameters:
+        - $ref: "#/components/parameters/agentNamespace"
+        - $ref: "#/components/parameters/agentName"
+      responses:
+        "200":
+          $ref: "#/components/responses/LifecycleResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: stopAgent
+      summary: Stop an agent
+      description: >-
+        Patches the Sandbox CR operatingMode to Suspended. Returns 409 if already stopped.
+  /api/v1/agents/runtimes/{ns}/{name}/start:
+    summary: Start an agent deployment.
+    post:
+      tags:
+        - AgentOperation
+      parameters:
+        - $ref: "#/components/parameters/agentNamespace"
+        - $ref: "#/components/parameters/agentName"
+      responses:
+        "200":
+          $ref: "#/components/responses/LifecycleResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: startAgent
+      summary: Start an agent
+      description: >-
+        Patches the Sandbox CR operatingMode to Running. Returns 409 if already running.
   /api/v1/agents/deploy:
     summary: Deploy a new agent runtime.
     description: >-
@@ -714,6 +768,32 @@ components:
         message:
           type: string
           example: Agent deployed successfully
+    LifecycleResult:
+      description: Result of a lifecycle operation (stop/start).
+      required:
+        - success
+        - name
+        - namespace
+        - action
+        - message
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        name:
+          type: string
+          example: my-agent
+        namespace:
+          type: string
+          example: agent-ops-demo
+        action:
+          type: string
+          enum: [stop, start]
+          example: stop
+        message:
+          type: string
+          example: Agent stop completed successfully
   responses:
     HealthCheckResponse:
       description: BFF service health status
@@ -744,7 +824,7 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorEnvelope"
-      description: A resource with the same name already exists
+      description: The request conflicts with the current state of the resource
     Forbidden:
       content:
         application/json:
@@ -896,7 +976,36 @@ components:
                   namespace: agent-ops-demo
                   message: Agent deployed successfully
       description: A response confirming successful agent deployment.
-
+    LifecycleResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: "#/components/schemas/LifecycleResult"
+          examples:
+            stopped:
+              summary: Agent stopped
+              value:
+                data:
+                  success: true
+                  name: my-agent
+                  namespace: agent-ops-demo
+                  action: stop
+                  message: Agent stop completed successfully
+            started:
+              summary: Agent started
+              value:
+                data:
+                  success: true
+                  name: my-agent
+                  namespace: agent-ops-demo
+                  action: start
+                  message: Agent start completed successfully
+      description: Confirms a lifecycle operation completed successfully.
 
   parameters:
     agentNamespace:


### PR DESCRIPTION
## Description

Stop/start lifecycle endpoints targeting Sandbox CRD (`agents.x-k8s.io/v1beta1`):

- **Stop** (`POST .../stop`) — patches `spec.operatingMode` to `Suspended`
- **Start** (`POST .../start`) — patches `spec.operatingMode` to `Running`

Returns 409 Conflict if already in requested state. No Deployment replica scaling or annotation tracking — `operatingMode` is the state machine. Mock client tracks state and returns ErrConflict on double-stop/start (addressing Taj's review feedback).

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-62715

## How Has This Been Tested?

- `agent_lifecycle_handler_test.go`: 6 tests (stop/start success, not-found, bad-params)
- Start test verifies stop-then-start flow
- `go test ./...` passes

## Test Impact

- New: `agent_lifecycle_handler.go`, `agent_lifecycle_handler_test.go`

## Request review criteria

- [x] The developer has manually tested the changes and verified that they work
- [x] Unit tests added
- [x] OpenAPI spec updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST` endpoints to start/stop a single agent runtime (`/start` and `/stop`) returning structured JSON lifecycle results.
* **Bug Fixes**
  * Implemented real Kubernetes `operatingMode` transitions and ensured `409 Conflict` is returned when already in the requested state; improved conflict/error handling.
* **Documentation**
  * Updated the OpenAPI spec with the new routes, lifecycle response schemas, and clarified conflict documentation.
* **Tests**
  * Added handler tests covering success, not-found, invalid parameters, and conflict scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->