### PR TITLE
feat(feature-store): Implement Feature Store creation form data model, validation logic, and CRD spec builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36348,7 +36348,8 @@
         "@odh-dashboard/internal": "*",
         "@odh-dashboard/k8s-core": "*",
         "@odh-dashboard/plugin-core": "*",
-        "@odh-dashboard/ui-core": "*"
+        "@odh-dashboard/ui-core": "*",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",

--- a/packages/feature-store/package.json
+++ b/packages/feature-store/package.json
@@ -55,7 +55,8 @@
     "@odh-dashboard/internal": "*",
     "@odh-dashboard/k8s-core": "*",
     "@odh-dashboard/plugin-core": "*",
-    "@odh-dashboard/ui-core": "*"
+    "@odh-dashboard/ui-core": "*",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",

--- a/packages/feature-store/src/k8sTypes.ts
+++ b/packages/feature-store/src/k8sTypes.ts
@@ -43,7 +43,10 @@ export type FeastContainerConfigs = {
   env?: FeastEnvVar[];
   envFrom?: FeastEnvFromSource[];
   imagePullPolicy?: string;
-  resources?: Record<string, unknown>;
+  resources?: {
+    requests?: Record<string, string>;
+    limits?: Record<string, string>;
+  };
   nodeSelector?: Record<string, string>;
 };
 

--- a/packages/feature-store/src/screens/create/__tests__/types.spec.ts
+++ b/packages/feature-store/src/screens/create/__tests__/types.spec.ts
@@ -1,0 +1,46 @@
+import { FEAST_PROJECT_NAME_REGEX } from '../types';
+
+describe('FEAST_PROJECT_NAME_REGEX', () => {
+  describe('valid names (RFC 1123 subdomain)', () => {
+    const validNames = [
+      'myfeaturestore',
+      'a',
+      '1',
+      'a1',
+      '1a',
+      'my-store',
+      'my.store',
+      'test123',
+      'a-b-c',
+      'a.b.c',
+      'feature-store-v2',
+      '0123456789',
+      'a-1.b-2',
+    ];
+
+    it.each(validNames)('should match "%s"', (name) => {
+      expect(FEAST_PROJECT_NAME_REGEX.test(name)).toBe(true);
+    });
+  });
+
+  describe('invalid names', () => {
+    const invalidNames = [
+      { name: 'my_store', reason: 'contains underscore' },
+      { name: 'MyStore', reason: 'contains uppercase' },
+      { name: 'My-Store', reason: 'contains uppercase' },
+      { name: '-store', reason: 'starts with hyphen' },
+      { name: 'store-', reason: 'ends with hyphen' },
+      { name: '.store', reason: 'starts with dot' },
+      { name: 'store.', reason: 'ends with dot' },
+      { name: '', reason: 'empty string' },
+      { name: 'my store', reason: 'contains space' },
+      { name: 'my@store', reason: 'contains special character' },
+      { name: 'my/store', reason: 'contains slash' },
+      { name: 'my_feature_store', reason: 'contains underscores (Feast SQLite incompatible)' },
+    ];
+
+    it.each(invalidNames)('should not match "$name" ($reason)', ({ name }) => {
+      expect(FEAST_PROJECT_NAME_REGEX.test(name)).toBe(false);
+    });
+  });
+});

