### PR TITLE
feat(agent-ops): display agent skills on deployment detail page 

### DIFF
--- a/packages/agent-ops/frontend/src/__mocks__/mockAgentRuntime.ts
+++ b/packages/agent-ops/frontend/src/__mocks__/mockAgentRuntime.ts
@@ -43,6 +43,32 @@ export const mockAgentCardDetail = (overrides?: Partial<AgentCardDetail>): Agent
     pushNotifications: false,
     optional: [],
   },
+  skills: [
+    {
+      id: 'code-generation',
+      name: 'Code generation',
+      description:
+        'Generate or refactor code from natural language prompts with repository context.',
+      tags: ['development', 'code'],
+      examples: [
+        'Add unit tests for the auth module',
+        'Refactor this handler to use dependency injection',
+      ],
+      inputModes: [],
+      outputModes: [],
+      parameters: [],
+    },
+    {
+      id: 'repository-analysis',
+      name: 'Repository analysis',
+      description: 'Summarize repository structure, dependencies, and recent changes.',
+      tags: ['development', 'git'],
+      examples: ['What changed in the last release branch?'],
+      inputModes: ['text/plain'],
+      outputModes: ['text/plain'],
+      parameters: [],
+    },
+  ],
   ...overrides,
 });
 

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeploymentDetail.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeploymentDetail.ts
@@ -29,6 +29,14 @@ class AgentDeploymentDetailPage {
     return cy.findByTestId('agent-card-details');
   }
 
+  findSkillsSection(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-capabilities-skills');
+  }
+
+  findSkillCard(skillId: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`agent-skill-card-${skillId}`);
+  }
+
   findLoadingState(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('agent-detail-loading');
   }

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeploymentDetail.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeploymentDetail.cy.ts
@@ -35,6 +35,38 @@ describe('Agent deployment detail', () => {
     cy.findByTestId('agent-card-provider').should('contain.text', 'Red Hat OpenShift AI');
   });
 
