### PR TITLE
fix(gen-ai): preserve streamed content when output guardrail triggers mid-stream (RHOAIENG-62281)

### DIFF
--- a/packages/gen-ai/frontend/src/app/services/__tests__/llamaStackService.guardrails.tracking.spec.ts
+++ b/packages/gen-ai/frontend/src/app/services/__tests__/llamaStackService.guardrails.tracking.spec.ts
@@ -217,7 +217,7 @@ describe('llamaStackService - Guardrail Violation Tracking', () => {
       expect(mockStreamData).toHaveBeenNthCalledWith(2, ' a normal response');
     });
 
-    it('should fire tracking event when response starts normal but then gets refused', async () => {
+    it('should reject stream with guardrail error when refusal arrives after content', async () => {
       const mockStreamData = jest.fn();
 
       // Mock ReadableStream with output_text.delta followed by refusal.delta
@@ -243,20 +243,11 @@ describe('llamaStackService - Guardrail Violation Tracking', () => {
             ),
           })
           .mockResolvedValueOnce({
-            done: false,
-            value: new TextEncoder().encode('data: {"type": "response.refusal.done"}\n'),
-          })
-          .mockResolvedValueOnce({
-            done: false,
-            value: new TextEncoder().encode(
-              'data: {"type": "response.completed", "response": {"id": "test-response", "model": "test-model", "status": "completed", "created_at": 1234567890, "content": [{"type": "refusal", "refusal": "I cannot process that request"}]}}\n',
-            ),
-          })
-          .mockResolvedValueOnce({
             done: true,
             value: undefined,
           }),
         releaseLock: jest.fn(),
+        cancel: jest.fn(),
       };
 
       const mockResponse = {
@@ -268,20 +259,31 @@ describe('llamaStackService - Guardrail Violation Tracking', () => {
 
       mockFetch.mockResolvedValueOnce(mockResponse);
 
-      await createResponse(URL_PREFIX, { namespace: TEST_NAMESPACE })(mockStreamingRequest, {
-        onStreamData: mockStreamData,
+      // Stream should reject when refusal arrives after content has been streamed
+      await expect(
+        createResponse(URL_PREFIX, { namespace: TEST_NAMESPACE })(mockStreamingRequest, {
+          onStreamData: mockStreamData,
+        }),
+      ).rejects.toMatchObject({
+        error: expect.objectContaining({
+          code: 'guardrail_output_violation',
+          component: 'guardrails',
+        }),
       });
 
-      // Verify tracking event was fired when refusal started
+      // Verify tracking event was fired
       expect(fireMiscTrackingEvent).toHaveBeenCalledWith('Guardrail Activated', {
         violationDetected: true,
       });
-      expect(fireMiscTrackingEvent).toHaveBeenCalledTimes(1);
 
-      // Verify stream data shows normal output, then refusal with clearPrevious
+      // Verify stream was cancelled to release resources
+      expect(mockReader.cancel).toHaveBeenCalledWith('Output guardrail violation');
+
+      // Verify safe content was streamed (NOT cleared) before rejection
       expect(mockStreamData).toHaveBeenNthCalledWith(1, 'Let me help');
       expect(mockStreamData).toHaveBeenNthCalledWith(2, ' you with');
-      expect(mockStreamData).toHaveBeenNthCalledWith(3, 'I cannot process that request', true);
+      // onStreamData should NOT have been called with clearPrevious=true
+      expect(mockStreamData).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
+++ b/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
@@ -65,7 +65,7 @@ import {
   MaaSTokenResponse,
 } from '~/app/types';
 import { URL_PREFIX, extractMCPToolCallData } from '~/app/utilities';
-import { GUARDRAIL_ERROR_CODES } from '~/app/Chatbot/const';
+import { GUARDRAIL_ERROR_CODES, GUARDRAIL_MESSAGES } from '~/app/Chatbot/const';
 import { ThinkTagParser } from './thinkTagParser';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -457,8 +457,20 @@ const streamCreateResponse = (
                         const isFirstRefusal = !receivedRefusal;
                         if (isFirstRefusal) {
                           receivedRefusal = true;
-                          fullContent = '';
                           fireMiscTrackingEvent('Guardrail Activated', { violationDetected: true });
+                          if (fullContent.length > 0) {
+                            await reader.cancel('Output guardrail violation');
+                            reject(
+                              new ApiErrorClass({
+                                code: GUARDRAIL_ERROR_CODES.OUTPUT_VIOLATION,
+                                message: GUARDRAIL_MESSAGES.OUTPUT_VIOLATION,
+                                component: ERROR_COMPONENTS.GUARDRAILS,
+                                retriable: false,
+                              }),
+                            );
+                            return;
+                          }
+                          fullContent = '';
                         }
                         fullContent += data.delta;
                         onStreamData(data.delta, isFirstRefusal);
@@ -503,8 +515,19 @@ const streamCreateResponse = (
                       const isFirstRefusal = !receivedRefusal;
                       if (isFirstRefusal) {
                         receivedRefusal = true;
-                        fullContent = '';
                         fireMiscTrackingEvent('Guardrail Activated', { violationDetected: true });
+                        if (fullContent.length > 0) {
+                          reject(
+                            new ApiErrorClass({
+                              code: GUARDRAIL_ERROR_CODES.OUTPUT_VIOLATION,
+                              message: GUARDRAIL_MESSAGES.OUTPUT_VIOLATION,
+                              component: ERROR_COMPONENTS.GUARDRAILS,
+                              retriable: false,
+                            }),
+                          );
+                          return;
+                        }
+                        fullContent = '';
                       }
                       fullContent += data.delta;
                       onStreamData(data.delta, isFirstRefusal);
@@ -718,6 +741,18 @@ export const createPassthroughResponse = (
                       fullContent += data.delta;
                       onStreamData(data.delta);
                     } else if (data.type === 'response.refusal.delta' && data.delta) {
+                      if (fullContent.length > 0) {
+                        await reader.cancel('Output guardrail violation');
+                        reject(
+                          new ApiErrorClass({
+                            code: GUARDRAIL_ERROR_CODES.OUTPUT_VIOLATION,
+                            message: GUARDRAIL_MESSAGES.OUTPUT_VIOLATION,
+                            component: ERROR_COMPONENTS.GUARDRAILS,
+                            retriable: false,
+                          }),
+                        );
+                        return;
+                      }
                       fullContent += data.delta;
                       onStreamData(data.delta);
                     } else if (data.type === 'response.completed' && data.response) {
@@ -753,6 +788,17 @@ export const createPassthroughResponse = (
                     fullContent += data.delta;
                     onStreamData(data.delta);
                   } else if (data.type === 'response.refusal.delta' && data.delta) {
+                    if (fullContent.length > 0) {
+                      reject(
+                        new ApiErrorClass({
+                          code: GUARDRAIL_ERROR_CODES.OUTPUT_VIOLATION,
+                          message: GUARDRAIL_MESSAGES.OUTPUT_VIOLATION,
+                          component: ERROR_COMPONENTS.GUARDRAILS,
+                          retriable: false,
+                        }),
+                      );
+                      return;
+                    }
                     fullContent += data.delta;
                     onStreamData(data.delta);
                   } else if (data.type === 'response.completed' && data.response) {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62281

## Description

Fix the output guardrails bug where safe content already streamed to the user gets erased when a guardrail violation is detected mid-stream.

### The problem

There are three paths through which an output guardrail violation can interrupt a streaming response:

| Path | Trigger | Behavior |
|------|---------|----------|
| **Path A** | Upstream (model/OGX) sends `response.refusal.delta` directly | Clears all previously streamed content (`clearPrevious=true`) |
| **Path B** | BFF async moderation (NeMo) flags a chunk → sends SSE error | Preserves content + shows warning alert |
| **Path C** | Final overwrite from `response.completed` after refusal reset `fullContent` | Only refusal text remains in final content |

Path B was already fixed by #7152 — the catch handler preserves content with `...` and displays an expandable warning alert via the error classification system. However, Path A (upstream refusal events) still erases safe content, and Path C is a consequence of Path A.

### Why Path A is hard to reproduce

Path A is triggered when the upstream model/OGX sends `response.refusal.delta` events natively (e.g., OpenAI models via MaaS with native refusals, or OGX with inline guardrails). The standard RHOAI configuration uses NeMo async moderation (Path B), which means Path A cannot be exercised on a live cluster with the default setup.

This behavior was confirmed by testing on a real cluster with NeMo output guardrails enabled, the content was correctly preserved (Path B working). To demonstrate that Path A is still broken, it was created a unit test that mocks the SSE stream with `output_text.delta` events followed by `response.refusal.delta`, confirming that `clearPrevious=true` is sent and content is erased.

### The fix

When `response.refusal.delta` arrives and `fullContent.length > 0` (safe content was already streamed), reject the stream with `ApiErrorClass({code: 'guardrail_output_violation', ...})` instead of clearing content. This makes Path A fall into the same catch handler as Path B, producing identical UX: content preserved with ellipsis + expandable warning alert.

When no content has been streamed yet (`fullContent.length === 0`), the existing behavior is preserved (input violation / model refused from the start).

Applied in 4 locations: main streaming loop, trailing buffer flush, and both locations in the passthrough variant (embedded playground).

### Additional fix (nit)

The trailing buffer flush error handler was using `Object.assign(new Error(errMsg), { code })` instead of `new ApiErrorClass(data.error)`. This was a timing gap, the flush seems that it was added on May 26 before `ApiErrorClass` existed (introduced June 4 in #7152), and was never migrated. Fixed for consistency so all error paths flow through the same classification system correctly.

## How Has This Been Tested?

- Updated existing unit test to verify that mid-stream refusal now rejects with `guardrail_output_violation` error (instead of calling `onStreamData` with `clearPrevious=true`)
- Test asserts: safe content is streamed (2 calls), stream is rejected with correct error shape, `reader.cancel()` is called for resource cleanup
- Verified that refusal without prior content (input violation) still clears correctly
- Full `llamaStackService` test suite passes: 124 tests, 0 failures
- Type-check clean (no errors introduced)
- ESLint passes (verified by pre-commit hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of guardrail-triggered refusals during streaming responses.
  * When partial content has already been shown, the app now stops the stream cleanly and returns a clearer guardrail error instead of continuing with inconsistent output.
  * Added better cleanup so interrupted streams release resources properly.
  * Guardrail events are now tracked more consistently when an output violation occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->