### PR TITLE
Fix missing RBAC rules for CRDs, HTTPRoutes, and operand CRs in dashboard-operator ClusterRole

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -129,6 +129,19 @@ rules:
       - update
       - patch
       - delete
+  # Gateway API routes for operand ingress
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   # Events
   - apiGroups:
       - ""
@@ -212,6 +225,18 @@ rules:
       - update
       - patch
       - delete
+  # CRDs managed by the operator (deploy library lookups + operand CRD deployment)
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
   #
   # RBAC escalation: permissions required by operand manifests
   # The operand deploys Roles/ClusterRoles that grant these permissions.
@@ -390,6 +415,10 @@ rules:
     verbs:
       - get
       - list
+      - create
+      - update
+      - patch
+      - delete
   # ODH Dashboard CRDs
   - apiGroups:
       - dashboard.opendatahub.io
@@ -410,6 +439,10 @@ rules:
     verbs:
       - get
       - list
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - opendatahub.io
     resources:

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -113,6 +113,19 @@ rules:
       - update
       - patch
       - delete
+  # Gateway API routes for operand ingress
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   # Events
   - apiGroups:
       - ""
@@ -196,6 +209,18 @@ rules:
       - update
       - patch
       - delete
+  # CRDs managed by the operator (deploy library lookups + operand CRD deployment)
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
   #
   # RBAC escalation: permissions required by operand manifests
   # The operand deploys Roles/ClusterRoles that grant these permissions.
@@ -374,6 +399,10 @@ rules:
     verbs:
       - get
       - list
+      - create
+      - update
+      - patch
+      - delete
   # ODH Dashboard CRDs
   - apiGroups:
       - dashboard.opendatahub.io
@@ -394,6 +423,10 @@ rules:
     verbs:
       - get
       - list
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - opendatahub.io
     resources:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-75508

## Description

The dashboard-operator Helm chart ClusterRole is missing several RBAC rules that cause E2E test failures when deployed via the modular architecture in [opendatahub-operator PR #3733](https://github.com/opendatahub-io/opendatahub-operator/pull/3733).

**E2E failure evidence:** `DashboardReady=False` with error:
```
failure deploying resource /odhapplications.dashboard.opendatahub.io:
customresourcedefinitions.apiextensions.k8s.io "odhapplications.dashboard.opendatahub.io" is forbidden:
User "system:serviceaccount:redhat-ods-applications:dashboard-operator" cannot get resource
"customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```

PR #8430 handled RBAC escalation for operand Roles/ClusterRoles but missed the operator's own direct resource management needs. This PR fixes 4 gaps:

1. **`apiextensions.k8s.io/customresourcedefinitions`** — entirely missing (BLOCKER). The deploy library GETs CRDs before applying them, and the operator deploys 4 CRDs from operand manifests.

2. **`gateway.networking.k8s.io/httproutes`** — entirely missing. Operand manifests deploy HTTPRoute resources for gateway-based ingress.

3. **`dashboard.opendatahub.io/odhapplications,odhdocuments`** — insufficient verbs (had `get`, `list`; added `create`, `update`, `patch`, `delete`). The operator deploys these via SSA from `manifests/`.

4. **`console.openshift.io/odhquickstarts`** — insufficient verbs (had `get`, `list`; added `create`, `update`, `patch`, `delete`). Same SSA deployment reason.

Both `config/rbac/role.yaml` and `charts/dashboard/templates/rbac.yaml` are updated in sync.

## How Has This Been Tested?

- Ran `make test` in `dashboard-operator/` — all test packages pass, including `chart_sync_test.go` which validates RBAC drift between `config/rbac/role.yaml` and the Helm chart template.

## Test Impact

No new tests needed in this repo — this is a YAML-only RBAC change. The chart sync test already validates both files are consistent. The corresponding test fixes (chart compliance `allowedKinds` whitelist) are in the opendatahub-operator repo (PR #3733).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`