### PR TITLE
Add links from connected feature stores in Workbench UI to the Featur…

### DIFF
--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import {
   Content,
   Flex,
@@ -19,7 +20,7 @@ import ShowAllButton from './ShowAllButton';
 
 type NotebookFeatureStoreListProps = {
   notebook: NotebookKind;
-  availableNames: Set<string>;
+  availableStoreMap: Map<string, string>;
   availabilityLoaded: boolean;
 };
 
@@ -38,7 +39,7 @@ const parseFeatureStoreNames = (annotation: string | undefined): string[] => {
 
 const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
   notebook,
-  availableNames,
+  availableStoreMap,
   availabilityLoaded,
 }) => {
   const [showAll, setShowAll] = React.useState(false);
@@ -66,7 +67,7 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
         ) : (
           <List data-testid="notebook-feature-store-list">
             {visibleNames.map((name) => {
-              const isUnavailable = availabilityLoaded && !availableNames.has(name);
+              const isUnavailable = availabilityLoaded && !availableStoreMap.has(name);
 
               if (isUnavailable) {
                 return (
@@ -90,7 +91,20 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
                 );
               }
 
-              return <ListItem key={name}>{name}</ListItem>;
+              if (!availabilityLoaded) {
+                return <ListItem key={name}>{name}</ListItem>;
+              }
+
+              return (
+                <ListItem key={name}>
+                  <Link
+                    to={`/develop-train/feature-store/overview/${name}`}
+                    state={{ registryNamespace: availableStoreMap.get(name) }}
+                  >
+                    {name}
+                  </Link>
+                </ListItem>
+              );
             })}
           </List>
         )}

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -100,6 +100,7 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
                   <Link
                     to={`/develop-train/feature-store/overview/${name}`}
                     state={{ registryNamespace: availableStoreMap.get(name) }}
