### PR TITLE
fix: Enable deployment resource auto-selection for generative LLMInferenceService deployments

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
@@ -1136,6 +1136,7 @@ describe('Model Serving LLMD', () => {
       modelServingWizard.findModelDeploymentNameInput().type('test-disabled-config');
       modelServingWizard.findDeploymentMethodSelect().should('not.be.disabled');
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-simple-vllm');
+      modelServingWizard.findModelServerManualSelectRadio().click();
       modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
 
       // Enabled config should be visible

--- a/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
+++ b/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
@@ -84,6 +84,19 @@ const getOptions = (
   return result;
 };
 
+const computeSuggestion = (options: ModelServerOption[]): ModelServerOption | undefined => {
+  if (options.length === 1) {
+    return options[0];
+  }
+
+  const compatibleOptions = options.filter((option) => option.compatibleWithHardwareProfile);
+  if (compatibleOptions.length === 1) {
+    return compatibleOptions[0];
+  }
+
+  return undefined;
+};
+
 export type LLMConfigOptionsFieldValue = {
   data?: ModelServerSelectFieldData;
 };
@@ -140,28 +153,18 @@ export const LLMConfigOptionsFieldWizardField: LLMConfigOptionsFieldType = {
       }
 
       const options = getOptions(externalData, dependencies?.hardwareProfile);
+      const suggestion = computeSuggestion(options);
 
-      // if there is only one matching hardware profile, select it
-      const matchingHardwareProfileOption = options.filter(
-        (option) => option.compatibleWithHardwareProfile,
-      );
-      if (matchingHardwareProfileOption.length === 1) {
+      if (suggestion) {
         return {
           data: {
-            selection: matchingHardwareProfileOption[0],
+            selection: suggestion,
             autoSelect: true,
-            suggestion: matchingHardwareProfileOption[0],
+            suggestion,
           },
         };
       }
-      // if there is only one option, select it
-      if (options.length === 1) {
-        return {
-          data: {
-            selection: options[0],
-          },
-        };
-      }
+
       return { data: { autoSelect: false } };
     },
     validationSchema: z.object({

--- a/packages/llmd-serving/src/wizardFields/__tests__/LlmConfigOptionsField.spec.ts
+++ b/packages/llmd-serving/src/wizardFields/__tests__/LlmConfigOptionsField.spec.ts
@@ -1,8 +1,10 @@
 import { testHook } from '@odh-dashboard/jest-config/hooks';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { mockHardwareProfile } from '@odh-dashboard/internal/__mocks__/mockHardwareProfile';
+import { IdentifierResourceType } from '@odh-dashboard/k8s-core';
 import * as projectSelectors from '@odh-dashboard/internal/redux/selectors/project';
 import * as llmConfigsApi from '../../api/LLMInferenceServiceConfigs';
-import { useLLMConfigOptions } from '../LlmConfigOptionsField';
+import { useLLMConfigOptions, LLMConfigOptionsFieldWizardField } from '../LlmConfigOptionsField';
 
 jest.mock('@odh-dashboard/internal/redux/selectors/project');
 jest.mock('../../api/LLMInferenceServiceConfigs');
@@ -139,5 +141,108 @@ describe('useLLMConfigOptions', () => {
     const renderResult = testHook(useLLMConfigOptions)();
 
     expect(renderResult.result.current.data.configs).toHaveLength(1);
+  });
+});
+
+describe('getInitialFieldData', () => {
+  const { getInitialFieldData } = LLMConfigOptionsFieldWizardField.reducerFunctions;
+
+  it('should return existing field data when provided', () => {
+    const existingData = {
+      data: {
+        selection: { name: 'existing', label: 'Existing' },
+        autoSelect: false,
+      },
+    };
+    const result = getInitialFieldData(existingData);
+    expect(result).toBe(existingData);
+  });
+
+  it('should auto-select with suggestion when there is only one config', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      name: 'only-config',
+      displayName: 'Only Config',
+    });
+    const result = getInitialFieldData(undefined, { configs: [config] });
+
+    expect(result.data?.autoSelect).toBe(true);
+    expect(result.data?.suggestion).toBeDefined();
+    expect(result.data?.suggestion?.name).toBe('only-config');
+    expect(result.data?.selection?.name).toBe('only-config');
+  });
+
+  it('should auto-select the single hardware-compatible config among multiple', () => {
+    const compatibleConfig = mockLLMInferenceServiceConfigK8sResource({
+      name: 'compatible',
+      displayName: 'Compatible Config',
+      recommendedAccelerators: '["nvidia.com/gpu"]',
+    });
+    const incompatibleConfig = mockLLMInferenceServiceConfigK8sResource({
+      name: 'incompatible',
+      displayName: 'Incompatible Config',
+    });
+    const gpuProfile = mockHardwareProfile({
+      name: 'gpu-profile',
+      identifiers: [
+        {
+          identifier: 'nvidia.com/gpu',
+          displayName: 'GPU',
+          resourceType: IdentifierResourceType.ACCELERATOR,
+          defaultCount: 1,
+          minCount: 1,
+          maxCount: 4,
+        },
+      ],
+    });
+    const result = getInitialFieldData(
+      undefined,
+      { configs: [compatibleConfig, incompatibleConfig] },
+      { hardwareProfile: gpuProfile },
+    );
+
+    expect(result.data?.autoSelect).toBe(true);
+    expect(result.data?.suggestion?.name).toBe('compatible');
+    expect(result.data?.selection?.name).toBe('compatible');
+  });
+
+  it('should not auto-select when multiple configs match hardware profile', () => {
+    const config1 = mockLLMInferenceServiceConfigK8sResource({
+      name: 'config-1',
+      displayName: 'Config 1',
+      recommendedAccelerators: '["nvidia.com/gpu"]',
+    });
+    const config2 = mockLLMInferenceServiceConfigK8sResource({
+      name: 'config-2',
+      displayName: 'Config 2',
+      recommendedAccelerators: '["nvidia.com/gpu"]',
+    });
+    const gpuProfile = mockHardwareProfile({
+      name: 'gpu-profile',
+      identifiers: [
+        {
+          identifier: 'nvidia.com/gpu',
+          displayName: 'GPU',
+          resourceType: IdentifierResourceType.ACCELERATOR,
+          defaultCount: 1,
+          minCount: 1,
+          maxCount: 4,
+        },
+      ],
+    });
+    const result = getInitialFieldData(
+      undefined,
+      { configs: [config1, config2] },
+      { hardwareProfile: gpuProfile },
+    );
+
+    expect(result.data?.autoSelect).toBe(false);
+    expect(result.data?.suggestion).toBeUndefined();
+  });
+
+  it('should not auto-select when there are no configs', () => {
+    const result = getInitialFieldData(undefined, { configs: [] });
+
+    expect(result.data?.autoSelect).toBe(false);
+    expect(result.data?.suggestion).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-58544

## Description

Fixes the deployment resource auto-selection being permanently disabled for generative models using the "LLM inference service deployment" method (LLMInferenceService + LLMInferenceServiceConfig).

**Root cause:** `LLMConfigOptionsField.getInitialFieldData` in `packages/llmd-serving` had a gap in its suggestion logic. When only one `LLMInferenceServiceConfig` was available, it would pre-select it in the manual dropdown but never set the `suggestion` property — which the `ModelServerTemplateSelectField` auto-select radio checks (`isDisabled={!data?.suggestion}`). This caused the "Automatic selection" radio to always appear disabled.

**Fix:** Extracted a `computeSuggestion` pure function (consistent with KServe's existing `computeSuggestion` pattern) that returns a suggestion when:
- There is exactly one available config (single-option case — the main bug)
- There are multiple configs but exactly one is compatible with the selected hardware profile (already worked, now consolidated)

When a suggestion is found, `getInitialFieldData` now consistently sets `autoSelect: true` and `suggestion`, enabling the auto-select radio.

**Files changed:**
- `packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx` — added `computeSuggestion`, simplified `getInitialFieldData`
- `packages/llmd-serving/src/wizardFields/__tests__/LlmConfigOptionsField.spec.ts` — added 5 unit tests for `getInitialFieldData`

## How Has This Been Tested?

- **Manual testing** on ODH Dashboard local dev (`npm run dev`) against a live cluster:
  - Verified auto-select radio is enabled and pre-selected when a single `LLMInferenceServiceConfig` is available
  - Verified auto-select radio remains correctly disabled when multiple configs exist with no unique hardware profile match
  - Verified manual selection still works as expected
  Before 
<img width="3018" height="1608" alt="Screenshot 2026-06-30 at 3 08 30 PM" src="https://github.com/user-attachments/assets/44d48311-37d3-4693-ba69-d92b84cf8adf" />

  After
<img width="1556" height="799" alt="Screenshot 2026-06-30 at 3 31 00 PM" src="https://github.com/user-attachments/assets/13f2c635-ff66-418a-932a-e6f9f97c65f5" />

- **Unit tests** — all 96 `llmd-serving` tests pass, all 15 `ModelServerTemplateSelectField` tests pass
- **Type-check** — `tsc --noEmit` passes with no errors
- **Lint** — no new warnings or errors introduced

## Test Impact

Added 5 new unit tests for `getInitialFieldData` in `LlmConfigOptionsField.spec.ts`:
- Returns existing field data when provided
- Auto-selects with suggestion when there is only one config
- Auto-selects the single hardware-compatible config among multiple
- Does not auto-select when multiple configs match hardware profile
- Does not auto-select when there are no configs

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved LLM configuration selection so the app can suggest and preselect the best option when there is only one choice or one compatible match for the current hardware profile.

* **Bug Fixes**
  * Preserves existing field data when a configuration has already been chosen.
  * Avoids auto-selection when multiple valid options are available or when no options exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->