### PR TITLE
feat: add model serving routes to core BFF

### DIFF
--- a/distributions/core-bff/bff/README.md
+++ b/distributions/core-bff/bff/README.md
@@ -56,6 +56,11 @@ make run LOG_LEVEL=DEBUG
 | `-dashboard-config-name` | `DASHBOARD_CONFIG_NAME` | Name of the OdhDashboardConfig CR (default `odh-dashboard-config`) |
 | `-enabled-apps-cm` | `ENABLED_APPS_CM` | Name of the ConfigMap tracking enabled applications |
 | `-mf-remotes-config` | `MF_REMOTES_CONFIG` | Path to module federation remotes config file |
+| `-model-serving-host` | `MODEL_SERVING_HOST` | Override URL for model-serving proxy target (default: auto-constructed from namespace) |
+| `-prometheus-host` | `PROMETHEUS_HOST` | Full Prometheus/Thanos host URL override |
+| `-prometheus-namespace` | `PROMETHEUS_NAMESPACE` | Prometheus/Thanos namespace (default `openshift-monitoring`) |
+| `-prometheus-instance` | `PROMETHEUS_INSTANCE` | Prometheus/Thanos instance name (default `thanos-querier`) |
+| `-prometheus-port` | `PROMETHEUS_PORT` | Prometheus/Thanos RBAC port (default `9092`) |
 
 TLS: If both `cert-file` and `key-file` are provided the server starts with HTTPS.
 
@@ -88,11 +93,16 @@ curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/a
 curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/cluster-settings
 curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/components
 curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/connection-types
+
+# Model Serving
+curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/nim-serving/apiKeySecret
+curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/integrations/nim
+curl -i -X POST -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" -H "Content-Type: application/json" -d '{"query":"up"}' localhost:4000/api/prometheus/query
 ```
 
 ### Route Security
 
-Authenticated endpoints use `secureRoute()` (token validation + audit logging) and admin endpoints use `secureAdminRoute()` (token validation + SSAR admin check + audit logging). Admin detection checks SSAR for `patch` on `auths/default-auth`. Non-admin users receive 401. Namespace validation is handled separately by `isAllowedNamespace`.
+Authenticated endpoints use `secureRoute()` (token validation + audit logging) and admin endpoints use `secureAdminRoute()` (token validation + SSAR admin check + audit logging). Admin detection checks SSAR for `patch` on `auths/default-auth`. Non-admin users receive 403. Namespace validation is handled separately by `isAllowedNamespace`.
 
 ### Privilege Model
 

--- a/distributions/core-bff/bff/cmd/main.go
+++ b/distributions/core-bff/bff/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"net/http/httptest"
 	"os/signal"
 	"syscall"
 
@@ -24,6 +25,36 @@ const defaultCABundlePaths = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem,
 	"/etc/pki/tls/certs/odh-trusted-ca-bundle.crt"
 
 func main() {
+	cfg, certFile, keyFile := parseFlags()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: cfg.LogLevel,
+	}))
+
+	if cfg.AuthMethod != config.AuthMethodDisabled && cfg.AuthMethod != config.AuthMethodUser {
+		logger.Error("invalid auth method: (must be disabled or user_token)", "authMethod", cfg.AuthMethod)
+		os.Exit(1)
+	}
+
+	slog.SetDefault(logger)
+
+	if cfg.MockK8Client {
+		if cleanup := startMockPrometheus(&cfg, logger); cleanup != nil {
+			defer cleanup()
+		}
+	}
+
+	app, err := api.NewApp(cfg, slog.New(logger.Handler()))
+	if err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
+	}
+
+	srv := newHTTPServer(app, cfg, certFile, keyFile, logger)
+	awaitShutdown(srv, app, logger)
+}
+
+func parseFlags() (config.EnvConfig, string, string) {
 	var cfg config.EnvConfig
 	var certFile, keyFile string
 
@@ -90,26 +121,44 @@ func main() {
 		getEnvAsString("DEV_GROUPS", ""),
 		"Comma-separated groups for dev-mode identity fallback")
 
+	// ─── Model Serving ──────────────────────────────────────────
+	flag.StringVar(&cfg.ModelServingServiceHost, "model-serving-host",
+		getEnvAsString("MODEL_SERVING_HOST", ""),
+		"Override for model-serving service proxy target URL")
+
+	// ─── Prometheus ─────────────────────────────────────────────
+	flag.StringVar(&cfg.PrometheusHost, "prometheus-host",
+		getEnvAsString("PROMETHEUS_HOST", ""),
+		"Full Prometheus/Thanos host URL override")
+	flag.StringVar(&cfg.PrometheusNamespace, "prometheus-namespace",
+		getEnvAsString("PROMETHEUS_NAMESPACE", "openshift-monitoring"),
+		"Prometheus/Thanos namespace")
+	flag.StringVar(&cfg.PrometheusInstance, "prometheus-instance",
+		getEnvAsString("PROMETHEUS_INSTANCE", "thanos-querier"),
+		"Prometheus/Thanos instance name")
+	flag.StringVar(&cfg.PrometheusPort, "prometheus-port",
+		getEnvAsString("PROMETHEUS_PORT", "9092"),
+		"Prometheus/Thanos RBAC port")
+
 	flag.Parse()
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level: cfg.LogLevel,
+	return cfg, certFile, keyFile
+}
+
+func startMockPrometheus(cfg *config.EnvConfig, logger *slog.Logger) func() {
+	if cfg.PrometheusHost != "" {
+		return nil
+	}
+	mockProm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
 	}))
+	cfg.PrometheusHost = mockProm.URL
+	logger.Info("Started mock Prometheus server", slog.String("url", mockProm.URL))
+	return mockProm.Close
+}
 
-	if cfg.AuthMethod != config.AuthMethodDisabled && cfg.AuthMethod != config.AuthMethodUser {
-		logger.Error("invalid auth method: (must be disabled or user_token)", "authMethod", cfg.AuthMethod)
-		os.Exit(1)
-	}
-
-	// Only use for logging errors about logging configuration.
-	slog.SetDefault(logger)
-
-	app, err := api.NewApp(cfg, slog.New(logger.Handler()))
-	if err != nil {
-		logger.Error(err.Error())
-		os.Exit(1)
-	}
-
+func newHTTPServer(app *api.App, cfg config.EnvConfig, certFile, keyFile string, logger *slog.Logger) *http.Server {
 	srv := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
 		Handler:      app.Routes(),
@@ -119,12 +168,10 @@ func main() {
 		ErrorLog:     slog.NewLogLogger(logger.Handler(), slog.LevelError),
 	}
 
-	// Start the server in a goroutine
 	go func() {
 		logger.Info("starting server", "addr", srv.Addr, "TLS enabled", (certFile != "" && keyFile != ""))
 		var err error
 		if certFile != "" && keyFile != "" {
-			// Configure TLS if both cert and key files are provided
 			tlsConfig := &tls.Config{
 				MinVersion: tls.VersionTLS13,
 			}
@@ -138,24 +185,23 @@ func main() {
 		}
 	}()
 
-	// Graceful shutdown setup
+	return srv
+}
+
+func awaitShutdown(srv *http.Server, app *api.App, logger *slog.Logger) {
 	shutdownCh := make(chan os.Signal, 1)
 	signal.Notify(shutdownCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
-	// Wait for shutdown signal
 	<-shutdownCh
 	logger.Info("shutting down gracefully...")
 
-	// Create a context with timeout for the shutdown process
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Shutdown the HTTP server gracefully
 	if err := srv.Shutdown(ctx); err != nil {
 		logger.Error("server shutdown failed", "error", err)
 	}
 
-	// Shutdown the App gracefully
 	if err := app.Shutdown(); err != nil {
 		logger.Error("failed to shutdown Kubernetes manager", "error", err)
 	}

--- a/distributions/core-bff/bff/go.mod
+++ b/distributions/core-bff/bff/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/stretchr/testify v1.11.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.1
+	k8s.io/apiextensions-apiserver v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
 	sigs.k8s.io/controller-runtime v0.22.3
@@ -64,7 +65,6 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/apiextensions-apiserver v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect

--- a/distributions/core-bff/bff/go.work.sum
+++ b/distributions/core-bff/bff/go.work.sum
@@ -93,6 +93,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
+github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
+github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
@@ -194,6 +196,8 @@ github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=

--- a/distributions/core-bff/bff/internal/api/app.go
+++ b/distributions/core-bff/bff/internal/api/app.go
@@ -93,7 +93,6 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 			SADynClient: k8sResult.saDynClient,
 			SAClientset: k8sResult.saClientset,
 			Namespace:   cfg.Namespace,
-			Logger:      logger,
 			Prometheus: repositories.PrometheusConfig{
 				Host:               cfg.PrometheusHost,
 				Namespace:          cfg.PrometheusNamespace,

--- a/distributions/core-bff/bff/internal/api/app.go
+++ b/distributions/core-bff/bff/internal/api/app.go
@@ -100,7 +100,7 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 				Instance:           cfg.PrometheusInstance,
 				Port:               cfg.PrometheusPort,
 				RootCAs:            rootCAs,
-				InsecureSkipVerify: cfg.InsecureSkipVerify,
+				InsecureSkipVerify: cfg.InsecureSkipVerify && (cfg.DevMode || cfg.MockK8Client),
 			},
 		}),
 		testEnv:          k8sResult.testEnv,

--- a/distributions/core-bff/bff/internal/api/app.go
+++ b/distributions/core-bff/bff/internal/api/app.go
@@ -49,6 +49,11 @@ type App struct {
 	wsTracker *proxy.ConnectionTracker
 	// wsProxy handles /wss/k8s/* WebSocket relay to the K8s API server
 	wsProxy http.Handler
+	// modelServingProxy handles /api/service/model-serving/* passthrough
+	modelServingProxy http.Handler
+	// devFallbackToken is the kubeconfig bearer token used in dev mode for
+	// proxied requests (Prometheus, model-serving) when the identity has no real token.
+	devFallbackToken string
 }
 
 type k8sSetupResult struct {
@@ -88,6 +93,15 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 			SADynClient: k8sResult.saDynClient,
 			SAClientset: k8sResult.saClientset,
 			Namespace:   cfg.Namespace,
+			Logger:      logger,
+			Prometheus: repositories.PrometheusConfig{
+				Host:               cfg.PrometheusHost,
+				Namespace:          cfg.PrometheusNamespace,
+				Instance:           cfg.PrometheusInstance,
+				Port:               cfg.PrometheusPort,
+				RootCAs:            rootCAs,
+				InsecureSkipVerify: cfg.InsecureSkipVerify,
+			},
 		}),
 		testEnv:          k8sResult.testEnv,
 		rootCAs:          rootCAs,
@@ -101,6 +115,11 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		return nil, fmt.Errorf("failed to initialize K8s proxy: %w", err)
 	}
 
+	if err := app.initModelServingProxy(); err != nil {
+		_ = app.Shutdown()
+		return nil, fmt.Errorf("failed to initialize model-serving proxy: %w", err)
+	}
+
 	return app, nil
 }
 
@@ -109,17 +128,15 @@ func initKubernetesClients(cfg config.EnvConfig, logger *slog.Logger) (k8sSetupR
 	var err error
 
 	if cfg.MockK8Client {
-		result.testEnv, result.clientset, err = k8mocks.SetupEnvTest(k8mocks.TestEnvInput{})
+		result.testEnv, result.clientset, result.saDynClient, err = k8mocks.SetupEnvTest(k8mocks.TestEnvInput{
+			CRDs: k8mocks.DefaultCRDs(),
+		})
 		if err != nil {
 			return result, fmt.Errorf("failed to setup envtest: %w", err)
 		}
 		result.factory, err = k8mocks.NewMockedKubernetesClientFactory(result.clientset, result.testEnv, cfg, logger)
 		if err != nil {
 			return result, err
-		}
-		result.saDynClient, err = dynamic.NewForConfig(result.testEnv.Config)
-		if err != nil {
-			return result, fmt.Errorf("failed to create SA dynamic client: %w", err)
 		}
 		result.saClientset, err = kubernetes.NewForConfig(result.testEnv.Config)
 	} else {

--- a/distributions/core-bff/bff/internal/api/app_proxy.go
+++ b/distributions/core-bff/bff/internal/api/app_proxy.go
@@ -74,6 +74,7 @@ func (app *App) initK8sProxy(cfg config.EnvConfig, k8sResult k8sSetupResult) err
 			}
 		}
 	}
+	app.devFallbackToken = devFallbackToken
 
 	k8sProxyHandler, err := proxy.NewK8sProxyHandler(proxy.K8sProxyConfig{
 		K8sHost:              k8sHost,

--- a/distributions/core-bff/bff/internal/api/app_test.go
+++ b/distributions/core-bff/bff/internal/api/app_test.go
@@ -397,10 +397,20 @@ func TestRoutes_OpenShiftRoutesReturn404OnNonOpenShift(t *testing.T) {
 	ts := httptest.NewServer(app.Routes())
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/api/status/test-ns/allowedUsers")
-	require.NoError(t, err)
-	defer resp.Body.Close()
+	openShiftOnlyPaths := []string{
+		"/api/status/test-ns/allowedUsers",
+		"/api/integrations/nim",
+		"/api/nim-serving/apiKeySecret",
+	}
 
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode,
-		"allowed users should return 404 on non-OpenShift platforms")
+	for _, path := range openShiftOnlyPaths {
+		t.Run(path, func(t *testing.T) {
+			resp, err := http.Get(ts.URL + path)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+				"%s should return 404 on non-OpenShift platforms", path)
+		})
+	}
 }

--- a/distributions/core-bff/bff/internal/api/audit.go
+++ b/distributions/core-bff/bff/internal/api/audit.go
@@ -32,6 +32,6 @@ func (app *App) emitAuditLogWithAdminCheckError(username string, r *http.Request
 		slog.String("endpoint", r.URL.Path),
 		slog.Bool("isAdmin", false),
 		slog.Bool("needsAdmin", true),
-		slog.String("adminCheckError", adminErr.Error()),
+		slog.Any("error", adminErr),
 	)
 }

--- a/distributions/core-bff/bff/internal/api/audit_test.go
+++ b/distributions/core-bff/bff/internal/api/audit_test.go
@@ -209,14 +209,14 @@ func TestSecureAdminRoute_EmitsAuditLogOnAdminCheckError(t *testing.T) {
 
 	handler(rr, req, nil)
 
-	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 
 	rec := ch.findAuditRecord()
 	require.NotNil(t, rec, "expected audit log on admin check error")
 	assert.Equal(t, "test-user", auditAttr(rec, "user"))
 	assert.True(t, auditAttrBool(rec, "needsAdmin"))
 	assert.False(t, auditAttrBool(rec, "isAdmin"))
-	assert.NotEmpty(t, auditAttr(rec, "adminCheckError"))
+	assert.NotEmpty(t, auditAttr(rec, "error"))
 	assert.Equal(t, "test-ns", auditAttr(rec, "namespace"))
 }
 

--- a/distributions/core-bff/bff/internal/api/errors.go
+++ b/distributions/core-bff/bff/internal/api/errors.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // HTTPError represents an HTTP error response with status code and error details.
@@ -68,4 +71,21 @@ func (app *App) methodNotAllowedResponse(w http.ResponseWriter, r *http.Request)
 
 	httpError := &HTTPError{StatusCode: http.StatusMethodNotAllowed, Error: ErrorPayload{Code: "METHOD_NOT_ALLOWED", Message: fmt.Sprintf("the %s method is not supported for this resource", r.Method)}}
 	app.errorResponse(w, r, httpError)
+}
+
+// k8sErrorResponse extracts the status code from a K8s StatusError and returns
+// the appropriate HTTP response. Falls back to 500 for non-K8s errors.
+func (app *App) k8sErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
+	var statusErr *k8serrors.StatusError
+	if errors.As(err, &statusErr) {
+		code := int(statusErr.Status().Code)
+		if code == 0 {
+			code = http.StatusInternalServerError
+		}
+		httpError := &HTTPError{StatusCode: code, Error: ErrorPayload{Code: string(statusErr.Status().Reason), Message: statusErr.Status().Message}}
+		app.LogError(r, err)
+		app.errorResponse(w, r, httpError)
+		return
+	}
+	app.serverErrorResponse(w, r, err)
 }

--- a/distributions/core-bff/bff/internal/api/errors.go
+++ b/distributions/core-bff/bff/internal/api/errors.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // HTTPError represents an HTTP error response with status code and error details.
@@ -84,8 +85,8 @@ func (app *App) k8sErrorResponse(w http.ResponseWriter, r *http.Request, err err
 		if code == 0 {
 			code = http.StatusInternalServerError
 		}
-		reason := string(statusErr.Status().Reason)
-		httpError := &HTTPError{StatusCode: code, Error: ErrorPayload{Code: reason, Message: sanitizeK8sReason(reason)}}
+		reason := statusErr.Status().Reason
+		httpError := &HTTPError{StatusCode: code, Error: ErrorPayload{Code: string(reason), Message: sanitizeK8sReason(reason)}}
 		app.LogError(r, err)
 		app.errorResponse(w, r, httpError)
 		return
@@ -93,25 +94,25 @@ func (app *App) k8sErrorResponse(w http.ResponseWriter, r *http.Request, err err
 	app.serverErrorResponse(w, r, err)
 }
 
-func sanitizeK8sReason(reason string) string {
+func sanitizeK8sReason(reason metav1.StatusReason) string {
 	switch reason {
-	case "NotFound":
+	case metav1.StatusReasonNotFound:
 		return "the requested resource could not be found"
-	case "AlreadyExists":
+	case metav1.StatusReasonAlreadyExists:
 		return "the resource already exists"
-	case "Conflict":
+	case metav1.StatusReasonConflict:
 		return "the resource was modified by another request"
-	case "Forbidden":
+	case metav1.StatusReasonForbidden:
 		return "insufficient permissions for this operation"
-	case "Unauthorized":
+	case metav1.StatusReasonUnauthorized:
 		return "authentication required"
-	case "BadRequest":
+	case metav1.StatusReasonBadRequest:
 		return "invalid request"
-	case "Gone":
+	case metav1.StatusReasonGone:
 		return "the requested resource is no longer available"
-	case "Expired":
+	case metav1.StatusReasonExpired:
 		return "the request has expired"
-	case "ServiceUnavailable":
+	case metav1.StatusReasonServiceUnavailable:
 		return "the service is temporarily unavailable"
 	default:
 		return "the server encountered an error processing your request"

--- a/distributions/core-bff/bff/internal/api/errors.go
+++ b/distributions/core-bff/bff/internal/api/errors.go
@@ -75,6 +75,8 @@ func (app *App) methodNotAllowedResponse(w http.ResponseWriter, r *http.Request)
 
 // k8sErrorResponse extracts the status code from a K8s StatusError and returns
 // the appropriate HTTP response. Falls back to 500 for non-K8s errors.
+// The client-facing message is derived from the Reason, not the raw Status.Message,
+// to avoid leaking resource names, RBAC details, or service account identifiers.
 func (app *App) k8sErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 	var statusErr *k8serrors.StatusError
 	if errors.As(err, &statusErr) {
@@ -82,10 +84,36 @@ func (app *App) k8sErrorResponse(w http.ResponseWriter, r *http.Request, err err
 		if code == 0 {
 			code = http.StatusInternalServerError
 		}
-		httpError := &HTTPError{StatusCode: code, Error: ErrorPayload{Code: string(statusErr.Status().Reason), Message: statusErr.Status().Message}}
+		reason := string(statusErr.Status().Reason)
+		httpError := &HTTPError{StatusCode: code, Error: ErrorPayload{Code: reason, Message: sanitizeK8sReason(reason)}}
 		app.LogError(r, err)
 		app.errorResponse(w, r, httpError)
 		return
 	}
 	app.serverErrorResponse(w, r, err)
+}
+
+func sanitizeK8sReason(reason string) string {
+	switch reason {
+	case "NotFound":
+		return "the requested resource could not be found"
+	case "AlreadyExists":
+		return "the resource already exists"
+	case "Conflict":
+		return "the resource was modified by another request"
+	case "Forbidden":
+		return "insufficient permissions for this operation"
+	case "Unauthorized":
+		return "authentication required"
+	case "BadRequest":
+		return "invalid request"
+	case "Gone":
+		return "the requested resource is no longer available"
+	case "Expired":
+		return "the request has expired"
+	case "ServiceUnavailable":
+		return "the service is temporarily unavailable"
+	default:
+		return "the server encountered an error processing your request"
+	}
 }

--- a/distributions/core-bff/bff/internal/api/errors_test.go
+++ b/distributions/core-bff/bff/internal/api/errors_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestK8sErrorResponse(t *testing.T) {
+	gr := schema.GroupResource{Group: "serving.kserve.io", Resource: "servingruntimes"}
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "NotFound returns 404",
+			err:        k8serrors.NewNotFound(gr, "test-runtime"),
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NotFound",
+		},
+		{
+			name:       "Forbidden returns 403",
+			err:        k8serrors.NewForbidden(gr, "test-runtime", fmt.Errorf("access denied")),
+			wantStatus: http.StatusForbidden,
+			wantCode:   "Forbidden",
+		},
+		{
+			name:       "Conflict returns 409",
+			err:        k8serrors.NewConflict(gr, "test-runtime", fmt.Errorf("already modified")),
+			wantStatus: http.StatusConflict,
+			wantCode:   "Conflict",
+		},
+		{
+			name:       "AlreadyExists returns 409",
+			err:        k8serrors.NewAlreadyExists(gr, "test-runtime"),
+			wantStatus: http.StatusConflict,
+			wantCode:   "AlreadyExists",
+		},
+		{
+			name:       "Non-K8s error falls back to 500",
+			err:        fmt.Errorf("unexpected failure"),
+			wantStatus: http.StatusInternalServerError,
+			wantCode:   "INTERNAL_SERVER_ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newTestApp()
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			app.k8sErrorResponse(rr, req, tt.err)
+
+			assert.Equal(t, tt.wantStatus, rr.Code)
+
+			var body HTTPError
+			err := json.Unmarshal(rr.Body.Bytes(), &body)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCode, body.Error.Code)
+		})
+	}
+}

--- a/distributions/core-bff/bff/internal/api/errors_test.go
+++ b/distributions/core-bff/bff/internal/api/errors_test.go
@@ -17,40 +17,46 @@ func TestK8sErrorResponse(t *testing.T) {
 	gr := schema.GroupResource{Group: "serving.kserve.io", Resource: "servingruntimes"}
 
 	tests := []struct {
-		name       string
-		err        error
-		wantStatus int
-		wantCode   string
+		name        string
+		err         error
+		wantStatus  int
+		wantCode    string
+		wantMessage string
 	}{
 		{
-			name:       "NotFound returns 404",
-			err:        k8serrors.NewNotFound(gr, "test-runtime"),
-			wantStatus: http.StatusNotFound,
-			wantCode:   "NotFound",
+			name:        "NotFound returns 404",
+			err:         k8serrors.NewNotFound(gr, "test-runtime"),
+			wantStatus:  http.StatusNotFound,
+			wantCode:    "NotFound",
+			wantMessage: "the requested resource could not be found",
 		},
 		{
-			name:       "Forbidden returns 403",
-			err:        k8serrors.NewForbidden(gr, "test-runtime", fmt.Errorf("access denied")),
-			wantStatus: http.StatusForbidden,
-			wantCode:   "Forbidden",
+			name:        "Forbidden returns 403",
+			err:         k8serrors.NewForbidden(gr, "test-runtime", fmt.Errorf("access denied")),
+			wantStatus:  http.StatusForbidden,
+			wantCode:    "Forbidden",
+			wantMessage: "insufficient permissions for this operation",
 		},
 		{
-			name:       "Conflict returns 409",
-			err:        k8serrors.NewConflict(gr, "test-runtime", fmt.Errorf("already modified")),
-			wantStatus: http.StatusConflict,
-			wantCode:   "Conflict",
+			name:        "Conflict returns 409",
+			err:         k8serrors.NewConflict(gr, "test-runtime", fmt.Errorf("already modified")),
+			wantStatus:  http.StatusConflict,
+			wantCode:    "Conflict",
+			wantMessage: "the resource was modified by another request",
 		},
 		{
-			name:       "AlreadyExists returns 409",
-			err:        k8serrors.NewAlreadyExists(gr, "test-runtime"),
-			wantStatus: http.StatusConflict,
-			wantCode:   "AlreadyExists",
+			name:        "AlreadyExists returns 409",
+			err:         k8serrors.NewAlreadyExists(gr, "test-runtime"),
+			wantStatus:  http.StatusConflict,
+			wantCode:    "AlreadyExists",
+			wantMessage: "the resource already exists",
 		},
 		{
-			name:       "Non-K8s error falls back to 500",
-			err:        fmt.Errorf("unexpected failure"),
-			wantStatus: http.StatusInternalServerError,
-			wantCode:   "INTERNAL_SERVER_ERROR",
+			name:        "Non-K8s error falls back to 500",
+			err:         fmt.Errorf("unexpected failure"),
+			wantStatus:  http.StatusInternalServerError,
+			wantCode:    "INTERNAL_SERVER_ERROR",
+			wantMessage: "the server encountered a problem and could not process your request",
 		},
 	}
 
@@ -68,6 +74,9 @@ func TestK8sErrorResponse(t *testing.T) {
 			err := json.Unmarshal(rr.Body.Bytes(), &body)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantCode, body.Error.Code)
+			assert.Equal(t, tt.wantMessage, body.Error.Message)
+			assert.NotContains(t, body.Error.Message, "test-runtime", "response must not leak resource names")
+			assert.NotContains(t, body.Error.Message, "servingruntimes", "response must not leak resource types")
 		})
 	}
 }

--- a/distributions/core-bff/bff/internal/api/middleware_auth.go
+++ b/distributions/core-bff/bff/internal/api/middleware_auth.go
@@ -104,7 +104,7 @@ func (app *App) secureRoute(next httprouter.Handle) httprouter.Handle {
 }
 
 // secureAdminRoute wraps a handler with token validation, admin check, and audit logging.
-// Returns 401 for unauthenticated or non-admin users.
+// Returns 401 for unauthenticated users, 403 for non-admin users.
 func (app *App) secureAdminRoute(next httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		username, client, identity, ok := app.resolveRequestAuth(w, r, true)
@@ -114,9 +114,9 @@ func (app *App) secureAdminRoute(next httprouter.Handle) httprouter.Handle {
 
 		isAdmin, err := client.IsUserAdmin(r.Context(), identity)
 		if err != nil {
-			app.logger.Warn("admin SAR check failed, denying by default", slog.Any("error", err))
+			app.logger.Warn("admin SAR check failed", slog.Any("error", err))
 			app.emitAuditLogWithAdminCheckError(username, r, err)
-			app.unauthorizedResponse(w, r, fmt.Errorf("insufficient permissions to make this request"))
+			app.serverErrorResponse(w, r, fmt.Errorf("failed to evaluate admin status: %w", err))
 			return
 		}
 		if !isAdmin {

--- a/distributions/core-bff/bff/internal/api/middleware_auth.go
+++ b/distributions/core-bff/bff/internal/api/middleware_auth.go
@@ -144,6 +144,19 @@ func (app *App) requirePlatform(platform config.PlatformType, next httprouter.Ha
 	}
 }
 
+// requirePlatformPublic returns 404 if the current platform does not match the required type.
+// This is the http.Handler variant of requirePlatform, for use with public routes registered
+// on the outer mux rather than the httprouter-based apiRouter.
+func (app *App) requirePlatformPublic(platform config.PlatformType, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if app.config.PlatformType != platform {
+			app.notFoundResponse(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // isAllowedNamespace checks if the namespace matches the dashboard or workbench namespace.
 // When WorkbenchNamespace is not configured, it defaults to the dashboard namespace.
 func (app *App) isAllowedNamespace(namespace string) bool {

--- a/distributions/core-bff/bff/internal/api/middleware_auth_test.go
+++ b/distributions/core-bff/bff/internal/api/middleware_auth_test.go
@@ -399,6 +399,27 @@ func TestSecureAdminRoute_GetUserFailureReturns401(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
+func TestSecureAdminRoute_AdminCheckErrorReturns500(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.kubernetesClientFactory = &failingAdminCheckFactory{username: "valid-user"}
+	})
+
+	handle, called := trackingHandle()
+	handler := app.secureAdminRoute(handle)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/api/config", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: "valid-user",
+		Token:  k8s.NewBearerToken("valid-token"),
+	})
+
+	handler(rr, req, nil)
+
+	assert.False(t, *called, "handler must not be invoked when admin check fails")
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
 // ─── Dev-mode identity fallback tests ───────────────────────────────────────
 
 func TestDevModeFallback_ActivatesWhenDevModeEnabled(t *testing.T) {

--- a/distributions/core-bff/bff/internal/api/model_serving_proxy.go
+++ b/distributions/core-bff/bff/internal/api/model_serving_proxy.go
@@ -12,7 +12,10 @@ import (
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/ssrf"
 )
 
-const modelServingPathPrefix = "/api/service/model-serving"
+const (
+	modelServingPathPrefix     = "/api/service/model-serving"
+	defaultModelServingHostFmt = "https://model-serving-api.%s.svc.cluster.local:443"
+)
 
 func (app *App) initModelServingProxy() error {
 	if app.config.MockK8Client {
@@ -26,7 +29,7 @@ func (app *App) initModelServingProxy() error {
 
 	host := app.config.ModelServingServiceHost
 	if host == "" {
-		host = fmt.Sprintf("https://model-serving-api.%s.svc.cluster.local:443", app.config.Namespace)
+		host = fmt.Sprintf(defaultModelServingHostFmt, app.config.Namespace)
 	}
 
 	targetURL, err := url.Parse(host)
@@ -48,6 +51,8 @@ func (app *App) initModelServingProxy() error {
 		AuthHeaderFn: func(r *http.Request) string {
 			identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
 			if !ok || identity == nil {
+				// Unreachable: InjectRequestIdentity middleware on serviceMux returns 401
+				// before requests reach this handler. Defensive fallback omits the header.
 				return ""
 			}
 			return "Bearer " + identity.ResolveToken(app.devFallbackToken)

--- a/distributions/core-bff/bff/internal/api/model_serving_proxy.go
+++ b/distributions/core-bff/bff/internal/api/model_serving_proxy.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/proxy"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/ssrf"
+)
+
+const modelServingPathPrefix = "/api/service/model-serving"
+
+func (app *App) initModelServingProxy() error {
+	if app.config.MockK8Client {
+		app.modelServingProxy = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"mock":true}`)) //nolint:errcheck // mock-only handler
+		})
+		return nil
+	}
+
+	host := app.config.ModelServingServiceHost
+	if host == "" {
+		host = fmt.Sprintf("https://model-serving-api.%s.svc.cluster.local:443", app.config.Namespace)
+	}
+
+	targetURL, err := url.Parse(host)
+	if err != nil {
+		return fmt.Errorf("failed to parse model-serving host URL: %w", err)
+	}
+
+	allowHTTP := app.config.DevMode || app.config.MockK8Client
+	insecureSkipVerify := app.config.InsecureSkipVerify && (app.config.DevMode || app.config.MockK8Client)
+
+	rp, err := proxy.NewReverseProxy(proxy.ProxyConfig{
+		TargetURL:          targetURL,
+		RootCAs:            app.rootCAs,
+		InsecureSkipVerify: insecureSkipVerify,
+		AllowHTTP:          allowHTTP,
+		PathRewriteFn: func(r *http.Request) string {
+			return strings.TrimPrefix(r.URL.Path, modelServingPathPrefix)
+		},
+		AuthHeaderFn: func(r *http.Request) string {
+			identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+			if !ok || identity == nil {
+				return ""
+			}
+			return "Bearer " + identity.ResolveToken(app.devFallbackToken)
+		},
+		StripHeaders:       proxy.SensitiveIngressHeaders(app.config.AuthTokenHeader),
+		ModifyResponse:     ssrf.NewRedirectValidator(app.logger),
+		SSRFValidateTarget: true,
+		SSRFAllowedHosts:   []string{targetURL.Hostname()},
+		Logger:             app.logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create model-serving proxy: %w", err)
+	}
+
+	app.modelServingProxy = rp
+	return nil
+}

