### PR TITLE
Overview Tab Toolbar and Filtering

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -1313,6 +1313,30 @@ class OverviewTabPage {
   findKebabAction(name: string): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByRole('menuitem', { name });
   }
+
+  findFilterInput(name: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`overview-${name}-name-filter-input`);
+  }
+
+  findFilterDropdownButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('overview-table-toolbar-dropdown');
+  }
+
+  findFilterDropdownItem(name: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`overview-table-toolbar-option-${name}`);
+  }
+
+  clearAllFilters() {
+    return cy.findByRole('button', { name: 'Clear all filters' }).click();
+  }
+
+  findCreateSubscriptionButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('toolbar-create-subscription-button');
+  }
+
+  findCreateAuthorizationPolicyButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('toolbar-create-authorization-policy-button');
+  }
 }
 
 class SubscriptionManagementPage {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
@@ -238,4 +238,59 @@ describe('Subscription Management Page', () => {
     premiumPolicy.findExpandedModelName().should('not.be.visible');
     premiumPolicy.findExpandedGroupName().should('not.be.visible');
   });
+
+  it('should filter by model name, model ID, description, group name, subscription name, and authorization policy name', () => {
+    subscriptionManagementPage.visit('overview');
+    // Display name
+    overviewTabPage.findFilterInput('model').type('Llama');
+    overviewTabPage.findModelRows().should('have.length', 1);
+    overviewTabPage.clearAllFilters();
+
+    // Resource name
+    overviewTabPage.findFilterInput('model').type('granite-3-8b-instruct');
+    overviewTabPage.findModelRows().should('have.length', 1);
+    overviewTabPage.clearAllFilters();
+
+    // Description
+    overviewTabPage.findFilterInput('model').type('instruction');
+    overviewTabPage.findModelRows().should('have.length', 2);
+
+    // Group name
+    overviewTabPage.clearAllFilters();
+    overviewTabPage.findFilterDropdownButton().click();
+    overviewTabPage.findFilterDropdownItem('groupName').click();
+    overviewTabPage.findFilterInput('group').type('interns');
+    overviewTabPage.findModelRows().should('have.length', 2);
+    overviewTabPage.clearAllFilters();
+    overviewTabPage.findModelRows().should('have.length', 4);
+
+    // Subscription name
+    overviewTabPage.findFilterDropdownButton().click();
+    overviewTabPage.findFilterDropdownItem('subscriptionName').click();
+    overviewTabPage.findFilterInput('subscription').type('Team');
+    overviewTabPage.findModelRows().should('have.length', 2);
+    overviewTabPage.clearAllFilters();
+    overviewTabPage.findModelRows().should('have.length', 4);
+
+    // Authorization policy name
+    overviewTabPage.findFilterDropdownButton().click();
+    overviewTabPage.findFilterDropdownItem('authPolicyName').click();
+    overviewTabPage.findFilterInput('policy').type('Team');
+    overviewTabPage.findModelRows().should('have.length', 2);
+    overviewTabPage.clearAllFilters();
+    overviewTabPage.findModelRows().should('have.length', 4);
+  });
+
+  it('should navigate to the correct form when creating a subscription or authorization policy via the overview toolbar', () => {
+    subscriptionManagementPage.visit('overview');
+    overviewTabPage.findCreateSubscriptionButton().click();
+    cy.url().should('include', '/subscription-management/subscriptions/create');
+    createSubscriptionPage.findCancelButton().click();
+    cy.url().should('include', '/subscription-management/overview');
+    subscriptionManagementPage.findOverviewTab().click();
+    overviewTabPage.findCreateAuthorizationPolicyButton().click();
+    cy.url().should('include', '/subscription-management/auth-policies/create');
+    policyPage.findCancelButton().click();
+    cy.url().should('include', '/subscription-management/overview');
+  });
 });

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
@@ -30,8 +30,8 @@ const AuthPoliciesToolbar: React.FC<AuthPoliciesToolbarProps> = ({
       [AuthPoliciesFilterOptions.keyword]: ({ onChange, ...props }) => (
         <SearchInput
           {...props}
-          aria-label="Filter by keyword"
-          placeholder="Filter by name or description"
+          aria-label="Filter by name, resource name, or description"
+          placeholder="Filter by name, resource name, or description"
           onChange={(_event, value) => onChange(value)}
           data-testid="auth-policies-filter-name-input"
           style={{ minWidth: '350px' }}

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
@@ -34,7 +34,7 @@ const AuthPoliciesToolbar: React.FC<AuthPoliciesToolbarProps> = ({
           placeholder="Filter by name or description"
           onChange={(_event, value) => onChange(value)}
           data-testid="auth-policies-filter-name-input"
-          style={{ width: '30ch' }}
+          style={{ minWidth: '350px' }}
         />
       ),
     }}

--- a/packages/maas/frontend/src/app/pages/subscription-management/OverviewTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/OverviewTab.tsx
@@ -1,10 +1,31 @@
 import * as React from 'react';
 import { Alert, Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import { useModelsOverview } from '~/app/hooks/useModelsOverview';
+import { URL_PREFIX } from '~/app/utilities/const';
 import OverviewTable from './overview/OverviewTable';
+import OverviewToolbar from './overview/OverviewToolbar';
+import { initialOverviewFilterData, OverviewFilterDataType } from './overview/const';
+import { filterOverviewModels } from './overview/utils';
+
+const OVERVIEW_RETURN_TO = `${URL_PREFIX}/subscription-management/overview`;
 
 const OverviewTab: React.FC = () => {
   const [rows, loaded, error] = useModelsOverview();
+  const [filterData, setFilterData] =
+    React.useState<OverviewFilterDataType>(initialOverviewFilterData);
+
+  const onFilterUpdate = React.useCallback(
+    (key: string, value?: string | { label: string; value: string }) =>
+      setFilterData((prev) => ({ ...prev, [key]: value })),
+    [],
+  );
+
+  const onClearFilters = React.useCallback(() => setFilterData(initialOverviewFilterData), []);
+
+  const filteredRows = React.useMemo(
+    () => filterOverviewModels(rows, filterData),
+    [rows, filterData],
+  );
 
   if (!loaded && !error) {
     return (
@@ -28,7 +49,17 @@ const OverviewTab: React.FC = () => {
 
   return (
     <PageSection isFilled>
-      <OverviewTable data={rows} />
+      <OverviewTable
+        data={filteredRows}
+        onClearFilters={onClearFilters}
+        toolbarContent={
+          <OverviewToolbar
+            filterData={filterData}
+            onFilterUpdate={onFilterUpdate}
+            returnTo={OVERVIEW_RETURN_TO}
+          />
+        }
+      />
     </PageSection>
   );
 };

--- a/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewTable.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewTable.tsx
@@ -8,7 +8,7 @@ import OverviewTableRow from './OverviewTableRow';
 
 type OverviewTableProps = {
   data: ModelOverviewItem[];
-  toolbarContent?: React.ReactNode;
+  toolbarContent: React.ReactNode;
   onClearFilters: () => void;
 };
 

--- a/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewTable.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewTable.tsx
@@ -1,12 +1,18 @@
 import * as React from 'react';
-import { Pagination } from '@patternfly/react-core';
-import { Table, Thead, Tr, Th } from '@patternfly/react-table';
-import { useTableColumnSort } from '@odh-dashboard/ui-core';
+import { Pagination, Toolbar, ToolbarContent } from '@patternfly/react-core';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { useTableColumnSort, DashboardEmptyTableView } from '@odh-dashboard/ui-core';
 import { ModelOverviewItem } from '~/app/types/subscriptions';
 import { overviewColumns } from './utils';
 import OverviewTableRow from './OverviewTableRow';
 
-const OverviewTable: React.FC<{ data: ModelOverviewItem[] }> = ({ data }) => {
+type OverviewTableProps = {
+  data: ModelOverviewItem[];
+  toolbarContent?: React.ReactNode;
+  onClearFilters: () => void;
+};
+
+const OverviewTable: React.FC<OverviewTableProps> = ({ data, toolbarContent, onClearFilters }) => {
   const [expandedModels, setExpandedModels] = React.useState<Set<string>>(new Set());
   const [page, setPage] = React.useState(1);
   const [pageSize, setPageSize] = React.useState(10);
@@ -41,6 +47,15 @@ const OverviewTable: React.FC<{ data: ModelOverviewItem[] }> = ({ data }) => {
 
   return (
     <>
+      {toolbarContent && (
+        <Toolbar
+          inset={{ default: 'insetNone' }}
+          className="pf-v6-u-w-100"
+          clearAllFilters={onClearFilters}
+        >
+          <ToolbarContent>{toolbarContent}</ToolbarContent>
+        </Toolbar>
+      )}
       <Table data-testid="overview-table">
         <Thead>
           <Tr>
@@ -66,15 +81,25 @@ const OverviewTable: React.FC<{ data: ModelOverviewItem[] }> = ({ data }) => {
             )}
           </Tr>
         </Thead>
-        {pageData.map((row, rowIndex) => (
-          <OverviewTableRow
-            key={row.id}
-            row={row}
-            rowIndex={rowIndex}
-            isExpanded={expandedModels.has(row.id)}
-            onToggleExpand={() => toggleModel(row)}
-          />
-        ))}
+        {pageData.length === 0 ? (
+          <Tbody>
+            <Tr>
+              <Td colSpan={overviewColumns.length}>
+                <DashboardEmptyTableView onClearFilters={onClearFilters} />
+              </Td>
+            </Tr>
+          </Tbody>
+        ) : (
+          pageData.map((row, rowIndex) => (
+            <OverviewTableRow
+              key={row.id}
+              row={row}
+              rowIndex={rowIndex}
+              isExpanded={expandedModels.has(row.id)}
+              onToggleExpand={() => toggleModel(row)}
+            />
+          ))
+        )}
       </Table>
       {data.length > pageSize && (
         <Pagination

--- a/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewToolbar.tsx
@@ -86,8 +86,6 @@ const OverviewToolbar: React.FC<OverviewToolbarProps> = ({
           Create subscription
         </Button>
       </ToolbarItem>
-    </ToolbarGroup>
-    <ToolbarGroup>
       <ToolbarItem>
         <Button
           variant="secondary"

--- a/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewToolbar.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { Button, SearchInput, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import FilterToolbar from '@odh-dashboard/internal/components/FilterToolbar';
+import { Link } from 'react-router-dom';
+import { URL_PREFIX } from '~/app/utilities/const';
+import { OverviewFilterDataType, OverviewFilterOptions, overviewFilterOptions } from './const';
+
+type OverviewToolbarProps = {
+  filterData: OverviewFilterDataType;
+  onFilterUpdate: (
+    key: OverviewFilterOptions,
+    value?: string | { label: string; value: string },
+  ) => void;
+  returnTo?: string;
+};
+
+const OverviewToolbar: React.FC<OverviewToolbarProps> = ({
+  filterData,
+  onFilterUpdate,
+  returnTo,
+}) => (
+  <FilterToolbar<OverviewFilterOptions>
+    testId="overview-table-toolbar"
+    filterOptions={overviewFilterOptions}
+    filterOptionRenders={{
+      [OverviewFilterOptions.modelName]: ({ onChange, ...props }) => (
+        <SearchInput
+          {...props}
+          style={{ minWidth: '350px' }}
+          aria-label="Filter by model name, model ID, or description"
+          placeholder="Filter by model name, model ID, or description"
+          onChange={(_event, value) => onChange(value)}
+          data-testid="overview-model-name-filter-input"
+        />
+      ),
+      [OverviewFilterOptions.groupName]: ({ onChange, ...props }) => (
+        <SearchInput
+          {...props}
+          style={{ minWidth: '350px' }}
+          aria-label="Filter by group name"
+          placeholder="Filter by group name"
+          onChange={(_event, value) => onChange(value)}
+          data-testid="overview-group-name-filter-input"
+        />
+      ),
+      [OverviewFilterOptions.subscriptionName]: ({ onChange, ...props }) => (
+        <SearchInput
+          {...props}
+          style={{ minWidth: '350px' }}
+          aria-label="Filter by subscription name"
+          placeholder="Filter by subscription name"
+          onChange={(_event, value) => onChange(value)}
+          data-testid="overview-subscription-name-filter-input"
+        />
+      ),
+      [OverviewFilterOptions.authPolicyName]: ({ onChange, ...props }) => (
+        <SearchInput
+          {...props}
+          style={{ minWidth: '350px' }}
+          aria-label="Filter by authorization policy name"
+          placeholder="Filter by authorization policy name"
+          onChange={(_event, value) => onChange(value)}
+          data-testid="overview-policy-name-filter-input"
+        />
+      ),
+    }}
+    filterData={filterData}
+    onFilterUpdate={onFilterUpdate}
+  >
+    <ToolbarGroup>
+      <ToolbarItem>
+        <Button
+          variant="secondary"
+          component={(props) => (
+            <Link
+              {...props}
+              to={`${URL_PREFIX}/subscription-management/subscriptions/create`}
+              state={{
+                returnTo: returnTo ?? `${URL_PREFIX}/subscription-management/overview`,
+                breadcrumbLabel: 'Subscription management',
+              }}
+            />
+          )}
+          data-testid="toolbar-create-subscription-button"
+        >
+          Create subscription
+        </Button>
+      </ToolbarItem>
+    </ToolbarGroup>
+    <ToolbarGroup>
+      <ToolbarItem>
+        <Button
+          variant="secondary"
+          component={(props) => (
+            <Link
+              {...props}
+              to={`${URL_PREFIX}/subscription-management/auth-policies/create`}
+              state={{
+                returnTo: returnTo ?? `${URL_PREFIX}/subscription-management/overview`,
+                breadcrumbLabel: 'Subscription management',
+              }}
+            />
+          )}
+          data-testid="toolbar-create-authorization-policy-button"
+        >
+          Create authorization policy
+        </Button>
+      </ToolbarItem>
+    </ToolbarGroup>
+  </FilterToolbar>
+);
+
+export default OverviewToolbar;

--- a/packages/maas/frontend/src/app/pages/subscription-management/overview/const.ts
+++ b/packages/maas/frontend/src/app/pages/subscription-management/overview/const.ts
@@ -1,0 +1,25 @@
+export enum OverviewFilterOptions {
+  modelName = 'modelName',
+  groupName = 'groupName',
+  subscriptionName = 'subscriptionName',
+  authPolicyName = 'authPolicyName',
+}
+
+export const overviewFilterOptions = {
+  [OverviewFilterOptions.modelName]: 'Model name',
+  [OverviewFilterOptions.groupName]: 'Group name',
+  [OverviewFilterOptions.subscriptionName]: 'Subscription name',
+  [OverviewFilterOptions.authPolicyName]: 'Authorization policy name',
+};
+
+export type OverviewFilterDataType = Record<
+  OverviewFilterOptions,
+  string | { label: string; value: string } | undefined
+>;
+
+export const initialOverviewFilterData: OverviewFilterDataType = {
+  [OverviewFilterOptions.modelName]: '',
+  [OverviewFilterOptions.groupName]: '',
+  [OverviewFilterOptions.subscriptionName]: '',
+  [OverviewFilterOptions.authPolicyName]: '',
+};

--- a/packages/maas/frontend/src/app/pages/subscription-management/overview/utils.ts
+++ b/packages/maas/frontend/src/app/pages/subscription-management/overview/utils.ts
@@ -1,5 +1,67 @@
 import { SortableData } from '@odh-dashboard/ui-core';
 import { ModelOverviewItem } from '~/app/types/subscriptions';
+import { OverviewFilterDataType, OverviewFilterOptions } from './const';
+
+const getFilterKeyword = (
+  filterData: OverviewFilterDataType,
+  key: OverviewFilterOptions,
+): string | undefined => {
+  const value = filterData[key];
+  if (!value) {
+    return undefined;
+  }
+  const keyword = typeof value === 'string' ? value : value.value;
+  const trimmed = keyword.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+};
+
+const textIncludes = (text: string | undefined, keyword: string): boolean =>
+  text?.toLowerCase().includes(keyword) ?? false;
+
+const modelMatchesModelName = (row: ModelOverviewItem, keyword: string): boolean =>
+  textIncludes(row.id, keyword) ||
+  textIncludes(row.modelDetails.displayName, keyword) ||
+  textIncludes(row.modelDetails.description, keyword);
+
+const modelMatchesGroupName = (row: ModelOverviewItem, keyword: string): boolean =>
+  row.subscriptions.some((sub) => sub.groups?.some((group) => textIncludes(group, keyword))) ||
+  row.authPolicies.some((policy) => policy.groups?.some((group) => textIncludes(group, keyword)));
+
+const modelMatchesSubscriptionName = (row: ModelOverviewItem, keyword: string): boolean =>
+  row.subscriptions.some(
+    (sub) => textIncludes(sub.name, keyword) || textIncludes(sub.displayName, keyword),
+  );
+
+const modelMatchesAuthPolicyName = (row: ModelOverviewItem, keyword: string): boolean =>
+  row.authPolicies.some(
+    (policy) => textIncludes(policy.name, keyword) || textIncludes(policy.displayName, keyword),
+  );
+
+export const filterOverviewModels = (
+  rows: ModelOverviewItem[],
+  filterData: OverviewFilterDataType,
+): ModelOverviewItem[] => {
+  const modelKeyword = getFilterKeyword(filterData, OverviewFilterOptions.modelName);
+  const groupKeyword = getFilterKeyword(filterData, OverviewFilterOptions.groupName);
+  const subscriptionKeyword = getFilterKeyword(filterData, OverviewFilterOptions.subscriptionName);
+  const authPolicyKeyword = getFilterKeyword(filterData, OverviewFilterOptions.authPolicyName);
+
+  return rows.filter((row) => {
+    if (modelKeyword && !modelMatchesModelName(row, modelKeyword)) {
+      return false;
+    }
+    if (groupKeyword && !modelMatchesGroupName(row, groupKeyword)) {
+      return false;
+    }
+    if (subscriptionKeyword && !modelMatchesSubscriptionName(row, subscriptionKeyword)) {
+      return false;
+    }
+    if (authPolicyKeyword && !modelMatchesAuthPolicyName(row, authPolicyKeyword)) {
+      return false;
+    }
+    return true;
+  });
+};
 
 export const overviewColumns: SortableData<ModelOverviewItem>[] = [
   {

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, SearchInput, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import FilterToolbar from '@odh-dashboard/internal/components/FilterToolbar';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { URL_PREFIX } from '~/app/utilities/const';
 import {
   SubscriptionsFilterDataType,
@@ -22,45 +22,43 @@ const SubscriptionsToolbar: React.FC<SubscriptionsToolbarProps> = ({
   filterData,
   onFilterUpdate,
   returnTo,
-}) => {
-  const navigate = useNavigate();
-  return (
-    <FilterToolbar<SubscriptionsFilterOptions>
-      data-testid="subscriptions-table-toolbar"
-      filterOptions={subscriptionsFilterOptions}
-      filterOptionRenders={{
-        [SubscriptionsFilterOptions.keyword]: ({ onChange, ...props }) => (
-          <SearchInput
-            {...props}
-            style={{ minWidth: '300px' }}
-            aria-label="Filter by name or description"
-            placeholder="Filter by name or description"
-            onChange={(_event, value) => onChange(value)}
-            data-testid="subscriptions-filter-input"
-          />
-        ),
-      }}
-      filterData={filterData}
-      onFilterUpdate={onFilterUpdate}
-    >
-      <ToolbarGroup>
-        <ToolbarItem>
-          <Button
-            variant="primary"
-            onClick={() => {
-              const base = returnTo ?? `${URL_PREFIX}/subscriptions`;
-              navigate(`${base}/create`, {
-                state: returnTo ? { returnTo } : undefined,
-              });
-            }}
-            data-testid="create-subscription-button"
-          >
-            Create subscription
-          </Button>
-        </ToolbarItem>
-      </ToolbarGroup>
-    </FilterToolbar>
-  );
-};
+}) => (
+  <FilterToolbar<SubscriptionsFilterOptions>
+    data-testid="subscriptions-table-toolbar"
+    filterOptions={subscriptionsFilterOptions}
+    filterOptionRenders={{
+      [SubscriptionsFilterOptions.keyword]: ({ onChange, ...props }) => (
+        <SearchInput
+          {...props}
+          style={{ minWidth: '350px' }}
+          aria-label="Filter by name or description"
+          placeholder="Filter by name or description"
+          onChange={(_event, value) => onChange(value)}
+          data-testid="subscriptions-filter-input"
+        />
+      ),
+    }}
+    filterData={filterData}
+    onFilterUpdate={onFilterUpdate}
+  >
+    <ToolbarGroup>
+      <ToolbarItem>
+        <Button
+          variant="primary"
+          component={(props) => (
+            <Link
+              {...props}
+              to={`${(returnTo ?? `${URL_PREFIX}/subscriptions`).split('?')[0]}/create`}
+              state={returnTo ? { returnTo } : undefined}
+            />
+          )}
+          data-testid="create-subscription-button"
+        >
+          Create subscription
+        </Button>
+      </ToolbarItem>
+    </ToolbarGroup>
+  </FilterToolbar>
+);
 
 export default SubscriptionsToolbar;

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar.tsx
@@ -31,8 +31,8 @@ const SubscriptionsToolbar: React.FC<SubscriptionsToolbarProps> = ({
         <SearchInput
           {...props}
           style={{ minWidth: '350px' }}
-          aria-label="Filter by name or description"
-          placeholder="Filter by name or description"
+          aria-label="Filter by name, resource name, or description"
+          placeholder="Filter by name, resource name, or description"
           onChange={(_event, value) => onChange(value)}
           data-testid="subscriptions-filter-input"
         />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-67115](https://redhat.atlassian.net/browse/RHOAIENG-67115)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added the toolbar to the overview tab which includes:
- a dropdown to select what you'd like to filter by (group, model name, model display name, model description, subscription, auth policy)
- an input to search with
- a create subscription button
- a create auth policy button


https://github.com/user-attachments/assets/98d3b97a-888e-46a9-a960-9d17dcadc21d


Empty state (no results found):
<img width="1583" height="734" alt="Screenshot 2026-06-30 at 2 39 00 PM" src="https://github.com/user-attachments/assets/b3320096-c6e9-44e5-a64f-2cb8268db29c" />



I also made some little changes to the search inputs to make them all `style={{ minWidth: '350px' }}` so they're all the same size -> and I updated the create subscription button to use the `Link` component like the other create buttons in this area do

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- Make sure the new create buttons work and the breadcrumbs and cancel button bring you back to the overview tab when you click them
- try out the different types of filtering: group, model name, model display name, model description, subscription, auth policy and make sure multiple combined filters work too (like filter by group and model name for example)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added mock tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filtering on the subscription management overview page across multiple fields, with a clear-filters action.
  * Added quick actions to create a subscription or an authorization policy from the overview page.
  * Expanded toolbar search on subscriptions and auth policies to support broader filtering terms.

* **Bug Fixes**
  * Improved empty-state handling so filtered results can be cleared directly when no matches are shown.
  * Updated navigation for create actions to return users back to the overview after canceling or finishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->