### PR TITLE
Fixed Workload metrics not loading in RHOAI and incorrect Distributed workload resource metrics displayed. 

### DIFF
--- a/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
@@ -78,6 +78,13 @@ const mockCpuUsageResults: WorkloadMetricPromQueryResponse['data']['result'] = [
     },
     value: [1711495542.368, '0.008'],
   },
+  {
+    metric: {
+      owner_kind: WorkloadOwnerType.ReplicaSet, // eslint-disable-line camelcase
+      owner_name: 'test-deployment-6c8949d6dc', // eslint-disable-line camelcase
+    },
+    value: [1711495542.368, '0.005'],
+  },
 ];
 
 const mockMemoryUsageResults: WorkloadMetricPromQueryResponse['data']['result'] = [
@@ -136,6 +143,13 @@ const mockMemoryUsageResults: WorkloadMetricPromQueryResponse['data']['result'] 
       owner_name: 'test-notebook-0', // eslint-disable-line camelcase
     },
     value: [1711495542.37, '5000000'],
+  },
+  {
+    metric: {
+      owner_kind: WorkloadOwnerType.ReplicaSet, // eslint-disable-line camelcase
+      owner_name: 'test-deployment-6c8949d6dc', // eslint-disable-line camelcase
+    },
+    value: [1711495542.37, '10485760'],
   },
 ];
 
@@ -234,7 +248,9 @@ describe('indexWorkloadMetricByOwner', () => {
       [WorkloadOwnerType.StatefulSet]: {
         'test-notebook-0': 0.008,
       },
-      [WorkloadOwnerType.ReplicaSet]: {},
+      [WorkloadOwnerType.ReplicaSet]: {
+        'test-deployment-6c8949d6dc': 0.005,
+      },
     };
     expect(indexWorkloadMetricByOwner(promResponse)).toEqual(indexedValues);
   });
@@ -416,7 +432,9 @@ describe('useDWProjectCurrentMetrics', () => {
             [WorkloadOwnerType.StatefulSet]: {
               'test-notebook-0': 0.008,
             },
-            [WorkloadOwnerType.ReplicaSet]: {},
+            [WorkloadOwnerType.ReplicaSet]: {
+              'test-deployment-6c8949d6dc': 0.005,
+            },
           },
           error: undefined,
           loaded: true,
@@ -438,7 +456,9 @@ describe('useDWProjectCurrentMetrics', () => {
             [WorkloadOwnerType.StatefulSet]: {
               'test-notebook-0': 5000000,
             },
-            [WorkloadOwnerType.ReplicaSet]: {},
+            [WorkloadOwnerType.ReplicaSet]: {
+              'test-deployment-6c8949d6dc': 10485760,
+            },
           },
           error: undefined,
           loaded: true,

--- a/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
@@ -234,6 +234,7 @@ describe('indexWorkloadMetricByOwner', () => {
       [WorkloadOwnerType.StatefulSet]: {
         'test-notebook-0': 0.008,
       },
+      [WorkloadOwnerType.ReplicaSet]: {},
     };
     expect(indexWorkloadMetricByOwner(promResponse)).toEqual(indexedValues);
   });
@@ -387,11 +388,11 @@ describe('useDWProjectCurrentMetrics', () => {
     expect(mockAxios).toHaveBeenCalledTimes(2);
     expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/query', {
       query:
-        'namespace=test-project&query=sum by(owner_name, owner_kind)  (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)',
+        'namespace=test-project&query=sum by(owner_name, owner_kind)  (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)',
     });
     expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/query', {
       query:
-        'namespace=test-project&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)',
+        'namespace=test-project&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)',
     });
     expect(renderResult).hookToHaveUpdateCount(1);
 
