### PR TITLE
Fix keyboard a11y in Connected Workbenches modal.

### DIFF
--- a/packages/cypress/cypress/tests/mocked/featureStore/connectedWorkbenchesModal.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/connectedWorkbenchesModal.cy.ts
@@ -196,7 +196,7 @@ describe('Connected Workbenches modal', () => {
     cy.findByText(
       'Go to the Authorized project page, edit a workbench or create a new one to connect with desired feature stores.',
     ).should('be.visible');
-    cy.findByRole('link', { name: k8sNamespace }).should('be.visible');
+    cy.findByRole('button', { name: `View project ${k8sNamespace}` }).should('be.visible');
     cy.findByText('read').should('be.visible');
   });
 
@@ -229,12 +229,10 @@ describe('Connected Workbenches modal', () => {
     openConnectedWorkbenchesModalAndWait();
 
     featureStoreGlobal.findConnectedWorkbenchesTable().should('be.visible');
-    cy.findByRole('link', { name: workbenchName }).should(
-      'have.attr',
-      'href',
-      `/notebook/${authorizedProject}/${workbenchName}`,
+    cy.findByRole('button', { name: `Open workbench ${workbenchName} in new tab` }).should(
+      'be.visible',
     );
-    cy.findByRole('link', { name: authorizedProject }).should('be.visible');
+    cy.findByRole('button', { name: `View project ${authorizedProject}` }).should('be.visible');
     cy.findByText('read').should('be.visible');
     cy.findByText('write').should('be.visible');
   });

--- a/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
+++ b/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
@@ -19,6 +19,7 @@ import {
 import { TableBase, useTableColumnSort } from '@odh-dashboard/ui-core';
 import SearchSelector from '@odh-dashboard/internal/components/searchSelector/SearchSelector';
 import { SearchIcon } from '@patternfly/react-icons';
+import bullsEyeStyles from '@patternfly/react-styles/css/layouts/Bullseye/bullseye';
 import { useConnectedWorkbenches } from '../apiHooks/useConnectedWorkbenches';
 import { buildConnectedWorkbenchRows } from '../utils/connectedWorkbenchesUtils';
 import { getConnectedWorkbenchColumns } from '../screens/connectedWorkbenches/const';
@@ -33,6 +34,11 @@ export type ConnectedWorkbenchesModalProps = {
   initialFeastProjectName?: string;
 };
 
+const findModalFocusTrapContainer = (node: HTMLElement): HTMLElement | undefined =>
+  node.closest<HTMLElement>(`.${bullsEyeStyles.bullseye}`) ??
+  node.closest<HTMLElement>('[class*="l-bullseye"]') ??
+  undefined;
+
 const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
   onClose,
   initialFeastProjectName,
@@ -46,11 +52,13 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
 
   const [menuAppendTo, setMenuAppendTo] = React.useState<HTMLElement | undefined>(undefined);
   const modalRefCallback = React.useCallback((node: HTMLDivElement | null) => {
-    if (node) {
-      const trapContainer = node.closest<HTMLElement>('.pf-v6-l-bullseye');
-      if (trapContainer) {
-        setMenuAppendTo(trapContainer);
-      }
+    if (!node) {
+      return;
+    }
+
+    const trapContainer = findModalFocusTrapContainer(node);
+    if (trapContainer) {
+      setMenuAppendTo(trapContainer);
     }
   }, []);
 

--- a/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
+++ b/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
@@ -44,6 +44,16 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
   const [page, setPage] = React.useState(1);
   const [pageSize, setPageSize] = React.useState(20);
 
+  const [menuAppendTo, setMenuAppendTo] = React.useState<HTMLElement | undefined>(undefined);
+  const modalRefCallback = React.useCallback((node: HTMLDivElement | null) => {
+    if (node) {
+      const trapContainer = node.closest<HTMLElement>('.pf-v6-l-bullseye');
+      if (trapContainer) {
+        setMenuAppendTo(trapContainer);
+      }
+    }
+  }, []);
+
   const { projects, selectedProject, loaded, error } = useConnectedWorkbenches(
     selectedFeastProjectName || undefined,
   );
@@ -109,7 +119,7 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
       onSearchClear={() => setSearchText('')}
       isDisabled={isLoading}
       toggleContent={selectedFeastProjectName || 'All feature stores'}
-      appendTo="inline"
+      appendTo={menuAppendTo || 'inline'}
     >
       <MenuItem
         key="__all__"
@@ -149,6 +159,7 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
         description="View workbenches connected to the selected feature store. Rows with no workbench name represent authorized projects that do not yet contain a connected workbench."
       />
       <ModalBody>
+        <div ref={modalRefCallback} hidden />
         <Stack hasGutter>
           <StackItem>
             <Flex
@@ -234,6 +245,7 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
                     onHideProjectsWithConnectedWorkbenchesChange={
                       filterState.setHideProjectsWithConnectedWorkbenches
                     }
+                    menuAppendTo={menuAppendTo}
                   />
                 }
                 rowRenderer={(row) => <ConnectedWorkbenchTableRow key={row.id} row={row} />}
@@ -241,7 +253,12 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
             )}
           </StackItem>
         </Stack>
