### PR TITLE
RHOAIENG-72328: Hardware usage stacked bar chart section

### DIFF
--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -40,6 +40,14 @@ class InfrastructurePage {
     return cy.findByTestId('infrastructure-refresh-badge');
   }
 
+  findHardwareUsageSection() {
+    return cy.findByTestId('infrastructure-hardware-usage-section');
+  }
+
+  findHardwareUsageEmpty() {
+    return cy.findByTestId('hardware-usage-empty');
+  }
+
   findBorrowingLendingSection() {
     return cy.findByTestId('infrastructure-borrowing-lending-section');
   }

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -236,7 +236,7 @@ describe('GPUaaS Infrastructure Page', () => {
       infrastructurePage.findComputeUtilizationCard().should('contain.text', '80%');
       infrastructurePage.findMemoryUtilizationCard().should('contain.text', '83%');
       infrastructurePage.findRefreshBadge().should('exist');
-      infrastructurePage.findRefreshBadge().should('contain.text', 'Refreshed');
+      infrastructurePage.findRefreshBadge().should('contain.text', 'Last update');
     });
   });
 

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -23,6 +23,29 @@ const mockEmptyPrometheusResponse = () => ({
   status: 'success',
 });
 
+const mockHardwareModelResponse = (models: { modelName: string; count: string }[]) => ({
+  data: {
+    result: models.map(({ modelName, count }) => ({
+      metric: { modelName },
+      value: [Date.now() / 1000, count],
+    })),
+    resultType: 'vector',
+  },
+  status: 'success',
+});
+
+const NODE_LABEL_KEY = 'label_nvidia_com_gpu_product';
+const mockNodeLabelResponse = (models: { label: string; count: string }[]) => ({
+  data: {
+    result: models.map(({ label, count }) => ({
+      metric: { [NODE_LABEL_KEY]: label },
+      value: [Date.now() / 1000, count],
+    })),
+    resultType: 'vector',
+  },
+  status: 'success',
+});
+
 const NOW_S = Math.floor(Date.now() / 1000);
 const ONE_HOUR_S = 3600;
 
@@ -51,16 +74,39 @@ type InitInterceptsOptions = {
   gpuaas?: boolean;
   hasAccelerators?: boolean;
   hasDcgm?: boolean;
+  hasHardwareModels?: boolean;
+  hasNodeLabels?: boolean;
   clusterQueues?: ClusterQueueKind[];
   cohorts?: CohortKind[];
   hasChartData?: boolean;
 };