@@ -415,6 +416,7 @@ describe('useDWProjectCurrentMetrics', () => {
             [WorkloadOwnerType.StatefulSet]: {
               'test-notebook-0': 0.008,
             },
+            [WorkloadOwnerType.ReplicaSet]: {},
           },
           error: undefined,
           loaded: true,
@@ -436,6 +438,7 @@ describe('useDWProjectCurrentMetrics', () => {
             [WorkloadOwnerType.StatefulSet]: {
               'test-notebook-0': 5000000,
             },
+            [WorkloadOwnerType.ReplicaSet]: {},
           },
           error: undefined,
           loaded: true,

--- a/frontend/src/api/prometheus/distributedWorkloads.ts
+++ b/frontend/src/api/prometheus/distributedWorkloads.ts
@@ -15,6 +15,7 @@ export const EMPTY_WORKLOAD_METRIC_INDEXED_BY_OWNER: WorkloadMetricIndexedByOwne
   [WorkloadOwnerType.RayCluster]: {},
   [WorkloadOwnerType.Job]: {},
   [WorkloadOwnerType.StatefulSet]: {},
+  [WorkloadOwnerType.ReplicaSet]: {},
 };
 
 export type WorkloadMetricPromQueryResponse = PrometheusQueryResponse<{
@@ -135,8 +136,8 @@ export const DEFAULT_DW_PROJECT_CURRENT_METRICS: DWProjectCurrentMetrics = {
 const getDWProjectCurrentMetricsQueries = (
   namespace: string,
 ): Record<DWProjectCurrentMetricType, string> => ({
-  cpuCoresUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind)  (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)`,
-  memoryBytesUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)`,
+  cpuCoresUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind)  (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)`,
+  memoryBytesUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)`,
 });
 
 export const useDWProjectCurrentMetrics = (

--- a/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
@@ -143,6 +143,19 @@ describe('getWorkloadOwner', () => {
     });
   });
 
+  it('returns the name of a replicaset found in ownerReferences of a workload if present', () => {
+    const mockWorkload = mockWorkloadK8sResource({
+      k8sName: 'test-workload',
+      namespace: 'test-project',
+      ownerKind: WorkloadOwnerType.ReplicaSet,
+      ownerName: 'test-replicaset-6c8949d6dc',
+    });
+    expect(getWorkloadOwner(mockWorkload)).toStrictEqual({
+      kind: 'ReplicaSet',
+      name: 'test-replicaset-6c8949d6dc',
+    });
+  });
+
   it('returns undefined if there is no job in ownerReferences', () => {
     const mockWorkload = mockWorkloadK8sResource({
       k8sName: 'test-workload',

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -810,6 +810,7 @@ export enum WorkloadOwnerType {
   RayCluster = 'RayCluster',
   Job = 'Job',
   StatefulSet = 'StatefulSet',
+  ReplicaSet = 'ReplicaSet',
 }
 
 // https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Workload

--- a/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -405,8 +405,8 @@ describe('Project Metrics tab', () => {
         .findByText('test-workload-replicaset')
         .closest('tr')
         .within(() => {
-          cy.get('td[data-label="CPU usage (cores)"]').should('not.contain.text', '-');
-          cy.get('td[data-label="Memory usage (GiB)"]').should('not.contain.text', '-');
+          cy.get('td[data-label="CPU usage (cores)"]').should('contain.text', '0.5');
+          cy.get('td[data-label="Memory usage (GiB)"]').should('contain.text', '0.25');
         });
     });
 

--- a/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -406,7 +406,7 @@ describe('Project Metrics tab', () => {
         .closest('tr')
         .within(() => {
           cy.get('td[data-label="CPU usage (cores)"]').should('contain.text', '0.5');
-          cy.get('td[data-label="Memory usage (GiB)"]').should('contain.text', '0.25');
+          cy.get('td[data-label="Memory usage (GiB)"]').should('contain.text', '0.3');
         });
     });
 

--- a/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -110,6 +110,13 @@ const initIntercepts = ({
       mockStatus: WorkloadStatusType.Running,
       podSets: [mockPodset],
     }),
+    mockWorkloadK8sResource({
+      k8sName: 'test-workload-replicaset',
+      ownerKind: WorkloadOwnerType.ReplicaSet,
+      ownerName: 'test-deployment-6c8949d6dc',
+      mockStatus: WorkloadStatusType.Running,
+      podSets: [mockPodset],
+    }),
   ],
 }: HandlersProps) => {
   cy.interceptOdh(
@@ -171,6 +178,9 @@ const initIntercepts = ({
           [WorkloadOwnerType.StatefulSet]: {
             'test-notebook-0': 1.5,
           },
+          [WorkloadOwnerType.ReplicaSet]: {
+            'test-deployment-6c8949d6dc': 0.5,
+          },
         }),
       });
     } else if (req.body.query.includes('container_memory_working_set_bytes')) {
@@ -187,6 +197,9 @@ const initIntercepts = ({
           },
           [WorkloadOwnerType.StatefulSet]: {
             'test-notebook-0': 524288000, // 500 MiB
+          },
+          [WorkloadOwnerType.ReplicaSet]: {
+            'test-deployment-6c8949d6dc': 268435456, // 256 MiB
           },
         }),
       });