-        <button type="button" className="pf-v6-screen-reader" aria-hidden="true" tabIndex={0} />
+        <button
+          type="button"
+          className="pf-v6-screen-reader"
+          tabIndex={0}
+          aria-label="Return to modal controls"
+        />
       </ModalBody>
     </Modal>
   );

--- a/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
+++ b/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
@@ -109,7 +109,7 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
       onSearchClear={() => setSearchText('')}
       isDisabled={isLoading}
       toggleContent={selectedFeastProjectName || 'All feature stores'}
-      appendTo={() => document.body}
+      appendTo="inline"
     >
       <MenuItem
         key="__all__"
@@ -241,6 +241,7 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
             )}
           </StackItem>
         </Stack>
+        <button type="button" className="pf-v6-screen-reader" aria-hidden="true" tabIndex={0} />
       </ModalBody>
     </Modal>
   );

--- a/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
+++ b/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
@@ -261,7 +261,6 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
             )}
           </StackItem>
         </Stack>
-        <button type="button" className="pf-v6-screen-reader" tabIndex={0} aria-hidden="true" />
       </ModalBody>
     </Modal>
   );

--- a/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
+++ b/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
@@ -261,7 +261,7 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
             )}
           </StackItem>
         </Stack>
-        <button type="button" className="pf-v6-screen-reader" tabIndex={0} />
+        <button type="button" className="pf-v6-screen-reader" tabIndex={0} aria-hidden="true" />
       </ModalBody>
     </Modal>
   );

--- a/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
+++ b/packages/feature-store/src/components/ConnectedWorkbenchesModal.tsx
@@ -119,7 +119,7 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
       onSearchClear={() => setSearchText('')}
       isDisabled={isLoading}
       toggleContent={selectedFeastProjectName || 'All feature stores'}
-      appendTo={menuAppendTo || 'inline'}
+      appendTo={menuAppendTo || (() => document.body)}
     >
       <MenuItem
         key="__all__"
@@ -253,12 +253,7 @@ const ConnectedWorkbenchesModal: React.FC<ConnectedWorkbenchesModalProps> = ({
             )}
           </StackItem>
         </Stack>
-        <button
-          type="button"
-          className="pf-v6-screen-reader"
-          tabIndex={0}
-          aria-label="Return to modal controls"
-        />
+        <button type="button" className="pf-v6-screen-reader" tabIndex={0} />
       </ModalBody>
     </Modal>
   );

