### PR TITLE
add ai insight microcopy

### DIFF
--- a/packages/eval-hub/frontend/src/app/api/k8s.ts
+++ b/packages/eval-hub/frontend/src/app/api/k8s.ts
@@ -271,13 +271,21 @@ export const getInferenceServices =
     });
 
 export const getCatalogSecurityArtifacts =
-  (hostPath: string, sourceId: string, modelName: string, namespace?: string) =>
-  (opts: APIOptions): Promise<CatalogSecurityArtifactList> =>
-    handleRestFailures(
+  (hostPath: string, sourceId: string, modelName: string, namespace?: string, pageSize?: number) =>
+  (opts: APIOptions): Promise<CatalogSecurityArtifactList> => {
+    const queryParams: Record<string, string> = {};
+    if (namespace) {
+      queryParams.namespace = namespace;
+    }
+    if (pageSize != null) {
+      queryParams.pageSize = String(pageSize);
+    }
+
+    return handleRestFailures(
       restGET(
         hostPath,
         `${URL_PREFIX}/api/${BFF_API_VERSION}/catalog/sources/${encodeURIComponent(sourceId)}/security_artifacts/${encodeURIComponent(modelName)}`,
-        { ...(namespace && { namespace }) },
+        queryParams,
         opts,
       ),
     ).then((response) => {
@@ -286,6 +294,7 @@ export const getCatalogSecurityArtifacts =
       }
       throw new Error('Invalid response format');
     });
+  };
 
 export const verifyConnection =
   (hostPath: string, namespace: string, request: VerifyConnectionRequest) =>

--- a/packages/eval-hub/frontend/src/app/hooks/__tests__/useSecurityArtifacts.spec.ts
+++ b/packages/eval-hub/frontend/src/app/hooks/__tests__/useSecurityArtifacts.spec.ts
@@ -105,7 +105,28 @@ describe('useSecurityArtifacts', () => {
       'my-source',
       'my-model',
       'my-ns',
+      undefined,
     );
     expect(mockFetcher).toHaveBeenCalledWith(mockOpts);
+  });
+
+  it('should pass pageSize when provided', () => {
+    const mockFetcher = jest.fn().mockResolvedValue(emptyList);
+    mockGetCatalogSecurityArtifacts.mockReturnValue(mockFetcher);
+
+    testHook(useSecurityArtifacts)('my-source', 'my-model', 'my-ns', 25);
+
+    const [fetchCallback] = mockUseFetchState.mock.calls[0] as unknown as [
+      (opts: unknown) => Promise<CatalogSecurityArtifactList>,
+    ];
+    fetchCallback({});
+
+    expect(mockGetCatalogSecurityArtifacts).toHaveBeenCalledWith(
+      '',
+      'my-source',
+      'my-model',
+      'my-ns',
+      25,
+    );
   });
 });

