### PR TITLE
feat(llmd-serving): add admin routing configurations settings tab

### DIFF
--- a/packages/cypress/cypress/pages/llmdRoutingSettings.ts
+++ b/packages/cypress/cypress/pages/llmdRoutingSettings.ts
@@ -65,4 +65,31 @@ class LlmdRoutingSettingsPage {
   }
 }
 
+class LlmdRoutingCreatePage {
+  findTitle() {
+    return cy.findByTestId('app-page-title');
+  }
+
+  findTopologyTypeSelect() {
+    return cy.findByTestId('topology-type-select');
+  }
+
+  findConfigSourceSelect() {
+    return cy.findByTestId('config-source-select');
+  }
+
+  findYamlEditor() {
+    return cy.findByTestId('config-yaml-editor');
+  }
+
+  findSubmitButton() {
+    return cy.findByTestId('submit-routing-config-button');
+  }
+
+  findCancelButton() {
+    return cy.findByTestId('cancel-routing-config-button');
+  }
+}
+
 export const llmdRoutingSettingsPage = new LlmdRoutingSettingsPage();
+export const llmdRoutingCreatePage = new LlmdRoutingCreatePage();

--- a/packages/cypress/cypress/pages/llmdRoutingSettings.ts
+++ b/packages/cypress/cypress/pages/llmdRoutingSettings.ts
@@ -1,0 +1,68 @@
+import { appChrome } from './appChrome';
+import { TableRow } from './components/table';
+
+class RoutingConfigRow extends TableRow {
+  findEnabledSwitch() {
+    return this.find().findByTestId('routing-config-enabled-toggle').parent('label');
+  }
+
+  shouldHavePreInstalledLabel(enabled = true) {
+    this.find()
+      .findByTestId('pre-installed-label')
+      .should(enabled ? 'exist' : 'not.exist');
+    return this;
+  }
+
+  findRoutingTypeLabel() {
+    return this.find().findByTestId('routing-type-label');
+  }
+}
+
+class LlmdRoutingSettingsPage {
+  visit(wait = true) {
+    cy.visitWithLogin('/settings/model-resources-operations/llmd-routing-configurations');
+    if (wait) {
+      this.wait();
+    }
+  }
+
+  navigate() {
+    this.findNavItem().click();
+    this.wait();
+  }
+
+  private wait() {
+    this.findTable();
+  }
+
+  findNavItem() {
+    return appChrome.findNavItem({
+      name: 'llm-d routing configurations',
+      rootSection: 'Settings',
+      subSection: 'Model resources and operations',
+    });
+  }
+
+  findAppTitle() {
+    return cy.findByTestId('app-page-title');
+  }
+
+  findTable() {
+    return cy.findByTestId('routing-configurations-table');
+  }
+
+  findAddButton() {
+    return cy.findByTestId('add-routing-config-button');
+  }
+
+  getRow(name: string) {
+    return new RoutingConfigRow(
+      () =>
+        this.findTable().findByTestId(`routing-config-row-${name}`) as unknown as Cypress.Chainable<
+          JQuery<HTMLTableRowElement>
+        >,
+    );
+  }
+}
+
+export const llmdRoutingSettingsPage = new LlmdRoutingSettingsPage();

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -447,6 +447,30 @@ const extensions: (
       component: () => import('../src/settings/TopologyConfigurationsRoutes'),
     },
   },
+  {
+    type: 'app.navigation/href',
+    flags: {
+      required: [SupportedArea.LLMD_TOPOLOGY_CONFIGS, ADMIN_USER],
+    },
+    properties: {
+      id: 'settings-llmd-routing-configurations',
+      title: 'llm-d routing configurations',
+      href: '/settings/model-resources-operations/llmd-routing-configurations',
+      section: 'settings-model-resources-and-operations',
+      path: '/settings/model-resources-operations/llmd-routing-configurations/*',
+      group: '2_model-resources',
+    },
+  },
+  {
+    type: 'app.route',
+    flags: {
+      required: [SupportedArea.LLMD_TOPOLOGY_CONFIGS, ADMIN_USER],
+    },
+    properties: {
+      path: '/settings/model-resources-operations/llmd-routing-configurations/*',
+      component: () => import('../src/settings/RoutingConfigurationsRoutes'),
+    },
+  },
 ];
 
 export default extensions;

