### PR TITLE
feat(llmd-serving): add advanced routing field and topology/routing C…

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -253,7 +253,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
   });
 
   describe('advanced routing field', () => {
-    it('should show checkbox in advanced settings when llm-d active and flag enabled', () => {
+    it('should show routing dropdown with default selected when llm-d active and flag enabled', () => {
       initIntercepts();
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
@@ -263,10 +263,11 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       modelServingWizard.findNextButton().should('be.enabled').click();
 
-      cy.findByTestId('advanced-routing-checkbox').should('exist');
+      cy.findByTestId('routing-config-select').should('exist');
+      cy.findByTestId('routing-config-select').should('contain.text', 'Default optimized routing');
     });
 
-    it('should hide checkbox when flag disabled', () => {
+    it('should hide routing dropdown when flag disabled', () => {
       initIntercepts({ llmdTopologyConfigsEnabled: false });
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
@@ -276,25 +277,25 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       modelServingWizard.findNextButton().should('be.enabled').click();
 
-      cy.findByTestId('advanced-routing-checkbox').should('not.exist');
-    });
-
-    it('should reveal routing config dropdown when checkbox is checked', () => {
-      initIntercepts();
-      modelServingGlobal.visit('test-project');
-      modelServingGlobal.findDeployModelButton().click();
-      navigateToModelDeploymentStep();
-
-      modelServingWizard.findModelDeploymentNameInput().type('test-model');
-      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-      modelServingWizard.findNextButton().should('be.enabled').click();
-
       cy.findByTestId('routing-config-select').should('not.exist');
-      cy.findByTestId('advanced-routing-checkbox').click();
-      cy.findByTestId('routing-config-select').should('exist');
     });
 
-    it('should show router configs in dropdown', () => {
+    it('should disable routing dropdown when no router configs exist', () => {
+      initIntercepts({ topologyConfigs: [], routerConfigs: [] });
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.findModelDeploymentNameInput().type('test-model');
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      cy.findByTestId('routing-config-select').should('exist');
+      cy.findByTestId('routing-config-select').should('contain.text', 'Default optimized routing');
+      cy.findByTestId('routing-config-select').should('be.disabled');
+    });
+
+    it('should show router configs alongside default option in dropdown', () => {
       initIntercepts();
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
@@ -304,13 +305,13 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       modelServingWizard.findNextButton().should('be.enabled').click();
 
-      cy.findByTestId('advanced-routing-checkbox').click();
       cy.findByTestId('routing-config-select').click();
+      cy.findByTestId('routing-config-option-default').should('exist');
       cy.findByTestId('routing-config-option-managed-scheduler-httproute').should('exist');
       cy.findByTestId('routing-config-option-managed-scheduler').should('exist');
     });
 
-    it('should clear selection when checkbox is unchecked', () => {
+    it('should allow selecting a custom routing config', () => {
       initIntercepts();
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
@@ -320,8 +321,25 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       modelServingWizard.findNextButton().should('be.enabled').click();
 
-      // Check and select a config
-      cy.findByTestId('advanced-routing-checkbox').click();
+      cy.findByTestId('routing-config-select').click();
+      cy.findByTestId('routing-config-option-managed-scheduler-httproute').click();
+      cy.findByTestId('routing-config-select').should(
+        'contain.text',
+        'Managed scheduler with HTTPRoute',
+      );
+    });
+
+    it('should revert to default when default option is re-selected', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.findModelDeploymentNameInput().type('test-model');
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      // Select a custom config
       cy.findByTestId('routing-config-select').click();
       cy.findByTestId('routing-config-option-managed-scheduler-httproute').click();
       cy.findByTestId('routing-config-select').should(
@@ -329,9 +347,10 @@ describe('Model Serving LLMD Topology & Routing', () => {
         'Managed scheduler with HTTPRoute',
       );
 
-      // Uncheck — dropdown should disappear
-      cy.findByTestId('advanced-routing-checkbox').click();
-      cy.findByTestId('routing-config-select').should('not.exist');
+      // Switch back to default
+      cy.findByTestId('routing-config-select').click();
+      cy.findByTestId('routing-config-option-default').click();
+      cy.findByTestId('routing-config-select').should('contain.text', 'Default optimized routing');
     });
   });
 });

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -182,25 +182,12 @@ describe('Model Serving LLMD Topology & Routing', () => {
       cy.findByTestId('topology-type-select').click();
 
       cy.findByTestId(`topology-type-${SINGLE_NODE}`).should(
-        'not.have.attr',
-        'aria-disabled',
-        'true',
+        'not.have.class',
+        'pf-m-aria-disabled',
       );
-      cy.findByTestId(`topology-type-${MULTI_NODE}`).should(
-        'not.have.attr',
-        'aria-disabled',
-        'true',
-      );
-      cy.findByTestId(`topology-type-${SINGLE_NODE_PD}`).should(
-        'have.attr',
-        'aria-disabled',
-        'true',
-      );
-      cy.findByTestId(`topology-type-${MULTI_NODE_PD}`).should(
-        'have.attr',
-        'aria-disabled',
-        'true',
-      );
+      cy.findByTestId(`topology-type-${MULTI_NODE}`).should('not.have.class', 'pf-m-aria-disabled');
+      cy.findByTestId(`topology-type-${SINGLE_NODE_PD}`).should('have.class', 'pf-m-aria-disabled');
+      cy.findByTestId(`topology-type-${MULTI_NODE_PD}`).should('have.class', 'pf-m-aria-disabled');
     });
 
     it('should always enable Single node even without configs', () => {
@@ -213,9 +200,8 @@ describe('Model Serving LLMD Topology & Routing', () => {
       cy.findByTestId('topology-type-select').click();
 
       cy.findByTestId(`topology-type-${SINGLE_NODE}`).should(
-        'not.have.attr',
-        'aria-disabled',
-        'true',
+        'not.have.class',
+        'pf-m-aria-disabled',
       );
     });
   });
@@ -275,8 +261,9 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
 
+      modelServingWizard.findModelDeploymentNameInput().type('test-model');
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-      modelServingWizard.findNextButton().click();
+      modelServingWizard.findNextButton().should('be.enabled').click();
 
       cy.findByTestId('advanced-routing-checkbox').should('exist');
     });
@@ -287,8 +274,9 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
 
+      modelServingWizard.findModelDeploymentNameInput().type('test-model');
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-      modelServingWizard.findNextButton().click();
+      modelServingWizard.findNextButton().should('be.enabled').click();
 
       cy.findByTestId('advanced-routing-checkbox').should('not.exist');
     });
@@ -299,8 +287,9 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
 
+      modelServingWizard.findModelDeploymentNameInput().type('test-model');
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-      modelServingWizard.findNextButton().click();
+      modelServingWizard.findNextButton().should('be.enabled').click();
 
       cy.findByTestId('routing-config-select').should('not.exist');
       cy.findByTestId('advanced-routing-checkbox').click();
@@ -313,8 +302,9 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
 
+      modelServingWizard.findModelDeploymentNameInput().type('test-model');
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-      modelServingWizard.findNextButton().click();
+      modelServingWizard.findNextButton().should('be.enabled').click();
 
       cy.findByTestId('advanced-routing-checkbox').click();
       cy.findByTestId('routing-config-select').click();
@@ -328,8 +318,9 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
 
+      modelServingWizard.findModelDeploymentNameInput().type('test-model');
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-      modelServingWizard.findNextButton().click();
+      modelServingWizard.findNextButton().should('be.enabled').click();
 
       // Check and select a config
       cy.findByTestId('advanced-routing-checkbox').click();

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -28,26 +28,24 @@ const MULTI_NODE = 'workload-multi-node-data-parallel';
 const SINGLE_NODE_PD = 'workload-single-node-pd';
 const MULTI_NODE_PD = 'workload-multi-node-data-parallel-pd';
 
+const buildTopologyConfig = (
+  name: string,
+  displayName: string,
+  topologyType: string,
+  disabled?: boolean,
+) => {
+  const config = mockLLMInferenceServiceConfigK8sResource({ name, displayName, disabled });
+  config.metadata.labels = {
+    ...config.metadata.labels,
+    'opendatahub.io/config-type': topologyType,
+  };
+  return config;
+};
+
 const mockTopologyConfigs = [
-  mockLLMInferenceServiceConfigK8sResource({
-    name: 'single-node-config',
-    displayName: 'Single Node Config',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    configType: SINGLE_NODE as any,
-  }),
-  mockLLMInferenceServiceConfigK8sResource({
-    name: 'multi-node-config',
-    displayName: 'Multi-node Data Parallel',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    configType: MULTI_NODE as any,
-  }),
-  mockLLMInferenceServiceConfigK8sResource({
-    name: 'disabled-config',
-    displayName: 'Disabled Config',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    configType: MULTI_NODE as any,
-    disabled: true,
-  }),
+  buildTopologyConfig('single-node-config', 'Single Node Config', SINGLE_NODE),
+  buildTopologyConfig('multi-node-config', 'Multi-node Data Parallel', MULTI_NODE),
+  buildTopologyConfig('disabled-config', 'Disabled Config', MULTI_NODE, true),
 ];
 
 const mockRouterConfigs = [

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -1,0 +1,351 @@
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
+import { mockProjectK8sResource } from '@odh-dashboard/internal/__mocks__/mockProjectK8sResource';
+import { mockGlobalScopedHardwareProfiles } from '@odh-dashboard/internal/__mocks__/mockHardwareProfile';
+import { mockStandardModelServingTemplateK8sResources } from '@odh-dashboard/internal/__mocks__/mockServingRuntimeTemplateK8sResource';
+import {
+  mockConnectionTypeConfigMap,
+  mockModelServingFields,
+} from '@odh-dashboard/internal/__mocks__/mockConnectionType';
+import { mockSecretK8sResource } from '@odh-dashboard/internal/__mocks__/mockSecretK8sResource';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { ModelTypeLabel } from '@odh-dashboard/model-serving/components/deploymentWizard/types';
+import {
+  HardwareProfileModel,
+  LLMInferenceServiceConfigModel,
+  LLMInferenceServiceModel,
+  ProjectModel,
+  SecretModel,
+  TemplateModel,
+} from '../../../utils/models';
+import { modelServingGlobal, modelServingWizard } from '../../../pages/modelServing';
+
+// Topology type values (inlined to avoid webpack bundling @odh-dashboard/llmd-serving/types)
+const SINGLE_NODE = 'workload-single-node';
+const MULTI_NODE = 'workload-multi-node-data-parallel';
+const SINGLE_NODE_PD = 'workload-single-node-pd';
+const MULTI_NODE_PD = 'workload-multi-node-data-parallel-pd';
+
+const mockTopologyConfigs = [
+  mockLLMInferenceServiceConfigK8sResource({
+    name: 'single-node-config',
+    displayName: 'Single Node Config',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    configType: SINGLE_NODE as any,
+  }),
+  mockLLMInferenceServiceConfigK8sResource({
+    name: 'multi-node-config',
+    displayName: 'Multi-node Data Parallel',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    configType: MULTI_NODE as any,
+  }),
+  mockLLMInferenceServiceConfigK8sResource({
+    name: 'disabled-config',
+    displayName: 'Disabled Config',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    configType: MULTI_NODE as any,
+    disabled: true,
+  }),
+];
+
+const mockRouterConfigs = [
+  mockLLMInferenceServiceConfigK8sResource({
+    name: 'managed-scheduler-httproute',
+    displayName: 'Managed scheduler with HTTPRoute',
+    configType: 'router',
+  }),
+  mockLLMInferenceServiceConfigK8sResource({
+    name: 'managed-scheduler',
+    displayName: 'Managed scheduler',
+    configType: 'router',
+  }),
+];
+
+const initIntercepts = ({
+  topologyConfigs = mockTopologyConfigs,
+  routerConfigs = mockRouterConfigs,
+  llmdTopologyConfigsEnabled = true,
+}: {
+  topologyConfigs?: ReturnType<typeof mockLLMInferenceServiceConfigK8sResource>[];
+  routerConfigs?: ReturnType<typeof mockLLMInferenceServiceConfigK8sResource>[];
+  llmdTopologyConfigsEnabled?: boolean;
+} = {}) => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+      },
+    }),
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dashboardConfig = {
+    disableNIMModelServing: true,
+    disableKServe: false,
+    genAiStudio: true,
+    modelAsService: true,
+    disableLLMd: false,
+    llmdTopologyConfigs: llmdTopologyConfigsEnabled,
+    vLLMDeploymentOnMaaS: true,
+  } as any;
+  cy.interceptOdh('GET /api/config', mockDashboardConfig(dashboardConfig));
+  cy.interceptOdh('GET /api/components', null, []);
+  cy.interceptK8sList(
+    { model: HardwareProfileModel, ns: 'opendatahub' },
+    mockK8sResourceList(mockGlobalScopedHardwareProfiles),
+  );
+  cy.interceptK8sList(
+    { model: SecretModel, ns: 'test-project' },
+    mockK8sResourceList([
+      mockSecretK8sResource({ name: 'test-s3-secret', displayName: 'test-s3-secret' }),
+    ]),
+  );
+  cy.interceptOdh('GET /api/connection-types', [
+    mockConnectionTypeConfigMap({
+      displayName: 'URI - v1',
+      name: 'uri-v1',
+      category: ['existing-category'],
+      fields: [
+        {
+          type: 'uri',
+          name: 'URI',
+          envVar: 'URI',
+          required: true,
+          properties: {},
+        },
+      ],
+    }),
+    mockConnectionTypeConfigMap({
+      displayName: 'S3',
+      name: 's3',
+      category: ['existing-category'],
+      fields: mockModelServingFields,
+    }),
+  ]);
+  cy.interceptK8sList(
+    TemplateModel,
+    mockK8sResourceList(mockStandardModelServingTemplateK8sResources(), {
+      namespace: 'opendatahub',
+    }),
+  );
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ enableKServe: true })]),
+  );
+  cy.interceptK8sList(LLMInferenceServiceModel, mockK8sResourceList([]));
+  cy.interceptK8sList(
+    { model: LLMInferenceServiceConfigModel, ns: 'opendatahub' },
+    mockK8sResourceList([...topologyConfigs, ...routerConfigs]),
+  );
+  cy.interceptK8sList(
+    { model: LLMInferenceServiceConfigModel, ns: 'test-project' },
+    mockK8sResourceList([]),
+  );
+};
+
+const navigateToModelDeploymentStep = () => {
+  modelServingWizard.findModelLocationSelectOption('URI').click();
+  modelServingWizard.findUrilocationInput().type('hf://test/model');
+  modelServingWizard.findSaveConnectionCheckbox().click();
+  modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
+  modelServingWizard.findNextButton().click();
+};
+
+describe('Model Serving LLMD Topology & Routing', () => {
+  describe('topology type field', () => {
+    it('should show topology type dropdown when flag enabled and llm-d active', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      cy.findByTestId('topology-type-select').should('exist').should('be.visible');
+    });
+
+    it('should hide topology type dropdown when flag disabled', () => {
+      initIntercepts({ llmdTopologyConfigsEnabled: false });
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      cy.findByTestId('topology-type-select').should('not.exist');
+    });
+
+    it('should disable topology types without configs via aria-disabled', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      cy.findByTestId('topology-type-select').click();
+
+      cy.findByTestId(`topology-type-${SINGLE_NODE}`).should(
+        'not.have.attr',
+        'aria-disabled',
+        'true',
+      );
+      cy.findByTestId(`topology-type-${MULTI_NODE}`).should(
+        'not.have.attr',
+        'aria-disabled',
+        'true',
+      );
+      cy.findByTestId(`topology-type-${SINGLE_NODE_PD}`).should(
+        'have.attr',
+        'aria-disabled',
+        'true',
+      );
+      cy.findByTestId(`topology-type-${MULTI_NODE_PD}`).should(
+        'have.attr',
+        'aria-disabled',
+        'true',
+      );
+    });
+
+    it('should always enable Single node even without configs', () => {
+      initIntercepts({ topologyConfigs: [] });
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      cy.findByTestId('topology-type-select').click();
+
+      cy.findByTestId(`topology-type-${SINGLE_NODE}`).should(
+        'not.have.attr',
+        'aria-disabled',
+        'true',
+      );
+    });
+  });
+
+  describe('custom topology config field', () => {
+    it('should show configs matching the selected topology type', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId(`topology-type-${MULTI_NODE}`).click();
+
+      cy.findByTestId('custom-topology-config-select').should('exist').click();
+      cy.findByTestId('topology-config-option-multi-node-config').should('exist');
+      cy.findByTestId('topology-config-option-single-node-config').should('not.exist');
+      cy.findByTestId('topology-config-option-disabled-config').should('not.exist');
+    });
+
+    it('should reset custom config when topology type changes', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+
+      // Select Multi-node and pick a config
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId(`topology-type-${MULTI_NODE}`).click();
+      cy.findByTestId('custom-topology-config-select').click();
+      cy.findByTestId('topology-config-option-multi-node-config').click();
+
+      cy.findByTestId('custom-topology-config-select').should(
+        'contain.text',
+        'Multi-node Data Parallel',
+      );
+
+      // Switch to Single node — config should reset
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId(`topology-type-${SINGLE_NODE}`).click();
+
+      cy.findByTestId('custom-topology-config-select').should(
+        'not.contain.text',
+        'Multi-node Data Parallel',
+      );
+    });
+  });
+
+  describe('advanced routing field', () => {
+    it('should show checkbox in advanced settings when llm-d active and flag enabled', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findNextButton().click();
+
+      cy.findByTestId('advanced-routing-checkbox').should('exist');
+    });
+
+    it('should hide checkbox when flag disabled', () => {
+      initIntercepts({ llmdTopologyConfigsEnabled: false });
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findNextButton().click();
+
+      cy.findByTestId('advanced-routing-checkbox').should('not.exist');
+    });
+
+    it('should reveal routing config dropdown when checkbox is checked', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findNextButton().click();
+
+      cy.findByTestId('routing-config-select').should('not.exist');
+      cy.findByTestId('advanced-routing-checkbox').click();
+      cy.findByTestId('routing-config-select').should('exist');
+    });
+
+    it('should show router configs in dropdown', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findNextButton().click();
+
+      cy.findByTestId('advanced-routing-checkbox').click();
+      cy.findByTestId('routing-config-select').click();
+      cy.findByTestId('routing-config-option-managed-scheduler-httproute').should('exist');
+      cy.findByTestId('routing-config-option-managed-scheduler').should('exist');
+    });
+
+    it('should clear selection when checkbox is unchecked', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findNextButton().click();
+
+      // Check and select a config
+      cy.findByTestId('advanced-routing-checkbox').click();
+      cy.findByTestId('routing-config-select').click();
+      cy.findByTestId('routing-config-option-managed-scheduler-httproute').click();
+      cy.findByTestId('routing-config-select').should(
+        'contain.text',
+        'Managed scheduler with HTTPRoute',
+      );
+
+      // Uncheck — dropdown should disappear
+      cy.findByTestId('advanced-routing-checkbox').click();
+      cy.findByTestId('routing-config-select').should('not.exist');
+    });
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -80,17 +80,16 @@ const initIntercepts = ({
       },
     }),
   );
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const dashboardConfig = {
+  const config = mockDashboardConfig({
     disableNIMModelServing: true,
     disableKServe: false,
     genAiStudio: true,
     modelAsService: true,
     disableLLMd: false,
-    llmdTopologyConfigs: llmdTopologyConfigsEnabled,
     vLLMDeploymentOnMaaS: true,
-  } as any;
-  cy.interceptOdh('GET /api/config', mockDashboardConfig(dashboardConfig));
+  });
+  config.spec.dashboardConfig.llmdTopologyConfigs = llmdTopologyConfigsEnabled;
+  cy.interceptOdh('GET /api/config', config);
   cy.interceptOdh('GET /api/components', null, []);
   cy.interceptK8sList(
     { model: HardwareProfileModel, ns: 'opendatahub' },

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -1,4 +1,6 @@
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { TopologyType } from '@odh-dashboard/llmd-serving/types';
 import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
@@ -22,27 +24,17 @@ import {
 } from '../../../utils/models';
 import { modelServingGlobal, modelServingWizard } from '../../../pages/modelServing';
 
-// Topology type values (inlined to avoid webpack bundling @odh-dashboard/llmd-serving/types)
-const SINGLE_NODE = 'workload-single-node';
-const MULTI_NODE = 'workload-multi-node-data-parallel';
-const SINGLE_NODE_PD = 'workload-single-node-pd';
-const MULTI_NODE_PD = 'workload-multi-node-data-parallel-pd';
-
 const buildTopologyConfig = (
   name: string,
   displayName: string,
-  configType:
-    | 'workload-single-node'
-    | 'workload-multi-node-data-parallel'
-    | 'workload-single-node-pd'
-    | 'workload-multi-node-data-parallel-pd',
+  configType: TopologyType,
   disabled?: boolean,
 ) => mockLLMInferenceServiceConfigK8sResource({ name, displayName, configType, disabled });
 
 const mockTopologyConfigs = [
-  buildTopologyConfig('single-node-config', 'Single Node Config', SINGLE_NODE),
-  buildTopologyConfig('multi-node-config', 'Multi-node Data Parallel', MULTI_NODE),
-  buildTopologyConfig('disabled-config', 'Disabled Config', MULTI_NODE, true),
+  buildTopologyConfig('single-node-config', 'Single Node Config', TopologyType.SINGLE_NODE),
+  buildTopologyConfig('multi-node-config', 'Multi-node Data Parallel', TopologyType.MULTI_NODE),
+  buildTopologyConfig('disabled-config', 'Disabled Config', TopologyType.MULTI_NODE, true),
 ];
 
 const mockRouterConfigs = [
@@ -178,13 +170,22 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('topology-type-select').click();
 
-      cy.findByTestId(`topology-type-${SINGLE_NODE}`).should(
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).should(
         'not.have.class',
         'pf-m-aria-disabled',
       );
-      cy.findByTestId(`topology-type-${MULTI_NODE}`).should('not.have.class', 'pf-m-aria-disabled');
-      cy.findByTestId(`topology-type-${SINGLE_NODE_PD}`).should('have.class', 'pf-m-aria-disabled');
-      cy.findByTestId(`topology-type-${MULTI_NODE_PD}`).should('have.class', 'pf-m-aria-disabled');
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).should(
+        'not.have.class',
+        'pf-m-aria-disabled',
+      );
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE_DISAGGREGATED}`).should(
+        'have.class',
+        'pf-m-aria-disabled',
+      );
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE_DISAGGREGATED}`).should(
+        'have.class',
+        'pf-m-aria-disabled',
+      );
     });
 
     it('should always enable Single node even without configs', () => {
@@ -196,7 +197,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('topology-type-select').click();
 
-      cy.findByTestId(`topology-type-${SINGLE_NODE}`).should(
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).should(
         'not.have.class',
         'pf-m-aria-disabled',
       );
@@ -213,7 +214,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
 
       cy.findByTestId('topology-type-select').click();
-      cy.findByTestId(`topology-type-${MULTI_NODE}`).click();
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
 
       cy.findByTestId('custom-topology-config-select').should('exist').click();
       cy.findByTestId('topology-config-option-multi-node-config').should('exist');
@@ -231,7 +232,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
 
       // Select Multi-node and pick a config
       cy.findByTestId('topology-type-select').click();
-      cy.findByTestId(`topology-type-${MULTI_NODE}`).click();
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
       cy.findByTestId('custom-topology-config-select').click();
       cy.findByTestId('topology-config-option-multi-node-config').click();
 
@@ -242,7 +243,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
 
       // Switch to Single node — config should reset
       cy.findByTestId('topology-type-select').click();
-      cy.findByTestId(`topology-type-${SINGLE_NODE}`).click();
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).click();
 
       cy.findByTestId('custom-topology-config-select').should(
         'not.contain.text',

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -1,6 +1,6 @@
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { TopologyType } from '@odh-dashboard/llmd-serving/types';
+import { type TopologyType } from '@odh-dashboard/llmd-serving/types';
 import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
@@ -24,17 +24,28 @@ import {
 } from '../../../utils/models';
 import { modelServingGlobal, modelServingWizard } from '../../../pages/modelServing';
 
+const SINGLE_NODE = 'workload-single-node';
+const MULTI_NODE = 'workload-multi-node-data-parallel';
+const SINGLE_NODE_PD = 'workload-single-node-pd';
+const MULTI_NODE_PD = 'workload-multi-node-data-parallel-pd';
+
 const buildTopologyConfig = (
   name: string,
   displayName: string,
-  configType: TopologyType,
+  configType: string,
   disabled?: boolean,
-) => mockLLMInferenceServiceConfigK8sResource({ name, displayName, configType, disabled });
+) =>
+  mockLLMInferenceServiceConfigK8sResource({
+    name,
+    displayName,
+    configType: configType as TopologyType,
+    disabled,
+  });
 
 const mockTopologyConfigs = [
-  buildTopologyConfig('single-node-config', 'Single Node Config', TopologyType.SINGLE_NODE),
-  buildTopologyConfig('multi-node-config', 'Multi-node Data Parallel', TopologyType.MULTI_NODE),
-  buildTopologyConfig('disabled-config', 'Disabled Config', TopologyType.MULTI_NODE, true),
+  buildTopologyConfig('single-node-config', 'Single Node Config', SINGLE_NODE),
+  buildTopologyConfig('multi-node-config', 'Multi-node Data Parallel', MULTI_NODE),
+  buildTopologyConfig('disabled-config', 'Disabled Config', MULTI_NODE, true),
 ];
 
 const mockRouterConfigs = [
@@ -170,22 +181,13 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('topology-type-select').click();
 
-      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).should(
+      cy.findByTestId(`topology-type-${SINGLE_NODE}`).should(
         'not.have.class',
         'pf-m-aria-disabled',
       );
-      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).should(
-        'not.have.class',
-        'pf-m-aria-disabled',
-      );
-      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE_DISAGGREGATED}`).should(
-        'have.class',
-        'pf-m-aria-disabled',
-      );
-      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE_DISAGGREGATED}`).should(
-        'have.class',
-        'pf-m-aria-disabled',
-      );
+      cy.findByTestId(`topology-type-${MULTI_NODE}`).should('not.have.class', 'pf-m-aria-disabled');
+      cy.findByTestId(`topology-type-${SINGLE_NODE_PD}`).should('have.class', 'pf-m-aria-disabled');
+      cy.findByTestId(`topology-type-${MULTI_NODE_PD}`).should('have.class', 'pf-m-aria-disabled');
     });
 
     it('should always enable Single node even without configs', () => {
@@ -197,7 +199,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('topology-type-select').click();
 
-      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).should(
+      cy.findByTestId(`topology-type-${SINGLE_NODE}`).should(
         'not.have.class',
         'pf-m-aria-disabled',
       );
@@ -214,7 +216,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
 
       cy.findByTestId('topology-type-select').click();
-      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
+      cy.findByTestId(`topology-type-${MULTI_NODE}`).click();
 
       cy.findByTestId('custom-topology-config-select').should('exist').click();
       cy.findByTestId('topology-config-option-multi-node-config').should('exist');
@@ -232,7 +234,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
 
       // Select Multi-node and pick a config
       cy.findByTestId('topology-type-select').click();
-      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
+      cy.findByTestId(`topology-type-${MULTI_NODE}`).click();
       cy.findByTestId('custom-topology-config-select').click();
       cy.findByTestId('topology-config-option-multi-node-config').click();
 
@@ -243,7 +245,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
 
       // Switch to Single node — config should reset
       cy.findByTestId('topology-type-select').click();
-      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).click();
+      cy.findByTestId(`topology-type-${SINGLE_NODE}`).click();
 
       cy.findByTestId('custom-topology-config-select').should(
         'not.contain.text',

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -1,6 +1,6 @@
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { type TopologyType } from '@odh-dashboard/llmd-serving/types';
+import { TopologyType } from '@odh-dashboard/llmd-serving/types';
 import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
@@ -24,28 +24,17 @@ import {
 } from '../../../utils/models';
 import { modelServingGlobal, modelServingWizard } from '../../../pages/modelServing';
 
-const SINGLE_NODE = 'workload-single-node';
-const MULTI_NODE = 'workload-multi-node-data-parallel';
-const SINGLE_NODE_PD = 'workload-single-node-pd';
-const MULTI_NODE_PD = 'workload-multi-node-data-parallel-pd';
-
 const buildTopologyConfig = (
   name: string,
   displayName: string,
-  configType: string,
+  configType: TopologyType,
   disabled?: boolean,
-) =>
-  mockLLMInferenceServiceConfigK8sResource({
-    name,
-    displayName,
-    configType: configType as TopologyType,
-    disabled,
-  });
+) => mockLLMInferenceServiceConfigK8sResource({ name, displayName, configType, disabled });
 
 const mockTopologyConfigs = [
-  buildTopologyConfig('single-node-config', 'Single Node Config', SINGLE_NODE),
-  buildTopologyConfig('multi-node-config', 'Multi-node Data Parallel', MULTI_NODE),
-  buildTopologyConfig('disabled-config', 'Disabled Config', MULTI_NODE, true),
+  buildTopologyConfig('single-node-config', 'Single Node Config', TopologyType.SINGLE_NODE),
+  buildTopologyConfig('multi-node-config', 'Multi-node Data Parallel', TopologyType.MULTI_NODE),
+  buildTopologyConfig('disabled-config', 'Disabled Config', TopologyType.MULTI_NODE, true),
 ];
 
 const mockRouterConfigs = [
@@ -181,13 +170,22 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('topology-type-select').click();
 
-      cy.findByTestId(`topology-type-${SINGLE_NODE}`).should(
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).should(
         'not.have.class',
         'pf-m-aria-disabled',
       );
-      cy.findByTestId(`topology-type-${MULTI_NODE}`).should('not.have.class', 'pf-m-aria-disabled');
-      cy.findByTestId(`topology-type-${SINGLE_NODE_PD}`).should('have.class', 'pf-m-aria-disabled');
-      cy.findByTestId(`topology-type-${MULTI_NODE_PD}`).should('have.class', 'pf-m-aria-disabled');
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).should(
+        'not.have.class',
+        'pf-m-aria-disabled',
+      );
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE_DISAGGREGATED}`).should(
+        'have.class',
+        'pf-m-aria-disabled',
+      );
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE_DISAGGREGATED}`).should(
+        'have.class',
+        'pf-m-aria-disabled',
+      );
     });
 
     it('should always enable Single node even without configs', () => {
@@ -199,7 +197,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('topology-type-select').click();
 
-      cy.findByTestId(`topology-type-${SINGLE_NODE}`).should(
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).should(
         'not.have.class',
         'pf-m-aria-disabled',
       );
@@ -216,7 +214,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
 
       cy.findByTestId('topology-type-select').click();
-      cy.findByTestId(`topology-type-${MULTI_NODE}`).click();
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
 
       cy.findByTestId('custom-topology-config-select').should('exist').click();
       cy.findByTestId('topology-config-option-multi-node-config').should('exist');
@@ -234,7 +232,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
 
       // Select Multi-node and pick a config
       cy.findByTestId('topology-type-select').click();
-      cy.findByTestId(`topology-type-${MULTI_NODE}`).click();
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
       cy.findByTestId('custom-topology-config-select').click();
       cy.findByTestId('topology-config-option-multi-node-config').click();
 
@@ -245,7 +243,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
 
       // Switch to Single node — config should reset
       cy.findByTestId('topology-type-select').click();
-      cy.findByTestId(`topology-type-${SINGLE_NODE}`).click();
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).click();
 
       cy.findByTestId('custom-topology-config-select').should(
         'not.contain.text',

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -31,16 +31,13 @@ const MULTI_NODE_PD = 'workload-multi-node-data-parallel-pd';
 const buildTopologyConfig = (
   name: string,
   displayName: string,
-  topologyType: string,
+  configType:
+    | 'workload-single-node'
+    | 'workload-multi-node-data-parallel'
+    | 'workload-single-node-pd'
+    | 'workload-multi-node-data-parallel-pd',
   disabled?: boolean,
-) => {
-  const config = mockLLMInferenceServiceConfigK8sResource({ name, displayName, disabled });
-  config.metadata.labels = {
-    ...config.metadata.labels,
-    'opendatahub.io/config-type': topologyType,
-  };
-  return config;
-};
+) => mockLLMInferenceServiceConfigK8sResource({ name, displayName, configType, disabled });
 
 const mockTopologyConfigs = [
   buildTopologyConfig('single-node-config', 'Single Node Config', SINGLE_NODE),

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -21,6 +21,7 @@ import type { LLMdDeployment, LLMInferenceServiceConfigKind } from '../src/types
 import type { LLMConfigOptionsFieldType } from '../src/wizardFields/LlmConfigOptionsField';
 import type { TopologyTypeFieldType } from '../src/wizardFields/TopologyTypeField';
 import type { CustomTopologyConfigFieldType } from '../src/wizardFields/CustomTopologyConfigField';
+import type { AdvancedRoutingFieldType } from '../src/wizardFields/AdvancedRoutingField';
 import type {
   GatewaySelectFieldData,
   GatewaySelectFieldType,
@@ -67,6 +68,23 @@ const customTopologyConfigFieldExtension: WizardFieldExtension<
     field: () =>
       import('../src/wizardFields/CustomTopologyConfigField').then(
         (m) => m.CustomTopologyConfigFieldWizardField,
+      ),
+  },
+  flags: {
+    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+  },
+};
+
+const advancedRoutingFieldExtension: WizardFieldExtension<
+  AdvancedRoutingFieldType,
+  LLMdDeployment
+> = {
+  type: 'model-serving.deployment/wizard-field',
+  properties: {
+    platform: LLMD_SERVING_ID,
+    field: () =>
+      import('../src/wizardFields/AdvancedRoutingField').then(
+        (m) => m.AdvancedRoutingFieldWizardField,
       ),
   },
   flags: {
@@ -168,6 +186,7 @@ const extensions: (
   | WizardFieldExtension<LLMConfigOptionsFieldType, LLMdDeployment>
   | WizardFieldExtension<TopologyTypeFieldType, LLMdDeployment>
   | WizardFieldExtension<CustomTopologyConfigFieldType, LLMdDeployment>
+  | WizardFieldExtension<AdvancedRoutingFieldType, LLMdDeployment>
   | WizardFieldExtension<GatewaySelectFieldType, LLMdDeployment>
   | WizardFieldApplyExtension<GatewaySelectFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<GatewaySelectFieldData, LLMdDeployment>
@@ -359,6 +378,7 @@ const extensions: (
   llmConfigOptionsFieldExtension,
   topologyTypeFieldExtension,
   customTopologyConfigFieldExtension,
+  advancedRoutingFieldExtension,
   gatewaySelectFieldExtension,
   gatewaySelectApplyExtension,
   gatewaySelectExtractorExtension,

--- a/packages/llmd-serving/src/types.ts
+++ b/packages/llmd-serving/src/types.ts
@@ -1,12 +1,11 @@
 import type { K8sModelCommon, K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
-import {
+import type {
   MetadataAnnotation,
-  type DisplayNameAnnotations,
-  type PodContainer,
+  DisplayNameAnnotations,
+  PodContainer,
 } from '@odh-dashboard/k8s-core';
 import type { ImagePullSecret } from '@odh-dashboard/internal/k8sTypes';
 import type { Deployment } from '@odh-dashboard/model-serving/extension-points';
-import { LLMD_SERVING_ID } from '../extensions/extensions';
 
 export const MAAS_ENDPOINT_LABEL = 'opendatahub.io/maas-endpoint';
 
@@ -141,8 +140,9 @@ export const isLLMInferenceServiceConfig = (
 
 export type LLMdDeployment = Deployment<LLMInferenceServiceKind, LLMInferenceServiceConfigKind>;
 
-export const isLLMdDeployment = (deployment: Deployment): deployment is LLMdDeployment =>
-  deployment.modelServingPlatformId === LLMD_SERVING_ID;
+// Moved to formUtils.ts to keep types.ts free of runtime imports (enables Cypress type-only import)
+// export const isLLMdDeployment = (deployment: Deployment): deployment is LLMdDeployment =>
+//   deployment.modelServingPlatformId === LLMD_SERVING_ID;
 
 export const LLMInferenceServiceModel: K8sModelCommon = {
   apiVersion: 'v1alpha2',

--- a/packages/llmd-serving/src/wizardFields/AdvancedRoutingField.tsx
+++ b/packages/llmd-serving/src/wizardFields/AdvancedRoutingField.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+import {
+  Checkbox,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import type {
+  WizardField,
+  WizardFormData,
+  WizardReviewSection,
+} from '@odh-dashboard/model-serving/types/form-data';
+import type { RecursivePartial } from '@odh-dashboard/internal/typeHelpers';
+import SimpleSelect, { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect';
+import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import { LLMD_DEPLOYMENT_METHOD_KEY } from './deploymentMethodField';
+import { isTopologyTypeFieldData } from './TopologyTypeField';
+import type { TopologyTypeFieldData } from './TopologyTypeField';
+import {
+  TopologyType,
+  RoutingTypeLabels,
+  type LLMInferenceServiceConfigKind,
+  getConfigRoutingType,
+  getConfigSupportedTopologies,
+  isConfigEnabled,
+} from '../types';
+import { useFetchRouterConfigs } from '../api/LLMInferenceServiceConfigs';
+import { isLLMInferenceServiceActive } from '../formUtils';
+
+// --- External data hook ---
+
+export type AdvancedRoutingExternalData = {
+  routerConfigs: LLMInferenceServiceConfigKind[];
+};
+
+export const useAdvancedRoutingData = (): {
+  data: AdvancedRoutingExternalData;
+  loaded: boolean;
+  loadError?: Error;
+} => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const { data: configs, loaded, error } = useFetchRouterConfigs(dashboardNamespace);
+
+  const enabledConfigs = React.useMemo(() => configs.filter(isConfigEnabled), [configs]);
+
+  return React.useMemo(
+    () => ({
+      data: { routerConfigs: enabledConfigs },
+      loaded,
+      loadError: error,
+    }),
+    [enabledConfigs, loaded, error],
+  );
+};
+
+// --- Dependencies ---
+
+type AdvancedRoutingDependencies = {
+  topologyType?: TopologyTypeFieldData;
+};
+
+// --- Field value ---
+
+export type AdvancedRoutingFieldData = {
+  enabled: boolean;
+  selectedConfig?: LLMInferenceServiceConfigKind;
+};
+
+export type AdvancedRoutingFieldType = WizardField<
+  AdvancedRoutingFieldData,
+  AdvancedRoutingExternalData,
+  AdvancedRoutingDependencies
+>;
+
+// --- Component ---
+
+const getCompatibleRouterConfigs = (
+  routerConfigs: LLMInferenceServiceConfigKind[],
+  topologyType?: TopologyType,
+): LLMInferenceServiceConfigKind[] => {
+  if (!topologyType) {
+    return routerConfigs;
+  }
+  return routerConfigs.filter((config) => {
+    const supportedTopologies = getConfigSupportedTopologies(config);
+    return supportedTopologies.length === 0 || supportedTopologies.includes(topologyType);
+  });
+};
+
+const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
+  value,
+  onChange,
+  externalData,
+  dependencies,
+}) => {
+  const topologyType = dependencies?.topologyType?.topologyType;
+  const routerConfigs = externalData?.data.routerConfigs;
+  const isLoaded = externalData?.loaded ?? false;
+  const hasLoadError = Boolean(externalData?.loadError);
+
+  const compatibleConfigs = React.useMemo(
+    () => getCompatibleRouterConfigs(routerConfigs ?? [], topologyType),
+    [routerConfigs, topologyType],
+  );
+
+  const options: SimpleSelectOption[] = React.useMemo(
+    () =>
+      compatibleConfigs.map((config) => {
+        const routingType = getConfigRoutingType(config);
+        const routingLabel = routingType ? ` · ${RoutingTypeLabels[routingType]}` : '';
+        return {
+          key: config.metadata.name,
+          label: getDisplayNameFromK8sResource(config),
+          description: routingLabel || undefined,
+          dataTestId: `routing-config-option-${config.metadata.name}`,
+        };
+      }),
+    [compatibleConfigs],
+  );
+
+  return (
+    <FormGroup fieldId="advanced-routing" label="Advanced routing">
+      <Stack hasGutter>
+        <StackItem>
+          <Checkbox
+            id="advanced-routing-checkbox"
+            label="Use advanced routing"
+            isChecked={value?.enabled ?? false}
+            onChange={(_event, checked) => {
+              onChange({
+                enabled: checked,
+                selectedConfig: checked ? value?.selectedConfig : undefined,
+              });
+            }}
+            data-testid="advanced-routing-checkbox"
+          />
+        </StackItem>
+        {value?.enabled && (
+          <StackItem>
+            <FormGroup fieldId="routing-config-select" label="Custom routing configuration">
+              <SimpleSelect
+                isFullWidth
+                options={options}
+                onChange={(key, isPlaceholder) => {
+                  if (!key || isPlaceholder) {
+                    onChange({ enabled: true, selectedConfig: undefined });
+                    return;
+                  }
+                  const config = compatibleConfigs.find((c) => c.metadata.name === key);
+                  onChange({ enabled: true, selectedConfig: config });
+                }}
+                placeholder="Select routing configuration"
+                value={value.selectedConfig?.metadata.name}
+                dataTestId="routing-config-select"
+                isDisabled={!isLoaded || hasLoadError}
+                autoSelectOnlyOption={false}
+                toggleProps={hasLoadError ? { status: 'warning' } : undefined}
+              />
+              {hasLoadError && (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem variant="warning">
+                      Failed to load routing configurations.
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              )}
+            </FormGroup>
+          </StackItem>
+        )}
+      </Stack>
+    </FormGroup>
+  );
+};
+
+// --- Review ---
+
+const getReviewSections = (value: AdvancedRoutingFieldData): WizardReviewSection[] => {
+  if (!value.enabled || !value.selectedConfig) {
+    return [];
+  }
+  return [
+    {
+      title: 'Advanced settings',
+      items: [
+        {
+          key: 'routing-config',
+          label: 'Routing configuration',
+          value: () =>
+            value.selectedConfig ? getDisplayNameFromK8sResource(value.selectedConfig) : '',
+        },
+      ],
+    },
+  ];
+};
+
+// --- isActive ---
+
+const isActive = (wizardState: RecursivePartial<WizardFormData['state']>): boolean => {
+  if (!isLLMInferenceServiceActive(wizardState)) {
+    return false;
+  }
+  return wizardState.deploymentMethod?.method === LLMD_DEPLOYMENT_METHOD_KEY;
+};
+
+// --- Field definition ---
+
+export const AdvancedRoutingFieldWizardField: AdvancedRoutingFieldType = {
+  id: 'llmd-serving/advanced-routing',
+  parentId: 'networking',
+  step: 'advancedOptions',
+  type: 'addition',
+  isActive,
+  reducerFunctions: {
+    resolveDependencies: (formData) => {
+      const rawTopologyData = formData['llmd-serving/topology-type'];
+      return {
+        topologyType: isTopologyTypeFieldData(rawTopologyData) ? rawTopologyData : undefined,
+      };
+    },
+    setFieldData: (value: AdvancedRoutingFieldData) => value,
+    getInitialFieldData: (existingFieldData?: AdvancedRoutingFieldData): AdvancedRoutingFieldData =>
+      existingFieldData ?? { enabled: false },
+  },
+  externalDataHook: useAdvancedRoutingData,
+  component: AdvancedRoutingFieldComponent,
+  getReviewSections,
+};

--- a/packages/llmd-serving/src/wizardFields/AdvancedRoutingField.tsx
+++ b/packages/llmd-serving/src/wizardFields/AdvancedRoutingField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Checkbox,
+  Content,
   FormGroup,
   FormHelperText,
   HelperText,
@@ -66,7 +66,6 @@ type AdvancedRoutingDependencies = {
 // --- Field value ---
 
 export type AdvancedRoutingFieldData = {
-  enabled: boolean;
   selectedConfig?: LLMInferenceServiceConfigKind;
 };
 
@@ -91,6 +90,8 @@ const getCompatibleRouterConfigs = (
   });
 };
 
+const DEFAULT_ROUTING_KEY = '__default-optimized-routing__';
+
 const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
   value,
   onChange,
@@ -107,11 +108,17 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
     [routerConfigs, topologyType],
   );
 
-  const noConfigsAvailable = isLoaded && !hasLoadError && compatibleConfigs.length === 0;
+  const options: SimpleSelectOption[] = React.useMemo(() => {
+    const result: SimpleSelectOption[] = [
+      {
+        key: DEFAULT_ROUTING_KEY,
+        label: 'Default optimized routing',
+        dataTestId: 'routing-config-option-default',
+      },
+    ];
 
-  const options: SimpleSelectOption[] = React.useMemo(
-    () =>
-      compatibleConfigs.map((config) => {
+    result.push(
+      ...compatibleConfigs.map((config) => {
         const routingType = getConfigRoutingType(config);
         const routingLabel = routingType ? ` · ${RoutingTypeLabels[routingType]}` : '';
         return {
@@ -121,72 +128,49 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
           dataTestId: `routing-config-option-${config.metadata.name}`,
         };
       }),
-    [compatibleConfigs],
-  );
+    );
+
+    return result;
+  }, [compatibleConfigs]);
+
+  const selectedValue = value?.selectedConfig?.metadata.name ?? DEFAULT_ROUTING_KEY;
 
   return (
     <FormGroup fieldId="advanced-routing" label="Advanced routing">
       <Stack hasGutter>
         <StackItem>
-          <Checkbox
-            id="advanced-routing-checkbox"
-            label="Use advanced routing"
-            isChecked={value?.enabled ?? false}
-            onChange={(_event, checked) => {
-              onChange({
-                enabled: checked,
-                selectedConfig: checked ? value?.selectedConfig : undefined,
-              });
-            }}
-            data-testid="advanced-routing-checkbox"
-          />
+          <Content component="p">
+            Select the llm-d routing configuration for this deployment
+          </Content>
         </StackItem>
-        {value?.enabled && (
-          <StackItem>
-            <FormGroup
-              fieldId="routing-config-select"
-              label="Custom routing configuration"
-              isRequired
-            >
-              <SimpleSelect
-                isFullWidth
-                options={options}
-                onChange={(key, isPlaceholder) => {
-                  if (!key || isPlaceholder) {
-                    onChange({ enabled: true, selectedConfig: undefined });
-                    return;
-                  }
-                  const config = compatibleConfigs.find((c) => c.metadata.name === key);
-                  onChange({ enabled: true, selectedConfig: config });
-                }}
-                placeholder="Select routing configuration"
-                value={value.selectedConfig?.metadata.name}
-                dataTestId="routing-config-select"
-                isDisabled={!isLoaded || hasLoadError || noConfigsAvailable}
-                autoSelectOnlyOption={false}
-                toggleProps={hasLoadError ? { status: 'warning' } : undefined}
-              />
-              {hasLoadError ? (
-                <FormHelperText>
-                  <HelperText>
-                    <HelperTextItem variant="warning">
-                      Failed to load routing configurations.
-                    </HelperTextItem>
-                  </HelperText>
-                </FormHelperText>
-              ) : noConfigsAvailable ? (
-                <FormHelperText>
-                  <HelperText>
-                    <HelperTextItem variant="warning">
-                      No routing configurations available for this topology type. Contact your
-                      administrator to create one.
-                    </HelperTextItem>
-                  </HelperText>
-                </FormHelperText>
-              ) : null}
-            </FormGroup>
-          </StackItem>
-        )}
+        <StackItem>
+          <SimpleSelect
+            isFullWidth
+            options={options}
+            onChange={(key, isPlaceholder) => {
+              if (!key || isPlaceholder || key === DEFAULT_ROUTING_KEY) {
+                onChange({ selectedConfig: undefined });
+                return;
+              }
+              const config = compatibleConfigs.find((c) => c.metadata.name === key);
+              onChange({ selectedConfig: config ?? value?.selectedConfig });
+            }}
+            value={selectedValue}
+            dataTestId="routing-config-select"
+            isDisabled={!isLoaded || hasLoadError || compatibleConfigs.length === 0}
+            autoSelectOnlyOption={false}
+            toggleProps={hasLoadError ? { status: 'warning' } : undefined}
+          />
+          {hasLoadError && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="warning">
+                  Failed to load routing configurations.
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
+        </StackItem>
       </Stack>
     </FormGroup>
   );
@@ -194,24 +178,21 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
 
 // --- Review ---
 
-const getReviewSections = (value: AdvancedRoutingFieldData): WizardReviewSection[] => {
-  if (!value.enabled || !value.selectedConfig) {
-    return [];
-  }
-  return [
-    {
-      title: 'Advanced settings',
-      items: [
-        {
-          key: 'routing-config',
-          label: 'Routing configuration',
-          value: () =>
-            value.selectedConfig ? getDisplayNameFromK8sResource(value.selectedConfig) : '',
-        },
-      ],
-    },
-  ];
-};
+const getReviewSections = (value: AdvancedRoutingFieldData): WizardReviewSection[] => [
+  {
+    title: 'Advanced settings',
+    items: [
+      {
+        key: 'routing-config',
+        label: 'Routing configuration',
+        value: () =>
+          value.selectedConfig
+            ? getDisplayNameFromK8sResource(value.selectedConfig)
+            : 'Default optimized routing',
+      },
+    ],
+  },
+];
 
 // --- isActive ---
 
@@ -239,7 +220,7 @@ export const AdvancedRoutingFieldWizardField: AdvancedRoutingFieldType = {
     },
     setFieldData: (value: AdvancedRoutingFieldData) => value,
     getInitialFieldData: (existingFieldData?: AdvancedRoutingFieldData): AdvancedRoutingFieldData =>
-      existingFieldData ?? { enabled: false },
+      existingFieldData ?? { selectedConfig: undefined },
   },
   externalDataHook: useAdvancedRoutingData,
   component: AdvancedRoutingFieldComponent,

--- a/packages/llmd-serving/src/wizardFields/AdvancedRoutingField.tsx
+++ b/packages/llmd-serving/src/wizardFields/AdvancedRoutingField.tsx
@@ -107,6 +107,8 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
     [routerConfigs, topologyType],
   );
 
+  const noConfigsAvailable = isLoaded && !hasLoadError && compatibleConfigs.length === 0;
+
   const options: SimpleSelectOption[] = React.useMemo(
     () =>
       compatibleConfigs.map((config) => {
@@ -141,7 +143,11 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
         </StackItem>
         {value?.enabled && (
           <StackItem>
-            <FormGroup fieldId="routing-config-select" label="Custom routing configuration">
+            <FormGroup
+              fieldId="routing-config-select"
+              label="Custom routing configuration"
+              isRequired
+            >
               <SimpleSelect
                 isFullWidth
                 options={options}
@@ -156,11 +162,11 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
                 placeholder="Select routing configuration"
                 value={value.selectedConfig?.metadata.name}
                 dataTestId="routing-config-select"
-                isDisabled={!isLoaded || hasLoadError}
+                isDisabled={!isLoaded || hasLoadError || noConfigsAvailable}
                 autoSelectOnlyOption={false}
                 toggleProps={hasLoadError ? { status: 'warning' } : undefined}
               />
-              {hasLoadError && (
+              {hasLoadError ? (
                 <FormHelperText>
                   <HelperText>
                     <HelperTextItem variant="warning">
@@ -168,7 +174,16 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
                     </HelperTextItem>
                   </HelperText>
                 </FormHelperText>
-              )}
+              ) : noConfigsAvailable ? (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem variant="warning">
+                      No routing configurations available for this topology type. Contact your
+                      administrator to create one.
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              ) : null}
             </FormGroup>
           </StackItem>
         )}

--- a/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
+++ b/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
@@ -19,6 +19,7 @@ import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { LLMD_DEPLOYMENT_METHOD_KEY } from './deploymentMethodField';
 import {
   useTopologyTypeData,
+  isTopologyTypeFieldData,
   type TopologyTypeFieldData,
   type TopologyTypeExternalData,
 } from './TopologyTypeField';
@@ -26,17 +27,6 @@ import { TopologyType, type LLMInferenceServiceConfigKind } from '../types';
 import { isLLMInferenceServiceActive } from '../formUtils';
 
 // --- Dependencies ---
-
-const topologyTypeValues: string[] = Object.values(TopologyType);
-const isTopologyTypeFieldData = (data: unknown): data is TopologyTypeFieldData => {
-  if (data == null || typeof data !== 'object' || !('topologyType' in data)) {
-    return false;
-  }
-  const record: Record<string, unknown> = data;
-  return (
-    typeof record.topologyType === 'string' && topologyTypeValues.includes(record.topologyType)
-  );
-};
 
 type CustomTopologyConfigDependencies = {
   topologyType?: TopologyTypeFieldData;

--- a/packages/llmd-serving/src/wizardFields/TopologyTypeField.tsx
+++ b/packages/llmd-serving/src/wizardFields/TopologyTypeField.tsx
@@ -81,6 +81,17 @@ export type TopologyTypeFieldData = {
   topologyType: TopologyType;
 };
 
+const topologyTypeValues: string[] = Object.values(TopologyType);
+export const isTopologyTypeFieldData = (data: unknown): data is TopologyTypeFieldData => {
+  if (data == null || typeof data !== 'object' || !('topologyType' in data)) {
+    return false;
+  }
+  const record: Record<string, unknown> = data;
+  return (
+    typeof record.topologyType === 'string' && topologyTypeValues.includes(record.topologyType)
+  );
+};
+
 export type TopologyTypeFieldType = WizardField<TopologyTypeFieldData, TopologyTypeExternalData>;
 
 // --- Component ---


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-70583
## Description
Adds the "Advanced routing" wizard field to the llm-d deployment wizard (Advanced Settings step) and mocked Cypress tests covering both topology and routing features (Stories 2 & 3).
**New wizard field — AdvancedRoutingField:**
- Checkbox "Use advanced routing" in the Advanced Settings step
- When checked, reveals a "Custom routing configuration" dropdown
- Dropdown shows router configs (`config-type=router`) from the dashboard namespace, filtered by `supported-topologies` annotation compatibility with the selected topology type
- Disabled while loading; shows warning on fetch error
- Gated by `llmdTopologyConfigs` Tech Preview flag + llm-d deployment method active
- Registered as `WizardFieldExtension` under `parentId: 'networking'`
**Shared typeguard extraction:**
- `isTopologyTypeFieldData` typeguard extracted from `CustomTopologyConfigField` to `TopologyTypeField` as a shared export, eliminating duplication between topology and routing fields
**Mocked Cypress tests (11 test cases):**
- Topology type field: visibility, disabled options, Single node always enabled
- Custom topology config: filtering by topology type, reset on change
- Advanced routing: checkbox visibility, dropdown reveal, config options, selection clearing
## How Has This Been Tested?
1. **Manual testing on cluster** with `?devFeatureFlags=true,llmdTopologyConfigs=true`:
   - Verified "Advanced routing" checkbox appears in Advanced Settings when llm-d deployment method selected
   - Verified checking the box reveals the routing config dropdown
   - Verified dropdown shows router configs from the cluster
   - 
<img width="1637" height="702" alt="Screenshot 2026-07-01 at 5 43 59 PM" src="https://github.com/user-attachments/assets/1a3cbe89-33fd-4ecd-85c2-def2c80e7c01" />

2. **Testing router config options on cluster:**
   Apply these to create routing configurations:
   ```bash
   oc apply -f - <<EOF
   apiVersion: serving.kserve.io/v1alpha2
   kind: LLMInferenceServiceConfig
   metadata:
     name: managed-scheduler-httproute
     namespace: opendatahub
     annotations:
       openshift.io/display-name: "Managed scheduler with HTTPRoute"
     labels:
       opendatahub.io/config-type: router
       opendatahub.io/dashboard: "true"
   spec:
     router:
       route: {}
       scheduler: {}
   ---
   apiVersion: serving.kserve.io/v1alpha2
   kind: LLMInferenceServiceConfig
   metadata:
     name: managed-scheduler
     namespace: opendatahub
     annotations:
       openshift.io/display-name: "Managed scheduler"
     labels:
       opendatahub.io/config-type: router
       opendatahub.io/dashboard: "true"
   spec:
     router:
       scheduler: {}
   ---
   apiVersion: serving.kserve.io/v1alpha2
   kind: LLMInferenceServiceConfig
   metadata:
     name: lab-routing-profile
     namespace: opendatahub
     annotations:
       openshift.io/display-name: "Lab routing profile"
     labels:
       opendatahub.io/config-type: router
       opendatahub.io/dashboard: "true"
   spec:
     router:
       route: {}
       scheduler: {}
   EOF

After applying, navigate to the deploy wizard → select llm-d deployment method → go to Advanced Settings → check "Use advanced routing" → dropdown should show all 3 configs.

3. **Cleanup:**
   ```bash
   oc delete llminferenceserviceconfig -n opendatahub managed-scheduler-httproute managed-scheduler lab-routing-profile 
Cleanup:

oc delete llminferenceserviceconfig -n opendatahub managed-scheduler-httproute managed-scheduler lab-routing-profile
Type-check passes for both packages/llmd-serving and packages/cypress.
no it's not readme 
Test Impact
Added new Cypress mocked test file: packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts (11 test cases covering Stories 2 & 3):

Request review criteria:
Self checklist (all need to be checked):


 The developer has manually tested the changes and verified that the changes work

 Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).

 The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

 The code follows our [Best Practices](vscode-file://vscode-app/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
If you have UI changes:


 Included any necessary screenshots or gifs if it was a UI change.

 Included tags to the UX team if it was a UI/UX change.
After the PR is posted & before it merges:


 The developer has tested their solution on a cluster by using the image produced by the PR to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Advanced routing** option to the model serving wizard, including an enable/disable toggle and a routing configuration dropdown.
  * Dropdown options are filtered based on the selected topology type and available (enabled) routing configurations.
* **Bug Fixes**
  * Improved topology and custom configuration selection, including disabling incompatible topology types and clearing invalid selections when switching types.
  * When routing configurations can’t be loaded, the routing dropdown is disabled and a warning is shown.
* **Tests**
  * Added a Cypress end-to-end suite covering topology selection, custom config filtering, and advanced routing UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->