### PR TITLE
RHOAIENG-72325: Add Kueue CRD types, API wrappers, and shared data hooks

### DIFF
--- a/frontend/src/api/k8s/cohorts.ts
+++ b/frontend/src/api/k8s/cohorts.ts
@@ -1,0 +1,13 @@
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import { CohortKind } from '#~/k8sTypes';
+import { CohortModel } from '#~/api/models/kueue';
+
+export const listCohorts = async (labelSelector?: string): Promise<CohortKind[]> => {
+  const queryOptions = {
+    ...(labelSelector && { queryParams: { labelSelector } }),
+  };
+  return k8sListResourceItems<CohortKind>({
+    model: CohortModel,
+    queryOptions,
+  });
+};

--- a/frontend/src/api/k8s/resourceFlavors.ts
+++ b/frontend/src/api/k8s/resourceFlavors.ts
@@ -1,0 +1,15 @@
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import { ResourceFlavorKind } from '#~/k8sTypes';
+import { ResourceFlavorModel } from '#~/api/models/kueue';
+
+export const listResourceFlavors = async (
+  labelSelector?: string,
+): Promise<ResourceFlavorKind[]> => {
+  const queryOptions = {
+    ...(labelSelector && { queryParams: { labelSelector } }),
+  };
+  return k8sListResourceItems<ResourceFlavorKind>({
+    model: ResourceFlavorModel,
+    queryOptions,
+  });
+};

--- a/frontend/src/api/models/kueue.ts
+++ b/frontend/src/api/models/kueue.ts
@@ -34,3 +34,17 @@ export const VisibilityLocalQueueModel: K8sModelCommon = {
   kind: 'LocalQueue',
   plural: 'localqueues',
 };
+
+export const CohortModel: K8sModelCommon = {
+  apiVersion: 'v1beta2',
+  apiGroup: 'kueue.x-k8s.io',
+  kind: 'Cohort',
+  plural: 'cohorts',
+};
+
+export const ResourceFlavorModel: K8sModelCommon = {
+  apiVersion: 'v1beta2',
+  apiGroup: 'kueue.x-k8s.io',
+  kind: 'ResourceFlavor',
+  plural: 'resourceflavors',
+};

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1071,6 +1071,52 @@ export type PendingWorkloadsSummary = {
   items: PendingWorkload[];
 };
 
+// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Cohort
+export type CohortKind = K8sResourceCommon & {
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
+  kind: 'Cohort';
+  spec: {
+    parentName?: string;
+    resourceGroups?: {
+      coveredResources: ContainerResourceAttributes[];
+      flavors: {
+        name: string;
+        resources: {
+          name: ContainerResourceAttributes;
+          nominalQuota: string | number;
+          borrowingLimit?: string | number;
+          lendingLimit?: string | number;
+        }[];
+      }[];
+    }[];
+    fairSharing?: {
+      weight?: string | number;
+    };
+  };
+  status?: {
+    fairSharing?: {
+      weightedShare: number;
+    };
+  };
+};
+
+// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ResourceFlavor
+export type ResourceFlavorKind = K8sResourceCommon & {
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
+  kind: 'ResourceFlavor';
+  spec: {
+    nodeLabels?: Record<string, string>;
+    nodeTaints?: {
+      key: string;
+      value?: string;
+      effect: 'NoSchedule' | 'NoExecute' | 'PreferNoSchedule';
+      operator?: 'Equal' | 'Exists';
+    }[];
+    tolerations?: Toleration[];
+    topologyName?: string;
+  };
+};
+
 export type SelfSubjectAccessReviewKind = K8sResourceCommon & {
   spec: {
     resourceAttributes?: AccessReviewResourceAttributes;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1110,7 +1110,6 @@ export type ResourceFlavorKind = K8sResourceCommon & {
       key: string;
       value?: string;
       effect: 'NoSchedule' | 'NoExecute' | 'PreferNoSchedule';
-      operator?: 'Equal' | 'Exists';
     }[];
     tolerations?: Toleration[];
     topologyName?: string;

--- a/packages/gpuaas/src/hooks/useCohorts.ts
+++ b/packages/gpuaas/src/hooks/useCohorts.ts
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import { ClusterQueueKind, CohortKind } from '@odh-dashboard/internal/k8sTypes';
+import useFetch, { FetchStateObject } from '@odh-dashboard/internal/utilities/useFetch';
+import { listClusterQueues } from '@odh-dashboard/internal/api/k8s/clusterQueues';
+import { listCohorts } from '@odh-dashboard/internal/api/k8s/cohorts';
+import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+import { FlavorQuota, UnifiedCohort } from '../types';
+import { INFRASTRUCTURE_REFRESH_INTERVAL } from '../const';
+
+const STANDALONE_BUCKET_NAME = '';
+
+const parseQuantity = (value: string | number): number =>
+  typeof value === 'number' ? value : parseFloat(value) || 0;
+
+const buildExplicitPool = (cohort: CohortKind): FlavorQuota[] =>
+  (cohort.spec.resourceGroups ?? []).flatMap((rg) =>
+    rg.flavors.map((f) => ({
+      name: f.name,
+      resources: f.resources.map((r) => ({
+        name: r.name,
+        nominalQuota: parseQuantity(r.nominalQuota),
+      })),
+    })),
+  );
+
+const buildImplicitPool = (memberCQs: ClusterQueueKind[]): FlavorQuota[] => {
+  const flavorMap = new Map<string, Map<ContainerResourceAttributes, number>>();
+
+  for (const cq of memberCQs) {
+    for (const rg of cq.spec.resourceGroups ?? []) {
+      for (const flavor of rg.flavors) {
+        let resourceMap = flavorMap.get(flavor.name);
+        if (!resourceMap) {
+          resourceMap = new Map();
+          flavorMap.set(flavor.name, resourceMap);
+        }
+        for (const r of flavor.resources) {
+          const current = resourceMap.get(r.name) ?? 0;
+          resourceMap.set(r.name, current + parseQuantity(r.nominalQuota));
+        }
+      }
+    }
+  }
+
+  return [...flavorMap.entries()].map(([name, resources]) => ({
+    name,
+    resources: [...resources.entries()].map(([rName, nominalQuota]) => ({
+      name: rName,
+      nominalQuota,
+    })),
+  }));
+};
+
+const buildUnifiedCohorts = (
+  clusterQueues: ClusterQueueKind[],
+  cohorts: CohortKind[],
+): UnifiedCohort[] => {
+  const cohortMap = new Map(cohorts.map((c) => [c.metadata?.name ?? '', c]));
+
+  const cohortNameToCQs = new Map<string, ClusterQueueKind[]>();
+  for (const cq of clusterQueues) {
+    const cohortName = cq.spec.cohortName ?? STANDALONE_BUCKET_NAME;
+    const existing = cohortNameToCQs.get(cohortName) ?? [];
+    existing.push(cq);
+    cohortNameToCQs.set(cohortName, existing);
+  }
+
+  const result: UnifiedCohort[] = [];
+
+  for (const [cohortName, memberCQs] of cohortNameToCQs) {
+    if (cohortName === STANDALONE_BUCKET_NAME) {
+      result.push({
+        name: STANDALONE_BUCKET_NAME,
+        state: 'standalone',
+        memberClusterQueues: memberCQs,
+        effectivePool: buildImplicitPool(memberCQs),
+      });
+      continue;
+    }
+
+    const cohortResource = cohortMap.get(cohortName);
+    if (cohortResource) {
+      result.push({
+        name: cohortName,
+        state: 'explicit',
+        cohortResource,
+        memberClusterQueues: memberCQs,
+        effectivePool: buildExplicitPool(cohortResource),
+      });
+      cohortMap.delete(cohortName);
+    } else {
+      result.push({
+        name: cohortName,
+        state: 'implicit',
+        memberClusterQueues: memberCQs,
+        effectivePool: buildImplicitPool(memberCQs),
+      });
+    }
+  }
+
+  for (const [name, cohortResource] of cohortMap) {
+    result.push({
+      name,
+      state: 'explicit',
+      cohortResource,
+      memberClusterQueues: [],
+      effectivePool: buildExplicitPool(cohortResource),
+    });
+  }
+
+  return result;
+};
+
+const useCohorts = (
+  refreshRate = INFRASTRUCTURE_REFRESH_INTERVAL,
+): FetchStateObject<UnifiedCohort[]> =>
+  useFetch<UnifiedCohort[]>(
+    React.useCallback(async () => {
+      const [clusterQueues, cohorts] = await Promise.all([listClusterQueues(), listCohorts()]);
+      return buildUnifiedCohorts(clusterQueues, cohorts);
+    }, []),
+    [],
+    { refreshRate },
+  );
+
+export default useCohorts;

--- a/packages/gpuaas/src/hooks/useCohorts.ts
+++ b/packages/gpuaas/src/hooks/useCohorts.ts
@@ -6,11 +6,10 @@ import { listCohorts } from '@odh-dashboard/internal/api/k8s/cohorts';
 import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
 import { FlavorQuota, UnifiedCohort } from '../types';
 import { INFRASTRUCTURE_REFRESH_INTERVAL } from '../const';
+import parseK8sQuantity from '../utils/parseK8sQuantity';
 
+// CQs with no cohortName are bucketed under the empty-string key
 const STANDALONE_BUCKET_NAME = '';
-
-const parseQuantity = (value: string | number): number =>
-  typeof value === 'number' ? value : parseFloat(value) || 0;
 
 const buildExplicitPool = (cohort: CohortKind): FlavorQuota[] =>
   (cohort.spec.resourceGroups ?? []).flatMap((rg) =>
@@ -18,7 +17,7 @@ const buildExplicitPool = (cohort: CohortKind): FlavorQuota[] =>
       name: f.name,
       resources: f.resources.map((r) => ({
         name: r.name,
-        nominalQuota: parseQuantity(r.nominalQuota),
+        nominalQuota: parseK8sQuantity(r.nominalQuota),
       })),
     })),
   );
