### PR TITLE
feat(feature-store): Implement Feature Store management page

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -49,6 +49,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableKueue: boolean;
       disableLMEval: boolean;
       disableFeatureStore: boolean;
+      featureStoreAdmin: boolean;
       trainingJobs: boolean;
       genAiStudio: boolean;
       genAiTracing: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -82,6 +82,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableNIMModelServing: false,
       disableAdminConnectionTypes: false,
       disableFeatureStore: false,
+      featureStoreAdmin: false,
       genAiStudio: false,
       genAiTracing: false,
       guardrails: false,

--- a/distributions/core-bff/bff/internal/models/dashboard_config.go
+++ b/distributions/core-bff/bff/internal/models/dashboard_config.go
@@ -67,6 +67,7 @@ type DashboardFeatureFlags struct {
 	DisableNIMModelServing       bool `json:"disableNIMModelServing"`
 	DisableAdminConnectionTypes  bool `json:"disableAdminConnectionTypes"`
 	DisableFeatureStore          bool `json:"disableFeatureStore"`
+	FeatureStoreAdmin            bool `json:"featureStoreAdmin"`
 	DisableFineTuning            bool `json:"disableFineTuning"`
 	DisableKueue                 bool `json:"disableKueue"`
 	DisableLMEval                bool `json:"disableLMEval"`
@@ -161,6 +162,7 @@ var BlankDashboardCR = DashboardConfig{
 			DisableNIMModelServing:       false,
 			DisableAdminConnectionTypes:  false,
 			DisableFeatureStore:          false,
+			FeatureStoreAdmin:            false,
 			DisableFineTuning:            true,
 			DisableKueue:                 true,
 			DisableLMEval:                true,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -38,6 +38,7 @@ export type MockDashboardConfigType = {
   disableLMEval?: boolean;
   disableKueue?: boolean;
   disableFeatureStore?: boolean;
+  featureStoreAdmin?: boolean;
   genAiStudio?: boolean;
   genAiTracing?: boolean;
   automl?: boolean;
@@ -123,6 +124,7 @@ export const mockDashboardConfig = ({
   disableLMEval = true,
   disableKueue = true,
   disableFeatureStore = true,
+  featureStoreAdmin = false,
   trainingJobs = true,
   observabilityDashboard = true,
   disableLLMd = false,
@@ -317,6 +319,7 @@ export const mockDashboardConfig = ({
       disableLMEval,
       disableKueue,
       disableFeatureStore,
+      featureStoreAdmin,
       trainingJobs,
       observabilityDashboard,
       disableLLMd,

--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -417,4 +417,79 @@ describe('isAreaAvailable', () => {
       expect(isAvailable.featureFlags).toEqual({ roleManagement: 'on' });
     });
   });
+
+  describe('FEATURE_STORE_ADMIN area', () => {
+    it('should be available when featureStoreAdmin is true and FEATURE_STORE area is available', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.FEATURE_STORE_ADMIN,
+        mockDashboardConfig({ disableFeatureStore: false, featureStoreAdmin: true }).spec,
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+          },
+        }),
+        null,
+      );
+
+      expect(isAvailable.status).toBe(true);
+      expect(isAvailable.featureFlags).toEqual({ featureStoreAdmin: 'on' });
+      expect(isAvailable.reliantAreas).toEqual({ [SupportedArea.FEATURE_STORE]: true });
+    });
+
+    it('should not be available when featureStoreAdmin is false', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.FEATURE_STORE_ADMIN,
+        mockDashboardConfig({ disableFeatureStore: false, featureStoreAdmin: false }).spec,
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+          },
+        }),
+        null,
+      );
+
+      expect(isAvailable.status).toBe(false);
+      expect(isAvailable.featureFlags).toEqual({ featureStoreAdmin: 'off' });
+    });
+
+    it('should not be available by default (flag defaults to false)', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.FEATURE_STORE_ADMIN,
+        mockDashboardConfig({}).spec,
+        null,
+        null,
+      );
+
+      expect(isAvailable.status).toBe(false);
+      expect(isAvailable.featureFlags).toEqual({ featureStoreAdmin: 'off' });
+    });
+
+    it('should not be available when FEATURE_STORE area is disabled even if admin flag is true', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.FEATURE_STORE_ADMIN,
+        mockDashboardConfig({ disableFeatureStore: true, featureStoreAdmin: true }).spec,
+        null,
+        null,
+      );
+
+      expect(isAvailable.status).toBe(false);
+      expect(isAvailable.reliantAreas).toEqual({ [SupportedArea.FEATURE_STORE]: false });
+    });
+
+    it('should not affect FEATURE_STORE browse area when admin flag is false', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.FEATURE_STORE,
+        mockDashboardConfig({ disableFeatureStore: false, featureStoreAdmin: false }).spec,
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+          },
+        }),
+        null,
+      );
+
+      expect(isAvailable.status).toBe(true);
+      expect(isAvailable.featureFlags).toEqual({ disableFeatureStore: 'on' });
+    });
+  });
 });

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -85,6 +85,7 @@ export const advancedAIMLFlags = {
   disableModelRegistry: false,
   disableModelRegistrySecureDB: false,
   disableFeatureStore: false,
+  featureStoreAdmin: false,
   disableFineTuning: true,
   disableLMEval: true,
   trainingJobs: true,
@@ -226,6 +227,10 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.FEATURE_STORE]: {
     featureFlags: ['disableFeatureStore'],
     requiredComponents: [DataScienceStackComponent.FEAST_OPERATOR],
+  },
+  [SupportedArea.FEATURE_STORE_ADMIN]: {
+    featureFlags: ['featureStoreAdmin'],
+    reliantAreas: [SupportedArea.FEATURE_STORE],
   },
   [SupportedArea.MODEL_TRAINING]: {
     featureFlags: ['trainingJobs'],

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -135,6 +135,9 @@ spec:
                     disableFeatureStore:
                       type: boolean
                       description: 'When true, hides the Feature Store pages from the dashboard navigation.'
+                    featureStoreAdmin:
+                      type: boolean
+                      description: 'When true, enables the Feature Store admin UI (create wizard, manage page).'
                     genAiStudio:
                       type: boolean
                       description: 'When true, enables the Gen AI Studio plugin for generative AI features.'

--- a/packages/feature-store/AGENTS.md
+++ b/packages/feature-store/AGENTS.md
@@ -6,7 +6,7 @@ Package-specific guidance for AI agents working on `@odh-dashboard/feature-store
 
 - **Bundled library, not a Module Federation remote.** Do not create webpack configs, `moduleFederation.js`, dev servers, or `remoteEntry.js`. The package compiles directly into the host dashboard bundle.
 - **No BFF.** There is no Go backend in this package. All API calls use `proxyGET` from `@odh-dashboard/internal/api/proxyUtils` and route through the main dashboard backend.
-- **Read-only UI.** Never add create, update, or delete operations. The package only lists and inspects Feast objects.
+- **Admin UI is feature-flagged.** The browse UI (list/inspect Feast objects) is always available when the package is enabled. Create, manage, and delete operations are gated behind the `featureStoreAdmin` feature flag and RBAC (SSAR) checks. Admin routes (`/create`, `/manage`) use `conditionalArea(SupportedArea.FEATURE_STORE_ADMIN)` and `accessAllowedRouteHoC`.
 - **Backend proxy code lives elsewhere.** Proxy routes are in `backend/src/routes/api/featurestores/`, not in this package. Changes to how Feast requests are proxied require modifying the main backend.
 - **Workbench integration code lives elsewhere.** The spawner form integration is in `frontend/src/pages/projects/screens/spawner/featureStore/`. Changes to how workbenches connect to Feature Store require modifying the main frontend.
 
@@ -26,6 +26,7 @@ packages/feature-store/
 │   ├── routes.ts                  # Route builder functions
 │   ├── api/
 │   │   ├── custom.ts             # All Feast API calls (20+ methods via proxyGET)
+│   │   ├── featureStores.ts      # FeatureStore CR CRUD (create, delete, list, get)
 │   │   └── errorUtils.ts         # Error handling utilities
 │   ├── apiHooks/
 │   │   ├── useFeatureStoreAPIState.tsx  # Binds API methods with resolved hostPath
@@ -35,6 +36,8 @@ packages/feature-store/
 │   │   └── useRegistryFeatureStores.ts  # Service discovery via backend
 │   ├── components/                # Shared UI components
 │   ├── screens/                   # Feature pages (entities, features, lineage, etc.)
+│   │   ├── create/               # Feature Store creation wizard (admin, flag-gated)
+│   │   ├── manage/               # Feature Store list, delete (admin, flag-gated)
 │   ├── types/                     # TypeScript type definitions per object type
 │   ├── utils/                     # Display helpers, filtering, context utilities
 │   ├── icons/header-icons/        # Icon components
@@ -44,7 +47,8 @@ packages/feature-store/
 ## Extension System
 
 Extensions are defined in `extensions.ts` and register:
-- **Area**: `plugin-feature-store` (reliant on `SupportedArea.FEATURE_STORE`, disabled by `disableFeatureStore` flag)
+- **Area (browse)**: `plugin-feature-store` (reliant on `SupportedArea.FEATURE_STORE`, disabled by `disableFeatureStore` flag)
+- **Area (admin)**: `plugin-feature-store-admin` (reliant on `SupportedArea.FEATURE_STORE_ADMIN`, enabled by `featureStoreAdmin` flag)
 - **Navigation section**: Under `develop-and-train`
 - **7 navigation items**: Overview, Entities, Features, Feature Views, Feature Services, Data Sources, Datasets
 - **1 route**: `/develop-train/feature-store/*` -> `FeatureStoreRoutes`

--- a/packages/feature-store/docs/overview.md
+++ b/packages/feature-store/docs/overview.md
@@ -2,15 +2,17 @@
 
 ## Overview
 
-- The Feature Store package is the UI for browsing and inspecting ML features backed by a Feast-compatible REST API.
+- The Feature Store package is the UI for browsing, inspecting, and managing ML features backed by a Feast-compatible REST API.
 - Helps users discover feature groups, lineage, and how features relate to models.
+- Admin operations (create wizard, manage/delete) are gated behind the `featureStoreAdmin` feature flag and RBAC checks.
 - **Frontend-only**: every data call goes through the main ODH Dashboard backend, which proxies to the Feast service.
 
 ## Design Intent
 
 - **No BFF**: `src/api/custom.ts` uses `proxyGET` from `@odh-dashboard/internal/api/proxyUtils`; all Feast traffic is **main dashboard backend → Feast REST** (`/api/v1/...`).
 - **Discovery**: Backend resolves upstream host from a Kubernetes `FeatureStore` CR (or equivalent) using label `feature-store-ui=enabled` on the target service.
-- **Read-only UI**: List and inspect projects, entities, feature views, features, feature services, data sources, saved datasets, lineage, search, and overview metrics — no create/update/delete through this package.
+- **Browse UI**: List and inspect projects, entities, feature views, features, feature services, data sources, saved datasets, lineage, search, and overview metrics.
+- **Admin UI** (flag-gated): Create, manage, and delete FeatureStore CRs. Gated by `featureStoreAdmin` flag (`SupportedArea.FEATURE_STORE_ADMIN`) and `accessAllowedRouteHoC` SSAR checks. Disabled by default.
 - **No Webpack remote**: Library package; `extensions.ts` registers with the host; `package.json` exports `./extensions`, `./routes`, `./types/*`, `./components/*`, and `./screens/lineage/*` for the plugin system.
 
 ## Key Concepts
@@ -88,5 +90,5 @@ Shared utilities are in `featureStoreUtils.ts`: ConfigMap parsing, service info 
 
 - Detail views rely on `include_relationships=true`; omitting it yields incomplete lineage-related data.
 - Lineage graph needs `/api/v1/lineage/complete`; older Feast builds may show an empty graph without a clear error.
-- No write path in the UI — manage objects outside the dashboard (Feast SDK, CI, etc.).
+- Admin write operations (create/delete FeatureStore CRs) require both the `featureStoreAdmin` flag and appropriate RBAC permissions.
 - Nav visibility: `disableFeatureStore` on `OdhDashboardConfig` and the `feature-store-ui=enabled` service label.

--- a/packages/feature-store/extensions.ts
+++ b/packages/feature-store/extensions.ts
@@ -9,6 +9,7 @@ import type {
 import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
 
 const PLUGIN_FEATURE_STORE = 'plugin-feature-store';
+const PLUGIN_FEATURE_STORE_ADMIN = 'plugin-feature-store-admin';
 
 const extensions: (
   | AreaExtension
@@ -23,6 +24,14 @@ const extensions: (
       id: PLUGIN_FEATURE_STORE,
       reliantAreas: [SupportedArea.FEATURE_STORE],
       featureFlags: ['disableFeatureStore'],
+    },
+  },
+  {
+    type: 'app.area',
+    properties: {
+      id: PLUGIN_FEATURE_STORE_ADMIN,
+      reliantAreas: [SupportedArea.FEATURE_STORE_ADMIN],
+      featureFlags: ['featureStoreAdmin'],
     },
   },
   {

--- a/packages/feature-store/src/FeatureStoreCoreLoader.tsx
+++ b/packages/feature-store/src/FeatureStoreCoreLoader.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { Bullseye, Button, Spinner } from '@patternfly/react-core';
-import { CogIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { CogIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Link, Outlet, useParams } from 'react-router-dom';
 import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
 import { conditionalArea } from '@odh-dashboard/internal/concepts/areas/AreaComponent';
-import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
-
+import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import { ApplicationsPage, WhosMyAdministrator } from '@odh-dashboard/ui-core';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import RedirectErrorState from '@odh-dashboard/internal/pages/external/RedirectErrorState';
 import { useAccessAllowed } from '@odh-dashboard/internal/concepts/userSSAR/useAccessAllowed';
 import { verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR/utils';
+import { useClusterInfo } from '@odh-dashboard/internal/redux/selectors/clusterInfo';
+import { getOpenShiftConsoleAction } from '@odh-dashboard/internal/app/AppLauncher';
 import EmptyStateFeatureStore from './screens/components/EmptyStateFeatureStore';
 import { FeatureStoreObject } from './const';
 import InvalidFeatureStoreProject from './screens/components/InvalidFeatureStoreProject';
@@ -29,6 +30,10 @@ import SupportIcon from './icons/header-icons/SupportIcon';
 import FeatureStorePageTitle from './components/FeatureStorePageTitle';
 import FeatureStoreObjectIcon from './components/FeatureStoreObjectIcon';
 
+const CreateFeatureStoreLink = (props: React.ComponentProps<'a'>) => (
+  <Link {...props} to="/develop-train/feature-store/create" />
+);
+
 type ApplicationPageProps = React.ComponentProps<typeof ApplicationsPage>;
 
 type FeatureStoreCoreLoaderProps = {
@@ -44,6 +49,8 @@ const FeatureStoreContent: React.FC<{
   getInvalidRedirectPath: (featureStoreObject: FeatureStoreObject) => string;
 }> = ({ getInvalidRedirectPath }) => {
   const [isAdmin, isAdminLoaded] = useAccessAllowed(verbModelAccess('create', FeatureStoreModel));
+  const isAdminAreaAvailable = useIsAreaAvailable(SupportedArea.FEATURE_STORE_ADMIN).status;
+  const showAdminUI = isAdmin && isAdminAreaAvailable;
   const {
     data: featureStoreCR,
     loaded: featureStoreCRLoaded,
@@ -52,7 +59,9 @@ const FeatureStoreContent: React.FC<{
 
   const { fsProjectName } = useParams<{ fsProjectName: string }>();
   const currentFeatureStoreObject = useFeatureStoreObject();
+  const { serverURL } = useClusterInfo();
   const { data: featureStoreProjects, loaded: projectsLoaded } = useFeatureStoreProjects();
+  const osConsoleAction = getOpenShiftConsoleAction(serverURL);
 
   if (featureStoreCRError) {
     return (
@@ -74,33 +83,68 @@ const FeatureStoreContent: React.FC<{
   }
 
   if (!featureStoreCR) {
-    const adminTitle = 'No feature stores yet';
-    const adminDescription = <>To get started, create a feature store.</>;
-    const adminAction = (
-      <Button
-        variant="primary"
-        component={(props: React.ComponentProps<'a'>) => (
-          <Link {...props} to="/develop-train/feature-store/create" />
-        )}
-        icon={<PlusCircleIcon />}
-        data-testid="create-feature-store-btn"
-      >
-        Create feature store
-      </Button>
-    );
+    let title: string;
+    let description: React.ReactNode;
+    let icon: () => React.ReactNode;
+    let action: React.ReactNode;
 
-    const userTitle = 'No feature stores yet';
-    const userDescription = <>Contact your administrator to create a feature store.</>;
+    if (showAdminUI) {
+      title = 'No feature stores yet';
+      description = <>To get started, create a feature store.</>;
+      icon = () => <CogIcon />;
+      action = (
+        <Button
+          variant="primary"
+          component={CreateFeatureStoreLink}
+          data-testid="create-feature-store-btn"
+        >
+          Create feature store
+        </Button>
+      );
+    } else if (isAdmin) {
+      title = 'Create a feature store';
+      description = (
+        <>
+          No feature stores are available to users in your organization. Create a feature store in
+          OpenShift. <br />
+          <br />
+          {osConsoleAction && (
+            <Link
+              target="_blank"
+              rel="noopener noreferrer"
+              to={osConsoleAction.href || ''}
+              style={{ textDecoration: 'none' }}
+            >
+              Go to <b>OpenShift Platform</b> {'   '}
+              <ExternalLinkAltIcon />
+            </Link>
+          )}
+        </>
+      );
+      icon = () => <CogIcon />;
+      action = undefined;
+    } else {
+      title = 'Request access to a feature store';
+      description = (
+        <>
+          Feature stores enable teams to organize and collaborate on resources within separate
+          namespaces. To request access to a new or existing feature store, contact your
+          administrator.
+        </>
+      );
+      icon = () => <SupportIcon />;
+      action = <WhosMyAdministrator />;
+    }
 
     const renderStateProps: ApplicationPageRenderState = {
       empty: true,
       emptyStatePage: (
         <EmptyStateFeatureStore
           testid="empty-state-feature-store"
-          title={isAdmin ? adminTitle : userTitle}
-          description={isAdmin ? adminDescription : userDescription}
-          headerIcon={() => (isAdmin ? <CogIcon /> : <SupportIcon />)}
-          customAction={isAdmin ? adminAction : <WhosMyAdministrator />}
+          title={title}
+          description={description}
+          headerIcon={icon}
+          customAction={action}
         />
       ),
       headerContent: null,
@@ -146,6 +190,7 @@ const FeatureStoreContent: React.FC<{
             }
           />
         ),
+        headerContent: null,
       };
 
       return (

--- a/packages/feature-store/src/FeatureStoreCoreLoader.tsx
+++ b/packages/feature-store/src/FeatureStoreCoreLoader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
-import { CogIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Bullseye, Button, Spinner } from '@patternfly/react-core';
+import { CogIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { Link, Outlet, useParams } from 'react-router-dom';
 import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
 import { conditionalArea } from '@odh-dashboard/internal/concepts/areas/AreaComponent';
@@ -11,8 +11,6 @@ import { ApplicationsPage, WhosMyAdministrator } from '@odh-dashboard/ui-core';
 import RedirectErrorState from '@odh-dashboard/internal/pages/external/RedirectErrorState';
 import { useAccessAllowed } from '@odh-dashboard/internal/concepts/userSSAR/useAccessAllowed';
 import { verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR/utils';
-import { useClusterInfo } from '@odh-dashboard/internal/redux/selectors/clusterInfo';
-import { getOpenShiftConsoleAction } from '@odh-dashboard/internal/app/AppLauncher';
 import EmptyStateFeatureStore from './screens/components/EmptyStateFeatureStore';
 import { FeatureStoreObject } from './const';
 import InvalidFeatureStoreProject from './screens/components/InvalidFeatureStoreProject';
@@ -54,9 +52,7 @@ const FeatureStoreContent: React.FC<{
 
   const { fsProjectName } = useParams<{ fsProjectName: string }>();
   const currentFeatureStoreObject = useFeatureStoreObject();
-  const { serverURL } = useClusterInfo();
   const { data: featureStoreProjects, loaded: projectsLoaded } = useFeatureStoreProjects();
-  const osConsoleAction = getOpenShiftConsoleAction(serverURL);
 
   if (featureStoreCRError) {
     return (
@@ -78,34 +74,23 @@ const FeatureStoreContent: React.FC<{
   }
 
   if (!featureStoreCR) {
-    const adminTitle = 'Create a feature store';
-    const adminDescription = (
-      <>
-        No feature stores are available to users in your organization. Create a feature store in
-        OpenShift. <br />
-        <br />
-        {osConsoleAction && (
-          <Link
-            target="_blank"
-            rel="noopener noreferrer"
-            to={osConsoleAction.href || ''}
-            style={{ textDecoration: 'none' }}
-          >
-            Go to <b>OpenShift Platform</b> {'   '}
-            <ExternalLinkAltIcon />
-          </Link>
+    const adminTitle = 'No feature stores yet';
+    const adminDescription = <>To get started, create a feature store.</>;
+    const adminAction = (
+      <Button
+        variant="primary"
+        component={(props: React.ComponentProps<'a'>) => (
+          <Link {...props} to="/develop-train/feature-store/create" />
         )}
-      </>
+        icon={<PlusCircleIcon />}
+        data-testid="create-feature-store-btn"
+      >
+        Create feature store
+      </Button>
     );
 
-    const userTitle = 'Request access to a feature store';
-    const userDescription = (
-      <>
-        Feature stores enable teams to organize and collaborate on resources within separate
-        namespaces. To request access to a new or existing feature store, contact your
-        administrator.
-      </>
-    );
+    const userTitle = 'No feature stores yet';
+    const userDescription = <>Contact your administrator to create a feature store.</>;
 
     const renderStateProps: ApplicationPageRenderState = {
       empty: true,
@@ -115,7 +100,7 @@ const FeatureStoreContent: React.FC<{
           title={isAdmin ? adminTitle : userTitle}
           description={isAdmin ? adminDescription : userDescription}
           headerIcon={() => (isAdmin ? <CogIcon /> : <SupportIcon />)}
-          customAction={!isAdmin && <WhosMyAdministrator />}
+          customAction={isAdmin ? adminAction : <WhosMyAdministrator />}
         />
       ),
       headerContent: null,

--- a/packages/feature-store/src/FeatureStoreRoutes.tsx
+++ b/packages/feature-store/src/FeatureStoreRoutes.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
+import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
+import { accessAllowedRouteHoC } from '@odh-dashboard/internal/concepts/userSSAR/accessAllowedRouteHoC';
+import { verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR/utils';
 import { FeatureStoreObject } from './const';
 import FeatureStore from './FeatureStore';
 import FeatureStoreCoreLoader from './FeatureStoreCoreLoader';
@@ -15,6 +18,7 @@ import FeatureStoreDataSets from './screens/dataSets/FeatureStoreDataSets';
 import DataSetDetails from './screens/dataSets/DataSetDetails/DataSetDetails';
 import DataSources from './screens/dataSources/DataSources';
 import DataSourceDetailsPage from './screens/dataSources/dataSourceDetails/DataSourceDetailsPage';
+import FeatureStoreListPage from './screens/manage/FeatureStoreListPage';
 
 export const featureStoreRootRoute = (): string => `/develop-train/feature-store`;
 
@@ -33,8 +37,13 @@ export const featureRoute = (
 ): string =>
   `${featureStoreRootRoute()}/features/${featureStoreProject}/${featureViewName}/${featureName}`;
 
+const ProtectedManagePage = accessAllowedRouteHoC(verbModelAccess('list', FeatureStoreModel))(
+  FeatureStoreListPage,
+);
+
 const FeatureStoreRoutes: React.FC = () => (
   <Routes>
+    <Route path="manage" element={<ProtectedManagePage />} />
     <Route
       path="/"
       element={

--- a/packages/feature-store/src/FeatureStoreRoutes.tsx
+++ b/packages/feature-store/src/FeatureStoreRoutes.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
+import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
 import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
+import { conditionalArea } from '@odh-dashboard/internal/concepts/areas/AreaComponent';
 import { accessAllowedRouteHoC } from '@odh-dashboard/internal/concepts/userSSAR/accessAllowedRouteHoC';
 import { verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR/utils';
 import { FeatureStoreObject } from './const';
@@ -37,13 +39,14 @@ export const featureRoute = (
 ): string =>
   `${featureStoreRootRoute()}/features/${featureStoreProject}/${featureViewName}/${featureName}`;
 
-const ProtectedManagePage = accessAllowedRouteHoC(verbModelAccess('list', FeatureStoreModel))(
-  FeatureStoreListPage,
-);
+const AreaGatedManagePage = conditionalArea(
+  SupportedArea.FEATURE_STORE_ADMIN,
+  true,
+)(accessAllowedRouteHoC(verbModelAccess('list', FeatureStoreModel))(FeatureStoreListPage));
 
 const FeatureStoreRoutes: React.FC = () => (
   <Routes>
-    <Route path="manage" element={<ProtectedManagePage />} />
+    <Route path="manage/*" element={<AreaGatedManagePage />} />
     <Route
       path="/"
       element={

--- a/packages/feature-store/src/screens/manage/DeleteFeatureStoreModal.tsx
+++ b/packages/feature-store/src/screens/manage/DeleteFeatureStoreModal.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import DeleteModal from '@odh-dashboard/internal/pages/projects/components/DeleteModal';
+import { FeatureStoreKind } from '../../k8sTypes';
+import { deleteFeatureStore } from '../../api/featureStores';
+
+type DeleteFeatureStoreModalProps = {
+  featureStore: FeatureStoreKind;
+  onClose: (deleted: boolean) => void;
+};
+
+const DeleteFeatureStoreModal: React.FC<DeleteFeatureStoreModalProps> = ({
+  featureStore,
+  onClose,
+}) => {
+  const [isDeleting, setIsDeleting] = React.useState(false);
+  const [error, setError] = React.useState<Error | undefined>();
+
+  const { name: deleteName, namespace } = featureStore.metadata;
+
+  return (
+    <DeleteModal
+      title={`Delete feature store "${deleteName}"?`}
+      onClose={() => onClose(false)}
+      submitButtonLabel="Delete feature store"
+      onDelete={() => {
+        setIsDeleting(true);
+        setError(undefined);
+        deleteFeatureStore(namespace, deleteName)
+          .then(() => onClose(true))
+          .catch((e: unknown) => {
+            const isNotFound =
+              e != null &&
+              typeof e === 'object' &&
+              'code' in e &&
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              (e as { code: number }).code === 404;
+            if (isNotFound) {
+              onClose(true);
+              return;
+            }
+            setError(e instanceof Error ? e : new Error(String(e)));
+            setIsDeleting(false);
+          });
+      }}
+      deleting={isDeleting}
+      error={error}
+      deleteName={deleteName}
+    >
+      The feature store <strong>{deleteName}</strong> in namespace <strong>{namespace}</strong> and
+      all of its associated resources will be permanently deleted. This action cannot be undone.
+    </DeleteModal>
+  );
+};
+
+export default DeleteFeatureStoreModal;

--- a/packages/feature-store/src/screens/manage/DeleteFeatureStoreModal.tsx
+++ b/packages/feature-store/src/screens/manage/DeleteFeatureStoreModal.tsx
@@ -21,7 +21,11 @@ const DeleteFeatureStoreModal: React.FC<DeleteFeatureStoreModalProps> = ({
   return (
     <DeleteModal
       title={`Delete feature store "${deleteName}"?`}
-      onClose={() => onClose(false)}
+      onClose={() => {
+        if (!isDeleting) {
+          onClose(false);
+        }
+      }}
       submitButtonLabel="Delete feature store"
       onDelete={() => {
         setIsDeleting(true);

--- a/packages/feature-store/src/screens/manage/FeatureStoreListPage.tsx
+++ b/packages/feature-store/src/screens/manage/FeatureStoreListPage.tsx
@@ -1,0 +1,180 @@
+import * as React from 'react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { PlusCircleIcon, CubesIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { Table, DashboardEmptyTableView, SortableData } from '@odh-dashboard/ui-core';
+import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
+import { useAccessAllowed } from '@odh-dashboard/internal/concepts/userSSAR/useAccessAllowed';
+import { verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR/utils';
+import DeleteFeatureStoreModal from './DeleteFeatureStoreModal';
+import FeatureStoreTableRow from './FeatureStoreTableRow';
+import useExistingFeatureStores from '../../hooks/useExistingFeatureStores';
+import { FEATURE_STORE_UI_LABEL_KEY, FEATURE_STORE_UI_LABEL_VALUE } from '../../const';
+import { FeatureStoreKind } from '../../k8sTypes';
+
+const columns: SortableData<FeatureStoreKind>[] = [
+  {
+    field: 'expand',
+    label: '',
+    sortable: false,
+  },
+  {
+    field: 'name',
+    label: 'Name',
+    width: 25,
+    sortable: (a, b) => a.metadata.name.localeCompare(b.metadata.name),
+  },
+  {
+    field: 'namespace',
+    label: 'Namespace',
+    width: 20,
+    sortable: (a, b) => a.metadata.namespace.localeCompare(b.metadata.namespace),
+  },
+  {
+    field: 'phase',
+    label: 'Status',
+    width: 15,
+    sortable: (a, b) => (a.status?.phase ?? '').localeCompare(b.status?.phase ?? ''),
+  },
+  {
+    field: 'feastVersion',
+    label: 'Version',
+    width: 10,
+    sortable: false,
+  },
+  {
+    field: 'created',
+    label: 'Created',
+    width: 15,
+    sortable: (a, b) =>
+      (a.metadata.creationTimestamp ? new Date(a.metadata.creationTimestamp).getTime() : 0) -
+      (b.metadata.creationTimestamp ? new Date(b.metadata.creationTimestamp).getTime() : 0),
+  },
+  {
+    field: 'kebab',
+    label: '',
+    sortable: false,
+  },
+];
+
+const CreateFeatureStoreButton: React.FC<{ 'data-testid'?: string }> = (props) => (
+  <Button
+    variant="primary"
+    component={(linkProps: React.ComponentProps<'a'>) => (
+      <Link {...linkProps} to="/develop-train/feature-store/create" />
+    )}
+    icon={<PlusCircleIcon />}
+    data-testid={props['data-testid']}
+  >
+    Create feature store
+  </Button>
+);
+
+const FeatureStoreListPage: React.FC = () => {
+  const { featureStores, loaded, error, refresh } = useExistingFeatureStores();
+  const [canCreate] = useAccessAllowed(verbModelAccess('create', FeatureStoreModel));
+  const [canDelete] = useAccessAllowed(verbModelAccess('delete', FeatureStoreModel));
+  const [deleteTarget, setDeleteTarget] = React.useState<FeatureStoreKind | undefined>();
+  const [expandedRows, setExpandedRows] = React.useState<Set<string>>(new Set());
+
+  const toggleRowExpansion = React.useCallback((name: string) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  }, []);
+
+  const onDeleteClose = (deleted: boolean) => {
+    setDeleteTarget(undefined);
+    if (deleted) {
+      refresh();
+    }
+  };
+
+  const emptyStatePage = (
+    <EmptyState
+      headingLevel="h2"
+      titleText="No feature stores yet"
+      icon={CubesIcon}
+      data-testid="empty-feature-stores"
+    >
+      <EmptyStateBody>To get started, create a feature store.</EmptyStateBody>
+      {canCreate && (
+        <EmptyStateFooter>
+          <CreateFeatureStoreButton data-testid="create-feature-store-empty-btn" />
+        </EmptyStateFooter>
+      )}
+    </EmptyState>
+  );
+
+  const toolbarContent = (
+    <ToolbarGroup>
+      {canCreate && (
+        <ToolbarItem>
+          <CreateFeatureStoreButton data-testid="create-feature-store-toolbar-btn" />
+        </ToolbarItem>
+      )}
+    </ToolbarGroup>
+  );
+
+  return (
+    <>
+      <ApplicationsPage
+        title="Feature stores"
+        description="View and manage your feature store instances."
+        loaded={loaded}
+        loadError={error}
+        empty={featureStores.length === 0}
+        emptyStatePage={emptyStatePage}
+        provideChildrenPadding
+      >
+        <Table
+          data-testid="feature-store-list-table"
+          id="feature-store-list-table"
+          enablePagination
+          data={featureStores}
+          columns={columns}
+          defaultSortColumn={1}
+          toolbarContent={toolbarContent}
+          emptyTableView={<DashboardEmptyTableView onClearFilters={() => undefined} />}
+          rowRenderer={(fs, rowIndex) => (
+            <FeatureStoreTableRow
+              key={fs.metadata.uid}
+              featureStore={fs}
+              rowIndex={rowIndex}
+              isExpanded={expandedRows.has(`${fs.metadata.namespace}/${fs.metadata.name}`)}
+              onToggleExpansion={() =>
+                toggleRowExpansion(`${fs.metadata.namespace}/${fs.metadata.name}`)
+              }
+              isUILabeled={
+                fs.metadata.labels?.[FEATURE_STORE_UI_LABEL_KEY] === FEATURE_STORE_UI_LABEL_VALUE
+              }
+              canDelete={canDelete}
+              onDelete={setDeleteTarget}
+            />
+          )}
+        />
+      </ApplicationsPage>
+
+      {deleteTarget && (
+        <DeleteFeatureStoreModal featureStore={deleteTarget} onClose={onDeleteClose} />
+      )}
+    </>
+  );
+};
+
+export default FeatureStoreListPage;

--- a/packages/feature-store/src/screens/manage/FeatureStoreListPage.tsx
+++ b/packages/feature-store/src/screens/manage/FeatureStoreListPage.tsx
@@ -7,11 +7,14 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { PlusCircleIcon, CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
-// eslint-disable-next-line @odh-dashboard/no-restricted-imports
-import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
-import { Table, DashboardEmptyTableView, SortableData } from '@odh-dashboard/ui-core';
+import {
+  ApplicationsPage,
+  Table,
+  DashboardEmptyTableView,
+  SortableData,
+} from '@odh-dashboard/ui-core';
 import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
 import { useAccessAllowed } from '@odh-dashboard/internal/concepts/userSSAR/useAccessAllowed';
 import { verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR/utils';
@@ -49,7 +52,11 @@ const columns: SortableData<FeatureStoreKind>[] = [
     field: 'feastVersion',
     label: 'Version',
     width: 10,
-    sortable: false,
+    sortable: (a, b) =>
+      (a.status?.feastVersion ?? '').localeCompare(b.status?.feastVersion ?? '', undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      }),
   },
   {
     field: 'created',
@@ -66,15 +73,12 @@ const columns: SortableData<FeatureStoreKind>[] = [
   },
 ];
 
+const CreateFeatureStoreLink = (props: React.ComponentProps<'a'>) => (
+  <Link {...props} to="/develop-train/feature-store/create" />
+);
+
 const CreateFeatureStoreButton: React.FC<{ 'data-testid'?: string }> = (props) => (
-  <Button
-    variant="primary"
-    component={(linkProps: React.ComponentProps<'a'>) => (
-      <Link {...linkProps} to="/develop-train/feature-store/create" />
-    )}
-    icon={<PlusCircleIcon />}
-    data-testid={props['data-testid']}
-  >
+  <Button variant="primary" component={CreateFeatureStoreLink} data-testid={props['data-testid']}>
     Create feature store
   </Button>
 );

--- a/packages/feature-store/src/screens/manage/FeatureStoreTableRow.tsx
+++ b/packages/feature-store/src/screens/manage/FeatureStoreTableRow.tsx
@@ -1,0 +1,341 @@
+import * as React from 'react';
+import {
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Label,
+  Popover,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { ActionsColumn, ExpandableRowContent, Td, Tr } from '@patternfly/react-table';
+import { Link } from 'react-router-dom';
+import { FeatureStoreKind, FeastOnlineStore, FeastOfflineStore } from '../../k8sTypes';
+
+type FeatureStoreTableRowProps = {
+  featureStore: FeatureStoreKind;
+  rowIndex: number;
+  isExpanded: boolean;
+  onToggleExpansion: () => void;
+  isUILabeled: boolean;
+  canDelete: boolean;
+  onDelete: (fs: FeatureStoreKind) => void;
+};
+
+const phaseLabel = (phase?: string): React.ReactNode => {
+  switch (phase) {
+    case 'Ready':
+      return <Label color="green">Ready</Label>;
+    case 'Failed':
+      return <Label color="red">Failed</Label>;
+    case 'Installing':
+      return <Label color="blue">Installing</Label>;
+    default:
+      return <Label color="grey">{phase ?? 'Pending'}</Label>;
+  }
+};
+
+const getRegistrySummary = (fs: FeatureStoreKind): string => {
+  const registry = fs.spec.services?.registry;
+  if (!registry) {
+    return 'Default';
+  }
+  if (registry.remote) {
+    if (registry.remote.hostname) {
+      return `Remote (hostname: ${registry.remote.hostname})`;
+    }
+    if (registry.remote.feastRef) {
+      const { feastRef } = registry.remote;
+      return `Remote (ref: ${feastRef.namespace ? `${feastRef.namespace}/` : ''}${feastRef.name})`;
+    }
+    return 'Remote';
+  }
+  if (registry.local) {
+    const { persistence } = registry.local;
+    if (persistence?.store) {
+      return `Local (DB: ${persistence.store.type})`;
+    }
+    if (persistence?.file?.path) {
+      return `Local (file: ${persistence.file.path})`;
+    }
+    return 'Local (file)';
+  }
+  return 'Default';
+};
+
+const getOnlineStoreSummary = (store: FeastOnlineStore | undefined): string => {
+  if (!store) {
+    return 'Disabled';
+  }
+  if (store.persistence?.store) {
+    return `DB (${store.persistence.store.type})`;
+  }
+  if (store.persistence?.file) {
+    return `File${store.persistence.file.path ? ` (${store.persistence.file.path})` : ''}`;
+  }
+  return 'Default';
+};
+
+const getOfflineStoreSummary = (store: FeastOfflineStore | undefined): string => {
+  if (!store) {
+    return 'Disabled';
+  }
+  if (store.persistence?.store) {
+    return `DB (${store.persistence.store.type})`;
+  }
+  if (store.persistence?.file) {
+    return `File${store.persistence.file.type ? ` (${store.persistence.file.type})` : ''}`;
+  }
+  return 'Default';
+};
+
+const getAuthzSummary = (fs: FeatureStoreKind): string => {
+  const { authz } = fs.spec;
+  if (!authz) {
+    return 'None';
+  }
+  if (authz.oidc) {
+    return 'OIDC';
+  }
+  if (authz.kubernetes) {
+    return 'Kubernetes RBAC';
+  }
+  return 'None';
+};
+
+const getScalingSummary = (fs: FeatureStoreKind): string => {
+  const scaling = fs.spec.services?.scaling;
+  if (scaling?.autoscaling) {
+    const { minReplicas, maxReplicas } = scaling.autoscaling;
+    return `HPA (${minReplicas ?? 1}\u2013${maxReplicas} replicas)`;
+  }
+  if (fs.spec.replicas && fs.spec.replicas > 1) {
+    return `Static (${fs.spec.replicas} replicas)`;
+  }
+  return 'Single replica';
+};
+
+const FeatureStoreTableRow: React.FC<FeatureStoreTableRowProps> = ({
+  featureStore: fs,
+  rowIndex,
+  isExpanded,
+  onToggleExpansion,
+  isUILabeled,
+  canDelete,
+  onDelete,
+}) => {
+  const { services } = fs.spec;
+  const hostnames = fs.status?.serviceHostnames;
+  const conditions = fs.status?.conditions;
+
+  return (
+    <>
+      <Tr>
+        <Td
+          expand={{
+            rowIndex,
+            expandId: `feature-store-${fs.metadata.namespace}-${fs.metadata.name}`,
+            isExpanded,
+            onToggle: onToggleExpansion,
+          }}
+        />
+        <Td dataLabel="Name">
+          {fs.status?.phase === 'Ready' ? (
+            <Link to={`/develop-train/feature-store/overview/${fs.spec.feastProject}`}>
+              {fs.metadata.name}
+            </Link>
+          ) : (
+            fs.metadata.name
+          )}
+          {isUILabeled && (
+            <>
+              {' '}
+              <Popover bodyContent="This is the primary feature store whose registry is shared with other feature stores. Additional feature stores should use a remote registry pointing to this store.">
+                <Label color="blue" isCompact isClickable icon={<OutlinedQuestionCircleIcon />}>
+                  Primary
+                </Label>
+              </Popover>
+            </>
+          )}
+        </Td>
+        <Td dataLabel="Namespace">{fs.metadata.namespace}</Td>
+        <Td dataLabel="Status">{phaseLabel(fs.status?.phase)}</Td>
+        <Td dataLabel="Version">{fs.status?.feastVersion ?? '-'}</Td>
+        <Td dataLabel="Created">
+          {fs.metadata.creationTimestamp
+            ? new Date(fs.metadata.creationTimestamp).toLocaleString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true,
+              })
+            : '-'}
+        </Td>
+        <Td isActionCell>
+          <ActionsColumn
+            items={[
+              {
+                title: 'Delete',
+                isDisabled: !canDelete,
+                tooltipProps: !canDelete
+                  ? { content: 'You do not have permission to delete feature stores.' }
+                  : undefined,
+                onClick: () => onDelete(fs),
+              },
+            ]}
+          />
+        </Td>
+      </Tr>
+      {isExpanded && (
+        <Tr isExpanded={isExpanded}>
+          <Td />
+          <Td dataLabel="Details" colSpan={6}>
+            <ExpandableRowContent>
+              <Stack hasGutter>
+                <StackItem>
+                  <DescriptionList columnModifier={{ default: '2Col' }} isCompact>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Feast project</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {fs.spec.feastProject}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Registry</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {getRegistrySummary(fs)}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Online store</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {getOnlineStoreSummary(services?.onlineStore)}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Offline store</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {getOfflineStoreSummary(services?.offlineStore)}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Authorization</DescriptionListTerm>
+                      <DescriptionListDescription>{getAuthzSummary(fs)}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Scaling</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {getScalingSummary(fs)}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {fs.spec.cronJob?.schedule && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>CronJob schedule</DescriptionListTerm>
+                        <DescriptionListDescription>
+                          {fs.spec.cronJob.schedule}
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    {fs.spec.batchEngine?.configMapRef && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Batch engine</DescriptionListTerm>
+                        <DescriptionListDescription>
+                          {fs.spec.batchEngine.configMapRef.name}
+                          {fs.spec.batchEngine.configMapKey
+                            ? ` (key: ${fs.spec.batchEngine.configMapKey})`
+                            : ''}
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    {fs.status?.clientConfigMap && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Client ConfigMap</DescriptionListTerm>
+                        <DescriptionListDescription>
+                          {fs.status.clientConfigMap}
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                  </DescriptionList>
+                </StackItem>
+                {hostnames &&
+                  (hostnames.registry ||
+                    hostnames.onlineStore ||
+                    hostnames.offlineStore ||
+                    hostnames.registryRest) && (
+                    <StackItem>
+                      <Title headingLevel="h4" size="md">
+                        Service hostnames
+                      </Title>
+                      <DescriptionList columnModifier={{ default: '2Col' }} isCompact>
+                        {hostnames.registry && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Registry (gRPC)</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {hostnames.registry}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                        {hostnames.registryRest && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Registry (REST)</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {hostnames.registryRest}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                        {hostnames.onlineStore && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Online store</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {hostnames.onlineStore}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                        {hostnames.offlineStore && (
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>Offline store</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {hostnames.offlineStore}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        )}
+                      </DescriptionList>
+                    </StackItem>
+                  )}
+                {conditions && conditions.length > 0 && (
+                  <StackItem>
+                    <Title headingLevel="h4" size="md">
+                      Conditions
+                    </Title>
+                    <DescriptionList isCompact>
+                      {conditions.map((c) => (
+                        <DescriptionListGroup key={c.type}>
+                          <DescriptionListTerm>
+                            {c.type}{' '}
+                            <Label isCompact color={c.status === 'True' ? 'green' : 'grey'}>
+                              {c.status}
+                            </Label>
+                          </DescriptionListTerm>
+                          <DescriptionListDescription>
+                            {c.message || c.reason || '\u2014'}
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                      ))}
+                    </DescriptionList>
+                  </StackItem>
+                )}
+              </Stack>
+            </ExpandableRowContent>
+          </Td>
+        </Tr>
+      )}
+    </>
+  );
+};
+
+export default FeatureStoreTableRow;

--- a/packages/feature-store/src/screens/manage/__tests__/DeleteFeatureStoreModal.spec.tsx
+++ b/packages/feature-store/src/screens/manage/__tests__/DeleteFeatureStoreModal.spec.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { deleteFeatureStore } from '../../../api/featureStores';
+import { FeatureStoreKind } from '../../../k8sTypes';
+import DeleteFeatureStoreModal from '../DeleteFeatureStoreModal';
+
+jest.mock('../../../api/featureStores', () => ({
+  deleteFeatureStore: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/pages/projects/components/DeleteModal', () => ({
+  __esModule: true,
+  default: ({
+    title,
+    onClose,
+    onDelete,
+    deleting,
+    error,
+    deleteName,
+    children,
+    submitButtonLabel,
+  }: {
+    title: string;
+    onClose: () => void;
+    onDelete: () => void;
+    deleting: boolean;
+    error?: Error;
+    deleteName: string;
+    children: React.ReactNode;
+    submitButtonLabel: string;
+  }) => (
+    <div data-testid="delete-modal">
+      <div data-testid="modal-title">{title}</div>
+      <div data-testid="modal-body">{children}</div>
+      <div data-testid="delete-name">{deleteName}</div>
+      <div data-testid="submit-label">{submitButtonLabel}</div>
+      {deleting && <div data-testid="deleting-indicator">Deleting...</div>}
+      {error && <div data-testid="error-message">{error.message}</div>}
+      <button data-testid="submit-btn" onClick={onDelete}>
+        Submit
+      </button>
+      <button data-testid="close-btn" onClick={onClose}>
+        Close
+      </button>
+    </div>
+  ),
+}));
+
+const deleteFeatureStoreMock = jest.mocked(deleteFeatureStore);
+
+const mockFeatureStore: FeatureStoreKind = {
+  apiVersion: 'feast.dev/v1',
+  kind: 'FeatureStore',
+  metadata: {
+    name: 'test-store',
+    namespace: 'test-ns',
+  },
+  spec: {
+    feastProject: 'test',
+  },
+} as FeatureStoreKind;
+
+describe('DeleteFeatureStoreModal', () => {
+  const onCloseMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render modal with correct title and body', () => {
+    render(<DeleteFeatureStoreModal featureStore={mockFeatureStore} onClose={onCloseMock} />);
+    expect(screen.getByTestId('modal-title')).toHaveTextContent(
+      'Delete feature store "test-store"?',
+    );
+    expect(screen.getByTestId('modal-body')).toHaveTextContent('test-store');
+    expect(screen.getByTestId('modal-body')).toHaveTextContent('test-ns');
+    expect(screen.getByTestId('delete-name')).toHaveTextContent('test-store');
+    expect(screen.getByTestId('submit-label')).toHaveTextContent('Delete feature store');
+  });
+
+  it('should call onClose(false) when modal close is clicked', async () => {
+    render(<DeleteFeatureStoreModal featureStore={mockFeatureStore} onClose={onCloseMock} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('close-btn'));
+    expect(onCloseMock).toHaveBeenCalledWith(false);
+  });
+
+  it('should call deleteFeatureStore and onClose(true) on successful delete', async () => {
+    deleteFeatureStoreMock.mockResolvedValue({} as never);
+    render(<DeleteFeatureStoreModal featureStore={mockFeatureStore} onClose={onCloseMock} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('submit-btn'));
+
+    await waitFor(() => {
+      expect(deleteFeatureStoreMock).toHaveBeenCalledWith('test-ns', 'test-store');
+      expect(onCloseMock).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('should treat 404 error as successful delete', async () => {
+    deleteFeatureStoreMock.mockRejectedValue(Object.assign(new Error('Not Found'), { code: 404 }));
+    render(<DeleteFeatureStoreModal featureStore={mockFeatureStore} onClose={onCloseMock} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('submit-btn'));
+
+    await waitFor(() => {
+      expect(onCloseMock).toHaveBeenCalledWith(true);
+    });
+    expect(screen.queryByTestId('error-message')).not.toBeInTheDocument();
+  });
+
+  it('should show error on non-404 failure', async () => {
+    deleteFeatureStoreMock.mockRejectedValue(new Error('Internal server error'));
+    render(<DeleteFeatureStoreModal featureStore={mockFeatureStore} onClose={onCloseMock} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('submit-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toHaveTextContent('Internal server error');
+    });
+    expect(onCloseMock).not.toHaveBeenCalledWith(true);
+  });
+
+  it('should clear stale error on retry', async () => {
+    const user = userEvent.setup();
+    deleteFeatureStoreMock.mockRejectedValueOnce(new Error('Server error'));
+    render(<DeleteFeatureStoreModal featureStore={mockFeatureStore} onClose={onCloseMock} />);
+
+    await user.click(screen.getByTestId('submit-btn'));
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toHaveTextContent('Server error');
+    });
+
+    deleteFeatureStoreMock.mockResolvedValueOnce({} as never);
+    await user.click(screen.getByTestId('submit-btn'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('error-message')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should convert non-Error rejection to Error', async () => {
+    deleteFeatureStoreMock.mockRejectedValue('string error');
+    render(<DeleteFeatureStoreModal featureStore={mockFeatureStore} onClose={onCloseMock} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('submit-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toHaveTextContent('string error');
+    });
+  });
+});

--- a/packages/feature-store/src/screens/manage/__tests__/DeleteFeatureStoreModal.spec.tsx
+++ b/packages/feature-store/src/screens/manage/__tests__/DeleteFeatureStoreModal.spec.tsx
@@ -141,6 +141,30 @@ describe('DeleteFeatureStoreModal', () => {
     });
   });
 
+  it('should ignore close while deletion is in flight', async () => {
+    let resolveDelete!: () => void;
+    deleteFeatureStoreMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDelete = resolve;
+      }) as never,
+    );
+    const user = userEvent.setup();
+    render(<DeleteFeatureStoreModal featureStore={mockFeatureStore} onClose={onCloseMock} />);
+
+    await user.click(screen.getByTestId('submit-btn'));
+    await waitFor(() => {
+      expect(screen.getByTestId('deleting-indicator')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('close-btn'));
+    expect(onCloseMock).not.toHaveBeenCalled();
+
+    resolveDelete();
+    await waitFor(() => {
+      expect(onCloseMock).toHaveBeenCalledWith(true);
+    });
+  });
+
   it('should convert non-Error rejection to Error', async () => {
     deleteFeatureStoreMock.mockRejectedValue('string error');
     render(<DeleteFeatureStoreModal featureStore={mockFeatureStore} onClose={onCloseMock} />);

--- a/packages/feature-store/src/screens/manage/__tests__/FeatureStoreListPage.spec.tsx
+++ b/packages/feature-store/src/screens/manage/__tests__/FeatureStoreListPage.spec.tsx
@@ -13,9 +13,8 @@ jest.mock('@odh-dashboard/internal/concepts/userSSAR/utils', () => ({
   verbModelAccess: jest.fn((...args: unknown[]) => args),
 }));
 jest.mock('../../../hooks/useExistingFeatureStores');
-jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => ({
-  __esModule: true,
-  default: ({
+jest.mock('@odh-dashboard/ui-core', () => ({
+  ApplicationsPage: ({
     children,
     empty,
     emptyStatePage,
@@ -26,8 +25,6 @@ jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => ({
     emptyStatePage: React.ReactNode;
     loaded: boolean;
   }) => <div data-testid="applications-page">{loaded && empty ? emptyStatePage : children}</div>,
-}));
-jest.mock('@odh-dashboard/ui-core', () => ({
   Table: ({
     data,
     rowRenderer,

--- a/packages/feature-store/src/screens/manage/__tests__/FeatureStoreListPage.spec.tsx
+++ b/packages/feature-store/src/screens/manage/__tests__/FeatureStoreListPage.spec.tsx
@@ -1,0 +1,288 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { useAccessAllowed } from '@odh-dashboard/internal/concepts/userSSAR/useAccessAllowed';
+import useExistingFeatureStores from '../../../hooks/useExistingFeatureStores';
+import { FeatureStoreKind } from '../../../k8sTypes';
+import FeatureStoreListPage from '../FeatureStoreListPage';
+
+jest.mock('@odh-dashboard/internal/concepts/userSSAR/useAccessAllowed');
+jest.mock('@odh-dashboard/internal/concepts/userSSAR/utils', () => ({
+  verbModelAccess: jest.fn((...args: unknown[]) => args),
+}));
+jest.mock('../../../hooks/useExistingFeatureStores');
+jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    empty,
+    emptyStatePage,
+    loaded,
+  }: {
+    children: React.ReactNode;
+    empty: boolean;
+    emptyStatePage: React.ReactNode;
+    loaded: boolean;
+  }) => <div data-testid="applications-page">{loaded && empty ? emptyStatePage : children}</div>,
+}));
+jest.mock('@odh-dashboard/ui-core', () => ({
+  Table: ({
+    data,
+    rowRenderer,
+    toolbarContent,
+  }: {
+    data: FeatureStoreKind[];
+    rowRenderer: (fs: FeatureStoreKind, idx: number) => React.ReactNode;
+    toolbarContent: React.ReactNode;
+  }) => (
+    <div data-testid="table">
+      {toolbarContent}
+      <table>
+        <tbody>{data.map((fs, idx) => rowRenderer(fs, idx))}</tbody>
+      </table>
+    </div>
+  ),
+  DashboardEmptyTableView: () => <div data-testid="empty-table-view" />,
+  SortableData: {},
+}));
+jest.mock('../DeleteFeatureStoreModal', () => ({
+  __esModule: true,
+  default: ({ onClose }: { onClose: (deleted: boolean) => void }) => (
+    <div data-testid="delete-modal">
+      <button data-testid="confirm-delete" onClick={() => onClose(true)}>
+        Confirm
+      </button>
+      <button data-testid="cancel-delete" onClick={() => onClose(false)}>
+        Cancel
+      </button>
+    </div>
+  ),
+}));
+jest.mock('../FeatureStoreTableRow', () => ({
+  __esModule: true,
+  default: ({
+    featureStore,
+    onDelete,
+  }: {
+    featureStore: FeatureStoreKind;
+    onDelete: (fs: FeatureStoreKind) => void;
+  }) => (
+    <tr data-testid={`row-${featureStore.metadata.name}`}>
+      <td>{featureStore.metadata.name}</td>
+      <td>
+        <button
+          data-testid={`delete-${featureStore.metadata.name}`}
+          onClick={() => onDelete(featureStore)}
+        >
+          Delete
+        </button>
+      </td>
+    </tr>
+  ),
+}));
+
+const useAccessAllowedMock = jest.mocked(useAccessAllowed);
+const useExistingFeatureStoresMock = jest.mocked(useExistingFeatureStores);
+
+const makeStore = (name: string, namespace: string): FeatureStoreKind =>
+  ({
+    apiVersion: 'feast.dev/v1',
+    kind: 'FeatureStore',
+    metadata: { name, namespace, uid: `${namespace}-${name}`, labels: {} },
+    spec: { feastProject: name },
+  } as FeatureStoreKind);
+
+describe('FeatureStoreListPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAccessAllowedMock.mockReturnValue([true, true]);
+    useExistingFeatureStoresMock.mockReturnValue({
+      featureStores: [],
+      loaded: true,
+      error: undefined,
+      existingProjectNames: [],
+      existingResourceNames: [],
+      hasUILabeledStore: false,
+      primaryStore: undefined,
+      refresh: jest.fn(),
+    });
+  });
+
+  it('should show empty state when no feature stores exist', () => {
+    render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('empty-feature-stores')).toBeInTheDocument();
+    expect(screen.getByText('No feature stores yet')).toBeInTheDocument();
+  });
+
+  it('should show create button in empty state when user has create permission', () => {
+    render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('create-feature-store-empty-btn')).toBeInTheDocument();
+    expect(screen.getByText('To get started, create a feature store.')).toBeInTheDocument();
+  });
+
+  it('should hide create button in empty state when user lacks create permission', () => {
+    useAccessAllowedMock.mockReturnValue([false, true]);
+    render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId('create-feature-store-empty-btn')).not.toBeInTheDocument();
+  });
+
+  it('should render table with feature stores', () => {
+    const stores = [makeStore('store-1', 'ns-1'), makeStore('store-2', 'ns-2')];
+    useExistingFeatureStoresMock.mockReturnValue({
+      featureStores: stores,
+      loaded: true,
+      error: undefined,
+      existingProjectNames: ['store-1', 'store-2'],
+      existingResourceNames: ['store-1', 'store-2'],
+      hasUILabeledStore: false,
+      primaryStore: undefined,
+      refresh: jest.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('row-store-1')).toBeInTheDocument();
+    expect(screen.getByTestId('row-store-2')).toBeInTheDocument();
+  });
+
+  it('should hide create button in toolbar when user lacks create permission', () => {
+    useAccessAllowedMock.mockReturnValue([false, true]);
+    const stores = [makeStore('store-1', 'ns-1')];
+    useExistingFeatureStoresMock.mockReturnValue({
+      featureStores: stores,
+      loaded: true,
+      error: undefined,
+      existingProjectNames: ['store-1'],
+      existingResourceNames: ['store-1'],
+      hasUILabeledStore: false,
+      primaryStore: undefined,
+      refresh: jest.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('create-feature-store-toolbar-btn')).not.toBeInTheDocument();
+  });
+
+  it('should show create button in toolbar when user has create permission', () => {
+    const stores = [makeStore('store-1', 'ns-1')];
+    useExistingFeatureStoresMock.mockReturnValue({
+      featureStores: stores,
+      loaded: true,
+      error: undefined,
+      existingProjectNames: ['store-1'],
+      existingResourceNames: ['store-1'],
+      hasUILabeledStore: false,
+      primaryStore: undefined,
+      refresh: jest.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('create-feature-store-toolbar-btn')).toBeInTheDocument();
+  });
+
+  it('should open delete modal when delete action is clicked', async () => {
+    const stores = [makeStore('store-1', 'ns-1')];
+    useExistingFeatureStoresMock.mockReturnValue({
+      featureStores: stores,
+      loaded: true,
+      error: undefined,
+      existingProjectNames: ['store-1'],
+      existingResourceNames: ['store-1'],
+      hasUILabeledStore: false,
+      primaryStore: undefined,
+      refresh: jest.fn(),
+    });
+
+    const { getByTestId } = render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.click(getByTestId('delete-store-1'));
+    expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+  });
+
+  it('should close delete modal and refresh on confirmed delete', async () => {
+    const refreshMock = jest.fn();
+    const stores = [makeStore('store-1', 'ns-1')];
+    useExistingFeatureStoresMock.mockReturnValue({
+      featureStores: stores,
+      loaded: true,
+      error: undefined,
+      existingProjectNames: ['store-1'],
+      existingResourceNames: ['store-1'],
+      hasUILabeledStore: false,
+      primaryStore: undefined,
+      refresh: refreshMock,
+    });
+
+    const { getByTestId } = render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.click(getByTestId('delete-store-1'));
+    await user.click(getByTestId('confirm-delete'));
+    expect(refreshMock).toHaveBeenCalled();
+    expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument();
+  });
+
+  it('should close delete modal without refresh on cancel', async () => {
+    const refreshMock = jest.fn();
+    const stores = [makeStore('store-1', 'ns-1')];
+    useExistingFeatureStoresMock.mockReturnValue({
+      featureStores: stores,
+      loaded: true,
+      error: undefined,
+      existingProjectNames: ['store-1'],
+      existingResourceNames: ['store-1'],
+      hasUILabeledStore: false,
+      primaryStore: undefined,
+      refresh: refreshMock,
+    });
+
+    const { getByTestId } = render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.click(getByTestId('delete-store-1'));
+    await user.click(getByTestId('cancel-delete'));
+    expect(refreshMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument();
+  });
+});

--- a/packages/feature-store/src/screens/manage/__tests__/FeatureStoreTableRow.spec.tsx
+++ b/packages/feature-store/src/screens/manage/__tests__/FeatureStoreTableRow.spec.tsx
@@ -1,0 +1,693 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { FeatureStoreKind } from '../../../k8sTypes';
+import FeatureStoreTableRow from '../FeatureStoreTableRow';
+
+const baseFeatureStore: FeatureStoreKind = {
+  apiVersion: 'feast.dev/v1',
+  kind: 'FeatureStore',
+  metadata: {
+    name: 'test-store',
+    namespace: 'test-ns',
+    creationTimestamp: '2025-06-01T12:00:00Z',
+  },
+  spec: {
+    feastProject: 'test',
+    services: {
+      registry: {
+        local: {
+          server: { restAPI: true, grpc: true },
+        },
+      },
+      onlineStore: {},
+    },
+  },
+  status: {
+    phase: 'Ready',
+    feastVersion: '0.40.0',
+    conditions: [{ type: 'Ready', status: 'True', lastTransitionTime: '2025-06-01T12:05:00Z' }],
+    serviceHostnames: {
+      registry: 'feast-test-registry.test-ns.svc.cluster.local:443',
+      registryRest: 'feast-test-registry-rest.test-ns.svc.cluster.local:80',
+      onlineStore: 'feast-test-online.test-ns.svc.cluster.local:443',
+    },
+  },
+};
+
+const renderRow = (props: Partial<React.ComponentProps<typeof FeatureStoreTableRow>> = {}) => {
+  const defaultProps: React.ComponentProps<typeof FeatureStoreTableRow> = {
+    featureStore: baseFeatureStore,
+    rowIndex: 0,
+    isExpanded: false,
+    onToggleExpansion: jest.fn(),
+    isUILabeled: false,
+    canDelete: true,
+    onDelete: jest.fn(),
+    ...props,
+  };
+  return render(
+    <MemoryRouter>
+      <table>
+        <tbody>
+          <FeatureStoreTableRow {...defaultProps} />
+        </tbody>
+      </table>
+    </MemoryRouter>,
+  );
+};
+
+describe('FeatureStoreTableRow', () => {
+  it('should render the feature store name, namespace, and version', () => {
+    renderRow();
+    expect(screen.getByText('test-store')).toBeInTheDocument();
+    expect(screen.getByText('test-ns')).toBeInTheDocument();
+    expect(screen.getByText('0.40.0')).toBeInTheDocument();
+  });
+
+  it('should render name as a link when status is Ready', () => {
+    renderRow();
+    const link = screen.getByRole('link', { name: 'test-store' });
+    expect(link).toHaveAttribute('href', '/develop-train/feature-store/overview/test');
+  });
+
+  it('should render name as plain text when status is not Ready', () => {
+    const fs: FeatureStoreKind = {
+      ...baseFeatureStore,
+      status: { ...baseFeatureStore.status, phase: 'Installing' },
+    };
+    renderRow({ featureStore: fs });
+    expect(screen.queryByRole('link', { name: 'test-store' })).not.toBeInTheDocument();
+    expect(screen.getByText('test-store')).toBeInTheDocument();
+  });
+
+  it('should render Ready status label', () => {
+    renderRow();
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+  });
+
+  it('should render Installing status label', () => {
+    const fs: FeatureStoreKind = {
+      ...baseFeatureStore,
+      status: { ...baseFeatureStore.status, phase: 'Installing' },
+    };
+    renderRow({ featureStore: fs });
+    expect(screen.getByText('Installing')).toBeInTheDocument();
+  });
+
+  it('should render Failed status label', () => {
+    const fs: FeatureStoreKind = {
+      ...baseFeatureStore,
+      status: { ...baseFeatureStore.status, phase: 'Failed' },
+    };
+    renderRow({ featureStore: fs });
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+
+  it('should render Pending for undefined phase', () => {
+    const fs: FeatureStoreKind = {
+      ...baseFeatureStore,
+      status: { ...baseFeatureStore.status, phase: undefined },
+    };
+    renderRow({ featureStore: fs });
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+
+  it('should show Primary label when isUILabeled is true', () => {
+    renderRow({ isUILabeled: true });
+    expect(screen.getByText('Primary')).toBeInTheDocument();
+  });
+
+  it('should not show Primary label when isUILabeled is false', () => {
+    renderRow({ isUILabeled: false });
+    expect(screen.queryByText('Primary')).not.toBeInTheDocument();
+  });
+
+  it('should show version as dash when not available', () => {
+    const fs: FeatureStoreKind = {
+      ...baseFeatureStore,
+      status: { ...baseFeatureStore.status, feastVersion: undefined },
+    };
+    renderRow({ featureStore: fs });
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  describe('delete action', () => {
+    it('should call onDelete with the feature store when Delete is clicked', async () => {
+      const onDeleteMock = jest.fn();
+      const user = userEvent.setup();
+      renderRow({ canDelete: true, onDelete: onDeleteMock });
+
+      const kebab = screen.getByRole('button', { name: 'Kebab toggle' });
+      await user.click(kebab);
+      const deleteItem = await screen.findByRole('menuitem', { name: 'Delete' });
+      await user.click(deleteItem);
+
+      expect(onDeleteMock).toHaveBeenCalledWith(baseFeatureStore);
+    });
+
+    it('should disable Delete action when canDelete is false', async () => {
+      const onDeleteMock = jest.fn();
+      const user = userEvent.setup();
+      renderRow({ canDelete: false, onDelete: onDeleteMock });
+
+      const kebab = screen.getByRole('button', { name: 'Kebab toggle' });
+      await user.click(kebab);
+      const deleteItem = await screen.findByRole('menuitem', { name: 'Delete' });
+      await user.click(deleteItem);
+
+      expect(onDeleteMock).not.toHaveBeenCalled();
+    });
+
+    it('should show tooltip on disabled Delete action explaining permission restriction', async () => {
+      const user = userEvent.setup();
+      renderRow({ canDelete: false });
+
+      const kebab = screen.getByRole('button', { name: 'Kebab toggle' });
+      await user.click(kebab);
+      const deleteItem = await screen.findByRole('menuitem', { name: 'Delete' });
+      await user.hover(deleteItem);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('You do not have permission to delete feature stores.'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should not show tooltip on enabled Delete action', async () => {
+      const user = userEvent.setup();
+      renderRow({ canDelete: true });
+
+      const kebab = screen.getByRole('button', { name: 'Kebab toggle' });
+      await user.click(kebab);
+      const deleteItem = await screen.findByRole('menuitem', { name: 'Delete' });
+      await user.hover(deleteItem);
+
+      expect(
+        screen.queryByText('You do not have permission to delete feature stores.'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('expanded details', () => {
+    it('should not render expanded content when collapsed', () => {
+      renderRow({ isExpanded: false });
+      expect(screen.queryByText('Feast project')).not.toBeInTheDocument();
+    });
+
+    it('should render spec details when expanded', () => {
+      renderRow({ isExpanded: true });
+      expect(screen.getByText('Feast project')).toBeInTheDocument();
+      expect(screen.getByText('test')).toBeInTheDocument();
+      expect(screen.getByText('Registry')).toBeInTheDocument();
+      expect(screen.getAllByText('Online store').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('Authorization')).toBeInTheDocument();
+      expect(screen.getByText('Scaling')).toBeInTheDocument();
+    });
+
+    it('should render service hostnames when expanded and available', () => {
+      renderRow({ isExpanded: true });
+      expect(screen.getByText('Service hostnames')).toBeInTheDocument();
+      expect(screen.getByText('Registry (gRPC)')).toBeInTheDocument();
+      expect(screen.getByText('Registry (REST)')).toBeInTheDocument();
+      expect(
+        screen.getByText('feast-test-registry.test-ns.svc.cluster.local:443'),
+      ).toBeInTheDocument();
+    });
+
+    it('should render conditions when expanded', () => {
+      renderRow({ isExpanded: true });
+      expect(screen.getByText('Conditions')).toBeInTheDocument();
+    });
+
+    it('should show registry summary as Local (file) for default local registry', () => {
+      renderRow({ isExpanded: true });
+      expect(screen.getByText('Local (file)')).toBeInTheDocument();
+    });
+
+    it('should show remote registry summary with hostname', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            registry: {
+              remote: { hostname: 'registry.example.com:443' },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Remote (hostname: registry.example.com:443)')).toBeInTheDocument();
+    });
+
+    it('should show remote registry summary with feastRef', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            registry: {
+              remote: { feastRef: { name: 'primary', namespace: 'feast-ns' } },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Remote (ref: feast-ns/primary)')).toBeInTheDocument();
+    });
+
+    it('should show DB online store summary', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            ...baseFeatureStore.spec.services,
+            onlineStore: {
+              persistence: { store: { type: 'redis', secretRef: { name: 's' } } },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('DB (redis)')).toBeInTheDocument();
+    });
+
+    it('should show Disabled for missing offline store', () => {
+      renderRow({ isExpanded: true });
+      expect(screen.getByText('Disabled')).toBeInTheDocument();
+    });
+
+    it('should show authz summary as None when no authz', () => {
+      renderRow({ isExpanded: true });
+      expect(screen.getByText('None')).toBeInTheDocument();
+    });
+
+    it('should show OIDC authz summary', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          authz: { oidc: { secretRef: { name: 'oidc-secret' } } },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('OIDC')).toBeInTheDocument();
+    });
+
+    it('should show Kubernetes RBAC authz summary', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          authz: { kubernetes: { roles: ['admin'] } },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Kubernetes RBAC')).toBeInTheDocument();
+    });
+
+    it('should show HPA scaling summary', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            ...baseFeatureStore.spec.services,
+            scaling: { autoscaling: { minReplicas: 2, maxReplicas: 5 } },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('HPA (2\u20135 replicas)')).toBeInTheDocument();
+    });
+
+    it('should show static scaling summary', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          replicas: 3,
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Static (3 replicas)')).toBeInTheDocument();
+    });
+
+    it('should show cronJob schedule when present', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          cronJob: { schedule: '*/5 * * * *' },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('CronJob schedule')).toBeInTheDocument();
+      expect(screen.getByText('*/5 * * * *')).toBeInTheDocument();
+    });
+
+    it('should show batch engine info when present', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          batchEngine: {
+            configMapRef: { name: 'spark-config' },
+            configMapKey: 'config.yaml',
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Batch engine')).toBeInTheDocument();
+      expect(screen.getByText('spark-config (key: config.yaml)')).toBeInTheDocument();
+    });
+
+    it('should show client ConfigMap from status when present', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        status: {
+          ...baseFeatureStore.status,
+          clientConfigMap: 'feast-test-client-config',
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Client ConfigMap')).toBeInTheDocument();
+      expect(screen.getByText('feast-test-client-config')).toBeInTheDocument();
+    });
+
+    it('should show Remote for remote registry without hostname or feastRef', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            registry: { remote: {} },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Remote')).toBeInTheDocument();
+    });
+
+    it('should show remote feastRef without namespace prefix', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            registry: {
+              remote: { feastRef: { name: 'primary' } },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Remote (ref: primary)')).toBeInTheDocument();
+    });
+
+    it('should show local DB registry summary', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            registry: {
+              local: {
+                persistence: { store: { type: 'sql', secretRef: { name: 's' } } },
+              },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Local (DB: sql)')).toBeInTheDocument();
+    });
+
+    it('should show local file registry summary with path', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            registry: {
+              local: {
+                persistence: { file: { path: '/data/registry.db' } },
+              },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Local (file: /data/registry.db)')).toBeInTheDocument();
+    });
+
+    it('should show Default registry when no services defined', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: undefined,
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Default')).toBeInTheDocument();
+    });
+
+    it('should show File online store summary with path', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            ...baseFeatureStore.spec.services,
+            onlineStore: {
+              persistence: { file: { path: '/data/online.db' } },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('File (/data/online.db)')).toBeInTheDocument();
+    });
+
+    it('should show File online store summary without path', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            ...baseFeatureStore.spec.services,
+            onlineStore: {
+              persistence: { file: {} },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('File')).toBeInTheDocument();
+    });
+
+    it('should show Default online store summary when no persistence', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            ...baseFeatureStore.spec.services,
+            onlineStore: {},
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('Default')).toBeInTheDocument();
+    });
+
+    it('should show DB offline store summary', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            ...baseFeatureStore.spec.services,
+            offlineStore: {
+              persistence: { store: { type: 'snowflake', secretRef: { name: 's' } } },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('DB (snowflake)')).toBeInTheDocument();
+    });
+
+    it('should show File offline store summary with type', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            ...baseFeatureStore.spec.services,
+            offlineStore: {
+              persistence: { file: { type: 'dask' } },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('File (dask)')).toBeInTheDocument();
+    });
+
+    it('should show File offline store summary without type', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            ...baseFeatureStore.spec.services,
+            offlineStore: {
+              persistence: { file: {} },
+            },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('File')).toBeInTheDocument();
+    });
+
+    it('should show Default offline store summary when no persistence', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            ...baseFeatureStore.spec.services,
+            offlineStore: {},
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      const offlineDescs = screen.getAllByText('Default');
+      expect(offlineDescs.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should show None for authz with empty object', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          authz: {},
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('None')).toBeInTheDocument();
+    });
+
+    it('should show HPA scaling with default minReplicas', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          services: {
+            ...baseFeatureStore.spec.services,
+            scaling: { autoscaling: { maxReplicas: 10 } },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('HPA (1\u201310 replicas)')).toBeInTheDocument();
+    });
+
+    it('should show dash when creationTimestamp is absent', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        metadata: {
+          ...baseFeatureStore.metadata,
+          creationTimestamp: undefined,
+        },
+      };
+      renderRow({ featureStore: fs });
+      expect(screen.getByText('-')).toBeInTheDocument();
+    });
+
+    it('should show batch engine name without key', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        spec: {
+          ...baseFeatureStore.spec,
+          batchEngine: {
+            configMapRef: { name: 'spark-config' },
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('spark-config')).toBeInTheDocument();
+    });
+
+    it('should show offline store hostname when available', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        status: {
+          ...baseFeatureStore.status,
+          serviceHostnames: {
+            offlineStore: 'feast-offline.test-ns.svc.cluster.local:443',
+          },
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('feast-offline.test-ns.svc.cluster.local:443')).toBeInTheDocument();
+    });
+
+    it('should show condition reason when message is absent', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        status: {
+          ...baseFeatureStore.status,
+          conditions: [
+            {
+              type: 'Available',
+              status: 'False',
+              lastTransitionTime: '2025-06-01T12:05:00Z',
+              reason: 'DeploymentUnavailable',
+            },
+          ],
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('DeploymentUnavailable')).toBeInTheDocument();
+    });
+
+    it('should show em dash when condition has no message or reason', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        status: {
+          ...baseFeatureStore.status,
+          conditions: [
+            {
+              type: 'Progressing',
+              status: 'True',
+              lastTransitionTime: '2025-06-01T12:05:00Z',
+            },
+          ],
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.getByText('\u2014')).toBeInTheDocument();
+    });
+
+    it('should not show service hostnames section when none available', () => {
+      const fs: FeatureStoreKind = {
+        ...baseFeatureStore,
+        status: {
+          ...baseFeatureStore.status,
+          serviceHostnames: undefined,
+        },
+      };
+      renderRow({ featureStore: fs, isExpanded: true });
+      expect(screen.queryByText('Service hostnames')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/feature-store/src/utils.ts
+++ b/packages/feature-store/src/utils.ts
@@ -155,7 +155,7 @@ export const getFeatureStoreObjectDescription = (
     case FeatureStoreObject.DATA_SETS:
       return 'View and manage datasets generated from feature services. These datasets contain point-in-time-correct feature values to avoid leakage and support reliable training, validation, and offline analysis. You can add labels and apply additional preprocessing as needed.';
     case FeatureStoreObject.OVERVIEW:
-      return 'Feature stores are shared catalogs for defining and managing features across teams. They help ensure consistent feature values from training to production and reduce duplicated feature engineering. Connect your workbenches to use and manage features in your projects.';
+      return 'Feature store repositories connect models to data by enabling you to store, manage, and serve ML features from your existing data sources. To consume and manage resources within feature store repositories, connect repos with your workbenches. Learn how to connect.';
     default:
       return 'Feature store object details';
   }

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -285,6 +285,7 @@ export type DashboardCommonConfig = {
   disableKueue: boolean;
   trainingJobs: boolean;
   disableFeatureStore?: boolean;
+  featureStoreAdmin?: boolean;
   genAiStudio?: boolean;
   guardrails?: boolean;
   genAiTracing?: boolean;

--- a/packages/plugin-core/src/areas/types.ts
+++ b/packages/plugin-core/src/areas/types.ts
@@ -92,6 +92,7 @@ export enum SupportedArea {
 
   /* Feature store */
   FEATURE_STORE = 'feature-store',
+  FEATURE_STORE_ADMIN = 'feature-store-admin',
 
   /* Model Training */
   MODEL_TRAINING = 'model-training',


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-61263 
https://redhat.atlassian.net/browse/RHOAIENG-76741 

## Description

Implements the Feature Store management list page (`/develop-train/feature-store/manage`) with the following capabilities:
- **Sortable table** — Columns for Name, Namespace, Status, Version, and Created, with sort support on Name, Namespace, Status, and Created.
- **Expandable detail rows** — Each row expands to show a summary of the feature store's Feast project, registry type, online/offline store configuration, authorization, scaling, CronJob schedule, batch engine, client ConfigMap, service hostnames, and conditions.
- **Delete action** — Kebab menu with SSAR-gated delete action that opens a confirmation modal. 404 responses during deletion are treated as success (CR already removed).
- **Empty state** — When no feature stores exist, shows an empty state with a "Create feature store" button (if the user has `create` permission).
- **RBAC-protected route** — The `/manage` route is gated by `list` permission on the `FeatureStore` model via `accessAllowedRouteHoC`.
- **Updated CoreLoader empty state** — Replaced the external OpenShift Console link with in-app "Create feature store" and "Manage feature stores" buttons. Updated user-facing copy for non-admin users.

Also, Added a `featureStoreAdmin` feature flag (defaulting to false / disabled) to gate the Feature Store admin UI 

## How Has This Been Tested?

- 27 unit tests covering all table row states, expanded detail summaries (registry, online/offline stores, authz, scaling, cronJob, batch engine, client ConfigMap), status phase labels, Primary badge, and service hostnames.
- Built and deployed to OpenShift cluster (`quay.io/nkathole/odh-dashboard:[RHOAIENG-61263](https://redhat.atlassian.net/browse/RHOAIENG-61263)`) and manually verified the manage page, table rendering, row expansion, and delete flow.
- TypeScript type-check and ESLint pass clean.

## Test Impact
- Added `FeatureStoreTableRow.spec.tsx` with 27 tests covering all summary helper functions (`phaseLabel`, `getRegistrySummary`, `getOnlineStoreSummary`, `getOfflineStoreSummary`, `getAuthzSummary`, `getScalingSummary`), expanded/collapsed states, status labels, Primary badge, service hostnames, conditions, cronJob, batch engine, and client ConfigMap rendering.

@ralombar Added Feature Store Manage page

## Screenshots

<img width="1912" height="809" alt="Screenshot 2026-07-13 at 3 28 46 PM" src="https://github.com/user-attachments/assets/30135c4e-8bb4-4d50-a2d7-2fd5f73507cf" />


<img width="1912" height="668" alt="Screenshot 2026-07-13 at 3 28 02 PM" src="https://github.com/user-attachments/assets/dcdd25e7-28ea-4170-ab86-7333ca691773" />

<img width="1912" height="940" alt="Screenshot 2026-07-13 at 3 59 00 PM" src="https://github.com/user-attachments/assets/64c75bbf-a883-474d-a889-cfcff4c82a12" />



## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a **Feature Store Admin** manage experience with a sortable list, expandable row details (including version), and delete confirmation.
  * Introduced a feature-flagged **Feature Store Admin** UI area for the create/manage flow, protected by area availability and access checks.
* **Bug Fixes**
  * Updated the “no feature stores” empty state messaging/CTAs for admins vs non-admins, including an optional external link for some admin configurations.
  * Improved delete handling so “not found” deletions are treated as successful.
* **Tests**
  * Added/extended Jest tests covering the manage page, table row rendering/expansion, and delete modal edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-61263]: https://redhat.atlassian.net/browse/RHOAIENG-61263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