### PR TITLE
feat(llmd-serving): hide hardware profile for non-single-node topologies

### DIFF
--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -1467,6 +1467,13 @@ class ModelServingWizard extends Wizard {
   findYAMLEditFallbackAlert() {
     return cy.findByTestId('yaml-fallback-alert');
   }
+
+  navigateToAdvancedSettings() {
+    this.findModelDeploymentNameInput().type('test-model');
+    this.selectDeploymentMethodByKey('llm-inference-service-llmd');
+    cy.findByTestId('hardware-profile-select').should('contain.text', 'Small');
+    this.findNextButton().should('be.enabled').click();
+  }
 }
 
 export const modelServingGlobal = new ModelServingGlobal();

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -23,6 +23,7 @@ import {
   TemplateModel,
 } from '../../../utils/models';
 import { modelServingGlobal, modelServingWizard } from '../../../pages/modelServing';
+import { hardwareProfileSection } from '../../../pages/components/HardwareProfileSection';
 
 const buildTopologyConfig = (
   name: string,
@@ -35,6 +36,16 @@ const mockTopologyConfigs = [
   buildTopologyConfig('single-node-config', 'Single Node Config', TopologyType.SINGLE_NODE),
   buildTopologyConfig('multi-node-config', 'Multi-node Data Parallel', TopologyType.MULTI_NODE),
   buildTopologyConfig('disabled-config', 'Disabled Config', TopologyType.MULTI_NODE, true),
+  buildTopologyConfig(
+    'single-node-pd-config',
+    'Single Node P/D',
+    TopologyType.SINGLE_NODE_DISAGGREGATED,
+  ),
+  buildTopologyConfig(
+    'multi-node-pd-config',
+    'Multi-node P/D',
+    TopologyType.MULTI_NODE_DISAGGREGATED,
+  ),
 ];
 
 const mockRouterConfigs = [
@@ -139,6 +150,13 @@ const navigateToModelDeploymentStep = () => {
   modelServingWizard.findNextButton().click();
 };
 
+const navigateToAdvancedSettings = () => {
+  modelServingWizard.findModelDeploymentNameInput().type('test-model');
+  modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+  hardwareProfileSection.findSelect().should('contain.text', 'Small');
+  modelServingWizard.findNextButton().should('be.enabled').click();
+};
+
 describe('Model Serving LLMD Topology & Routing', () => {
   describe('topology type field', () => {
     it('should show topology type dropdown when flag enabled and llm-d active', () => {
@@ -179,11 +197,11 @@ describe('Model Serving LLMD Topology & Routing', () => {
         'pf-m-aria-disabled',
       );
       cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE_DISAGGREGATED}`).should(
-        'have.class',
+        'not.have.class',
         'pf-m-aria-disabled',
       );
       cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE_DISAGGREGATED}`).should(
-        'have.class',
+        'not.have.class',
         'pf-m-aria-disabled',
       );
     });
@@ -224,6 +242,32 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('topology-type-select').click();
       cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
+
+      cy.findByTestId('hardware-profile-select').should('not.exist');
+    });
+
+    it('should hide hardware profile for single node disaggregated topology', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE_DISAGGREGATED}`).click();
+
+      cy.findByTestId('hardware-profile-select').should('not.exist');
+    });
+
+    it('should hide hardware profile for multi-node disaggregated topology', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE_DISAGGREGATED}`).click();
 
       cy.findByTestId('hardware-profile-select').should('not.exist');
     });
@@ -300,10 +344,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
-
-      modelServingWizard.findModelDeploymentNameInput().type('test-model');
-      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-      modelServingWizard.findNextButton().should('be.enabled').click();
+      navigateToAdvancedSettings();
 
       cy.findByTestId('routing-config-select').should('exist');
       cy.findByTestId('routing-config-select').should('contain.text', 'Default optimized routing');
@@ -342,10 +383,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
-
-      modelServingWizard.findModelDeploymentNameInput().type('test-model');
-      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-      modelServingWizard.findNextButton().should('be.enabled').click();
+      navigateToAdvancedSettings();
 
       cy.findByTestId('routing-config-select').click();
       cy.findByTestId('routing-config-option-default').should('exist');