--- a/packages/llmd-serving/src/settings/ConfigYAMLEditor.tsx
+++ b/packages/llmd-serving/src/settings/ConfigYAMLEditor.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import { Language } from '@patternfly/react-code-editor';
-
-const DashboardCodeEditor = React.lazy(
-  () => import('@odh-dashboard/internal/concepts/dashboard/codeEditor/DashboardCodeEditor'),
-);
+import { CodeEditor, Language } from '@patternfly/react-code-editor';
 
 type ConfigYAMLEditorProps = {
   code: string;
@@ -16,20 +12,20 @@ const ConfigYAMLEditor: React.FC<ConfigYAMLEditorProps> = ({
   onCodeChange,
   topologyTypeLabel,
 }) => (
-  <React.Suspense fallback={null}>
-    <DashboardCodeEditor
-      testId="config-yaml-editor"
+  <div data-testid="config-yaml-editor">
+    <CodeEditor
       code={code}
       isUploadEnabled
       isLanguageLabelVisible
       language={Language.yaml}
+      height="400px"
       emptyStateTitle={`Add a ${topologyTypeLabel || 'topology'} configuration`}
       emptyStateBody="Drag a file here, upload files, or start from scratch."
       emptyStateButton="Upload files"
       onCodeChange={onCodeChange}
       options={{ tabSize: 2 }}
     />
-  </React.Suspense>
+  </div>
 );
 
 export default ConfigYAMLEditor;

--- a/packages/llmd-serving/src/settings/ConfigYAMLEditor.tsx
+++ b/packages/llmd-serving/src/settings/ConfigYAMLEditor.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import { Language } from '@patternfly/react-code-editor';
+import DashboardCodeEditor from '@odh-dashboard/internal/concepts/dashboard/codeEditor/DashboardCodeEditor';
 
 type ConfigYAMLEditorProps = {
   code: string;
@@ -12,20 +13,18 @@ const ConfigYAMLEditor: React.FC<ConfigYAMLEditorProps> = ({
   onCodeChange,
   topologyTypeLabel,
 }) => (
-  <div data-testid="config-yaml-editor" style={{ minHeight: '400px', height: '100%' }}>
-    <CodeEditor
-      code={code}
-      isUploadEnabled
-      isLanguageLabelVisible
-      language={Language.yaml}
-      height="400px"
-      emptyStateTitle={`Add a ${topologyTypeLabel || 'topology'} configuration`}
-      emptyStateBody="Drag a file here, upload files, or start from scratch."
-      emptyStateButton="Upload files"
-      onCodeChange={onCodeChange}
-      options={{ tabSize: 2 }}
-    />
-  </div>
+  <DashboardCodeEditor
+    testId="config-yaml-editor"
+    code={code}
+    isUploadEnabled
+    isLanguageLabelVisible
+    language={Language.yaml}
+    emptyStateTitle={`Add a ${topologyTypeLabel || 'topology'} configuration`}
+    emptyStateBody="Drag a file here, upload files, or start from scratch."
+    emptyStateButton="Upload files"
+    onCodeChange={onCodeChange}
+    options={{ tabSize: 2 }}
+  />
 );
 
 export default ConfigYAMLEditor;

--- a/packages/llmd-serving/src/settings/ConfigYAMLEditor.tsx
+++ b/packages/llmd-serving/src/settings/ConfigYAMLEditor.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { Language } from '@patternfly/react-code-editor';
-import DashboardCodeEditor from '@odh-dashboard/internal/concepts/dashboard/codeEditor/DashboardCodeEditor';
+
+const DashboardCodeEditor = React.lazy(
+  () => import('@odh-dashboard/internal/concepts/dashboard/codeEditor/DashboardCodeEditor'),
+);
 
 type ConfigYAMLEditorProps = {
   code: string;
@@ -13,18 +16,20 @@ const ConfigYAMLEditor: React.FC<ConfigYAMLEditorProps> = ({
   onCodeChange,
   topologyTypeLabel,
 }) => (
-  <DashboardCodeEditor
-    testId="config-yaml-editor"
-    code={code}
-    isUploadEnabled
-    isLanguageLabelVisible
-    language={Language.yaml}
-    emptyStateTitle={`Add a ${topologyTypeLabel || 'topology'} configuration`}
-    emptyStateBody="Drag a file here, upload files, or start from scratch."
-    emptyStateButton="Upload files"
-    onCodeChange={onCodeChange}
-    options={{ tabSize: 2 }}
-  />
+  <React.Suspense fallback={null}>
+    <DashboardCodeEditor
+      testId="config-yaml-editor"
+      code={code}
+      isUploadEnabled
+      isLanguageLabelVisible
+      language={Language.yaml}
+      emptyStateTitle={`Add a ${topologyTypeLabel || 'topology'} configuration`}
+      emptyStateBody="Drag a file here, upload files, or start from scratch."
+      emptyStateButton="Upload files"
+      onCodeChange={onCodeChange}
+      options={{ tabSize: 2 }}
+    />
+  </React.Suspense>
 );
 
 export default ConfigYAMLEditor;

--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -41,7 +41,12 @@ import {
 } from '../api/LLMInferenceServiceConfigs';
 
 const isConfigObject = (value: unknown): value is LLMInferenceServiceConfigKind =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  'metadata' in value &&
+  typeof value.metadata === 'object' &&
+  value.metadata !== null;
 
 const stripServerManagedFields = (
   metadata: LLMInferenceServiceConfigKind['metadata'],
@@ -97,20 +102,17 @@ const resolveTopologyFromConfig = (
 const buildSamplesUrl = (topology: TopologyType): string =>
   `/api/service/model-serving/api/v1/samples/llm-d?type=router&topology=${topology}`;
 
-const RoutingConfigurationCreateEdit: React.FC = () => {
-  const { configName } = useParams<{ configName?: string }>();
+const RoutingConfigurationCreateEditInner: React.FC<{
+  existingConfig?: LLMInferenceServiceConfigKind;
+}> = ({ existingConfig }) => {
   const navigate = useNavigate();
   const { state }: { state?: { sourceConfig: LLMInferenceServiceConfigKind } } = useLocation();
+  const { configName } = useParams<{ configName?: string }>();
   const { dashboardNamespace } = useDashboardNamespace();
   const notification = useNotification();
 
   const isDuplicateMode = !!state?.sourceConfig;
   const isEditMode = !!configName && !isDuplicateMode;
-  const [configs] = useWatchRouterConfigs(dashboardNamespace);
-  const existingConfig = React.useMemo(
-    () => (configName ? configs.find((c) => c.metadata.name === configName) : undefined),
-    [configs, configName],
-  );
 
   // --- Topology type state ---
   const resolvedTopology = React.useMemo((): TopologyType | undefined => {
@@ -123,14 +125,9 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
     return undefined;
   }, [existingConfig, state?.sourceConfig]);
 
-  const [selectedTopology, setSelectedTopology] = React.useState<TopologyType | ''>('');
-
-  React.useEffect(() => {
-    if (resolvedTopology && !selectedTopology) {
-      setSelectedTopology(resolvedTopology);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resolvedTopology]);
+  const [selectedTopology, setSelectedTopology] = React.useState<TopologyType | ''>(
+    resolvedTopology ?? '',
+  );
 
   // --- Configuration source state ---
   const [configSource, setConfigSource] = React.useState<'template' | 'editor' | undefined>(
@@ -142,20 +139,27 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
   // Probe API on topology change to check if a sample exists
   React.useEffect(() => {
     if (!selectedTopology || isEditMode || isDuplicateMode) {
-      return;
+      return undefined;
     }
     setTemplateError(false);
     setConfigSource(undefined);
     setYamlCode('');
-    fetch(buildSamplesUrl(selectedTopology))
+
+    const controller = new AbortController();
+    fetch(buildSamplesUrl(selectedTopology), { signal: controller.signal })
       .then((res) => {
         if (!res.ok) {
           setTemplateError(true);
         }
       })
-      .catch(() => {
+      .catch((e: unknown) => {
+        if (e instanceof DOMException && e.name === 'AbortError') {
+          return;
+        }
         setTemplateError(true);
       });
+
+    return () => controller.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTopology, isEditMode, isDuplicateMode]);
 
@@ -275,7 +279,7 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
     configSource === 'editor' ||
     (configSource === 'template' && yamlCode !== '');
 
-  // --- Topology type dropdown options (4 topology types, no "all") ---
+  // --- Topology type dropdown options (4 topology types) ---
   const topologyOptions: SimpleSelectOption[] = Object.values(TopologyType).map((tt) => ({
     key: tt,
     label: TopologyTypeLabels[tt],
@@ -308,7 +312,7 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
     try {
       const parsed: unknown = YAML.parse(yamlCode);
       if (!isConfigObject(parsed)) {
-        throw new Error('YAML must represent a valid object');
+        throw new Error('YAML must represent a valid object with a metadata block');
       }
 
       const resourceName = isEditMode && configName ? configName : k8sNameDesc.data.k8sName.value;
@@ -328,12 +332,12 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
           name: resourceName,
           namespace: dashboardNamespace,
           labels: {
-            ...parsed.metadata.labels,
+            ...(parsed.metadata.labels ?? {}),
             [CONFIG_TYPE_LABEL]: ConfigType.ROUTER,
             [DASHBOARD_RESOURCE_LABEL]: 'true',
           },
           annotations: {
-            ...parsed.metadata.annotations,
+            ...(parsed.metadata.annotations ?? {}),
             'openshift.io/display-name': k8sNameDesc.data.name,
             'openshift.io/description': k8sNameDesc.data.description,
             [SUPPORTED_TOPOLOGIES_ANNOTATION]: JSON.stringify([selectedTopology]),
@@ -372,7 +376,6 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
       loaded
       empty={false}
       provideChildrenPadding
-      data-testid="routing-config-create-edit-page"
     >
       <Form style={{ height: '100%' }}>
         <K8sNameDescriptionField
@@ -460,6 +463,31 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
       </Form>
     </ApplicationsPage>
   );
+};
+
+const RoutingConfigurationCreateEdit: React.FC = () => {
+  const { configName } = useParams<{ configName?: string }>();
+  const { state }: { state?: { sourceConfig: LLMInferenceServiceConfigKind } } = useLocation();
+  const { dashboardNamespace } = useDashboardNamespace();
+  const [configs, loaded] = useWatchRouterConfigs(dashboardNamespace);
+
+  const isDuplicateMode = !!state?.sourceConfig;
+  const isEditMode = !!configName && !isDuplicateMode;
+
+  const existingConfig = React.useMemo(
+    () => (configName ? configs.find((c) => c.metadata.name === configName) : undefined),
+    [configs, configName],
+  );
+
+  if (isEditMode && !loaded) {
+    return (
+      <ApplicationsPage title="Edit routing configuration" loaded={false} empty={false}>
+        {null}
+      </ApplicationsPage>
+    );
+  }
+
+  return <RoutingConfigurationCreateEditInner existingConfig={existingConfig} />;
 };
 
 export default RoutingConfigurationCreateEdit;

--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -1,0 +1,336 @@
+import * as React from 'react';
+import {
+  ActionGroup,
+  Alert,
+  AlertActionCloseButton,
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  Form,
+  FormGroup,
+} from '@patternfly/react-core';
+import { Link, useLocation, useNavigate, useParams } from 'react-router';
+import YAML from 'yaml';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
+import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
+import {
+  getDisplayNameFromK8sResource,
+  isK8sNameDescriptionDataValid,
+} from '@odh-dashboard/k8s-core';
+import K8sNameDescriptionField, {
+  useK8sNameDescriptionFieldData,
+} from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import useNotification from '@odh-dashboard/internal/utilities/useNotification';
+import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
+import ConfigYAMLEditor from './ConfigYAMLEditor';
+import {
+  type LLMInferenceServiceConfigKind,
+  LLMInferenceServiceConfigModel,
+  ConfigType,
+  TopologyType,
+  TopologyTypeLabels,
+  CONFIG_TYPE_LABEL,
+  SUPPORTED_TOPOLOGIES_ANNOTATION,
+  DASHBOARD_RESOURCE_LABEL,
+} from '../types';
+import {
+  createLLMInferenceServiceConfig,
+  patchLLMInferenceServiceConfig,
+  useWatchRouterConfigs,
+} from '../api/LLMInferenceServiceConfigs';
+
+const isConfigObject = (value: unknown): value is LLMInferenceServiceConfigKind =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const stripServerManagedFields = (
+  metadata: LLMInferenceServiceConfigKind['metadata'],
+): Omit<
+  LLMInferenceServiceConfigKind['metadata'],
+  | 'resourceVersion'
+  | 'uid'
+  | 'creationTimestamp'
+  | 'generation'
+  | 'managedFields'
+  | 'ownerReferences'
+> => {
+  const result = { ...metadata };
+  delete result.resourceVersion;
+  delete result.uid;
+  delete result.creationTimestamp;
+  delete result.generation;
+  delete result.managedFields;
+  delete result.ownerReferences;
+  return result;
+};
+
+const RoutingConfigurationCreateEdit: React.FC = () => {
+  const { configName } = useParams<{ configName?: string }>();
+  const navigate = useNavigate();
+  const { state }: { state?: { sourceConfig: LLMInferenceServiceConfigKind } } = useLocation();
+  const { dashboardNamespace } = useDashboardNamespace();
+  const notification = useNotification();
+
+  const isDuplicateMode = !!state?.sourceConfig;
+  const isEditMode = !!configName && !isDuplicateMode;
+  const [configs] = useWatchRouterConfigs(dashboardNamespace);
+  const existingConfig = React.useMemo(
+    () => (configName ? configs.find((c) => c.metadata.name === configName) : undefined),
+    [configs, configName],
+  );
+
+  const resolvedRoutingType = React.useMemo((): RoutingType | undefined => {
+    if (existingConfig) {
+      const annotation = existingConfig.metadata.annotations?.[ROUTING_TYPE_ANNOTATION];
+      return Object.values(RoutingType).find((t) => t === annotation);
+    }
+    if (state?.sourceConfig) {
+      const annotation = state.sourceConfig.metadata.annotations?.[ROUTING_TYPE_ANNOTATION];
+      return Object.values(RoutingType).find((t) => t === annotation);
+    }
+    return undefined;
+  }, [existingConfig, state?.sourceConfig]);
+
+  const [selectedRoutingType, setSelectedRoutingType] = React.useState<RoutingType | ''>('');
+
+  React.useEffect(() => {
+    if (resolvedRoutingType && !selectedRoutingType) {
+      setSelectedRoutingType(resolvedRoutingType);
+    }
+  }, [resolvedRoutingType, selectedRoutingType]);
+
+  const initialResource = React.useMemo(() => {
+    if (existingConfig) {
+      return existingConfig;
+    }
+    if (state?.sourceConfig) {
+      const cleanMeta = stripServerManagedFields(state.sourceConfig.metadata);
+      return {
+        ...state.sourceConfig,
+        metadata: {
+          ...cleanMeta,
+          name: `${state.sourceConfig.metadata.name}-copy`,
+          annotations: {
+            ...cleanMeta.annotations,
+            'openshift.io/display-name': `Copy of ${getDisplayNameFromK8sResource(
+              state.sourceConfig,
+            )}`,
+          },
+        },
+      };
+    }
+    return undefined;
+  }, [existingConfig, state?.sourceConfig]);
+
+  const k8sNameDesc = useK8sNameDescriptionFieldData({
+    initialData: initialResource,
+  });
+
+  const [yamlCode, setYamlCode] = React.useState(() => {
+    if (existingConfig) {
+      return YAML.stringify(existingConfig);
+    }
+    if (state?.sourceConfig) {
+      const cleanMeta = stripServerManagedFields(state.sourceConfig.metadata);
+      return YAML.stringify({
+        ...state.sourceConfig,
+        metadata: {
+          ...cleanMeta,
+          name: `${state.sourceConfig.metadata.name}-copy`,
+          annotations: {
+            ...cleanMeta.annotations,
+            'openshift.io/display-name': `Copy of ${getDisplayNameFromK8sResource(
+              state.sourceConfig,
+            )}`,
+          },
+        },
+      });
+    }
+    return '';
+  });
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<Error | undefined>();
+
+  const sourceDisplayName = state?.sourceConfig
+    ? getDisplayNameFromK8sResource(state.sourceConfig)
+    : '';
+
+  const pageTitle = isDuplicateMode
+    ? 'Duplicate llm-d routing configuration'
+    : isEditMode
+    ? `Edit ${k8sNameDesc.data.name || configName}`
+    : 'Add llm-d routing configuration';
+
+  const pageDescription = isDuplicateMode
+    ? `Create a copy based on ${sourceDisplayName}. Update the configuration before saving.`
+    : !isEditMode
+    ? 'Add a new routing configuration that will be available for users on this cluster.'
+    : undefined;
+
+  const handleSubmit = async () => {
+    if (!selectedRoutingType) {
+      return;
+    }
+
+    setLoading(true);
+    setError(undefined);
+
+    let parsedConfig: LLMInferenceServiceConfigKind;
+    try {
+      const parsed: unknown = YAML.parse(yamlCode);
+      if (!isConfigObject(parsed)) {
+        throw new Error('YAML must represent a valid object');
+      }
+      parsedConfig = parsed;
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error('Invalid YAML'));
+      setLoading(false);
+      return;
+    }
+
+    const resourceName = isEditMode && configName ? configName : k8sNameDesc.data.k8sName.value;
+    if (!resourceName) {
+      setError(new Error('Name must contain at least one alphanumeric character'));
+      setLoading(false);
+      return;
+    }
+
+    const apiGroup = LLMInferenceServiceConfigModel.apiGroup ?? '';
+    const apiVer = LLMInferenceServiceConfigModel.apiVersion;
+    const newConfig: LLMInferenceServiceConfigKind = {
+      ...parsedConfig,
+      apiVersion: `${apiGroup}/${apiVer}`,
+      kind: 'LLMInferenceServiceConfig',
+      metadata: {
+        ...parsedConfig.metadata,
+        name: resourceName,
+        namespace: dashboardNamespace,
+        labels: {
+          ...parsedConfig.metadata.labels,
+          [CONFIG_TYPE_LABEL]: ConfigType.ROUTER,
+          [DASHBOARD_RESOURCE_LABEL]: 'true',
+        },
+        annotations: {
+          ...parsedConfig.metadata.annotations,
+          'openshift.io/display-name': k8sNameDesc.data.name,
+          'openshift.io/description': k8sNameDesc.data.description,
+          [ROUTING_TYPE_ANNOTATION]: selectedRoutingType,
+        },
+      },
+    };
+
+    try {
+      if (isEditMode && existingConfig) {
+        await patchLLMInferenceServiceConfig(existingConfig, newConfig);
+      } else {
+        await createLLMInferenceServiceConfig(newConfig);
+      }
+      navigate('..');
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error('Unknown error');
+      setError(err);
+      notification.error(
+        `Error ${isEditMode ? 'updating' : 'creating'} configuration`,
+        err.message,
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ApplicationsPage
+      title={pageTitle}
+      description={pageDescription}
+      breadcrumb={
+        <Breadcrumb>
+          <BreadcrumbItem render={() => <Link to="..">llm-d routing configurations</Link>} />
+          <BreadcrumbItem isActive>{pageTitle}</BreadcrumbItem>
+        </Breadcrumb>
+      }
+      loaded
+      empty={false}
+      provideChildrenPadding
+      data-testid="routing-config-create-edit-page"
+    >
+      <Form style={{ height: '100%' }}>
+        <K8sNameDescriptionField
+          data={k8sNameDesc.data}
+          dataTestId="routing-config"
+          onDataChange={k8sNameDesc.onDataChange}
+        />
+        <FormGroup label="Routing type" isRequired fieldId="routing-type-select">
+          <SimpleSelect
+            isFullWidth
+            dataTestId="routing-type-select"
+            value={selectedRoutingType || undefined}
+            placeholder="Select routing type"
+            isDisabled={isEditMode}
+            options={Object.values(RoutingType).map((rt) => ({
+              key: rt,
+              label: RoutingTypeLabels[rt],
+            }))}
+            onChange={(key) => {
+              const matched = Object.values(RoutingType).find((v) => v === key);
+              if (matched) {
+                setSelectedRoutingType(matched);
+              }
+            }}
+          />
+        </FormGroup>
+        <FormGroup
+          label="LLMInferenceServiceConfig YAML"
+          isRequired
+          fieldId="config-yaml"
+          style={{ flex: 1 }}
+        >
+          <ConfigYAMLEditor
+            code={yamlCode}
+            onCodeChange={setYamlCode}
+            name={k8sNameDesc.data.k8sName.value}
+            displayName={k8sNameDesc.data.name}
+            description={k8sNameDesc.data.description}
+            topologyType={ConfigType.ROUTER}
+            topologyTypeLabel="routing"
+          />
+        </FormGroup>
+        {error && (
+          <Alert
+            isInline
+            variant="danger"
+            title={error.name}
+            actionClose={<AlertActionCloseButton onClose={() => setError(undefined)} />}
+          >
+            {error.message}
+          </Alert>
+        )}
+        <ActionGroup>
+          <Button
+            variant="primary"
+            data-testid="submit-routing-config-button"
+            isDisabled={
+              !isK8sNameDescriptionDataValid(k8sNameDesc.data) ||
+              !selectedRoutingType ||
+              !yamlCode.trim() ||
+              loading
+            }
+            isLoading={loading}
+            onClick={handleSubmit}
+          >
+            {isEditMode ? 'Update' : 'Create'}
+          </Button>
+          <Button
+            variant="link"
+            data-testid="cancel-routing-config-button"
+            isDisabled={loading}
+            onClick={() => navigate('..')}
+          >
+            Cancel
+          </Button>
+        </ActionGroup>
+      </Form>
+    </ApplicationsPage>
+  );
+};
+
+export default RoutingConfigurationCreateEdit;

--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -40,8 +40,6 @@ import {
   useWatchRouterConfigs,
 } from '../api/LLMInferenceServiceConfigs';
 
-const ALL_TOPOLOGIES_KEY = 'all';
-
 const isConfigObject = (value: unknown): value is LLMInferenceServiceConfigKind =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -80,32 +78,24 @@ const stripAnnotation = (
 
 const resolveTopologyFromConfig = (
   config: LLMInferenceServiceConfigKind,
-): TopologyType | typeof ALL_TOPOLOGIES_KEY => {
+): TopologyType | undefined => {
   const raw = config.metadata.annotations?.[SUPPORTED_TOPOLOGIES_ANNOTATION];
   if (!raw) {
-    return ALL_TOPOLOGIES_KEY;
+    return undefined;
   }
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (Array.isArray(parsed) && parsed.length === 1) {
-      const matched = Object.values(TopologyType).find((t) => t === parsed[0]);
-      if (matched) {
-        return matched;
-      }
+    if (Array.isArray(parsed) && parsed.length >= 1) {
+      return Object.values(TopologyType).find((t) => t === parsed[0]);
     }
   } catch {
     // invalid JSON — fall through
   }
-  return ALL_TOPOLOGIES_KEY;
+  return undefined;
 };
 
-const buildSamplesUrl = (topologySelection: TopologyType | typeof ALL_TOPOLOGIES_KEY): string => {
-  const base = '/api/v1/llm-d/samples?type=router';
-  if (topologySelection === ALL_TOPOLOGIES_KEY) {
-    return base;
-  }
-  return `${base}&topology=${topologySelection}`;
-};
+const buildSamplesUrl = (topology: TopologyType): string =>
+  `/api/service/model-serving/api/v1/samples/llm-d?type=router&topology=${topology}`;
 
 const RoutingConfigurationCreateEdit: React.FC = () => {
   const { configName } = useParams<{ configName?: string }>();
@@ -123,10 +113,7 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
   );
 
   // --- Topology type state ---
-  const resolvedTopology = React.useMemo(():
-    | TopologyType
-    | typeof ALL_TOPOLOGIES_KEY
-    | undefined => {
+  const resolvedTopology = React.useMemo((): TopologyType | undefined => {
     if (existingConfig) {
       return resolveTopologyFromConfig(existingConfig);
     }
@@ -136,15 +123,12 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
     return undefined;
   }, [existingConfig, state?.sourceConfig]);
 
-  const [selectedTopology, setSelectedTopology] = React.useState<
-    TopologyType | typeof ALL_TOPOLOGIES_KEY
-  >(ALL_TOPOLOGIES_KEY);
+  const [selectedTopology, setSelectedTopology] = React.useState<TopologyType | ''>('');
 
   React.useEffect(() => {
-    if (resolvedTopology && resolvedTopology !== selectedTopology) {
+    if (resolvedTopology && !selectedTopology) {
       setSelectedTopology(resolvedTopology);
     }
-    // only sync once from resolved → local on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resolvedTopology]);
 
@@ -157,7 +141,7 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
 
   // Probe API on topology change to check if a sample exists
   React.useEffect(() => {
-    if (isEditMode || isDuplicateMode) {
+    if (!selectedTopology || isEditMode || isDuplicateMode) {
       return;
     }
     setTemplateError(false);
@@ -177,6 +161,9 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
 
   const handleConfigSourceChange = (key: string) => {
     if (key === 'template') {
+      if (!selectedTopology) {
+        return;
+      }
       setConfigSource('template');
       setTemplateLoading(true);
       fetch(buildSamplesUrl(selectedTopology))
@@ -288,14 +275,11 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
     configSource === 'editor' ||
     (configSource === 'template' && yamlCode !== '');
 
-  // --- Topology type dropdown options ---
-  const topologyOptions: SimpleSelectOption[] = [
-    { key: ALL_TOPOLOGIES_KEY, label: 'All topologies' },
-    ...Object.values(TopologyType).map((tt) => ({
-      key: tt,
-      label: TopologyTypeLabels[tt],
-    })),
-  ];
+  // --- Topology type dropdown options (4 topology types, no "all") ---
+  const topologyOptions: SimpleSelectOption[] = Object.values(TopologyType).map((tt) => ({
+    key: tt,
+    label: TopologyTypeLabels[tt],
+  }));
 
   // --- Configuration source dropdown options ---
   const configSourceOptions: SimpleSelectOption[] = [
@@ -314,6 +298,10 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
 
   // --- Submit ---
   const handleSubmit = async () => {
+    if (!selectedTopology) {
+      return;
+    }
+
     setLoading(true);
     setError(undefined);
 
@@ -330,11 +318,6 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
 
       const apiGroup = LLMInferenceServiceConfigModel.apiGroup ?? '';
       const apiVer = LLMInferenceServiceConfigModel.apiVersion;
-
-      const supportedTopologiesAnnotation =
-        selectedTopology !== ALL_TOPOLOGIES_KEY
-          ? { [SUPPORTED_TOPOLOGIES_ANNOTATION]: JSON.stringify([selectedTopology]) }
-          : {};
 
       const newConfig: LLMInferenceServiceConfigKind = {
         ...parsed,
@@ -353,7 +336,7 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
             ...parsed.metadata.annotations,
             'openshift.io/display-name': k8sNameDesc.data.name,
             'openshift.io/description': k8sNameDesc.data.description,
-            ...supportedTopologiesAnnotation,
+            [SUPPORTED_TOPOLOGIES_ANNOTATION]: JSON.stringify([selectedTopology]),
           },
         },
       };
@@ -401,14 +384,12 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
           <SimpleSelect
             isFullWidth
             dataTestId="topology-type-select"
-            value={selectedTopology}
+            value={selectedTopology || undefined}
             placeholder="Select topology type"
             isDisabled={isEditMode}
             options={topologyOptions}
             onChange={(key) => {
-              const allMatch = key === ALL_TOPOLOGIES_KEY ? ALL_TOPOLOGIES_KEY : undefined;
-              const topoMatch = Object.values(TopologyType).find((v) => v === key);
-              const matched = allMatch ?? topoMatch;
+              const matched = Object.values(TopologyType).find((v) => v === key);
               if (matched) {
                 setSelectedTopology(matched);
               }
@@ -422,7 +403,7 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
               value={configSource}
               placeholder="Select a configuration source"
               onChange={handleConfigSourceChange}
-              isDisabled={templateLoading}
+              isDisabled={templateLoading || !selectedTopology}
               isFullWidth
               dataTestId="config-source-select"
             />
@@ -457,7 +438,10 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
             variant="primary"
             data-testid="submit-routing-config-button"
             isDisabled={
-              !isK8sNameDescriptionDataValid(k8sNameDesc.data) || !yamlCode.trim() || loading
+              !isK8sNameDescriptionDataValid(k8sNameDesc.data) ||
+              !selectedTopology ||
+              !yamlCode.trim() ||
+              loading
             }
             isLoading={loading}
             onClick={handleSubmit}

--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -9,7 +9,7 @@ import {
   Form,
   FormGroup,
 } from '@patternfly/react-core';
-import { Link, useLocation, useNavigate, useParams } from 'react-router';
+import { Link, Navigate, useLocation, useNavigate, useParams } from 'react-router';
 import YAML from 'yaml';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
@@ -34,52 +34,15 @@ import {
   SUPPORTED_TOPOLOGIES_ANNOTATION,
   DASHBOARD_RESOURCE_LABEL,
 } from '../types';
+import { isConfigObject, cleanResourceForYAMLViewer, stripAnnotation } from '../utils';
 import {
   createLLMInferenceServiceConfig,
   patchLLMInferenceServiceConfig,
   useWatchRouterConfigs,
 } from '../api/LLMInferenceServiceConfigs';
 
-const isConfigObject = (value: unknown): value is LLMInferenceServiceConfigKind =>
-  typeof value === 'object' &&
-  value !== null &&
-  !Array.isArray(value) &&
-  'metadata' in value &&
-  typeof value.metadata === 'object' &&
-  value.metadata !== null;
-
-const stripServerManagedFields = (
-  metadata: LLMInferenceServiceConfigKind['metadata'],
-): Omit<
-  LLMInferenceServiceConfigKind['metadata'],
-  | 'resourceVersion'
-  | 'uid'
-  | 'creationTimestamp'
-  | 'generation'
-  | 'managedFields'
-  | 'ownerReferences'
-> => {
-  const result = { ...metadata };
-  delete result.resourceVersion;
-  delete result.uid;
-  delete result.creationTimestamp;
-  delete result.generation;
-  delete result.managedFields;
-  delete result.ownerReferences;
-  return result;
-};
-
-const stripAnnotation = (
-  annotations: Record<string, string> | undefined,
-  key: string,
-): Record<string, string> | undefined => {
-  if (!annotations) {
-    return annotations;
-  }
-  const result = { ...annotations };
-  delete result[key];
-  return result;
-};
+const SAMPLE_DISPLAY_NAME_ANNOTATION = 'openshift.io/display-name';
+const SAMPLE_DESCRIPTION_ANNOTATION = 'description';
 
 const resolveTopologyFromConfig = (
   config: LLMInferenceServiceConfigKind,
@@ -99,7 +62,7 @@ const resolveTopologyFromConfig = (
   return undefined;
 };
 
-const buildSamplesUrl = (topology: TopologyType): string =>
+const buildRouterSamplesUrl = (topology: TopologyType): string =>
   `/api/service/model-serving/api/v1/samples/llm-d?type=router&topology=${topology}`;
 
 const RoutingConfigurationCreateEditInner: React.FC<{
@@ -115,19 +78,13 @@ const RoutingConfigurationCreateEditInner: React.FC<{
   const isEditMode = !!configName && !isDuplicateMode;
 
   // --- Topology type state ---
-  const resolvedTopology = React.useMemo((): TopologyType | undefined => {
-    if (existingConfig) {
-      return resolveTopologyFromConfig(existingConfig);
+  const [selectedTopology, setSelectedTopology] = React.useState<TopologyType | ''>(() => {
+    const source = existingConfig ?? state?.sourceConfig;
+    if (source) {
+      return resolveTopologyFromConfig(source) ?? '';
     }
-    if (state?.sourceConfig) {
-      return resolveTopologyFromConfig(state.sourceConfig);
-    }
-    return undefined;
-  }, [existingConfig, state?.sourceConfig]);
-
-  const [selectedTopology, setSelectedTopology] = React.useState<TopologyType | ''>(
-    resolvedTopology ?? '',
-  );
+    return '';
+  });
 
   // --- Configuration source state ---
   const [configSource, setConfigSource] = React.useState<'template' | 'editor' | undefined>(
@@ -146,7 +103,7 @@ const RoutingConfigurationCreateEditInner: React.FC<{
     setYamlCode('');
 
     const controller = new AbortController();
-    fetch(buildSamplesUrl(selectedTopology), { signal: controller.signal })
+    fetch(buildRouterSamplesUrl(selectedTopology), { signal: controller.signal })
       .then((res) => {
         if (!res.ok) {
           setTemplateError(true);
@@ -170,7 +127,7 @@ const RoutingConfigurationCreateEditInner: React.FC<{
       }
       setConfigSource('template');
       setTemplateLoading(true);
-      fetch(buildSamplesUrl(selectedTopology))
+      fetch(buildRouterSamplesUrl(selectedTopology))
         .then((res) => {
           if (!res.ok) {
             throw new Error('Template not found');
@@ -179,6 +136,23 @@ const RoutingConfigurationCreateEditInner: React.FC<{
         })
         .then((yaml) => {
           setYamlCode(yaml);
+          try {
+            const parsed: unknown = YAML.parse(yaml);
+            if (isConfigObject(parsed)) {
+              const annotations = parsed.metadata.annotations ?? {};
+              const sampleName =
+                annotations[SAMPLE_DISPLAY_NAME_ANNOTATION] ?? parsed.metadata.name;
+              const sampleDesc = annotations[SAMPLE_DESCRIPTION_ANNOTATION] ?? '';
+              if (sampleName) {
+                k8sNameDesc.onDataChange('name', String(sampleName));
+              }
+              if (sampleDesc) {
+                k8sNameDesc.onDataChange('description', String(sampleDesc));
+              }
+            }
+          } catch {
+            // sample parsing for form fields is best-effort
+          }
         })
         .catch(() => {
           setTemplateError(true);
@@ -202,7 +176,7 @@ const RoutingConfigurationCreateEditInner: React.FC<{
       return existingConfig;
     }
     if (state?.sourceConfig) {
-      const cleanMeta = stripServerManagedFields(state.sourceConfig.metadata);
+      const cleanMeta = cleanResourceForYAMLViewer(state.sourceConfig.metadata);
       return {
         ...state.sourceConfig,
         metadata: {
@@ -230,7 +204,7 @@ const RoutingConfigurationCreateEditInner: React.FC<{
       return YAML.stringify(existingConfig);
     }
     if (state?.sourceConfig) {
-      const cleanMeta = stripServerManagedFields(state.sourceConfig.metadata);
+      const cleanMeta = cleanResourceForYAMLViewer(state.sourceConfig.metadata);
       const cleanAnnotations = stripAnnotation(
         cleanMeta.annotations,
         'kubectl.kubernetes.io/last-applied-configuration',
@@ -483,6 +457,14 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
     return (
       <ApplicationsPage title="Edit routing configuration" loaded={false} empty={false}>
         {null}
+      </ApplicationsPage>
+    );
+  }
+
+  if (isEditMode && loaded && !existingConfig) {
+    return (
+      <ApplicationsPage title="Routing configuration not found" loaded empty={false}>
+        <Navigate to=".." />
       </ApplicationsPage>
     );
   }

--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -22,7 +22,7 @@ import K8sNameDescriptionField, {
   useK8sNameDescriptionFieldData,
 } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import useNotification from '@odh-dashboard/internal/utilities/useNotification';
-import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
+import SimpleSelect, { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect';
 import ConfigYAMLEditor from './ConfigYAMLEditor';
 import {
   type LLMInferenceServiceConfigKind,
@@ -39,6 +39,8 @@ import {
   patchLLMInferenceServiceConfig,
   useWatchRouterConfigs,
 } from '../api/LLMInferenceServiceConfigs';
+
+const ALL_TOPOLOGIES_KEY = 'all';
 
 const isConfigObject = (value: unknown): value is LLMInferenceServiceConfigKind =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -64,6 +66,47 @@ const stripServerManagedFields = (
   return result;
 };
 
+const stripAnnotation = (
+  annotations: Record<string, string> | undefined,
+  key: string,
+): Record<string, string> | undefined => {
+  if (!annotations) {
+    return annotations;
+  }
+  const result = { ...annotations };
+  delete result[key];
+  return result;
+};
+
+const resolveTopologyFromConfig = (
+  config: LLMInferenceServiceConfigKind,
+): TopologyType | typeof ALL_TOPOLOGIES_KEY => {
+  const raw = config.metadata.annotations?.[SUPPORTED_TOPOLOGIES_ANNOTATION];
+  if (!raw) {
+    return ALL_TOPOLOGIES_KEY;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.length === 1) {
+      const matched = Object.values(TopologyType).find((t) => t === parsed[0]);
+      if (matched) {
+        return matched;
+      }
+    }
+  } catch {
+    // invalid JSON — fall through
+  }
+  return ALL_TOPOLOGIES_KEY;
+};
+
+const buildSamplesUrl = (topologySelection: TopologyType | typeof ALL_TOPOLOGIES_KEY): string => {
+  const base = '/api/v1/llm-d/samples?type=router';
+  if (topologySelection === ALL_TOPOLOGIES_KEY) {
+    return base;
+  }
+  return `${base}&topology=${topologySelection}`;
+};
+
 const RoutingConfigurationCreateEdit: React.FC = () => {
   const { configName } = useParams<{ configName?: string }>();
   const navigate = useNavigate();
@@ -79,26 +122,90 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
     [configs, configName],
   );
 
-  const resolvedRoutingType = React.useMemo((): RoutingType | undefined => {
+  // --- Topology type state ---
+  const resolvedTopology = React.useMemo(():
+    | TopologyType
+    | typeof ALL_TOPOLOGIES_KEY
+    | undefined => {
     if (existingConfig) {
-      const annotation = existingConfig.metadata.annotations?.[ROUTING_TYPE_ANNOTATION];
-      return Object.values(RoutingType).find((t) => t === annotation);
+      return resolveTopologyFromConfig(existingConfig);
     }
     if (state?.sourceConfig) {
-      const annotation = state.sourceConfig.metadata.annotations?.[ROUTING_TYPE_ANNOTATION];
-      return Object.values(RoutingType).find((t) => t === annotation);
+      return resolveTopologyFromConfig(state.sourceConfig);
     }
     return undefined;
   }, [existingConfig, state?.sourceConfig]);
 
-  const [selectedRoutingType, setSelectedRoutingType] = React.useState<RoutingType | ''>('');
+  const [selectedTopology, setSelectedTopology] = React.useState<
+    TopologyType | typeof ALL_TOPOLOGIES_KEY
+  >(ALL_TOPOLOGIES_KEY);
 
   React.useEffect(() => {
-    if (resolvedRoutingType && !selectedRoutingType) {
-      setSelectedRoutingType(resolvedRoutingType);
+    if (resolvedTopology && resolvedTopology !== selectedTopology) {
+      setSelectedTopology(resolvedTopology);
     }
-  }, [resolvedRoutingType, selectedRoutingType]);
+    // only sync once from resolved → local on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resolvedTopology]);
 
+  // --- Configuration source state ---
+  const [configSource, setConfigSource] = React.useState<'template' | 'editor' | undefined>(
+    undefined,
+  );
+  const [templateLoading, setTemplateLoading] = React.useState(false);
+  const [templateError, setTemplateError] = React.useState(false);
+
+  // Probe API on topology change to check if a sample exists
+  React.useEffect(() => {
+    if (isEditMode || isDuplicateMode) {
+      return;
+    }
+    setTemplateError(false);
+    setConfigSource(undefined);
+    setYamlCode('');
+    fetch(buildSamplesUrl(selectedTopology))
+      .then((res) => {
+        if (!res.ok) {
+          setTemplateError(true);
+        }
+      })
+      .catch(() => {
+        setTemplateError(true);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTopology, isEditMode, isDuplicateMode]);
+
+  const handleConfigSourceChange = (key: string) => {
+    if (key === 'template') {
+      setConfigSource('template');
+      setTemplateLoading(true);
+      fetch(buildSamplesUrl(selectedTopology))
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error('Template not found');
+          }
+          return res.text();
+        })
+        .then((yaml) => {
+          setYamlCode(yaml);
+        })
+        .catch(() => {
+          setTemplateError(true);
+          notification.error(
+            'Unable to pull template',
+            'No sample configuration found for the selected topology.',
+          );
+        })
+        .finally(() => {
+          setTemplateLoading(false);
+        });
+    } else if (key === 'editor') {
+      setConfigSource('editor');
+      setYamlCode('');
+    }
+  };
+
+  // --- Name/description and YAML state ---
   const initialResource = React.useMemo(() => {
     if (existingConfig) {
       return existingConfig;
@@ -124,6 +231,7 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
 
   const k8sNameDesc = useK8sNameDescriptionFieldData({
     initialData: initialResource,
+    editableK8sName: isDuplicateMode,
   });
 
   const [yamlCode, setYamlCode] = React.useState(() => {
@@ -132,18 +240,24 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
     }
     if (state?.sourceConfig) {
       const cleanMeta = stripServerManagedFields(state.sourceConfig.metadata);
+      const cleanAnnotations = stripAnnotation(
+        cleanMeta.annotations,
+        'kubectl.kubernetes.io/last-applied-configuration',
+      );
       return YAML.stringify({
-        ...state.sourceConfig,
+        apiVersion: state.sourceConfig.apiVersion,
+        kind: state.sourceConfig.kind,
         metadata: {
           ...cleanMeta,
           name: `${state.sourceConfig.metadata.name}-copy`,
           annotations: {
-            ...cleanMeta.annotations,
+            ...cleanAnnotations,
             'openshift.io/display-name': `Copy of ${getDisplayNameFromK8sResource(
               state.sourceConfig,
             )}`,
           },
         },
+        spec: state.sourceConfig.spec,
       });
     }
     return '';
@@ -151,6 +265,7 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
 
+  // --- Page chrome ---
   const sourceDisplayName = state?.sourceConfig
     ? getDisplayNameFromK8sResource(state.sourceConfig)
     : '';
@@ -167,59 +282,82 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
     ? 'Add a new routing configuration that will be available for users on this cluster.'
     : undefined;
 
-  const handleSubmit = async () => {
-    if (!selectedRoutingType) {
-      return;
-    }
+  const showEditor =
+    isEditMode ||
+    isDuplicateMode ||
+    configSource === 'editor' ||
+    (configSource === 'template' && yamlCode !== '');
 
+  // --- Topology type dropdown options ---
+  const topologyOptions: SimpleSelectOption[] = [
+    { key: ALL_TOPOLOGIES_KEY, label: 'All topologies' },
+    ...Object.values(TopologyType).map((tt) => ({
+      key: tt,
+      label: TopologyTypeLabels[tt],
+    })),
+  ];
+
+  // --- Configuration source dropdown options ---
+  const configSourceOptions: SimpleSelectOption[] = [
+    {
+      key: 'template',
+      label: 'Start from a sample configuration file',
+      isDisabled: templateError,
+      isAriaDisabled: templateError,
+      description: templateError ? 'Unable to pull template' : undefined,
+    },
+    {
+      key: 'editor',
+      label: 'Upload an existing configuration file',
+    },
+  ];
+
+  // --- Submit ---
+  const handleSubmit = async () => {
     setLoading(true);
     setError(undefined);
 
-    let parsedConfig: LLMInferenceServiceConfigKind;
     try {
       const parsed: unknown = YAML.parse(yamlCode);
       if (!isConfigObject(parsed)) {
         throw new Error('YAML must represent a valid object');
       }
-      parsedConfig = parsed;
-    } catch (e) {
-      setError(e instanceof Error ? e : new Error('Invalid YAML'));
-      setLoading(false);
-      return;
-    }
 
-    const resourceName = isEditMode && configName ? configName : k8sNameDesc.data.k8sName.value;
-    if (!resourceName) {
-      setError(new Error('Name must contain at least one alphanumeric character'));
-      setLoading(false);
-      return;
-    }
+      const resourceName = isEditMode && configName ? configName : k8sNameDesc.data.k8sName.value;
+      if (!resourceName) {
+        throw new Error('Name must contain at least one alphanumeric character');
+      }
 
-    const apiGroup = LLMInferenceServiceConfigModel.apiGroup ?? '';
-    const apiVer = LLMInferenceServiceConfigModel.apiVersion;
-    const newConfig: LLMInferenceServiceConfigKind = {
-      ...parsedConfig,
-      apiVersion: `${apiGroup}/${apiVer}`,
-      kind: 'LLMInferenceServiceConfig',
-      metadata: {
-        ...parsedConfig.metadata,
-        name: resourceName,
-        namespace: dashboardNamespace,
-        labels: {
-          ...parsedConfig.metadata.labels,
-          [CONFIG_TYPE_LABEL]: ConfigType.ROUTER,
-          [DASHBOARD_RESOURCE_LABEL]: 'true',
+      const apiGroup = LLMInferenceServiceConfigModel.apiGroup ?? '';
+      const apiVer = LLMInferenceServiceConfigModel.apiVersion;
+
+      const supportedTopologiesAnnotation =
+        selectedTopology !== ALL_TOPOLOGIES_KEY
+          ? { [SUPPORTED_TOPOLOGIES_ANNOTATION]: JSON.stringify([selectedTopology]) }
+          : {};
+
+      const newConfig: LLMInferenceServiceConfigKind = {
+        ...parsed,
+        apiVersion: `${apiGroup}/${apiVer}`,
+        kind: 'LLMInferenceServiceConfig',
+        metadata: {
+          ...parsed.metadata,
+          name: resourceName,
+          namespace: dashboardNamespace,
+          labels: {
+            ...parsed.metadata.labels,
+            [CONFIG_TYPE_LABEL]: ConfigType.ROUTER,
+            [DASHBOARD_RESOURCE_LABEL]: 'true',
+          },
+          annotations: {
+            ...parsed.metadata.annotations,
+            'openshift.io/display-name': k8sNameDesc.data.name,
+            'openshift.io/description': k8sNameDesc.data.description,
+            ...supportedTopologiesAnnotation,
+          },
         },
-        annotations: {
-          ...parsedConfig.metadata.annotations,
-          'openshift.io/display-name': k8sNameDesc.data.name,
-          'openshift.io/description': k8sNameDesc.data.description,
-          [ROUTING_TYPE_ANNOTATION]: selectedRoutingType,
-        },
-      },
-    };
+      };
 
-    try {
       if (isEditMode && existingConfig) {
         await patchLLMInferenceServiceConfig(existingConfig, newConfig);
       } else {
@@ -259,41 +397,51 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
           dataTestId="routing-config"
           onDataChange={k8sNameDesc.onDataChange}
         />
-        <FormGroup label="Routing type" isRequired fieldId="routing-type-select">
+        <FormGroup label="Topology type" isRequired fieldId="topology-type-select">
           <SimpleSelect
             isFullWidth
-            dataTestId="routing-type-select"
-            value={selectedRoutingType || undefined}
-            placeholder="Select routing type"
+            dataTestId="topology-type-select"
+            value={selectedTopology}
+            placeholder="Select topology type"
             isDisabled={isEditMode}
-            options={Object.values(RoutingType).map((rt) => ({
-              key: rt,
-              label: RoutingTypeLabels[rt],
-            }))}
+            options={topologyOptions}
             onChange={(key) => {
-              const matched = Object.values(RoutingType).find((v) => v === key);
+              const allMatch = key === ALL_TOPOLOGIES_KEY ? ALL_TOPOLOGIES_KEY : undefined;
+              const topoMatch = Object.values(TopologyType).find((v) => v === key);
+              const matched = allMatch ?? topoMatch;
               if (matched) {
-                setSelectedRoutingType(matched);
+                setSelectedTopology(matched);
               }
             }}
           />
         </FormGroup>
-        <FormGroup
-          label="LLMInferenceServiceConfig YAML"
-          isRequired
-          fieldId="config-yaml"
-          style={{ flex: 1 }}
-        >
-          <ConfigYAMLEditor
-            code={yamlCode}
-            onCodeChange={setYamlCode}
-            name={k8sNameDesc.data.k8sName.value}
-            displayName={k8sNameDesc.data.name}
-            description={k8sNameDesc.data.description}
-            topologyType={ConfigType.ROUTER}
-            topologyTypeLabel="routing"
-          />
-        </FormGroup>
+        {!isEditMode && !isDuplicateMode && (
+          <FormGroup label="Configuration source" isRequired fieldId="config-source">
+            <SimpleSelect
+              options={configSourceOptions}
+              value={configSource}
+              placeholder="Select a configuration source"
+              onChange={handleConfigSourceChange}
+              isDisabled={templateLoading}
+              isFullWidth
+              dataTestId="config-source-select"
+            />
+          </FormGroup>
+        )}
+        {showEditor && (
+          <FormGroup
+            label="LLMInferenceServiceConfig YAML"
+            isRequired
+            fieldId="config-yaml"
+            style={{ flex: 1 }}
+          >
+            <ConfigYAMLEditor
+              code={yamlCode}
+              onCodeChange={setYamlCode}
+              topologyTypeLabel="routing"
+            />
+          </FormGroup>
+        )}
         {error && (
           <Alert
             isInline
@@ -309,10 +457,7 @@ const RoutingConfigurationCreateEdit: React.FC = () => {
             variant="primary"
             data-testid="submit-routing-config-button"
             isDisabled={
-              !isK8sNameDescriptionDataValid(k8sNameDesc.data) ||
-              !selectedRoutingType ||
-              !yamlCode.trim() ||
-              loading
+              !isK8sNameDescriptionDataValid(k8sNameDesc.data) || !yamlCode.trim() || loading
             }
             isLoading={loading}
             onClick={handleSubmit}

--- a/packages/llmd-serving/src/settings/RoutingConfigurationRow.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationRow.tsx
@@ -81,12 +81,12 @@ const RoutingConfigurationRow: React.FC<RoutingConfigurationRowProps> = ({
             isDashboardCreated
               ? [
                   {
-                    title: 'Duplicate',
-                    onClick: () => navigate('add', { state: { sourceConfig: config } }),
-                  },
-                  {
                     title: 'Edit',
                     onClick: () => navigate(`edit/${configName}`),
+                  },
+                  {
+                    title: 'Duplicate',
+                    onClick: () => navigate('add', { state: { sourceConfig: config } }),
                   },
                   { isSeparator: true },
                   {

--- a/packages/llmd-serving/src/settings/RoutingConfigurationRow.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationRow.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import { Label, Switch } from '@patternfly/react-core';
+import { ActionsColumn, Tr, Td } from '@patternfly/react-table';
+import { useNavigate } from 'react-router';
+import {
+  getDisplayNameFromK8sResource,
+  getDescriptionFromK8sResource,
+} from '@odh-dashboard/k8s-core';
+import TableRowTitleDescription from '@odh-dashboard/internal/components/table/TableRowTitleDescription';
+import {
+  type LLMInferenceServiceConfigKind,
+  RoutingTypeLabels,
+  DASHBOARD_RESOURCE_LABEL,
+  getConfigRoutingType,
+} from '../types';
+import { isConfigPreInstalled, isConfigEnabled } from '../utils';
+
+type RoutingConfigurationRowProps = {
+  config: LLMInferenceServiceConfigKind;
+  onToggleEnabled: (config: LLMInferenceServiceConfigKind) => void;
+  onDelete: (config: LLMInferenceServiceConfigKind) => void;
+  isToggling: boolean;
+};
+
+const RoutingConfigurationRow: React.FC<RoutingConfigurationRowProps> = ({
+  config,
+  onToggleEnabled,
+  onDelete,
+  isToggling,
+}) => {
+  const navigate = useNavigate();
+  const configName = config.metadata.name;
+  const displayName = getDisplayNameFromK8sResource(config);
+  const description = getDescriptionFromK8sResource(config);
+  const preInstalled = isConfigPreInstalled(config);
+  const enabled = isConfigEnabled(config);
+  const routingType = getConfigRoutingType(config);
+  const isDashboardCreated =
+    config.metadata.labels?.[DASHBOARD_RESOURCE_LABEL] === 'true' && !preInstalled;
+
+  return (
+    <Tr data-testid={`routing-config-row-${configName}`}>
+      <Td dataLabel="Name">
+        <TableRowTitleDescription
+          title={<strong>{displayName}</strong>}
+          resource={config}
+          description={description}
+          label={
+            preInstalled ? (
+              <div>
+                <Label data-testid="pre-installed-label" isCompact>
+                  Pre-installed
+                </Label>
+              </div>
+            ) : undefined
+          }
+        />
+      </Td>
+      <Td dataLabel="Enabled">
+        <Switch
+          id={`routing-config-toggle-${configName}`}
+          aria-label={`${configName}-enabled-toggle`}
+          data-testid="routing-config-enabled-toggle"
+          isChecked={enabled}
+          isDisabled={isToggling}
+          onChange={() => onToggleEnabled(config)}
+        />
+      </Td>
+      <Td dataLabel="Routing type">
+        {routingType ? (
+          <Label color="blue" data-testid="routing-type-label">
+            {RoutingTypeLabels[routingType]}
+          </Label>
+        ) : (
+          '-'
+        )}
+      </Td>
+      <Td isActionCell>
+        <ActionsColumn
+          items={
+            isDashboardCreated
+              ? [
+                  {
+                    title: 'Duplicate',
+                    onClick: () => navigate('add', { state: { sourceConfig: config } }),
+                  },
+                  {
+                    title: 'Edit',
+                    onClick: () => navigate(`edit/${configName}`),
+                  },
+                  { isSeparator: true },
+                  {
+                    title: 'Delete',
+                    onClick: () => onDelete(config),
+                    isDanger: true,
+                  },
+                ]
+              : [
+                  {
+                    title: 'Duplicate',
+                    onClick: () => navigate('add', { state: { sourceConfig: config } }),
+                  },
+                ]
+          }
+        />
+      </Td>
+    </Tr>
+  );
+};
+
+export default RoutingConfigurationRow;

--- a/packages/llmd-serving/src/settings/RoutingConfigurationsRoutes.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationsRoutes.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Navigate, Route, Routes } from 'react-router';
+
+const RoutingConfigurationsView = React.lazy(() => import('./RoutingConfigurationsView'));
+const RoutingConfigurationCreateEdit = React.lazy(() => import('./RoutingConfigurationCreateEdit'));
+
+const RoutingConfigurationsRoutes: React.FC = () => (
+  <React.Suspense fallback={null}>
+    <Routes>
+      <Route index element={<RoutingConfigurationsView />} />
+      <Route path="add" element={<RoutingConfigurationCreateEdit />} />
+      <Route path="edit/:configName" element={<RoutingConfigurationCreateEdit />} />
+      <Route path="*" element={<Navigate to="." />} />
+    </Routes>
+  </React.Suspense>
+);
+
+export default RoutingConfigurationsRoutes;

--- a/packages/llmd-serving/src/settings/RoutingConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationsTable.tsx
@@ -1,0 +1,164 @@
+import * as React from 'react';
+import { Button, EmptyState, EmptyStateBody, ToolbarItem } from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+import ContentModal from '@odh-dashboard/internal/components/modals/ContentModal';
+import { Table, SortableData } from '@odh-dashboard/ui-core';
+import { useNavigate } from 'react-router';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import { k8sDeleteResource, K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
+import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
+import useNotification from '@odh-dashboard/internal/utilities/useNotification';
+import RoutingConfigurationRow from './RoutingConfigurationRow';
+import { type LLMInferenceServiceConfigKind, LLMInferenceServiceConfigModel } from '../types';
+import { isConfigEnabled } from '../utils';
+import { patchLLMInferenceServiceConfig } from '../api/LLMInferenceServiceConfigs';
+
+const columns: SortableData<LLMInferenceServiceConfigKind>[] = [
+  { label: 'Name', field: 'name', sortable: false },
+  { label: 'Enabled', field: 'enabled', sortable: false },
+  { label: 'Routing type', field: 'routingType', sortable: false },
+  { label: '', field: 'kebab', sortable: false },
+];
+
+type RoutingConfigurationsTableProps = {
+  configs: LLMInferenceServiceConfigKind[];
+};
+
+const RoutingConfigurationsTable: React.FC<RoutingConfigurationsTableProps> = ({ configs }) => {
+  const navigate = useNavigate();
+  const { dashboardNamespace } = useDashboardNamespace();
+  const notification = useNotification();
+  const [togglingConfigs, setTogglingConfigs] = React.useState<Record<string, boolean>>({});
+  const [deleteConfig, setDeleteConfig] = React.useState<LLMInferenceServiceConfigKind>();
+  const [isDeleting, setIsDeleting] = React.useState(false);
+
+  const handleToggleEnabled = async (config: LLMInferenceServiceConfigKind) => {
+    const configName = config.metadata.name;
+    setTogglingConfigs((prev) => ({ ...prev, [configName]: true }));
+
+    const currentlyEnabled = isConfigEnabled(config);
+    const updatedConfig: LLMInferenceServiceConfigKind = {
+      ...config,
+      metadata: {
+        ...config.metadata,
+        annotations: {
+          ...config.metadata.annotations,
+          'opendatahub.io/disabled': currentlyEnabled ? 'true' : 'false',
+        },
+      },
+    };
+
+    try {
+      await patchLLMInferenceServiceConfig(config, updatedConfig);
+    } catch (e) {
+      notification.error(
+        `Error ${currentlyEnabled ? 'disabling' : 'enabling'} configuration`,
+        e instanceof Error ? e.message : 'Unknown error',
+      );
+    } finally {
+      setTogglingConfigs((prev) => ({ ...prev, [configName]: false }));
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteConfig) {
+      return;
+    }
+    setIsDeleting(true);
+    try {
+      await k8sDeleteResource<typeof LLMInferenceServiceConfigModel, K8sStatus>({
+        model: LLMInferenceServiceConfigModel,
+        queryOptions: {
+          name: deleteConfig.metadata.name,
+          ns: dashboardNamespace,
+        },
+      });
+      setDeleteConfig(undefined);
+    } catch (e) {
+      notification.error(
+        'Error deleting configuration',
+        e instanceof Error ? e.message : 'Unknown error',
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const toolbarContent = (
+    <ToolbarItem>
+      <Button
+        variant="primary"
+        data-testid="add-routing-config-button"
+        onClick={() => navigate('add')}
+      >
+        Add llm-d routing configuration
+      </Button>
+    </ToolbarItem>
+  );
+
+  return (
+    <>
+      <Table
+        aria-label="Routing configurations table"
+        data-testid="routing-configurations-table"
+        data={configs}
+        columns={columns}
+        toolbarContent={toolbarContent}
+        emptyTableView={
+          <EmptyState
+            headingLevel="h2"
+            titleText="No routing configurations found"
+            icon={CubesIcon}
+            data-testid="routing-configurations-empty-state"
+          >
+            <EmptyStateBody>
+              To get started, add a routing configuration using the button above.
+            </EmptyStateBody>
+          </EmptyState>
+        }
+        rowRenderer={(config) => (
+          <RoutingConfigurationRow
+            key={config.metadata.name}
+            config={config}
+            onToggleEnabled={handleToggleEnabled}
+            onDelete={setDeleteConfig}
+            isToggling={!!togglingConfigs[config.metadata.name]}
+          />
+        )}
+      />
+      {deleteConfig && (
+        <ContentModal
+          title="Delete llm-d routing configuration?"
+          onClose={() => setDeleteConfig(undefined)}
+          variant="small"
+          dataTestId="delete-routing-config-modal"
+          contents={
+            <>
+              Delete <strong>{getDisplayNameFromK8sResource(deleteConfig)}</strong>? This cannot be
+              undone. Out-of-the-box configurations cannot be deleted from the cluster from this UI
+              (disable them instead).
+            </>
+          }
+          buttonActions={[
+            {
+              label: 'Delete',
+              variant: 'danger',
+              onClick: handleDelete,
+              isLoading: isDeleting,
+              isDisabled: isDeleting,
+              dataTestId: 'delete-routing-config-confirm',
+            },
+            {
+              label: 'Cancel',
+              variant: 'link',
+              onClick: () => setDeleteConfig(undefined),
+              isDisabled: isDeleting,
+            },
+          ]}
+        />
+      )}
+    </>
+  );
+};
+
+export default RoutingConfigurationsTable;

--- a/packages/llmd-serving/src/settings/RoutingConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationsTable.tsx
@@ -37,14 +37,17 @@ const RoutingConfigurationsTable: React.FC<RoutingConfigurationsTableProps> = ({
     setTogglingConfigs((prev) => ({ ...prev, [configName]: true }));
 
     const currentlyEnabled = isConfigEnabled(config);
+    const annotations = { ...config.metadata.annotations };
+    if (currentlyEnabled) {
+      annotations['opendatahub.io/disabled'] = 'true';
+    } else {
+      delete annotations['opendatahub.io/disabled'];
+    }
     const updatedConfig: LLMInferenceServiceConfigKind = {
       ...config,
       metadata: {
         ...config.metadata,
-        annotations: {
-          ...config.metadata.annotations,
-          'opendatahub.io/disabled': currentlyEnabled ? 'true' : 'false',
-        },
+        annotations,
       },
     };
 

--- a/packages/llmd-serving/src/settings/RoutingConfigurationsView.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationsView.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
+import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
+import RoutingConfigurationsTable from './RoutingConfigurationsTable';
+import { useWatchRouterConfigs } from '../api/LLMInferenceServiceConfigs';
+
+const RoutingConfigurationsView: React.FC = () => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const [configs, loaded, error] = useWatchRouterConfigs(dashboardNamespace);
+
+  return (
+    <ApplicationsPage
+      title="llm-d routing configurations"
+      description="Manage llm-d routing configurations. Enabled configurations can be selected when deploying models with advanced routing."
+      loaded={loaded}
+      loadError={error}
+      empty={false}
+      provideChildrenPadding
+    >
+      <RoutingConfigurationsTable configs={configs} />
+    </ApplicationsPage>
+  );
+};
+
+export default RoutingConfigurationsView;

--- a/packages/llmd-serving/src/settings/RoutingConfigurationsView.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationsView.tsx
@@ -15,7 +15,7 @@ const RoutingConfigurationsView: React.FC = () => {
       description="Manage llm-d routing configurations. Enabled configurations can be selected when deploying models with advanced routing."
       loaded={loaded}
       loadError={error}
-      empty={false}
+      empty={loaded && configs.length === 0}
       provideChildrenPadding
     >
       <RoutingConfigurationsTable configs={configs} />

--- a/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
@@ -9,7 +9,7 @@ import {
   Form,
   FormGroup,
 } from '@patternfly/react-core';
-import { Link, useLocation, useNavigate, useParams } from 'react-router';
+import { Link, Navigate, useLocation, useNavigate, useParams } from 'react-router';
 import YAML from 'yaml';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
@@ -32,49 +32,16 @@ import {
   CONFIG_TYPE_LABEL,
   DASHBOARD_RESOURCE_LABEL,
 } from '../types';
+import { isConfigObject, cleanResourceForYAMLViewer, stripAnnotation } from '../utils';
 import {
   createLLMInferenceServiceConfig,
   patchLLMInferenceServiceConfig,
   useWatchTopologyConfigs,
 } from '../api/LLMInferenceServiceConfigs';
 
-const isConfigObject = (value: unknown): value is LLMInferenceServiceConfigKind =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const stripServerManagedFields = (
-  metadata: LLMInferenceServiceConfigKind['metadata'],
-): Omit<
-  LLMInferenceServiceConfigKind['metadata'],
-  | 'resourceVersion'
-  | 'uid'
-  | 'creationTimestamp'
-  | 'generation'
-  | 'managedFields'
-  | 'ownerReferences'
-> => {
-  const result = { ...metadata };
-  delete result.resourceVersion;
-  delete result.uid;
-  delete result.creationTimestamp;
-  delete result.generation;
-  delete result.managedFields;
-  delete result.ownerReferences;
-  return result;
-};
-
-const stripAnnotation = (
-  annotations: Record<string, string> | undefined,
-  key: string,
-): Record<string, string> | undefined => {
-  if (!annotations) {
-    return annotations;
-  }
-  const result = { ...annotations };
-  delete result[key];
-  return result;
-};
-
-const TopologyConfigurationCreateEdit: React.FC = () => {
+const TopologyConfigurationCreateEditInner: React.FC<{
+  existingConfig?: LLMInferenceServiceConfigKind;
+}> = ({ existingConfig }) => {
   const { topologyType, configName } = useParams<{
     topologyType?: string;
     configName?: string;
@@ -86,11 +53,6 @@ const TopologyConfigurationCreateEdit: React.FC = () => {
 
   const isDuplicateMode = !!state?.sourceConfig;
   const isEditMode = !!configName && !isDuplicateMode;
-  const [configs] = useWatchTopologyConfigs(dashboardNamespace);
-  const existingConfig = React.useMemo(
-    () => (configName ? configs.find((c) => c.metadata.name === configName) : undefined),
-    [configs, configName],
-  );
 
   const resolvedTopologyType = React.useMemo((): TopologyType | undefined => {
     if (existingConfig) {
@@ -109,7 +71,7 @@ const TopologyConfigurationCreateEdit: React.FC = () => {
       return existingConfig;
     }
     if (state?.sourceConfig) {
-      const cleanMeta = stripServerManagedFields(state.sourceConfig.metadata);
+      const cleanMeta = cleanResourceForYAMLViewer(state.sourceConfig.metadata);
       return {
         ...state.sourceConfig,
         metadata: {
@@ -137,7 +99,7 @@ const TopologyConfigurationCreateEdit: React.FC = () => {
       return YAML.stringify(existingConfig);
     }
     if (state?.sourceConfig) {
-      const cleanMeta = stripServerManagedFields(state.sourceConfig.metadata);
+      const cleanMeta = cleanResourceForYAMLViewer(state.sourceConfig.metadata);
       const cleanAnnotations = stripAnnotation(
         cleanMeta.annotations,
         'kubectl.kubernetes.io/last-applied-configuration',
@@ -400,6 +362,39 @@ const TopologyConfigurationCreateEdit: React.FC = () => {
       </Form>
     </ApplicationsPage>
   );
+};
+
+const TopologyConfigurationCreateEdit: React.FC = () => {
+  const { configName } = useParams<{ configName?: string }>();
+  const { state }: { state?: { sourceConfig: LLMInferenceServiceConfigKind } } = useLocation();
+  const { dashboardNamespace } = useDashboardNamespace();
+  const [configs, loaded] = useWatchTopologyConfigs(dashboardNamespace);
+
+  const isDuplicateMode = !!state?.sourceConfig;
+  const isEditMode = !!configName && !isDuplicateMode;
+
+  const existingConfig = React.useMemo(
+    () => (configName ? configs.find((c) => c.metadata.name === configName) : undefined),
+    [configs, configName],
+  );
+
+  if (isEditMode && !loaded) {
+    return (
+      <ApplicationsPage title="Edit topology configuration" loaded={false} empty={false}>
+        {null}
+      </ApplicationsPage>
+    );
+  }
+
+  if (isEditMode && loaded && !existingConfig) {
+    return (
+      <ApplicationsPage title="Topology configuration not found" loaded empty={false}>
+        <Navigate to=".." />
+      </ApplicationsPage>
+    );
+  }
+
+  return <TopologyConfigurationCreateEditInner existingConfig={existingConfig} />;
 };
 
 export default TopologyConfigurationCreateEdit;

--- a/packages/llmd-serving/src/settings/TopologyConfigurationsTable.tsx
+++ b/packages/llmd-serving/src/settings/TopologyConfigurationsTable.tsx
@@ -56,26 +56,29 @@ const TopologyConfigurationsTable: React.FC<TopologyConfigurationsTableProps> = 
     setTogglingConfigs((prev) => ({ ...prev, [configName]: true }));
 
     const currentlyEnabled = isConfigEnabled(config);
+    const annotations = { ...config.metadata.annotations };
+    if (currentlyEnabled) {
+      annotations['opendatahub.io/disabled'] = 'true';
+    } else {
+      delete annotations['opendatahub.io/disabled'];
+    }
     const updatedConfig: LLMInferenceServiceConfigKind = {
       ...config,
       metadata: {
         ...config.metadata,
-        annotations: {
-          ...config.metadata.annotations,
-          'opendatahub.io/disabled': currentlyEnabled ? 'true' : 'false',
-        },
+        annotations,
       },
     };
 
     try {
-      await patchLLMInferenceServiceConfig(config, updatedConfig).finally(() => {
-        setTogglingConfigs((prev) => ({ ...prev, [configName]: false }));
-      });
+      await patchLLMInferenceServiceConfig(config, updatedConfig);
     } catch (e) {
       notification.error(
         `Error ${currentlyEnabled ? 'disabling' : 'enabling'} configuration`,
         e instanceof Error ? e.message : 'Unknown error',
       );
+    } finally {
+      setTogglingConfigs((prev) => ({ ...prev, [configName]: false }));
     }
   };
 

--- a/packages/llmd-serving/src/utils.ts
+++ b/packages/llmd-serving/src/utils.ts
@@ -2,6 +2,47 @@ import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { WELL_KNOWN_ANNOTATION, DISABLED_ANNOTATION, DASHBOARD_RESOURCE_LABEL } from './const';
 import type { LLMInferenceServiceConfigKind } from './types';
 
+export const isConfigObject = (value: unknown): value is LLMInferenceServiceConfigKind =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  'metadata' in value &&
+  typeof value.metadata === 'object' &&
+  value.metadata !== null;
+
+export const cleanResourceForYAMLViewer = (
+  metadata: LLMInferenceServiceConfigKind['metadata'],
+): Omit<
+  LLMInferenceServiceConfigKind['metadata'],
+  | 'resourceVersion'
+  | 'uid'
+  | 'creationTimestamp'
+  | 'generation'
+  | 'managedFields'
+  | 'ownerReferences'
+> => {
+  const result = { ...metadata };
+  delete result.resourceVersion;
+  delete result.uid;
+  delete result.creationTimestamp;
+  delete result.generation;
+  delete result.managedFields;
+  delete result.ownerReferences;
+  return result;
+};
+
+export const stripAnnotation = (
+  annotations: Record<string, string> | undefined,
+  key: string,
+): Record<string, string> | undefined => {
+  if (!annotations) {
+    return annotations;
+  }
+  const result = { ...annotations };
+  delete result[key];
+  return result;
+};
+
 const hasKserveOwnership = (resource: K8sResourceCommon): boolean =>
   resource.metadata?.ownerReferences?.some(
     (ref) => ref.kind === 'KServe' || ref.apiVersion.startsWith('operator.kserve.io/'),

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
@@ -1,19 +1,22 @@
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { RoutingType } from '@odh-dashboard/llmd-serving/types';
+import { ConfigType, RoutingType } from '@odh-dashboard/llmd-serving/types';
 import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { LLMInferenceServiceConfigModel } from '@odh-dashboard/cypress/cypress/utils/models';
 import { asProductAdminUser } from '@odh-dashboard/cypress/cypress/utils/mockUsers';
-import { llmdRoutingSettingsPage, llmdRoutingCreatePage } from '@odh-dashboard/cypress/cypress/pages/llmdRoutingSettings';
+import {
+  llmdRoutingSettingsPage,
+  llmdRoutingCreatePage,
+} from '@odh-dashboard/cypress/cypress/pages/llmdRoutingSettings';
 import { pageNotfound } from '@odh-dashboard/cypress/cypress/pages/pageNotFound';
 
 const mockPreInstalledScheduler = mockLLMInferenceServiceConfigK8sResource({
   name: 'managed-scheduler',
   displayName: 'Managed scheduler',
-  configType: 'router',
+  configType: ConfigType.ROUTER,
   routingType: RoutingType.SCHEDULER,
   preInstalled: true,
 });
@@ -21,7 +24,7 @@ const mockPreInstalledScheduler = mockLLMInferenceServiceConfigK8sResource({
 const mockPreInstalledHttpRoute = mockLLMInferenceServiceConfigK8sResource({
   name: 'managed-httproute',
   displayName: 'Managed HTTPRoute',
-  configType: 'router',
+  configType: ConfigType.ROUTER,
   routingType: RoutingType.HTTP_ROUTE,
   preInstalled: true,
   disabled: true,
@@ -30,7 +33,7 @@ const mockPreInstalledHttpRoute = mockLLMInferenceServiceConfigK8sResource({
 const mockPreInstalledCombo = mockLLMInferenceServiceConfigK8sResource({
   name: 'managed-scheduler-httproute',
   displayName: 'Managed scheduler with HTTPRoute',
-  configType: 'router',
+  configType: ConfigType.ROUTER,
   routingType: RoutingType.SCHEDULER_AND_HTTP_ROUTE,
   preInstalled: true,
 });
@@ -38,7 +41,7 @@ const mockPreInstalledCombo = mockLLMInferenceServiceConfigK8sResource({
 const mockUserConfig = mockLLMInferenceServiceConfigK8sResource({
   name: 'lab-routing-profile',
   displayName: 'Lab routing profile',
-  configType: 'router',
+  configType: ConfigType.ROUTER,
   routingType: RoutingType.SCHEDULER_AND_HTTP_ROUTE,
 });
 
@@ -147,7 +150,7 @@ describe('LLMD Routing Admin Settings', () => {
       const patchedConfig = mockLLMInferenceServiceConfigK8sResource({
         name: 'lab-routing-profile',
         displayName: 'Lab routing profile',
-        configType: 'router',
+        configType: ConfigType.ROUTER,
         routingType: RoutingType.SCHEDULER_AND_HTTP_ROUTE,
         disabled: true,
       });
@@ -162,7 +165,13 @@ describe('LLMD Routing Admin Settings', () => {
       ).as('patchConfig');
 
       llmdRoutingSettingsPage.getRow('lab-routing-profile').findEnabledSwitch().click();
-      cy.wait('@patchConfig');
+      cy.wait('@patchConfig').then((interception) => {
+        const patches: { op: string; path: string; value: string }[] = interception.request.body;
+        const disabledPatch = patches.find(
+          (p) => p.path === '/metadata/annotations/opendatahub.io~1disabled',
+        );
+        expect(disabledPatch?.value).to.equal('true');
+      });
     });
 
     it('should hide delete action for pre-installed configs', () => {
@@ -195,7 +204,7 @@ describe('LLMD Routing Admin Settings', () => {
     });
 
     it('should disable config source until topology is selected', () => {
-      llmdRoutingCreatePage.findConfigSourceSelect().findByRole('button').should('be.disabled');
+      llmdRoutingCreatePage.findConfigSourceSelect().should('be.disabled');
     });
 
     it('should navigate back on cancel', () => {

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
@@ -176,4 +176,31 @@ describe('LLMD Routing Admin Settings', () => {
       llmdRoutingSettingsPage.getRow('lab-routing-profile').findKebabAction('Delete');
     });
   });
+
+  describe('create page', () => {
+    beforeEach(() => {
+      initIntercepts();
+      llmdRoutingSettingsPage.visit();
+      llmdRoutingSettingsPage.findAddButton().click();
+      llmdRoutingCreatePage.findTitle().should('contain', 'Add llm-d routing configuration');
+    });
+
+    it('should show create page with topology type and config source dropdowns', () => {
+      llmdRoutingCreatePage.findTopologyTypeSelect().should('exist');
+      llmdRoutingCreatePage.findConfigSourceSelect().should('exist');
+    });
+
+    it('should have submit button disabled when no topology selected', () => {
+      llmdRoutingCreatePage.findSubmitButton().should('be.disabled');
+    });
+
+    it('should disable config source until topology is selected', () => {
+      llmdRoutingCreatePage.findConfigSourceSelect().findByRole('button').should('be.disabled');
+    });
+
+    it('should navigate back on cancel', () => {
+      llmdRoutingCreatePage.findCancelButton().click();
+      llmdRoutingSettingsPage.findTable().should('exist');
+    });
+  });
 });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
@@ -1,0 +1,179 @@
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { RoutingType } from '@odh-dashboard/llmd-serving/types';
+import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { LLMInferenceServiceConfigModel } from '@odh-dashboard/cypress/cypress/utils/models';
+import { asProductAdminUser } from '@odh-dashboard/cypress/cypress/utils/mockUsers';
+import { llmdRoutingSettingsPage, llmdRoutingCreatePage } from '@odh-dashboard/cypress/cypress/pages/llmdRoutingSettings';
+import { pageNotfound } from '@odh-dashboard/cypress/cypress/pages/pageNotFound';
+
+const mockPreInstalledScheduler = mockLLMInferenceServiceConfigK8sResource({
+  name: 'managed-scheduler',
+  displayName: 'Managed scheduler',
+  configType: 'router',
+  routingType: RoutingType.SCHEDULER,
+  preInstalled: true,
+});
+
+const mockPreInstalledHttpRoute = mockLLMInferenceServiceConfigK8sResource({
+  name: 'managed-httproute',
+  displayName: 'Managed HTTPRoute',
+  configType: 'router',
+  routingType: RoutingType.HTTP_ROUTE,
+  preInstalled: true,
+  disabled: true,
+});
+
+const mockPreInstalledCombo = mockLLMInferenceServiceConfigK8sResource({
+  name: 'managed-scheduler-httproute',
+  displayName: 'Managed scheduler with HTTPRoute',
+  configType: 'router',
+  routingType: RoutingType.SCHEDULER_AND_HTTP_ROUTE,
+  preInstalled: true,
+});
+
+const mockUserConfig = mockLLMInferenceServiceConfigK8sResource({
+  name: 'lab-routing-profile',
+  displayName: 'Lab routing profile',
+  configType: 'router',
+  routingType: RoutingType.SCHEDULER_AND_HTTP_ROUTE,
+});
+
+const allConfigs = [
+  mockPreInstalledCombo,
+  mockPreInstalledScheduler,
+  mockPreInstalledHttpRoute,
+  mockUserConfig,
+];
+
+const initIntercepts = ({
+  configs = allConfigs,
+  llmdTopologyConfigsEnabled = true,
+}: {
+  configs?: ReturnType<typeof mockLLMInferenceServiceConfigK8sResource>[];
+  llmdTopologyConfigsEnabled?: boolean;
+} = {}) => {
+  asProductAdminUser();
+
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+      },
+    }),
+  );
+
+  const config = mockDashboardConfig({
+    disableKServe: false,
+    disableLLMd: false,
+  });
+  config.spec.dashboardConfig.llmdTopologyConfigs = llmdTopologyConfigsEnabled;
+  cy.interceptOdh('GET /api/config', config);
+  cy.interceptOdh('GET /api/components', null, []);
+
+  cy.interceptK8sList(
+    { model: LLMInferenceServiceConfigModel, ns: 'opendatahub' },
+    mockK8sResourceList(configs),
+  );
+};
+
+describe('LLMD Routing Admin Settings', () => {
+  describe('tab visibility', () => {
+    it('should show routing configurations tab when flags enabled', () => {
+      initIntercepts();
+      llmdRoutingSettingsPage.visit();
+      llmdRoutingSettingsPage.findAppTitle().should('contain', 'llm-d routing configurations');
+      llmdRoutingSettingsPage.findTable().should('exist');
+    });
+
+    it('should show 404 when flag disabled', () => {
+      initIntercepts({ llmdTopologyConfigsEnabled: false });
+      llmdRoutingSettingsPage.visit(false);
+      pageNotfound.findPage().should('exist');
+    });
+  });
+
+  describe('configurations table', () => {
+    beforeEach(() => {
+      initIntercepts();
+      llmdRoutingSettingsPage.visit();
+    });
+
+    it('should list routing configs with correct columns', () => {
+      llmdRoutingSettingsPage.getRow('managed-scheduler-httproute').find().should('exist');
+      llmdRoutingSettingsPage
+        .getRow('managed-scheduler-httproute')
+        .find()
+        .should('contain.text', 'Managed scheduler with HTTPRoute');
+
+      llmdRoutingSettingsPage.getRow('managed-scheduler').find().should('exist');
+      llmdRoutingSettingsPage
+        .getRow('managed-scheduler')
+        .find()
+        .should('contain.text', 'Managed scheduler');
+
+      llmdRoutingSettingsPage.getRow('lab-routing-profile').find().should('exist');
+      llmdRoutingSettingsPage
+        .getRow('lab-routing-profile')
+        .find()
+        .should('contain.text', 'Lab routing profile');
+    });
+
+    it('should show pre-installed badge on well-known configs', () => {
+      llmdRoutingSettingsPage.getRow('managed-scheduler').shouldHavePreInstalledLabel(true);
+      llmdRoutingSettingsPage.getRow('lab-routing-profile').shouldHavePreInstalledLabel(false);
+    });
+
+    it('should show routing type labels', () => {
+      llmdRoutingSettingsPage
+        .getRow('managed-scheduler-httproute')
+        .findRoutingTypeLabel()
+        .should('contain.text', 'Scheduler + HTTPRoute');
+      llmdRoutingSettingsPage
+        .getRow('managed-scheduler')
+        .findRoutingTypeLabel()
+        .should('contain.text', 'Scheduler');
+      llmdRoutingSettingsPage
+        .getRow('managed-httproute')
+        .findRoutingTypeLabel()
+        .should('contain.text', 'HTTPRoute');
+    });
+
+    it('should toggle enabled state via switch', () => {
+      const patchedConfig = mockLLMInferenceServiceConfigK8sResource({
+        name: 'lab-routing-profile',
+        displayName: 'Lab routing profile',
+        configType: 'router',
+        routingType: RoutingType.SCHEDULER_AND_HTTP_ROUTE,
+        disabled: true,
+      });
+      cy.interceptK8s(
+        'PATCH',
+        {
+          model: LLMInferenceServiceConfigModel,
+          ns: 'opendatahub',
+          name: 'lab-routing-profile',
+        },
+        patchedConfig,
+      ).as('patchConfig');
+
+      llmdRoutingSettingsPage.getRow('lab-routing-profile').findEnabledSwitch().click();
+      cy.wait('@patchConfig');
+    });
+
+    it('should hide delete action for pre-installed configs', () => {
+      llmdRoutingSettingsPage
+        .getRow('managed-scheduler')
+        .findKebabAction('Delete', false)
+        .should('not.exist');
+    });
+
+    it('should show delete action for user-created configs', () => {
+      llmdRoutingSettingsPage.getRow('lab-routing-profile').findKebabAction('Delete');
+    });
+  });
+});


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-70586

## Description

Adds an admin settings tab for managing llm-d routing configurations under **Settings > Model resources and operations > llm-d routing configurations**.

### What's included:

**Extension registration** (`extensions.ts`)
**List page** (`RoutingConfigurationsView` + `RoutingConfigurationsTable`)
**Row component** (`RoutingConfigurationRow`)
**Create/Edit/Duplicate page** (`RoutingConfigurationCreateEdit`)
**Shared components**
- `ConfigYAMLEditor` — reusable YAML editor with metadata field sync (shared with topology configs tab from PR #8400- will be resolved once it merges)

**Cypress mock tests** (7 test cases)

## How Has This Been Tested?

- Manual testing on a live cluster (`zaffre`) with `llmdTopologyConfigs` feature flag enabled

https://github.com/user-attachments/assets/7b1e6a2b-7be1-4837-93dd-c55e5149370f


- Created 4 test `LLMInferenceServiceConfig` resources (3 pre-installed, 1 user-created) to verify:
  - List page renders routing configs with descriptions, pre-installed badges, and routing type labels
  - Enable/disable toggle patches the correct annotation
  - Kebab actions: Duplicate-only for pre-installed, full menu (Duplicate/Edit/Delete) for user-created
  - Add page shows topology type dropdown (defaulting to "All topologies") and configuration source dropdown
  - Sample template API probe correctly disables "Start from sample" when API returns 404
- Cypress mock tests written and passing (7/7, with 1 transient ESOCKETTIMEOUT on first run — passes on retry)
## Test Impact

**New test files:**
- `packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts` — 7 test cases covering tab visibility, table rendering, routing type labels, toggle, and kebab actions
- `packages/cypress/cypress/pages/llmdRoutingSettings.ts` — page object with `RoutingConfigRow` helpers

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an LLM-D routing configurations settings entry with a sortable table and full add/edit/duplicate and delete-confirmation flows.
  * Users can toggle routing configurations, view routing type and pre-installed status, and manage row actions.
* **Bug Fixes**
  * Improved enable/disable behavior by correctly adding/removing the disabled annotation.
  * Enhanced create/edit flows for topology/routing configurations with clearer not-found and loading handling, and more reliable YAML initialization for duplication/editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->