### PR TITLE
Add missing RBAC escalation permissions to dashboard-operator ClusterRole

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     {{- include "dashboard.labels" . | nindent 4 }}
 rules:
+  # Dashboard CR access
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -45,6 +46,7 @@ rules:
       - dashboards/finalizers
     verbs:
       - update
+  # Core resources the operator deploys
   - apiGroups:
       - ""
     resources:
@@ -61,6 +63,7 @@ rules:
       - update
       - patch
       - delete
+  # Namespace access for platform detection and operand configuration
   - apiGroups:
       - ""
     resources:
@@ -69,6 +72,7 @@ rules:
       - get
       - list
       - watch
+      - patch
   - apiGroups:
       - apps
     resources:
@@ -82,6 +86,7 @@ rules:
       - update
       - patch
       - delete
+  # OpenShift Routes for URL extraction
   - apiGroups:
       - route.openshift.io
     resources:
@@ -94,6 +99,7 @@ rules:
       - update
       - patch
       - delete
+  # RBAC resources
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -109,6 +115,7 @@ rules:
       - update
       - patch
       - delete
+  # Networking
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -122,13 +129,26 @@ rules:
       - update
       - patch
       - delete
+  # Events
   - apiGroups:
       - ""
     resources:
       - events
     verbs:
+      - get
+      - list
+      - watch
       - create
       - patch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  # Coordination for leader election
   - apiGroups:
       - coordination.k8s.io
     resources:
@@ -141,6 +161,7 @@ rules:
       - update
       - patch
       - delete
+  # OAuthClients for OpenShift auth
   - apiGroups:
       - oauth.openshift.io
     resources:
@@ -153,15 +174,19 @@ rules:
       - update
       - patch
       - delete
+  # OLM resources for platform detection
   - apiGroups:
       - operators.coreos.com
     resources:
       - catalogsources
+      - clusterserviceversions
       - operatorconditions
+      - subscriptions
     verbs:
       - get
       - list
       - watch
+  # Console links
   - apiGroups:
       - console.openshift.io
     resources:
@@ -174,6 +199,7 @@ rules:
       - update
       - patch
       - delete
+  # Perses observability dashboards
   - apiGroups:
       - perses.dev
     resources:
@@ -186,6 +212,345 @@ rules:
       - update
       - patch
       - delete
