### PR TITLE
Show workspace context in MLflow breadcrumbs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8355,7 +8355,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9042,7 +9041,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9059,7 +9057,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9076,7 +9073,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9093,7 +9089,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9110,7 +9105,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9127,7 +9121,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9144,7 +9137,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9161,7 +9153,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9178,7 +9169,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9195,7 +9185,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9212,7 +9201,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9229,7 +9217,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13745,7 +13732,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -36864,7 +36850,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@odh-dashboard/internal": "*",
-        "@odh-dashboard/k8s-core": "^0.0.0",
+        "@odh-dashboard/k8s-core": "*",
         "@odh-dashboard/plugin-core": "*"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8355,6 +8355,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9041,6 +9042,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9057,6 +9059,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9073,6 +9076,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9089,6 +9093,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9105,6 +9110,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9121,6 +9127,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9137,6 +9144,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9153,6 +9161,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9169,6 +9178,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9185,6 +9195,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9201,6 +9212,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9217,6 +9229,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13732,6 +13745,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -36850,6 +36864,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@odh-dashboard/internal": "*",
+        "@odh-dashboard/k8s-core": "^0.0.0",
         "@odh-dashboard/plugin-core": "*"
       },
       "devDependencies": {

--- a/packages/mlflow-embedded/package.json
+++ b/packages/mlflow-embedded/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
-    "@odh-dashboard/k8s-core": "^0.0.0",
+    "@odh-dashboard/k8s-core": "*",
     "@odh-dashboard/plugin-core": "*"
   },
   "devDependencies": {

--- a/packages/mlflow-embedded/package.json
+++ b/packages/mlflow-embedded/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
+    "@odh-dashboard/k8s-core": "^0.0.0",
     "@odh-dashboard/plugin-core": "*"
   },
   "devDependencies": {

--- a/packages/mlflow-embedded/shared/MlflowBreadcrumbs.scss
+++ b/packages/mlflow-embedded/shared/MlflowBreadcrumbs.scss
@@ -1,0 +1,18 @@
+// Workaround so the link underline spans the full text+icon row.
+// Mirrors the same fix in GlobalPipelineCoreDetails.scss (PF issue #7554).
+.mlflow-breadcrumb-project-link {
+  position: relative;
+  text-decoration: none;
+
+  &::after {
+    content: '\00A0';
+    position: absolute;
+    text-decoration: underline;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    top: 2px;
+    letter-spacing: 1000px;
+    overflow: hidden;
+  }
+}

--- a/packages/mlflow-embedded/shared/MlflowBreadcrumbs.scss
+++ b/packages/mlflow-embedded/shared/MlflowBreadcrumbs.scss
@@ -1,5 +1,5 @@
 // Workaround so the link underline spans the full text+icon row.
-// Mirrors the same fix in GlobalPipelineCoreDetails.scss (PF issue #7554).
+// FIXME: Upstream still open — https://github.com/patternfly/patternfly/issues/7554 (breadcrumb icon underline). Re-check after PF ships fix.
 .mlflow-breadcrumb-project-link {
   position: relative;
   text-decoration: none;

--- a/packages/mlflow-embedded/shared/MlflowBreadcrumbs.tsx
+++ b/packages/mlflow-embedded/shared/MlflowBreadcrumbs.tsx
@@ -29,10 +29,10 @@ const MlflowBreadcrumbs: React.FC<{
 }> = ({ basePath, workspace, breadcrumbs }) => {
   const { projects } = React.useContext(ProjectsContext);
   const project = projects.find(byName(workspace));
-  const projectDisplayName = project ? getDisplayNameFromK8sResource(project) : workspace;
+  const projectDisplayName = project && getDisplayNameFromK8sResource(project);
 
   return (
-    <Flex>
+    <Flex alignItems={{ default: 'alignItemsCenter' }}>
       <Breadcrumb>
         {breadcrumbs.map((b, idx) => {
           const isLast = idx === breadcrumbs.length - 1;

--- a/packages/mlflow-embedded/shared/MlflowBreadcrumbs.tsx
+++ b/packages/mlflow-embedded/shared/MlflowBreadcrumbs.tsx
@@ -1,6 +1,21 @@
 import React from 'react';
-import { Breadcrumb, BreadcrumbItem, Button } from '@patternfly/react-core';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  Content,
+  ContentVariants,
+  Divider,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { WORKSPACE_QUERY_PARAM } from '@odh-dashboard/internal/routes/pipelines/mlflow';
+import { byName, ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/ProjectIconWithSize';
+import { IconSize } from '@odh-dashboard/internal/types';
+import './MlflowBreadcrumbs.scss';
 
 export interface BreadcrumbEntry {
   label: string;
@@ -11,43 +26,71 @@ const MlflowBreadcrumbs: React.FC<{
   basePath: string;
   workspace: string;
   breadcrumbs: BreadcrumbEntry[];
-}> = ({ basePath, workspace, breadcrumbs }) => (
-  <Breadcrumb>
-    {breadcrumbs.map((b, idx) => {
-      const isLast = idx === breadcrumbs.length - 1;
-      // Prepend the host's base route and workspace param to MLflow's relative path
-      const separator = b.path.includes('?') ? '&' : '?';
-      const fullPath = `${basePath}${
-        b.path
-      }${separator}${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace)}`;
-      return (
-        <BreadcrumbItem
-          key={b.path}
-          isActive={isLast}
-          {...(isLast ? { 'data-testid': 'mlflow-breadcrumb-active' } : {})}
-          render={() =>
-            isLast ? (
-              b.label
-            ) : (
-              <Button
-                variant="link"
-                isInline
-                component="a"
-                href={fullPath}
-                onClick={(e) => {
-                  e.preventDefault();
-                  window.history.pushState({}, '', fullPath);
-                  window.dispatchEvent(new PopStateEvent('popstate'));
-                }}
-              >
-                {b.label}
-              </Button>
-            )
-          }
-        />
-      );
-    })}
-  </Breadcrumb>
-);
+}> = ({ basePath, workspace, breadcrumbs }) => {
+  const { projects } = React.useContext(ProjectsContext);
+  const project = projects.find(byName(workspace));
+  const projectDisplayName = project ? getDisplayNameFromK8sResource(project) : workspace;
+
+  return (
+    <Flex>
+      <Breadcrumb>
+        {breadcrumbs.map((b, idx) => {
+          const isLast = idx === breadcrumbs.length - 1;
+          const separator = b.path.includes('?') ? '&' : '?';
+          const fullPath = `${basePath}${
+            b.path
+          }${separator}${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace)}`;
+          return (
+            <BreadcrumbItem
+              key={b.path}
+              isActive={isLast}
+              {...(isLast ? { 'data-testid': 'mlflow-breadcrumb-active' } : {})}
+              render={() =>
+                isLast ? (
+                  b.label
+                ) : (
+                  <Button
+                    variant="link"
+                    isInline
+                    component="a"
+                    href={fullPath}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      window.history.pushState({}, '', fullPath);
+                      window.dispatchEvent(new PopStateEvent('popstate'));
+                    }}
+                  >
+                    {b.label}
+                  </Button>
+                )
+              }
+            />
+          );
+        })}
+      </Breadcrumb>
+      {project && (
+        <Flex>
+          <Divider orientation={{ default: 'vertical' }} />
+          <FlexItem data-testid="project-navigator-link-in-breadcrumb">
+            <Content component={ContentVariants.small}>
+              <Link to={`/projects/${workspace}`} className="mlflow-breadcrumb-project-link">
+                <Flex
+                  alignItems={{ default: 'alignItemsCenter' }}
+                  spaceItems={{ default: 'spaceItemsXs' }}
+                >
+                  <FlexItem>Go to</FlexItem>
+                  <ProjectIconWithSize size={IconSize.MD} />
+                  <FlexItem>
+                    <strong>{projectDisplayName}</strong>
+                  </FlexItem>
+                </Flex>
+              </Link>
+            </Content>
+          </FlexItem>
+        </Flex>
+      )}
+    </Flex>
+  );
+};
 
 export default MlflowBreadcrumbs;


### PR DESCRIPTION
## Description

For https://redhat.atlassian.net/browse/RHOAIENG-65809

When users drill into an MLflow experiment or prompt, the breadcrumb only shows the MLflow path (e.g., `Experiments > experiments-1`). There was no indication of which workspace/project they were in unless they checked the URL. 

This change adds a workspace link to the MLflow breadcrumb, matching the existing pipelines pattern in `PipelineContextBreadcrumb`:
- A vertical divider after the breadcrumb trail
- `Go to [project icon] <project name>` linking to `/projects/<workspace>`
- Uses `getDisplayNameFromK8sResource` from `@odh-dashboard/k8s-core` for the display name
- Adds `MlflowBreadcrumbs.scss` with the same underline workaround used in `GlobalPipelineCoreDetails.scss` 

<img width="501" height="272" alt="image" src="https://github.com/user-attachments/assets/726b4a14-cccd-48dc-8cb2-9477221ae2bc" />

## How Has This Been Tested?

This has been manually tested: 
- Open MLflow Experiments in the workspace
- Confirm the breadcrumb shows `Go to <workspace A name>`.


## Test Impact

No new unit or Cypress tests added. 

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a “Go to” project link to the MLflow breadcrumbs for quicker navigation to the current workspace’s project.
  * Updated breadcrumbs layout to better support the added navigation element.
* **Bug Fixes**
  * Improved breadcrumb link styling so the underline consistently spans the full breadcrumb text and icon area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->