--- a/packages/feature-store/src/screens/create/__tests__/utils.spec.ts
+++ b/packages/feature-store/src/screens/create/__tests__/utils.spec.ts
@@ -1,0 +1,730 @@
+import { buildFormSpec, formSpecToYaml } from '../utils';
+import {
+  FeatureStoreFormData,
+  RegistryType,
+  PersistenceType,
+  AuthzType,
+  ProjectDirType,
+  RemoteRegistryType,
+  ScalingMode,
+} from '../types';
+import { DEFAULT_FEATURE_STORE_FORM_DATA } from '../useCreateFeatureStoreProjectState';
+import { FEATURE_STORE_UI_LABEL_KEY, FEATURE_STORE_UI_LABEL_VALUE } from '../../../const';
+
+const makeFormData = (overrides: Partial<FeatureStoreFormData> = {}): FeatureStoreFormData => ({
+  ...DEFAULT_FEATURE_STORE_FORM_DATA,
+  ...overrides,
+});
+
+describe('buildFormSpec', () => {
+  describe('basic fields', () => {
+    it('should set feastProject and namespace from form data', () => {
+      const data = makeFormData({ feastProject: 'mystore', namespace: 'test-ns' });
+      const spec = buildFormSpec(data, false);
+      expect(spec.feastProject).toBe('mystore');
+      expect(spec.namespace).toBe('test-ns');
+    });
+
+    it('should include UI label when addUILabel is true', () => {
+      const data = makeFormData({ feastProject: 'test', namespace: 'ns' });
+      const spec = buildFormSpec(data, true);
+      expect(spec.labels).toEqual({
+        [FEATURE_STORE_UI_LABEL_KEY]: FEATURE_STORE_UI_LABEL_VALUE,
+      });
+    });
+
+    it('should not include labels when addUILabel is false', () => {
+      const data = makeFormData({ feastProject: 'test', namespace: 'ns' });
+      const spec = buildFormSpec(data, false);
+      expect(spec.labels).toBeUndefined();
+    });
+  });
+
+  describe('registry services', () => {
+    it('should preserve restAPI and grpc for local registry with defaults', () => {
+      const data = makeFormData({ feastProject: 'test', namespace: 'ns' });
+      const spec = buildFormSpec(data, false);
+      const registryServer = spec.services?.registry?.local?.server;
+      expect(registryServer?.restAPI).toBe(true);
+      expect(registryServer?.grpc).toBe(true);
+    });
+
+    it('should preserve restAPI true and grpc false', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.LOCAL,
+        services: {
+          registry: {
+            local: {
+              server: { restAPI: true, grpc: false },
+            },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      const registryServer = spec.services?.registry?.local?.server;
+      expect(registryServer?.restAPI).toBe(true);
+      expect(registryServer?.grpc).toBe(false);
+    });
+
+    it('should include envFrom for registry secret when path is object-store URI', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registrySecretName: 's3-secret',
+        registryPersistenceType: PersistenceType.FILE,
+        services: {
+          registry: {
+            local: { persistence: { file: { path: 's3://bucket/registry.db' } } },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      const envFrom = spec.services?.registry?.local?.server?.envFrom;
+      expect(envFrom).toEqual([{ secretRef: { name: 's3-secret' } }]);
+    });
+
+    it('should not include envFrom when registry secret is empty', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registrySecretName: '',
+      });
+      const spec = buildFormSpec(data, false);
+      const envFrom = spec.services?.registry?.local?.server?.envFrom;
+      expect(envFrom).toBeUndefined();
+    });
+
+    it('should not include envFrom when path is not an object-store URI', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registrySecretName: 'stale-secret',
+        registryPersistenceType: PersistenceType.FILE,
+        services: {
+          registry: {
+            local: { persistence: { file: { path: '/data/registry.db' } } },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      const envFrom = spec.services?.registry?.local?.server?.envFrom;
+      expect(envFrom).toBeUndefined();
+    });
+
+    it('should not include envFrom when persistence is DB', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registrySecretName: 'stale-secret',
+        registryPersistenceType: PersistenceType.DB,
+      });
+      const spec = buildFormSpec(data, false);
+      const envFrom = spec.services?.registry?.local?.server?.envFrom;
+      expect(envFrom).toBeUndefined();
+    });
+
+    it('should include file persistence for local registry when path provided', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.LOCAL,
+        registryPersistenceType: PersistenceType.FILE,
+        services: {
+          registry: {
+            local: {
+              server: { restAPI: true, grpc: true },
+              persistence: { file: { path: 's3://bucket/registry.db' } },
+            },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.registry?.local?.persistence?.file?.path).toBe(
+        's3://bucket/registry.db',
+      );
+    });
+
+    it('should include DB persistence for local registry when type provided', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.LOCAL,
+        registryPersistenceType: PersistenceType.DB,
+        services: {
+          registry: {
+            local: {
+              server: { restAPI: true, grpc: true },
+              persistence: { store: { type: 'sql', secretRef: { name: 'db-secret' } } },
+            },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.registry?.local?.persistence?.store?.type).toBe('sql');
+    });
+
+    it('should build remote registry with feastRef', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.REMOTE,
+        remoteRegistryType: RemoteRegistryType.FEAST_REF,
+        services: {
+          registry: {
+            remote: { feastRef: { name: 'primary', namespace: 'feast-ns' } },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.registry?.remote?.feastRef).toEqual({
+        name: 'primary',
+        namespace: 'feast-ns',
+      });
+    });
+
+    it('should build remote registry with hostname', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.REMOTE,
+        remoteRegistryType: RemoteRegistryType.HOSTNAME,
+        services: {
+          registry: {
+            remote: { hostname: 'registry.example.com:443' },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.registry?.remote?.hostname).toBe('registry.example.com:443');
+    });
+  });
+
+  describe('online store', () => {
+    it('should always include online store in the spec', () => {
+      const data = makeFormData({ feastProject: 'test', namespace: 'ns' });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.onlineStore).toBeDefined();
+    });
+
+    it('should include online store envFrom when secret is provided', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        onlineStoreSecretName: 'redis-secret',
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.onlineStore?.server?.envFrom).toEqual([
+        { secretRef: { name: 'redis-secret' } },
+      ]);
+    });
+
+    it('should include online store file persistence when path is provided', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        onlinePersistenceType: PersistenceType.FILE,
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          onlineStore: {
+            persistence: { file: { path: '/data/online.db' } },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.onlineStore?.persistence?.file?.path).toBe('/data/online.db');
+    });
+
+    it('should include online store DB persistence', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        onlinePersistenceType: PersistenceType.DB,
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          onlineStore: {
+            persistence: { store: { type: 'redis', secretRef: { name: 's' } } },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.onlineStore?.persistence?.store?.type).toBe('redis');
+    });
+  });
+
+  describe('offline store', () => {
+    it('should include offline store when enabled', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        offlineStoreEnabled: true,
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.offlineStore).toBeDefined();
+    });
+
+    it('should not include offline store when disabled', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        offlineStoreEnabled: false,
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.offlineStore).toBeUndefined();
+    });
+
+    it('should include offline store file persistence when type is set', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        offlineStoreEnabled: true,
+        offlinePersistenceType: PersistenceType.FILE,
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          offlineStore: {
+            persistence: { file: { type: 'duckdb' } },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.offlineStore?.persistence?.file?.type).toBe('duckdb');
+    });
+
+    it('should include offline store DB persistence when type is set', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        offlineStoreEnabled: true,
+        offlinePersistenceType: PersistenceType.DB,
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          offlineStore: {
+            persistence: { store: { type: 'postgres', secretRef: { name: 'pg-secret' } } },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.offlineStore?.persistence?.store?.type).toBe('postgres');
+    });
+
+    it('should include offline store envFrom when secret is provided', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        offlineStoreEnabled: true,
+        offlineStoreSecretName: 'offline-creds',
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.offlineStore?.server?.envFrom).toEqual([
+        { secretRef: { name: 'offline-creds' } },
+      ]);
+    });
+  });
+
+  describe('scaling', () => {
+    it('should include HPA scaling config', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        scalingEnabled: true,
+        scalingMode: ScalingMode.HPA,
+        hpaMinReplicas: 2,
+        hpaMaxReplicas: 5,
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.scaling?.autoscaling).toEqual({
+        minReplicas: 2,
+        maxReplicas: 5,
+      });
+      expect(spec.replicas).toBeUndefined();
+    });
+
+    it('should include static replicas when scaling is static', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        scalingEnabled: true,
+        scalingMode: ScalingMode.STATIC,
+        replicas: 3,
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.replicas).toBe(3);
+      expect(spec.services?.scaling).toBeUndefined();
+    });
+
+    it('should not include replicas when scaling is disabled', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        scalingEnabled: false,
+        replicas: 5,
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.replicas).toBeUndefined();
+    });
+  });
+
+  describe('advanced options', () => {
+    it('should include authorization config', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        authzType: AuthzType.OIDC,
+        authz: { oidc: { secretRef: { name: 'oidc-secret' } } },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.authz).toEqual({ oidc: { secretRef: { name: 'oidc-secret' } } });
+    });
+
+    it('should not include authz when AuthzType is NONE', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        authzType: AuthzType.NONE,
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.authz).toBeUndefined();
+    });
+
+    it('should include cronJob when provided', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        cronJob: { schedule: '*/5 * * * *' },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.cronJob).toEqual({ schedule: '*/5 * * * *' });
+    });
+
+    it('should include batch engine when enabled with configMap', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        batchEngineEnabled: true,
+        batchEngineConfigMapName: 'spark-config',
+        batchEngineConfigMapKey: 'config.yaml',
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.batchEngine).toEqual({
+        configMapRef: { name: 'spark-config' },
+        configMapKey: 'config.yaml',
+      });
+    });
+
+    it('should not include batch engine when disabled', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        batchEngineEnabled: false,
+        batchEngineConfigMapName: 'spark-config',
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.batchEngine).toBeUndefined();
+    });
+
+    it('should include disableInitContainers when true', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          disableInitContainers: true,
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.disableInitContainers).toBe(true);
+    });
+
+    it('should include podDisruptionBudgets when set', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          podDisruptionBudgets: { minAvailable: 1 },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.podDisruptionBudgets).toEqual({ minAvailable: 1 });
+    });
+
+    it('should include runFeastApplyOnInit as false when set', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          runFeastApplyOnInit: false,
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.runFeastApplyOnInit).toBe(false);
+    });
+  });
+
+  describe('feastProjectDir', () => {
+    it('should not set feastProjectDir for NONE type', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        projectDirType: ProjectDirType.NONE,
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.feastProjectDir).toBeUndefined();
+    });
+
+    it('should strip stale git config when user switches back to NONE', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        projectDirType: ProjectDirType.NONE,
+        feastProjectDir: {
+          git: { url: 'https://github.com/example/repo.git', ref: 'main' },
+        },
+        gitSecretName: 'git-creds',
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.feastProjectDir).toBeUndefined();
+    });
+
+    it('should include git config with envFrom when git secret is provided', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        projectDirType: ProjectDirType.GIT,
+        feastProjectDir: {
+          git: { url: 'https://github.com/example/repo.git', ref: 'main' },
+        },
+        gitSecretName: 'git-creds',
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.feastProjectDir?.git?.envFrom).toEqual([{ secretRef: { name: 'git-creds' } }]);
+    });
+
+    it('should not include git envFrom when git secret is empty', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        projectDirType: ProjectDirType.GIT,
+        feastProjectDir: {
+          git: { url: 'https://github.com/example/repo.git', ref: 'main' },
+        },
+        gitSecretName: '',
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.feastProjectDir?.git?.envFrom).toBeUndefined();
+    });
+  });
+
+  describe('server config cleaning', () => {
+    it('should strip empty resource values from server config', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          onlineStore: {
+            server: {
+              resources: {
+                requests: { cpu: '', memory: '256Mi' },
+                limits: { cpu: '', memory: '' },
+              },
+            },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      const resources = spec.services?.onlineStore?.server?.resources;
+      expect(resources?.requests).toEqual({ memory: '256Mi' });
+      expect(resources?.limits).toBeUndefined();
+    });
+
+    it('should include logLevel when set', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          onlineStore: {
+            server: { logLevel: 'debug' },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.onlineStore?.server?.logLevel).toBe('debug');
+    });
+
+    it('should include worker configs when set', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          onlineStore: {
+            server: {
+              workerConfigs: { workers: 4, workerConnections: 100 },
+            },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      const wc = spec.services?.onlineStore?.server?.workerConfigs;
+      expect(wc?.workers).toBe(4);
+      expect(wc?.workerConnections).toBe(100);
+    });
+
+    it('should include all worker config fields when set', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          onlineStore: {
+            server: {
+              workerConfigs: {
+                workers: 2,
+                workerConnections: 500,
+                maxRequests: 1000,
+                maxRequestsJitter: 50,
+                keepAliveTimeout: 30,
+                registryTTLSeconds: 60,
+              },
+            },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      const wc = spec.services?.onlineStore?.server?.workerConfigs;
+      expect(wc).toEqual({
+        workers: 2,
+        workerConnections: 500,
+        maxRequests: 1000,
+        maxRequestsJitter: 50,
+        keepAliveTimeout: 30,
+        registryTTLSeconds: 60,
+      });
+    });
+
+    it('should include metrics and image when set on server config', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          onlineStore: {
+            server: { metrics: true, image: 'quay.io/feast:latest' },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      expect(spec.services?.onlineStore?.server?.metrics).toBe(true);
+      expect(spec.services?.onlineStore?.server?.image).toBe('quay.io/feast:latest');
+    });
+
+    it('should include both requests and limits in resources when non-empty', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          onlineStore: {
+            server: {
+              resources: {
+                requests: { cpu: '100m', memory: '256Mi' },
+                limits: { cpu: '500m', memory: '512Mi' },
+              },
+            },
+          },
+        },
+      });
+      const spec = buildFormSpec(data, false);
+      const resources = spec.services?.onlineStore?.server?.resources;
+      expect(resources?.requests).toEqual({ cpu: '100m', memory: '256Mi' });
+      expect(resources?.limits).toEqual({ cpu: '500m', memory: '512Mi' });
+    });
+  });
+});
+
+describe('formSpecToYaml', () => {
+  it('should produce valid YAML structure with apiVersion, kind, metadata, spec', () => {
+    const data = makeFormData({ feastProject: 'test', namespace: 'test-ns' });
+    const spec = buildFormSpec(data, false);
+    const yaml = formSpecToYaml(spec);
+
+    expect(yaml).toContain('apiVersion: feast.dev/v1');
+    expect(yaml).toContain('kind: FeatureStore');
+    expect(yaml).toContain('name: test');
+    expect(yaml).toContain('namespace: test-ns');
+    expect(yaml).toContain('feastProject: test');
+  });
+
+  it('should include labels in metadata when present', () => {
+    const data = makeFormData({ feastProject: 'test', namespace: 'ns' });
+    const spec = buildFormSpec(data, true);
+    const yaml = formSpecToYaml(spec);
+
+    expect(yaml).toContain('labels:');
+    expect(yaml).toContain(`${FEATURE_STORE_UI_LABEL_KEY}: ${FEATURE_STORE_UI_LABEL_VALUE}`);
+  });
+
+  it('should not include labels in metadata when absent', () => {
+    const data = makeFormData({ feastProject: 'test', namespace: 'ns' });
+    const spec = buildFormSpec(data, false);
+    const yaml = formSpecToYaml(spec);
+
+    expect(yaml).not.toContain('labels:');
+  });
+
+  it('should handle nested services in YAML output', () => {
+    const data = makeFormData({
+      feastProject: 'test',
+      namespace: 'ns',
+      onlinePersistenceType: PersistenceType.DB,
+      services: {
+        registry: { local: { server: { restAPI: true, grpc: true } } },
+        onlineStore: {
+          persistence: { store: { type: 'redis', secretRef: { name: 'redis-secret' } } },
+        },
+      },
+    });
+    const spec = buildFormSpec(data, false);
+    const yaml = formSpecToYaml(spec);
+
+    expect(yaml).toContain('services:');
+    expect(yaml).toContain('onlineStore:');
+    expect(yaml).toContain('type: redis');
+  });
+
+  it('should render envFrom with correct nested indentation', () => {
+    const data = makeFormData({
+      feastProject: 'test',
+      namespace: 'ns',
+      registrySecretName: 's3-creds',
+      registryPersistenceType: PersistenceType.FILE,
+      services: {
+        registry: {
+          local: {
+            server: { restAPI: true, grpc: true },
+            persistence: { file: { path: 's3://bucket/registry.db' } },
+          },
+        },
+      },
+    });
+    const spec = buildFormSpec(data, false);
+    const yaml = formSpecToYaml(spec);
+    const lines = yaml.split('\n');
+
+    const envFromIdx = lines.findIndex((l) => l.includes('envFrom:'));
+    expect(envFromIdx).toBeGreaterThan(-1);
+
+    const secretRefLine = lines[envFromIdx + 1];
+    const nameLine = lines[envFromIdx + 2];
+    expect(secretRefLine).toMatch(/^\s+- secretRef:/);
+    expect(nameLine).toMatch(/^\s+name: s3-creds/);
+
+    const secretRefIndent = secretRefLine.search(/\S/);
+    const nameIndent = nameLine.search(/\S/);
+    expect(nameIndent).toBeGreaterThan(secretRefIndent);
+  });
+});

