### PR TITLE
RHOAIENG-72326: Infrastructure summary cards for accelerator and utilization metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36414,6 +36414,7 @@
         "@odh-dashboard/tsconfig": "*"
       },
       "peerDependencies": {
+        "@patternfly/react-charts": "^8",
         "@patternfly/react-core": "^6",
         "@patternfly/react-icons": "^6",
         "react": "^18",

--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -1,0 +1,49 @@
+import { appChrome } from './appChrome';
+
+class InfrastructurePage {
+  visit(wait = true) {
+    cy.visitWithLogin('/observe-and-monitor/infrastructure');
+    if (wait) {
+      this.wait();
+    }
+  }
+
+  findNavItem() {
+    return appChrome.findNavItem({ name: 'Infrastructure', rootSection: 'Observe & monitor' });
+  }
+
+  shouldNotFoundPage() {
+    return cy.findByTestId('not-found-page').should('exist');
+  }
+
+  shouldHavePageTitle() {
+    return cy.findByTestId('app-page-title').should('have.text', 'Infrastructure');
+  }
+
+  findClusterSection() {
+    return cy.findByTestId('infrastructure-cluster-section');
+  }
+
+  findTotalAcceleratorsCard() {
+    return cy.findByTestId('cluster-card-total-accelerators');
+  }
+
+  findComputeUtilizationCard() {
+    return cy.findByTestId('cluster-card-compute-utilization');
+  }
+
+  findMemoryUtilizationCard() {
+    return cy.findByTestId('cluster-card-memory-utilization');
+  }
+
+  findRefreshBadge() {
+    return cy.findByTestId('infrastructure-refresh-badge');
+  }
+
+  private wait() {
+    this.shouldHavePageTitle();
+    cy.testA11y();
+  }
+}
+
+export const infrastructurePage = new InfrastructurePage();

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -104,28 +104,13 @@ describe('GPUaaS Infrastructure Page', () => {
       initIntercepts({ hasAccelerators: true, hasDcgm: true });
     });
 
-    it('should display the page with cluster summary cards', () => {
+    it('should display cluster section with correct card data and refresh badge', () => {
       infrastructurePage.visit();
       infrastructurePage.findClusterSection().should('exist');
-      infrastructurePage.findTotalAcceleratorsCard().should('exist');
-      infrastructurePage.findComputeUtilizationCard().should('exist');
-      infrastructurePage.findMemoryUtilizationCard().should('exist');
-    });
-
-    it('should show accelerator count in the total accelerators card', () => {
-      infrastructurePage.visit();
       infrastructurePage.findTotalAcceleratorsCard().should('contain.text', '11/16');
       infrastructurePage.findTotalAcceleratorsCard().should('contain.text', 'Accelerators in use');
-    });
-
-    it('should show utilization percentages', () => {
-      infrastructurePage.visit();
       infrastructurePage.findComputeUtilizationCard().should('contain.text', '80%');
       infrastructurePage.findMemoryUtilizationCard().should('contain.text', '83%');
-    });
-
-    it('should display the refresh badge', () => {
-      infrastructurePage.visit();
       infrastructurePage.findRefreshBadge().should('exist');
       infrastructurePage.findRefreshBadge().should('contain.text', 'Refreshed');
     });

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -1,0 +1,171 @@
+import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockComponents } from '@odh-dashboard/internal/__mocks__/mockComponents';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { asClusterAdminUser, asProjectAdminUser } from '../../../utils/mockUsers';
+import { infrastructurePage } from '../../../pages/infrastructure';
+
+const mockPrometheusResponse = (value: string) => ({
+  data: {
+    result: [{ value: [Date.now() / 1000, value] }],
+    resultType: 'vector',
+  },
+  status: 'success',
+});
+
+const mockEmptyPrometheusResponse = () => ({
+  data: { result: [], resultType: 'vector' },
+  status: 'success',
+});
+
+type InitInterceptsOptions = {
+  isKueueInstalled?: boolean;
+  gpuaas?: boolean;
+  hasAccelerators?: boolean;
+  hasDcgm?: boolean;
+};
+
+const initIntercepts = ({
+  isKueueInstalled = true,
+  gpuaas = true,
+  hasAccelerators = true,
+  hasDcgm = true,
+}: InitInterceptsOptions = {}) => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.KUEUE]: {
+          managementState: isKueueInstalled ? 'Managed' : 'Removed',
+        },
+      },
+    }),
+  );
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ gpuaas }));
+  cy.interceptOdh('GET /api/components', null, mockComponents());
+
+  cy.interceptOdh('POST /api/prometheus/query', (req) => {
+    const query = req.body.query as string;
+
+    if (query.includes('kube_node_status_allocatable')) {
+      req.reply({
+        code: 200,
+        response: hasAccelerators ? mockPrometheusResponse('16') : mockEmptyPrometheusResponse(),
+      });
+    } else if (query.includes('kube_pod_container_resource_requests')) {
+      req.reply({
+        code: 200,
+        response: hasAccelerators ? mockPrometheusResponse('11') : mockEmptyPrometheusResponse(),
+      });
+    } else if (query.includes('DCGM_FI_PROF_GR_ENGINE_ACTIVE')) {
+      req.reply({
+        code: 200,
+        response: hasDcgm ? mockPrometheusResponse('79.5') : mockEmptyPrometheusResponse(),
+      });
+    } else if (query.includes('DCGM_FI_DEV_FB_USED')) {
+      req.reply({
+        code: 200,
+        response: hasDcgm ? mockPrometheusResponse('83.2') : mockEmptyPrometheusResponse(),
+      });
+    } else {
+      req.reply(404);
+    }
+  });
+};
+
+describe('GPUaaS Infrastructure Page', () => {
+  it('should not be accessible for non-admin users', () => {
+    asProjectAdminUser();
+    initIntercepts();
+    infrastructurePage.visit(false);
+    infrastructurePage.findNavItem().should('not.exist');
+    infrastructurePage.shouldNotFoundPage();
+  });
+
+  it('should not exist when Kueue is not installed', () => {
+    asClusterAdminUser();
+    initIntercepts({ isKueueInstalled: false });
+    infrastructurePage.visit(false);
+    infrastructurePage.findNavItem().should('not.exist');
+    infrastructurePage.shouldNotFoundPage();
+  });
+
+  it('should not exist when feature flag is disabled', () => {
+    asClusterAdminUser();
+    initIntercepts({ gpuaas: false });
+    infrastructurePage.visit(false);
+    infrastructurePage.findNavItem().should('not.exist');
+    infrastructurePage.shouldNotFoundPage();
+  });
+
+  describe('with GPU data available', () => {
+    beforeEach(() => {
+      asClusterAdminUser();
+      initIntercepts({ hasAccelerators: true, hasDcgm: true });
+    });
+
+    it('should display the page with cluster summary cards', () => {
+      infrastructurePage.visit();
+      infrastructurePage.findClusterSection().should('exist');
+      infrastructurePage.findTotalAcceleratorsCard().should('exist');
+      infrastructurePage.findComputeUtilizationCard().should('exist');
+      infrastructurePage.findMemoryUtilizationCard().should('exist');
+    });
+
+    it('should show accelerator count in the total accelerators card', () => {
+      infrastructurePage.visit();
+      infrastructurePage.findTotalAcceleratorsCard().should('contain.text', '11/16');
+      infrastructurePage.findTotalAcceleratorsCard().should('contain.text', 'Accelerators in use');
+    });
+
+    it('should show utilization percentages', () => {
+      infrastructurePage.visit();
+      infrastructurePage.findComputeUtilizationCard().should('contain.text', '80%');
+      infrastructurePage.findMemoryUtilizationCard().should('contain.text', '83%');
+    });
+
+    it('should display the refresh badge', () => {
+      infrastructurePage.visit();
+      infrastructurePage.findRefreshBadge().should('exist');
+      infrastructurePage.findRefreshBadge().should('contain.text', 'Refreshed');
+    });
+  });
+
+  describe('with no accelerators', () => {
+    beforeEach(() => {
+      asClusterAdminUser();
+      initIntercepts({ hasAccelerators: false, hasDcgm: false });
+    });
+
+    it('should display empty states for all cards', () => {
+      infrastructurePage.visit();
+      infrastructurePage
+        .findTotalAcceleratorsCard()
+        .should('contain.text', 'No accelerator resources detected');
+      infrastructurePage
+        .findComputeUtilizationCard()
+        .should('contain.text', 'Utilization metrics unavailable');
+      infrastructurePage
+        .findMemoryUtilizationCard()
+        .should('contain.text', 'Utilization metrics unavailable');
+    });
+  });
+
+  describe('with accelerators but no DCGM', () => {
+    beforeEach(() => {
+      asClusterAdminUser();
+      initIntercepts({ hasAccelerators: true, hasDcgm: false });
+    });
+
+    it('should show accelerator data but empty utilization cards', () => {
+      infrastructurePage.visit();
+      infrastructurePage.findTotalAcceleratorsCard().should('contain.text', '11/16');
+      infrastructurePage
+        .findComputeUtilizationCard()
+        .should('contain.text', 'Utilization metrics unavailable');
+      infrastructurePage
+        .findMemoryUtilizationCard()
+        .should('contain.text', 'Utilization metrics unavailable');
+    });
+  });
+});

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -25,6 +25,7 @@
     "@odh-dashboard/tsconfig": "*"
   },
   "peerDependencies": {
+    "@patternfly/react-charts": "^8",
     "@patternfly/react-core": "^6",
     "@patternfly/react-icons": "^6",
     "react": "^18",

--- a/packages/gpuaas/src/components/ClusterSummaryCards.scss
+++ b/packages/gpuaas/src/components/ClusterSummaryCards.scss
@@ -1,0 +1,3 @@
+.gpuaas-cluster-spinner {
+  min-height: var(--pf-t--global--spacer--3xl);
+}

--- a/packages/gpuaas/src/components/ClusterSummaryCards.tsx
+++ b/packages/gpuaas/src/components/ClusterSummaryCards.tsx
@@ -7,6 +7,8 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
+  Flex,
+  FlexItem,
   Grid,
   GridItem,
   Spinner,
@@ -57,7 +59,11 @@ const TotalAcceleratorsCard: React.FC<TotalAcceleratorsCardProps> = ({ accelerat
   if (!accelerators) {
     return (
       <Card isFullHeight data-testid="cluster-card-total-accelerators">
-        <CardTitle className="pf-v6-u-text-align-center">Total accelerators</CardTitle>
+        <CardTitle>
+          <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+            <FlexItem>Total accelerators</FlexItem>
+          </Flex>
+        </CardTitle>
         <CardBody>
           <EmptyState
             headingLevel="h4"
@@ -77,24 +83,30 @@ const TotalAcceleratorsCard: React.FC<TotalAcceleratorsCardProps> = ({ accelerat
 
   return (
     <Card isFullHeight data-testid="cluster-card-total-accelerators">
-      <CardTitle className="pf-v6-u-text-align-center">Total accelerators</CardTitle>
-      <CardBody className="pf-v6-u-display-flex pf-v6-u-justify-content-center">
-        <ChartDonutUtilization
-          ariaTitle="Total accelerator utilization"
-          constrainToVisibleArea
-          data={{ x: 'Accelerators in use', y: percentage }}
-          height={CHART_HEIGHT}
-          width={CHART_WIDTH}
-          innerRadius={INNER_RADIUS}
-          labels={({ datum }) =>
-            datum.x === 'Accelerators in use'
-              ? `Accelerators in use: ${percentage}%`
-              : `Available: ${100 - percentage}%`
-          }
-          subTitle="Accelerators in use"
-          title={`${inUse}/${total}`}
-          name="total-accelerators"
-        />
+      <CardTitle>
+        <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+          <FlexItem>Total accelerators</FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <Bullseye>
+          <ChartDonutUtilization
+            ariaTitle="Total accelerator utilization"
+            constrainToVisibleArea
+            data={{ x: 'Accelerators in use', y: percentage }}
+            height={CHART_HEIGHT}
+            width={CHART_WIDTH}
+            innerRadius={INNER_RADIUS}
+            labels={({ datum }) =>
+              datum.x === 'Accelerators in use'
+                ? `Accelerators in use: ${percentage}%`
+                : `Available: ${100 - percentage}%`
+            }
+            subTitle="Accelerators in use"
+            title={`${inUse}/${total}`}
+            name="total-accelerators"
+          />
+        </Bullseye>
       </CardBody>
     </Card>
   );
@@ -108,7 +120,11 @@ const ComputeUtilizationCard: React.FC<UtilizationCardProps> = ({ utilization })
   if (!utilization) {
     return (
       <Card isFullHeight data-testid="cluster-card-compute-utilization">
-        <CardTitle className="pf-v6-u-text-align-center">Avg. compute utilization</CardTitle>
+        <CardTitle>
+          <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+            <FlexItem>Avg. compute utilization</FlexItem>
+          </Flex>
+        </CardTitle>
         <CardBody>
           <EmptyState
             headingLevel="h4"
@@ -127,24 +143,30 @@ const ComputeUtilizationCard: React.FC<UtilizationCardProps> = ({ utilization })
 
   return (
     <Card isFullHeight data-testid="cluster-card-compute-utilization">
-      <CardTitle className="pf-v6-u-text-align-center">Avg. compute utilization</CardTitle>
-      <CardBody className="pf-v6-u-display-flex pf-v6-u-justify-content-center">
-        <ChartDonutUtilization
-          ariaTitle="Average compute utilization"
-          constrainToVisibleArea
-          data={{ x: 'Compute', y: utilization.percentage }}
-          height={CHART_HEIGHT}
-          width={CHART_WIDTH}
-          innerRadius={INNER_RADIUS}
-          labels={({ datum }) =>
-            datum.x === 'Compute'
-              ? `Compute: ${utilization.percentage}%`
-              : `Available: ${100 - utilization.percentage}%`
-          }
-          subTitle="utilization"
-          title={`${utilization.percentage}%`}
-          name="compute-utilization"
-        />
+      <CardTitle>
+        <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+          <FlexItem>Avg. compute utilization</FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <Bullseye>
+          <ChartDonutUtilization
+            ariaTitle="Average compute utilization"
+            constrainToVisibleArea
+            data={{ x: 'Compute', y: utilization.percentage }}
+            height={CHART_HEIGHT}
+            width={CHART_WIDTH}
+            innerRadius={INNER_RADIUS}
+            labels={({ datum }) =>
+              datum.x === 'Compute'
+                ? `Compute: ${utilization.percentage}%`
+                : `Available: ${100 - utilization.percentage}%`
+            }
+            subTitle="utilization"
+            title={`${utilization.percentage}%`}
+            name="compute-utilization"
+          />
+        </Bullseye>
       </CardBody>
     </Card>
   );
@@ -154,8 +176,10 @@ const MemoryUtilizationCard: React.FC<UtilizationCardProps> = ({ utilization }) 
   if (!utilization) {
     return (
       <Card isFullHeight data-testid="cluster-card-memory-utilization">
-        <CardTitle className="pf-v6-u-text-align-center">
-          Avg. accelerator memory utilization
+        <CardTitle>
+          <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+            <FlexItem>Avg. accelerator memory utilization</FlexItem>
+          </Flex>
         </CardTitle>
         <CardBody>
           <EmptyState
@@ -175,26 +199,30 @@ const MemoryUtilizationCard: React.FC<UtilizationCardProps> = ({ utilization }) 
 
   return (
     <Card isFullHeight data-testid="cluster-card-memory-utilization">
-      <CardTitle className="pf-v6-u-text-align-center">
-        Avg. accelerator memory utilization
+      <CardTitle>
+        <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+          <FlexItem>Avg. accelerator memory utilization</FlexItem>
+        </Flex>
       </CardTitle>
-      <CardBody className="pf-v6-u-display-flex pf-v6-u-justify-content-center">
-        <ChartDonutUtilization
-          ariaTitle="Average accelerator memory utilization"
-          constrainToVisibleArea
-          data={{ x: 'Memory', y: utilization.percentage }}
-          height={CHART_HEIGHT}
-          width={CHART_WIDTH}
-          innerRadius={INNER_RADIUS}
-          labels={({ datum }) =>
-            datum.x === 'Memory'
-              ? `Memory: ${utilization.percentage}%`
-              : `Available: ${100 - utilization.percentage}%`
-          }
-          subTitle="utilization"
-          title={`${utilization.percentage}%`}
-          name="memory-utilization"
-        />
+      <CardBody>
+        <Bullseye>
+          <ChartDonutUtilization
+            ariaTitle="Average accelerator memory utilization"
+            constrainToVisibleArea
+            data={{ x: 'Memory', y: utilization.percentage }}
+            height={CHART_HEIGHT}
+            width={CHART_WIDTH}
+            innerRadius={INNER_RADIUS}
+            labels={({ datum }) =>
+              datum.x === 'Memory'
+                ? `Memory: ${utilization.percentage}%`
+                : `Available: ${100 - utilization.percentage}%`
+            }
+            subTitle="utilization"
+            title={`${utilization.percentage}%`}
+            name="memory-utilization"
+          />
+        </Bullseye>
       </CardBody>
     </Card>
   );

--- a/packages/gpuaas/src/components/ClusterSummaryCards.tsx
+++ b/packages/gpuaas/src/components/ClusterSummaryCards.tsx
@@ -27,7 +27,7 @@ const CHART_WIDTH = 230;
 const INNER_RADIUS = 100;
 
 const ClusterSummaryCards: React.FC<ClusterSummaryCardsProps> = ({ metrics }) => {
-  const { accelerators, computeUtilization, memoryUtilization, loaded } = metrics;
+  const { accelerators, computeUtilization, memoryUtilization, loaded, error } = metrics;
 
   if (!loaded) {
     return (
@@ -37,15 +37,29 @@ const ClusterSummaryCards: React.FC<ClusterSummaryCardsProps> = ({ metrics }) =>
     );
   }
 
+  if (error) {
+    return (
+      <EmptyState
+        headingLevel="h4"
+        icon={CubesIcon}
+        titleText="Error loading metrics"
+        variant={EmptyStateVariant.sm}
+        data-testid="cluster-metrics-error"
+      >
+        <EmptyStateBody>{error.message}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
   return (
     <Grid hasGutter>
-      <GridItem span={4}>
+      <GridItem sm={12} md={6} lg={4}>
         <TotalAcceleratorsCard accelerators={accelerators} />
       </GridItem>
-      <GridItem span={4}>
+      <GridItem sm={12} md={6} lg={4}>
         <ComputeUtilizationCard utilization={computeUtilization} />
       </GridItem>
-      <GridItem span={4}>
+      <GridItem sm={12} md={6} lg={4}>
         <MemoryUtilizationCard utilization={memoryUtilization} />
       </GridItem>
     </Grid>

--- a/packages/gpuaas/src/components/ClusterSummaryCards.tsx
+++ b/packages/gpuaas/src/components/ClusterSummaryCards.tsx
@@ -16,6 +16,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
 import { ClusterMetrics } from '../hooks/useInfrastructureMetrics';
+import './ClusterSummaryCards.scss';
 
 type ClusterSummaryCardsProps = {
   metrics: ClusterMetrics;
@@ -30,7 +31,7 @@ const ClusterSummaryCards: React.FC<ClusterSummaryCardsProps> = ({ metrics }) =>
 
   if (!loaded) {
     return (
-      <Bullseye style={{ minHeight: 150 }}>
+      <Bullseye className="gpuaas-cluster-spinner">
         <Spinner />
       </Bullseye>
     );

--- a/packages/gpuaas/src/components/ClusterSummaryCards.tsx
+++ b/packages/gpuaas/src/components/ClusterSummaryCards.tsx
@@ -1,0 +1,203 @@
+import * as React from 'react';
+import {
+  Bullseye,
+  Card,
+  CardBody,
+  CardTitle,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Grid,
+  GridItem,
+  Spinner,
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+import { ClusterMetrics } from '../hooks/useInfrastructureMetrics';
+
+type ClusterSummaryCardsProps = {
+  metrics: ClusterMetrics;
+};
+
+const CHART_HEIGHT = 230;
+const CHART_WIDTH = 230;
+const INNER_RADIUS = 100;
+
+const ClusterSummaryCards: React.FC<ClusterSummaryCardsProps> = ({ metrics }) => {
+  const { accelerators, computeUtilization, memoryUtilization, loaded } = metrics;
+
+  if (!loaded) {
+    return (
+      <Bullseye style={{ minHeight: 150 }}>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  return (
+    <Grid hasGutter>
+      <GridItem span={4}>
+        <TotalAcceleratorsCard accelerators={accelerators} />
+      </GridItem>
+      <GridItem span={4}>
+        <ComputeUtilizationCard utilization={computeUtilization} />
+      </GridItem>
+      <GridItem span={4}>
+        <MemoryUtilizationCard utilization={memoryUtilization} />
+      </GridItem>
+    </Grid>
+  );
+};
+
+type TotalAcceleratorsCardProps = {
+  accelerators: ClusterMetrics['accelerators'];
+};
+
+const TotalAcceleratorsCard: React.FC<TotalAcceleratorsCardProps> = ({ accelerators }) => {
+  if (!accelerators) {
+    return (
+      <Card isFullHeight data-testid="cluster-card-total-accelerators">
+        <CardTitle className="pf-v6-u-text-align-center">Total accelerators</CardTitle>
+        <CardBody>
+          <EmptyState
+            headingLevel="h4"
+            icon={CubesIcon}
+            titleText="No accelerator resources detected"
+            variant={EmptyStateVariant.xs}
+          >
+            <EmptyStateBody>No accelerator resources were detected on this cluster.</EmptyStateBody>
+          </EmptyState>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  const { total, inUse } = accelerators;
+  const percentage = total > 0 ? Math.round((inUse / total) * 100) : 0;
+
+  return (
+    <Card isFullHeight data-testid="cluster-card-total-accelerators">
+      <CardTitle className="pf-v6-u-text-align-center">Total accelerators</CardTitle>
+      <CardBody className="pf-v6-u-display-flex pf-v6-u-justify-content-center">
+        <ChartDonutUtilization
+          ariaTitle="Total accelerator utilization"
+          constrainToVisibleArea
+          data={{ x: 'Accelerators in use', y: percentage }}
+          height={CHART_HEIGHT}
+          width={CHART_WIDTH}
+          innerRadius={INNER_RADIUS}
+          labels={({ datum }) =>
+            datum.x === 'Accelerators in use'
+              ? `Accelerators in use: ${percentage}%`
+              : `Available: ${100 - percentage}%`
+          }
+          subTitle="Accelerators in use"
+          title={`${inUse}/${total}`}
+          name="total-accelerators"
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
+type UtilizationCardProps = {
+  utilization: ClusterMetrics['computeUtilization'];
+};
+
+const ComputeUtilizationCard: React.FC<UtilizationCardProps> = ({ utilization }) => {
+  if (!utilization) {
+    return (
+      <Card isFullHeight data-testid="cluster-card-compute-utilization">
+        <CardTitle className="pf-v6-u-text-align-center">Avg. compute utilization</CardTitle>
+        <CardBody>
+          <EmptyState
+            headingLevel="h4"
+            icon={CubesIcon}
+            titleText="Utilization metrics unavailable"
+            variant={EmptyStateVariant.xs}
+          >
+            <EmptyStateBody>
+              Install a supported GPU operator for detailed telemetry.
+            </EmptyStateBody>
+          </EmptyState>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  return (
+    <Card isFullHeight data-testid="cluster-card-compute-utilization">
+      <CardTitle className="pf-v6-u-text-align-center">Avg. compute utilization</CardTitle>
+      <CardBody className="pf-v6-u-display-flex pf-v6-u-justify-content-center">
+        <ChartDonutUtilization
+          ariaTitle="Average compute utilization"
+          constrainToVisibleArea
+          data={{ x: 'Compute', y: utilization.percentage }}
+          height={CHART_HEIGHT}
+          width={CHART_WIDTH}
+          innerRadius={INNER_RADIUS}
+          labels={({ datum }) =>
+            datum.x === 'Compute'
+              ? `Compute: ${utilization.percentage}%`
+              : `Available: ${100 - utilization.percentage}%`
+          }
+          subTitle="utilization"
+          title={`${utilization.percentage}%`}
+          name="compute-utilization"
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
+const MemoryUtilizationCard: React.FC<UtilizationCardProps> = ({ utilization }) => {
+  if (!utilization) {
+    return (
+      <Card isFullHeight data-testid="cluster-card-memory-utilization">
+        <CardTitle className="pf-v6-u-text-align-center">
+          Avg. accelerator memory utilization
+        </CardTitle>
+        <CardBody>
+          <EmptyState
+            headingLevel="h4"
+            icon={CubesIcon}
+            titleText="Utilization metrics unavailable"
+            variant={EmptyStateVariant.xs}
+          >
+            <EmptyStateBody>
+              Install a supported GPU operator for detailed telemetry.
+            </EmptyStateBody>
+          </EmptyState>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  return (
+    <Card isFullHeight data-testid="cluster-card-memory-utilization">
+      <CardTitle className="pf-v6-u-text-align-center">
+        Avg. accelerator memory utilization
+      </CardTitle>
+      <CardBody className="pf-v6-u-display-flex pf-v6-u-justify-content-center">
+        <ChartDonutUtilization
+          ariaTitle="Average accelerator memory utilization"
+          constrainToVisibleArea
+          data={{ x: 'Memory', y: utilization.percentage }}
+          height={CHART_HEIGHT}
+          width={CHART_WIDTH}
+          innerRadius={INNER_RADIUS}
+          labels={({ datum }) =>
+            datum.x === 'Memory'
+              ? `Memory: ${utilization.percentage}%`
+              : `Available: ${100 - utilization.percentage}%`
+          }
+          subTitle="utilization"
+          title={`${utilization.percentage}%`}
+          name="memory-utilization"
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
+export default ClusterSummaryCards;

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -6,3 +6,22 @@ export const INFRASTRUCTURE_SECTIONS = [
   { id: 'borrowing-lending', title: 'Borrowing & lending' },
   { id: 'cluster-queue-utilization', title: 'Cluster queue utilization' },
 ] as const;
+
+// PromQL queries for the Cluster summary section
+// These are formatted as URL query strings for the Prometheus API (appended after /api/v1/query?)
+// Values must be encoded to avoid + being decoded as space
+export const PROMQL_ACCELERATOR_ALLOCATABLE = `query=${encodeURIComponent(
+  'sum(kube_node_status_allocatable{resource=~"nvidia.com/gpu|nvidia_com_gpu|amd.com/gpu|amd_com_gpu|habana.ai/gaudi|habana_ai_gaudi|nvidia.com/mig.*"})',
+)}`;
+
+export const PROMQL_ACCELERATOR_IN_USE = `query=${encodeURIComponent(
+  'sum(kube_pod_container_resource_requests{resource=~"nvidia.com/gpu|nvidia_com_gpu|amd.com/gpu|amd_com_gpu|habana.ai/gaudi|habana_ai_gaudi|nvidia.com/mig.*"})',
+)}`;
+
+export const PROMQL_COMPUTE_UTILIZATION = `query=${encodeURIComponent(
+  'avg(avg_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE[30m])) * 100',
+)}`;
+
+export const PROMQL_MEMORY_UTILIZATION = `query=${encodeURIComponent(
+  'avg(DCGM_FI_DEV_FB_USED / (DCGM_FI_DEV_FB_USED + DCGM_FI_DEV_FB_FREE)) * 100',
+)}`;

--- a/packages/gpuaas/src/hooks/__tests__/useInfrastructureMetrics.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useInfrastructureMetrics.spec.ts
@@ -46,21 +46,29 @@ const setupMocks = (states: [MockFetchState, MockFetchState, MockFetchState, Moc
   });
 };
 
+const loadedState = (data: PrometheusQueryResponse): MockFetchState => ({
+  data,
+  loaded: true,
+  error: undefined,
+  refresh: jest.fn(),
+});
+
+const unloadedState: MockFetchState = {
+  data: null,
+  loaded: false,
+  error: undefined,
+  refresh: jest.fn(),
+};
+
 describe('useInfrastructureMetrics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should call usePrometheusQuery with correct parameters', () => {
-    const state: MockFetchState = {
-      data: null,
-      loaded: false,
-      error: undefined,
-      refresh: jest.fn(),
-    };
-    setupMocks([state, state, state, state]);
+  it('should call usePrometheusQuery with correct parameters and return loading state initially', () => {
+    setupMocks([unloadedState, unloadedState, unloadedState, unloadedState]);
 
-    testHook(useInfrastructureMetrics)();
+    const renderResult = testHook(useInfrastructureMetrics)();
 
     expect(usePrometheusQueryMock).toHaveBeenCalledTimes(4);
     expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
@@ -87,18 +95,6 @@ describe('useInfrastructureMetrics', () => {
       PROMQL_MEMORY_UTILIZATION,
       expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
     );
-  });
-
-  it('should return loading state when queries have not loaded', () => {
-    const state: MockFetchState = {
-      data: null,
-      loaded: false,
-      error: undefined,
-      refresh: jest.fn(),
-    };
-    setupMocks([state, state, state, state]);
-
-    const renderResult = testHook(useInfrastructureMetrics)();
 
     expect(renderResult.result.current.loaded).toBe(false);
     expect(renderResult.result.current.accelerators).toBeNull();
@@ -106,33 +102,52 @@ describe('useInfrastructureMetrics', () => {
     expect(renderResult.result.current.memoryUtilization).toBeNull();
   });
 
-  it('should return accelerator metrics when data is available', () => {
-    const allocatableData = createPromResponse('16');
-    const inUseData = createPromResponse('11');
-    const computeData = createPromResponse('1.73');
-    const memoryData = createPromResponse('57.68');
+  it.each([
+    {
+      label: 'returns parsed and rounded metrics for all queries',
+      allocatable: '16',
+      inUse: '11',
+      compute: '79.6',
+      memory: '83.2',
+      expectedAccel: { total: 16, inUse: 11 },
+      expectedCompute: { percentage: 80 },
+      expectedMemory: { percentage: 83 },
+    },
+    {
+      label: 'rounds down small utilization values',
+      allocatable: '30',
+      inUse: '28',
+      compute: '1.73',
+      memory: '57.68',
+      expectedAccel: { total: 30, inUse: 28 },
+      expectedCompute: { percentage: 2 },
+      expectedMemory: { percentage: 58 },
+    },
+  ])(
+    'should return correct metrics: $label',
+    ({ allocatable, inUse, compute, memory, expectedAccel, expectedCompute, expectedMemory }) => {
+      setupMocks([
+        loadedState(createPromResponse(allocatable)),
+        loadedState(createPromResponse(inUse)),
+        loadedState(createPromResponse(compute)),
+        loadedState(createPromResponse(memory)),
+      ]);
 
-    setupMocks([
-      { data: allocatableData, loaded: true, error: undefined, refresh: jest.fn() },
-      { data: inUseData, loaded: true, error: undefined, refresh: jest.fn() },
-      { data: computeData, loaded: true, error: undefined, refresh: jest.fn() },
-      { data: memoryData, loaded: true, error: undefined, refresh: jest.fn() },
-    ]);
+      const renderResult = testHook(useInfrastructureMetrics)();
 
-    const renderResult = testHook(useInfrastructureMetrics)();
-
-    expect(renderResult.result.current.loaded).toBe(true);
-    expect(renderResult.result.current.accelerators).toEqual({ total: 16, inUse: 11 });
-    expect(renderResult.result.current.computeUtilization).toEqual({ percentage: 2 });
-    expect(renderResult.result.current.memoryUtilization).toEqual({ percentage: 58 });
-  });
+      expect(renderResult.result.current.loaded).toBe(true);
+      expect(renderResult.result.current.accelerators).toEqual(expectedAccel);
+      expect(renderResult.result.current.computeUtilization).toEqual(expectedCompute);
+      expect(renderResult.result.current.memoryUtilization).toEqual(expectedMemory);
+    },
+  );
 
   it('should return null accelerators when allocatable returns empty result', () => {
     setupMocks([
-      { data: EMPTY_PROM_RESPONSE, loaded: true, error: undefined, refresh: jest.fn() },
-      { data: EMPTY_PROM_RESPONSE, loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('80'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('83'), loaded: true, error: undefined, refresh: jest.fn() },
+      loadedState(EMPTY_PROM_RESPONSE),
+      loadedState(EMPTY_PROM_RESPONSE),
+      loadedState(createPromResponse('80')),
+      loadedState(createPromResponse('83')),
     ]);
 
     const renderResult = testHook(useInfrastructureMetrics)();
@@ -144,10 +159,10 @@ describe('useInfrastructureMetrics', () => {
 
   it('should return null utilization when DCGM queries return empty', () => {
     setupMocks([
-      { data: createPromResponse('16'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('11'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: EMPTY_PROM_RESPONSE, loaded: true, error: undefined, refresh: jest.fn() },
-      { data: EMPTY_PROM_RESPONSE, loaded: true, error: undefined, refresh: jest.fn() },
+      loadedState(createPromResponse('16')),
+      loadedState(createPromResponse('11')),
+      loadedState(EMPTY_PROM_RESPONSE),
+      loadedState(EMPTY_PROM_RESPONSE),
     ]);
 
     const renderResult = testHook(useInfrastructureMetrics)();
@@ -174,10 +189,10 @@ describe('useInfrastructureMetrics', () => {
 
   it('should handle NaN values gracefully', () => {
     setupMocks([
-      { data: createPromResponse('NaN'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('11'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('NaN'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('57'), loaded: true, error: undefined, refresh: jest.fn() },
+      loadedState(createPromResponse('NaN')),
+      loadedState(createPromResponse('11')),
+      loadedState(createPromResponse('NaN')),
+      loadedState(createPromResponse('57')),
     ]);
 
     const renderResult = testHook(useInfrastructureMetrics)();
@@ -187,30 +202,16 @@ describe('useInfrastructureMetrics', () => {
     expect(renderResult.result.current.memoryUtilization).toEqual({ percentage: 57 });
   });
 
-  it('should return inUse=0 when allocatable exists but inUse is empty', () => {
+  it('should clamp inUse to total and default to 0 when inUse is empty', () => {
     setupMocks([
-      { data: createPromResponse('16'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: EMPTY_PROM_RESPONSE, loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('50'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('60'), loaded: true, error: undefined, refresh: jest.fn() },
+      loadedState(createPromResponse('16')),
+      loadedState(EMPTY_PROM_RESPONSE),
+      loadedState(createPromResponse('50')),
+      loadedState(createPromResponse('60')),
     ]);
 
     const renderResult = testHook(useInfrastructureMetrics)();
 
     expect(renderResult.result.current.accelerators).toEqual({ total: 16, inUse: 0 });
-  });
-
-  it('should round utilization percentages to nearest integer', () => {
-    setupMocks([
-      { data: createPromResponse('16'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('11'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('79.6'), loaded: true, error: undefined, refresh: jest.fn() },
-      { data: createPromResponse('83.2'), loaded: true, error: undefined, refresh: jest.fn() },
-    ]);
-
-    const renderResult = testHook(useInfrastructureMetrics)();
-
-    expect(renderResult.result.current.computeUtilization).toEqual({ percentage: 80 });
-    expect(renderResult.result.current.memoryUtilization).toEqual({ percentage: 83 });
   });
 });

--- a/packages/gpuaas/src/hooks/__tests__/useInfrastructureMetrics.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useInfrastructureMetrics.spec.ts
@@ -1,0 +1,216 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import usePrometheusQuery from '@odh-dashboard/internal/api/prometheus/usePrometheusQuery';
+import { PrometheusQueryResponse } from '@odh-dashboard/internal/types';
+import useInfrastructureMetrics from '../useInfrastructureMetrics';
+import {
+  INFRASTRUCTURE_REFRESH_INTERVAL,
+  PROMQL_ACCELERATOR_ALLOCATABLE,
+  PROMQL_ACCELERATOR_IN_USE,
+  PROMQL_COMPUTE_UTILIZATION,
+  PROMQL_MEMORY_UTILIZATION,
+} from '../../const';
+
+jest.mock('@odh-dashboard/internal/api/prometheus/usePrometheusQuery', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const usePrometheusQueryMock = jest.mocked(usePrometheusQuery);
+
+const createPromResponse = (value: string): PrometheusQueryResponse => ({
+  data: {
+    result: [{ value: [Date.now() / 1000, value] }],
+    resultType: 'vector',
+  },
+  status: 'success',
+});
+
+const EMPTY_PROM_RESPONSE: PrometheusQueryResponse = {
+  data: { result: [], resultType: 'vector' },
+  status: 'success',
+};
+
+type MockFetchState = {
+  data: PrometheusQueryResponse | null;
+  loaded: boolean;
+  error?: Error;
+  refresh: jest.Mock;
+};
+
+const setupMocks = (states: [MockFetchState, MockFetchState, MockFetchState, MockFetchState]) => {
+  let callIdx = 0;
+  usePrometheusQueryMock.mockImplementation(() => {
+    const state = states[callIdx % 4];
+    callIdx++;
+    return state;
+  });
+};
+
+describe('useInfrastructureMetrics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call usePrometheusQuery with correct parameters', () => {
+    const state: MockFetchState = {
+      data: null,
+      loaded: false,
+      error: undefined,
+      refresh: jest.fn(),
+    };
+    setupMocks([state, state, state, state]);
+
+    testHook(useInfrastructureMetrics)();
+
+    expect(usePrometheusQueryMock).toHaveBeenCalledTimes(4);
+    expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/prometheus/query',
+      PROMQL_ACCELERATOR_ALLOCATABLE,
+      expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
+    );
+    expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/prometheus/query',
+      PROMQL_ACCELERATOR_IN_USE,
+      expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
+    );
+    expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/prometheus/query',
+      PROMQL_COMPUTE_UTILIZATION,
+      expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
+    );
+    expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
+      4,
+      '/api/prometheus/query',
+      PROMQL_MEMORY_UTILIZATION,
+      expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
+    );
+  });
+
+  it('should return loading state when queries have not loaded', () => {
+    const state: MockFetchState = {
+      data: null,
+      loaded: false,
+      error: undefined,
+      refresh: jest.fn(),
+    };
+    setupMocks([state, state, state, state]);
+
+    const renderResult = testHook(useInfrastructureMetrics)();
+
+    expect(renderResult.result.current.loaded).toBe(false);
+    expect(renderResult.result.current.accelerators).toBeNull();
+    expect(renderResult.result.current.computeUtilization).toBeNull();
+    expect(renderResult.result.current.memoryUtilization).toBeNull();
+  });
+
+  it('should return accelerator metrics when data is available', () => {
+    const allocatableData = createPromResponse('16');
+    const inUseData = createPromResponse('11');
+    const computeData = createPromResponse('1.73');
+    const memoryData = createPromResponse('57.68');
+
+    setupMocks([
+      { data: allocatableData, loaded: true, error: undefined, refresh: jest.fn() },
+      { data: inUseData, loaded: true, error: undefined, refresh: jest.fn() },
+      { data: computeData, loaded: true, error: undefined, refresh: jest.fn() },
+      { data: memoryData, loaded: true, error: undefined, refresh: jest.fn() },
+    ]);
+
+    const renderResult = testHook(useInfrastructureMetrics)();
+
+    expect(renderResult.result.current.loaded).toBe(true);
+    expect(renderResult.result.current.accelerators).toEqual({ total: 16, inUse: 11 });
+    expect(renderResult.result.current.computeUtilization).toEqual({ percentage: 2 });
+    expect(renderResult.result.current.memoryUtilization).toEqual({ percentage: 58 });
+  });
+
+  it('should return null accelerators when allocatable returns empty result', () => {
+    setupMocks([
+      { data: EMPTY_PROM_RESPONSE, loaded: true, error: undefined, refresh: jest.fn() },
+      { data: EMPTY_PROM_RESPONSE, loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('80'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('83'), loaded: true, error: undefined, refresh: jest.fn() },
+    ]);
+
+    const renderResult = testHook(useInfrastructureMetrics)();
+
+    expect(renderResult.result.current.accelerators).toBeNull();
+    expect(renderResult.result.current.computeUtilization).toEqual({ percentage: 80 });
+    expect(renderResult.result.current.memoryUtilization).toEqual({ percentage: 83 });
+  });
+
+  it('should return null utilization when DCGM queries return empty', () => {
+    setupMocks([
+      { data: createPromResponse('16'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('11'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: EMPTY_PROM_RESPONSE, loaded: true, error: undefined, refresh: jest.fn() },
+      { data: EMPTY_PROM_RESPONSE, loaded: true, error: undefined, refresh: jest.fn() },
+    ]);
+
+    const renderResult = testHook(useInfrastructureMetrics)();
+
+    expect(renderResult.result.current.accelerators).toEqual({ total: 16, inUse: 11 });
+    expect(renderResult.result.current.computeUtilization).toBeNull();
+    expect(renderResult.result.current.memoryUtilization).toBeNull();
+  });
+
+  it('should set loaded=true when any query has an error', () => {
+    const testError = new Error('Prometheus call error');
+    setupMocks([
+      { data: null, loaded: true, error: undefined, refresh: jest.fn() },
+      { data: null, loaded: true, error: undefined, refresh: jest.fn() },
+      { data: null, loaded: true, error: undefined, refresh: jest.fn() },
+      { data: null, loaded: false, error: testError, refresh: jest.fn() },
+    ]);
+
+    const renderResult = testHook(useInfrastructureMetrics)();
+
+    expect(renderResult.result.current.loaded).toBe(true);
+    expect(renderResult.result.current.error).toBe(testError);
+  });
+
+  it('should handle NaN values gracefully', () => {
+    setupMocks([
+      { data: createPromResponse('NaN'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('11'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('NaN'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('57'), loaded: true, error: undefined, refresh: jest.fn() },
+    ]);
+
+    const renderResult = testHook(useInfrastructureMetrics)();
+
+    expect(renderResult.result.current.accelerators).toBeNull();
+    expect(renderResult.result.current.computeUtilization).toBeNull();
+    expect(renderResult.result.current.memoryUtilization).toEqual({ percentage: 57 });
+  });
+
+  it('should return inUse=0 when allocatable exists but inUse is empty', () => {
+    setupMocks([
+      { data: createPromResponse('16'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: EMPTY_PROM_RESPONSE, loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('50'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('60'), loaded: true, error: undefined, refresh: jest.fn() },
+    ]);
+
+    const renderResult = testHook(useInfrastructureMetrics)();
+
+    expect(renderResult.result.current.accelerators).toEqual({ total: 16, inUse: 0 });
+  });
+
+  it('should round utilization percentages to nearest integer', () => {
+    setupMocks([
+      { data: createPromResponse('16'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('11'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('79.6'), loaded: true, error: undefined, refresh: jest.fn() },
+      { data: createPromResponse('83.2'), loaded: true, error: undefined, refresh: jest.fn() },
+    ]);
+
+    const renderResult = testHook(useInfrastructureMetrics)();
+
+    expect(renderResult.result.current.computeUtilization).toEqual({ percentage: 80 });
+    expect(renderResult.result.current.memoryUtilization).toEqual({ percentage: 83 });
+  });
+});

--- a/packages/gpuaas/src/hooks/useInfrastructureMetrics.ts
+++ b/packages/gpuaas/src/hooks/useInfrastructureMetrics.ts
@@ -40,7 +40,6 @@ const parseScalarResult = (response: PrometheusQueryResponse | null): number | n
 
 const useInfrastructureMetrics = (): ClusterMetrics => {
   const [lastRefreshed, setLastRefreshed] = React.useState<Date | null>(null);
-  const refreshCountRef = React.useRef(0);
   const fetchOptions = React.useMemo(() => ({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }), []);
 
   const allocatable = usePrometheusQuery(
@@ -95,7 +94,6 @@ const useInfrastructureMetrics = (): ClusterMetrics => {
     inUse.refresh();
     compute.refresh();
     memory.refresh();
-    refreshCountRef.current += 1;
     setLastRefreshed(new Date());
     // eslint-disable-next-line react-hooks/exhaustive-deps -- .refresh references are stable from useFetch
   }, [allocatable.refresh, inUse.refresh, compute.refresh, memory.refresh]);

--- a/packages/gpuaas/src/hooks/useInfrastructureMetrics.ts
+++ b/packages/gpuaas/src/hooks/useInfrastructureMetrics.ts
@@ -31,7 +31,7 @@ export type ClusterMetrics = {
 };
 
 const parseScalarResult = (response: PrometheusQueryResponse | null): number | null => {
-  if (!response?.data.result[0]?.value?.[1]) {
+  if (response?.data.result[0]?.value?.[1] == null) {
     return null;
   }
   const val = parseFloat(response.data.result[0].value[1]);
@@ -40,6 +40,7 @@ const parseScalarResult = (response: PrometheusQueryResponse | null): number | n
 
 const useInfrastructureMetrics = (): ClusterMetrics => {
   const [lastRefreshed, setLastRefreshed] = React.useState<Date | null>(null);
+  const refreshCountRef = React.useRef(0);
   const fetchOptions = React.useMemo(() => ({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }), []);
 
   const allocatable = usePrometheusQuery(
@@ -70,7 +71,7 @@ const useInfrastructureMetrics = (): ClusterMetrics => {
     if (total === null) {
       return null;
     }
-    return { total, inUse: used ?? 0 };
+    return { total, inUse: Math.min(used ?? 0, total) };
   }, [allocatable.data, inUse.data]);
 
   const computeUtilization = React.useMemo((): UtilizationMetrics | null => {
@@ -94,7 +95,10 @@ const useInfrastructureMetrics = (): ClusterMetrics => {
     inUse.refresh();
     compute.refresh();
     memory.refresh();
-  }, [allocatable, inUse, compute, memory]);
+    refreshCountRef.current += 1;
+    setLastRefreshed(new Date());
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- .refresh references are stable from useFetch
+  }, [allocatable.refresh, inUse.refresh, compute.refresh, memory.refresh]);
 
   return {
     accelerators,

--- a/packages/gpuaas/src/hooks/useInfrastructureMetrics.ts
+++ b/packages/gpuaas/src/hooks/useInfrastructureMetrics.ts
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import usePrometheusQuery from '@odh-dashboard/internal/api/prometheus/usePrometheusQuery';
+import { PrometheusQueryResponse } from '@odh-dashboard/internal/types';
+import {
+  INFRASTRUCTURE_REFRESH_INTERVAL,
+  PROMQL_ACCELERATOR_ALLOCATABLE,
+  PROMQL_ACCELERATOR_IN_USE,
+  PROMQL_COMPUTE_UTILIZATION,
+  PROMQL_MEMORY_UTILIZATION,
+} from '../const';
+
+const PROMETHEUS_API = '/api/prometheus/query';
+
+type AcceleratorMetrics = {
+  total: number;
+  inUse: number;
+};
+
+type UtilizationMetrics = {
+  percentage: number;
+};
+
+export type ClusterMetrics = {
+  accelerators: AcceleratorMetrics | null;
+  computeUtilization: UtilizationMetrics | null;
+  memoryUtilization: UtilizationMetrics | null;
+  loaded: boolean;
+  error?: Error;
+  lastRefreshed: Date | null;
+  refresh: () => void;
+};
+
+const parseScalarResult = (response: PrometheusQueryResponse | null): number | null => {
+  if (!response?.data.result[0]?.value?.[1]) {
+    return null;
+  }
+  const val = parseFloat(response.data.result[0].value[1]);
+  return Number.isNaN(val) ? null : val;
+};
+
+const useInfrastructureMetrics = (): ClusterMetrics => {
+  const [lastRefreshed, setLastRefreshed] = React.useState<Date | null>(null);
+  const fetchOptions = React.useMemo(() => ({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }), []);
+
+  const allocatable = usePrometheusQuery(
+    PROMETHEUS_API,
+    PROMQL_ACCELERATOR_ALLOCATABLE,
+    fetchOptions,
+  );
+  const inUse = usePrometheusQuery(PROMETHEUS_API, PROMQL_ACCELERATOR_IN_USE, fetchOptions);
+  const compute = usePrometheusQuery(PROMETHEUS_API, PROMQL_COMPUTE_UTILIZATION, fetchOptions);
+  const memory = usePrometheusQuery(PROMETHEUS_API, PROMQL_MEMORY_UTILIZATION, fetchOptions);
+
+  const loaded =
+    (allocatable.loaded || !!allocatable.error) &&
+    (inUse.loaded || !!inUse.error) &&
+    (compute.loaded || !!compute.error) &&
+    (memory.loaded || !!memory.error);
+  const error = allocatable.error || inUse.error || compute.error || memory.error;
+
+  React.useEffect(() => {
+    if (loaded) {
+      setLastRefreshed(new Date());
+    }
+  }, [loaded, allocatable.data, inUse.data, compute.data, memory.data]);
+
+  const accelerators = React.useMemo((): AcceleratorMetrics | null => {
+    const total = parseScalarResult(allocatable.data);
+    const used = parseScalarResult(inUse.data);
+    if (total === null) {
+      return null;
+    }
+    return { total, inUse: used ?? 0 };
+  }, [allocatable.data, inUse.data]);
+
+  const computeUtilization = React.useMemo((): UtilizationMetrics | null => {
+    const pct = parseScalarResult(compute.data);
+    if (pct === null) {
+      return null;
+    }
+    return { percentage: Math.round(pct) };
+  }, [compute.data]);
+
+  const memoryUtilization = React.useMemo((): UtilizationMetrics | null => {
+    const pct = parseScalarResult(memory.data);
+    if (pct === null) {
+      return null;
+    }
+    return { percentage: Math.round(pct) };
+  }, [memory.data]);
+
+  const refresh = React.useCallback(() => {
+    allocatable.refresh();
+    inUse.refresh();
+    compute.refresh();
+    memory.refresh();
+  }, [allocatable, inUse, compute, memory]);
+
+  return {
+    accelerators,
+    computeUtilization,
+    memoryUtilization,
+    loaded,
+    error,
+    lastRefreshed,
+    refresh,
+  };
+};
+
+export default useInfrastructureMetrics;

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -1,28 +1,66 @@
 import * as React from 'react';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
-import { Card, CardBody, CardTitle, Stack, StackItem } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Content,
+  ContentVariants,
+  Icon,
+  Label,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { SyncAltIcon } from '@patternfly/react-icons';
 import { INFRASTRUCTURE_SECTIONS } from '../const';
+import ClusterSummaryCards from '../components/ClusterSummaryCards';
+import useInfrastructureMetrics from '../hooks/useInfrastructureMetrics';
 
-const InfrastructurePage: React.FC = () => (
-  <ApplicationsPage
-    title="Infrastructure"
-    description="Cluster capacity and accelerator utilization."
-    loaded
-    empty={false}
-    provideChildrenPadding
-  >
-    <Stack hasGutter>
-      {INFRASTRUCTURE_SECTIONS.map(({ id, title }) => (
-        <StackItem key={id}>
-          <Card data-testid={`infrastructure-${id}-section`}>
-            <CardTitle>{title}</CardTitle>
-            <CardBody />
-          </Card>
+const formatRefreshTime = (date: Date): string =>
+  date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' });
+
+const InfrastructurePage: React.FC = () => {
+  const metrics = useInfrastructureMetrics();
+
+  const headerAction = metrics.lastRefreshed ? (
+    <Label
+      icon={
+        <Icon isInline>
+          <SyncAltIcon />
+        </Icon>
+      }
+      data-testid="infrastructure-refresh-badge"
+    >
+      Refreshed ({formatRefreshTime(metrics.lastRefreshed)})
+    </Label>
+  ) : null;
+
+  return (
+    <ApplicationsPage
+      title="Infrastructure"
+      description="Cluster capacity and accelerator utilization."
+      loaded
+      empty={false}
+      provideChildrenPadding
+      headerAction={headerAction}
+    >
+      <Stack hasGutter>
+        <StackItem data-testid="infrastructure-cluster-section">
+          <Content component={ContentVariants.h2}>{INFRASTRUCTURE_SECTIONS[0].title}</Content>
+          <ClusterSummaryCards metrics={metrics} />
         </StackItem>
-      ))}
-    </Stack>
-  </ApplicationsPage>
-);
+        {INFRASTRUCTURE_SECTIONS.slice(1).map(({ id, title }) => (
+          <StackItem key={id}>
+            <Card data-testid={`infrastructure-${id}-section`}>
+              <CardTitle>{title}</CardTitle>
+              <CardBody />
+            </Card>
+          </StackItem>
+        ))}
+      </Stack>
+    </ApplicationsPage>
+  );
+};
 
 export default InfrastructurePage;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72326

## Description

Implements the "Cluster" section of the GPUaaS Infrastructure page with three `ChartDonutUtilization` cards

<img width="1630" height="482" alt="Screenshot 2026-07-02 at 4 04 30 PM" src="https://github.com/user-attachments/assets/135fffbf-8748-49ad-a8c4-937c70a90ec2" />
<img width="1632" height="551" alt="Screenshot 2026-07-02 at 4 46 11 PM" src="https://github.com/user-attachments/assets/ab52074d-a8f5-48f4-bd57-87a5c7bc39a4" />


## How Has This Been Tested?

* Use Tangerine cluster to view empty state
* Use KFTO cluster to view charts

## Test Impact

Added cypress and mock test

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @kywalker-rh 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GPUaaS Infrastructure page with cluster summary cards for accelerator totals, compute utilization, and memory utilization.
  * Added refresh status feedback and clearer loading/error/empty states for metrics.

* **Bug Fixes**
  * Improved handling when accelerator data or utilization metrics are unavailable.
  * Ensured the page only appears when the feature is enabled and the required platform support is present.
  * Restricted access so non-admin users cannot view the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->