### PR TITLE
Add enabled toggle with unsupported acceptance flow for LLM accelerator configs

### DIFF
--- a/packages/cypress/cypress/pages/llmAcceleratorConfigs.ts
+++ b/packages/cypress/cypress/pages/llmAcceleratorConfigs.ts
@@ -21,15 +21,41 @@ class LlmAcceleratorConfigRow {
     return this;
   }
 
-  findEnabledToggle() {
+  private findEnabledToggleInput() {
     return this.find().findByTestId(`llm-accelerator-config-enabled-toggle-${this.name}`);
   }
 
+  findEnabledToggle() {
+    return this.findEnabledToggleInput().parent('label');
+  }
+
   shouldBeEnabled(enabled = true) {
-    this.findEnabledToggle()
-      .find('input')
-      .should(enabled ? 'be.checked' : 'not.be.checked');
+    this.findEnabledToggleInput().should(enabled ? 'be.checked' : 'not.be.checked');
     return this;
+  }
+}
+
+class UnsupportedStatusAcceptanceModal {
+  find() {
+    return cy.findByTestId('unsupported-status-acceptance-modal');
+  }
+
+  shouldBeOpen() {
+    this.find().should('exist');
+    return this;
+  }
+
+  shouldNotExist() {
+    cy.findByTestId('unsupported-status-acceptance-modal').should('not.exist');
+    return this;
+  }
+
+  findAcceptButton() {
+    return this.find().findByTestId('unsupported-status-accept-button');
+  }
+
+  findCancelButton() {
+    return this.find().findByTestId('unsupported-status-cancel-button');
   }
 }
 
@@ -68,3 +94,4 @@ class LlmAcceleratorConfigs {
 }
 
 export const llmAcceleratorConfigs = new LlmAcceleratorConfigs();
+export const unsupportedStatusAcceptanceModal = new UnsupportedStatusAcceptanceModal();

--- a/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigs.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigs.cy.ts
@@ -1,5 +1,8 @@
 import { llmAcceleratorConfigsIntercept } from './llmAcceleratorConfigsUtils';
-import { llmAcceleratorConfigs } from '../../../pages/llmAcceleratorConfigs';
+import {
+  llmAcceleratorConfigs,
+  unsupportedStatusAcceptanceModal,
+} from '../../../pages/llmAcceleratorConfigs';
 import { asProductAdminUser, asProjectAdminUser } from '../../../utils/mockUsers';
 import { pageNotfound } from '../../../pages/pageNotFound';
 
@@ -24,5 +27,80 @@ describe('LLM accelerator configurations', () => {
     llmAcceleratorConfigs.getRowByName('vllm-rocm').find().should('exist');
     llmAcceleratorConfigs.getRowByName('vllm-cpu').find().should('exist');
     llmAcceleratorConfigs.getRowByName('vllm-tpu').find().should('exist');
+    llmAcceleratorConfigs.getRowByName('vllm-gaudi').find().should('exist');
+  });
+
+  it('should show enabled toggle ON for enabled config and OFF for disabled config', () => {
+    llmAcceleratorConfigs.getRowByName('vllm-cuda').shouldBeEnabled(true);
+    llmAcceleratorConfigs.getRowByName('vllm-cpu').shouldBeEnabled(false);
+  });
+
+  it('should show toggle OFF for unsupported unaccepted config', () => {
+    llmAcceleratorConfigs.getRowByName('vllm-tpu').shouldBeEnabled(false);
+    llmAcceleratorConfigs.getRowByName('vllm-tpu').shouldHaveUnsupportedLabel(true);
+  });
+
+  it('should disable a config by toggling off', () => {
+    llmAcceleratorConfigs.getRowByName('vllm-cuda').findEnabledToggle().click();
+
+    cy.wait('@patchConfig').then((interception) => {
+      const body = interception.request.body as { op: string; path: string; value: string }[];
+      expect(body).to.containSubset([
+        { path: '/metadata/annotations/opendatahub.io~1disabled', value: 'true' },
+      ]);
+    });
+  });
+
+  it('should show acceptance modal when toggling on an unsupported unaccepted config', () => {
+    unsupportedStatusAcceptanceModal.shouldNotExist();
+
+    llmAcceleratorConfigs.getRowByName('vllm-tpu').findEnabledToggle().click();
+
+    unsupportedStatusAcceptanceModal.shouldBeOpen();
+    unsupportedStatusAcceptanceModal
+      .find()
+      .should('contain.text', 'Enable limited support accelerator configuration');
+  });
+
+  it('should dismiss modal without patching when cancel is clicked', () => {
+    llmAcceleratorConfigs.getRowByName('vllm-tpu').findEnabledToggle().click();
+    unsupportedStatusAcceptanceModal.shouldBeOpen();
+
+    unsupportedStatusAcceptanceModal.findCancelButton().click();
+
+    unsupportedStatusAcceptanceModal.shouldNotExist();
+  });
+
+  it('should patch config when accept is clicked on unsupported modal', () => {
+    llmAcceleratorConfigs.getRowByName('vllm-tpu').findEnabledToggle().click();
+    unsupportedStatusAcceptanceModal.shouldBeOpen();
+
+    unsupportedStatusAcceptanceModal.findAcceptButton().click();
+
+    cy.wait('@patchConfig').then((interception) => {
+      const body = interception.request.body as { op: string; path: string; value: string }[];
+      expect(body).to.containSubset([
+        {
+          path: '/metadata/annotations/opendatahub.io~1unsupported-status-accepted',
+          value: 'true',
+        },
+        { path: '/metadata/annotations/opendatahub.io~1disabled', value: 'false' },
+      ]);
+    });
+    unsupportedStatusAcceptanceModal.shouldNotExist();
+  });
+
+  it('should toggle already-accepted unsupported config normally without modal', () => {
+    llmAcceleratorConfigs.getRowByName('vllm-gaudi').shouldBeEnabled(false);
+
+    llmAcceleratorConfigs.getRowByName('vllm-gaudi').findEnabledToggle().click();
+
+    cy.wait('@patchConfig').then((interception) => {
+      const body = interception.request.body as { op: string; path: string; value: string }[];
+      expect(body).to.containSubset([
+        { path: '/metadata/annotations/opendatahub.io~1disabled', value: 'false' },
+      ]);
+    });
+    unsupportedStatusAcceptanceModal.shouldNotExist();
   });
 });