--- a/packages/feature-store/src/screens/create/__tests__/validationUtils.spec.ts
+++ b/packages/feature-store/src/screens/create/__tests__/validationUtils.spec.ts
@@ -1,0 +1,644 @@
+import { validateFeatureStoreForm, isFormValid, StepValidation } from '../validationUtils';
+import {
+  FeatureStoreFormData,
+  RegistryType,
+  PersistenceType,
+  AuthzType,
+  ProjectDirType,
+  RemoteRegistryType,
+  ScalingMode,
+} from '../types';
+import { DEFAULT_FEATURE_STORE_FORM_DATA } from '../useCreateFeatureStoreProjectState';
+
+const makeFormData = (overrides: Partial<FeatureStoreFormData> = {}): FeatureStoreFormData => ({
+  ...DEFAULT_FEATURE_STORE_FORM_DATA,
+  ...overrides,
+});
+
+describe('validateFeatureStoreForm', () => {
+  describe('projectBasics', () => {
+    it('should fail when name is empty', () => {
+      const data = makeFormData({ feastProject: '', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(false);
+      expect(result.projectBasics.message).toBe('Name is required.');
+    });
+
+    it('should fail when name is only whitespace', () => {
+      const data = makeFormData({ feastProject: '   ', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(false);
+      expect(result.projectBasics.message).toBe('Name is required.');
+    });
+
+    it('should fail when name has underscores (invalid RFC 1123)', () => {
+      const data = makeFormData({ feastProject: 'my_store', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(false);
+      expect(result.projectBasics.message).toContain('lowercase alphanumeric');
+    });
+
+    it('should fail when name has uppercase characters', () => {
+      const data = makeFormData({ feastProject: 'MyStore', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(false);
+    });
+
+    it('should fail when name starts with a hyphen', () => {
+      const data = makeFormData({ feastProject: '-store', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(false);
+    });
+
+    it('should fail when name ends with a hyphen', () => {
+      const data = makeFormData({ feastProject: 'store-', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(false);
+    });
+
+    it('should fail when name starts with a dot', () => {
+      const data = makeFormData({ feastProject: '.store', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(false);
+    });
+
+    it('should pass for valid lowercase alphanumeric name', () => {
+      const data = makeFormData({ feastProject: 'mystore', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(true);
+    });
+
+    it('should pass for name with hyphens', () => {
+      const data = makeFormData({ feastProject: 'my-feature-store', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(true);
+    });
+
+    it('should pass for name with dots', () => {
+      const data = makeFormData({ feastProject: 'my.store', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(true);
+    });
+
+    it('should pass for single character name', () => {
+      const data = makeFormData({ feastProject: 'a', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(true);
+    });
+
+    it('should fail when name is a duplicate', () => {
+      const data = makeFormData({ feastProject: 'mystore', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, ['mystore', 'other']);
+      expect(result.projectBasics.valid).toBe(false);
+      expect(result.projectBasics.message).toBe('A feature store with this name already exists.');
+    });
+
+    it('should pass when name is not a duplicate', () => {
+      const data = makeFormData({ feastProject: 'mystore', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, ['other']);
+      expect(result.projectBasics.valid).toBe(true);
+    });
+
+    it('should fail when namespace is empty', () => {
+      const data = makeFormData({ feastProject: 'mystore', namespace: '' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.projectBasics.valid).toBe(false);
+      expect(result.projectBasics.message).toBe('Namespace is required.');
+    });
+  });
+
+  describe('registry', () => {
+    it('should pass with default local registry (restAPI and grpc true)', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.LOCAL,
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(true);
+    });
+
+    it('should fail when restAPI is disabled even if grpc is enabled', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.LOCAL,
+        services: {
+          registry: {
+            local: {
+              server: { restAPI: false, grpc: true },
+            },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(false);
+      expect(result.registry.message).toContain('REST API must be enabled');
+    });
+
+    it('should fail when both restAPI and grpc are disabled', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.LOCAL,
+        services: {
+          registry: {
+            local: {
+              server: { restAPI: false, grpc: false },
+            },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(false);
+      expect(result.registry.message).toContain('REST API must be enabled');
+    });
+
+    it('should pass when restAPI is enabled', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.LOCAL,
+        services: {
+          registry: {
+            local: {
+              server: { restAPI: true, grpc: false },
+            },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(true);
+    });
+
+    it('should fail when local registry DB type is missing', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.LOCAL,
+        registryPersistenceType: PersistenceType.DB,
+        services: {
+          registry: {
+            local: {
+              server: { restAPI: true, grpc: true },
+              persistence: {
+                store: { type: '', secretRef: { name: 'secret' } },
+              },
+            },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(false);
+      expect(result.registry.message).toBe('Registry DB store type is required.');
+    });
+
+    it('should fail when local registry DB secret is missing', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.LOCAL,
+        registryPersistenceType: PersistenceType.DB,
+        services: {
+          registry: {
+            local: {
+              server: { restAPI: true, grpc: true },
+              persistence: {
+                store: { type: 'sql', secretRef: { name: '' } },
+              },
+            },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(false);
+      expect(result.registry.message).toBe('Registry DB store secret reference is required.');
+    });
+
+    it('should fail when remote hostname is empty', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.REMOTE,
+        remoteRegistryType: RemoteRegistryType.HOSTNAME,
+        services: { registry: { remote: { hostname: '' } } },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(false);
+      expect(result.registry.message).toBe('Remote registry hostname is required.');
+    });
+
+    it('should pass when remote hostname is provided', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.REMOTE,
+        remoteRegistryType: RemoteRegistryType.HOSTNAME,
+        services: { registry: { remote: { hostname: 'registry.example.com:443' } } },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(true);
+    });
+
+    it('should fail when TLS ConfigMap name is empty', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.REMOTE,
+        remoteRegistryType: RemoteRegistryType.HOSTNAME,
+        services: {
+          registry: {
+            remote: {
+              hostname: 'registry.example.com:443',
+              tls: { configMapRef: { name: '' }, certName: 'service-ca.crt' },
+            },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(false);
+      expect(result.registry.message).toBe('TLS CA certificate ConfigMap is required.');
+    });
+
+    it('should fail when TLS cert key name is empty', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.REMOTE,
+        remoteRegistryType: RemoteRegistryType.HOSTNAME,
+        services: {
+          registry: {
+            remote: {
+              hostname: 'registry.example.com:443',
+              tls: { configMapRef: { name: 'ca-bundle' }, certName: '' },
+            },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(false);
+      expect(result.registry.message).toBe('TLS certificate key name is required.');
+    });
+
+    it('should fail when feastRef name is empty', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        registryType: RegistryType.REMOTE,
+        remoteRegistryType: RemoteRegistryType.FEAST_REF,
+        services: { registry: { remote: { feastRef: { name: '' } } } },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.registry.valid).toBe(false);
+      expect(result.registry.message).toContain('FeatureStore reference name is required');
+    });
+  });
+
+  describe('storeConfig', () => {
+    it('should pass with default file persistence', () => {
+      const data = makeFormData({ feastProject: 'test', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.storeConfig.valid).toBe(true);
+    });
+
+    it('should fail when offline store DB type is missing', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        offlineStoreEnabled: true,
+        offlinePersistenceType: PersistenceType.DB,
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          offlineStore: {
+            persistence: { store: { type: '', secretRef: { name: 'secret' } } },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.storeConfig.valid).toBe(false);
+      expect(result.storeConfig.message).toBe('Offline store DB type is required.');
+    });
+
+    it('should fail when offline store DB secret is missing', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        offlineStoreEnabled: true,
+        offlinePersistenceType: PersistenceType.DB,
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          offlineStore: {
+            persistence: { store: { type: 'postgres', secretRef: { name: '' } } },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.storeConfig.valid).toBe(false);
+      expect(result.storeConfig.message).toBe('Offline store DB secret reference is required.');
+    });
+
+    it('should fail when online store DB type is missing', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        onlinePersistenceType: PersistenceType.DB,
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          onlineStore: {
+            persistence: { store: { type: '', secretRef: { name: 'secret' } } },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.storeConfig.valid).toBe(false);
+      expect(result.storeConfig.message).toBe('Online store DB type is required.');
+    });
+
+    it('should fail when online store DB secret is missing', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        onlinePersistenceType: PersistenceType.DB,
+        services: {
+          registry: { local: { server: { restAPI: true, grpc: true } } },
+          onlineStore: {
+            persistence: { store: { type: 'redis', secretRef: { name: '' } } },
+          },
+        },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.storeConfig.valid).toBe(false);
+      expect(result.storeConfig.message).toBe('Online store DB secret reference is required.');
+    });
+
+    it('should pass when offline store is disabled (regardless of config)', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        offlineStoreEnabled: false,
+        offlinePersistenceType: PersistenceType.DB,
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.storeConfig.valid).toBe(true);
+    });
+  });
+
+  describe('advanced', () => {
+    it('should pass with default config', () => {
+      const data = makeFormData({ feastProject: 'test', namespace: 'ns' });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.advanced.valid).toBe(true);
+    });
+
+    it('should fail when OIDC is selected but secret is empty', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        authzType: AuthzType.OIDC,
+        authz: { oidc: { secretRef: { name: '' } } },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.advanced.valid).toBe(false);
+      expect(result.advanced.message).toBe('OIDC secret reference is required.');
+    });
+
+    it('should pass when OIDC is selected with valid secret', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        authzType: AuthzType.OIDC,
+        authz: { oidc: { secretRef: { name: 'oidc-secret' } } },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.advanced.valid).toBe(true);
+    });
+
+    it('should fail when Git is selected but URL is empty', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        projectDirType: ProjectDirType.GIT,
+        feastProjectDir: { git: { url: '', ref: '' } },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.advanced.valid).toBe(false);
+      expect(result.advanced.message).toBe('Git repository URL is required.');
+    });
+
+    it('should pass when Git is selected with valid URL', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        projectDirType: ProjectDirType.GIT,
+        feastProjectDir: { git: { url: 'https://github.com/example/repo.git', ref: 'main' } },
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.advanced.valid).toBe(true);
+    });
+
+    it('should fail when batch engine is enabled but ConfigMap name is empty', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        batchEngineEnabled: true,
+        batchEngineConfigMapName: '',
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.advanced.valid).toBe(false);
+      expect(result.advanced.message).toBe('Batch compute engine ConfigMap is required.');
+    });
+
+    it('should pass when batch engine is enabled with a ConfigMap selected', () => {
+      const data = makeFormData({
+        feastProject: 'test',
+        namespace: 'ns',
+        batchEngineEnabled: true,
+        batchEngineConfigMapName: 'spark-config',
+      });
+      const result = validateFeatureStoreForm(data, []);
+      expect(result.advanced.valid).toBe(true);
+    });
+
+    describe('scaling validation', () => {
+      it('should fail when HPA max < min replicas', () => {
+        const data = makeFormData({
+          feastProject: 'test',
+          namespace: 'ns',
+          scalingEnabled: true,
+          scalingMode: ScalingMode.HPA,
+          hpaMinReplicas: 5,
+          hpaMaxReplicas: 2,
+          onlinePersistenceType: PersistenceType.DB,
+          registryPersistenceType: PersistenceType.DB,
+          registryType: RegistryType.LOCAL,
+          services: {
+            registry: {
+              local: {
+                server: { restAPI: true, grpc: true },
+                persistence: { store: { type: 'sql', secretRef: { name: 's' } } },
+              },
+            },
+            onlineStore: {
+              persistence: { store: { type: 'redis', secretRef: { name: 's' } } },
+            },
+          },
+        });
+        const result = validateFeatureStoreForm(data, []);
+        expect(result.advanced.valid).toBe(false);
+        expect(result.advanced.message).toContain('maximum replicas');
+      });
+
+      it('should fail when HPA scaling with file-based online store', () => {
+        const data = makeFormData({
+          feastProject: 'test',
+          namespace: 'ns',
+          scalingEnabled: true,
+          scalingMode: ScalingMode.HPA,
+          hpaMinReplicas: 1,
+          hpaMaxReplicas: 3,
+          onlinePersistenceType: PersistenceType.FILE,
+          registryType: RegistryType.LOCAL,
+          registryPersistenceType: PersistenceType.DB,
+          services: {
+            registry: {
+              local: {
+                server: { restAPI: true, grpc: true },
+                persistence: { store: { type: 'sql', secretRef: { name: 's' } } },
+              },
+            },
+          },
+        });
+        const result = validateFeatureStoreForm(data, []);
+        expect(result.advanced.valid).toBe(false);
+        expect(result.advanced.message).toContain('DB-backed persistence for the online store');
+      });
+
+      it('should fail when HPA scaling with file-based local registry', () => {
+        const data = makeFormData({
+          feastProject: 'test',
+          namespace: 'ns',
+          scalingEnabled: true,
+          scalingMode: ScalingMode.HPA,
+          hpaMinReplicas: 1,
+          hpaMaxReplicas: 3,
+          onlinePersistenceType: PersistenceType.DB,
+          registryType: RegistryType.LOCAL,
+          registryPersistenceType: PersistenceType.FILE,
+          services: {
+            registry: {
+              local: {
+                server: { restAPI: true, grpc: true },
+              },
+            },
+            onlineStore: {
+              persistence: { store: { type: 'redis', secretRef: { name: 's' } } },
+            },
+          },
+        });
+        const result = validateFeatureStoreForm(data, []);
+        expect(result.advanced.valid).toBe(false);
+        expect(result.advanced.message).toContain('DB-backed or remote registry');
+      });
+
+      it('should pass when HPA scaling with S3 registry path', () => {
+        const data = makeFormData({
+          feastProject: 'test',
+          namespace: 'ns',
+          scalingEnabled: true,
+          scalingMode: ScalingMode.HPA,
+          hpaMinReplicas: 1,
+          hpaMaxReplicas: 3,
+          onlinePersistenceType: PersistenceType.DB,
+          registryType: RegistryType.LOCAL,
+          registryPersistenceType: PersistenceType.FILE,
+          services: {
+            registry: {
+              local: {
+                server: { restAPI: true, grpc: true },
+                persistence: { file: { path: 's3://my-bucket/registry.db' } },
+              },
+            },
+            onlineStore: {
+              persistence: { store: { type: 'redis', secretRef: { name: 's' } } },
+            },
+          },
+        });
+        const result = validateFeatureStoreForm(data, []);
+        expect(result.advanced.valid).toBe(true);
+      });
+
+      it('should pass when static scaling with 1 replica (no multi-replica constraints)', () => {
+        const data = makeFormData({
+          feastProject: 'test',
+          namespace: 'ns',
+          scalingEnabled: true,
+          scalingMode: ScalingMode.STATIC,
+          replicas: 1,
+        });
+        const result = validateFeatureStoreForm(data, []);
+        expect(result.advanced.valid).toBe(true);
+      });
+
+      it('should fail when static scaling > 1 replica with file-based offline store', () => {
+        const data = makeFormData({
+          feastProject: 'test',
+          namespace: 'ns',
+          scalingEnabled: true,
+          scalingMode: ScalingMode.STATIC,
+          replicas: 3,
+          offlineStoreEnabled: true,
+          offlinePersistenceType: PersistenceType.FILE,
+          onlinePersistenceType: PersistenceType.DB,
+          registryType: RegistryType.LOCAL,
+          registryPersistenceType: PersistenceType.DB,
+          services: {
+            registry: {
+              local: {
+                server: { restAPI: true, grpc: true },
+                persistence: { store: { type: 'sql', secretRef: { name: 's' } } },
+              },
+            },
+            onlineStore: {
+              persistence: { store: { type: 'redis', secretRef: { name: 's' } } },
+            },
+          },
+        });
+        const result = validateFeatureStoreForm(data, []);
+        expect(result.advanced.valid).toBe(false);
+        expect(result.advanced.message).toContain('DB-backed persistence for the offline store');
+      });
+    });
+  });
+});
+
+describe('isFormValid', () => {
+  it('should return true when all steps are valid', () => {
+    const validation: StepValidation = {
+      projectBasics: { valid: true },
+      registry: { valid: true },
+      storeConfig: { valid: true },
+      advanced: { valid: true },
+    };
+    expect(isFormValid(validation)).toBe(true);
+  });
+
+  it('should return false when any step is invalid', () => {
+    const validation: StepValidation = {
+      projectBasics: { valid: true },
+      registry: { valid: false, message: 'error' },
+      storeConfig: { valid: true },
+      advanced: { valid: true },
+    };
+    expect(isFormValid(validation)).toBe(false);
+  });
+
+  it('should return false when multiple steps are invalid', () => {
+    const validation: StepValidation = {
+      projectBasics: { valid: false, message: 'err1' },
+      registry: { valid: false, message: 'err2' },
+      storeConfig: { valid: true },
+      advanced: { valid: true },
+    };
+    expect(isFormValid(validation)).toBe(false);
+  });
+});

--- a/packages/feature-store/src/screens/create/types.ts
+++ b/packages/feature-store/src/screens/create/types.ts
@@ -1,0 +1,134 @@
+import { FeastServices, FeastProjectDir, FeastAuthzConfig, FeastCronJob } from '../../k8sTypes';
+
+export enum RegistryType {
+  LOCAL = 'local',
+  REMOTE = 'remote',
+}
+
+export enum PersistenceType {
+  FILE = 'file',
+  DB = 'store',
+}
+
+export enum RemoteRegistryType {
+  HOSTNAME = 'hostname',
+  FEAST_REF = 'feastRef',
+}
+
+export enum AuthzType {
+  NONE = 'none',
+  KUBERNETES = 'kubernetes',
+  OIDC = 'oidc',
+}
+
+export enum ProjectDirType {
+  NONE = 'none',
+  INIT = 'init',
+  GIT = 'git',
+}
+
+export enum ScalingMode {
+  STATIC = 'static',
+  HPA = 'hpa',
+}
+
+export type FeatureStoreFormData = {
+  feastProject: string;
+  namespace: string;
+  projectDirType: ProjectDirType;
+  feastProjectDir?: FeastProjectDir;
+
+  registryType: RegistryType;
+  services?: FeastServices;
+
+  authzType: AuthzType;
+  authz?: FeastAuthzConfig;
+
+  cronJob?: FeastCronJob;
+  replicas: number;
+
+  offlinePersistenceType: PersistenceType;
+  onlinePersistenceType: PersistenceType;
+  registryPersistenceType: PersistenceType;
+
+  remoteRegistryType: RemoteRegistryType;
+
+  offlineStoreEnabled: boolean;
+
+  registrySecretName: string;
+  onlineStoreSecretName: string;
+  offlineStoreSecretName: string;
+
+  scalingEnabled: boolean;
+  scalingMode: ScalingMode;
+  hpaMinReplicas: number;
+  hpaMaxReplicas: number;
+
+  batchEngineEnabled: boolean;
+  batchEngineConfigMapName: string;
+  batchEngineConfigMapKey: string;
+
+  gitSecretName: string;
+};
+
+export const FEAST_PROJECT_NAME_REGEX = /^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/;
+
+export const VALID_OFFLINE_FILE_TYPES = ['file', 'dask', 'duckdb'];
+export const VALID_OFFLINE_DB_TYPES = [
+  'snowflake.offline',
+  'bigquery',
+  'redshift',
+  'spark',
+  'postgres',
+  'trino',
+  'athena',
+  'mssql',
+  'couchbase.offline',
+  'clickhouse',
+  'ray',
+  'oracle',
+];
+
+export const VALID_ONLINE_DB_TYPES = [
+  'snowflake.online',
+  'redis',
+  'datastore',
+  'dynamodb',
+  'bigtable',
+  'postgres',
+  'cassandra',
+  'mysql',
+  'hazelcast',
+  'singlestore',
+  'hbase',
+  'elasticsearch',
+  'qdrant',
+  'couchbase.online',
+  'milvus',
+  'hybrid',
+  'mongodb',
+  'aerospike',
+];
+
+export const VALID_REGISTRY_DB_TYPES = ['sql', 'snowflake.registry'];
+
+export const VALID_INIT_TEMPLATES = [
+  'local',
+  'gcp',
+  'aws',
+  'snowflake',
+  'spark',
+  'postgres',
+  'hbase',
+  'cassandra',
+  'hazelcast',
+  'couchbase',
+  'clickhouse',
+  'milvus',
+  'ray',
+  'ray_rag',
+  'pytorch_nlp',
+];
+
+export const VALID_LOG_LEVELS = ['debug', 'info', 'warning', 'error', 'critical'];
+export const VALID_CONCURRENCY_POLICIES = ['Allow', 'Forbid', 'Replace'];

--- a/packages/feature-store/src/screens/create/useCreateFeatureStoreProjectState.ts
+++ b/packages/feature-store/src/screens/create/useCreateFeatureStoreProjectState.ts
@@ -1,0 +1,66 @@
+import useGenericObjectState, {
+  GenericObjectState,
+} from '@odh-dashboard/ui-core/utilities/useGenericObjectState';
+import {
+  FeatureStoreFormData,
+  RegistryType,
+  PersistenceType,
+  AuthzType,
+  ProjectDirType,
+  RemoteRegistryType,
+  ScalingMode,
+} from './types';
+
+export const DEFAULT_FEATURE_STORE_FORM_DATA: FeatureStoreFormData = {
+  feastProject: '',
+  namespace: '',
+
+  projectDirType: ProjectDirType.NONE,
+  feastProjectDir: undefined,
+
+  registryType: RegistryType.LOCAL,
+  services: {
+    registry: {
+      local: {
+        server: {
+          restAPI: true,
+          grpc: true,
+        },
+      },
+    },
+  },
+
+  authzType: AuthzType.NONE,
+  authz: undefined,
+
+  cronJob: undefined,
+  replicas: 1,
+
+  offlinePersistenceType: PersistenceType.FILE,
+  onlinePersistenceType: PersistenceType.FILE,
+  registryPersistenceType: PersistenceType.FILE,
+
+  remoteRegistryType: RemoteRegistryType.FEAST_REF,
+
+  offlineStoreEnabled: false,
+
+  registrySecretName: '',
+  onlineStoreSecretName: '',
+  offlineStoreSecretName: '',
+
+  scalingEnabled: false,
+  scalingMode: ScalingMode.STATIC,
+  hpaMinReplicas: 1,
+  hpaMaxReplicas: 3,
+
+  batchEngineEnabled: false,
+  batchEngineConfigMapName: '',
+  batchEngineConfigMapKey: '',
+
+  gitSecretName: '',
+};
+
+const useCreateFeatureStoreProjectState = (): GenericObjectState<FeatureStoreFormData> =>
+  useGenericObjectState<FeatureStoreFormData>(DEFAULT_FEATURE_STORE_FORM_DATA);
+
+export default useCreateFeatureStoreProjectState;

--- a/packages/feature-store/src/screens/create/utils.ts
+++ b/packages/feature-store/src/screens/create/utils.ts
@@ -1,0 +1,311 @@
+import YAML from 'yaml';
+import {
+  FeatureStoreFormData,
+  RegistryType,
+  PersistenceType,
+  AuthzType,
+  ScalingMode,
+  ProjectDirType,
+} from './types';
+import {
+  FeastServices,
+  FeastAuthzConfig,
+  FeastServerConfigs,
+  FeastRegistryServerConfigs,
+  FeastWorkerConfigs,
+} from '../../k8sTypes';
+import { FeatureStoreFormSpec } from '../../api/featureStores';
+import { FEATURE_STORE_UI_LABEL_KEY, FEATURE_STORE_UI_LABEL_VALUE } from '../../const';
+
+const buildEnvFrom = (secretName: string): Record<string, unknown>[] | undefined => {
+  if (!secretName.trim()) {
+    return undefined;
+  }
+  return [{ secretRef: { name: secretName.trim() } }];
+};
+
+const cleanWorkerConfigs = (wc: FeastWorkerConfigs | undefined): FeastWorkerConfigs | undefined => {
+  if (!wc) {
+    return undefined;
+  }
+  const cleaned: FeastWorkerConfigs = {};
+  if (wc.workers != null) {
+    cleaned.workers = wc.workers;
+  }
+  if (wc.workerConnections != null) {
+    cleaned.workerConnections = wc.workerConnections;
+  }
+  if (wc.maxRequests != null) {
+    cleaned.maxRequests = wc.maxRequests;
+  }
+  if (wc.maxRequestsJitter != null) {
+    cleaned.maxRequestsJitter = wc.maxRequestsJitter;
+  }
+  if (wc.keepAliveTimeout != null) {
+    cleaned.keepAliveTimeout = wc.keepAliveTimeout;
+  }
+  if (wc.registryTTLSeconds != null) {
+    cleaned.registryTTLSeconds = wc.registryTTLSeconds;
+  }
+  return Object.keys(cleaned).length > 0 ? cleaned : undefined;
+};
+
+const cleanServerConfig = (
+  config: FeastServerConfigs | undefined,
+): FeastServerConfigs | undefined => {
+  if (!config) {
+    return undefined;
+  }
+  const cleaned: FeastServerConfigs = {};
+  if (config.logLevel) {
+    cleaned.logLevel = config.logLevel;
+  }
+  if (config.metrics != null) {
+    cleaned.metrics = config.metrics;
+  }
+  if (config.image) {
+    cleaned.image = config.image;
+  }
+  if (config.resources) {
+    const requests = config.resources.requests ?? {};
+    const limits = config.resources.limits ?? {};
+    const cleanedRequests = Object.fromEntries(
+      Object.entries(requests).filter(([, v]) => v !== ''),
+    );
+    const cleanedLimits = Object.fromEntries(Object.entries(limits).filter(([, v]) => v !== ''));
+    const cleanedResources: { requests?: Record<string, string>; limits?: Record<string, string> } =
+      {};
+    if (Object.keys(cleanedRequests).length > 0) {
+      cleanedResources.requests = cleanedRequests;
+    }
+    if (Object.keys(cleanedLimits).length > 0) {
+      cleanedResources.limits = cleanedLimits;
+    }
+    if (Object.keys(cleanedResources).length > 0) {
+      cleaned.resources = cleanedResources;
+    }
+  }
+  const wc = cleanWorkerConfigs(config.workerConfigs);
+  if (wc) {
+    cleaned.workerConfigs = wc;
+  }
+  return Object.keys(cleaned).length > 0 ? cleaned : undefined;
+};
+
+const buildServices = (data: FeatureStoreFormData): FeastServices | undefined => {
+  const services: FeastServices = {};
+
+  if (data.registryType === RegistryType.LOCAL) {
+    const rawRegistryServer = data.services?.registry?.local?.server;
+    const cleanedBase = cleanServerConfig(rawRegistryServer);
+    const registryServer: FeastRegistryServerConfigs = {
+      ...cleanedBase,
+      ...(rawRegistryServer?.restAPI != null && { restAPI: rawRegistryServer.restAPI }),
+      ...(rawRegistryServer?.grpc != null && { grpc: rawRegistryServer.grpc }),
+    };
+    const registryFilePath = data.services?.registry?.local?.persistence?.file?.path ?? '';
+    const registryIsObjectStore =
+      registryFilePath.startsWith('s3://') || registryFilePath.startsWith('gs://');
+    if (data.registryPersistenceType === PersistenceType.FILE && registryIsObjectStore) {
+      const registryEnvFrom = buildEnvFrom(data.registrySecretName);
+      if (registryEnvFrom) {
+        registryServer.envFrom = registryEnvFrom;
+      }
+    }
+
+    const localRegistry: FeastServices['registry'] = {
+      local: {
+        server: Object.keys(registryServer).length > 0 ? registryServer : undefined,
+      },
+    };
+
+    if (data.registryPersistenceType === PersistenceType.FILE) {
+      const filePersistence = data.services?.registry?.local?.persistence?.file;
+      if (
+        filePersistence?.path ||
+        filePersistence?.pvc ||
+        filePersistence?.cache_ttl_seconds ||
+        filePersistence?.cache_mode
+      ) {
+        localRegistry.local = {
+          ...localRegistry.local,
+          persistence: { file: filePersistence },
+        };
+      }
+    } else {
+      const storePersistence = data.services?.registry?.local?.persistence?.store;
+      if (storePersistence?.type) {
+        localRegistry.local = {
+          ...localRegistry.local,
+          persistence: { store: storePersistence },
+        };
+      }
+    }
+
+    services.registry = localRegistry;
+  } else {
+    services.registry = {
+      remote: data.services?.registry?.remote,
+    };
+  }
+
+  {
+    const onlineStore: FeastServices['onlineStore'] = {};
+
+    if (data.onlinePersistenceType === PersistenceType.FILE) {
+      const filePersistence = data.services?.onlineStore?.persistence?.file;
+      if (filePersistence?.path || filePersistence?.pvc) {
+        onlineStore.persistence = { file: filePersistence };
+      }
+    } else {
+      const storePersistence = data.services?.onlineStore?.persistence?.store;
+      if (storePersistence?.type) {
+        onlineStore.persistence = { store: storePersistence };
+      }
+    }
+
+    const cleanedOnlineServer = cleanServerConfig(data.services?.onlineStore?.server);
+    const onlineServer: FeastServerConfigs = cleanedOnlineServer ?? {};
+    const onlineEnvFrom = buildEnvFrom(data.onlineStoreSecretName);
+    if (onlineEnvFrom) {
+      onlineServer.envFrom = onlineEnvFrom;
+    }
+    if (Object.keys(onlineServer).length > 0) {
+      onlineStore.server = onlineServer;
+    }
+
+    services.onlineStore = onlineStore;
+  }
+
+  if (data.offlineStoreEnabled) {
+    const offlineStore: FeastServices['offlineStore'] = {};
+
+    if (data.offlinePersistenceType === PersistenceType.FILE) {
+      const filePersistence = data.services?.offlineStore?.persistence?.file;
+      if (filePersistence?.type || filePersistence?.pvc) {
+        offlineStore.persistence = { file: filePersistence };
+      }
+    } else {
+      const storePersistence = data.services?.offlineStore?.persistence?.store;
+      if (storePersistence?.type) {
+        offlineStore.persistence = { store: storePersistence };
+      }
+    }
+
+    const cleanedOfflineServer = cleanServerConfig(data.services?.offlineStore?.server);
+    const offlineServer: FeastServerConfigs = cleanedOfflineServer ?? {};
+    const offlineEnvFrom = buildEnvFrom(data.offlineStoreSecretName);
+    if (offlineEnvFrom) {
+      offlineServer.envFrom = offlineEnvFrom;
+    }
+    if (Object.keys(offlineServer).length > 0) {
+      offlineStore.server = offlineServer;
+    }
+
+    services.offlineStore = offlineStore;
+  }
+
+  if (data.services?.disableInitContainers) {
+    services.disableInitContainers = true;
+  }
+
+  if (data.services?.runFeastApplyOnInit === false) {
+    services.runFeastApplyOnInit = false;
+  }
+
+  if (data.scalingEnabled && data.scalingMode === ScalingMode.HPA) {
+    services.scaling = {
+      autoscaling: {
+        minReplicas: data.hpaMinReplicas,
+        maxReplicas: data.hpaMaxReplicas,
+      },
+    };
+  }
+
+  if (data.services?.podDisruptionBudgets) {
+    services.podDisruptionBudgets = data.services.podDisruptionBudgets;
+  }
+
+  return Object.keys(services).length > 0 ? services : undefined;
+};
+
+const buildAuthz = (data: FeatureStoreFormData): FeastAuthzConfig | undefined => {
+  if (data.authzType === AuthzType.NONE) {
+    return undefined;
+  }
+  return data.authz;
+};
+
+export const buildFormSpec = (
+  data: FeatureStoreFormData,
+  addUILabel: boolean,
+): FeatureStoreFormSpec => {
+  const labels: Record<string, string> = {};
+  if (addUILabel) {
+    labels[FEATURE_STORE_UI_LABEL_KEY] = FEATURE_STORE_UI_LABEL_VALUE;
+  }
+
+  let feastProjectDir =
+    data.projectDirType !== ProjectDirType.NONE ? data.feastProjectDir : undefined;
+  if (feastProjectDir?.git && data.gitSecretName.trim()) {
+    feastProjectDir = {
+      ...feastProjectDir,
+      git: {
+        ...feastProjectDir.git,
+        envFrom: [{ secretRef: { name: data.gitSecretName.trim() } }],
+      },
+    };
+  }
+
+  return {
+    feastProject: data.feastProject,
+    namespace: data.namespace,
+    feastProjectDir,
+    services: buildServices(data),
+    authz: buildAuthz(data),
+    cronJob: data.cronJob,
+    batchEngine:
+      data.batchEngineEnabled && data.batchEngineConfigMapName
+        ? {
+            configMapRef: { name: data.batchEngineConfigMapName },
+            ...(data.batchEngineConfigMapKey && { configMapKey: data.batchEngineConfigMapKey }),
+          }
+        : undefined,
+    replicas:
+      data.scalingEnabled && data.scalingMode === ScalingMode.STATIC ? data.replicas : undefined,
+    labels: Object.keys(labels).length > 0 ? labels : undefined,
+  };
+};
+
+const stripEmpty = (obj: unknown): unknown => {
+  if (Array.isArray(obj)) {
+    return obj.map(stripEmpty);
+  }
+  if (obj !== null && typeof obj === 'object') {
+    return Object.fromEntries(
+      Object.entries(obj)
+        .filter(([, v]) => v !== undefined && v !== null && v !== '')
+        .map(([k, v]) => [k, stripEmpty(v)]),
+    );
+  }
+  return obj;
+};
+
+export const formSpecToYaml = (formSpec: FeatureStoreFormSpec): string => {
+  const { namespace, labels, ...specData } = formSpec;
+
+  const cleanSpec = JSON.parse(JSON.stringify(specData));
+
+  const cr = {
+    apiVersion: 'feast.dev/v1',
+    kind: 'FeatureStore',
+    metadata: {
+      name: formSpec.feastProject,
+      namespace,
+      ...(labels && Object.keys(labels).length > 0 && { labels }),
+    },
+    spec: cleanSpec,
+  };
+
+  return YAML.stringify(stripEmpty(cr), { lineWidth: 0 }).trimEnd();
+};

--- a/packages/feature-store/src/screens/create/validationUtils.ts
+++ b/packages/feature-store/src/screens/create/validationUtils.ts
@@ -1,0 +1,195 @@
+import {
+  FeatureStoreFormData,
+  FEAST_PROJECT_NAME_REGEX,
+  RegistryType,
+  PersistenceType,
+  AuthzType,
+  RemoteRegistryType,
+  ProjectDirType,
+  ScalingMode,
+} from './types';
+
+export type ValidationResult = {
+  valid: boolean;
+  message?: string;
+};
+
+export type StepValidation = {
+  projectBasics: ValidationResult;
+  registry: ValidationResult;
+  storeConfig: ValidationResult;
+  advanced: ValidationResult;
+};
+
+const validateProjectBasics = (
+  data: FeatureStoreFormData,
+  existingProjectNames: string[],
+): ValidationResult => {
+  if (!data.feastProject.trim()) {
+    return { valid: false, message: 'Name is required.' };
+  }
+  if (!FEAST_PROJECT_NAME_REGEX.test(data.feastProject)) {
+    return {
+      valid: false,
+      message:
+        'Name must consist of lowercase alphanumeric characters, hyphens, or dots, ' +
+        'and must start and end with an alphanumeric character.',
+    };
+  }
+  if (existingProjectNames.includes(data.feastProject)) {
+    return { valid: false, message: 'A feature store with this name already exists.' };
+  }
+  if (!data.namespace.trim()) {
+    return { valid: false, message: 'Namespace is required.' };
+  }
+  return { valid: true };
+};
+
+const validateRegistry = (data: FeatureStoreFormData): ValidationResult => {
+  if (data.registryType === RegistryType.LOCAL) {
+    const localRegistry = data.services?.registry?.local;
+    const server = localRegistry?.server;
+    if (server?.restAPI !== true) {
+      return {
+        valid: false,
+        message:
+          'REST API must be enabled for the registry server. The Feature Store UI requires it.',
+      };
+    }
+    if (data.registryPersistenceType === PersistenceType.DB) {
+      const store = localRegistry?.persistence?.store;
+      if (!store?.type) {
+        return { valid: false, message: 'Registry DB store type is required.' };
+      }
+      if (!store.secretRef.name.trim()) {
+        return { valid: false, message: 'Registry DB store secret reference is required.' };
+      }
+    }
+  } else if (data.remoteRegistryType === RemoteRegistryType.HOSTNAME) {
+    const hostname = data.services?.registry?.remote?.hostname;
+    if (!hostname?.trim()) {
+      return { valid: false, message: 'Remote registry hostname is required.' };
+    }
+    const tls = data.services?.registry?.remote?.tls;
+    if (tls) {
+      if (!tls.configMapRef.name.trim()) {
+        return { valid: false, message: 'TLS CA certificate ConfigMap is required.' };
+      }
+      if (!tls.certName.trim()) {
+        return { valid: false, message: 'TLS certificate key name is required.' };
+      }
+    }
+  } else {
+    const feastRef = data.services?.registry?.remote?.feastRef;
+    if (!feastRef?.name.trim()) {
+      return {
+        valid: false,
+        message: 'FeatureStore reference name is required for remote registry.',
+      };
+    }
+  }
+  return { valid: true };
+};
+
+const validateStoreConfig = (data: FeatureStoreFormData): ValidationResult => {
+  if (data.offlineStoreEnabled && data.offlinePersistenceType === PersistenceType.DB) {
+    const store = data.services?.offlineStore?.persistence?.store;
+    if (!store?.type) {
+      return { valid: false, message: 'Offline store DB type is required.' };
+    }
+    if (!store.secretRef.name.trim()) {
+      return { valid: false, message: 'Offline store DB secret reference is required.' };
+    }
+  }
+
+  if (data.onlinePersistenceType === PersistenceType.DB) {
+    const store = data.services?.onlineStore?.persistence?.store;
+    if (!store?.type) {
+      return { valid: false, message: 'Online store DB type is required.' };
+    }
+    if (!store.secretRef.name.trim()) {
+      return { valid: false, message: 'Online store DB secret reference is required.' };
+    }
+  }
+
+  return { valid: true };
+};
+
+const validateAdvanced = (data: FeatureStoreFormData): ValidationResult => {
+  if (data.authzType === AuthzType.OIDC) {
+    if (!data.authz?.oidc?.secretRef?.name.trim()) {
+      return { valid: false, message: 'OIDC secret reference is required.' };
+    }
+  }
+
+  if (data.projectDirType === ProjectDirType.GIT) {
+    if (!data.feastProjectDir?.git?.url.trim()) {
+      return { valid: false, message: 'Git repository URL is required.' };
+    }
+  }
+
+  if (data.batchEngineEnabled && !data.batchEngineConfigMapName.trim()) {
+    return { valid: false, message: 'Batch compute engine ConfigMap is required.' };
+  }
+
+  if (data.scalingEnabled) {
+    const needsMultiReplicaValidation =
+      (data.scalingMode === ScalingMode.STATIC && data.replicas > 1) ||
+      data.scalingMode === ScalingMode.HPA;
+
+    if (data.scalingMode === ScalingMode.HPA) {
+      if (data.hpaMaxReplicas < data.hpaMinReplicas) {
+        return {
+          valid: false,
+          message: 'HPA maximum replicas must be >= minimum replicas.',
+        };
+      }
+    }
+
+    if (needsMultiReplicaValidation) {
+      if (data.onlinePersistenceType !== PersistenceType.DB) {
+        return {
+          valid: false,
+          message: 'Scaling requires DB-backed persistence for the online store.',
+        };
+      }
+      if (data.offlineStoreEnabled && data.offlinePersistenceType !== PersistenceType.DB) {
+        return {
+          valid: false,
+          message: 'Scaling requires DB-backed persistence for the offline store.',
+        };
+      }
+      if (data.registryType === RegistryType.LOCAL) {
+        const registryPersistence = data.services?.registry?.local?.persistence;
+        const hasDBRegistry = data.registryPersistenceType === PersistenceType.DB;
+        const hasS3OrGSRegistry =
+          registryPersistence?.file?.path?.startsWith('s3://') ||
+          registryPersistence?.file?.path?.startsWith('gs://');
+        if (!hasDBRegistry && !hasS3OrGSRegistry) {
+          return {
+            valid: false,
+            message: 'Scaling requires DB-backed or remote registry, or S3/GCS registry file path.',
+          };
+        }
+      }
+    }
+  }
+
+  return { valid: true };
+};
+
+export const validateFeatureStoreForm = (
+  data: FeatureStoreFormData,
+  existingProjectNames: string[],
+): StepValidation => ({
+  projectBasics: validateProjectBasics(data, existingProjectNames),
+  registry: validateRegistry(data),
+  storeConfig: validateStoreConfig(data),
+  advanced: validateAdvanced(data),
+});
+
+export const isFormValid = (validation: StepValidation): boolean =>
+  validation.projectBasics.valid &&
+  validation.registry.valid &&
+  validation.storeConfig.valid &&
+  validation.advanced.valid;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-61259 

## Description

This PR adds the form data model, multi-step validation logic, and CRD spec builder
for the Feature Store creation wizard to the `@odh-dashboard/feature-store` package.
These are the data/logic layer consumed by the wizard UI components in subsequent PRs.

No UI-visible changes. No new package exports needed — all modules are consumed
internally within the `feature-store` package by the wizard UI
([RHOAIENG-61260](https://redhat.atlassian.net/browse/RHOAIENG-61260)).

## How Has This Been Tested?

- All validation rules, spec builder outputs, and YAML generation verified via
  unit tests.
- Type-checked with `npm run type-check`.
- Deployed custom image to cluster and verified no regressions in existing
  Feature Store screens.

## Test Impact

Added comprehensive unit tests co-located with source.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the Feature Store “create” experience with a structured configuration flow covering registry, storage persistence, scaling/autoscaling, auth, cron/batch options, and related constraints.
  * Added export of the configured Feature Store setup to YAML.
* **Bug Fixes**
  * Improved validation with stricter project name checks and clearer step-by-step error handling for incompatible settings.
  * Cleaner generated output by omitting empty optional fields.
* **Tests**
  * Added extensive unit tests for project name validation, form spec generation/YAML rendering, and step validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-61260]: https://redhat.atlassian.net/browse/RHOAIENG-61260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