### PR TITLE
chore: add caponetto to distribution-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -254,9 +254,9 @@ aliases:
   # Distributions
   distributions-approvers:
     - andyatmiami
+    - caponetto
     - paulovmr
   distributions-reviewers:
-    - caponetto
     - jenny-s51
 
   # MLflow


### PR DESCRIPTION
## Description
Adds @caponetto to `distribution-approvers` (as he probably should have been there to begin with - he is already in other `*-approvers` groups!

## How Has This Been Tested?
n/a

## Test Impact
n/a

## Request review criteria:
n/a

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review/approval assignments so one contributor is now included in the approvals group and removed from the reviewers group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->