### PR TITLE
feat(operator): implement independent pod deployment with DeploymentMode feature flag

### DIFF
--- a/dashboard-operator/Dockerfile
+++ b/dashboard-operator/Dockerfile
@@ -19,7 +19,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 WORKDIR /
 
 COPY --from=builder /tmp/manager .
-COPY manifests/ /opt/manifests/dashboard/
+COPY --chown=65532:0 manifests/ /opt/manifests/dashboard/
+RUN chmod -R g+w /opt/manifests/dashboard/
 
 USER 65532:65532
 

--- a/dashboard-operator/Dockerfile
+++ b/dashboard-operator/Dockerfile
@@ -20,7 +20,9 @@ WORKDIR /
 
 COPY --from=builder /tmp/manager .
 COPY --chown=65532:0 manifests/ /opt/manifests/dashboard/
-RUN chmod -R g+w /opt/manifests/dashboard/
+RUN chmod -R g+w /opt/manifests/dashboard/modular-architecture/modules/ \
+    && chmod g+w /opt/manifests/dashboard/odh/params.env \
+    && chmod g+w /opt/manifests/dashboard/modular-architecture/params.env
 
 USER 65532:65532
 

--- a/dashboard-operator/api/v1alpha1/dashboard_types.go
+++ b/dashboard-operator/api/v1alpha1/dashboard_types.go
@@ -30,6 +30,14 @@ const (
 	ModulePhaseDisabled    ModulePhase = "Disabled"
 )
 
+// DeploymentMode controls how BFF modules are deployed.
+type DeploymentMode string
+
+const (
+	DeploymentModeSidecar    DeploymentMode = "Sidecar"
+	DeploymentModeStandalone DeploymentMode = "Standalone"
+)
+
 // GatewaySpec defines gateway configuration for the dashboard.
 // On OpenShift this translates to a Route; on vanilla Kubernetes it
 // configures an Ingress resource with the specified domain.
@@ -144,6 +152,14 @@ type DashboardSpec struct {
 	// Observability configures the observability stack integration.
 	// +optional
 	Observability *ObservabilitySpec `json:"observability,omitempty"`
+
+	// DeploymentMode controls how BFF modules are deployed.
+	// Sidecar (default): modules run as containers in the main dashboard pod.
+	// Standalone: each module gets its own Deployment, Service, and RBAC.
+	// +kubebuilder:validation:Enum=Sidecar;Standalone
+	// +kubebuilder:default=Sidecar
+	// +optional
+	DeploymentMode DeploymentMode `json:"deploymentMode,omitempty"`
 }
 
 // DashboardStatus defines the observed state of the Dashboard.

--- a/dashboard-operator/api/v1alpha1/dashboard_types.go
+++ b/dashboard-operator/api/v1alpha1/dashboard_types.go
@@ -38,6 +38,8 @@ const (
 	DeploymentModeStandalone DeploymentMode = "Standalone"
 )
 
+// +kubebuilder:object:generate=true
+
 // GatewaySpec defines gateway configuration for the dashboard.
 // On OpenShift this translates to a Route; on vanilla Kubernetes it
 // configures an Ingress resource with the specified domain.
@@ -47,6 +49,8 @@ type GatewaySpec struct {
 	// +kubebuilder:validation:Pattern=`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`
 	Domain string `json:"domain"`
 }
+
+// +kubebuilder:object:generate=true
 
 // ComponentAvailability represents a DSC component's availability state
 // as projected by the orchestrator.
@@ -60,6 +64,8 @@ type ComponentAvailability struct {
 	ManagementState string `json:"managementState"`
 }
 