--- a/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigsUtils.ts
+++ b/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigsUtils.ts
@@ -4,6 +4,25 @@ import {
   MockConfigType,
 } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
 
+const llmInferenceServiceConfigModel = {
+  apiVersion: 'v1alpha2',
+  apiGroup: 'serving.kserve.io',
+  kind: 'LLMInferenceServiceConfig',
+  plural: 'llminferenceserviceconfigs',
+};
+
+const unsupportedAcceptedConfig = mockLLMInferenceServiceConfigK8sResource({
+  name: 'vllm-gaudi',
+  displayName: 'vLLM Gaudi Accelerator',
+  configType: MockConfigType.ACCELERATOR,
+  unsupported: true,
+  disabled: true,
+});
+unsupportedAcceptedConfig.metadata.annotations = {
+  ...unsupportedAcceptedConfig.metadata.annotations,
+  'opendatahub.io/unsupported-status-accepted': 'true',
+};
+
 export const llmAcceleratorConfigsInitialMock = [
   mockLLMInferenceServiceConfigK8sResource({
     name: 'vllm-cuda',
@@ -28,18 +47,16 @@ export const llmAcceleratorConfigsInitialMock = [
     configType: MockConfigType.ACCELERATOR,
     unsupported: true,
   }),
+  unsupportedAcceptedConfig,
 ];
 
 export const llmAcceleratorConfigsIntercept = (): void => {
   cy.interceptK8sList(
-    {
-      model: {
-        apiVersion: 'v1alpha2',
-        apiGroup: 'serving.kserve.io',
-        kind: 'LLMInferenceServiceConfig',
-        plural: 'llminferenceserviceconfigs',
-      },
-    },
+    { model: llmInferenceServiceConfigModel },
     mockK8sResourceList(llmAcceleratorConfigsInitialMock),
   );
+  cy.intercept(
+    { method: 'PATCH', pathname: new RegExp('/apis/serving.kserve.io/v1alpha2/.*') },
+    {},
+  ).as('patchConfig');
 };

--- a/packages/llmd-serving/src/admin/LlmAcceleratorConfigEnabledToggle.tsx
+++ b/packages/llmd-serving/src/admin/LlmAcceleratorConfigEnabledToggle.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { Switch } from '@patternfly/react-core';
+import useNotification from '@odh-dashboard/internal/utilities/useNotification';
+import {
+  isUnsupportedUnaccepted,
+  UNSUPPORTED_STATUS_ACCEPTED_ANNOTATION,
+} from '@odh-dashboard/model-serving/concepts/unsupportedResources';
+import UnsupportedStatusAcceptanceModal from '@odh-dashboard/model-serving/components/UnsupportedStatusAcceptanceModal';
+import type { LLMInferenceServiceConfigKind } from '../types';
+import { DISABLED_ANNOTATION } from '../const';
+import { isConfigEnabled } from '../utils';
+import { patchLLMInferenceServiceConfig } from '../api/LLMInferenceServiceConfigs';
+
+type LlmAcceleratorConfigEnabledToggleProps = {
+  config: LLMInferenceServiceConfigKind;
+};
+
+const LlmAcceleratorConfigEnabledToggle: React.FC<LlmAcceleratorConfigEnabledToggleProps> = ({
+  config,
+}) => {
+  const notification = useNotification();
+  const [isToggling, setIsToggling] = React.useState(false);
+  const [showAcceptanceModal, setShowAcceptanceModal] = React.useState(false);
+
+  const configName = config.metadata.name;
+  const unsupportedUnaccepted = isUnsupportedUnaccepted(config);
+  const effectiveEnabled = unsupportedUnaccepted ? false : isConfigEnabled(config);
+
+  const patchConfigAnnotations = React.useCallback(
+    async (annotationUpdates: Record<string, string>) => {
+      setIsToggling(true);
+      const updatedConfig: LLMInferenceServiceConfigKind = {
+        ...config,
+        metadata: {
+          ...config.metadata,
+          annotations: {
+            ...config.metadata.annotations,
+            ...annotationUpdates,
+          },
+        },
+      };
+
+      try {
+        await patchLLMInferenceServiceConfig(config, updatedConfig);
+      } catch (e) {
+        notification.error(
+          'Error updating accelerator configuration',
+          e instanceof Error ? e.message : 'Unknown error',
+        );
+      } finally {
+        setIsToggling(false);
+      }
+    },
+    [config, notification],
+  );
+
+  const handleToggle = React.useCallback(() => {
+    if (effectiveEnabled) {
+      patchConfigAnnotations({ [DISABLED_ANNOTATION]: 'true' });
+    } else if (unsupportedUnaccepted) {
+      setShowAcceptanceModal(true);
+    } else {
+      patchConfigAnnotations({ [DISABLED_ANNOTATION]: 'false' });
+    }
+  }, [effectiveEnabled, unsupportedUnaccepted, patchConfigAnnotations]);
+
+  const handleAccept = React.useCallback(() => {
+    setShowAcceptanceModal(false);
+    patchConfigAnnotations({
+      [UNSUPPORTED_STATUS_ACCEPTED_ANNOTATION]: 'true',
+      [DISABLED_ANNOTATION]: 'false',
+    });
+  }, [patchConfigAnnotations]);
+
+  return (
+    <>
+      <Switch
+        id={`llm-accelerator-config-enabled-toggle-${configName}`}
+        aria-label={`${configName}-enabled-toggle`}
+        data-testid={`llm-accelerator-config-enabled-toggle-${configName}`}
+        isChecked={effectiveEnabled}
+        isDisabled={isToggling}
+        onChange={handleToggle}
+      />
+      {showAcceptanceModal ? (
+        <UnsupportedStatusAcceptanceModal
+          resourceTypeLabel="accelerator configuration"
+          onAccept={handleAccept}
+          onClose={() => setShowAcceptanceModal(false)}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default LlmAcceleratorConfigEnabledToggle;

--- a/packages/llmd-serving/src/admin/LlmAcceleratorConfigTableRow.tsx
+++ b/packages/llmd-serving/src/admin/LlmAcceleratorConfigTableRow.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
-import { Label, LabelGroup, Switch } from '@patternfly/react-core';
+import { Label, LabelGroup } from '@patternfly/react-core';
 import { ResourceNameTooltip } from '@odh-dashboard/ui-core';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { isUnsupportedResource } from '@odh-dashboard/model-serving/concepts/unsupportedResources';
 import { PreInstalledName } from '@odh-dashboard/internal/concepts/k8s/utils';
+import LlmAcceleratorConfigEnabledToggle from './LlmAcceleratorConfigEnabledToggle';
 import type { LLMInferenceServiceConfigKind } from '../types';
-import { isConfigEnabled, isConfigPreInstalled } from '../utils';
+import { isConfigPreInstalled } from '../utils';
 
 type LlmAcceleratorConfigTableRowProps = {
   obj: LLMInferenceServiceConfigKind;
@@ -29,17 +30,11 @@ const LlmAcceleratorConfigTableRow: React.FC<LlmAcceleratorConfigTableRowProps> 
         </ResourceNameTooltip>
         <LabelGroup>
           {preInstalled && <Label data-testid="pre-installed-label">{PreInstalledName}</Label>}
-          {unsupported && <Label data-testid="unsupported-label">Unsupported</Label>}
+          {unsupported && <Label data-testid="unsupported-label">Limited support</Label>}
         </LabelGroup>
       </Td>
       <Td dataLabel="Enabled">
-        <Switch
-          id={`llm-accelerator-config-enabled-toggle-${configName}`}
-          aria-label={`${configName}-enabled-toggle`}
-          isChecked={isConfigEnabled(config)}
-          isDisabled // TODO wire this up in a followup PR
-          data-testid={`llm-accelerator-config-enabled-toggle-${configName}`}
-        />
+        <LlmAcceleratorConfigEnabledToggle config={config} />
       </Td>
       <Td isActionCell>
         <ActionsColumn

--- a/packages/llmd-serving/src/admin/__tests__/LlmAcceleratorConfigEnabledToggle.spec.tsx
+++ b/packages/llmd-serving/src/admin/__tests__/LlmAcceleratorConfigEnabledToggle.spec.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import LlmAcceleratorConfigEnabledToggle from '../LlmAcceleratorConfigEnabledToggle';
+import { patchLLMInferenceServiceConfig } from '../../api/LLMInferenceServiceConfigs';
+import type { LLMInferenceServiceConfigKind } from '../../types';
+
+jest.mock('@odh-dashboard/internal/utilities/useNotification', () => {
+  const mockNotification = { error: jest.fn(), success: jest.fn(), info: jest.fn() };
+  return { __esModule: true, default: () => mockNotification };
+});
+
+jest.mock('../../api/LLMInferenceServiceConfigs', () => ({
+  patchLLMInferenceServiceConfig: jest.fn(),
+}));
+
+const mockPatchConfig = jest.mocked(patchLLMInferenceServiceConfig);
+
+const mockNotification =
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('@odh-dashboard/internal/utilities/useNotification').default();
+
+describe('LlmAcceleratorConfigEnabledToggle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPatchConfig.mockResolvedValue({} as LLMInferenceServiceConfigKind);
+  });
+
+  it('should render a checked toggle when config is enabled', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({});
+
+    render(<LlmAcceleratorConfigEnabledToggle config={config} />);
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle).toBeChecked();
+  });
+
+  it('should render an unchecked toggle when config is disabled', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({ disabled: true });
+
+    render(<LlmAcceleratorConfigEnabledToggle config={config} />);
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('should patch disabled annotation to true when toggling off', async () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({});
+
+    render(<LlmAcceleratorConfigEnabledToggle config={config} />);
+
+    fireEvent.click(screen.getByRole('switch'));
+
+    await waitFor(() => {
+      expect(mockPatchConfig).toHaveBeenCalledWith(
+        config,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({
+              'opendatahub.io/disabled': 'true',
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  it('should patch disabled annotation to false when toggling on a supported config', async () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({ disabled: true });
+
+    render(<LlmAcceleratorConfigEnabledToggle config={config} />);
+
+    fireEvent.click(screen.getByRole('switch'));
+
+    await waitFor(() => {
+      expect(mockPatchConfig).toHaveBeenCalledWith(
+        config,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({
+              'opendatahub.io/disabled': 'false',
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  it('should show error notification on patch failure', async () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({});
+    mockPatchConfig.mockRejectedValue(new Error('Network error'));
+
+    render(<LlmAcceleratorConfigEnabledToggle config={config} />);
+
+    fireEvent.click(screen.getByRole('switch'));
+
+    await waitFor(() => {
+      expect(mockNotification.error).toHaveBeenCalledWith(
+        'Error updating accelerator configuration',
+        'Network error',
+      );
+    });
+  });
+
+  it('should show toggle OFF for unsupported unaccepted config regardless of disabled annotation', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({ unsupported: true });
+
+    render(<LlmAcceleratorConfigEnabledToggle config={config} />);
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('should open acceptance modal when toggling ON an unsupported unaccepted config', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({ unsupported: true });
+
+    render(<LlmAcceleratorConfigEnabledToggle config={config} />);
+
+    expect(screen.queryByTestId('unsupported-status-acceptance-modal')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('switch'));
+
+    expect(screen.getByTestId('unsupported-status-acceptance-modal')).toBeInTheDocument();
+    expect(
+      screen.getByText('Enable limited support accelerator configuration'),
+    ).toBeInTheDocument();
+    expect(mockPatchConfig).not.toHaveBeenCalled();
+  });
+
+  it('should patch both annotations on accept from the modal', async () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({ unsupported: true });
+
+    render(<LlmAcceleratorConfigEnabledToggle config={config} />);
+
+    fireEvent.click(screen.getByRole('switch'));
+    fireEvent.click(screen.getByTestId('unsupported-status-accept-button'));
+
+    await waitFor(() => {
+      expect(mockPatchConfig).toHaveBeenCalledWith(
+        config,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({
+              'opendatahub.io/unsupported-status-accepted': 'true',
+              'opendatahub.io/disabled': 'false',
+            }),
+          }),
+        }),
+      );
+    });
+
+    expect(screen.queryByTestId('unsupported-status-acceptance-modal')).not.toBeInTheDocument();
+  });
+
+  it('should close modal without patching when cancel is clicked', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({ unsupported: true });
+
+    render(<LlmAcceleratorConfigEnabledToggle config={config} />);
+
+    fireEvent.click(screen.getByRole('switch'));
+    expect(screen.getByTestId('unsupported-status-acceptance-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('unsupported-status-cancel-button'));
+
+    expect(screen.queryByTestId('unsupported-status-acceptance-modal')).not.toBeInTheDocument();
+    expect(mockPatchConfig).not.toHaveBeenCalled();
+  });
+
+  it('should toggle normally without modal for already-accepted unsupported config', async () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({ unsupported: true, disabled: true });
+    config.metadata.annotations = {
+      ...config.metadata.annotations,
+      'opendatahub.io/unsupported-status-accepted': 'true',
+    };
+
+    render(<LlmAcceleratorConfigEnabledToggle config={config} />);
+
+    fireEvent.click(screen.getByRole('switch'));
+
+    await waitFor(() => {
+      expect(mockPatchConfig).toHaveBeenCalledWith(
+        config,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({
+              'opendatahub.io/disabled': 'false',
+            }),
+          }),
+        }),
+      );
+    });
+
+    expect(screen.queryByTestId('unsupported-status-acceptance-modal')).not.toBeInTheDocument();
+  });
+});

--- a/packages/llmd-serving/src/admin/__tests__/LlmAcceleratorConfigTableRow.spec.tsx
+++ b/packages/llmd-serving/src/admin/__tests__/LlmAcceleratorConfigTableRow.spec.tsx
@@ -1,65 +1,27 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
 import LlmAcceleratorConfigTableRow from '../LlmAcceleratorConfigTableRow';
-import { isConfigEnabled, isConfigPreInstalled } from '../../utils';
-import type { LLMInferenceServiceConfigKind } from '../../types';
 
-jest.mock('@odh-dashboard/ui-core', () => ({
-  ResourceNameTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-
-jest.mock('@odh-dashboard/k8s-core', () => ({
-  getDisplayNameFromK8sResource: jest.fn(),
-}));
-
-jest.mock('@odh-dashboard/model-serving/concepts/unsupportedResources', () => ({
-  isUnsupportedResource: jest.fn(),
-}));
-
-jest.mock('../../utils', () => ({
-  ...jest.requireActual('../../utils'),
-  isConfigEnabled: jest.fn(),
-  isConfigPreInstalled: jest.fn(),
-}));
-
-const mockGetDisplayNameFromK8sResource = jest.mocked(
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('@odh-dashboard/k8s-core').getDisplayNameFromK8sResource,
-);
-const mockIsUnsupportedResource = jest.mocked(
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('@odh-dashboard/model-serving/concepts/unsupportedResources').isUnsupportedResource,
-);
-
-const mockIsConfigEnabled = jest.mocked(isConfigEnabled);
-const mockIsConfigPreInstalled = jest.mocked(isConfigPreInstalled);
-
-const createMockConfig = (
-  overrides: Partial<LLMInferenceServiceConfigKind> = {},
-): LLMInferenceServiceConfigKind => ({
-  kind: 'LLMInferenceServiceConfig',
-  apiVersion: 'serving.kserve.io/v1alpha2',
-  metadata: {
-    name: 'test-config',
-    namespace: 'opendatahub',
-    ...overrides.metadata,
-  },
-  ...overrides,
+jest.mock('@odh-dashboard/internal/utilities/useNotification', () => {
+  const mockNotification = { error: jest.fn(), success: jest.fn(), info: jest.fn() };
+  return { __esModule: true, default: () => mockNotification };
 });
+
+jest.mock('../../api/LLMInferenceServiceConfigs', () => ({
+  patchLLMInferenceServiceConfig: jest.fn(),
+}));
 
 describe('LlmAcceleratorConfigTableRow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetDisplayNameFromK8sResource.mockReturnValue('Test Config Display Name');
-    mockIsUnsupportedResource.mockReturnValue(false);
-    mockIsConfigEnabled.mockReturnValue(true);
-    mockIsConfigPreInstalled.mockReturnValue(false);
   });
 
-  it('should render the display name from getDisplayNameFromK8sResource', () => {
-    const config = createMockConfig();
-    mockGetDisplayNameFromK8sResource.mockReturnValue('Custom Display Name');
+  it('should render the display name', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      displayName: 'Custom Display Name',
+    });
 
     render(
       <table>
@@ -70,12 +32,10 @@ describe('LlmAcceleratorConfigTableRow', () => {
     );
 
     expect(screen.getByText('Custom Display Name')).toBeInTheDocument();
-    expect(mockGetDisplayNameFromK8sResource).toHaveBeenCalledWith(config);
   });
 
-  it('should show Pre-installed label when isConfigPreInstalled returns true', () => {
-    const config = createMockConfig();
-    mockIsConfigPreInstalled.mockReturnValue(true);
+  it('should show Pre-installed label when config is pre-installed', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({ preInstalled: true });
 
     render(
       <table>
@@ -89,9 +49,8 @@ describe('LlmAcceleratorConfigTableRow', () => {
     expect(screen.getByTestId('pre-installed-label')).toHaveTextContent('Pre-installed');
   });
 
-  it('should not show Pre-installed label when isConfigPreInstalled returns false', () => {
-    const config = createMockConfig();
-    mockIsConfigPreInstalled.mockReturnValue(false);
+  it('should not show Pre-installed label when config is not pre-installed', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({});
 
     render(
       <table>
@@ -104,9 +63,8 @@ describe('LlmAcceleratorConfigTableRow', () => {
     expect(screen.queryByTestId('pre-installed-label')).not.toBeInTheDocument();
   });
 
-  it('should show Unsupported label when isUnsupportedResource returns true', () => {
-    const config = createMockConfig();
-    mockIsUnsupportedResource.mockReturnValue(true);
+  it('should show Unsupported label when config is unsupported', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({ unsupported: true });
 
     render(
       <table>
@@ -117,12 +75,11 @@ describe('LlmAcceleratorConfigTableRow', () => {
     );
 
     expect(screen.getByTestId('unsupported-label')).toBeInTheDocument();
-    expect(screen.getByTestId('unsupported-label')).toHaveTextContent('Unsupported');
+    expect(screen.getByTestId('unsupported-label')).toHaveTextContent('Limited support');
   });
 
-  it('should not show Unsupported label when isUnsupportedResource returns false', () => {
-    const config = createMockConfig();
-    mockIsUnsupportedResource.mockReturnValue(false);
+  it('should not show Unsupported label when config is not unsupported', () => {
+    const config = mockLLMInferenceServiceConfigK8sResource({});
 
     render(
       <table>
@@ -136,9 +93,10 @@ describe('LlmAcceleratorConfigTableRow', () => {
   });
 
   it('should show both Pre-installed and Unsupported labels when both conditions are true', () => {
-    const config = createMockConfig();
-    mockIsConfigPreInstalled.mockReturnValue(true);
-    mockIsUnsupportedResource.mockReturnValue(true);
+    const config = mockLLMInferenceServiceConfigK8sResource({
+      preInstalled: true,
+      unsupported: true,
+    });
 
     render(
       <table>
@@ -152,45 +110,8 @@ describe('LlmAcceleratorConfigTableRow', () => {
     expect(screen.getByTestId('unsupported-label')).toBeInTheDocument();
   });
 
-  it('should render disabled toggle reflecting config enabled state', () => {
-    const config = createMockConfig({ metadata: { name: 'my-config', namespace: 'opendatahub' } });
-    mockIsConfigEnabled.mockReturnValue(false);
-
-    render(
-      <table>
-        <tbody>
-          <LlmAcceleratorConfigTableRow obj={config} rowIndex={0} />
-        </tbody>
-      </table>,
-    );
-
-    const toggle = screen.getByTestId('llm-accelerator-config-enabled-toggle-my-config');
-    expect(toggle).toBeInTheDocument();
-    expect(toggle).not.toBeChecked();
-    expect(toggle).toBeDisabled();
-  });
-
-  it('should render checked toggle when config is enabled', () => {
-    const config = createMockConfig({
-      metadata: { name: 'enabled-config', namespace: 'opendatahub' },
-    });
-    mockIsConfigEnabled.mockReturnValue(true);
-
-    render(
-      <table>
-        <tbody>
-          <LlmAcceleratorConfigTableRow obj={config} rowIndex={0} />
-        </tbody>
-      </table>,
-    );
-
-    const toggle = screen.getByTestId('llm-accelerator-config-enabled-toggle-enabled-config');
-    expect(toggle).toBeChecked();
-    expect(toggle).toBeDisabled();
-  });
-
   it('should render Duplicate action in kebab menu', () => {
-    const config = createMockConfig();
+    const config = mockLLMInferenceServiceConfigK8sResource({});
 
     render(
       <table>
@@ -204,9 +125,7 @@ describe('LlmAcceleratorConfigTableRow', () => {
   });
 
   it('should use correct data-testid for the row', () => {
-    const config = createMockConfig({
-      metadata: { name: 'my-test-config', namespace: 'opendatahub' },
-    });
+    const config = mockLLMInferenceServiceConfigK8sResource({ name: 'my-test-config' });
 
     const { container } = render(
       <table>

--- a/packages/llmd-serving/src/admin/columns.ts
+++ b/packages/llmd-serving/src/admin/columns.ts
@@ -1,11 +1,13 @@
 import { type SortableData, kebabTableColumn } from '@odh-dashboard/ui-core';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import type { LLMInferenceServiceConfigKind } from '../types';
 
 export const columns: SortableData<LLMInferenceServiceConfigKind>[] = [
   {
     field: 'name',
     label: 'Name',
-    sortable: false,
+    sortable: (a, b) =>
+      getDisplayNameFromK8sResource(a).localeCompare(getDisplayNameFromK8sResource(b)),
   },
   {
     field: 'enabled',

--- a/packages/model-serving/src/components/UnsupportedStatusAcceptanceModal.tsx
+++ b/packages/model-serving/src/components/UnsupportedStatusAcceptanceModal.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import ContentModal from '@odh-dashboard/internal/components/modals/ContentModal';
+
+type UnsupportedStatusAcceptanceModalProps = {
+  resourceTypeLabel: string;
+  onAccept: () => void;
+  onClose: () => void;
+};
+
+const UnsupportedStatusAcceptanceModal: React.FC<UnsupportedStatusAcceptanceModalProps> = ({
+  resourceTypeLabel,
+  onAccept,
+  onClose,
+}) => (
+  <ContentModal
+    title={`Enable limited support ${resourceTypeLabel}`}
+    variant="small"
+    onClose={onClose}
+    dataTestId="unsupported-status-acceptance-modal"
+    contents={`By enabling this ${resourceTypeLabel}, you acknowledge that it is not recommended for production workloads and that support coverage differs from standard ${resourceTypeLabel}s.`}
+    buttonActions={[
+      {
+        label: 'Enable',
+        onClick: onAccept,
+        variant: 'primary',
+        dataTestId: 'unsupported-status-accept-button',
+      },
+      {
+        label: 'Cancel',
+        onClick: onClose,
+        variant: 'link',
+        dataTestId: 'unsupported-status-cancel-button',
+      },
+    ]}
+  />
+);
+
+export default UnsupportedStatusAcceptanceModal;

--- a/packages/model-serving/src/components/__tests__/UnsupportedStatusAcceptanceModal.spec.tsx
+++ b/packages/model-serving/src/components/__tests__/UnsupportedStatusAcceptanceModal.spec.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UnsupportedStatusAcceptanceModal from '../UnsupportedStatusAcceptanceModal';
+
+describe('UnsupportedStatusAcceptanceModal', () => {
+  const mockOnAccept = jest.fn();
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with the correct title for accelerator configuration', () => {
+    render(
+      <UnsupportedStatusAcceptanceModal
+        resourceTypeLabel="accelerator configuration"
+        onAccept={mockOnAccept}
+        onClose={mockOnClose}
+      />,
+    );
+
+    expect(
+      screen.getByText('Enable limited support accelerator configuration'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render with the correct title for runtime', () => {
+    render(
+      <UnsupportedStatusAcceptanceModal
+        resourceTypeLabel="runtime"
+        onAccept={mockOnAccept}
+        onClose={mockOnClose}
+      />,
+    );
+
+    expect(screen.getByText('Enable limited support runtime')).toBeInTheDocument();
+  });
+
+  it('should render body text with the resource type label', () => {
+    render(
+      <UnsupportedStatusAcceptanceModal
+        resourceTypeLabel="accelerator configuration"
+        onAccept={mockOnAccept}
+        onClose={mockOnClose}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'By enabling this accelerator configuration, you acknowledge that it is not recommended for production workloads and that support coverage differs from standard accelerator configurations.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should call onAccept when Enable button is clicked', () => {
+    render(
+      <UnsupportedStatusAcceptanceModal
+        resourceTypeLabel="runtime"
+        onAccept={mockOnAccept}
+        onClose={mockOnClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('unsupported-status-accept-button'));
+    expect(mockOnAccept).toHaveBeenCalledTimes(1);
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('should call onClose when Cancel button is clicked', () => {
+    render(
+      <UnsupportedStatusAcceptanceModal
+        resourceTypeLabel="runtime"
+        onAccept={mockOnAccept}
+        onClose={mockOnClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('unsupported-status-cancel-button'));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockOnAccept).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-69749
https://issues.redhat.com/browse/RHOAIENG-69752

Followup to https://github.com/opendatahub-io/odh-dashboard/pull/8431

cc @vconzola 

## Description
Wires up the enable toggle on the LLM accelerator configurations admin page with support-status awareness:
- **Toggle ON/OFF**: Patches `opendatahub.io/disabled` annotation via `patchLLMInferenceServiceConfig`
- **Unsupported + unaccepted configs**: Toggle shows OFF regardless of disabled annotation. Toggling ON opens a confirmation modal ("Enable limited support accelerator configuration") before enabling
- **On accept**: Patches both `opendatahub.io/unsupported-status-accepted: "true"` and `opendatahub.io/disabled: "false"` in a single call
- **Already-accepted unsupported configs**: Toggle normally without modal
- **Error handling**: Shows error notification on patch failure
- **Microcopy update**: "Unsupported" label changed to "Limited support" per UX guidance

### New components
- `UnsupportedStatusAcceptanceModal` (`packages/model-serving/src/components/`) — reusable modal parameterized by `resourceTypeLabel` (e.g. "accelerator configuration", "runtime")
- `LlmAcceleratorConfigEnabledToggle` (`packages/llmd-serving/src/admin/`) — self-contained toggle with patch logic, loading state, and unsupported flow

### Screenshots

When clicking a toggle on a limited-support config that has not yet been approved by a user, this modal appears:
<img width="571" height="226" alt="Screenshot 2026-07-08 at 7 36 34 PM" src="https://github.com/user-attachments/assets/7522e7d0-905d-4b1f-b5de-3d368bc1ad5a" />

After confirming that modal (or when clicking a toggle that doesn't require approval, either because it's not limited-support or it has already been approved), while the annotations are being patched the toggle is disabled. If the patch fails, an alert is shown: 
<img width="615" height="105" alt="image" src="https://github.com/user-attachments/assets/96214088-f55e-4ed0-94ba-72114e64e19c" />


## How Has This Been Tested?
- Unit tests: 32 tests across modal, toggle, and table row (all passing)
- Cypress mock tests: 9 tests covering toggle states, acceptance flow, payload assertions (all passing)
- Manual testing via dev server using zaffre ROSA cluster

## Test Impact
- **Unit tests added**: `UnsupportedStatusAcceptanceModal.spec.tsx` (5 tests), `LlmAcceleratorConfigEnabledToggle.spec.tsx` (10 tests)
- **Unit tests updated**: `LlmAcceleratorConfigTableRow.spec.tsx` — reduced mocking, uses shared `mockLLMInferenceServiceConfigK8sResource` factory
- **Cypress mock tests expanded**: `llmAcceleratorConfigs.cy.ts` — 7 new tests for toggle states, unsupported modal flow, and PATCH payload validation

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an “Enable” confirmation modal for unsupported-but-unaccepted accelerator configurations.
  * Introduced a dedicated enable/disable toggle component and updated the table “Enabled” interaction flow.
  * Improved name column sorting using resource display names.

* **Bug Fixes**
  * Prevent enabling unsupported-but-unaccepted configs until confirmation is accepted.
  * Supported and already-accepted limited-support configs now toggle without prompting.

* **Tests**
  * Expanded unit and end-to-end coverage for toggle states, modal accept/cancel behavior, and expected PATCH annotation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->