+  #
+  # RBAC escalation: permissions required by operand manifests
+  # The operand deploys Roles/ClusterRoles that grant these permissions.
+  # Kubernetes RBAC escalation prevention requires the operator SA to hold
+  # at least the same permissions it grants via those operand RBAC resources.
+  #
+  # Core resources referenced by operand SA roles
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  # Impersonation for BFF module proxy
+  - apiGroups:
+      - ""
+    resources:
+      - users
+      - groups
+      - serviceaccounts
+    verbs:
+      - impersonate
+  # Batch resources for operand notebook management
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - update
+      - delete
+  # Storage classes for operand cluster detection
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - update
+      - patch
+  # Auth delegation for operand service accounts
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  # OpenShift platform detection for operand
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - clusterversions
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - consoles
+    verbs:
+      - get
+      - list
+      - watch
+  # OpenShift image and build resources
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreams
+      - imagestreams/layers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - build.openshift.io
+    resources:
+      - builds
+      - buildconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  # OpenShift deployment configs
+  - apiGroups:
+      - apps.openshift.io
+    resources:
+      - deploymentconfigs
+      - deploymentconfigs/instantiate
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # OpenShift templates
+  - apiGroups:
+      - template.openshift.io
+    resources:
+      - templates
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # OpenShift user and group access
+  - apiGroups:
+      - user.openshift.io
+    resources:
+      - groups
+      - users
+    verbs:
+      - get
+      - list
+      - watch
+  # OpenShift machine management for operand cluster detection
+  - apiGroups:
+      - machine.openshift.io
+      - autoscaling.openshift.io
+    resources:
+      - machineautoscalers
+      - machinesets
+    verbs:
+      - get
+      - list
+  # RHMI detection
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - rhmis
+    verbs:
+      - get
+      - list
+      - watch
+  # Console quickstarts
+  - apiGroups:
+      - console.openshift.io
+    resources:
+      - odhquickstarts
+    verbs:
+      - get
+      - list
+  # ODH Dashboard CRDs
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - acceleratorprofiles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - odhapplications
+      - odhdocuments
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - opendatahub.io
+    resources:
+      - odhdashboardconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - hardwareprofiles
+    verbs:
+      - get
+      - list
+      - watch
+  # ODH platform CRDs
+  - apiGroups:
+      - datasciencecluster.opendatahub.io
+    resources:
+      - datascienceclusters
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - dscinitialization.opendatahub.io
+    resources:
+      - dscinitializations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - services.platform.opendatahub.io
+    resources:
+      - auths
+    verbs:
+      - get
+  # Kubeflow notebooks
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # KServe model serving
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+      - llminferenceserviceconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - servingruntimes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # NIM integration
+  - apiGroups:
+      - nim.opendatahub.io
+    resources:
+      - accounts
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # Model registry
+  - apiGroups:
+      - modelregistry.opendatahub.io
+    resources:
+      - modelregistries
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # TrustyAI
+  - apiGroups:
+      - trustyai.opendatahub.io
+    resources:
+      - evalhubs
+    verbs:
+      - get
+      - list
+      - watch
+  # Feast feature stores
+  - apiGroups:
+      - feast.dev
+    resources:
+      - featurestores
+    verbs:
+      - get
+      - list
+      - watch
+  # MLflow
+  - apiGroups:
+      - mlflow.opendatahub.io
+    resources:
+      - mlflows
+    verbs:
+      - get
+      - list
+      - watch
+  # AI agent and MCP server resources
+  - apiGroups:
+      - agent.kagenti.dev
+    resources:
+      - agentruntimes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - mcp.kuadrant.io
+      - mcp.kagenti.com
+    resources:
+      - mcpserverregistrations
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -240,7 +240,9 @@ rules:
       - get
       - list
       - watch
-  # Impersonation for BFF module proxy
+  # Impersonation for BFF module proxy (modules-cluster-role.yaml).
+  # Unscoped: the BFF proxy forwards requests on behalf of any authenticated
+  # user, so the set of impersonatable identities is not known at deploy time.
   - apiGroups:
       - ""
     resources:
@@ -258,7 +260,9 @@ rules:
       - get
       - update
       - delete
-  # Storage classes for operand cluster detection
+  # Storage classes — write-only mirrors sa-rbac/cluster-role.yaml exactly.
+  # Read verbs are not granted by the operand; add here only if the operand
+  # ClusterRole is updated to include them.
   - apiGroups:
       - storage.k8s.io
     resources:
@@ -311,6 +315,8 @@ rules:
       - update
       - patch
       - delete
+  # Verbs cover both sa-rbac/role.yaml (list) and
+  # fetch-builds-and-images.rbac.yaml (get, list, watch).
   - apiGroups:
       - build.openshift.io
     resources:

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -47,7 +47,7 @@ rules:
       - update
       - patch
       - delete
-  # Namespace read access for platform detection
+  # Namespace access for platform detection and operand configuration
   - apiGroups:
       - ""
     resources:
@@ -56,6 +56,7 @@ rules:
       - get
       - list
       - watch
+      - patch
   - apiGroups:
       - apps
     resources:
@@ -118,8 +119,19 @@ rules:
     resources:
       - events
     verbs:
+      - get
+      - list
+      - watch
       - create
       - patch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
   # Coordination for leader election
   - apiGroups:
       - coordination.k8s.io
@@ -151,7 +163,9 @@ rules:
       - operators.coreos.com
     resources:
       - catalogsources
+      - clusterserviceversions
       - operatorconditions
+      - subscriptions
     verbs:
       - get
       - list
@@ -182,3 +196,342 @@ rules:
       - update
       - patch
       - delete