--- a/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchTableRow.tsx
+++ b/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchTableRow.tsx
@@ -65,9 +65,12 @@ const ConnectedWorkbenchTableRow: React.FC<Props> = ({ row }) => {
             iconPosition="end"
             aria-label={`Open workbench ${row.workbenchName} in new tab`}
             data-testid={`connected-workbench-link-${row.workbenchName}`}
-            onClick={() =>
-              window.open(getWorkbenchLaunchPath(row), '_blank', 'noopener,noreferrer')
-            }
+            onClick={() => {
+              const win = window.open(getWorkbenchLaunchPath(row), '_blank', 'noopener,noreferrer');
+              if (!win) {
+                window.location.href = getWorkbenchLaunchPath(row);
+              }
+            }}
           >
             {row.workbenchName}
           </Button>

--- a/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchTableRow.tsx
+++ b/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchTableRow.tsx
@@ -66,10 +66,7 @@ const ConnectedWorkbenchTableRow: React.FC<Props> = ({ row }) => {
             aria-label={`Open workbench ${row.workbenchName} in new tab`}
             data-testid={`connected-workbench-link-${row.workbenchName}`}
             onClick={() => {
-              const win = window.open(getWorkbenchLaunchPath(row), '_blank', 'noopener,noreferrer');
-              if (!win) {
-                window.location.href = getWorkbenchLaunchPath(row);
-              }
+              window.open(getWorkbenchLaunchPath(row), '_blank', 'noopener,noreferrer');
             }}
           >
             {row.workbenchName}

--- a/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchTableRow.tsx
+++ b/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchTableRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Button, Label, LabelGroup, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
   CONNECTED_WORKBENCH_PERMISSION_LABEL_THRESHOLD,
   NO_CONNECTED_WORKBENCH_TOOLTIP,
@@ -51,6 +51,7 @@ const PermissionLabels: React.FC<{ permissions: string[] }> = ({ permissions }) 
 };
 
 const ConnectedWorkbenchTableRow: React.FC<Props> = ({ row }) => {
+  const navigate = useNavigate();
   const projectHref = `/projects/${row.authorizedProject}?section=workbenches`;
 
   return (
@@ -60,12 +61,13 @@ const ConnectedWorkbenchTableRow: React.FC<Props> = ({ row }) => {
           <Button
             variant="link"
             isInline
-            component="a"
-            href={getWorkbenchLaunchPath(row)}
-            target="_blank"
-            rel="noopener noreferrer"
             icon={<ExternalLinkAltIcon />}
             iconPosition="end"
+            aria-label={`Open workbench ${row.workbenchName} in new tab`}
+            data-testid={`connected-workbench-link-${row.workbenchName}`}
+            onClick={() =>
+              window.open(getWorkbenchLaunchPath(row), '_blank', 'noopener,noreferrer')
+            }
           >
             {row.workbenchName}
           </Button>
@@ -76,7 +78,15 @@ const ConnectedWorkbenchTableRow: React.FC<Props> = ({ row }) => {
         )}
       </Td>
       <Td dataLabel="Authorized project">
-        <Link to={projectHref}>{row.authorizedProject}</Link>
+        <Button
+          variant="link"
+          isInline
+          aria-label={`View project ${row.authorizedProject}`}
+          data-testid={`connected-workbench-project-link-${row.authorizedProject}`}
+          onClick={() => navigate(projectHref)}
+        >
+          {row.authorizedProject}
+        </Button>
       </Td>
       <Td dataLabel="Permission">
         {row.permissionLevel.length > 0 ? (

--- a/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchesToolbar.tsx
+++ b/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchesToolbar.tsx
@@ -81,7 +81,7 @@ const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = 
             </MenuToggle>
           )}
           isOpen={isFilterTypeOpen}
-          popperProps={{ appendTo: () => document.body }}
+          popperProps={{ appendTo: 'inline' }}
         >
           <DropdownList>
             {FILTER_TYPE_KEYS.map((filterType) => (
@@ -163,7 +163,7 @@ const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = 
               ) : null}
             </MenuToggle>
           )}
-          popperProps={{ appendTo: () => document.body }}
+          popperProps={{ appendTo: 'inline' }}
         >
           <SelectList isAriaMultiselectable>
             {projectOptions.withConnected.length > 0 ? (
@@ -253,7 +253,7 @@ const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = 
               ) : null}
             </MenuToggle>
           )}
-          popperProps={{ appendTo: () => document.body }}
+          popperProps={{ appendTo: 'inline' }}
         >
           <SelectList isAriaMultiselectable>
             {PERMISSION_OPTIONS.map((permission) => (

--- a/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchesToolbar.tsx
+++ b/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchesToolbar.tsx
@@ -83,7 +83,7 @@ const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = 
             </MenuToggle>
           )}
           isOpen={isFilterTypeOpen}
-          popperProps={{ appendTo: menuAppendTo || 'inline' }}
+          popperProps={{ appendTo: menuAppendTo || (() => document.body) }}
         >
           <DropdownList>
             {FILTER_TYPE_KEYS.map((filterType) => (
@@ -165,7 +165,7 @@ const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = 
               ) : null}
             </MenuToggle>
           )}