+                    data-testid={`feature-store-link-${name}`}
                   >
                     {name}
                   </Link>

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { InfoCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import {
   DashboardPopupIconButton,
   ResourceNameTooltip,
@@ -91,8 +92,8 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   const showKueueAnomalyIndicator =
     isKueueFeatureEnabled && isProjectKueueEnabled && !hasQueueLabel;
   const { featureStores, loaded: featureStoresLoaded } = useWorkbenchFeatureStores();
-  const availableFeatureStoreNames = React.useMemo(
-    () => new Set(featureStores.map((fs) => fs.projectName)),
+  const availableStoreMap = React.useMemo(
+    () => new Map(featureStores.map((fs) => [fs.projectName, fs.namespace])),
     [featureStores],
   );
 
@@ -320,7 +321,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
               <NotebookFeatureStoreList
                 key={obj.notebook.metadata.uid}
                 notebook={obj.notebook}
-                availableNames={availableFeatureStoreNames}
+                availableStoreMap={availableStoreMap}
                 availabilityLoaded={featureStoresLoaded}
               />
             </ExpandableRowContent>

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import NotebookFeatureStoreList from '#~/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList';
@@ -10,7 +11,7 @@ const SEVEN_STORES = 'store-1,store-2,store-3,store-4,store-5,store-6,store-7';
 
 const renderFeatureStoreList = (
   annotation?: string,
-  availableNames: Set<string> = new Set(),
+  availableStoreMap: Map<string, string> = new Map(),
   availabilityLoaded = true,
 ) => {
   const notebook = mockNotebookK8sResource({
@@ -23,22 +24,26 @@ const renderFeatureStoreList = (
     }),
   });
   render(
-    <NotebookFeatureStoreList
-      notebook={notebook}
-      availableNames={availableNames}
-      availabilityLoaded={availabilityLoaded}
-    />,
+    <MemoryRouter>
+      <NotebookFeatureStoreList
+        notebook={notebook}
+        availableStoreMap={availableStoreMap}
+        availabilityLoaded={availabilityLoaded}
+      />
+    </MemoryRouter>,
   );
 };
 
 describe('NotebookFeatureStoreList', () => {
   it('should show title and "None" when annotation is absent or empty', () => {
     const { unmount } = render(
-      <NotebookFeatureStoreList
-        notebook={mockNotebookK8sResource({})}
-        availableNames={new Set()}
-        availabilityLoaded
-      />,
+      <MemoryRouter>
+        <NotebookFeatureStoreList
+          notebook={mockNotebookK8sResource({})}
+          availableStoreMap={new Map()}
+          availabilityLoaded
+        />
+      </MemoryRouter>,
     );
     expect(screen.getByTestId('notebook-feature-store-title')).toHaveTextContent(
       'Connected feature stores',
@@ -53,7 +58,11 @@ describe('NotebookFeatureStoreList', () => {
   it('should render deduplicated and trimmed names without expand button', () => {
     renderFeatureStoreList(
       '  project-a , project-b , project-a , project-c  ',
-      new Set(['project-a', 'project-b', 'project-c']),
+      new Map([
+        ['project-a', 'ns-a'],
+        ['project-b', 'ns-b'],
+        ['project-c', 'ns-c'],
+      ]),
     );
 
     const list = screen.getByTestId('notebook-feature-store-list');
@@ -87,17 +96,19 @@ describe('NotebookFeatureStoreList', () => {
 
   it('should show info icon only for unavailable stores and hide icons while loading', () => {
     const { unmount } = render(
-      <NotebookFeatureStoreList
-        notebook={mockNotebookK8sResource({
-          opts: {
-            metadata: {
-              annotations: { [FEAST_CONFIG_ANNOTATION]: 'project-a,project-b,project-c' },
+      <MemoryRouter>
+        <NotebookFeatureStoreList
+          notebook={mockNotebookK8sResource({
+            opts: {
+              metadata: {
+                annotations: { [FEAST_CONFIG_ANNOTATION]: 'project-a,project-b,project-c' },
+              },
             },
-          },
-        })}
-        availableNames={new Set()}
-        availabilityLoaded={false}
-      />,
+          })}
+          availableStoreMap={new Map()}
+          availabilityLoaded={false}
+        />
+      </MemoryRouter>,
     );
     expect(screen.queryAllByTestId('feature-store-unavailable-icon')).toHaveLength(0);
     expect(
@@ -105,7 +116,7 @@ describe('NotebookFeatureStoreList', () => {
     ).toHaveLength(3);
     unmount();
 
-    renderFeatureStoreList('project-a,project-b,project-c', new Set(['project-b']));
+    renderFeatureStoreList('project-a,project-b,project-c', new Map([['project-b', 'ns-b']]));
     const list = screen.getByTestId('notebook-feature-store-list');
     const items = within(list).getAllByRole('listitem');
     expect(within(items[0]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
@@ -115,9 +126,68 @@ describe('NotebookFeatureStoreList', () => {
     expect(within(items[2]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
   });
 
+  it('should render links only when availability is loaded', () => {
+    const { unmount } = render(
+      <MemoryRouter>
+        <NotebookFeatureStoreList
+          notebook={mockNotebookK8sResource({
+            opts: {
+              metadata: {
+                annotations: { [FEAST_CONFIG_ANNOTATION]: 'project-a,project-b' },
+              },
+            },
+          })}
+          availableStoreMap={
+            new Map([
+              ['project-a', 'ns-a'],
+              ['project-b', 'ns-b'],
+            ])
+          }
+          availabilityLoaded={false}
+        />
+      </MemoryRouter>,
+    );
+    const list = screen.getByTestId('notebook-feature-store-list');
+    expect(within(list).queryAllByRole('link')).toHaveLength(0);
+    unmount();
+
+    render(
+      <MemoryRouter>
+        <NotebookFeatureStoreList
+          notebook={mockNotebookK8sResource({
+            opts: {
+              metadata: {
+                annotations: { [FEAST_CONFIG_ANNOTATION]: 'project-a,project-b' },
+              },
+            },
+          })}
+          availableStoreMap={
+            new Map([
+              ['project-a', 'ns-a'],
+              ['project-b', 'ns-b'],
+            ])
+          }
+          availabilityLoaded
+        />
+      </MemoryRouter>,
+    );
+    const loadedList = screen.getByTestId('notebook-feature-store-list');
+    const links = within(loadedList).getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', '/develop-train/feature-store/overview/project-a');
+    expect(links[1]).toHaveAttribute('href', '/develop-train/feature-store/overview/project-b');
+  });
+
   it('should show info icons with expand/collapse for mixed stores', async () => {
     const user = userEvent.setup();
-    renderFeatureStoreList(SEVEN_STORES, new Set(['store-1', 'store-3', 'store-5']));
+    renderFeatureStoreList(
+      SEVEN_STORES,
+      new Map([
+        ['store-1', 'ns-1'],
+        ['store-3', 'ns-3'],
+        ['store-5', 'ns-5'],
+      ]),
+    );
 
     const list = screen.getByTestId('notebook-feature-store-list');
     const initialItems = within(list).getAllByRole('listitem');

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
@@ -7,6 +7,25 @@ import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import NotebookFeatureStoreList from '#~/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList';
 import { FEAST_CONFIG_ANNOTATION } from '#~/pages/projects/screens/spawner/featureStore/const';
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Link: ({
+    to,
+    state,
+    children,
+    ...rest
+  }: {
+    to: string;
+    state?: Record<string, unknown>;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={to} data-state={JSON.stringify(state)} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
 const SEVEN_STORES = 'store-1,store-2,store-3,store-4,store-5,store-6,store-7';
 
 const renderFeatureStoreList = (
@@ -176,6 +195,12 @@ describe('NotebookFeatureStoreList', () => {
     expect(links).toHaveLength(2);
     expect(links[0]).toHaveAttribute('href', '/develop-train/feature-store/overview/project-a');
     expect(links[1]).toHaveAttribute('href', '/develop-train/feature-store/overview/project-b');
+    expect(JSON.parse(links[0].getAttribute('data-state') ?? '{}')).toEqual({
+      registryNamespace: 'ns-a',
+    });
+    expect(JSON.parse(links[1].getAttribute('data-state') ?? '{}')).toEqual({
+      registryNamespace: 'ns-b',
+    });
   });
 
   it('should show info icons with expand/collapse for mixed stores', async () => {

--- a/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTable.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTable.tsx
@@ -8,11 +8,13 @@ import { getFeatureStoreProjectId } from './selectFeatureStoresModalConst';
 
 export type FeatureStoreConnectedTableProps = {
   featureStores: SelectedFeatureStoreConfig[];
+  availabilityLoaded: boolean;
   onRemove: (projectId: string) => void;
 };
 
 export const FeatureStoreConnectedTable: React.FC<FeatureStoreConnectedTableProps> = ({
   featureStores,
+  availabilityLoaded,
   onRemove,
 }) => (
   <Table
@@ -23,6 +25,7 @@ export const FeatureStoreConnectedTable: React.FC<FeatureStoreConnectedTableProp
       <FeatureStoreConnectedTableRow
         key={getFeatureStoreProjectId(featureStore)}
         featureStore={featureStore}
+        availabilityLoaded={availabilityLoaded}
         onRemove={onRemove}
       />
     )}

--- a/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTableRow.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTableRow.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import {
   ActionList,
   ActionListItem,
@@ -47,7 +48,12 @@ export const FeatureStoreConnectedTableRow: React.FC<FeatureStoreConnectedTableR
             </FlexItem>
           </Flex>
         ) : (
-          <Truncate content={featureStore.projectName} />
+          <Link
+            to={`/develop-train/feature-store/overview/${featureStore.projectName}`}
+            state={{ registryNamespace: featureStore.namespace }}
+          >
+            <Truncate content={featureStore.projectName} />
+          </Link>
         )}
       </Td>
       <Td dataLabel="Namespace">

--- a/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTableRow.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTableRow.tsx
@@ -19,11 +19,13 @@ import { FEATURE_STORE_UNAVAILABLE_TOOLTIP } from './utils';
 
 export type FeatureStoreConnectedTableRowProps = {
   featureStore: SelectedFeatureStoreConfig;
+  availabilityLoaded: boolean;
   onRemove: (projectId: string) => void;
 };
 
 export const FeatureStoreConnectedTableRow: React.FC<FeatureStoreConnectedTableRowProps> = ({
   featureStore,
+  availabilityLoaded,
   onRemove,
 }) => {
   const projectId = getFeatureStoreProjectId(featureStore);
@@ -47,13 +49,16 @@ export const FeatureStoreConnectedTableRow: React.FC<FeatureStoreConnectedTableR
               </Tooltip>
             </FlexItem>
           </Flex>
-        ) : (
+        ) : availabilityLoaded ? (
           <Link
             to={`/develop-train/feature-store/overview/${featureStore.projectName}`}
             state={{ registryNamespace: featureStore.namespace }}
+            data-testid={`feature-store-link-${featureStore.projectName}`}
           >
             <Truncate content={featureStore.projectName} />
           </Link>
+        ) : (
+          <Truncate content={featureStore.projectName} />
         )}
       </Td>
       <Td dataLabel="Namespace">

--- a/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreFormSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreFormSection.tsx
@@ -101,6 +101,7 @@ export const FeatureStoreFormSection: React.FC<FeatureStoreFormSectionProps> = (
           <StackItem>
             <FeatureStoreConnectedTable
               featureStores={selectedFeatureStores}
+              availabilityLoaded={loaded}
               onRemove={(projectId) => {
                 onSelect(removeFeatureStoreProjectById(selectedFeatureStores, projectId));
               }}

--- a/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/FeatureStoreFormSection.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/FeatureStoreFormSection.spec.tsx
@@ -1,6 +1,7 @@
 import React, { act } from 'react';
 import '@testing-library/jest-dom';
 import { render, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import { FeatureStoreFormSection } from '#~/pages/projects/screens/spawner/featureStore/FeatureStoreFormSection';
 import type {
@@ -126,12 +127,14 @@ describe('FeatureStoreFormSection', () => {
 
   it('should render the connected table and example code for selected stores', () => {
     const result = render(
-      <FeatureStoreFormSection
-        loaded
-        availableFeatureStores={[mockFeatureStore()]}
-        selectedFeatureStores={[mockFeatureStore()]}
-        onSelect={jest.fn()}
-      />,
+      <MemoryRouter>
+        <FeatureStoreFormSection
+          loaded
+          availableFeatureStores={[mockFeatureStore()]}
+          selectedFeatureStores={[mockFeatureStore()]}
+          onSelect={jest.fn()}
+        />
+      </MemoryRouter>,
     );
 
     expect(result.getByTestId('feature-store-connected-table')).toBeInTheDocument();
@@ -178,12 +181,14 @@ describe('FeatureStoreFormSection', () => {
     const availableStore = mockFeatureStore();
 
     const result = render(
-      <FeatureStoreFormSection
-        loaded
-        availableFeatureStores={[availableStore]}
-        selectedFeatureStores={[availableStore, unavailableStore]}
-        onSelect={jest.fn()}
-      />,
+      <MemoryRouter>
+        <FeatureStoreFormSection
+          loaded
+          availableFeatureStores={[availableStore]}
+          selectedFeatureStores={[availableStore, unavailableStore]}
+          onSelect={jest.fn()}
+        />
+      </MemoryRouter>,
     );
 
     await act(async () => {
@@ -209,12 +214,14 @@ describe('FeatureStoreFormSection', () => {
     ];
 
     const result = render(
-      <FeatureStoreFormSection
-        loaded
-        availableFeatureStores={availableFeatureStores}
-        selectedFeatureStores={selectedFeatureStores}
-        onSelect={onSelect}
-      />,
+      <MemoryRouter>
+        <FeatureStoreFormSection
+          loaded
+          availableFeatureStores={availableFeatureStores}
+          selectedFeatureStores={selectedFeatureStores}
+          onSelect={onSelect}
+        />
+      </MemoryRouter>,
     );
 
     await act(async () => {

--- a/packages/cypress/cypress/pages/workbench.ts
+++ b/packages/cypress/cypress/pages/workbench.ts
@@ -394,7 +394,9 @@ class NotebookRow extends TableRow {
 
   shouldHaveFeatureStoreLinks(expected: Array<{ name: string; href: string }>) {
     expected.forEach(({ name, href }) => {
-      this.findFeatureStoreList().contains('a', name).should('have.attr', 'href', href);
+      this.findFeatureStoreList()
+        .findByTestId(`feature-store-link-${name}`)
+        .should('have.attr', 'href', href);
     });
     return this;
   }
@@ -816,7 +818,7 @@ class CreateSpawnerPage {
 
   shouldHaveFeatureStoreLink(projectName: string, href: string) {
     this.findFeatureStoreConnectedTable()
-      .contains('a', projectName)
+      .findByTestId(`feature-store-link-${projectName}`)
       .should('have.attr', 'href', href);
     return this;
   }

--- a/packages/cypress/cypress/pages/workbench.ts
+++ b/packages/cypress/cypress/pages/workbench.ts
@@ -392,6 +392,18 @@ class NotebookRow extends TableRow {
     return this;
   }
 
+  shouldHaveFeatureStoreLinks(expected: Array<{ name: string; href: string }>) {
+    expected.forEach(({ name, href }) => {
+      this.findFeatureStoreList().contains('a', name).should('have.attr', 'href', href);
+    });
+    return this;
+  }
+
+  shouldNotHaveFeatureStoreLinks() {
+    this.findFeatureStoreList().find('a').should('not.exist');
+    return this;
+  }
+
   findFeatureStoreShowAll() {
     return this.findExpansion().findByTestId('feature-store-show-all');
   }
@@ -799,6 +811,13 @@ class CreateSpawnerPage {
 
   shouldHaveFeatureStoreSelected(projectName: string) {
     this.findFeatureStoreConnectedTable().should('contain.text', projectName);
+    return this;
+  }
+
+  shouldHaveFeatureStoreLink(projectName: string, href: string) {
+    this.findFeatureStoreConnectedTable()
+      .contains('a', projectName)
+      .should('have.attr', 'href', href);
     return this;
   }
 

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -2217,32 +2217,6 @@ describe('Workbench page', () => {
         },
       ]);
     });
-
-    it('renders store names as plain text when workbench integration is not loaded', () => {
-      initIntercepts({
-        notebooks: [
-          mockNotebookK8sResource({
-            lastImageSelection: 'test-imagestream:1.2',
-            opts: {
-              metadata: {
-                name: 'test-notebook',
-                labels: { 'opendatahub.io/notebook-image': 'true' },
-                annotations: {
-                  'opendatahub.io/image-display-name': 'Test image',
-                  'opendatahub.io/feast-config': 'project-a,project-b',
-                },
-              },
-            },
-          }),
-        ],
-      });
-      enableFeatureStoreArea();
-      workbenchPage.visit('test-project');
-      const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
-      notebookRow.findExpansionButton().click();
-      notebookRow.shouldHaveFeatureStoreItems(['project-a', 'project-b']);
-      notebookRow.shouldNotHaveFeatureStoreLinks();
-    });
   });
 
   it('Delete Workbench', () => {
@@ -2517,7 +2491,7 @@ describe('Workbench page', () => {
         );
       });
 
-      it('should render connected feature store names as links', () => {
+      it('should render the selected store as a link and show the code block', () => {
         initIntercepts({ isEmpty: true });
         initFeatureStoreSpawnerIntercepts();
 
@@ -2531,28 +2505,8 @@ describe('Workbench page', () => {
           FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.projectName,
           `/develop-train/feature-store/overview/${FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.projectName}`,
         );
-      });
-
-      it('should display code block when feature stores are selected', () => {
-        initIntercepts({ isEmpty: true });
-        initFeatureStoreSpawnerIntercepts();
-
-        visitCreateSpawner();
-        createSpawnerPage.selectFeatureStore(
-          FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.namespace,
-          FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.projectName,
-        );
-
         createSpawnerPage.shouldHaveFeatureStoreCodeBlock();
         createSpawnerPage.findFeatureStoreCodeBlockInstructionText().should('exist');
-      });
-
-      it('should not display code block when no feature stores are selected', () => {
-        initIntercepts({ isEmpty: true });
-        initFeatureStoreSpawnerIntercepts();
-
-        visitCreateSpawner();
-        createSpawnerPage.shouldNotHaveFeatureStoreCodeBlock();
       });
 
       it('should keep the select button enabled when all available feature stores are connected', () => {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -67,6 +67,7 @@ import {
   initFeatureStoreSpawnerIntercepts,
   mockEmptyWorkbenchIntegrationResponse,
   mockNotebookWithFeastConfig,
+  mockWorkbenchIntegrationResponse,
 } from '../../../../utils/featureStoreSpawnerMocks';
 
 const configYamlPath = './cypress/fixtures/resources/yaml/mock-upload-configmap.yaml';
@@ -2178,6 +2179,70 @@ describe('Workbench page', () => {
       notebookRow.findFeatureStoreList().find('li').should('have.length', 5);
       notebookRow.findFeatureStoreShowAll().should('contain.text', 'Show all');
     });
+
+    it('renders available store names as links when workbench integration is loaded', () => {
+      initIntercepts({
+        notebooks: [
+          mockNotebookK8sResource({
+            lastImageSelection: 'test-imagestream:1.2',
+            opts: {
+              metadata: {
+                name: 'test-notebook',
+                labels: { 'opendatahub.io/notebook-image': 'true' },
+                annotations: {
+                  'opendatahub.io/image-display-name': 'Test image',
+                  'opendatahub.io/feast-config': `${FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.projectName},${FEATURE_STORE_SPAWNER_PROJECTS.banking.projectName}`,
+                },
+              },
+            },
+          }),
+        ],
+      });
+      enableFeatureStoreArea();
+      cy.interceptOdh(
+        'GET /api/featurestores/workbench-integration',
+        mockWorkbenchIntegrationResponse,
+      );
+      workbenchPage.visit('test-project');
+      const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
+      notebookRow.findExpansionButton().click();
+      notebookRow.shouldHaveFeatureStoreLinks([
+        {
+          name: FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.projectName,
+          href: `/develop-train/feature-store/overview/${FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.projectName}`,
+        },
+        {
+          name: FEATURE_STORE_SPAWNER_PROJECTS.banking.projectName,
+          href: `/develop-train/feature-store/overview/${FEATURE_STORE_SPAWNER_PROJECTS.banking.projectName}`,
+        },
+      ]);
+    });
+
+    it('renders store names as plain text when workbench integration is not loaded', () => {
+      initIntercepts({
+        notebooks: [
+          mockNotebookK8sResource({
+            lastImageSelection: 'test-imagestream:1.2',
+            opts: {
+              metadata: {
+                name: 'test-notebook',
+                labels: { 'opendatahub.io/notebook-image': 'true' },
+                annotations: {
+                  'opendatahub.io/image-display-name': 'Test image',
+                  'opendatahub.io/feast-config': 'project-a,project-b',
+                },
+              },
+            },
+          }),
+        ],
+      });
+      enableFeatureStoreArea();
+      workbenchPage.visit('test-project');
+      const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
+      notebookRow.findExpansionButton().click();
+      notebookRow.shouldHaveFeatureStoreItems(['project-a', 'project-b']);
+      notebookRow.shouldNotHaveFeatureStoreLinks();
+    });
   });
 
   it('Delete Workbench', () => {
@@ -2449,6 +2514,22 @@ describe('Workbench page', () => {
         );
         createSpawnerPage.shouldHaveFeatureStoreSelected(
           FEATURE_STORE_SPAWNER_PROJECTS.banking.projectName,
+        );
+      });
+
+      it('should render connected feature store names as links', () => {
+        initIntercepts({ isEmpty: true });
+        initFeatureStoreSpawnerIntercepts();
+
+        visitCreateSpawner();
+        createSpawnerPage.selectFeatureStore(
+          FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.namespace,
+          FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.projectName,
+        );
+
+        createSpawnerPage.shouldHaveFeatureStoreLink(
+          FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.projectName,
+          `/develop-train/feature-store/overview/${FEATURE_STORE_SPAWNER_PROJECTS.creditScoring.projectName}`,
         );
       });
 

--- a/packages/feature-store/src/FeatureStoreContext.tsx
+++ b/packages/feature-store/src/FeatureStoreContext.tsx
@@ -85,14 +85,12 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
   );
 
   React.useEffect(() => {
-    if (!registryLoaded) {
+    if (!navRegistryNamespace || !registryLoaded) {
       return;
     }
-    if (navRegistryNamespace) {
-      const match = registryFeatureStores.find((fs) => fs.namespace === navRegistryNamespace);
-      setSelectedFeatureStoreName(match ? match.name : null);
-    } else {
-      setSelectedFeatureStoreName(null);
+    const match = registryFeatureStores.find((fs) => fs.namespace === navRegistryNamespace);
+    if (match) {
+      setSelectedFeatureStoreName(match.name);
     }
   }, [navRegistryNamespace, registryLoaded, registryFeatureStores]);
 

--- a/packages/feature-store/src/FeatureStoreContext.tsx
+++ b/packages/feature-store/src/FeatureStoreContext.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
 import { conditionalArea } from '@odh-dashboard/internal/concepts/areas/AreaComponent';
 import { useRegistryFeatureStores, RegistryFeatureStore } from './hooks/useRegistryFeatureStores';
@@ -76,22 +76,38 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
     refresh: refreshRegistry,
   } = useRegistryFeatureStores();
 
+  const location = useLocation();
+  const navRegistryNamespace: string | undefined = location.state?.registryNamespace;
+
   // Reserved for future multi-store UI selection. GA currently defaults to first discovered store.
   const [selectedFeatureStoreName, setSelectedFeatureStoreName] = React.useState<string | null>(
     null,
   );
 
+  React.useEffect(() => {
+    if (navRegistryNamespace && registryLoaded) {
+      const match = registryFeatureStores.find((fs) => fs.namespace === navRegistryNamespace);
+      if (match) {
+        setSelectedFeatureStoreName(match.name);
+      }
+    }
+  }, [navRegistryNamespace, registryLoaded, registryFeatureStores]);
+
   const activeFeatureStore = React.useMemo(() => {
     if (selectedFeatureStoreName) {
       const featureStore = registryFeatureStores.find((fs) => fs.name === selectedFeatureStoreName);
-
       if (featureStore) {
         return featureStore;
       }
     }
-    // NOTE: Currently limited to one FeatureStore. Selecting the first enabled available one.
+    if (navRegistryNamespace) {
+      const match = registryFeatureStores.find((fs) => fs.namespace === navRegistryNamespace);
+      if (match) {
+        return match;
+      }
+    }
     return registryFeatureStores.length > 0 ? registryFeatureStores[0] : null;
-  }, [registryFeatureStores, selectedFeatureStoreName]);
+  }, [registryFeatureStores, selectedFeatureStoreName, navRegistryNamespace]);
 
   // Use backend proxy to access registry services
   const hostPath = activeFeatureStore

--- a/packages/feature-store/src/FeatureStoreContext.tsx
+++ b/packages/feature-store/src/FeatureStoreContext.tsx
@@ -85,11 +85,14 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
   );
 
   React.useEffect(() => {
-    if (navRegistryNamespace && registryLoaded) {
+    if (!registryLoaded) {
+      return;
+    }
+    if (navRegistryNamespace) {
       const match = registryFeatureStores.find((fs) => fs.namespace === navRegistryNamespace);
-      if (match) {
-        setSelectedFeatureStoreName(match.name);
-      }
+      setSelectedFeatureStoreName(match ? match.name : null);
+    } else {
+      setSelectedFeatureStoreName(null);
     }
   }, [navRegistryNamespace, registryLoaded, registryFeatureStores]);
 

--- a/packages/feature-store/src/__tests__/FeatureStoreContext.test.tsx
+++ b/packages/feature-store/src/__tests__/FeatureStoreContext.test.tsx
@@ -15,9 +15,12 @@ import { DEFAULT_PROJECT_LIST } from '../const';
 jest.mock('../hooks/useRegistryFeatureStores');
 jest.mock('../apiHooks/useFeatureStoreAPIState');
 jest.mock('../apiHooks/useFeatureStoreProjectsAPI');
+const mockUseLocation = jest.fn<{ state: { registryNamespace: string } | null }, []>(() => ({
+  state: null,
+}));
 jest.mock('react-router-dom', () => ({
   useParams: jest.fn(() => ({})),
-  useLocation: jest.fn(() => ({ state: null })),
+  useLocation: () => mockUseLocation(),
 }));
 jest.mock('@odh-dashboard/internal/concepts/areas/AreaComponent', () => ({
   conditionalArea: () => (Component: React.ComponentType) => Component,
@@ -115,6 +118,22 @@ describe('FeatureStoreContext — activeFeatureStore', () => {
     setupStores([makeStore('store-a')]);
     rerender();
 
+    expect(result.current.activeFeatureStore?.name).toBe('store-a');
+  });
+
+  it('selects the matching store when navRegistryNamespace is provided', () => {
+    mockUseLocation.mockReturnValue({ state: { registryNamespace: 'ns-b' } });
+    setupStores([makeStore('store-a', 'ns-a'), makeStore('store-b', 'ns-b')]);
+
+    const { result } = renderHook(useContextHook, { wrapper });
+    expect(result.current.activeFeatureStore?.name).toBe('store-b');
+  });
+
+  it('falls back to the first store when navRegistryNamespace does not match', () => {
+    mockUseLocation.mockReturnValue({ state: { registryNamespace: 'ns-unknown' } });
+    setupStores([makeStore('store-a', 'ns-a'), makeStore('store-b', 'ns-b')]);
+
+    const { result } = renderHook(useContextHook, { wrapper });
     expect(result.current.activeFeatureStore?.name).toBe('store-a');
   });
 });

--- a/packages/feature-store/src/__tests__/FeatureStoreContext.test.tsx
+++ b/packages/feature-store/src/__tests__/FeatureStoreContext.test.tsx
@@ -15,7 +15,10 @@ import { DEFAULT_PROJECT_LIST } from '../const';
 jest.mock('../hooks/useRegistryFeatureStores');
 jest.mock('../apiHooks/useFeatureStoreAPIState');
 jest.mock('../apiHooks/useFeatureStoreProjectsAPI');
-jest.mock('react-router-dom', () => ({ useParams: jest.fn(() => ({})) }));
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(() => ({})),
+  useLocation: jest.fn(() => ({ state: null })),
+}));
 jest.mock('@odh-dashboard/internal/concepts/areas/AreaComponent', () => ({
   conditionalArea: () => (Component: React.ComponentType) => Component,
 }));


### PR DESCRIPTION
…e Store overview page

https://redhat.atlassian.net/browse/RHOAIENG-73055

## Description
Connected feature store names in the Workbench UI are currently plain text. This PR adds a link on each available feature store name that takes the user to its Feature Store overview page.

This applies in two places:

The "Connected feature stores" section in the Workbench detail expanded row

The connected feature stores table in the Workbench spawner form

## Screenshots and videos


https://github.com/user-attachments/assets/4fbed1b2-68e5-433f-9f9d-6c8064192585


https://github.com/user-attachments/assets/71f087d0-5c93-4425-a6e7-3f64d2c0d8ac



<img width="2523" height="1265" alt="SCR-20260702-merd" src="https://github.com/user-attachments/assets/af859c5d-9300-4dfc-9b48-0eefb12a9bab" />

<img width="2523" height="1265" alt="SCR-20260702-meoi" src="https://github.com/user-attachments/assets/9cda3b8f-d247-4120-a713-9d3c69e887fe" />


### All specs pass
<img width="2542" height="1269" alt="SCR-20260702-mbgy" src="https://github.com/user-attachments/assets/c22f8182-fa85-4954-9c61-543aa1b31918" />


## How Has This Been Tested?
- Manually verified links navigate to the correct feature store overview page from both the workbench detail row and the spawner form
- Confirmed unavailable stores remain plain text with the info icon

## Test Impact
Added Cypress mocked tests and page object helpers to verify links appear when integration is loaded and stay as plain text.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature store names now become clickable links (to the feature-store overview) once availability finishes loading in notebook lists and connected-store tables.
  * Link navigation carries registry namespace data to support automatic feature-store preselection after the registry loads.

* **Bug Fixes**
  * While availability is loading, feature store names render as plain text (no links).
  * Unavailable store indicators/tooltip icons are shown only for stores not present in the availability map, and are hidden while availability is loading (including expand/collapse cases).

* **Tests**
  * Updated unit and Cypress coverage to validate link vs. non-link rendering, correct href/state behavior, and namespace-based preselection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->