### PR TITLE
perf: enable turbo caching for Cypress builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,6 +266,15 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           include-modules: 'true'
+      - name: Cache turbo (Cypress)
+        if: steps.cypress-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            **/.turbo
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-cypress-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-cypress-
       - name: Build for cypress
         if: steps.cypress-build-cache.outputs.cache-hit != 'true'
         run: npm run cypress:server:build:coverage -- --concurrency=4

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -54,12 +54,14 @@
 
     // Cypress tasks
     "cypress:server:build": {
-      // no caching until we can optimize the dependency graph
-      "cache": false
+      "cache": true,
+      "outputs": ["**/public-cypress/**"],
+      "dependsOn": ["^build"]
     },
     "cypress:server:build:coverage": {
-      // no caching until we can optimize the dependency graph
-      "cache": false
+      "cache": true,
+      "outputs": ["**/public-cypress/**"],
+      "dependsOn": ["^build"]
     },
     "cypress:server": {
       // TODO depend on build once caching is enabled


### PR DESCRIPTION
- Enable cache for cypress:server:build and cypress:server:build:coverage tasks
- Add turbo cache restore step to Cypress-Setup job in CI workflow
- Configure outputs to cache public-cypress directories
- Add dependsOn to ensure proper build order

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
