### PR TITLE
chore: npm workspaces support for distributions/

### DIFF
--- a/distributions/base/README.md
+++ b/distributions/base/README.md
@@ -4,25 +4,7 @@ Minimal app shell framework - renders a PatternFly page chrome (masthead, sideba
 
 ## Running locally
 
-`distributions/base` depends on private workspace packages
-(`@odh-dashboard/eslint-config`, `@odh-dashboard/tsconfig`), so it cannot
-install cleanly as a standalone `npm install`.
-
-The easiest workaround is to temporarily add `distributions/*` back to the
-root `workspaces` list in the repo-root `package.json`:
-
-```jsonc
-// package.json (repo root)
-"workspaces": [
-  "backend",
-  "packages/*",
-  "frontend",
-  "frontend/src",
-  "distributions/*"   // ← add this line
-]
-```
-
-Then from the repo root:
+From the repo root:
 
 ```bash
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "backend",
         "frontend",
         "frontend/src",
-        "packages/*"
+        "packages/*",
+        "distributions/base",
+        "distributions/rhaii"
       ],
       "dependencies": {
         "@kubernetes/client-node": "^0.12.3",
@@ -133,6 +135,98 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "distributions/base": {
+      "name": "@odh-dashboard/base-distribution",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@odh-dashboard/plugin-core": "*",
+        "@openshift/dynamic-plugin-sdk": "^5.0.1",
+        "@patternfly/patternfly": "6.4.0",
+        "@patternfly/react-core": "6.4.1",
+        "@patternfly/react-icons": "6.4.0",
+        "@patternfly/react-styles": "6.4.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.17.0"
+      },
+      "devDependencies": {
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/tsconfig": "*",
+        "@swc/core": "^1.15.40",
+        "css-loader": "^5.2.7",
+        "file-loader": "^6.2.0",
+        "fork-ts-checker-webpack-plugin": "^9.1.0",
+        "html-webpack-plugin": "^5.6.7",
+        "js-yaml": "^4.1.0",
+        "raw-loader": "^4.0.2",
+        "sass": "^1.100.0",
+        "sass-loader": "^13.3.3",
+        "style-loader": "^2.0.0",
+        "svg-url-loader": "^6.0.0",
+        "swc-loader": "^0.2.7",
+        "typescript": "^5.9.3",
+        "url-loader": "^4.1.1",
+        "webpack": "5.104.1",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.2.4",
+        "webpack-merge": "^6.0.1",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "distributions/rhaii": {
+      "name": "@odh-dashboard/rhaii-distribution",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@odh-dashboard/k8s-core": "*",
+        "@odh-dashboard/model-serving": "*",
+        "@odh-dashboard/plugin-core": "*",
+        "@openshift/dynamic-plugin-sdk": "^5.0.1",
+        "@openshift/dynamic-plugin-sdk-utils": "^5.0.0",
+        "@patternfly/patternfly": "^6.4.0",
+        "@patternfly/react-code-editor": "^6.4.0",
+        "@patternfly/react-core": "^6.4.1",
+        "@patternfly/react-icons": "^6.4.0",
+        "@patternfly/react-styles": "^6.4.0",
+        "@patternfly/react-table": "^6.4.0",
+        "lodash-es": "^4.18.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router": "^7.17.0",
+        "react-router-dom": "^7.17.0",
+        "yaml": "^2.9.0",
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/tsconfig": "*",
+        "@swc/core": "^1.15.40",
+        "concurrently": "^9.2.1",
+        "css-loader": "^5.2.7",
+        "file-loader": "^6.2.0",
+        "fork-ts-checker-webpack-plugin": "^9.1.0",
+        "html-webpack-plugin": "^5.6.7",
+        "raw-loader": "^4.0.2",
+        "sass": "^1.100.0",
+        "sass-loader": "^13.3.3",
+        "style-loader": "^2.0.0",
+        "svg-url-loader": "^6.0.0",
+        "swc-loader": "^0.2.7",
+        "typescript": "^5.9.3",
+        "url-loader": "^4.1.1",
+        "webpack": "5.104.1",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.2.4",
+        "webpack-merge": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "frontend": {
@@ -6105,6 +6199,10 @@
       "resolved": "packages/autorag",
       "link": true
     },
+    "node_modules/@odh-dashboard/base-distribution": {
+      "resolved": "distributions/base",
+      "link": true
+    },
     "node_modules/@odh-dashboard/contract-tests": {
       "resolved": "packages/contract-tests",
       "link": true
@@ -6199,6 +6297,10 @@
     },
     "node_modules/@odh-dashboard/plugin-core": {
       "resolved": "packages/plugin-core",
+      "link": true
+    },
+    "node_modules/@odh-dashboard/rhaii-distribution": {
+      "resolved": "distributions/rhaii",
       "link": true
     },
     "node_modules/@odh-dashboard/template": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "backend",
     "frontend",
     "frontend/src",
-    "packages/*"
+    "packages/*",
+    "distributions/base",
+    "distributions/rhaii"
   ],
   "scripts": {
     "build": "run-p -l build:*",


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
Distributions were initially excluded from the root npm workspaces due to the infancy of the distributions/ directory — the architecture was still taking shape and isolation seemed prudent. Now that the pattern is established and distributions will always consume packages/* as shared code (with additional distributions like rhoai planned), there is no benefit to keeping them out of the workspace.

Adding distributions/base and distributions/rhaii to the root workspaces list gives us:

- Dependency resolution via workspace symlinks (no manual workaround)
- Lockfile coverage through the root package-lock.json
- Turbo task participation (lint, type-check, build all pass; tasks not defined in a distribution's package.json are silently skipped)

distributions/core-bff is intentionally excluded — its root package.json is orchestrated via Makefile, and its frontend/ subdirectory already has its own standalone package-lock.json with no @odh-dashboard/* dependencies.

Also removes the now-unnecessary install workaround from the base distribution README.

## How Has This Been Tested?

Verified all Turbo tasks that overlap with distribution scripts pass:

- `turbo run lint --filter=@odh-dashboard/base-distribution --filter=@odh-dashboard/rhaii-distribution` — passed
- `turbo run type-check --filter=@odh-dashboard/base-distribution --filter=@odh-dashboard/rhaii-distribution` — passed
- `turbo run build --filter=@odh-dashboard/base-distribution --filter=@odh-dashboard/rhaii-distribution` — passed
- `turbo run test-unit --filter=@odh-dashboard/base-distribution --filter=@odh-dashboard/rhaii-distribution` — passed (Turbo silently
skips tasks not defined in the distribution's package.json)

Confirmed `npm install` at root resolves all `@odh-dashboard/*` dependencies for both distributions without the manual workaround
previously documented in the base README.

## Test Impact

No new tests required. This is a workspace/build configuration change — the existing Turbo tasks (lint, type-check, build) serve as the
verification. No runtime behavior is affected.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance
considerations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the local setup guide to start from the repository root and removed the old workaround steps.

* **Chores**
  * Expanded the workspace configuration to include distribution packages (`distributions/*`) alongside the existing packages (`packages/*`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->