--- a/packages/eval-hub/frontend/src/app/hooks/useSecurityArtifacts.ts
+++ b/packages/eval-hub/frontend/src/app/hooks/useSecurityArtifacts.ts
@@ -19,10 +19,12 @@ const useSecurityArtifacts = (
   sourceId: string,
   modelName: string,
   namespace: string,
+  pageSize?: number,
 ): UseSecurityArtifactsResult => {
   const callback = React.useCallback<FetchStateCallbackPromise<CatalogSecurityArtifactList>>(
-    (opts: APIOptions) => getCatalogSecurityArtifacts('', sourceId, modelName, namespace)(opts),
-    [sourceId, modelName, namespace],
+    (opts: APIOptions) =>
+      getCatalogSecurityArtifacts('', sourceId, modelName, namespace, pageSize)(opts),
+    [sourceId, modelName, namespace, pageSize],
   );
 
   const [data, loaded, loadError] = useFetchState<CatalogSecurityArtifactList>(

--- a/packages/eval-hub/frontend/src/app/pages/modelCatalog/SecurityInsightsView.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/modelCatalog/SecurityInsightsView.tsx
@@ -42,19 +42,27 @@ import {
   getSortableValue,
 } from './const';
 
+const SECURITY_ARTIFACTS_PAGE_SIZE = 100;
+
 const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
   sourceId,
   modelName,
   namespace,
 }) => {
-  const { insights, loaded, loadError } = useSecurityArtifacts(sourceId, modelName, namespace);
+  const { insights, loaded, loadError } = useSecurityArtifacts(
+    sourceId,
+    modelName,
+    namespace,
+    SECURITY_ARTIFACTS_PAGE_SIZE,
+  );
+
+  const [perPage, setPerPage] = React.useState(DEFAULT_TABLE_PER_PAGE);
 
   const [activeFilter, setActiveFilter] = React.useState<FilterOption>('evaluation');
   const [isFilterSelectOpen, setIsFilterSelectOpen] = React.useState(false);
   const [filterValue, setFilterValue] = React.useState('');
   const [sortConfig, setSortConfig] = React.useState<SortConfig>({ index: 1, direction: 'asc' });
   const [page, setPage] = React.useState(1);
-  const [perPage, setPerPage] = React.useState(DEFAULT_TABLE_PER_PAGE);
 
   const filtered = React.useMemo(
     () =>
@@ -145,8 +153,8 @@ const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
           </FlexItem>
           <FlexItem>
             <Content component={ContentVariants.p}>
-              Compare safety and security evaluation scores across benchmarks to assess model safety
-              and alignment.
+              Compare safety and security evaluation scores across benchmarks to determine if this
+              model is suitable for your use case.
             </Content>
           </FlexItem>
         </Flex>
@@ -170,7 +178,7 @@ const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
                         value="evaluation"
                         data-testid="security-filter-option-evaluation"
                       >
-                        Evaluation
+                        Evaluation name
                       </SelectOption>
                       <SelectOption value="category" data-testid="security-filter-option-category">
                         Category
@@ -217,7 +225,7 @@ const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
           <Thead>
             <Tr>
               <Th sort={getSortParams(0)} modifier="nowrap">
-                Evaluation
+                Evaluation name
               </Th>
               <Th sort={getSortParams(1)} modifier="nowrap">
                 Category
@@ -227,10 +235,11 @@ const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
                 sort={getSortParams(3)}
                 modifier="nowrap"
                 info={{
-                  popover: "The normalized value of the benchmark's primary metric.",
+                  popover:
+                    'The normalized, weighted value of the benchmarks’ primary metric, such as accuracy, speed, or resource efficiency.',
                 }}
               >
-                Result
+                Evaluation score
               </Th>
             </Tr>
           </Thead>
@@ -240,7 +249,7 @@ const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
                 key={`${insight.benchmarkName}-${insight.evaluation}`}
                 data-testid="security-insight-row"
               >
-                <Td dataLabel="Evaluation">{insight.evaluation}</Td>
+                <Td dataLabel="Evaluation name">{insight.evaluation}</Td>
                 <Td dataLabel="Category">
                   {insight.category && (
                     <Label color={getCategoryColor(insight.category)} isCompact>
@@ -255,7 +264,7 @@ const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
                     truncateDescriptionLines={2}
                   />
                 </Td>
-                <Td dataLabel="Result">{insight.result}</Td>
+                <Td dataLabel="Evaluation score">{insight.result}</Td>
               </Tr>
             ))}
           </Tbody>

--- a/packages/eval-hub/frontend/src/app/pages/modelCatalog/const.ts
+++ b/packages/eval-hub/frontend/src/app/pages/modelCatalog/const.ts
@@ -3,13 +3,13 @@ import { type SecurityInsight } from './securityInsightsTypes';
 export type FilterOption = 'evaluation' | 'category' | 'benchmark';
 
 export const FILTER_LABELS: Record<FilterOption, string> = {
-  evaluation: 'Evaluation',
+  evaluation: 'Evaluation name',
   category: 'Category',
   benchmark: 'Benchmark',
 };
 
 export const FILTER_PLACEHOLDERS: Record<FilterOption, string> = {
-  evaluation: 'Filter by evaluation',
+  evaluation: 'Filter by evaluation name',
   category: 'Filter by category',
   benchmark: 'Filter by benchmark',
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-73119
## Description
The SecurityInsightsView was fetching security artifacts from the model-catalog BFF without specifying a pageSize, which meant the backend would use its default (typically 10). This caused the table to show fewer results than expected, and users couldn't see all available security insights for a model.

This change passes pageSize=100 from the frontend through the eval-hub BFF to the model-registry BFF, ensuring all security artifacts are fetched upfront for client-side filtering, sorting, and pagination.

Changes:

k8s.ts — getCatalogSecurityArtifacts now accepts an optional pageSize parameter and forwards it as a query param
useSecurityArtifacts.ts — Accepts optional pageSize and passes it through to the API call
SecurityInsightsView.tsx — Passes SECURITY_ARTIFACTS_PAGE_SIZE (100) to fetch all artifacts upfront; client-side table pagination remains unchanged
const.ts — Minor refactor (no behavioral change)
No BFF code changes needed — the eval-hub BFF already forwards raw query params to the model-registry BFF, and the model-registry BFF's FilterPageValues already extracts pageSize.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Unit tests updated and passing (5/5 in useSecurityArtifacts.spec.ts)
TypeScript type-check passing
Lint passing (no errors)
Verified locally with dev servers running:
Eval-hub BFF logs confirm pageSize=100 in the request URL
Curl to model-registry BFF confirms it receives and responds to pageSize=100 with HTTP 200
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination control for security insights, improving how many results load per page.
  * Updated security insight labels and table text for clearer wording, including “Evaluation name” and “Evaluation score”.

* **Bug Fixes**
  * Search/filter behavior now passes page size through consistently, helping results display with the expected pagination settings.

* **Documentation**
  * Updated filter placeholder text to better guide users when searching by evaluation name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->