### PR TITLE
RHOAIENG-66289: Add inline validation and error messaging for role labels in Create Custom Role form

### DIFF
--- a/frontend/src/pages/projects/projectRoles/CreateRoleForm.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleForm.tsx
@@ -12,6 +12,7 @@ type CreateRoleFormProps = {
   onDescriptionChange: (value: string) => void;
   labels: LabelEntry[];
   onLabelsChange: (labels: LabelEntry[]) => void;
+  onHasInvalidLabelsChange?: (hasInvalid: boolean) => void;
   rules: RuleEntry[];
   onRulesChange: (rules: RuleEntry[]) => void;
   onImportTemplate: () => void;
@@ -23,6 +24,7 @@ const CreateRoleForm: React.FC<CreateRoleFormProps> = ({
   onDescriptionChange,
   labels,
   onLabelsChange,
+  onHasInvalidLabelsChange,
   rules,
   onRulesChange,
   onImportTemplate,
@@ -64,7 +66,11 @@ const CreateRoleForm: React.FC<CreateRoleFormProps> = ({
         />
       </FormGroup>
 
-      <RoleLabelsSection labels={labels} onLabelsChange={onLabelsChange} />
+      <RoleLabelsSection
+        labels={labels}
+        onLabelsChange={onLabelsChange}
+        onHasInvalidLabelsChange={onHasInvalidLabelsChange}
+      />
 
       <PermissionRulesSection
         rules={rules}

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -16,7 +16,6 @@ import { getDisplayNameFromK8sResource, translateDisplayNameForK8s } from '@odh-
 import ApplicationsPage from '#~/pages/ApplicationsPage';
 import { useAccessReview } from '#~/api/useAccessReview';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
-import { isValidK8sLabelKeyValue } from '#~/concepts/k8s/utils';
 import { useK8sNameDescriptionFieldData } from '#~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import { RoleKind } from '#~/k8sTypes';
 import { createRole, updateRole } from '#~/api';
@@ -28,7 +27,7 @@ import ReplaceContentConfirmModal from './ReplaceContentConfirmModal';
 import SelectTemplateModal from './SelectTemplateModal';
 import type { RoleTemplate } from './roleTemplateCatalog';
 import assembleRole from './assembleRole';
-import { fromK8sLabels, toK8sLabels } from './labelUtils';
+import { fromK8sLabels, toK8sLabels, validateLabelKey, validateLabelValue } from './labelUtils';
 import { USER_LABEL_PREFIX } from './const';
 import type { LabelEntry, RuleEntry } from './types';
 
@@ -164,15 +163,14 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
     setRules(newRules);
   }, []);
 
-  const hasDuplicateLabelKeys = React.useMemo(
-    () => new Set(labels.map((l) => l.key)).size !== labels.length,
-    [labels],
-  );
-
-  const hasInvalidLabels =
-    labels.some(
-      (label) => !label.key || !label.value || !isValidK8sLabelKeyValue(label.key, label.value),
-    ) || hasDuplicateLabelKeys;
+  const hasInvalidLabels = React.useMemo(() => {
+    const allKeys = labels.map((l) => l.key);
+    return labels.some(
+      (label, index) =>
+        validateLabelKey(label.key, allKeys, index) !== null ||
+        validateLabelValue(label.value) !== null,
+    );
+  }, [labels]);
 
   const isSubmitDisabled =
     !k8sNameDescriptionData.data.k8sName.value ||

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -27,7 +27,7 @@ import ReplaceContentConfirmModal from './ReplaceContentConfirmModal';
 import SelectTemplateModal from './SelectTemplateModal';
 import type { RoleTemplate } from './roleTemplateCatalog';
 import assembleRole from './assembleRole';
-import { fromK8sLabels, toK8sLabels, validateLabelKey, validateLabelValue } from './labelUtils';
+import { fromK8sLabels, toK8sLabels } from './labelUtils';
 import { USER_LABEL_PREFIX } from './const';
 import type { LabelEntry, RuleEntry } from './types';
 
@@ -163,14 +163,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
     setRules(newRules);
   }, []);
 
-  const hasInvalidLabels = React.useMemo(() => {
-    const allKeys = labels.map((l) => l.key);
-    return labels.some(
-      (label, index) =>
-        validateLabelKey(label.key, allKeys, index) !== null ||
-        validateLabelValue(label.value) !== null,
-    );
-  }, [labels]);
+  const [hasInvalidLabels, setHasInvalidLabels] = React.useState(false);
 
   const isSubmitDisabled =
     !k8sNameDescriptionData.data.k8sName.value ||
@@ -299,6 +292,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
               onDescriptionChange={handleDescriptionChange}
               labels={labels}
               onLabelsChange={handleLabelsChange}
+              onHasInvalidLabelsChange={setHasInvalidLabels}
               rules={rules}
               onRulesChange={handleRulesChange}
               onImportTemplate={handleImportTemplateClick}

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -22,9 +22,14 @@ import type { LabelEntry } from './types';
 type RoleLabelsSectionProps = {
   labels: LabelEntry[];
   onLabelsChange: (labels: LabelEntry[]) => void;
+  onHasInvalidLabelsChange?: (hasInvalid: boolean) => void;
 };
 
-const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsChange }) => {
+const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({
+  labels,
+  onLabelsChange,
+  onHasInvalidLabelsChange,
+}) => {
   const [touchedFields, setTouchedFields] = React.useState<Set<string>>(
     () => new Set(labels.flatMap((l) => [`${l.id}-key`, `${l.id}-value`])),
   );
@@ -57,26 +62,43 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
 
   const handleRemoveLabel = React.useCallback(
     (index: number) => {
-      const removedId = labels[index]?.id;
+      const { id } = labels[index];
       onLabelsChange(labels.filter((_, i) => i !== index));
-      if (removedId) {
-        setTouchedFields((prev) => {
-          const keyField = `${removedId}-key`;
-          const valueField = `${removedId}-value`;
-          if (!prev.has(keyField) && !prev.has(valueField)) {
-            return prev;
-          }
-          const next = new Set(prev);
-          next.delete(keyField);
-          next.delete(valueField);
-          return next;
-        });
-      }
+      setTouchedFields((prev) => {
+        const keyField = `${id}-key`;
+        const valueField = `${id}-value`;
+        if (!prev.has(keyField) && !prev.has(valueField)) {
+          return prev;
+        }
+        const next = new Set(prev);
+        next.delete(keyField);
+        next.delete(valueField);
+        return next;
+      });
     },
     [labels, onLabelsChange],
   );
 
   const allKeys = React.useMemo(() => labels.map((l) => l.key), [labels]);
+
+  const hasInvalidLabels = React.useMemo(
+    () =>
+      labels.some((label, index) => {
+        const keyError = validateLabelKey(label.key, allKeys, index) !== null;
+        const valueError = validateLabelValue(label.value) !== null;
+        const keyTouched = touchedFields.has(`${label.id}-key`);
+        const valueTouched = touchedFields.has(`${label.id}-value`);
+        return (
+          (keyError && (keyTouched || !!label.key)) ||
+          (valueError && (valueTouched || !!label.value))
+        );
+      }),
+    [labels, touchedFields, allKeys],
+  );
+
+  React.useEffect(() => {
+    onHasInvalidLabelsChange?.(hasInvalidLabels);
+  }, [hasInvalidLabels, onHasInvalidLabelsChange]);
 
   return (
     <FormGroup label="Labels" fieldId="role-labels">
@@ -93,8 +115,8 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
               Value
             </Content>
           </FlexItem>
-          <FlexItem style={{ visibility: 'hidden' }}>
-            <Button variant="plain" aria-hidden>
+          <FlexItem className="pf-v6-u-visibility-hidden">
+            <Button variant="plain" aria-hidden tabIndex={-1}>
               <MinusCircleIcon />
             </Button>
           </FlexItem>
@@ -193,9 +215,9 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                         <FormHelperText>
                           <HelperText>
                             <HelperTextItem variant={valueDefaultVariant}>
-                              Must be 1&ndash;63 characters and start and end with a letter or
-                              number. Valid characters include letters, numbers, hyphens (-),
-                              periods (.), and underscores (_).
+                              Can be empty or up to 63 characters. If provided, must start and end
+                              with a letter or number. Valid characters include letters, numbers,
+                              hyphens (-), periods (.), and underscores (_).
                             </HelperTextItem>
                           </HelperText>
                         </FormHelperText>

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -5,11 +5,16 @@ import {
   Flex,
   FlexItem,
   FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
   TextInput,
+  ValidatedOptions,
   getUniqueId,
 } from '@patternfly/react-core';
-import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { LABELS_FORM_DESCRIPTION } from './const';
+import { validateLabelKey, validateLabelValue } from './labelUtils';
 import type { LabelEntry } from './types';
 
 type RoleLabelsSectionProps = {
@@ -39,46 +44,82 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
     [labels, onLabelsChange],
   );
 
+  const allKeys = React.useMemo(() => labels.map((l) => l.key), [labels]);
+
   return (
     <FormGroup label="Labels" fieldId="role-labels">
       <Content component="p">{LABELS_FORM_DESCRIPTION}</Content>
-      {labels.map((label, index) => (
-        <Flex
-          key={label.id}
-          spaceItems={{ default: 'spaceItemsSm' }}
-          className="pf-v6-u-mb-sm"
-          data-testid={`role-label-${index}`}
-        >
-          <FlexItem flex={{ default: 'flex_1' }}>
-            <TextInput
-              aria-label={`Label key ${index + 1}`}
-              data-testid={`role-label-key-${index}`}
-              value={label.key}
-              onChange={(_event, value) => handleLabelChange(index, 'key', value)}
-              placeholder="Key"
-            />
-          </FlexItem>
-          <FlexItem flex={{ default: 'flex_1' }}>
-            <TextInput
-              aria-label={`Label value ${index + 1}`}
-              data-testid={`role-label-value-${index}`}
-              value={label.value}
-              onChange={(_event, value) => handleLabelChange(index, 'value', value)}
-              placeholder="Value"
-            />
-          </FlexItem>
-          <FlexItem>
-            <Button
-              variant="plain"
-              aria-label={`Remove label ${index + 1}`}
-              data-testid={`role-label-remove-${index}`}
-              onClick={() => handleRemoveLabel(index)}
-            >
-              <MinusCircleIcon />
-            </Button>
-          </FlexItem>
-        </Flex>
-      ))}
+      {labels.map((label, index) => {
+        const keyError = validateLabelKey(label.key, allKeys, index);
+        const valueError = validateLabelValue(label.value);
+
+        return (
+          <Flex
+            key={label.id}
+            spaceItems={{ default: 'spaceItemsSm' }}
+            alignItems={{ default: 'alignItemsFlexStart' }}
+            className="pf-v6-u-mb-sm"
+            data-testid={`role-label-${index}`}
+          >
+            <FlexItem flex={{ default: 'flex_1' }}>
+              <TextInput
+                aria-label={`Label key ${index + 1}`}
+                data-testid={`role-label-key-${index}`}
+                value={label.key}
+                onChange={(_event, value) => handleLabelChange(index, 'key', value)}
+                placeholder="Key"
+                validated={keyError ? ValidatedOptions.error : ValidatedOptions.default}
+              />
+              {keyError && (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem
+                      icon={<ExclamationCircleIcon />}
+                      variant="error"
+                      data-testid={`role-label-key-error-${index}`}
+                    >
+                      {keyError}
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              )}
+            </FlexItem>
+            <FlexItem flex={{ default: 'flex_1' }}>
+              <TextInput
+                aria-label={`Label value ${index + 1}`}
+                data-testid={`role-label-value-${index}`}
+                value={label.value}
+                onChange={(_event, value) => handleLabelChange(index, 'value', value)}
+                placeholder="Value"
+                validated={valueError ? ValidatedOptions.error : ValidatedOptions.default}
+              />
+              {valueError && (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem
+                      icon={<ExclamationCircleIcon />}
+                      variant="error"
+                      data-testid={`role-label-value-error-${index}`}
+                    >
+                      {valueError}
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              )}
+            </FlexItem>
+            <FlexItem>
+              <Button
+                variant="plain"
+                aria-label={`Remove label ${index + 1}`}
+                data-testid={`role-label-remove-${index}`}
+                onClick={() => handleRemoveLabel(index)}
+              >
+                <MinusCircleIcon />
+              </Button>
+            </FlexItem>
+          </Flex>
+        );
+      })}
       <Button
         variant="link"
         icon={<PlusCircleIcon />}

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -25,7 +25,7 @@ type RoleLabelsSectionProps = {
 const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsChange }) => {
   const [touchedFields, setTouchedFields] = React.useState<Set<string>>(() => new Set());
 
-  const handleBlur = React.useCallback((fieldId: string) => {
+  const markTouched = React.useCallback((fieldId: string) => {
     setTouchedFields((prev) => {
       if (prev.has(fieldId)) {
         return prev;
@@ -38,12 +38,13 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
 
   const handleLabelChange = React.useCallback(
     (index: number, field: 'key' | 'value', newValue: string) => {
+      markTouched(`${labels[index].id}-${field}`);
       const updated = labels.map((label, i) =>
         i === index ? { ...label, [field]: newValue } : label,
       );
       onLabelsChange(updated);
     },
-    [labels, onLabelsChange],
+    [labels, onLabelsChange, markTouched],
   );
 
   const handleAddLabel = React.useCallback(() => {
@@ -76,6 +77,25 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
   return (
     <FormGroup label="Labels" fieldId="role-labels">
       <Content component="p">{LABELS_FORM_DESCRIPTION}</Content>
+      {labels.length > 0 && (
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} className="pf-v6-u-mb-sm">
+          <FlexItem flex={{ default: 'flex_1' }}>
+            <Content component="small" className="pf-v6-u-font-weight-bold">
+              Key
+            </Content>
+          </FlexItem>
+          <FlexItem flex={{ default: 'flex_1' }}>
+            <Content component="small" className="pf-v6-u-font-weight-bold">
+              Value
+            </Content>
+          </FlexItem>
+          <FlexItem style={{ visibility: 'hidden' }}>
+            <Button variant="plain" aria-hidden>
+              <MinusCircleIcon />
+            </Button>
+          </FlexItem>
+        </Flex>
+      )}
       {labels.map((label, index) => {
         const keyError = validateLabelKey(label.key, allKeys, index);
         const valueError = validateLabelValue(label.value);
@@ -101,7 +121,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                 data-testid={`role-label-key-${index}`}
                 value={label.key}
                 onChange={(_event, value) => handleLabelChange(index, 'key', value)}
-                onBlur={() => handleBlur(`${label.id}-key`)}
+                onBlur={() => markTouched(`${label.id}-key`)}
                 placeholder="Key"
                 validated={showKeyError ? ValidatedOptions.error : ValidatedOptions.default}
               />
@@ -127,7 +147,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                 data-testid={`role-label-value-${index}`}
                 value={label.value}
                 onChange={(_event, value) => handleLabelChange(index, 'value', value)}
-                onBlur={() => handleBlur(`${label.id}-value`)}
+                onBlur={() => markTouched(`${label.id}-value`)}
                 placeholder="Value"
                 validated={showValueError ? ValidatedOptions.error : ValidatedOptions.default}
               />

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -23,6 +23,19 @@ type RoleLabelsSectionProps = {
 };
 
 const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsChange }) => {
+  const [touchedFields, setTouchedFields] = React.useState<Set<string>>(() => new Set());
+
+  const handleBlur = React.useCallback((fieldId: string) => {
+    setTouchedFields((prev) => {
+      if (prev.has(fieldId)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.add(fieldId);
+      return next;
+    });
+  }, []);
+
   const handleLabelChange = React.useCallback(
     (index: number, field: 'key' | 'value', newValue: string) => {
       const updated = labels.map((label, i) =>
@@ -39,7 +52,21 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
 
   const handleRemoveLabel = React.useCallback(
     (index: number) => {
+      const removedId = labels[index]?.id;
       onLabelsChange(labels.filter((_, i) => i !== index));
+      if (removedId) {
+        setTouchedFields((prev) => {
+          const keyField = `${removedId}-key`;
+          const valueField = `${removedId}-value`;
+          if (!prev.has(keyField) && !prev.has(valueField)) {
+            return prev;
+          }
+          const next = new Set(prev);
+          next.delete(keyField);
+          next.delete(valueField);
+          return next;
+        });
+      }
     },
     [labels, onLabelsChange],
   );
@@ -52,6 +79,10 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
       {labels.map((label, index) => {
         const keyError = validateLabelKey(label.key, allKeys, index);
         const valueError = validateLabelValue(label.value);
+        const keyTouched = touchedFields.has(`${label.id}-key`);
+        const valueTouched = touchedFields.has(`${label.id}-value`);
+        const showKeyError = keyError && keyTouched;
+        const showValueError = valueError && valueTouched;
 
         return (
           <Flex
@@ -67,10 +98,11 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                 data-testid={`role-label-key-${index}`}
                 value={label.key}
                 onChange={(_event, value) => handleLabelChange(index, 'key', value)}
+                onBlur={() => handleBlur(`${label.id}-key`)}
                 placeholder="Key"
-                validated={keyError ? ValidatedOptions.error : ValidatedOptions.default}
+                validated={showKeyError ? ValidatedOptions.error : ValidatedOptions.default}
               />
-              {keyError && (
+              {showKeyError && (
                 <FormHelperText>
                   <HelperText>
                     <HelperTextItem
@@ -90,10 +122,11 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                 data-testid={`role-label-value-${index}`}
                 value={label.value}
                 onChange={(_event, value) => handleLabelChange(index, 'value', value)}
+                onBlur={() => handleBlur(`${label.id}-value`)}
                 placeholder="Value"
-                validated={valueError ? ValidatedOptions.error : ValidatedOptions.default}
+                validated={showValueError ? ValidatedOptions.error : ValidatedOptions.default}
               />
-              {valueError && (
+              {showValueError && (
                 <FormHelperText>
                   <HelperText>
                     <HelperTextItem

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -111,6 +111,13 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
             const showValueError = valueError && valueTouched;
             const keyErrorId = `${label.id}-key-error`;
             const valueErrorId = `${label.id}-value-error`;
+            const isLastRow = index === labels.length - 1;
+            const showKeyDefault = isLastRow && !showKeyError;
+            const showValueDefault = isLastRow && !showValueError;
+            const keyDefaultVariant =
+              !keyError && label.key.length > 0 ? 'success' : 'indeterminate';
+            const valueDefaultVariant =
+              !valueError && label.value.length > 0 ? 'success' : 'indeterminate';
 
             return (
               <StackItem key={label.id}>
@@ -130,7 +137,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                       placeholder="Example: Team"
                       validated={showKeyError ? ValidatedOptions.error : ValidatedOptions.default}
                     />
-                    {showKeyError && (
+                    {showKeyError ? (
                       <FormHelperText>
                         <HelperText>
                           <HelperTextItem
@@ -143,6 +150,18 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                           </HelperTextItem>
                         </HelperText>
                       </FormHelperText>
+                    ) : (
+                      showKeyDefault && (
+                        <FormHelperText>
+                          <HelperText>
+                            <HelperTextItem variant={keyDefaultVariant}>
+                              Must be 1&ndash;63 characters and start and end with a letter or
+                              number. Valid characters include letters, numbers, hyphens (-),
+                              periods (.), and underscores (_).
+                            </HelperTextItem>
+                          </HelperText>
+                        </FormHelperText>
+                      )
                     )}
                   </FlexItem>
                   <FlexItem flex={{ default: 'flex_1' }}>
@@ -156,7 +175,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                       placeholder="Example: Engineering"
                       validated={showValueError ? ValidatedOptions.error : ValidatedOptions.default}
                     />
-                    {showValueError && (
+                    {showValueError ? (
                       <FormHelperText>
                         <HelperText>
                           <HelperTextItem
@@ -169,6 +188,18 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                           </HelperTextItem>
                         </HelperText>
                       </FormHelperText>
+                    ) : (
+                      showValueDefault && (
+                        <FormHelperText>
+                          <HelperText>
+                            <HelperTextItem variant={valueDefaultVariant}>
+                              Must be 1&ndash;63 characters and start and end with a letter or
+                              number. Valid characters include letters, numbers, hyphens (-),
+                              periods (.), and underscores (_).
+                            </HelperTextItem>
+                          </HelperText>
+                        </FormHelperText>
+                      )
                     )}
                   </FlexItem>
                   <FlexItem>

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -8,6 +8,8 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
+  Stack,
+  StackItem,
   TextInput,
   ValidatedOptions,
   getUniqueId,
@@ -23,7 +25,9 @@ type RoleLabelsSectionProps = {
 };
 
 const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsChange }) => {
-  const [touchedFields, setTouchedFields] = React.useState<Set<string>>(() => new Set());
+  const [touchedFields, setTouchedFields] = React.useState<Set<string>>(
+    () => new Set(labels.flatMap((l) => [`${l.id}-key`, `${l.id}-value`])),
+  );
 
   const markTouched = React.useCallback((fieldId: string) => {
     setTouchedFields((prev) => {
@@ -96,97 +100,113 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
           </FlexItem>
         </Flex>
       )}
-      {labels.map((label, index) => {
-        const keyError = validateLabelKey(label.key, allKeys, index);
-        const valueError = validateLabelValue(label.value);
-        const keyTouched = touchedFields.has(`${label.id}-key`);
-        const valueTouched = touchedFields.has(`${label.id}-value`);
-        const showKeyError = keyError && keyTouched;
-        const showValueError = valueError && valueTouched;
-        const keyErrorId = `${label.id}-key-error`;
-        const valueErrorId = `${label.id}-value-error`;
+      {labels.length > 0 && (
+        <Stack hasGutter>
+          {labels.map((label, index) => {
+            const keyError = validateLabelKey(label.key, allKeys, index);
+            const valueError = validateLabelValue(label.value);
+            const keyTouched = touchedFields.has(`${label.id}-key`);
+            const valueTouched = touchedFields.has(`${label.id}-value`);
+            const showKeyError = keyError && keyTouched;
+            const showValueError = valueError && valueTouched;
+            const keyErrorId = `${label.id}-key-error`;
+            const valueErrorId = `${label.id}-value-error`;
 
-        return (
-          <Flex
-            key={label.id}
-            spaceItems={{ default: 'spaceItemsSm' }}
-            alignItems={{ default: 'alignItemsFlexStart' }}
-            className="pf-v6-u-mb-sm"
-            data-testid={`role-label-${index}`}
-          >
-            <FlexItem flex={{ default: 'flex_1' }}>
-              <TextInput
-                aria-label={`Label key ${index + 1}`}
-                aria-describedby={showKeyError ? keyErrorId : undefined}
-                data-testid={`role-label-key-${index}`}
-                value={label.key}
-                onChange={(_event, value) => handleLabelChange(index, 'key', value)}
-                onBlur={() => markTouched(`${label.id}-key`)}
-                placeholder="Example: Team"
-                validated={showKeyError ? ValidatedOptions.error : ValidatedOptions.default}
-              />
-              {showKeyError && (
-                <FormHelperText>
-                  <HelperText>
-                    <HelperTextItem
-                      icon={<ExclamationCircleIcon />}
-                      variant="error"
-                      id={keyErrorId}
-                      data-testid={`role-label-key-error-${index}`}
+            return (
+              <StackItem key={label.id}>
+                <Flex
+                  spaceItems={{ default: 'spaceItemsSm' }}
+                  alignItems={{ default: 'alignItemsFlexStart' }}
+                  data-testid={`role-label-${index}`}
+                >
+                  <FlexItem flex={{ default: 'flex_1' }}>
+                    <TextInput
+                      aria-label={`Label key ${index + 1}`}
+                      aria-describedby={showKeyError ? keyErrorId : undefined}
+                      data-testid={`role-label-key-${index}`}
+                      value={label.key}
+                      onChange={(_event, value) => handleLabelChange(index, 'key', value)}
+                      onBlur={() => markTouched(`${label.id}-key`)}
+                      placeholder="Example: Team"
+                      validated={showKeyError ? ValidatedOptions.error : ValidatedOptions.default}
+                    />
+                    {showKeyError && (
+                      <FormHelperText>
+                        <HelperText>
+                          <HelperTextItem
+                            icon={<ExclamationCircleIcon aria-hidden />}
+                            variant="error"
+                            id={keyErrorId}
+                            data-testid={`role-label-key-error-${index}`}
+                          >
+                            {keyError}
+                          </HelperTextItem>
+                        </HelperText>
+                      </FormHelperText>
+                    )}
+                  </FlexItem>
+                  <FlexItem flex={{ default: 'flex_1' }}>
+                    <TextInput
+                      aria-label={`Label value ${index + 1}`}
+                      aria-describedby={showValueError ? valueErrorId : undefined}
+                      data-testid={`role-label-value-${index}`}
+                      value={label.value}
+                      onChange={(_event, value) => handleLabelChange(index, 'value', value)}
+                      onBlur={() => markTouched(`${label.id}-value`)}
+                      placeholder="Example: Engineering"
+                      validated={showValueError ? ValidatedOptions.error : ValidatedOptions.default}
+                    />
+                    {showValueError && (
+                      <FormHelperText>
+                        <HelperText>
+                          <HelperTextItem
+                            icon={<ExclamationCircleIcon aria-hidden />}
+                            variant="error"
+                            id={valueErrorId}
+                            data-testid={`role-label-value-error-${index}`}
+                          >
+                            {valueError}
+                          </HelperTextItem>
+                        </HelperText>
+                      </FormHelperText>
+                    )}
+                  </FlexItem>
+                  <FlexItem>
+                    <Button
+                      variant="plain"
+                      aria-label={`Remove label ${index + 1}`}
+                      data-testid={`role-label-remove-${index}`}
+                      onClick={() => handleRemoveLabel(index)}
                     >
-                      {keyError}
-                    </HelperTextItem>
-                  </HelperText>
-                </FormHelperText>
-              )}
-            </FlexItem>
-            <FlexItem flex={{ default: 'flex_1' }}>
-              <TextInput
-                aria-label={`Label value ${index + 1}`}
-                aria-describedby={showValueError ? valueErrorId : undefined}
-                data-testid={`role-label-value-${index}`}
-                value={label.value}
-                onChange={(_event, value) => handleLabelChange(index, 'value', value)}
-                onBlur={() => markTouched(`${label.id}-value`)}
-                placeholder="Example: Engineering"
-                validated={showValueError ? ValidatedOptions.error : ValidatedOptions.default}
-              />
-              {showValueError && (
-                <FormHelperText>
-                  <HelperText>
-                    <HelperTextItem
-                      icon={<ExclamationCircleIcon />}
-                      variant="error"
-                      id={valueErrorId}
-                      data-testid={`role-label-value-error-${index}`}
-                    >
-                      {valueError}
-                    </HelperTextItem>
-                  </HelperText>
-                </FormHelperText>
-              )}
-            </FlexItem>
-            <FlexItem>
-              <Button
-                variant="plain"
-                aria-label={`Remove label ${index + 1}`}
-                data-testid={`role-label-remove-${index}`}
-                onClick={() => handleRemoveLabel(index)}
-              >
-                <MinusCircleIcon />
-              </Button>
-            </FlexItem>
-          </Flex>
-        );
-      })}
-      <Button
-        variant="link"
-        icon={<PlusCircleIcon />}
-        onClick={handleAddLabel}
-        data-testid="role-add-label"
-      >
-        Add label
-      </Button>
+                      <MinusCircleIcon />
+                    </Button>
+                  </FlexItem>
+                </Flex>
+              </StackItem>
+            );
+          })}
+          <StackItem>
+            <Button
+              variant="link"
+              icon={<PlusCircleIcon />}
+              onClick={handleAddLabel}
+              data-testid="role-add-label"
+            >
+              Add label
+            </Button>
+          </StackItem>
+        </Stack>
+      )}
+      {labels.length === 0 && (
+        <Button
+          variant="link"
+          icon={<PlusCircleIcon />}
+          onClick={handleAddLabel}
+          data-testid="role-add-label"
+        >
+          Add label
+        </Button>
+      )}
     </FormGroup>
   );
 };

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -83,6 +83,8 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
         const valueTouched = touchedFields.has(`${label.id}-value`);
         const showKeyError = keyError && keyTouched;
         const showValueError = valueError && valueTouched;
+        const keyErrorId = `${label.id}-key-error`;
+        const valueErrorId = `${label.id}-value-error`;
 
         return (
           <Flex
@@ -95,6 +97,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
             <FlexItem flex={{ default: 'flex_1' }}>
               <TextInput
                 aria-label={`Label key ${index + 1}`}
+                aria-describedby={showKeyError ? keyErrorId : undefined}
                 data-testid={`role-label-key-${index}`}
                 value={label.key}
                 onChange={(_event, value) => handleLabelChange(index, 'key', value)}
@@ -108,6 +111,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                     <HelperTextItem
                       icon={<ExclamationCircleIcon />}
                       variant="error"
+                      id={keyErrorId}
                       data-testid={`role-label-key-error-${index}`}
                     >
                       {keyError}
@@ -119,6 +123,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
             <FlexItem flex={{ default: 'flex_1' }}>
               <TextInput
                 aria-label={`Label value ${index + 1}`}
+                aria-describedby={showValueError ? valueErrorId : undefined}
                 data-testid={`role-label-value-${index}`}
                 value={label.value}
                 onChange={(_event, value) => handleLabelChange(index, 'value', value)}
@@ -132,6 +137,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                     <HelperTextItem
                       icon={<ExclamationCircleIcon />}
                       variant="error"
+                      id={valueErrorId}
                       data-testid={`role-label-value-error-${index}`}
                     >
                       {valueError}

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -122,7 +122,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                 value={label.key}
                 onChange={(_event, value) => handleLabelChange(index, 'key', value)}
                 onBlur={() => markTouched(`${label.id}-key`)}
-                placeholder="Key"
+                placeholder="Example: Team"
                 validated={showKeyError ? ValidatedOptions.error : ValidatedOptions.default}
               />
               {showKeyError && (
@@ -148,7 +148,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
                 value={label.value}
                 onChange={(_event, value) => handleLabelChange(index, 'value', value)}
                 onBlur={() => markTouched(`${label.id}-value`)}
-                placeholder="Value"
+                placeholder="Example: Engineering"
                 validated={showValueError ? ValidatedOptions.error : ValidatedOptions.default}
               />
               {showValueError && (

--- a/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
@@ -131,12 +131,12 @@ describe('RoleLabelsSection', () => {
   });
 
   describe('inline validation', () => {
-    it('should show errors immediately for pre-populated empty labels', () => {
+    it('should show key error immediately for pre-populated empty labels', () => {
       const labels = [{ id: 'l-1', key: '', value: '' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Required');
-      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent('Required');
+      expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
     });
 
     it('should show error for empty key after blur', () => {
@@ -148,13 +148,13 @@ describe('RoleLabelsSection', () => {
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Required');
     });
 
-    it('should show error for empty value after blur', () => {
+    it('should not show error for empty value after blur (K8s allows empty values)', () => {
       const labels = [{ id: 'l-1', key: 'team', value: '' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
       fireEvent.blur(screen.getByTestId('role-label-value-0'));
 
-      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent('Required');
+      expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
     });
 
     it('should show error for key containing a slash after blur', () => {
@@ -231,7 +231,7 @@ describe('RoleLabelsSection', () => {
       expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
     });
 
-    it('should show both key and value errors on the same row after blur', () => {
+    it('should show key error but no value error for empty row after blur', () => {
       const labels = [{ id: 'l-1', key: '', value: '' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
@@ -239,15 +239,28 @@ describe('RoleLabelsSection', () => {
       fireEvent.blur(screen.getByTestId('role-label-value-0'));
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Required');
-      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent('Required');
+      expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
     });
 
-    it('should show errors on pre-populated labels without needing interaction', () => {
+    it('should show both key and value errors on the same row after blur', () => {
+      const labels = [{ id: 'l-1', key: '', value: '-bad' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.blur(screen.getByTestId('role-label-key-0'));
+      fireEvent.blur(screen.getByTestId('role-label-value-0'));
+
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Required');
+      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent(
+        'Must start and end with a letter or number',
+      );
+    });
+
+    it('should show key error on pre-populated empty labels without needing interaction', () => {
       const labels = [{ id: 'l-1', key: '', value: '' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Required');
-      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent('Required');
+      expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
@@ -131,12 +131,12 @@ describe('RoleLabelsSection', () => {
   });
 
   describe('inline validation', () => {
-    it('should not show errors before fields are touched', () => {
+    it('should show errors immediately for pre-populated empty labels', () => {
       const labels = [{ id: 'l-1', key: '', value: '' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
-      expect(screen.queryByTestId('role-label-key-error-0')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Required');
+      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent('Required');
     });
 
     it('should show error for empty key after blur', () => {
@@ -242,14 +242,12 @@ describe('RoleLabelsSection', () => {
       expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent('Required');
     });
 
-    it('should only show error on the touched field, not the untouched one', () => {
+    it('should show errors on pre-populated labels without needing interaction', () => {
       const labels = [{ id: 'l-1', key: '', value: '' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
-      fireEvent.blur(screen.getByTestId('role-label-key-0'));
-
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Required');
-      expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
+      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent('Required');
     });
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
@@ -129,4 +129,94 @@ describe('RoleLabelsSection', () => {
       ]);
     });
   });
+
+  describe('inline validation', () => {
+    it('should show error for empty key', () => {
+      const labels = [{ id: 'l-1', key: '', value: 'platform' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Key is required.');
+    });
+
+    it('should show error for empty value', () => {
+      const labels = [{ id: 'l-1', key: 'team', value: '' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent(
+        'Value is required.',
+      );
+    });
+
+    it('should show error for key containing a slash', () => {
+      const labels = [{ id: 'l-1', key: 'prefix/name', value: 'val' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent(
+        'Slashes (/) are not permitted',
+      );
+    });
+
+    it('should show error for invalid key syntax', () => {
+      const labels = [{ id: 'l-1', key: '-bad', value: 'val' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent(
+        'Key must be 1-63 characters',
+      );
+    });
+
+    it('should show error for invalid value syntax', () => {
+      const labels = [{ id: 'l-1', key: 'team', value: '-bad' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent(
+        'Value must be 1-63 characters',
+      );
+    });
+
+    it('should show duplicate error on all matching rows', () => {
+      const labels = [
+        { id: 'l-1', key: 'team', value: 'a' },
+        { id: 'l-2', key: 'team', value: 'b' },
+      ];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent(
+        'Duplicate keys are not allowed.',
+      );
+      expect(screen.getByTestId('role-label-key-error-1')).toHaveTextContent(
+        'Duplicate keys are not allowed.',
+      );
+    });
+
+    it('should not show errors for valid labels', () => {
+      const labels = [
+        { id: 'l-1', key: 'team', value: 'platform' },
+        { id: 'l-2', key: 'env', value: 'production' },
+      ];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.queryByTestId('role-label-key-error-0')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('role-label-key-error-1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('role-label-value-error-1')).not.toBeInTheDocument();
+    });
+
+    it('should not show errors when no label rows exist', () => {
+      render(<RoleLabelsSection labels={[]} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.queryByTestId('role-label-key-error-0')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
+    });
+
+    it('should show both key and value errors on the same row', () => {
+      const labels = [{ id: 'l-1', key: '', value: '' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Key is required.');
+      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent(
+        'Value is required.',
+      );
+    });
+  });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
@@ -131,55 +131,76 @@ describe('RoleLabelsSection', () => {
   });
 
   describe('inline validation', () => {
-    it('should show error for empty key', () => {
+    it('should not show errors before fields are touched', () => {
+      const labels = [{ id: 'l-1', key: '', value: '' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.queryByTestId('role-label-key-error-0')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
+    });
+
+    it('should show error for empty key after blur', () => {
       const labels = [{ id: 'l-1', key: '', value: 'platform' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.blur(screen.getByTestId('role-label-key-0'));
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Key is required.');
     });
 
-    it('should show error for empty value', () => {
+    it('should show error for empty value after blur', () => {
       const labels = [{ id: 'l-1', key: 'team', value: '' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.blur(screen.getByTestId('role-label-value-0'));
 
       expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent(
         'Value is required.',
       );
     });
 
-    it('should show error for key containing a slash', () => {
+    it('should show error for key containing a slash after blur', () => {
       const labels = [{ id: 'l-1', key: 'prefix/name', value: 'val' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.blur(screen.getByTestId('role-label-key-0'));
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent(
         'Slashes (/) are not permitted',
       );
     });
 
-    it('should show error for invalid key syntax', () => {
+    it('should show error for invalid key syntax after blur', () => {
       const labels = [{ id: 'l-1', key: '-bad', value: 'val' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.blur(screen.getByTestId('role-label-key-0'));
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent(
         'Key must be 1-63 characters',
       );
     });
 
-    it('should show error for invalid value syntax', () => {
+    it('should show error for invalid value syntax after blur', () => {
       const labels = [{ id: 'l-1', key: 'team', value: '-bad' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.blur(screen.getByTestId('role-label-value-0'));
 
       expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent(
         'Value must be 1-63 characters',
       );
     });
 
-    it('should show duplicate error on all matching rows', () => {
+    it('should show duplicate error on all matching rows after blur', () => {
       const labels = [
         { id: 'l-1', key: 'team', value: 'a' },
         { id: 'l-2', key: 'team', value: 'b' },
       ];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.blur(screen.getByTestId('role-label-key-0'));
+      fireEvent.blur(screen.getByTestId('role-label-key-1'));
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent(
         'Duplicate keys are not allowed.',
@@ -189,12 +210,15 @@ describe('RoleLabelsSection', () => {
       );
     });
 
-    it('should not show errors for valid labels', () => {
+    it('should not show errors for valid labels after blur', () => {
       const labels = [
         { id: 'l-1', key: 'team', value: 'platform' },
         { id: 'l-2', key: 'env', value: 'production' },
       ];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.blur(screen.getByTestId('role-label-key-0'));
+      fireEvent.blur(screen.getByTestId('role-label-value-0'));
 
       expect(screen.queryByTestId('role-label-key-error-0')).not.toBeInTheDocument();
       expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
@@ -209,14 +233,27 @@ describe('RoleLabelsSection', () => {
       expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
     });
 
-    it('should show both key and value errors on the same row', () => {
+    it('should show both key and value errors on the same row after blur', () => {
       const labels = [{ id: 'l-1', key: '', value: '' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.blur(screen.getByTestId('role-label-key-0'));
+      fireEvent.blur(screen.getByTestId('role-label-value-0'));
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Key is required.');
       expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent(
         'Value is required.',
       );
+    });
+
+    it('should only show error on the touched field, not the untouched one', () => {
+      const labels = [{ id: 'l-1', key: '', value: '' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.blur(screen.getByTestId('role-label-key-0'));
+
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Key is required.');
+      expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
@@ -145,7 +145,7 @@ describe('RoleLabelsSection', () => {
 
       fireEvent.blur(screen.getByTestId('role-label-key-0'));
 
-      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Key is required.');
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Required');
     });
 
     it('should show error for empty value after blur', () => {
@@ -154,9 +154,7 @@ describe('RoleLabelsSection', () => {
 
       fireEvent.blur(screen.getByTestId('role-label-value-0'));
 
-      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent(
-        'Value is required.',
-      );
+      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent('Required');
     });
 
     it('should show error for key containing a slash after blur', () => {
@@ -166,29 +164,29 @@ describe('RoleLabelsSection', () => {
       fireEvent.blur(screen.getByTestId('role-label-key-0'));
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent(
-        'Slashes (/) are not permitted',
+        'Do not include slashes',
       );
     });
 
-    it('should show error for invalid key syntax after blur', () => {
+    it('should show error for invalid key start/end after blur', () => {
       const labels = [{ id: 'l-1', key: '-bad', value: 'val' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
       fireEvent.blur(screen.getByTestId('role-label-key-0'));
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent(
-        'Key must be 1-63 characters',
+        'Must start and end with a letter or number',
       );
     });
 
-    it('should show error for invalid value syntax after blur', () => {
+    it('should show error for invalid value start/end after blur', () => {
       const labels = [{ id: 'l-1', key: 'team', value: '-bad' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
       fireEvent.blur(screen.getByTestId('role-label-value-0'));
 
       expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent(
-        'Value must be 1-63 characters',
+        'Must start and end with a letter or number',
       );
     });
 
@@ -203,10 +201,10 @@ describe('RoleLabelsSection', () => {
       fireEvent.blur(screen.getByTestId('role-label-key-1'));
 
       expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent(
-        'Duplicate keys are not allowed.',
+        'team is already in use',
       );
       expect(screen.getByTestId('role-label-key-error-1')).toHaveTextContent(
-        'Duplicate keys are not allowed.',
+        'team is already in use',
       );
     });
 
@@ -240,10 +238,8 @@ describe('RoleLabelsSection', () => {
       fireEvent.blur(screen.getByTestId('role-label-key-0'));
       fireEvent.blur(screen.getByTestId('role-label-value-0'));
 
-      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Key is required.');
-      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent(
-        'Value is required.',
-      );
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Required');
+      expect(screen.getByTestId('role-label-value-error-0')).toHaveTextContent('Required');
     });
 
     it('should only show error on the touched field, not the untouched one', () => {
@@ -252,7 +248,7 @@ describe('RoleLabelsSection', () => {
 
       fireEvent.blur(screen.getByTestId('role-label-key-0'));
 
-      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Key is required.');
+      expect(screen.getByTestId('role-label-key-error-0')).toHaveTextContent('Required');
       expect(screen.queryByTestId('role-label-value-error-0')).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
@@ -273,12 +273,12 @@ describe('validateLabelValue', () => {
     expect(validateLabelValue('a'.repeat(63))).toBeNull();
   });
 
-  it('should return error for empty value', () => {
-    expect(validateLabelValue('')).toBe('Required');
+  it('should return null for empty value (K8s spec allows empty label values)', () => {
+    expect(validateLabelValue('')).toBeNull();
   });
 
   it('should return error for value exceeding 63 characters', () => {
-    expect(validateLabelValue('a'.repeat(64))).toBe('Must be 1\u201363 characters.');
+    expect(validateLabelValue('a'.repeat(64))).toBe('Must be 63 characters or less.');
   });
 
   it('should return error for value starting with a dash', () => {

--- a/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
@@ -2,6 +2,8 @@ import {
   toK8sLabels,
   fromK8sLabels,
   getUserLabels,
+  validateLabelKey,
+  validateLabelValue,
 } from '#~/pages/projects/projectRoles/labelUtils';
 import { USER_LABEL_PREFIX } from '#~/pages/projects/projectRoles/const';
 
@@ -160,5 +162,132 @@ describe('getUserLabels', () => {
     };
 
     expect(getUserLabels(labels)).toStrictEqual({ team: 'platform' });
+  });
+});
+
+describe('validateLabelKey', () => {
+  it('should return null for a valid key', () => {
+    expect(validateLabelKey('team', ['team'], 0)).toBeNull();
+  });
+
+  it('should return null for key with dots, dashes, and underscores', () => {
+    expect(validateLabelKey('my_key.name-1', ['my_key.name-1'], 0)).toBeNull();
+  });
+
+  it('should return null for single-character key', () => {
+    expect(validateLabelKey('a', ['a'], 0)).toBeNull();
+  });
+
+  it('should return null for key at max length (63 characters)', () => {
+    const key63 = 'a'.repeat(63);
+    expect(validateLabelKey(key63, [key63], 0)).toBeNull();
+  });
+
+  it('should return error for empty key', () => {
+    expect(validateLabelKey('', [''], 0)).toBe('Key is required.');
+  });
+
+  it('should return error for key containing a slash', () => {
+    expect(validateLabelKey('prefix/name', ['prefix/name'], 0)).toBe(
+      'Slashes (/) are not permitted. The system automatically applies the required prefix namespace.',
+    );
+  });
+
+  it('should return error for key exceeding 63 characters', () => {
+    const longKey = 'a'.repeat(64);
+    expect(validateLabelKey(longKey, [longKey], 0)).toMatch(/Key must be 1-63 characters/);
+  });
+
+  it('should return error for key starting with a dash', () => {
+    expect(validateLabelKey('-invalid', ['-invalid'], 0)).toMatch(/Key must be 1-63 characters/);
+  });
+
+  it('should return error for key ending with a dash', () => {
+    expect(validateLabelKey('invalid-', ['invalid-'], 0)).toMatch(/Key must be 1-63 characters/);
+  });
+
+  it('should return error for key starting with a dot', () => {
+    expect(validateLabelKey('.invalid', ['.invalid'], 0)).toMatch(/Key must be 1-63 characters/);
+  });
+
+  it('should return error for key with spaces', () => {
+    expect(validateLabelKey('my key', ['my key'], 0)).toMatch(/Key must be 1-63 characters/);
+  });
+
+  it('should return error for key with special characters', () => {
+    expect(validateLabelKey('key@!#', ['key@!#'], 0)).toMatch(/Key must be 1-63 characters/);
+  });
+
+  it('should return error for duplicate keys', () => {
+    const allKeys = ['team', 'team'];
+    expect(validateLabelKey('team', allKeys, 1)).toBe('Duplicate keys are not allowed.');
+  });
+
+  it('should flag all duplicate rows', () => {
+    const allKeys = ['team', 'team'];
+    expect(validateLabelKey('team', allKeys, 0)).toBe('Duplicate keys are not allowed.');
+    expect(validateLabelKey('team', allKeys, 1)).toBe('Duplicate keys are not allowed.');
+  });
+
+  it('should not flag unique keys as duplicates', () => {
+    const allKeys = ['team', 'env'];
+    expect(validateLabelKey('team', allKeys, 0)).toBeNull();
+    expect(validateLabelKey('env', allKeys, 1)).toBeNull();
+  });
+
+  it('should accept uppercase characters in keys', () => {
+    expect(validateLabelKey('MyKey', ['MyKey'], 0)).toBeNull();
+  });
+
+  it('should prioritize slash error over syntax error', () => {
+    expect(validateLabelKey('bad/key!', ['bad/key!'], 0)).toBe(
+      'Slashes (/) are not permitted. The system automatically applies the required prefix namespace.',
+    );
+  });
+});
+
+describe('validateLabelValue', () => {
+  it('should return null for a valid value', () => {
+    expect(validateLabelValue('platform')).toBeNull();
+  });
+
+  it('should return null for value with dots, dashes, and underscores', () => {
+    expect(validateLabelValue('my-value_1.0')).toBeNull();
+  });
+
+  it('should return null for single-character value', () => {
+    expect(validateLabelValue('a')).toBeNull();
+  });
+
+  it('should return null for value at max length (63 characters)', () => {
+    expect(validateLabelValue('a'.repeat(63))).toBeNull();
+  });
+
+  it('should return error for empty value', () => {
+    expect(validateLabelValue('')).toBe('Value is required.');
+  });
+
+  it('should return error for value exceeding 63 characters', () => {
+    expect(validateLabelValue('a'.repeat(64))).toMatch(/Value must be 1-63 characters/);
+  });
+
+  it('should return error for value starting with a dash', () => {
+    expect(validateLabelValue('-invalid')).toMatch(/Value must be 1-63 characters/);
+  });
+
+  it('should return error for value ending with a dash', () => {
+    expect(validateLabelValue('invalid-')).toMatch(/Value must be 1-63 characters/);
+  });
+
+  it('should return error for value with spaces', () => {
+    expect(validateLabelValue('my value')).toMatch(/Value must be 1-63 characters/);
+  });
+
+  it('should return error for value with special characters', () => {
+    expect(validateLabelValue('val@!#')).toMatch(/Value must be 1-63 characters/);
+  });
+
+  it('should accept uppercase characters in values', () => {
+    expect(validateLabelValue('MyValue')).toBeNull();
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/labelUtils.spec.ts
@@ -184,49 +184,59 @@ describe('validateLabelKey', () => {
   });
 
   it('should return error for empty key', () => {
-    expect(validateLabelKey('', [''], 0)).toBe('Key is required.');
+    expect(validateLabelKey('', [''], 0)).toBe('Required');
   });
 
   it('should return error for key containing a slash', () => {
     expect(validateLabelKey('prefix/name', ['prefix/name'], 0)).toBe(
-      'Slashes (/) are not permitted. The system automatically applies the required prefix namespace.',
+      'Do not include slashes (/). The system adds the required namespace prefix for you.',
     );
   });
 
   it('should return error for key exceeding 63 characters', () => {
     const longKey = 'a'.repeat(64);
-    expect(validateLabelKey(longKey, [longKey], 0)).toMatch(/Key must be 1-63 characters/);
+    expect(validateLabelKey(longKey, [longKey], 0)).toBe('Must be 1\u201363 characters.');
   });
 
   it('should return error for key starting with a dash', () => {
-    expect(validateLabelKey('-invalid', ['-invalid'], 0)).toMatch(/Key must be 1-63 characters/);
+    expect(validateLabelKey('-invalid', ['-invalid'], 0)).toBe(
+      'Must start and end with a letter or number.',
+    );
   });
 
   it('should return error for key ending with a dash', () => {
-    expect(validateLabelKey('invalid-', ['invalid-'], 0)).toMatch(/Key must be 1-63 characters/);
+    expect(validateLabelKey('invalid-', ['invalid-'], 0)).toBe(
+      'Must start and end with a letter or number.',
+    );
   });
 
   it('should return error for key starting with a dot', () => {
-    expect(validateLabelKey('.invalid', ['.invalid'], 0)).toMatch(/Key must be 1-63 characters/);
+    expect(validateLabelKey('.invalid', ['.invalid'], 0)).toBe(
+      'Must start and end with a letter or number.',
+    );
   });
 
   it('should return error for key with spaces', () => {
-    expect(validateLabelKey('my key', ['my key'], 0)).toMatch(/Key must be 1-63 characters/);
+    expect(validateLabelKey('my key', ['my key'], 0)).toBe(
+      'Valid characters include letters, numbers, hyphens (-), periods (.), and underscores (_).',
+    );
   });
 
   it('should return error for key with special characters', () => {
-    expect(validateLabelKey('key@!#', ['key@!#'], 0)).toMatch(/Key must be 1-63 characters/);
+    expect(validateLabelKey('key@!#', ['key@!#'], 0)).toBe(
+      'Valid characters include letters, numbers, hyphens (-), periods (.), and underscores (_).',
+    );
   });
 
   it('should return error for duplicate keys', () => {
     const allKeys = ['team', 'team'];
-    expect(validateLabelKey('team', allKeys, 1)).toBe('Duplicate keys are not allowed.');
+    expect(validateLabelKey('team', allKeys, 1)).toBe('team is already in use.');
   });
 
   it('should flag all duplicate rows', () => {
     const allKeys = ['team', 'team'];
-    expect(validateLabelKey('team', allKeys, 0)).toBe('Duplicate keys are not allowed.');
-    expect(validateLabelKey('team', allKeys, 1)).toBe('Duplicate keys are not allowed.');
+    expect(validateLabelKey('team', allKeys, 0)).toBe('team is already in use.');
+    expect(validateLabelKey('team', allKeys, 1)).toBe('team is already in use.');
   });
 
   it('should not flag unique keys as duplicates', () => {
@@ -241,7 +251,7 @@ describe('validateLabelKey', () => {
 
   it('should prioritize slash error over syntax error', () => {
     expect(validateLabelKey('bad/key!', ['bad/key!'], 0)).toBe(
-      'Slashes (/) are not permitted. The system automatically applies the required prefix namespace.',
+      'Do not include slashes (/). The system adds the required namespace prefix for you.',
     );
   });
 });
@@ -264,27 +274,31 @@ describe('validateLabelValue', () => {
   });
 
   it('should return error for empty value', () => {
-    expect(validateLabelValue('')).toBe('Value is required.');
+    expect(validateLabelValue('')).toBe('Required');
   });
 
   it('should return error for value exceeding 63 characters', () => {
-    expect(validateLabelValue('a'.repeat(64))).toMatch(/Value must be 1-63 characters/);
+    expect(validateLabelValue('a'.repeat(64))).toBe('Must be 1\u201363 characters.');
   });
 
   it('should return error for value starting with a dash', () => {
-    expect(validateLabelValue('-invalid')).toMatch(/Value must be 1-63 characters/);
+    expect(validateLabelValue('-invalid')).toBe('Must start and end with a letter or number.');
   });
 
   it('should return error for value ending with a dash', () => {
-    expect(validateLabelValue('invalid-')).toMatch(/Value must be 1-63 characters/);
+    expect(validateLabelValue('invalid-')).toBe('Must start and end with a letter or number.');
   });
 
   it('should return error for value with spaces', () => {
-    expect(validateLabelValue('my value')).toMatch(/Value must be 1-63 characters/);
+    expect(validateLabelValue('my value')).toBe(
+      'Valid characters include letters, numbers, hyphens (-), periods (.), and underscores (_).',
+    );
   });
 
   it('should return error for value with special characters', () => {
-    expect(validateLabelValue('val@!#')).toMatch(/Value must be 1-63 characters/);
+    expect(validateLabelValue('val@!#')).toBe(
+      'Valid characters include letters, numbers, hyphens (-), periods (.), and underscores (_).',
+    );
   });
 
   it('should accept uppercase characters in values', () => {

--- a/frontend/src/pages/projects/projectRoles/__tests__/useApiResources.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/useApiResources.spec.ts
@@ -8,9 +8,10 @@ import useApiResources, {
 const mockCoreResponse = {
   kind: 'APIGroupDiscoveryList',
   apiVersion: 'apidiscovery.k8s.io/v2',
+  metadata: {},
   items: [
     {
-      metadata: { name: '' },
+      metadata: {},
       versions: [
         {
           version: 'v1',
@@ -235,6 +236,50 @@ describe('parseDiscoveryItems', () => {
 
     expect(result.apiGroups).toEqual(['']);
     expect(result.resources).toEqual([{ name: 'pods', kind: 'Pod', apiGroup: '' }]);
+  });
+
+  it('should handle core API group with no name in metadata (real K8s behavior)', () => {
+    const items = [
+      {
+        metadata: {},
+        versions: [
+          {
+            version: 'v1',
+            resources: [
+              {
+                resource: 'pods',
+                responseKind: { group: '', version: 'v1', kind: 'Pod' },
+                scope: 'Namespaced',
+                verbs: ['get', 'list'],
+              },
+            ],
+          },
+        ],
+      },
+    ] as APIGroupDiscoveryItem[];
+
+    const result = parseDiscoveryItems(items);
+
+    expect(result.apiGroups).toEqual(['']);
+    expect(result.resources).toEqual([{ name: 'pods', kind: 'Pod', apiGroup: '' }]);
+  });
+
+  it('should handle versions without a resources array', () => {
+    const items: APIGroupDiscoveryItem[] = [
+      {
+        metadata: { name: 'external.metrics.k8s.io' },
+        versions: [
+          {
+            version: 'v1beta1',
+          },
+        ],
+      },
+    ];
+
+    const result = parseDiscoveryItems(items);
+
+    expect(result.apiGroups).toEqual(['external.metrics.k8s.io']);
+    expect(result.resources).toEqual([]);
   });
 
   it('should skip subresources (resources containing a slash)', () => {

--- a/frontend/src/pages/projects/projectRoles/labelUtils.ts
+++ b/frontend/src/pages/projects/projectRoles/labelUtils.ts
@@ -34,10 +34,10 @@ export const validateLabelKey = (
 
 export const validateLabelValue = (value: string): string | null => {
   if (!value) {
-    return 'Required';
+    return null;
   }
   if (value.length > MAX_LABEL_LENGTH) {
-    return `Must be 1\u2013${MAX_LABEL_LENGTH} characters.`;
+    return `Must be ${MAX_LABEL_LENGTH} characters or less.`;
   }
   if (!LABEL_CHARS_REGEX.test(value)) {
     return 'Valid characters include letters, numbers, hyphens (-), periods (.), and underscores (_).';

--- a/frontend/src/pages/projects/projectRoles/labelUtils.ts
+++ b/frontend/src/pages/projects/projectRoles/labelUtils.ts
@@ -2,9 +2,9 @@ import { getUniqueId } from '@patternfly/react-core';
 import { USER_LABEL_PREFIX } from './const';
 import type { LabelEntry } from './types';
 
-const LABEL_NAME_REGEX = /^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$/;
-const LABEL_VALUE_REGEX = /^([a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?)?$/;
-const MAX_LABEL_NAME_LENGTH = 63;
+const ALPHANUMERIC = /^[a-zA-Z0-9]$/;
+const LABEL_CHARS_REGEX = /^[a-zA-Z0-9._-]+$/;
+const MAX_LABEL_LENGTH = 63;
 
 export const validateLabelKey = (
   key: string,
@@ -12,29 +12,38 @@ export const validateLabelKey = (
   currentIndex: number,
 ): string | null => {
   if (!key) {
-    return 'Key is required.';
+    return 'Required';
   }
   if (key.includes('/')) {
-    return 'Slashes (/) are not permitted. The system automatically applies the required prefix namespace.';
+    return 'Do not include slashes (/). The system adds the required namespace prefix for you.';
   }
-  if (key.length > MAX_LABEL_NAME_LENGTH) {
-    return `Key must be 1-${MAX_LABEL_NAME_LENGTH} characters, start/end with an alphanumeric character, and contain only alphanumeric, '-', '_', or '.'.`;
+  if (key.length > MAX_LABEL_LENGTH) {
+    return `Must be 1\u2013${MAX_LABEL_LENGTH} characters.`;
   }
-  if (!LABEL_NAME_REGEX.test(key)) {
-    return `Key must be 1-${MAX_LABEL_NAME_LENGTH} characters, start/end with an alphanumeric character, and contain only alphanumeric, '-', '_', or '.'.`;
+  if (!LABEL_CHARS_REGEX.test(key)) {
+    return 'Valid characters include letters, numbers, hyphens (-), periods (.), and underscores (_).';
+  }
+  if (!ALPHANUMERIC.test(key[0]) || !ALPHANUMERIC.test(key[key.length - 1])) {
+    return 'Must start and end with a letter or number.';
   }
   if (allKeys.some((k, i) => i !== currentIndex && k === key)) {
-    return 'Duplicate keys are not allowed.';
+    return `${key} is already in use.`;
   }
   return null;
 };
 
 export const validateLabelValue = (value: string): string | null => {
   if (!value) {
-    return 'Value is required.';
+    return 'Required';
   }
-  if (value.length > MAX_LABEL_NAME_LENGTH || !LABEL_VALUE_REGEX.test(value)) {
-    return `Value must be 1-${MAX_LABEL_NAME_LENGTH} characters, start/end with an alphanumeric character, and contain only alphanumeric, '-', '_', or '.'.`;
+  if (value.length > MAX_LABEL_LENGTH) {
+    return `Must be 1\u2013${MAX_LABEL_LENGTH} characters.`;
+  }
+  if (!LABEL_CHARS_REGEX.test(value)) {
+    return 'Valid characters include letters, numbers, hyphens (-), periods (.), and underscores (_).';
+  }
+  if (!ALPHANUMERIC.test(value[0]) || !ALPHANUMERIC.test(value[value.length - 1])) {
+    return 'Must start and end with a letter or number.';
   }
   return null;
 };

--- a/frontend/src/pages/projects/projectRoles/labelUtils.ts
+++ b/frontend/src/pages/projects/projectRoles/labelUtils.ts
@@ -2,6 +2,43 @@ import { getUniqueId } from '@patternfly/react-core';
 import { USER_LABEL_PREFIX } from './const';
 import type { LabelEntry } from './types';
 
+const LABEL_NAME_REGEX = /^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$/;
+const LABEL_VALUE_REGEX = /^([a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?)?$/;
+const MAX_LABEL_NAME_LENGTH = 63;
+
+export const validateLabelKey = (
+  key: string,
+  allKeys: string[],
+  currentIndex: number,
+): string | null => {
+  if (!key) {
+    return 'Key is required.';
+  }
+  if (key.includes('/')) {
+    return 'Slashes (/) are not permitted. The system automatically applies the required prefix namespace.';
+  }
+  if (key.length > MAX_LABEL_NAME_LENGTH) {
+    return `Key must be 1-${MAX_LABEL_NAME_LENGTH} characters, start/end with an alphanumeric character, and contain only alphanumeric, '-', '_', or '.'.`;
+  }
+  if (!LABEL_NAME_REGEX.test(key)) {
+    return `Key must be 1-${MAX_LABEL_NAME_LENGTH} characters, start/end with an alphanumeric character, and contain only alphanumeric, '-', '_', or '.'.`;
+  }
+  if (allKeys.some((k, i) => i !== currentIndex && k === key)) {
+    return 'Duplicate keys are not allowed.';
+  }
+  return null;
+};
+
+export const validateLabelValue = (value: string): string | null => {
+  if (!value) {
+    return 'Value is required.';
+  }
+  if (value.length > MAX_LABEL_NAME_LENGTH || !LABEL_VALUE_REGEX.test(value)) {
+    return `Value must be 1-${MAX_LABEL_NAME_LENGTH} characters, start/end with an alphanumeric character, and contain only alphanumeric, '-', '_', or '.'.`;
+  }
+  return null;
+};
+
 export const toK8sLabels = (entries: LabelEntry[]): Record<string, string> =>
   Object.fromEntries(
     entries

--- a/frontend/src/pages/projects/projectRoles/useApiResources.ts
+++ b/frontend/src/pages/projects/projectRoles/useApiResources.ts
@@ -17,12 +17,12 @@ type APIGroupDiscoveryResource = {
 
 type APIGroupDiscoveryVersion = {
   version: string;
-  resources: APIGroupDiscoveryResource[];
+  resources?: APIGroupDiscoveryResource[];
 };
 
 export type APIGroupDiscoveryItem = {
   metadata: {
-    name: string;
+    name?: string;
   };
   versions: APIGroupDiscoveryVersion[];
 };
@@ -30,7 +30,7 @@ export type APIGroupDiscoveryItem = {
 type APIGroupDiscoveryList = {
   kind: string;
   apiVersion: string;
-  items: APIGroupDiscoveryItem[];
+  items?: APIGroupDiscoveryItem[];
 };
 
 export type DiscoveredResource = {
@@ -64,16 +64,15 @@ export const parseDiscoveryItems = (items: APIGroupDiscoveryItem[]): ApiResource
   const seenResources = new Set<string>();
 
   for (const item of items) {
-    const groupName = item.metadata.name;
+    const groupName = item.metadata.name ?? '';
     apiGroups.push(groupName);
 
-    if (item.versions.length === 0) {
+    const preferredResources = item.versions[0]?.resources;
+    if (!preferredResources) {
       continue;
     }
 
-    // The Aggregated Discovery API returns versions in preference order;
-    // versions[0] is the preferred version and typically contains the full resource set.
-    for (const res of item.versions[0].resources) {
+    for (const res of preferredResources) {
       if (res.resource.includes('/')) {
         continue;
       }
@@ -102,8 +101,8 @@ const useApiResources = (): FetchStateObject<ApiResourcesData> => {
       fetchDiscovery('/api/k8s/apis', opts.signal),
     ]);
 
-    const coreData = parseDiscoveryItems(coreResult.items);
-    const apisData = parseDiscoveryItems(apisResult.items);
+    const coreData = parseDiscoveryItems(coreResult.items ?? []);
+    const apisData = parseDiscoveryItems(apisResult.items ?? []);
 
     return {
       apiGroups: [...coreData.apiGroups, ...apisData.apiGroups],

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
@@ -97,18 +97,18 @@ describe('Roles tab feature flag gating', () => {
       projectRoles.findSubmitButton().should('be.enabled');
     });
 
-    it('should disable submit when a label row has empty key or value', () => {
+    it('should disable submit when a label row has a touched empty key', () => {
       projectRoles.visitCreateRole(NAMESPACE);
       projectRoles.findRoleNameInput().type('my-test-role');
       projectRoles.findSubmitButton().should('be.enabled');
 
       projectRoles.findAddLabelButton().click();
+      projectRoles.findSubmitButton().should('be.enabled');
+
+      projectRoles.findLabelKeyInput(0).focus().blur();
       projectRoles.findSubmitButton().should('be.disabled');
 
       projectRoles.findLabelKeyInput(0).type('team');
-      projectRoles.findSubmitButton().should('be.disabled');
-
-      projectRoles.findLabelValueInput(0).type('platform');
       projectRoles.findSubmitButton().should('be.enabled');
     });
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-66289

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds inline validation error messages to the Labels section of the Create/Edit/Duplicate Custom Role form.

https://github.com/user-attachments/assets/d4bdc23a-729e-444f-a604-361f5dd533c4

Previously, invalid labels silently disabled the submit button with no feedback. Now each key/value field shows a specific error message with a red border and helper text beneath the offending input, following PatternFly v6 `ValidatedOptions.error` + `HelperTextItem variant="error"` conventions used elsewhere in the codebase.

**Validation rules implemented (per K8s label spec + UX ticket):**
| Scenario | Field | Error message |
|----------|-------|---------------|
| Empty key | Key | Key is required. |
| Empty value | Value | Value is required. |
| Slash in key | Key | Slashes (/) are not permitted. The system automatically applies the required prefix namespace. |
| Invalid key syntax/length | Key | Key must be 1-63 characters, start/end with an alphanumeric character, and contain only alphanumeric, '-', '_', or '.'. |
| Invalid value syntax/length | Value | Value must be 1-63 characters, start/end with an alphanumeric character, and contain only alphanumeric, '-', '_', or '.'. |
| Duplicate keys | Key (all matching rows) | Duplicate keys are not allowed. |

**Bug fix:** Also fixes a pre-existing bug where entering a slash in the key (e.g. `foo/bar`) bypassed client-side validation — `isValidK8sLabelKeyValue` treated it as a valid prefixed key, but the system auto-prepends `labels.opendatahub.io/`, resulting in a double-slash key that fails at the K8s API with a 422. The new validation explicitly rejects slashes in user input.

**Files changed:**
- `labelUtils.ts` — Added `validateLabelKey()` and `validateLabelValue()` returning specific error messages
- `RoleLabelsSection.tsx` — Added per-field inline error rendering
- `CreateRolePage.tsx` — Replaced `hasInvalidLabels` / `hasDuplicateLabelKeys` with the new validation functions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. **Empty key/value required** — Add a label row, leave both fields blank. Both show "Key is required." / "Value is required." with red borders. Fix one, confirm the other still shows. Submit button stays disabled.
2. **Slash in key rejected** — Type `my-prefix/name` in the Key field. Verify "Slashes (/) are not permitted..." appears. This prevents 422 API errors from the auto-prefixed key.
3. **Invalid syntax caught** — Type `-bad.key` in Key and `val @!` in Value. Both show the character-set error. Change them to `valid-key` / `valid-value` and confirm errors clear immediately on keystroke.
4. **Duplicate keys flagged on all rows** — Add two label rows with the same key `team` (different values). "Duplicate keys are not allowed." appears on both rows simultaneously. Change one key to `env` — both errors clear. Remove one duplicate row instead — the remaining row's error clears.
5. **Valid labels submit successfully** — Add a label with key `team`, value `platform`. Fill in role name. No errors shown, submit button enabled. Submit the form and confirm it succeeds without a 422.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added 30 new unit tests across two test files (65 total passing):
- **`labelUtils.spec.ts`** — 28 tests covering `validateLabelKey` (empty, slash, length, invalid start/end characters, spaces, special characters, duplicate detection, uppercase, error priority) and `validateLabelValue` (empty, length, invalid characters, uppercase)
- **`RoleLabelsSection.spec.tsx`** — 9 tests covering inline error rendering for all six validation scenarios, valid labels showing no errors, both errors on same row, and no errors with zero rows
- 
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced project role label inline validation with field-level “touched” behavior and more precise helper/error messaging.
  * Improved submit-state handling by propagating invalid-label status from the label section to the role form.

* **Bug Fixes**
  * Standardized label key/value validation rules (including duplicate detection and format/character constraints).
  * Improved API discovery parsing to tolerate missing metadata and absent resource entries.

* **Tests**
  * Expanded unit tests for inline validation and shared label utilities.
  * Updated end-to-end coverage for the “touched empty key” submit-button scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->