### PR TITLE
RHOAIENG-65507: Fix incorrect descriptions for OdhDashboardConfig CRD spec fields

### DIFF
--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -59,7 +59,7 @@ spec:
                       description: 'When true, hides the Data Science Projects page from the dashboard navigation.'
                     disableProjectScoped:
                       type: boolean
-                      description: 'When true, disables project-scoped navigation mode for workbenches and model serving.'
+                      description: 'When true, disables project-scoped resource management, such as project-level hardware profiles, workbench images, and serving runtime templates.'
                     disableModelServing:
                       type: boolean
                       description: 'When true, hides the Model Serving pages and disables model deployment features.'
@@ -188,7 +188,7 @@ spec:
                       description: 'When true, enables the YAML viewer in the model deployment wizard.'
                     vLLMDeploymentOnMaaS:
                       type: boolean
-                      description: 'When true, enables vLLM deployment options within Model-as-a-Service.'
+                      description: 'When true, enables vLLM deployment options in the model serving deployment wizard for generative AI model deployments.'
                     promptManagement:
                       type: boolean
                       description: 'When true, enables prompt management features.'
@@ -318,13 +318,13 @@ spec:
                       type: string
                 # Likely needs a better spot to exist -- hard to do granular permissions
                 templateOrder:
-                  description: 'Ordered list of workbench image template names controlling their display order.'
+                  description: 'Ordered list of serving runtime template names controlling their display order across the dashboard, including the Custom Serving Runtimes admin page and the model deployment wizard.'
                   type: array
                   items:
                     type: string
                 # Likely needs a better spot to exist -- hard to do granular permissions
                 templateDisablement:
-                  description: 'List of workbench image template names to hide from users.'
+                  description: 'List of serving runtime template names to hide across the dashboard, including the Custom Serving Runtimes admin page and the model deployment wizard.'
                   type: array
                   items:
                     type: string
@@ -346,7 +346,7 @@ spec:
                         - rolling
                         - recreate
                     isLLMdDefault:
-                      description: 'When true, sets LLMd as the default serving platform for new model deployments.'
+                      description: 'When true, pre-selects LLMd as the suggested serving platform in the model deployment wizard.'
                       type: boolean
                 globalMLflowNamespaces:
                   description: >-

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -56,7 +56,7 @@ spec:
                       description: 'When true, hides the Home page from the dashboard navigation.'
                     disableProjects:
                       type: boolean
-                      description: 'When true, hides the Data Science Projects page from the dashboard navigation.'
+                      description: 'When true, hides the Projects page from the dashboard navigation.'
                     disableProjectScoped:
                       type: boolean
                       description: 'When true, disables project-scoped resource management, such as project-level hardware profiles, workbench images, and serving runtime templates.'
@@ -65,7 +65,7 @@ spec:
                       description: 'When true, hides the Model Serving pages and disables model deployment features.'
                     disableProjectSharing:
                       type: boolean
-                      description: 'When true, hides the project sharing and permissions tab within Data Science Projects.'
+                      description: 'When true, hides the project sharing and permissions tab within the Project details.'
                     disableCustomServingRuntimes:
                       type: boolean
                       description: 'When true, hides the Serving Runtimes administration page for managing custom runtimes.'
@@ -194,7 +194,7 @@ spec:
                       description: 'When true, enables prompt management features.'
                     llmGatewayField:
                       type: boolean
-                      description: 'When true, shows the LLM gateway configuration field on LLMd serving forms.'
+                      description: 'When true, shows the LLM gateway configuration field for generative AI model deployments that support gateway selections.'
                     gpuaas:
                       type: boolean
                       description: 'When true, enables the GPUaaS Infrastructure page for cluster capacity and accelerator utilization monitoring.'


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-65507

## Description

Follow-up from [RHOAIENG-64633](https://redhat.atlassian.net/browse/RHOAIENG-64633). PR [#7684](https://github.com/opendatahub-io/odh-dashboard/pull/7684) added descriptions to all OdhDashboardConfig CRD spec fields, but several were inaccurate (generated by an automated agent). This PR fixes 5 incorrect descriptions based on actual code usage:

| Field | Problem | Fix |
|-------|---------|-----|
| `templateOrder` | Said "workbench image template" | Serving runtime templates, used across admin page and deployment wizard |
| `templateDisablement` | Said "workbench image template" | Serving runtime templates, hidden across admin page and deployment wizard |
| `vLLMDeploymentOnMaaS` | Said "within Model-as-a-Service" | Enables vLLM options in the model serving deployment wizard for generative AI models |
| `disableProjectScoped` | Said "navigation mode" | Disables project-scoped resource management (hardware profiles, workbench images, serving runtime templates) |
| `modelServing.isLLMdDefault` | Said "sets LLMd as the default" | Pre-selects LLMd as the *suggested* option (not a hard default) |

Supersedes [#7762](https://github.com/opendatahub-io/odh-dashboard/pull/7762), incorporating its review feedback (broader scope for `templateOrder`/`templateDisablement`/`disableProjectScoped` descriptions per [andrewballantyne's review](https://github.com/opendatahub-io/odh-dashboard/pull/7762#discussion_r3341140292)).

## How Has This Been Tested?

Verified YAML validity with `yaml.safe_load`. These are CRD description-only changes — no runtime behavior is affected. Descriptions were cross-referenced against actual code usage in `frontend/src/concepts/areas/const.ts`, `frontend/src/pages/modelServing/customServingRuntimes/utils.ts`, and the relevant feature packages (`model-serving`, `kserve`, `llmd-serving`).

## Test Impact

No tests needed — this is a YAML-only CRD manifest change affecting `oc explain` output and API documentation. No runtime behavior change.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-64633]: https://redhat.atlassian.net/browse/RHOAIENG-64633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified multiple `OdhDashboardConfig` schema option descriptions, including project-scoped resource management and project sharing/permissions visibility.
  * Updated generative AI model deployment wizard descriptions for vLLM deployment and LLM gateway configuration.
  * Revised template ordering and disablement wording to align with serving runtime templates, and clarified the default LLMd selection in the wizard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->