@@ -358,10 +396,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
-
-      modelServingWizard.findModelDeploymentNameInput().type('test-model');
-      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-      modelServingWizard.findNextButton().should('be.enabled').click();
+      navigateToAdvancedSettings();
 
       cy.findByTestId('routing-config-select').click();
       cy.findByTestId('routing-config-option-managed-scheduler-httproute').click();
@@ -376,10 +411,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
-
-      modelServingWizard.findModelDeploymentNameInput().type('test-model');
-      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-      modelServingWizard.findNextButton().should('be.enabled').click();
+      navigateToAdvancedSettings();
 
       // Select a custom config
       cy.findByTestId('routing-config-select').click();

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -23,7 +23,6 @@ import {
   TemplateModel,
 } from '../../../utils/models';
 import { modelServingGlobal, modelServingWizard } from '../../../pages/modelServing';
-import { hardwareProfileSection } from '../../../pages/components/HardwareProfileSection';
 
 const buildTopologyConfig = (
   name: string,
@@ -148,13 +147,6 @@ const navigateToModelDeploymentStep = () => {
   modelServingWizard.findSaveConnectionCheckbox().click();
   modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
   modelServingWizard.findNextButton().click();
-};
-
-const navigateToAdvancedSettings = () => {
-  modelServingWizard.findModelDeploymentNameInput().type('test-model');
-  modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-  hardwareProfileSection.findSelect().should('contain.text', 'Small');
-  modelServingWizard.findNextButton().should('be.enabled').click();
 };
 
 describe('Model Serving LLMD Topology & Routing', () => {
@@ -344,7 +336,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
-      navigateToAdvancedSettings();
+      modelServingWizard.navigateToAdvancedSettings();
 
       cy.findByTestId('routing-config-select').should('exist');
       cy.findByTestId('routing-config-select').should('contain.text', 'Default optimized routing');
@@ -383,7 +375,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
-      navigateToAdvancedSettings();
+      modelServingWizard.navigateToAdvancedSettings();
 
       cy.findByTestId('routing-config-select').click();
       cy.findByTestId('routing-config-option-default').should('exist');
@@ -396,7 +388,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
-      navigateToAdvancedSettings();
+      modelServingWizard.navigateToAdvancedSettings();
 
       cy.findByTestId('routing-config-select').click();
       cy.findByTestId('routing-config-option-managed-scheduler-httproute').click();
@@ -411,7 +403,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
-      navigateToAdvancedSettings();
+      modelServingWizard.navigateToAdvancedSettings();
 
       // Select a custom config
       cy.findByTestId('routing-config-select').click();

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -204,6 +204,48 @@ describe('Model Serving LLMD Topology & Routing', () => {
     });
   });
 
+  describe('hardware profile visibility', () => {
+    it('should show hardware profile for single node topology', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      cy.findByTestId('hardware-profile-select').should('exist');
+    });
+
+    it('should hide hardware profile for multi-node topology', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
+
+      cy.findByTestId('hardware-profile-select').should('not.exist');
+    });
+
+    it('should show hardware profile when switching back to single node', () => {
+      initIntercepts();
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
+      cy.findByTestId('hardware-profile-select').should('not.exist');
+
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).click();
+      cy.findByTestId('hardware-profile-select').should('exist');
+    });
+  });
+
   describe('custom topology config field', () => {
     it('should show configs matching the selected topology type', () => {
       initIntercepts();

--- a/packages/llmd-serving/src/types.ts
+++ b/packages/llmd-serving/src/types.ts
@@ -140,7 +140,6 @@ export const isLLMInferenceServiceConfig = (
 
 export type LLMdDeployment = Deployment<LLMInferenceServiceKind, LLMInferenceServiceConfigKind>;
 
-
 export const LLMInferenceServiceModel: K8sModelCommon = {
   apiVersion: 'v1alpha2',
   apiGroup: 'serving.kserve.io',

--- a/packages/llmd-serving/src/types.ts
+++ b/packages/llmd-serving/src/types.ts
@@ -140,9 +140,6 @@ export const isLLMInferenceServiceConfig = (
 
 export type LLMdDeployment = Deployment<LLMInferenceServiceKind, LLMInferenceServiceConfigKind>;
 
-// Moved to formUtils.ts to keep types.ts free of runtime imports (enables Cypress type-only import)
-// export const isLLMdDeployment = (deployment: Deployment): deployment is LLMdDeployment =>
-//   deployment.modelServingPlatformId === LLMD_SERVING_ID;
 
 export const LLMInferenceServiceModel: K8sModelCommon = {
   apiVersion: 'v1alpha2',

--- a/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
+++ b/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
@@ -10,10 +10,8 @@ import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/p
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import type { HardwareProfileKind } from '@odh-dashboard/k8s-core';
 import { isCompatibleWithIdentifier } from '@odh-dashboard/internal/pages/projects/screens/spawner/spawnerUtils';
-import { LLMD_DEPLOYMENT_METHOD_KEY } from './deploymentMethodField';
-import { isTopologyTypeFieldData } from './TopologyTypeField';
 import { useFetchLLMInferenceServiceConfigs } from '../api/LLMInferenceServiceConfigs';
-import { LLMInferenceServiceConfigKind, TopologyType } from '../types';
+import { LLMInferenceServiceConfigKind } from '../types';
 import { isSimpleLLMInferenceService } from '../formUtils';
 
 // External data hook
@@ -126,19 +124,7 @@ export const LLMConfigOptionsFieldWizardField: LLMConfigOptionsFieldType = {
   step: 'modelDeployment',
   type: 'replacement',
   stateKey: 'modelServer',
-  isActive: (wizardState) => {
-    if (isSimpleLLMInferenceService(wizardState)) {
-      return true;
-    }
-    if (wizardState.deploymentMethod?.method === LLMD_DEPLOYMENT_METHOD_KEY) {
-      const topologyData = wizardState['llmd-serving/topology-type'];
-      if (isTopologyTypeFieldData(topologyData)) {
-        return topologyData.topologyType === TopologyType.SINGLE_NODE;
-      }
-      return true;
-    }
-    return false;
-  },
+  isActive: isSimpleLLMInferenceService,
   reducerFunctions: {
     resolveDependencies: (formData) => ({
       hardwareProfile: formData.hardwareProfileConfig.formData.selectedProfile,

--- a/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
+++ b/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
@@ -10,8 +10,10 @@ import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/p
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import type { HardwareProfileKind } from '@odh-dashboard/k8s-core';
 import { isCompatibleWithIdentifier } from '@odh-dashboard/internal/pages/projects/screens/spawner/spawnerUtils';
+import { LLMD_DEPLOYMENT_METHOD_KEY } from './deploymentMethodField';
+import { isTopologyTypeFieldData } from './TopologyTypeField';
 import { useFetchLLMInferenceServiceConfigs } from '../api/LLMInferenceServiceConfigs';
-import { LLMInferenceServiceConfigKind } from '../types';
+import { LLMInferenceServiceConfigKind, TopologyType } from '../types';
 import { isSimpleLLMInferenceService } from '../formUtils';
 
 // External data hook
@@ -124,7 +126,19 @@ export const LLMConfigOptionsFieldWizardField: LLMConfigOptionsFieldType = {
   step: 'modelDeployment',
   type: 'replacement',
   stateKey: 'modelServer',
-  isActive: isSimpleLLMInferenceService,
+  isActive: (wizardState) => {
+    if (isSimpleLLMInferenceService(wizardState)) {
+      return true;
+    }
+    if (wizardState.deploymentMethod?.method === LLMD_DEPLOYMENT_METHOD_KEY) {
+      const topologyData = wizardState['llmd-serving/topology-type'];
+      if (isTopologyTypeFieldData(topologyData)) {
+        return topologyData.topologyType === TopologyType.SINGLE_NODE;
+      }
+      return true;
+    }
+    return false;
+  },
   reducerFunctions: {
     resolveDependencies: (formData) => ({
       hardwareProfile: formData.hardwareProfileConfig.formData.selectedProfile,

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -21,12 +21,25 @@ type ModelDeploymentStepProps = {
   hideProjectSection?: boolean;
 };
 
+const SINGLE_NODE_TOPOLOGY = 'workload-single-node';
+
+const isHardwareProfileHidden = (state: Record<string, unknown>): boolean => {
+  const topologyData: unknown = state['llmd-serving/topology-type'];
+  if (topologyData != null && typeof topologyData === 'object' && 'topologyType' in topologyData) {
+    const { topologyType } = topologyData as Record<string, unknown>; // eslint-disable-line @typescript-eslint/consistent-type-assertions
+    return topologyType !== SINGLE_NODE_TOPOLOGY;
+  }
+  return false;
+};
+
 export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
   projectName,
   wizardState,
   externalData,
   hideProjectSection,
 }) => {
+  const hideHwp = isHardwareProfileHidden(wizardState.state);
+
   const modelDeploymentExtensionFields = React.useMemo(
     () =>
       wizardState.fields.filter(
@@ -79,11 +92,13 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
           externalData={externalData}
           isEditing={wizardState.initialData?.isEditing}
         />
-        <ModelServingHardwareProfileSection
-          project={projectName}
-          hardwareProfileConfig={wizardState.state.hardwareProfileConfig}
-          isEditing={wizardState.initialData?.isEditing}
-        />
+        {!hideHwp && (
+          <ModelServingHardwareProfileSection
+            project={projectName}
+            hardwareProfileConfig={wizardState.state.hardwareProfileConfig}
+            isEditing={wizardState.initialData?.isEditing}
+          />
+        )}
         {wizardState.state.modelFormatState.isVisible && (
           <ModelFormatField
             modelFormatState={wizardState.state.modelFormatState}

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -8,6 +8,7 @@ import { ModelFormatField } from '../fields/ModelFormatField';
 import { NumReplicasField } from '../fields/NumReplicasField';
 import { GenericFieldRenderer } from '../fields/GenericFieldRenderer';
 import { ExternalDataMap } from '../ExternalDataLoader';
+import { isNonSingleNodeTopologyActive } from '../topologyUtils';
 
 const EXPLICIT_TOPOLOGY_FIELD_IDS = [
   'llmd-serving/topology-type',
@@ -21,24 +22,13 @@ type ModelDeploymentStepProps = {
   hideProjectSection?: boolean;
 };
 
-const SINGLE_NODE_TOPOLOGY = 'workload-single-node';
-
-const isHardwareProfileHidden = (state: Record<string, unknown>): boolean => {
-  const topologyData: unknown = state['llmd-serving/topology-type'];
-  if (topologyData != null && typeof topologyData === 'object' && 'topologyType' in topologyData) {
-    const { topologyType } = topologyData as Record<string, unknown>; // eslint-disable-line @typescript-eslint/consistent-type-assertions
-    return topologyType !== SINGLE_NODE_TOPOLOGY;
-  }
-  return false;
-};
-
 export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
   projectName,
   wizardState,
   externalData,
   hideProjectSection,
 }) => {
-  const hideHwp = isHardwareProfileHidden(wizardState.state);
+  const hideHwp = isNonSingleNodeTopologyActive(wizardState.state);
 
   const modelDeploymentExtensionFields = React.useMemo(
     () =>

--- a/packages/model-serving/src/components/deploymentWizard/topologyUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/topologyUtils.ts
@@ -4,6 +4,7 @@
  * Cannot import TopologyType enum or isTopologyTypeFieldData from @odh-dashboard/llmd-serving
  * because llmd-serving depends on model-serving — importing the other way would be circular.
  * These string constants mirror TopologyType.SINGLE_NODE from llmd-serving/types.
+ * Tech debt ticket- https://redhat.atlassian.net/browse/RHOAIENG-73746
  */
 
 const TOPOLOGY_TYPE_FIELD_KEY = 'llmd-serving/topology-type';
@@ -13,7 +14,7 @@ const isTopologyFieldData = (data: unknown): data is { topologyType: string } =>
   data != null &&
   typeof data === 'object' &&
   'topologyType' in data &&
-  typeof (data as Record<string, unknown>).topologyType === 'string'; // eslint-disable-line @typescript-eslint/consistent-type-assertions
+  typeof data.topologyType === 'string';
 
 export const isNonSingleNodeTopologyActive = (state: Record<string, unknown>): boolean => {
   const topologyData: unknown = state[TOPOLOGY_TYPE_FIELD_KEY];

--- a/packages/model-serving/src/components/deploymentWizard/topologyUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/topologyUtils.ts
@@ -1,0 +1,16 @@
+const TOPOLOGY_TYPE_FIELD_KEY = 'llmd-serving/topology-type';
+const SINGLE_NODE_TOPOLOGY = 'workload-single-node';
+
+const getTopologyType = (state: Record<string, unknown>): string | undefined => {
+  const topologyData: unknown = state[TOPOLOGY_TYPE_FIELD_KEY];
+  if (topologyData != null && typeof topologyData === 'object' && 'topologyType' in topologyData) {
+    const record = topologyData as Record<string, unknown>; // eslint-disable-line @typescript-eslint/consistent-type-assertions
+    return typeof record.topologyType === 'string' ? record.topologyType : undefined;
+  }
+  return undefined;
+};
+
+export const isNonSingleNodeTopologyActive = (state: Record<string, unknown>): boolean => {
+  const topologyType = getTopologyType(state);
+  return topologyType != null && topologyType !== SINGLE_NODE_TOPOLOGY;
+};

--- a/packages/model-serving/src/components/deploymentWizard/topologyUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/topologyUtils.ts
@@ -1,16 +1,24 @@
+/**
+ * Topology-aware visibility helpers for the deployment wizard.
+ *
+ * Cannot import TopologyType enum or isTopologyTypeFieldData from @odh-dashboard/llmd-serving
+ * because llmd-serving depends on model-serving — importing the other way would be circular.
+ * These string constants mirror TopologyType.SINGLE_NODE from llmd-serving/types.
+ */
+
 const TOPOLOGY_TYPE_FIELD_KEY = 'llmd-serving/topology-type';
 const SINGLE_NODE_TOPOLOGY = 'workload-single-node';
 
-const getTopologyType = (state: Record<string, unknown>): string | undefined => {
-  const topologyData: unknown = state[TOPOLOGY_TYPE_FIELD_KEY];
-  if (topologyData != null && typeof topologyData === 'object' && 'topologyType' in topologyData) {
-    const record = topologyData as Record<string, unknown>; // eslint-disable-line @typescript-eslint/consistent-type-assertions
-    return typeof record.topologyType === 'string' ? record.topologyType : undefined;
-  }
-  return undefined;
-};
+const isTopologyFieldData = (data: unknown): data is { topologyType: string } =>
+  data != null &&
+  typeof data === 'object' &&
+  'topologyType' in data &&
+  typeof (data as Record<string, unknown>).topologyType === 'string'; // eslint-disable-line @typescript-eslint/consistent-type-assertions
 
 export const isNonSingleNodeTopologyActive = (state: Record<string, unknown>): boolean => {
-  const topologyType = getTopologyType(state);
-  return topologyType != null && topologyType !== SINGLE_NODE_TOPOLOGY;
+  const topologyData: unknown = state[TOPOLOGY_TYPE_FIELD_KEY];
+  if (isTopologyFieldData(topologyData)) {
+    return topologyData.topologyType !== SINGLE_NODE_TOPOLOGY;
+  }
+  return false;
 };

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
@@ -19,6 +19,17 @@ import { modelFormatFieldSchema } from './fields/ModelFormatField';
 import { isValidProjectName } from './fields/ProjectSection';
 import { getStateKey } from './dynamicFormUtils';
 
+const SINGLE_NODE_TOPOLOGY = 'workload-single-node';
+
+const isHardwareProfileHidden = (state: Record<string, unknown>): boolean => {
+  const topologyData: unknown = state['llmd-serving/topology-type'];
+  if (topologyData != null && typeof topologyData === 'object' && 'topologyType' in topologyData) {
+    const { topologyType } = topologyData as Record<string, unknown>; // eslint-disable-line @typescript-eslint/consistent-type-assertions
+    return topologyType !== SINGLE_NODE_TOPOLOGY;
+  }
+  return false;
+};
+
 export type ModelDeploymentWizardValidation = {
   modelSource: ReturnType<typeof useZodFormValidation<ModelSourceStepData>>;
   hardwareProfile: ReturnType<typeof useValidation>;
@@ -124,12 +135,13 @@ export const useModelDeploymentWizardValidation = (
     isValidProjectName(state.project.initialProjectName ?? state.project.projectName ?? undefined);
   const isModelSourceStepValid =
     modelSourceStepValidation.getFieldValidation(undefined, true).length === 0;
+  const hwpHidden = isHardwareProfileHidden(state);
   const isModelDeploymentStepValid =
     isValidProjectName(
       state.project.initialProjectName ?? state.project.projectName ?? undefined,
     ) &&
     isK8sNameDescriptionDataValid(state.k8sNameDesc.data) &&
-    Object.keys(hardwareProfileValidation.getAllValidationIssues()).length === 0 &&
+    (hwpHidden || Object.keys(hardwareProfileValidation.getAllValidationIssues()).length === 0) &&
     modelDeploymentStepValidation.getFieldValidation(undefined, true).length === 0;
   const isAdvancedSettingsStepValid =
     advancedOptionsValidation.getFieldValidation(undefined, true).length === 0;

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
@@ -18,17 +18,7 @@ import { environmentVariablesFieldSchema } from './fields/EnvironmentVariablesFi
 import { modelFormatFieldSchema } from './fields/ModelFormatField';
 import { isValidProjectName } from './fields/ProjectSection';
 import { getStateKey } from './dynamicFormUtils';
-
-const SINGLE_NODE_TOPOLOGY = 'workload-single-node';
-
-const isHardwareProfileHidden = (state: Record<string, unknown>): boolean => {
-  const topologyData: unknown = state['llmd-serving/topology-type'];
-  if (topologyData != null && typeof topologyData === 'object' && 'topologyType' in topologyData) {
-    const { topologyType } = topologyData as Record<string, unknown>; // eslint-disable-line @typescript-eslint/consistent-type-assertions
-    return topologyType !== SINGLE_NODE_TOPOLOGY;
-  }
-  return false;
-};
+import { isNonSingleNodeTopologyActive } from './topologyUtils';
 
 export type ModelDeploymentWizardValidation = {
   modelSource: ReturnType<typeof useZodFormValidation<ModelSourceStepData>>;
@@ -135,7 +125,7 @@ export const useModelDeploymentWizardValidation = (
     isValidProjectName(state.project.initialProjectName ?? state.project.projectName ?? undefined);
   const isModelSourceStepValid =
     modelSourceStepValidation.getFieldValidation(undefined, true).length === 0;
-  const hwpHidden = isHardwareProfileHidden(state);
+  const hwpHidden = isNonSingleNodeTopologyActive(state);
   const isModelDeploymentStepValid =
     isValidProjectName(
       state.project.initialProjectName ?? state.project.projectName ?? undefined,


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-73694

## Description

Hides the Hardware Profile section in the model deployment wizard when a non-single-node topology type is selected for llm-d deployments. Multi-node, single-node disaggregated, and multi-node disaggregated topologies do not use hardware profiles — their resource configuration is defined in the topology configuration template instead.

### Behavior

| Topology type | Hardware Profile |
|---|---|
| Single node (default) | Visible |
| Multi-node | Hidden |
| Single node disaggregated | Hidden |
| Multi-node disaggregated | Hidden |
| Non-llm-d deployment methods | Always visible (no change) |

## How Has This Been Tested?
<img width="1290" height="588" alt="Screenshot 2026-07-03 at 11 57 34 AM" src="https://github.com/user-attachments/assets/852ef304-0f85-42ec-b206-8ed310500a68" />
<img width="1295" height="406" alt="Screenshot 2026-07-03 at 11 57 44 AM" src="https://github.com/user-attachments/assets/bdb6ef60-191c-428d-a9a6-406a29048266" />
<img width="1330" height="529" alt="Screenshot 2026-07-03 at 11 57 53 AM" src="https://github.com/user-attachments/assets/8cf02bae-b5e6-4cd2-8982-be6225902e3f" />

- Manually tested on a live cluster with `llmdTopologyConfigs` feature flag enabled
- Verified HWP appears for single-node, disappears for multi-node/disaggregated topologies
- Verified switching between topologies toggles HWP visibility correctly
- Verified the wizard Next button works correctly when HWP is hidden (validation skipped)
- Verified non-llm-d deployment methods (legacy, simple vLLM) are unaffected
- Cypress mock tests pass locally

## Test Impact

**Updated:** `packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts`
- Added `describe('hardware profile visibility')` block with 3 test cases

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hardware profile settings now automatically hide for non-single-node topology selections in the deployment wizard.

* **Bug Fixes**
  * Step validation now correctly accounts for topology-based hardware profile visibility, reducing false validation errors.
  * Topology changes now properly toggle the hardware profile field when switching between supported modes.

* **Tests**
  * Expanded test coverage for multiple topology types, including disaggregated variants, and improved advanced settings navigation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->