@@ -36,7 +35,7 @@ const buildImplicitPool = (memberCQs: ClusterQueueKind[]): FlavorQuota[] => {
         }
         for (const r of flavor.resources) {
           const current = resourceMap.get(r.name) ?? 0;
-          resourceMap.set(r.name, current + parseQuantity(r.nominalQuota));
+          resourceMap.set(r.name, current + parseK8sQuantity(r.nominalQuota));
         }
       }
     }

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -1,0 +1,22 @@
+import { ClusterQueueKind, CohortKind } from '@odh-dashboard/internal/k8sTypes';
+import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+
+export type CohortState = 'explicit' | 'implicit' | 'standalone';
+
+export type ResourceQuota = {
+  name: ContainerResourceAttributes;
+  nominalQuota: number;
+};
+
+export type FlavorQuota = {
+  name: string;
+  resources: ResourceQuota[];
+};
+
+export type UnifiedCohort = {
+  name: string;
+  state: CohortState;
+  cohortResource?: CohortKind;
+  memberClusterQueues: ClusterQueueKind[];
+  effectivePool: FlavorQuota[];
+};

--- a/packages/gpuaas/src/utils/__tests__/parseK8sQuantity.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/parseK8sQuantity.spec.ts
@@ -1,0 +1,138 @@
+import parseK8sQuantity from '../parseK8sQuantity';
+
+describe('parseK8sQuantity', () => {
+  it('should return 0 for null/undefined', () => {
+    expect(parseK8sQuantity(undefined)).toBe(0);
+    expect(parseK8sQuantity(null as unknown as undefined)).toBe(0);
+  });
+
+  it('should return the number directly for numeric inputs', () => {
+    expect(parseK8sQuantity(0)).toBe(0);
+    expect(parseK8sQuantity(42)).toBe(42);
+    expect(parseK8sQuantity(3.14)).toBe(3.14);
+    expect(parseK8sQuantity(-1)).toBe(-1);
+  });
+
+  it('should parse plain numeric strings', () => {
+    expect(parseK8sQuantity('0')).toBe(0);
+    expect(parseK8sQuantity('100')).toBe(100);
+    expect(parseK8sQuantity('3.5')).toBe(3.5);
+    expect(parseK8sQuantity('-7')).toBe(-7);
+    expect(parseK8sQuantity('+5')).toBe(5);
+  });
+
+  describe('binary SI suffixes', () => {
+    it('should parse Ki (kibibytes)', () => {
+      expect(parseK8sQuantity('1Ki')).toBe(1024);
+      expect(parseK8sQuantity('4Ki')).toBe(4096);
+    });
+
+    it('should parse Mi (mebibytes)', () => {
+      expect(parseK8sQuantity('1Mi')).toBe(1024 ** 2);
+      expect(parseK8sQuantity('512Mi')).toBe(512 * 1024 ** 2);
+    });
+
+    it('should parse Gi (gibibytes)', () => {
+      expect(parseK8sQuantity('1Gi')).toBe(1024 ** 3);
+      expect(parseK8sQuantity('64Gi')).toBe(64 * 1024 ** 3);
+      expect(parseK8sQuantity('128Gi')).toBe(128 * 1024 ** 3);
+    });
+
+    it('should parse Ti, Pi, Ei', () => {
+      expect(parseK8sQuantity('1Ti')).toBe(1024 ** 4);
+      expect(parseK8sQuantity('1Pi')).toBe(1024 ** 5);
+      expect(parseK8sQuantity('1Ei')).toBe(1024 ** 6);
+    });
+  });
+
+  describe('decimal SI suffixes', () => {
+    it('should parse m (milli)', () => {
+      expect(parseK8sQuantity('500m')).toBeCloseTo(0.5);
+      expect(parseK8sQuantity('100m')).toBeCloseTo(0.1);
+      expect(parseK8sQuantity('1000m')).toBeCloseTo(1);
+    });
+
+    it('should parse k (kilo)', () => {
+      expect(parseK8sQuantity('1k')).toBe(1000);
+      expect(parseK8sQuantity('2.5k')).toBe(2500);
+    });
+
+    it('should parse M (mega)', () => {
+      expect(parseK8sQuantity('1M')).toBe(1e6);
+    });
+
+    it('should parse G (giga)', () => {
+      expect(parseK8sQuantity('1G')).toBe(1e9);
+    });
+
+    it('should parse n and u (nano, micro)', () => {
+      expect(parseK8sQuantity('1n')).toBeCloseTo(1e-9);
+      expect(parseK8sQuantity('1u')).toBeCloseTo(1e-6);
+    });
+
+    it('should parse T, P, E', () => {
+      expect(parseK8sQuantity('1T')).toBe(1e12);
+      expect(parseK8sQuantity('1P')).toBe(1e15);
+      expect(parseK8sQuantity('1E')).toBe(1e18);
+    });
+  });
+
+  describe('decimal exponent notation', () => {
+    it('should parse positive exponents', () => {
+      expect(parseK8sQuantity('129e6')).toBe(129_000_000);
+      expect(parseK8sQuantity('1e3')).toBe(1000);
+    });
+
+    it('should parse negative exponents', () => {
+      expect(parseK8sQuantity('1e-3')).toBeCloseTo(0.001);
+      expect(parseK8sQuantity('500E-3')).toBeCloseTo(0.5);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return 0 for empty string', () => {
+      expect(parseK8sQuantity('')).toBe(0);
+    });
+
+    it('should return 0 for whitespace-only strings', () => {
+      expect(parseK8sQuantity('  ')).toBe(0);
+    });
+
+    it('should return 0 for invalid strings', () => {
+      expect(parseK8sQuantity('abc')).toBe(0);
+      expect(parseK8sQuantity('Gi')).toBe(0);
+    });
+
+    it('should handle leading dot notation', () => {
+      expect(parseK8sQuantity('.5Gi')).toBe(0.5 * 1024 ** 3);
+    });
+
+    it('should handle unknown suffixes by returning the number', () => {
+      expect(parseK8sQuantity('100x')).toBe(100);
+    });
+
+    it('should handle signed quantities', () => {
+      expect(parseK8sQuantity('-64Gi')).toBe(-64 * 1024 ** 3);
+      expect(parseK8sQuantity('+500m')).toBeCloseTo(0.5);
+    });
+  });
+
+  describe('real-world Kueue values', () => {
+    it('should correctly parse typical ClusterQueue quota values', () => {
+      // CPU quota (plain cores)
+      expect(parseK8sQuantity('100')).toBe(100);
+      // Memory quota
+      expect(parseK8sQuantity('64Gi')).toBe(64 * 1024 ** 3);
+      // GPU count
+      expect(parseK8sQuantity('8')).toBe(8);
+      // CPU in millicores
+      expect(parseK8sQuantity('200m')).toBeCloseTo(0.2);
+    });
+
+    it('should produce correct sums within the same resource type', () => {
+      const mem1 = parseK8sQuantity('64Gi');
+      const mem2 = parseK8sQuantity('128Gi');
+      expect(mem1 + mem2).toBe(192 * 1024 ** 3);
+    });
+  });
+});

