### PR TITLE
Feat(RHOAIENG-72329): lending borrowing chart

### DIFF
--- a/frontend/src/__mocks__/mockClusterQueueK8sResource.ts
+++ b/frontend/src/__mocks__/mockClusterQueueK8sResource.ts
@@ -4,6 +4,7 @@ import { genUID } from '#~/__mocks__/mockUtils';
 
 type MockResourceConfigType = {
   name?: string;
+  cohortName?: string;
   hasResourceGroups?: boolean;
   isCpuOverQuota?: boolean;
   isMemoryOverQuota?: boolean;
@@ -11,6 +12,7 @@ type MockResourceConfigType = {
 
 export const mockClusterQueueK8sResource = ({
   name = 'test-cluster-queue',
+  cohortName,
   hasResourceGroups = true,
   isCpuOverQuota = false,
   isMemoryOverQuota = false,
@@ -25,6 +27,7 @@ export const mockClusterQueueK8sResource = ({
     uid: genUID('clusterqueue'),
   },
   spec: {
+    ...(cohortName && { cohortName }),
     flavorFungibility: { whenCanBorrow: 'Borrow', whenCanPreempt: 'TryNextFlavor' },
     namespaceSelector: {},
     preemption: {

--- a/frontend/src/__mocks__/mockCohortK8sResource.ts
+++ b/frontend/src/__mocks__/mockCohortK8sResource.ts
@@ -1,0 +1,40 @@
+import { CohortKind } from '#~/k8sTypes';
+import { genUID } from '#~/__mocks__/mockUtils';
+
+type MockCohortConfigType = {
+  name?: string;
+  parentName?: string;
+  resourceName?: string;
+  gpuFlavors?: { flavorName: string; gpuQuota: string }[];
+};
+
+export const mockCohortK8sResource = ({
+  name = 'test-cohort',
+  parentName,
+  resourceName = 'nvidia.com/gpu',
+  gpuFlavors = [{ flavorName: 'gpu-flavor', gpuQuota: '16' }],
+}: MockCohortConfigType = {}): CohortKind => ({
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
+  kind: 'Cohort',
+  metadata: {
+    creationTimestamp: '2024-02-22T17:26:19Z',
+    generation: 1,
+    name,
+    uid: genUID('cohort'),
+  },
+  spec: {
+    ...(parentName && { parentName }),
+    resourceGroups:
+      gpuFlavors.length > 0
+        ? [
+            {
+              coveredResources: [resourceName as never],
+              flavors: gpuFlavors.map(({ flavorName, gpuQuota }) => ({
+                name: flavorName,
+                resources: [{ name: resourceName as never, nominalQuota: gpuQuota }],
+              })),
+            },
+          ]
+        : [],
+  },
+});

--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -40,6 +40,30 @@ class InfrastructurePage {
     return cy.findByTestId('infrastructure-refresh-badge');
   }
 
+  findBorrowingLendingSection() {
+    return cy.findByTestId('infrastructure-borrowing-lending-section');
+  }
+
+  findBorrowingLendingChart() {
+    return cy.findByTestId('borrowing-lending-chart-has-data');
+  }
+
+  findBorrowingLendingEmptyState() {
+    return cy.findByTestId('borrowing-lending-empty-state');
+  }
+
+  findCohortSelect() {
+    return cy.findByTestId('borrowing-lending-cohort-select');
+  }
+
+  findCqNameFilter() {
+    return cy.findByTestId('borrowing-lending-cq-filter');
+  }
+
+  findCountLabel() {
+    return cy.findByTestId('borrowing-lending-count-label');
+  }
+
   private wait() {
     this.shouldHavePageTitle();
     cy.testA11y();

--- a/packages/cypress/cypress/support/commands/odh.ts
+++ b/packages/cypress/cypress/support/commands/odh.ts
@@ -403,6 +403,10 @@ declare global {
           response: OdhResponse<{ code: number; response: PrometheusQueryRangeResponse }>,
         ) => Cypress.Chainable<null>) &
         ((
+          type: 'POST /api/prometheus/queryRange',
+          response: OdhResponse<{ code: number; response: PrometheusQueryRangeResponse }>,
+        ) => Cypress.Chainable<null>) &
+        ((
           type: 'GET /api/service/trustyai/:namespace/trustyai-service/metrics/all/requests',
           options: {
             path: { namespace: string };

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -1,8 +1,13 @@
 import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
 import { mockComponents } from '@odh-dashboard/internal/__mocks__/mockComponents';
+import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
+import { mockClusterQueueK8sResource } from '@odh-dashboard/internal/__mocks__/mockClusterQueueK8sResource';
+import { mockCohortK8sResource } from '@odh-dashboard/internal/__mocks__/mockCohortK8sResource';
+import type { ClusterQueueKind, CohortKind } from '@odh-dashboard/internal/k8sTypes';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { asClusterAdminUser, asProjectAdminUser } from '../../../utils/mockUsers';
+import { ClusterQueueModel, CohortModel } from '../../../utils/models';
 import { infrastructurePage } from '../../../pages/infrastructure';
 
 const mockPrometheusResponse = (value: string) => ({
@@ -18,11 +23,37 @@ const mockEmptyPrometheusResponse = () => ({
   status: 'success',
 });
 
+const NOW_S = Math.floor(Date.now() / 1000);
+const ONE_HOUR_S = 3600;
+
+const makeRangeResult = (cqName: string, netValues: number[]) => ({
+  // eslint-disable-next-line camelcase
+  metric: { cluster_queue: cqName },
+  values: netValues.map((v, i): [number, string] => [
+    NOW_S - (netValues.length - i) * ONE_HOUR_S,
+    String(v),
+  ]),
+});
+
+const makePrometheusRangeResponse = (results: ReturnType<typeof makeRangeResult>[]) => ({
+  code: 200,
+  response: {
+    status: 'success',
+    data: {
+      resultType: 'matrix',
+      result: results,
+    },
+  },
+});
+
 type InitInterceptsOptions = {
   isKueueInstalled?: boolean;
   gpuaas?: boolean;
   hasAccelerators?: boolean;
   hasDcgm?: boolean;
+  clusterQueues?: ClusterQueueKind[];
+  cohorts?: CohortKind[];
+  hasChartData?: boolean;
 };
 
 const initIntercepts = ({
@@ -30,6 +61,9 @@ const initIntercepts = ({
   gpuaas = true,
   hasAccelerators = true,
   hasDcgm = true,
+  clusterQueues = [mockClusterQueueK8sResource({ name: 'test-cq' })],
+  cohorts = [mockCohortK8sResource({ name: 'test-cohort' })],
+  hasChartData = false,
 }: InitInterceptsOptions = {}) => {
   cy.interceptOdh(
     'GET /api/dsc/status',
@@ -43,6 +77,8 @@ const initIntercepts = ({
   );
   cy.interceptOdh('GET /api/config', mockDashboardConfig({ gpuaas }));
   cy.interceptOdh('GET /api/components', null, mockComponents());
+  cy.interceptK8sList(ClusterQueueModel, mockK8sResourceList(clusterQueues));
+  cy.interceptK8sList(CohortModel, mockK8sResourceList(cohorts));
 
   cy.interceptOdh('POST /api/prometheus/query', (req) => {
     const query = req.body.query as string;
@@ -71,6 +107,20 @@ const initIntercepts = ({
       req.reply(404);
     }
   });
+
+  cy.interceptOdh('POST /api/prometheus/queryRange', (req) => {
+    if (req.body.query && req.body.query.includes('kueue_cluster_queue_resource_usage')) {
+      req.reply(
+        makePrometheusRangeResponse(
+          hasChartData
+            ? clusterQueues.map((cq) =>
+                makeRangeResult(cq.metadata?.name ?? '', [2, -1, 3, 0, 2, -2, 1]),
+              )
+            : [],
+        ),
+      );
+    }
+  });
 };
 
 describe('GPUaaS Infrastructure Page', () => {
@@ -90,7 +140,7 @@ describe('GPUaaS Infrastructure Page', () => {
     infrastructurePage.shouldNotFoundPage();
   });
 
-  it('should not exist when feature flag is disabled', () => {
+  it('should not exist when the gpuaas feature flag is disabled', () => {
     asClusterAdminUser();
     initIntercepts({ gpuaas: false });
     infrastructurePage.visit(false);
@@ -151,6 +201,48 @@ describe('GPUaaS Infrastructure Page', () => {
       infrastructurePage
         .findMemoryUtilizationCard()
         .should('contain.text', 'Utilization metrics unavailable');
+    });
+  });
+
+  describe('Borrowing & lending chart', () => {
+    const cohort1 = mockCohortK8sResource({ name: 'cohort-inference' });
+    const cq1 = mockClusterQueueK8sResource({
+      name: 'cq-inference',
+      cohortName: 'cohort-inference',
+    });
+    const cq2 = mockClusterQueueK8sResource({
+      name: 'cq-training',
+      cohortName: 'cohort-inference',
+    });
+
+    it('renders the chart, cohort filter, and CQ filter when data is present', () => {
+      asClusterAdminUser();
+      initIntercepts({ hasChartData: true, clusterQueues: [cq1, cq2], cohorts: [cohort1] });
+      infrastructurePage.visit();
+
+      infrastructurePage.findBorrowingLendingChart().should('exist');
+
+      infrastructurePage
+        .findCohortSelect()
+        .should('contain.text', 'All cohorts')
+        .click({ force: true });
+      cy.findByText('cohort-inference').should('exist');
+      cy.findByText('Not in a cohort').should('exist');
+      cy.get('body').click();
+
+      infrastructurePage.findCqNameFilter().type('inference');
+      infrastructurePage
+        .findCountLabel()
+        .invoke('text')
+        .should('match', /Showing \d+ of \d+ cluster queues/)
+        .and('not.include', 'Showing 2 of 2');
+    });
+
+    it('shows empty state when Prometheus returns no data', () => {
+      asClusterAdminUser();
+      initIntercepts({ hasChartData: false, clusterQueues: [cq1], cohorts: [cohort1] });
+      infrastructurePage.visit();
+      infrastructurePage.findBorrowingLendingEmptyState().should('exist');
     });
   });
 });

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -119,6 +119,8 @@ const initIntercepts = ({
             : [],
         ),
       );
+    } else {
+      req.reply(404);
     }
   });
 };
@@ -230,12 +232,14 @@ describe('GPUaaS Infrastructure Page', () => {
       cy.findByText('Not in a cohort').should('exist');
       cy.get('body').click();
 
-      infrastructurePage.findCqNameFilter().type('inference');
-      infrastructurePage
-        .findCountLabel()
-        .invoke('text')
-        .should('match', /Showing \d+ of \d+ cluster queues/)
-        .and('not.include', 'Showing 2 of 2');
+      // Filter by CQ name
+      infrastructurePage.findCqNameFilter().type('training');
+      infrastructurePage.findCountLabel().should('have.text', 'Showing 1 of 2 cluster queues');
+
+      // Filter by cohort name: both CQs are in cohort-inference
+      infrastructurePage.findCqNameFilter().clear();
+      infrastructurePage.findCqNameFilter().type('cohort-inference');
+      infrastructurePage.findCountLabel().should('have.text', 'Showing 2 of 2 cluster queues');
     });
 
     it('shows empty state when Prometheus returns no data', () => {

--- a/packages/gpuaas/src/components/BorrowingLendingChart.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingChart.tsx
@@ -135,7 +135,7 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
           }}
         >
           <Chart
-            ariaDesc="Borrowing and lending trends"
+            ariaTitle="Borrowing and lending trends"
             containerComponent={
               <CursorVoronoiContainer
                 cursorDimension="x"
@@ -179,14 +179,14 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
             <ChartLabel
               text="Borrow"
               x={4}
-              y={CHART_PADDING.top}
+              y={CHART_PADDING.top - 12}
               style={AXIS_DIRECTION_LABEL_STYLE}
               textAnchor="start"
             />
             <ChartLabel
               text="Lend"
               x={4}
-              y={CHART_HEIGHT - CHART_PADDING.bottom}
+              y={CHART_HEIGHT - CHART_PADDING.bottom - 12}
               style={AXIS_DIRECTION_LABEL_STYLE}
               textAnchor="start"
             />

--- a/packages/gpuaas/src/components/BorrowingLendingChart.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingChart.tsx
@@ -128,7 +128,10 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
           data-testid="borrowing-lending-chart-has-data"
-          onClick={() => {
+          onClick={(e) => {
+            if (e.target instanceof SVGTextElement) {
+              return;
+            }
             if (activeSnapshotRef.current) {
               setPinnedSnapshot({ ...activeSnapshotRef.current, id: crypto.randomUUID() });
             }

--- a/packages/gpuaas/src/components/BorrowingLendingChart.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingChart.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
 import { EmptyState, EmptyStateBody, Spinner, Tooltip } from '@patternfly/react-core';
 import { ChartLineIcon } from '@patternfly/react-icons';
 import {
@@ -27,7 +26,7 @@ import {
   getYAxisTicks,
   formatYTick,
 } from '../utils/borrowingLendingChart';
-import { CHART_HEIGHT, CHART_PADDING, SEVEN_DAYS_MS } from '../const';
+import { AXIS_DIRECTION_LABEL_STYLE, CHART_HEIGHT, CHART_PADDING, SEVEN_DAYS_MS } from '../const';
 
 const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
 
@@ -131,7 +130,7 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
           data-testid="borrowing-lending-chart-has-data"
           onClick={() => {
             if (activeSnapshotRef.current) {
-              setPinnedSnapshot(activeSnapshotRef.current);
+              setPinnedSnapshot({ ...activeSnapshotRef.current, id: crypto.randomUUID() });
             }
           }}
         >
@@ -171,11 +170,26 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
             legendComponent={
               <ChartLegend
                 title="Cluster queues"
+                style={{ title: { fontWeight: 'bold' } }}
                 events={legendEvents}
                 labelComponent={<LegendLabel />}
               />
             }
           >
+            <ChartLabel
+              text="Borrow"
+              x={4}
+              y={CHART_PADDING.top}
+              style={AXIS_DIRECTION_LABEL_STYLE}
+              textAnchor="start"
+            />
+            <ChartLabel
+              text="Lend"
+              x={4}
+              y={CHART_HEIGHT - CHART_PADDING.bottom}
+              style={AXIS_DIRECTION_LABEL_STYLE}
+              textAnchor="start"
+            />
             <ChartLine
               data={[
                 { x: domainStart, y: 0 },
@@ -195,8 +209,15 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
               tickCount={7}
               fixLabelOverlap
               offsetY={CHART_PADDING.bottom}
+              style={{ tickLabels: { fontSize: 11 } }}
             />
-            <ChartAxis dependentAxis tickValues={yTicks} tickFormat={formatYTick} showGrid />
+            <ChartAxis
+              dependentAxis
+              tickValues={yTicks}
+              tickFormat={formatYTick}
+              showGrid
+              style={{ tickLabels: { fontSize: 11 } }}
+            />
             <ChartGroup>
               {series.map((s) =>
                 hiddenSeries.has(s.cqName) ? null : (
@@ -230,11 +251,9 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
           </Chart>
         </div>
       )}
-      {pinnedSnapshot &&
-        ReactDOM.createPortal(
-          <PinnedTooltipPanel snapshot={pinnedSnapshot} onClose={() => setPinnedSnapshot(null)} />,
-          document.body,
-        )}
+      {pinnedSnapshot && (
+        <PinnedTooltipPanel snapshot={pinnedSnapshot} onClose={() => setPinnedSnapshot(null)} />
+      )}
     </>
   );
 };

--- a/packages/gpuaas/src/components/BorrowingLendingChart.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingChart.tsx
@@ -1,0 +1,242 @@
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import { EmptyState, EmptyStateBody, Spinner, Tooltip } from '@patternfly/react-core';
+import { ChartLineIcon } from '@patternfly/react-icons';
+import {
+  Chart,
+  ChartAxis,
+  ChartGroup,
+  ChartLabel,
+  ChartLegend,
+  ChartLine,
+  ChartPoint,
+  ChartScatter,
+  ChartThemeColor,
+  createContainer,
+} from '@patternfly/react-charts/victory';
+import { LineSegment } from 'victory-core';
+import { CustomTooltip, PinnedTooltipPanel, TooltipSnapshot } from './BorrowingLendingTooltip';
+import { CQMetricSeries } from '../hooks/useBorrowingLendingMetrics';
+import {
+  CHART_COLOR_SCALE,
+  buildColorByName,
+  buildLegendData,
+  buildLegendEvents,
+  buildYDomain,
+  formatXTick,
+  getYAxisTicks,
+  formatYTick,
+} from '../utils/borrowingLendingChart';
+import { CHART_HEIGHT, CHART_PADDING, SEVEN_DAYS_MS } from '../const';
+
+const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
+
+type ConditionalPointProps = {
+  active?: boolean;
+  x?: number;
+  y?: number;
+  style?: object;
+  size?: number;
+  datum?: unknown;
+};
+
+type LegendLabelProps = { datum?: { name?: string; fullName?: string }; [key: string]: unknown };
+
+type BorrowingLendingChartProps = {
+  series: CQMetricSeries[];
+  loaded: boolean;
+  error: Error | undefined;
+  chartWidth?: number;
+  containerRef?: React.RefObject<HTMLDivElement | null>;
+};
+
+const ConditionalPoint: React.FC<ConditionalPointProps> = ({ active, ...rest }) => {
+  if (!active) {
+    return null;
+  }
+  return <ChartPoint {...rest} />;
+};
+
+const LegendLabel = ({ datum, ...rest }: LegendLabelProps) => {
+  const ref = React.useRef<SVGGElement>(null);
+  const isTruncated = datum?.fullName && datum.name !== datum.fullName;
+  return (
+    <g ref={ref}>
+      <ChartLabel {...rest} />
+      {isTruncated && (
+        <Tooltip content={datum.fullName} position="right" enableFlip triggerRef={ref} />
+      )}
+    </g>
+  );
+};
+
+const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
+  series,
+  loaded,
+  error,
+  chartWidth = 0,
+  containerRef,
+}) => {
+  const [hiddenSeries, setHiddenSeries] = React.useState<Set<string>>(new Set());
+  const [pinnedSnapshot, setPinnedSnapshot] = React.useState<TooltipSnapshot | null>(null);
+  const activeSnapshotRef = React.useRef<TooltipSnapshot | null>(null);
+
+  const toggleSeries = React.useCallback((cqName: string) => {
+    setHiddenSeries((prev) => {
+      const next = new Set(prev);
+      if (next.has(cqName)) {
+        next.delete(cqName);
+      } else {
+        next.add(cqName);
+      }
+      return next;
+    });
+  }, []);
+
+  const hasSomeData = series.some((s) => s.data.length > 0);
+  const showChart = loaded && !error && hasSomeData;
+
+  const { minY, maxY } = buildYDomain(series);
+  const yTicks = getYAxisTicks(minY, maxY);
+  const colorByName = buildColorByName(series, hiddenSeries);
+  const legendData = buildLegendData(series, hiddenSeries);
+  const legendEvents = buildLegendEvents(toggleSeries);
+  const now = Date.now();
+  const domainStart = now - SEVEN_DAYS_MS;
+
+  return (
+    <>
+      {!loaded && !error && <EmptyState icon={Spinner} titleText="Loading" headingLevel="h4" />}
+      {error && (
+        <EmptyState titleText="Error loading metrics" headingLevel="h4">
+          <EmptyStateBody>{error.message}</EmptyStateBody>
+        </EmptyState>
+      )}
+      {loaded && !error && !hasSomeData && (
+        <EmptyState
+          icon={ChartLineIcon}
+          titleText="No borrowing/lending activity detected"
+          headingLevel="h4"
+          data-testid="borrowing-lending-empty-state"
+        >
+          <EmptyStateBody>
+            No accelerator usage data is available for the selected cluster queues over the past 7
+            days.
+          </EmptyStateBody>
+        </EmptyState>
+      )}
+      {showChart && (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+        <div
+          data-testid="borrowing-lending-chart-has-data"
+          onClick={() => {
+            if (activeSnapshotRef.current) {
+              setPinnedSnapshot(activeSnapshotRef.current);
+            }
+          }}
+        >
+          <Chart
+            ariaDesc="Borrowing and lending trends"
+            containerComponent={
+              <CursorVoronoiContainer
+                cursorDimension="x"
+                cursorComponent={
+                  <LineSegment
+                    style={{ strokeDasharray: '2 3', strokeOpacity: 0.4, strokeWidth: 1 }}
+                  />
+                }
+                labels={() => ' '}
+                labelComponent={
+                  <CustomTooltip
+                    series={series}
+                    colorByName={colorByName}
+                    containerRef={containerRef}
+                    snapshotRef={activeSnapshotRef}
+                    isPinned={pinnedSnapshot !== null}
+                  />
+                }
+                mouseFollowTooltips
+                voronoiDimension="x"
+                voronoiPadding={50}
+              />
+            }
+            domain={{ x: [domainStart, now], y: [minY, maxY] }}
+            height={CHART_HEIGHT}
+            width={chartWidth}
+            padding={CHART_PADDING}
+            themeColor={ChartThemeColor.multiOrdered}
+            legendData={legendData}
+            legendOrientation="vertical"
+            legendPosition="right"
+            legendComponent={
+              <ChartLegend
+                title="Cluster queues"
+                events={legendEvents}
+                labelComponent={<LegendLabel />}
+              />
+            }
+          >
+            <ChartLine
+              data={[
+                { x: domainStart, y: 0 },
+                { x: now, y: 0 },
+              ]}
+              style={{
+                data: {
+                  stroke: 'var(--pf-t--chart--global--stroke--Color--200, #d2d2d2)',
+                  strokeWidth: 1,
+                  strokeDasharray: '4 4',
+                },
+              }}
+              name="zero-reference"
+            />
+            <ChartAxis
+              tickFormat={formatXTick}
+              tickCount={7}
+              fixLabelOverlap
+              offsetY={CHART_PADDING.bottom}
+            />
+            <ChartAxis dependentAxis tickValues={yTicks} tickFormat={formatYTick} showGrid />
+            <ChartGroup>
+              {series.map((s) =>
+                hiddenSeries.has(s.cqName) ? null : (
+                  <ChartLine
+                    key={s.cqName}
+                    data={s.data.map((d) => ({ ...d, nominalQuota: s.nominalQuota }))}
+                    name={s.cqName}
+                    interpolation="stepAfter"
+                  />
+                ),
+              )}
+            </ChartGroup>
+            {series.map((s) =>
+              hiddenSeries.has(s.cqName) ? null : (
+                <ChartScatter
+                  key={`__dot__${s.cqName}`}
+                  name={`__dot__${s.cqName}`}
+                  data={s.data.map((d) => ({ ...d, nominalQuota: s.nominalQuota }))}
+                  dataComponent={<ConditionalPoint />}
+                  style={{
+                    data: {
+                      fill: colorByName.get(s.cqName) ?? CHART_COLOR_SCALE[0],
+                      stroke: 'white',
+                      strokeWidth: 2,
+                    },
+                  }}
+                  size={5}
+                />
+              ),
+            )}
+          </Chart>
+        </div>
+      )}
+      {pinnedSnapshot &&
+        ReactDOM.createPortal(
+          <PinnedTooltipPanel snapshot={pinnedSnapshot} onClose={() => setPinnedSnapshot(null)} />,
+          document.body,
+        )}
+    </>
+  );
+};
+
+export default BorrowingLendingChart;

--- a/packages/gpuaas/src/components/BorrowingLendingSection.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingSection.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import {
+  Content,
+  SearchInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  getResizeObserver,
+} from '@patternfly/react-core';
+import SimpleSelect, { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect';
+import BorrowingLendingChart from './BorrowingLendingChart';
+import useCohorts from '../hooks/useCohorts';
+import useBorrowingLendingMetrics, { CQMetricSeries } from '../hooks/useBorrowingLendingMetrics';
+
+const ALL_COHORTS = '__all__';
+const NOT_IN_COHORT = '__none__';
+
+const filterSeries = (
+  series: CQMetricSeries[],
+  selectedCohort: string,
+  cqNameFilter: string,
+): CQMetricSeries[] => {
+  let filtered = series;
+
+  filtered = filtered.filter((s) => {
+    if (selectedCohort === ALL_COHORTS) {
+      return s.cohortName !== '';
+    }
+    if (selectedCohort === NOT_IN_COHORT) {
+      return s.cohortName === '';
+    }
+    return s.cohortName === selectedCohort;
+  });
+
+  const trimmed = cqNameFilter.trim().toLowerCase();
+  if (trimmed) {
+    filtered = filtered.filter((s) => s.cqName.toLowerCase().includes(trimmed));
+  }
+
+  return filtered;
+};
+
+const BorrowingLendingSection: React.FC = () => {
+  const chartContainerRef = React.useRef<HTMLDivElement>(null);
+  const [chartWidth, setChartWidth] = React.useState(0);
+
+  React.useEffect(() => {
+    const el = chartContainerRef.current;
+    if (!el) {
+      return undefined;
+    }
+    const handleResize = () => setChartWidth(el.clientWidth);
+    const cleanup = getResizeObserver(el, handleResize);
+    handleResize();
+    return cleanup;
+  }, []);
+
+  const [selectedCohort, setSelectedCohort] = React.useState<string>(ALL_COHORTS);
+  const [cqNameFilter, setCqNameFilter] = React.useState('');
+
+  const { data: cohorts, loaded: cohortsLoaded } = useCohorts();
+  const { series, loaded: metricsLoaded, error } = useBorrowingLendingMetrics(cohorts);
+
+  const cohortSelectOptions = React.useMemo((): SimpleSelectOption[] => {
+    const options: SimpleSelectOption[] = [
+      { key: ALL_COHORTS, label: 'All cohorts' },
+      { key: NOT_IN_COHORT, label: 'Not in a cohort' },
+    ];
+    cohorts
+      .filter((c) => c.state !== 'standalone' && c.name)
+      .forEach((c) => {
+        options.push({ key: c.name, label: c.name });
+      });
+    return options;
+  }, [cohorts]);
+
+  const visibleSeries = React.useMemo(
+    () => filterSeries(series, selectedCohort, cqNameFilter),
+    [series, selectedCohort, cqNameFilter],
+  );
+
+  // Scope the denominator to the current cohort selection so "Showing X of Y"
+  // only counts CQs reachable by the name filter in this view.
+  const scopedSeries = React.useMemo(
+    () => filterSeries(series, selectedCohort, ''),
+    [series, selectedCohort],
+  );
+
+  const totalCQCount = scopedSeries.length;
+  const visibleCQCount = visibleSeries.length;
+
+  return (
+    <>
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarItem style={{ minWidth: '200px' }}>
+            <SimpleSelect
+              isFullWidth
+              value={selectedCohort}
+              onChange={(val) => setSelectedCohort(val)}
+              options={cohortSelectOptions}
+              isDisabled={!cohortsLoaded}
+              toggleProps={{ id: 'borrowing-lending-cohort-select-toggle' }}
+              dataTestId="borrowing-lending-cohort-select"
+              popperProps={{ maxWidth: undefined }}
+            />
+          </ToolbarItem>
+          <ToolbarItem className="pf-v6-u-flex-grow-1">
+            <SearchInput
+              className="pf-v6-u-w-100"
+              placeholder="Filter by cluster queue name"
+              value={cqNameFilter}
+              onChange={(_ev, val) => setCqNameFilter(val)}
+              onClear={() => setCqNameFilter('')}
+              data-testid="borrowing-lending-cq-filter"
+            />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+      <ToolbarGroup>
+        <ToolbarItem>
+          <Content component="small" data-testid="borrowing-lending-count-label">
+            {`Showing ${visibleCQCount} of ${totalCQCount} cluster queues`}
+          </Content>
+        </ToolbarItem>
+      </ToolbarGroup>
+      <div ref={chartContainerRef}>
+        <BorrowingLendingChart
+          series={visibleSeries}
+          loaded={metricsLoaded && cohortsLoaded}
+          error={error}
+          chartWidth={chartWidth}
+          containerRef={chartContainerRef}
+        />
+      </div>
+    </>
+  );
+};
+
+export default BorrowingLendingSection;

--- a/packages/gpuaas/src/components/BorrowingLendingSection.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingSection.tsx
@@ -110,6 +110,7 @@ const BorrowingLendingSection: React.FC = () => {
           </ToolbarItem>
           <ToolbarItem className="pf-v6-u-flex-grow-1">
             <SearchInput
+              aria-label="Filter by cluster queue name"
               className="pf-v6-u-w-100"
               placeholder="Filter by cluster queue name"
               value={cqNameFilter}

--- a/packages/gpuaas/src/components/BorrowingLendingSection.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingSection.tsx
@@ -4,7 +4,6 @@ import {
   SearchInput,
   Toolbar,
   ToolbarContent,
-  ToolbarGroup,
   ToolbarItem,
   getResizeObserver,
 } from '@patternfly/react-core';
@@ -35,7 +34,10 @@ const filterSeries = (
 
   const trimmed = cqNameFilter.trim().toLowerCase();
   if (trimmed) {
-    filtered = filtered.filter((s) => s.cqName.toLowerCase().includes(trimmed));
+    filtered = filtered.filter(
+      (s) =>
+        s.cqName.toLowerCase().includes(trimmed) || s.cohortName.toLowerCase().includes(trimmed),
+    );
   }
 
   return filtered;
@@ -94,7 +96,7 @@ const BorrowingLendingSection: React.FC = () => {
     <>
       <Toolbar>
         <ToolbarContent>
-          <ToolbarItem style={{ minWidth: '200px' }}>
+          <ToolbarItem className="gpuaas-cohort-select-toolbar-item">
             <SimpleSelect
               isFullWidth
               value={selectedCohort}
@@ -113,18 +115,14 @@ const BorrowingLendingSection: React.FC = () => {
               value={cqNameFilter}
               onChange={(_ev, val) => setCqNameFilter(val)}
               onClear={() => setCqNameFilter('')}
-              data-testid="borrowing-lending-cq-filter"
+              inputProps={{ 'data-testid': 'borrowing-lending-cq-filter' }}
             />
           </ToolbarItem>
         </ToolbarContent>
       </Toolbar>
-      <ToolbarGroup>
-        <ToolbarItem>
-          <Content component="small" data-testid="borrowing-lending-count-label">
-            {`Showing ${visibleCQCount} of ${totalCQCount} cluster queues`}
-          </Content>
-        </ToolbarItem>
-      </ToolbarGroup>
+      <Content component="small" data-testid="borrowing-lending-count-label">
+        {`Showing ${visibleCQCount} of ${totalCQCount} cluster queues`}
+      </Content>
       <div ref={chartContainerRef}>
         <BorrowingLendingChart
           series={visibleSeries}

--- a/packages/gpuaas/src/components/BorrowingLendingTooltip.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingTooltip.tsx
@@ -263,16 +263,16 @@ export const CustomTooltip: React.FC<CustomTooltipProps> = ({
   snapshotRef,
   isPinned = false,
 }) => {
-  const hoverData =
-    active && !isPinned
-      ? buildTooltipSnapshot(activePoints, series, colorByName, containerRef, x, y)
-      : null;
+  // Keep the ref current even while a panel is pinned so clicking re-pins to the latest hover position.
+  const hoverData = active
+    ? buildTooltipSnapshot(activePoints, series, colorByName, containerRef, x, y)
+    : null;
 
-  // Only overwrites when hover data exists don't null out the ref while pinned or inactive.
   // eslint-disable-next-line no-param-reassign
-  if (snapshotRef && hoverData) snapshotRef.current = hoverData;
+  if (snapshotRef) snapshotRef.current = hoverData;
 
-  if (!hoverData) {
+  // Suppress the hover portal while pinned; the ref is already up to date above.
+  if (isPinned || !hoverData) {
     return null;
   }
 

--- a/packages/gpuaas/src/components/BorrowingLendingTooltip.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingTooltip.tsx
@@ -1,0 +1,286 @@
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import './ClusterSummaryCards.scss';
+import {
+  Badge,
+  Button,
+  Content,
+  Flex,
+  FlexItem,
+  Panel,
+  PanelMain,
+  PanelMainBody,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+import { CQMetricSeries } from '../hooks/useBorrowingLendingMetrics';
+import {
+  CHART_COLOR_SCALE,
+  TooltipPoint,
+  formatTooltipDate,
+  getEntryLabel,
+  getTooltipPosition,
+} from '../utils/borrowingLendingChart';
+import { FLYOUT_MAX_WIDTH, TOOLTIP_PAGE_SIZE } from '../const';
+
+export type TooltipSnapshot = {
+  /** Top TOOLTIP_PAGE_SIZE by |y|, shown in the floating tooltip. */
+  initialPoints: TooltipPoint[];
+  allSortedPoints: TooltipPoint[];
+  overflowCount: number;
+  seriesMap: Map<string, CQMetricSeries>;
+  colorByName: Map<string, string>;
+  finalLeft: number;
+  finalTop: number;
+};
+
+export type CustomTooltipProps = {
+  /** Injected by Victory's voronoi container */
+  active?: boolean;
+  x?: number;
+  y?: number;
+  activePoints?: TooltipPoint[];
+  /** Series metadata — passed via React.cloneElement */
+  series?: CQMetricSeries[];
+  /** cqName → color, keyed to visible render order */
+  colorByName?: Map<string, string>;
+  /** Ref to the chart container div — used to convert SVG coords to viewport coords */
+  containerRef?: React.RefObject<HTMLDivElement | null>;
+  /** Written on every render so the parent can pin the current state on click */
+  snapshotRef?: React.MutableRefObject<TooltipSnapshot | null>;
+  /** When true, suppresses the hover tooltip (a pinned panel is already visible) */
+  isPinned?: boolean;
+};
+
+type PinnedTooltipPanelProps = {
+  snapshot: TooltipSnapshot;
+  onClose: () => void;
+};
+
+type TooltipSeriesEntryProps = {
+  point: TooltipPoint;
+  info: CQMetricSeries | undefined;
+  color: string;
+};
+
+type TooltipBodyProps = {
+  points: TooltipPoint[];
+  seriesMap: Map<string, CQMetricSeries>;
+  colorByName: Map<string, string>;
+};
+
+type TooltipPanelProps = {
+  snapshot: TooltipSnapshot;
+  /** When provided the panel is interactive (pinned): shows close button, scrollable list, "View more". */
+  onClose?: () => void;
+};
+
+const buildTooltipSnapshot = (
+  activePoints: TooltipPoint[] | undefined,
+  series: CQMetricSeries[],
+  colorByName: Map<string, string>,
+  containerRef: React.RefObject<HTMLDivElement | null> | undefined,
+  x: number,
+  y: number,
+): TooltipSnapshot | null => {
+  const allPoints = (activePoints ?? []).filter(
+    (p) => p.childName && p.childName !== 'zero-reference' && !p.childName.startsWith('__dot__'),
+  );
+  if (!allPoints.length) {
+    return null;
+  }
+  const sortedPoints = allPoints.toSorted((a, b) => Math.abs(b.y) - Math.abs(a.y));
+  const initialPoints = sortedPoints.slice(0, TOOLTIP_PAGE_SIZE);
+  const overflowCount = sortedPoints.length - initialPoints.length;
+  const { finalLeft, finalTop } = getTooltipPosition(containerRef, x, y);
+  return {
+    initialPoints,
+    allSortedPoints: sortedPoints,
+    overflowCount,
+    seriesMap: new Map(series.map((s) => [s.cqName, s])),
+    colorByName,
+    finalLeft,
+    finalTop,
+  };
+};
+
+const TooltipSeriesEntry: React.FC<TooltipSeriesEntryProps> = ({ point, info, color }) => {
+  const net = Math.round(point.y);
+  const quota = Math.round(point.nominalQuota ?? 0);
+  const usage = Math.round(point.y + (point.nominalQuota ?? 0));
+  const borrowing = Math.max(0, net);
+  const lending = Math.max(0, -net);
+  const entryLabel = getEntryLabel(info, point.childName ?? '');
+
+  return (
+    <Stack>
+      <StackItem>
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          flexWrap={{ default: 'nowrap' }}
+          gap={{ default: 'gapXs' }}
+        >
+          <FlexItem>
+            <span className="gpuaas-tooltip-dot" style={{ background: color }} />
+          </FlexItem>
+          <FlexItem>
+            <strong>{entryLabel}</strong>
+          </FlexItem>
+        </Flex>
+      </StackItem>
+      <StackItem>
+        <Content component="small" className="gpuaas-tooltip-subtle">
+          {`Usage ${usage} of ${quota} quota`}
+        </Content>
+      </StackItem>
+      <StackItem>
+        <Content component="small" className="gpuaas-tooltip-subtle">
+          {`Borrowing ${borrowing} · Lending ${lending}`}
+        </Content>
+      </StackItem>
+    </Stack>
+  );
+};
+
+const TooltipBody: React.FC<TooltipBodyProps> = ({ points, seriesMap, colorByName }) => (
+  <Stack hasGutter>
+    {points.map((point) => (
+      <StackItem key={point.childName}>
+        <TooltipSeriesEntry
+          point={point}
+          info={seriesMap.get(point.childName ?? '')}
+          color={colorByName.get(point.childName ?? '') ?? CHART_COLOR_SCALE[0]}
+        />
+      </StackItem>
+    ))}
+  </Stack>
+);
+
+const TooltipPanel: React.FC<TooltipPanelProps> = ({ snapshot, onClose }) => {
+  const pinned = !!onClose;
+  const [visibleCount, setVisibleCount] = React.useState(TOOLTIP_PAGE_SIZE);
+  const listRef = React.useRef<HTMLDivElement>(null);
+
+  const points = pinned ? snapshot.allSortedPoints.slice(0, visibleCount) : snapshot.initialPoints;
+  const remainingCount = pinned ? snapshot.allSortedPoints.length - visibleCount : 0;
+
+  return (
+    <Panel
+      variant="bordered"
+      style={{
+        position: 'fixed',
+        left: snapshot.finalLeft,
+        top: snapshot.finalTop,
+        width: 'max-content',
+        maxWidth: FLYOUT_MAX_WIDTH,
+        zIndex: pinned ? 10000 : 9999,
+        pointerEvents: pinned ? 'auto' : 'none',
+      }}
+    >
+      <PanelMain>
+        <PanelMainBody>
+          <Flex
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <FlexItem>
+              <Content component="small" className="gpuaas-tooltip-header-date">
+                {formatTooltipDate(points[0].x)}
+              </Content>
+            </FlexItem>
+            {pinned && (
+              <FlexItem>
+                <Button
+                  variant="plain"
+                  aria-label="Close pinned tooltip"
+                  onClick={onClose}
+                  style={{ padding: 0 }}
+                >
+                  <TimesIcon />
+                </Button>
+              </FlexItem>
+            )}
+          </Flex>
+        </PanelMainBody>
+      </PanelMain>
+      <PanelMain>
+        <PanelMainBody>
+          <div
+            ref={pinned ? listRef : undefined}
+            style={pinned ? { maxHeight: 300, overflowY: 'auto' } : undefined}
+          >
+            <TooltipBody
+              points={points}
+              seriesMap={snapshot.seriesMap}
+              colorByName={snapshot.colorByName}
+            />
+          </div>
+        </PanelMainBody>
+      </PanelMain>
+      {snapshot.allSortedPoints.length > TOOLTIP_PAGE_SIZE && (
+        <PanelMain>
+          <PanelMainBody>
+            <Flex
+              spaceItems={{ default: 'spaceItemsSm' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+            >
+              {(pinned ? remainingCount : snapshot.overflowCount) > 0 && (
+                <FlexItem>
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={
+                      pinned ? () => setVisibleCount((prev) => prev + TOOLTIP_PAGE_SIZE) : undefined
+                    }
+                  >
+                    View more
+                  </Button>
+                </FlexItem>
+              )}
+              <FlexItem>
+                <Badge isRead>
+                  {`Showing ${
+                    pinned
+                      ? Math.min(visibleCount, snapshot.allSortedPoints.length)
+                      : snapshot.initialPoints.length
+                  }/${snapshot.allSortedPoints.length}`}
+                </Badge>
+              </FlexItem>
+            </Flex>
+          </PanelMainBody>
+        </PanelMain>
+      )}
+    </Panel>
+  );
+};
+
+export const CustomTooltip: React.FC<CustomTooltipProps> = ({
+  active,
+  x = 0,
+  y = 0,
+  activePoints,
+  series = [],
+  colorByName = new Map(),
+  containerRef,
+  snapshotRef,
+  isPinned = false,
+}) => {
+  const hoverData =
+    active && !isPinned
+      ? buildTooltipSnapshot(activePoints, series, colorByName, containerRef, x, y)
+      : null;
+
+  // Keep the ref in sync so the parent can pin on click — safe to do in render for refs.
+  // eslint-disable-next-line no-param-reassign
+  if (snapshotRef) snapshotRef.current = hoverData;
+
+  if (!hoverData) {
+    return null;
+  }
+
+  return ReactDOM.createPortal(<TooltipPanel snapshot={hoverData} />, document.body);
+};
+
+export const PinnedTooltipPanel: React.FC<PinnedTooltipPanelProps> = ({ snapshot, onClose }) =>
+  ReactDOM.createPortal(<TooltipPanel snapshot={snapshot} onClose={onClose} />, document.body);

--- a/packages/gpuaas/src/components/BorrowingLendingTooltip.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingTooltip.tsx
@@ -22,9 +22,10 @@ import {
   getEntryLabel,
   getTooltipPosition,
 } from '../utils/borrowingLendingChart';
-import { FLYOUT_MAX_WIDTH, TOOLTIP_PAGE_SIZE } from '../const';
+import { FLYOUT_MAX_WIDTH, TOOLTIP_PAGE_SIZE, TOOLTIP_PANEL_MAX_HEIGHT } from '../const';
 
 export type TooltipSnapshot = {
+  id: string;
   /** Top TOOLTIP_PAGE_SIZE by |y|, shown in the floating tooltip. */
   initialPoints: TooltipPoint[];
   allSortedPoints: TooltipPoint[];
@@ -95,6 +96,7 @@ const buildTooltipSnapshot = (
   const overflowCount = sortedPoints.length - initialPoints.length;
   const { finalLeft, finalTop } = getTooltipPosition(containerRef, x, y);
   return {
+    id: '',
     initialPoints,
     allSortedPoints: sortedPoints,
     overflowCount,
@@ -191,12 +193,7 @@ const TooltipPanel: React.FC<TooltipPanelProps> = ({ snapshot, onClose }) => {
             </FlexItem>
             {pinned && (
               <FlexItem>
-                <Button
-                  variant="plain"
-                  aria-label="Close pinned tooltip"
-                  onClick={onClose}
-                  style={{ padding: 0 }}
-                >
+                <Button variant="plain" aria-label="Close pinned tooltip" onClick={onClose}>
                   <TimesIcon />
                 </Button>
               </FlexItem>
@@ -208,7 +205,7 @@ const TooltipPanel: React.FC<TooltipPanelProps> = ({ snapshot, onClose }) => {
         <PanelMainBody>
           <div
             ref={pinned ? listRef : undefined}
-            style={pinned ? { maxHeight: 300, overflowY: 'auto' } : undefined}
+            style={pinned ? { maxHeight: TOOLTIP_PANEL_MAX_HEIGHT, overflowY: 'auto' } : undefined}
           >
             <TooltipBody
               points={points}
@@ -271,9 +268,9 @@ export const CustomTooltip: React.FC<CustomTooltipProps> = ({
       ? buildTooltipSnapshot(activePoints, series, colorByName, containerRef, x, y)
       : null;
 
-  // Keep the ref in sync so the parent can pin on click — safe to do in render for refs.
+  // Only overwrites when hover data exists don't null out the ref while pinned or inactive.
   // eslint-disable-next-line no-param-reassign
-  if (snapshotRef) snapshotRef.current = hoverData;
+  if (snapshotRef && hoverData) snapshotRef.current = hoverData;
 
   if (!hoverData) {
     return null;
@@ -283,4 +280,7 @@ export const CustomTooltip: React.FC<CustomTooltipProps> = ({
 };
 
 export const PinnedTooltipPanel: React.FC<PinnedTooltipPanelProps> = ({ snapshot, onClose }) =>
-  ReactDOM.createPortal(<TooltipPanel snapshot={snapshot} onClose={onClose} />, document.body);
+  ReactDOM.createPortal(
+    <TooltipPanel key={snapshot.id} snapshot={snapshot} onClose={onClose} />,
+    document.body,
+  );

--- a/packages/gpuaas/src/components/ClusterSummaryCards.scss
+++ b/packages/gpuaas/src/components/ClusterSummaryCards.scss
@@ -1,3 +1,31 @@
 .gpuaas-cluster-spinner {
   min-height: var(--pf-t--global--spacer--3xl);
 }
+
+.gpuaas-tooltip-list {
+  scrollbar-width: none; /* Firefox */
+
+  &::-webkit-scrollbar {
+    display: none; /* Chrome / Safari / Edge */
+  }
+}
+
+.gpuaas-tooltip-dot {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.gpuaas-tooltip-subtle {
+  display: block;
+  padding-inline-start: var(--pf-t--global--spacer--md);
+  color: var(--pf-t--global--text--color--subtle);
+}
+
+.gpuaas-tooltip-header-date {
+  display: block;
+  font-weight: 700;
+  color: var(--pf-t--global--text--color--subtle);
+}

--- a/packages/gpuaas/src/components/ClusterSummaryCards.scss
+++ b/packages/gpuaas/src/components/ClusterSummaryCards.scss
@@ -1,3 +1,8 @@
+.gpuaas-cohort-select-toolbar-item {
+  --gpuaas-cohort-select-min-width: 200px;
+  min-width: var(--gpuaas-cohort-select-min-width);
+}
+
 .gpuaas-cluster-spinner {
   min-height: var(--pf-t--global--spacer--3xl);
 }

--- a/packages/gpuaas/src/components/__tests__/BorrowingLendingChart.spec.tsx
+++ b/packages/gpuaas/src/components/__tests__/BorrowingLendingChart.spec.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import BorrowingLendingChart from '../BorrowingLendingChart';
+import { CQMetricSeries } from '../../hooks/useBorrowingLendingMetrics';
+
+const NOW = 1700000000000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+const makeSeries = (cqName: string, cohortName: string, points = 3): CQMetricSeries => ({
+  cqName,
+  cohortName,
+  nominalQuota: 8,
+  data: Array.from({ length: points }, (_, i) => ({
+    x: NOW - (points - i) * ONE_HOUR_MS,
+    y: i % 2 === 0 ? 2 : -1,
+  })),
+});
+
+describe('BorrowingLendingChart', () => {
+  it('shows a loading state when not loaded and no error', () => {
+    render(<BorrowingLendingChart series={[]} loaded={false} error={undefined} />);
+    expect(screen.getByText('Loading')).toBeInTheDocument();
+  });
+
+  it('shows empty state when loaded with no data', () => {
+    render(<BorrowingLendingChart series={[]} loaded error={undefined} />);
+    expect(screen.getByTestId('borrowing-lending-empty-state')).toBeInTheDocument();
+    expect(screen.getByText(/No borrowing\/lending activity detected/i)).toBeInTheDocument();
+  });
+
+  it('shows error message when an error is provided', () => {
+    const error = new Error('Prometheus unavailable');
+    render(<BorrowingLendingChart series={[]} loaded={false} error={error} />);
+    expect(screen.getByText('Error loading metrics')).toBeInTheDocument();
+    expect(screen.getByText('Prometheus unavailable')).toBeInTheDocument();
+  });
+
+  it('renders the chart and hides the empty state when data is present', () => {
+    const series = [makeSeries('cq-a', 'cohort-1')];
+    render(<BorrowingLendingChart series={series} loaded error={undefined} />);
+    expect(document.querySelector('svg')).toBeInTheDocument();
+    expect(screen.queryByTestId('borrowing-lending-empty-state')).not.toBeInTheDocument();
+  });
+});

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -1,11 +1,23 @@
 export const INFRASTRUCTURE_REFRESH_INTERVAL = 30_000;
 
+export const TREND_REFRESH_INTERVAL = 5 * 60 * 1000;
+
 export const INFRASTRUCTURE_SECTIONS = [
-  { id: 'cluster', title: 'Cluster' },
-  { id: 'hardware-usage', title: 'Hardware usage' },
-  { id: 'borrowing-lending', title: 'Borrowing & lending' },
-  { id: 'cluster-queue-utilization', title: 'Cluster queue utilization' },
+  { id: 'cluster', title: 'Cluster', description: undefined },
+  { id: 'hardware-usage', title: 'Hardware usage', description: undefined },
+  {
+    id: 'borrowing-lending',
+    title: 'Borrowing & lending',
+    description: 'Seven-day trend of borrow and lend activity by cluster queue.',
+  },
+  { id: 'cluster-queue-utilization', title: 'Cluster queue utilization', description: undefined },
 ] as const;
+
+export const ACCELERATOR_RESOURCE_REGEX =
+  'nvidia.com/gpu|nvidia.com/mig.*|amd.com/gpu|habana.ai/gaudi';
+
+/** k8s resource name prefixes used to identify GPU resources in ClusterQueue specs. */
+export const ACCELERATOR_RESOURCE_PREFIXES = ['nvidia.com/', 'amd.com/', 'habana.ai/'];
 
 // PromQL queries for the Cluster summary section
 // These are formatted as URL query strings for the Prometheus API (appended after /api/v1/query?)
@@ -25,3 +37,20 @@ export const PROMQL_COMPUTE_UTILIZATION = `query=${encodeURIComponent(
 export const PROMQL_MEMORY_UTILIZATION = `query=${encodeURIComponent(
   'avg(DCGM_FI_DEV_FB_USED / (DCGM_FI_DEV_FB_USED + DCGM_FI_DEV_FB_FREE)) * 100',
 )}`;
+
+// ── Borrowing & Lending chart ─────────────────────────────────────────────────
+
+export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+export const CHART_HEIGHT = 400;
+export const CHART_PADDING = { left: 55, right: 220, bottom: 50, top: 40 };
+/** Max width cap used for the right-vs-left flip calculation. Actual rendered width is auto. */
+export const FLYOUT_MAX_WIDTH = 360;
+export const CURSOR_GAP = 14;
+/**
+ * Max characters allowed in an SVG legend label before it is truncated.
+ * Derived from CHART_PADDING.right (220px) minus symbol + gap (~30px) at ~7px/char ≈ 27.
+ */
+export const LEGEND_MAX_CHARS = 27;
+
+/** Number of tooltip entries shown before the "View more" footer appears. */
+export const TOOLTIP_PAGE_SIZE = 5;

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -38,8 +38,6 @@ export const PROMQL_MEMORY_UTILIZATION = `query=${encodeURIComponent(
   'avg(DCGM_FI_DEV_FB_USED / (DCGM_FI_DEV_FB_USED + DCGM_FI_DEV_FB_FREE)) * 100',
 )}`;
 
-// ── Borrowing & Lending chart ─────────────────────────────────────────────────
-
 export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 export const CHART_HEIGHT = 400;
 export const CHART_PADDING = { left: 55, right: 220, bottom: 50, top: 40 };
@@ -54,3 +52,15 @@ export const LEGEND_MAX_CHARS = 27;
 
 /** Number of tooltip entries shown before the "View more" footer appears. */
 export const TOOLTIP_PAGE_SIZE = 5;
+
+/** Max height (px) of the scrollable content area inside the pinned tooltip panel. */
+export const TOOLTIP_PANEL_MAX_HEIGHT = 300;
+
+/** Estimated total height (px) of the pinned tooltip panel (header + content + footer) for viewport-flip calculations. */
+export const TOOLTIP_PANEL_TOTAL_HEIGHT = 420;
+
+export const AXIS_DIRECTION_LABEL_STYLE = {
+  fontWeight: 'bold',
+  fontSize: 12,
+  fill: 'var(--pf-t--global--text--color--subtle)',
+};

--- a/packages/gpuaas/src/hooks/__tests__/useBorrowingLendingMetrics.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useBorrowingLendingMetrics.spec.ts
@@ -1,0 +1,124 @@
+import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import {
+  buildSeries,
+  getGpuNominalQuota,
+  KueueUsageMetricResult,
+} from '../useBorrowingLendingMetrics';
+
+const makeClusterQueue = (name: string, gpuQuota: number): ClusterQueueKind => ({
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
+  kind: 'ClusterQueue',
+  metadata: { name },
+  spec: {
+    queueingStrategy: 'BestEffortFIFO',
+    stopPolicy: 'None',
+    namespaceSelector: {},
+    resourceGroups: [
+      {
+        coveredResources: ['nvidia.com/gpu' as never],
+        flavors: [
+          {
+            name: 'gpu-flavor',
+            resources: [{ name: 'nvidia.com/gpu' as never, nominalQuota: String(gpuQuota) }],
+          },
+        ],
+      },
+    ],
+  },
+});
+
+const makeResult = (cqName: string, values: [number, string][]): KueueUsageMetricResult => ({
+  // eslint-disable-next-line camelcase
+  metric: { cluster_queue: cqName },
+  values,
+});
+
+const makeCQInfoMap = (entries: [string, { nominalQuota: number; cohortName: string }][]) =>
+  new Map(entries);
+
+describe('getGpuNominalQuota', () => {
+  it('sums nvidia.com/* resources across all flavors and resource groups', () => {
+    expect(getGpuNominalQuota(makeClusterQueue('cq-a', 8))).toBe(8);
+  });
+
+  it('returns 0 for a CQ with no resource groups', () => {
+    const cq = makeClusterQueue('cq-b', 0);
+    cq.spec.resourceGroups = [];
+    expect(getGpuNominalQuota(cq)).toBe(0);
+  });
+
+  it('ignores non-nvidia resources', () => {
+    const cq: ClusterQueueKind = {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      kind: 'ClusterQueue',
+      metadata: { name: 'cq-cpu' },
+      spec: {
+        queueingStrategy: 'BestEffortFIFO',
+        stopPolicy: 'None',
+        namespaceSelector: {},
+        resourceGroups: [
+          {
+            coveredResources: ['cpu' as never, 'memory' as never],
+            flavors: [
+              {
+                name: 'default',
+                resources: [
+                  { name: 'cpu' as never, nominalQuota: '100' },
+                  { name: 'memory' as never, nominalQuota: '64Gi' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    expect(getGpuNominalQuota(cq)).toBe(0);
+  });
+});
+
+describe('buildSeries', () => {
+  it('returns empty array for empty prometheus results', () => {
+    expect(buildSeries([], new Map())).toEqual([]);
+  });
+
+  it('returns one series per matched CQ', () => {
+    const series = buildSeries(
+      [makeResult('cq-a', [[1700000000, '6']]), makeResult('cq-b', [[1700000000, '1']])],
+      makeCQInfoMap([
+        ['cq-a', { nominalQuota: 4, cohortName: 'cohort-1' }],
+        ['cq-b', { nominalQuota: 2, cohortName: 'cohort-1' }],
+      ]),
+    );
+    expect(series).toHaveLength(2);
+  });
+
+  it('skips results whose CQ name is not in the info map', () => {
+    const series = buildSeries(
+      [makeResult('cq-unknown', [[1700000000, '4']])],
+      makeCQInfoMap([['cq-a', { nominalQuota: 4, cohortName: 'cohort-1' }]]),
+    );
+    expect(series).toHaveLength(0);
+  });
+
+  it('maps a prometheus result to a series with correct y, x, and cohortName', () => {
+    const ts = 1700000000;
+    const series = buildSeries(
+      [makeResult('cq-a', [[ts, '6']])],
+      makeCQInfoMap([['cq-a', { nominalQuota: 4, cohortName: 'cohort-1' }]]),
+    );
+    expect(series[0].data[0].y).toBeCloseTo(2); // borrowing: usage(6) - quota(4)
+    expect(series[0].data[0].x).toBe(ts * 1000); // seconds → milliseconds
+    expect(series[0].cohortName).toBe('cohort-1');
+  });
+
+  it.each([
+    ['borrowing (usage > quota)', '6', 4, 2],
+    ['lending (usage < quota)', '1', 4, -3],
+  ])('computes y correctly for %s', (_label, usage, quota, expectedY) => {
+    const series = buildSeries(
+      [makeResult('cq-a', [[1700000000, usage]])],
+      makeCQInfoMap([['cq-a', { nominalQuota: quota, cohortName: 'cohort-1' }]]),
+    );
+    expect(series[0].data[0].y).toBeCloseTo(expectedY);
+  });
+});

--- a/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
+++ b/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
@@ -1,0 +1,198 @@
+import * as React from 'react';
+import usePrometheusQueryRange from '@odh-dashboard/internal/api/prometheus/usePrometheusQueryRange';
+import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import type {
+  PrometheusQueryRangeResponseData,
+  PrometheusQueryRangeResponseDataResult,
+  PrometheusQueryRangeResultValue,
+} from '@odh-dashboard/internal/types';
+import {
+  ACCELERATOR_RESOURCE_PREFIXES,
+  ACCELERATOR_RESOURCE_REGEX,
+  SEVEN_DAYS_MS,
+  TREND_REFRESH_INTERVAL,
+} from '../const';
+import { UnifiedCohort } from '../types';
+import parseK8sQuantity from '../utils/parseK8sQuantity';
+
+const SEVEN_DAYS_IN_SECONDS = SEVEN_DAYS_MS / 1000;
+const HOURLY_STEP = 3600;
+const PROMETHEUS_API_PATH = '/api/prometheus/queryRange';
+
+const isAcceleratorResource = (resourceName: string): boolean =>
+  ACCELERATOR_RESOURCE_PREFIXES.some((prefix) => resourceName.startsWith(prefix));
+
+/** Extended metric type that includes Kueue-specific Prometheus labels. */
+export type KueueUsageMetricResult = {
+  metric: PrometheusQueryRangeResponseDataResult['metric'] & {
+    cluster_queue?: string;
+    cohort?: string;
+  };
+  values: PrometheusQueryRangeResultValue[];
+};
+
+/** Type guard that widens a base result to include optional Kueue label fields. */
+const isKueueUsageResult = (
+  r: PrometheusQueryRangeResponseDataResult,
+): r is KueueUsageMetricResult => 'metric' in r && 'values' in r;
+
+const kueueUsagePredicate = (data: PrometheusQueryRangeResponseData): KueueUsageMetricResult[] =>
+  (data.result ?? []).filter(isKueueUsageResult);
+
+export type CQMetricSeries = {
+  cqName: string;
+  /** Empty string means standalone (not in a cohort). */
+  cohortName: string;
+  /** Nominal GPU quota declared for this cluster queue (in GPU units). */
+  nominalQuota: number;
+  data: { x: number; y: number }[];
+};
+
+type CQInfo = {
+  nominalQuota: number;
+  cohortName: string;
+};
+
+type BorrowingLendingMetricsResult = {
+  series: CQMetricSeries[];
+  loaded: boolean;
+  error: Error | undefined;
+};
+
+const getGpuNominalQuota = (cq: ClusterQueueKind): number =>
+  (cq.spec.resourceGroups ?? []).reduce(
+    (total, rg) =>
+      total +
+      rg.flavors.reduce(
+        (sum, f) =>
+          sum +
+          f.resources
+            .filter((r) => isAcceleratorResource(r.name))
+            .reduce((s, r) => s + parseK8sQuantity(r.nominalQuota), 0),
+        0,
+      ),
+    0,
+  );
+
+/** Sum accelerator quota from a FlavorQuota pool (cohort-level). */
+const getGpuNominalQuotaFromPool = (pool: UnifiedCohort['effectivePool']): number =>
+  pool.reduce(
+    (total, f) =>
+      total +
+      f.resources
+        .filter((r) => isAcceleratorResource(r.name))
+        .reduce((s, r) => s + r.nominalQuota, 0),
+    0,
+  );
+
+const buildCQInfoMap = (cohorts: UnifiedCohort[]): Map<string, CQInfo> => {
+  const map = new Map<string, CQInfo>();
+  cohorts.forEach((cohort) => {
+    const isStandalone = cohort.state === 'standalone';
+
+    // For cohort members, use the cohort-level GPU pool as a fallback quota
+    // when a CQ inherits quota implicitly rather than declaring it explicitly.
+    const cohortPoolQuota = isStandalone ? 0 : getGpuNominalQuotaFromPool(cohort.effectivePool);
+
+    cohort.memberClusterQueues.forEach((cq) => {
+      const cqName = cq.metadata?.name ?? '';
+      if (!cqName) {
+        return;
+      }
+      const cqQuota = getGpuNominalQuota(cq);
+
+      // Standalone CQs always use their own declared quota (no cohort pool).
+      // Cohort CQs fall back to an equal share of the cohort pool when they
+      // don't declare GPU resources explicitly in spec.resourceGroups.
+      const nominalQuota = isStandalone
+        ? cqQuota
+        : cqQuota > 0
+        ? cqQuota
+        : cohort.memberClusterQueues.length > 0
+        ? cohortPoolQuota / cohort.memberClusterQueues.length
+        : 0;
+
+      // Only add CQs that have GPU quota — standalone CQs with quota=0
+      // have no GPU resources tracked and would only add noise.
+      if (nominalQuota === 0) {
+        return;
+      }
+
+      map.set(cqName, {
+        nominalQuota,
+        // Empty string signals "standalone" to the chart label formatter.
+        cohortName: isStandalone ? '' : cohort.name,
+      });
+    });
+  });
+  return map;
+};
+
+const buildSeries = (
+  prometheusResults: KueueUsageMetricResult[],
+  cqInfoMap: Map<string, CQInfo>,
+): CQMetricSeries[] =>
+  prometheusResults
+    .map((result) => {
+      const cqName = result.metric.cluster_queue ?? '';
+      if (!cqName) {
+        return null;
+      }
+      const info = cqInfoMap.get(cqName);
+      // Only include CQs that are members of a cohort — borrowing and lending
+      // are cohort-level concepts. Standalone CQs cannot borrow or lend.
+      if (!info) {
+        return null;
+      }
+      return {
+        cqName,
+        cohortName: info.cohortName,
+        nominalQuota: info.nominalQuota,
+        data: result.values.map(([timestamp, valueStr]) => ({
+          x: timestamp * 1000,
+          y: parseFloat(valueStr) - info.nominalQuota,
+        })),
+      };
+    })
+    .filter((s): s is CQMetricSeries => s !== null);
+
+// Use max instead of sum: Kueue runs with leader/follower replicas and both
+// emit the same metric value. Summing across replicas would double-count.
+// max by (cluster_queue) is equivalent to the leader's value and works for
+// both single-replica and HA deployments.
+const QUERY_LANG = `max by (cluster_queue) (kueue_cluster_queue_resource_usage{resource=~"${ACCELERATOR_RESOURCE_REGEX}"})`;
+
+const useBorrowingLendingMetrics = (cohorts: UnifiedCohort[]): BorrowingLendingMetricsResult => {
+  const cqInfoMap = React.useMemo(() => buildCQInfoMap(cohorts), [cohorts]);
+
+  // Stabilise endInMs: initialise once and tick at the refresh interval.
+  // Passing Date.now() directly would produce a new value on every render,
+  // which recreates usePrometheusQueryRange's fetchData callback and triggers
+  // a new HTTP request on every render cycle.
+  const [endInMs, setEndInMs] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    const id = setInterval(() => setEndInMs(Date.now()), TREND_REFRESH_INTERVAL);
+    return () => clearInterval(id);
+  }, []);
+
+  const [prometheusResults, loaded, error] = usePrometheusQueryRange(
+    true,
+    PROMETHEUS_API_PATH,
+    QUERY_LANG,
+    SEVEN_DAYS_IN_SECONDS,
+    endInMs,
+    HOURLY_STEP,
+    kueueUsagePredicate,
+    '',
+  );
+
+  const series = React.useMemo(
+    () => buildSeries(prometheusResults, cqInfoMap),
+    [prometheusResults, cqInfoMap],
+  );
+
+  return { series, loaded, error };
+};
+
+export { buildSeries, getGpuNominalQuota };
+export default useBorrowingLendingMetrics;

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -1,27 +1,27 @@
 import * as React from 'react';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
-import {
-  Card,
-  CardBody,
-  CardTitle,
-  Content,
-  ContentVariants,
-  Icon,
-  Label,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
+import { Card, CardBody, Content, Icon, Label, Stack, StackItem } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
 import { INFRASTRUCTURE_SECTIONS } from '../const';
 import ClusterSummaryCards from '../components/ClusterSummaryCards';
+import BorrowingLendingSection from '../components/BorrowingLendingSection';
 import useInfrastructureMetrics from '../hooks/useInfrastructureMetrics';
+
+type SectionId = (typeof INFRASTRUCTURE_SECTIONS)[number]['id'];
 
 const formatRefreshTime = (date: Date): string =>
   date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' });
 
 const InfrastructurePage: React.FC = () => {
   const metrics = useInfrastructureMetrics();
+
+  const SECTION_COMPONENTS: Record<SectionId, React.ReactElement | null> = {
+    cluster: <ClusterSummaryCards metrics={metrics} />,
+    'hardware-usage': null,
+    'borrowing-lending': <BorrowingLendingSection />,
+    'cluster-queue-utilization': null,
+  };
 
   const headerAction = metrics.lastRefreshed ? (
     <Label
@@ -46,16 +46,19 @@ const InfrastructurePage: React.FC = () => {
       headerAction={headerAction}
     >
       <Stack hasGutter>
-        <StackItem data-testid="infrastructure-cluster-section">
-          <Content component={ContentVariants.h2}>{INFRASTRUCTURE_SECTIONS[0].title}</Content>
-          <ClusterSummaryCards metrics={metrics} />
-        </StackItem>
-        {INFRASTRUCTURE_SECTIONS.slice(1).map(({ id, title }) => (
+        {INFRASTRUCTURE_SECTIONS.map(({ id, title, description }) => (
           <StackItem key={id}>
-            <Card data-testid={`infrastructure-${id}-section`}>
-              <CardTitle>{title}</CardTitle>
-              <CardBody />
-            </Card>
+            <Stack hasGutter>
+              <StackItem>
+                <Content component="h2">{title}</Content>
+                {description && <Content component="p">{description}</Content>}
+              </StackItem>
+              <StackItem>
+                <Card data-testid={`infrastructure-${id}-section`}>
+                  <CardBody>{SECTION_COMPONENTS[id]}</CardBody>
+                </Card>
+              </StackItem>
+            </Stack>
           </StackItem>
         ))}
       </Stack>

--- a/packages/gpuaas/src/utils/__tests__/borrowingLendingChart.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/borrowingLendingChart.spec.ts
@@ -1,0 +1,221 @@
+import { LEGEND_MAX_CHARS } from '../../const';
+import {
+  buildColorByName,
+  buildLegendData,
+  buildLegendEvents,
+  buildYDomain,
+  formatTooltipDate,
+  formatXTick,
+  formatYTick,
+  getEntryLabel,
+  getLegendLabel,
+  getTooltipPosition,
+  getYAxisTicks,
+  truncateLabel,
+} from '../borrowingLendingChart';
+import { CQMetricSeries } from '../../hooks/useBorrowingLendingMetrics';
+
+const CQ_A = 'cq-a';
+const CQ_B = 'cq-b';
+const MY_CQ = 'my-cq';
+const MY_COHORT = 'my-cohort';
+const SHORT_COHORT = 'c';
+const COHORT_CQ_LABEL = `${MY_COHORT} · ${MY_CQ}`;
+const DISABLED_FILL = 'var(--pf-t--global--text--color--disabled)';
+const LONG_LABEL_LEN = 20;
+const WIDE_VIEWPORT = 1200;
+const NARROW_VIEWPORT = 200;
+
+/** Builds a minimal CQMetricSeries for test use. */
+const makeSeries = (
+  cqName: string,
+  cohortName: string,
+  yValues: number[] = [0],
+): CQMetricSeries => ({
+  cqName,
+  cohortName,
+  nominalQuota: 4,
+  data: yValues.map((y, i) => ({ x: i * 1000, y })),
+});
+
+/** Returns a ref-like object whose getBoundingClientRect reports the given origin. */
+const makeRef = (rectLeft: number, rectTop: number) => ({
+  current: {
+    getBoundingClientRect: () => ({ left: rectLeft, top: rectTop }),
+  } as HTMLDivElement,
+});
+
+// 2024-01-09T12:00:00Z is a Tuesday — noon UTC keeps the date stable across all timezones
+const TUESDAY_TS = new Date('2024-01-09T12:00:00Z').getTime();
+
+describe('formatXTick', () => {
+  it('formats a timestamp as "Weekday Day Month"', () => {
+    expect(formatXTick(TUESDAY_TS)).toMatch(/^Tue 9 Jan$/);
+  });
+});
+
+describe('formatTooltipDate', () => {
+  it('formats a timestamp as "Weekday Day Month, HH:MM <tz>"', () => {
+    // Timezone suffix varies by environment (e.g. "GMT+5:30", "UTC", "IST")
+    expect(formatTooltipDate(TUESDAY_TS)).toMatch(/^Tue 9 Jan, \d{2}:\d{2} \S+$/);
+  });
+});
+
+describe('formatYTick', () => {
+  it.each([
+    [0, '0'],
+    [3, '+3'],
+    [-3, '-3'],
+    [1000, '+1.0k'],
+    [-2500, '-2.5k'],
+  ])('formats %d as "%s"', (y, expected) => {
+    expect(formatYTick(y)).toBe(expected);
+  });
+});
+
+describe('truncateLabel', () => {
+  it.each([
+    ['short label', 'abc', undefined, 'abc'],
+    ['label at exact limit', 'a'.repeat(LEGEND_MAX_CHARS), undefined, 'a'.repeat(LEGEND_MAX_CHARS)],
+    ['custom maxChars', 'hello world', 6, 'hello…'],
+  ])('returns unchanged or truncated for %s', (_desc, input, maxChars, expected) => {
+    expect(truncateLabel(input, maxChars)).toBe(expected);
+  });
+
+  it('appends ellipsis and caps length when label exceeds the limit', () => {
+    const result = truncateLabel('a'.repeat(LEGEND_MAX_CHARS + 5));
+    expect(result).toHaveLength(LEGEND_MAX_CHARS);
+    expect(result.endsWith('…')).toBe(true);
+  });
+});
+
+describe('getEntryLabel', () => {
+  it.each([
+    ['undefined info returns fallback', undefined, 'fallback-cq', 'fallback-cq'],
+    ['empty cohortName returns cqName alone', makeSeries(MY_CQ, ''), 'fallback', MY_CQ],
+    [
+      'set cohortName prefixes the label',
+      makeSeries(MY_CQ, MY_COHORT),
+      'fallback',
+      COHORT_CQ_LABEL,
+    ],
+  ] as const)('%s', (_desc, info, fallback, expected) => {
+    expect(getEntryLabel(info as CQMetricSeries | undefined, fallback)).toBe(expected);
+  });
+});
+
+describe('getLegendLabel', () => {
+  it('truncates long cohort-prefixed labels to LEGEND_MAX_CHARS', () => {
+    const result = getLegendLabel(
+      makeSeries('a'.repeat(LONG_LABEL_LEN), 'b'.repeat(LONG_LABEL_LEN)),
+    );
+    expect(result.length).toBeLessThanOrEqual(LEGEND_MAX_CHARS);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('returns the full label unchanged when it fits within the limit', () => {
+    expect(getLegendLabel(makeSeries('cq', 'cohort'))).toBe('cohort · cq');
+  });
+});
+
+describe('buildYDomain', () => {
+  it('returns ±1 buffer around zero for empty series', () => {
+    expect(buildYDomain([])).toEqual({ minY: -1, maxY: 1 });
+  });
+
+  it.each([
+    ['only positive values', [3, 5], { minY: -1, maxY: 6 }],
+    ['mixed values', [-3, 4], { minY: -4, maxY: 5 }],
+  ])('applies ±1 buffer and always includes zero for %s', (_desc, yValues, expected) => {
+    expect(buildYDomain([makeSeries('cq', SHORT_COHORT, yValues)])).toEqual(expected);
+  });
+});
+
+describe('getYAxisTicks', () => {
+  it('generates evenly-spaced integer ticks that always include 0', () => {
+    const ticks = getYAxisTicks(-4, 4);
+    expect(ticks).toContain(0);
+    const diffs = ticks.slice(1).map((t, i) => t - ticks[i]);
+    expect(diffs.every((d) => d === diffs[0])).toBe(true);
+  });
+
+  it('uses step size 1 for a small range and covers all boundary values', () => {
+    expect(getYAxisTicks(-1, 1)).toEqual(expect.arrayContaining([-1, 0, 1]));
+  });
+});
+
+describe('buildColorByName', () => {
+  const twoSeries = [makeSeries(CQ_A, SHORT_COHORT), makeSeries(CQ_B, SHORT_COHORT)];
+
+  it('includes visible series and excludes hidden ones', () => {
+    const map = buildColorByName(twoSeries, new Set([CQ_A]));
+    expect(map.has(CQ_A)).toBe(false);
+    expect(map.has(CQ_B)).toBe(true);
+  });
+
+  it('returns an empty map when all series are hidden', () => {
+    expect(buildColorByName([makeSeries(CQ_A, SHORT_COHORT)], new Set([CQ_A])).size).toBe(0);
+  });
+});
+
+describe('buildLegendData', () => {
+  const singleSeries = [makeSeries(CQ_A, SHORT_COHORT)];
+
+  it('greys out hidden series and leaves visible series without a fill', () => {
+    const [hidden] = buildLegendData(singleSeries, new Set([CQ_A]));
+    const [visible] = buildLegendData(singleSeries, new Set());
+    expect(hidden.symbol.fill).toBe(DISABLED_FILL);
+    expect(visible.symbol.fill).toBeUndefined();
+  });
+
+  it('sets childName and fullName correctly for event targeting and tooltip labels', () => {
+    const [item] = buildLegendData([makeSeries(MY_CQ, MY_COHORT)], new Set());
+    expect(item.childName).toBe(MY_CQ);
+    expect(item.fullName).toBe(COHORT_CQ_LABEL);
+  });
+});
+
+describe('buildLegendEvents', () => {
+  it('returns click handlers for both data and labels targets', () => {
+    const toggle = jest.fn();
+    const events = buildLegendEvents(toggle);
+    expect(events.map((e) => e.target)).toEqual(expect.arrayContaining(['data', 'labels']));
+    events[0].eventHandlers.onClick({}, { datum: { childName: CQ_A } });
+    expect(toggle).toHaveBeenCalledWith(CQ_A);
+  });
+
+  it('does not call toggleSeries when childName is missing', () => {
+    const toggle = jest.fn();
+    buildLegendEvents(toggle)[0].eventHandlers.onClick({}, { datum: {} });
+    expect(toggle).not.toHaveBeenCalled();
+  });
+});
+
+describe('getTooltipPosition', () => {
+  const DEFAULT_REF = makeRef(100, 200);
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: WIDE_VIEWPORT,
+    });
+  });
+
+  it('positions to the right when space is available', () => {
+    const { finalLeft } = getTooltipPosition(DEFAULT_REF, 50, 100);
+    expect(finalLeft).toBeGreaterThan(150); // vpX=150, placed right of cursor
+  });
+
+  it('flips to the left when tooltip would overflow the viewport', () => {
+    Object.defineProperty(window, 'innerWidth', { value: NARROW_VIEWPORT });
+    const { finalLeft } = getTooltipPosition(DEFAULT_REF, 50, 100);
+    expect(finalLeft).toBeLessThan(150); // vpX=150, flipped left
+  });
+
+  it('clamps finalTop to at least 8px and returns numbers when ref is undefined', () => {
+    const { finalLeft, finalTop } = getTooltipPosition(undefined, 0, 0);
+    expect(finalTop).toBeGreaterThanOrEqual(8);
+    expect(typeof finalLeft).toBe('number');
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/borrowingLendingChart.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/borrowingLendingChart.spec.ts
@@ -200,21 +200,33 @@ describe('getTooltipPosition', () => {
       configurable: true,
       value: WIDE_VIEWPORT,
     });
+    Object.defineProperty(window, 'innerHeight', {
+      writable: true,
+      configurable: true,
+      value: 768,
+    });
   });
 
-  it('positions to the right when space is available', () => {
+  // vpX = rectLeft(100) + x(50) = 150
+  it.each([
+    ['right', WIDE_VIEWPORT, true],
+    ['left (flipped)', NARROW_VIEWPORT, false],
+  ])('places tooltip to the %s of cursor (innerWidth=%i)', (_dir, innerWidth, expectRight) => {
+    Object.defineProperty(window, 'innerWidth', { value: innerWidth });
     const { finalLeft } = getTooltipPosition(DEFAULT_REF, 50, 100);
-    expect(finalLeft).toBeGreaterThan(150); // vpX=150, placed right of cursor
+    if (expectRight) {
+      expect(finalLeft).toBeGreaterThan(150);
+    } else {
+      expect(finalLeft).toBeLessThan(150);
+    }
   });
 
-  it('flips to the left when tooltip would overflow the viewport', () => {
-    Object.defineProperty(window, 'innerWidth', { value: NARROW_VIEWPORT });
-    const { finalLeft } = getTooltipPosition(DEFAULT_REF, 50, 100);
-    expect(finalLeft).toBeLessThan(150); // vpX=150, flipped left
-  });
-
-  it('clamps finalTop to at least 8px and returns numbers when ref is undefined', () => {
-    const { finalLeft, finalTop } = getTooltipPosition(undefined, 0, 0);
+  it.each<[string, ReturnType<typeof makeRef> | undefined, number, number, number]>([
+    ['fitsBelow=true, ref undefined', undefined, 0, 0, 768],
+    ['fitsBelow=false (small screen), flips up', makeRef(0, 0), 0, 100, 400],
+  ])('finalTop is always ≥ 8px: %s', (_desc, ref, x, y, innerHeight) => {
+    Object.defineProperty(window, 'innerHeight', { value: innerHeight });
+    const { finalLeft, finalTop } = getTooltipPosition(ref, x, y);
     expect(finalTop).toBeGreaterThanOrEqual(8);
     expect(typeof finalLeft).toBe('number');
   });

--- a/packages/gpuaas/src/utils/borrowingLendingChart.ts
+++ b/packages/gpuaas/src/utils/borrowingLendingChart.ts
@@ -1,0 +1,174 @@
+import { ChartThemeColor, getTheme } from '@patternfly/react-charts/victory';
+import { CQMetricSeries } from '../hooks/useBorrowingLendingMetrics';
+import { CURSOR_GAP, FLYOUT_MAX_WIDTH, LEGEND_MAX_CHARS } from '../const';
+
+export type TooltipPoint = {
+  childName?: string;
+  x: number;
+  y: number;
+  nominalQuota?: number;
+};
+
+/**
+ * Pull the color scale directly from PF's Victory theme so tooltip dots
+ * always match chart line colors — including dark/high-contrast variants.
+ */
+export const CHART_COLOR_SCALE: string[] = (() => {
+  const scale = getTheme(ChartThemeColor.multiOrdered).chart?.colorScale;
+  return Array.isArray(scale) ? scale.map(String) : [];
+})();
+
+/** "Tue 30 Jun" — x-axis label format matching the UX design */
+export const formatXTick = (x: number): string => {
+  const d = new Date(x);
+  const weekday = d.toLocaleDateString('en-US', { weekday: 'short' });
+  const day = d.getDate();
+  const month = d.toLocaleDateString('en-US', { month: 'short' });
+  return `${weekday} ${day} ${month}`;
+};
+
+/** "Fri 3 Jul, 01:00 GMT+5:30" — full timestamp with timezone for tooltip headers */
+export const formatTooltipDate = (x: number): string => {
+  const d = new Date(x);
+  const weekday = d.toLocaleDateString('en-US', { weekday: 'short' });
+  const day = d.getDate();
+  const month = d.toLocaleDateString('en-US', { month: 'short' });
+  const time = d.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZoneName: 'short',
+  });
+  return `${weekday} ${day} ${month}, ${time}`;
+};
+
+/** Signed values: "+2", "0", "-3" so positive = borrowing, negative = lending */
+export const formatYTick = (y: number): string => {
+  if (y === 0) {
+    return '0';
+  }
+  const abs = Math.abs(y);
+  const val = abs >= 1000 ? `${(abs / 1000).toFixed(1)}k` : String(Math.round(abs));
+  return y > 0 ? `+${val}` : `-${val}`;
+};
+
+/**
+ * Truncate a string to maxChars, appending "…" if it exceeds the limit.
+ * Used for SVG legend labels where CSS text-overflow is unavailable.
+ */
+export const truncateLabel = (label: string, maxChars = LEGEND_MAX_CHARS): string =>
+  label.length > maxChars ? `${label.slice(0, maxChars - 1)}…` : label;
+
+/** Cohort-prefixed label for a series — used in both tooltips and the legend. */
+export const getEntryLabel = (info: CQMetricSeries | undefined, fallback: string): string => {
+  if (!info) {
+    return fallback;
+  }
+  return info.cohortName ? `${info.cohortName} · ${info.cqName}` : info.cqName;
+};
+
+/** Truncated legend label for the SVG legend column (CSS text-overflow is unavailable in SVG). */
+export const getLegendLabel = (s: CQMetricSeries): string =>
+  truncateLabel(getEntryLabel(s, s.cqName));
+
+/**
+ * Compute the Y-axis domain from all series data, always including zero.
+ * A fixed ±1 buffer is added so peak data points never sit on the chart boundary,
+ * which would cause the Voronoi container to miss hover events at those extremes.
+ */
+export const buildYDomain = (series: CQMetricSeries[]): { minY: number; maxY: number } => {
+  const allY = series.flatMap((s) => s.data.map((d) => d.y));
+  const rawMin = Math.min(0, ...allY);
+  const rawMax = Math.max(0, ...allY);
+  return { minY: rawMin - 1, maxY: rawMax + 1 };
+};
+
+/**
+ * Compute explicit Y-axis tick values that always include 0.
+ * Uses a step size derived from the domain range so ticks are evenly spaced
+ * and land on whole numbers (GPU quota values are always integers).
+ */
+export const getYAxisTicks = (minY: number, maxY: number): number[] => {
+  const range = maxY - minY;
+  const step = Math.max(1, Math.ceil(range / 8));
+  const ticks: number[] = [];
+  for (let t = Math.ceil(minY / step) * step; t <= maxY; t += step) {
+    ticks.push(t);
+  }
+  return ticks;
+};
+
+/**
+ * Build a cqName → color map keyed to the *visible* render order so tooltip
+ * dots match chart line colors even when series are toggled.
+ */
+export const buildColorByName = (
+  series: CQMetricSeries[],
+  hiddenSeries: Set<string>,
+): Map<string, string> =>
+  new Map(
+    series
+      .filter((s) => !hiddenSeries.has(s.cqName))
+      .map((s, i) => [
+        s.cqName,
+        CHART_COLOR_SCALE.length > 0 ? CHART_COLOR_SCALE[i % CHART_COLOR_SCALE.length] : '#aaa',
+      ]),
+  );
+
+/** Build the legend data array, greying out hidden series symbols. */
+export const buildLegendData = (
+  series: CQMetricSeries[],
+  hiddenSeries: Set<string>,
+): {
+  name: string;
+  fullName: string;
+  childName: string;
+  symbol: { type: string; fill?: string };
+}[] =>
+  series.map((s) => ({
+    name: getLegendLabel(s),
+    fullName: getEntryLabel(s, s.cqName),
+    childName: s.cqName,
+    symbol: hiddenSeries.has(s.cqName)
+      ? { type: 'circle', fill: 'var(--pf-t--global--text--color--disabled)' }
+      : { type: 'circle' },
+  }));
+
+/**
+ * Build Victory legend event handlers that toggle a series on click.
+ * Victory's event system is untyped; the eslint-disable is intentional.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const buildLegendEvents = (toggleSeries: (name: string) => void): any[] => {
+  const onClick = (_evt: unknown, props: { datum: { childName?: string } }) => {
+    if (props.datum.childName) {
+      toggleSeries(props.datum.childName);
+    }
+    return null;
+  };
+  const onMouseOver = () => [{ mutation: () => ({ style: { cursor: 'pointer' } }) }];
+  const onMouseOut = () => [{ mutation: () => null }];
+  return [
+    { target: 'data', eventHandlers: { onClick, onMouseOver, onMouseOut } },
+    { target: 'labels', eventHandlers: { onClick, onMouseOver, onMouseOut } },
+  ];
+};
+
+/**
+ * Convert Victory's SVG-local cursor coordinates into a viewport-relative
+ * tooltip position, flipping left/right to stay within the window bounds.
+ */
+export const getTooltipPosition = (
+  containerRef: { current: HTMLDivElement | null } | undefined,
+  x: number,
+  y: number,
+): { finalLeft: number; finalTop: number } => {
+  const svgRect = containerRef?.current?.getBoundingClientRect();
+  const vpX = (svgRect?.left ?? 0) + x;
+  const vpY = (svgRect?.top ?? 0) + y;
+  const fitsRight = vpX + CURSOR_GAP + FLYOUT_MAX_WIDTH <= window.innerWidth;
+  return {
+    finalLeft: fitsRight ? vpX + CURSOR_GAP : vpX - CURSOR_GAP - FLYOUT_MAX_WIDTH,
+    finalTop: Math.max(8, vpY - 60),
+  };
+};

--- a/packages/gpuaas/src/utils/borrowingLendingChart.ts
+++ b/packages/gpuaas/src/utils/borrowingLendingChart.ts
@@ -1,6 +1,11 @@
 import { ChartThemeColor, getTheme } from '@patternfly/react-charts/victory';
 import { CQMetricSeries } from '../hooks/useBorrowingLendingMetrics';
-import { CURSOR_GAP, FLYOUT_MAX_WIDTH, LEGEND_MAX_CHARS } from '../const';
+import {
+  CURSOR_GAP,
+  FLYOUT_MAX_WIDTH,
+  LEGEND_MAX_CHARS,
+  TOOLTIP_PANEL_TOTAL_HEIGHT,
+} from '../const';
 
 export type TooltipPoint = {
   childName?: string;
@@ -78,8 +83,8 @@ export const getLegendLabel = (s: CQMetricSeries): string =>
  */
 export const buildYDomain = (series: CQMetricSeries[]): { minY: number; maxY: number } => {
   const allY = series.flatMap((s) => s.data.map((d) => d.y));
-  const rawMin = Math.min(0, ...allY);
-  const rawMax = Math.max(0, ...allY);
+  const rawMin = allY.reduce((min, y) => Math.min(min, y), 0);
+  const rawMax = allY.reduce((max, y) => Math.max(max, y), 0);
   return { minY: rawMin - 1, maxY: rawMax + 1 };
 };
 
@@ -167,8 +172,9 @@ export const getTooltipPosition = (
   const vpX = (svgRect?.left ?? 0) + x;
   const vpY = (svgRect?.top ?? 0) + y;
   const fitsRight = vpX + CURSOR_GAP + FLYOUT_MAX_WIDTH <= window.innerWidth;
+  const fitsBelow = vpY - 60 + TOOLTIP_PANEL_TOTAL_HEIGHT + 8 <= window.innerHeight;
   return {
     finalLeft: fitsRight ? vpX + CURSOR_GAP : vpX - CURSOR_GAP - FLYOUT_MAX_WIDTH,
-    finalTop: Math.max(8, vpY - 60),
+    finalTop: fitsBelow ? Math.max(8, vpY - 60) : Math.max(8, vpY - TOOLTIP_PANEL_TOTAL_HEIGHT),
   };
 };


### PR DESCRIPTION
Closes [RHOAIENG-72329](https://issues.redhat.com/browse/RHOAIENG-72329)

## Description

Adds the Borrowing & Lending 7-day trend chart to the Infrastructure page. The chart shows net GPU usage (`actual usage - nominal quota`) per cluster queue over the last 7 days. Positive values mean the queue is borrowing from its cohort, negative means it's lending capacity back.

<img width="1677" height="963" alt="Screenshot 2026-07-09 at 12 21 59 PM" src="https://github.com/user-attachments/assets/3ee34f28-edf7-433c-850f-75c3e5e23ce0" />

<img width="1629" height="919" alt="image" src="https://github.com/user-attachments/assets/86670fd0-2b8e-4bee-b91f-d4547128d545" />


https://github.com/user-attachments/assets/adb924ee-8977-4bff-892d-b809fa3cec19


**Chart** (`BorrowingLendingChart.tsx`, `BorrowingLendingSection.tsx`)
- Victory Charts line chart with a responsive width, hover crosshair, and dots on hovered data points
- Legend on the right, clickable to toggle series, truncated with a full-label tooltip if the name is long
- Cohort filter dropdown + CQ name search so operators can zoom into a specific cohort or find a queue by name
- "Showing X of Y" count scoped to the current cohort view (standalone CQs don't inflate the total when you're in "All cohorts")
- Empty state when no accelerator data is available

**Tooltip** (`BorrowingLendingTooltip.tsx`)
- Hover shows the top 5 series by `|y|` (keeps it readable when there are 20+ queues)
- Click anywhere on the chart to pin the tooltip as an interactive panel; scroll through all entries and expand with "View more"
- Panel opens at the top of the list

**Data** (`useBorrowingLendingMetrics.ts`)
- Queries `kueue_cluster_queue_resource_usage` with `max by (cluster_queue)` to handle Kueue HA replicas without double-counting
- Quota lookup: uses each CQ's declared GPU quota, falls back to an equal share of the cohort pool for CQs that inherit implicitly
- Refreshes every **5 minutes** since the underlying Prometheus data has 1h resolution (30s polling was wasteful)
- Waits for both Prometheus metrics and K8s cohort data before rendering to avoid an empty state flicker on load

## How Has This Been Tested?

Manually tested on a cluster with Kueue and GPU cluster queues in cohorts:
- Queues borrowing show positive values (above zero), queues lending show negative (below zero)
- Hover crosshair and dots work; clicking pins the tooltip panel
- "View more" expands the list; panel opens at the top of the list
- Cohort filter and CQ name search work together
- Chart refreshes on its own every ~5 minutes

## Test Impact

- Jest: `buildSeries`, `getGpuNominalQuota`, all chart utility functions, and chart component rendering
- Cypress mock: chart renders with data, empty state when Prometheus returns nothing, cohort dropdown content, CQ name filter

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

cc @kywalker-rh

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-72329]: https://redhat.atlassian.net/browse/RHOAIENG-72329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a **Borrowing & lending** section to the Infrastructure page with a last-7-days activity chart, cohort selection, search filtering, and interactive legend toggles.
  * Introduced hover and pinned tooltips for chart insights.

* **Bug Fixes**
  * Improved metric fetching to prevent unnecessary refresh behavior and keep loading/error/empty states accurate.

* **Tests**
  * Expanded unit and end-to-end coverage for chart rendering, tooltips, and mocked metric/query scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->