+  #
+  # RBAC escalation: permissions required by operand manifests
+  # The operand deploys Roles/ClusterRoles that grant these permissions.
+  # Kubernetes RBAC escalation prevention requires the operator SA to hold
+  # at least the same permissions it grants via those operand RBAC resources.
+  #
+  # Core resources referenced by operand SA roles
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  # Impersonation for BFF module proxy
+  - apiGroups:
+      - ""
+    resources:
+      - users
+      - groups
+      - serviceaccounts
+    verbs:
+      - impersonate
+  # Batch resources for operand notebook management
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - update
+      - delete
+  # Storage classes for operand cluster detection
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - update
+      - patch
+  # Auth delegation for operand service accounts
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  # OpenShift platform detection for operand
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - clusterversions
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - consoles
+    verbs:
+      - get
+      - list
+      - watch
+  # OpenShift image and build resources
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreams
+      - imagestreams/layers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - build.openshift.io
+    resources:
+      - builds
+      - buildconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  # OpenShift deployment configs
+  - apiGroups:
+      - apps.openshift.io
+    resources:
+      - deploymentconfigs
+      - deploymentconfigs/instantiate
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # OpenShift templates
+  - apiGroups:
+      - template.openshift.io
+    resources:
+      - templates
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # OpenShift user and group access
+  - apiGroups:
+      - user.openshift.io
+    resources:
+      - groups
+      - users
+    verbs:
+      - get
+      - list
+      - watch
+  # OpenShift machine management for operand cluster detection
+  - apiGroups:
+      - machine.openshift.io
+      - autoscaling.openshift.io
+    resources:
+      - machineautoscalers
+      - machinesets
+    verbs:
+      - get
+      - list
+  # RHMI detection
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - rhmis
+    verbs:
+      - get
+      - list
+      - watch
+  # Console quickstarts
+  - apiGroups:
+      - console.openshift.io
+    resources:
+      - odhquickstarts
+    verbs:
+      - get
+      - list
+  # ODH Dashboard CRDs
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - acceleratorprofiles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - odhapplications
+      - odhdocuments
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - opendatahub.io
+    resources:
+      - odhdashboardconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - hardwareprofiles
+    verbs:
+      - get
+      - list
+      - watch
+  # ODH platform CRDs
+  - apiGroups:
+      - datasciencecluster.opendatahub.io
+    resources:
+      - datascienceclusters
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - dscinitialization.opendatahub.io
+    resources:
+      - dscinitializations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - services.platform.opendatahub.io
+    resources:
+      - auths
+    verbs:
+      - get
+  # Kubeflow notebooks
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # KServe model serving
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+      - llminferenceserviceconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - servingruntimes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # NIM integration
+  - apiGroups:
+      - nim.opendatahub.io
+    resources:
+      - accounts
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # Model registry
+  - apiGroups:
+      - modelregistry.opendatahub.io
+    resources:
+      - modelregistries
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # TrustyAI
+  - apiGroups:
+      - trustyai.opendatahub.io
+    resources:
+      - evalhubs
+    verbs:
+      - get
+      - list
+      - watch
+  # Feast feature stores
+  - apiGroups:
+      - feast.dev
+    resources:
+      - featurestores
+    verbs:
+      - get
+      - list
+      - watch
+  # MLflow
+  - apiGroups:
+      - mlflow.opendatahub.io
+    resources:
+      - mlflows
+    verbs:
+      - get
+      - list
+      - watch
+  # AI agent and MCP server resources
+  - apiGroups:
+      - agent.kagenti.dev
+    resources:
+      - agentruntimes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - mcp.kuadrant.io
+      - mcp.kagenti.com
+    resources:
+      - mcpserverregistrations
+    verbs:
+      - get
+      - list

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -224,7 +224,9 @@ rules:
       - get
       - list
       - watch
-  # Impersonation for BFF module proxy
+  # Impersonation for BFF module proxy (modules-cluster-role.yaml).
+  # Unscoped: the BFF proxy forwards requests on behalf of any authenticated
+  # user, so the set of impersonatable identities is not known at deploy time.
   - apiGroups:
       - ""
     resources:
@@ -242,7 +244,9 @@ rules:
       - get
       - update
       - delete
-  # Storage classes for operand cluster detection
+  # Storage classes — write-only mirrors sa-rbac/cluster-role.yaml exactly.
+  # Read verbs are not granted by the operand; add here only if the operand
+  # ClusterRole is updated to include them.
   - apiGroups:
       - storage.k8s.io
     resources:
@@ -295,6 +299,8 @@ rules:
       - update
       - patch
       - delete
+  # Verbs cover both sa-rbac/role.yaml (list) and
+  # fetch-builds-and-images.rbac.yaml (get, list, watch).
   - apiGroups:
       - build.openshift.io
     resources:


### PR DESCRIPTION
## Description

The dashboard-operator's ClusterRole (defined in `config/rbac/role.yaml` and synced to the Helm chart) is missing permissions on many API groups and resources that the operand manifests reference in their RBAC resources (Roles, ClusterRoles, ClusterRoleBindings).

Kubernetes RBAC escalation prevention means a ServiceAccount cannot create a Role/ClusterRole that grants permissions the SA itself does not hold. When the dashboard-operator deploys operand manifests via SSA, some contain Roles and ClusterRoles that grant permissions outside the operator's own ClusterRole, causing `RBAC escalation` errors.

**This only affects the modular architecture (Helm-based) install path** where the chart ClusterRole is the sole source of RBAC. In OLM-managed installs (RHOAI), the CSV provides a comprehensive ClusterRole with all necessary permissions.

### Changes

Audited all RBAC resources under `manifests/` (common/rbac, core-bases, modular-architecture) and added every missing apiGroup/resource/verb combination to:

1. `dashboard-operator/config/rbac/role.yaml` — the source-of-truth ClusterRole
2. `dashboard-operator/charts/dashboard/templates/rbac.yaml` — the Helm chart template (kept in sync)

### New permission groups added

| Category | API Groups / Resources |
|----------|----------------------|
| Core resources | pods, nodes, endpoints (read); users/groups/serviceaccounts (impersonate) |
| Batch & Storage | cronjobs; storageclasses |
| Auth delegation | tokenreviews, subjectaccessreviews |
| OpenShift platform | config.openshift.io (clusterversions, ingresses), operator.openshift.io (consoles), image/build/apps/template/user/machine/autoscaling, integreatly.org (rhmis), console quickstarts |
| ODH/RHOAI CRDs | dashboard.opendatahub.io, opendatahub.io, infrastructure.opendatahub.io, datasciencecluster/dscinitialization, services.platform, kubeflow.org (notebooks) |
| Model Serving | serving.kserve.io (inferenceservices, llminferenceserviceconfigs, servingruntimes), nim.opendatahub.io (accounts) |
| ML ecosystem | modelregistry, trustyai (evalhubs), feast (featurestores), mlflow |
| AI/MCP | agent.kagenti.dev (agentruntimes), mcp.kuadrant.io / mcp.kagenti.com (mcpserverregistrations) |

### What was NOT changed

- No wildcard verbs or resources (all expanded to explicit verbs per repo conventions)
- Existing rules preserved; only extended where needed (namespaces +patch, events +get/list/watch, operators.coreos.com +clusterserviceversions/subscriptions)
- opendatahub-operator chart copy (`opt/charts/dashboard-operator/templates/rbac.yaml`) is a follow-up after this merges

Fixes: [RHOAIENG-74903](https://issues.redhat.com/browse/RHOAIENG-74903)

## How Has This Been Tested?

- `go test ./charts/` — all tests pass including `TestDashboardChartRBACInSync` which validates the chart template stays in sync with `config/rbac/role.yaml`
- `make test` — all 4 test packages pass (api, charts, controller, webhook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded operator permissions to support a wider set of dashboard, AI, ML, and OpenShift-integrated workloads.
  * Improved access for event handling, namespace updates, and related platform resources.
  * Added support for additional managed services and custom resources, including notebooks, model serving, feature stores, and model registry components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-74903]: https://redhat.atlassian.net/browse/RHOAIENG-74903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