+// +kubebuilder:object:generate=true
+
 // ModuleOverride allows the orchestrator or admin to override the
 // automatic dependency-based module enablement decision.
 type ModuleOverride struct {
@@ -71,6 +77,8 @@ type ModuleOverride struct {
 	State ModuleOverrideState `json:"state,omitempty"`
 }
 
+// +kubebuilder:object:generate=true
+
 // Distribution reports the product distribution identity (e.g. "RHOAI" / "2.20").
 type Distribution struct {
 	// +kubebuilder:validation:MaxLength=256
@@ -81,6 +89,8 @@ type Distribution struct {
 	// +optional
 	Version string `json:"version,omitempty"`
 }
+
+// +kubebuilder:object:generate=true
 
 // ObservabilitySpec configures the Perses observability proxy.
 type ObservabilitySpec struct {
@@ -96,6 +106,8 @@ type ObservabilitySpec struct {
 	// +optional
 	PersesService *ServiceTarget `json:"persesService,omitempty"`
 }
+
+// +kubebuilder:object:generate=true
 
 // ServiceTarget identifies a Kubernetes service for proxy configuration.
 type ServiceTarget struct {
@@ -113,6 +125,8 @@ type ServiceTarget struct {
 	Port int32 `json:"port,omitempty"`
 }
 
+// +kubebuilder:object:generate=true
+
 // ModuleStatus reports the current state of a single module.
 type ModuleStatus struct {
 	// +kubebuilder:validation:Enum=Deployed;NotDeployed;Degraded;Disabled
@@ -128,6 +142,8 @@ type ModuleStatus struct {
 	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 }
+
+// +kubebuilder:object:generate=true
 
 // DashboardSpec defines the desired state of the Dashboard module.
 type DashboardSpec struct {
@@ -161,6 +177,8 @@ type DashboardSpec struct {
 	// +optional
 	DeploymentMode DeploymentMode `json:"deploymentMode,omitempty"`
 }
+
+// +kubebuilder:object:generate=true
 
 // DashboardStatus defines the observed state of the Dashboard.
 type DashboardStatus struct {

--- a/dashboard-operator/charts/dashboard/crds/components.platform.opendatahub.io_dashboards.yaml
+++ b/dashboard-operator/charts/dashboard/crds/components.platform.opendatahub.io_dashboards.yaml
@@ -84,6 +84,16 @@ spec:
                   Components is a snapshot of DSC component availability, projected by
                   the ODH Operator onto this CR.
                 type: object
+              deploymentMode:
+                default: Sidecar
+                description: |-
+                  DeploymentMode controls how BFF modules are deployed.
+                  Sidecar (default): modules run as containers in the main dashboard pod.
+                  Standalone: each module gets its own Deployment, Service, and RBAC.
+                enum:
+                - Sidecar
+                - Standalone
+                type: string
               gateway:
                 description: Gateway configures the ingress point for the dashboard.
                 properties:

--- a/dashboard-operator/config/crd/bases/components.platform.opendatahub.io_dashboards.yaml
+++ b/dashboard-operator/config/crd/bases/components.platform.opendatahub.io_dashboards.yaml
@@ -84,6 +84,16 @@ spec:
                   Components is a snapshot of DSC component availability, projected by
                   the ODH Operator onto this CR.
                 type: object
+              deploymentMode:
+                default: Sidecar
+                description: |-
+                  DeploymentMode controls how BFF modules are deployed.
+                  Sidecar (default): modules run as containers in the main dashboard pod.
+                  Standalone: each module gets its own Deployment, Service, and RBAC.
+                enum:
+                - Sidecar
+                - Standalone
+                type: string
               gateway:
                 description: Gateway configures the ingress point for the dashboard.
                 properties:

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -195,6 +195,19 @@ func (r *DashboardReconciler) reconcile(
 	cm *conditions.Manager,
 	cfg OperatorConfig,
 ) (ctrl.Result, error) {
+	mode := dashboard.Spec.DeploymentMode
+	if mode == "" || mode == v1alpha1.DeploymentModeSidecar {
+		return r.reconcileSidecar(ctx, dashboard, cm, cfg)
+	}
+	return r.reconcileStandalone(ctx, dashboard, cm, cfg)
+}
+
+func (r *DashboardReconciler) reconcileSidecar(
+	ctx context.Context,
+	dashboard *v1alpha1.Dashboard,
+	cm *conditions.Manager,
+	cfg OperatorConfig,
+) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	manifests := manifestSets(r.ManifestsBasePath, r.Platform)
@@ -342,6 +355,182 @@ func (r *DashboardReconciler) reconcile(
 		logger.Info("Dashboard reconcile cycle complete, requeuing", "requeueAfter", requeueAfter, "modules", len(dashboard.Status.ModuleStatuses))
 	} else {
 		logger.Info("Dashboard reconciled successfully", "url", url, "modules", len(dashboard.Status.ModuleStatuses))
+	}
+
+	if requeueAfter == 0 && cfg.ReconcileInterval > 0 {
+		requeueAfter = cfg.ReconcileInterval
+	}
+
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+func (r *DashboardReconciler) reconcileStandalone(
+	ctx context.Context,
+	dashboard *v1alpha1.Dashboard,
+	cm *conditions.Manager,
+	cfg OperatorConfig,
+) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Step 1: Deploy core manifests (main dashboard deployment without sidecar patches)
+	manifests := manifestSets(r.ManifestsBasePath, r.Platform)
+
+	if err := applyKustomizeParams(dashboard, manifests, r.Platform); err != nil {
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("KustomizeParamsFailed"),
+			conditions.WithError(err))
+		return ctrl.Result{}, fmt.Errorf("failed to apply kustomize params: %w", err)
+	}
+
+	engine := kustomize.NewEngine()
+	var allResources []unstructured.Unstructured
+	for _, m := range manifests {
+		rendered, err := engine.Render(m.String(), kustomize.WithNamespace(r.ApplicationsNamespace))
+		if err != nil {
+			cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+				conditions.WithReason("RenderFailed"),
+				conditions.WithError(err))
+			return ctrl.Result{}, fmt.Errorf("failed to render core manifests from %s: %w", m, err)
+		}
+		allResources = append(allResources, rendered...)
+	}
+
+	deployer := deploy.NewDeployer(
+		deploy.WithFieldOwner("dashboard-operator"),
+		deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
+		deploy.WithApplyOrder(),
+	)
+
+	if err := deployer.Deploy(ctx, deploy.DeployInput{
+		Client:    r.Client,
+		Owner:     dashboard,
+		Release:   deploy.ReleaseInfo{Type: string(r.Platform)},
+		Resources: allResources,
+	}); err != nil {
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("DeployFailed"),
+			conditions.WithError(err))
+		return ctrl.Result{}, fmt.Errorf("failed to deploy core resources: %w", err)
+	}
+
+	// Step 2: Resolve module statuses
+	nextStatuses := resolveModuleStatuses(&dashboard.Spec)
+
+	// Step 3: Deploy enabled modules
+	if err := r.deployModuleManifests(ctx, dashboard, nextStatuses); err != nil {
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("ModuleDeployFailed"),
+			conditions.WithError(err))
+		return ctrl.Result{}, fmt.Errorf("failed to deploy module manifests: %w", err)
+	}
+
+	// Step 4: GC disabled modules
+	if err := r.deleteModuleResources(ctx, nextStatuses); err != nil {
+		logger.Error(err, "Failed to clean up disabled module resources")
+	}
+
+	cm.MarkTrue(string(common.ConditionTypeProvisioningSucceeded),
+		conditions.WithReason("ResourcesApplied"),
+		conditions.WithMessage("Dashboard and module manifests applied successfully"))
+
+	// Step 5: Deploy observability
+	switch obsErr := deployObservabilityManifests(ctx, r.Client, dashboard, r.ManifestsBasePath, r.Platform); {
+	case obsErr == nil:
+		cm.MarkTrue(conditionObservabilityAvailable,
+			conditions.WithReason("Deployed"),
+			conditions.WithMessage("Observability manifests applied successfully"))
+	case errors.Is(obsErr, ErrObservabilityDisabled):
+		cm.MarkFalse(conditionObservabilityAvailable,
+			conditions.WithReason("Disabled"),
+			conditions.WithMessage("Observability is not enabled"),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+	case errors.Is(obsErr, ErrPersesServiceRequired):
+		cm.MarkFalse(conditionObservabilityAvailable,
+			conditions.WithReason("InvalidConfig"),
+			conditions.WithError(obsErr))
+	case errors.Is(obsErr, ErrPersesCRDNotFound):
+		cm.MarkFalse(conditionObservabilityAvailable,
+			conditions.WithReason("PersesCRDNotFound"),
+			conditions.WithMessage("PersesDashboard CRD is not installed; install Cluster Observability Operator"),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+	default:
+		cm.MarkFalse(conditionObservabilityAvailable,
+			conditions.WithReason("DeployFailed"),
+			conditions.WithError(obsErr))
+	}
+
+	// Step 6: Build and deploy federation ConfigMap
+	fedCM, err := r.buildFederationConfigMap(nextStatuses, dashboard)
+	if err != nil {
+		logger.Error(err, "Failed to build federation ConfigMap")
+	} else {
+		fedResources, convErr := configMapToUnstructured(fedCM)
+		if convErr == nil {
+			fedDeployer := deploy.NewDeployer(
+				deploy.WithFieldOwner("dashboard-operator"),
+				deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
+			)
+			if deployErr := fedDeployer.Deploy(ctx, deploy.DeployInput{
+				Client:    r.Client,
+				Owner:     dashboard,
+				Release:   deploy.ReleaseInfo{Type: string(r.Platform)},
+				Resources: []unstructured.Unstructured{fedResources},
+			}); deployErr != nil {
+				logger.Error(deployErr, "Failed to deploy federation ConfigMap")
+			}
+		}
+	}
+
+	// Step 7: URL extraction
+	url, urlErr := extractDashboardURL(ctx, r.Client, dashboard, r.ApplicationsNamespace, r.Platform)
+	var requeueAfter time.Duration
+
+	switch {
+	case errors.Is(urlErr, ErrDashboardRouteNotReady):
+		cm.MarkFalse(string(common.ConditionTypeDegraded),
+			conditions.WithReason("RouteNotReady"),
+			conditions.WithMessage("Dashboard route is not yet admitted"),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+		cm.MarkFalse(string(common.ConditionTypeReady),
+			conditions.WithReason("RouteNotReady"),
+			conditions.WithMessage("Dashboard route is not yet admitted"))
+		requeueAfter = 10 * time.Second
+	case urlErr != nil:
+		cm.MarkFalse(string(common.ConditionTypeDegraded),
+			conditions.WithReason("URLExtractionFailed"),
+			conditions.WithError(urlErr),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+		cm.MarkFalse(string(common.ConditionTypeReady),
+			conditions.WithReason("URLExtractionFailed"),
+			conditions.WithError(urlErr))
+		return ctrl.Result{}, fmt.Errorf("failed to extract dashboard URL: %w", urlErr)
+	default:
+		cm.MarkFalse(string(common.ConditionTypeDegraded),
+			conditions.WithReason("NoDegradation"),
+			conditions.WithMessage("All sub-modules healthy"),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+		dashboard.Status.URL = url
+	}
+
+	// Step 8: Overlay readiness from standalone deployments
+	r.overlayStandaloneReadiness(ctx, nextStatuses)
+
+	// Preserve LastTransitionTime
+	for name, next := range nextStatuses {
+		if prev, ok := dashboard.Status.ModuleStatuses[name]; ok &&
+			prev.Phase == next.Phase &&
+			prev.Reason == next.Reason &&
+			prev.Message == next.Message {
+			next.LastTransitionTime = prev.LastTransitionTime
+			nextStatuses[name] = next
+		}
+	}
+	dashboard.Status.ModuleStatuses = nextStatuses
+
+	if requeueAfter > 0 {
+		logger.Info("Standalone reconcile cycle complete, requeuing", "requeueAfter", requeueAfter)
+	} else {
+		logger.Info("Standalone mode reconciled successfully", "url", url, "modules", len(dashboard.Status.ModuleStatuses))
 	}
 
 	if requeueAfter == 0 && cfg.ReconcileInterval > 0 {

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -433,7 +433,11 @@ func (r *DashboardReconciler) reconcileStandalone(
 		conditions.WithReason("ResourcesApplied"),
 		conditions.WithMessage("Dashboard and module manifests applied successfully"))
 
-	// Step 5: Deploy observability
+	// Step 5: Overlay readiness from standalone deployments (before federation ConfigMap
+	// so the ConfigMap reflects actual deployment health, e.g. Degraded modules)
+	r.overlayStandaloneReadiness(ctx, nextStatuses)
+
+	// Step 6: Deploy observability
 	switch obsErr := deployObservabilityManifests(ctx, r.Client, dashboard, r.ManifestsBasePath, r.Platform); {
 	case obsErr == nil:
 		cm.MarkTrue(conditionObservabilityAvailable,
@@ -462,7 +466,7 @@ func (r *DashboardReconciler) reconcileStandalone(
 		logger.Error(obsErr, "Failed to deploy observability manifests")
 	}
 
-	// Step 6: Build and deploy federation ConfigMap (critical for standalone routing)
+	// Step 7: Build and deploy federation ConfigMap (critical for standalone routing)
 	if err := r.deployFederationConfigMap(ctx, nextStatuses, dashboard); err != nil {
 		cm.MarkTrue(string(common.ConditionTypeDegraded),
 			conditions.WithReason("FederationConfigMapFailed"),
@@ -471,7 +475,7 @@ func (r *DashboardReconciler) reconcileStandalone(
 		return ctrl.Result{}, fmt.Errorf("federation ConfigMap: %w", err)
 	}
 
-	// Step 7: URL extraction
+	// Step 8: URL extraction
 	url, urlErr := extractDashboardURL(ctx, r.Client, dashboard, r.ApplicationsNamespace, r.Platform)
 	var requeueAfter time.Duration
 
@@ -501,9 +505,6 @@ func (r *DashboardReconciler) reconcileStandalone(
 			conditions.WithSeverity(common.ConditionSeverityInfo))
 		dashboard.Status.URL = url
 	}
-
-	// Step 8: Overlay readiness from standalone deployments
-	r.overlayStandaloneReadiness(ctx, nextStatuses)
 
 	// Preserve LastTransitionTime
 	for name, next := range nextStatuses {

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -259,68 +259,11 @@ func (r *DashboardReconciler) reconcileSidecar(
 		conditions.WithReason("ResourcesApplied"),
 		conditions.WithMessage("Dashboard manifests applied successfully"))
 
-	switch obsErr := deployObservabilityManifests(ctx, r.Client, dashboard, r.ManifestsBasePath, r.Platform); {
-	case obsErr == nil:
-		cm.MarkTrue(conditionObservabilityAvailable,
-			conditions.WithReason("Deployed"),
-			conditions.WithMessage("Observability manifests applied successfully"))
-	case errors.Is(obsErr, ErrObservabilityDisabled):
-		cm.MarkFalse(conditionObservabilityAvailable,
-			conditions.WithReason("Disabled"),
-			conditions.WithMessage("Observability is not enabled"),
-			conditions.WithSeverity(common.ConditionSeverityInfo))
-	case errors.Is(obsErr, ErrPersesServiceRequired):
-		cm.MarkFalse(conditionObservabilityAvailable,
-			conditions.WithReason("InvalidConfig"),
-			conditions.WithError(obsErr))
-		logger.Error(obsErr, "Observability is enabled but PersesService is not configured")
-	case errors.Is(obsErr, ErrPersesCRDNotFound):
-		cm.MarkFalse(conditionObservabilityAvailable,
-			conditions.WithReason("PersesCRDNotFound"),
-			conditions.WithMessage("PersesDashboard CRD is not installed; install Cluster Observability Operator"),
-			conditions.WithSeverity(common.ConditionSeverityInfo))
-		logger.Info("PersesDashboard CRD not found, skipping observability deployment")
-	default:
-		cm.MarkFalse(conditionObservabilityAvailable,
-			conditions.WithReason("DeployFailed"),
-			conditions.WithError(obsErr))
-		logger.Error(obsErr, "Failed to deploy observability manifests")
-	}
+	r.reconcileObservability(ctx, dashboard, cm)
 
-	url, err := extractDashboardURL(ctx, r.Client, dashboard, r.ApplicationsNamespace, r.Platform)
-
-	var requeueAfter time.Duration
-
-	// URL is intentionally not cleared on error — "last known good" semantic.
-	// Conditions (Ready, Degraded) communicate the actual state.
-	switch {
-	case errors.Is(err, ErrDashboardRouteNotReady):
-		cm.MarkFalse(string(common.ConditionTypeDegraded),
-			conditions.WithReason("RouteNotReady"),
-			conditions.WithMessage("Dashboard route is not yet admitted"),
-			conditions.WithSeverity(common.ConditionSeverityInfo))
-		cm.MarkFalse(string(common.ConditionTypeReady),
-			conditions.WithReason("RouteNotReady"),
-			conditions.WithMessage("Dashboard route is not yet admitted"))
-		logger.Info("Dashboard route not yet available, requeuing")
-		requeueAfter = 10 * time.Second
-	case err != nil:
-		cm.MarkFalse(string(common.ConditionTypeDegraded),
-			conditions.WithReason("URLExtractionFailed"),
-			conditions.WithError(err),
-			conditions.WithSeverity(common.ConditionSeverityInfo))
-		cm.MarkFalse(string(common.ConditionTypeReady),
-			conditions.WithReason("URLExtractionFailed"),
-			conditions.WithError(err))
-		logger.Error(err, "Failed to extract dashboard URL")
-
-		return ctrl.Result{}, fmt.Errorf("failed to extract dashboard URL: %w", err)
-	default:
-		cm.MarkFalse(string(common.ConditionTypeDegraded),
-			conditions.WithReason("NoDegradation"),
-			conditions.WithMessage("All sub-modules healthy"),
-			conditions.WithSeverity(common.ConditionSeverityInfo))
-		dashboard.Status.URL = url
+	url, requeueAfter, err := r.reconcileURL(ctx, dashboard, cm)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	nextStatuses := resolveModuleStatuses(&dashboard.Spec)
@@ -438,6 +381,58 @@ func (r *DashboardReconciler) reconcileStandalone(
 	r.overlayStandaloneReadiness(ctx, nextStatuses)
 
 	// Step 6: Deploy observability
+	r.reconcileObservability(ctx, dashboard, cm)
+
+	// Step 7: Build and deploy federation ConfigMap (critical for standalone routing)
+	if err := r.deployFederationConfigMap(ctx, nextStatuses, dashboard); err != nil {
+		cm.MarkTrue(string(common.ConditionTypeDegraded),
+			conditions.WithReason("FederationConfigMapFailed"),
+			conditions.WithError(err))
+		logger.Error(err, "Failed to deploy federation ConfigMap")
+		return ctrl.Result{}, fmt.Errorf("federation ConfigMap: %w", err)
+	}
+
+	// Step 8: URL extraction + degraded condition
+	url, requeueAfter, urlErr := r.reconcileURL(ctx, dashboard, cm)
+	if urlErr != nil {
+		return ctrl.Result{}, urlErr
+	}
+	if requeueAfter == 0 {
+		r.reconcileDegradedCondition(cm, nextStatuses)
+	}
+
+	// Preserve LastTransitionTime
+	for name, next := range nextStatuses {
+		if prev, ok := dashboard.Status.ModuleStatuses[name]; ok &&
+			prev.Phase == next.Phase &&
+			prev.Reason == next.Reason &&
+			prev.Message == next.Message {
+			next.LastTransitionTime = prev.LastTransitionTime
+			nextStatuses[name] = next
+		}
+	}
+	dashboard.Status.ModuleStatuses = nextStatuses
+
+	if requeueAfter > 0 {
+		logger.Info("Standalone reconcile cycle complete, requeuing", "requeueAfter", requeueAfter)
+	} else {
+		logger.Info("Standalone mode reconciled successfully", "url", url, "modules", len(dashboard.Status.ModuleStatuses))
+	}
+
+	if requeueAfter == 0 && cfg.ReconcileInterval > 0 {
+		requeueAfter = cfg.ReconcileInterval
+	}
+
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+func (r *DashboardReconciler) reconcileObservability(
+	ctx context.Context,
+	dashboard *v1alpha1.Dashboard,
+	cm *conditions.Manager,
+) {
+	logger := log.FromContext(ctx)
+
 	switch obsErr := deployObservabilityManifests(ctx, r.Client, dashboard, r.ManifestsBasePath, r.Platform); {
 	case obsErr == nil:
 		cm.MarkTrue(conditionObservabilityAvailable,
@@ -465,22 +460,19 @@ func (r *DashboardReconciler) reconcileStandalone(
 			conditions.WithError(obsErr))
 		logger.Error(obsErr, "Failed to deploy observability manifests")
 	}
+}
 
-	// Step 7: Build and deploy federation ConfigMap (critical for standalone routing)
-	if err := r.deployFederationConfigMap(ctx, nextStatuses, dashboard); err != nil {
-		cm.MarkTrue(string(common.ConditionTypeDegraded),
-			conditions.WithReason("FederationConfigMapFailed"),
-			conditions.WithError(err))
-		logger.Error(err, "Failed to deploy federation ConfigMap")
-		return ctrl.Result{}, fmt.Errorf("federation ConfigMap: %w", err)
-	}
+func (r *DashboardReconciler) reconcileURL(
+	ctx context.Context,
+	dashboard *v1alpha1.Dashboard,
+	cm *conditions.Manager,
+) (string, time.Duration, error) {
+	logger := log.FromContext(ctx)
 
-	// Step 8: URL extraction
-	url, urlErr := extractDashboardURL(ctx, r.Client, dashboard, r.ApplicationsNamespace, r.Platform)
-	var requeueAfter time.Duration
+	url, err := extractDashboardURL(ctx, r.Client, dashboard, r.ApplicationsNamespace, r.Platform)
 
 	switch {
-	case errors.Is(urlErr, ErrDashboardRouteNotReady):
+	case errors.Is(err, ErrDashboardRouteNotReady):
 		cm.MarkFalse(string(common.ConditionTypeDegraded),
 			conditions.WithReason("RouteNotReady"),
 			conditions.WithMessage("Dashboard route is not yet admitted"),
@@ -488,47 +480,44 @@ func (r *DashboardReconciler) reconcileStandalone(
 		cm.MarkFalse(string(common.ConditionTypeReady),
 			conditions.WithReason("RouteNotReady"),
 			conditions.WithMessage("Dashboard route is not yet admitted"))
-		requeueAfter = 10 * time.Second
-	case urlErr != nil:
+		logger.Info("Dashboard route not yet available, requeuing")
+		return "", 10 * time.Second, nil
+	case err != nil:
 		cm.MarkFalse(string(common.ConditionTypeDegraded),
 			conditions.WithReason("URLExtractionFailed"),
-			conditions.WithError(urlErr),
+			conditions.WithError(err),
 			conditions.WithSeverity(common.ConditionSeverityInfo))
 		cm.MarkFalse(string(common.ConditionTypeReady),
 			conditions.WithReason("URLExtractionFailed"),
-			conditions.WithError(urlErr))
-		return ctrl.Result{}, fmt.Errorf("failed to extract dashboard URL: %w", urlErr)
+			conditions.WithError(err))
+		logger.Error(err, "Failed to extract dashboard URL")
+		return "", 0, fmt.Errorf("failed to extract dashboard URL: %w", err)
 	default:
 		cm.MarkFalse(string(common.ConditionTypeDegraded),
 			conditions.WithReason("NoDegradation"),
 			conditions.WithMessage("All sub-modules healthy"),
 			conditions.WithSeverity(common.ConditionSeverityInfo))
 		dashboard.Status.URL = url
+		return url, 0, nil
 	}
+}
 
-	// Preserve LastTransitionTime
-	for name, next := range nextStatuses {
-		if prev, ok := dashboard.Status.ModuleStatuses[name]; ok &&
-			prev.Phase == next.Phase &&
-			prev.Reason == next.Reason &&
-			prev.Message == next.Message {
-			next.LastTransitionTime = prev.LastTransitionTime
-			nextStatuses[name] = next
+func (r *DashboardReconciler) reconcileDegradedCondition(
+	cm *conditions.Manager,
+	statuses map[string]v1alpha1.ModuleStatus,
+) {
+	degradedModules := 0
+	for _, ns := range statuses {
+		if ns.Phase == v1alpha1.ModulePhaseDegraded {
+			degradedModules++
 		}
 	}
-	dashboard.Status.ModuleStatuses = nextStatuses
-
-	if requeueAfter > 0 {
-		logger.Info("Standalone reconcile cycle complete, requeuing", "requeueAfter", requeueAfter)
-	} else {
-		logger.Info("Standalone mode reconciled successfully", "url", url, "modules", len(dashboard.Status.ModuleStatuses))
+	if degradedModules > 0 {
+		cm.MarkTrue(string(common.ConditionTypeDegraded),
+			conditions.WithReason("ModulesDegraded"),
+			conditions.WithError(fmt.Errorf("%d module(s) degraded", degradedModules)),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
 	}
-
-	if requeueAfter == 0 && cfg.ReconcileInterval > 0 {
-		requeueAfter = cfg.ReconcileInterval
-	}
-
-	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
 // cleanupCrossNamespaceResources deletes Perses monitoring resources in the

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -462,28 +462,13 @@ func (r *DashboardReconciler) reconcileStandalone(
 		logger.Error(obsErr, "Failed to deploy observability manifests")
 	}
 
-	// Step 6: Build and deploy federation ConfigMap
-	fedCM, err := r.buildFederationConfigMap(nextStatuses, dashboard)
-	if err != nil {
-		logger.Error(err, "Failed to build federation ConfigMap")
-	} else {
-		fedResources, convErr := configMapToUnstructured(fedCM)
-		if convErr != nil {
-			logger.Error(convErr, "Failed to convert federation ConfigMap to unstructured")
-		} else {
-			fedDeployer := deploy.NewDeployer(
-				deploy.WithFieldOwner("dashboard-operator"),
-				deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
-			)
-			if deployErr := fedDeployer.Deploy(ctx, deploy.DeployInput{
-				Client:    r.Client,
-				Owner:     dashboard,
-				Release:   deploy.ReleaseInfo{Type: string(r.Platform)},
-				Resources: []unstructured.Unstructured{fedResources},
-			}); deployErr != nil {
-				logger.Error(deployErr, "Failed to deploy federation ConfigMap")
-			}
-		}
+	// Step 6: Build and deploy federation ConfigMap (critical for standalone routing)
+	if err := r.deployFederationConfigMap(ctx, nextStatuses, dashboard); err != nil {
+		cm.MarkTrue(string(common.ConditionTypeDegraded),
+			conditions.WithReason("FederationConfigMapFailed"),
+			conditions.WithError(err))
+		logger.Error(err, "Failed to deploy federation ConfigMap")
+		return ctrl.Result{}, fmt.Errorf("federation ConfigMap: %w", err)
 	}
 
 	// Step 7: URL extraction

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -380,6 +380,19 @@ func (r *DashboardReconciler) reconcileStandalone(
 	// so the ConfigMap reflects actual deployment health, e.g. Degraded modules)
 	r.overlayStandaloneReadiness(ctx, nextStatuses)
 
+	// Persist module statuses now so early returns from steps 6-8 don't leave
+	// stale status on the CR (the outer Reconcile always calls Status().Update).
+	for name, next := range nextStatuses {
+		if prev, ok := dashboard.Status.ModuleStatuses[name]; ok &&
+			prev.Phase == next.Phase &&
+			prev.Reason == next.Reason &&
+			prev.Message == next.Message {
+			next.LastTransitionTime = prev.LastTransitionTime
+			nextStatuses[name] = next
+		}
+	}
+	dashboard.Status.ModuleStatuses = nextStatuses
+
 	// Step 6: Deploy observability
 	r.reconcileObservability(ctx, dashboard, cm)
 
@@ -400,18 +413,6 @@ func (r *DashboardReconciler) reconcileStandalone(
 	if requeueAfter == 0 {
 		r.reconcileDegradedCondition(cm, nextStatuses)
 	}
-
-	// Preserve LastTransitionTime
-	for name, next := range nextStatuses {
-		if prev, ok := dashboard.Status.ModuleStatuses[name]; ok &&
-			prev.Phase == next.Phase &&
-			prev.Reason == next.Reason &&
-			prev.Message == next.Message {
-			next.LastTransitionTime = prev.LastTransitionTime
-			nextStatuses[name] = next
-		}
-	}
-	dashboard.Status.ModuleStatuses = nextStatuses
 
 	if requeueAfter > 0 {
 		logger.Info("Standalone reconcile cycle complete, requeuing", "requeueAfter", requeueAfter)

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -448,15 +448,18 @@ func (r *DashboardReconciler) reconcileStandalone(
 		cm.MarkFalse(conditionObservabilityAvailable,
 			conditions.WithReason("InvalidConfig"),
 			conditions.WithError(obsErr))
+		logger.Error(obsErr, "Observability is enabled but PersesService is not configured")
 	case errors.Is(obsErr, ErrPersesCRDNotFound):
 		cm.MarkFalse(conditionObservabilityAvailable,
 			conditions.WithReason("PersesCRDNotFound"),
 			conditions.WithMessage("PersesDashboard CRD is not installed; install Cluster Observability Operator"),
 			conditions.WithSeverity(common.ConditionSeverityInfo))
+		logger.Info("PersesDashboard CRD not found, skipping observability deployment")
 	default:
 		cm.MarkFalse(conditionObservabilityAvailable,
 			conditions.WithReason("DeployFailed"),
 			conditions.WithError(obsErr))
+		logger.Error(obsErr, "Failed to deploy observability manifests")
 	}
 
 	// Step 6: Build and deploy federation ConfigMap

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -468,7 +468,9 @@ func (r *DashboardReconciler) reconcileStandalone(
 		logger.Error(err, "Failed to build federation ConfigMap")
 	} else {
 		fedResources, convErr := configMapToUnstructured(fedCM)
-		if convErr == nil {
+		if convErr != nil {
+			logger.Error(convErr, "Failed to convert federation ConfigMap to unstructured")
+		} else {
 			fedDeployer := deploy.NewDeployer(
 				deploy.WithFieldOwner("dashboard-operator"),
 				deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -118,7 +118,6 @@ func (r *DashboardReconciler) deployModuleManifests(
 
 	computed := computeKustomizeVariables(dashboard, r.Platform)
 	maps.Copy(computed, resolveImageParams())
-	computed = addInterBFFParams(computed, statuses, r.Platform)
 
 	for name, mod := range moduleRegistry {
 		status := statuses[name]
@@ -133,10 +132,9 @@ func (r *DashboardReconciler) deployModuleManifests(
 			continue
 		}
 
-		defaults := readExistingParams(modulePath + "/params.env")
-		params := make(map[string]string, len(defaults)+len(computed))
-		maps.Copy(params, defaults)
+		params := make(map[string]string, len(computed))
 		maps.Copy(params, computed)
+		addInterBFFParams(params, name, statuses, r.Platform)
 		if err := writeParamsEnv(modulePath, params); err != nil {
 			return fmt.Errorf("failed to write params.env for module %s: %w", name, err)
 		}
@@ -268,23 +266,24 @@ func (r *DashboardReconciler) deleteModuleResources(
 
 // --- Inter-BFF env var params ---
 
-func addInterBFFParams(params map[string]string, statuses map[string]v1alpha1.ModuleStatus, platform cluster.Platform) map[string]string {
-	for _, deps := range interBFFDependencies {
-		for _, dep := range deps {
-			targetMod, ok := moduleRegistry[dep.TargetModule]
-			if !ok {
-				continue
-			}
-			ts := statuses[dep.TargetModule]
-			if ts.Phase != v1alpha1.ModulePhaseDeployed && ts.Phase != v1alpha1.ModulePhaseDegraded {
-				continue
-			}
-			svcName := standaloneServiceName(platform, targetMod.ManifestSlug)
-			params[dep.EnvServiceName] = svcName
-			params[dep.EnvServicePort] = fmt.Sprintf("%d", targetMod.Port)
-		}
+func addInterBFFParams(params map[string]string, moduleName string, statuses map[string]v1alpha1.ModuleStatus, platform cluster.Platform) {
+	deps, ok := interBFFDependencies[moduleName]
+	if !ok {
+		return
 	}
-	return params
+	for _, dep := range deps {
+		targetMod, ok := moduleRegistry[dep.TargetModule]
+		if !ok {
+			continue
+		}
+		ts := statuses[dep.TargetModule]
+		if ts.Phase != v1alpha1.ModulePhaseDeployed && ts.Phase != v1alpha1.ModulePhaseDegraded {
+			continue
+		}
+		svcName := standaloneServiceName(platform, targetMod.ManifestSlug)
+		params[dep.EnvServiceName] = svcName
+		params[dep.EnvServicePort] = fmt.Sprintf("%d", targetMod.Port)
+	}
 }
 
 // --- Build dynamic federation ConfigMap ---

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -1,0 +1,462 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/render/kustomize"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+const (
+	federationConfigMapName  = "federation-config"
+	federationConfigKey      = "module-federation-config.json"
+	federationHashAnnotation = "dashboard.opendatahub.io/federation-config-hash"
+	moduleComponentLabel     = "app.kubernetes.io/component"
+)
+
+// --- Module proxy configuration (static data needed for federation ConfigMap) ---
+
+type proxyRoute struct {
+	Path        string `json:"path"`
+	PathRewrite string `json:"pathRewrite"`
+}
+
+type serviceRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Port      int32  `json:"port"`
+}
+
+type federationEntry struct {
+	Name         string              `json:"name"`
+	RemoteEntry  string              `json:"remoteEntry,omitempty"`
+	Authorize    bool                `json:"authorize"`
+	TLS          bool                `json:"tls"`
+	Enabled      bool                `json:"enabled"`
+	Proxy        []proxyRoute        `json:"proxy,omitempty"`
+	Service      *serviceRef         `json:"service,omitempty"`
+	ProxyService []proxyServiceEntry `json:"proxyService,omitempty"`
+}
+
+type proxyServiceEntry struct {
+	Authorize   bool       `json:"authorize"`
+	Path        string     `json:"path"`
+	PathRewrite string     `json:"pathRewrite"`
+	TLS         bool       `json:"tls"`
+	Service     serviceRef `json:"service"`
+}
+
+var moduleProxyPaths = map[string][]proxyRoute{
+	"modelRegistry": {{Path: "/model-registry/api", PathRewrite: "/api"}},
+	"genAi":         {{Path: "/gen-ai/api", PathRewrite: "/api"}},
+	"maas":          {{Path: "/maas/api", PathRewrite: "/api"}},
+	"mlflow":        {{Path: "/_bff/mlflow/api", PathRewrite: "/api"}},
+	"evalHub":       {{Path: "/eval-hub/api", PathRewrite: "/api"}},
+	"automl":        {{Path: "/automl/api", PathRewrite: "/api"}},
+	"autorag":       {{Path: "/autorag/api", PathRewrite: "/api"}},
+	"agentOps": {
+		{Path: "/agent-ops/api", PathRewrite: "/api"},
+		{Path: "/agent-ops/healthcheck", PathRewrite: "/healthcheck"},
+	},
+}
+
+// --- Service discovery env vars (inter-BFF injection) ---
+
+type interBFFDependency struct {
+	EnvServiceName string
+	EnvServicePort string
+	TargetModule   string
+}
+
+var interBFFDependencies = map[string][]interBFFDependency{
+	"genAi": {
+		{
+			EnvServiceName: "BFF_MAAS_SERVICE_NAME",
+			EnvServicePort: "BFF_MAAS_SERVICE_PORT",
+			TargetModule:   "maas",
+		},
+	},
+}
+
+// --- Platform-aware service name resolution ---
+
+func standaloneServiceName(platform cluster.Platform, slug string) string {
+	prefix := "odh-dashboard"
+	if platform == cluster.SelfManagedRhoai || platform == cluster.ManagedRhoai {
+		prefix = "rhods-dashboard"
+	}
+	return prefix + "-" + slug + "-ui"
+}
+
+// --- Deploy individual module manifests ---
+
+func (r *DashboardReconciler) deployModuleManifests(
+	ctx context.Context,
+	dashboard *v1alpha1.Dashboard,
+	statuses map[string]v1alpha1.ModuleStatus,
+) error {
+	logger := log.FromContext(ctx)
+
+	computed := computeKustomizeVariables(dashboard, r.Platform)
+	maps.Copy(computed, resolveImageParams())
+	computed = addInterBFFParams(computed, statuses, r.Platform)
+
+	for name, mod := range moduleRegistry {
+		status := statuses[name]
+		if status.Phase != v1alpha1.ModulePhaseDeployed {
+			continue
+		}
+
+		modulePath := filepath.Join(r.ManifestsBasePath, "modular-architecture", "modules", mod.ManifestSlug)
+
+		if _, err := os.Stat(modulePath); os.IsNotExist(err) {
+			logger.Info("Module manifest directory not found, skipping standalone deployment", "module", name, "path", modulePath)
+			continue
+		}
+
+		params := readExistingParams(modulePath + "/params.env")
+		maps.Copy(params, computed)
+		if err := writeParamsEnv(modulePath, params); err != nil {
+			return fmt.Errorf("failed to write params.env for module %s: %w", name, err)
+		}
+
+		engine := kustomize.NewEngine()
+		rendered, err := engine.Render(modulePath, kustomize.WithNamespace(r.ApplicationsNamespace))
+		if err != nil {
+			logger.Error(err, "Failed to render module manifests", "module", name)
+			return fmt.Errorf("failed to render manifests for module %s: %w", name, err)
+		}
+
+		deployer := deploy.NewDeployer(
+			deploy.WithFieldOwner("dashboard-operator"),
+			deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
+			deploy.WithLabel(moduleComponentLabel, mod.ManifestSlug),
+			deploy.WithApplyOrder(),
+		)
+
+		if err := deployer.Deploy(ctx, deploy.DeployInput{
+			Client:    r.Client,
+			Owner:     dashboard,
+			Release:   deploy.ReleaseInfo{Type: string(r.Platform)},
+			Resources: rendered,
+		}); err != nil {
+			return fmt.Errorf("failed to deploy module %s: %w", name, err)
+		}
+
+		logger.Info("Deployed module", "module", name, "slug", mod.ManifestSlug)
+	}
+
+	return nil
+}
+
+// --- Delete disabled module resources ---
+
+func (r *DashboardReconciler) deleteModuleResources(
+	ctx context.Context,
+	statuses map[string]v1alpha1.ModuleStatus,
+) error {
+	logger := log.FromContext(ctx)
+
+	for name, mod := range moduleRegistry {
+		status := statuses[name]
+		if status.Phase == v1alpha1.ModulePhaseDeployed || status.Phase == v1alpha1.ModulePhaseDegraded {
+			continue
+		}
+
+		matchLabels := client.MatchingLabels{
+			labels.PlatformPartOf: strings.ToLower(v1alpha1.DashboardKind),
+			moduleComponentLabel:  mod.ManifestSlug,
+		}
+		inNamespace := client.InNamespace(r.ApplicationsNamespace)
+
+		deleted := false
+
+		var deployments appsv1.DeploymentList
+		if err := r.List(ctx, &deployments, matchLabels, inNamespace); err != nil {
+			return fmt.Errorf("listing deployments for module %s: %w", name, err)
+		}
+		for i := range deployments.Items {
+			if err := r.Delete(ctx, &deployments.Items[i]); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("deleting deployment for module %s: %w", name, err)
+			}
+			deleted = true
+		}
+
+		var services corev1.ServiceList
+		if err := r.List(ctx, &services, matchLabels, inNamespace); err != nil {
+			return fmt.Errorf("listing services for module %s: %w", name, err)
+		}
+		for i := range services.Items {
+			if err := r.Delete(ctx, &services.Items[i]); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("deleting service for module %s: %w", name, err)
+			}
+			deleted = true
+		}
+
+		var serviceAccounts corev1.ServiceAccountList
+		if err := r.List(ctx, &serviceAccounts, matchLabels, inNamespace); err != nil {
+			return fmt.Errorf("listing serviceaccounts for module %s: %w", name, err)
+		}
+		for i := range serviceAccounts.Items {
+			if err := r.Delete(ctx, &serviceAccounts.Items[i]); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("deleting serviceaccount for module %s: %w", name, err)
+			}
+			deleted = true
+		}
+
+		var netpols networkingv1.NetworkPolicyList
+		if err := r.List(ctx, &netpols, matchLabels, inNamespace); err != nil {
+			return fmt.Errorf("listing networkpolicies for module %s: %w", name, err)
+		}
+		for i := range netpols.Items {
+			if err := r.Delete(ctx, &netpols.Items[i]); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("deleting networkpolicy for module %s: %w", name, err)
+			}
+			deleted = true
+		}
+
+		var clusterRoles rbacv1.ClusterRoleList
+		if err := r.List(ctx, &clusterRoles, matchLabels); err != nil {
+			return fmt.Errorf("listing clusterroles for module %s: %w", name, err)
+		}
+		for i := range clusterRoles.Items {
+			if err := r.Delete(ctx, &clusterRoles.Items[i]); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("deleting clusterrole for module %s: %w", name, err)
+			}
+			deleted = true
+		}
+
+		var clusterRoleBindings rbacv1.ClusterRoleBindingList
+		if err := r.List(ctx, &clusterRoleBindings, matchLabels); err != nil {
+			return fmt.Errorf("listing clusterrolebindings for module %s: %w", name, err)
+		}
+		for i := range clusterRoleBindings.Items {
+			if err := r.Delete(ctx, &clusterRoleBindings.Items[i]); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("deleting clusterrolebinding for module %s: %w", name, err)
+			}
+			deleted = true
+		}
+
+		if deleted {
+			logger.Info("Cleaned up resources for disabled module", "module", name)
+		}
+	}
+
+	return nil
+}
+
+// --- Inter-BFF env var params ---
+
+func addInterBFFParams(params map[string]string, statuses map[string]v1alpha1.ModuleStatus, platform cluster.Platform) map[string]string {
+	for _, deps := range interBFFDependencies {
+		for _, dep := range deps {
+			targetMod, ok := moduleRegistry[dep.TargetModule]
+			if !ok {
+				continue
+			}
+			svcName := standaloneServiceName(platform, targetMod.ManifestSlug)
+			params[dep.EnvServiceName] = svcName
+			params[dep.EnvServicePort] = fmt.Sprintf("%d", targetMod.Port)
+		}
+	}
+	return params
+}
+
+// --- Build dynamic federation ConfigMap ---
+
+func (r *DashboardReconciler) buildFederationConfigMap(
+	statuses map[string]v1alpha1.ModuleStatus,
+	dashboard *v1alpha1.Dashboard,
+) (*corev1.ConfigMap, error) {
+	var entries []federationEntry
+
+	for name, mod := range moduleRegistry {
+		status := statuses[name]
+		if status.Phase != v1alpha1.ModulePhaseDeployed && status.Phase != v1alpha1.ModulePhaseDegraded {
+			continue
+		}
+
+		svcName := standaloneServiceName(r.Platform, mod.ManifestSlug)
+		enabled := status.Phase == v1alpha1.ModulePhaseDeployed
+
+		entry := federationEntry{
+			Name:        name,
+			RemoteEntry: "/remoteEntry.js",
+			Authorize:   true,
+			TLS:         true,
+			Enabled:     enabled,
+			Proxy:       moduleProxyPaths[name],
+			Service: &serviceRef{
+				Name:      svcName,
+				Namespace: r.ApplicationsNamespace,
+				Port:      mod.Port,
+			},
+		}
+		entries = append(entries, entry)
+	}
+
+	// Add perses entry if observability is enabled
+	if dashboard.Spec.Observability != nil && dashboard.Spec.Observability.Enabled &&
+		dashboard.Spec.Observability.PersesService != nil {
+		ps := dashboard.Spec.Observability.PersesService
+		entries = append(entries, federationEntry{
+			Name: "perses",
+			ProxyService: []proxyServiceEntry{{
+				Authorize:   true,
+				Path:        "/perses/api",
+				PathRewrite: "",
+				TLS:         false,
+				Service: serviceRef{
+					Name:      ps.Name,
+					Namespace: ps.Namespace,
+					Port:      ps.Port,
+				},
+			}},
+		})
+	}
+
+	// Add mlflowEmbedded entry if mlflow is deployed
+	if s, ok := statuses["mlflow"]; ok && (s.Phase == v1alpha1.ModulePhaseDeployed || s.Phase == v1alpha1.ModulePhaseDegraded) {
+		entries = append(entries, federationEntry{
+			Name:        "mlflowEmbedded",
+			RemoteEntry: "/mlflow/static-files/federated/remoteEntry.js",
+			Authorize:   true,
+			TLS:         true,
+			Enabled:     s.Phase == v1alpha1.ModulePhaseDeployed,
+			Service: &serviceRef{
+				Name:      "mlflow",
+				Namespace: r.ApplicationsNamespace,
+				Port:      8443,
+			},
+		})
+	}
+
+	// Sort entries by name for deterministic output
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+
+	data, err := json.MarshalIndent(entries, "    ", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal federation config: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      federationConfigMapName,
+			Namespace: r.ApplicationsNamespace,
+		},
+		Data: map[string]string{
+			federationConfigKey: string(data),
+		},
+	}
+
+	return cm, nil
+}
+
+// --- Standalone readiness overlay ---
+
+func (r *DashboardReconciler) overlayStandaloneReadiness(
+	ctx context.Context,
+	statuses map[string]v1alpha1.ModuleStatus,
+) {
+	now := metav1.Now()
+
+	for name, mod := range moduleRegistry {
+		s, ok := statuses[name]
+		if !ok || s.Phase != v1alpha1.ModulePhaseDeployed {
+			continue
+		}
+
+		var deployList appsv1.DeploymentList
+		if err := r.List(ctx, &deployList,
+			client.InNamespace(r.ApplicationsNamespace),
+			client.MatchingLabels{
+				labels.PlatformPartOf: strings.ToLower(v1alpha1.DashboardKind),
+				moduleComponentLabel:  mod.ManifestSlug,
+			},
+		); err != nil {
+			statuses[name] = v1alpha1.ModuleStatus{
+				Phase:              v1alpha1.ModulePhaseDegraded,
+				Reason:             "ListFailed",
+				Message:            fmt.Sprintf("Failed to list deployments for module %s: %v", name, err),
+				LastTransitionTime: now,
+			}
+			continue
+		}
+
+		if len(deployList.Items) == 0 {
+			statuses[name] = v1alpha1.ModuleStatus{
+				Phase:              v1alpha1.ModulePhaseNotDeployed,
+				Reason:             "DeploymentNotFound",
+				Message:            fmt.Sprintf("No Deployment found for module %s", name),
+				LastTransitionTime: now,
+			}
+			continue
+		}
+
+		dep := deployList.Items[0]
+		desired := int32(1)
+		if dep.Spec.Replicas != nil {
+			desired = *dep.Spec.Replicas
+		}
+
+		if dep.Status.ReadyReplicas < desired {
+			reason := "ReplicasNotReady"
+			msg := fmt.Sprintf("Module %s: %d/%d replicas ready", name, dep.Status.ReadyReplicas, desired)
+
+			for _, cond := range dep.Status.Conditions {
+				if cond.Type == appsv1.DeploymentAvailable && cond.Status != "True" {
+					reason = cond.Reason
+					msg = cond.Message
+					break
+				}
+			}
+
+			statuses[name] = v1alpha1.ModuleStatus{
+				Phase:              v1alpha1.ModulePhaseDegraded,
+				Reason:             reason,
+				Message:            msg,
+				LastTransitionTime: now,
+			}
+		}
+	}
+}
+
+// --- Helper: ConfigMap to Unstructured ---
+
+func configMapToUnstructured(cm *corev1.ConfigMap) (unstructured.Unstructured, error) {
+	data, err := json.Marshal(cm)
+	if err != nil {
+		return unstructured.Unstructured{}, fmt.Errorf("failed to marshal ConfigMap: %w", err)
+	}
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return unstructured.Unstructured{}, fmt.Errorf("failed to unmarshal ConfigMap: %w", err)
+	}
+	return unstructured.Unstructured{Object: obj}, nil
+}

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -175,6 +176,7 @@ func (r *DashboardReconciler) deleteModuleResources(
 	statuses map[string]v1alpha1.ModuleStatus,
 ) error {
 	logger := log.FromContext(ctx)
+	var errs []error
 
 	for name, mod := range moduleRegistry {
 		status := statuses[name]
@@ -192,68 +194,80 @@ func (r *DashboardReconciler) deleteModuleResources(
 
 		var deployments appsv1.DeploymentList
 		if err := r.List(ctx, &deployments, matchLabels, inNamespace); err != nil {
-			return fmt.Errorf("listing deployments for module %s: %w", name, err)
-		}
-		for i := range deployments.Items {
-			if err := r.Delete(ctx, &deployments.Items[i]); client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf("deleting deployment for module %s: %w", name, err)
+			errs = append(errs, fmt.Errorf("listing deployments for module %s: %w", name, err))
+		} else {
+			for i := range deployments.Items {
+				if err := r.Delete(ctx, &deployments.Items[i]); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("deleting deployment for module %s: %w", name, err))
+				} else {
+					deleted = true
+				}
 			}
-			deleted = true
 		}
 
 		var services corev1.ServiceList
 		if err := r.List(ctx, &services, matchLabels, inNamespace); err != nil {
-			return fmt.Errorf("listing services for module %s: %w", name, err)
-		}
-		for i := range services.Items {
-			if err := r.Delete(ctx, &services.Items[i]); client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf("deleting service for module %s: %w", name, err)
+			errs = append(errs, fmt.Errorf("listing services for module %s: %w", name, err))
+		} else {
+			for i := range services.Items {
+				if err := r.Delete(ctx, &services.Items[i]); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("deleting service for module %s: %w", name, err))
+				} else {
+					deleted = true
+				}
 			}
-			deleted = true
 		}
 
 		var serviceAccounts corev1.ServiceAccountList
 		if err := r.List(ctx, &serviceAccounts, matchLabels, inNamespace); err != nil {
-			return fmt.Errorf("listing serviceaccounts for module %s: %w", name, err)
-		}
-		for i := range serviceAccounts.Items {
-			if err := r.Delete(ctx, &serviceAccounts.Items[i]); client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf("deleting serviceaccount for module %s: %w", name, err)
+			errs = append(errs, fmt.Errorf("listing serviceaccounts for module %s: %w", name, err))
+		} else {
+			for i := range serviceAccounts.Items {
+				if err := r.Delete(ctx, &serviceAccounts.Items[i]); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("deleting serviceaccount for module %s: %w", name, err))
+				} else {
+					deleted = true
+				}
 			}
-			deleted = true
 		}
 
 		var netpols networkingv1.NetworkPolicyList
 		if err := r.List(ctx, &netpols, matchLabels, inNamespace); err != nil {
-			return fmt.Errorf("listing networkpolicies for module %s: %w", name, err)
-		}
-		for i := range netpols.Items {
-			if err := r.Delete(ctx, &netpols.Items[i]); client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf("deleting networkpolicy for module %s: %w", name, err)
+			errs = append(errs, fmt.Errorf("listing networkpolicies for module %s: %w", name, err))
+		} else {
+			for i := range netpols.Items {
+				if err := r.Delete(ctx, &netpols.Items[i]); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("deleting networkpolicy for module %s: %w", name, err))
+				} else {
+					deleted = true
+				}
 			}
-			deleted = true
 		}
 
 		var clusterRoles rbacv1.ClusterRoleList
 		if err := r.List(ctx, &clusterRoles, matchLabels); err != nil {
-			return fmt.Errorf("listing clusterroles for module %s: %w", name, err)
-		}
-		for i := range clusterRoles.Items {
-			if err := r.Delete(ctx, &clusterRoles.Items[i]); client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf("deleting clusterrole for module %s: %w", name, err)
+			errs = append(errs, fmt.Errorf("listing clusterroles for module %s: %w", name, err))
+		} else {
+			for i := range clusterRoles.Items {
+				if err := r.Delete(ctx, &clusterRoles.Items[i]); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("deleting clusterrole for module %s: %w", name, err))
+				} else {
+					deleted = true
+				}
 			}
-			deleted = true
 		}
 
 		var clusterRoleBindings rbacv1.ClusterRoleBindingList
 		if err := r.List(ctx, &clusterRoleBindings, matchLabels); err != nil {
-			return fmt.Errorf("listing clusterrolebindings for module %s: %w", name, err)
-		}
-		for i := range clusterRoleBindings.Items {
-			if err := r.Delete(ctx, &clusterRoleBindings.Items[i]); client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf("deleting clusterrolebinding for module %s: %w", name, err)
+			errs = append(errs, fmt.Errorf("listing clusterrolebindings for module %s: %w", name, err))
+		} else {
+			for i := range clusterRoleBindings.Items {
+				if err := r.Delete(ctx, &clusterRoleBindings.Items[i]); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("deleting clusterrolebinding for module %s: %w", name, err))
+				} else {
+					deleted = true
+				}
 			}
-			deleted = true
 		}
 
 		if deleted {
@@ -261,7 +275,7 @@ func (r *DashboardReconciler) deleteModuleResources(
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // --- Inter-BFF env var params ---
@@ -423,29 +437,31 @@ func (r *DashboardReconciler) overlayStandaloneReadiness(
 			continue
 		}
 
-		dep := deployList.Items[0]
-		desired := int32(1)
-		if dep.Spec.Replicas != nil {
-			desired = *dep.Spec.Replicas
-		}
-
-		if dep.Status.ReadyReplicas < desired {
-			reason := "ReplicasNotReady"
-			msg := fmt.Sprintf("Module %s: %d/%d replicas ready", name, dep.Status.ReadyReplicas, desired)
-
-			for _, cond := range dep.Status.Conditions {
-				if cond.Type == appsv1.DeploymentAvailable && cond.Status != "True" {
-					reason = cond.Reason
-					msg = cond.Message
-					break
-				}
+		for _, dep := range deployList.Items {
+			desired := int32(1)
+			if dep.Spec.Replicas != nil {
+				desired = *dep.Spec.Replicas
 			}
 
-			statuses[name] = v1alpha1.ModuleStatus{
-				Phase:              v1alpha1.ModulePhaseDegraded,
-				Reason:             reason,
-				Message:            msg,
-				LastTransitionTime: now,
+			if dep.Status.ReadyReplicas < desired {
+				reason := "ReplicasNotReady"
+				msg := fmt.Sprintf("Module %s: %d/%d replicas ready", name, dep.Status.ReadyReplicas, desired)
+
+				for _, cond := range dep.Status.Conditions {
+					if cond.Type == appsv1.DeploymentAvailable && cond.Status != "True" {
+						reason = cond.Reason
+						msg = cond.Message
+						break
+					}
+				}
+
+				statuses[name] = v1alpha1.ModuleStatus{
+					Phase:              v1alpha1.ModulePhaseDegraded,
+					Reason:             reason,
+					Message:            msg,
+					LastTransitionTime: now,
+				}
+				break
 			}
 		}
 	}

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -28,10 +28,9 @@ import (
 )
 
 const (
-	federationConfigMapName  = "federation-config"
-	federationConfigKey      = "module-federation-config.json"
-	federationHashAnnotation = "dashboard.opendatahub.io/federation-config-hash"
-	moduleComponentLabel     = "app.kubernetes.io/component"
+	federationConfigMapName = "federation-config"
+	federationConfigKey     = "module-federation-config.json"
+	moduleComponentLabel    = "app.kubernetes.io/component"
 )
 
 // --- Module proxy configuration (static data needed for federation ConfigMap) ---
@@ -451,6 +450,40 @@ func (r *DashboardReconciler) overlayStandaloneReadiness(
 			}
 		}
 	}
+}
+
+// --- Deploy federation ConfigMap ---
+
+func (r *DashboardReconciler) deployFederationConfigMap(
+	ctx context.Context,
+	statuses map[string]v1alpha1.ModuleStatus,
+	dashboard *v1alpha1.Dashboard,
+) error {
+	fedCM, err := r.buildFederationConfigMap(statuses, dashboard)
+	if err != nil {
+		return fmt.Errorf("building federation ConfigMap: %w", err)
+	}
+
+	fedResources, err := configMapToUnstructured(fedCM)
+	if err != nil {
+		return fmt.Errorf("converting federation ConfigMap: %w", err)
+	}
+
+	fedDeployer := deploy.NewDeployer(
+		deploy.WithFieldOwner("dashboard-operator"),
+		deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
+	)
+
+	if err := fedDeployer.Deploy(ctx, deploy.DeployInput{
+		Client:    r.Client,
+		Owner:     dashboard,
+		Release:   deploy.ReleaseInfo{Type: string(r.Platform)},
+		Resources: []unstructured.Unstructured{fedResources},
+	}); err != nil {
+		return fmt.Errorf("deploying federation ConfigMap: %w", err)
+	}
+
+	return nil
 }
 
 // --- Helper: ConfigMap to Unstructured ---

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -134,7 +134,9 @@ func (r *DashboardReconciler) deployModuleManifests(
 			continue
 		}
 
-		params := readExistingParams(modulePath + "/params.env")
+		defaults := readExistingParams(modulePath + "/params.env")
+		params := make(map[string]string, len(defaults)+len(computed))
+		maps.Copy(params, defaults)
 		maps.Copy(params, computed)
 		if err := writeParamsEnv(modulePath, params); err != nil {
 			return fmt.Errorf("failed to write params.env for module %s: %w", name, err)
@@ -272,6 +274,10 @@ func addInterBFFParams(params map[string]string, statuses map[string]v1alpha1.Mo
 		for _, dep := range deps {
 			targetMod, ok := moduleRegistry[dep.TargetModule]
 			if !ok {
+				continue
+			}
+			ts := statuses[dep.TargetModule]
+			if ts.Phase != v1alpha1.ModulePhaseDeployed && ts.Phase != v1alpha1.ModulePhaseDegraded {
 				continue
 			}
 			svcName := standaloneServiceName(platform, targetMod.ManifestSlug)

--- a/dashboard-operator/internal/controller/modules.go
+++ b/dashboard-operator/internal/controller/modules.go
@@ -12,55 +12,101 @@ import (
 
 // ModuleDefinition describes a module's static properties.
 type ModuleDefinition struct {
-	Name          string
-	ContainerName string
-	Port          int32
-	ImageEnvVar   string
+	Name                    string
+	ContainerName           string
+	Port                    int32
+	ImageEnvVar             string
+	RequiredDSCComponents   []string
+	InterModuleDependencies []string
+	ManifestSlug            string
 }
 
 var moduleRegistry = map[string]ModuleDefinition{
 	"modelRegistry": {
 		Name: "modelRegistry", ContainerName: "model-registry-ui", Port: 8043,
-		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
+		ImageEnvVar:           "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
+		RequiredDSCComponents: []string{"modelregistry"},
+		ManifestSlug:          "model-registry",
 	},
 	"genAi": {
 		Name: "genAi", ContainerName: "gen-ai-ui", Port: 8143,
-		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
+		ImageEnvVar:  "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
+		ManifestSlug: "gen-ai",
 	},
 	"mlflow": {
 		Name: "mlflow", ContainerName: "mlflow-ui", Port: 8343,
-		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
+		ImageEnvVar:           "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
+		RequiredDSCComponents: []string{"mlflowoperator"},
+		ManifestSlug:          "mlflow",
 	},
 	"maas": {
 		Name: "maas", ContainerName: "maas-ui", Port: 8243,
-		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
+		ImageEnvVar:  "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
+		ManifestSlug: "maas",
 	},
 	"evalHub": {
-		Name: "evalHub", ContainerName: "eval-hub-ui", Port: 8443,
-		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
+		Name: "evalHub", ContainerName: "eval-hub-ui", Port: 8543,
+		ImageEnvVar:           "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
+		RequiredDSCComponents: []string{"trustyai"},
+		ManifestSlug:          "eval-hub",
 	},
 	"automl": {
-		Name: "automl", ContainerName: "automl-ui", Port: 8543,
-		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
+		Name: "automl", ContainerName: "automl-ui", Port: 8643,
+		ImageEnvVar:           "RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
+		RequiredDSCComponents: []string{"aipipelines"},
+		ManifestSlug:          "automl",
 	},
 	"autorag": {
-		Name: "autorag", ContainerName: "autorag-ui", Port: 8643,
-		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
+		Name: "autorag", ContainerName: "autorag-ui", Port: 8743,
+		ImageEnvVar:             "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
+		RequiredDSCComponents:   []string{"aipipelines"},
+		InterModuleDependencies: []string{"genAi"},
+		ManifestSlug:            "autorag",
 	},
 	"agentOps": {
 		Name: "agentOps", ContainerName: "agent-ops-ui", Port: 8843,
-		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE",
+		ImageEnvVar:  "RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE",
+		ManifestSlug: "agent-ops",
 	},
 }
 
 // resolveModuleStatuses determines the status of each module based on
-// spec overrides. All registered modules are deployed by default unless
-// explicitly disabled.
+// DSC component availability, spec overrides, and inter-module dependencies.
+// It uses a three-pass algorithm:
+//
+//	Pass 1: DSC component gate + explicit CR overrides
+//	Pass 2: Inter-module dependency resolution (transitive propagation)
+//	Pass 3: Unknown module detection
 func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.ModuleStatus {
 	now := metav1.Now()
 	result := make(map[string]v1alpha1.ModuleStatus, len(moduleRegistry))
 
-	for name := range moduleRegistry {
+	// Pass 1: DSC component gate + explicit CR overrides
+	for name, mod := range moduleRegistry {
+		// Check DSC component dependencies (only when Components map is non-nil)
+		if len(mod.RequiredDSCComponents) > 0 && spec.Components != nil {
+			disabled := false
+			for _, comp := range mod.RequiredDSCComponents {
+				ca, exists := spec.Components[comp]
+				if !exists || (ca.ManagementState != "Managed" && ca.ManagementState != "Unmanaged") {
+					result[name] = v1alpha1.ModuleStatus{
+						Phase:              v1alpha1.ModulePhaseDisabled,
+						Reason:             "ComponentNotAvailable",
+						Message:            fmt.Sprintf("Required DSC component %q is not available", comp),
+						LastTransitionTime: now,
+					}
+					disabled = true
+
+					break
+				}
+			}
+
+			if disabled {
+				continue
+			}
+		}
+
+		// Check explicit CR override
 		if override, ok := spec.Modules[name]; ok && override.State == v1alpha1.ModuleDisabled {
 			result[name] = v1alpha1.ModuleStatus{
 				Phase:              v1alpha1.ModulePhaseDisabled,
@@ -72,6 +118,7 @@ func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.Mod
 			continue
 		}
 
+		// Tentatively enabled
 		result[name] = v1alpha1.ModuleStatus{
 			Phase:              v1alpha1.ModulePhaseDeployed,
 			Reason:             "Deployed",
@@ -80,6 +127,35 @@ func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.Mod
 		}
 	}
 
+	// Pass 2: Inter-module dependency resolution (propagate transitively)
+	changed := true
+	for changed {
+		changed = false
+
+		for name, mod := range moduleRegistry {
+			s := result[name]
+			if s.Phase != v1alpha1.ModulePhaseDeployed {
+				continue
+			}
+
+			for _, dep := range mod.InterModuleDependencies {
+				depStatus, ok := result[dep]
+				if !ok || depStatus.Phase == v1alpha1.ModulePhaseDisabled || depStatus.Phase == v1alpha1.ModulePhaseNotDeployed {
+					result[name] = v1alpha1.ModuleStatus{
+						Phase:              v1alpha1.ModulePhaseDisabled,
+						Reason:             "DependencyNotMet",
+						Message:            fmt.Sprintf("Required module %q is not available", dep),
+						LastTransitionTime: now,
+					}
+					changed = true
+
+					break
+				}
+			}
+		}
+	}
+
+	// Pass 3: Unknown module detection
 	for name := range spec.Modules {
 		if _, known := moduleRegistry[name]; !known {
 			result[name] = v1alpha1.ModuleStatus{

--- a/dashboard-operator/internal/controller/modules_test.go
+++ b/dashboard-operator/internal/controller/modules_test.go
@@ -45,10 +45,12 @@ func TestResolveModuleStatuses(t *testing.T) {
 			},
 			wantPhases: map[string]v1alpha1.ModulePhase{
 				"genAi":         v1alpha1.ModulePhaseDisabled,
+				"autorag":       v1alpha1.ModulePhaseDisabled,
 				"modelRegistry": v1alpha1.ModulePhaseDeployed,
 			},
 			wantReason: map[string]string{
-				"genAi": "ExplicitOverride",
+				"genAi":   "ExplicitOverride",
+				"autorag": "DependencyNotMet",
 			},
 		},
 		{
@@ -102,6 +104,89 @@ func TestResolveModuleStatuses(t *testing.T) {
 			},
 			wantReason: map[string]string{
 				"modelregistry": "UnknownModule",
+			},
+		},
+		{
+			name:    "DSC component removed disables module",
+			wantLen: 8,
+			spec: v1alpha1.DashboardSpec{
+				Components: map[string]v1alpha1.ComponentAvailability{
+					"modelregistry": {ManagementState: "Removed"},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"modelRegistry": v1alpha1.ModulePhaseDisabled,
+				"genAi":         v1alpha1.ModulePhaseDeployed,
+			},
+			wantReason: map[string]string{
+				"modelRegistry": "ComponentNotAvailable",
+			},
+		},
+		{
+			name:    "DSC component Managed enables module",
+			wantLen: 8,
+			spec: v1alpha1.DashboardSpec{
+				Components: map[string]v1alpha1.ComponentAvailability{
+					"modelregistry": {ManagementState: "Managed"},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"modelRegistry": v1alpha1.ModulePhaseDeployed,
+			},
+		},
+		{
+			name:    "DSC component absent from non-nil map disables module",
+			wantLen: 8,
+			spec: v1alpha1.DashboardSpec{
+				Components: map[string]v1alpha1.ComponentAvailability{
+					"someother": {ManagementState: "Managed"},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"modelRegistry": v1alpha1.ModulePhaseDisabled,
+				"genAi":         v1alpha1.ModulePhaseDeployed,
+				"maas":          v1alpha1.ModulePhaseDeployed,
+				"agentOps":      v1alpha1.ModulePhaseDeployed,
+			},
+			wantReason: map[string]string{
+				"modelRegistry": "ComponentNotAvailable",
+			},
+		},
+		{
+			name:    "inter-module dependency cascade: genAi disabled disables autorag",
+			wantLen: 8,
+			spec: v1alpha1.DashboardSpec{
+				Modules: map[string]v1alpha1.ModuleOverride{
+					"genAi": {State: v1alpha1.ModuleDisabled},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"genAi":   v1alpha1.ModulePhaseDisabled,
+				"autorag": v1alpha1.ModulePhaseDisabled,
+				"automl":  v1alpha1.ModulePhaseDeployed,
+				"maas":    v1alpha1.ModulePhaseDeployed,
+			},
+			wantReason: map[string]string{
+				"genAi":   "ExplicitOverride",
+				"autorag": "DependencyNotMet",
+			},
+		},
+		{
+			name:    "aipipelines removed disables automl and autorag",
+			wantLen: 8,
+			spec: v1alpha1.DashboardSpec{
+				Components: map[string]v1alpha1.ComponentAvailability{
+					"aipipelines": {ManagementState: "Removed"},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"automl":  v1alpha1.ModulePhaseDisabled,
+				"autorag": v1alpha1.ModulePhaseDisabled,
+				"genAi":   v1alpha1.ModulePhaseDeployed,
+			},
+			wantReason: map[string]string{
+				"automl":  "ComponentNotAvailable",
+				"autorag": "ComponentNotAvailable",
 			},
 		},
 	}
@@ -326,6 +411,7 @@ func TestModuleRegistry(t *testing.T) {
 			assert.NotEmpty(t, mod.ContainerName, "module must have ContainerName")
 			assert.Greater(t, mod.Port, int32(0), "module must have Port > 0")
 			assert.NotEmpty(t, mod.ImageEnvVar, "module must have ImageEnvVar")
+			assert.NotEmpty(t, mod.ManifestSlug, "module must have ManifestSlug")
 		})
 	}
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-47771
https://issues.redhat.com/browse/RHOAIENG-61017
https://issues.redhat.com/browse/RHOAIENG-61018
https://issues.redhat.com/browse/RHOAIENG-61019
https://issues.redhat.com/browse/RHOAIENG-61020
https://issues.redhat.com/browse/RHOAIENG-61021
https://issues.redhat.com/browse/RHOAIENG-58975

## Description

Implements the controller-side logic for deploying BFF modules as independent Kubernetes pods instead of sidecar containers. A `DeploymentMode` field (`Sidecar` | `Standalone`) in the Dashboard CRD gates the new behavior, allowing phased rollout — the operator continues deploying sidecars by default and only switches to standalone pods when the flag is flipped.

**ADR**: [bff-module-deployment-rules-adr.md](https://github.com/opendatahub-io/odh-dashboard/blob/main/.claude/local-specs/bff-module-deployment-rules-adr.md)

### Changes

**CRD (`api/v1alpha1/dashboard_types.go`)**:
- `DeploymentMode` enum type (`Sidecar` default, `Standalone`)
- New field on `DashboardSpec` with kubebuilder validation

**Module Registry (`modules.go`)**:
- Enhanced `ModuleDefinition` with `RequiredDSCComponents`, `InterModuleDependencies`, `ManifestSlug`
- Three-pass `resolveModuleStatuses()`: DSC component gate → inter-module topological sort → unknown module detection
- Port corrections: evalHub=8543, automl=8643, autorag=8743 (matching standalone manifests)

**Standalone Deployment (`module_deploy.go` — new)**:
- Per-module kustomize rendering from `modules/<slug>/` and SSA deployment
- Dynamic federation ConfigMap generation with platform-aware service names (`odh-dashboard-<slug>-ui` / `rhods-dashboard-<slug>-ui`)
- Inter-BFF env var injection (genAi→maas service discovery)
- Module resource GC (Deployment, Service, SA, RBAC, NetworkPolicy) when disabled
- Standalone readiness overlay (per-Deployment health checks)
- Graceful skip for modules without manifest directories (agentOps)

**Reconciler (`dashboard_reconciler.go`)**:
- `reconcile()` dispatches to `reconcileSidecar` (existing behavior, unchanged) or `reconcileStandalone` (new) based on `spec.deploymentMode`

**Dockerfile**:
- `--chown=65532:0` + `chmod -R g+w` for OpenShift SCC compatibility (arbitrary UID)

## How Has This Been Tested?

**Cluster validation** on `ui-monarch-rosa` (ROSA, ODH) with image `quay.io/lferrnan/odh-dashboard-operator:independent-pods-v7`:

### Manual Tests Performed

**1. Degraded Condition Detection**
- Deployed a module with a broken image reference to trigger `ImagePullBackOff`
- Verified the Dashboard CR status shows `modelRegistry: Degraded/ImagePullBackOff`
- Confirmed the overall Dashboard stays `Ready` (per ADR Rule 3.1 — module degradation does not cascade to component level)
- Fixed the image and confirmed recovery to `Deployed` status

**2. Deploy/Undeploy via DSC Changes**
- Started with all DSC components enabled — all modules reported `Deployed`
- Set `modelregistry=Removed` in the DSC — verified module status changed to `Disabled/ComponentNotAvailable`
- Set `aipipelines=Removed` in the DSC — verified the aipipelines-dependent modules (genAi, autorag) cascaded to `Disabled/ComponentNotAvailable`
- Re-enabled DSC components — verified all modules recovered to `Deployed`

**3. Deploy/Undeploy via Dashboard CR Module Overrides**
- Disabled modules individually via CR overrides (modelRegistry, genAi, maas) — verified `Disabled/ExplicitOverride`
- Re-enabled by removing overrides — verified all modules recovered to `Deployed`

**4. Inter-Module Dependency Cascade**
- Disabled genAi module — verified autorag status changed to `DependencyNotMet`
- Confirmed maas stays `Deployed` (service-discovery dependency only, not hard gate)
- Re-enabled genAi — verified autorag recovered to `Deployed`

**5. Standalone ↔ Sidecar Mode Switching**
- Switched Dashboard CR `deploymentMode` from `Sidecar` to `Standalone` — verified 7 standalone Deployments + Services created, dynamic federation ConfigMap generated
- Switched back to `Sidecar` — verified return to sidecar path, all 8 modules reported `Deployed`
- Performed full round-trip (Standalone → Sidecar → Standalone) — verified clean transitions with no resource leaks

**6. No Pods Detection**
- Verified `NotDeployed/ContainerNotFound` status when no pods exist for a module — all 8 modules correctly detected

### Results Summary

| Test | Result |
|------|--------|
| CR module overrides (disable modelRegistry, genAi, maas) | `Disabled/ExplicitOverride` — verified |
| DSC component gating (modelregistry=Removed, aipipelines=Removed) | `Disabled/ComponentNotAvailable` — verified |
| Inter-module cascade (genAi disabled → autorag `DependencyNotMet`) | Verified, maas stays Deployed (service-discovery only) |
| Degraded detection (broken image → `ImagePullBackOff`) | `modelRegistry: Degraded/ImagePullBackOff` — verified. Dashboard stays `Ready` (ADR Rule 3.1) |
| No pods → `NotDeployed/ContainerNotFound` | All 8 modules correctly detected — verified |
| Recovery (remove overrides → all `Deployed`) | Verified |
| Switch to Standalone mode | 7 Deployments + Services created, dynamic ConfigMap generated — verified |
| Switch back to Sidecar | Returns to sidecar path, all 8 modules Deployed — verified |
| Standalone → Sidecar → Standalone round-trip | Clean transitions — verified |

Full E2E test suite documented in [RHOAIENG-61023](https://issues.redhat.com/browse/RHOAIENG-61023).

## Test Impact

- 5 new test cases in `modules_test.go`: DSC component gates, inter-module dependency cascade, component absence from non-nil map, aipipelines cascade
- All 50+ existing tests pass, 0 lint issues
- `TestModuleRegistry` updated to verify `ManifestSlug` field

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-61023]: https://redhat.atlassian.net/browse/RHOAIENG-61023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Sidecar** and **Standalone** dashboard deployment modes (default **Sidecar**) with CRD/API support via `deploymentMode`.
  * Introduced standalone module lifecycle management, including dependency-aware enablement and federation configuration for enabled modules.
* **Improvements**
  * Enhanced module enablement logic using required component availability and transitive inter-module dependency propagation, including improved handling for unknown/disabled modules.
  * Improved standalone status/readiness evaluation and observability availability behavior; updated permissions/ownership for dashboard manifests.
* **Tests**
  * Expanded test coverage for deployment mode, dependency resolution, component availability effects, and module registry completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->