### PR TITLE
feat(feature-store): Add FeatureStore CRUD API helpers and React data-fetching hooks

### DIFF
--- a/packages/feature-store/src/api/__tests__/featureStores.spec.ts
+++ b/packages/feature-store/src/api/__tests__/featureStores.spec.ts
@@ -1,0 +1,214 @@
+import {
+  k8sCreateResource,
+  k8sDeleteResource,
+  k8sGetResource,
+  k8sListResource,
+} from '@openshift/dynamic-plugin-sdk-utils';
+import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
+import { PodModel } from '@odh-dashboard/internal/api/models/k8s';
+import { FeatureStoreKind } from '../../k8sTypes';
+import {
+  createFeatureStore,
+  listFeatureStores,
+  listAllFeatureStores,
+  getFeatureStore,
+  deleteFeatureStore,
+  getPodsForFeatureStore,
+  FeatureStoreFormSpec,
+} from '../featureStores';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sCreateResource: jest.fn(),
+  k8sDeleteResource: jest.fn(),
+  k8sGetResource: jest.fn(),
+  k8sListResource: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/api/apiMergeUtils', () => ({
+  applyK8sAPIOptions: jest.fn((opts: object) => opts),
+}));
+
+jest.mock('@odh-dashboard/k8s-core', () => ({
+  kindApiVersion: jest.fn(() => 'feast.dev/v1'),
+  isValidK8sName: jest.requireActual('@odh-dashboard/k8s-core').isValidK8sName,
+}));
+
+const k8sCreateResourceMock = jest.mocked(k8sCreateResource);
+const k8sDeleteResourceMock = jest.mocked(k8sDeleteResource);
+const k8sGetResourceMock = jest.mocked(k8sGetResource);
+const k8sListResourceMock = jest.mocked(k8sListResource);
+
+const makeFeatureStore = (
+  overrides: Partial<FeatureStoreKind> & {
+    name?: string;
+    namespace?: string;
+    feastProject?: string;
+  } = {},
+): FeatureStoreKind => ({
+  apiVersion: 'feast.dev/v1',
+  kind: 'FeatureStore',
+  metadata: {
+    name: overrides.name ?? 'test-store',
+    namespace: overrides.namespace ?? 'test-ns',
+    ...overrides.metadata,
+  },
+  spec: {
+    feastProject: overrides.feastProject ?? 'test-project',
+    ...overrides.spec,
+  },
+  ...('status' in overrides ? { status: overrides.status } : {}),
+});
+
+describe('listFeatureStores', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call k8sListResource with correct model and namespace', async () => {
+    const mockStore = makeFeatureStore();
+    k8sListResourceMock.mockResolvedValue({ items: [mockStore] } as never);
+
+    const result = await listFeatureStores('test-ns');
+
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: FeatureStoreModel,
+      queryOptions: { ns: 'test-ns' },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].metadata.name).toBe('test-store');
+  });
+
+  it('should apply validation and normalization to results', async () => {
+    const valid = makeFeatureStore({ name: 'valid' });
+    const invalid = makeFeatureStore({ name: '' });
+    k8sListResourceMock.mockResolvedValue({ items: [invalid, valid] } as never);
+
+    const result = await listFeatureStores('test-ns');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].metadata.labels).toEqual({});
+  });
+});
+
+describe('listAllFeatureStores', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call k8sListResource with empty queryOptions', async () => {
+    const stores = [
+      makeFeatureStore({ name: 'store-1', namespace: 'ns-1' }),
+      makeFeatureStore({ name: 'store-2', namespace: 'ns-2' }),
+    ];
+    k8sListResourceMock.mockResolvedValue({ items: stores } as never);
+
+    const result = await listAllFeatureStores();
+
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: FeatureStoreModel,
+      queryOptions: {},
+    });
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('getFeatureStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call k8sGetResource and normalize the result', async () => {
+    const store = makeFeatureStore({ status: { phase: 'Ready' } } as Partial<FeatureStoreKind>);
+    k8sGetResourceMock.mockResolvedValue(store as never);
+
+    const result = await getFeatureStore('test-ns', 'test-store');
+
+    expect(k8sGetResourceMock).toHaveBeenCalledWith({
+      model: FeatureStoreModel,
+      queryOptions: { name: 'test-store', ns: 'test-ns' },
+    });
+    expect(result.metadata.labels).toEqual({});
+  });
+});
+
+describe('createFeatureStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should assemble resource and call k8sCreateResource', async () => {
+    const mockCreated = makeFeatureStore();
+    k8sCreateResourceMock.mockResolvedValue(mockCreated as never);
+
+    const formData: FeatureStoreFormSpec = {
+      feastProject: 'test-project',
+      namespace: 'test-ns',
+    };
+    const result = await createFeatureStore(formData);
+
+    expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
+    const callArg = k8sCreateResourceMock.mock.calls[0][0] as unknown as {
+      resource: FeatureStoreKind;
+    };
+    expect(callArg.resource.spec.feastProject).toBe('test-project');
+    expect(result.metadata.labels).toEqual({});
+  });
+});
+
+describe('deleteFeatureStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call k8sDeleteResource and return K8sStatus', async () => {
+    const mockStatus = {
+      kind: 'Status',
+      apiVersion: 'v1',
+      status: 'Success',
+      code: 200,
+    };
+    k8sDeleteResourceMock.mockResolvedValue(mockStatus as never);
+
+    const result = await deleteFeatureStore('test-ns', 'test-store');
+
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      model: FeatureStoreModel,
+      queryOptions: { name: 'test-store', ns: 'test-ns' },
+    });
+    expect(result).toEqual(mockStatus);
+  });
+});
+
+describe('getPodsForFeatureStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call k8sListResource with correct label selector', async () => {
+    const mockPods = [{ metadata: { name: 'pod-1' } }];
+    k8sListResourceMock.mockResolvedValue({ items: mockPods } as never);
+
+    const result = await getPodsForFeatureStore('test-ns', 'my-store');
+
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: PodModel,
+      queryOptions: {
+        ns: 'test-ns',
+        queryParams: { labelSelector: 'feast.dev/name=my-store' },
+      },
+    });
+    expect(result).toEqual(mockPods);
+  });
+
+  it('should reject invalid featureStoreName', async () => {
+    await expect(getPodsForFeatureStore('test-ns', 'store,app=nginx')).rejects.toThrow(
+      /Invalid featureStoreName/,
+    );
+    expect(k8sListResourceMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject empty featureStoreName', async () => {
+    await expect(getPodsForFeatureStore('test-ns', '')).rejects.toThrow(/Invalid featureStoreName/);
+    expect(k8sListResourceMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/feature-store/src/api/featureStores.ts
+++ b/packages/feature-store/src/api/featureStores.ts
@@ -1,0 +1,91 @@
+import {
+  k8sCreateResource,
+  k8sDeleteResource,
+  k8sGetResource,
+  k8sListResource,
+  K8sStatus,
+} from '@openshift/dynamic-plugin-sdk-utils';
+import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
+import { PodModel } from '@odh-dashboard/internal/api/models/k8s';
+import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
+import { isValidK8sName, PodKind } from '@odh-dashboard/k8s-core';
+import { FeatureStoreKind } from '../k8sTypes';
+import {
+  assembleFeatureStore,
+  normalizeFeatureStore,
+  normalizeFeatureStoreList,
+  FeatureStoreFormSpec,
+} from '../utils/featureStoreUtils';
+
+export { assembleFeatureStore, type FeatureStoreFormSpec } from '../utils/featureStoreUtils';
+
+export const createFeatureStore = async (
+  formData: FeatureStoreFormSpec,
+  opts?: K8sAPIOptions,
+): Promise<FeatureStoreKind> => {
+  const resource = assembleFeatureStore(formData);
+  const created = await k8sCreateResource<FeatureStoreKind>(
+    applyK8sAPIOptions(
+      {
+        model: FeatureStoreModel,
+        resource,
+      },
+      opts,
+    ),
+  );
+  return normalizeFeatureStore(created);
+};
+
+export const listFeatureStores = (namespace: string): Promise<FeatureStoreKind[]> =>
+  k8sListResource<FeatureStoreKind>({
+    model: FeatureStoreModel,
+    queryOptions: {
+      ns: namespace,
+    },
+  }).then((listResource) => normalizeFeatureStoreList(listResource.items));
+
+/**
+ * Lists FeatureStore CRs across all namespaces (cluster-wide).
+ * Requires cluster-level `list` permission on `featurestores.feast.dev`.
+ * Prefer per-namespace {@link listFeatureStores} gated by SSAR for unprivileged users.
+ */
+export const listAllFeatureStores = (): Promise<FeatureStoreKind[]> =>
+  k8sListResource<FeatureStoreKind>({
+    model: FeatureStoreModel,
+    queryOptions: {},
+  }).then((listResource) => normalizeFeatureStoreList(listResource.items));
+
+export const getFeatureStore = (namespace: string, name: string): Promise<FeatureStoreKind> =>
+  k8sGetResource<FeatureStoreKind>({
+    model: FeatureStoreModel,
+    queryOptions: {
+      name,
+      ns: namespace,
+    },
+  }).then(normalizeFeatureStore);
+
+export const deleteFeatureStore = (namespace: string, name: string): Promise<K8sStatus> =>
+  k8sDeleteResource<FeatureStoreKind, K8sStatus>({
+    model: FeatureStoreModel,
+    queryOptions: { name, ns: namespace },
+  });
+
+export const getPodsForFeatureStore = async (
+  namespace: string,
+  featureStoreName: string,
+): Promise<PodKind[]> => {
+  if (!isValidK8sName(featureStoreName)) {
+    throw new Error(
+      `Invalid featureStoreName "${featureStoreName}". Must be a valid DNS-1123 label.`,
+    );
+  }
+  const result = await k8sListResource<PodKind>({
+    model: PodModel,
+    queryOptions: {
+      ns: namespace,
+      queryParams: { labelSelector: `feast.dev/name=${featureStoreName}` },
+    },
+  });
+  return result.items;
+};

--- a/packages/feature-store/src/const.ts
+++ b/packages/feature-store/src/const.ts
@@ -4,6 +4,8 @@ export const FEATURE_STORE_API_VERSION = 'v1';
 
 /** Max items per page for /all endpoints (Feast API rejects limit > 100 with 422). */
 export const FEATURE_STORE_PAGE_SIZE = 100;
+export const FEAST_NAMESPACE_LABEL_KEY = 'opendatahub.io/feast';
+export const FEAST_NAMESPACE_LABEL_VALUE = 'true';
 export const FEATURE_STORE_UI_LABEL_KEY = 'feature-store-ui';
 export const FEATURE_STORE_UI_LABEL_VALUE = 'enabled';
 

--- a/packages/feature-store/src/hooks/__tests__/useAccessibleNamespaces.spec.tsx
+++ b/packages/feature-store/src/hooks/__tests__/useAccessibleNamespaces.spec.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { checkAccess } from '@odh-dashboard/internal/api/useAccessReview';
+import { ProjectKind } from '@odh-dashboard/k8s-core';
+import useAccessibleNamespaces from '../useAccessibleNamespaces';
+
+jest.mock('@odh-dashboard/internal/api/useAccessReview', () => ({
+  checkAccess: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/utilities/useFetch', () => {
+  const actual = jest.requireActual('@odh-dashboard/internal/utilities/useFetch');
+  return actual;
+});
+
+const checkAccessMock = jest.mocked(checkAccess);
+
+const makeProject = (name: string, displayName?: string): ProjectKind =>
+  ({
+    metadata: {
+      name,
+      annotations: displayName ? { 'openshift.io/display-name': displayName } : {},
+    },
+  } as unknown as ProjectKind);
+
+const createWrapper = (projects: ProjectKind[], loaded = true) => {
+  const contextValue = {
+    projects,
+    loaded,
+    refresh: jest.fn(),
+  } as unknown as React.ContextType<typeof ProjectsContext>;
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <ProjectsContext.Provider value={contextValue}>{children}</ProjectsContext.Provider>
+  );
+  Wrapper.displayName = 'ProjectsContextWrapper';
+  return Wrapper;
+};
+
+describe('useAccessibleNamespaces', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return namespaces where user has create access', async () => {
+    checkAccessMock.mockImplementation(async ({ namespace }) => namespace === 'allowed-ns');
+
+    const projects = [makeProject('allowed-ns', 'Allowed'), makeProject('denied-ns', 'Denied')];
+    const { result } = renderHook(() => useAccessibleNamespaces(), {
+      wrapper: createWrapper(projects),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.namespaces).toEqual([{ name: 'allowed-ns', displayName: 'Allowed' }]);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('should use namespace name as displayName when annotation is missing', async () => {
+    checkAccessMock.mockResolvedValue(true);
+
+    const projects = [makeProject('my-ns')];
+    const { result } = renderHook(() => useAccessibleNamespaces(), {
+      wrapper: createWrapper(projects),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.namespaces).toEqual([{ name: 'my-ns', displayName: 'my-ns' }]);
+  });
+
+  it('should treat checkAccess rejection as denied', async () => {
+    checkAccessMock.mockRejectedValue(new Error('RBAC error'));
+
+    const projects = [makeProject('ns-1')];
+    const { result } = renderHook(() => useAccessibleNamespaces(), {
+      wrapper: createWrapper(projects),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.namespaces).toEqual([]);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('should not fetch when projects are not loaded', () => {
+    const { result } = renderHook(() => useAccessibleNamespaces(), {
+      wrapper: createWrapper([], false),
+    });
+
+    expect(result.current.loaded).toBe(false);
+    expect(result.current.namespaces).toEqual([]);
+    expect(checkAccessMock).not.toHaveBeenCalled();
+  });
+
+  it('should return empty array when no projects exist', async () => {
+    const { result } = renderHook(() => useAccessibleNamespaces(), {
+      wrapper: createWrapper([]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.namespaces).toEqual([]);
+  });
+
+  it('should preserve data across rerenders when dependencies are unchanged', async () => {
+    checkAccessMock.mockResolvedValue(true);
+    const projects = [makeProject('ns-1')];
+
+    const { result, rerender } = renderHook(() => useAccessibleNamespaces(), {
+      wrapper: createWrapper(projects),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.namespaces).toHaveLength(1);
+
+    rerender();
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.namespaces).toHaveLength(1);
+  });
+});

--- a/packages/feature-store/src/hooks/__tests__/useExistingFeatureStores.spec.tsx
+++ b/packages/feature-store/src/hooks/__tests__/useExistingFeatureStores.spec.tsx
@@ -1,0 +1,225 @@
+import * as React from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectKind } from '@odh-dashboard/k8s-core';
+import { FeatureStoreKind } from '../../k8sTypes';
+import { listFeatureStores } from '../../api/featureStores';
+import useExistingFeatureStores from '../useExistingFeatureStores';
+
+jest.mock('../../api/featureStores', () => ({
+  listFeatureStores: jest.fn(),
+}));
+
+const listFeatureStoresMock = jest.mocked(listFeatureStores);
+
+const makeProject = (name: string, feastLabeled = true): ProjectKind =>
+  ({
+    metadata: {
+      name,
+      annotations: {},
+      labels: feastLabeled ? { 'opendatahub.io/feast': 'true' } : {},
+    },
+  } as unknown as ProjectKind);
+
+const makeStore = (
+  name: string,
+  namespace: string,
+  feastProject: string,
+  labels?: Record<string, string>,
+): FeatureStoreKind =>
+  ({
+    apiVersion: 'feast.dev/v1',
+    kind: 'FeatureStore',
+    metadata: { name, namespace, labels: labels ?? {}, annotations: {} },
+    spec: { feastProject },
+  } as FeatureStoreKind);
+
+const createWrapper = (projects: ProjectKind[], loaded = true) => {
+  const contextValue = {
+    projects,
+    loaded,
+    refresh: jest.fn(),
+  } as unknown as React.ContextType<typeof ProjectsContext>;
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <ProjectsContext.Provider value={contextValue}>{children}</ProjectsContext.Provider>
+  );
+  Wrapper.displayName = 'ProjectsContextWrapper';
+  return Wrapper;
+};
+
+describe('useExistingFeatureStores', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should load feature stores from all project namespaces', async () => {
+    const store1 = makeStore('store-1', 'ns-1', 'proj-1');
+    const store2 = makeStore('store-2', 'ns-2', 'proj-2');
+    listFeatureStoresMock.mockImplementation(async (ns) => (ns === 'ns-1' ? [store1] : [store2]));
+
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([makeProject('ns-1'), makeProject('ns-2')]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.featureStores).toHaveLength(2);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('should extract existingProjectNames and existingResourceNames', async () => {
+    const store = makeStore('my-store', 'ns-1', 'my-project');
+    listFeatureStoresMock.mockResolvedValue([store]);
+
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([makeProject('ns-1')]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.existingProjectNames).toEqual(['my-project']);
+    expect(result.current.existingResourceNames).toEqual(['my-store']);
+  });
+
+  it('should identify primaryStore by UI label', async () => {
+    const unlabeled = makeStore('store-a', 'ns-1', 'proj-a');
+    const labeled = makeStore('store-b', 'ns-1', 'proj-b', { 'feature-store-ui': 'enabled' });
+    listFeatureStoresMock.mockResolvedValue([unlabeled, labeled]);
+
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([makeProject('ns-1')]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.hasUILabeledStore).toBe(true);
+    expect(result.current.primaryStore?.metadata.name).toBe('store-b');
+  });
+
+  it('should fall back to alphabetically first store when no UI label', async () => {
+    const storeZ = makeStore('z-store', 'ns-1', 'proj-z');
+    const storeA = makeStore('a-store', 'ns-1', 'proj-a');
+    listFeatureStoresMock.mockResolvedValue([storeZ, storeA]);
+
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([makeProject('ns-1')]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.hasUILabeledStore).toBe(false);
+    expect(result.current.primaryStore?.metadata.name).toBe('a-store');
+  });
+
+  it('should surface non-403 partial failures as error', async () => {
+    listFeatureStoresMock.mockImplementation(async (ns) => {
+      if (ns === 'ns-fail') {
+        throw new Error('Internal server error');
+      }
+      return [makeStore('store-1', ns, 'proj-1')];
+    });
+
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([makeProject('ns-ok'), makeProject('ns-fail')]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.featureStores).toHaveLength(1);
+    expect(result.current.error?.message).toContain('ns-fail');
+  });
+
+  it('should silently skip namespaces with 403 RBAC errors', async () => {
+    listFeatureStoresMock.mockImplementation(async (ns) => {
+      if (ns === 'ns-forbidden') {
+        throw Object.assign(new Error('Forbidden'), { code: 403 });
+      }
+      return [makeStore('store-1', ns, 'proj-1')];
+    });
+
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([makeProject('ns-ok'), makeProject('ns-forbidden')]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.featureStores).toHaveLength(1);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('should skip namespaces without opendatahub.io/feast label', async () => {
+    listFeatureStoresMock.mockResolvedValue([makeStore('store-1', 'ns-labeled', 'proj-1')]);
+
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([makeProject('ns-labeled', true), makeProject('ns-unlabeled', false)]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(listFeatureStoresMock).toHaveBeenCalledTimes(1);
+    expect(listFeatureStoresMock).toHaveBeenCalledWith('ns-labeled');
+  });
+
+  it('should handle unexpected errors in fetchAll', async () => {
+    listFeatureStoresMock.mockImplementation(() => {
+      throw new Error('unexpected runtime error');
+    });
+
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([makeProject('ns-1')]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe('unexpected runtime error');
+    expect(result.current.featureStores).toEqual([]);
+  });
+
+  it('should not fetch when projects are not loaded', () => {
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([], false),
+    });
+
+    expect(result.current.loaded).toBe(false);
+    expect(listFeatureStoresMock).not.toHaveBeenCalled();
+  });
+
+  it('should support manual refresh', async () => {
+    listFeatureStoresMock.mockResolvedValue([makeStore('store-1', 'ns-1', 'proj-1')]);
+
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([makeProject('ns-1')]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(listFeatureStoresMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(listFeatureStoresMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/feature-store/src/hooks/__tests__/useNamespaceConfigMaps.spec.ts
+++ b/packages/feature-store/src/hooks/__tests__/useNamespaceConfigMaps.spec.ts
@@ -1,0 +1,75 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { ConfigMapModel } from '@odh-dashboard/internal/api/models';
+import useNamespaceConfigMaps from '../useNamespaceConfigMaps';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/utilities/useFetch', () => {
+  const actual = jest.requireActual('@odh-dashboard/internal/utilities/useFetch');
+  return actual;
+});
+
+const k8sListResourceMock = jest.mocked(k8sListResource);
+
+describe('useNamespaceConfigMaps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return sorted configmap names for a namespace', async () => {
+    k8sListResourceMock.mockResolvedValue({
+      items: [
+        { metadata: { name: 'z-config' } },
+        { metadata: { name: 'a-config' } },
+        { metadata: { name: 'm-config' } },
+      ],
+    } as never);
+
+    const { result } = renderHook(() => useNamespaceConfigMaps('test-ns'));
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.configMaps).toEqual(['a-config', 'm-config', 'z-config']);
+    expect(result.current.error).toBeUndefined();
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: ConfigMapModel,
+      queryOptions: { ns: 'test-ns' },
+    });
+  });
+
+  it('should return empty array when namespace has no configmaps', async () => {
+    k8sListResourceMock.mockResolvedValue({ items: [] } as never);
+
+    const { result } = renderHook(() => useNamespaceConfigMaps('test-ns'));
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.configMaps).toEqual([]);
+  });
+
+  it('should not fetch when namespace is empty', () => {
+    const { result } = renderHook(() => useNamespaceConfigMaps(''));
+
+    expect(result.current.loaded).toBe(false);
+    expect(k8sListResourceMock).not.toHaveBeenCalled();
+  });
+
+  it('should set error on API failure', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('forbidden'));
+
+    const { result } = renderHook(() => useNamespaceConfigMaps('test-ns'));
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+
+    expect(result.current.error?.message).toBe('forbidden');
+  });
+});

--- a/packages/feature-store/src/hooks/__tests__/useNamespaceSecrets.spec.ts
+++ b/packages/feature-store/src/hooks/__tests__/useNamespaceSecrets.spec.ts
@@ -1,0 +1,75 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { SecretModel } from '@odh-dashboard/internal/api/models';
+import useNamespaceSecrets from '../useNamespaceSecrets';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/utilities/useFetch', () => {
+  const actual = jest.requireActual('@odh-dashboard/internal/utilities/useFetch');
+  return actual;
+});
+
+const k8sListResourceMock = jest.mocked(k8sListResource);
+
+describe('useNamespaceSecrets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return sorted secret names for a namespace', async () => {
+    k8sListResourceMock.mockResolvedValue({
+      items: [
+        { metadata: { name: 'z-secret' } },
+        { metadata: { name: 'a-secret' } },
+        { metadata: { name: 'm-secret' } },
+      ],
+    } as never);
+
+    const { result } = renderHook(() => useNamespaceSecrets('test-ns'));
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.secrets).toEqual(['a-secret', 'm-secret', 'z-secret']);
+    expect(result.current.error).toBeUndefined();
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      model: SecretModel,
+      queryOptions: { ns: 'test-ns' },
+    });
+  });
+
+  it('should return empty array when namespace has no secrets', async () => {
+    k8sListResourceMock.mockResolvedValue({ items: [] } as never);
+
+    const { result } = renderHook(() => useNamespaceSecrets('test-ns'));
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.secrets).toEqual([]);
+  });
+
+  it('should not fetch when namespace is empty', () => {
+    const { result } = renderHook(() => useNamespaceSecrets(''));
+
+    expect(result.current.loaded).toBe(false);
+    expect(k8sListResourceMock).not.toHaveBeenCalled();
+  });
+
+  it('should set error on API failure', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('forbidden'));
+
+    const { result } = renderHook(() => useNamespaceSecrets('test-ns'));
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+
+    expect(result.current.error?.message).toBe('forbidden');
+  });
+});