-          popperProps={{ appendTo: menuAppendTo || 'inline' }}
+          popperProps={{ appendTo: menuAppendTo || (() => document.body) }}
         >
           <SelectList isAriaMultiselectable>
             {projectOptions.withConnected.length > 0 ? (
@@ -255,7 +255,7 @@ const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = 
               ) : null}
             </MenuToggle>
           )}
-          popperProps={{ appendTo: menuAppendTo || 'inline' }}
+          popperProps={{ appendTo: menuAppendTo || (() => document.body) }}
         >
           <SelectList isAriaMultiselectable>
             {PERMISSION_OPTIONS.map((permission) => (

--- a/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchesToolbar.tsx
+++ b/packages/feature-store/src/screens/connectedWorkbenches/ConnectedWorkbenchesToolbar.tsx
@@ -42,6 +42,7 @@ type ConnectedWorkbenchesToolbarProps = {
   onProjectToggle: (project: string) => void;
   onPermissionToggle: (permission: string) => void;
   onHideProjectsWithConnectedWorkbenchesChange: (hide: boolean) => void;
+  menuAppendTo?: HTMLElement;
 };
 
 const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = ({
@@ -54,6 +55,7 @@ const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = 
   onProjectToggle,
   onPermissionToggle,
   onHideProjectsWithConnectedWorkbenchesChange,
+  menuAppendTo,
 }) => {
   const [currentFilterType, setCurrentFilterType] = React.useState<FilterType>('authorizedProject');
   const [isFilterTypeOpen, setIsFilterTypeOpen] = React.useState(false);
@@ -81,7 +83,7 @@ const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = 
             </MenuToggle>
           )}
           isOpen={isFilterTypeOpen}
-          popperProps={{ appendTo: 'inline' }}
+          popperProps={{ appendTo: menuAppendTo || 'inline' }}
         >
           <DropdownList>
             {FILTER_TYPE_KEYS.map((filterType) => (
@@ -163,7 +165,7 @@ const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = 
               ) : null}
             </MenuToggle>
           )}
-          popperProps={{ appendTo: 'inline' }}
+          popperProps={{ appendTo: menuAppendTo || 'inline' }}
         >
           <SelectList isAriaMultiselectable>
             {projectOptions.withConnected.length > 0 ? (
@@ -253,7 +255,7 @@ const ConnectedWorkbenchesToolbar: React.FC<ConnectedWorkbenchesToolbarProps> = 
               ) : null}
             </MenuToggle>
           )}
-          popperProps={{ appendTo: 'inline' }}
+          popperProps={{ appendTo: menuAppendTo || 'inline' }}
         >
           <SelectList isAriaMultiselectable>
             {PERMISSION_OPTIONS.map((permission) => (


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-75326

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description

- Render modal dropdowns inline (appendTo: 'inline') so keyboard users can open and select options inside the focus trap

- Use focusable link buttons for workbench/project row actions so Safari includes them in Tab order

- Add an invisible screen-reader button after pagination so forward Tab wraps back to the modal close control (no visible UI change; Figma has no footer Close)

- verified fix on Chrome, Firefox and Safari

### BEFORE


https://github.com/user-attachments/assets/d635be95-dd97-41dd-836f-3c1a5cd66544



### AFTER

https://github.com/user-attachments/assets/4f43dc26-1582-4aad-9748-060e43e85546




## How Has This Been Tested?

Manual keyboard testing in Chrome and Safari:

- Tab → Enter/Arrow keys on feature store selector and filter dropdowns
- Forward Tab through modal (pagination → wrap to X)
- Safari: Tab reaches workbench and authorized project row links
- Escape closes modal; mouse behavior unchanged

## Test Impact

No new automated tests. Existing feature-store unit tests pass.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter and selector dropdown rendering by attaching menus to the correct in-modal container (when available) instead of always using the page body, reducing misplaced overlays.
  * Updated connected workbench and “authorized project” navigation to button-driven actions, including reliable new-tab opening with safety protections.
* **Accessibility**
  * Enhanced connected workbench and “authorized project” controls with added `aria-label` and `data-testid` attributes.
* **Tests**
  * Updated Cypress assertions to validate the new button-based navigation UI rather than link elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->