--- a/distributions/core-bff/bff/internal/api/model_serving_proxy_test.go
+++ b/distributions/core-bff/bff/internal/api/model_serving_proxy_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelServingProxy_StripsHeaders(t *testing.T) {
+	var receivedHeaders http.Header
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer backend.Close()
+
+	app := newTestApp(func(a *App) {
+		a.config.ModelServingServiceHost = backend.URL
+		a.config.DevMode = true
+		a.config.MockK8Client = false
+		a.config.Namespace = "test-ns"
+	})
+
+	err := app.initModelServingProxy()
+	require.NoError(t, err)
+	require.NotNil(t, app.modelServingProxy)
+
+	admin := k8mocks.DefaultTestUsers[0]
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, modelServingPathPrefix+"/v1/models", nil)
+	req.Header.Set("Cookie", "session=abc123")
+	req.Header.Set("X-Forwarded-For", "10.0.0.1")
+	req.Header.Set("X-Forwarded-Host", "example.com")
+	req.Header.Set("X-Real-Ip", "10.0.0.1")
+	req.Header.Set("Forwarded", "for=10.0.0.1")
+
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.modelServingProxy.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, receivedHeaders)
+	assert.Empty(t, receivedHeaders.Get("Cookie"), "Cookie header should be stripped")
+	assert.Empty(t, receivedHeaders.Get("X-Forwarded-For"), "X-Forwarded-For should be stripped")
+	assert.Empty(t, receivedHeaders.Get("X-Forwarded-Host"), "X-Forwarded-Host should be stripped")
+	assert.Empty(t, receivedHeaders.Get("X-Real-Ip"), "X-Real-Ip should be stripped")
+	assert.Empty(t, receivedHeaders.Get("Forwarded"), "Forwarded should be stripped")
+}
+
+func TestModelServingProxy_MockMode(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.MockK8Client = true
+	})
+
+	err := app.initModelServingProxy()
+	require.NoError(t, err)
+	require.NotNil(t, app.modelServingProxy)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, modelServingPathPrefix+"/v1/models", nil)
+
+	app.modelServingProxy.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"mock":true`)
+}

--- a/distributions/core-bff/bff/internal/api/namespace_mutation_handler.go
+++ b/distributions/core-bff/bff/internal/api/namespace_mutation_handler.go
@@ -14,7 +14,7 @@ import (
 
 // NamespaceMutationHandler handles GET /api/namespaces/:name/:context.
 // Applies model-serving-platform label/annotation mutations to a namespace.
-// Context 0 (DSG_CREATION) is not supported in RHAII and returns 400.
+// Context 0 (DSG_CREATION) is not supported and returns 400.
 // Contexts 1-3 require SSAR permission: create on serving.kserve.io/servingruntimes.
 func (app *App) NamespaceMutationHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	namespaceName := ps.ByName("name")
@@ -33,8 +33,9 @@ func (app *App) NamespaceMutationHandler(w http.ResponseWriter, r *http.Request,
 
 	appCase := models.NamespaceApplicationCase(contextInt)
 
+	// TODO: implement DSG_CREATION for OpenShift (context 0 with admin SSAR)
 	if appCase == models.DSGCreation {
-		app.badRequestResponse(w, r, fmt.Errorf("namespace creation (context 0) is not supported in RHAII"))
+		app.badRequestResponse(w, r, fmt.Errorf("namespace creation (context 0) is not supported"))
 		return
 	}
 
@@ -73,13 +74,15 @@ func (app *App) NamespaceMutationHandler(w http.ResponseWriter, r *http.Request,
 
 	dryRun := r.URL.Query().Get("dryRun") == "All"
 
-	result, err := app.repositories.NamespaceMutation.ApplyMutation(ctx, namespaceName, appCase, dryRun)
-	if err != nil {
-		app.k8sErrorResponse(w, r, err)
+	if err := app.repositories.NamespaceMutation.ApplyMutation(ctx, namespaceName, appCase, dryRun); err != nil {
+		app.LogError(r, err)
+		if writeErr := app.WriteJSON(w, http.StatusOK, &models.NamespaceMutationResponse{Applied: false}, nil); writeErr != nil {
+			app.serverErrorResponse(w, r, writeErr)
+		}
 		return
 	}
 
-	if err := app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+	if err := app.WriteJSON(w, http.StatusOK, &models.NamespaceMutationResponse{Applied: true}, nil); err != nil {
 		app.serverErrorResponse(w, r, err)
 	}
 }

--- a/distributions/core-bff/bff/internal/api/namespace_mutation_handler.go
+++ b/distributions/core-bff/bff/internal/api/namespace_mutation_handler.go
@@ -49,7 +49,11 @@ func (app *App) NamespaceMutationHandler(w http.ResponseWriter, r *http.Request,
 	}
 
 	ctx := r.Context()
-	identity, _ := ctx.Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+	if !ok || identity == nil {
+		app.unauthorizedResponse(w, r, fmt.Errorf("missing request identity"))
+		return
+	}
 
 	client, err := app.kubernetesClientFactory.GetClient(ctx)
 	if err != nil {

--- a/distributions/core-bff/bff/internal/api/namespace_mutation_handler.go
+++ b/distributions/core-bff/bff/internal/api/namespace_mutation_handler.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+)
+
+// NamespaceMutationHandler handles GET /api/namespaces/:name/:context.
+// Applies model-serving-platform label/annotation mutations to a namespace.
+// Context 0 (DSG_CREATION) is not supported in RHAII and returns 400.
+// Contexts 1-3 require SSAR permission: create on serving.kserve.io/servingruntimes.
+func (app *App) NamespaceMutationHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	namespaceName := ps.ByName("name")
+	contextStr := ps.ByName("context")
+
+	if namespaceName == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("namespace name is required"))
+		return
+	}
+
+	contextInt, err := strconv.Atoi(contextStr)
+	if err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("context must be an integer"))
+		return
+	}
+
+	appCase := models.NamespaceApplicationCase(contextInt)
+
+	if appCase == models.DSGCreation {
+		app.badRequestResponse(w, r, fmt.Errorf("namespace creation (context 0) is not supported in RHAII"))
+		return
+	}
+
+	if appCase < models.KServePromotion || appCase > models.ResetModelServingPlatform {
+		app.badRequestResponse(w, r, fmt.Errorf("invalid context: %d (must be 1-3)", contextInt))
+		return
+	}
+
+	if isSystemNamespace(namespaceName) {
+		app.badRequestResponse(w, r, fmt.Errorf("cannot mutate system namespace %q", namespaceName))
+		return
+	}
+
+	ctx := r.Context()
+	identity, _ := ctx.Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to get kubernetes client: %w", err))
+		return
+	}
+
+	allowed, err := client.CheckAccess(ctx, identity, "create", "serving.kserve.io", "servingruntimes", namespaceName)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to check namespace permissions: %w", err))
+		return
+	}
+	if !allowed {
+		app.forbiddenResponse(w, r, fmt.Errorf("insufficient permissions to modify serving platform in namespace %q", namespaceName))
+		return
+	}
+
+	dryRun := r.URL.Query().Get("dryRun") == "All"
+
+	result, err := app.repositories.NamespaceMutation.ApplyMutation(ctx, namespaceName, appCase, dryRun)
+	if err != nil {
+		app.k8sErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func isSystemNamespace(name string) bool {
+	return strings.HasPrefix(name, "openshift") || strings.HasPrefix(name, "kube")
+}

--- a/distributions/core-bff/bff/internal/api/namespace_mutation_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/namespace_mutation_handler_test.go
@@ -1,0 +1,363 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes"
+)
+
+func ensureNamespace(t *testing.T, name string) {
+	t.Helper()
+	if testEnvInstance == nil || testEnvInstance.Config == nil {
+		t.Fatal("testEnvInstance not initialized")
+	}
+	clientset, err := k8sclient.NewForConfig(testEnvInstance.Config)
+	require.NoError(t, err)
+
+	nsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	_, err = clientset.CoreV1().Namespaces().Create(context.Background(), nsObj, metav1.CreateOptions{})
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		t.Fatalf("unexpected error creating namespace: %v", err)
+	}
+}
+
+func TestNamespaceMutation_Context0_Returns400(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/namespaces/test-ns/0", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "name", Value: "test-ns"},
+		{Key: "context", Value: "0"},
+	}
+	app.NamespaceMutationHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestNamespaceMutation_InvalidContext_Returns400(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	tests := []struct {
+		name    string
+		context string
+	}{
+		{"context 5", "5"},
+		{"context -1", "-1"},
+		{"non-integer", "abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/namespaces/test-ns/"+tt.context, nil)
+			req = reqWithIdentity(req, &k8s.RequestIdentity{
+				UserID: admin.UserName,
+				Groups: admin.Groups,
+				Token:  k8s.NewBearerToken(admin.Token),
+			})
+
+			ps := httprouter.Params{
+				{Key: "name", Value: "test-ns"},
+				{Key: "context", Value: tt.context},
+			}
+			app.NamespaceMutationHandler(rr, req, ps)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+		})
+	}
+}
+
+func TestNamespaceMutation_SystemNamespace_Returns400(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	tests := []struct {
+		name      string
+		namespace string
+	}{
+		{"openshift prefix", "openshift-monitoring"},
+		{"kube prefix", "kube-system"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/namespaces/"+tt.namespace+"/1", nil)
+			req = reqWithIdentity(req, &k8s.RequestIdentity{
+				UserID: admin.UserName,
+				Groups: admin.Groups,
+				Token:  k8s.NewBearerToken(admin.Token),
+			})
+
+			ps := httprouter.Params{
+				{Key: "name", Value: tt.namespace},
+				{Key: "context", Value: "1"},
+			}
+			app.NamespaceMutationHandler(rr, req, ps)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+		})
+	}
+}
+
+func TestNamespaceMutation_SSARDenied_Returns403(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.kubernetesClientFactory = &deniedAccessFactory{}
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/namespaces/my-ns/1", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: "denied-user",
+		Token:  k8s.NewBearerToken("FAKE_TOKEN"),
+	})
+
+	ps := httprouter.Params{
+		{Key: "name", Value: "my-ns"},
+		{Key: "context", Value: "1"},
+	}
+	app.NamespaceMutationHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestNamespaceMutation_KServePromotion_Success(t *testing.T) {
+	const ns = "ns-kserve-promo"
+	ensureNamespace(t, ns)
+
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/namespaces/"+ns+"/1", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "name", Value: ns},
+		{Key: "context", Value: "1"},
+	}
+	app.NamespaceMutationHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"applied":true`)
+
+	clientset, err := k8sclient.NewForConfig(testEnvInstance.Config)
+	require.NoError(t, err)
+	nsObj, err := clientset.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "false", nsObj.Labels["modelmesh-enabled"])
+}
+
+func TestNamespaceMutation_KServeNIMPromotion_Success(t *testing.T) {
+	const ns = "ns-nim-promo"
+	ensureNamespace(t, ns)
+
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/namespaces/"+ns+"/2", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "name", Value: ns},
+		{Key: "context", Value: "2"},
+	}
+	app.NamespaceMutationHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"applied":true`)
+
+	clientset, err := k8sclient.NewForConfig(testEnvInstance.Config)
+	require.NoError(t, err)
+	nsObj, err := clientset.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", nsObj.Annotations["opendatahub.io/nim-support"])
+}
+
+func TestNamespaceMutation_Reset_Success(t *testing.T) {
+	const ns = "ns-reset"
+	ensureNamespace(t, ns)
+
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	// First set the labels/annotations via context 1 and 2
+	for _, ctx := range []string{"1", "2"} {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/namespaces/"+ns+"/"+ctx, nil)
+		req = reqWithIdentity(req, &k8s.RequestIdentity{
+			UserID: admin.UserName,
+			Groups: admin.Groups,
+			Token:  k8s.NewBearerToken(admin.Token),
+		})
+		ps := httprouter.Params{
+			{Key: "name", Value: ns},
+			{Key: "context", Value: ctx},
+		}
+		app.NamespaceMutationHandler(rr, req, ps)
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	// Now reset
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/namespaces/"+ns+"/3", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "name", Value: ns},
+		{Key: "context", Value: "3"},
+	}
+	app.NamespaceMutationHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"applied":true`)
+
+	clientset, err := k8sclient.NewForConfig(testEnvInstance.Config)
+	require.NoError(t, err)
+	nsObj, err := clientset.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
+	require.NoError(t, err)
+	_, hasLabel := nsObj.Labels["modelmesh-enabled"]
+	assert.False(t, hasLabel, "modelmesh-enabled label should be removed")
+	_, hasAnnotation := nsObj.Annotations["opendatahub.io/nim-support"]
+	assert.False(t, hasAnnotation, "nim-support annotation should be removed")
+}
+
+func TestNamespaceMutation_DryRun(t *testing.T) {
+	const ns = "ns-dryrun"
+	ensureNamespace(t, ns)
+
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/namespaces/"+ns+"/1?dryRun=All", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "name", Value: ns},
+		{Key: "context", Value: "1"},
+	}
+	app.NamespaceMutationHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"applied":true`)
+
+	clientset, err := k8sclient.NewForConfig(testEnvInstance.Config)
+	require.NoError(t, err)
+	nsObj, err := clientset.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
+	require.NoError(t, err)
+	_, hasLabel := nsObj.Labels["modelmesh-enabled"]
+	assert.False(t, hasLabel, "label should not be applied in dry-run mode")
+}
+
+func TestNamespaceMutation_PatchFailure_ReturnsAppliedFalse(t *testing.T) {
+	// Do NOT create the namespace - patching a non-existent namespace triggers a failure
+	// in the repository, which should return 200 with {applied: false} (matching Fastify).
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/namespaces/nonexistent-ns/1", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "name", Value: "nonexistent-ns"},
+		{Key: "context", Value: "1"},
+	}
+	app.NamespaceMutationHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"applied":false`)
+}
+
+func TestIsSystemNamespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		ns       string
+		expected bool
+	}{
+		{"openshift prefix", "openshift-monitoring", true},
+		{"openshift exact", "openshift", true},
+		{"kube prefix", "kube-system", true},
+		{"kube exact", "kube", true},
+		{"regular namespace", "my-project", false},
+		{"opendatahub", "opendatahub", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isSystemNamespace(tt.ns))
+		})
+	}
+}
+
+// deniedAccessClient is a KubernetesClientInterface where CheckAccess always denies.
+type deniedAccessClient struct {
+	stubDynClient
+}
+
+func (d *deniedAccessClient) GetUser(_ context.Context, _ *k8s.RequestIdentity) (string, error) {
+	return "denied-user", nil
+}
+
+func (d *deniedAccessClient) CheckAccess(_ context.Context, _ *k8s.RequestIdentity, _, _, _, _ string) (bool, error) {
+	return false, nil
+}
+
+type deniedAccessFactory struct{}
+
+func (f *deniedAccessFactory) ExtractRequestIdentity(_ http.Header) (*k8s.RequestIdentity, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *deniedAccessFactory) ValidateRequestIdentity(_ *k8s.RequestIdentity) error {
+	return nil
+}
+
+func (f *deniedAccessFactory) GetClient(_ context.Context) (k8s.KubernetesClientInterface, error) {
+	return &deniedAccessClient{}, nil
+}