--- a/packages/feature-store/src/hooks/__tests__/useWatchFeatureStoreDeployment.spec.ts
+++ b/packages/feature-store/src/hooks/__tests__/useWatchFeatureStoreDeployment.spec.ts
@@ -1,0 +1,392 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { PodKind } from '@odh-dashboard/k8s-core';
+import { getPodContainerLogText } from '@odh-dashboard/internal/api/k8s/pods';
+import { FeatureStoreKind } from '../../k8sTypes';
+import { getFeatureStore, getPodsForFeatureStore } from '../../api/featureStores';
+import useWatchFeatureStoreDeployment, {
+  isTerminal,
+  isTransientLogError,
+  transientLogMessage,
+  resolvePhase,
+  DeploymentPhase,
+} from '../useWatchFeatureStoreDeployment';
+
+jest.mock('../../api/featureStores', () => ({
+  getFeatureStore: jest.fn(),
+  getPodsForFeatureStore: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/api/k8s/pods', () => ({
+  getPodContainerLogText: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/utilities/useFetch', () => {
+  const actual = jest.requireActual('@odh-dashboard/internal/utilities/useFetch');
+  return actual;
+});
+
+const getFeatureStoreMock = jest.mocked(getFeatureStore);
+const getPodsForFeatureStoreMock = jest.mocked(getPodsForFeatureStore);
+const getPodContainerLogTextMock = jest.mocked(getPodContainerLogText);
+
+const makeFS = (phase?: string): FeatureStoreKind =>
+  ({
+    apiVersion: 'feast.dev/v1',
+    kind: 'FeatureStore',
+    metadata: { name: 'test', namespace: 'ns' },
+    spec: { feastProject: 'proj' },
+    ...(phase !== undefined ? { status: { phase } } : {}),
+  } as FeatureStoreKind);
+
+const makePod = (name: string, containers: string[], initContainers?: string[]): PodKind =>
+  ({
+    metadata: { name },
+    spec: {
+      containers: containers.map((c) => ({ name: c })),
+      initContainers: initContainers?.map((c) => ({ name: c })),
+    },
+  } as unknown as PodKind);
+
+describe('resolvePhase', () => {
+  it('returns Pending when FeatureStore is null', () => {
+    expect(resolvePhase(null)).toBe('Pending');
+  });
+
+  it('returns Pending when status is undefined', () => {
+    expect(resolvePhase(makeFS())).toBe('Pending');
+  });
+
+  it('returns Pending when status.phase is an empty string', () => {
+    expect(resolvePhase(makeFS(''))).toBe('Pending');
+  });
+
+  it('returns Pending for explicit "Pending" phase', () => {
+    expect(resolvePhase(makeFS('Pending'))).toBe('Pending');
+  });
+
+  it('returns Ready for "Ready" phase', () => {
+    expect(resolvePhase(makeFS('Ready'))).toBe('Ready');
+  });
+
+  it('returns Failed for "Failed" phase', () => {
+    expect(resolvePhase(makeFS('Failed'))).toBe('Failed');
+  });
+
+  it('returns Installing for "Installing" phase', () => {
+    expect(resolvePhase(makeFS('Installing'))).toBe('Installing');
+  });
+
+  it('returns Installing for "Provisioning" phase', () => {
+    expect(resolvePhase(makeFS('Provisioning'))).toBe('Installing');
+  });
+
+  it('returns Unknown for unrecognized phase strings', () => {
+    expect(resolvePhase(makeFS('SomethingElse'))).toBe('Unknown');
+  });
+});
+
+describe('isTerminal', () => {
+  it.each<[DeploymentPhase, boolean]>([
+    ['Ready', true],
+    ['Failed', true],
+    ['Pending', false],
+    ['Installing', false],
+    ['Unknown', false],
+  ])('returns %s for phase "%s"', (phase, expected) => {
+    expect(isTerminal(phase)).toBe(expected);
+  });
+});
+
+describe('isTransientLogError', () => {
+  it('returns true for ContainerCreating errors', () => {
+    expect(isTransientLogError(new Error('ContainerCreating'))).toBe(true);
+  });
+
+  it('returns true for PodInitializing errors', () => {
+    expect(isTransientLogError(new Error('PodInitializing'))).toBe(true);
+  });
+
+  it('returns true for standalone 400 status code', () => {
+    expect(isTransientLogError(new Error('request failed with status 400'))).toBe(true);
+  });
+
+  it('returns false for port 8400 (word-boundary check)', () => {
+    expect(isTransientLogError(new Error('port 8400 in use'))).toBe(false);
+  });
+
+  it('returns false for http://svc:8400 (word-boundary check)', () => {
+    expect(isTransientLogError(new Error('connect to http://svc:8400'))).toBe(false);
+  });
+
+  it('returns false for RBAC/auth errors', () => {
+    expect(isTransientLogError(new Error('forbidden: User cannot get pods/log'))).toBe(false);
+  });
+
+  it('returns false for connection errors', () => {
+    expect(isTransientLogError(new Error('connection refused'))).toBe(false);
+  });
+
+  it('handles non-Error thrown values', () => {
+    expect(isTransientLogError('ContainerCreating')).toBe(true);
+    expect(isTransientLogError('some other error')).toBe(false);
+  });
+});
+
+describe('transientLogMessage', () => {
+  it('returns init-container waiting message when isInit is true', () => {
+    expect(transientLogMessage(true)).toBe('(waiting for init container to start...)');
+  });
+
+  it('returns container waiting message when isInit is false', () => {
+    expect(transientLogMessage(false)).toBe('(waiting for container to start...)');
+  });
+});
+
+describe('useWatchFeatureStoreDeployment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should return initial pending state when namespace/name are empty', () => {
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('', ''));
+
+    expect(result.current.featureStore).toBeNull();
+    expect(result.current.phase).toBe('Pending');
+    expect(result.current.pods).toEqual([]);
+    expect(result.current.isComplete).toBe(false);
+    expect(result.current.isFailed).toBe(false);
+  });
+
+  it('should fetch deployment and resolve phase', async () => {
+    const fs = makeFS('Installing');
+    getFeatureStoreMock.mockResolvedValue(fs);
+    getPodsForFeatureStoreMock.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.featureStore).toEqual(fs);
+    expect(result.current.phase).toBe('Installing');
+    expect(result.current.isComplete).toBe(false);
+    expect(result.current.isFailed).toBe(false);
+    expect(getFeatureStoreMock).toHaveBeenCalledWith('ns', 'test');
+    expect(getPodsForFeatureStoreMock).toHaveBeenCalledWith('ns', 'test');
+  });
+
+  it('should set isComplete when phase is Ready', async () => {
+    getFeatureStoreMock.mockResolvedValue(makeFS('Ready'));
+    getPodsForFeatureStoreMock.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.isComplete).toBe(true);
+    expect(result.current.isFailed).toBe(false);
+  });
+
+  it('should set isFailed when phase is Failed', async () => {
+    getFeatureStoreMock.mockResolvedValue(makeFS('Failed'));
+    getPodsForFeatureStoreMock.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.isComplete).toBe(false);
+    expect(result.current.isFailed).toBe(true);
+  });
+
+  it('should extract conditions from feature store status', async () => {
+    const fs = {
+      ...makeFS('Installing'),
+      status: {
+        phase: 'Installing',
+        conditions: [{ type: 'Available', status: 'True' }],
+      },
+    } as FeatureStoreKind;
+    getFeatureStoreMock.mockResolvedValue(fs);
+    getPodsForFeatureStoreMock.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.conditions).toEqual([{ type: 'Available', status: 'True' }]);
+  });
+
+  it('should return empty conditions when status has none', async () => {
+    getFeatureStoreMock.mockResolvedValue(makeFS('Installing'));
+    getPodsForFeatureStoreMock.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.conditions).toEqual([]);
+  });
+
+  it('should set error on API failure', async () => {
+    getFeatureStoreMock.mockRejectedValue(new Error('not found'));
+    getPodsForFeatureStoreMock.mockRejectedValue(new Error('not found'));
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+
+    expect(result.current.error?.message).toBe('not found');
+  });
+
+  it('should fetch pod logs when pods are available', async () => {
+    const pod = makePod('pod-1', ['main']);
+    getFeatureStoreMock.mockResolvedValue(makeFS('Installing'));
+    getPodsForFeatureStoreMock.mockResolvedValue([pod]);
+    getPodContainerLogTextMock.mockResolvedValue('log line 1\nlog line 2');
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.podLogs.data).toEqual({ 'pod-1/main': 'log line 1\nlog line 2' });
+    });
+
+    expect(getPodContainerLogTextMock).toHaveBeenCalledWith('ns', 'pod-1', 'main', 200);
+  });
+
+  it('should fetch logs for init containers', async () => {
+    const pod = makePod('pod-1', ['main'], ['init-1']);
+    getFeatureStoreMock.mockResolvedValue(makeFS('Installing'));
+    getPodsForFeatureStoreMock.mockResolvedValue([pod]);
+    getPodContainerLogTextMock.mockResolvedValue('init log');
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.podLogs.data).toHaveProperty('pod-1/init:init-1', 'init log');
+    });
+  });
+
+  it('should return transient message for ContainerCreating errors on init containers', async () => {
+    const pod = makePod('pod-1', ['main'], ['init-1']);
+    getFeatureStoreMock.mockResolvedValue(makeFS('Installing'));
+    getPodsForFeatureStoreMock.mockResolvedValue([pod]);
+    getPodContainerLogTextMock.mockImplementation(async (_ns, _pod, container) => {
+      if (container === 'init-1') {
+        throw new Error('ContainerCreating');
+      }
+      return 'main log';
+    });
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.podLogs.data).toHaveProperty(
+        'pod-1/init:init-1',
+        '(waiting for init container to start...)',
+      );
+    });
+  });
+
+  it('should return transient message for ContainerCreating on regular containers', async () => {
+    const pod = makePod('pod-1', ['main']);
+    getFeatureStoreMock.mockResolvedValue(makeFS('Installing'));
+    getPodsForFeatureStoreMock.mockResolvedValue([pod]);
+    getPodContainerLogTextMock.mockRejectedValue(new Error('ContainerCreating'));
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.podLogs.data).toHaveProperty(
+        'pod-1/main',
+        '(waiting for container to start...)',
+      );
+    });
+  });
+
+  it('should propagate hard log errors', async () => {
+    const pod = makePod('pod-1', ['main']);
+    getFeatureStoreMock.mockResolvedValue(makeFS('Installing'));
+    getPodsForFeatureStoreMock.mockResolvedValue([pod]);
+    getPodContainerLogTextMock.mockRejectedValue(new Error('forbidden: RBAC denied'));
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.podLogs.error).toBeDefined();
+    });
+
+    expect(result.current.podLogs.error?.message).toBe('forbidden: RBAC denied');
+  });
+
+  it('should limit log fetches to MAX_LOG_PODS pods', async () => {
+    const pods = Array.from({ length: 8 }, (_, i) => makePod(`pod-${i}`, ['main']));
+    getFeatureStoreMock.mockResolvedValue(makeFS('Installing'));
+    getPodsForFeatureStoreMock.mockResolvedValue(pods);
+    getPodContainerLogTextMock.mockResolvedValue('log');
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.podLogs.loaded).toBe(true);
+    });
+
+    expect(getPodContainerLogTextMock).toHaveBeenCalledTimes(5);
+  });
+
+  it('should limit total log entries to MAX_LOG_ENTRIES across containers', async () => {
+    const manyContainers = Array.from({ length: 10 }, (_, i) => `container-${i}`);
+    const pods = [makePod('pod-0', manyContainers), makePod('pod-1', manyContainers)];
+    getFeatureStoreMock.mockResolvedValue(makeFS('Installing'));
+    getPodsForFeatureStoreMock.mockResolvedValue(pods);
+    getPodContainerLogTextMock.mockResolvedValue('log');
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.podLogs.loaded).toBe(true);
+    });
+
+    expect(getPodContainerLogTextMock).toHaveBeenCalledTimes(15);
+  });
+
+  it('should propagate hard log errors from init containers', async () => {
+    const pod = makePod('pod-1', ['main'], ['init-1']);
+    getFeatureStoreMock.mockResolvedValue(makeFS('Installing'));
+    getPodsForFeatureStoreMock.mockResolvedValue([pod]);
+    getPodContainerLogTextMock.mockImplementation(async (_ns, _pod, container) => {
+      if (container === 'init-1') {
+        throw new Error('forbidden: init RBAC denied');
+      }
+      return 'main log';
+    });
+
+    const { result } = renderHook(() => useWatchFeatureStoreDeployment('ns', 'test'));
+
+    await waitFor(() => {
+      expect(result.current.podLogs.error).toBeDefined();
+    });
+
+    expect(result.current.podLogs.error?.message).toBe('forbidden: init RBAC denied');
+  });
+});

