### PR TITLE
fix(e2e): update llamaStackDistribution import to ogxServer

### DIFF
--- a/packages/cypress/cypress/tests/e2e/gen-ai/testCustomEndpoints.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testCustomEndpoints.cy.ts
@@ -4,7 +4,7 @@ import {
   deleteOpenShiftProject,
   waitForUserProjectAccess,
 } from '../../../utils/oc_commands/project';
-import { checkLlamaStackDistributionReady } from '../../../utils/oc_commands/llamaStackDistribution';
+import { waitForOGXServerReady } from '../../../utils/oc_commands/ogxServer';
 import { waitForResource, waitForPodReady } from '../../../utils/oc_commands/baseCommands';
 import {
   enableExternalProviders,
@@ -118,8 +118,8 @@ describe('Verify Custom Endpoints in Playground - Full Lifecycle', () => {
       cy.step('Click Create in the configuration modal');
       genAiPlayground.findCreateButtonInDialog().should('be.enabled').click();
 
-      cy.step('Wait for LlamaStack Distribution to be ready');
-      checkLlamaStackDistributionReady(projectName);
+      cy.step('Wait for OGX Server to be ready');
+      waitForOGXServerReady(projectName);
 
       cy.step('Wait for playground service to be created');
       waitForResource('service', testData.lsdServiceName, projectName);


### PR DESCRIPTION
## Description

PR #8091 renamed `packages/cypress/cypress/utils/oc_commands/llamaStackDistribution.ts` to `ogxServer.ts` and removed the deprecated `checkLlamaStackDistributionReady` alias. However, it missed updating `testCustomEndpoints.cy.ts` (introduced by PR #8316 two days earlier), which still imported from the deleted module path.

This fixes the `@odh-dashboard/cypress#type-check` CI failure:
```
Cannot find module '../../../utils/oc_commands/llamaStackDistribution' or its corresponding type declarations.
```

Changes:
- Update import from `llamaStackDistribution` → `ogxServer`
- Update function reference from `checkLlamaStackDistributionReady` → `waitForOGXServerReady`

## How Has This Been Tested?

Ran the cypress package type-check locally:
```bash
cd packages/cypress && npx tsc --noEmit
```
Passes cleanly after the fix.

## Test Impact

No new tests needed — this is a one-line import fix for an existing test file.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the custom endpoints end-to-end test flow to wait for the correct service before continuing setup.
  * This makes the test process more reliable and reduces failures caused by starting too early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->