### PR TITLE
RHOAIENG-72362: Extract genRandomChars to @odh-dashboard/foundation

### DIFF
--- a/distributions/core-bff/Dockerfile.workspace
+++ b/distributions/core-bff/Dockerfile.workspace
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports
 COPY --chown=default:root frontend/src/ ./frontend/src/

--- a/distributions/rhaii/Dockerfile
+++ b/distributions/rhaii/Dockerfile
@@ -28,6 +28,7 @@ COPY packages/tsconfig/ ./packages/tsconfig/
 # Copy optional packages (always copied for npm workspace resolution;
 # only compiled into the bundle when their env flag is set)
 COPY packages/model-serving/ ./packages/model-serving/
+COPY packages/foundation/ ./packages/foundation/
 COPY packages/k8s-core/ ./packages/k8s-core/
 COPY packages/model-registry/ ./packages/model-registry/
 COPY packages/ui-core/ ./packages/ui-core/

--- a/frontend/src/__mocks__/mockUtils.ts
+++ b/frontend/src/__mocks__/mockUtils.ts
@@ -1,5 +1,5 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
-import { genRandomChars } from '#~/utilities/string';
+import { genRandomChars } from '@odh-dashboard/foundation';
 
 export const genUID = (name: string): string => `test-uid_${name}_${genRandomChars()}`;
 

--- a/frontend/src/api/k8s/__tests__/secrets.spec.ts
+++ b/frontend/src/api/k8s/__tests__/secrets.spec.ts
@@ -6,7 +6,7 @@ import {
   k8sListResource,
   k8sUpdateResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
-import { genRandomChars } from '@odh-dashboard/k8s-core';
+import { genRandomChars } from '@odh-dashboard/foundation';
 import type { SecretKind } from '@odh-dashboard/k8s-core';
 import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import { mock200Status, mock404Error } from '#~/__mocks__/mockK8sStatus';
@@ -24,10 +24,13 @@ import {
 } from '#~/api/k8s/secrets';
 import { SecretModel } from '#~/api/models/k8s';
 
-jest.mock('@odh-dashboard/k8s-core', () => ({
-  ...jest.requireActual('@odh-dashboard/k8s-core'),
-  genRandomChars: jest.fn(),
-}));
+jest.mock('@odh-dashboard/foundation', () => {
+  const actual = jest.requireActual('@odh-dashboard/foundation');
+  return {
+    ...actual,
+    genRandomChars: jest.fn(actual.genRandomChars),
+  };
+});
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sGetResource: jest.fn(),

--- a/frontend/src/api/k8s/__tests__/templates.spec.ts
+++ b/frontend/src/api/k8s/__tests__/templates.spec.ts
@@ -1,5 +1,6 @@
 import { K8sStatus, k8sDeleteResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { genRandomChars } from '@odh-dashboard/foundation';
 import type { K8sDSGResource, TemplateKind } from '@odh-dashboard/k8s-core';
 import { mock200Status, mock404Error } from '#~/__mocks__/mockK8sStatus';
 import { mockServingRuntimeTemplateK8sResource } from '#~/__mocks__/mockServingRuntimeTemplateK8sResource';
@@ -17,7 +18,6 @@ import {
   ServingRuntimePlatform,
   ServingRuntimeModelType,
 } from '#~/types';
-import { genRandomChars } from '#~/utilities/string';
 import useK8sWatchResourceList from '#~/utilities/useK8sWatchResourceList';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
@@ -25,7 +25,8 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sDeleteResource: jest.fn(),
 }));
 