--- a/distributions/core-bff/bff/internal/api/nim_integration_handler.go
+++ b/distributions/core-bff/bff/internal/api/nim_integration_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -28,6 +29,11 @@ func (app *App) CreateNIMIntegrationHandler(w http.ResponseWriter, r *http.Reque
 	var secretData map[string]string
 	if err := app.ReadJSON(w, r, &secretData); err != nil {
 		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	if len(secretData) == 0 {
+		app.badRequestResponse(w, r, fmt.Errorf("secret data must not be empty"))
 		return
 	}
 

--- a/distributions/core-bff/bff/internal/api/nim_integration_handler.go
+++ b/distributions/core-bff/bff/internal/api/nim_integration_handler.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// GetNIMIntegrationStatusHandler handles GET /api/v1/integrations/nim.
+// Returns the NIM integration status derived from the Account CR.
+// Registered as a publicRoute (no auth) - uses SA client, not user token.
+func (app *App) GetNIMIntegrationStatusHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	status, err := app.repositories.NIM.GetNIMStatus(r.Context(), app.config.Namespace)
+	if err != nil {
+		app.k8sErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, status, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// CreateNIMIntegrationHandler handles POST /api/v1/integrations/nim.
+// Creates or updates the NIM secret and Account CR.
+// Wrapped with secureAdminRoute - returns 401 for unauthenticated, 403 for non-admin.
+func (app *App) CreateNIMIntegrationHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var secretData map[string]string
+	if err := app.ReadJSON(w, r, &secretData); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	status, err := app.repositories.NIM.CreateNIMAccount(r.Context(), app.config.Namespace, secretData)
+	if err != nil {
+		app.k8sErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, status, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// DeleteNIMIntegrationHandler handles DELETE /api/v1/integrations/nim.
+// Deletes the NIM Account CR.
+// Wrapped with secureAdminRoute - returns 401 for unauthenticated, 403 for non-admin.
+func (app *App) DeleteNIMIntegrationHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	result, err := app.repositories.NIM.DeleteNIMAccount(r.Context(), app.config.Namespace)
+	if err != nil {
+		app.k8sErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/distributions/core-bff/bff/internal/api/nim_integration_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/nim_integration_handler_test.go
@@ -78,6 +78,27 @@ func TestCreateNIMIntegration_EmptyBody(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
+func TestCreateNIMIntegration_EmptySecretData(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "nim-create-empty-data"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, NIMIntegrationPath, strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateNIMIntegrationHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "secret data must not be empty")
+}
+
 func TestDeleteNIMIntegration_NoAccount(t *testing.T) {
 	app := newTestApp(func(a *App) {
 		a.config.Namespace = "nim-delete-noaccount"

--- a/distributions/core-bff/bff/internal/api/nim_integration_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/nim_integration_handler_test.go
@@ -121,5 +121,5 @@ func TestDeleteNIMIntegration_NoAccount(t *testing.T) {
 	err := json.Unmarshal(rr.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	assert.False(t, resp.Success)
-	assert.Contains(t, resp.Error, "Unable to delete nim account")
+	assert.Equal(t, "Unable to delete NIM account: the resource was not found", resp.Error)
 }

--- a/distributions/core-bff/bff/internal/api/nim_integration_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/nim_integration_handler_test.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetNIMIntegrationStatus_NoCRD(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "nim-status-nocrd"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, NIMIntegrationPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.GetNIMIntegrationStatusHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var status models.NIMIntegrationStatus
+	err := json.Unmarshal(rr.Body.Bytes(), &status)
+	require.NoError(t, err)
+	assert.Equal(t, "Unknown", status.VariablesValidationStatus)
+}
+
+func TestCreateNIMIntegration_InvalidBody(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "nim-create-bad"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, NIMIntegrationPath, strings.NewReader(`{invalid`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateNIMIntegrationHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCreateNIMIntegration_EmptyBody(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "nim-create-empty"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, NIMIntegrationPath, strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateNIMIntegrationHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestDeleteNIMIntegration_NoAccount(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "nim-delete-noaccount"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, NIMIntegrationPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.DeleteNIMIntegrationHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp models.NIMDeleteResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.False(t, resp.Success)
+	assert.Contains(t, resp.Error, "Unable to delete nim account")
+}

--- a/distributions/core-bff/bff/internal/api/nim_serving_handler.go
+++ b/distributions/core-bff/bff/internal/api/nim_serving_handler.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+)
+
+// GetNIMServingResourceHandler handles GET /api/v1/nim-serving/:nimResource.
+// Performs a cross-resource lookup: fetches NIM Account CR, resolves the resource name,
+// then fetches the Secret or ConfigMap.
+// Registered as a publicRoute (no auth) - uses SA client, not user token.
+func (app *App) GetNIMServingResourceHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	nimResource := ps.ByName("nimResource")
+
+	result, err := app.repositories.NIM.GetNIMServingResource(r.Context(), app.config.Namespace, nimResource)
+	if err != nil {
+		var notFound *models.NIMNotFoundError
+		if errors.As(err, &notFound) {
+			app.notFoundResponse(w, r)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	resp := models.NIMServingResourceResponse{Body: result}
+	if err := app.WriteJSON(w, http.StatusOK, resp, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/distributions/core-bff/bff/internal/api/nim_serving_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/nim_serving_handler_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetNIMServingResource_InvalidResource(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "nim-invalid"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/nim-serving/invalidType", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "nimResource", Value: "invalidType"}}
+	app.GetNIMServingResourceHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+
+	var body HTTPError
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "NOT_FOUND", body.Error.Code)
+}
+
+func TestGetNIMServingResource_NoAccount(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "nim-no-account"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/nim-serving/apiKeySecret", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "nimResource", Value: "apiKeySecret"}}
+	app.GetNIMServingResourceHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestGetNIMServingResource_AllValidResourceTypes(t *testing.T) {
+	validTypes := []string{"apiKeySecret", "nimPullSecret", "nimConfig"}
+
+	for _, rt := range validTypes {
+		t.Run(rt, func(t *testing.T) {
+			app := newTestApp(func(a *App) {
+				a.config.Namespace = "nim-valid-" + rt
+			})
+			admin := k8mocks.DefaultTestUsers[0]
+
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/nim-serving/"+rt, nil)
+			req = reqWithIdentity(req, &k8s.RequestIdentity{
+				UserID: admin.UserName,
+				Groups: admin.Groups,
+				Token:  k8s.NewBearerToken(admin.Token),
+			})
+
+			ps := httprouter.Params{{Key: "nimResource", Value: rt}}
+			app.GetNIMServingResourceHandler(rr, req, ps)
+
+			// NIM CRD is not installed in envtest, so expect 404 from the handler's error path.
+			// The important thing is that the resource type was valid (no panic, no 400).
+			assert.Equal(t, http.StatusNotFound, rr.Code)
+		})
+	}
+}

--- a/distributions/core-bff/bff/internal/api/nim_serving_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/nim_serving_handler_test.go
@@ -79,8 +79,8 @@ func TestGetNIMServingResource_AllValidResourceTypes(t *testing.T) {
 			ps := httprouter.Params{{Key: "nimResource", Value: rt}}
 			app.GetNIMServingResourceHandler(rr, req, ps)
 
-			// NIM CRD is not installed in envtest, so expect 404 from the handler's error path.
-			// The important thing is that the resource type was valid (no panic, no 400).
+			// No NIM Account instance exists in the namespace, so GetNIMServingResource
+			// returns NIMNotFoundError. The resource type itself is valid (no panic, no 400).
 			assert.Equal(t, http.StatusNotFound, rr.Code)
 		})
 	}

--- a/distributions/core-bff/bff/internal/api/prometheus_handler.go
+++ b/distributions/core-bff/bff/internal/api/prometheus_handler.go
@@ -88,10 +88,8 @@ func (app *App) PrometheusQueryHandler(w http.ResponseWriter, r *http.Request, _
 
 // resolvePrometheusQueryType maps the URL sub-path to a Prometheus query type.
 func resolvePrometheusQueryType(path string) string {
-	switch {
-	case strings.HasSuffix(path, "/queryRange"),
-		strings.HasSuffix(path, "/bias"),
-		strings.HasSuffix(path, "/serving"):
+	switch path {
+	case PrometheusQueryRangePath, PrometheusBiasPath, PrometheusServingPath:
 		return "query_range"
 	default:
 		return "query"

--- a/distributions/core-bff/bff/internal/api/prometheus_handler.go
+++ b/distributions/core-bff/bff/internal/api/prometheus_handler.go
@@ -42,36 +42,14 @@ func (app *App) PrometheusQueryHandler(w http.ResponseWriter, r *http.Request, _
 
 	result, err := app.repositories.Prometheus.Query(r.Context(), token, req.Query, queryType)
 	if err != nil {
-		var unavailable *models.PrometheusUnavailableError
-		var unparsable *models.PrometheusUnparsableError
-		var queryErr *models.PrometheusQueryError
-		var upstream *models.PrometheusUpstreamError
-		switch {
-		case errors.As(err, &unavailable):
-			app.WriteJSON(w, http.StatusServiceUnavailable, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
-				Code:     http.StatusServiceUnavailable,
-				Response: []byte(`"Prometheus service is not available"`),
+		var promErr models.PrometheusHTTPError
+		if errors.As(err, &promErr) {
+			app.WriteJSON(w, promErr.HTTPStatus(), models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
+				Code:     promErr.HTTPStatus(),
+				Response: promErr.ResponseBody(),
 			}, nil)
-		case errors.As(err, &unparsable):
-			app.WriteJSON(w, http.StatusUnprocessableEntity, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
-				Code:     http.StatusUnprocessableEntity,
-				Response: []byte(`"Unprocessable prometheus response"`),
-			}, nil)
-		case errors.As(err, &queryErr):
-			escaped, _ := json.Marshal(queryErr.Message)
-			app.WriteJSON(w, http.StatusBadRequest, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
-				Code:     http.StatusBadRequest,
-				Response: escaped,
-			}, nil)
-		case errors.As(err, &upstream):
-			escaped, _ := json.Marshal(fmt.Sprintf("Cannot fetch prometheus data, %s", upstream.Body))
-			app.WriteJSON(w, upstream.StatusCode, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
-				Code:     upstream.StatusCode,
-				Response: escaped,
-			}, nil)
-		default:
-			msg := fmt.Sprintf("Cannot fetch prometheus data, %s", err.Error())
-			escaped, _ := json.Marshal(msg)
+		} else {
+			escaped, _ := json.Marshal(fmt.Sprintf("Cannot fetch prometheus data, %s", err.Error()))
 			app.LogError(r, err)
 			app.WriteJSON(w, http.StatusInternalServerError, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
 				Code:     http.StatusInternalServerError,

--- a/distributions/core-bff/bff/internal/api/prometheus_handler.go
+++ b/distributions/core-bff/bff/internal/api/prometheus_handler.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+)
+
+// PrometheusQueryHandler handles POST /api/v1/prometheus/*.
+// Transforms the POST body into a GET request to Prometheus/Thanos.
+// No secureRoute wrapper - K8s RBAC provides authorization via the user token on the proxied request.
+func (app *App) PrometheusQueryHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var req models.PrometheusQueryRequest
+	if err := app.ReadJSON(w, r, &req); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	if strings.TrimSpace(req.Query) == "" {
+		app.WriteJSON(w, http.StatusBadRequest, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
+			Code:     http.StatusBadRequest,
+			Response: []byte(`"Failed to provide a query"`),
+		}, nil)
+		return
+	}
+
+	queryType := resolvePrometheusQueryType(r.URL.Path)
+
+	identity, ok := r.Context().Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+	if !ok || identity == nil {
+		app.unauthorizedResponse(w, r, errors.New("missing identity"))
+		return
+	}
+	token := identity.ResolveToken(app.devFallbackToken)
+
+	result, err := app.repositories.Prometheus.Query(r.Context(), token, req.Query, queryType)
+	if err != nil {
+		var unavailable *models.PrometheusUnavailableError
+		var unparsable *models.PrometheusUnparsableError
+		var queryErr *models.PrometheusQueryError
+		var upstream *models.PrometheusUpstreamError
+		switch {
+		case errors.As(err, &unavailable):
+			app.WriteJSON(w, http.StatusServiceUnavailable, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
+				Code:     http.StatusServiceUnavailable,
+				Response: []byte(`"Prometheus service is not available"`),
+			}, nil)
+		case errors.As(err, &unparsable):
+			app.WriteJSON(w, http.StatusUnprocessableEntity, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
+				Code:     http.StatusUnprocessableEntity,
+				Response: []byte(`"Unprocessable prometheus response"`),
+			}, nil)
+		case errors.As(err, &queryErr):
+			escaped, _ := json.Marshal(queryErr.Message)
+			app.WriteJSON(w, http.StatusBadRequest, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
+				Code:     http.StatusBadRequest,
+				Response: escaped,
+			}, nil)
+		case errors.As(err, &upstream):
+			escaped, _ := json.Marshal(fmt.Sprintf("Cannot fetch prometheus data, %s", upstream.Body))
+			app.WriteJSON(w, upstream.StatusCode, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
+				Code:     upstream.StatusCode,
+				Response: escaped,
+			}, nil)
+		default:
+			msg := fmt.Sprintf("Cannot fetch prometheus data, %s", err.Error())
+			escaped, _ := json.Marshal(msg)
+			app.LogError(r, err)
+			app.WriteJSON(w, http.StatusInternalServerError, models.PrometheusQueryResponse{ //nolint:errcheck // response write failure is non-recoverable
+				Code:     http.StatusInternalServerError,
+				Response: escaped,
+			}, nil)
+		}
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// resolvePrometheusQueryType maps the URL sub-path to a Prometheus query type.
+func resolvePrometheusQueryType(path string) string {
+	switch {
+	case strings.HasSuffix(path, "/queryRange"),
+		strings.HasSuffix(path, "/bias"),
+		strings.HasSuffix(path, "/serving"):
+		return "query_range"
+	default:
+		return "query"
+	}
+}

--- a/distributions/core-bff/bff/internal/api/prometheus_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/prometheus_handler_test.go
@@ -1,0 +1,308 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/repositories"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrometheusQuery_EmptyQuery(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, PrometheusQueryPath, strings.NewReader(`{"query":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PrometheusQueryHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp models.PrometheusQueryResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+}
+
+func TestPrometheusQuery_WhitespaceOnlyQuery(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, PrometheusQueryPath, strings.NewReader(`{"query":"   "}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PrometheusQueryHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestPrometheusQuery_NoIdentity(t *testing.T) {
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer mockSrv.Close()
+
+	app := newTestApp(func(a *App) {
+		a.repositories.Prometheus = repositories.NewPrometheusRepository(repositories.PrometheusConfig{
+			Host: mockSrv.URL,
+		})
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, PrometheusQueryPath, strings.NewReader(`{"query":"up"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	app.PrometheusQueryHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestPrometheusQuery_NoHost(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.repositories.Prometheus = repositories.NewPrometheusRepository(repositories.PrometheusConfig{})
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, PrometheusQueryPath, strings.NewReader(`{"query":"up"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PrometheusQueryHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+
+	var resp models.PrometheusQueryResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.Code)
+}
+
+func TestPrometheusQuery_Success(t *testing.T) {
+	promResponse := `{"status":"success","data":{"resultType":"vector","result":[]}}`
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/query")
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer ")
+		assert.Equal(t, "up", r.URL.Query().Get("query"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(promResponse))
+	}))
+	defer mockSrv.Close()
+
+	app := newTestApp(func(a *App) {
+		a.repositories.Prometheus = repositories.NewPrometheusRepository(repositories.PrometheusConfig{
+			Host: mockSrv.URL,
+		})
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, PrometheusQueryPath, strings.NewReader(`{"query":"query=up"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PrometheusQueryHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp models.PrometheusQueryResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestPrometheusQuery_UpstreamError(t *testing.T) {
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`bad gateway`))
+	}))
+	defer mockSrv.Close()
+
+	app := newTestApp(func(a *App) {
+		a.repositories.Prometheus = repositories.NewPrometheusRepository(repositories.PrometheusConfig{
+			Host: mockSrv.URL,
+		})
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, PrometheusQueryPath, strings.NewReader(`{"query":"query=up"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PrometheusQueryHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadGateway, rr.Code)
+}
+
+func TestPrometheusQuery_UnparsableResponse(t *testing.T) {
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(`this is not json`))
+	}))
+	defer mockSrv.Close()
+
+	app := newTestApp(func(a *App) {
+		a.repositories.Prometheus = repositories.NewPrometheusRepository(repositories.PrometheusConfig{
+			Host: mockSrv.URL,
+		})
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, PrometheusQueryPath, strings.NewReader(`{"query":"query=up"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PrometheusQueryHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rr.Code)
+
+	var resp models.PrometheusQueryResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+}
+
+func TestPrometheusQuery_InvalidJSON(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, PrometheusQueryPath, strings.NewReader(`{invalid`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PrometheusQueryHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestPrometheusQuery_QueryRangePath(t *testing.T) {
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/api/v1/query_range")
+		assert.Equal(t, "rate(up[5m])", r.URL.Query().Get("query"))
+		assert.Equal(t, "1234", r.URL.Query().Get("start"))
+		assert.Equal(t, "5678", r.URL.Query().Get("end"))
+		assert.Equal(t, "30", r.URL.Query().Get("step"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{}}`))
+	}))
+	defer mockSrv.Close()
+
+	app := newTestApp(func(a *App) {
+		a.repositories.Prometheus = repositories.NewPrometheusRepository(repositories.PrometheusConfig{
+			Host: mockSrv.URL,
+		})
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, PrometheusQueryRangePath, strings.NewReader(`{"query":"query=rate(up[5m])&start=1234&end=5678&step=30"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PrometheusQueryHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestPrometheusQuery_QueryError(t *testing.T) {
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"error","error":"parse error: unexpected end of input"}`))
+	}))
+	defer mockSrv.Close()
+
+	app := newTestApp(func(a *App) {
+		a.repositories.Prometheus = repositories.NewPrometheusRepository(repositories.PrometheusConfig{
+			Host: mockSrv.URL,
+		})
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, PrometheusQueryPath, strings.NewReader(`{"query":"query=invalid("}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PrometheusQueryHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp models.PrometheusQueryResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Contains(t, string(resp.Response), "parse error")
+}
+
+func TestResolvePrometheusQueryType(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/api/prometheus/query", "query"},
+		{"/api/prometheus/queryRange", "query_range"},
+		{"/api/prometheus/pvc", "query"},
+		{"/api/prometheus/bias", "query_range"},
+		{"/api/prometheus/serving", "query_range"},
+		{"/some/other/path", "query"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolvePrometheusQueryType(tt.path))
+		})
+	}
+}

--- a/distributions/core-bff/bff/internal/api/routes.go
+++ b/distributions/core-bff/bff/internal/api/routes.go
@@ -6,7 +6,6 @@ import (
 	"path"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/config"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/helpers"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/proxy"
 )
@@ -18,33 +17,6 @@ const (
 	APIPathPrefix = "/api"
 	// APIVersion is the API version path segment.
 	APIVersion = "/v1"
-
-	// Infrastructure paths
-	HealthCheckPath    = "/healthcheck"
-	APIHealthCheckPath = APIPathPrefix + APIVersion + "/healthcheck"
-	OpenAPIPath        = PathPrefix + "/openapi"
-	OpenAPIJSONPath    = PathPrefix + "/openapi.json"
-	OpenAPIYAMLPath    = PathPrefix + "/openapi.yaml"
-	SwaggerUIPath      = PathPrefix + "/swagger-ui"
-
-	// Starter endpoints (mod-arch-starter convention, /api/v1/ prefix)
-	UserPath      = APIPathPrefix + APIVersion + "/user"
-	NamespacePath = APIPathPrefix + APIVersion + "/namespaces"
-
-	// Config endpoints, /api/ prefix
-	ConfigPath           = APIPathPrefix + "/config"
-	ComponentsPath       = APIPathPrefix + "/components"
-	StatusPath           = APIPathPrefix + "/status"
-	DashboardConfigPath  = APIPathPrefix + "/dashboardConfig/:namespace/:name"
-	ClusterSettingsPath  = APIPathPrefix + "/cluster-settings"
-	ComponentsRemovePath = APIPathPrefix + "/components/remove"
-
-	// OpenShift-only endpoints
-	AllowedUsersPath = APIPathPrefix + "/status/:namespace/allowedUsers"
-
-	// Connection type endpoints
-	ConnectionTypesPath      = APIPathPrefix + "/connection-types"
-	ConnectionTypeSinglePath = APIPathPrefix + "/connection-types/:name"
 )
 
 // Routes builds the full HTTP handler tree: API router, proxies, static files, and middleware.
@@ -54,6 +26,10 @@ func (app *App) Routes() http.Handler {
 	return app.newCombinedMux(serviceMux, staticHandler)
 }
 
+// Auth contract: apiRouter routes require a token (InjectRequestIdentity).
+// Route-level auth is via secureRoute (user) or secureAdminRoute (admin).
+// Unauthenticated routes use publicRoute on the outer mux.
+//
 // newServiceMux creates the mux for API routes and proxies (all require authentication).
 func (app *App) newServiceMux() *http.ServeMux {
 	apiRouter := httprouter.New()
@@ -63,7 +39,7 @@ func (app *App) newServiceMux() *http.ServeMux {
 	app.registerStarterRoutes(apiRouter)
 	app.registerConfigRoutes(apiRouter)
 	app.registerConnectionTypeRoutes(apiRouter)
-	app.registerOpenShiftRoutes(apiRouter)
+	app.registerModelServingRoutes(apiRouter)
 
 	mux := http.NewServeMux()
 	mux.Handle(APIPathPrefix+"/", apiRouter)
@@ -83,6 +59,7 @@ func (app *App) newServiceMux() *http.ServeMux {
 		mux.Handle(proxy.WssProxyPrefix, app.wsProxy)
 		mux.Handle(PathPrefix+proxy.WssProxyPrefix, http.StripPrefix(PathPrefix, app.wsProxy))
 	}
+	app.registerModelServingProxy(mux)
 
 	return mux
 }
@@ -109,19 +86,11 @@ func (app *App) newStaticHandler() http.Handler {
 func (app *App) newCombinedMux(serviceMux *http.ServeMux, staticHandler http.Handler) *http.ServeMux {
 	authedHandler := app.RecoverPanic(app.EnableTelemetry(app.EnableCORS(app.InjectRequestIdentity(serviceMux))))
 
-	healthcheckRouter := httprouter.New()
-	healthcheckRouter.GET(HealthCheckPath, app.HealthcheckHandler)
-
 	mux := http.NewServeMux()
 
-	// Public routes (no authentication required)
-	mux.Handle(HealthCheckPath, app.publicRoute(healthcheckRouter))
-	mux.Handle(OpenAPIJSONPath, app.publicRouteFunc(app.openAPI.HandleOpenAPIJSONWrapper))
-	mux.Handle(OpenAPIYAMLPath, app.publicRouteFunc(app.openAPI.HandleOpenAPIYAMLWrapper))
-	if app.config.DevMode {
-		mux.Handle(SwaggerUIPath, app.publicRouteFunc(app.openAPI.HandleSwaggerUIWrapper))
-		mux.Handle(OpenAPIPath, app.publicRouteFunc(app.openAPI.HandleOpenAPIRedirectWrapper))
-	}
+	app.registerPublicHealthcheckRoute(mux)
+	app.registerPublicNIMRoutes(mux)
+	app.registerPublicOpenAPIRoutes(mux)
 	mux.Handle("/", app.publicRoute(staticHandler))
 
 	// Authenticated routes (token required)
@@ -134,47 +103,4 @@ func (app *App) newCombinedMux(serviceMux *http.ServeMux, staticHandler http.Han
 	mux.HandleFunc(PathPrefix, app.notFoundResponse)
 
 	return mux
-}
-
-// Auth contract: every route in the register* functions below must be wrapped
-// with secureRoute (authenticated) or secureAdminRoute (admin-only).
-// The only exception is APIHealthCheckPath which is unauthenticated by convention
-// (K8s probes use /healthcheck which bypasses auth entirely).
-// When adding a new route, choose the appropriate wrapper explicitly.
-
-func (app *App) registerStarterRoutes(r *httprouter.Router) {
-	r.GET(APIHealthCheckPath, app.HealthcheckHandler)
-	r.GET(UserPath, app.secureRoute(app.UserHandler))
-	r.GET(NamespacePath, app.secureRoute(app.GetNamespacesHandler))
-}
-
-func (app *App) registerConfigRoutes(r *httprouter.Router) {
-	// Authenticated
-	r.GET(ConfigPath, app.secureRoute(app.GetConfigHandler))
-	r.GET(ComponentsPath, app.secureRoute(app.GetComponentsHandler))
-	r.GET(StatusPath, app.secureRoute(app.GetStatusHandler))
-
-	// Admin-only
-	r.PATCH(ConfigPath, app.secureAdminRoute(app.PatchConfigHandler))
-	r.GET(ComponentsRemovePath, app.secureAdminRoute(app.RemoveComponentHandler))
-	r.GET(DashboardConfigPath, app.secureAdminRoute(app.GetDashboardConfigByNameHandler))
-	r.PATCH(DashboardConfigPath, app.secureAdminRoute(app.PatchDashboardConfigByNameHandler))
-	r.GET(ClusterSettingsPath, app.secureAdminRoute(app.GetClusterSettingsHandler))
-	r.PUT(ClusterSettingsPath, app.secureAdminRoute(app.UpdateClusterSettingsHandler))
-}
-
-func (app *App) registerOpenShiftRoutes(r *httprouter.Router) {
-	r.GET(AllowedUsersPath, app.requirePlatform(config.PlatformOpenShift, app.secureAdminRoute(app.GetAllowedUsersHandler)))
-}
-
-func (app *App) registerConnectionTypeRoutes(r *httprouter.Router) {
-	// Authenticated
-	r.GET(ConnectionTypesPath, app.secureRoute(app.ListConnectionTypesHandler))
-	r.GET(ConnectionTypeSinglePath, app.secureRoute(app.GetConnectionTypeHandler))
-
-	// Admin-only
-	r.POST(ConnectionTypesPath, app.secureAdminRoute(app.CreateConnectionTypeHandler))
-	r.PUT(ConnectionTypeSinglePath, app.secureAdminRoute(app.UpdateConnectionTypeHandler))
-	r.PATCH(ConnectionTypeSinglePath, app.secureAdminRoute(app.PatchConnectionTypeHandler))
-	r.DELETE(ConnectionTypeSinglePath, app.secureAdminRoute(app.DeleteConnectionTypeHandler))
 }

--- a/distributions/core-bff/bff/internal/api/routes.go
+++ b/distributions/core-bff/bff/internal/api/routes.go
@@ -36,7 +36,7 @@ func (app *App) newServiceMux() *http.ServeMux {
 	apiRouter.NotFound = http.HandlerFunc(app.notFoundResponse)
 	apiRouter.MethodNotAllowed = http.HandlerFunc(app.methodNotAllowedResponse)
 
-	app.registerStarterRoutes(apiRouter)
+	app.registerBaseRoutes(apiRouter)
 	app.registerConfigRoutes(apiRouter)
 	app.registerConnectionTypeRoutes(apiRouter)
 	app.registerModelServingRoutes(apiRouter)

--- a/distributions/core-bff/bff/internal/api/routes_base.go
+++ b/distributions/core-bff/bff/internal/api/routes_base.go
@@ -19,7 +19,7 @@ func (app *App) registerPublicHealthcheckRoute(mux *http.ServeMux) {
 	mux.Handle(HealthCheckPath, app.publicRoute(r))
 }
 
-func (app *App) registerStarterRoutes(r *httprouter.Router) {
+func (app *App) registerBaseRoutes(r *httprouter.Router) {
 	r.GET(APIHealthCheckPath, app.HealthcheckHandler)
 
 	// Authenticated

--- a/distributions/core-bff/bff/internal/api/routes_config.go
+++ b/distributions/core-bff/bff/internal/api/routes_config.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/config"
+)
+
+const (
+	ConfigPath           = APIPathPrefix + "/config"
+	ComponentsPath       = APIPathPrefix + "/components"
+	StatusPath           = APIPathPrefix + "/status"
+	DashboardConfigPath  = APIPathPrefix + "/dashboardConfig/:namespace/:name"
+	ClusterSettingsPath  = APIPathPrefix + "/cluster-settings"
+	ComponentsRemovePath = APIPathPrefix + "/components/remove"
+	AllowedUsersPath     = APIPathPrefix + "/status/:namespace/allowedUsers"
+)
+
+func (app *App) registerConfigRoutes(r *httprouter.Router) {
+	// Authenticated
+	r.GET(ConfigPath, app.secureRoute(app.GetConfigHandler))
+	r.GET(ComponentsPath, app.secureRoute(app.GetComponentsHandler))
+	r.GET(StatusPath, app.secureRoute(app.GetStatusHandler))
+
+	// Admin-only
+	r.PATCH(ConfigPath, app.secureAdminRoute(app.PatchConfigHandler))
+	r.GET(ComponentsRemovePath, app.secureAdminRoute(app.RemoveComponentHandler))
+	r.GET(DashboardConfigPath, app.secureAdminRoute(app.GetDashboardConfigByNameHandler))
+	r.PATCH(DashboardConfigPath, app.secureAdminRoute(app.PatchDashboardConfigByNameHandler))
+	r.GET(ClusterSettingsPath, app.secureAdminRoute(app.GetClusterSettingsHandler))
+	r.PUT(ClusterSettingsPath, app.secureAdminRoute(app.UpdateClusterSettingsHandler))
+
+	// Platform-specific (OpenShift only)
+	r.GET(AllowedUsersPath, app.requirePlatform(config.PlatformOpenShift, app.secureAdminRoute(app.GetAllowedUsersHandler)))
+}

--- a/distributions/core-bff/bff/internal/api/routes_connection_types.go
+++ b/distributions/core-bff/bff/internal/api/routes_connection_types.go
@@ -1,0 +1,20 @@
+package api
+
+import "github.com/julienschmidt/httprouter"
+
+const (
+	ConnectionTypesPath      = APIPathPrefix + "/connection-types"
+	ConnectionTypeSinglePath = APIPathPrefix + "/connection-types/:name"
+)
+
+func (app *App) registerConnectionTypeRoutes(r *httprouter.Router) {
+	// Authenticated
+	r.GET(ConnectionTypesPath, app.secureRoute(app.ListConnectionTypesHandler))
+	r.GET(ConnectionTypeSinglePath, app.secureRoute(app.GetConnectionTypeHandler))
+
+	// Admin-only
+	r.POST(ConnectionTypesPath, app.secureAdminRoute(app.CreateConnectionTypeHandler))
+	r.PUT(ConnectionTypeSinglePath, app.secureAdminRoute(app.UpdateConnectionTypeHandler))
+	r.PATCH(ConnectionTypeSinglePath, app.secureAdminRoute(app.PatchConnectionTypeHandler))
+	r.DELETE(ConnectionTypeSinglePath, app.secureAdminRoute(app.DeleteConnectionTypeHandler))
+}

--- a/distributions/core-bff/bff/internal/api/routes_model_serving.go
+++ b/distributions/core-bff/bff/internal/api/routes_model_serving.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	ModelServingProxyPrefix  = "/api/service/model-serving/"
+	ModelServingProxyPrefix  = APIPathPrefix + "/service/model-serving/"
 	ServingRuntimesPath      = APIPathPrefix + "/servingRuntimes"
 	NIMServingResourcePath   = APIPathPrefix + "/nim-serving/:nimResource"
 	PrometheusQueryPath      = APIPathPrefix + "/prometheus/query"

--- a/distributions/core-bff/bff/internal/api/routes_model_serving.go
+++ b/distributions/core-bff/bff/internal/api/routes_model_serving.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+const (
+	ModelServingProxyPrefix  = "/api/service/model-serving/"
+	ServingRuntimesPath      = APIPathPrefix + "/servingRuntimes"
+	NIMServingResourcePath   = APIPathPrefix + "/nim-serving/:nimResource"
+	PrometheusQueryPath      = APIPathPrefix + "/prometheus/query"
+	PrometheusQueryRangePath = APIPathPrefix + "/prometheus/queryRange"
+	PrometheusPVCPath        = APIPathPrefix + "/prometheus/pvc"
+	PrometheusBiasPath       = APIPathPrefix + "/prometheus/bias"
+	PrometheusServingPath    = APIPathPrefix + "/prometheus/serving"
+	NIMIntegrationPath       = APIPathPrefix + "/integrations/nim"
+	NamespaceMutationPath    = APIPathPrefix + "/namespaces/:name/:context"
+)
+
+func (app *App) registerModelServingProxy(mux *http.ServeMux) {
+	if app.modelServingProxy != nil {
+		mux.Handle(ModelServingProxyPrefix, app.modelServingProxy)
+		mux.Handle(PathPrefix+ModelServingProxyPrefix, http.StripPrefix(PathPrefix, app.modelServingProxy))
+	}
+}
+
+func (app *App) registerModelServingRoutes(r *httprouter.Router) {
+	// Admin-only
+	r.POST(ServingRuntimesPath, app.secureAdminRoute(app.CreateServingRuntimeHandler))
+
+	// Namespace serving platform mutations (SSAR-gated in handler)
+	r.GET(NamespaceMutationPath, app.secureRoute(app.NamespaceMutationHandler))
+
+	// Prometheus (handler checks auth internally)
+	r.POST(PrometheusQueryPath, app.PrometheusQueryHandler)
+	r.POST(PrometheusQueryRangePath, app.PrometheusQueryHandler)
+	r.POST(PrometheusPVCPath, app.PrometheusQueryHandler)
+	r.POST(PrometheusBiasPath, app.PrometheusQueryHandler)
+	r.POST(PrometheusServingPath, app.PrometheusQueryHandler)
+
+	// NIM admin
+	r.POST(NIMIntegrationPath, app.secureAdminRoute(app.CreateNIMIntegrationHandler))
+	r.DELETE(NIMIntegrationPath, app.secureAdminRoute(app.DeleteNIMIntegrationHandler))
+}
+
+func (app *App) registerPublicNIMRoutes(mux *http.ServeMux) {
+	r := httprouter.New()
+	r.GET(NIMServingResourcePath, app.GetNIMServingResourceHandler)
+	r.GET(NIMIntegrationPath, app.GetNIMIntegrationStatusHandler)
+
+	public := app.publicRoute(r)
+	publicPrefixed := app.publicRoute(http.StripPrefix(PathPrefix, r))
+
+	mux.Handle("GET "+NIMIntegrationPath, public)
+	mux.Handle("GET "+APIPathPrefix+"/nim-serving/", public)
+	mux.Handle("GET "+PathPrefix+NIMIntegrationPath, publicPrefixed)
+	mux.Handle("GET "+PathPrefix+APIPathPrefix+"/nim-serving/", publicPrefixed)
+}

--- a/distributions/core-bff/bff/internal/api/routes_model_serving.go
+++ b/distributions/core-bff/bff/internal/api/routes_model_serving.go
@@ -4,19 +4,25 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/config"
 )
 
 const (
-	ModelServingProxyPrefix  = APIPathPrefix + "/service/model-serving/"
-	ServingRuntimesPath      = APIPathPrefix + "/servingRuntimes"
-	NIMServingResourcePath   = APIPathPrefix + "/nim-serving/:nimResource"
+	// Model serving
+	ModelServingProxyPrefix = APIPathPrefix + "/service/model-serving/"
+	ServingRuntimesPath     = APIPathPrefix + "/servingRuntimes"
+	NamespaceMutationPath   = APIPathPrefix + "/namespaces/:name/:context"
+
+	// Prometheus
 	PrometheusQueryPath      = APIPathPrefix + "/prometheus/query"
 	PrometheusQueryRangePath = APIPathPrefix + "/prometheus/queryRange"
 	PrometheusPVCPath        = APIPathPrefix + "/prometheus/pvc"
 	PrometheusBiasPath       = APIPathPrefix + "/prometheus/bias"
 	PrometheusServingPath    = APIPathPrefix + "/prometheus/serving"
-	NIMIntegrationPath       = APIPathPrefix + "/integrations/nim"
-	NamespaceMutationPath    = APIPathPrefix + "/namespaces/:name/:context"
+
+	// NIM (OpenShift-only)
+	NIMServingResourcePath = APIPathPrefix + "/nim-serving/:nimResource"
+	NIMIntegrationPath     = APIPathPrefix + "/integrations/nim"
 )
 
 func (app *App) registerModelServingProxy(mux *http.ServeMux) {
@@ -40,9 +46,9 @@ func (app *App) registerModelServingRoutes(r *httprouter.Router) {
 	r.POST(PrometheusBiasPath, app.PrometheusQueryHandler)
 	r.POST(PrometheusServingPath, app.PrometheusQueryHandler)
 
-	// NIM admin
-	r.POST(NIMIntegrationPath, app.secureAdminRoute(app.CreateNIMIntegrationHandler))
-	r.DELETE(NIMIntegrationPath, app.secureAdminRoute(app.DeleteNIMIntegrationHandler))
+	// NIM admin (OpenShift-only)
+	r.POST(NIMIntegrationPath, app.requirePlatform(config.PlatformOpenShift, app.secureAdminRoute(app.CreateNIMIntegrationHandler)))
+	r.DELETE(NIMIntegrationPath, app.requirePlatform(config.PlatformOpenShift, app.secureAdminRoute(app.DeleteNIMIntegrationHandler)))
 }
 
 func (app *App) registerPublicNIMRoutes(mux *http.ServeMux) {
@@ -50,8 +56,8 @@ func (app *App) registerPublicNIMRoutes(mux *http.ServeMux) {
 	r.GET(NIMServingResourcePath, app.GetNIMServingResourceHandler)
 	r.GET(NIMIntegrationPath, app.GetNIMIntegrationStatusHandler)
 
-	public := app.publicRoute(r)
-	publicPrefixed := app.publicRoute(http.StripPrefix(PathPrefix, r))
+	public := app.requirePlatformPublic(config.PlatformOpenShift, app.publicRoute(r))
+	publicPrefixed := app.requirePlatformPublic(config.PlatformOpenShift, app.publicRoute(http.StripPrefix(PathPrefix, r)))
 
 	mux.Handle("GET "+NIMIntegrationPath, public)
 	mux.Handle("GET "+APIPathPrefix+"/nim-serving/", public)

--- a/distributions/core-bff/bff/internal/api/routes_model_serving.go
+++ b/distributions/core-bff/bff/internal/api/routes_model_serving.go
@@ -39,12 +39,12 @@ func (app *App) registerModelServingRoutes(r *httprouter.Router) {
 	// Namespace serving platform mutations (SSAR-gated in handler)
 	r.GET(NamespaceMutationPath, app.secureRoute(app.NamespaceMutationHandler))
 
-	// Prometheus (handler checks auth internally)
-	r.POST(PrometheusQueryPath, app.PrometheusQueryHandler)
-	r.POST(PrometheusQueryRangePath, app.PrometheusQueryHandler)
-	r.POST(PrometheusPVCPath, app.PrometheusQueryHandler)
-	r.POST(PrometheusBiasPath, app.PrometheusQueryHandler)
-	r.POST(PrometheusServingPath, app.PrometheusQueryHandler)
+	// Prometheus (OpenShift-only)
+	r.POST(PrometheusQueryPath, app.requirePlatform(config.PlatformOpenShift, app.PrometheusQueryHandler))
+	r.POST(PrometheusQueryRangePath, app.requirePlatform(config.PlatformOpenShift, app.PrometheusQueryHandler))
+	r.POST(PrometheusPVCPath, app.requirePlatform(config.PlatformOpenShift, app.PrometheusQueryHandler))
+	r.POST(PrometheusBiasPath, app.requirePlatform(config.PlatformOpenShift, app.PrometheusQueryHandler))
+	r.POST(PrometheusServingPath, app.requirePlatform(config.PlatformOpenShift, app.PrometheusQueryHandler))
 
 	// NIM admin (OpenShift-only)
 	r.POST(NIMIntegrationPath, app.requirePlatform(config.PlatformOpenShift, app.secureAdminRoute(app.CreateNIMIntegrationHandler)))

--- a/distributions/core-bff/bff/internal/api/routes_openapi.go
+++ b/distributions/core-bff/bff/internal/api/routes_openapi.go
@@ -1,0 +1,21 @@
+package api
+
+import "net/http"
+
+const (
+	OpenAPIPath     = PathPrefix + "/openapi"
+	OpenAPIJSONPath = PathPrefix + "/openapi.json"
+	OpenAPIYAMLPath = PathPrefix + "/openapi.yaml"
+	SwaggerUIPath   = PathPrefix + "/swagger-ui"
+)
+
+// registerPublicOpenAPIRoutes registers OpenAPI spec and Swagger UI routes as
+// public (no auth). Swagger UI and the redirect are only registered in dev mode.
+func (app *App) registerPublicOpenAPIRoutes(mux *http.ServeMux) {
+	mux.Handle(OpenAPIJSONPath, app.publicRouteFunc(app.openAPI.HandleOpenAPIJSONWrapper))
+	mux.Handle(OpenAPIYAMLPath, app.publicRouteFunc(app.openAPI.HandleOpenAPIYAMLWrapper))
+	if app.config.DevMode {
+		mux.Handle(SwaggerUIPath, app.publicRouteFunc(app.openAPI.HandleSwaggerUIWrapper))
+		mux.Handle(OpenAPIPath, app.publicRouteFunc(app.openAPI.HandleOpenAPIRedirectWrapper))
+	}
+}

--- a/distributions/core-bff/bff/internal/api/routes_starter.go
+++ b/distributions/core-bff/bff/internal/api/routes_starter.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+const (
+	HealthCheckPath    = "/healthcheck"
+	APIHealthCheckPath = APIPathPrefix + APIVersion + "/healthcheck"
+	UserPath           = APIPathPrefix + APIVersion + "/user"
+	NamespacePath      = APIPathPrefix + APIVersion + "/namespaces"
+)
+
+func (app *App) registerPublicHealthcheckRoute(mux *http.ServeMux) {
+	r := httprouter.New()
+	r.GET(HealthCheckPath, app.HealthcheckHandler)
+	mux.Handle(HealthCheckPath, app.publicRoute(r))
+}
+
+func (app *App) registerStarterRoutes(r *httprouter.Router) {
+	r.GET(APIHealthCheckPath, app.HealthcheckHandler)
+
+	// Authenticated
+	r.GET(UserPath, app.secureRoute(app.UserHandler))
+	r.GET(NamespacePath, app.secureRoute(app.GetNamespacesHandler))
+}

--- a/distributions/core-bff/bff/internal/api/serving_runtime_handler.go
+++ b/distributions/core-bff/bff/internal/api/serving_runtime_handler.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// CreateServingRuntimeHandler handles POST /api/v1/servingRuntimes.
+// Creates a ServingRuntime CR in the specified namespace.
+func (app *App) CreateServingRuntimeHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var body map[string]interface{}
+	if err := app.ReadJSON(w, r, &body); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	namespace, err := extractNamespaceFromBody(body)
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	if !app.isAllowedNamespace(namespace) {
+		app.forbiddenResponse(w, r, fmt.Errorf("request invalid against a resource from a non-dashboard namespace"))
+		return
+	}
+
+	dryRun := r.URL.Query().Get("dryRun")
+
+	obj := &unstructured.Unstructured{Object: body}
+	obj.SetGroupVersionKind(models.ServingRuntimeGVR.GroupVersion().WithKind("ServingRuntime"))
+
+	result, err := app.repositories.ServingRuntime.Create(r.Context(), namespace, obj, dryRun)
+	if err != nil {
+		app.k8sErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, result.Object, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func extractNamespaceFromBody(body map[string]interface{}) (string, error) {
+	metadata, ok := body["metadata"]
+	if !ok {
+		return "", errors.New("missing metadata in request body")
+	}
+	metaMap, ok := metadata.(map[string]interface{})
+	if !ok {
+		return "", errors.New("metadata must be an object")
+	}
+	ns, ok := metaMap["namespace"]
+	if !ok {
+		return "", errors.New("missing metadata.namespace in request body")
+	}
+	nsStr, ok := ns.(string)
+	if !ok || nsStr == "" {
+		return "", errors.New("metadata.namespace must be a non-empty string")
+	}
+	return nsStr, nil
+}

--- a/distributions/core-bff/bff/internal/api/serving_runtime_handler.go
+++ b/distributions/core-bff/bff/internal/api/serving_runtime_handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -30,7 +31,10 @@ func (app *App) CreateServingRuntimeHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	dryRun := r.URL.Query().Get("dryRun")
+	dryRun := ""
+	if r.URL.Query().Get("dryRun") == metav1.DryRunAll {
+		dryRun = metav1.DryRunAll
+	}
 
 	obj := &unstructured.Unstructured{Object: body}
 	obj.SetGroupVersionKind(models.ServingRuntimeGVR.GroupVersion().WithKind("ServingRuntime"))

--- a/distributions/core-bff/bff/internal/api/serving_runtime_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/serving_runtime_handler_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,8 +10,11 @@ import (
 
 	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCreateServingRuntime_MissingMetadata(t *testing.T) {
@@ -257,6 +261,10 @@ func TestCreateServingRuntime_DryRun(t *testing.T) {
 	require.NoError(t, err)
 	meta, _ := result["metadata"].(map[string]interface{})
 	assert.Equal(t, "dryrun-runtime", meta["name"])
+
+	// Verify the object was not actually persisted.
+	_, err = testSADynClient.Resource(models.ServingRuntimeGVR).Namespace(ns).Get(context.Background(), "dryrun-runtime", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err), "dry-run request must not persist the resource")
 }
 
 func TestExtractNamespaceFromBody(t *testing.T) {

--- a/distributions/core-bff/bff/internal/api/serving_runtime_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/serving_runtime_handler_test.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateServingRuntime_MissingMetadata(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "sr-missing-meta"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	body := map[string]interface{}{
+		"apiVersion": "serving.kserve.io/v1alpha1",
+		"kind":       "ServingRuntime",
+	}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ServingRuntimesPath, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateServingRuntimeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCreateServingRuntime_MissingNamespace(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "sr-missing-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	body := map[string]interface{}{
+		"apiVersion": "serving.kserve.io/v1alpha1",
+		"kind":       "ServingRuntime",
+		"metadata": map[string]interface{}{
+			"name": "test-runtime",
+		},
+	}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ServingRuntimesPath, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateServingRuntimeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCreateServingRuntime_DisallowedNamespace(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "sr-allowed-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	body := map[string]interface{}{
+		"apiVersion": "serving.kserve.io/v1alpha1",
+		"kind":       "ServingRuntime",
+		"metadata": map[string]interface{}{
+			"name":      "test-runtime",
+			"namespace": "some-other-ns",
+		},
+	}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ServingRuntimesPath, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateServingRuntimeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestCreateServingRuntime_EmptyBody(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ServingRuntimesPath, bytes.NewReader([]byte("")))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateServingRuntimeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCreateServingRuntime_InvalidJSON(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ServingRuntimesPath, bytes.NewReader([]byte("{invalid")))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateServingRuntimeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCreateServingRuntime_EmptyNamespaceString(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "sr-empty-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	body := map[string]interface{}{
+		"apiVersion": "serving.kserve.io/v1alpha1",
+		"kind":       "ServingRuntime",
+		"metadata": map[string]interface{}{
+			"name":      "test-runtime",
+			"namespace": "",
+		},
+	}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ServingRuntimesPath, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateServingRuntimeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestExtractNamespaceFromBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid namespace",
+			body: map[string]interface{}{
+				"metadata": map[string]interface{}{"namespace": "test-ns"},
+			},
+			want: "test-ns",
+		},
+		{
+			name:    "missing metadata",
+			body:    map[string]interface{}{},
+			wantErr: true,
+		},
+		{
+			name: "metadata not an object",
+			body: map[string]interface{}{
+				"metadata": "not-a-map",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing namespace key",
+			body: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "test"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty namespace string",
+			body: map[string]interface{}{
+				"metadata": map[string]interface{}{"namespace": ""},
+			},
+			wantErr: true,
+		},
+		{
+			name: "namespace not a string",
+			body: map[string]interface{}{
+				"metadata": map[string]interface{}{"namespace": 123},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractNamespaceFromBody(tt.body)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/distributions/core-bff/bff/internal/api/serving_runtime_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/serving_runtime_handler_test.go
@@ -168,6 +168,97 @@ func TestCreateServingRuntime_EmptyNamespaceString(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
+func TestCreateServingRuntime_Success(t *testing.T) {
+	const ns = "sr-success"
+	ensureNamespace(t, ns)
+
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	body := map[string]interface{}{
+		"apiVersion": "serving.kserve.io/v1alpha1",
+		"kind":       "ServingRuntime",
+		"metadata": map[string]interface{}{
+			"name":      "test-runtime",
+			"namespace": ns,
+		},
+		"spec": map[string]interface{}{
+			"supportedModelFormats": []interface{}{
+				map[string]interface{}{"name": "openvino_ir", "version": "opset1"},
+			},
+		},
+	}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ServingRuntimesPath, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateServingRuntimeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	meta, _ := result["metadata"].(map[string]interface{})
+	assert.Equal(t, "test-runtime", meta["name"])
+	assert.Equal(t, ns, meta["namespace"])
+}
+
+func TestCreateServingRuntime_DryRun(t *testing.T) {
+	const ns = "sr-dryrun"
+	ensureNamespace(t, ns)
+
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	body := map[string]interface{}{
+		"apiVersion": "serving.kserve.io/v1alpha1",
+		"kind":       "ServingRuntime",
+		"metadata": map[string]interface{}{
+			"name":      "dryrun-runtime",
+			"namespace": ns,
+		},
+		"spec": map[string]interface{}{
+			"supportedModelFormats": []interface{}{
+				map[string]interface{}{"name": "openvino_ir", "version": "opset1"},
+			},
+		},
+	}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ServingRuntimesPath+"?dryRun=All", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateServingRuntimeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	meta, _ := result["metadata"].(map[string]interface{})
+	assert.Equal(t, "dryrun-runtime", meta["name"])
+}
+
 func TestExtractNamespaceFromBody(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/distributions/core-bff/bff/internal/api/stub_client_test.go
+++ b/distributions/core-bff/bff/internal/api/stub_client_test.go
@@ -32,6 +32,9 @@ func (s *stubDynClient) IsUserAdmin(_ context.Context, _ *k8s.RequestIdentity) (
 func (s *stubDynClient) IsUserAllowed(_ context.Context, _ *k8s.RequestIdentity) (bool, error) {
 	return false, nil
 }
+func (s *stubDynClient) CheckAccess(_ context.Context, _ *k8s.RequestIdentity, _, _, _, _ string) (bool, error) {
+	return true, nil
+}
 func (s *stubDynClient) GetConfigMap(_ context.Context, _, _ string) (*corev1.ConfigMap, error) {
 	return nil, nil
 }

--- a/distributions/core-bff/bff/internal/api/test_setup_test.go
+++ b/distributions/core-bff/bff/internal/api/test_setup_test.go
@@ -28,7 +28,9 @@ var (
 func TestMain(m *testing.M) {
 	logger := testLogger()
 
-	env, clientset, err := k8mocks.SetupEnvTest(k8mocks.TestEnvInput{})
+	env, clientset, saDyn, err := k8mocks.SetupEnvTest(k8mocks.TestEnvInput{
+		CRDs: k8mocks.DefaultCRDs(),
+	})
 	if err != nil {
 		logger.Error("failed to setup envtest", slog.Any("error", err))
 		os.Exit(1)
@@ -49,13 +51,6 @@ func TestMain(m *testing.M) {
 
 	testK8sFactory = factory
 	testEnvInstance = env
-
-	saDyn, err := dynamic.NewForConfig(env.Config)
-	if err != nil {
-		logger.Error("failed to create SA dynamic client", slog.Any("error", err))
-		_ = env.Stop()
-		os.Exit(1)
-	}
 	testSADynClient = saDyn
 
 	saCS, err := kubernetes.NewForConfig(env.Config)

--- a/distributions/core-bff/bff/internal/config/environment.go
+++ b/distributions/core-bff/bff/internal/config/environment.go
@@ -178,4 +178,23 @@ type EnvConfig struct {
 
 	// DevGroups is a comma-separated list of groups injected alongside DevUser in dev mode.
 	DevGroups string
+
+	// ─── MODEL SERVING ──────────────────────────────────────────
+	// ModelServingServiceHost overrides the model-serving service proxy target URL.
+	// When empty, the target is constructed as https://model-serving-api.<namespace>.svc.cluster.local:443.
+	ModelServingServiceHost string
+
+	// ─── PROMETHEUS ─────────────────────────────────────────────
+	// PrometheusHost is a full Prometheus/Thanos host URL override. When set, used directly
+	// instead of constructing from namespace/instance/port. On RHAII, the deployer sets this.
+	PrometheusHost string
+
+	// PrometheusNamespace is the namespace where Prometheus/Thanos is deployed.
+	PrometheusNamespace string
+
+	// PrometheusInstance is the Prometheus/Thanos instance name.
+	PrometheusInstance string
+
+	// PrometheusPort is the Prometheus/Thanos RBAC port.
+	PrometheusPort string
 }

--- a/distributions/core-bff/bff/internal/config/environment.go
+++ b/distributions/core-bff/bff/internal/config/environment.go
@@ -184,9 +184,9 @@ type EnvConfig struct {
 	// When empty, the target is constructed as https://model-serving-api.<namespace>.svc.cluster.local:443.
 	ModelServingServiceHost string
 
-	// ─── PROMETHEUS ─────────────────────────────────────────────
+	// ─── PROMETHEUS (OpenShift-only) ────────────────────────────
 	// PrometheusHost is a full Prometheus/Thanos host URL override. When set, used directly
-	// instead of constructing from namespace/instance/port. On RHAII, the deployer sets this.
+	// instead of constructing from namespace/instance/port.
 	PrometheusHost string
 
 	// PrometheusNamespace is the namespace where Prometheus/Thanos is deployed.

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/client.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/client.go
@@ -24,6 +24,9 @@ type KubernetesClientInterface interface {
 	IsUserAdmin(ctx context.Context, identity *RequestIdentity) (bool, error)
 	IsUserAllowed(ctx context.Context, identity *RequestIdentity) (bool, error)
 
+	// Generic SSAR check for custom resource permissions
+	CheckAccess(ctx context.Context, identity *RequestIdentity, verb, group, resource, namespace string) (bool, error)
+
 	// Dynamic client for CRD operations
 	GetDynamicClient() (dynamic.Interface, error)
 

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -177,10 +177,8 @@ func setupMock(ctx context.Context, mockK8sClient k8sclient.Interface, dynClient
 		}
 	}
 
-	if dynClient != nil {
-		if err := createNIMTestData(ctx, mockK8sClient, dynClient); err != nil {
-			return fmt.Errorf("failed to create NIM test data: %w", err)
-		}
+	if err := createNIMTestData(ctx, mockK8sClient, dynClient); err != nil {
+		return fmt.Errorf("failed to create NIM test data: %w", err)
 	}
 
 	return nil

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -8,11 +8,9 @@ import (
 	"path/filepath"
 	"runtime"
 
-	kubernetes2 "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/dynamic"
+	k8sclient "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
@@ -48,10 +46,11 @@ type TestUser struct {
 type TestEnvInput struct {
 	Users []TestUser
 	Ctx   context.Context
+	CRDs  []*apiextensionsv1.CustomResourceDefinition
 }
 
 // SetupEnvTest creates an envtest environment with configured test users.
-func SetupEnvTest(input TestEnvInput) (*envtest.Environment, kubernetes.Interface, error) {
+func SetupEnvTest(input TestEnvInput) (*envtest.Environment, k8sclient.Interface, dynamic.Interface, error) {
 	if input.Ctx == nil {
 		input.Ctx = context.Background()
 	}
@@ -62,35 +61,42 @@ func SetupEnvTest(input TestEnvInput) (*envtest.Environment, kubernetes.Interfac
 	} else {
 		projectRoot, err := getProjectRoot()
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to find project root: %w", err)
+			return nil, nil, nil, fmt.Errorf("failed to find project root: %w", err)
 		}
 		binaryAssetsDir = filepath.Join(projectRoot, "bin", "k8s", fmt.Sprintf("1.29.3-%s-%s", runtime.GOOS, runtime.GOARCH))
 	}
 
 	testEnv := &envtest.Environment{
 		BinaryAssetsDirectory: binaryAssetsDir,
+		CRDs:                  input.CRDs,
 	}
 
 	cfg, err := testEnv.Start()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to start envtest: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to start envtest: %w", err)
 	}
 
-	clientset, err := kubernetes.NewForConfig(cfg)
+	clientset, err := k8sclient.NewForConfig(cfg)
 	if err != nil {
 		_ = testEnv.Stop()
-		return nil, nil, fmt.Errorf("failed to create clientset: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create clientset: %w", err)
 	}
 
-	if err := setupMock(input.Ctx, clientset, input.Users); err != nil {
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
 		_ = testEnv.Stop()
-		return nil, nil, fmt.Errorf("failed to setup mock data: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 
-	return testEnv, clientset, nil
+	if err := setupMock(input.Ctx, clientset, dynClient, input.Users); err != nil {
+		_ = testEnv.Stop()
+		return nil, nil, nil, fmt.Errorf("failed to setup mock data: %w", err)
+	}
+
+	return testEnv, clientset, dynClient, nil
 }
 
-func setupMock(ctx context.Context, mockK8sClient kubernetes.Interface, users []TestUser) error {
+func setupMock(ctx context.Context, mockK8sClient k8sclient.Interface, dynClient dynamic.Interface, users []TestUser) error {
 	if len(users) == 0 {
 		users = DefaultTestUsers
 	}
@@ -171,249 +177,13 @@ func setupMock(ctx context.Context, mockK8sClient kubernetes.Interface, users []
 		}
 	}
 
-	return nil
-}
-
-func createNamespace(ctx context.Context, k8sClient kubernetes.Interface, namespace string) error {
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
-		},
-	}
-
-	_, err := k8sClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create namespace %s: %w", namespace, err)
+	if dynClient != nil {
+		if err := createNIMTestData(ctx, mockK8sClient, dynClient); err != nil {
+			return fmt.Errorf("failed to create NIM test data: %w", err)
+		}
 	}
 
 	return nil
-}
-
-func createClusterAdminRBAC(ctx context.Context, k8sClient kubernetes.Interface, username string) error {
-	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("cluster-admin-binding-%s", username),
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind: "User",
-				Name: username,
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "ClusterRole",
-			Name:     "cluster-admin",
-			APIGroup: "rbac.authorization.k8s.io",
-		},
-	}
-
-	_, err := k8sClient.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create cluster admin ClusterRoleBinding: %w", err)
-	}
-
-	return nil
-}
-
-func createNamespaceRestrictedRBAC(ctx context.Context, k8sClient kubernetes.Interface, username, namespace string) error {
-	role := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "namespace-restricted-role",
-			Namespace: namespace,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"services", "namespaces"},
-				Verbs:     []string{"get", "list"},
-			},
-		},
-	}
-
-	_, err := k8sClient.RbacV1().Roles(namespace).Create(ctx, role, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create Role: %w", err)
-	}
-
-	roleBinding := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "namespace-restricted-binding",
-			Namespace: namespace,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind: "User",
-				Name: username,
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "Role",
-			Name:     "namespace-restricted-role",
-			APIGroup: "rbac.authorization.k8s.io",
-		},
-	}
-
-	_, err = k8sClient.RbacV1().RoleBindings(namespace).Create(ctx, roleBinding, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create RoleBinding: %w", err)
-	}
-
-	return nil
-}
-
-func createGroupAccessRBAC(ctx context.Context, k8sClient kubernetes.Interface, groupName, namespace, serviceName string) error {
-	role := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "group-service-access",
-			Namespace: namespace,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"services"},
-				Verbs:     []string{"get", "list"},
-				ResourceNames: []string{
-					serviceName,
-				},
-			},
-		},
-	}
-
-	_, err := k8sClient.RbacV1().Roles(namespace).Create(ctx, role, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create Role for group: %w", err)
-	}
-
-	roleBinding := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "group-access-binding",
-			Namespace: namespace,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind: "Group",
-				Name: groupName,
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "Role",
-			Name:     "group-service-access",
-			APIGroup: "rbac.authorization.k8s.io",
-		},
-	}
-
-	_, err = k8sClient.RbacV1().RoleBindings(namespace).Create(ctx, roleBinding, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create RoleBinding for group: %w", err)
-	}
-	return nil
-}
-
-func createGroupNamespaceAccessRBAC(ctx context.Context, k8sClient kubernetes.Interface, groupName, namespace string) error {
-
-	role := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "group-namespace-access-role",
-			Namespace: namespace,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"namespaces", "services"},
-				Verbs:     []string{"get", "list"},
-			},
-		},
-	}
-
-	_, err := k8sClient.RbacV1().Roles(namespace).Create(ctx, role, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create Role for group namespace access: %w", err)
-	}
-
-	roleBinding := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "group-namespace-access-binding",
-			Namespace: namespace,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind: "Group",
-				Name: groupName,
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "Role",
-			Name:     "group-namespace-access-role",
-			APIGroup: "rbac.authorization.k8s.io",
-		},
-	}
-
-	_, err = k8sClient.RbacV1().RoleBindings(namespace).Create(ctx, roleBinding, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create RoleBinding for group namespace access: %w", err)
-	}
-
-	return nil
-}
-
-func createService(ctx context.Context, k8sClient kubernetes.Interface, name string, namespace string, displayName string, description string, clusterIP string, componentLabel string) error {
-
-	annotations := map[string]string{}
-
-	if displayName != "" {
-		annotations["displayName"] = displayName
-	}
-
-	if description != "" {
-		annotations["description"] = description
-	}
-
-	labels := map[string]string{}
-	if componentLabel != "" {
-		labels["component"] = componentLabel
-	}
-
-	service := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Annotations: annotations,
-			Labels:      labels,
-		},
-		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				"component": kubernetes2.ComponentLabelValue,
-			},
-			Type:      corev1.ServiceTypeClusterIP,
-			ClusterIP: clusterIP,
-			Ports: []corev1.ServicePort{
-				{
-					Name:        "http-api",
-					Port:        8080,
-					Protocol:    corev1.ProtocolTCP,
-					AppProtocol: strPtr("http"),
-				},
-				{
-					Name:        "grpc-api",
-					Port:        9090,
-					Protocol:    corev1.ProtocolTCP,
-					AppProtocol: strPtr("grpc"),
-				},
-			},
-		},
-	}
-
-	// Create the service using kubernetes.Interface
-	_, err := k8sClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
-	}
-
-	return nil
-}
-
-func strPtr(s string) *string {
-	return &s
 }
 
 func getProjectRoot() (string, error) {
@@ -424,13 +194,11 @@ func getProjectRoot() (string, error) {
 
 	for {
 		if _, err := os.Stat(filepath.Join(currentDir, "go.mod")); err == nil {
-			// Found the project root where go.mod is located
 			return currentDir, nil
 		}
 
 		parentDir := filepath.Dir(currentDir)
 		if parentDir == currentDir {
-			// We reached the root directory and did not find the go.mod
 			return "", fmt.Errorf("could not find project root")
 		}
 

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_crds.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_crds.go
@@ -1,0 +1,70 @@
+package k8mocks
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DefaultCRDs returns the set of custom resource definitions used by the core BFF.
+func DefaultCRDs() []*apiextensionsv1.CustomResourceDefinition {
+	return []*apiextensionsv1.CustomResourceDefinition{
+		CreateServingRuntimeCRD(),
+		CreateNIMAccountCRD(),
+	}
+}
+
+// CreateServingRuntimeCRD creates a minimal CRD for KServe ServingRuntime so envtest accepts the type.
+func CreateServingRuntimeCRD() *apiextensionsv1.CustomResourceDefinition {
+	preserveUnknown := true
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "servingruntimes.serving.kserve.io"},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "serving.kserve.io",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name: "v1alpha1", Served: true, Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"spec":   {Type: "object", XPreserveUnknownFields: &preserveUnknown},
+							"status": {Type: "object", XPreserveUnknownFields: &preserveUnknown},
+						},
+					},
+				},
+			}},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "servingruntimes", Singular: "servingruntime",
+				Kind: "ServingRuntime", ListKind: "ServingRuntimeList",
+			},
+		},
+	}
+}
+
+// CreateNIMAccountCRD creates a minimal CRD for NIM Account so envtest accepts the type.
+func CreateNIMAccountCRD() *apiextensionsv1.CustomResourceDefinition {
+	preserveUnknown := true
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "accounts.nim.opendatahub.io"},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "nim.opendatahub.io",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name: "v1", Served: true, Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"spec":   {Type: "object", XPreserveUnknownFields: &preserveUnknown},
+							"status": {Type: "object", XPreserveUnknownFields: &preserveUnknown},
+						},
+					},
+				},
+			}},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "accounts", Singular: "account",
+				Kind: "Account", ListKind: "AccountList",
+			},
+		},
+	}
+}

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_nim.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_nim.go
@@ -1,0 +1,60 @@
+package k8mocks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	k8sclient "k8s.io/client-go/kubernetes"
+)
+
+//nolint:gosec // G101: test-only fake data, not real credentials
+func createNIMTestData(ctx context.Context, k8sClient k8sclient.Interface, dynClient dynamic.Interface) error {
+	ns := "opendatahub"
+
+	_, err := k8sClient.CoreV1().Secrets(ns).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "nvidia-nim-access", Namespace: ns},
+		Data:       map[string][]byte{"api_key": []byte("fake-nim-api-key")},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create NIM api key secret: %w", err)
+	}
+
+	_, err = k8sClient.CoreV1().Secrets(ns).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "nim-pull-secret", Namespace: ns},
+		Data:       map[string][]byte{".dockerconfigjson": []byte(`{"auths":{}}`)},
+		Type:       corev1.SecretTypeDockerConfigJson,
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create NIM pull secret: %w", err)
+	}
+
+	_, err = k8sClient.CoreV1().ConfigMaps(ns).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "nim-config", Namespace: ns},
+		Data:       map[string]string{"config.yaml": "nim-models: []"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create NIM config map: %w", err)
+	}
+
+	account := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "nim.opendatahub.io/v1",
+		"kind":       "Account",
+		"metadata":   map[string]interface{}{"name": models.NIMAccountName, "namespace": ns},
+		"spec":       map[string]interface{}{"apiKeySecret": map[string]interface{}{"name": "nvidia-nim-access"}},
+		"status": map[string]interface{}{
+			"nimPullSecret": map[string]interface{}{"name": "nim-pull-secret"},
+			"nimConfig":     map[string]interface{}{"name": "nim-config"},
+		},
+	}}
+	_, err = dynClient.Resource(models.NIMAccountGVR).Namespace(ns).Create(ctx, account, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create NIM account: %w", err)
+	}
+
+	return nil
+}

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_rbac.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_rbac.go
@@ -1,0 +1,177 @@
+package k8mocks
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes"
+)
+
+func createClusterAdminRBAC(ctx context.Context, k8sClient k8sclient.Interface, username string) error {
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("cluster-admin-binding-%s", username),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "User",
+				Name: username,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	_, err := k8sClient.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create cluster admin ClusterRoleBinding: %w", err)
+	}
+
+	return nil
+}
+
+func createNamespaceRestrictedRBAC(ctx context.Context, k8sClient k8sclient.Interface, username, namespace string) error {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "namespace-restricted-role",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services", "namespaces"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+
+	_, err := k8sClient.RbacV1().Roles(namespace).Create(ctx, role, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create Role: %w", err)
+	}
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "namespace-restricted-binding",
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "User",
+				Name: username,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     "namespace-restricted-role",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	_, err = k8sClient.RbacV1().RoleBindings(namespace).Create(ctx, roleBinding, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create RoleBinding: %w", err)
+	}
+
+	return nil
+}
+
+func createGroupAccessRBAC(ctx context.Context, k8sClient k8sclient.Interface, groupName, namespace, serviceName string) error {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "group-service-access",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+				Verbs:     []string{"get", "list"},
+				ResourceNames: []string{
+					serviceName,
+				},
+			},
+		},
+	}
+
+	_, err := k8sClient.RbacV1().Roles(namespace).Create(ctx, role, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create Role for group: %w", err)
+	}
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "group-access-binding",
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: groupName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     "group-service-access",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	_, err = k8sClient.RbacV1().RoleBindings(namespace).Create(ctx, roleBinding, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create RoleBinding for group: %w", err)
+	}
+	return nil
+}
+
+func createGroupNamespaceAccessRBAC(ctx context.Context, k8sClient k8sclient.Interface, groupName, namespace string) error {
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "group-namespace-access-role",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "services"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+
+	_, err := k8sClient.RbacV1().Roles(namespace).Create(ctx, role, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create Role for group namespace access: %w", err)
+	}
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "group-namespace-access-binding",
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: groupName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     "group-namespace-access-role",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	_, err = k8sClient.RbacV1().RoleBindings(namespace).Create(ctx, roleBinding, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create RoleBinding for group namespace access: %w", err)
+	}
+
+	return nil
+}

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_resources.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_resources.go
@@ -1,0 +1,82 @@
+package k8mocks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/ptr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes"
+)
+
+func createNamespace(ctx context.Context, k8sClient k8sclient.Interface, namespace string) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+
+	_, err := k8sClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create namespace %s: %w", namespace, err)
+	}
+
+	return nil
+}
+
+func createService(ctx context.Context, k8sClient k8sclient.Interface, name string, namespace string, displayName string, description string, clusterIP string, componentLabel string) error {
+
+	annotations := map[string]string{}
+
+	if displayName != "" {
+		annotations["displayName"] = displayName
+	}
+
+	if description != "" {
+		annotations["description"] = description
+	}
+
+	labels := map[string]string{}
+	if componentLabel != "" {
+		labels["component"] = componentLabel
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"component": kubernetes.ComponentLabelValue,
+			},
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: clusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:        "http-api",
+					Port:        8080,
+					Protocol:    corev1.ProtocolTCP,
+					AppProtocol: ptr.To("http"),
+				},
+				{
+					Name:        "grpc-api",
+					Port:        9090,
+					Protocol:    corev1.ProtocolTCP,
+					AppProtocol: ptr.To("grpc"),
+				},
+			},
+		},
+	}
+
+	_, err := k8sClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create service: %w", err)
+	}
+
+	return nil
+}

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -133,12 +133,12 @@ func (kc *TokenKubernetesClient) CanListServicesInNamespace(ctx context.Context,
 
 		resp, err := kc.Client.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 		if err != nil {
-			kc.Logger.Error("self-SAR failed", "namespace", namespace, "verb", verb, "error", err)
+			kc.Logger.Warn("self-SAR failed", "namespace", namespace, "verb", verb, "error", err)
 			return false, err
 		}
 
 		if !resp.Status.Allowed {
-			kc.Logger.Error("self-SAR denied", "namespace", namespace, "verb", verb)
+			kc.Logger.Warn("self-SAR denied", "namespace", namespace, "verb", verb)
 			return false, nil
 		}
 	}
