### PR TITLE
Disable modelAsService flag in gen-ai E2E tests

### DIFF
--- a/packages/cypress/cypress/pages/genAiPlayground.ts
+++ b/packages/cypress/cypress/pages/genAiPlayground.ts
@@ -1,5 +1,6 @@
-const GEN_AI_DEV_FLAG = 'devFeatureFlags=genAiStudio=true';
-const GEN_AI_CUSTOM_ENDPOINTS_FLAG = 'devFeatureFlags=genAiStudio=true,aiAssetCustomEndpoints=true';
+const GEN_AI_DEV_FLAG = 'devFeatureFlags=genAiStudio=true,modelAsService=false';
+const GEN_AI_CUSTOM_ENDPOINTS_FLAG =
+  'devFeatureFlags=genAiStudio=true,aiAssetCustomEndpoints=true,modelAsService=false';
 
 class GenAiPlayground {
   navigate(projectName: string) {

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testCustomEndpoints.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testCustomEndpoints.cy.ts
@@ -62,7 +62,7 @@ describe('Verify Custom Endpoints in Playground - Full Lifecycle', () => {
     () => {
       cy.step('Log into the application with custom endpoints enabled');
       cy.visitWithLogin(
-        `/?devFeatureFlags=genAiStudio=true,aiAssetCustomEndpoints=true`,
+        `/?devFeatureFlags=genAiStudio=true,aiAssetCustomEndpoints=true,modelAsService=false`,
         HTPASSWD_CLUSTER_ADMIN_USER,
       );
 

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testGenAi.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testGenAi.cy.ts
@@ -91,7 +91,10 @@ describe('Verify Gen AI Namespace - Creation and Connection', () => {
     },
     () => {
       cy.step('Log into the application');
-      cy.visitWithLogin('/?devFeatureFlags=genAiStudio=true', HTPASSWD_CLUSTER_ADMIN_USER);
+      cy.visitWithLogin(
+        '/?devFeatureFlags=genAiStudio=true,modelAsService=false',
+        HTPASSWD_CLUSTER_ADMIN_USER,
+      );
 
       cy.step('Navigate to AI asset endpoints page');
       genAiPlayground.navigateToAssets(projectName);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://redhat.atlassian.net/browse/RHOAIENG-73430

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Disable modelAsService flag in gen-ai E2E tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In Jenkins:
/dashboard/job/dashboard-e2e-tests/1672/
<img width="728" height="219" alt="Screenshot 2026-07-03 at 11 58 58" src="https://github.com/user-attachments/assets/8d1e2056-565d-4d3b-913e-7e62846ea7a9" />


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Updated Gen AI Playground navigation to use the correct developer feature-flag combinations for studio and custom-endpoint experiences.
  * Ensured the app launches with the expected model configuration for these flows.

* **Tests**
  * Adjusted Gen AI end-to-end test setup to match the updated login and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->