--- a/packages/gpuaas/src/utils/borrowingLending.ts
+++ b/packages/gpuaas/src/utils/borrowingLending.ts
@@ -1,5 +1,6 @@
 import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
 import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+import parseK8sQuantity from './parseK8sQuantity';
 
 type FlavorResourceUsage = {
   name: string;
@@ -10,23 +11,13 @@ type FlavorResourceUsage = {
   }[];
 };
 
-const parseQuantity = (value: string | number | undefined): number => {
-  if (value == null) {
-    return 0;
-  }
-  if (typeof value === 'number') {
-    return value;
-  }
-  return parseFloat(value) || 0;
-};
-
 const getTotalBorrowed = (flavorsUsage?: FlavorResourceUsage[]): number => {
   if (!flavorsUsage) {
     return 0;
   }
   return flavorsUsage.reduce(
     (total, flavor) =>
-      total + flavor.resources.reduce((sum, r) => sum + parseQuantity(r.borrowed), 0),
+      total + flavor.resources.reduce((sum, r) => sum + parseK8sQuantity(r.borrowed), 0),
     0,
   );
 };
@@ -39,7 +30,7 @@ const getNominalQuota = (cq: ClusterQueueKind): number => {
     (total, rg) =>
       total +
       rg.flavors.reduce(
-        (sum, f) => sum + f.resources.reduce((s, r) => s + parseQuantity(r.nominalQuota), 0),
+        (sum, f) => sum + f.resources.reduce((s, r) => s + parseK8sQuantity(r.nominalQuota), 0),
         0,
       ),
     0,
@@ -51,7 +42,8 @@ const getTotalUsage = (flavorsUsage?: FlavorResourceUsage[]): number => {
     return 0;
   }
   return flavorsUsage.reduce(
-    (total, flavor) => total + flavor.resources.reduce((sum, r) => sum + parseQuantity(r.total), 0),
+    (total, flavor) =>
+      total + flavor.resources.reduce((sum, r) => sum + parseK8sQuantity(r.total), 0),
     0,
   );
 };