-jest.mock('#~/utilities/string', () => ({
+jest.mock('@odh-dashboard/foundation', () => ({
+  ...jest.requireActual('@odh-dashboard/foundation'),
   genRandomChars: jest.fn(),
 }));
 

--- a/frontend/src/api/k8s/configMaps.ts
+++ b/frontend/src/api/k8s/configMaps.ts
@@ -5,10 +5,10 @@ import {
   k8sUpdateResource,
   K8sStatus,
 } from '@openshift/dynamic-plugin-sdk-utils';
+import { genRandomChars } from '@odh-dashboard/foundation';
 import { KnownLabels } from '@odh-dashboard/k8s-core';
 import { ConfigMapKind, K8sAPIOptions } from '#~/k8sTypes';
 import { ConfigMapModel } from '#~/api/models';
-import { genRandomChars } from '#~/utilities/string';
 import { applyK8sAPIOptions } from '#~/api/apiMergeUtils';
 
 export const CONFIGMAP_PREFIX = 'configmap-';

--- a/frontend/src/api/k8s/roleBindings.ts
+++ b/frontend/src/api/k8s/roleBindings.ts
@@ -8,6 +8,7 @@ import {
   K8sResourceCommon,
   k8sListResourceItems,
 } from '@openshift/dynamic-plugin-sdk-utils';
+import { genRandomChars } from '@odh-dashboard/foundation';
 import { KnownLabels } from '@odh-dashboard/k8s-core';
 import {
   K8sAPIOptions,
@@ -16,7 +17,6 @@ import {
   RoleBindingSubject,
 } from '#~/k8sTypes';
 import { RoleBindingModel } from '#~/api/models';
-import { genRandomChars } from '#~/utilities/string';
 import { applyK8sAPIOptions } from '#~/api/apiMergeUtils';
 import { RoleBindingPermissionsRoleType } from '#~/concepts/roleBinding/types';
 import { addOwnerReference } from '#~/api/k8sUtils';

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -8,10 +8,10 @@ import {
   k8sPatchResource,
   K8sResourceCommon,
 } from '@openshift/dynamic-plugin-sdk-utils';
+import { genRandomChars } from '@odh-dashboard/foundation';
 import {
   KnownLabels,
   DATA_CONNECTION_PREFIX,
-  genRandomChars,
   getGeneratedSecretName,
   translateDisplayNameForK8s,
 } from '@odh-dashboard/k8s-core';

--- a/frontend/src/api/k8s/templates.ts
+++ b/frontend/src/api/k8s/templates.ts
@@ -5,10 +5,10 @@ import {
   k8sGetResource,
   WatchK8sResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
+import { genRandomChars } from '@odh-dashboard/foundation';
 import { KnownLabels, type TemplateKind } from '@odh-dashboard/k8s-core';
 import { ServingRuntimeKind } from '#~/k8sTypes';
 import { TemplateModel } from '#~/api/models';
-import { genRandomChars } from '#~/utilities/string';
 import {
   CustomWatchK8sResult,
   ServingRuntimeAPIProtocol,

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/utils.spec.ts
@@ -1,3 +1,4 @@
+import { genRandomChars } from '@odh-dashboard/foundation';
 import { mockDataSciencePipelineApplicationK8sResource } from '#~/__mocks__/mockDataSciencePipelinesApplicationK8sResource';
 import { deleteSecret, getPipelinesCR } from '#~/api';
 import { DSPA_SECRET_NAME } from '#~/concepts/pipelines/content/configurePipelinesServer/const';
@@ -6,7 +7,6 @@ import { createDSPipelineResourceSpec } from '#~/concepts/pipelines/content/conf
 import { deleteServer, isGeneratedDSPAExternalStorageSecret } from '#~/concepts/pipelines/utils';
 import { DSPipelineAPIServerStore } from '#~/k8sTypes.ts';
 import { AwsKeys } from '#~/pages/projects/dataConnections/const';
-import { genRandomChars } from '#~/utilities/string';
 
 jest.mock('#~/api', () => ({
   getPipelinesCR: jest.fn(),

--- a/frontend/src/package.json
+++ b/frontend/src/package.json
@@ -37,6 +37,7 @@
     ]
   },
   "dependencies": {
+    "@odh-dashboard/foundation": "*",
     "@odh-dashboard/k8s-core": "*",
     "@odh-dashboard/plugin-core": "*",
     "@odh-dashboard/ui-core": "*"

--- a/frontend/src/pages/pipelines/global/modelCustomization/FineTunePageFooter.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/FineTunePageFooter.tsx
@@ -8,6 +8,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { genRandomChars } from '@odh-dashboard/foundation';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import { ModelCustomizationFormData } from '#~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/validationUtils';
 import useRunFormData from '#~/concepts/pipelines/content/createRun/useRunFormData';
@@ -38,7 +39,6 @@ import {
   createConnectionSecret,
   translateIlabForm,
 } from '#~/pages/pipelines/global/modelCustomization/utils';
-import { genRandomChars } from '#~/utilities/string';
 import { RunTypeOption } from '#~/concepts/pipelines/content/createRun/types';
 import { ValidationContext } from '#~/utilities/useValidation';
 import { FineTunedModelNewConnectionContext } from '#~/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelNewConnectionContext';

--- a/frontend/src/pages/pipelines/global/modelCustomization/utils.ts
+++ b/frontend/src/pages/pipelines/global/modelCustomization/utils.ts
@@ -4,6 +4,7 @@ import type {
   K8sNameDescriptionFieldData,
   SecretKind,
 } from '@odh-dashboard/k8s-core';
+import { genRandomChars } from '@odh-dashboard/foundation';
 import { getResourceNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { assembleSecretJudge, assembleSecretTeacher, createSecret } from '#~/api';
 import {
@@ -15,7 +16,6 @@ import {
   ModelCustomizationFormData,
   TeacherJudgeFormData,
 } from '#~/concepts/pipelines/content/modelCustomizationForm/modelCustomizationFormSchema/validationUtils';
-import { genRandomChars } from '#~/utilities/string';
 import { getInputDefinitionParams } from '#~/concepts/pipelines/content/createRun/utils';
 import {
   PipelineVersionKF,

--- a/frontend/src/utilities/string.ts
+++ b/frontend/src/utilities/string.ts
@@ -1,11 +1,5 @@
 export { containsOnlySlashes, isS3PathValid } from '@odh-dashboard/ui-core/utilities';
 
-export const genRandomChars = (len = 6): string =>
-  Math.random()
-    .toString(36)
-    .replace(/[^a-z0-9]+/g, '')
-    .substr(1, len);
-
 export const downloadString = (filename: string, data: string): void => {
   const element = document.createElement('a');
   const file = new Blob([data], { type: 'text/plain' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -422,6 +422,7 @@
       "name": "@odh-dashboard/internal",
       "version": "0.0.0",
       "dependencies": {
+        "@odh-dashboard/foundation": "*",
         "@odh-dashboard/k8s-core": "*",
         "@odh-dashboard/plugin-core": "*",
         "@odh-dashboard/ui-core": "*"
@@ -6225,6 +6226,10 @@
     },
     "node_modules/@odh-dashboard/feature-store": {
       "resolved": "packages/feature-store",
+      "link": true
+    },
+    "node_modules/@odh-dashboard/foundation": {
+      "resolved": "packages/foundation",
       "link": true
     },
     "node_modules/@odh-dashboard/gen-ai": {
@@ -36370,6 +36375,14 @@
         "react-router-dom": "^7"
       }
     },
+    "packages/foundation": {
+      "name": "@odh-dashboard/foundation",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/tsconfig": "*"
+      }
+    },
     "packages/gen-ai": {
       "name": "@odh-dashboard/gen-ai",
       "version": "0.0.0",
@@ -36493,6 +36506,7 @@
       "name": "@odh-dashboard/k8s-core",
       "version": "0.0.0",
       "dependencies": {
+        "@odh-dashboard/foundation": "*",
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
         "@openshift/dynamic-plugin-sdk-utils": "^5.0.0",
         "lodash-es": "^4.18.1"

--- a/packages/agent-ops/Dockerfile.workspace
+++ b/packages/agent-ops/Dockerfile.workspace
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/packages/automl/Dockerfile.workspace
+++ b/packages/automl/Dockerfile.workspace
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/packages/autorag/Dockerfile.workspace
+++ b/packages/autorag/Dockerfile.workspace
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/packages/eval-hub/Dockerfile.workspace
+++ b/packages/eval-hub/Dockerfile.workspace
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/packages/foundation/.eslintrc.js
+++ b/packages/foundation/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = require('@odh-dashboard/eslint-config')
+  .extend({
+    rules: {
+      'no-barrel-files/no-barrel-files': 'off',
+    },
+  })
+  .recommendedTypescript(__dirname);

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
-  "name": "@odh-dashboard/k8s-core",
-  "description": "Shared Kubernetes resource types and utilities",
+  "name": "@odh-dashboard/foundation",
+  "description": "Pure types and generic utility functions — tier 0, zero @odh-dashboard dependencies",
   "version": "0.0.0",
   "exports": {
     ".": "./src/index.ts"
@@ -10,12 +10,6 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "type-check": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@odh-dashboard/foundation": "*",
-    "@openshift/dynamic-plugin-sdk": "^5.0.1",
-    "@openshift/dynamic-plugin-sdk-utils": "^5.0.0",
-    "lodash-es": "^4.18.1"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -1,0 +1,1 @@
+export { genRandomChars } from './utils';

--- a/packages/foundation/src/utils.ts
+++ b/packages/foundation/src/utils.ts
@@ -1,0 +1,5 @@
+export const genRandomChars = (len = 6): string =>
+  Math.random()
+    .toString(36)
+    .replace(/[^a-z0-9]+/g, '')
+    .substr(1, len);

--- a/packages/foundation/tsconfig.json
+++ b/packages/foundation/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@odh-dashboard/tsconfig/tsconfig.json"
+}

--- a/packages/gen-ai/Dockerfile.workspace
+++ b/packages/gen-ai/Dockerfile.workspace
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/packages/k8s-core/src/index.ts
+++ b/packages/k8s-core/src/index.ts
@@ -61,7 +61,6 @@ export type {
 } from './k8sTypes';
 
 export {
-  genRandomChars,
   isK8sDSGResource,
   getDisplayNameFromK8sResource,
   getResourceNameFromK8sResource,

--- a/packages/k8s-core/src/k8sResourceUtils.ts
+++ b/packages/k8s-core/src/k8sResourceUtils.ts
@@ -1,11 +1,6 @@
 import { K8sModelCommon, K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { genRandomChars } from '@odh-dashboard/foundation';
 import type { K8sCondition, K8sDSGResource } from './k8sTypes';
-
-export const genRandomChars = (len = 6): string =>
-  Math.random()
-    .toString(36)
-    .replace(/[^a-z0-9]+/g, '')
-    .substr(1, len);
 
 export const isK8sDSGResource = (x?: K8sResourceCommon): x is K8sDSGResource =>
   x?.metadata?.name != null;

--- a/packages/k8s-core/src/secretUtils.ts
+++ b/packages/k8s-core/src/secretUtils.ts
@@ -1,4 +1,4 @@
-import { genRandomChars } from './k8sResourceUtils';
+import { genRandomChars } from '@odh-dashboard/foundation';
 
 export const DATA_CONNECTION_PREFIX = 'aws-connection';
 export const SECRET_PREFIX = 'secret-';

--- a/packages/maas/Dockerfile.workspace
+++ b/packages/maas/Dockerfile.workspace
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy packages required for @odh-dashboard/llmd-serving and its dependencies

--- a/packages/mlflow/Dockerfile.workspace
+++ b/packages/mlflow/Dockerfile.workspace
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/packages/model-registry/Dockerfile.workspace
+++ b/packages/model-registry/Dockerfile.workspace
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/packages/notebooks/Dockerfile.workspace
+++ b/packages/notebooks/Dockerfile.workspace
@@ -31,6 +31,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports

--- a/packages/plugin-template/Dockerfile.workspace
+++ b/packages/plugin-template/Dockerfile.workspace
@@ -30,6 +30,7 @@ COPY --chown=default:root frontend/package.json ./frontend/
 # Copy required shared workspace packages needed for module builds
 COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
 COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root packages/foundation/ ./packages/foundation/
 COPY --chown=default:root packages/k8s-core/ ./packages/k8s-core/
 COPY --chown=default:root packages/ui-core/ ./packages/ui-core/
 # Copy only the frontend source (not the entire frontend build artifacts) for cross-module imports


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-72362

## Description

  `genRandomChars` is a pure JavaScript utility (random string generator) with no K8s or domain dependencies. Generic utilities that don't operate on K8s types should live in `@odh-dashboard/foundation` (tier 0 — zero `@odh-dashboard/*` runtime dependencies), not in `k8s-core`.

  This creates the `@odh-dashboard/foundation` package and moves `genRandomChars` there. `k8s-core` and `frontend/src/` now import from `foundation` instead. No re-exports — `genRandomChars` is fully removed from `k8s-core`'s public API.

  ### Changes

  - **New package `packages/foundation/`** — tier 0, zero `@odh-dashboard/*` runtime deps. Contains `genRandomChars` as its first export.
  - **`k8s-core`** — removed `genRandomChars` from public exports. Internal usages (`secretUtils.ts`, `k8sResourceUtils.ts`) now import from `@odh-dashboard/foundation`. Added `foundation` as a dependency.
  - **`frontend/src/`** — 11 consumer files updated to import `genRandomChars` from `@odh-dashboard/foundation` instead of `@odh-dashboard/k8s-core`. Added `foundation` as a dependency.
  - **12 Dockerfiles** — added `COPY packages/foundation/` to every Dockerfile that copies `k8s-core` (10 workspace Dockerfiles + `distributions/core-bff/Dockerfile.workspace` + `distributions/rhaii/Dockerfile`).
  - **Test fix** — updated `secrets.spec.ts` mock to use `jest.fn(actual.genRandomChars)` so the mock delegates to the real implementation by default while remaining overridable.

  ## How Has This Been Tested?

  - `npx turbo run type-check lint --force` — 51/51 tasks pass (0 errors)
  - `npx jest --no-coverage` — 3271/3271 tests pass across 334 suites

  ## Test Impact

  No new tests added. Existing unit tests cover `genRandomChars` usage across all updated files. The `secrets.spec.ts` mock was updated to preserve the same test behavior after the import source changed.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared **foundation** package that provides consistent random character generation for IDs and autogenerated resource names.
* **Bug Fixes**
  * Standardized autogenerated name generation across K8s and pipeline-related flows to use the same helper.
* **Tests**
  * Updated unit tests and Jest mocks to reference the **foundation** utility.
* **Chores**
  * Updated multiple UI-builder Docker workspace builds to include the **foundation** package.
* **Refactor**
  * Removed local/previous random-generator exports and switched callers to use **foundation** instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->