### PR TITLE
fix(autorag/automl): fall back to task topology when stage map nodes are empty

### DIFF
--- a/packages/automl/frontend/src/app/components/run-results/AutomlResults.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlResults.tsx
@@ -73,7 +73,7 @@ function AutomlResults(): React.JSX.Element {
   const pipelineSpec = pipelineRun?.pipeline_spec?.pipeline_spec ?? pipelineRun?.pipeline_spec;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- pipelineSpec shape varies at runtime
   const hasStageMapTask = Boolean(pipelineSpec?.root?.dag?.tasks?.['publish-component-stage-map']);
-  const useStageMap = hasStageMapTask && !componentStageMapError;
+  const useStageMap = hasStageMapTask && !componentStageMapError && stageMapNodes.length > 0;
   const nodes = useStageMap ? stageMapNodes : fallbackNodes;
   const [modalState, setModalState] = React.useState<ModalState | null>(null);
   const [registerModelName, setRegisterModelName] = React.useState<string | null>(null);

--- a/packages/automl/frontend/src/app/components/run-results/AutomlResults.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlResults.tsx
@@ -73,8 +73,8 @@ function AutomlResults(): React.JSX.Element {
   const pipelineSpec = pipelineRun?.pipeline_spec?.pipeline_spec ?? pipelineRun?.pipeline_spec;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- pipelineSpec shape varies at runtime
   const hasStageMapTask = Boolean(pipelineSpec?.root?.dag?.tasks?.['publish-component-stage-map']);
-  const useStageMap = hasStageMapTask && !componentStageMapError && stageMapNodes.length > 0;
-  const nodes = useStageMap ? stageMapNodes : fallbackNodes;
+  const useStageMap = hasStageMapTask && !componentStageMapError;
+  const nodes = useStageMap && stageMapNodes.length > 0 ? stageMapNodes : fallbackNodes;
   const [modalState, setModalState] = React.useState<ModalState | null>(null);
   const [registerModelName, setRegisterModelName] = React.useState<string | null>(null);
   const [downloadError, setDownloadError] = React.useState<NotebookDownloadError | null>(null);

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
@@ -75,7 +75,7 @@ function AutoragResults({ onTryPattern, onViewCode }: AutoragResultsProps): Reac
   const pipelineSpec = pipelineRun?.pipeline_spec?.pipeline_spec ?? pipelineRun?.pipeline_spec;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- pipelineSpec shape varies at runtime
   const hasStageMapTask = Boolean(pipelineSpec?.root?.dag?.tasks?.['publish-component-stage-map']);
-  const useStageMap = hasStageMapTask && !componentStageMapError;
+  const useStageMap = hasStageMapTask && !componentStageMapError && stageMapNodes.length > 0;
   const nodes = useStageMap ? stageMapNodes : fallbackNodes;
   const optimizedMetric = getOptimizedMetricForRAG(pipelineRun);
 

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
@@ -75,8 +75,8 @@ function AutoragResults({ onTryPattern, onViewCode }: AutoragResultsProps): Reac
   const pipelineSpec = pipelineRun?.pipeline_spec?.pipeline_spec ?? pipelineRun?.pipeline_spec;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- pipelineSpec shape varies at runtime
   const hasStageMapTask = Boolean(pipelineSpec?.root?.dag?.tasks?.['publish-component-stage-map']);
-  const useStageMap = hasStageMapTask && !componentStageMapError && stageMapNodes.length > 0;
-  const nodes = useStageMap ? stageMapNodes : fallbackNodes;
+  const useStageMap = hasStageMapTask && !componentStageMapError;
+  const nodes = useStageMap && stageMapNodes.length > 0 ? stageMapNodes : fallbackNodes;
   const optimizedMetric = getOptimizedMetricForRAG(pipelineRun);
 
   const patternsArray = React.useMemo(() => Object.values(patterns), [patterns]);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-73223

## Description

When the stage map task exists in the pipeline spec but produces an empty `stageMapNodes` array (e.g., when a run is stopped before the stage map is published), the topology node selection fell through to `stageMapNodes` — an empty array — instead of the `fallbackNodes` from `useAutoragTaskTopology` / `useAutomlTaskTopology`. This resulted in an empty topology view with no task status indicators.

This adds a `stageMapNodes.length > 0` guard to the node selection (`const nodes = ...`) in both `AutoragResults.tsx` and `AutomlResults.tsx`. The `useStageMap` flag is left unchanged so that the loading spinner still shows correctly while the stage map is being fetched.

Validate with this run on main branch vs this branch
https://rh-ai.apps.rhoai-autorag-pool-gzkqj.aws.rh-ods.com/gen-ai-studio/autorag/results/nick-test-managed-pipelines/33c8fb4b-a885-4a6d-916b-fcfc9439419b

<table><tr><td>Before</td><td>After</td></tr>
<tr><td>
<img width="1512" height="736" alt="2026-07-02_09-04-21" src="https://github.com/user-attachments/assets/a596095b-02cf-4a5a-8d78-40a3383d0bda" />
</td><td>
<img width="1507" height="738" alt="image" src="https://github.com/user-attachments/assets/3ee87f7e-acf7-4656-8f68-ce2bac04666f" />
</td></tr></table>

## How Has This Been Tested?

- Ran `AutoragResults.spec.tsx` unit tests — all 23 tests pass, including stage map loading spinner and fallback topology scenarios.

## Test Impact

No new tests added. Existing `AutoragResults.spec.tsx` tests cover the loading spinner and fallback topology behavior and continue to pass.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run result views to show topology data more reliably when stage-based nodes are unavailable.
  * If stage-map data is empty, the app now automatically falls back to the default node set instead of showing an incomplete layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->