--- a/packages/feature-store/src/hooks/useAccessibleNamespaces.ts
+++ b/packages/feature-store/src/hooks/useAccessibleNamespaces.ts
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { ProjectKind } from '@odh-dashboard/k8s-core';
+import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { checkAccess } from '@odh-dashboard/internal/api/useAccessReview';
+import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
+import useFetch, {
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '@odh-dashboard/internal/utilities/useFetch';
+
+type NamespaceInfo = {
+  name: string;
+  displayName: string;
+};
+
+type UseAccessibleNamespacesReturn = {
+  namespaces: NamespaceInfo[];
+  loaded: boolean;
+  error?: Error;
+};
+
+const useAccessibleNamespaces = (): UseAccessibleNamespacesReturn => {
+  const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
+
+  const fetchAccessibleNamespaces = React.useCallback<
+    FetchStateCallbackPromise<NamespaceInfo[]>
+  >(() => {
+    if (!projectsLoaded) {
+      return Promise.reject(new NotReadyError('Projects not loaded'));
+    }
+    return Promise.all(
+      projects.map(async (project: ProjectKind) => {
+        const ns = project.metadata.name;
+        const displayName = project.metadata.annotations?.['openshift.io/display-name'] || ns;
+        let allowed: boolean;
+        try {
+          allowed = await checkAccess({
+            group: FeatureStoreModel.apiGroup ?? '',
+            resource: FeatureStoreModel.plural,
+            verb: 'create',
+            name: '',
+            namespace: ns,
+            subresource: '',
+          });
+        } catch {
+          allowed = false;
+        }
+        return { name: ns, displayName, allowed };
+      }),
+    ).then((results) =>
+      results.filter((r) => r.allowed).map((r) => ({ name: r.name, displayName: r.displayName })),
+    );
+  }, [projects, projectsLoaded]);
+
+  const { data: namespaces, loaded, error } = useFetch(fetchAccessibleNamespaces, []);
+
+  return { namespaces, loaded, error };
+};
+
+export default useAccessibleNamespaces;

--- a/packages/feature-store/src/hooks/useExistingFeatureStores.ts
+++ b/packages/feature-store/src/hooks/useExistingFeatureStores.ts
@@ -1,0 +1,128 @@
+import React from 'react';
+import { ProjectKind } from '@odh-dashboard/k8s-core';
+import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { FeatureStoreKind } from '../k8sTypes';
+import { listFeatureStores } from '../api/featureStores';
+import {
+  FEAST_NAMESPACE_LABEL_KEY,
+  FEAST_NAMESPACE_LABEL_VALUE,
+  FEATURE_STORE_UI_LABEL_KEY,
+  FEATURE_STORE_UI_LABEL_VALUE,
+} from '../const';
+
+type UseExistingFeatureStoresReturn = {
+  featureStores: FeatureStoreKind[];
+  loaded: boolean;
+  error?: Error;
+  existingProjectNames: string[];
+  existingResourceNames: string[];
+  hasUILabeledStore: boolean;
+  primaryStore: FeatureStoreKind | undefined;
+  refresh: () => void;
+};
+
+const useExistingFeatureStores = (): UseExistingFeatureStoresReturn => {
+  const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
+  const [featureStores, setFeatureStores] = React.useState<FeatureStoreKind[]>([]);
+  const [loaded, setLoaded] = React.useState(false);
+  const [error, setError] = React.useState<Error | undefined>();
+  const [refreshKey, setRefreshKey] = React.useState(0);
+
+  const refresh = React.useCallback(() => setRefreshKey((k) => k + 1), []);
+
+  React.useEffect(() => {
+    if (!projectsLoaded) {
+      return;
+    }
+    let cancelled = false;
+    setLoaded(false);
+    setError(undefined);
+
+    const fetchAll = async () => {
+      try {
+        const feastProjects = projects.filter(
+          (p: ProjectKind) =>
+            p.metadata.labels?.[FEAST_NAMESPACE_LABEL_KEY] === FEAST_NAMESPACE_LABEL_VALUE,
+        );
+        const namespaces = feastProjects.map((p: ProjectKind) => p.metadata.name);
+        const emptyList: FeatureStoreKind[] = [];
+        const failures: string[] = [];
+        const results = await Promise.all(
+          namespaces.map((ns) =>
+            listFeatureStores(ns).catch((e: unknown) => {
+              const isRbacDenied =
+                e != null &&
+                typeof e === 'object' &&
+                'code' in e &&
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                (e as { code: number }).code === 403;
+              if (!isRbacDenied) {
+                failures.push(ns);
+              }
+              return emptyList;
+            }),
+          ),
+        );
+
+        if (!cancelled) {
+          setFeatureStores(results.flat());
+          if (failures.length > 0) {
+            setError(
+              new Error(`Failed to list FeatureStores in namespace(s): ${failures.join(', ')}`),
+            );
+          }
+          setLoaded(true);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e : new Error(String(e)));
+          setLoaded(true);
+        }
+      }
+    };
+
+    fetchAll();
+    return () => {
+      cancelled = true;
+    };
+  }, [projects, projectsLoaded, refreshKey]);
+
+  const existingProjectNames = React.useMemo(
+    () => featureStores.map((fs) => fs.spec.feastProject),
+    [featureStores],
+  );
+
+  const existingResourceNames = React.useMemo(
+    () => featureStores.map((fs) => fs.metadata.name),
+    [featureStores],
+  );
+
+  const hasUILabeledStore = React.useMemo(
+    () =>
+      featureStores.some(
+        (fs) => fs.metadata.labels?.[FEATURE_STORE_UI_LABEL_KEY] === FEATURE_STORE_UI_LABEL_VALUE,
+      ),
+    [featureStores],
+  );
+
+  const primaryStore = React.useMemo(
+    () =>
+      featureStores.find(
+        (fs) => fs.metadata.labels?.[FEATURE_STORE_UI_LABEL_KEY] === FEATURE_STORE_UI_LABEL_VALUE,
+      ) || featureStores.toSorted((a, b) => a.metadata.name.localeCompare(b.metadata.name))[0],
+    [featureStores],
+  );
+
+  return {
+    featureStores,
+    loaded,
+    error,
+    existingProjectNames,
+    existingResourceNames,
+    hasUILabeledStore,
+    primaryStore,
+    refresh,
+  };
+};
+
+export default useExistingFeatureStores;

