### PR TITLE
fix:added fix for local queues visibility based on namespaces

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -510,5 +510,7 @@ describe('HardwareProfileSelect - LocalQueue availability filtering', () => {
     expect(screen.getByText('Kueue Profile')).toBeInTheDocument();
     // kueueHardwareProfile2's queue exists → it is also shown normally
     expect(screen.getByText('Kueue Profile 2')).toBeInTheDocument();
+    // info icon shown only for the profile with the missing queue
+    expect(screen.getByTestId('queue-missing-icon')).toBeInTheDocument();
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -15,6 +15,7 @@ import {
 } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
 import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
+import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
 import {
   ProjectDetailsContext,
   ProjectDetailsContextType,
@@ -57,6 +58,20 @@ kueueHardwareProfile2.spec.scheduling = {
   },
 };
 
+// Extra profile sharing test-queue-2 — keeps the dropdown interactive in filtering tests
+// (SimpleSelect auto-selects and locks when there's only one option).
+const kueueHardwareProfile3 = mockHardwareProfile({
+  name: 'kueue-profile-3',
+  displayName: 'Kueue Profile 3',
+});
+kueueHardwareProfile3.spec.scheduling = {
+  type: SchedulingType.QUEUE,
+  kueue: {
+    localQueueName: 'test-queue-2',
+    priorityClass: 'normal-priority',
+  },
+};
+
 const nodeHardwareProfile = mockHardwareProfile({
   name: 'node-profile',
   displayName: 'Node Profile',
@@ -81,6 +96,8 @@ const renderComponent = (
   projects: ProjectKind[] = [],
   projectProp?: string,
   allowExistingSettings = false,
+  localQueuesOverride?: ProjectDetailsContextType['localQueues'],
+  initialHardwareProfile?: HardwareProfileKind,
 ) => {
   // Mock useKueueConfiguration to return the specified filtering state
   useKueueConfigurationMock.mockReturnValue({
@@ -131,12 +148,12 @@ const renderComponent = (
           {
             currentProject,
             refresh: jest.fn(),
-            localQueues: DEFAULT_LIST_FETCH_STATE,
+            localQueues: localQueuesOverride ?? DEFAULT_LIST_FETCH_STATE,
           } as unknown as ProjectDetailsContextType
         }
       >
         <HardwareProfileSelect
-          initialHardwareProfile={undefined}
+          initialHardwareProfile={initialHardwareProfile}
           previewDescription={false}
           hardwareProfiles={hardwareProfiles}
           isProjectScoped={false}
@@ -362,5 +379,136 @@ describe('HardwareProfileSelect - Use existing settings', () => {
     expect(screen.getByRole('button')).toHaveTextContent(
       'No enabled or valid hardware profiles are available. Contact your administrator.',
     );
+  });
+});
+
+describe('HardwareProfileSelect - LocalQueue availability filtering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should hide Kueue profiles whose localQueue does not exist in the project', async () => {
+    const project = mockProjectK8sResource({});
+    // Only 'test-queue-2' exists in the project. kueueHardwareProfile ('test-queue') is absent.
+    // Include kueueHardwareProfile3 (also 'test-queue-2') so there are 2 visible options and
+    // SimpleSelect stays interactive (it auto-selects + disables when only 1 option exists).
+    const localQueues = {
+      data: [mockLocalQueueK8sResource({ name: 'test-queue-2' })],
+      loaded: true,
+      error: undefined,
+      refresh: jest.fn(),
+    };
+    const profilesForTest = [
+      kueueHardwareProfile,
+      kueueHardwareProfile2,
+      kueueHardwareProfile3,
+      nodeHardwareProfile,
+    ];
+
+    renderComponent(
+      profilesForTest,
+      project,
+      KueueFilteringState.ONLY_KUEUE_PROFILES,
+      [],
+      undefined,
+      false,
+      localQueues,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    // test-queue-2 exists → profiles 2 and 3 are shown
+    expect(screen.getByText('Kueue Profile 2')).toBeInTheDocument();
+    expect(screen.getByText('Kueue Profile 3')).toBeInTheDocument();
+    // test-queue does not exist → profile 1 hidden; non-Kueue also hidden
+    expect(screen.queryByText('Kueue Profile')).not.toBeInTheDocument();
+    expect(screen.queryByText('Node Profile')).not.toBeInTheDocument();
+  });
+
+  it('should show all Kueue profiles when their localQueues all exist in the project', async () => {
+    const project = mockProjectK8sResource({});
+    const localQueues = {
+      data: [
+        mockLocalQueueK8sResource({ name: 'test-queue' }),
+        mockLocalQueueK8sResource({ name: 'test-queue-2' }),
+      ],
+      loaded: true,
+      error: undefined,
+      refresh: jest.fn(),
+    };
+
+    renderComponent(
+      mockProfiles,
+      project,
+      KueueFilteringState.ONLY_KUEUE_PROFILES,
+      [],
+      undefined,
+      false,
+      localQueues,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    expect(screen.getByText('Kueue Profile')).toBeInTheDocument();
+    expect(screen.getByText('Kueue Profile 2')).toBeInTheDocument();
+  });
+
+  it('should show all Kueue profiles while localQueues are still loading (no premature filtering)', async () => {
+    const project = mockProjectK8sResource({});
+    // loaded: false simulates data still in flight — no filtering should happen yet
+    const localQueues = {
+      data: [],
+      loaded: false,
+      error: undefined,
+      refresh: jest.fn(),
+    };
+
+    renderComponent(
+      mockProfiles,
+      project,
+      KueueFilteringState.ONLY_KUEUE_PROFILES,
+      [],
+      undefined,
+      false,
+      localQueues,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    // Both Kueue profiles must still be visible while queues are loading
+    expect(screen.getByText('Kueue Profile')).toBeInTheDocument();
+    expect(screen.getByText('Kueue Profile 2')).toBeInTheDocument();
+  });
+
+  it('should keep initialHardwareProfile in options even when its localQueue is missing (edit mode)', async () => {
+    const project = mockProjectK8sResource({});
+    // Only 'test-queue-2' exists — kueueHardwareProfile's 'test-queue' is absent.
+    // kueueHardwareProfile2 stays visible because its queue exists, giving us 2 options
+    // so SimpleSelect stays interactive (it auto-selects + disables at exactly 1 option).
+    const localQueues = {
+      data: [mockLocalQueueK8sResource({ name: 'test-queue-2' })],
+      loaded: true,
+      error: undefined,
+      refresh: jest.fn(),
+    };
+
+    // Edit mode: initialHardwareProfile is the previously saved profile (queue is missing)
+    renderComponent(
+      [kueueHardwareProfile, kueueHardwareProfile2],
+      project,
+      KueueFilteringState.ONLY_KUEUE_PROFILES,
+      [],
+      undefined,
+      false,
+      localQueues,
+      kueueHardwareProfile, // initialHardwareProfile — queue 'test-queue' is absent
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    // initialHardwareProfile must remain visible even though its queue is missing
+    expect(screen.getByText('Kueue Profile')).toBeInTheDocument();
+    // kueueHardwareProfile2's queue exists → it is also shown normally
+    expect(screen.getByText('Kueue Profile 2')).toBeInTheDocument();
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -480,6 +480,112 @@ describe('HardwareProfileSelect - LocalQueue availability filtering', () => {
     expect(screen.getByText('Kueue Profile 2')).toBeInTheDocument();
   });
 
+  it('should not duplicate initialHardwareProfile across both groups when its localQueue is missing (project-scoped edit mode)', async () => {
+    const project = mockProjectK8sResource({ k8sName: 'test-project' });
+
+    // Project-scoped profile whose queue is absent — the previously saved selection in edit mode
+    const projectKueueProfile = mockHardwareProfile({
+      name: 'project-kueue-profile',
+      displayName: 'Project Kueue Profile',
+      namespace: 'test-project',
+    });
+    projectKueueProfile.spec.scheduling = {
+      type: SchedulingType.QUEUE,
+      kueue: { localQueueName: 'test-queue', priorityClass: 'high-priority' },
+    };
+
+    // Global profile with an existing queue — anchors the global group so it renders
+    const globalKueueProfile = mockHardwareProfile({
+      name: 'global-kueue-profile',
+      displayName: 'Global Kueue Profile',
+    });
+    globalKueueProfile.spec.scheduling = {
+      type: SchedulingType.QUEUE,
+      kueue: { localQueueName: 'test-queue-2', priorityClass: 'normal-priority' },
+    };
+
+    // 'test-queue' is absent; 'test-queue-2' exists
+    const localQueues = {
+      data: [mockLocalQueueK8sResource({ name: 'test-queue-2' })],
+      loaded: true,
+      error: undefined,
+      refresh: jest.fn(),
+    };
+
+    useKueueConfigurationMock.mockReturnValue({
+      isKueueDisabled: false,
+      isKueueFeatureEnabled: true,
+      isProjectKueueEnabled: true,
+      kueueFilteringState: KueueFilteringState.ONLY_KUEUE_PROFILES,
+    });
+
+    const hardwareProfileConfig = {
+      formData: { useExistingSettings: false },
+      useExistingSettings: false,
+      setFormData: () => null,
+      resetFormData: () => null,
+      isFormDataValid: true,
+      profilesLoaded: true,
+      profilesLoadError: undefined,
+      initialHardwareProfile: undefined,
+    };
+    useHardwareProfileConfigMock.mockReturnValue(hardwareProfileConfig);
+
+    render(
+      <ProjectsContext.Provider
+        value={{
+          projects: [project],
+          modelServingProjects: [],
+          nonActiveProjects: [],
+          preferredProject: null,
+          updatePreferredProject: () => undefined,
+          loaded: true,
+          loadError: undefined,
+          waitForProject: () => Promise.resolve(),
+        }}
+      >
+        <ProjectDetailsContext.Provider
+          value={
+            {
+              currentProject: project,
+              refresh: jest.fn(),
+              localQueues,
+            } as unknown as ProjectDetailsContextType
+          }
+        >
+          <HardwareProfileSelect
+            isProjectScoped
+            initialHardwareProfile={projectKueueProfile}
+            previewDescription={false}
+            hardwareProfiles={[globalKueueProfile]}
+            hardwareProfilesLoaded
+            hardwareProfilesError={undefined}
+            projectScopedHardwareProfiles={[[projectKueueProfile], true, undefined]}
+            allowExistingSettings={false}
+            hardwareProfileConfig={hardwareProfileConfig}
+            isHardwareProfileSupported={() => true}
+            onChange={() => null}
+            project="test-project"
+          />
+        </ProjectDetailsContext.Provider>
+      </ProjectsContext.Provider>,
+    );
+
+    await userEvent.click(screen.getByTestId('hardware-profile-selection-toggle'));
+
+    // Rescued profile appears exactly once — in the project group, not the global group
+    expect(screen.getAllByText('Project Kueue Profile')).toHaveLength(1);
+    expect(screen.getByTestId('project-scoped-hardware-profiles')).toHaveTextContent(
+      'Project Kueue Profile',
+    );
+    expect(screen.getByTestId('global-scoped-hardware-profiles')).not.toHaveTextContent(
+      'Project Kueue Profile',
+    );
+    expect(screen.getByTestId('global-scoped-hardware-profiles')).toHaveTextContent(
+      'Global Kueue Profile',
+    );
+  });
+
   it('should keep initialHardwareProfile in options even when its localQueue is missing (edit mode)', async () => {
     const project = mockProjectK8sResource({});
     // Only 'test-queue-2' exists — kueueHardwareProfile's 'test-queue' is absent.

--- a/frontend/src/concepts/hardwareProfiles/__tests__/kueueUtils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/kueueUtils.spec.ts
@@ -1,16 +1,10 @@
-import * as React from 'react';
 import { SchedulingType } from '@odh-dashboard/k8s-core';
-import { renderHook } from '@odh-dashboard/jest-config/hooks';
 import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
 import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
 import {
-  ProjectDetailsContext,
-  type ProjectDetailsContextType,
-} from '#~/pages/projects/ProjectDetailsContext';
-import {
+  computeLocalQueueNamesResult,
   filterProfilesByKueue,
   KueueFilteringState,
-  useAvailableLocalQueueNames,
 } from '#~/concepts/hardwareProfiles/kueueUtils';
 
 const kueueProfile = mockHardwareProfile({
@@ -130,68 +124,52 @@ describe('filterProfilesByKueue', () => {
   });
 });
 
-const makeWrapper = (localQueues: ProjectDetailsContextType['localQueues']) => {
-  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
-    React.createElement(
-      ProjectDetailsContext.Provider,
-      { value: { localQueues } as unknown as ProjectDetailsContextType },
-      children,
-    );
-  Wrapper.displayName = 'LocalQueueWrapper';
-  return Wrapper;
-};
-
-describe('useAvailableLocalQueueNames', () => {
-  it('returns { status: "loading" } while localQueues are still loading', () => {
-    const { result } = renderHook(() => useAvailableLocalQueueNames(), {
-      wrapper: makeWrapper({ data: [], loaded: false, error: undefined, refresh: jest.fn() }),
+describe('computeLocalQueueNamesResult', () => {
+  it('returns loading while queues are still fetching', () => {
+    expect(computeLocalQueueNamesResult({ data: [], loaded: false, error: undefined })).toEqual({
+      status: 'loading',
     });
-    expect(result.current).toEqual({ status: 'loading' });
   });
 
+  // error takes priority over loaded — both states should return 'error'
   it.each([
-    [
-      'loaded=true',
-      { data: [], loaded: true, error: new Error('fetch failed'), refresh: jest.fn() },
-    ],
-    [
-      'loaded=false',
-      { data: [], loaded: false, error: new Error('fetch failed'), refresh: jest.fn() },
-    ],
-  ])('returns { status: "error" } when localQueues errored (%s)', (_, localQueues) => {
-    const { result } = renderHook(() => useAvailableLocalQueueNames(), {
-      wrapper: makeWrapper(localQueues),
+    ['loaded=false', false],
+    ['loaded=true', true],
+  ])('returns error when fetch failed (%s)', (_, loaded) => {
+    const error = new Error('fetch failed');
+    expect(computeLocalQueueNamesResult({ data: [], loaded, error })).toEqual({
+      status: 'error',
+      error,
     });
-    expect(result.current).toEqual({ status: 'error', error: localQueues.error });
   });
 
-  it('returns { status: "ready", names: Set } when loaded successfully', () => {
-    const { result } = renderHook(() => useAvailableLocalQueueNames(), {
-      wrapper: makeWrapper({
+  it('returns ready with empty set when no queues exist', () => {
+    expect(computeLocalQueueNamesResult({ data: [], loaded: true, error: undefined })).toEqual({
+      status: 'ready',
+      names: new Set(),
+    });
+  });
+
+  it('returns ready with queue names extracted from metadata', () => {
+    expect(
+      computeLocalQueueNamesResult({
         data: [
           mockLocalQueueK8sResource({ name: 'queue-a' }),
           mockLocalQueueK8sResource({ name: 'queue-b' }),
         ],
         loaded: true,
         error: undefined,
-        refresh: jest.fn(),
       }),
-    });
-    expect(result.current).toEqual({ status: 'ready', names: new Set(['queue-a', 'queue-b']) });
+    ).toEqual({ status: 'ready', names: new Set(['queue-a', 'queue-b']) });
   });
 
-  it('filters out local queues with no metadata.name', () => {
-    const lqNoName = mockLocalQueueK8sResource({ name: 'queue-a' });
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    delete lqNoName.metadata!.name;
-    const { result } = renderHook(() => useAvailableLocalQueueNames(), {
-      wrapper: makeWrapper({
-        data: [lqNoName],
+  it('filters out entries with missing metadata name', () => {
+    expect(
+      computeLocalQueueNamesResult({
+        data: [{ metadata: {} }, { metadata: { name: 'queue-a' } }],
         loaded: true,
         error: undefined,
-        refresh: jest.fn(),
       }),
-    });
-    expect(result.current).toEqual({ status: 'ready', names: new Set() });
+    ).toEqual({ status: 'ready', names: new Set(['queue-a']) });
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/kueueUtils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/kueueUtils.spec.ts
@@ -1,0 +1,197 @@
+import * as React from 'react';
+import { SchedulingType } from '@odh-dashboard/k8s-core';
+import { renderHook } from '@odh-dashboard/jest-config/hooks';
+import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
+import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
+import {
+  ProjectDetailsContext,
+  type ProjectDetailsContextType,
+} from '#~/pages/projects/ProjectDetailsContext';
+import {
+  filterProfilesByKueue,
+  KueueFilteringState,
+  useAvailableLocalQueueNames,
+} from '#~/concepts/hardwareProfiles/kueueUtils';
+
+const kueueProfile = mockHardwareProfile({
+  name: 'kueue-profile',
+  schedulingType: SchedulingType.QUEUE,
+  localQueueName: 'queue-a',
+});
+
+const kueueProfileB = mockHardwareProfile({
+  name: 'kueue-profile-b',
+  schedulingType: SchedulingType.QUEUE,
+  localQueueName: 'queue-b',
+});
+
+const nodeProfile = mockHardwareProfile({
+  name: 'node-profile',
+  schedulingType: SchedulingType.NODE,
+});
+
+const allProfiles = [kueueProfile, kueueProfileB, nodeProfile];
+
+describe('filterProfilesByKueue', () => {
+  describe('NO_PROFILES state', () => {
+    it('should return an empty array regardless of input profiles', () => {
+      expect(filterProfilesByKueue(allProfiles, KueueFilteringState.NO_PROFILES)).toEqual([]);
+    });
+
+    it('should return an empty array for empty input', () => {
+      expect(filterProfilesByKueue([], KueueFilteringState.NO_PROFILES)).toEqual([]);
+    });
+  });
+
+  describe('ONLY_NON_KUEUE_PROFILES state', () => {
+    it('should return only non-Kueue profiles', () => {
+      const result = filterProfilesByKueue(
+        allProfiles,
+        KueueFilteringState.ONLY_NON_KUEUE_PROFILES,
+      );
+      expect(result).toEqual([nodeProfile]);
+    });
+
+    it('should return empty array when all profiles are Kueue type', () => {
+      const result = filterProfilesByKueue(
+        [kueueProfile, kueueProfileB],
+        KueueFilteringState.ONLY_NON_KUEUE_PROFILES,
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should ignore availableLocalQueueNames — it has no effect outside ONLY_KUEUE_PROFILES', () => {
+      const result = filterProfilesByKueue(
+        allProfiles,
+        KueueFilteringState.ONLY_NON_KUEUE_PROFILES,
+        new Set(['queue-a']),
+      );
+      expect(result).toEqual([nodeProfile]);
+    });
+  });
+
+  describe('ONLY_KUEUE_PROFILES state — without availableLocalQueueNames', () => {
+    it('should return all Kueue profiles when availableLocalQueueNames is undefined', () => {
+      const result = filterProfilesByKueue(allProfiles, KueueFilteringState.ONLY_KUEUE_PROFILES);
+      expect(result).toEqual([kueueProfile, kueueProfileB]);
+    });
+
+    it('should return empty array when all profiles are non-Kueue type', () => {
+      const result = filterProfilesByKueue([nodeProfile], KueueFilteringState.ONLY_KUEUE_PROFILES);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('ONLY_KUEUE_PROFILES state — with availableLocalQueueNames', () => {
+    it('should show only Kueue profiles whose localQueueName is in the available set', () => {
+      const result = filterProfilesByKueue(
+        allProfiles,
+        KueueFilteringState.ONLY_KUEUE_PROFILES,
+        new Set(['queue-a']),
+      );
+      expect(result).toEqual([kueueProfile]);
+    });
+
+    it('should hide all Kueue profiles when none of their queues are in the available set', () => {
+      const result = filterProfilesByKueue(
+        allProfiles,
+        KueueFilteringState.ONLY_KUEUE_PROFILES,
+        new Set(['queue-does-not-exist']),
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should show all Kueue profiles when all their queues are in the available set', () => {
+      const result = filterProfilesByKueue(
+        allProfiles,
+        KueueFilteringState.ONLY_KUEUE_PROFILES,
+        new Set(['queue-a', 'queue-b']),
+      );
+      expect(result).toEqual([kueueProfile, kueueProfileB]);
+    });
+
+    it('should show Kueue profiles without a localQueueName regardless of the available set', () => {
+      const kueueProfileNoQueue = mockHardwareProfile({
+        name: 'kueue-no-queue',
+        schedulingType: SchedulingType.QUEUE,
+      });
+      // Remove the localQueueName that the mock sets by default
+      if (kueueProfileNoQueue.spec.scheduling?.kueue) {
+        kueueProfileNoQueue.spec.scheduling.kueue.localQueueName = '';
+      }
+
+      const result = filterProfilesByKueue(
+        [kueueProfileNoQueue],
+        KueueFilteringState.ONLY_KUEUE_PROFILES,
+        new Set(['queue-a']),
+      );
+      expect(result).toEqual([kueueProfileNoQueue]);
+    });
+  });
+});
+
+const makeWrapper = (localQueues: ProjectDetailsContextType['localQueues']) => {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+    React.createElement(
+      ProjectDetailsContext.Provider,
+      { value: { localQueues } as unknown as ProjectDetailsContextType },
+      children,
+    );
+  Wrapper.displayName = 'LocalQueueWrapper';
+  return Wrapper;
+};
+
+describe('useAvailableLocalQueueNames', () => {
+  it('returns { status: "loading" } while localQueues are still loading', () => {
+    const { result } = renderHook(() => useAvailableLocalQueueNames(), {
+      wrapper: makeWrapper({ data: [], loaded: false, error: undefined, refresh: jest.fn() }),
+    });
+    expect(result.current).toEqual({ status: 'loading' });
+  });
+
+  it.each([
+    [
+      'loaded=true',
+      { data: [], loaded: true, error: new Error('fetch failed'), refresh: jest.fn() },
+    ],
+    [
+      'loaded=false',
+      { data: [], loaded: false, error: new Error('fetch failed'), refresh: jest.fn() },
+    ],
+  ])('returns { status: "error" } when localQueues errored (%s)', (_, localQueues) => {
+    const { result } = renderHook(() => useAvailableLocalQueueNames(), {
+      wrapper: makeWrapper(localQueues),
+    });
+    expect(result.current).toEqual({ status: 'error', error: localQueues.error });
+  });
+
+  it('returns { status: "ready", names: Set } when loaded successfully', () => {
+    const { result } = renderHook(() => useAvailableLocalQueueNames(), {
+      wrapper: makeWrapper({
+        data: [
+          mockLocalQueueK8sResource({ name: 'queue-a' }),
+          mockLocalQueueK8sResource({ name: 'queue-b' }),
+        ],
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      }),
+    });
+    expect(result.current).toEqual({ status: 'ready', names: new Set(['queue-a', 'queue-b']) });
+  });
+
+  it('filters out local queues with no metadata.name', () => {
+    const lqNoName = mockLocalQueueK8sResource({ name: 'queue-a' });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    delete lqNoName.metadata!.name;
+    const { result } = renderHook(() => useAvailableLocalQueueNames(), {
+      wrapper: makeWrapper({
+        data: [lqNoName],
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      }),
+    });
+    expect(result.current).toEqual({ status: 'ready', names: new Set() });
+  });
+});

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
@@ -766,20 +766,6 @@ describe('useHardwareProfileConfig — Kueue auto-selection guard', () => {
     });
   });
 
-  it('defers auto-selection while localQueues are still loading', () => {
-    const { result } = renderHook(() => useHardwareProfileConfig(), {
-      wrapper: makeKueueProjectWrapper({
-        data: [],
-        loaded: false,
-        error: undefined,
-        refresh: jest.fn(),
-      }),
-    });
-
-    // Guard fires: ONLY_KUEUE_PROFILES && localQueues not loaded → return early
-    expect(result.current.formData.selectedProfile).toBeUndefined();
-  });
-
   it('auto-selects first matching Kueue profile once localQueues have loaded', () => {
     const { result } = renderHook(() => useHardwareProfileConfig(), {
       wrapper: makeKueueProjectWrapper({

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
@@ -1,10 +1,18 @@
+import * as React from 'react';
 import { act } from '@testing-library/react';
-import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { renderHook, testHook } from '@odh-dashboard/jest-config/hooks';
 import * as areasUtils from '@odh-dashboard/plugin-core/areas';
+import { SchedulingType } from '@odh-dashboard/k8s-core';
 import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
+import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
 import { useHardwareProfileConfig } from '#~/concepts/hardwareProfiles/useHardwareProfileConfig';
 import * as reduxSelectors from '#~/redux/selectors';
 import * as useHardwareProfilesModule from '#~/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility';
+import { useAvailableLocalQueueNames } from '#~/concepts/hardwareProfiles/kueueUtils';
+import {
+  ProjectDetailsContext,
+  type ProjectDetailsContextType,
+} from '#~/pages/projects/ProjectDetailsContext';
 
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({
   ...jest.requireActual('@odh-dashboard/plugin-core/areas'),
@@ -17,11 +25,17 @@ jest.mock('#~/redux/selectors', () => ({
   useDashboardNamespace: jest.fn(),
 }));
 
+jest.mock('#~/concepts/hardwareProfiles/kueueUtils', () => ({
+  ...jest.requireActual('#~/concepts/hardwareProfiles/kueueUtils'),
+  useAvailableLocalQueueNames: jest.fn(),
+}));
+
 const mockUseIsAreaAvailable = jest.mocked(areasUtils.useIsAreaAvailable);
 const mockUseHardwareProfiles = jest.mocked(
   useHardwareProfilesModule.useHardwareProfilesByFeatureVisibility,
 );
 const mockUseDashboardNamespace = jest.mocked(reduxSelectors.useDashboardNamespace);
+const mockUseAvailableLocalQueueNames = jest.mocked(useAvailableLocalQueueNames);
 
 describe('useHardwareProfileConfig', () => {
   beforeEach(() => {
@@ -39,6 +53,9 @@ describe('useHardwareProfileConfig', () => {
       requiredCapabilities: {},
       customCondition: () => false,
     });
+    // Default: queues still loading. Existing tests use non-Kueue projects
+    // so kueueFilteringState === ONLY_NON_KUEUE_PROFILES and this value is never consulted.
+    mockUseAvailableLocalQueueNames.mockReturnValue({ status: 'loading' });
   });
 
   it('should initialize with default values', () => {
@@ -707,5 +724,109 @@ describe('useHardwareProfileConfig', () => {
       requests: { cpu: '4', memory: '8Gi' },
       limits: { cpu: '4', memory: '8Gi' },
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Kueue auto-selection guard
+// Tests the new-form guard that delays auto-selection until localQueues have
+// loaded, preventing the selection of a profile whose localQueue may not exist
+// in the current project's namespace.
+// ---------------------------------------------------------------------------
+
+const makeKueueProjectWrapper = (localQueues: ProjectDetailsContextType['localQueues']) => {
+  const kueueProject = mockProjectK8sResource({ enableKueue: true });
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+    React.createElement(
+      ProjectDetailsContext.Provider,
+      {
+        value: {
+          currentProject: kueueProject,
+          localQueues,
+        } as unknown as ProjectDetailsContextType,
+      },
+      children,
+    );
+  Wrapper.displayName = 'KueueProjectWrapper';
+  return Wrapper;
+};
+
+describe('useHardwareProfileConfig — Kueue auto-selection guard', () => {
+  const kueueProfile = mockHardwareProfile({
+    name: 'kueue-profile',
+    schedulingType: SchedulingType.QUEUE,
+    localQueueName: 'queue-a',
+  });
+
+  beforeEach(() => {
+    mockUseHardwareProfiles.mockReturnValue({
+      projectProfiles: [[], true, undefined],
+      globalProfiles: [[kueueProfile], true, undefined],
+    });
+    mockUseDashboardNamespace.mockReturnValue({ dashboardNamespace: 'opendatahub' });
+    mockUseIsAreaAvailable.mockReturnValue({
+      status: true,
+      devFlags: {},
+      featureFlags: {},
+      reliantAreas: {},
+      requiredComponents: {},
+      requiredCapabilities: {},
+      customCondition: () => false,
+    });
+  });
+
+  it('defers auto-selection while localQueues are still loading', () => {
+    mockUseAvailableLocalQueueNames.mockReturnValue({ status: 'loading' });
+
+    const { result } = renderHook(() => useHardwareProfileConfig(), {
+      wrapper: makeKueueProjectWrapper({
+        data: [],
+        loaded: false,
+        error: undefined,
+        refresh: jest.fn(),
+      }),
+    });
+
+    // Guard fires: ONLY_KUEUE_PROFILES && status === 'loading' → return early
+    expect(result.current.formData.selectedProfile).toBeUndefined();
+  });
+
+  it('auto-selects first matching Kueue profile once localQueues have loaded', () => {
+    mockUseAvailableLocalQueueNames.mockReturnValue({
+      status: 'ready',
+      names: new Set(['queue-a']),
+    });
+
+    const { result } = renderHook(() => useHardwareProfileConfig(), {
+      wrapper: makeKueueProjectWrapper({
+        data: [],
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      }),
+    });
+
+    // status === 'ready' → guard doesn't fire → kueueProfile is selected
+    expect(result.current.formData.selectedProfile).toBe(kueueProfile);
+  });
+
+  it('auto-selects immediately when localQueues fetch fails (fail-open)', () => {
+    mockUseAvailableLocalQueueNames.mockReturnValue({
+      status: 'error',
+      error: new Error('fetch failed'),
+    });
+
+    const { result } = renderHook(() => useHardwareProfileConfig(), {
+      wrapper: makeKueueProjectWrapper({
+        data: [],
+        loaded: true,
+        error: new Error('fetch failed'),
+        refresh: jest.fn(),
+      }),
+    });
+
+    // status === 'error' → guard doesn't fire (only 'loading' blocks)
+    // filterProfilesByKueue with names=undefined → no queue filtering → kueueProfile selected
+    expect(result.current.formData.selectedProfile).toBe(kueueProfile);
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
@@ -766,6 +766,20 @@ describe('useHardwareProfileConfig — Kueue auto-selection guard', () => {
     });
   });
 
+  it('defers auto-selection while localQueues are still loading', () => {
+    const { result } = renderHook(() => useHardwareProfileConfig(), {
+      wrapper: makeKueueProjectWrapper({
+        data: [],
+        loaded: false,
+        error: undefined,
+        refresh: jest.fn(),
+      }),
+    });
+
+    // Guard fires: ONLY_KUEUE_PROFILES && localQueues not loaded → return early
+    expect(result.current.formData.selectedProfile).toBeUndefined();
+  });
+
   it('auto-selects first matching Kueue profile once localQueues have loaded', () => {
     const { result } = renderHook(() => useHardwareProfileConfig(), {
       wrapper: makeKueueProjectWrapper({

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
@@ -5,10 +5,10 @@ import * as areasUtils from '@odh-dashboard/plugin-core/areas';
 import { SchedulingType } from '@odh-dashboard/k8s-core';
 import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
+import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
 import { useHardwareProfileConfig } from '#~/concepts/hardwareProfiles/useHardwareProfileConfig';
 import * as reduxSelectors from '#~/redux/selectors';
 import * as useHardwareProfilesModule from '#~/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility';
-import { useAvailableLocalQueueNames } from '#~/concepts/hardwareProfiles/kueueUtils';
 import {
   ProjectDetailsContext,
   type ProjectDetailsContextType,
@@ -25,17 +25,11 @@ jest.mock('#~/redux/selectors', () => ({
   useDashboardNamespace: jest.fn(),
 }));
 
-jest.mock('#~/concepts/hardwareProfiles/kueueUtils', () => ({
-  ...jest.requireActual('#~/concepts/hardwareProfiles/kueueUtils'),
-  useAvailableLocalQueueNames: jest.fn(),
-}));
-
 const mockUseIsAreaAvailable = jest.mocked(areasUtils.useIsAreaAvailable);
 const mockUseHardwareProfiles = jest.mocked(
   useHardwareProfilesModule.useHardwareProfilesByFeatureVisibility,
 );
 const mockUseDashboardNamespace = jest.mocked(reduxSelectors.useDashboardNamespace);
-const mockUseAvailableLocalQueueNames = jest.mocked(useAvailableLocalQueueNames);
 
 describe('useHardwareProfileConfig', () => {
   beforeEach(() => {
@@ -53,9 +47,6 @@ describe('useHardwareProfileConfig', () => {
       requiredCapabilities: {},
       customCondition: () => false,
     });
-    // Default: queues still loading. Existing tests use non-Kueue projects
-    // so kueueFilteringState === ONLY_NON_KUEUE_PROFILES and this value is never consulted.
-    mockUseAvailableLocalQueueNames.mockReturnValue({ status: 'loading' });
   });
 
   it('should initialize with default values', () => {
@@ -776,8 +767,6 @@ describe('useHardwareProfileConfig — Kueue auto-selection guard', () => {
   });
 
   it('defers auto-selection while localQueues are still loading', () => {
-    mockUseAvailableLocalQueueNames.mockReturnValue({ status: 'loading' });
-
     const { result } = renderHook(() => useHardwareProfileConfig(), {
       wrapper: makeKueueProjectWrapper({
         data: [],
@@ -787,35 +776,25 @@ describe('useHardwareProfileConfig — Kueue auto-selection guard', () => {
       }),
     });
 
-    // Guard fires: ONLY_KUEUE_PROFILES && status === 'loading' → return early
+    // Guard fires: ONLY_KUEUE_PROFILES && localQueues not loaded → return early
     expect(result.current.formData.selectedProfile).toBeUndefined();
   });
 
   it('auto-selects first matching Kueue profile once localQueues have loaded', () => {
-    mockUseAvailableLocalQueueNames.mockReturnValue({
-      status: 'ready',
-      names: new Set(['queue-a']),
-    });
-
     const { result } = renderHook(() => useHardwareProfileConfig(), {
       wrapper: makeKueueProjectWrapper({
-        data: [],
+        data: [mockLocalQueueK8sResource({ name: 'queue-a' })],
         loaded: true,
         error: undefined,
         refresh: jest.fn(),
       }),
     });
 
-    // status === 'ready' → guard doesn't fire → kueueProfile is selected
+    // localQueues loaded with queue-a → profile whose localQueueName matches → selected
     expect(result.current.formData.selectedProfile).toBe(kueueProfile);
   });
 
   it('auto-selects immediately when localQueues fetch fails (fail-open)', () => {
-    mockUseAvailableLocalQueueNames.mockReturnValue({
-      status: 'error',
-      error: new Error('fetch failed'),
-    });
-
     const { result } = renderHook(() => useHardwareProfileConfig(), {
       wrapper: makeKueueProjectWrapper({
         data: [],
@@ -825,8 +804,21 @@ describe('useHardwareProfileConfig — Kueue auto-selection guard', () => {
       }),
     });
 
-    // status === 'error' → guard doesn't fire (only 'loading' blocks)
-    // filterProfilesByKueue with names=undefined → no queue filtering → kueueProfile selected
+    // error state → fail-open: no queue filtering → kueueProfile is selected
     expect(result.current.formData.selectedProfile).toBe(kueueProfile);
+  });
+
+  it('does not auto-select a Kueue profile whose queue is missing once localQueues are ready', () => {
+    const { result } = renderHook(() => useHardwareProfileConfig(), {
+      wrapper: makeKueueProjectWrapper({
+        data: [mockLocalQueueK8sResource({ name: 'some-other-queue' })],
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      }),
+    });
+
+    // queue-a (kueueProfile's localQueueName) is not in the available queues → filtered out
+    expect(result.current.formData.selectedProfile).toBeUndefined();
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/kueueUtils.ts
+++ b/frontend/src/concepts/hardwareProfiles/kueueUtils.ts
@@ -1,5 +1,7 @@
 export {
   KueueFilteringState,
+  computeLocalQueueNamesResult,
   useKueueConfiguration,
   filterProfilesByKueue,
 } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
+export type { LocalQueueNamesResult } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';

--- a/packages/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
@@ -1379,22 +1379,17 @@ describe('Workbench Hardware Profiles', () => {
         );
     });
 
-    it('shows warning when selected HP references a missing local queue and can be dismissed', () => {
+    it('hides Kueue profile from dropdown when its local queue does not exist in the project', () => {
       setupKueueIntercepts({ localQueueExists: false });
       projectDetails.visit('test-project');
       projectDetails.findSectionTab('workbenches').click();
       workbenchPage.findCreateButton().click();
       cy.wait('@hardwareProfiles');
+      cy.wait('@getLocalQueues');
 
-      hardwareProfileSection.findSelect().should('contain', 'Kueue Profile');
-      createSpawnerPage
-        .findLocalQueueMissingWarning()
-        .should('be.visible')
-        .and('contain.text', 'my-local-queue')
-        .and('contain.text', 'create');
-
-      // Dismiss the warning
-      createSpawnerPage.findLocalQueueMissingWarningCloseButton().click();
+      // Profile is filtered from the dropdown — its localQueue is not in this project
+      hardwareProfileSection.findSelect().should('not.contain', 'Kueue Profile');
+      // No warning shown — the profile was never selectable
       createSpawnerPage.findLocalQueueMissingWarning().should('not.exist');
     });
 

--- a/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
+++ b/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
@@ -326,7 +326,12 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
       kueueFilteringState,
       availableLocalQueueNames,
     );
-    if (initialHardwareProfile && !filteredProfiles.includes(initialHardwareProfile)) {
+    // Rescue only in the group the profile came from, to avoid showing it in both sections.
+    if (
+      initialHardwareProfile &&
+      profiles.includes(initialHardwareProfile) &&
+      !filteredProfiles.includes(initialHardwareProfile)
+    ) {
       filteredProfiles.push(initialHardwareProfile);
     }
     return orderHardwareProfiles(filteredProfiles, hardwareProfileOrder).filter((profile) =>

--- a/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
+++ b/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
@@ -7,6 +7,7 @@ import {
   Label,
   Split,
   SplitItem,
+  Tooltip,
   Truncate,
   Stack,
   StackItem,
@@ -16,10 +17,12 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { InfoCircleIcon } from '@patternfly/react-icons';
+import { t_global_icon_color_disabled as disabledIconColor } from '@patternfly/react-tokens';
 import type { HardwareProfileKind } from '@odh-dashboard/k8s-core';
 import SimpleSelect, { SimpleSelectOption } from '@odh-dashboard/ui-core/components/SimpleSelect';
 import TruncatedText from '@odh-dashboard/ui-core/components/TruncatedText';
 import ProjectScopedIcon from '@odh-dashboard/ui-core/components/searchSelector/ProjectScopedIcon';
+import { DashboardPopupIconButton } from '@odh-dashboard/ui-core';
 import {
   ProjectScopedGroupLabel,
   ProjectScopedSearchDropdown,
@@ -34,7 +37,12 @@ import {
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { ProjectsContext, byName } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
 import { useApplicationSettings } from '@odh-dashboard/internal/app/useApplicationSettings';
-import { filterProfilesByKueue, KueueFilteringState, useKueueConfiguration } from './kueueUtils';
+import {
+  computeLocalQueueNamesResult,
+  filterProfilesByKueue,
+  KueueFilteringState,
+  useKueueConfiguration,
+} from './kueueUtils';
 import { formatResource, formatResourceValue } from './utils';
 import { HardwareProfileConfig } from './useHardwareProfileConfig';
 import HardwareProfileDetailsPopover from './HardwareProfileDetailsPopover';
@@ -82,7 +90,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     currentProjectHardwareProfilesError,
   ] = projectScopedHardwareProfiles;
 
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const { currentProject, localQueues } = React.useContext(ProjectDetailsContext);
   const { projects } = React.useContext(ProjectsContext);
   const { dashboardConfig } = useApplicationSettings();
   const hardwareProfileOrder = React.useMemo(
@@ -99,13 +107,36 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
 
   const { kueueFilteringState } = useKueueConfiguration(projectForKueue);
 
+  const { data: lqData, loaded: lqLoaded, error: lqError } = localQueues;
+  const localQueueNamesResult = React.useMemo(
+    () => computeLocalQueueNamesResult({ data: lqData, loaded: lqLoaded, error: lqError }),
+    [lqData, lqLoaded, lqError],
+  );
+  const availableLocalQueueNames =
+    localQueueNamesResult.status === 'ready' ? localQueueNamesResult.names : undefined;
+
+  const isQueueMissing = React.useCallback(
+    (profile: HardwareProfileKind): boolean => {
+      const localQueueName = profile.spec.scheduling?.kueue?.localQueueName;
+      if (!localQueueName || !availableLocalQueueNames) {
+        return false;
+      }
+      return !availableLocalQueueNames.has(localQueueName);
+    },
+    [availableLocalQueueNames],
+  );
+
   const options = React.useMemo(() => {
     const enabledProfiles = orderHardwareProfiles(
-      filterProfilesByKueue(hardwareProfiles.filter(isHardwareProfileEnabled), kueueFilteringState),
+      filterProfilesByKueue(
+        hardwareProfiles.filter(isHardwareProfileEnabled),
+        kueueFilteringState,
+        availableLocalQueueNames,
+      ),
       hardwareProfileOrder,
     );
 
-    if (initialHardwareProfile && !isHardwareProfileEnabled(initialHardwareProfile)) {
+    if (initialHardwareProfile && !enabledProfiles.includes(initialHardwareProfile)) {
       enabledProfiles.push(initialHardwareProfile);
     }
 
@@ -114,6 +145,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
         !isHardwareProfileEnabled(profile) ? ' (disabled)' : ''
       }`;
       const description = getHardwareProfileDescription(profile);
+      const queueMissing = profile === initialHardwareProfile && isQueueMissing(profile);
 
       return {
         key: profile.metadata.name,
@@ -171,6 +203,17 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
             <SplitItem>
               {isHardwareProfileSupported(profile) && <Label color="blue">Compatible</Label>}
             </SplitItem>
+            {queueMissing && (
+              <SplitItem>
+                <Tooltip content="The local queue for this profile is no longer available in this project.">
+                  <DashboardPopupIconButton
+                    aria-label="Local queue unavailable"
+                    data-testid="queue-missing-icon"
+                    icon={<InfoCircleIcon color={disabledIconColor.value} />}
+                  />
+                </Tooltip>
+              </SplitItem>
+            )}
           </Split>
         ),
       };
@@ -190,6 +233,8 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     initialHardwareProfile,
     allowExistingSettings,
     isHardwareProfileSupported,
+    isQueueMissing,
+    availableLocalQueueNames,
     kueueFilteringState,
     hardwareProfileOrder,
   ]);
@@ -200,6 +245,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     scope: 'project' | 'global',
   ) => {
     const description = getHardwareProfileDescription(profile);
+    const queueMissing = profile === initialHardwareProfile && isQueueMissing(profile);
     return (
       <MenuItem
         key={`${index}-${scope}-hardware-profile-${profile.metadata.name}`}
@@ -258,18 +304,32 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
           <SplitItem>
             {isHardwareProfileSupported(profile) && <Label color="blue">Compatible</Label>}
           </SplitItem>
+          {queueMissing && (
+            <SplitItem>
+              <Tooltip content="The local queue for this profile is no longer available in this project.">
+                <DashboardPopupIconButton
+                  aria-label="Local queue unavailable"
+                  data-testid="queue-missing-icon"
+                  icon={<InfoCircleIcon color={disabledIconColor.value} />}
+                />
+              </Tooltip>
+            </SplitItem>
+          )}
         </Split>
       </MenuItem>
     );
   };
 
   const processHardwareProfilesForSelection = (profiles: HardwareProfileKind[]) => {
-    const enabledProfiles = profiles.filter(isHardwareProfileEnabled);
-    if (initialHardwareProfile && !isHardwareProfileEnabled(initialHardwareProfile)) {
-      enabledProfiles.push(initialHardwareProfile);
+    const filteredProfiles = filterProfilesByKueue(
+      profiles.filter(isHardwareProfileEnabled),
+      kueueFilteringState,
+      availableLocalQueueNames,
+    );
+    if (initialHardwareProfile && !filteredProfiles.includes(initialHardwareProfile)) {
+      filteredProfiles.push(initialHardwareProfile);
     }
-    const orderedProfiles = orderHardwareProfiles(enabledProfiles, hardwareProfileOrder);
-    return filterProfilesByKueue(orderedProfiles, kueueFilteringState).filter((profile) =>
+    return orderHardwareProfiles(filteredProfiles, hardwareProfileOrder).filter((profile) =>
       getHardwareProfileDisplayName(profile)
         .toLocaleLowerCase()
         .includes(searchHardwareProfile.toLocaleLowerCase()),

--- a/packages/hardware-profiles/shared/kueueUtils.ts
+++ b/packages/hardware-profiles/shared/kueueUtils.ts
@@ -21,6 +21,38 @@ export enum KueueFilteringState {
   NO_PROFILES = 'no-profiles',
 }
 
+export type LocalQueueNamesResult =
+  | { status: 'loading' }
+  | { status: 'error'; error: Error }
+  | { status: 'ready'; names: Set<string> };
+
+/**
+ * Pure helper — converts a LocalQueue fetch-state object into a typed result.
+ * Keeps context reads out of the utility layer: callers read context and pass the data in.
+ */
+export const computeLocalQueueNamesResult = (localQueues: {
+  data: Array<{ metadata?: { name?: string } }>;
+  loaded: boolean;
+  error?: Error;
+}): LocalQueueNamesResult => {
+  if (localQueues.error) {
+    return { status: 'error', error: localQueues.error };
+  }
+  if (!localQueues.loaded) {
+    return { status: 'loading' };
+  }
+  return {
+    status: 'ready',
+    names: new Set(
+      localQueues.data
+        .filter((lq): lq is typeof lq & { metadata: { name: string } } =>
+          Boolean(lq.metadata?.name),
+        )
+        .map((lq) => lq.metadata.name),
+    ),
+  };
+};
+
 export const useKueueConfiguration = (
   project: ProjectKind | undefined,
 ): {
@@ -67,6 +99,7 @@ export const useKueueConfiguration = (
 export const filterProfilesByKueue = (
   profiles: HardwareProfileKind[],
   kueueFilteringState: KueueFilteringState,
+  availableLocalQueueNames?: Set<string>,
 ): HardwareProfileKind[] => {
   if (kueueFilteringState === KueueFilteringState.NO_PROFILES) {
     return [];
@@ -75,8 +108,17 @@ export const filterProfilesByKueue = (
   return profiles.filter((profile) => {
     const isKueueProfile = profile.spec.scheduling?.type === SchedulingType.QUEUE;
     switch (kueueFilteringState) {
-      case KueueFilteringState.ONLY_KUEUE_PROFILES:
-        return isKueueProfile;
+      case KueueFilteringState.ONLY_KUEUE_PROFILES: {
+        if (!isKueueProfile) {
+          return false;
+        }
+        // When we know which local queues exist, hide profiles whose queue is absent
+        const localQueueName = profile.spec.scheduling?.kueue?.localQueueName;
+        if (availableLocalQueueNames && localQueueName) {
+          return availableLocalQueueNames.has(localQueueName);
+        }
+        return true;
+      }
       case KueueFilteringState.ONLY_NON_KUEUE_PROFILES:
         return !isKueueProfile;
       default:

--- a/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
+++ b/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
@@ -13,7 +13,7 @@ import { isHardwareProfileEnabled } from '@odh-dashboard/internal/pages/hardware
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors';
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { useHardwareProfilesByFeatureVisibility } from '@odh-dashboard/internal/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility';
-import { filterProfilesByKueue, useKueueConfiguration } from './kueueUtils';
+import { computeLocalQueueNamesResult, filterProfilesByKueue, useKueueConfiguration } from './kueueUtils';
 import { isHardwareProfileConfigValid } from './validationUtils';
 import { getContainerResourcesFromHardwareProfile } from './utils';
 
@@ -116,7 +116,7 @@ export const useHardwareProfileConfig = (
   hardwareProfileNamespace?: string | null,
 ): UseHardwareProfileConfigResult => {
   const { dashboardNamespace } = useDashboardNamespace();
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const { currentProject, localQueues } = React.useContext(ProjectDetailsContext);
 
   const {
     globalProfiles: [dashboardProfiles, dashboardProfilesLoaded, dashboardProfilesLoadError],
@@ -142,6 +142,12 @@ export const useHardwareProfileConfig = (
 
   const isFormDataValid = React.useMemo(() => isHardwareProfileConfigValid(formData), [formData]);
   const { kueueFilteringState } = useKueueConfiguration(currentProject);
+
+  const { data: lqData, loaded: lqLoaded, error: lqError } = localQueues;
+  const availableLocalQueueNames = React.useMemo(() => {
+    const result = computeLocalQueueNamesResult({ data: lqData, loaded: lqLoaded, error: lqError });
+    return result.status === 'ready' ? result.names : undefined;
+  }, [lqData, lqLoaded, lqError]);
 
   React.useEffect(() => {
     if (!profilesLoaded || formData.selectedProfile) {
@@ -184,6 +190,7 @@ export const useHardwareProfileConfig = (
         const filteredProfiles = filterProfilesByKueue(
           profiles.filter(isHardwareProfileEnabled),
           kueueFilteringState,
+          availableLocalQueueNames,
         );
         selectedProfile = filteredProfiles.length > 0 ? filteredProfiles[0] : undefined;
         if (selectedProfile) {
@@ -207,6 +214,7 @@ export const useHardwareProfileConfig = (
     dashboardProfiles,
     dashboardNamespace,
     kueueFilteringState,
+    availableLocalQueueNames,
   ]);
 
   return {

--- a/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
+++ b/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
@@ -13,7 +13,11 @@ import { isHardwareProfileEnabled } from '@odh-dashboard/internal/pages/hardware
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors';
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { useHardwareProfilesByFeatureVisibility } from '@odh-dashboard/internal/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility';
-import { computeLocalQueueNamesResult, filterProfilesByKueue, useKueueConfiguration } from './kueueUtils';
+import {
+  computeLocalQueueNamesResult,
+  filterProfilesByKueue,
+  useKueueConfiguration,
+} from './kueueUtils';
 import { isHardwareProfileConfigValid } from './validationUtils';
 import { getContainerResourcesFromHardwareProfile } from './utils';
 

--- a/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
+++ b/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
@@ -16,6 +16,7 @@ import { useHardwareProfilesByFeatureVisibility } from '@odh-dashboard/internal/
 import {
   computeLocalQueueNamesResult,
   filterProfilesByKueue,
+  KueueFilteringState,
   useKueueConfiguration,
 } from './kueueUtils';
 import { isHardwareProfileConfigValid } from './validationUtils';
@@ -191,6 +192,15 @@ export const useHardwareProfileConfig = (
 
       // if not editing existing profile, select the first enabled profile
       else {
+        // Wait for localQueues to load before auto-selecting, so we don't pick a profile
+        // whose localQueueName doesn't exist in the namespace. Fail-open on error.
+        if (
+          kueueFilteringState === KueueFilteringState.ONLY_KUEUE_PROFILES &&
+          !lqLoaded &&
+          !lqError
+        ) {
+          return;
+        }
         const filteredProfiles = filterProfilesByKueue(
           profiles.filter(isHardwareProfileEnabled),
           kueueFilteringState,
@@ -219,6 +229,8 @@ export const useHardwareProfileConfig = (
     dashboardNamespace,
     kueueFilteringState,
     availableLocalQueueNames,
+    lqLoaded,
+    lqError,
   ]);
 
   return {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-67395

## Description

When a project has Kueue enabled, hardware profiles are filtered to only show those with a
`localQueueName`. The bug was that we only checked whether a profile *had* a queue name, never
whether that queue actually exists in the current project's namespace. `LocalQueue` resources are
namespace-scoped, so a profile configured with `localQueueName: team-queue` would show up in any
Kueue-enabled project even if that queue was never created there, and selecting it would fail
silently at workload submission.

**What this PR does:**

- Reads the `LocalQueue` resources already fetched for the current namespace and cross-references
  them against each profile's `localQueueName` before showing it in the dropdown
- Profiles whose queue doesn't exist in the namespace are hidden
- While the queue list is still loading, all profiles are shown and auto-selection is deferred
  so we don't immediately pick a profile whose queue turns out to be missing
- In edit mode, the previously-selected profile stays visible even if its queue is gone, so the
  existing LQ-missing warning can still fire

## Tested on cluster

Verified in `kueue-phase2-dev` (has `default` and `constrained-queue` LocalQueues):
1. Verification in `kueue-integration-test`

https://github.com/user-attachments/assets/92069718-f9f6-4c60-aa9b-3f2de931c285

2. Verification in `kueue-phase2-dev`

https://github.com/user-attachments/assets/d0961cca-9c4b-4a10-b748-0f0156e2fcf6



- `GPU Profile Test`, `Kueue Dev Profile`, `Test GPU Profile` (all referencing `localQueueName: default`) showed up correctly
- `Test Hardware Profile scoping` (referencing `localQueueName: constrained-queue`) showed up in `kueue-phase2-dev` but was hidden in `kueue-integration-test`, which does not have `constrained-queue`
- `Test Hardware -no LQ` (`localQueueName: no-lq`), `Test Hardware profile-no-lq2` (`localQueueName: no-lq2`), and `test` (`localQueueName: f`) were all hidden since none of those queues exist in the namespace
- Created a new profile `Test Hardware Profile scoping 2` with `localQueueName: workbench-queue` — it was hidden in `kueue-phase2-dev` and appeared correctly in `kueue-integration-test` where that queue exists

<!-- add screenshots / recordings here -->

## Test Impact

- New `kueueUtils.spec.ts` covering all filtering branches and loading/error/ready states of the
  queue names hook
- `useHardwareProfileConfig.spec.ts` updated for the new hook return type
- `HardwareProfileSelect.spec.tsx` has a new test for the edit-mode profile preservation
- `workbenchHardwareProfiles.cy.ts` updated to assert the profile is hidden in the CREATE flow
  when its queue is missing (the old test expected a warning that no longer fires)

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not
  immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests
  for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards,
  PatternFly usage, performance considerations)

If you have UI changes:

- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:

- [ ] The developer has tested their solution on a cluster by using the image produced by the PR
  to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardware profile selection now hides Kueue profiles when their referenced LocalQueue is unavailable.
  * Kueue-driven auto-selection waits for LocalQueue data to finish loading, and won’t select profiles with missing queues.
  * In edit mode, the currently selected profile remains visible even if its LocalQueue becomes unavailable (with a queue-missing indicator).
  * If LocalQueue data fails to load, Kueue profiles are still selectable (filtering is bypassed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->