### PR TITLE
ci: add frontend lockfile drift check to core-bff workflow

### DIFF
--- a/.github/workflows/core-bff-build.yml
+++ b/.github/workflows/core-bff-build.yml
@@ -20,16 +20,34 @@ on:
 permissions:
   contents: read
 
+env:
+  NODE_VERSION: 22
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.25.0'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: core-bff frontend node_modules cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: distributions/core-bff/frontend/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-core-bff-${{ hashFiles('distributions/core-bff/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-core-bff-
 
       - name: Lint
         working-directory: distributions/core-bff/bff
@@ -42,6 +60,10 @@ jobs:
       - name: Test (BFF)
         working-directory: distributions/core-bff/bff
         run: make test
+
+      - name: Install frontend dependencies
+        working-directory: distributions/core-bff/frontend
+        run: npm install
 
       - name: Check if there are uncommitted file changes
         working-directory: distributions/core-bff


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
The core-bff CI only built and tested the Go BFF, so the porcelain check never detected package-lock.json drift from package.json. Add Node.js setup and npm install for the frontend before the existing porcelain check, matching  the pattern used by gen-ai and model-registry workflows. Also pin all action references to SHAs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and consistency of Core BFF automated checks.
  * Standardized the Node.js version used during validation (now set to Node.js 22).
  * Updated the CI workflow to use fixed, versioned action releases, added caching for the frontend `node_modules`, and ensured dependencies are installed before lint/build/test steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->