--- a/packages/feature-store/src/hooks/useNamespaceConfigMaps.ts
+++ b/packages/feature-store/src/hooks/useNamespaceConfigMaps.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import useFetch, {
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '@odh-dashboard/internal/utilities/useFetch';
+import { ConfigMapKind } from '@odh-dashboard/internal/k8sTypes';
+import { ConfigMapModel } from '@odh-dashboard/internal/api/models';
+
+const useNamespaceConfigMaps = (
+  namespace: string,
+): { configMaps: string[]; loaded: boolean; error?: Error } => {
+  const fetchConfigMaps = React.useCallback<FetchStateCallbackPromise<string[]>>(() => {
+    if (!namespace) {
+      return Promise.reject(new NotReadyError('No namespace selected'));
+    }
+    return k8sListResource<ConfigMapKind>({
+      model: ConfigMapModel,
+      queryOptions: { ns: namespace },
+    }).then((result) => result.items.map((cm) => cm.metadata.name).toSorted());
+  }, [namespace]);
+
+  const { data: configMaps, loaded, error } = useFetch(fetchConfigMaps, []);
+
+  return { configMaps, loaded, error };
+};
+
+export default useNamespaceConfigMaps;

--- a/packages/feature-store/src/hooks/useNamespaceSecrets.ts
+++ b/packages/feature-store/src/hooks/useNamespaceSecrets.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import useFetch, {
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '@odh-dashboard/internal/utilities/useFetch';
+import { SecretKind } from '@odh-dashboard/k8s-core';
+import { SecretModel } from '@odh-dashboard/internal/api/models';
+
+const useNamespaceSecrets = (
+  namespace: string,
+): { secrets: string[]; loaded: boolean; error?: Error } => {
+  const fetchSecrets = React.useCallback<FetchStateCallbackPromise<string[]>>(() => {
+    if (!namespace) {
+      return Promise.reject(new NotReadyError('No namespace selected'));
+    }
+    return k8sListResource<SecretKind>({
+      model: SecretModel,
+      queryOptions: { ns: namespace },
+    }).then((result) => result.items.map((s) => s.metadata.name).toSorted());
+  }, [namespace]);
+
+  const { data: secrets, loaded, error } = useFetch(fetchSecrets, []);
+
+  return { secrets, loaded, error };
+};
+
+export default useNamespaceSecrets;

--- a/packages/feature-store/src/hooks/useWatchFeatureStoreDeployment.ts
+++ b/packages/feature-store/src/hooks/useWatchFeatureStoreDeployment.ts
@@ -1,0 +1,160 @@
+import React from 'react';
+import { K8sCondition, PodKind } from '@odh-dashboard/k8s-core';
+import useFetch, { FetchStateObject } from '@odh-dashboard/internal/utilities/useFetch';
+import { NotReadyError } from '@odh-dashboard/internal/utilities/useFetchState';
+import { FAST_POLL_INTERVAL } from '@odh-dashboard/internal/utilities/const';
+import { getPodContainerLogText } from '@odh-dashboard/internal/api/k8s/pods';
+import { FeatureStoreKind } from '../k8sTypes';
+import { getFeatureStore, getPodsForFeatureStore } from '../api/featureStores';
+
+const LOG_TAIL_LINES = 200;
+const MAX_LOG_PODS = 5;
+const MAX_LOG_ENTRIES = 15;
+
+export type DeploymentPhase = 'Pending' | 'Installing' | 'Ready' | 'Failed' | 'Unknown';
+
+export const isTerminal = (phase: DeploymentPhase): boolean =>
+  phase === 'Ready' || phase === 'Failed';
+
+export const isTransientLogError = (e: unknown): boolean => {
+  const msg = e instanceof Error ? e.message : String(e);
+  return (
+    msg.includes('ContainerCreating') || msg.includes('PodInitializing') || /\b400\b/.test(msg)
+  );
+};
+
+export const transientLogMessage = (isInit: boolean): string =>
+  isInit ? '(waiting for init container to start...)' : '(waiting for container to start...)';
+
+type DeploymentData = {
+  featureStore: FeatureStoreKind | null;
+  pods: PodKind[];
+};
+
+export type DeploymentStatus = {
+  featureStore: FeatureStoreKind | null;
+  phase: DeploymentPhase;
+  conditions: K8sCondition[];
+  pods: PodKind[];
+  podLogs: FetchStateObject<Record<string, string>>;
+  isComplete: boolean;
+  isFailed: boolean;
+  loaded: boolean;
+  error: Error | undefined;
+  refresh: () => Promise<DeploymentData | undefined>;
+};
+
+export const resolvePhase = (fs: FeatureStoreKind | null): DeploymentPhase => {
+  if (!fs?.status?.phase) {
+    return 'Pending';
+  }
+  const p = fs.status.phase;
+  if (p === 'Ready') {
+    return 'Ready';
+  }
+  if (p === 'Failed') {
+    return 'Failed';
+  }
+  if (p === 'Installing' || p === 'Provisioning') {
+    return 'Installing';
+  }
+  if (p === 'Pending') {
+    return 'Pending';
+  }
+  return 'Unknown';
+};
+
+const INITIAL_DATA: DeploymentData = { featureStore: null, pods: [] };
+
+const useWatchFeatureStoreDeployment = (namespace: string, name: string): DeploymentStatus => {
+  const fetchDeployment = React.useCallback(() => {
+    if (!namespace || !name) {
+      return Promise.reject(new NotReadyError('Missing namespace or name'));
+    }
+    return Promise.all([
+      getFeatureStore(namespace, name),
+      getPodsForFeatureStore(namespace, name),
+    ]).then(([featureStore, pods]) => ({ featureStore, pods }));
+  }, [namespace, name]);
+
+  const phaseRef = React.useRef<DeploymentPhase>('Pending');
+
+  const { data, loaded, error, refresh } = useFetch<DeploymentData>(fetchDeployment, INITIAL_DATA, {
+    refreshRate: isTerminal(phaseRef.current) ? 0 : FAST_POLL_INTERVAL,
+  });
+
+  const { featureStore, pods } = data;
+  const phase = resolvePhase(featureStore);
+  phaseRef.current = phase;
+  const isComplete = phase === 'Ready';
+  const isFailed = phase === 'Failed';
+
+  const fetchLogs = React.useCallback(() => {
+    if (!namespace || pods.length === 0) {
+      return Promise.reject(new NotReadyError('No pods available'));
+    }
+    const entries: Promise<[string, string]>[] = [];
+    const recentPods = pods.slice(0, MAX_LOG_PODS);
+    for (const pod of recentPods) {
+      for (const initContainer of pod.spec.initContainers ?? []) {
+        if (entries.length >= MAX_LOG_ENTRIES) {
+          break;
+        }
+        const key = `${pod.metadata.name}/init:${initContainer.name}`;
+        entries.push(
+          getPodContainerLogText(namespace, pod.metadata.name, initContainer.name, LOG_TAIL_LINES)
+            .then((text): [string, string] => [key, text])
+            .catch((e): [string, string] => {
+              if (isTransientLogError(e)) {
+                return [key, transientLogMessage(true)];
+              }
+              throw e;
+            }),
+        );
+      }
+      if (entries.length >= MAX_LOG_ENTRIES) {
+        break;
+      }
+      for (const container of pod.spec.containers) {
+        if (entries.length >= MAX_LOG_ENTRIES) {
+          break;
+        }
+        const key = `${pod.metadata.name}/${container.name}`;
+        entries.push(
+          getPodContainerLogText(namespace, pod.metadata.name, container.name, LOG_TAIL_LINES)
+            .then((text): [string, string] => [key, text])
+            .catch((e): [string, string] => {
+              if (isTransientLogError(e)) {
+                return [key, transientLogMessage(false)];
+              }
+              throw e;
+            }),
+        );
+      }
+    }
+    return Promise.all(entries).then((results) =>
+      results.reduce<Record<string, string>>((acc, [k, v]) => {
+        acc[k] = v;
+        return acc;
+      }, {}),
+    );
+  }, [namespace, pods]);
+
+  const logPollRate = isTerminal(phase) ? 0 : FAST_POLL_INTERVAL;
+  const podLogs = useFetch<Record<string, string>>(fetchLogs, {}, { refreshRate: logPollRate });
+
+  return {
+    featureStore,
+    phase,
+    conditions: featureStore?.status?.conditions ?? [],
+    pods,
+    podLogs,
+    isComplete,
+    isFailed,
+    loaded,
+    error,
+    refresh,
+  };
+};
+
+export default useWatchFeatureStoreDeployment;

--- a/packages/feature-store/src/utils/__tests__/featureStoreUtils.spec.ts
+++ b/packages/feature-store/src/utils/__tests__/featureStoreUtils.spec.ts
@@ -1,0 +1,257 @@
+import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
+import { FeatureStoreKind } from '../../k8sTypes';
+import {
+  assembleFeatureStore,
+  isValidFeatureStore,
+  normalizeFeatureStore,
+  normalizeFeatureStoreList,
+  FeatureStoreFormSpec,
+} from '../featureStoreUtils';
+
+jest.mock('@odh-dashboard/k8s-core', () => ({
+  kindApiVersion: jest.fn(() => 'feast.dev/v1'),
+  isValidK8sName: jest.requireActual('@odh-dashboard/k8s-core').isValidK8sName,
+}));
+
+const makeFeatureStore = (
+  overrides: Partial<FeatureStoreKind> & {
+    name?: string;
+    namespace?: string;
+    feastProject?: string;
+  } = {},
+): FeatureStoreKind => ({
+  apiVersion: 'feast.dev/v1',
+  kind: 'FeatureStore',
+  metadata: {
+    name: overrides.name ?? 'test-store',
+    namespace: overrides.namespace ?? 'test-ns',
+    ...overrides.metadata,
+  },
+  spec: {
+    feastProject: overrides.feastProject ?? 'test-project',
+    ...overrides.spec,
+  },
+  ...('status' in overrides ? { status: overrides.status } : {}),
+});
+
+describe('assembleFeatureStore', () => {
+  const minimalFormData: FeatureStoreFormSpec = {
+    feastProject: 'my-project',
+    namespace: 'my-namespace',
+  };
+
+  it('should assemble a minimal FeatureStore with only required fields', () => {
+    const result = assembleFeatureStore(minimalFormData);
+
+    expect(result).toEqual({
+      apiVersion: 'feast.dev/v1',
+      kind: FeatureStoreModel.kind,
+      metadata: {
+        name: 'my-project',
+        namespace: 'my-namespace',
+      },
+      spec: {
+        feastProject: 'my-project',
+      },
+    });
+  });
+
+  it('should include services when provided', () => {
+    const formData: FeatureStoreFormSpec = {
+      ...minimalFormData,
+      services: { onlineStore: { persistence: { file: { path: '/data' } } } },
+    };
+    const result = assembleFeatureStore(formData);
+
+    expect(result.spec.services).toEqual({
+      onlineStore: { persistence: { file: { path: '/data' } } },
+    });
+  });
+
+  it('should include authz when provided', () => {
+    const formData: FeatureStoreFormSpec = {
+      ...minimalFormData,
+      authz: { kubernetes: { roles: ['admin'] } },
+    };
+    const result = assembleFeatureStore(formData);
+
+    expect(result.spec.authz).toEqual({ kubernetes: { roles: ['admin'] } });
+  });
+
+  it('should include feastProjectDir when provided', () => {
+    const formData: FeatureStoreFormSpec = {
+      ...minimalFormData,
+      feastProjectDir: {
+        git: { url: 'https://github.com/example/repo.git' },
+      },
+    };
+    const result = assembleFeatureStore(formData);
+
+    expect(result.spec.feastProjectDir).toEqual({
+      git: { url: 'https://github.com/example/repo.git' },
+    });
+  });
+
+  it('should include cronJob when provided', () => {
+    const formData: FeatureStoreFormSpec = {
+      ...minimalFormData,
+      cronJob: { schedule: '*/5 * * * *' },
+    };
+    const result = assembleFeatureStore(formData);
+
+    expect(result.spec.cronJob).toEqual({ schedule: '*/5 * * * *' });
+  });
+
+  it('should include batchEngine when provided', () => {
+    const formData: FeatureStoreFormSpec = {
+      ...minimalFormData,
+      batchEngine: { configMapRef: { name: 'spark-config' } },
+    };
+    const result = assembleFeatureStore(formData);
+
+    expect(result.spec.batchEngine).toEqual({ configMapRef: { name: 'spark-config' } });
+  });
+
+  it('should include replicas only when greater than 1', () => {
+    expect(assembleFeatureStore({ ...minimalFormData, replicas: 3 }).spec.replicas).toBe(3);
+    expect(assembleFeatureStore({ ...minimalFormData, replicas: 1 }).spec.replicas).toBeUndefined();
+    expect(assembleFeatureStore({ ...minimalFormData, replicas: 0 }).spec.replicas).toBeUndefined();
+  });
+
+  it('should include labels when non-empty', () => {
+    const formData: FeatureStoreFormSpec = {
+      ...minimalFormData,
+      labels: { 'feature-store-ui': 'enabled' },
+    };
+    const result = assembleFeatureStore(formData);
+
+    expect(result.metadata.labels).toEqual({ 'feature-store-ui': 'enabled' });
+  });
+
+  it('should omit labels when empty object', () => {
+    const formData: FeatureStoreFormSpec = {
+      ...minimalFormData,
+      labels: {},
+    };
+    const result = assembleFeatureStore(formData);
+
+    expect(result.metadata.labels).toBeUndefined();
+  });
+
+  it('should throw on invalid namespace', () => {
+    expect(() => assembleFeatureStore({ ...minimalFormData, namespace: '' })).toThrow(
+      /Invalid namespace/,
+    );
+    expect(() => assembleFeatureStore({ ...minimalFormData, namespace: 'Bad-NS' })).toThrow(
+      /Invalid namespace/,
+    );
+  });
+
+  it('should throw on uppercase characters in feastProject', () => {
+    expect(() => assembleFeatureStore({ ...minimalFormData, feastProject: 'MyProject' })).toThrow(
+      /Invalid feastProject name/,
+    );
+  });
+
+  it('should throw on feastProject starting with a hyphen', () => {
+    expect(() => assembleFeatureStore({ ...minimalFormData, feastProject: '-bad-name' })).toThrow(
+      /Invalid feastProject name/,
+    );
+  });
+
+  it('should throw on feastProject ending with a hyphen', () => {
+    expect(() => assembleFeatureStore({ ...minimalFormData, feastProject: 'bad-name-' })).toThrow(
+      /Invalid feastProject name/,
+    );
+  });
+
+  it('should throw on feastProject with spaces', () => {
+    expect(() => assembleFeatureStore({ ...minimalFormData, feastProject: 'bad name' })).toThrow(
+      /Invalid feastProject name/,
+    );
+  });
+
+  it('should throw on empty feastProject', () => {
+    expect(() => assembleFeatureStore({ ...minimalFormData, feastProject: '' })).toThrow(
+      /Invalid feastProject name/,
+    );
+  });
+
+  it('should accept valid DNS-1123 names', () => {
+    expect(() =>
+      assembleFeatureStore({ ...minimalFormData, feastProject: 'my-project-01' }),
+    ).not.toThrow();
+    expect(() => assembleFeatureStore({ ...minimalFormData, feastProject: 'a' })).not.toThrow();
+    expect(() =>
+      assembleFeatureStore({ ...minimalFormData, feastProject: 'test-123-store' }),
+    ).not.toThrow();
+  });
+
+  it('should not include optional spec fields when not provided', () => {
+    const result = assembleFeatureStore(minimalFormData);
+
+    expect(result.spec.services).toBeUndefined();
+    expect(result.spec.authz).toBeUndefined();
+    expect(result.spec.feastProjectDir).toBeUndefined();
+    expect(result.spec.cronJob).toBeUndefined();
+    expect(result.spec.batchEngine).toBeUndefined();
+    expect(result.spec.replicas).toBeUndefined();
+  });
+});
+
+describe('isValidFeatureStore', () => {
+  it('returns true for a valid store', () => {
+    expect(isValidFeatureStore(makeFeatureStore())).toBe(true);
+  });
+
+  it('returns false when name is empty', () => {
+    expect(isValidFeatureStore(makeFeatureStore({ name: '' }))).toBe(false);
+  });
+
+  it('returns false when namespace is empty', () => {
+    expect(isValidFeatureStore(makeFeatureStore({ namespace: '' }))).toBe(false);
+  });
+
+  it('returns false when feastProject is empty', () => {
+    expect(isValidFeatureStore(makeFeatureStore({ feastProject: '' }))).toBe(false);
+  });
+});
+
+describe('normalizeFeatureStore', () => {
+  it('defaults labels and annotations to empty objects', () => {
+    const result = normalizeFeatureStore(makeFeatureStore());
+    expect(result.metadata.labels).toEqual({});
+    expect(result.metadata.annotations).toEqual({});
+  });
+
+  it('defaults status fields when status exists', () => {
+    const store = makeFeatureStore({ status: { phase: 'Ready' } } as Partial<FeatureStoreKind>);
+    const result = normalizeFeatureStore(store);
+    expect(result.status?.conditions).toEqual([]);
+    expect(result.status?.phase).toBe('Ready');
+    expect(result.status?.serviceHostnames).toEqual({});
+  });
+
+  it('defaults phase to Pending when missing', () => {
+    const store = makeFeatureStore({ status: {} } as Partial<FeatureStoreKind>);
+    const result = normalizeFeatureStore(store);
+    expect(result.status?.phase).toBe('Pending');
+  });
+
+  it('leaves status undefined when not present', () => {
+    const result = normalizeFeatureStore(makeFeatureStore());
+    expect(result.status).toBeUndefined();
+  });
+});
+
+describe('normalizeFeatureStoreList', () => {
+  it('filters invalid and normalizes valid stores', () => {
+    const valid = makeFeatureStore({ name: 'valid' });
+    const invalid = makeFeatureStore({ name: '' });
+    const result = normalizeFeatureStoreList([valid, invalid]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].metadata.name).toBe('valid');
+    expect(result[0].metadata.labels).toEqual({});
+  });
+});

--- a/packages/feature-store/src/utils/featureStoreUtils.ts
+++ b/packages/feature-store/src/utils/featureStoreUtils.ts
@@ -1,0 +1,101 @@
+import { isValidK8sName, kindApiVersion } from '@odh-dashboard/k8s-core';
+import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
+import {
+  FeatureStoreKind,
+  FeastServices,
+  FeastProjectDir,
+  FeastAuthzConfig,
+  FeastCronJob,
+  FeastBatchEngineConfig,
+} from '../k8sTypes';
+
+export const isValidFeatureStore = (fs: FeatureStoreKind): boolean =>
+  Boolean(fs.metadata.name && fs.metadata.namespace && fs.spec.feastProject);
+
+export const normalizeFeatureStore = (fs: FeatureStoreKind): FeatureStoreKind => ({
+  ...fs,
+  metadata: {
+    ...fs.metadata,
+    labels: fs.metadata.labels ?? {},
+    annotations: fs.metadata.annotations ?? {},
+  },
+  status: fs.status
+    ? {
+        ...fs.status,
+        conditions: fs.status.conditions ?? [],
+        phase: fs.status.phase ?? 'Pending',
+        serviceHostnames: fs.status.serviceHostnames ?? {},
+      }
+    : undefined,
+});
+
+export const normalizeFeatureStoreList = (items: FeatureStoreKind[]): FeatureStoreKind[] =>
+  items.filter(isValidFeatureStore).map(normalizeFeatureStore);
+
+export type FeatureStoreFormSpec = {
+  feastProject: string;
+  namespace: string;
+  feastProjectDir?: FeastProjectDir;
+  services?: FeastServices;
+  authz?: FeastAuthzConfig;
+  cronJob?: FeastCronJob;
+  batchEngine?: FeastBatchEngineConfig;
+  replicas?: number;
+  labels?: Record<string, string>;
+};
+
+export const assembleFeatureStore = (formData: FeatureStoreFormSpec): FeatureStoreKind => {
+  const { namespace, labels, ...specFields } = formData;
+
+  if (!isValidK8sName(namespace)) {
+    throw new Error(
+      `Invalid namespace "${namespace}". ` +
+        'Must be a DNS-1123 subdomain: lowercase alphanumeric characters or hyphens, ' +
+        'must start and end with an alphanumeric character.',
+    );
+  }
+
+  if (!isValidK8sName(specFields.feastProject)) {
+    throw new Error(
+      `Invalid feastProject name "${specFields.feastProject}". ` +
+        'Must be a DNS-1123 subdomain: lowercase alphanumeric characters or hyphens, ' +
+        'must start and end with an alphanumeric character.',
+    );
+  }
+
+  const spec: FeatureStoreKind['spec'] = {
+    feastProject: specFields.feastProject,
+  };
+
+  if (specFields.feastProjectDir) {
+    spec.feastProjectDir = specFields.feastProjectDir;
+  }
+  if (specFields.services) {
+    spec.services = specFields.services;
+  }
+  if (specFields.authz) {
+    spec.authz = specFields.authz;
+  }
+  if (specFields.cronJob) {
+    spec.cronJob = specFields.cronJob;
+  }
+  if (specFields.batchEngine) {
+    spec.batchEngine = specFields.batchEngine;
+  }
+  // Omit replicas when <= 1; the CRD controller defaults to 1.
+  // Scale-to-zero is not a creation-time use case.
+  if (specFields.replicas != null && specFields.replicas > 1) {
+    spec.replicas = specFields.replicas;
+  }
+
+  return {
+    apiVersion: kindApiVersion(FeatureStoreModel),
+    kind: FeatureStoreModel.kind,
+    metadata: {
+      name: specFields.feastProject,
+      namespace,
+      ...(labels && Object.keys(labels).length > 0 && { labels }),
+    },
+    spec,
+  };
+};


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-61258 

## Description

This PR adds the Kubernetes CRUD API layer and React data-fetching hooks for the FeatureStore CRD to the `@odh-dashboard/feature-store` package. These are the foundational building blocks consumed by the creation wizard, management page, and deployment tracking UI in subsequent PRs.

These API helpers and hooks encapsulate all Kubernetes interactions for the Feature Store feature, providing a clean abstraction layer between the CRD and the UI components. The creation wizard ([RHOAIENG-61260](https://redhat.atlassian.net/browse/RHOAIENG-61260)), management page ([RHOAIENG-61262](https://redhat.atlassian.net/browse/RHOAIENG-61262)), and deployment tracking ([RHOAIENG-61261](https://redhat.atlassian.net/browse/RHOAIENG-61261)) all consume these modules. Shipping them as a standalone PR keeps the diff focused and reviewable.

No UI-visible changes. No new package exports needed — all modules are consumed internally within the `feature-store` package.

## How Has This Been Tested?

- Verified import paths resolve correctly against `@odh-dashboard/k8s-core` and `@odh-dashboard/internal`.


## Test Impact

Added unit tests in `packages/feature-store/src/api/__tests__/featureStores.spec.ts` covering the `assembleFeatureStore` resource builder, all CRUD operations (`create`, `list`, `listAll`, `get`, `delete`), pod listing, and the internal validation/normalization logic (`isValidFeatureStore`, `normalizeFeatureStore`) exercised through the public API. Hook tests are deferred to the Cypress E2E PR ([RHOAIENG-61270](https://redhat.atlassian.net/browse/RHOAIENG-61270)) where they are tested end-to-end with mocked API responses.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added Feature Store API support (create, list scoped/all, get, delete, and pod lookups).
  - Added hooks for accessible namespaces, existing feature stores, namespace ConfigMaps/secrets, and deployment monitoring with pod log tailing.
  - Added Feast namespace label constants and shared Feature Store assembly/normalization utilities.

- **Bug Fixes**
  - Added validation, normalization (labels/annotations/status defaults), and improved handling of invalid stores and transient pod log errors.

- **Tests**
  - Added Jest/React Testing Library coverage for the API, hooks, utilities, and deployment watching logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->