### PR TITLE
feat(gen-ai): Surface model association in prompt picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7829,6 +7829,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -8515,6 +8516,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8531,6 +8533,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8547,6 +8550,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8563,6 +8567,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8579,6 +8584,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8595,6 +8601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8611,6 +8618,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8627,6 +8635,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8643,6 +8652,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8659,6 +8669,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8675,6 +8686,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8691,6 +8703,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13311,6 +13324,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/packages/gen-ai/bff/internal/models/mlflow.go
+++ b/packages/gen-ai/bff/internal/models/mlflow.go
@@ -2,13 +2,20 @@ package models
 
 import "time"
 
+// MLflowModelConfig contains the model association for a prompt.
+type MLflowModelConfig struct {
+	Provider  string `json:"provider,omitempty"`
+	ModelName string `json:"model_name,omitempty"`
+}
+
 // MLflowPrompt represents a prompt from MLflow in BFF response format.
 type MLflowPrompt struct {
-	Name              string            `json:"name"`
-	Description       string            `json:"description"`
-	LatestVersion     int               `json:"latest_version"`
-	Tags              map[string]string `json:"tags,omitempty"`
-	CreationTimestamp time.Time         `json:"creation_timestamp"`
+	Name              string             `json:"name"`
+	Description       string             `json:"description"`
+	LatestVersion     int                `json:"latest_version"`
+	ModelConfig       *MLflowModelConfig `json:"model_config,omitempty"`
+	Tags              map[string]string  `json:"tags,omitempty"`
+	CreationTimestamp time.Time          `json:"creation_timestamp"`
 }
 
 // MLflowPromptsResponse is the response for listing MLflow prompts.
