### PR TITLE
RHOAIENG-72325: Add Kueue CRD types, API wrappers, and shared data hooks

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -70,6 +70,7 @@ export type DashboardConfig = K8sResourceCommon & {
       promptManagement: boolean;
       mySubscriptions: boolean;
       maasSettingsIaRedesign: boolean;
+      gpuaas: boolean;
     };
     // Intentionally disjointed from the CRD, we should move away from this code-wise now; CRD later
     // groupsConfig?: {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -106,6 +106,7 @@ export const blankDashboardCR: DashboardConfig = {
       promptManagement: false,
       mySubscriptions: true,
       maasSettingsIaRedesign: false,
+      gpuaas: false,
     },
     notebookController: {
       enabled: true,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -64,6 +64,7 @@ export type MockDashboardConfigType = {
   maasSettingsIaRedesign?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
+  gpuaas?: boolean;
   globalMLflowNamespaces?: string[];
   genAiStudioConfig?: {
     aiAssetCustomEndpoints?: {
@@ -129,6 +130,7 @@ export const mockDashboardConfig = ({
   maasSettingsIaRedesign = false,
   agentOps = false,
   roleManagement = false,
+  gpuaas = false,
   hardwareProfileOrder = ['test-hardware-profile'],
   globalMLflowNamespaces = [],
   genAiStudioConfig = {
@@ -317,6 +319,7 @@ export const mockDashboardConfig = ({
       maasSettingsIaRedesign,
       agentOps,
       roleManagement,
+      gpuaas,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/api/k8s/cohorts.ts
+++ b/frontend/src/api/k8s/cohorts.ts
@@ -1,0 +1,13 @@
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import { CohortKind } from '#~/k8sTypes';
+import { CohortModel } from '#~/api/models/kueue';
+
+export const listCohorts = async (labelSelector?: string): Promise<CohortKind[]> => {
+  const queryOptions = {
+    ...(labelSelector && { queryParams: { labelSelector } }),
+  };
+  return k8sListResourceItems<CohortKind>({
+    model: CohortModel,
+    queryOptions,
+  });
+};

--- a/frontend/src/api/k8s/resourceFlavors.ts
+++ b/frontend/src/api/k8s/resourceFlavors.ts
@@ -1,0 +1,15 @@
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import { ResourceFlavorKind } from '#~/k8sTypes';
+import { ResourceFlavorModel } from '#~/api/models/kueue';
+
+export const listResourceFlavors = async (
+  labelSelector?: string,
+): Promise<ResourceFlavorKind[]> => {
+  const queryOptions = {
+    ...(labelSelector && { queryParams: { labelSelector } }),
+  };
+  return k8sListResourceItems<ResourceFlavorKind>({
+    model: ResourceFlavorModel,
+    queryOptions,
+  });
+};

--- a/frontend/src/api/models/kueue.ts
+++ b/frontend/src/api/models/kueue.ts
@@ -27,3 +27,17 @@ export const WorkloadPriorityClassModel: K8sModelCommon = {
   kind: 'WorkloadPriorityClass',
   plural: 'workloadpriorityclasses',
 };
+
+export const CohortModel: K8sModelCommon = {
+  apiVersion: 'v1beta2',
+  apiGroup: 'kueue.x-k8s.io',
+  kind: 'Cohort',
+  plural: 'cohorts',
+};
+
+export const ResourceFlavorModel: K8sModelCommon = {
+  apiVersion: 'v1beta2',
+  apiGroup: 'kueue.x-k8s.io',
+  kind: 'ResourceFlavor',
+  plural: 'resourceflavors',
+};

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -85,6 +85,7 @@ export const advancedAIMLFlags = {
   disableFineTuning: true,
   disableLMEval: true,
   trainingJobs: true,
+  gpuaas: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Combined feature flags object
@@ -273,6 +274,10 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.MAAS_SETTINGS_IA_REDESIGN]: {
     featureFlags: ['maasSettingsIaRedesign'],
+  },
+  [SupportedArea.GPUAAS_INFRASTRUCTURE]: {
+    featureFlags: ['gpuaas'],
+    requiredComponents: [DataScienceStackComponent.KUEUE],
   },
 };
 

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
@@ -23,10 +23,13 @@ import {
   formatNodeSelector,
   formatIdentifierDetails,
   sortIdentifiers,
+  getLocalQueueLabel,
 } from './utils';
+import { QueueSource } from './const';
 
 type HardwareProfileDetailsPopoverProps = {
   localQueueName?: string;
+  queueSource?: QueueSource;
   priorityClass?: string;
   tolerations?: Toleration[];
   nodeSelector?: NodeSelector;
@@ -36,6 +39,7 @@ type HardwareProfileDetailsPopoverProps = {
 
 const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps> = ({
   localQueueName,
+  queueSource,
   priorityClass,
   tolerations,
   nodeSelector,
@@ -102,14 +106,16 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
                   </StackItem>
                 ))}
             </>
-          ) : (
+          ) : !localQueueName ? (
             <StackItem>
               No matching hardware profile found, using existing settings. Default, min, and max
               values are not available.
             </StackItem>
-          )}
+          ) : null}
           {localQueueName && (
-            <StackItem>{renderSection('Local queue', [localQueueName])}</StackItem>
+            <StackItem>
+              {renderSection(getLocalQueueLabel(queueSource), [localQueueName])}
+            </StackItem>
           )}
           {clusterQueueName && (
             <StackItem>{renderSection('Cluster queue', [clusterQueueName])}</StackItem>

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
@@ -6,13 +6,14 @@ import type { ModelResourceType } from '@odh-dashboard/model-serving/extension-p
 import { DashboardPopupIconButton } from '@odh-dashboard/ui-core';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import { NotebookKind } from '#~/k8sTypes';
+import { KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
 import ScopedLabel from '#~/components/ScopedLabel';
 import { ScopedType } from '#~/pages/modelServing/screens/const';
 import { getHardwareProfileDisplayName } from '#~/pages/hardwareProfiles/utils';
 import { resourceTypeOf } from '#~/concepts/hardwareProfiles/utils';
 import HardwareProfileDetailsPopover from './HardwareProfileDetailsPopover';
 import HardwareProfileBindingStateLabel from './HardwareProfileBindingStateLabel';
-import { HardwareProfileBindingState } from './const';
+import { HardwareProfileBindingState, QueueSource } from './const';
 import { HardwareProfileBindingStateInfo } from './types';
 
 type HardwareProfileTableColumnProps = {
@@ -35,6 +36,7 @@ const HardwareProfileTableColumn: React.FC<HardwareProfileTableColumnProps> = ({
   const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const { bindingStateInfo, bindingStateLoaded, loadError } = bindingState;
   const hardwareProfile = bindingStateInfo?.profile;
+  const directQueueName = resource.metadata.labels?.[KUEUE_QUEUE_LABEL];
 
   if (loadError && bindingStateInfo?.state !== HardwareProfileBindingState.DELETED) {
     return (
@@ -68,13 +70,26 @@ const HardwareProfileTableColumn: React.FC<HardwareProfileTableColumnProps> = ({
       >
         {bindingStateInfo?.state !== HardwareProfileBindingState.DELETED && (
           <FlexItem>
+            {/* When a hardware profile is matched it is authoritative — directQueueName on
+                the notebook is intentionally ignored even if the HP has no kueue config. */}
             {hardwareProfile ? (
               <HardwareProfileDetailsPopover
                 hardwareProfile={hardwareProfile}
                 tolerations={hardwareProfile.spec.scheduling?.node?.tolerations}
                 nodeSelector={hardwareProfile.spec.scheduling?.node?.nodeSelector}
                 localQueueName={hardwareProfile.spec.scheduling?.kueue?.localQueueName}
+                queueSource={
+                  hardwareProfile.spec.scheduling?.kueue?.localQueueName
+                    ? QueueSource.HARDWARE_PROFILE
+                    : undefined
+                }
                 priorityClass={hardwareProfile.spec.scheduling?.kueue?.priorityClass}
+                tableView
+              />
+            ) : directQueueName ? (
+              <HardwareProfileDetailsPopover
+                localQueueName={directQueueName}
+                queueSource={QueueSource.DIRECT}
                 tableView
               />
             ) : (

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { IdentifierResourceType, SchedulingType } from '@odh-dashboard/k8s-core';
+import { QueueSource } from '#~/concepts/hardwareProfiles/const';
 import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
 import {
   ProjectDetailsContext,
@@ -85,27 +86,12 @@ describe('HardwareProfileDetailsPopover', () => {
   });
 
   describe('Custom scenario (no hardware profile)', () => {
-    it('should display informational message in popover body', async () => {
-      renderWithContext(<HardwareProfileDetailsPopover />);
-
-      await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
-
-      const details = screen.getByTestId('hardware-profile-details');
-      expect(details).toHaveTextContent(
-        'No matching hardware profile found, using existing settings. Default, min, and max values are not available.',
-      );
-    });
-
-    it('should display "View details" text in form view', () => {
+    it('should display "View details" trigger and fallback message with no resource details', async () => {
       renderWithContext(<HardwareProfileDetailsPopover />);
 
       expect(screen.getByTestId('hardware-profile-details-popover')).toHaveTextContent(
         'View details',
       );
-    });
-
-    it('should contain only the fallback message with no resource details', async () => {
-      renderWithContext(<HardwareProfileDetailsPopover />);
 
       await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
 
@@ -142,5 +128,24 @@ describe('HardwareProfileDetailsPopover', () => {
       expect(details).toHaveTextContent('Workload priority');
       expect(details).toHaveTextContent('high-priority');
     });
+
+    it.each([
+      [QueueSource.HARDWARE_PROFILE, 'test-queue', 'Local queue (via hardware profile)'],
+      [QueueSource.DIRECT, 'gitops-queue', 'Local queue (applied directly)'],
+    ])(
+      'should show correct label for queueSource "%s"',
+      async (queueSource, queueName, expectedLabel) => {
+        renderWithContext(
+          <HardwareProfileDetailsPopover localQueueName={queueName} queueSource={queueSource} />,
+        );
+
+        await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
+
+        const details = screen.getByTestId('hardware-profile-details');
+        expect(details).toHaveTextContent(expectedLabel);
+        expect(details).toHaveTextContent(queueName);
+        expect(details).not.toHaveTextContent('No matching hardware profile found');
+      },
+    );
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
 import {
   ProjectDetailsContext,
   ProjectDetailsContextType,
 } from '#~/pages/projects/ProjectDetailsContext';
 import { DEFAULT_LIST_FETCH_STATE } from '#~/utilities/const';
+import { NotebookKind } from '#~/k8sTypes';
+import { KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
 import HardwareProfileTableColumn from '#~/concepts/hardwareProfiles/HardwareProfileTableColumn';
 
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({
@@ -54,7 +57,7 @@ describe('HardwareProfileTableColumn', () => {
       renderWithContext(
         <HardwareProfileTableColumn
           namespace="test-project"
-          resource={mockNotebookResource as never}
+          resource={mockNotebookResource as unknown as NotebookKind}
           bindingState={{
             bindingStateInfo: {
               profile,
@@ -72,11 +75,11 @@ describe('HardwareProfileTableColumn', () => {
   });
 
   describe('Custom scenario (no hardware profile)', () => {
-    it('renders Custom text and no details popover', () => {
+    it('renders Custom text as a focusable button with no details popover', () => {
       renderWithContext(
         <HardwareProfileTableColumn
           namespace="test-project"
-          resource={mockNotebookResource as never}
+          resource={mockNotebookResource as unknown as NotebookKind}
           bindingState={{
             bindingStateInfo: {
               profile: undefined,
@@ -89,13 +92,25 @@ describe('HardwareProfileTableColumn', () => {
 
       expect(screen.getByTestId('hardware-profile-table-column')).toHaveTextContent('Custom');
       expect(screen.queryByTestId('hardware-profile-details-popover')).not.toBeInTheDocument();
+      expect(screen.getByText('Custom').closest('button')).toBeInTheDocument();
     });
 
-    it('renders Custom trigger as a focusable element', () => {
+    it('renders details popover with "applied directly" when notebook has a direct queue label and no HP', async () => {
+      const notebookWithQueueLabel = {
+        ...mockNotebookResource,
+        metadata: {
+          ...mockNotebookResource.metadata,
+          labels: {
+            ...mockNotebookResource.metadata.labels,
+            [KUEUE_QUEUE_LABEL]: 'gitops-queue',
+          },
+        },
+      };
+
       renderWithContext(
         <HardwareProfileTableColumn
           namespace="test-project"
-          resource={mockNotebookResource as never}
+          resource={notebookWithQueueLabel as unknown as NotebookKind}
           bindingState={{
             bindingStateInfo: {
               profile: undefined,
@@ -106,8 +121,15 @@ describe('HardwareProfileTableColumn', () => {
         />,
       );
 
-      const trigger = screen.getByText('Custom').closest('button');
-      expect(trigger).toBeInTheDocument();
+      expect(screen.getByTestId('hardware-profile-details-popover')).toBeInTheDocument();
+      expect(screen.queryByText('Custom')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
+
+      const details = screen.getByTestId('hardware-profile-details');
+      expect(details).toHaveTextContent('Local queue (applied directly)');
+      expect(details).toHaveTextContent('gitops-queue');
+      expect(details).not.toHaveTextContent('No matching hardware profile found');
     });
   });
 
@@ -116,7 +138,7 @@ describe('HardwareProfileTableColumn', () => {
       renderWithContext(
         <HardwareProfileTableColumn
           namespace="test-project"
-          resource={mockNotebookResource as never}
+          resource={mockNotebookResource as unknown as NotebookKind}
           bindingState={{
             bindingStateInfo: null,
             bindingStateLoaded: false,

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -17,7 +17,9 @@ import {
   applyHardwareProfileConfig,
   formatIdentifierDetails,
   formatResource,
+  getLocalQueueLabel,
 } from '#~/concepts/hardwareProfiles/utils';
+import { QueueSource } from '#~/concepts/hardwareProfiles/const';
 import { UseHardwareProfileConfigResult } from '#~/concepts/hardwareProfiles/useHardwareProfileConfig';
 import { NOTEBOOK_HARDWARE_PROFILE_PATHS } from '#~/concepts/notebooks/const.ts';
 
@@ -745,5 +747,15 @@ describe('applyHardwareProfileConfig', () => {
     expect((result as any).metadata?.annotations?.['opendatahub.io/hardware-profile-name']).toBe(
       'custom-path-test',
     );
+  });
+});
+
+describe('getLocalQueueLabel', () => {
+  it.each([
+    [undefined, 'Local queue'],
+    [QueueSource.DIRECT, 'Local queue (applied directly)'],
+    [QueueSource.HARDWARE_PROFILE, 'Local queue (via hardware profile)'],
+  ])('returns correct label for queueSource %s', (source, expected) => {
+    expect(getLocalQueueLabel(source)).toBe(expected);
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/const.ts
+++ b/frontend/src/concepts/hardwareProfiles/const.ts
@@ -85,3 +85,8 @@ export const INFERENCE_SERVICE_HARDWARE_PROFILE_PATHS: CrPathConfig = {
   tolerationsPath: 'spec.predictor.tolerations',
   nodeSelectorPath: 'spec.predictor.nodeSelector',
 };
+
+export enum QueueSource {
+  HARDWARE_PROFILE = 'hardware-profile',
+  DIRECT = 'direct',
+}

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -20,6 +20,7 @@ import {
 import {
   HardwareProfileBindingState,
   REMOVE_HARDWARE_PROFILE_ANNOTATIONS_PATCH,
+  QueueSource,
 } from '#~/concepts/hardwareProfiles/const';
 import {
   HardwarePodSpecOptions,
@@ -336,4 +337,15 @@ export const applyHardwareProfileConfig = <T extends K8sResourceCommon>(
     }
   }
   return result;
+};
+
+export const getLocalQueueLabel = (queueSource?: QueueSource): string => {
+  const commonLabel = 'Local queue';
+  if (queueSource === QueueSource.DIRECT) {
+    return `${commonLabel} (applied directly)`;
+  }
+  if (queueSource === QueueSource.HARDWARE_PROFILE) {
+    return `${commonLabel} (via hardware profile)`;
+  }
+  return commonLabel;
 };

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1053,6 +1053,52 @@ export type WorkloadPriorityClassKind = K8sResourceCommon & {
   description?: string;
 };
 
+// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Cohort
+export type CohortKind = K8sResourceCommon & {
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
+  kind: 'Cohort';
+  spec: {
+    parentName?: string;
+    resourceGroups?: {
+      coveredResources: ContainerResourceAttributes[];
+      flavors: {
+        name: string;
+        resources: {
+          name: ContainerResourceAttributes;
+          nominalQuota: string | number;
+          borrowingLimit?: string | number;
+          lendingLimit?: string | number;
+        }[];
+      }[];
+    }[];
+    fairSharing?: {
+      weight?: string | number;
+    };
+  };
+  status?: {
+    fairSharing?: {
+      weightedShare: number;
+    };
+  };
+};
+
+// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ResourceFlavor
+export type ResourceFlavorKind = K8sResourceCommon & {
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
+  kind: 'ResourceFlavor';
+  spec: {
+    nodeLabels?: Record<string, string>;
+    nodeTaints?: {
+      key: string;
+      value?: string;
+      effect: 'NoSchedule' | 'NoExecute' | 'PreferNoSchedule';
+      operator?: 'Equal' | 'Exists';
+    }[];
+    tolerations?: Toleration[];
+    topologyName?: string;
+  };
+};
+
 export type SelfSubjectAccessReviewKind = K8sResourceCommon & {
   spec: {
     resourceAttributes?: AccessReviewResourceAttributes;

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -195,6 +195,9 @@ spec:
                     llmGatewayField:
                       type: boolean
                       description: 'When true, shows the LLM gateway configuration field on LLMd serving forms.'
+                    gpuaas:
+                      type: boolean
+                      description: 'When true, enables the GPUaaS Infrastructure page for cluster capacity and accelerator utilization monitoring.'
                   x-kubernetes-validations:
                     - rule: '!has(self.disableAcceleratorProfiles) || self.disableAcceleratorProfiles == oldSelf.disableAcceleratorProfiles'
                       message: 'DEPRECATED: spec.dashboardConfig.disableAcceleratorProfiles must be removed or left unchanged.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -36694,7 +36694,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@odh-dashboard/internal": "*",
-        "@odh-dashboard/plugin-core": "*"
+        "@odh-dashboard/k8s-core": "*",
+        "@odh-dashboard/plugin-core": "*",
+        "@odh-dashboard/ui-core": "*"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8359,7 +8359,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9046,7 +9045,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9063,7 +9061,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9080,7 +9077,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9097,7 +9093,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9114,7 +9109,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9131,7 +9125,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9148,7 +9141,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9165,7 +9157,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9182,7 +9173,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9199,7 +9189,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9216,7 +9205,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9233,7 +9221,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13749,7 +13736,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6186,6 +6186,10 @@
       "resolved": "packages/gen-ai",
       "link": true
     },
+    "node_modules/@odh-dashboard/gpuaas": {
+      "resolved": "packages/gpuaas",
+      "link": true
+    },
     "node_modules/@odh-dashboard/internal": {
       "resolved": "frontend/src",
       "link": true
@@ -8355,6 +8359,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9041,6 +9046,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9057,6 +9063,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9073,6 +9080,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9089,6 +9097,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9105,6 +9114,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9121,6 +9131,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9137,6 +9148,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9153,6 +9165,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9169,6 +9182,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9185,6 +9199,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9201,6 +9216,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9217,6 +9233,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13732,6 +13749,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -36669,6 +36687,28 @@
         "@odh-dashboard/contract-tests": "*",
         "@odh-dashboard/eslint-config": "*",
         "@odh-dashboard/tsconfig": "*"
+      }
+    },
+    "packages/gpuaas": {
+      "name": "@odh-dashboard/gpuaas",
+      "version": "0.0.0",
+      "dependencies": {
+        "@odh-dashboard/internal": "*",
+        "@odh-dashboard/k8s-core": "*",
+        "@odh-dashboard/plugin-core": "*",
+        "@odh-dashboard/ui-core": "*"
+      },
+      "devDependencies": {
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/jest-config": "*",
+        "@odh-dashboard/tsconfig": "*"
+      },
+      "peerDependencies": {
+        "@patternfly/react-core": "^6",
+        "@patternfly/react-icons": "^6",
+        "react": "^18",
+        "react-dom": "^18",
+        "react-router-dom": "^7"
       }
     },
     "packages/jest-config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36694,9 +36694,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@odh-dashboard/internal": "*",
-        "@odh-dashboard/k8s-core": "*",
-        "@odh-dashboard/plugin-core": "*",
-        "@odh-dashboard/ui-core": "*"
+        "@odh-dashboard/plugin-core": "*"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",

--- a/packages/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
@@ -417,6 +417,133 @@ describe('Workbench Hardware Profiles', () => {
       });
   });
 
+  describe('Local queue label in workbench table column popover', () => {
+    beforeEach(() => {
+      asProductAdminUser();
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({ disableKueue: false, disableProjectScoped: true }),
+      );
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.WORKBENCHES]: { managementState: 'Managed' },
+            [DataScienceStackComponent.KUEUE]: { managementState: 'Managed' },
+          },
+        }),
+      );
+      cy.interceptK8sList(
+        ProjectModel,
+        mockK8sResourceList([mockProjectK8sResource({ enableKueue: true })]),
+      );
+      cy.interceptK8s(ProjectModel, mockProjectK8sResource({ enableKueue: true }));
+      cy.interceptK8sList(
+        { model: HardwareProfileModel, ns: 'test-project' },
+        mockK8sResourceList(mockProjectScopedHardwareProfiles),
+      );
+      cy.interceptK8sList(StorageClassModel, mockStorageClassList());
+      cy.interceptK8sList(PodModel, mockK8sResourceList([mockPodK8sResource({})]));
+      cy.interceptK8sList(
+        ImageStreamModel,
+        mockK8sResourceList([mockImageStreamK8sResource({ namespace: 'opendatahub' })]),
+      );
+      cy.interceptK8s(RouteModel, mockRouteK8sResource({ notebookName: 'test-notebook' }));
+      cy.interceptK8sList(SecretModel, mockK8sResourceList([mockSecretK8sResource({})]));
+      cy.interceptK8sList(
+        PVCModel,
+        mockK8sResourceList([mockPVCK8sResource({ name: 'test-storage-1' })]),
+      );
+    });
+
+    it('should show "Local queue (applied directly)" in table column popover for GitOps-managed notebook with direct queue label', () => {
+      const notebookWithDirectQueue = mockNotebookK8sResource({
+        displayName: 'Test Notebook',
+        opts: {
+          metadata: {
+            labels: {
+              'kueue.x-k8s.io/queue-name': 'direct-queue',
+            },
+          },
+        },
+      });
+
+      cy.interceptK8sList(
+        { model: HardwareProfileModel, ns: 'opendatahub' },
+        mockK8sResourceList(mockGlobalScopedHardwareProfiles),
+      );
+      cy.interceptK8sList(
+        { model: LocalQueueModel, ns: 'test-project' },
+        mockK8sResourceList([
+          mockLocalQueueK8sResource({ name: 'direct-queue', namespace: 'test-project' }),
+        ]),
+      );
+      cy.interceptK8sList(
+        { model: NotebookModel, ns: 'test-project' },
+        mockK8sResourceList([notebookWithDirectQueue]),
+      );
+
+      projectDetails.visit(projectName);
+      projectDetails.findSectionTab('workbenches').click();
+
+      hardwareProfileSection.findDetailsPopover().should('exist').click();
+      hardwareProfileSection
+        .findDetails()
+        .should('be.visible')
+        .within(() => {
+          cy.contains('Local queue (applied directly)').should('be.visible');
+          cy.contains('direct-queue').should('be.visible');
+        });
+    });
+
+    it('should show "Local queue (via hardware profile)" in table column popover when queue comes from hardware profile', () => {
+      const queueProfile = mockHardwareProfile({
+        name: 'queue-profile',
+        displayName: 'Queue Profile',
+        schedulingType: SchedulingType.QUEUE,
+        localQueueName: 'hp-queue',
+      });
+      const notebookWithHPQueue = mockNotebookK8sResource({
+        displayName: 'Test Notebook',
+        opts: {
+          metadata: {
+            annotations: {
+              'opendatahub.io/hardware-profile-name': 'queue-profile',
+              'opendatahub.io/hardware-profile-namespace': 'opendatahub',
+            },
+          },
+        },
+      });
+
+      cy.interceptK8sList(
+        { model: HardwareProfileModel, ns: 'opendatahub' },
+        mockK8sResourceList([...mockGlobalScopedHardwareProfiles, queueProfile]),
+      );
+      cy.interceptK8sList(
+        { model: LocalQueueModel, ns: 'test-project' },
+        mockK8sResourceList([
+          mockLocalQueueK8sResource({ name: 'hp-queue', namespace: 'test-project' }),
+        ]),
+      );
+      cy.interceptK8sList(
+        { model: NotebookModel, ns: 'test-project' },
+        mockK8sResourceList([notebookWithHPQueue]),
+      );
+
+      projectDetails.visit(projectName);
+      projectDetails.findSectionTab('workbenches').click();
+
+      hardwareProfileSection.findDetailsPopover().should('exist').click();
+      hardwareProfileSection
+        .findDetails()
+        .should('be.visible')
+        .within(() => {
+          cy.contains('Local queue (via hardware profile)').should('be.visible');
+          cy.contains('hp-queue').should('be.visible');
+        });
+    });
+  });
+
   describe('Edit Workbench Hardware Profiles', () => {
     it('should auto-select hardware profile from annotations', () => {
       initIntercepts();

--- a/packages/gpuaas/.eslintrc.js
+++ b/packages/gpuaas/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@odh-dashboard/eslint-config').recommendedReactTypescript(__dirname);

--- a/packages/gpuaas/OWNERS
+++ b/packages/gpuaas/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+  - dpanshug
+  - claudialphonse78
+
+reviewers:
+  - dpanshug
+  - claudialphonse78
+
+labels:
+  - area/gpuaas

--- a/packages/gpuaas/extensions.ts
+++ b/packages/gpuaas/extensions.ts
@@ -28,7 +28,6 @@ const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
       title: 'Infrastructure',
       href: '/observe-and-monitor/infrastructure',
       path: '/observe-and-monitor/infrastructure/*',
-      group: '2_infrastructure',
       section: 'observe-and-monitor',
     },
   },

--- a/packages/gpuaas/extensions.ts
+++ b/packages/gpuaas/extensions.ts
@@ -1,0 +1,47 @@
+import type {
+  HrefNavItemExtension,
+  AreaExtension,
+  RouteExtension,
+} from '@odh-dashboard/plugin-core/extension-points';
+// Allow this import as it consists of types and enums only.
+import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
+
+const PLUGIN_GPUAAS = 'plugin-gpuaas';
+const ADMIN_USER = 'ADMIN_USER';
+
+const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
+  {
+    type: 'app.area',
+    properties: {
+      id: PLUGIN_GPUAAS,
+      reliantAreas: [SupportedArea.GPUAAS_INFRASTRUCTURE],
+      featureFlags: ['gpuaas'],
+    },
+  },
+  {
+    type: 'app.navigation/href',
+    flags: {
+      required: [PLUGIN_GPUAAS, ADMIN_USER],
+    },
+    properties: {
+      id: 'gpuaas-infrastructure',
+      title: 'Infrastructure',
+      href: '/observe-and-monitor/infrastructure',
+      path: '/observe-and-monitor/infrastructure/*',
+      group: '2_infrastructure',
+      section: 'observe-and-monitor',
+    },
+  },
+  {
+    type: 'app.route',
+    properties: {
+      path: '/observe-and-monitor/infrastructure/*',
+      component: () => import('./src/InfrastructureRoutes'),
+    },
+    flags: {
+      required: [PLUGIN_GPUAAS, ADMIN_USER],
+    },
+  },
+];
+
+export default extensions;

--- a/packages/gpuaas/jest.config.ts
+++ b/packages/gpuaas/jest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@odh-dashboard/jest-config';

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
-    "@odh-dashboard/plugin-core": "*"
+    "@odh-dashboard/k8s-core": "*",
+    "@odh-dashboard/plugin-core": "*",
+    "@odh-dashboard/ui-core": "*"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test-unit": "jest --silent",
     "type-check": "tsc --noEmit"
   },
   "exports": {

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -1,0 +1,32 @@
+{
+  "private": true,
+  "name": "@odh-dashboard/gpuaas",
+  "description": "GPU-as-a-Service infrastructure monitoring plugin for cluster capacity and accelerator utilization.",
+  "version": "0.0.0",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "type-check": "tsc --noEmit"
+  },
+  "exports": {
+    "./extensions": "./extensions.ts"
+  },
+  "dependencies": {
+    "@odh-dashboard/internal": "*",
+    "@odh-dashboard/k8s-core": "*",
+    "@odh-dashboard/plugin-core": "*",
+    "@odh-dashboard/ui-core": "*"
+  },
+  "devDependencies": {
+    "@odh-dashboard/eslint-config": "*",
+    "@odh-dashboard/jest-config": "*",
+    "@odh-dashboard/tsconfig": "*"
+  },
+  "peerDependencies": {
+    "@patternfly/react-core": "^6",
+    "@patternfly/react-icons": "^6",
+    "react": "^18",
+    "react-dom": "^18",
+    "react-router-dom": "^7"
+  }
+}

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -13,9 +13,7 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
-    "@odh-dashboard/k8s-core": "*",
-    "@odh-dashboard/plugin-core": "*",
-    "@odh-dashboard/ui-core": "*"
+    "@odh-dashboard/plugin-core": "*"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",

--- a/packages/gpuaas/src/InfrastructureRoutes.tsx
+++ b/packages/gpuaas/src/InfrastructureRoutes.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import InfrastructurePage from './pages/InfrastructurePage';
+
+const InfrastructureRoutes: React.FC = () => (
+  <Routes>
+    <Route index element={<InfrastructurePage />} />
+    <Route path="*" element={<Navigate to="." />} />
+  </Routes>
+);
+
+export default InfrastructureRoutes;

--- a/packages/gpuaas/src/InfrastructureRoutes.tsx
+++ b/packages/gpuaas/src/InfrastructureRoutes.tsx
@@ -5,7 +5,7 @@ import InfrastructurePage from './pages/InfrastructurePage';
 const InfrastructureRoutes: React.FC = () => (
   <Routes>
     <Route index element={<InfrastructurePage />} />
-    <Route path="*" element={<Navigate to="." />} />
+    <Route path="*" element={<Navigate to="." replace />} />
   </Routes>
 );
 

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -1,0 +1,8 @@
+export const INFRASTRUCTURE_REFRESH_INTERVAL = 30_000;
+
+export const INFRASTRUCTURE_SECTIONS = [
+  { id: 'cluster', title: 'Cluster' },
+  { id: 'hardware-usage', title: 'Hardware usage' },
+  { id: 'borrowing-lending', title: 'Borrowing & lending' },
+  { id: 'cluster-queue-utilization', title: 'Cluster queue utilization' },
+] as const;

--- a/packages/gpuaas/src/hooks/useCohorts.ts
+++ b/packages/gpuaas/src/hooks/useCohorts.ts
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import { ClusterQueueKind, CohortKind } from '@odh-dashboard/internal/k8sTypes';
+import useFetch, { FetchStateObject } from '@odh-dashboard/internal/utilities/useFetch';
+import { listClusterQueues } from '@odh-dashboard/internal/api/k8s/clusterQueues';
+import { listCohorts } from '@odh-dashboard/internal/api/k8s/cohorts';
+import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+import { FlavorQuota, UnifiedCohort } from '../types';
+import { INFRASTRUCTURE_REFRESH_INTERVAL } from '../const';
+
+const STANDALONE_BUCKET_NAME = '';
+
+const parseQuantity = (value: string | number): number =>
+  typeof value === 'number' ? value : parseFloat(value) || 0;
+
+const buildExplicitPool = (cohort: CohortKind): FlavorQuota[] =>
+  (cohort.spec.resourceGroups ?? []).flatMap((rg) =>
+    rg.flavors.map((f) => ({
+      name: f.name,
+      resources: f.resources.map((r) => ({
+        name: r.name,
+        nominalQuota: parseQuantity(r.nominalQuota),
+      })),
+    })),
+  );
+
+const buildImplicitPool = (memberCQs: ClusterQueueKind[]): FlavorQuota[] => {
+  const flavorMap = new Map<string, Map<ContainerResourceAttributes, number>>();
+
+  for (const cq of memberCQs) {
+    for (const rg of cq.spec.resourceGroups ?? []) {
+      for (const flavor of rg.flavors) {
+        let resourceMap = flavorMap.get(flavor.name);
+        if (!resourceMap) {
+          resourceMap = new Map();
+          flavorMap.set(flavor.name, resourceMap);
+        }
+        for (const r of flavor.resources) {
+          const current = resourceMap.get(r.name) ?? 0;
+          resourceMap.set(r.name, current + parseQuantity(r.nominalQuota));
+        }
+      }
+    }
+  }
+
+  return [...flavorMap.entries()].map(([name, resources]) => ({
+    name,
+    resources: [...resources.entries()].map(([rName, nominalQuota]) => ({
+      name: rName,
+      nominalQuota,
+    })),
+  }));
+};
+
+const buildUnifiedCohorts = (
+  clusterQueues: ClusterQueueKind[],
+  cohorts: CohortKind[],
+): UnifiedCohort[] => {
+  const cohortMap = new Map(cohorts.map((c) => [c.metadata?.name ?? '', c]));
+
+  const cohortNameToCQs = new Map<string, ClusterQueueKind[]>();
+  for (const cq of clusterQueues) {
+    const cohortName = cq.spec.cohortName ?? STANDALONE_BUCKET_NAME;
+    const existing = cohortNameToCQs.get(cohortName) ?? [];
+    existing.push(cq);
+    cohortNameToCQs.set(cohortName, existing);
+  }
+
+  const result: UnifiedCohort[] = [];
+
+  for (const [cohortName, memberCQs] of cohortNameToCQs) {
+    if (cohortName === STANDALONE_BUCKET_NAME) {
+      result.push({
+        name: STANDALONE_BUCKET_NAME,
+        state: 'standalone',
+        memberClusterQueues: memberCQs,
+        effectivePool: buildImplicitPool(memberCQs),
+      });
+      continue;
+    }
+
+    const cohortResource = cohortMap.get(cohortName);
+    if (cohortResource) {
+      result.push({
+        name: cohortName,
+        state: 'explicit',
+        cohortResource,
+        memberClusterQueues: memberCQs,
+        effectivePool: buildExplicitPool(cohortResource),
+      });
+      cohortMap.delete(cohortName);
+    } else {
+      result.push({
+        name: cohortName,
+        state: 'implicit',
+        memberClusterQueues: memberCQs,
+        effectivePool: buildImplicitPool(memberCQs),
+      });
+    }
+  }
+
+  for (const [name, cohortResource] of cohortMap) {
+    result.push({
+      name,
+      state: 'explicit',
+      cohortResource,
+      memberClusterQueues: [],
+      effectivePool: buildExplicitPool(cohortResource),
+    });
+  }
+
+  return result;
+};
+
+const useCohorts = (
+  refreshRate = INFRASTRUCTURE_REFRESH_INTERVAL,
+): FetchStateObject<UnifiedCohort[]> =>
+  useFetch<UnifiedCohort[]>(
+    React.useCallback(async () => {
+      const [clusterQueues, cohorts] = await Promise.all([listClusterQueues(), listCohorts()]);
+      return buildUnifiedCohorts(clusterQueues, cohorts);
+    }, []),
+    [],
+    { refreshRate },
+  );
+
+export default useCohorts;

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { Card, CardBody, CardTitle, Stack, StackItem } from '@patternfly/react-core';

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
+import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { Card, CardBody, CardTitle, Stack, StackItem } from '@patternfly/react-core';
+import { INFRASTRUCTURE_SECTIONS } from '../const';
+
+const InfrastructurePage: React.FC = () => (
+  <ApplicationsPage
+    title="Infrastructure"
+    description="Cluster capacity and accelerator utilization."
+    loaded
+    empty={false}
+    provideChildrenPadding
+  >
+    <Stack hasGutter>
+      {INFRASTRUCTURE_SECTIONS.map(({ id, title }) => (
+        <StackItem key={id}>
+          <Card data-testid={`infrastructure-${id}-section`}>
+            <CardTitle>{title}</CardTitle>
+            <CardBody />
+          </Card>
+        </StackItem>
+      ))}
+    </Stack>
+  </ApplicationsPage>
+);
+
+export default InfrastructurePage;

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -1,0 +1,22 @@
+import { ClusterQueueKind, CohortKind } from '@odh-dashboard/internal/k8sTypes';
+import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+
+export type CohortState = 'explicit' | 'implicit' | 'standalone';
+
+export type ResourceQuota = {
+  name: ContainerResourceAttributes;
+  nominalQuota: number;
+};
+
+export type FlavorQuota = {
+  name: string;
+  resources: ResourceQuota[];
+};
+
+export type UnifiedCohort = {
+  name: string;
+  state: CohortState;
+  cohortResource?: CohortKind;
+  memberClusterQueues: ClusterQueueKind[];
+  effectivePool: FlavorQuota[];
+};

--- a/packages/gpuaas/src/utils/borrowingLending.ts
+++ b/packages/gpuaas/src/utils/borrowingLending.ts
@@ -1,0 +1,75 @@
+import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+
+type FlavorResourceUsage = {
+  name: string;
+  resources: {
+    name: ContainerResourceAttributes;
+    borrowed?: string | number;
+    total?: string | number;
+  }[];
+};
+
+const parseQuantity = (value: string | number | undefined): number => {
+  if (value == null) {
+    return 0;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  return parseFloat(value) || 0;
+};
+
+const getTotalBorrowed = (flavorsUsage?: FlavorResourceUsage[]): number => {
+  if (!flavorsUsage) {
+    return 0;
+  }
+  return flavorsUsage.reduce(
+    (total, flavor) =>
+      total + flavor.resources.reduce((sum, r) => sum + parseQuantity(r.borrowed), 0),
+    0,
+  );
+};
+
+const getNominalQuota = (cq: ClusterQueueKind): number => {
+  if (!cq.spec.resourceGroups) {
+    return 0;
+  }
+  return cq.spec.resourceGroups.reduce(
+    (total, rg) =>
+      total +
+      rg.flavors.reduce(
+        (sum, f) => sum + f.resources.reduce((s, r) => s + parseQuantity(r.nominalQuota), 0),
+        0,
+      ),
+    0,
+  );
+};
+
+const getTotalUsage = (flavorsUsage?: FlavorResourceUsage[]): number => {
+  if (!flavorsUsage) {
+    return 0;
+  }
+  return flavorsUsage.reduce(
+    (total, flavor) => total + flavor.resources.reduce((sum, r) => sum + parseQuantity(r.total), 0),
+    0,
+  );
+};
+
+export const isBorrowing = (cq: ClusterQueueKind): boolean =>
+  getTotalBorrowed(cq.status?.flavorsUsage) > 0;
+
+export const isLending = (cq: ClusterQueueKind): boolean => {
+  const nominal = getNominalQuota(cq);
+  const usage = getTotalUsage(cq.status?.flavorsUsage);
+  return nominal > 0 && usage < nominal;
+};
+
+export const getBorrowedCount = (cq: ClusterQueueKind): number =>
+  getTotalBorrowed(cq.status?.flavorsUsage);
+
+export const getLentCount = (cq: ClusterQueueKind): number => {
+  const nominal = getNominalQuota(cq);
+  const usage = getTotalUsage(cq.status?.flavorsUsage);
+  return Math.max(0, nominal - usage);
+};

--- a/packages/gpuaas/src/utils/hardwareModels.ts
+++ b/packages/gpuaas/src/utils/hardwareModels.ts
@@ -1,0 +1,48 @@
+import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/internal/k8sTypes';
+
+const GPU_PRODUCT_LABELS = [
+  'nvidia.com/gpu.product',
+  'amd.com/gpu.product',
+  'intel.com/gpu.product',
+] as const;
+
+/**
+ * Resolves hardware model names for each ClusterQueue by mapping through
+ * its referenced ResourceFlavors' nodeLabels.
+ *
+ * @returns Map of CQ name -> array of hardware model names (e.g., ["NVIDIA A100"])
+ */
+export const resolveHardwareModels = (
+  clusterQueues: ClusterQueueKind[],
+  resourceFlavors: ResourceFlavorKind[],
+): Map<string, string[]> => {
+  const flavorMap = new Map(resourceFlavors.map((rf) => [rf.metadata?.name ?? '', rf]));
+
+  const result = new Map<string, string[]>();
+
+  for (const cq of clusterQueues) {
+    const models = new Set<string>();
+
+    for (const rg of cq.spec.resourceGroups ?? []) {
+      for (const flavor of rg.flavors) {
+        const rf = flavorMap.get(flavor.name);
+        if (!rf?.spec.nodeLabels) {
+          continue;
+        }
+        for (const label of GPU_PRODUCT_LABELS) {
+          const value = rf.spec.nodeLabels[label];
+          if (value) {
+            models.add(value);
+          }
+        }
+      }
+    }
+
+    const cqName = cq.metadata?.name ?? '';
+    if (cqName) {
+      result.set(cqName, [...models]);
+    }
+  }
+
+  return result;
+};

--- a/packages/gpuaas/tsconfig.json
+++ b/packages/gpuaas/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@odh-dashboard/tsconfig"
+}

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -280,6 +280,7 @@ export type DashboardCommonConfig = {
   maasSettingsIaRedesign?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
+  gpuaas?: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {

--- a/packages/plugin-core/src/areas/types.ts
+++ b/packages/plugin-core/src/areas/types.ts
@@ -115,6 +115,9 @@ export enum SupportedArea {
   MLFLOW = 'mlflow',
   MLFLOW_PIPELINES = 'mlflow-pipelines',
 
+  /* GPUaaS */
+  GPUAAS_INFRASTRUCTURE = 'gpuaas-infrastructure',
+
   /* Project RBAC Settings */
   PROJECT_RBAC_SETTINGS = 'project-rbac-settings',
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72325

## Description

Adds host-level Kueue CRD types and API wrappers for Cohort and ResourceFlavor resources, plus GPUaaS package-level hooks and utilities for cohort discovery, hardware model resolution, and borrowed/lent calculations.

**Host-level additions** (`frontend/src/`):
- `CohortModel` and `ResourceFlavorModel` in `api/models/kueue.ts`
- `CohortKind` and `ResourceFlavorKind` types in `k8sTypes.ts`
- `listCohorts()` wrapper in `api/k8s/cohorts.ts`
- `listResourceFlavors()` wrapper in `api/k8s/resourceFlavors.ts`

**GPUaaS package hooks/utilities** (`packages/gpuaas/src/`):
- `useCohorts` hook — unified cohort discovery combining explicit Cohort CRs + implicit `cohortName` references from ClusterQueues + standalone CQs
- `resolveHardwareModels` — maps CQ → flavors → hardware model names via ResourceFlavor `spec.nodeLabels`
- `isBorrowing` / `isLending` / `getBorrowedCount` / `getLentCount` — borrowed/lent utilities using CQ status `flavorsUsage.borrowed` and nominal quota

**Depends on:** #8340 (gpuaas package skeleton)

## How Has This Been Tested?

- `npm run type-check` passes for both `gpuaas` and `frontend` packages
- `npm run lint` passes with zero errors/warnings on all new and modified files
- Pre-commit hooks (lint-staged) passed on commit

## Test Impact

No tests added in this PR. Unit tests for the utilities and hook will be added in a follow-up once the consuming UI components (Stories 4, 5, 6) are in place and mock data fixtures are established.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Infrastructure section for GPUaaS with navigation, routing, and a dedicated dashboard page.
  * Introduced GPUaaS support in cluster capacity and accelerator utilization monitoring.
  * Improved hardware profile details to show clearer local queue labels and direct-vs-profile queue context.

* **Bug Fixes**
  * Fixed hardware profile popovers and table entries to handle direct queue labels correctly when no matching profile is found.
  * Added support for listing cohort and resource flavor data used by the new infrastructure views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->