@@ -376,6 +389,20 @@ describe('Project Metrics tab', () => {
       globalDistributedWorkloads
         .findWorkloadResourceMetricsTable()
         .findByText('test-workload-notebook')
+        .closest('tr')
+        .within(() => {
+          cy.get('td[data-label="CPU usage (cores)"]').should('not.contain.text', '-');
+          cy.get('td[data-label="Memory usage (GiB)"]').should('not.contain.text', '-');
+        });
+    });
+
+    it('Should render usage bars on a ReplicaSet workload', () => {
+      initIntercepts({});
+      globalDistributedWorkloads.visit();
+      cy.findByLabelText('Project metrics tab').click();
+      globalDistributedWorkloads
+        .findWorkloadResourceMetricsTable()
+        .findByText('test-workload-replicaset')
         .closest('tr')
         .within(() => {
           cy.get('td[data-label="CPU usage (cores)"]').should('not.contain.text', '-');


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-68456

## Description
Workload metrics show `0` for workloads owned by `ReplicaSet`because:
1. The `WorkloadOwnerType` enum did not include `ReplicaSet`, so `getWorkloadOwner()` returned `undefined` for Workloads with `ownerReferences: [{kind: ReplicaSet}]` — skipping the metrics lookup entirely.
2. The Prometheus query filter (`owner_kind=~"RayCluster|Job|StatefulSet"`) excluded `ReplicaSet`, so no metrics were fetched for ReplicaSet-owned pods.

###  Screenshots

### BEFORE


<img width="2533" height="1272" alt="SCR-20260703-mfxw" src="https://github.com/user-attachments/assets/efa4a865-01ca-4cdf-a7de-a9c77e2f3d5a" />

### AFTER


<img width="2539" height="1265" alt="SCR-20260703-mfpa" src="https://github.com/user-attachments/assets/c4a8f13c-5b96-4d95-87a4-617ca7ab2efd" />


## How Has This Been Tested?

- Unit tests pass (`npx jest --testPathPattern="distributedWorkloads"`)
- Manually verified on a cluster by creating Workload CRs

## Test Impact

- Updated existing unit tests in `distributedWorkloads.spec.ts` to include `ReplicaSet` in expected query
- Added unit test for `getWorkloadOwner` resolving `ReplicaSet` ownerReferences
- Added Cypress mock test verifying usage bars render for ReplicaSet workloads




## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ReplicaSet-backed workloads in distributed workload metrics, including owner detection and per-owner metric indexing.
  * Distributed Project Metrics now include CPU and memory usage bars for ReplicaSet workloads.

* **Tests**
  * Expanded unit and integration coverage to validate ReplicaSet ownership, metric query filtering, and expected hook state.
  * Updated end-to-end Cypress fixtures and assertions to verify ReplicaSet rows render usage bars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->