--- a/packages/gpuaas/src/utils/borrowingLending.ts
+++ b/packages/gpuaas/src/utils/borrowingLending.ts
@@ -1,0 +1,75 @@
+import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+
+type FlavorResourceUsage = {
+  name: string;
+  resources: {
+    name: ContainerResourceAttributes;
+    borrowed?: string | number;
+    total?: string | number;
+  }[];
+};
+
+const parseQuantity = (value: string | number | undefined): number => {
+  if (value == null) {
+    return 0;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  return parseFloat(value) || 0;
+};
+
+const getTotalBorrowed = (flavorsUsage?: FlavorResourceUsage[]): number => {
+  if (!flavorsUsage) {
+    return 0;
+  }
+  return flavorsUsage.reduce(
+    (total, flavor) =>
+      total + flavor.resources.reduce((sum, r) => sum + parseQuantity(r.borrowed), 0),
+    0,
+  );
+};
+
+const getNominalQuota = (cq: ClusterQueueKind): number => {
+  if (!cq.spec.resourceGroups) {
+    return 0;
+  }
+  return cq.spec.resourceGroups.reduce(
+    (total, rg) =>
+      total +
+      rg.flavors.reduce(
+        (sum, f) => sum + f.resources.reduce((s, r) => s + parseQuantity(r.nominalQuota), 0),
+        0,
+      ),
+    0,
+  );
+};
+
+const getTotalUsage = (flavorsUsage?: FlavorResourceUsage[]): number => {
+  if (!flavorsUsage) {
+    return 0;
+  }
+  return flavorsUsage.reduce(
+    (total, flavor) => total + flavor.resources.reduce((sum, r) => sum + parseQuantity(r.total), 0),
+    0,
+  );
+};
+
+export const isBorrowing = (cq: ClusterQueueKind): boolean =>
+  getTotalBorrowed(cq.status?.flavorsUsage) > 0;
+
+export const isLending = (cq: ClusterQueueKind): boolean => {
+  const nominal = getNominalQuota(cq);
+  const usage = getTotalUsage(cq.status?.flavorsUsage);
+  return nominal > 0 && usage < nominal;
+};
+
+export const getBorrowedCount = (cq: ClusterQueueKind): number =>
+  getTotalBorrowed(cq.status?.flavorsUsage);
+
+export const getLentCount = (cq: ClusterQueueKind): number => {
+  const nominal = getNominalQuota(cq);
+  const usage = getTotalUsage(cq.status?.flavorsUsage);
+  return Math.max(0, nominal - usage);
+};

--- a/packages/gpuaas/src/utils/hardwareModels.ts
+++ b/packages/gpuaas/src/utils/hardwareModels.ts
@@ -1,0 +1,48 @@
+import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/internal/k8sTypes';
+
+const GPU_PRODUCT_LABELS = [
+  'nvidia.com/gpu.product',
+  'amd.com/gpu.product',
+  'intel.com/gpu.product',
+] as const;
+
+/**
+ * Resolves hardware model names for each ClusterQueue by mapping through
+ * its referenced ResourceFlavors' nodeLabels.
+ *
+ * @returns Map of CQ name -> array of hardware model names (e.g., ["NVIDIA A100"])
+ */
+export const resolveHardwareModels = (
+  clusterQueues: ClusterQueueKind[],
+  resourceFlavors: ResourceFlavorKind[],
+): Map<string, string[]> => {
+  const flavorMap = new Map(resourceFlavors.map((rf) => [rf.metadata?.name ?? '', rf]));
+
+  const result = new Map<string, string[]>();
+
+  for (const cq of clusterQueues) {
+    const models = new Set<string>();
+
+    for (const rg of cq.spec.resourceGroups ?? []) {
+      for (const flavor of rg.flavors) {
+        const rf = flavorMap.get(flavor.name);
+        if (!rf?.spec.nodeLabels) {
+          continue;
+        }
+        for (const label of GPU_PRODUCT_LABELS) {
+          const value = rf.spec.nodeLabels[label];
+          if (value) {
+            models.add(value);
+          }
+        }
+      }
+    }
+
+    const cqName = cq.metadata?.name ?? '';
+    if (cqName) {
+      result.set(cqName, [...models]);
+    }
+  }
+
+  return result;
+};

--- a/packages/gpuaas/src/utils/parseK8sQuantity.ts
+++ b/packages/gpuaas/src/utils/parseK8sQuantity.ts
@@ -1,0 +1,72 @@
+const BINARY_SUFFIXES: Record<string, number> = {
+  Ki: 1024,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  Pi: 1024 ** 5,
+  Ei: 1024 ** 6,
+};
+
+const DECIMAL_SUFFIXES: Record<string, number> = {
+  n: 1e-9,
+  u: 1e-6,
+  m: 1e-3,
+  k: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+  P: 1e15,
+  E: 1e18,
+};
+
+// Matches: optional sign, number (with optional decimal), suffix (letters only) or exponent (e/E + signed int)
+const QUANTITY_RE = /^([+-]?\d*\.?\d*\.?)([A-Za-z]*)$/;
+const EXPONENT_RE = /^([+-]?\d*\.?\d*\.?)[eE]([+-]?\d+)$/;
+
+// Parses a Kubernetes resource.Quantity string into a numeric base-unit value.
+const parseK8sQuantity = (value: string | number | undefined): number => {
+  if (value == null) {
+    return 0;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return 0;
+  }
+
+  // Try decimal exponent form first (e.g., "129e6", "100E-3")
+  const expMatch = trimmed.match(EXPONENT_RE);
+  if (expMatch && expMatch[1]) {
+    const base = parseFloat(expMatch[1]);
+    const exp = parseInt(expMatch[2], 10);
+    return base * 10 ** exp;
+  }
+
+  const match = trimmed.match(QUANTITY_RE);
+  if (!match || !match[1] || match[1] === '.' || match[1] === '+' || match[1] === '-') {
+    return 0;
+  }
+
+  const num = parseFloat(match[1]);
+  if (Number.isNaN(num)) {
+    return 0;
+  }
+
+  const suffix = match[2];
+  if (!suffix) {
+    return num;
+  }
+  if (suffix in BINARY_SUFFIXES) {
+    return num * BINARY_SUFFIXES[suffix];
+  }
+  if (suffix in DECIMAL_SUFFIXES) {
+    return num * DECIMAL_SUFFIXES[suffix];
+  }
+
+  return num;
+};
+
+export default parseK8sQuantity;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72325

## Description

Adds host-level Kueue CRD types and API wrappers for Cohort and ResourceFlavor resources, plus GPUaaS package-level hooks and utilities for cohort discovery, hardware model resolution, and borrowed/lent calculations.

## How Has This Been Tested?

- `npm run type-check` passes for both `gpuaas` and `frontend` packages
- `npm run lint` passes with zero errors/warnings on all new and modified files
- Pre-commit hooks (lint-staged) passed on commit

## Test Impact

No tests added in this PR. Unit tests for the utilities and hook will be added in a follow-up once the consuming UI components (Stories 4, 5, 6) are in place and mock data fixtures are established.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing Kueue cohorts and resource flavors in the GPUaaS experience.
  * Introduced a unified cohort view that groups related queues into explicit, implicit, and standalone cohorts.
  * Added hardware model detection to improve GPU resource visibility.
* **Bug Fixes**
  * Improved borrowing/lending and quota-related calculations for more accurate availability.
* **Tests**
  * Added unit tests for Kubernetes quantity parsing to ensure correct numeric conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->