### PR TITLE
fix(e2e): use metrics endpoint for feature store overview card assertion

### DIFF
--- a/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
@@ -11,7 +11,10 @@ import {
 } from '../../../utils/oc_commands/featureStoreResources';
 import { retryableBefore } from '../../../utils/retryableHooks';
 import { generateTestUUID } from '../../../utils/uuidGenerator';
-import { getAllFeatureStoreCounts } from '../../../utils/api/featureStoreRest';
+import {
+  getAllFeatureStoreCounts,
+  getMetricsResourceCounts,
+} from '../../../utils/api/featureStoreRest';
 import { featureMetricsOverview } from '../../../pages/featureStore/featureMetrics';
 import { getCustomResource } from '../../../utils/oc_commands/customResources';
 
@@ -24,6 +27,12 @@ describe('Feature Store Page Validation', () => {
   let dataSourceCount: number;
   let featureViewCount: number;
   let featureServiceCount: number;
+  let metricsFeatureCount: number;
+  let metricsEntityCount: number;
+  let metricsDatasetCount: number;
+  let metricsDataSourceCount: number;
+  let metricsFeatureViewCount: number;
+  let metricsFeatureServiceCount: number;
   let skipTest = false;
   const uuid = generateTestUUID();
 
@@ -57,18 +66,29 @@ describe('Feature Store Page Validation', () => {
         .then(() => {
           // Create route and fetch counts for the Feast instance
           return createRouteAndGetUrl(projectName, testData.feastInstanceName).then((routeUrl) => {
-            return getAllFeatureStoreCounts(routeUrl, testData.feastCreditScoringProject).then(
-              (feastInstanceCounts) => {
-                // Assign all counts from the returned object
-                featureCount = feastInstanceCounts.featureCount;
-                entityCount = feastInstanceCounts.entityCount;
-                datasetCount = feastInstanceCounts.datasetCount;
-                dataSourceCount = feastInstanceCounts.dataSourceCount;
-                featureViewCount = feastInstanceCounts.featureViewCount;
-                featureServiceCount = feastInstanceCounts.featureServiceCount;
+            return getMetricsResourceCounts(routeUrl, testData.feastCreditScoringProject).then(
+              (metricsCounts) => {
+                metricsFeatureCount = metricsCounts.featureCount;
+                metricsEntityCount = metricsCounts.entityCount;
+                metricsDatasetCount = metricsCounts.datasetCount;
+                metricsDataSourceCount = metricsCounts.dataSourceCount;
+                metricsFeatureViewCount = metricsCounts.featureViewCount;
+                metricsFeatureServiceCount = metricsCounts.featureServiceCount;
 
-                cy.log('Counts assigned successfully:', feastInstanceCounts);
-                return cy.wrap(feastInstanceCounts);
+                return getAllFeatureStoreCounts(routeUrl, testData.feastCreditScoringProject).then(
+                  (listCounts) => {
+                    featureCount = listCounts.featureCount;
+                    entityCount = listCounts.entityCount;
+                    datasetCount = listCounts.datasetCount;
+                    dataSourceCount = listCounts.dataSourceCount;
+                    featureViewCount = listCounts.featureViewCount;
+                    featureServiceCount = listCounts.featureServiceCount;
+
+                    cy.log(`Metrics counts: ${JSON.stringify(metricsCounts)}`);
+                    cy.log(`List counts: ${JSON.stringify(listCounts)}`);
+                    return cy.wrap({ metricsCounts, listCounts });
+                  },
+                );
               },
             );
           });
@@ -103,11 +123,14 @@ describe('Feature Store Page Validation', () => {
       featureStoreGlobal.navigateToOverview();
       featureStoreGlobal.selectProject(testData.feastCreditScoringProject);
       cy.step(`Verify Metrics contents count is displayed correctly`);
-      featureMetricsOverview.findEntitiesCard().should('contain.text', entityCount);
-      featureMetricsOverview.findDataSourcesCard().should('contain.text', dataSourceCount);
-      featureMetricsOverview.findSavedDatasetsCard().should('contain.text', datasetCount);
-      featureMetricsOverview.findFeaturesCard().should('contain.text', featureCount);
-      featureMetricsOverview.findFeatureServicesCard().should('contain.text', featureServiceCount);
+      featureMetricsOverview.findEntitiesCard().should('contain.text', metricsEntityCount);
+      featureMetricsOverview.findDataSourcesCard().should('contain.text', metricsDataSourceCount);
+      featureMetricsOverview.findSavedDatasetsCard().should('contain.text', metricsDatasetCount);
+      featureMetricsOverview.findFeaturesCard().should('contain.text', metricsFeatureCount);
+      featureMetricsOverview.findFeatureViewsCard().should('contain.text', metricsFeatureViewCount);
+      featureMetricsOverview
+        .findFeatureServicesCard()
+        .should('contain.text', metricsFeatureServiceCount);
 
       cy.step(`Navigate to the Feature Store Entities page`);
       featureStoreGlobal.navigateToEntities();

--- a/packages/cypress/cypress/utils/api/featureStoreRest.ts
+++ b/packages/cypress/cypress/utils/api/featureStoreRest.ts
@@ -170,7 +170,58 @@ export const getDatasetsCount = (routeUrl: string, project: string): Cypress.Cha
 };
 
 /**
- * Fetches all Feature Store counts in a single function call
+ * Fetches resource counts from the metrics endpoint (same source the dashboard overview cards use)
+ *
+ * @param {string} routeUrl - The Feature Store route URL
+ * @param {string} project - The project name
+ * @returns {Cypress.Chainable<object>} Object containing all counts from the metrics endpoint
+ */
+export const getMetricsResourceCounts = (
+  routeUrl: string,
+  project: string,
+): Cypress.Chainable<{
+  featureCount: number;
+  entityCount: number;
+  datasetCount: number;
+  dataSourceCount: number;
+  featureViewCount: number;
+  featureServiceCount: number;
+}> => {
+  const apiUrl = `${routeUrl}/api/v1/metrics/resource_counts?project=${encodeURIComponent(
+    project,
+  )}`;
+
+  return cy
+    .request({
+      method: 'GET',
+      url: apiUrl,
+      headers: { accept: 'application/json' },
+      failOnStatusCode: false,
+    })
+    .then((response) => {
+      if (response.status !== 200 || !response.body || !('counts' in response.body)) {
+        throw new Error(`Failed to get metrics resource counts: ${response.status}`);
+      }
+      const { counts } = response.body;
+      if (typeof counts.features !== 'number' || typeof counts.entities !== 'number') {
+        throw new Error(`Unexpected metrics response shape: ${JSON.stringify(counts)}`);
+      }
+      const allCounts = {
+        featureCount: counts.features,
+        entityCount: counts.entities,
+        datasetCount: counts.savedDatasets,
+        dataSourceCount: counts.dataSources,
+        featureViewCount: counts.featureViews,
+        featureServiceCount: counts.featureServices,
+      };
+
+      cy.log(`Metrics resource counts fetched: ${JSON.stringify(allCounts)}`);
+      return cy.wrap(allCounts);
+    });
+};
+
+/**
+ * Fetches all Feature Store counts from individual list endpoints (for page pagination validation)
  * @param {string} routeUrl - The route URL for the API
  * @param {string} project - The project name
  * @returns {Cypress.Chainable<object>} Object containing all counts


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72339

## Summary

Backport of [#8331](https://github.com/opendatahub-io/odh-dashboard/pull/8331) to `v3.3.0-fixes`.

The Feature Store overview card E2E test was hitting the generic REST endpoints to assert counts, but
the UI cards actually pull their numbers from the metrics endpoint. This mismatch caused test failures
even when the UI was working correctly.

## Changes

- Switched overview card assertions to use `getMetricsResourceCounts` (same endpoint the UI uses)
- Added missing `featureViewCount` assertion for the overview card
- Encoded the project name parameter in the metrics API call for safety
- Added a shape guard on the API response and fixed `cy.log` to use `JSON.stringify`

## Affected files

- `packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts`
- `packages/cypress/cypress/utils/api/featureStoreRest.ts`

## Test plan

- Run `testFeatureStoreFeatures.cy.ts` against a cluster with a populated Feature Store project
- Overview card counts should match what the UI displays and the test should pass

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not
  immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests
  for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards,
  PatternFly usage, performance considerations)

After the PR is posted & before it merges:

- [ ] The developer has tested their solution on a cluster by using the image produced by the PR
  to `main`