@@ -38,25 +45,27 @@ type MLflowRegisterPromptRequest struct {
 
 // MLflowPromptVersion represents a full prompt version with content.
 type MLflowPromptVersion struct {
-	Name          string            `json:"name"`
-	Version       int               `json:"version"`
-	Template      string            `json:"template,omitempty"`
-	Messages      []MLflowMessage   `json:"messages,omitempty"`
-	CommitMessage string            `json:"commit_message,omitempty"`
-	Aliases       []string          `json:"aliases,omitempty"`
-	Tags          map[string]string `json:"tags,omitempty"`
-	CreatedAt     time.Time         `json:"created_at"`
-	UpdatedAt     time.Time         `json:"updated_at"`
+	Name          string             `json:"name"`
+	Version       int                `json:"version"`
+	Template      string             `json:"template,omitempty"`
+	Messages      []MLflowMessage    `json:"messages,omitempty"`
+	CommitMessage string             `json:"commit_message,omitempty"`
+	Aliases       []string           `json:"aliases,omitempty"`
+	ModelConfig   *MLflowModelConfig `json:"model_config,omitempty"`
+	Tags          map[string]string  `json:"tags,omitempty"`
+	CreatedAt     time.Time          `json:"created_at"`
+	UpdatedAt     time.Time          `json:"updated_at"`
 }
 
 // MLflowPromptVersionMeta represents version metadata without full content.
 type MLflowPromptVersionMeta struct {
-	Version       int               `json:"version"`
-	CommitMessage string            `json:"commit_message,omitempty"`
-	Aliases       []string          `json:"aliases,omitempty"`
-	Tags          map[string]string `json:"tags,omitempty"`
-	CreatedAt     time.Time         `json:"created_at"`
-	UpdatedAt     time.Time         `json:"updated_at"`
+	Version       int                `json:"version"`
+	CommitMessage string             `json:"commit_message,omitempty"`
+	Aliases       []string           `json:"aliases,omitempty"`
+	ModelConfig   *MLflowModelConfig `json:"model_config,omitempty"`
+	Tags          map[string]string  `json:"tags,omitempty"`
+	CreatedAt     time.Time          `json:"created_at"`
+	UpdatedAt     time.Time          `json:"updated_at"`
 }
 
 // MLflowPromptVersionsResponse is the response for listing prompt versions.

--- a/packages/gen-ai/bff/internal/repositories/mlflow_prompts.go
+++ b/packages/gen-ai/bff/internal/repositories/mlflow_prompts.go
@@ -9,6 +9,16 @@ import (
 	"github.com/opendatahub-io/mlflow-go/mlflow/promptregistry"
 )
 
+func toMLflowModelConfig(mc *promptregistry.PromptModelConfig) *models.MLflowModelConfig {
+	if mc == nil {
+		return nil
+	}
+	return &models.MLflowModelConfig{
+		Provider:  mc.Provider,
+		ModelName: mc.ModelName,
+	}
+}
+
 // MLflowPromptsRepository handles MLflow prompt-related operations and data transformations.
 type MLflowPromptsRepository struct {
 	// No fields needed - client comes from context
@@ -59,6 +69,7 @@ func (r *MLflowPromptsRepository) ListPrompts(ctx context.Context, pageToken str
 			Name:              p.Name,
 			Description:       p.Description,
 			LatestVersion:     p.LatestVersion,
+			ModelConfig:       toMLflowModelConfig(p.ModelConfig),
 			Tags:              p.Tags,
 			CreationTimestamp: p.CreationTimestamp,
 		}
@@ -192,6 +203,7 @@ func (r *MLflowPromptsRepository) ListPromptVersions(ctx context.Context, name s
 			Version:       v.Version,
 			CommitMessage: v.CommitMessage,
 			Aliases:       v.Aliases,
+			ModelConfig:   toMLflowModelConfig(v.ModelConfig),
 			Tags:          v.Tags,
 			CreatedAt:     v.CreatedAt,
 			UpdatedAt:     v.UpdatedAt,
@@ -242,6 +254,7 @@ func toMLflowPromptVersion(pv *promptregistry.PromptVersion) *models.MLflowPromp
 		Messages:      messages,
 		CommitMessage: pv.CommitMessage,
 		Aliases:       pv.Aliases,
+		ModelConfig:   toMLflowModelConfig(pv.ModelConfig),
 		Tags:          pv.Tags,
 		CreatedAt:     pv.CreatedAt,
 		UpdatedAt:     pv.UpdatedAt,

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/__mocks__/mockMLflowPrompts.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/__mocks__/mockMLflowPrompts.ts
@@ -1,5 +1,18 @@
 /* eslint-disable camelcase */
-import type { MLflowPrompt, MLflowPromptVersion, MLflowPromptVersionMeta } from '~/app/types';
+import type {
+  MLflowModelConfig,
+  MLflowPrompt,
+  MLflowPromptVersion,
+  MLflowPromptVersionMeta,
+} from '~/app/types';
+
+export const mockMLflowModelConfig = (
+  overrides: Partial<MLflowModelConfig> = {},
+): MLflowModelConfig => ({
+  provider: 'openai',
+  model_name: 'gpt-4',
+  ...overrides,
+});
 
 export const mockMLflowPrompt = (overrides: Partial<MLflowPrompt> = {}): MLflowPrompt => ({
   name: 'test-prompt',
@@ -15,11 +28,16 @@ export const mockMLflowPromptsList = (
   nextPageToken?: string,
 ): { data: { prompts: MLflowPrompt[]; next_page_token?: string; total_count: number } } => {
   const promptsList = prompts ?? [
-    mockMLflowPrompt({ name: 'summarization-prompt', description: 'Summarize content' }),
+    mockMLflowPrompt({
+      name: 'summarization-prompt',
+      description: 'Summarize content',
+      model_config: mockMLflowModelConfig({ model_name: 'gpt-4' }),
+    }),
     mockMLflowPrompt({
       name: 'code-review-prompt',
       description: 'Review code',
       latest_version: 3,
+      model_config: mockMLflowModelConfig({ provider: 'anthropic', model_name: 'claude-sonnet-5' }),
     }),
     mockMLflowPrompt({
       name: 'translation-prompt',

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/__tests__/promptTable.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/__tests__/promptTable.spec.tsx
@@ -166,6 +166,32 @@ describe('PromptTable', () => {
     expect(screen.getByTestId('prompt-model-not-specified')).toHaveTextContent('Not specified');
   });
 
+  it('should truncate long model names with tooltip', () => {
+    const longModelName = 'a]'.repeat(26); // 52 chars, exceeds 50
+    const promptsWithLongModel: MLflowPrompt[] = [
+      {
+        name: 'long-model-prompt',
+        description: 'Prompt with long model name',
+        latest_version: 1,
+        tags: {},
+        creation_timestamp: '2024-01-15T10:00:00Z',
+        model_config: { provider: 'custom', model_name: longModelName },
+      },
+    ];
+    mockUsePromptsList.mockReturnValue({
+      prompts: promptsWithLongModel,
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<PromptTable {...defaultProps} />);
+
+    const modelCell = screen.getByTestId('prompt-model-name');
+    expect(modelCell).toHaveTextContent(longModelName);
+    expect(modelCell).toHaveClass('pf-v6-u-text-truncate');
+  });
+
   it('should call onClose when Cancel button is clicked', () => {
     mockUsePromptsList.mockReturnValue({
       prompts: mockPrompts,

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/__tests__/promptTable.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/__tests__/promptTable.spec.tsx
@@ -17,6 +17,7 @@ const mockPrompts: MLflowPrompt[] = [
     latest_version: 2,
     tags: { env: 'dev' },
     creation_timestamp: '2024-01-15T10:00:00Z',
+    model_config: { provider: 'openai', model_name: 'gpt-4' },
   },
   {
     name: 'test-prompt-2',
@@ -134,8 +135,35 @@ describe('PromptTable', () => {
 
     expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Version' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Model' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Last Modified' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Tags' })).toBeInTheDocument();
+  });
+
+  it('should display model name when model_config is present', () => {
+    mockUsePromptsList.mockReturnValue({
+      prompts: mockPrompts,
+      totalCount: mockPrompts.length,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<PromptTable {...defaultProps} />);
+
+    expect(screen.getByTestId('prompt-model-name')).toHaveTextContent('gpt-4');
+  });
+
+  it('should display "Not specified" when model_config is absent', () => {
+    mockUsePromptsList.mockReturnValue({
+      prompts: mockPrompts,
+      totalCount: mockPrompts.length,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<PromptTable {...defaultProps} />);
+
+    expect(screen.getByTestId('prompt-model-not-specified')).toHaveTextContent('Not specified');
   });
 
   it('should call onClose when Cancel button is clicked', () => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/promptDrawer.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/promptDrawer.tsx
@@ -171,6 +171,12 @@ export default function PromptDrawer({
               <DescriptionListDescription>{commitMessage}</DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
+              <DescriptionListTerm>Model:</DescriptionListTerm>
+              <DescriptionListDescription data-testid="prompt-drawer-model">
+                {selectedPrompt.model_config?.model_name ?? 'Not specified'}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
               <DescriptionListTerm>Tags:</DescriptionListTerm>
               <DescriptionListDescription>
                 <LabelGroup>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/promptTable.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/promptTable.tsx
@@ -24,6 +24,7 @@ import {
   LabelGroup,
   Label,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import { SearchIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tr, Th, Tbody, Td, InnerScrollContainer } from '@patternfly/react-table';
@@ -163,7 +164,9 @@ export default function PromptTable({
     );
   }
 
-  const columns = isDrawerOpen ? ['Name', 'Version'] : ['Name', 'Version', 'Last Modified', 'Tags'];
+  const columns = isDrawerOpen
+    ? ['Name', 'Version']
+    : ['Name', 'Version', 'Model', 'Last Modified', 'Tags'];
 
   function handleRowClick(row: MLflowPrompt) {
     if (selectedRow?.name !== row.name) {
@@ -276,12 +279,36 @@ export default function PromptTable({
                     {!isDrawerOpen && (
                       <>
                         <Td dataLabel={columns[2]}>
+                          {(() => {
+                            const modelName = row.model_config?.model_name;
+                            if (!modelName) {
+                              return (
+                                <span data-testid="prompt-model-not-specified">Not specified</span>
+                              );
+                            }
+                            if (modelName.length > 50) {
+                              return (
+                                <Tooltip content={modelName}>
+                                  <span
+                                    data-testid="prompt-model-name"
+                                    className="pf-v6-u-text-truncate"
+                                    style={{ maxWidth: '200px', display: 'inline-block' }}
+                                  >
+                                    {modelName}
+                                  </span>
+                                </Tooltip>
+                              );
+                            }
+                            return <span data-testid="prompt-model-name">{modelName}</span>;
+                          })()}
+                        </Td>
+                        <Td dataLabel={columns[3]}>
                           <Timestamp
                             date={new Date(row.creation_timestamp)}
                             dateFormat={TimestampFormat.full}
                           />
                         </Td>
-                        <Td dataLabel={columns[3]}>
+                        <Td dataLabel={columns[4]}>
                           <LabelGroup>
                             {Object.entries(row.tags ?? {}).map(([key, value]) => (
                               <Label variant="outline" key={key}>{`${key}: ${value}`}</Label>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/promptTable.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/promptTable.tsx
@@ -32,6 +32,26 @@ import { MLflowPrompt, MLflowPromptVersion } from '~/app/types';
 import { usePromptsList, usePromptVersions } from './usePromptQueries';
 import PromptDrawer from './promptDrawer';
 
+const ModelNameCell: React.FC<{ modelName?: string }> = ({ modelName }) => {
+  if (!modelName) {
+    return <span data-testid="prompt-model-not-specified">Not specified</span>;
+  }
+  if (modelName.length > 50) {
+    return (
+      <Tooltip content={modelName}>
+        <span
+          data-testid="prompt-model-name"
+          className="pf-v6-u-text-truncate"
+          style={{ maxWidth: '200px', display: 'inline-block' }}
+        >
+          {modelName}
+        </span>
+      </Tooltip>
+    );
+  }
+  return <span data-testid="prompt-model-name">{modelName}</span>;
+};
+
 type PromptTableProps = {
   onClickLoad: (prompt: MLflowPromptVersion) => void;
   onClose: () => void;
@@ -279,28 +299,7 @@ export default function PromptTable({
                     {!isDrawerOpen && (
                       <>
                         <Td dataLabel={columns[2]}>
-                          {(() => {
-                            const modelName = row.model_config?.model_name;
-                            if (!modelName) {
-                              return (
-                                <span data-testid="prompt-model-not-specified">Not specified</span>
-                              );
-                            }
-                            if (modelName.length > 50) {
-                              return (
-                                <Tooltip content={modelName}>
-                                  <span
-                                    data-testid="prompt-model-name"
-                                    className="pf-v6-u-text-truncate"
-                                    style={{ maxWidth: '200px', display: 'inline-block' }}
-                                  >
-                                    {modelName}
-                                  </span>
-                                </Tooltip>
-                              );
-                            }
-                            return <span data-testid="prompt-model-name">{modelName}</span>;
-                          })()}
+                          <ModelNameCell modelName={row.model_config?.model_name} />
                         </Td>
                         <Td dataLabel={columns[3]}>
                           <Timestamp

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -493,10 +493,16 @@ export type {
 export type IconType = React.ComponentType<{ style?: React.CSSProperties }>;
 
 /** MLflow Prompt Registry Types */
+export type MLflowModelConfig = {
+  provider?: string;
+  model_name?: string;
+};
+
 export type MLflowPrompt = {
   name: string;
   description: string;
   latest_version: number;
+  model_config?: MLflowModelConfig;
   tags?: Record<string, string>;
   creation_timestamp: string;
 };
@@ -528,6 +534,7 @@ export type MLflowPromptVersion = {
   messages?: MLflowMessage[];
   commit_message?: string;
   aliases?: string[];
+  model_config?: MLflowModelConfig;
   tags?: Record<string, string>;
   created_at: string;
   updated_at: string;
@@ -537,6 +544,7 @@ export type MLflowPromptVersionMeta = {
   version: number;
   commit_message?: string;
   aliases?: string[];
+  model_config?: MLflowModelConfig;
   tags?: Record<string, string>;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72531

## Description

Surfaces the model name from the MLflow prompt registry in the Gen AI Studio prompt picker.

**BFF (Go):** Added MLflowModelConfig struct, model_config field on prompt models, toMLflowModelConfig passthrough helper.

**Frontend (TypeScript/React):** Added Model column in prompt table, Model field in prompt drawer, Not specified fallback, >50 char truncation with tooltip, mock data factory, unit tests.

## How Has This Been Tested?

- Unit tests: promptTable.spec.tsx — 12 tests passing (3 new)
- Go compilation verified
- Lint-staged pre-commit hooks pass
- Automated review scored 8.7/10

## Test Impact

- 3 new unit tests for model display, fallback, truncation
- Updated mock data with mockMLflowModelConfig factory

Self checklist:
- [ ] The developer has manually tested the changes
- [x] Testing instructions added
- [x] Tests added
- [x] Code follows Best Practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt details now show the selected model information alongside each prompt.
  * Long model names are neatly truncated with a tooltip for easier viewing.

* **Bug Fixes**
  * Prompts without model information now display “Not specified” instead of leaving the field blank.
  * Updated prompt listings and details to keep model information consistent across views.

* **Tests**
  * Expanded coverage for prompt table and drawer behavior, including model display and missing-value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->