+
+const MOCK_HARDWARE_MODELS = [
+  { modelName: 'NVIDIA H100', count: '8' },
+  { modelName: 'NVIDIA A100', count: '12' },
+  { modelName: 'NVIDIA L40S', count: '6' },
+  { modelName: 'AMD MI300X', count: '4' },
+];
+
+const MOCK_HARDWARE_IN_USE = [
+  { modelName: 'NVIDIA H100', count: '8' },
+  { modelName: 'NVIDIA A100', count: '12' },
+  { modelName: 'NVIDIA L40S', count: '4' },
+  { modelName: 'AMD MI300X', count: '2' },
+];
+
+const MOCK_NODE_LABELS = [
+  { label: 'NVIDIA L40S', count: '4' },
+  { label: 'AMD MI300X', count: '2' },
+];
 
 const initIntercepts = ({
   isKueueInstalled = true,
   gpuaas = true,
   hasAccelerators = true,
   hasDcgm = true,
+  hasHardwareModels = true,
+  hasNodeLabels = false,
   clusterQueues = [mockClusterQueueK8sResource({ name: 'test-cq' })],
   cohorts = [mockCohortK8sResource({ name: 'test-cohort' })],
   hasChartData = false,
@@ -83,7 +129,26 @@ const initIntercepts = ({
   cy.interceptOdh('POST /api/prometheus/query', (req) => {
     const query = req.body.query as string;
 
-    if (query.includes('kube_node_status_allocatable')) {
+    // Hardware usage per-model queries (must come before generic DCGM checks
+    // since they also contain DCGM_FI_PROF_GR_ENGINE_ACTIVE).
+    // Match on 'modelName' which is alphanumeric and survives encodeURIComponent.
+    if (query.includes('modelName') && query.includes('pod')) {
+      req.reply({
+        code: 200,
+        response:
+          hasDcgm && hasHardwareModels
+            ? mockHardwareModelResponse(MOCK_HARDWARE_IN_USE)
+            : mockEmptyPrometheusResponse(),
+      });
+    } else if (query.includes('modelName')) {
+      req.reply({
+        code: 200,
+        response:
+          hasDcgm && hasHardwareModels
+            ? mockHardwareModelResponse(MOCK_HARDWARE_MODELS)
+            : mockEmptyPrometheusResponse(),
+      });
+    } else if (query.includes('kube_node_status_allocatable')) {
       req.reply({
         code: 200,
         response: hasAccelerators ? mockPrometheusResponse('16') : mockEmptyPrometheusResponse(),
@@ -102,6 +167,13 @@ const initIntercepts = ({
       req.reply({
         code: 200,
         response: hasDcgm ? mockPrometheusResponse('83.2') : mockEmptyPrometheusResponse(),
+      });
+    } else if (query.includes('kube_node_labels')) {
+      req.reply({
+        code: 200,
+        response: hasNodeLabels
+          ? mockNodeLabelResponse(MOCK_NODE_LABELS)
+          : mockEmptyPrometheusResponse(),
       });
     } else {
       req.reply(404);
@@ -203,6 +275,48 @@ describe('GPUaaS Infrastructure Page', () => {
       infrastructurePage
         .findMemoryUtilizationCard()
         .should('contain.text', 'Utilization metrics unavailable');
+    });
+  });
+
+  describe('Hardware usage section', () => {
+    describe('with hardware model data', () => {
+      beforeEach(() => {
+        asClusterAdminUser();
+        initIntercepts({ hasHardwareModels: true });
+      });
+
+      it('should display the chart with model names and legend', () => {
+        infrastructurePage.visit();
+        infrastructurePage.findHardwareUsageSection().should('exist');
+        infrastructurePage.findHardwareUsageSection().should('contain.text', 'Hardware usage');
+        infrastructurePage.findHardwareUsageSection().should('contain.text', 'NVIDIA H100');
+        infrastructurePage.findHardwareUsageSection().should('contain.text', 'NVIDIA A100');
+        infrastructurePage.findHardwareUsageSection().should('contain.text', 'NVIDIA L40S');
+        infrastructurePage.findHardwareUsageSection().should('contain.text', 'AMD MI300X');
+        infrastructurePage.findHardwareUsageSection().should('contain.text', 'In use');
+        infrastructurePage.findHardwareUsageSection().should('contain.text', 'Available');
+      });
+    });
+
+    it('should show empty state when no hardware model data is available', () => {
+      asClusterAdminUser();
+      initIntercepts({ hasAccelerators: false, hasDcgm: false, hasHardwareModels: false });
+      infrastructurePage.visit();
+      infrastructurePage
+        .findHardwareUsageEmpty()
+        .should('contain.text', 'Hardware model information unavailable');
+    });
+
+    it('should fall back to node labels when DCGM hardware models are unavailable', () => {
+      asClusterAdminUser();
+      initIntercepts({
+        hasDcgm: false,
+        hasHardwareModels: false,
+        hasNodeLabels: true,
+      });
+      infrastructurePage.visit();
+      infrastructurePage.findHardwareUsageSection().should('contain.text', 'NVIDIA L40S');
+      infrastructurePage.findHardwareUsageSection().should('contain.text', 'AMD MI300X');
     });
   });
 

--- a/packages/gpuaas/src/components/HardwareUsageChart.tsx
+++ b/packages/gpuaas/src/components/HardwareUsageChart.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import {
+  Chart,
+  ChartAxis,
+  ChartBar,
+  ChartLegendTooltip,
+  ChartStack,
+  createContainer,
+} from '@patternfly/react-charts/victory';
+import { getResizeObserver } from '@patternfly/react-core';
+import type { HardwareModelUsage } from '../hooks/useInfrastructureMetrics';
+
+type HardwareUsageChartProps = {
+  data: HardwareModelUsage[];
+};
+
+const CHART_HEIGHT = 300;
+const COLOR_IN_USE = 'var(--pf-t--chart--color--blue--300)';
+const COLOR_AVAILABLE = 'var(--pf-t--chart--color--black--200)';
+
+const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
+
+const HardwareUsageChart: React.FC<HardwareUsageChartProps> = ({ data }) => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line @typescript-eslint/no-empty-function -- cleanup noop until observer is assigned
+  const observer = React.useRef(() => {});
+  const [width, setWidth] = React.useState(0);
+  const [hiddenSeries, setHiddenSeries] = React.useState<Set<string>>(new Set());
+
+  const handleResize = React.useCallback(() => {
+    if (containerRef.current?.clientWidth) {
+      setWidth(containerRef.current.clientWidth);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (containerRef.current) {
+      observer.current = getResizeObserver(containerRef.current, handleResize);
+      handleResize();
+    }
+    return () => observer.current();
+  }, [handleResize]);
+
+  const toggleSeries = React.useCallback((name: string) => {
+    setHiddenSeries((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  }, []);
+
+  const inUseHidden = hiddenSeries.has('in-use');
+  const availableHidden = hiddenSeries.has('available');
+
+  const legendData = React.useMemo(
+    () => [
+      {
+        childName: 'in-use',
+        name: 'In use',
+        symbol: { fill: inUseHidden ? COLOR_AVAILABLE : COLOR_IN_USE, type: 'square' },
+      },
+      {
+        childName: 'available',
+        name: 'Available',
+        symbol: { fill: availableHidden ? COLOR_IN_USE : COLOR_AVAILABLE, type: 'square' },
+      },
+    ],
+    [inUseHidden, availableHidden],
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Victory event system is untyped
+  const legendEvents: any[] = React.useMemo(() => {
+    const handleClick = (_evt: unknown, props: { datum?: { childName?: string } }) => {
+      if (props.datum?.childName) {
+        toggleSeries(props.datum.childName);
+      }
+      return null;
+    };
+    const onMouseOver = () => [{ mutation: () => ({ style: { cursor: 'pointer' } }) }];
+    const onMouseOut = () => [{ mutation: () => null }];
+    return [
+      { target: 'data', eventHandlers: { onClick: handleClick, onMouseOver, onMouseOut } },
+      { target: 'labels', eventHandlers: { onClick: handleClick, onMouseOver, onMouseOut } },
+    ];
+  }, [toggleSeries]);
+
+  const inUseData = React.useMemo(
+    () =>
+      data.map(({ modelName, inUse }) => ({
+        x: modelName,
+        y: inUseHidden ? 0 : inUse,
+      })),
+    [data, inUseHidden],
+  );
+
+  const availableData = React.useMemo(
+    () =>
+      data.map(({ modelName, available }) => ({
+        x: modelName,
+        y: availableHidden ? 0 : available,
+      })),
+    [data, availableHidden],
+  );
+
+  const maxY = React.useMemo(() => {
+    let max = 0;
+    for (const { inUse, available } of data) {
+      const total = (inUseHidden ? 0 : inUse) + (availableHidden ? 0 : available);
+      if (total > max) {
+        max = total;
+      }
+    }
+    return Math.max(max, 1);
+  }, [data, inUseHidden, availableHidden]);
+
+  const plotWidth = width - 90;
+  const domainPad = Math.max(30, plotWidth / (data.length * 3));
+  const barWidth = Math.max(20, (plotWidth - domainPad * 2) / (data.length * 2));
+
+  return (
+    <div ref={containerRef}>
+      <Chart
+        ariaTitle="Hardware usage"
+        ariaDesc="Stacked bar chart showing accelerator usage per hardware model"
+        height={CHART_HEIGHT}
+        width={width}
+        domainPadding={{ x: domainPad }}
+        domain={{ y: [0, maxY * 1.1] }}
+        padding={{ bottom: 75, left: 60, right: 30, top: 30 }}
+        legendData={legendData}
+        legendPosition="bottom"
+        legendAllowInteractive
+        events={legendEvents}
+        containerComponent={
+          <CursorVoronoiContainer
+            cursorDimension="x"
+            voronoiDimension="x"
+            voronoiPadding={50}
+            mouseFollowTooltips
+            labels={({ datum }: { datum: { y: number } }) => `${datum.y}`}
+            labelComponent={
+              <ChartLegendTooltip legendData={legendData} title={(args) => String(args.x ?? '')} />
+            }
+            constrainToVisibleArea
+          />
+        }
+      >
+        <ChartAxis
+          label="Accelerators"
+          dependentAxis
+          showGrid
+          style={{ axisLabel: { padding: 45 } }}
+        />
+        <ChartAxis />
+        <ChartStack colorScale={[COLOR_IN_USE, COLOR_AVAILABLE]}>
+          <ChartBar data={inUseData} name="in-use" barWidth={barWidth} />
+          <ChartBar data={availableData} name="available" barWidth={barWidth} />
+        </ChartStack>
+      </Chart>
+    </div>
+  );
+};
+
+export default HardwareUsageChart;

--- a/packages/gpuaas/src/components/HardwareUsageChart.tsx
+++ b/packages/gpuaas/src/components/HardwareUsageChart.tsx
@@ -3,6 +3,7 @@ import {
   Chart,
   ChartAxis,
   ChartBar,
+  ChartLegend,
   ChartLegendTooltip,
   ChartStack,
   createContainer,
@@ -133,8 +134,7 @@ const HardwareUsageChart: React.FC<HardwareUsageChartProps> = ({ data }) => {
         padding={{ bottom: 75, left: 60, right: 30, top: 30 }}
         legendData={legendData}
         legendPosition="bottom"
-        legendAllowInteractive
-        events={legendEvents}
+        legendComponent={<ChartLegend events={legendEvents} />}
         containerComponent={
           <CursorVoronoiContainer
             cursorDimension="x"

--- a/packages/gpuaas/src/components/HardwareUsageChart.tsx
+++ b/packages/gpuaas/src/components/HardwareUsageChart.tsx
@@ -1,25 +1,101 @@
 import * as React from 'react';
+import ReactDOM from 'react-dom';
 import {
   Chart,
   ChartAxis,
   ChartBar,
+  ChartLabel,
   ChartLegend,
-  ChartLegendTooltip,
   ChartStack,
   createContainer,
 } from '@patternfly/react-charts/victory';
-import { getResizeObserver } from '@patternfly/react-core';
+import { LineSegment } from 'victory-core';
+import { chart_axis_grid_stroke_Color as chartStrokeColor } from '@patternfly/react-tokens';
+import {
+  Flex,
+  FlexItem,
+  Panel,
+  PanelMain,
+  PanelMainBody,
+  getResizeObserver,
+} from '@patternfly/react-core';
 import type { HardwareModelUsage } from '../hooks/useInfrastructureMetrics';
+import { AXIS_DIRECTION_LABEL_STYLE } from '../const';
 
 type HardwareUsageChartProps = {
   data: HardwareModelUsage[];
 };
 
+const CursorContainer = createContainer('cursor', 'cursor');
+
 const CHART_HEIGHT = 300;
 const COLOR_IN_USE = 'var(--pf-t--chart--color--blue--300)';
 const COLOR_AVAILABLE = 'var(--pf-t--chart--color--black--200)';
+const COLOR_HIDDEN = 'var(--pf-t--global--color--disabled)';
+const TOOLTIP_OFFSET_X = 14;
+const TOOLTIP_OFFSET_Y = -20;
 
-const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
+const SWATCH_BASE: React.CSSProperties = {
+  display: 'inline-block',
+  width: 10,
+  height: 10,
+  borderRadius: 2,
+};
+const SWATCH_IN_USE: React.CSSProperties = { ...SWATCH_BASE, background: COLOR_IN_USE };
+const SWATCH_AVAILABLE: React.CSSProperties = { ...SWATCH_BASE, background: COLOR_AVAILABLE };
+
+type HardwareTooltipProps = {
+  activeModel: string;
+  mousePos: { x: number; y: number };
+  data: HardwareModelUsage[];
+};
+
+const HardwareTooltip: React.FC<HardwareTooltipProps> = ({ activeModel, mousePos, data }) => {
+  const entry = data.find((d) => d.modelName === activeModel);
+  if (!entry) {
+    return null;
+  }
+
+  return ReactDOM.createPortal(
+    <Panel
+      variant="bordered"
+      style={{
+        position: 'fixed',
+        left: mousePos.x + TOOLTIP_OFFSET_X,
+        top: mousePos.y + TOOLTIP_OFFSET_Y,
+        width: 'max-content',
+        maxWidth: 320,
+        zIndex: 9999,
+        pointerEvents: 'none',
+      }}
+    >
+      <PanelMain>
+        <PanelMainBody>
+          <strong>{entry.modelName}</strong>
+          <Flex direction={{ default: 'column' }} gap={{ default: 'gapXs' }}>
+            <FlexItem>
+              <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                <FlexItem>
+                  <span style={SWATCH_IN_USE} />
+                </FlexItem>
+                <FlexItem>{`In use: ${entry.inUse}`}</FlexItem>
+              </Flex>
+            </FlexItem>
+            <FlexItem>
+              <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                <FlexItem>
+                  <span style={SWATCH_AVAILABLE} />
+                </FlexItem>
+                <FlexItem>{`Available: ${entry.available}`}</FlexItem>
+              </Flex>
+            </FlexItem>
+          </Flex>
+        </PanelMainBody>
+      </PanelMain>
+    </Panel>,
+    document.body,
+  );
+};
 
 const HardwareUsageChart: React.FC<HardwareUsageChartProps> = ({ data }) => {
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -27,6 +103,8 @@ const HardwareUsageChart: React.FC<HardwareUsageChartProps> = ({ data }) => {
   const observer = React.useRef(() => {});
   const [width, setWidth] = React.useState(0);
   const [hiddenSeries, setHiddenSeries] = React.useState<Set<string>>(new Set());
+  const [activeModel, setActiveModel] = React.useState<string | null>(null);
+  const [mousePos, setMousePos] = React.useState({ x: 0, y: 0 });
 
   const handleResize = React.useCallback(() => {
     if (containerRef.current?.clientWidth) {
@@ -41,6 +119,24 @@ const HardwareUsageChart: React.FC<HardwareUsageChartProps> = ({ data }) => {
     }
     return () => observer.current();
   }, [handleResize]);
+
+  React.useEffect(() => {
+    if (!activeModel) {
+      return undefined;
+    }
+    let rafId = 0;
+    const handleMouseMove = (e: MouseEvent) => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        setMousePos({ x: e.clientX, y: e.clientY });
+      });
+    };
+    window.addEventListener('mousemove', handleMouseMove);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      cancelAnimationFrame(rafId);
+    };
+  }, [activeModel]);
 
   const toggleSeries = React.useCallback((name: string) => {
     setHiddenSeries((prev) => {
@@ -62,12 +158,12 @@ const HardwareUsageChart: React.FC<HardwareUsageChartProps> = ({ data }) => {
       {
         childName: 'in-use',
         name: 'In use',
-        symbol: { fill: inUseHidden ? COLOR_AVAILABLE : COLOR_IN_USE, type: 'square' },
+        symbol: { fill: inUseHidden ? COLOR_HIDDEN : COLOR_IN_USE, type: 'square' },
       },
       {
         childName: 'available',
         name: 'Available',
-        symbol: { fill: availableHidden ? COLOR_IN_USE : COLOR_AVAILABLE, type: 'square' },
+        symbol: { fill: availableHidden ? COLOR_HIDDEN : COLOR_AVAILABLE, type: 'square' },
       },
     ],
     [inUseHidden, availableHidden],
@@ -88,6 +184,28 @@ const HardwareUsageChart: React.FC<HardwareUsageChartProps> = ({ data }) => {
       { target: 'labels', eventHandlers: { onClick: handleClick, onMouseOver, onMouseOut } },
     ];
   }, [toggleSeries]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Victory event system is untyped
+  const barEvents: any[] = React.useMemo(
+    () => [
+      {
+        target: 'data',
+        eventHandlers: {
+          onMouseOver: (_evt: React.SyntheticEvent, props: { datum?: { x?: string } }) => {
+            if (props.datum?.x) {
+              setActiveModel(props.datum.x);
+            }
+            return null;
+          },
+          onMouseOut: () => {
+            setActiveModel(null);
+            return null;
+          },
+        },
+      },
+    ],
+    [],
+  );
 
   const inUseData = React.useMemo(
     () =>
@@ -136,31 +254,36 @@ const HardwareUsageChart: React.FC<HardwareUsageChartProps> = ({ data }) => {
         legendPosition="bottom"
         legendComponent={<ChartLegend events={legendEvents} />}
         containerComponent={
-          <CursorVoronoiContainer
+          <CursorContainer
             cursorDimension="x"
-            voronoiDimension="x"
-            voronoiPadding={50}
-            mouseFollowTooltips
-            labels={({ datum }: { datum: { y: number } }) => `${datum.y}`}
-            labelComponent={
-              <ChartLegendTooltip legendData={legendData} title={(args) => String(args.x ?? '')} />
+            cursorComponent={
+              <LineSegment
+                style={{
+                  stroke: chartStrokeColor.var,
+                  strokeDasharray: '2 3',
+                  strokeOpacity: 0.6,
+                  strokeWidth: 1,
+                }}
+              />
             }
-            constrainToVisibleArea
           />
         }
       >
-        <ChartAxis
-          label="Accelerators"
-          dependentAxis
-          showGrid
-          style={{ axisLabel: { padding: 45 } }}
+        <ChartLabel
+          text="Accelerators"
+          x={4}
+          y={18}
+          style={AXIS_DIRECTION_LABEL_STYLE}
+          textAnchor="start"
         />
+        <ChartAxis dependentAxis showGrid />
         <ChartAxis />
         <ChartStack colorScale={[COLOR_IN_USE, COLOR_AVAILABLE]}>
-          <ChartBar data={inUseData} name="in-use" barWidth={barWidth} />
-          <ChartBar data={availableData} name="available" barWidth={barWidth} />
+          <ChartBar data={inUseData} name="in-use" barWidth={barWidth} events={barEvents} />
+          <ChartBar data={availableData} name="available" barWidth={barWidth} events={barEvents} />
         </ChartStack>
       </Chart>
+      {activeModel && <HardwareTooltip activeModel={activeModel} mousePos={mousePos} data={data} />}
     </div>
   );
 };

--- a/packages/gpuaas/src/components/HardwareUsageSection.tsx
+++ b/packages/gpuaas/src/components/HardwareUsageSection.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Spinner,
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+import HardwareUsageChart from './HardwareUsageChart';
+import type { ClusterMetrics } from '../hooks/useInfrastructureMetrics';
+
+type HardwareUsageSectionProps = {
+  metrics: ClusterMetrics;
+};
+
+const HardwareUsageSection: React.FC<HardwareUsageSectionProps> = ({ metrics }) => {
+  const { hardwareUsage, hardwareLoaded, error } = metrics;
+
+  if (!hardwareLoaded) {
+    return (
+      <Bullseye className="gpuaas-cluster-spinner">
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        headingLevel="h4"
+        icon={CubesIcon}
+        titleText="Error loading hardware usage data"
+        variant={EmptyStateVariant.xs}
+        data-testid="hardware-usage-error"
+      >
+        <EmptyStateBody>{error.message}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  if (!hardwareUsage) {
+    return (
+      <EmptyState
+        headingLevel="h4"
+        icon={CubesIcon}
+        titleText="Hardware model information unavailable"
+        variant={EmptyStateVariant.xs}
+        data-testid="hardware-usage-empty"
+      >
+        <EmptyStateBody>
+          No hardware model data is available. Install a supported GPU operator for per-model
+          breakdown.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return <HardwareUsageChart data={hardwareUsage} />;
+};
+
+export default HardwareUsageSection;

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -38,6 +38,19 @@ export const PROMQL_MEMORY_UTILIZATION = `query=${encodeURIComponent(
   'avg(DCGM_FI_DEV_FB_USED / (DCGM_FI_DEV_FB_USED + DCGM_FI_DEV_FB_FREE)) * 100',
 )}`;
 
+// PromQL queries for the Hardware usage section (per-model breakdown)
+export const PROMQL_HARDWARE_TOTAL = `query=${encodeURIComponent(
+  'count by (modelName)(DCGM_FI_PROF_GR_ENGINE_ACTIVE)',
+)}`;
+
+export const PROMQL_HARDWARE_IN_USE = `query=${encodeURIComponent(
+  'count by (modelName)(DCGM_FI_PROF_GR_ENGINE_ACTIVE{pod!=""})',
+)}`;
+
+export const PROMQL_HARDWARE_NODE_LABELS = `query=${encodeURIComponent(
+  'count by (label_nvidia_com_gpu_product, label_amd_com_gpu_product, label_habana_ai_gaudi, label_intel_com_gpu_product)(kube_node_labels{label_nvidia_com_gpu_product!=""} or kube_node_labels{label_amd_com_gpu_product!=""} or kube_node_labels{label_habana_ai_gaudi!=""} or kube_node_labels{label_intel_com_gpu_product!=""})',
+)}`;
+
 export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 export const CHART_HEIGHT = 400;
 export const CHART_PADDING = { left: 55, right: 220, bottom: 50, top: 40 };

--- a/packages/gpuaas/src/hooks/__tests__/useInfrastructureMetrics.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useInfrastructureMetrics.spec.ts
@@ -7,6 +7,9 @@ import {
   PROMQL_ACCELERATOR_ALLOCATABLE,
   PROMQL_ACCELERATOR_IN_USE,
   PROMQL_COMPUTE_UTILIZATION,
+  PROMQL_HARDWARE_IN_USE,
+  PROMQL_HARDWARE_NODE_LABELS,
+  PROMQL_HARDWARE_TOTAL,
   PROMQL_MEMORY_UTILIZATION,
 } from '../../const';
 
@@ -16,6 +19,8 @@ jest.mock('@odh-dashboard/internal/api/prometheus/usePrometheusQuery', () => ({
 }));
 
 const usePrometheusQueryMock = jest.mocked(usePrometheusQuery);
+
+const QUERY_COUNT = 7;
 
 const createPromResponse = (value: string): PrometheusQueryResponse => ({
   data: {
@@ -37,15 +42,6 @@ type MockFetchState = {
   refresh: jest.Mock;
 };
 
-const setupMocks = (states: [MockFetchState, MockFetchState, MockFetchState, MockFetchState]) => {
-  let callIdx = 0;
-  usePrometheusQueryMock.mockImplementation(() => {
-    const state = states[callIdx % 4];
-    callIdx++;
-    return state;
-  });
-};
-
 const loadedState = (data: PrometheusQueryResponse): MockFetchState => ({
   data,
   loaded: true,
@@ -60,17 +56,39 @@ const unloadedState: MockFetchState = {
   refresh: jest.fn(),
 };
 
+const DEFAULT_LOADED_STATE = loadedState(EMPTY_PROM_RESPONSE);
+
+const setupMocks = (states: MockFetchState[]) => {
+  let callIdx = 0;
+  usePrometheusQueryMock.mockImplementation(() => {
+    const state = states[callIdx % states.length];
+    callIdx++;
+    return state;
+  });
+};
+
+const setupClusterMocks = (
+  cluster: [MockFetchState, MockFetchState, MockFetchState, MockFetchState],
+  hardware: [MockFetchState, MockFetchState, MockFetchState] = [
+    DEFAULT_LOADED_STATE,
+    DEFAULT_LOADED_STATE,
+    DEFAULT_LOADED_STATE,
+  ],
+) => {
+  setupMocks([...cluster, ...hardware]);
+};
+
 describe('useInfrastructureMetrics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('should call usePrometheusQuery with correct parameters and return loading state initially', () => {
-    setupMocks([unloadedState, unloadedState, unloadedState, unloadedState]);
+    setupMocks(Array(QUERY_COUNT).fill(unloadedState));
 
     const renderResult = testHook(useInfrastructureMetrics)();
 
-    expect(usePrometheusQueryMock).toHaveBeenCalledTimes(4);
+    expect(usePrometheusQueryMock).toHaveBeenCalledTimes(QUERY_COUNT);
     expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
       1,
       '/api/prometheus/query',
@@ -95,11 +113,30 @@ describe('useInfrastructureMetrics', () => {
       PROMQL_MEMORY_UTILIZATION,
       expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
     );
+    expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
+      5,
+      '/api/prometheus/query',
+      PROMQL_HARDWARE_TOTAL,
+      expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
+    );
+    expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
+      6,
+      '/api/prometheus/query',
+      PROMQL_HARDWARE_IN_USE,
+      expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
+    );
+    expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
+      7,
+      '/api/prometheus/query',
+      PROMQL_HARDWARE_NODE_LABELS,
+      expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
+    );
 
     expect(renderResult.result.current.loaded).toBe(false);
     expect(renderResult.result.current.accelerators).toBeNull();
     expect(renderResult.result.current.computeUtilization).toBeNull();
     expect(renderResult.result.current.memoryUtilization).toBeNull();
+    expect(renderResult.result.current.hardwareUsage).toBeNull();
   });
 
   it.each([
@@ -126,7 +163,7 @@ describe('useInfrastructureMetrics', () => {
   ])(
     'should return correct metrics: $label',
     ({ allocatable, inUse, compute, memory, expectedAccel, expectedCompute, expectedMemory }) => {
-      setupMocks([
+      setupClusterMocks([
         loadedState(createPromResponse(allocatable)),
         loadedState(createPromResponse(inUse)),
         loadedState(createPromResponse(compute)),
@@ -143,7 +180,7 @@ describe('useInfrastructureMetrics', () => {
   );
 
   it('should return null accelerators when allocatable returns empty result', () => {
-    setupMocks([
+    setupClusterMocks([
       loadedState(EMPTY_PROM_RESPONSE),
       loadedState(EMPTY_PROM_RESPONSE),
       loadedState(createPromResponse('80')),
@@ -158,7 +195,7 @@ describe('useInfrastructureMetrics', () => {
   });
 
   it('should return null utilization when DCGM queries return empty', () => {
-    setupMocks([
+    setupClusterMocks([
       loadedState(createPromResponse('16')),
       loadedState(createPromResponse('11')),
       loadedState(EMPTY_PROM_RESPONSE),
@@ -179,6 +216,9 @@ describe('useInfrastructureMetrics', () => {
       { data: null, loaded: true, error: undefined, refresh: jest.fn() },
       { data: null, loaded: true, error: undefined, refresh: jest.fn() },
       { data: null, loaded: false, error: testError, refresh: jest.fn() },
+      DEFAULT_LOADED_STATE,
+      DEFAULT_LOADED_STATE,
+      DEFAULT_LOADED_STATE,
     ]);
 
     const renderResult = testHook(useInfrastructureMetrics)();
@@ -188,7 +228,7 @@ describe('useInfrastructureMetrics', () => {
   });
 
   it('should handle NaN values gracefully', () => {
-    setupMocks([
+    setupClusterMocks([
       loadedState(createPromResponse('NaN')),
       loadedState(createPromResponse('11')),
       loadedState(createPromResponse('NaN')),
@@ -203,7 +243,7 @@ describe('useInfrastructureMetrics', () => {
   });
 
   it('should clamp inUse to total and default to 0 when inUse is empty', () => {
-    setupMocks([
+    setupClusterMocks([
       loadedState(createPromResponse('16')),
       loadedState(EMPTY_PROM_RESPONSE),
       loadedState(createPromResponse('50')),
@@ -213,5 +253,111 @@ describe('useInfrastructureMetrics', () => {
     const renderResult = testHook(useInfrastructureMetrics)();
 
     expect(renderResult.result.current.accelerators).toEqual({ total: 16, inUse: 0 });
+  });
+
+  describe('hardware usage', () => {
+    const createHwResponse = (
+      models: { modelName: string; count: string }[],
+    ): PrometheusQueryResponse => ({
+      data: {
+        result: models.map(({ modelName, count }) => ({
+          metric: { modelName },
+          value: [Date.now() / 1000, count],
+        })),
+        resultType: 'vector',
+      },
+      status: 'success',
+    });
+
+    const NODE_LABEL_KEY = 'label_nvidia_com_gpu_product';
+    const createNodeLabelResponse = (
+      models: { label: string; count: string }[],
+    ): PrometheusQueryResponse => ({
+      data: {
+        result: models.map(({ label, count }) => ({
+          metric: { [NODE_LABEL_KEY]: label },
+          value: [Date.now() / 1000, count],
+        })),
+        resultType: 'vector',
+      },
+      status: 'success',
+    });
+
+    it('should parse DCGM hardware data into per-model breakdown', () => {
+      const hwTotalData = createHwResponse([
+        { modelName: 'NVIDIA H100', count: '8' },
+        { modelName: 'NVIDIA A100', count: '12' },
+      ]);
+      const hwInUseData = createHwResponse([
+        { modelName: 'NVIDIA H100', count: '8' },
+        { modelName: 'NVIDIA A100', count: '10' },
+      ]);
+
+      setupMocks([
+        ...Array(4).fill(DEFAULT_LOADED_STATE),
+        loadedState(hwTotalData),
+        loadedState(hwInUseData),
+        DEFAULT_LOADED_STATE,
+      ]);
+
+      const renderResult = testHook(useInfrastructureMetrics)();
+
+      expect(renderResult.result.current.hardwareUsage).toEqual([
+        { modelName: 'NVIDIA A100', inUse: 10, available: 2 },
+        { modelName: 'NVIDIA H100', inUse: 8, available: 0 },
+      ]);
+    });
+
+    it('should fall back to node labels when DCGM is empty', () => {
+      const nodeLabelData = createNodeLabelResponse([
+        { label: 'NVIDIA L40S', count: '4' },
+        { label: 'AMD MI300X', count: '2' },
+      ]);
+
+      setupMocks([
+        ...Array(4).fill(DEFAULT_LOADED_STATE),
+        loadedState(EMPTY_PROM_RESPONSE),
+        loadedState(EMPTY_PROM_RESPONSE),
+        loadedState(nodeLabelData),
+      ]);
+
+      const renderResult = testHook(useInfrastructureMetrics)();
+
+      expect(renderResult.result.current.hardwareUsage).toEqual([
+        { modelName: 'NVIDIA L40S', inUse: 0, available: 4 },
+        { modelName: 'AMD MI300X', inUse: 0, available: 2 },
+      ]);
+    });
+
+    it('should return null when no hardware data is available', () => {
+      setupMocks([
+        ...Array(4).fill(DEFAULT_LOADED_STATE),
+        loadedState(EMPTY_PROM_RESPONSE),
+        loadedState(EMPTY_PROM_RESPONSE),
+        loadedState(EMPTY_PROM_RESPONSE),
+      ]);
+
+      const renderResult = testHook(useInfrastructureMetrics)();
+
+      expect(renderResult.result.current.hardwareUsage).toBeNull();
+    });
+
+    it('should cap inUse at total when in-use exceeds total', () => {
+      const hwTotalData = createHwResponse([{ modelName: 'NVIDIA A100', count: '8' }]);
+      const hwInUseData = createHwResponse([{ modelName: 'NVIDIA A100', count: '10' }]);
+
+      setupMocks([
+        ...Array(4).fill(DEFAULT_LOADED_STATE),
+        loadedState(hwTotalData),
+        loadedState(hwInUseData),
+        DEFAULT_LOADED_STATE,
+      ]);
+
+      const renderResult = testHook(useInfrastructureMetrics)();
+
+      expect(renderResult.result.current.hardwareUsage).toEqual([
+        { modelName: 'NVIDIA A100', inUse: 8, available: 0 },
+      ]);
+    });
   });
 });

--- a/packages/gpuaas/src/hooks/useInfrastructureMetrics.ts
+++ b/packages/gpuaas/src/hooks/useInfrastructureMetrics.ts
@@ -6,6 +6,9 @@ import {
   PROMQL_ACCELERATOR_ALLOCATABLE,
   PROMQL_ACCELERATOR_IN_USE,
   PROMQL_COMPUTE_UTILIZATION,
+  PROMQL_HARDWARE_IN_USE,
+  PROMQL_HARDWARE_NODE_LABELS,
+  PROMQL_HARDWARE_TOTAL,
   PROMQL_MEMORY_UTILIZATION,
 } from '../const';
 
@@ -20,15 +23,33 @@ type UtilizationMetrics = {
   percentage: number;
 };
 
+export type HardwareModelUsage = {
+  modelName: string;
+  inUse: number;
+  available: number;
+};
+
 export type ClusterMetrics = {
   accelerators: AcceleratorMetrics | null;
   computeUtilization: UtilizationMetrics | null;
   memoryUtilization: UtilizationMetrics | null;
+  hardwareUsage: HardwareModelUsage[] | null;
+  clusterLoaded: boolean;
+  hardwareLoaded: boolean;
   loaded: boolean;
   error?: Error;
   lastRefreshed: Date | null;
   refresh: () => void;
 };
+
+type HardwareModelResponse = PrometheusQueryResponse<{ metric: { modelName: string } }>;
+type NodeLabelMetric = {
+  label_nvidia_com_gpu_product?: string;
+  label_amd_com_gpu_product?: string;
+  label_habana_ai_gaudi?: string;
+  label_intel_com_gpu_product?: string;
+};
+type NodeLabelResponse = PrometheusQueryResponse<{ metric: NodeLabelMetric }>;
 
 const parseScalarResult = (response: PrometheusQueryResponse | null): number | null => {
   if (response?.data.result[0]?.value?.[1] == null) {
@@ -36,6 +57,51 @@ const parseScalarResult = (response: PrometheusQueryResponse | null): number | n
   }
   const val = parseFloat(response.data.result[0].value[1]);
   return Number.isNaN(val) ? null : val;
+};
+
+const parseHardwareDcgm = (
+  totalResponse: HardwareModelResponse | null,
+  inUseResponse: HardwareModelResponse | null,
+): HardwareModelUsage[] => {
+  if (!totalResponse?.data.result.length) {
+    return [];
+  }
+
+  const inUseMap = new Map<string, number>();
+  inUseResponse?.data.result.forEach(({ metric, value }) => {
+    inUseMap.set(metric.modelName, Number(value[1]) || 0);
+  });
+
+  return totalResponse.data.result
+    .map(({ metric, value }) => {
+      const total = Number(value[1]) || 0;
+      const inUse = inUseMap.get(metric.modelName) ?? 0;
+      return {
+        modelName: metric.modelName,
+        inUse: Math.min(inUse, total),
+        available: Math.max(0, total - inUse),
+      };
+    })
+    .toSorted((a, b) => b.inUse + b.available - (a.inUse + a.available));
+};
+
+const parseHardwareNodeLabels = (response: NodeLabelResponse | null): HardwareModelUsage[] => {
+  if (!response?.data.result.length) {
+    return [];
+  }
+
+  return response.data.result
+    .map(({ metric, value }) => {
+      const name =
+        metric.label_nvidia_com_gpu_product ||
+        metric.label_amd_com_gpu_product ||
+        metric.label_habana_ai_gaudi ||
+        metric.label_intel_com_gpu_product ||
+        'Unknown';
+      return { modelName: name, inUse: 0, available: Number(value[1]) || 0 };
+    })
+    .filter(({ modelName }) => modelName !== 'Unknown')
+    .toSorted((a, b) => b.available - a.available);
 };
 
 const useInfrastructureMetrics = (): ClusterMetrics => {
@@ -51,18 +117,48 @@ const useInfrastructureMetrics = (): ClusterMetrics => {
   const compute = usePrometheusQuery(PROMETHEUS_API, PROMQL_COMPUTE_UTILIZATION, fetchOptions);
   const memory = usePrometheusQuery(PROMETHEUS_API, PROMQL_MEMORY_UTILIZATION, fetchOptions);
 
-  const loaded =
+  const hwTotal = usePrometheusQuery<HardwareModelResponse>(
+    PROMETHEUS_API,
+    PROMQL_HARDWARE_TOTAL,
+    fetchOptions,
+  );
+  const hwInUse = usePrometheusQuery<HardwareModelResponse>(
+    PROMETHEUS_API,
+    PROMQL_HARDWARE_IN_USE,
+    fetchOptions,
+  );
+  const hwNodeLabels = usePrometheusQuery<NodeLabelResponse>(
+    PROMETHEUS_API,
+    PROMQL_HARDWARE_NODE_LABELS,
+    fetchOptions,
+  );
+
+  const clusterLoaded =
     (allocatable.loaded || !!allocatable.error) &&
     (inUse.loaded || !!inUse.error) &&
     (compute.loaded || !!compute.error) &&
     (memory.loaded || !!memory.error);
-  const error = allocatable.error || inUse.error || compute.error || memory.error;
+  const hardwareLoaded =
+    (hwTotal.loaded || !!hwTotal.error) &&
+    (hwInUse.loaded || !!hwInUse.error) &&
+    (hwNodeLabels.loaded || !!hwNodeLabels.error);
+  const loaded = clusterLoaded && hardwareLoaded;
+  const error = allocatable.error || inUse.error || compute.error || memory.error || hwTotal.error;
 
   React.useEffect(() => {
     if (loaded) {
       setLastRefreshed(new Date());
     }
-  }, [loaded, allocatable.data, inUse.data, compute.data, memory.data]);
+  }, [
+    loaded,
+    allocatable.data,
+    inUse.data,
+    compute.data,
+    memory.data,
+    hwTotal.data,
+    hwInUse.data,
+    hwNodeLabels.data,
+  ]);
 
   const accelerators = React.useMemo((): AcceleratorMetrics | null => {
     const total = parseScalarResult(allocatable.data);
@@ -89,19 +185,42 @@ const useInfrastructureMetrics = (): ClusterMetrics => {
     return { percentage: Math.round(pct) };
   }, [memory.data]);
 
+  const hardwareUsage = React.useMemo((): HardwareModelUsage[] | null => {
+    const dcgm = parseHardwareDcgm(hwTotal.data, hwInUse.data);
+    if (dcgm.length > 0) {
+      return dcgm;
+    }
+    const nodeLabels = parseHardwareNodeLabels(hwNodeLabels.data);
+    return nodeLabels.length > 0 ? nodeLabels : null;
+  }, [hwTotal.data, hwInUse.data, hwNodeLabels.data]);
+
   const refresh = React.useCallback(() => {
     allocatable.refresh();
     inUse.refresh();
     compute.refresh();
     memory.refresh();
+    hwTotal.refresh();
+    hwInUse.refresh();
+    hwNodeLabels.refresh();
     setLastRefreshed(new Date());
     // eslint-disable-next-line react-hooks/exhaustive-deps -- .refresh references are stable from useFetch
-  }, [allocatable.refresh, inUse.refresh, compute.refresh, memory.refresh]);
+  }, [
+    allocatable.refresh,
+    inUse.refresh,
+    compute.refresh,
+    memory.refresh,
+    hwTotal.refresh,
+    hwInUse.refresh,
+    hwNodeLabels.refresh,
+  ]);
 
   return {
     accelerators,
     computeUtilization,
     memoryUtilization,
+    hardwareUsage,
+    clusterLoaded,
+    hardwareLoaded,
     loaded,
     error,
     lastRefreshed,

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -5,6 +5,7 @@ import { Card, CardBody, Content, Icon, Label, Stack, StackItem } from '@pattern
 import { SyncAltIcon } from '@patternfly/react-icons';
 import { INFRASTRUCTURE_SECTIONS } from '../const';
 import ClusterSummaryCards from '../components/ClusterSummaryCards';
+import HardwareUsageSection from '../components/HardwareUsageSection';
 import BorrowingLendingSection from '../components/BorrowingLendingSection';
 import useInfrastructureMetrics from '../hooks/useInfrastructureMetrics';
 
@@ -18,7 +19,7 @@ const InfrastructurePage: React.FC = () => {
 
   const SECTION_COMPONENTS: Record<SectionId, React.ReactElement | null> = {
     cluster: <ClusterSummaryCards metrics={metrics} />,
-    'hardware-usage': null,
+    'hardware-usage': <HardwareUsageSection metrics={metrics} />,
     'borrowing-lending': <BorrowingLendingSection />,
     'cluster-queue-utilization': null,
   };
@@ -30,6 +31,8 @@ const InfrastructurePage: React.FC = () => {
           <SyncAltIcon />
         </Icon>
       }
+      onClick={metrics.refresh}
+      style={{ cursor: 'pointer' }}
       data-testid="infrastructure-refresh-badge"
     >
       Refreshed ({formatRefreshTime(metrics.lastRefreshed)})

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -1,8 +1,19 @@
 import * as React from 'react';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
-import { Card, CardBody, Content, Icon, Label, Stack, StackItem } from '@patternfly/react-core';
+import {
+  Button,
+  Card,
+  CardBody,
+  Content,
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  Tooltip,
+} from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
+import { relativeTime } from '@odh-dashboard/internal/utilities/time';
 import { INFRASTRUCTURE_SECTIONS } from '../const';
 import ClusterSummaryCards from '../components/ClusterSummaryCards';
 import HardwareUsageSection from '../components/HardwareUsageSection';
@@ -10,9 +21,6 @@ import BorrowingLendingSection from '../components/BorrowingLendingSection';
 import useInfrastructureMetrics from '../hooks/useInfrastructureMetrics';
 
 type SectionId = (typeof INFRASTRUCTURE_SECTIONS)[number]['id'];
-
-const formatRefreshTime = (date: Date): string =>
-  date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' });
 
 const InfrastructurePage: React.FC = () => {
   const metrics = useInfrastructureMetrics();
@@ -25,18 +33,24 @@ const InfrastructurePage: React.FC = () => {
   };
 
   const headerAction = metrics.lastRefreshed ? (
-    <Label
-      icon={
-        <Icon isInline>
-          <SyncAltIcon />
-        </Icon>
-      }
-      onClick={metrics.refresh}
-      style={{ cursor: 'pointer' }}
+    <Flex
+      alignItems={{ default: 'alignItemsCenter' }}
+      spaceItems={{ default: 'spaceItemsSm' }}
       data-testid="infrastructure-refresh-badge"
     >
-      Refreshed ({formatRefreshTime(metrics.lastRefreshed)})
-    </Label>
+      <FlexItem>
+        <Tooltip content="Refresh page data">
+          <Button variant="plain" aria-label="Refresh page data" onClick={metrics.refresh}>
+            <SyncAltIcon />
+          </Button>
+        </Tooltip>
+      </FlexItem>
+      <FlexItem>
+        <Content component="small">
+          Last update: {relativeTime(Date.now(), metrics.lastRefreshed.getTime())}
+        </Content>
+      </FlexItem>
+    </Flex>
   ) : null;
 
   return (


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72328

## Description

Implements the "Hardware usage" section of the GPUaaS Infrastructure page with a PatternFly stacked bar chart showing per-hardware-model accelerator breakdown ("In use" vs "Available").

https://github.com/user-attachments/assets/7d46bdc5-0a53-4c1f-bd28-484bdb060b62

<img width="1182" height="252" alt="Screenshot 2026-07-09 at 5 21 19 PM" src="https://github.com/user-attachments/assets/b5b4224e-bee0-49d6-9dd1-1caa61542932" />


## How Has This Been Tested?

* Tested on KFTO cluster with DCGM metrics available — chart renders with real GPU model data
* Tested on Tangerine cluster without DCGM — empty state renders correctly

## Test Impact

- Extended `useInfrastructureMetrics.spec.ts` with 4 hardware usage unit tests (DCGM parsing, node label fallback, null handling, inUse capping)
- Added 5 Cypress mock tests covering: section rendering, model names in chart, legend items, empty state, node label fallback
- Extended Cypress page object with `findHardwareUsageSection()` and `findHardwareUsageEmpty()`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our Best Practices

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

cc @kywalker-rh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new “Hardware usage” section to the infrastructure page with a responsive stacked bar chart by GPU hardware model (including “In use” and “Available”).

* **Bug Fixes**
  * Improved loading and empty-state handling for hardware usage.
  * Added fallback to node-label-derived data when primary hardware model metrics aren’t available, and ensured “In use” never exceeds totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
