### PR TITLE
RHOAIENG-75768: Add monitoring.coreos.com RBAC escalation rule to dashboard-operator ClusterRole

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -308,6 +308,19 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+  # Prometheus API access for cluster-monitoring-view ClusterRoleBinding escalation.
+  # The operand deploys a ClusterRoleBinding to the OpenShift built-in
+  # cluster-monitoring-view ClusterRole, which grants these permissions.
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheuses/api
+    resourceNames:
+      - k8s
+    verbs:
+      - get
+      - create
+      - update
   # OpenShift platform detection for operand
   - apiGroups:
       - config.openshift.io

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -292,6 +292,19 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+  # Prometheus API access for cluster-monitoring-view ClusterRoleBinding escalation.
+  # The operand deploys a ClusterRoleBinding to the OpenShift built-in
+  # cluster-monitoring-view ClusterRole, which grants these permissions.
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheuses/api
+    resourceNames:
+      - k8s
+    verbs:
+      - get
+      - create
+      - update
   # OpenShift platform detection for operand
   - apiGroups:
       - config.openshift.io


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-75768

## Description

The operand deploys a `ClusterRoleBinding` (`odh-dashboard-monitoring`) that binds the `odh-dashboard` ServiceAccount to the OpenShift built-in `cluster-monitoring-view` ClusterRole. Kubernetes RBAC escalation prevention requires the creating ServiceAccount to hold all permissions that the referenced ClusterRole grants.

`cluster-monitoring-view` grants `monitoring.coreos.com/prometheuses/api` (resourceNames: `k8s`, verbs: `get`, `create`, `update`), which was **not** covered in the operator's ClusterRole. This causes `DashboardReady` failures with RBAC escalation errors in opendatahub-operator E2E tests.

This is the last remaining RBAC gap after PRs #8430, #8455, and #8459 fixed the previous escalation issues.

## How Has This Been Tested?

- `make test` in `dashboard-operator/` passes all 4 test packages, including the `TestDashboardChartRBACInSync` chart sync test that validates `config/rbac/role.yaml` and `charts/dashboard/templates/rbac.yaml` stay in sync.

## Test Impact

No new tests needed — the existing `TestDashboardChartRBACInSync` test already validates that both RBAC files are in sync, and passing confirms the new rule is correctly placed in both files.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator access to monitoring data, helping it interact with the metrics endpoint more reliably.
  * This should reduce permission-related issues when the system needs to read or update Prometheus-related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->