@@ -164,11 +164,11 @@ func (kc *TokenKubernetesClient) CanAccessServiceInNamespace(ctx context.Context
 
 	resp, err := kc.Client.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 	if err != nil {
-		kc.Logger.Error("self-SAR failed", "service", serviceName, "namespace", namespace, "error", err)
+		kc.Logger.Warn("self-SAR failed", "service", serviceName, "namespace", namespace, "error", err)
 		return false, err
 	}
 	if !resp.Status.Allowed {
-		kc.Logger.Error("self-SAR denied", "service", serviceName, "namespace", namespace)
+		kc.Logger.Warn("self-SAR denied", "service", serviceName, "namespace", namespace)
 		return false, nil
 	}
 
@@ -176,14 +176,15 @@ func (kc *TokenKubernetesClient) CanAccessServiceInNamespace(ctx context.Context
 }
 
 // RequestIdentity is unused because the token already represents the user identity.
-// This endpoint is used only on dev mode that is why is safe to ignore permissions errors
+// This endpoint is used only in dev mode. Permission failures are expected there,
+// so they are logged at Warn, but the request still returns an error to the caller.
 func (kc *TokenKubernetesClient) GetNamespaces(ctx context.Context, _ *RequestIdentity) ([]corev1.Namespace, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	nsList, err := kc.Client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		kc.Logger.Error("user is not allowed to list namespaces or failed to list namespaces")
+		kc.Logger.Warn("user is not allowed to list namespaces or failed to list namespaces")
 		return []corev1.Namespace{}, fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
@@ -259,6 +260,34 @@ func (kc *TokenKubernetesClient) checkAuthSingletonAccess(ctx context.Context, v
 	resp, err := kc.Client.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 	if err != nil {
 		return false, fmt.Errorf("failed to perform auth singleton SAR (verb=%s): %w", verb, err)
+	}
+
+	return resp.Status.Allowed, nil
+}
+
+func (kc *TokenKubernetesClient) CheckAccess(ctx context.Context, _ *RequestIdentity, verb, group, resource, namespace string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	sar := &authv1.SelfSubjectAccessReview{
+		Spec: authv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authv1.ResourceAttributes{
+				Verb:      verb,
+				Group:     group,
+				Resource:  resource,
+				Namespace: namespace,
+			},
+		},
+	}
+
+	resp, err := kc.Client.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+	if err != nil {
+		kc.Logger.Error("SSAR check failed", "verb", verb, "group", group, "resource", resource, "namespace", namespace, "error", err)
+		return false, fmt.Errorf("failed to check access (verb=%s, resource=%s/%s): %w", verb, group, resource, err)
+	}
+
+	if !resp.Status.Allowed {
+		kc.Logger.Info("SSAR denied", "verb", verb, "group", group, "resource", resource, "namespace", namespace)
 	}
 
 	return resp.Status.Allowed, nil

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -133,7 +133,7 @@ func (kc *TokenKubernetesClient) CanListServicesInNamespace(ctx context.Context,
 
 		resp, err := kc.Client.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 		if err != nil {
-			kc.Logger.Warn("self-SAR failed", "namespace", namespace, "verb", verb, "error", err)
+			kc.Logger.Error("self-SAR failed", "namespace", namespace, "verb", verb, "error", err)
 			return false, err
 		}
 
@@ -164,7 +164,7 @@ func (kc *TokenKubernetesClient) CanAccessServiceInNamespace(ctx context.Context
 
 	resp, err := kc.Client.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 	if err != nil {
-		kc.Logger.Warn("self-SAR failed", "service", serviceName, "namespace", namespace, "error", err)
+		kc.Logger.Error("self-SAR failed", "service", serviceName, "namespace", namespace, "error", err)
 		return false, err
 	}
 	if !resp.Status.Allowed {

--- a/distributions/core-bff/bff/internal/models/namespace_mutation.go
+++ b/distributions/core-bff/bff/internal/models/namespace_mutation.go
@@ -1,0 +1,21 @@
+package models
+
+// NamespaceApplicationCase determines which labels/annotations to apply to a namespace.
+type NamespaceApplicationCase int
+
+const (
+	DSGCreation               NamespaceApplicationCase = 0
+	KServePromotion           NamespaceApplicationCase = 1
+	KServeNIMPromotion        NamespaceApplicationCase = 2
+	ResetModelServingPlatform NamespaceApplicationCase = 3
+)
+
+const (
+	LabelModelMeshEnabled = "modelmesh-enabled"
+	AnnotationNIMSupport  = "opendatahub.io/nim-support"
+)
+
+// NamespaceMutationResponse is the response for namespace serving platform mutations.
+type NamespaceMutationResponse struct {
+	Applied bool `json:"applied"`
+}

--- a/distributions/core-bff/bff/internal/models/nim.go
+++ b/distributions/core-bff/bff/internal/models/nim.go
@@ -1,0 +1,62 @@
+package models
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	NIMAccountName          = "odh-nim-account"
+	NIMSecretName           = "nvidia-nim-access" //nolint:gosec // G101: resource name, not a credential
+	NIMAccountKind          = "Account"
+	NIMManagedLabel         = "opendatahub.io/managed"
+	NIMForceValidationAnnot = "runtimes.opendatahub.io/nim-force-validation"
+)
+
+// NIMAccountGVR is the GroupVersionResource for NIM Account CRDs.
+var NIMAccountGVR = schema.GroupVersionResource{
+	Group:    "nim.opendatahub.io",
+	Version:  "v1",
+	Resource: "accounts",
+}
+
+// NIMResourceMapping maps nim-serving resource param values to their K8s type and
+// the JSON path within the NIM Account CR where the resource name is found.
+type NIMResourceMapping struct {
+	ResourceType string   // "Secret" or "ConfigMap"
+	Path         []string // nested keys in the Account CR to reach the resource name
+}
+
+// NIMResourceMap defines how each :nimResource param resolves to a K8s resource.
+var NIMResourceMap = map[string]NIMResourceMapping{
+	"apiKeySecret":  {ResourceType: "Secret", Path: []string{"spec", "apiKeySecret", "name"}},
+	"nimPullSecret": {ResourceType: "Secret", Path: []string{"status", "nimPullSecret", "name"}},
+	"nimConfig":     {ResourceType: "ConfigMap", Path: []string{"status", "nimConfig", "name"}},
+}
+
+// NIMServingResourceResponse wraps the result of a cross-resource NIM lookup.
+type NIMServingResourceResponse struct {
+	Body interface{} `json:"body"`
+}
+
+// NIMIntegrationStatus represents the status of a NIM integration.
+type NIMIntegrationStatus struct {
+	IsInstalled                  bool   `json:"isInstalled"`
+	IsEnabled                    bool   `json:"isEnabled"`
+	VariablesValidationStatus    string `json:"variablesValidationStatus"`
+	VariablesValidationTimestamp string `json:"variablesValidationTimestamp"`
+	CanInstall                   bool   `json:"canInstall"`
+	Error                        string `json:"error"`
+}
+
+// NIMDeleteResponse represents the result of deleting a NIM account.
+type NIMDeleteResponse struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error"`
+}
+
+// NIMNotFoundError indicates an expected not-found condition in NIM resource lookups.
+type NIMNotFoundError struct {
+	Reason string
+}
+
+func (e *NIMNotFoundError) Error() string {
+	return e.Reason
+}

--- a/distributions/core-bff/bff/internal/models/prometheus.go
+++ b/distributions/core-bff/bff/internal/models/prometheus.go
@@ -1,0 +1,54 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// PrometheusQueryRequest is the POST body sent by the frontend.
+type PrometheusQueryRequest struct {
+	Query string `json:"query"`
+}
+
+// PrometheusQueryResponse is the envelope returned to the frontend.
+type PrometheusQueryResponse struct {
+	Code     int             `json:"code"`
+	Response json.RawMessage `json:"response"`
+}
+
+// PrometheusUnavailableError indicates Prometheus is not configured or unreachable.
+type PrometheusUnavailableError struct {
+	Reason string
+}
+
+func (e *PrometheusUnavailableError) Error() string {
+	return fmt.Sprintf("Prometheus service is not available: %s", e.Reason)
+}
+
+// PrometheusUnparsableError indicates a Prometheus response could not be decoded.
+type PrometheusUnparsableError struct {
+	Reason string
+}
+
+func (e *PrometheusUnparsableError) Error() string {
+	return fmt.Sprintf("unprocessable prometheus response: %s", e.Reason)
+}
+
+// PrometheusQueryError indicates Prometheus returned status:"error" in its response envelope.
+type PrometheusQueryError struct {
+	Message string
+}
+
+func (e *PrometheusQueryError) Error() string {
+	return e.Message
+}
+
+// PrometheusUpstreamError indicates Prometheus returned a non-2xx HTTP status.
+type PrometheusUpstreamError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *PrometheusUpstreamError) Error() string {
+	return fmt.Sprintf("cannot fetch prometheus data, status %d: %s", e.StatusCode, e.Body)
+}

--- a/distributions/core-bff/bff/internal/models/prometheus.go
+++ b/distributions/core-bff/bff/internal/models/prometheus.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 )
 
 // PrometheusQueryRequest is the POST body sent by the frontend.
@@ -16,6 +17,14 @@ type PrometheusQueryResponse struct {
 	Response json.RawMessage `json:"response"`
 }
 
+// PrometheusHTTPError is implemented by Prometheus errors that map to a specific
+// HTTP status and client-facing response body.
+type PrometheusHTTPError interface {
+	error
+	HTTPStatus() int
+	ResponseBody() json.RawMessage
+}
+
 // PrometheusUnavailableError indicates Prometheus is not configured or unreachable.
 type PrometheusUnavailableError struct {
 	Reason string
@@ -23,6 +32,12 @@ type PrometheusUnavailableError struct {
 
 func (e *PrometheusUnavailableError) Error() string {
 	return fmt.Sprintf("Prometheus service is not available: %s", e.Reason)
+}
+
+func (e *PrometheusUnavailableError) HTTPStatus() int { return http.StatusServiceUnavailable }
+
+func (e *PrometheusUnavailableError) ResponseBody() json.RawMessage {
+	return []byte(`"Prometheus service is not available"`)
 }
 
 // PrometheusUnparsableError indicates a Prometheus response could not be decoded.
@@ -34,13 +49,24 @@ func (e *PrometheusUnparsableError) Error() string {
 	return fmt.Sprintf("unprocessable prometheus response: %s", e.Reason)
 }
 
+func (e *PrometheusUnparsableError) HTTPStatus() int { return http.StatusUnprocessableEntity }
+
+func (e *PrometheusUnparsableError) ResponseBody() json.RawMessage {
+	return []byte(`"Unprocessable prometheus response"`)
+}
+
 // PrometheusQueryError indicates Prometheus returned status:"error" in its response envelope.
 type PrometheusQueryError struct {
 	Message string
 }
 
-func (e *PrometheusQueryError) Error() string {
-	return e.Message
+func (e *PrometheusQueryError) Error() string { return e.Message }
+
+func (e *PrometheusQueryError) HTTPStatus() int { return http.StatusBadRequest }
+
+func (e *PrometheusQueryError) ResponseBody() json.RawMessage {
+	escaped, _ := json.Marshal(e.Message)
+	return escaped
 }
 
 // PrometheusUpstreamError indicates Prometheus returned a non-2xx HTTP status.
@@ -51,4 +77,11 @@ type PrometheusUpstreamError struct {
 
 func (e *PrometheusUpstreamError) Error() string {
 	return fmt.Sprintf("cannot fetch prometheus data, status %d: %s", e.StatusCode, e.Body)
+}
+
+func (e *PrometheusUpstreamError) HTTPStatus() int { return e.StatusCode }
+
+func (e *PrometheusUpstreamError) ResponseBody() json.RawMessage {
+	escaped, _ := json.Marshal(fmt.Sprintf("Cannot fetch prometheus data, %s", e.Body))
+	return escaped
 }

--- a/distributions/core-bff/bff/internal/models/serving_runtime.go
+++ b/distributions/core-bff/bff/internal/models/serving_runtime.go
@@ -1,0 +1,10 @@
+package models
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+// ServingRuntimeGVR is the GroupVersionResource for KServe ServingRuntime CRDs.
+var ServingRuntimeGVR = schema.GroupVersionResource{
+	Group:    "serving.kserve.io",
+	Version:  "v1alpha1",
+	Resource: "servingruntimes",
+}

--- a/distributions/core-bff/bff/internal/proxy/k8s_proxy.go
+++ b/distributions/core-bff/bff/internal/proxy/k8s_proxy.go
@@ -17,10 +17,10 @@ import (
 // K8sProxyPrefix is the URL path prefix for Kubernetes API proxy requests.
 const K8sProxyPrefix = "/api/k8s/"
 
-// sensitiveIngressHeaders returns header names that must not leak from the ingress
-// layer to the K8s API server. authTokenHeader is included dynamically because it
+// SensitiveIngressHeaders returns header names that must not leak from the ingress
+// layer to upstream services. authTokenHeader is included dynamically because it
 // is configurable (default: x-forwarded-access-token).
-func sensitiveIngressHeaders(authTokenHeader string) []string {
+func SensitiveIngressHeaders(authTokenHeader string) []string {
 	headers := []string{
 		"cookie",
 		"x-forwarded-for",
@@ -88,7 +88,7 @@ func NewK8sProxyHandler(cfg K8sProxyConfig) (http.Handler, error) {
 		InsecureSkipVerify:   cfg.InsecureSkipVerify,
 		AllowHTTP:            cfg.AllowHTTP,
 		SetOutboundHeadersFn: cfg.SetOutboundHeadersFn,
-		StripHeaders:         sensitiveIngressHeaders(cfg.AuthTokenHeader),
+		StripHeaders:         SensitiveIngressHeaders(cfg.AuthTokenHeader),
 		SSRFValidateTarget:   cfg.SSRFValidateTarget,
 		SSRFAllowedHosts:     []string{targetURL.Hostname()},
 		Logger:               cfg.Logger,

--- a/distributions/core-bff/bff/internal/repositories/namespace_mutation.go
+++ b/distributions/core-bff/bff/internal/repositories/namespace_mutation.go
@@ -1,0 +1,105 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// NamespaceMutationRepository handles namespace label/annotation mutations
+// for model serving platform changes. Uses the SA clientset for privileged
+// namespace patches (privileged watcher model).
+type NamespaceMutationRepository struct {
+	saClientset kubernetes.Interface
+	logger      *slog.Logger
+}
+
+func NewNamespaceMutationRepository(saClientset kubernetes.Interface, logger *slog.Logger) *NamespaceMutationRepository {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &NamespaceMutationRepository{saClientset: saClientset, logger: logger}
+}
+
+// ApplyMutation patches a namespace with the appropriate labels/annotations
+// based on the mutation context. Returns {applied: true} on success, or
+// {applied: false} if the patch fails (matching Fastify's failure contract).
+func (r *NamespaceMutationRepository) ApplyMutation(ctx context.Context, namespace string, appCase models.NamespaceApplicationCase, dryRun bool) (*models.NamespaceMutationResponse, error) {
+	patch, err := buildMutationPatch(appCase)
+	if err != nil {
+		return nil, err
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal namespace patch: %w", err)
+	}
+
+	opts := metav1.PatchOptions{}
+	if dryRun {
+		opts.DryRun = []string{metav1.DryRunAll}
+	}
+
+	_, err = r.saClientset.CoreV1().Namespaces().Patch(ctx, namespace, types.MergePatchType, patchBytes, opts)
+	if err != nil {
+		r.logger.Error("failed to patch namespace",
+			slog.String("namespace", namespace),
+			slog.String("context", fmt.Sprintf("%d", appCase)),
+			slog.Any("error", err))
+		return &models.NamespaceMutationResponse{Applied: false}, nil
+	}
+
+	return &models.NamespaceMutationResponse{Applied: true}, nil
+}
+
+type namespacePatch struct {
+	Metadata namespacePatchMetadata `json:"metadata"`
+}
+
+type namespacePatchMetadata struct {
+	Labels      map[string]interface{} `json:"labels,omitempty"`
+	Annotations map[string]interface{} `json:"annotations,omitempty"`
+}
+
+func buildMutationPatch(appCase models.NamespaceApplicationCase) (*namespacePatch, error) {
+	switch appCase {
+	case models.KServePromotion:
+		return &namespacePatch{
+			Metadata: namespacePatchMetadata{
+				Labels: map[string]interface{}{
+					models.LabelModelMeshEnabled: "false",
+				},
+			},
+		}, nil
+
+	case models.KServeNIMPromotion:
+		return &namespacePatch{
+			Metadata: namespacePatchMetadata{
+				Annotations: map[string]interface{}{
+					models.AnnotationNIMSupport: "true",
+				},
+			},
+		}, nil
+
+	case models.ResetModelServingPlatform:
+		return &namespacePatch{
+			Metadata: namespacePatchMetadata{
+				Labels: map[string]interface{}{
+					models.LabelModelMeshEnabled: nil,
+				},
+				Annotations: map[string]interface{}{
+					models.AnnotationNIMSupport: nil,
+				},
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported namespace mutation context: %d", appCase)
+	}
+}

--- a/distributions/core-bff/bff/internal/repositories/namespace_mutation.go
+++ b/distributions/core-bff/bff/internal/repositories/namespace_mutation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,28 +16,24 @@ import (
 // namespace patches (privileged watcher model).
 type NamespaceMutationRepository struct {
 	saClientset kubernetes.Interface
-	logger      *slog.Logger
 }
 
-func NewNamespaceMutationRepository(saClientset kubernetes.Interface, logger *slog.Logger) *NamespaceMutationRepository {
-	if logger == nil {
-		logger = slog.Default()
-	}
-	return &NamespaceMutationRepository{saClientset: saClientset, logger: logger}
+func NewNamespaceMutationRepository(saClientset kubernetes.Interface) *NamespaceMutationRepository {
+	return &NamespaceMutationRepository{saClientset: saClientset}
 }
 
 // ApplyMutation patches a namespace with the appropriate labels/annotations
-// based on the mutation context. Returns {applied: true} on success, or
-// {applied: false} if the patch fails (matching Fastify's failure contract).
-func (r *NamespaceMutationRepository) ApplyMutation(ctx context.Context, namespace string, appCase models.NamespaceApplicationCase, dryRun bool) (*models.NamespaceMutationResponse, error) {
+// based on the mutation context. Returns an error if the patch fails;
+// the caller decides whether to surface or absorb it.
+func (r *NamespaceMutationRepository) ApplyMutation(ctx context.Context, namespace string, appCase models.NamespaceApplicationCase, dryRun bool) error {
 	patch, err := buildMutationPatch(appCase)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	patchBytes, err := json.Marshal(patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal namespace patch: %w", err)
+		return fmt.Errorf("failed to marshal namespace patch: %w", err)
 	}
 
 	opts := metav1.PatchOptions{}
@@ -48,14 +43,10 @@ func (r *NamespaceMutationRepository) ApplyMutation(ctx context.Context, namespa
 
 	_, err = r.saClientset.CoreV1().Namespaces().Patch(ctx, namespace, types.MergePatchType, patchBytes, opts)
 	if err != nil {
-		r.logger.Error("failed to patch namespace",
-			slog.String("namespace", namespace),
-			slog.String("context", fmt.Sprintf("%d", appCase)),
-			slog.Any("error", err))
-		return &models.NamespaceMutationResponse{Applied: false}, nil
+		return fmt.Errorf("failed to patch namespace %q: %w", namespace, err)
 	}
 
-	return &models.NamespaceMutationResponse{Applied: true}, nil
+	return nil
 }
 
 type namespacePatch struct {

--- a/distributions/core-bff/bff/internal/repositories/nim.go
+++ b/distributions/core-bff/bff/internal/repositories/nim.go
@@ -170,6 +170,9 @@ func (r *NIMRepository) DeleteNIMAccount(ctx context.Context, namespace string) 
 }
 
 // manageNIMSecret creates or replaces the NIM access secret.
+// On update, the secret is reset to template state (matching Fastify's blind-replace behavior).
+// This wipes any metadata added by external controllers. If that becomes a problem we can
+// switch to fetch-modify-update in the future.
 func (r *NIMRepository) manageNIMSecret(ctx context.Context, namespace string, data map[string]string) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -190,17 +193,15 @@ func (r *NIMRepository) manageNIMSecret(ctx context.Context, namespace string, d
 		}
 		existing, getErr := r.saClientset.CoreV1().Secrets(namespace).Get(ctx, models.NIMSecretName, metav1.GetOptions{})
 		if getErr != nil {
-			return fmt.Errorf("failed to get existing NIM secret: %w", getErr)
+			return fmt.Errorf("failed to get existing NIM secret for replace: %w", getErr)
 		}
-		existing.Data = nil
-		existing.StringData = data
-		if existing.Annotations == nil {
-			existing.Annotations = make(map[string]string)
+		secret.ResourceVersion = existing.ResourceVersion
+		secret.Annotations = map[string]string{
+			models.NIMForceValidationAnnot: time.Now().UTC().Format(time.RFC3339),
 		}
-		existing.Annotations[models.NIMForceValidationAnnot] = time.Now().UTC().Format(time.RFC3339)
-		_, updateErr := r.saClientset.CoreV1().Secrets(namespace).Update(ctx, existing, metav1.UpdateOptions{})
+		_, updateErr := r.saClientset.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
 		if updateErr != nil {
-			return fmt.Errorf("failed to update NIM secret: %w", updateErr)
+			return fmt.Errorf("failed to replace NIM secret: %w", updateErr)
 		}
 	}
 	return nil

--- a/distributions/core-bff/bff/internal/repositories/nim.go
+++ b/distributions/core-bff/bff/internal/repositories/nim.go
@@ -2,11 +2,11 @@ package repositories
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/k8sutil"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -91,7 +91,7 @@ func (r *NIMRepository) fetchNIMResource(ctx context.Context, resourceType, name
 func (r *NIMRepository) GetNIMStatus(ctx context.Context, namespace string) (*models.NIMIntegrationStatus, error) {
 	account, err := r.GetNIMAccount(ctx, namespace)
 	if err != nil {
-		if k8serrors.IsNotFound(err) || isNIMCRDNotInstalled(err) {
+		if k8serrors.IsNotFound(err) || k8sutil.IsDiscoveryError(err) {
 			return &models.NIMIntegrationStatus{
 				VariablesValidationStatus: "Unknown",
 				CanInstall:                false,
@@ -158,7 +158,7 @@ func (r *NIMRepository) CreateNIMAccount(ctx context.Context, namespace string, 
 func (r *NIMRepository) DeleteNIMAccount(ctx context.Context, namespace string) (*models.NIMDeleteResponse, error) {
 	err := r.saDynClient.Resource(models.NIMAccountGVR).Namespace(namespace).Delete(ctx, models.NIMAccountName, metav1.DeleteOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) || isNIMCRDNotInstalled(err) {
+		if k8serrors.IsNotFound(err) || k8sutil.IsDiscoveryError(err) {
 			return &models.NIMDeleteResponse{
 				Success: false,
 				Error:   "Unable to delete NIM account: the resource was not found",
@@ -249,16 +249,4 @@ func deriveStatusFromAccount(account *unstructured.Unstructured) *models.NIMInte
 	status.CanInstall = !status.IsEnabled
 
 	return status
-}
-
-// isNIMCRDNotInstalled checks if the error indicates the NIM CRD is not installed.
-func isNIMCRDNotInstalled(err error) bool {
-	if err == nil {
-		return false
-	}
-	var statusErr *k8serrors.StatusError
-	if !errors.As(err, &statusErr) {
-		return false
-	}
-	return statusErr.Status().Code == 404
 }

--- a/distributions/core-bff/bff/internal/repositories/nim.go
+++ b/distributions/core-bff/bff/internal/repositories/nim.go
@@ -260,5 +260,5 @@ func isNIMCRDNotInstalled(err error) bool {
 	if !errors.As(err, &statusErr) {
 		return false
 	}
-	return statusErr.Status().Code == 404 && statusErr.Status().Message == "404 page not found"
+	return statusErr.Status().Code == 404
 }

--- a/distributions/core-bff/bff/internal/repositories/nim.go
+++ b/distributions/core-bff/bff/internal/repositories/nim.go
@@ -1,0 +1,264 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+// NIMRepository handles NIM Account CR and related resource operations.
+// Shared by the nim-serving cross-resource lookup and the integrations/nim endpoints.
+type NIMRepository struct {
+	saDynClient dynamic.Interface
+	saClientset kubernetes.Interface
+}
+
+func NewNIMRepository(saDynClient dynamic.Interface, saClientset kubernetes.Interface) *NIMRepository {
+	return &NIMRepository{saDynClient: saDynClient, saClientset: saClientset}
+}
+
+// GetNIMAccount lists NIM Account CRs and returns the first one.
+func (r *NIMRepository) GetNIMAccount(ctx context.Context, namespace string) (*unstructured.Unstructured, error) {
+	list, err := r.saDynClient.Resource(models.NIMAccountGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list NIM accounts: %w", err)
+	}
+	if len(list.Items) == 0 {
+		return nil, nil
+	}
+	return &list.Items[0], nil
+}
+
+// GetNIMServingResource performs the cross-resource lookup for a NIM serving resource.
+// It fetches the NIM Account CR, resolves the resource name from it, then fetches the
+// Secret or ConfigMap.
+func (r *NIMRepository) GetNIMServingResource(ctx context.Context, namespace, nimResource string) (interface{}, error) {
+	mapping, ok := models.NIMResourceMap[nimResource]
+	if !ok {
+		return nil, &models.NIMNotFoundError{Reason: fmt.Sprintf("invalid NIM resource type %q", nimResource)}
+	}
+
+	account, err := r.GetNIMAccount(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get NIM account: %w", err)
+	}
+	if account == nil {
+		return nil, &models.NIMNotFoundError{Reason: fmt.Sprintf("no NIM account found in namespace %q", namespace)}
+	}
+
+	resourceName, found, err := unstructured.NestedString(account.Object, mapping.Path...)
+	if err != nil || !found || resourceName == "" {
+		return nil, &models.NIMNotFoundError{Reason: fmt.Sprintf("resource name not found in NIM account at path %v", mapping.Path)}
+	}
+
+	return r.fetchNIMResource(ctx, mapping.ResourceType, namespace, resourceName)
+}
+
+// fetchNIMResource fetches a Secret or ConfigMap by type and name.
+func (r *NIMRepository) fetchNIMResource(ctx context.Context, resourceType, namespace, name string) (interface{}, error) {
+	var result interface{}
+	var err error
+
+	switch resourceType {
+	case "Secret":
+		result, err = r.saClientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	case "ConfigMap":
+		result, err = r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	default:
+		return nil, fmt.Errorf("unsupported resource type %q", resourceType)
+	}
+
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, &models.NIMNotFoundError{Reason: fmt.Sprintf("%s %q not found", strings.ToLower(resourceType), name)}
+		}
+		return nil, fmt.Errorf("failed to get %s %q: %w", strings.ToLower(resourceType), name, err)
+	}
+	return result, nil
+}
+
+// GetNIMStatus derives the NIM integration status from the Account CR.
+func (r *NIMRepository) GetNIMStatus(ctx context.Context, namespace string) (*models.NIMIntegrationStatus, error) {
+	account, err := r.GetNIMAccount(ctx, namespace)
+	if err != nil {
+		if k8serrors.IsNotFound(err) || isNIMCRDNotInstalled(err) {
+			return &models.NIMIntegrationStatus{
+				VariablesValidationStatus: "Unknown",
+				CanInstall:                false,
+				Error:                     "NIM not installed",
+			}, nil
+		}
+		return &models.NIMIntegrationStatus{
+			VariablesValidationStatus: "Unknown",
+			CanInstall:                false,
+			Error:                     "An unexpected error occurred. Please try again later.",
+		}, nil
+	}
+
+	if account == nil {
+		return &models.NIMIntegrationStatus{
+			CanInstall:                true,
+			VariablesValidationStatus: "Unknown",
+		}, nil
+	}
+
+	return deriveStatusFromAccount(account), nil
+}
+
+// CreateNIMAccount creates or updates the NIM secret and ensures the Account CR exists.
+func (r *NIMRepository) CreateNIMAccount(ctx context.Context, namespace string, secretData map[string]string) (*models.NIMIntegrationStatus, error) {
+	if err := r.manageNIMSecret(ctx, namespace, secretData); err != nil {
+		return nil, fmt.Errorf("failed to manage NIM secret: %w", err)
+	}
+
+	account, err := r.GetNIMAccount(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing NIM account: %w", err)
+	}
+
+	if account == nil {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "nim.opendatahub.io/v1",
+				"kind":       models.NIMAccountKind,
+				"metadata": map[string]interface{}{
+					"name":      models.NIMAccountName,
+					"namespace": namespace,
+					"labels": map[string]interface{}{
+						models.NIMManagedLabel: "true",
+					},
+				},
+				"spec": map[string]interface{}{
+					"apiKeySecret": map[string]interface{}{
+						"name": models.NIMSecretName,
+					},
+				},
+			},
+		}
+		_, err = r.saDynClient.Resource(models.NIMAccountGVR).Namespace(namespace).Create(ctx, obj, metav1.CreateOptions{})
+		if err != nil && !k8serrors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("failed to create NIM account: %w", err)
+		}
+	}
+
+	return r.GetNIMStatus(ctx, namespace)
+}
+
+// DeleteNIMAccount deletes the NIM Account CR.
+func (r *NIMRepository) DeleteNIMAccount(ctx context.Context, namespace string) (*models.NIMDeleteResponse, error) {
+	err := r.saDynClient.Resource(models.NIMAccountGVR).Namespace(namespace).Delete(ctx, models.NIMAccountName, metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) || isNIMCRDNotInstalled(err) {
+			return &models.NIMDeleteResponse{
+				Success: false,
+				Error:   fmt.Sprintf("Unable to delete nim account: %v", err),
+			}, nil
+		}
+		return nil, fmt.Errorf("failed to delete NIM account: %w", err)
+	}
+	return &models.NIMDeleteResponse{Success: true}, nil
+}
+
+// manageNIMSecret creates or replaces the NIM access secret.
+func (r *NIMRepository) manageNIMSecret(ctx context.Context, namespace string, data map[string]string) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      models.NIMSecretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				models.NIMManagedLabel: "true",
+			},
+		},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: data,
+	}
+
+	_, err := r.saClientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create NIM secret: %w", err)
+		}
+		existing, getErr := r.saClientset.CoreV1().Secrets(namespace).Get(ctx, models.NIMSecretName, metav1.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("failed to get existing NIM secret: %w", getErr)
+		}
+		existing.Data = nil
+		existing.StringData = data
+		if existing.Annotations == nil {
+			existing.Annotations = make(map[string]string)
+		}
+		existing.Annotations[models.NIMForceValidationAnnot] = time.Now().UTC().Format(time.RFC3339)
+		_, updateErr := r.saClientset.CoreV1().Secrets(namespace).Update(ctx, existing, metav1.UpdateOptions{})
+		if updateErr != nil {
+			return fmt.Errorf("failed to update NIM secret: %w", updateErr)
+		}
+	}
+	return nil
+}
+
+// deriveStatusFromAccount extracts integration status from the NIM Account CR conditions.
+func deriveStatusFromAccount(account *unstructured.Unstructured) *models.NIMIntegrationStatus {
+	status := &models.NIMIntegrationStatus{
+		IsInstalled:               true,
+		VariablesValidationStatus: "Unknown",
+	}
+
+	conditions, found, _ := unstructured.NestedSlice(account.Object, "status", "conditions")
+	if !found {
+		status.CanInstall = true
+		return status
+	}
+
+	var errorMessages []string
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _, _ := unstructured.NestedString(cond, "type")
+		condStatus, _, _ := unstructured.NestedString(cond, "status")
+		condMessage, _, _ := unstructured.NestedString(cond, "message")
+
+		switch condType {
+		case "AccountStatus":
+			status.IsEnabled = condStatus == "True"
+		case "APIKeyValidation":
+			status.VariablesValidationStatus = condStatus
+		}
+
+		if condStatus != "True" && condMessage != "" {
+			errorMessages = append(errorMessages, condMessage)
+		}
+	}
+	if len(errorMessages) > 0 {
+		status.Error = strings.Join(errorMessages, "; ")
+	}
+
+	lastCheck, _, _ := unstructured.NestedString(account.Object, "status", "lastAccountCheck")
+	status.VariablesValidationTimestamp = lastCheck
+	status.CanInstall = !status.IsEnabled
+
+	return status
+}
+
+// isNIMCRDNotInstalled checks if the error indicates the NIM CRD is not installed.
+func isNIMCRDNotInstalled(err error) bool {
+	if err == nil {
+		return false
+	}
+	var statusErr *k8serrors.StatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	return statusErr.Status().Code == 404 && statusErr.Status().Message == "404 page not found"
+}

--- a/distributions/core-bff/bff/internal/repositories/nim.go
+++ b/distributions/core-bff/bff/internal/repositories/nim.go
@@ -161,7 +161,7 @@ func (r *NIMRepository) DeleteNIMAccount(ctx context.Context, namespace string) 
 		if k8serrors.IsNotFound(err) || isNIMCRDNotInstalled(err) {
 			return &models.NIMDeleteResponse{
 				Success: false,
-				Error:   fmt.Sprintf("Unable to delete nim account: %v", err),
+				Error:   "Unable to delete NIM account: the resource was not found",
 			}, nil
 		}
 		return nil, fmt.Errorf("failed to delete NIM account: %w", err)

--- a/distributions/core-bff/bff/internal/repositories/nim_test.go
+++ b/distributions/core-bff/bff/internal/repositories/nim_test.go
@@ -1,0 +1,119 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func TestDeriveStatusFromAccount_NoConditions(t *testing.T) {
+	account := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "nim.opendatahub.io/v1",
+			"kind":       "Account",
+			"metadata":   map[string]interface{}{"name": "odh-nim-account"},
+		},
+	}
+
+	status := deriveStatusFromAccount(account)
+
+	assert.True(t, status.IsInstalled)
+	assert.False(t, status.IsEnabled)
+	assert.True(t, status.CanInstall)
+	assert.Equal(t, "Unknown", status.VariablesValidationStatus)
+}
+
+func TestDeriveStatusFromAccount_EnabledWithValidKey(t *testing.T) {
+	account := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "nim.opendatahub.io/v1",
+			"kind":       "Account",
+			"metadata":   map[string]interface{}{"name": "odh-nim-account"},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "AccountStatus",
+						"status": "True",
+					},
+					map[string]interface{}{
+						"type":   "APIKeyValidation",
+						"status": "True",
+					},
+				},
+				"lastAccountCheck": "2025-01-15T10:00:00Z",
+			},
+		},
+	}
+
+	status := deriveStatusFromAccount(account)
+
+	assert.True(t, status.IsInstalled)
+	assert.True(t, status.IsEnabled)
+	assert.False(t, status.CanInstall)
+	assert.Equal(t, "True", status.VariablesValidationStatus)
+	assert.Equal(t, "2025-01-15T10:00:00Z", status.VariablesValidationTimestamp)
+	assert.Empty(t, status.Error)
+}
+
+func TestDeriveStatusFromAccount_DisabledWithError(t *testing.T) {
+	account := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "nim.opendatahub.io/v1",
+			"kind":       "Account",
+			"metadata":   map[string]interface{}{"name": "odh-nim-account"},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":    "AccountStatus",
+						"status":  "False",
+						"message": "API key expired",
+					},
+					map[string]interface{}{
+						"type":   "APIKeyValidation",
+						"status": "False",
+					},
+				},
+			},
+		},
+	}
+
+	status := deriveStatusFromAccount(account)
+
+	assert.True(t, status.IsInstalled)
+	assert.False(t, status.IsEnabled)
+	assert.True(t, status.CanInstall)
+	assert.Equal(t, "False", status.VariablesValidationStatus)
+	assert.Equal(t, "API key expired", status.Error)
+}
+
+func TestIsNIMCRDNotInstalled_NilError(t *testing.T) {
+	assert.False(t, isNIMCRDNotInstalled(nil))
+}
+
+func TestIsNIMCRDNotInstalled_MatchingError(t *testing.T) {
+	err := &k8serrors.StatusError{
+		ErrStatus: metav1.Status{
+			Code:    404,
+			Message: "404 page not found",
+		},
+	}
+	assert.True(t, isNIMCRDNotInstalled(err))
+}
+
+func TestIsNIMCRDNotInstalled_DifferentNotFound(t *testing.T) {
+	err := &k8serrors.StatusError{
+		ErrStatus: metav1.Status{
+			Code:    404,
+			Message: "accounts.nim.opendatahub.io not found",
+		},
+	}
+	assert.False(t, isNIMCRDNotInstalled(err))
+}
+
+func TestIsNIMCRDNotInstalled_NonStatusError(t *testing.T) {
+	assert.False(t, isNIMCRDNotInstalled(assert.AnError))
+}

