### PR TITLE
RHOAIENG-73368: Upgrade mlflow-go SDK in odh-dashboard BFFs

### DIFF
--- a/packages/gen-ai/bff/go.mod
+++ b/packages/gen-ai/bff/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.37.0
 	github.com/openai/openai-go/v2 v2.7.1
-	github.com/opendatahub-io/mlflow-go v0.0.0-20260226152654-e76893730e71
+	github.com/opendatahub-io/mlflow-go v0.0.0-20260703183401-93243c6d2589
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.11.1
 	github.com/shirou/gopsutil/v4 v4.25.12

--- a/packages/gen-ai/bff/go.sum
+++ b/packages/gen-ai/bff/go.sum
@@ -264,8 +264,8 @@ github.com/openai/openai-go/v2 v2.7.1 h1:/tfvTJhfv7hTSL8mWwc5VL4WLLSDL5yn9VqVykd
 github.com/openai/openai-go/v2 v2.7.1/go.mod h1:jrJs23apqJKKbT+pqtFgNKpRju/KP9zpUTZhz3GElQE=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opendatahub-io/mlflow-go v0.0.0-20260226152654-e76893730e71 h1:uIbgM+A32dijqCEJSmiGcrBKKmgF+ZMAWjt5f5MNwk4=
-github.com/opendatahub-io/mlflow-go v0.0.0-20260226152654-e76893730e71/go.mod h1:PnE/8/k+jnNoUxKFU+tR3PRquDXTMZYQrw+9SRg0ROU=
+github.com/opendatahub-io/mlflow-go v0.0.0-20260703183401-93243c6d2589 h1:D/5+K6/08+93jaLkeXDis0EzxjA2aMIDAFD+tyFL6M0=
+github.com/opendatahub-io/mlflow-go v0.0.0-20260703183401-93243c6d2589/go.mod h1:PnE/8/k+jnNoUxKFU+tR3PRquDXTMZYQrw+9SRg0ROU=
 github.com/opendatahub-io/ogx-k8s-operator v0.0.0-20260512184943-d419c039b7b9 h1:fcugrchnLQS/jEheCAXZcea4ae1c2R4p1g4NPV0X0lM=
 github.com/opendatahub-io/ogx-k8s-operator v0.0.0-20260512184943-d419c039b7b9/go.mod h1:XmnI4PC9oX3slSkhaV5znuadKGYfkQX+gIM0f1ckSO4=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=

--- a/packages/mlflow/bff/go.mod
+++ b/packages/mlflow/bff/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/google/uuid v1.6.0
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/opendatahub-io/mlflow-go v0.0.0-20260226152654-e76893730e71
+	github.com/opendatahub-io/mlflow-go v0.0.0-20260703183401-93243c6d2589
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.11.0
 	k8s.io/api v0.34.1

--- a/packages/mlflow/bff/go.sum
+++ b/packages/mlflow/bff/go.sum
@@ -63,8 +63,8 @@ github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
 github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
-github.com/opendatahub-io/mlflow-go v0.0.0-20260226152654-e76893730e71 h1:uIbgM+A32dijqCEJSmiGcrBKKmgF+ZMAWjt5f5MNwk4=
-github.com/opendatahub-io/mlflow-go v0.0.0-20260226152654-e76893730e71/go.mod h1:PnE/8/k+jnNoUxKFU+tR3PRquDXTMZYQrw+9SRg0ROU=
+github.com/opendatahub-io/mlflow-go v0.0.0-20260703183401-93243c6d2589 h1:D/5+K6/08+93jaLkeXDis0EzxjA2aMIDAFD+tyFL6M0=
+github.com/opendatahub-io/mlflow-go v0.0.0-20260703183401-93243c6d2589/go.mod h1:PnE/8/k+jnNoUxKFU+tR3PRquDXTMZYQrw+9SRg0ROU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-73368

## Description

Upgrades the `github.com/opendatahub-io/mlflow-go` dependency in both odh-dashboard Go BFF modules from `v0.0.0-20260226152654-e76893730e71` to `v0.0.0-20260703183401-93243c6d2589`.

This references the merge commit from [opendatahub-io/mlflow-go#21](https://github.com/opendatahub-io/mlflow-go/pull/21), which exposes `ModelConfig` on `Prompt` and `PromptVersion` structs in listing operations. This is a prerequisite for [RHOAIENG-72531](https://redhat.atlassian.net/browse/RHOAIENG-72531) and RHOAIENG-72532.

**Changes:**
- `packages/mlflow/bff/go.mod` + `go.sum` — updated mlflow-go version
- `packages/gen-ai/bff/go.mod` + `go.sum` — updated mlflow-go version

No functional code changes — the new SDK fields are additive and existing code compiles unchanged.

## How Has This Been Tested?

- `go build ./...` passes in both BFF modules
- `go test ./...` passes in mlflow BFF (all 11 packages)
- `go test ./internal/integrations/mlflow/...` and related packages pass in gen-ai BFF
- gen-ai full test suite has pre-existing failures requiring external services (Llama Stack) not related to this change

## Test Impact

No new tests needed — this is a dependency version bump. The existing test suites exercise the mlflow-go SDK imports and verify backwards compatibility.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