+  it('should display skills from agent card under the description', () => {
+    interceptDetail();
+    agentDeploymentDetailPage.visit(TEST_NAMESPACE, TEST_AGENT);
+
+    agentDeploymentDetailPage.findSkillsSection().should('be.visible');
+    agentDeploymentDetailPage
+      .findSkillCard('code-generation')
+      .should('contain.text', 'Code generation')
+      .and('contain.text', 'ID: code-generation')
+      .and('contain.text', 'Generate or refactor code from natural language prompts')
+      .and('contain.text', 'development')
+      .and('contain.text', 'Add unit tests for the auth module');
+    agentDeploymentDetailPage
+      .findSkillCard('code-generation')
+      .should('not.contain.text', 'Input: text/plain');
+    agentDeploymentDetailPage
+      .findSkillCard('repository-analysis')
+      .should('contain.text', 'Repository analysis')
+      .and('contain.text', 'Input: text/plain · Output: text/plain');
+  });
+
+  it('should hide skills section when agent card has no skills', () => {
+    interceptDetail(
+      mockAgentRuntimeDetail({
+        agentCard: mockAgentCardDetail({ skills: [] }),
+      }),
+    );
+    agentDeploymentDetailPage.visit(TEST_NAMESPACE, TEST_AGENT);
+
+    cy.findByTestId('agent-capabilities-skills').should('not.exist');
+  });
+
   it('should show agent details at full width when description is absent', () => {
     interceptDetail(
       mockAgentRuntimeDetail({

--- a/packages/agent-ops/frontend/src/app/components/AgentCapabilitiesCard.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentCapabilitiesCard.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Card, CardBody, CardTitle, Stack, StackItem } from '@patternfly/react-core';
+import AgentSkillCard from '~/app/components/AgentSkillCard';
+import { AgentCardDetail } from '~/app/types/agentRuntimes';
+
+type AgentCapabilitiesCardProps = {
+  agentCard: AgentCardDetail;
+};
+
+const AgentCapabilitiesCard: React.FC<AgentCapabilitiesCardProps> = ({ agentCard }) => {
+  const skills = agentCard.skills ?? [];
+
+  if (skills.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card data-testid="agent-capabilities-skills">
+      <CardTitle>Skills</CardTitle>
+      <CardBody>
+        <Stack hasGutter data-testid="agent-capabilities-skills-list">
+          {skills.map((skill) => (
+            <StackItem key={skill.id}>
+              <AgentSkillCard skill={skill} />
+            </StackItem>
+          ))}
+        </Stack>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default AgentCapabilitiesCard;

--- a/packages/agent-ops/frontend/src/app/components/AgentSkillCard.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentSkillCard.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import {
+  Card,
+  CardBody,
+  Content,
+  ContentVariants,
+  Flex,
+  FlexItem,
+  Label,
+  LabelGroup,
+  List,
+  ListItem,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
+import MarkdownComponent from '@odh-dashboard/internal/components/markdown/MarkdownComponent';
+import { AgentCardSkill } from '~/app/types/agentRuntimes';
+
+type AgentSkillCardProps = {
+  skill: AgentCardSkill;
+};
+
+const formatModes = (label: string, modes: string[]): string | undefined => {
+  if (modes.length === 0) {
+    return undefined;
+  }
+  return `${label}: ${modes.join(', ')}`;
+};
+
+const AgentSkillCard: React.FC<AgentSkillCardProps> = ({ skill }) => {
+  const inputModes = formatModes('Input', skill.inputModes);
+  const outputModes = formatModes('Output', skill.outputModes);
+  const modeSummary = [inputModes, outputModes].filter(Boolean).join(' · ');
+
+  return (
+    <Card isCompact data-testid={`agent-skill-card-${skill.id}`}>
+      <CardBody>
+        <Stack hasGutter>
+          <StackItem>
+            <Title headingLevel="h3" size="md" data-testid="agent-skill-name">
+              {skill.name}
+            </Title>
+            <Content component={ContentVariants.small} data-testid="agent-skill-id">
+              ID: {skill.id}
+            </Content>
+          </StackItem>
+          {skill.description && (
+            <StackItem>
+              <MarkdownComponent
+                data={skill.description}
+                dataTestId={`agent-skill-description-${skill.id}`}
+                maxHeading={3}
+              />
+            </StackItem>
+          )}
+          {skill.tags.length > 0 && (
+            <StackItem>
+              <LabelGroup data-testid="agent-skill-tags">
+                {skill.tags.map((tag) => (
+                  <Label key={tag} isCompact variant="outline">
+                    {tag}
+                  </Label>
+                ))}
+              </LabelGroup>
+            </StackItem>
+          )}
+          {skill.examples.length > 0 && (
+            <StackItem>
+              <Stack hasGutter>
+                <StackItem>
+                  <Content component={ContentVariants.small}>Examples</Content>
+                </StackItem>
+                <StackItem>
+                  <Flex>
+                    <FlexItem spacer={{ default: 'spacerMd' }} />
+                    <FlexItem>
+                      <List isPlain data-testid="agent-skill-examples">
+                        {skill.examples.map((example) => (
+                          <ListItem key={example}>{example}</ListItem>
+                        ))}
+                      </List>
+                    </FlexItem>
+                  </Flex>
+                </StackItem>
+              </Stack>
+            </StackItem>
+          )}
+          {modeSummary && (
+            <StackItem>
+              <Content
+                component={ContentVariants.small}
+                className="pf-v6-u-color-200"
+                data-testid="agent-skill-modes"
+              >
+                {modeSummary}
+              </Content>
+            </StackItem>
+          )}
+        </Stack>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default AgentSkillCard;

--- a/packages/agent-ops/frontend/src/app/components/__tests__/AgentCapabilitiesCard.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/components/__tests__/AgentCapabilitiesCard.spec.tsx
@@ -1,0 +1,64 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import AgentCapabilitiesCard from '~/app/components/AgentCapabilitiesCard';
+import { mockAgentCardDetail } from '~/__mocks__/mockAgentRuntime';
+
+jest.mock('@odh-dashboard/internal/components/markdown/MarkdownComponent', () => ({
+  __esModule: true,
+  default: ({ data, dataTestId }: { data: string; dataTestId?: string }) => (
+    <div data-testid={dataTestId}>{data}</div>
+  ),
+}));
+
+describe('AgentCapabilitiesCard', () => {
+  it('renders skills from agent card data', () => {
+    render(<AgentCapabilitiesCard agentCard={mockAgentCardDetail()} />);
+
+    expect(screen.getByTestId('agent-capabilities-skills')).toBeInTheDocument();
+    expect(screen.getByText('Skills')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-skill-card-code-generation')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-skill-card-code-generation')).toHaveTextContent(
+      'ID: code-generation',
+    );
+    expect(screen.getByTestId('agent-skill-description-code-generation')).toBeInTheDocument();
+    expect(screen.getByText('Add unit tests for the auth module')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no skills are available', () => {
+    const { container } = render(
+      <AgentCapabilitiesCard agentCard={mockAgentCardDetail({ skills: [] })} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('hides input and output modes when skill modes are empty', () => {
+    const [skill] = mockAgentCardDetail().skills ?? [];
+    render(
+      <AgentCapabilitiesCard
+        agentCard={mockAgentCardDetail({
+          skills: [{ ...skill, inputModes: [], outputModes: [] }],
+        })}
+      />,
+    );
+
+    expect(screen.queryByTestId('agent-skill-modes')).not.toBeInTheDocument();
+  });
+
+  it('renders skill metadata including tags and modes', () => {
+    const [skill] = mockAgentCardDetail().skills ?? [];
+    render(
+      <AgentCapabilitiesCard
+        agentCard={mockAgentCardDetail({
+          skills: [{ ...skill, inputModes: ['text/plain'], outputModes: ['text/plain'] }],
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId('agent-skill-tags')).toHaveTextContent('development');
+    expect(screen.getByTestId('agent-skill-modes')).toHaveTextContent(
+      'Input: text/plain · Output: text/plain',
+    );
+  });
+});

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentDetailPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentDetailPage.tsx
@@ -168,7 +168,7 @@ const AgentDeploymentDetailPage: React.FC = () => {
                         </Card>
                       </StackItem>
                     )}
-                    {detail.agentCard && (
+                    {hasSkills && detail.agentCard && (
                       <StackItem>
                         <AgentCapabilitiesCard agentCard={detail.agentCard} />
                       </StackItem>

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentDetailPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentDetailPage.tsx
@@ -15,6 +15,8 @@ import {
   GridItem,
   PageSection,
   Spinner,
+  Stack,
+  StackItem,
   Title,
 } from '@patternfly/react-core';
 import { BanIcon, ExclamationCircleIcon, SearchIcon } from '@patternfly/react-icons';
@@ -23,6 +25,7 @@ import HeaderIcon from '@odh-dashboard/internal/concepts/design/HeaderIcon';
 import { ProjectObjectType } from '@odh-dashboard/internal/concepts/design/utils';
 import MarkdownComponent from '@odh-dashboard/internal/components/markdown/MarkdownComponent';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import AgentCapabilitiesCard from '~/app/components/AgentCapabilitiesCard';
 import AgentDetailsCard from '~/app/components/AgentDetailsCard';
 import AgentRuntimeStatusLabel from '~/app/components/AgentRuntimeStatusLabel';
 import { useAgentRuntimeDetail } from '~/app/hooks/useAgentRuntimeDetail';
@@ -107,6 +110,8 @@ const AgentDeploymentDetailPage: React.FC = () => {
     .map((value) => value?.trim())
     .find((value): value is string => Boolean(value));
   const hasDescription = Boolean(descriptionText);
+  const hasSkills = (detail?.agentCard?.skills?.length ?? 0) > 0;
+  const hasMainColumnContent = hasDescription || hasSkills;
 
   return (
     <ApplicationsPage
@@ -146,22 +151,33 @@ const AgentDeploymentDetailPage: React.FC = () => {
           </PageSection>
           <PageSection hasBodyWrapper={false} isFilled>
             <Grid hasGutter>
-              {descriptionText && (
+              {hasMainColumnContent && (
                 <GridItem lg={detail.agentCard ? 8 : 12} md={12}>
-                  <Card data-testid="agent-description-card">
-                    <CardTitle>Description</CardTitle>
-                    <CardBody>
-                      <MarkdownComponent
-                        data={descriptionText}
-                        dataTestId="agent-description"
-                        maxHeading={3}
-                      />
-                    </CardBody>
-                  </Card>
+                  <Stack hasGutter>
+                    {descriptionText && (
+                      <StackItem>
+                        <Card data-testid="agent-description-card">
+                          <CardTitle>Description</CardTitle>
+                          <CardBody>
+                            <MarkdownComponent
+                              data={descriptionText}
+                              dataTestId="agent-description"
+                              maxHeading={3}
+                            />
+                          </CardBody>
+                        </Card>
+                      </StackItem>
+                    )}
+                    {detail.agentCard && (
+                      <StackItem>
+                        <AgentCapabilitiesCard agentCard={detail.agentCard} />
+                      </StackItem>
+                    )}
+                  </Stack>
                 </GridItem>
               )}
               {detail.agentCard && (
-                <GridItem lg={hasDescription ? 4 : 12} md={12}>
+                <GridItem lg={hasMainColumnContent ? 4 : 12} md={12}>
                   <AgentDetailsCard agentCard={detail.agentCard} />
                 </GridItem>
               )}


### PR DESCRIPTION

## Description
For https://issues.redhat.com/browse/RHOAIENG-62708
 
Adds a **Skills** section to the agent deployment detail page, rendering the skills from the agent card. 

<img width="1452" height="656" alt="image" src="https://github.com/user-attachments/assets/9fd49bc3-567e-48ac-9dd1-84155f243ad7" />

## How Has This Been Tested?

Manually Tested: 
- Navigate to **Agent deployments** → open a deployment detail page
- Confirm the **Skills** card appears below the description with skill name, ID, description, tags, and examples

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Adjusted the `agentDeploymentDetail.cy.ts `tests to include the skills card and added `AgentCapabilitiesCard.spec.tsx `

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Skills section on agent deployment detail pages, showing skill cards with descriptions, tags, examples, and input/output mode details.
  * Skills now appear only when available, keeping the page clean when no skills are present.

* **Bug Fixes**
  * Improved page layout so the main content area displays correctly when skills are shown alongside the description.

* **Tests**
  * Added and updated automated tests to cover skills rendering, empty-state behavior, and filter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->