--- a/distributions/core-bff/bff/internal/repositories/nim_test.go
+++ b/distributions/core-bff/bff/internal/repositories/nim_test.go
@@ -104,14 +104,14 @@ func TestIsNIMCRDNotInstalled_MatchingError(t *testing.T) {
 	assert.True(t, isNIMCRDNotInstalled(err))
 }
 
-func TestIsNIMCRDNotInstalled_DifferentNotFound(t *testing.T) {
+func TestIsNIMCRDNotInstalled_Any404(t *testing.T) {
 	err := &k8serrors.StatusError{
 		ErrStatus: metav1.Status{
 			Code:    404,
 			Message: "accounts.nim.opendatahub.io not found",
 		},
 	}
-	assert.False(t, isNIMCRDNotInstalled(err))
+	assert.True(t, isNIMCRDNotInstalled(err))
 }
 
 func TestIsNIMCRDNotInstalled_NonStatusError(t *testing.T) {

--- a/distributions/core-bff/bff/internal/repositories/nim_test.go
+++ b/distributions/core-bff/bff/internal/repositories/nim_test.go
@@ -4,10 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func TestDeriveStatusFromAccount_NoConditions(t *testing.T) {
@@ -88,32 +85,4 @@ func TestDeriveStatusFromAccount_DisabledWithError(t *testing.T) {
 	assert.True(t, status.CanInstall)
 	assert.Equal(t, "False", status.VariablesValidationStatus)
 	assert.Equal(t, "API key expired", status.Error)
-}
-
-func TestIsNIMCRDNotInstalled_NilError(t *testing.T) {
-	assert.False(t, isNIMCRDNotInstalled(nil))
-}
-
-func TestIsNIMCRDNotInstalled_MatchingError(t *testing.T) {
-	err := &k8serrors.StatusError{
-		ErrStatus: metav1.Status{
-			Code:    404,
-			Message: "404 page not found",
-		},
-	}
-	assert.True(t, isNIMCRDNotInstalled(err))
-}
-
-func TestIsNIMCRDNotInstalled_Any404(t *testing.T) {
-	err := &k8serrors.StatusError{
-		ErrStatus: metav1.Status{
-			Code:    404,
-			Message: "accounts.nim.opendatahub.io not found",
-		},
-	}
-	assert.True(t, isNIMCRDNotInstalled(err))
-}
-
-func TestIsNIMCRDNotInstalled_NonStatusError(t *testing.T) {
-	assert.False(t, isNIMCRDNotInstalled(assert.AnError))
 }

--- a/distributions/core-bff/bff/internal/repositories/prometheus.go
+++ b/distributions/core-bff/bff/internal/repositories/prometheus.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
 )
@@ -37,11 +38,13 @@ func NewPrometheusRepository(cfg PrometheusConfig) *PrometheusRepository {
 
 	tlsConfig := &tls.Config{
 		RootCAs:            cfg.RootCAs,
-		InsecureSkipVerify: cfg.InsecureSkipVerify, //nolint:gosec // configurable for dev mode
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: cfg.InsecureSkipVerify, //nolint:gosec // gated to dev/mock mode at call site (app.go)
 	}
 
 	return &PrometheusRepository{
 		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
 				TLSClientConfig: tlsConfig,
 			},
@@ -79,7 +82,8 @@ func (r *PrometheusRepository) Query(ctx context.Context, token, query, queryTyp
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	const maxPrometheusBodyBytes = 10 << 20 // 10 MiB
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPrometheusBodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch prometheus data, failed to read response: %w", err)
 	}

--- a/distributions/core-bff/bff/internal/repositories/prometheus.go
+++ b/distributions/core-bff/bff/internal/repositories/prometheus.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"time"
 
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
 )
 
@@ -23,6 +24,11 @@ type PrometheusConfig struct {
 	RootCAs            *x509.CertPool
 	InsecureSkipVerify bool
 }
+
+const (
+	maxPrometheusBodyBytes = 10 << 20 // 10 MiB
+	prometheusStatusError  = "error"
+)
 
 // PrometheusRepository handles Prometheus/Thanos query operations.
 type PrometheusRepository struct {
@@ -74,7 +80,7 @@ func (r *PrometheusRepository) Query(ctx context.Context, token, query, queryTyp
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Prometheus request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", k8s.BearerTokenPrefix+token)
 
 	resp, err := r.httpClient.Do(req)
 	if err != nil {
@@ -82,7 +88,6 @@ func (r *PrometheusRepository) Query(ctx context.Context, token, query, queryTyp
 	}
 	defer resp.Body.Close()
 
-	const maxPrometheusBodyBytes = 10 << 20 // 10 MiB
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPrometheusBodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch prometheus data, failed to read response: %w", err)
@@ -100,7 +105,7 @@ func (r *PrometheusRepository) Query(ctx context.Context, token, query, queryTyp
 		return nil, &models.PrometheusUnparsableError{Reason: err.Error()}
 	}
 
-	if parsed.Status == "error" {
+	if parsed.Status == prometheusStatusError {
 		return nil, &models.PrometheusQueryError{Message: parsed.Error}
 	}
 

--- a/distributions/core-bff/bff/internal/repositories/prometheus.go
+++ b/distributions/core-bff/bff/internal/repositories/prometheus.go
@@ -1,0 +1,107 @@
+package repositories
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+)
+
+// PrometheusConfig holds configuration for creating a PrometheusRepository.
+type PrometheusConfig struct {
+	Host               string
+	Namespace          string
+	Instance           string
+	Port               string
+	RootCAs            *x509.CertPool
+	InsecureSkipVerify bool
+}
+
+// PrometheusRepository handles Prometheus/Thanos query operations.
+type PrometheusRepository struct {
+	httpClient *http.Client
+	host       string
+}
+
+func NewPrometheusRepository(cfg PrometheusConfig) *PrometheusRepository {
+	host := cfg.Host
+	if host == "" && cfg.Instance != "" && cfg.Namespace != "" && cfg.Port != "" {
+		host = fmt.Sprintf("https://%s.%s.svc.cluster.local:%s", cfg.Instance, cfg.Namespace, cfg.Port)
+	}
+
+	tlsConfig := &tls.Config{
+		RootCAs:            cfg.RootCAs,
+		InsecureSkipVerify: cfg.InsecureSkipVerify, //nolint:gosec // configurable for dev mode
+	}
+
+	return &PrometheusRepository{
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		},
+		host: host,
+	}
+}
+
+// Query executes a Prometheus query and returns the response.
+// queryType should be "query" for instant or "query_range" for range queries.
+func (r *PrometheusRepository) Query(ctx context.Context, token, query, queryType string) (*models.PrometheusQueryResponse, error) {
+	if r.host == "" {
+		return nil, &models.PrometheusUnavailableError{Reason: "no Prometheus host configured"}
+	}
+
+	u, err := url.Parse(fmt.Sprintf("%s/api/v1/%s", r.host, queryType))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Prometheus URL: %w", err)
+	}
+	vals, err := url.ParseQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query parameters: %w", err)
+	}
+	u.RawQuery = vals.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Prometheus request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, &models.PrometheusUnavailableError{Reason: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch prometheus data, failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &models.PrometheusUpstreamError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+
+	var parsed struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, &models.PrometheusUnparsableError{Reason: err.Error()}
+	}
+
+	if parsed.Status == "error" {
+		return nil, &models.PrometheusQueryError{Message: parsed.Error}
+	}
+
+	return &models.PrometheusQueryResponse{
+		Code:     resp.StatusCode,
+		Response: json.RawMessage(body),
+	}, nil
+}

--- a/distributions/core-bff/bff/internal/repositories/prometheus_test.go
+++ b/distributions/core-bff/bff/internal/repositories/prometheus_test.go
@@ -1,0 +1,147 @@
+package repositories
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrometheusQuery_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/query")
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "up", r.URL.Query().Get("query"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	repo := NewPrometheusRepository(PrometheusConfig{Host: srv.URL})
+	resp, err := repo.Query(context.Background(), "test-token", "query=up", "query")
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Contains(t, string(resp.Response), "success")
+}
+
+func TestPrometheusQuery_RangeQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/api/v1/query_range")
+		assert.Equal(t, "rate(up[5m])", r.URL.Query().Get("query"))
+		assert.Equal(t, "1234", r.URL.Query().Get("start"))
+		assert.Equal(t, "5678", r.URL.Query().Get("end"))
+		assert.Equal(t, "30", r.URL.Query().Get("step"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{}}`))
+	}))
+	defer srv.Close()
+
+	repo := NewPrometheusRepository(PrometheusConfig{Host: srv.URL})
+	resp, err := repo.Query(context.Background(), "test-token", "query=rate(up[5m])&start=1234&end=5678&step=30", "query_range")
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestPrometheusQuery_SpecialCharsEncoded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, `sum(kube_pod_owner{owner_kind=~"RayCluster|Job", namespace="test"})`, r.URL.Query().Get("query"))
+		assert.Equal(t, "test", r.URL.Query().Get("namespace"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{}}`))
+	}))
+	defer srv.Close()
+
+	repo := NewPrometheusRepository(PrometheusConfig{Host: srv.URL})
+	resp, err := repo.Query(context.Background(), "test-token",
+		`namespace=test&query=sum(kube_pod_owner{owner_kind=~"RayCluster|Job", namespace="test"})`, "query")
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestPrometheusQuery_NoHost(t *testing.T) {
+	repo := NewPrometheusRepository(PrometheusConfig{})
+	resp, err := repo.Query(context.Background(), "test-token", "up", "query")
+
+	assert.Nil(t, resp)
+	require.Error(t, err)
+	var unavailable *models.PrometheusUnavailableError
+	assert.ErrorAs(t, err, &unavailable)
+}
+
+func TestPrometheusQuery_HostFromComponents(t *testing.T) {
+	repo := NewPrometheusRepository(PrometheusConfig{
+		Namespace: "openshift-monitoring",
+		Instance:  "thanos-querier",
+		Port:      "9092",
+	})
+	assert.Equal(t, "https://thanos-querier.openshift-monitoring.svc.cluster.local:9092", repo.host)
+}
+
+func TestPrometheusQuery_UpstreamNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`Forbidden`))
+	}))
+	defer srv.Close()
+
+	repo := NewPrometheusRepository(PrometheusConfig{Host: srv.URL})
+	resp, err := repo.Query(context.Background(), "test-token", "query=up", "query")
+
+	assert.Nil(t, resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 403")
+}
+
+func TestPrometheusQuery_UnparsableJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(`not json at all`))
+	}))
+	defer srv.Close()
+
+	repo := NewPrometheusRepository(PrometheusConfig{Host: srv.URL})
+	resp, err := repo.Query(context.Background(), "test-token", "query=up", "query")
+
+	assert.Nil(t, resp)
+	require.Error(t, err)
+	var unparsable *models.PrometheusUnparsableError
+	assert.ErrorAs(t, err, &unparsable)
+}
+
+func TestPrometheusQuery_ConnectionRefused(t *testing.T) {
+	repo := NewPrometheusRepository(PrometheusConfig{Host: "http://127.0.0.1:1"})
+	resp, err := repo.Query(context.Background(), "test-token", "query=up", "query")
+
+	assert.Nil(t, resp)
+	require.Error(t, err)
+	var unavailable *models.PrometheusUnavailableError
+	assert.ErrorAs(t, err, &unavailable)
+}
+
+func TestPrometheusQuery_StatusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"error","error":"bad PromQL expression"}`))
+	}))
+	defer srv.Close()
+
+	repo := NewPrometheusRepository(PrometheusConfig{Host: srv.URL})
+	resp, err := repo.Query(context.Background(), "test-token", "query=up", "query")
+
+	assert.Nil(t, resp)
+	require.Error(t, err)
+	var queryErr *models.PrometheusQueryError
+	assert.ErrorAs(t, err, &queryErr)
+	assert.Equal(t, "bad PromQL expression", queryErr.Message)
+}

--- a/distributions/core-bff/bff/internal/repositories/repositories.go
+++ b/distributions/core-bff/bff/internal/repositories/repositories.go
@@ -2,6 +2,8 @@
 package repositories
 
 import (
+	"log/slog"
+
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/config"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -9,16 +11,20 @@ import (
 
 // Repositories is a convenient container that holds all repository instances.
 type Repositories struct {
-	HealthCheck     *HealthCheckRepository
-	User            *UserRepository
-	Namespace       *NamespaceRepository
-	DashboardConfig *DashboardConfigRepository
-	Status          *StatusRepository
-	Auth            *AuthRepository
-	Components      *ComponentsRepository
-	ClusterSettings *ClusterSettingsRepository
-	ConnectionType  *ConnectionTypeRepository
-	AllowedUsers    *AllowedUsersRepository
+	HealthCheck       *HealthCheckRepository
+	User              *UserRepository
+	Namespace         *NamespaceRepository
+	DashboardConfig   *DashboardConfigRepository
+	Status            *StatusRepository
+	Auth              *AuthRepository
+	Components        *ComponentsRepository
+	ClusterSettings   *ClusterSettingsRepository
+	ConnectionType    *ConnectionTypeRepository
+	AllowedUsers      *AllowedUsersRepository
+	ServingRuntime    *ServingRuntimeRepository
+	NIM               *NIMRepository
+	NamespaceMutation *NamespaceMutationRepository
+	Prometheus        *PrometheusRepository
 }
 
 // RepositoriesConfig holds the dependencies needed to construct all repositories.
@@ -29,21 +35,27 @@ type RepositoriesConfig struct {
 	SADynClient dynamic.Interface
 	SAClientset kubernetes.Interface
 	Namespace   string
+	Prometheus  PrometheusConfig
+	Logger      *slog.Logger
 }
 
 // NewRepositories creates a new Repositories instance with all repositories initialized.
 func NewRepositories(cfg RepositoriesConfig) *Repositories {
 	auth := NewAuthRepository(cfg.SADynClient)
 	return &Repositories{
-		HealthCheck:     NewHealthCheckRepository(),
-		User:            NewUserRepository(),
-		Namespace:       NewNamespaceRepository(),
-		DashboardConfig: NewDashboardConfigRepository(cfg.Platform, cfg.SADynClient),
-		Status:          NewStatusRepository(cfg.SADynClient, cfg.Namespace, auth),
-		Auth:            auth,
-		Components:      NewComponentsRepository(cfg.SADynClient, cfg.SAClientset),
-		ClusterSettings: NewClusterSettingsRepository(cfg.SAClientset),
-		ConnectionType:  NewConnectionTypeRepository(cfg.SAClientset),
-		AllowedUsers:    NewAllowedUsersRepository(cfg.SADynClient),
+		HealthCheck:       NewHealthCheckRepository(),
+		User:              NewUserRepository(),
+		Namespace:         NewNamespaceRepository(),
+		DashboardConfig:   NewDashboardConfigRepository(cfg.Platform, cfg.SADynClient),
+		Status:            NewStatusRepository(cfg.SADynClient, cfg.Namespace, auth),
+		Auth:              auth,
+		Components:        NewComponentsRepository(cfg.SADynClient, cfg.SAClientset),
+		ClusterSettings:   NewClusterSettingsRepository(cfg.SAClientset),
+		ConnectionType:    NewConnectionTypeRepository(cfg.SAClientset),
+		AllowedUsers:      NewAllowedUsersRepository(cfg.SADynClient),
+		ServingRuntime:    NewServingRuntimeRepository(cfg.SADynClient),
+		NIM:               NewNIMRepository(cfg.SADynClient, cfg.SAClientset),
+		NamespaceMutation: NewNamespaceMutationRepository(cfg.SAClientset, cfg.Logger),
+		Prometheus:        NewPrometheusRepository(cfg.Prometheus),
 	}
 }

--- a/distributions/core-bff/bff/internal/repositories/repositories.go
+++ b/distributions/core-bff/bff/internal/repositories/repositories.go
@@ -2,8 +2,6 @@
 package repositories
 
 import (
-	"log/slog"
-
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/config"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -36,7 +34,6 @@ type RepositoriesConfig struct {
 	SAClientset kubernetes.Interface
 	Namespace   string
 	Prometheus  PrometheusConfig
-	Logger      *slog.Logger
 }
 
 // NewRepositories creates a new Repositories instance with all repositories initialized.
@@ -55,7 +52,7 @@ func NewRepositories(cfg RepositoriesConfig) *Repositories {
 		AllowedUsers:      NewAllowedUsersRepository(cfg.SADynClient),
 		ServingRuntime:    NewServingRuntimeRepository(cfg.SADynClient),
 		NIM:               NewNIMRepository(cfg.SADynClient, cfg.SAClientset),
-		NamespaceMutation: NewNamespaceMutationRepository(cfg.SAClientset, cfg.Logger),
+		NamespaceMutation: NewNamespaceMutationRepository(cfg.SAClientset),
 		Prometheus:        NewPrometheusRepository(cfg.Prometheus),
 	}
 }

--- a/distributions/core-bff/bff/internal/repositories/serving_runtime.go
+++ b/distributions/core-bff/bff/internal/repositories/serving_runtime.go
@@ -1,0 +1,36 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// ServingRuntimeRepository handles creation of ServingRuntime CRs.
+// Uses the SA dynamic client for privileged operations.
+type ServingRuntimeRepository struct {
+	saDynClient dynamic.Interface
+}
+
+func NewServingRuntimeRepository(saDynClient dynamic.Interface) *ServingRuntimeRepository {
+	return &ServingRuntimeRepository{saDynClient: saDynClient}
+}
+
+// Create creates a ServingRuntime CR in the given namespace.
+// dryRun can be "All" to validate without persisting.
+func (r *ServingRuntimeRepository) Create(ctx context.Context, namespace string, obj *unstructured.Unstructured, dryRun string) (*unstructured.Unstructured, error) {
+	opts := metav1.CreateOptions{}
+	if dryRun != "" {
+		opts.DryRun = []string{dryRun}
+	}
+
+	result, err := r.saDynClient.Resource(models.ServingRuntimeGVR).Namespace(namespace).Create(ctx, obj, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ServingRuntime in namespace %q: %w", namespace, err)
+	}
+	return result, nil
+}

--- a/distributions/core-bff/bff/openapi/src/core-bff.yaml
+++ b/distributions/core-bff/bff/openapi/src/core-bff.yaml
@@ -310,7 +310,7 @@ paths:
       tags:
         - Status
       operationId: getAllowedUsers
-      summary: List users with notebook access in a namespace (admin)
+      summary: List users with notebook access in a namespace (admin, OpenShift-only)
       parameters:
         - name: namespace
           in: path
@@ -647,8 +647,9 @@ paths:
       tags:
         - NIM Serving
       operationId: getNIMServingResource
-      summary: Get a NIM-related K8s resource by cross-resource lookup
+      summary: Get a NIM-related K8s resource by cross-resource lookup (OpenShift-only)
       description: >-
+        OpenShift-only. Returns 404 on non-OpenShift platforms.
         Fetches the NIM Account CR, resolves the resource name from it using the
         nimResource parameter, then fetches and returns the Secret or ConfigMap.
       parameters:
@@ -932,8 +933,9 @@ paths:
       tags:
         - NIM Integration
       operationId: getNIMIntegrationStatus
-      summary: Get NIM integration status
+      summary: Get NIM integration status (OpenShift-only)
       description: >-
+        OpenShift-only. Returns 404 on non-OpenShift platforms.
         Returns the NIM integration status derived from the Account CR conditions.
         Reports installation state, enablement, API key validation, and errors.
       responses:
@@ -949,8 +951,9 @@ paths:
       tags:
         - NIM Integration
       operationId: createNIMIntegration
-      summary: Create or enable NIM integration (admin)
+      summary: Create or enable NIM integration (admin, OpenShift-only)
       description: >-
+        OpenShift-only. Returns 404 on non-OpenShift platforms.
         Creates or updates the NIM access secret and ensures the Account CR exists.
         Returns the updated integration status.
       requestBody:
@@ -983,8 +986,10 @@ paths:
       tags:
         - NIM Integration
       operationId: deleteNIMIntegration
-      summary: Delete NIM integration (admin)
-      description: Deletes the NIM Account CR.
+      summary: Delete NIM integration (admin, OpenShift-only)
+      description: >-
+        OpenShift-only. Returns 404 on non-OpenShift platforms.
+        Deletes the NIM Account CR.
       responses:
         '200':
           description: Deletion result

--- a/distributions/core-bff/bff/openapi/src/core-bff.yaml
+++ b/distributions/core-bff/bff/openapi/src/core-bff.yaml
@@ -599,6 +599,406 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/servingRuntimes:
+    post:
+      tags:
+        - Model Serving
+      operationId: createServingRuntime
+      summary: Create a ServingRuntime CR (admin)
+      description: >-
+        Creates a KServe ServingRuntime custom resource in the specified namespace.
+        The namespace is extracted from metadata.namespace in the request body and
+        validated against the allowed namespace list (dashboard and workbench namespaces only).
+      parameters:
+        - name: dryRun
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [All]
+          description: Set to "All" to validate without persisting
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Unstructured ServingRuntime CR JSON
+      responses:
+        '200':
+          description: Created ServingRuntime CR
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/BFFForbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/nim-serving/{nimResource}:
+    get:
+      tags:
+        - NIM Serving
+      operationId: getNIMServingResource
+      summary: Get a NIM-related K8s resource by cross-resource lookup
+      description: >-
+        Fetches the NIM Account CR, resolves the resource name from it using the
+        nimResource parameter, then fetches and returns the Secret or ConfigMap.
+      parameters:
+        - name: nimResource
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [apiKeySecret, nimPullSecret, nimConfig]
+          description: The NIM resource type to look up
+      responses:
+        '200':
+          description: Resolved NIM resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NIMServingResourceResponse'
+        '404':
+          $ref: '#/components/responses/BFFNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/service/model-serving/{path}:
+    summary: Model serving service proxy
+    description: >-
+      Proxies all HTTP methods to the model-serving-api service. Strips the
+      /api/service/model-serving prefix and forwards the remaining path,
+      including nested segments (e.g. /api/service/model-serving/a/b/c).
+      OpenAPI 3.0 cannot represent multi-segment path parameters; the actual
+      route is a wildcard prefix match, not a single-segment capture.
+      The user's bearer token is injected as the Authorization header.
+      Responses depend on the upstream model serving service.
+    parameters:
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+        description: >-
+          Remainder of the URL after /api/service/model-serving/, including
+          any nested segments. Forwarded verbatim to the upstream service.
+    get:
+      tags:
+        - Model Serving Proxy
+      operationId: modelServingProxyGet
+      summary: Proxy GET to model serving service
+      responses:
+        '200':
+          description: Upstream response (passthrough)
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
+          $ref: '#/components/responses/BadGateway'
+    post:
+      tags:
+        - Model Serving Proxy
+      operationId: modelServingProxyPost
+      summary: Proxy POST to model serving service
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Upstream response (passthrough)
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
+          $ref: '#/components/responses/BadGateway'
+    put:
+      tags:
+        - Model Serving Proxy
+      operationId: modelServingProxyPut
+      summary: Proxy PUT to model serving service
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Upstream response (passthrough)
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
+          $ref: '#/components/responses/BadGateway'
+    delete:
+      tags:
+        - Model Serving Proxy
+      operationId: modelServingProxyDelete
+      summary: Proxy DELETE to model serving service
+      responses:
+        '200':
+          description: Upstream response (passthrough)
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
+          $ref: '#/components/responses/BadGateway'
+    patch:
+      tags:
+        - Model Serving Proxy
+      operationId: modelServingProxyPatch
+      summary: Proxy PATCH to model serving service
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Upstream response (passthrough)
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
+          $ref: '#/components/responses/BadGateway'
+
+  /api/prometheus/{queryType}:
+    post:
+      tags:
+        - Prometheus
+      operationId: prometheusQuery
+      summary: Proxy a PromQL query to Prometheus/Thanos
+      description: >-
+        Accepts a POST with a query string, transforms it into a GET request to
+        the configured Prometheus/Thanos endpoint. Supports instant queries (query, pvc)
+        and range queries (queryRange, bias, serving).
+      parameters:
+        - name: queryType
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [query, queryRange, pvc, bias, serving]
+          description: >-
+            The Prometheus query sub-path. "query" and "pvc" map to instant queries;
+            "queryRange", "bias", and "serving" map to range queries.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PrometheusQueryRequest'
+      responses:
+        '200':
+          description: Prometheus query result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrometheusQueryResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '400':
+          description: Empty or invalid query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrometheusQueryResponse'
+              example:
+                code: 400
+                response: 'Failed to provide a query'
+        '422':
+          description: Unparsable Prometheus response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrometheusQueryResponse'
+              example:
+                code: 422
+                response: 'Unprocessable prometheus response'
+        '500':
+          description: Internal server error or upstream Prometheus 500
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrometheusQueryResponse'
+              example:
+                code: 500
+                response: 'Cannot fetch prometheus data'
+        '502':
+          description: Upstream Prometheus returned an error (bad gateway)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrometheusQueryResponse'
+              example:
+                code: 502
+                response: 'Cannot fetch prometheus data, upstream returned 502'
+        '503':
+          description: Prometheus service unavailable (e.g. no host configured or unreachable)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrometheusQueryResponse'
+              example:
+                code: 503
+                response: 'Prometheus service is not available'
+        '504':
+          description: Upstream Prometheus timed out (gateway timeout)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrometheusQueryResponse'
+              example:
+                code: 504
+                response: 'Cannot fetch prometheus data, upstream returned 504'
+
+  /api/namespaces/{name}/{context}:
+    get:
+      tags:
+        - Namespaces
+      operationId: mutateNamespaceServingPlatform
+      summary: Mutate namespace serving platform labels/annotations
+      description: >-
+        Applies model-serving-platform label/annotation mutations to a namespace.
+        Context 1 (KSERVE_PROMOTION) sets label modelmesh-enabled=false.
+        Context 2 (KSERVE_NIM_PROMOTION) sets annotation opendatahub.io/nim-support=true.
+        Context 3 (RESET) removes both.
+        Context 0 (DSG_CREATION) is not supported in RHAII and returns 400.
+        Requires SSAR permission: create on serving.kserve.io/servingruntimes.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Kubernetes namespace name
+        - name: context
+          in: path
+          required: true
+          schema:
+            type: integer
+            enum: [0, 1, 2, 3]
+          description: >-
+            Namespace mutation context.
+            0=DSG_CREATION (returns 400 on RHAII),
+            1=KSERVE_PROMOTION,
+            2=KSERVE_NIM_PROMOTION,
+            3=RESET_MODEL_SERVING_PLATFORM
+        - name: dryRun
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [All]
+          description: Set to "All" to validate without persisting
+      responses:
+        '200':
+          $ref: '#/components/responses/NamespaceMutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/BFFForbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/integrations/nim:
+    get:
+      tags:
+        - NIM Integration
+      operationId: getNIMIntegrationStatus
+      summary: Get NIM integration status
+      description: >-
+        Returns the NIM integration status derived from the Account CR conditions.
+        Reports installation state, enablement, API key validation, and errors.
+      responses:
+        '200':
+          description: NIM integration status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NIMIntegrationStatus'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - NIM Integration
+      operationId: createNIMIntegration
+      summary: Create or enable NIM integration (admin)
+      description: >-
+        Creates or updates the NIM access secret and ensures the Account CR exists.
+        Returns the updated integration status.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+              description: Key-value pairs for the NIM access secret stringData
+              example:
+                api_key: 'nvapi-xxxx'
+      responses:
+        '200':
+          description: Updated NIM integration status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NIMIntegrationStatus'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/BFFForbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - NIM Integration
+      operationId: deleteNIMIntegration
+      summary: Delete NIM integration (admin)
+      description: Deletes the NIM Account CR.
+      responses:
+        '200':
+          description: Deletion result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NIMDeleteResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/BFFForbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
 components:
   schemas:
     HealthCheckResponse:
@@ -793,6 +1193,97 @@ components:
         error:
           type: string
 
+    NIMServingResourceResponse:
+      type: object
+      required:
+        - body
+      properties:
+        body:
+          type: object
+          description: The resolved Secret or ConfigMap object
+
+    NIMIntegrationStatus:
+      type: object
+      required:
+        - isInstalled
+        - isEnabled
+        - variablesValidationStatus
+        - variablesValidationTimestamp
+        - canInstall
+        - error
+      properties:
+        isInstalled:
+          type: boolean
+          example: true
+        isEnabled:
+          type: boolean
+          example: true
+        variablesValidationStatus:
+          type: string
+          example: 'True'
+          description: APIKeyValidation condition status (True, False, Unknown)
+        variablesValidationTimestamp:
+          type: string
+          example: '2024-01-01T00:00:00Z'
+        canInstall:
+          type: boolean
+          example: false
+        error:
+          type: string
+          example: ''
+
+    NamespaceMutationResponse:
+      type: object
+      required:
+        - applied
+      properties:
+        applied:
+          type: boolean
+          description: Whether the mutation was applied
+
+    NIMDeleteResponse:
+      type: object
+      required:
+        - success
+        - error
+      properties:
+        success:
+          type: boolean
+        error:
+          type: string
+
+    PrometheusQueryRequest:
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          description: >-
+            URL-encoded query string forwarded to the Prometheus API.
+            The frontend assembles all parameters (query, namespace,
+            start, end, step) via URLSearchParams and sends the result
+            as a single string.
+          example: 'query=up{job="apiserver"}'
+
+    PrometheusQueryResponse:
+      type: object
+      required:
+        - code
+        - response
+      properties:
+        code:
+          type: integer
+          description: HTTP status code
+          example: 200
+        response:
+          description: Parsed Prometheus JSON response or error message
+          example:
+            status: 'success'
+            data:
+              resultType: 'vector'
+              result: []
+
   responses:
     HealthCheckResponse:
       description: Service is healthy
@@ -853,6 +1344,13 @@ components:
             type: array
             items:
               type: object
+
+    NamespaceMutationResponse:
+      description: Namespace mutation result
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NamespaceMutationResponse'
 
     BadRequest:
       description: Bad request
@@ -918,6 +1416,39 @@ components:
           schema:
             type: string
           example: 'Bad Gateway'
+
+    BFFForbidden:
+      description: Access forbidden (authenticated but not admin)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: 'FORBIDDEN'
+              message: 'admin access required'
+
+    BFFNotFound:
+      description: Resource not found (BFF JSON envelope)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: 'NOT_FOUND'
+              message: 'the requested resource could not be found'
+
+    Conflict:
+      description: Resource already exists or update conflict
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: 'AlreadyExists'
+              message: 'servingruntime.serving.kserve.io "my-runtime" already exists'
 
     InternalServerError:
       description: Internal server error

--- a/distributions/core-bff/bff/openapi/src/core-bff.yaml
+++ b/distributions/core-bff/bff/openapi/src/core-bff.yaml
@@ -4,7 +4,7 @@ openapi: '3.0.3'
 info:
   title: 'Core BFF REST API'
   version: '1.0.0'
-  description: 'REST API for the Core Backend for Frontend (BFF). Replaces Fastify across RHOAI (sidecar) and RHAII (standalone) deployments.'
+  description: 'REST API for the Core Backend for Frontend (BFF). Replaces Fastify across sidecar and standalone deployments.'
   license:
     name: 'Apache 2.0'
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
@@ -263,7 +263,7 @@ paths:
         - Components
       operationId: getComponents
       summary: List OdhApplication components
-      description: Returns OdhApplication CRDs. Returns empty array when CRD is absent (RHAII).
+      description: Returns OdhApplication CRDs. Returns empty array when CRD is absent.
       parameters:
         - name: installed
           in: query
@@ -888,7 +888,7 @@ paths:
         Context 1 (KSERVE_PROMOTION) sets label modelmesh-enabled=false.
         Context 2 (KSERVE_NIM_PROMOTION) sets annotation opendatahub.io/nim-support=true.
         Context 3 (RESET) removes both.
-        Context 0 (DSG_CREATION) is not supported in RHAII and returns 400.
+        Context 0 (DSG_CREATION) is not supported and returns 400.
         Requires SSAR permission: create on serving.kserve.io/servingruntimes.
       parameters:
         - name: name
@@ -905,7 +905,7 @@ paths:
             enum: [0, 1, 2, 3]
           description: >-
             Namespace mutation context.
-            0=DSG_CREATION (returns 400 on RHAII),
+            0=DSG_CREATION (returns 400, not supported),
             1=KSERVE_PROMOTION,
             2=KSERVE_NIM_PROMOTION,
             3=RESET_MODEL_SERVING_PLATFORM

--- a/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffModelServing.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffModelServing.test.ts
@@ -93,29 +93,6 @@ describe('Core BFF Model Serving', () => {
     });
   });
 
-  const prometheusRoutes = ['query', 'queryRange', 'pvc', 'bias', 'serving'];
-
-  describe.each(prometheusRoutes)('Prometheus %s POST', (route) => {
-    it('should return 400 for empty query', async () => {
-      expectError(await apiClient.post(`/api/prometheus/${route}`, { query: '' }), 400);
-    });
-
-    it('should return 401 when no auth token is provided', async () => {
-      expectError(
-        await unauthenticatedClient.post(`/api/prometheus/${route}`, { query: 'query=up' }),
-        401,
-      );
-    });
-
-    it('should return 200 with PrometheusQueryResponse schema', async () => {
-      const result = await apiClient.post(`/api/prometheus/${route}`, { query: 'query=up' });
-      expect(result).toMatchContract(apiSchema, {
-        ref: '#/components/schemas/PrometheusQueryResponse',
-        status: 200,
-      });
-    });
-  });
-
   describe('Namespace Mutation GET', () => {
     it('should return 401 when no auth token is provided', async () => {
       expectError(await unauthenticatedClient.get('/api/namespaces/test-ns/1'), 401);

--- a/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffModelServing.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffModelServing.test.ts
@@ -89,15 +89,11 @@ describe('Core BFF Model Serving', () => {
     });
 
     it('should proxy POST requests and return 200', async () => {
-      expectSuccess(
-        await apiClient.post('/api/service/model-serving/test-path', { key: 'value' }),
-      );
+      expectSuccess(await apiClient.post('/api/service/model-serving/test-path', { key: 'value' }));
     });
 
     it('should proxy PUT requests and return 200', async () => {
-      expectSuccess(
-        await apiClient.put('/api/service/model-serving/test-path', { key: 'value' }),
-      );
+      expectSuccess(await apiClient.put('/api/service/model-serving/test-path', { key: 'value' }));
     });
 
     it('should proxy PATCH requests and return 200', async () => {
@@ -115,10 +111,7 @@ describe('Core BFF Model Serving', () => {
     });
 
     it('should return 401 when no auth token is provided', async () => {
-      expectError(
-        await unauthenticatedClient.get('/api/service/model-serving/test-path'),
-        401,
-      );
+      expectError(await unauthenticatedClient.get('/api/service/model-serving/test-path'), 401);
     });
   });
 
@@ -173,6 +166,14 @@ describe('Core BFF Model Serving', () => {
         status: 200,
       });
     });
+
+    it('should return 200 for dryRun without persisting changes', async () => {
+      const result = await apiClient.get('/api/namespaces/opendatahub/1?dryRun=All');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/NamespaceMutationResponse',
+        status: 200,
+      });
+    });
   });
 
   describe('NIM Integration', () => {
@@ -197,16 +198,15 @@ describe('Core BFF Model Serving', () => {
     describe('POST /api/integrations/nim', () => {
       it('should return 401 when no auth token is provided', async () => {
         expectError(
+          // eslint-disable-next-line camelcase
           await unauthenticatedClient.post('/api/integrations/nim', { api_key: 'test' }),
           401,
         );
       });
 
       it('should return 403 for non-admin user', async () => {
-        expectError(
-          await restrictedClient.post('/api/integrations/nim', { api_key: 'test' }),
-          403,
-        );
+        // eslint-disable-next-line camelcase
+        expectError(await restrictedClient.post('/api/integrations/nim', { api_key: 'test' }), 403);
       });
 
       it('should return 400 for invalid body', async () => {
@@ -214,6 +214,7 @@ describe('Core BFF Model Serving', () => {
       });
 
       it('should return 200 with NIMIntegrationStatus schema', async () => {
+        // eslint-disable-next-line camelcase
         const result = await apiClient.post('/api/integrations/nim', { api_key: 'test-key' });
         expect(result).toMatchContract(apiSchema, {
           ref: '#/components/schemas/NIMIntegrationStatus',

--- a/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffModelServing.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffModelServing.test.ts
@@ -61,28 +61,6 @@ describe('Core BFF Model Serving', () => {
     });
   });
 
-  describe('NIM Serving Resource GET', () => {
-    it('should return 200 when no auth token is provided', async () => {
-      const result = await unauthenticatedClient.get('/api/nim-serving/apiKeySecret');
-      expect(result).toMatchContract(apiSchema, {
-        ref: '#/components/schemas/NIMServingResourceResponse',
-        status: 200,
-      });
-    });
-
-    it('should return 200 for valid resource type', async () => {
-      const result = await apiClient.get('/api/nim-serving/apiKeySecret');
-      expect(result).toMatchContract(apiSchema, {
-        ref: '#/components/schemas/NIMServingResourceResponse',
-        status: 200,
-      });
-    });
-
-    it('should return 404 for invalid resource type', async () => {
-      expectError(await apiClient.get('/api/nim-serving/invalidType'), 404);
-    });
-  });
-
   describe('Model Serving Proxy', () => {
     it('should proxy GET requests and return 200', async () => {
       expectSuccess(await apiClient.get('/api/service/model-serving/test-path'));
@@ -172,74 +150,6 @@ describe('Core BFF Model Serving', () => {
       expect(result).toMatchContract(apiSchema, {
         ref: '#/components/schemas/NamespaceMutationResponse',
         status: 200,
-      });
-    });
-  });
-
-  describe('NIM Integration', () => {
-    describe('GET /api/integrations/nim', () => {
-      it('should return NIM integration status', async () => {
-        const result = await apiClient.get('/api/integrations/nim');
-        expect(result).toMatchContract(apiSchema, {
-          ref: '#/components/schemas/NIMIntegrationStatus',
-          status: 200,
-        });
-      });
-
-      it('should return 200 when no auth token is provided', async () => {
-        const result = await unauthenticatedClient.get('/api/integrations/nim');
-        expect(result).toMatchContract(apiSchema, {
-          ref: '#/components/schemas/NIMIntegrationStatus',
-          status: 200,
-        });
-      });
-    });
-
-    describe('POST /api/integrations/nim', () => {
-      it('should return 401 when no auth token is provided', async () => {
-        expectError(
-          // eslint-disable-next-line camelcase
-          await unauthenticatedClient.post('/api/integrations/nim', { api_key: 'test' }),
-          401,
-        );
-      });
-
-      it('should return 403 for non-admin user', async () => {
-        // eslint-disable-next-line camelcase
-        expectError(await restrictedClient.post('/api/integrations/nim', { api_key: 'test' }), 403);
-      });
-
-      it('should return 400 for invalid body', async () => {
-        expectError(await apiClient.post('/api/integrations/nim', 'invalid'), 400);
-      });
-
-      it('should return 200 with NIMIntegrationStatus schema', async () => {
-        // eslint-disable-next-line camelcase
-        const result = await apiClient.post('/api/integrations/nim', { api_key: 'test-key' });
-        expect(result).toMatchContract(apiSchema, {
-          ref: '#/components/schemas/NIMIntegrationStatus',
-          status: 200,
-        });
-      });
-    });
-
-    describe('DELETE /api/integrations/nim', () => {
-      it('should return 401 when no auth token is provided', async () => {
-        expectError(await unauthenticatedClient.delete('/api/integrations/nim'), 401);
-      });
-
-      it('should return 403 for non-admin user', async () => {
-        expectError(await restrictedClient.delete('/api/integrations/nim'), 403);
-      });
-
-      it('should return 200 with NIMDeleteResponse schema', async () => {
-        const result = await apiClient.delete('/api/integrations/nim');
-        expect(result).toMatchContract(apiSchema, {
-          ref: '#/components/schemas/NIMDeleteResponse',
-          status: 200,
-        });
-        const { response } = expectSuccess(result);
-        expect((response.data as { success: boolean }).success).toBe(true);
       });
     });
   });

--- a/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffModelServing.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffModelServing.test.ts
@@ -1,0 +1,245 @@
+/**
+ * @jest-environment node
+ */
+import {
+  apiClient,
+  unauthenticatedClient,
+  restrictedClient,
+  apiSchema,
+  expectError,
+  expectSuccess,
+} from '../helpers';
+
+describe('Core BFF Model Serving', () => {
+  describe('ServingRuntimes POST', () => {
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(
+        await unauthenticatedClient.post('/api/servingRuntimes', {
+          metadata: { name: 'test', namespace: 'test-ns' },
+        }),
+        401,
+      );
+    });
+
+    it('should return 403 for non-admin user', async () => {
+      expectError(
+        await restrictedClient.post('/api/servingRuntimes', {
+          metadata: { name: 'test', namespace: 'test-ns' },
+        }),
+        403,
+      );
+    });
+
+    it('should return 400 for missing metadata', async () => {
+      expectError(
+        await apiClient.post('/api/servingRuntimes', {
+          apiVersion: 'serving.kserve.io/v1alpha1',
+          kind: 'ServingRuntime',
+        }),
+        400,
+      );
+    });
+
+    it('should create a serving runtime and return 200', async () => {
+      const result = await apiClient.post('/api/servingRuntimes', {
+        apiVersion: 'serving.kserve.io/v1alpha1',
+        kind: 'ServingRuntime',
+        metadata: { name: 'contract-test-sr', namespace: 'opendatahub' },
+        spec: { containers: [] },
+      });
+      expectSuccess(result);
+    });
+
+    it('should handle trailing slash (redirect)', async () => {
+      const result = await apiClient.post('/api/servingRuntimes/', {
+        apiVersion: 'serving.kserve.io/v1alpha1',
+        kind: 'ServingRuntime',
+        metadata: { name: 'contract-test-sr-slash', namespace: 'opendatahub' },
+        spec: { containers: [] },
+      });
+      expectSuccess(result);
+    });
+  });
+
+  describe('NIM Serving Resource GET', () => {
+    it('should return 200 when no auth token is provided', async () => {
+      const result = await unauthenticatedClient.get('/api/nim-serving/apiKeySecret');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/NIMServingResourceResponse',
+        status: 200,
+      });
+    });
+
+    it('should return 200 for valid resource type', async () => {
+      const result = await apiClient.get('/api/nim-serving/apiKeySecret');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/NIMServingResourceResponse',
+        status: 200,
+      });
+    });
+
+    it('should return 404 for invalid resource type', async () => {
+      expectError(await apiClient.get('/api/nim-serving/invalidType'), 404);
+    });
+  });
+
+  describe('Model Serving Proxy', () => {
+    it('should proxy GET requests and return 200', async () => {
+      expectSuccess(await apiClient.get('/api/service/model-serving/test-path'));
+    });
+
+    it('should proxy POST requests and return 200', async () => {
+      expectSuccess(
+        await apiClient.post('/api/service/model-serving/test-path', { key: 'value' }),
+      );
+    });
+
+    it('should proxy PUT requests and return 200', async () => {
+      expectSuccess(
+        await apiClient.put('/api/service/model-serving/test-path', { key: 'value' }),
+      );
+    });
+
+    it('should proxy PATCH requests and return 200', async () => {
+      expectSuccess(
+        await apiClient.patch('/api/service/model-serving/test-path', { key: 'value' }),
+      );
+    });
+
+    it('should proxy DELETE requests and return 200', async () => {
+      expectSuccess(await apiClient.delete('/api/service/model-serving/test-path'));
+    });
+
+    it('should proxy nested paths and return 200', async () => {
+      expectSuccess(await apiClient.get('/api/service/model-serving/nested/deep/path'));
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(
+        await unauthenticatedClient.get('/api/service/model-serving/test-path'),
+        401,
+      );
+    });
+  });
+
+  const prometheusRoutes = ['query', 'queryRange', 'pvc', 'bias', 'serving'];
+
+  describe.each(prometheusRoutes)('Prometheus %s POST', (route) => {
+    it('should return 400 for empty query', async () => {
+      expectError(await apiClient.post(`/api/prometheus/${route}`, { query: '' }), 400);
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(
+        await unauthenticatedClient.post(`/api/prometheus/${route}`, { query: 'query=up' }),
+        401,
+      );
+    });
+
+    it('should return 200 with PrometheusQueryResponse schema', async () => {
+      const result = await apiClient.post(`/api/prometheus/${route}`, { query: 'query=up' });
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/PrometheusQueryResponse',
+        status: 200,
+      });
+    });
+  });
+
+  describe('Namespace Mutation GET', () => {
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(await unauthenticatedClient.get('/api/namespaces/test-ns/1'), 401);
+    });
+
+    it('should return 400 for context 0 (DSG_CREATION)', async () => {
+      expectError(await apiClient.get('/api/namespaces/test-ns/0'), 400);
+    });
+
+    it('should return 400 for invalid context', async () => {
+      expectError(await apiClient.get('/api/namespaces/test-ns/5'), 400);
+    });
+
+    it('should return 400 for system namespace', async () => {
+      expectError(await apiClient.get('/api/namespaces/openshift-monitoring/1'), 400);
+    });
+
+    it.each([
+      [1, 'KSERVE_PROMOTION'],
+      [2, 'KSERVE_NIM_PROMOTION'],
+      [3, 'RESET'],
+    ])('should return 200 for context %i (%s)', async (context) => {
+      const result = await apiClient.get(`/api/namespaces/opendatahub/${context}`);
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/NamespaceMutationResponse',
+        status: 200,
+      });
+    });
+  });
+
+  describe('NIM Integration', () => {
+    describe('GET /api/integrations/nim', () => {
+      it('should return NIM integration status', async () => {
+        const result = await apiClient.get('/api/integrations/nim');
+        expect(result).toMatchContract(apiSchema, {
+          ref: '#/components/schemas/NIMIntegrationStatus',
+          status: 200,
+        });
+      });
+
+      it('should return 200 when no auth token is provided', async () => {
+        const result = await unauthenticatedClient.get('/api/integrations/nim');
+        expect(result).toMatchContract(apiSchema, {
+          ref: '#/components/schemas/NIMIntegrationStatus',
+          status: 200,
+        });
+      });
+    });
+
+    describe('POST /api/integrations/nim', () => {
+      it('should return 401 when no auth token is provided', async () => {
+        expectError(
+          await unauthenticatedClient.post('/api/integrations/nim', { api_key: 'test' }),
+          401,
+        );
+      });
+
+      it('should return 403 for non-admin user', async () => {
+        expectError(
+          await restrictedClient.post('/api/integrations/nim', { api_key: 'test' }),
+          403,
+        );
+      });
+
+      it('should return 400 for invalid body', async () => {
+        expectError(await apiClient.post('/api/integrations/nim', 'invalid'), 400);
+      });
+
+      it('should return 200 with NIMIntegrationStatus schema', async () => {
+        const result = await apiClient.post('/api/integrations/nim', { api_key: 'test-key' });
+        expect(result).toMatchContract(apiSchema, {
+          ref: '#/components/schemas/NIMIntegrationStatus',
+          status: 200,
+        });
+      });
+    });
+
+    describe('DELETE /api/integrations/nim', () => {
+      it('should return 401 when no auth token is provided', async () => {
+        expectError(await unauthenticatedClient.delete('/api/integrations/nim'), 401);
+      });
+
+      it('should return 403 for non-admin user', async () => {
+        expectError(await restrictedClient.delete('/api/integrations/nim'), 403);
+      });
+
+      it('should return 200 with NIMDeleteResponse schema', async () => {
+        const result = await apiClient.delete('/api/integrations/nim');
+        expect(result).toMatchContract(apiSchema, {
+          ref: '#/components/schemas/NIMDeleteResponse',
+          status: 200,
+        });
+        const { response } = expectSuccess(result);
+        expect((response.data as { success: boolean }).success).toBe(true);
+      });
+    });
+  });
+});

--- a/distributions/core-bff/contract-tests/__tests__/openshift/testCoreBffNIM.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/openshift/testCoreBffNIM.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment node
+ */
+import {
+  apiClient,
+  unauthenticatedClient,
+  restrictedClient,
+  apiSchema,
+  expectError,
+  expectSuccess,
+} from '../helpers';
+
+describe('Core BFF NIM - OpenShift Platform', () => {
+  describe('NIM Serving Resource GET', () => {
+    it('should return 200 when no auth token is provided', async () => {
+      const result = await unauthenticatedClient.get('/api/nim-serving/apiKeySecret');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/NIMServingResourceResponse',
+        status: 200,
+      });
+    });
+
+    it('should return 200 for valid resource type', async () => {
+      const result = await apiClient.get('/api/nim-serving/apiKeySecret');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/NIMServingResourceResponse',
+        status: 200,
+      });
+    });
+
+    it('should return 404 for invalid resource type', async () => {
+      expectError(await apiClient.get('/api/nim-serving/invalidType'), 404);
+    });
+  });
+
+  describe('NIM Integration', () => {
+    describe('GET /api/integrations/nim', () => {
+      it('should return NIM integration status', async () => {
+        const result = await apiClient.get('/api/integrations/nim');
+        expect(result).toMatchContract(apiSchema, {
+          ref: '#/components/schemas/NIMIntegrationStatus',
+          status: 200,
+        });
+      });
+
+      it('should return 200 when no auth token is provided', async () => {
+        const result = await unauthenticatedClient.get('/api/integrations/nim');
+        expect(result).toMatchContract(apiSchema, {
+          ref: '#/components/schemas/NIMIntegrationStatus',
+          status: 200,
+        });
+      });
+    });
+
+    describe('POST /api/integrations/nim', () => {
+      it('should return 401 when no auth token is provided', async () => {
+        expectError(
+          // eslint-disable-next-line camelcase
+          await unauthenticatedClient.post('/api/integrations/nim', { api_key: 'test' }),
+          401,
+        );
+      });
+
+      it('should return 403 for non-admin user', async () => {
+        // eslint-disable-next-line camelcase
+        expectError(await restrictedClient.post('/api/integrations/nim', { api_key: 'test' }), 403);
+      });
+
+      it('should return 400 for invalid body', async () => {
+        expectError(await apiClient.post('/api/integrations/nim', 'invalid'), 400);
+      });
+
+      it('should return 200 with NIMIntegrationStatus schema', async () => {
+        // eslint-disable-next-line camelcase
+        const result = await apiClient.post('/api/integrations/nim', { api_key: 'test-key' });
+        expect(result).toMatchContract(apiSchema, {
+          ref: '#/components/schemas/NIMIntegrationStatus',
+          status: 200,
+        });
+      });
+    });
+
+    describe('DELETE /api/integrations/nim', () => {
+      it('should return 401 when no auth token is provided', async () => {
+        expectError(await unauthenticatedClient.delete('/api/integrations/nim'), 401);
+      });
+
+      it('should return 403 for non-admin user', async () => {
+        expectError(await restrictedClient.delete('/api/integrations/nim'), 403);
+      });
+
+      it('should return 200 with NIMDeleteResponse schema', async () => {
+        const result = await apiClient.delete('/api/integrations/nim');
+        expect(result).toMatchContract(apiSchema, {
+          ref: '#/components/schemas/NIMDeleteResponse',
+          status: 200,
+        });
+        const { response } = expectSuccess(result);
+        expect((response.data as { success: boolean }).success).toBe(true);
+      });
+    });
+  });
+});

--- a/distributions/core-bff/contract-tests/__tests__/openshift/testCoreBffPrometheus.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/openshift/testCoreBffPrometheus.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment node
+ */
+import { apiClient, unauthenticatedClient, apiSchema, expectError } from '../helpers';
+
+describe('Core BFF Prometheus - OpenShift Platform', () => {
+  const prometheusRoutes = ['query', 'queryRange', 'pvc', 'bias', 'serving'];
+
+  describe.each(prometheusRoutes)('Prometheus %s POST', (route) => {
+    it('should return 400 for empty query', async () => {
+      expectError(await apiClient.post(`/api/prometheus/${route}`, { query: '' }), 400);
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(
+        await unauthenticatedClient.post(`/api/prometheus/${route}`, { query: 'query=up' }),
+        401,
+      );
+    });
+
+    it('should return 200 with PrometheusQueryResponse schema', async () => {
+      const result = await apiClient.post(`/api/prometheus/${route}`, { query: 'query=up' });
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/PrometheusQueryResponse',
+        status: 200,
+      });
+    });
+  });
+});

--- a/distributions/core-bff/contract-tests/__tests__/xks/testCoreBffNIM.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/xks/testCoreBffNIM.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment node
+ */
+import { apiClient, unauthenticatedClient, expectError } from '../helpers';
+
+describe('Core BFF NIM - XKS Platform', () => {
+  describe('NIM Serving Resource', () => {
+    it('should return 404 because NIM is OpenShift-only', async () => {
+      expectError(await apiClient.get('/api/nim-serving/apiKeySecret'), 404);
+    });
+  });
+
+  describe('NIM Integration GET', () => {
+    it('should return 404 because NIM is OpenShift-only', async () => {
+      expectError(await unauthenticatedClient.get('/api/integrations/nim'), 404);
+    });
+  });
+
+  describe('NIM Integration POST', () => {
+    it('should return 404 because NIM is OpenShift-only', async () => {
+      // eslint-disable-next-line camelcase
+      expectError(await apiClient.post('/api/integrations/nim', { api_key: 'test' }), 404);
+    });
+  });
+
+  describe('NIM Integration DELETE', () => {
+    it('should return 404 because NIM is OpenShift-only', async () => {
+      expectError(await apiClient.delete('/api/integrations/nim'), 404);
+    });
+  });
+});

--- a/distributions/core-bff/contract-tests/__tests__/xks/testCoreBffPrometheus.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/xks/testCoreBffPrometheus.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+import { apiClient, expectError } from '../helpers';
+
+describe('Core BFF Prometheus - XKS Platform', () => {
+  const prometheusRoutes = ['query', 'queryRange', 'pvc', 'bias', 'serving'];
+
+  describe.each(prometheusRoutes)('Prometheus %s POST', (route) => {
+    it('should return 404 because Prometheus is OpenShift-only', async () => {
+      expectError(await apiClient.post(`/api/prometheus/${route}`, { query: 'query=up' }), 404);
+    });
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-67106

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Model Serving is the first RHAII use case requiring server-side orchestration in the Core BFF. This PR adds six dedicated route groups to the Go BFF under `distributions/core-bff/`, covering admin-only access control, cross-resource lookups, upstream service proxying, and Prometheus query forwarding -- capabilities that cannot be handled client-side.

### Route groups added

| Route | Auth | Purpose |
|---|---|---|
| `POST /api/servingRuntimes` | `secureAdminRoute` | Create ServingRuntime CRs via SA dynamic client with dryRun support |
| `GET /api/nim-serving/:nimResource` | `publicRoute` | Cross-resource lookup: NIMAccount CR -> resolve resource name -> fetch Secret/ConfigMap |
| `ALL /api/service/model-serving/*` | Authenticated (no wrapper) | Reverse proxy to model-serving-api with SSRF protection, auth forwarding, path rewriting |
| `POST /api/prometheus/{query,queryRange,pvc,bias,serving}` | Authenticated (no wrapper) | POST body -> GET to Thanos with query type resolution and user token forwarding for K8s RBAC |
| `GET /api/namespaces/:name/:context` | `secureRoute` + SSAR | Namespace mutation via MergePatch, gated on `create serving.kserve.io/servingruntimes` |
| `GET/POST/DELETE /api/integrations/nim` | GET: `publicRoute`, POST/DELETE: `secureAdminRoute` | NIM integration lifecycle (status, enable, disable) |

**Note**: NIM and Prometheus endpoints are registered only on OpenShift platforms and return 404 on all other platforms.

### Intentional HTTP status differences from Fastify

These are deliberate improvements over the Fastify implementation:

- **Admin-only routes**: non-admin returns **403** (Fastify returns 401) -- correct HTTP semantics (authenticated but not authorized)
- **Prometheus**: returns **503** when no host configured (Fastify returns 400) -- reflects service unavailability, not a bad request
- **NIM serving**: non-404 fetch errors return **500** (Fastify maps all errors to 404) -- preserves actual error type for debugging

### Key implementation details

- **NIM secret updates** clear existing `Data` map before setting `StringData`, preventing stale keys from surviving updates (matches Fastify's `replaceNamespacedSecret` semantics)
- **Namespace mutation** rejects context 0 (DSG_CREATION) with 400 -- not applicable for RHAII
- **Namespace allowlist** enforced on ServingRuntime creation, matching Fastify's `secureAdminRoute` namespace validation
- **Prometheus query type resolution**: `queryRange`/`bias`/`serving` -> `query_range`; `query`/`pvc` -> instant `query`
- **Model serving proxy** forwards all HTTP methods (GET/POST/PUT/PATCH/DELETE) with Bearer token from request identity
- Route registration supports both `/api/` and `/core-bff/api/` path prefixes

### Route registration reorganization

The previously monolithic `routes.go` has been split into focused files by domain: `routes_model_serving.go`, `routes_config.go`, `routes_connection_types.go`, `routes_openapi.go`, and `routes_starter.go`. Each file owns the registration for its route group, keeping `routes.go` as the top-level combiner that wires the service mux, static handler, and public/authenticated split. The same split was applied to the k8mocks test helpers (`mock_crds.go`, `mock_nim.go`, `mock_rbac.go`, `mock_resources.go`) to keep test setup manageable as the handler count grows.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Automated [smoke-test.sh](https://gist.github.com/caponetto/97d1bc3b525e342a1cfba92fa7221b06) that creates a kind cluster with admin/viewer service accounts and exercises  endpoint tests covering public, secureRoute, secureAdminRoute, no-auth rejection, namespace mutation, and Prometheus proxy scenarios.
- Contract tests validate all 6 endpoint groups against the OpenAPI spec (auth, schema, error paths)
- Unit tests for every handler and repository (serving runtime, NIM, namespace mutation, Prometheus, model serving proxy)
- Handler tests use stub clients to verify auth enforcement (401 unauthenticated, 403 non-admin), validation errors (400), and success paths (200)
- Repository tests cover Prometheus query construction, NIM secret create-on-conflict-update flow, and namespace mutation patch building

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Contract tests added for all 6 model serving endpoint groups, validating auth enforcement, response schemas against the OpenAPI spec, and error paths
- Unit tests added for every new handler and repository, covering auth (401/403), input validation (400), success paths (200), and edge cases like NIM secret conflict resolution and Prometheus query type mapping

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-serving proxy endpoints with secure request forwarding.
  * Added ServingRuntime creation, namespace serving-platform mutations (including dry-run), and NIM integration/serving-resource endpoints.
  * Added Prometheus/Thanos query endpoints (instant and range) and updated OpenAPI coverage.
* **Bug Fixes**
  * Improved authorization responses: unauthenticated requests return **401**, authenticated non-admin requests return **403**.
  * Standardized Kubernetes error-to-HTTP handling for clearer client-facing responses.
* **Documentation**
  * Updated Core BFF README with new Prometheus/model-serving override environment variables and expanded local call examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->