### PR TITLE
feat(maas-bff): external models list MVP (namespaces + list/delete)

### DIFF
--- a/packages/maas/bff/internal/api/api_keys_handlers_test.go
+++ b/packages/maas/bff/internal/api/api_keys_handlers_test.go
@@ -354,7 +354,7 @@ var _ = Describe("APIKeysHandlers", Ordered, func() {
 			subsRepo := repositories.NewSubscriptionsRepository(testLogger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 			policiesRepo := repositories.NewPoliciesRepository(testLogger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 			modelRefsRepo := repositories.NewMaaSModelRefsRepository(testLogger, k8Factory)
-			repos, err := repositories.NewRepositories(testLogger, k8Factory, envConfig, subsRepo, policiesRepo, modelRefsRepo, nil)
+			repos, err := repositories.NewRepositories(testLogger, k8Factory, envConfig, subsRepo, policiesRepo, modelRefsRepo, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			app := &App{

--- a/packages/maas/bff/internal/api/app.go
+++ b/packages/maas/bff/internal/api/app.go
@@ -160,21 +160,24 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 	var subscriptionsRepo repositories.SubscriptionsRepositoryInterface
 	var policiesRepo repositories.PoliciesRepositoryInterface
 	var modelRefsRepo repositories.MaaSModelRefsRepositoryInterface
+	var externalModelsRepo repositories.ExternalModelsRepositoryInterface
 	var yamlRepo repositories.YamlRepositoryInterface
 
 	if cfg.MockK8Client {
 		subscriptionsRepo = repositories.NewMockSubscriptionsRepository(logger)
 		policiesRepo = repositories.NewMockPoliciesRepository(logger)
 		modelRefsRepo = repositories.NewMockMaaSModelRefsRepository(logger)
+		externalModelsRepo = repositories.NewMockExternalModelsRepository(logger, modelRefsRepo)
 		yamlRepo = repositories.NewMockYamlRepository(logger)
 	} else {
 		subscriptionsRepo = repositories.NewSubscriptionsRepository(logger, k8sFactory, cfg.MaaSSubscriptionNamespace)
 		policiesRepo = repositories.NewPoliciesRepository(logger, k8sFactory, cfg.MaaSSubscriptionNamespace)
 		modelRefsRepo = repositories.NewMaaSModelRefsRepository(logger, k8sFactory)
+		externalModelsRepo = repositories.NewExternalModelsRepository(logger, k8sFactory, modelRefsRepo)
 		yamlRepo = repositories.NewYamlRepository(logger, k8sFactory, cfg.MaaSSubscriptionNamespace)
 	}
 
-	repos, err := repositories.NewRepositories(logger, k8sFactory, cfg, subscriptionsRepo, policiesRepo, modelRefsRepo, yamlRepo)
+	repos, err := repositories.NewRepositories(logger, k8sFactory, cfg, subscriptionsRepo, policiesRepo, modelRefsRepo, externalModelsRepo, yamlRepo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repositories: %w", err)
 	}
@@ -222,6 +225,7 @@ func (app *App) Routes() http.Handler {
 	attachSubscriptionHandlers(apiRouter, app)
 	attachPolicyHandlers(apiRouter, app)
 	attachMaaSModelRefHandlers(apiRouter, app)
+	attachExternalModelHandlers(apiRouter, app)
 	attachYamlHandlers(apiRouter, app)
 	apiRouter.GET(constants.ApiPathPrefix+"/models", handlerWithApp(app, ListModelsHandler))
 	apiRouter.GET(constants.ModelsOverviewPath, handlerWithApp(app, ListModelsOverviewHandler))

--- a/packages/maas/bff/internal/api/app_test.go
+++ b/packages/maas/bff/internal/api/app_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Static File serving Test", func() {
 			envConfig := config.EnvConfig{
 				StaticAssetsDir: "../../static",
 			}
-			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			app := &App{
 				kubernetesClientFactory: k8Factory,

--- a/packages/maas/bff/internal/api/externalmodel_handlers.go
+++ b/packages/maas/bff/internal/api/externalmodel_handlers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/julienschmidt/httprouter"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
@@ -48,7 +49,7 @@ func DeleteExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request
 	}
 
 	if err := app.repositories.ExternalModels.DeleteExternalModel(ctx, namespace, name); err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if k8sErrors.IsNotFound(err) {
 			app.errorResponse(w, r, &HTTPError{
 				StatusCode: http.StatusNotFound,
 				Error:      ErrorPayload{Code: "404", Message: err.Error()},

--- a/packages/maas/bff/internal/api/externalmodel_handlers.go
+++ b/packages/maas/bff/internal/api/externalmodel_handlers.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+func attachExternalModelHandlers(apiRouter *httprouter.Router, app *App) {
+	apiRouter.GET(constants.ExternalModelListPath, handlerWithApp(app, ListExternalModelsHandler))
+	apiRouter.DELETE(constants.ExternalModelDeletePath, handlerWithApp(app, DeleteExternalModelHandler))
+}
+
+// ListExternalModelsHandler handles GET /api/v1/externalmodel?namespace=X
+func ListExternalModelsHandler(app *App, w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+	namespace, err := namespaceFromContext(r)
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	modelsList, err := app.repositories.ExternalModels.ListExternalModels(ctx, namespace)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	response := Envelope[[]models.ExternalModelSummary, None]{Data: modelsList}
+	if err := app.WriteJSON(w, http.StatusOK, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// DeleteExternalModelHandler handles DELETE /api/v1/externalmodel/:namespace/:name
+func DeleteExternalModelHandler(app *App, w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	ctx := r.Context()
+	namespace := params.ByName("namespace")
+	name := params.ByName("name")
+	if namespace == "" || name == "" {
+		app.badRequestResponse(w, r, errors.New("ExternalModel namespace and name are required"))
+		return
+	}
+
+	if err := app.repositories.ExternalModels.DeleteExternalModel(ctx, namespace, name); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			app.errorResponse(w, r, &HTTPError{
+				StatusCode: http.StatusNotFound,
+				Error:      ErrorPayload{Code: "404", Message: err.Error()},
+			})
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	response := Envelope[None, None]{Data: nil}
+	if err := app.WriteJSON(w, http.StatusOK, response, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func namespaceFromContext(r *http.Request) (string, error) {
+	if namespace, ok := r.Context().Value(constants.NamespaceHeaderParameterKey).(string); ok && strings.TrimSpace(namespace) != "" {
+		return namespace, nil
+	}
+	namespace := r.URL.Query().Get("namespace")
+	if strings.TrimSpace(namespace) == "" {
+		return "", errors.New("namespace is required")
+	}
+	return namespace, nil
+}

--- a/packages/maas/bff/internal/api/externalmodel_handlers_test.go
+++ b/packages/maas/bff/internal/api/externalmodel_handlers_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+var _ = Describe("ExternalModelHandlers", Ordered, func() {
+	identity := &kubernetes.RequestIdentity{UserID: "user@example.com"}
+
+	It("lists ExternalModels", func() {
+		actual, rs, err := setupApiTest[Envelope[[]models.ExternalModelSummary, None]](
+			http.MethodGet,
+			"/api/v1/externalmodel?namespace=maas-models",
+			nil,
+			k8Factory,
+			identity,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		Expect(len(actual.Data)).To(BeNumerically(">=", 1))
+
+		var gptModel *models.ExternalModelSummary
+		for i := range actual.Data {
+			if actual.Data[i].Name == "gpt-4o-external" {
+				gptModel = &actual.Data[i]
+				break
+			}
+		}
+		Expect(gptModel).NotTo(BeNil())
+		Expect(gptModel.DisplayName).To(Equal("GPT-4o External"))
+		Expect(gptModel.ProviderRefs).NotTo(BeEmpty())
+		Expect(gptModel.ProviderRefs[0].Provider).NotTo(BeNil())
+		Expect(gptModel.ProviderRefs[0].Provider.EndpointUrl).To(Equal("api.openai.com"))
+		Expect(gptModel.ProviderRefs[0].Provider.DisplayName).To(Equal("OpenAI Production"))
+		Expect(gptModel.MaaSModelRef).NotTo(BeNil())
+		Expect(gptModel.MaaSModelRef.Endpoint).To(Equal("https://gpt-4o-external.maas.example.com"))
+		Expect(gptModel.MaaSModelRef.Phase).To(Equal("Ready"))
+		Expect(gptModel.MaaSModelRef.StatusMessage).To(Equal("Published external GPT-4o model"))
+		Expect(gptModel.StatusMessage).To(Equal("External model is ready"))
+		Expect(gptModel.ProviderRefs[0].Provider.StatusMessage).To(Equal("External provider is ready"))
+	})
+
+	It("deletes an ExternalModel and its companion MaaSModelRef", func() {
+		const refName = "gpt-4o-external"
+		const namespace = "maas-models"
+
+		listBefore, rs1, err := setupApiTest[Envelope[[]models.ExternalModelSummary, None]](
+			http.MethodGet,
+			fmt.Sprintf("/api/v1/externalmodel?namespace=%s", namespace),
+			nil,
+			k8Factory,
+			identity,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs1.StatusCode).To(Equal(http.StatusOK))
+
+		var found bool
+		for _, item := range listBefore.Data {
+			if item.Name == refName {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(), "expected envtest fixture %s to exist before delete", refName)
+
+		_, rs2, err := setupApiTest[Envelope[None, None]](
+			http.MethodDelete,
+			fmt.Sprintf("/api/v1/externalmodel/%s/%s", namespace, refName),
+			nil,
+			k8Factory,
+			identity,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs2.StatusCode).To(Equal(http.StatusOK))
+
+		_, rs3, err := setupApiTest[Envelope[*models.MaaSModelRefSummary, None]](
+			http.MethodPut,
+			fmt.Sprintf("/api/v1/maasmodel/%s/%s", namespace, refName),
+			Envelope[models.UpdateMaaSModelRefRequest, None]{
+				Data: models.UpdateMaaSModelRefRequest{
+					ModelRef: models.ModelReference{Kind: "ExternalModel", Name: refName},
+				},
+			},
+			k8Factory,
+			identity,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs3.StatusCode).To(Equal(http.StatusNotFound))
+
+		listAfter, rs4, err := setupApiTest[Envelope[[]models.ExternalModelSummary, None]](
+			http.MethodGet,
+			fmt.Sprintf("/api/v1/externalmodel?namespace=%s", namespace),
+			nil,
+			k8Factory,
+			identity,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs4.StatusCode).To(Equal(http.StatusOK))
+
+		for _, item := range listAfter.Data {
+			Expect(item.Name).NotTo(Equal(refName))
+		}
+	})
+})

--- a/packages/maas/bff/internal/api/healthcheck_handler_test.go
+++ b/packages/maas/bff/internal/api/healthcheck_handler_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestHealthCheckHandler(t *testing.T) {
-	repos, err := repositories.NewRepositories(nil, nil, config.EnvConfig{}, nil, nil, nil, nil)
+	repos, err := repositories.NewRepositories(nil, nil, config.EnvConfig{}, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 	app := App{config: config.EnvConfig{
 		Port: 4000,

--- a/packages/maas/bff/internal/api/namespaces_handler_test.go
+++ b/packages/maas/bff/internal/api/namespaces_handler_test.go
@@ -24,7 +24,7 @@ var _ = Describe("TestNamespacesHandler", func() {
 
 		BeforeAll(func() {
 			By("setting up the test app in dev mode")
-			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			testApp = App{
@@ -61,8 +61,8 @@ var _ = Describe("TestNamespacesHandler", func() {
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
 			By("validating the response contains only dora-namespace")
-			doraDisplayName := "dora-namespace-maas"
-			expected := []models.NamespaceModel{{Name: "dora-namespace-maas", DisplayName: &doraDisplayName}}
+			doraDisplayName := "dora-namespace"
+			expected := []models.NamespaceModel{{Name: "dora-namespace", DisplayName: &doraDisplayName}}
 			Expect(actual.Data).To(ConsistOf(expected))
 		})
 
@@ -91,14 +91,18 @@ var _ = Describe("TestNamespacesHandler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
-			By("validating the response contains all namespaces")
-			maasDisplayName := "default-maas"
-			doraDisplayName := "dora-namespace-maas"
+			By("validating the response contains accessible namespaces and excludes system namespaces")
+			doraDisplayName := "dora-namespace"
 			expected := []models.NamespaceModel{
-				{Name: "default-maas", DisplayName: &maasDisplayName},
-				{Name: "dora-namespace-maas", DisplayName: &doraDisplayName},
+				{Name: "dora-namespace", DisplayName: &doraDisplayName},
 			}
 			Expect(actual.Data).To(ContainElements(expected))
+
+			names := make([]string, 0, len(actual.Data))
+			for _, ns := range actual.Data {
+				names = append(names, ns.Name)
+			}
+			Expect(names).NotTo(ContainElement("openshift-ingress"))
 		})
 
 		It("should return no namespaces for non-existent user", func() {
@@ -137,7 +141,7 @@ var _ = Describe("TestNamespacesHandler", func() {
 			By("setting up the test app in dev mode")
 			kubernetesMockedTokenClientFactory, err := k8mocks.NewTokenClientFactory(clientset, restConfig, logger)
 			Expect(err).NotTo(HaveOccurred())
-			repos, err := repositories.NewRepositories(logger, kubernetesMockedTokenClientFactory, envConfig, nil, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, kubernetesMockedTokenClientFactory, envConfig, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			testApp = App{
 				config:                  config.EnvConfig{DevMode: true},

--- a/packages/maas/bff/internal/api/test_utils.go
+++ b/packages/maas/bff/internal/api/test_utils.go
@@ -59,9 +59,10 @@ func setupApiTest[T any](method, url string, body interface{}, k8Factory kuberne
 	subscriptionsRepo := repositories.NewSubscriptionsRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 	policiesRepo := repositories.NewPoliciesRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 	modelRefsRepo := repositories.NewMaaSModelRefsRepository(logger, k8Factory)
+	externalModelsRepo := repositories.NewExternalModelsRepository(logger, k8Factory, modelRefsRepo)
 	yamlRepo := repositories.NewYamlRepository(logger, k8Factory, envConfig.MaaSSubscriptionNamespace)
 
-	repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, subscriptionsRepo, policiesRepo, modelRefsRepo, yamlRepo)
+	repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, subscriptionsRepo, policiesRepo, modelRefsRepo, externalModelsRepo, yamlRepo)
 	if err != nil {
 		return empty, nil, err
 	}

--- a/packages/maas/bff/internal/api/user_handler_test.go
+++ b/packages/maas/bff/internal/api/user_handler_test.go
@@ -35,7 +35,7 @@ var _ = Describe("TestUserHandler", func() {
 
 		BeforeAll(func() {
 			By("creating the test app")
-			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil)
+			repos, err := repositories.NewRepositories(logger, k8Factory, envConfig, nil, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			testApp = App{
 				kubernetesClientFactory: k8Factory,

--- a/packages/maas/bff/internal/constants/annotations.go
+++ b/packages/maas/bff/internal/constants/annotations.go
@@ -1,0 +1,7 @@
+package constants
+
+// OpenShift resource annotation keys used for human-readable metadata on CRs and namespaces.
+const (
+	DisplayNameAnnotation = "openshift.io/display-name"
+	DescriptionAnnotation = "openshift.io/description"
+)

--- a/packages/maas/bff/internal/constants/api_routes.go
+++ b/packages/maas/bff/internal/constants/api_routes.go
@@ -43,4 +43,8 @@ const (
 
 	// YAML export
 	YamlPath = ApiPathPrefix + "/yaml"
+
+	// ExternalModel routes
+	ExternalModelListPath   = ApiPathPrefix + "/externalmodel"
+	ExternalModelDeletePath = ApiPathPrefix + "/externalmodel/:namespace/:name"
 )

--- a/packages/maas/bff/internal/constants/gvr.go
+++ b/packages/maas/bff/internal/constants/gvr.go
@@ -33,6 +33,18 @@ var (
 		Resource: "maasmodelrefs",
 	}
 
+	ExternalProviderGvr = schema.GroupVersionResource{
+		Group:    "inference.opendatahub.io",
+		Version:  "v1alpha1",
+		Resource: "externalproviders",
+	}
+
+	ExternalModelGvr = schema.GroupVersionResource{
+		Group:    "inference.opendatahub.io",
+		Version:  "v1alpha1",
+		Resource: "externalmodels",
+	}
+
 	GroupGvr = schema.GroupVersionResource{
 		Group:    "user.openshift.io",
 		Version:  "v1",

--- a/packages/maas/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/packages/maas/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -12,6 +12,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -19,6 +20,56 @@ import (
 	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	kubernetes2 "github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
 )
+
+func readyResourceStatus(phase, message string) map[string]interface{} {
+	return map[string]interface{}{
+		"phase": phase,
+		"conditions": []interface{}{
+			map[string]interface{}{
+				"type":               "Ready",
+				"status":             "True",
+				"reason":             "Reconciled",
+				"message":            message,
+				"lastTransitionTime": "2026-01-01T00:00:00Z",
+			},
+		},
+	}
+}
+
+func readyResourceStatusWithEndpoint(phase, message, endpoint string) map[string]interface{} {
+	status := readyResourceStatus(phase, message)
+	if endpoint != "" {
+		status["endpoint"] = endpoint
+	}
+	return status
+}
+
+func createDynamicResourceWithStatus(
+	ctx context.Context,
+	dynamicClient dynamic.Interface,
+	gvr schema.GroupVersionResource,
+	obj map[string]interface{},
+) error {
+	namespace := obj["metadata"].(map[string]interface{})["namespace"].(string)
+	resource := &unstructured.Unstructured{Object: obj}
+	status, hasStatus, _ := unstructured.NestedMap(resource.Object, "status")
+	if hasStatus {
+		unstructured.RemoveNestedField(resource.Object, "status")
+	}
+
+	created, err := dynamicClient.Resource(gvr).Namespace(namespace).Create(ctx, resource, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	if !hasStatus {
+		return nil
+	}
+
+	created.Object["status"] = status
+	_, err = dynamicClient.Resource(gvr).Namespace(namespace).UpdateStatus(ctx, created, metav1.UpdateOptions{})
+	return err
+}
 
 var DefaultTestUsers = []TestUser{
 	{
@@ -156,6 +207,21 @@ func setupMock(mockK8sClient kubernetes.Interface, mockDynamicClient dynamic.Int
 	}
 
 	err = createMaaSModelRefs(mockDynamicClient, ctx)
+	if err != nil {
+		return err
+	}
+
+	err = createExternalProviders(mockDynamicClient, ctx)
+	if err != nil {
+		return err
+	}
+
+	err = createExternalModels(mockDynamicClient, ctx)
+	if err != nil {
+		return err
+	}
+
+	err = createExternalSecrets(mockK8sClient, ctx)
 	if err != nil {
 		return err
 	}
@@ -477,16 +543,138 @@ func createMaaSModelRefs(dynamicClient dynamic.Interface, ctx context.Context) e
 				},
 			},
 		},
+		{
+			"apiVersion": "maas.opendatahub.io/v1alpha1",
+			"kind":       "MaaSModelRef",
+			"metadata": map[string]interface{}{
+				"name":      "gpt-4o-external",
+				"namespace": "maas-models",
+				"annotations": map[string]interface{}{
+					"openshift.io/display-name": "GPT-4o External",
+					"openshift.io/description":  "Published external GPT-4o model.",
+				},
+			},
+			"spec": map[string]interface{}{
+				"modelRef": map[string]interface{}{
+					"kind": "ExternalModel",
+					"name": "gpt-4o-external",
+				},
+			},
+			"status": readyResourceStatusWithEndpoint(
+				"Ready",
+				"Published external GPT-4o model",
+				"https://gpt-4o-external.maas.example.com",
+			),
+		},
 	}
 
 	for _, ref := range refs {
-		_, err := dynamicClient.Resource(constants.MaaSModelRefGvr).Namespace(ref["metadata"].(map[string]interface{})["namespace"].(string)).Create(
-			ctx, &unstructured.Unstructured{Object: ref}, metav1.CreateOptions{})
-		if err != nil {
+		if err := createDynamicResourceWithStatus(ctx, dynamicClient, constants.MaaSModelRefGvr, ref); err != nil {
 			return fmt.Errorf("failed to create MaaSModelRef: %w", err)
 		}
 	}
 
+	return nil
+}
+
+func createExternalProviders(dynamicClient dynamic.Interface, ctx context.Context) error {
+	providers := []map[string]interface{}{
+		{
+			"apiVersion": "inference.opendatahub.io/v1alpha1",
+			"kind":       "ExternalProvider",
+			"metadata": map[string]interface{}{
+				"name":      "openai-prod",
+				"namespace": "maas-models",
+				"annotations": map[string]interface{}{
+					"openshift.io/display-name": "OpenAI Production",
+					"openshift.io/description":  "Production OpenAI endpoint.",
+				},
+			},
+			"spec": map[string]interface{}{
+				"provider": "openai",
+				"endpoint": "api.openai.com",
+				"auth": map[string]interface{}{
+					"type": "apikey",
+					"secretRef": map[string]interface{}{
+						"name": "openai-api-key",
+					},
+				},
+				"config": map[string]interface{}{
+					"organization": "test-org",
+				},
+			},
+			"status": readyResourceStatus("Ready", "External provider is ready"),
+		},
+	}
+
+	for _, provider := range providers {
+		if err := createDynamicResourceWithStatus(ctx, dynamicClient, constants.ExternalProviderGvr, provider); err != nil {
+			return fmt.Errorf("failed to create ExternalProvider: %w", err)
+		}
+	}
+	return nil
+}
+
+func createExternalModels(dynamicClient dynamic.Interface, ctx context.Context) error {
+	models := []map[string]interface{}{
+		{
+			"apiVersion": "inference.opendatahub.io/v1alpha1",
+			"kind":       "ExternalModel",
+			"metadata": map[string]interface{}{
+				"name":      "gpt-4o-external",
+				"namespace": "maas-models",
+				"annotations": map[string]interface{}{
+					"openshift.io/display-name": "GPT-4o External",
+					"openshift.io/description":  "External GPT-4o model.",
+				},
+			},
+			"spec": map[string]interface{}{
+				"modelName": "gpt-4o",
+				"externalProviderRefs": []interface{}{
+					map[string]interface{}{
+						"ref": map[string]interface{}{
+							"name": "openai-prod",
+						},
+						"weight":      100,
+						"apiFormat":   "openai-chat",
+						"path":        "/v1/chat/completions",
+						"targetModel": "gpt-4o",
+						"config": map[string]interface{}{
+							"deployment": "production",
+						},
+					},
+				},
+			},
+			"status": readyResourceStatus("Ready", "External model is ready"),
+		},
+	}
+
+	for _, model := range models {
+		if err := createDynamicResourceWithStatus(ctx, dynamicClient, constants.ExternalModelGvr, model); err != nil {
+			return fmt.Errorf("failed to create ExternalModel: %w", err)
+		}
+	}
+	return nil
+}
+
+func createExternalSecrets(k8sClient kubernetes.Interface, ctx context.Context) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openai-api-key",
+			Namespace: "maas-models",
+			Labels: map[string]string{
+				"inference.networking.k8s.io/bbr-managed": "true",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"api-key": "test-key-value",
+		},
+	}
+	_, err := k8sClient.CoreV1().Secrets("maas-models").Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create Secret: %w", err)
+	}
 	return nil
 }
 

--- a/packages/maas/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/packages/maas/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -211,17 +211,7 @@ func setupMock(mockK8sClient kubernetes.Interface, mockDynamicClient dynamic.Int
 		return err
 	}
 
-	err = createExternalProviders(mockDynamicClient, ctx)
-	if err != nil {
-		return err
-	}
-
-	err = createExternalModels(mockDynamicClient, ctx)
-	if err != nil {
-		return err
-	}
-
-	err = createExternalSecrets(mockK8sClient, ctx)
+	err = seedExternalModelListFixtures(mockDynamicClient, ctx)
 	if err != nil {
 		return err
 	}
@@ -577,104 +567,73 @@ func createMaaSModelRefs(dynamicClient dynamic.Interface, ctx context.Context) e
 	return nil
 }
 
-func createExternalProviders(dynamicClient dynamic.Interface, ctx context.Context) error {
-	providers := []map[string]interface{}{
-		{
-			"apiVersion": "inference.opendatahub.io/v1alpha1",
-			"kind":       "ExternalProvider",
-			"metadata": map[string]interface{}{
-				"name":      "openai-prod",
-				"namespace": "maas-models",
-				"annotations": map[string]interface{}{
-					"openshift.io/display-name": "OpenAI Production",
-					"openshift.io/description":  "Production OpenAI endpoint.",
-				},
+// seedExternalModelListFixtures installs envtest CRs used by list/delete handler tests.
+// This seeds the cluster directly; it is not exercising BFF create endpoints.
+func seedExternalModelListFixtures(dynamicClient dynamic.Interface, ctx context.Context) error {
+	provider := map[string]interface{}{
+		"apiVersion": "inference.opendatahub.io/v1alpha1",
+		"kind":       "ExternalProvider",
+		"metadata": map[string]interface{}{
+			"name":      "openai-prod",
+			"namespace": "maas-models",
+			"annotations": map[string]interface{}{
+				"openshift.io/display-name": "OpenAI Production",
+				"openshift.io/description":  "Production OpenAI endpoint.",
 			},
-			"spec": map[string]interface{}{
-				"provider": "openai",
-				"endpoint": "api.openai.com",
-				"auth": map[string]interface{}{
-					"type": "apikey",
-					"secretRef": map[string]interface{}{
-						"name": "openai-api-key",
-					},
-				},
-				"config": map[string]interface{}{
-					"organization": "test-org",
-				},
-			},
-			"status": readyResourceStatus("Ready", "External provider is ready"),
 		},
-	}
-
-	for _, provider := range providers {
-		if err := createDynamicResourceWithStatus(ctx, dynamicClient, constants.ExternalProviderGvr, provider); err != nil {
-			return fmt.Errorf("failed to create ExternalProvider: %w", err)
-		}
-	}
-	return nil
-}
-
-func createExternalModels(dynamicClient dynamic.Interface, ctx context.Context) error {
-	models := []map[string]interface{}{
-		{
-			"apiVersion": "inference.opendatahub.io/v1alpha1",
-			"kind":       "ExternalModel",
-			"metadata": map[string]interface{}{
-				"name":      "gpt-4o-external",
-				"namespace": "maas-models",
-				"annotations": map[string]interface{}{
-					"openshift.io/display-name": "GPT-4o External",
-					"openshift.io/description":  "External GPT-4o model.",
+		"spec": map[string]interface{}{
+			"provider": "openai",
+			"endpoint": "api.openai.com",
+			"auth": map[string]interface{}{
+				"type": "apikey",
+				"secretRef": map[string]interface{}{
+					"name": "openai-api-key",
 				},
 			},
-			"spec": map[string]interface{}{
-				"modelName": "gpt-4o",
-				"externalProviderRefs": []interface{}{
-					map[string]interface{}{
-						"ref": map[string]interface{}{
-							"name": "openai-prod",
-						},
-						"weight":      100,
-						"apiFormat":   "openai-chat",
-						"path":        "/v1/chat/completions",
-						"targetModel": "gpt-4o",
-						"config": map[string]interface{}{
-							"deployment": "production",
-						},
+			"config": map[string]interface{}{
+				"organization": "test-org",
+			},
+		},
+		"status": readyResourceStatus("Ready", "External provider is ready"),
+	}
+	if err := createDynamicResourceWithStatus(ctx, dynamicClient, constants.ExternalProviderGvr, provider); err != nil {
+		return fmt.Errorf("failed to seed ExternalProvider fixture: %w", err)
+	}
+
+	model := map[string]interface{}{
+		"apiVersion": "inference.opendatahub.io/v1alpha1",
+		"kind":       "ExternalModel",
+		"metadata": map[string]interface{}{
+			"name":      "gpt-4o-external",
+			"namespace": "maas-models",
+			"annotations": map[string]interface{}{
+				"openshift.io/display-name": "GPT-4o External",
+				"openshift.io/description":  "External GPT-4o model.",
+			},
+		},
+		"spec": map[string]interface{}{
+			"modelName": "gpt-4o",
+			"externalProviderRefs": []interface{}{
+				map[string]interface{}{
+					"ref": map[string]interface{}{
+						"name": "openai-prod",
+					},
+					"weight":      100,
+					"apiFormat":   "openai-chat",
+					"path":        "/v1/chat/completions",
+					"targetModel": "gpt-4o",
+					"config": map[string]interface{}{
+						"deployment": "production",
 					},
 				},
 			},
-			"status": readyResourceStatus("Ready", "External model is ready"),
 		},
+		"status": readyResourceStatus("Ready", "External model is ready"),
+	}
+	if err := createDynamicResourceWithStatus(ctx, dynamicClient, constants.ExternalModelGvr, model); err != nil {
+		return fmt.Errorf("failed to seed ExternalModel fixture: %w", err)
 	}
 
-	for _, model := range models {
-		if err := createDynamicResourceWithStatus(ctx, dynamicClient, constants.ExternalModelGvr, model); err != nil {
-			return fmt.Errorf("failed to create ExternalModel: %w", err)
-		}
-	}
-	return nil
-}
-
-func createExternalSecrets(k8sClient kubernetes.Interface, ctx context.Context) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "openai-api-key",
-			Namespace: "maas-models",
-			Labels: map[string]string{
-				"inference.networking.k8s.io/bbr-managed": "true",
-			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		StringData: map[string]string{
-			"api-key": "test-key-value",
-		},
-	}
-	_, err := k8sClient.CoreV1().Secrets("maas-models").Create(ctx, secret, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create Secret: %w", err)
-	}
 	return nil
 }
 

--- a/packages/maas/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/packages/maas/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -540,8 +540,8 @@ func createMaaSModelRefs(dynamicClient dynamic.Interface, ctx context.Context) e
 				"name":      "gpt-4o-external",
 				"namespace": "maas-models",
 				"annotations": map[string]interface{}{
-					"openshift.io/display-name": "GPT-4o External",
-					"openshift.io/description":  "Published external GPT-4o model.",
+					constants.DisplayNameAnnotation: "GPT-4o External",
+					constants.DescriptionAnnotation: "Published external GPT-4o model.",
 				},
 			},
 			"spec": map[string]interface{}{
@@ -577,8 +577,8 @@ func seedExternalModelListFixtures(dynamicClient dynamic.Interface, ctx context.
 			"name":      "openai-prod",
 			"namespace": "maas-models",
 			"annotations": map[string]interface{}{
-				"openshift.io/display-name": "OpenAI Production",
-				"openshift.io/description":  "Production OpenAI endpoint.",
+				constants.DisplayNameAnnotation: "OpenAI Production",
+				constants.DescriptionAnnotation: "Production OpenAI endpoint.",
 			},
 		},
 		"spec": map[string]interface{}{
@@ -607,8 +607,8 @@ func seedExternalModelListFixtures(dynamicClient dynamic.Interface, ctx context.
 			"name":      "gpt-4o-external",
 			"namespace": "maas-models",
 			"annotations": map[string]interface{}{
-				"openshift.io/display-name": "GPT-4o External",
-				"openshift.io/description":  "External GPT-4o model.",
+				constants.DisplayNameAnnotation: "GPT-4o External",
+				constants.DescriptionAnnotation: "External GPT-4o model.",
 			},
 		},
 		"spec": map[string]interface{}{

--- a/packages/maas/bff/internal/integrations/kubernetes/k8mocks/mock_factory.go
+++ b/packages/maas/bff/internal/integrations/kubernetes/k8mocks/mock_factory.go
@@ -173,7 +173,12 @@ func (f *MockedTokenClientFactory) GetClient(ctx context.Context) (k8s.Kubernete
 		return nil, fmt.Errorf("failed to create impersonated client: %w", err)
 	}
 
-	client := newMockedTokenKubernetesClientFromClientset(clientset, f.logger)
+	dynamicClient, err := dynamic.NewForConfig(impersonatedCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create impersonated dynamic client: %w", err)
+	}
+
+	client := newMockedTokenKubernetesClientFromClientset(clientset, dynamicClient, f.logger)
 	f.clients[identity.Token] = client
 	return client, nil
 }

--- a/packages/maas/bff/internal/integrations/kubernetes/k8mocks/token_k8s_client_mock.go
+++ b/packages/maas/bff/internal/integrations/kubernetes/k8mocks/token_k8s_client_mock.go
@@ -1,9 +1,14 @@
 package k8mocks
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 
 	k8s "github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -16,13 +21,14 @@ type TokenKubernetesClientMock struct {
 	*k8s.TokenKubernetesClient
 }
 
-func newMockedTokenKubernetesClientFromClientset(clientset kubernetes.Interface, logger *slog.Logger) k8s.KubernetesClientInterface {
+func newMockedTokenKubernetesClientFromClientset(clientset kubernetes.Interface, dynamicClient dynamic.Interface, logger *slog.Logger) k8s.KubernetesClientInterface {
 	return &TokenKubernetesClientMock{
 		TokenKubernetesClient: &k8s.TokenKubernetesClient{
 			SharedClientLogic: k8s.SharedClientLogic{
-				Client: clientset,
-				Logger: logger,
-				Token:  k8s.NewBearerToken(""), // Unused because impersonation is already handled in the client config
+				Client:        clientset,
+				DynamicClient: dynamicClient,
+				Logger:        logger,
+				Token:         k8s.NewBearerToken(""), // Unused because impersonation is already handled in the client config
 			},
 		},
 	}
@@ -30,6 +36,15 @@ func newMockedTokenKubernetesClientFromClientset(clientset kubernetes.Interface,
 
 // GetServiceDetails overrides to simulate ClusterIP for localhost access
 // Client service discovery removed in minimal starter.
+
+// GetNamespaces lists namespaces from the envtest cluster.
+func (m *TokenKubernetesClientMock) GetNamespaces(ctx context.Context, identity *k8s.RequestIdentity) ([]corev1.Namespace, error) {
+	nsList, err := m.Client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespaces: %w", err)
+	}
+	return nsList.Items, nil
+}
 
 // BearerToken always returns a fake token for tests
 func (m *TokenKubernetesClientMock) BearerToken() (string, error) {

--- a/packages/maas/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/maas/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -10,6 +10,7 @@ import (
 	authnv1 "k8s.io/api/authentication/v1"
 	authv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -173,6 +174,10 @@ func (kc *TokenKubernetesClient) GetNamespaces(ctx context.Context, identity *Re
 	if err == nil {
 		kc.Logger.Debug("user can list namespaces cluster-wide", "count", len(nsList.Items))
 		return nsList.Items, nil
+	}
+	if !apierrors.IsForbidden(err) {
+		kc.Logger.Error("failed to list namespaces cluster-wide", "error", err)
+		return nil, fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
 	kc.Logger.Debug("falling back to OpenShift Projects API", "error", err)

--- a/packages/maas/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/maas/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -11,6 +11,7 @@ import (
 	authv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -156,19 +157,59 @@ func (kc *TokenKubernetesClient) CanAccessServiceInNamespace(ctx context.Context
 	return true, nil
 }
 
-// RequestIdentity is unused because the token already represents the user identity.
-// This endpoint is used only on dev mode that is why is safe to ignore permissions errors
-func (kc *TokenKubernetesClient) GetNamespaces(ctx context.Context, _ *RequestIdentity) ([]corev1.Namespace, error) {
+// GetNamespaces returns namespaces accessible to the user.
+// For cluster admins, returns all namespaces.
+// For regular users, uses OpenShift Projects API which returns only accessible projects.
+func (kc *TokenKubernetesClient) GetNamespaces(ctx context.Context, identity *RequestIdentity) ([]corev1.Namespace, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	nsList, err := kc.Client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		kc.Logger.Error("user is not allowed to list namespaces or failed to list namespaces")
-		return []corev1.Namespace{}, fmt.Errorf("failed to list namespaces: %w", err)
+	if identity == nil {
+		kc.Logger.Error("identity is nil")
+		return nil, fmt.Errorf("identity cannot be nil")
 	}
 
-	return nsList.Items, nil
+	nsList, err := kc.Client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err == nil {
+		kc.Logger.Debug("user can list namespaces cluster-wide", "count", len(nsList.Items))
+		return nsList.Items, nil
+	}
+
+	kc.Logger.Debug("falling back to OpenShift Projects API", "error", err)
+
+	projectGVR := schema.GroupVersionResource{
+		Group:    "project.openshift.io",
+		Version:  "v1",
+		Resource: "projects",
+	}
+
+	projectList, err := kc.DynamicClient.Resource(projectGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		kc.Logger.Error("failed to list OpenShift projects", "error", err)
+		return nil, fmt.Errorf("failed to list projects: %w", err)
+	}
+
+	namespaces := make([]corev1.Namespace, 0, len(projectList.Items))
+	for _, project := range projectList.Items {
+		projectName := project.GetName()
+
+		ns, getErr := kc.Client.CoreV1().Namespaces().Get(ctx, projectName, metav1.GetOptions{})
+		if getErr != nil {
+			kc.Logger.Warn("failed to get namespace details", "namespace", projectName, "error", getErr)
+			namespaces = append(namespaces, corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        projectName,
+					Annotations: project.GetAnnotations(),
+					Labels:      project.GetLabels(),
+				},
+			})
+			continue
+		}
+		namespaces = append(namespaces, *ns)
+	}
+
+	kc.Logger.Debug("listed namespaces via OpenShift Projects API", "count", len(namespaces))
+	return namespaces, nil
 }
 
 func (kc *TokenKubernetesClient) CheckSelfAccess(ctx context.Context, group, resource, verb, namespace string) (bool, error) {

--- a/packages/maas/bff/internal/mocks/external_mock.go
+++ b/packages/maas/bff/internal/mocks/external_mock.go
@@ -65,7 +65,7 @@ func GetMockExternalModelSummaries() []models.ExternalModelSummary {
 					TargetModel:  "gpt-4o",
 				},
 			},
-			Phase: "Ready",
+			Phase:         "Ready",
 			StatusMessage: "External model is ready",
 		},
 		{
@@ -93,7 +93,7 @@ func GetMockExternalModelSummaries() []models.ExternalModelSummary {
 					},
 				},
 			},
-			Phase: "Ready",
+			Phase:         "Ready",
 			StatusMessage: "External model is ready",
 		},
 	}

--- a/packages/maas/bff/internal/mocks/external_mock.go
+++ b/packages/maas/bff/internal/mocks/external_mock.go
@@ -1,0 +1,100 @@
+package mocks
+
+import (
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+// GetMockExternalProviderSummaries returns mock ExternalProvider summaries.
+func GetMockExternalProviderSummaries() []models.ExternalProviderSummary {
+	return []models.ExternalProviderSummary{
+		{
+			Name:                "openai-prod",
+			Namespace:           "maas-models",
+			DisplayName:         "OpenAI Production",
+			Description:         "Production OpenAI endpoint for chat models.",
+			EndpointUrl:         "api.openai.com",
+			AuthMechanism:       models.AuthMechanismAPIKey,
+			CredentialSecretRef: "openai-api-key",
+			Provider:            "openai",
+			Phase:               "Ready",
+			StatusMessage:       "External provider is ready",
+		},
+		{
+			Name:                "anthropic-dev",
+			Namespace:           "maas-models",
+			DisplayName:         "Anthropic Development",
+			Description:         "Development Anthropic endpoint.",
+			EndpointUrl:         "api.anthropic.com",
+			AuthMechanism:       models.AuthMechanismAPIKey,
+			CredentialSecretRef: "anthropic-api-key",
+			Provider:            "anthropic",
+			Phase:               "Ready",
+		},
+		{
+			Name:                "bedrock-us-east",
+			Namespace:           "maas-models",
+			DisplayName:         "AWS Bedrock US East",
+			Description:         "SigV4-authenticated Bedrock endpoint.",
+			EndpointUrl:         "bedrock.us-east-1.amazonaws.com",
+			AuthMechanism:       models.AuthMechanismSigV4,
+			CredentialSecretRef: "bedrock-credentials",
+			Provider:            "aws-bedrock",
+			Config: map[string]string{
+				"region": "us-east-1",
+			},
+			Phase: "Pending",
+		},
+	}
+}
+
+// GetMockExternalModelSummaries returns mock ExternalModel summaries.
+func GetMockExternalModelSummaries() []models.ExternalModelSummary {
+	return []models.ExternalModelSummary{
+		{
+			Name:        "gpt-4o-external",
+			Namespace:   "maas-models",
+			DisplayName: "GPT-4o External",
+			Description: "External GPT-4o model routed through OpenAI provider.",
+			ModelName:   "gpt-4o",
+			ProviderRefs: []models.ProviderRef{
+				{
+					ProviderName: "openai-prod",
+					Weight:       100,
+					APIFormat:    "openai-chat",
+					Path:         "/v1/chat/completions",
+					TargetModel:  "gpt-4o",
+				},
+			},
+			Phase: "Ready",
+			StatusMessage: "External model is ready",
+		},
+		{
+			Name:        "claude-split",
+			Namespace:   "maas-models",
+			DisplayName: "Claude A/B Split",
+			Description: "Weighted routing across Anthropic and Bedrock providers.",
+			ModelName:   "claude-sonnet",
+			ProviderRefs: []models.ProviderRef{
+				{
+					ProviderName: "anthropic-dev",
+					Weight:       60,
+					APIFormat:    "messages",
+					Path:         "/v1/messages",
+					TargetModel:  "claude-sonnet-4-5-20241022",
+				},
+				{
+					ProviderName: "bedrock-us-east",
+					Weight:       40,
+					APIFormat:    "messages",
+					Path:         "/v1/messages",
+					TargetModel:  "anthropic.claude-3-sonnet",
+					Config: map[string]string{
+						"region": "us-east-1",
+					},
+				},
+			},
+			Phase: "Ready",
+			StatusMessage: "External model is ready",
+		},
+	}
+}

--- a/packages/maas/bff/internal/mocks/subscription_mock.go
+++ b/packages/maas/bff/internal/mocks/subscription_mock.go
@@ -285,6 +285,19 @@ func GetMockMaaSModelRefSummaries() []models.MaaSModelRefSummary {
 			Phase:    "Ready",
 			Endpoint: "https://gemma-7b-it.example.com",
 		},
+		{
+			Name:        "gpt-4o-external",
+			Namespace:   "maas-models",
+			DisplayName: "GPT-4o External",
+			Description: "Published external GPT-4o model.",
+			ModelRef: models.ModelReference{
+				Kind: "ExternalModel",
+				Name: "gpt-4o-external",
+			},
+			Phase:         "Ready",
+			Endpoint:      "https://gpt-4o-external.maas.example.com",
+			StatusMessage: "Published external GPT-4o model",
+		},
 	}
 }
 

--- a/packages/maas/bff/internal/models/externalmodel.go
+++ b/packages/maas/bff/internal/models/externalmodel.go
@@ -1,0 +1,32 @@
+package models
+
+// ProviderRef references an ExternalProvider with routing configuration.
+type ProviderRef struct {
+	ProviderName string                   `json:"providerName"`
+	Weight       int                      `json:"weight"`
+	APIFormat    string                   `json:"apiFormat"`
+	Path         string                   `json:"path"`
+	TargetModel  string                   `json:"targetModel"`
+	Config       map[string]string        `json:"config,omitempty"`
+	Provider     *ExternalProviderDetails `json:"provider,omitempty"`
+}
+
+// ExternalModelMaaSModelRefStatus contains published endpoint details from the companion MaaSModelRef.
+type ExternalModelMaaSModelRefStatus struct {
+	Phase         string `json:"phase,omitempty"`
+	Endpoint      string `json:"endpoint,omitempty"`
+	StatusMessage string `json:"statusMessage,omitempty"`
+}
+
+// ExternalModelSummary is the BFF representation of an ExternalModel CR.
+type ExternalModelSummary struct {
+	Name          string                           `json:"name"`
+	Namespace     string                           `json:"namespace"`
+	DisplayName   string                           `json:"displayName,omitempty"`
+	Description   string                           `json:"description,omitempty"`
+	ModelName     string                           `json:"modelName,omitempty"`
+	ProviderRefs  []ProviderRef                    `json:"providerRefs"`
+	Phase         string                           `json:"phase,omitempty"`
+	StatusMessage string                           `json:"statusMessage,omitempty"`
+	MaaSModelRef  *ExternalModelMaaSModelRefStatus `json:"maaSModelRef,omitempty"`
+}

--- a/packages/maas/bff/internal/models/externalprovider.go
+++ b/packages/maas/bff/internal/models/externalprovider.go
@@ -1,0 +1,47 @@
+package models
+
+// AuthMechanism matches ExternalProvider spec.auth.type in the inference CRD.
+type AuthMechanism string
+
+const (
+	AuthMechanismAPIKey AuthMechanism = "apikey"
+	AuthMechanismSigV4  AuthMechanism = "sigv4"
+	AuthMechanismOAuth2 AuthMechanism = "oauth2"
+)
+
+// IsValid reports whether the auth mechanism is a supported CRD value.
+func (a AuthMechanism) IsValid() bool {
+	switch a {
+	case AuthMechanismAPIKey, AuthMechanismSigV4, AuthMechanismOAuth2:
+		return true
+	default:
+		return false
+	}
+}
+
+// ExternalProviderDetails contains ExternalProvider fields not present on ExternalModel providerRefs.
+type ExternalProviderDetails struct {
+	DisplayName   string            `json:"displayName,omitempty"`
+	Description   string            `json:"description,omitempty"`
+	EndpointUrl   string            `json:"endpointUrl,omitempty"`
+	AuthMechanism AuthMechanism     `json:"authMechanism,omitempty"`
+	Provider      string            `json:"provider,omitempty"`
+	Config        map[string]string `json:"config,omitempty"`
+	Phase         string            `json:"phase,omitempty"`
+	StatusMessage string            `json:"statusMessage,omitempty"`
+}
+
+// ExternalProviderSummary is the BFF representation of an ExternalProvider CR.
+type ExternalProviderSummary struct {
+	Name                string            `json:"name"`
+	Namespace           string            `json:"namespace"`
+	DisplayName         string            `json:"displayName,omitempty"`
+	Description         string            `json:"description,omitempty"`
+	EndpointUrl         string            `json:"endpointUrl"`
+	AuthMechanism       AuthMechanism     `json:"authMechanism"`
+	CredentialSecretRef string            `json:"credentialSecretRef"`
+	Provider            string            `json:"provider,omitempty"`
+	Config              map[string]string `json:"config,omitempty"`
+	Phase               string            `json:"phase,omitempty"`
+	StatusMessage       string            `json:"statusMessage,omitempty"`
+}

--- a/packages/maas/bff/internal/models/namespace.go
+++ b/packages/maas/bff/internal/models/namespace.go
@@ -5,10 +5,12 @@ type NamespaceModel struct {
 	DisplayName *string `json:"displayName,omitempty"`
 }
 
-func NewNamespaceModelFromNamespace(name string) NamespaceModel {
-	displayName := name + "-maas" // For now, use name as display name, but this can be customized later
+func NewNamespaceModelFromNamespace(name string, displayName string) NamespaceModel {
+	if displayName == "" {
+		displayName = name
+	}
 	return NamespaceModel{
-		Name:        name + "-maas",
+		Name:        name,
 		DisplayName: &displayName,
 	}
 }

--- a/packages/maas/bff/internal/models/subscription.go
+++ b/packages/maas/bff/internal/models/subscription.go
@@ -132,8 +132,9 @@ type MaaSModelRefSummary struct {
 	DisplayName string         `json:"displayName,omitempty"`
 	Description string         `json:"description,omitempty"`
 	ModelRef    ModelReference `json:"modelRef"`
-	Phase       string         `json:"phase,omitempty"`
-	Endpoint    string         `json:"endpoint,omitempty"`
+	Phase         string         `json:"phase,omitempty"`
+	Endpoint      string         `json:"endpoint,omitempty"`
+	StatusMessage string         `json:"statusMessage,omitempty"`
 }
 
 // CreateSubscriptionRequest is the request body for creating a new subscription.

--- a/packages/maas/bff/internal/models/subscription.go
+++ b/packages/maas/bff/internal/models/subscription.go
@@ -127,11 +127,11 @@ type ModelReference struct {
 
 // MaaSModelRefSummary is the BFF representation of a MaaSModelRef CR.
 type MaaSModelRefSummary struct {
-	Name        string         `json:"name"`
-	Namespace   string         `json:"namespace"`
-	DisplayName string         `json:"displayName,omitempty"`
-	Description string         `json:"description,omitempty"`
-	ModelRef    ModelReference `json:"modelRef"`
+	Name          string         `json:"name"`
+	Namespace     string         `json:"namespace"`
+	DisplayName   string         `json:"displayName,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	ModelRef      ModelReference `json:"modelRef"`
 	Phase         string         `json:"phase,omitempty"`
 	Endpoint      string         `json:"endpoint,omitempty"`
 	StatusMessage string         `json:"statusMessage,omitempty"`

--- a/packages/maas/bff/internal/repositories/external_helpers.go
+++ b/packages/maas/bff/internal/repositories/external_helpers.go
@@ -28,7 +28,7 @@ func readDisplayAnnotations(annotations map[string]string) (displayName, descrip
 	if annotations == nil {
 		return "", ""
 	}
-	return annotations[displayNameAnnotation], annotations[descriptionAnnotation]
+	return annotations[constants.DisplayNameAnnotation], annotations[constants.DescriptionAnnotation]
 }
 
 func stringMapFromUnstructured(raw map[string]interface{}) map[string]string {

--- a/packages/maas/bff/internal/repositories/external_helpers.go
+++ b/packages/maas/bff/internal/repositories/external_helpers.go
@@ -1,0 +1,204 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+func authMechanismFromCRD(authType string) models.AuthMechanism {
+	switch strings.ToLower(authType) {
+	case string(models.AuthMechanismSigV4):
+		return models.AuthMechanismSigV4
+	case string(models.AuthMechanismOAuth2):
+		return models.AuthMechanismOAuth2
+	default:
+		return models.AuthMechanismAPIKey
+	}
+}
+
+func readDisplayAnnotations(annotations map[string]string) (displayName, description string) {
+	if annotations == nil {
+		return "", ""
+	}
+	return annotations[displayNameAnnotation], annotations[descriptionAnnotation]
+}
+
+func stringMapFromUnstructured(raw map[string]interface{}) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(raw))
+	for key, value := range raw {
+		if str, ok := value.(string); ok {
+			result[key] = str
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func convertUnstructuredToExternalProviderSummary(obj *unstructured.Unstructured) *models.ExternalProviderSummary {
+	content := obj.UnstructuredContent()
+	displayName, description := readDisplayAnnotations(obj.GetAnnotations())
+
+	summary := &models.ExternalProviderSummary{
+		Name:        obj.GetName(),
+		Namespace:   obj.GetNamespace(),
+		DisplayName: displayName,
+		Description: description,
+	}
+
+	endpoint, _, _ := unstructured.NestedString(content, "spec", "endpoint")
+	summary.EndpointUrl = endpoint
+
+	provider, _, _ := unstructured.NestedString(content, "spec", "provider")
+	summary.Provider = provider
+
+	authType, _, _ := unstructured.NestedString(content, "spec", "auth", "type")
+	summary.AuthMechanism = authMechanismFromCRD(authType)
+
+	secretRef, _, _ := unstructured.NestedString(content, "spec", "auth", "secretRef", "name")
+	summary.CredentialSecretRef = secretRef
+
+	configMap, _, _ := unstructured.NestedStringMap(content, "spec", "config")
+	summary.Config = configMap
+
+	phase, _, _ := unstructured.NestedString(content, "status", "phase")
+	summary.Phase = phase
+	summary.StatusMessage = extractReadyConditionMessage(content)
+
+	return summary
+}
+
+func buildExternalProviderSummaryIndex(summaries []models.ExternalProviderSummary) map[string]models.ExternalProviderSummary {
+	idx := make(map[string]models.ExternalProviderSummary, len(summaries))
+	for _, summary := range summaries {
+		idx[summary.Namespace+"/"+summary.Name] = summary
+	}
+	return idx
+}
+
+func externalProviderDetailsFromSummary(summary models.ExternalProviderSummary) *models.ExternalProviderDetails {
+	return &models.ExternalProviderDetails{
+		DisplayName:   summary.DisplayName,
+		Description:   summary.Description,
+		EndpointUrl:   summary.EndpointUrl,
+		AuthMechanism: summary.AuthMechanism,
+		Provider:      summary.Provider,
+		Config:        summary.Config,
+		Phase:         summary.Phase,
+		StatusMessage: summary.StatusMessage,
+	}
+}
+
+func listExternalProviderSummariesInNamespace(
+	ctx context.Context,
+	kubeClient dynamic.Interface,
+	namespace string,
+) ([]models.ExternalProviderSummary, error) {
+	list, err := kubeClient.Resource(constants.ExternalProviderGvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list ExternalProviders: %w", err)
+	}
+
+	summaries := make([]models.ExternalProviderSummary, 0, len(list.Items))
+	for _, item := range list.Items {
+		summaries = append(summaries, *convertUnstructuredToExternalProviderSummary(&item))
+	}
+	return summaries, nil
+}
+
+func enrichExternalModelSummaries(
+	summaries []models.ExternalModelSummary,
+	providers map[string]models.ExternalProviderSummary,
+	modelRefs map[string]models.MaaSModelRefSummary,
+) []models.ExternalModelSummary {
+	for i := range summaries {
+		summary := &summaries[i]
+
+		if modelRef, ok := modelRefs[summary.Namespace+"/"+summary.Name]; ok &&
+			modelRef.ModelRef.Kind == "ExternalModel" && modelRef.ModelRef.Name == summary.Name {
+			summary.MaaSModelRef = &models.ExternalModelMaaSModelRefStatus{
+				Phase:         modelRef.Phase,
+				Endpoint:      modelRef.Endpoint,
+				StatusMessage: modelRef.StatusMessage,
+			}
+		}
+
+		for j := range summary.ProviderRefs {
+			providerKey := summary.Namespace + "/" + summary.ProviderRefs[j].ProviderName
+			if provider, ok := providers[providerKey]; ok {
+				summary.ProviderRefs[j].Provider = externalProviderDetailsFromSummary(provider)
+			}
+		}
+	}
+	return summaries
+}
+
+func convertUnstructuredToExternalModelSummary(obj *unstructured.Unstructured) *models.ExternalModelSummary {
+	content := obj.UnstructuredContent()
+	displayName, description := readDisplayAnnotations(obj.GetAnnotations())
+
+	summary := &models.ExternalModelSummary{
+		Name:        obj.GetName(),
+		Namespace:   obj.GetNamespace(),
+		DisplayName: displayName,
+		Description: description,
+	}
+
+	modelName, _, _ := unstructured.NestedString(content, "spec", "modelName")
+	if modelName != "" {
+		summary.ModelName = modelName
+	} else {
+		summary.ModelName = obj.GetName()
+	}
+
+	refs, _, _ := unstructured.NestedSlice(content, "spec", "externalProviderRefs")
+	summary.ProviderRefs = make([]models.ProviderRef, 0, len(refs))
+	for _, ref := range refs {
+		refMap, ok := ref.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		providerRef := models.ProviderRef{}
+		if refObj, ok := refMap["ref"].(map[string]interface{}); ok {
+			if name, ok := refObj["name"].(string); ok {
+				providerRef.ProviderName = name
+			}
+		}
+		if weight, ok := refMap["weight"].(int64); ok {
+			providerRef.Weight = int(weight)
+		} else if weight, ok := refMap["weight"].(float64); ok {
+			providerRef.Weight = int(weight)
+		}
+		if apiFormat, ok := refMap["apiFormat"].(string); ok {
+			providerRef.APIFormat = apiFormat
+		}
+		if path, ok := refMap["path"].(string); ok {
+			providerRef.Path = path
+		}
+		if targetModel, ok := refMap["targetModel"].(string); ok {
+			providerRef.TargetModel = targetModel
+		}
+		if config, ok := refMap["config"].(map[string]interface{}); ok {
+			providerRef.Config = stringMapFromUnstructured(config)
+		}
+		summary.ProviderRefs = append(summary.ProviderRefs, providerRef)
+	}
+
+	phase, _, _ := unstructured.NestedString(content, "status", "phase")
+	summary.Phase = phase
+	summary.StatusMessage = extractReadyConditionMessage(content)
+
+	return summary
+}

--- a/packages/maas/bff/internal/repositories/external_helpers_test.go
+++ b/packages/maas/bff/internal/repositories/external_helpers_test.go
@@ -1,0 +1,106 @@
+package repositories
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+func TestConvertUnstructuredToExternalProviderSummary(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "inference.opendatahub.io/v1alpha1",
+		"kind":       "ExternalProvider",
+		"metadata": map[string]interface{}{
+			"name":      "openai-prod",
+			"namespace": "maas-models",
+			"annotations": map[string]interface{}{
+				displayNameAnnotation: "OpenAI Production",
+				descriptionAnnotation: "Production endpoint",
+			},
+		},
+		"spec": map[string]interface{}{
+			"provider": "openai",
+			"endpoint": "api.openai.com",
+			"auth": map[string]interface{}{
+				"type": "apikey",
+				"secretRef": map[string]interface{}{
+					"name": "openai-api-key",
+				},
+			},
+			"config": map[string]interface{}{
+				"organization": "test-org",
+			},
+		},
+		"status": map[string]interface{}{
+			"phase": "Ready",
+		},
+	}}
+
+	summary := convertUnstructuredToExternalProviderSummary(obj)
+	if summary.DisplayName != "OpenAI Production" {
+		t.Fatalf("displayName = %q", summary.DisplayName)
+	}
+	if summary.Description != "Production endpoint" {
+		t.Fatalf("description = %q", summary.Description)
+	}
+	if summary.AuthMechanism != models.AuthMechanismAPIKey {
+		t.Fatalf("authMechanism = %q", summary.AuthMechanism)
+	}
+	if summary.Config["organization"] != "test-org" {
+		t.Fatalf("config = %#v", summary.Config)
+	}
+}
+
+func TestEnrichExternalModelSummaries(t *testing.T) {
+	summaries := []models.ExternalModelSummary{
+		{
+			Name:      "gpt-4o-external",
+			Namespace: "maas-models",
+			ProviderRefs: []models.ProviderRef{
+				{ProviderName: "openai-prod", Weight: 100},
+			},
+		},
+	}
+
+	providers := map[string]models.ExternalProviderSummary{
+		"maas-models/openai-prod": {
+			Name:        "openai-prod",
+			Namespace:   "maas-models",
+			DisplayName: "OpenAI Production",
+			EndpointUrl: "api.openai.com",
+			Provider:    "openai",
+			Phase:       "Ready",
+		},
+	}
+
+	modelRefs := map[string]models.MaaSModelRefSummary{
+		"maas-models/gpt-4o-external": {
+			Name:          "gpt-4o-external",
+			Namespace:     "maas-models",
+			ModelRef:      models.ModelReference{Kind: "ExternalModel", Name: "gpt-4o-external"},
+			Phase:         "Ready",
+			Endpoint:      "https://gpt-4o-external.maas.example.com",
+			StatusMessage: "Published external GPT-4o model",
+		},
+	}
+
+	enriched := enrichExternalModelSummaries(summaries, providers, modelRefs)
+
+	if enriched[0].ProviderRefs[0].Provider == nil {
+		t.Fatal("expected provider enrichment")
+	}
+	if enriched[0].ProviderRefs[0].Provider.EndpointUrl != "api.openai.com" {
+		t.Fatalf("endpointUrl = %q", enriched[0].ProviderRefs[0].Provider.EndpointUrl)
+	}
+	if enriched[0].MaaSModelRef == nil {
+		t.Fatal("expected maaSModelRef enrichment")
+	}
+	if enriched[0].MaaSModelRef.Endpoint != "https://gpt-4o-external.maas.example.com" {
+		t.Fatalf("endpoint = %q", enriched[0].MaaSModelRef.Endpoint)
+	}
+	if enriched[0].MaaSModelRef.StatusMessage != "Published external GPT-4o model" {
+		t.Fatalf("statusMessage = %q", enriched[0].MaaSModelRef.StatusMessage)
+	}
+}

--- a/packages/maas/bff/internal/repositories/external_helpers_test.go
+++ b/packages/maas/bff/internal/repositories/external_helpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
 )
 
@@ -16,8 +17,8 @@ func TestConvertUnstructuredToExternalProviderSummary(t *testing.T) {
 			"name":      "openai-prod",
 			"namespace": "maas-models",
 			"annotations": map[string]interface{}{
-				displayNameAnnotation: "OpenAI Production",
-				descriptionAnnotation: "Production endpoint",
+				constants.DisplayNameAnnotation: "OpenAI Production",
+				constants.DescriptionAnnotation: "Production endpoint",
 			},
 		},
 		"spec": map[string]interface{}{

--- a/packages/maas/bff/internal/repositories/externalmodels.go
+++ b/packages/maas/bff/internal/repositories/externalmodels.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,23 +75,23 @@ func (r *ExternalModelsRepository) DeleteExternalModel(ctx context.Context, name
 		return err
 	}
 
-	if err := r.deleteMaaSModelRefForExternalModel(ctx, namespace, name); err != nil {
-		return fmt.Errorf("failed to delete MaaSModelRef for ExternalModel: %w", err)
-	}
-
 	err = client.GetDynamicClient().Resource(constants.ExternalModelGvr).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
-			return fmt.Errorf("ExternalModel '%s' not found", name)
+			return fmt.Errorf("ExternalModel '%s' not found: %w", name, err)
 		}
 		return fmt.Errorf("failed to delete ExternalModel: %w", err)
+	}
+
+	if err := r.deleteMaaSModelRefForExternalModel(ctx, namespace, name); err != nil {
+		return fmt.Errorf("failed to delete MaaSModelRef for ExternalModel: %w", err)
 	}
 	return nil
 }
 
 func (r *ExternalModelsRepository) deleteMaaSModelRefForExternalModel(ctx context.Context, namespace, name string) error {
 	err := r.modelRefsRepo.DeleteMaaSModelRef(ctx, namespace, name, false)
-	if err != nil && strings.Contains(err.Error(), "not found") {
+	if k8sErrors.IsNotFound(err) {
 		return nil
 	}
 	return err

--- a/packages/maas/bff/internal/repositories/externalmodels.go
+++ b/packages/maas/bff/internal/repositories/externalmodels.go
@@ -1,0 +1,99 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
+	"github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+// ExternalModelsRepository handles ExternalModel operations via the Kubernetes API.
+type ExternalModelsRepository struct {
+	logger        *slog.Logger
+	k8sFactory    kubernetes.KubernetesClientFactory
+	modelRefsRepo MaaSModelRefsRepositoryInterface
+}
+
+// NewExternalModelsRepository creates a new ExternalModel repository.
+func NewExternalModelsRepository(logger *slog.Logger, k8sFactory kubernetes.KubernetesClientFactory, modelRefsRepo MaaSModelRefsRepositoryInterface) *ExternalModelsRepository {
+	return &ExternalModelsRepository{
+		logger:        logger,
+		k8sFactory:    k8sFactory,
+		modelRefsRepo: modelRefsRepo,
+	}
+}
+
+// ListExternalModels returns ExternalModel resources in a namespace.
+func (r *ExternalModelsRepository) ListExternalModels(ctx context.Context, namespace string) ([]models.ExternalModelSummary, error) {
+	r.logger.Debug("Listing ExternalModels", slog.String("namespace", namespace))
+
+	client, err := r.k8sFactory.GetClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := client.GetDynamicClient().Resource(constants.ExternalModelGvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list ExternalModels: %w", err)
+	}
+
+	summaries := make([]models.ExternalModelSummary, 0, len(list.Items))
+	for _, item := range list.Items {
+		summaries = append(summaries, *convertUnstructuredToExternalModelSummary(&item))
+	}
+
+	kubeClient := client.GetDynamicClient()
+	providers, err := listExternalProviderSummariesInNamespace(ctx, kubeClient, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	modelRefs, err := listModelRefSummariesInNamespace(ctx, kubeClient, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return enrichExternalModelSummaries(
+		summaries,
+		buildExternalProviderSummaryIndex(providers),
+		buildModelRefSummaryIndex(modelRefs),
+	), nil
+}
+
+// DeleteExternalModel deletes an ExternalModel resource and its companion MaaSModelRef.
+func (r *ExternalModelsRepository) DeleteExternalModel(ctx context.Context, namespace, name string) error {
+	r.logger.Debug("Deleting ExternalModel", slog.String("namespace", namespace), slog.String("name", name))
+
+	client, err := r.k8sFactory.GetClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := r.deleteMaaSModelRefForExternalModel(ctx, namespace, name); err != nil {
+		return fmt.Errorf("failed to delete MaaSModelRef for ExternalModel: %w", err)
+	}
+
+	err = client.GetDynamicClient().Resource(constants.ExternalModelGvr).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return fmt.Errorf("ExternalModel '%s' not found", name)
+		}
+		return fmt.Errorf("failed to delete ExternalModel: %w", err)
+	}
+	return nil
+}
+
+func (r *ExternalModelsRepository) deleteMaaSModelRefForExternalModel(ctx context.Context, namespace, name string) error {
+	err := r.modelRefsRepo.DeleteMaaSModelRef(ctx, namespace, name, false)
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		return nil
+	}
+	return err
+}

--- a/packages/maas/bff/internal/repositories/externalmodels_mock.go
+++ b/packages/maas/bff/internal/repositories/externalmodels_mock.go
@@ -1,0 +1,79 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/mocks"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+// MockExternalModelsRepository returns mock data for development.
+type MockExternalModelsRepository struct {
+	logger        *slog.Logger
+	modelRefsRepo MaaSModelRefsRepositoryInterface
+}
+
+// NewMockExternalModelsRepository creates a new mock ExternalModel repository.
+func NewMockExternalModelsRepository(logger *slog.Logger, modelRefsRepo MaaSModelRefsRepositoryInterface) *MockExternalModelsRepository {
+	return &MockExternalModelsRepository{
+		logger:        logger,
+		modelRefsRepo: modelRefsRepo,
+	}
+}
+
+func (r *MockExternalModelsRepository) ListExternalModels(ctx context.Context, namespace string) ([]models.ExternalModelSummary, error) {
+	r.logger.Debug("Listing ExternalModels (mock)", slog.String("namespace", namespace))
+
+	result := make([]models.ExternalModelSummary, 0)
+	for _, item := range mocks.GetMockExternalModelSummaries() {
+		if item.Namespace == namespace {
+			result = append(result, item)
+		}
+	}
+
+	providers := make([]models.ExternalProviderSummary, 0)
+	for _, item := range mocks.GetMockExternalProviderSummaries() {
+		if item.Namespace == namespace {
+			providers = append(providers, item)
+		}
+	}
+
+	modelRefs, err := r.modelRefsRepo.ListMaaSModelRefs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	filteredModelRefs := make([]models.MaaSModelRefSummary, 0, len(modelRefs))
+	for _, item := range modelRefs {
+		if item.Namespace == namespace {
+			filteredModelRefs = append(filteredModelRefs, item)
+		}
+	}
+
+	return enrichExternalModelSummaries(
+		result,
+		buildExternalProviderSummaryIndex(providers),
+		buildModelRefSummaryIndex(filteredModelRefs),
+	), nil
+}
+
+func (r *MockExternalModelsRepository) DeleteExternalModel(ctx context.Context, namespace, name string) error {
+	r.logger.Debug("Deleting ExternalModel (mock)", slog.String("namespace", namespace), slog.String("name", name))
+
+	for _, item := range mocks.GetMockExternalModelSummaries() {
+		if item.Name == name && item.Namespace == namespace {
+			return r.deleteMaaSModelRefForExternalModel(ctx, namespace, name)
+		}
+	}
+	return fmt.Errorf("ExternalModel '%s' not found", name)
+}
+
+func (r *MockExternalModelsRepository) deleteMaaSModelRefForExternalModel(ctx context.Context, namespace, name string) error {
+	err := r.modelRefsRepo.DeleteMaaSModelRef(ctx, namespace, name, false)
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		return nil
+	}
+	return err
+}

--- a/packages/maas/bff/internal/repositories/maasmodelrefs.go
+++ b/packages/maas/bff/internal/repositories/maasmodelrefs.go
@@ -168,7 +168,7 @@ func (r *MaaSModelRefsRepository) DeleteMaaSModelRef(ctx context.Context, namesp
 	err = kubeClient.Resource(constants.MaaSModelRefGvr).Namespace(namespace).Delete(ctx, name, deleteOpts)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
-			return fmt.Errorf("MaaSModelRef '%s' not found", name)
+			return fmt.Errorf("MaaSModelRef '%s' not found: %w", name, err)
 		}
 		return fmt.Errorf("failed to delete MaaSModelRef: %w", err)
 	}

--- a/packages/maas/bff/internal/repositories/maasmodelrefs.go
+++ b/packages/maas/bff/internal/repositories/maasmodelrefs.go
@@ -122,16 +122,16 @@ func (r *MaaSModelRefsRepository) UpdateMaaSModelRef(ctx context.Context, namesp
 
 	if request.DisplayName != nil {
 		if *request.DisplayName == "" {
-			delete(annotations, displayNameAnnotation)
+			delete(annotations, constants.DisplayNameAnnotation)
 		} else {
-			annotations[displayNameAnnotation] = *request.DisplayName
+			annotations[constants.DisplayNameAnnotation] = *request.DisplayName
 		}
 	}
 	if request.Description != nil {
 		if *request.Description == "" {
-			delete(annotations, descriptionAnnotation)
+			delete(annotations, constants.DescriptionAnnotation)
 		} else {
-			annotations[descriptionAnnotation] = *request.Description
+			annotations[constants.DescriptionAnnotation] = *request.Description
 		}
 	}
 	existing.SetAnnotations(annotations)
@@ -195,10 +195,10 @@ func buildModelRefUnstructured(name, namespace string, modelRef models.ModelRefe
 	}
 	annotations := map[string]string{}
 	if displayName != "" {
-		annotations[displayNameAnnotation] = displayName
+		annotations[constants.DisplayNameAnnotation] = displayName
 	}
 	if description != "" {
-		annotations[descriptionAnnotation] = description
+		annotations[constants.DescriptionAnnotation] = description
 	}
 	obj.SetAnnotations(annotations)
 

--- a/packages/maas/bff/internal/repositories/modelref_helpers.go
+++ b/packages/maas/bff/internal/repositories/modelref_helpers.go
@@ -44,6 +44,26 @@ func listAllModelRefSummaries(ctx context.Context, logger *slog.Logger, kubeClie
 	return summaries, nil
 }
 
+// listModelRefSummariesInNamespace fetches MaaSModelRef CRs in a namespace.
+func listModelRefSummariesInNamespace(
+	ctx context.Context,
+	kubeClient dynamic.Interface,
+	namespace string,
+) ([]models.MaaSModelRefSummary, error) {
+	list, err := kubeClient.Resource(constants.MaaSModelRefGvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list MaaSModelRefs: %w", err)
+	}
+
+	summaries := make([]models.MaaSModelRefSummary, 0, len(list.Items))
+	for _, item := range list.Items {
+		summary := convertUnstructuredToModelRefSummary(&item)
+		summaries = append(summaries, *summary)
+	}
+
+	return summaries, nil
+}
+
 // convertUnstructuredToModelRefSummary converts a MaaSModelRef unstructured object to a MaaSModelRefSummary.
 func convertUnstructuredToModelRefSummary(obj *unstructured.Unstructured) *models.MaaSModelRefSummary {
 	content := obj.UnstructuredContent()
@@ -63,6 +83,7 @@ func convertUnstructuredToModelRefSummary(obj *unstructured.Unstructured) *model
 
 	phase, _, _ := unstructured.NestedString(content, "status", "phase")
 	summary.Phase = phase
+	summary.StatusMessage = extractReadyConditionMessage(content)
 
 	endpoint, _, _ := unstructured.NestedString(content, "status", "endpoint")
 	summary.Endpoint = endpoint

--- a/packages/maas/bff/internal/repositories/modelref_helpers.go
+++ b/packages/maas/bff/internal/repositories/modelref_helpers.go
@@ -13,11 +13,6 @@ import (
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
 )
 
-const (
-	displayNameAnnotation = "openshift.io/display-name"
-	descriptionAnnotation = "openshift.io/description"
-)
-
 // buildModelRefSummaryIndex returns a lookup map from "namespace/name" to MaaSModelRefSummary.
 func buildModelRefSummaryIndex(summaries []models.MaaSModelRefSummary) map[string]models.MaaSModelRefSummary {
 	idx := make(map[string]models.MaaSModelRefSummary, len(summaries))
@@ -74,8 +69,8 @@ func convertUnstructuredToModelRefSummary(obj *unstructured.Unstructured) *model
 	}
 
 	annotations := obj.GetAnnotations()
-	summary.DisplayName = annotations[displayNameAnnotation]
-	summary.Description = annotations[descriptionAnnotation]
+	summary.DisplayName = annotations[constants.DisplayNameAnnotation]
+	summary.Description = annotations[constants.DescriptionAnnotation]
 
 	kind, _, _ := unstructured.NestedString(content, "spec", "modelRef", "kind")
 	name, _, _ := unstructured.NestedString(content, "spec", "modelRef", "name")

--- a/packages/maas/bff/internal/repositories/modelref_helpers_test.go
+++ b/packages/maas/bff/internal/repositories/modelref_helpers_test.go
@@ -19,10 +19,10 @@ import (
 func newModelRefObj(name, namespace, displayName, description, phase, endpoint string) *unstructured.Unstructured {
 	annotations := map[string]interface{}{}
 	if displayName != "" {
-		annotations["openshift.io/display-name"] = displayName
+		annotations[constants.DisplayNameAnnotation] = displayName
 	}
 	if description != "" {
-		annotations["openshift.io/description"] = description
+		annotations[constants.DescriptionAnnotation] = description
 	}
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/packages/maas/bff/internal/repositories/modelref_helpers_test.go
+++ b/packages/maas/bff/internal/repositories/modelref_helpers_test.go
@@ -42,6 +42,12 @@ func newModelRefObj(name, namespace, displayName, description, phase, endpoint s
 			"status": map[string]interface{}{
 				"phase":    phase,
 				"endpoint": endpoint,
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":    "Ready",
+						"message": "Model endpoint is ready",
+					},
+				},
 			},
 		},
 	}
@@ -106,6 +112,7 @@ func TestConvertUnstructuredToModelRefSummary_Full(t *testing.T) {
 		"Description":   {"A test model", summary.Description},
 		"Phase":         {"Ready", summary.Phase},
 		"Endpoint":      {"http://ep:8080", summary.Endpoint},
+		"StatusMessage": {"Model endpoint is ready", summary.StatusMessage},
 		"ModelRef.Kind": {"LLMInferenceService", summary.ModelRef.Kind},
 		"ModelRef.Name": {"my-model", summary.ModelRef.Name},
 	} {

--- a/packages/maas/bff/internal/repositories/namespace.go
+++ b/packages/maas/bff/internal/repositories/namespace.go
@@ -3,9 +3,11 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	k8s "github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type NamespaceRepository struct{}
@@ -14,6 +16,8 @@ func NewNamespaceRepository() *NamespaceRepository {
 	return &NamespaceRepository{}
 }
 
+const DisplayNameAnnotation = "openshift.io/display-name"
+
 func (r *NamespaceRepository) GetNamespaces(client k8s.KubernetesClientInterface, ctx context.Context, identity *k8s.RequestIdentity) ([]models.NamespaceModel, error) {
 
 	namespaces, err := client.GetNamespaces(ctx, identity)
@@ -21,10 +25,34 @@ func (r *NamespaceRepository) GetNamespaces(client k8s.KubernetesClientInterface
 		return nil, fmt.Errorf("error fetching namespaces: %w", err)
 	}
 
+	namespaces = filterAvailableNamespaces(namespaces)
+
 	var namespaceModels = []models.NamespaceModel{}
 	for _, ns := range namespaces {
-		namespaceModels = append(namespaceModels, models.NewNamespaceModelFromNamespace(ns.Name))
+		namespaceModels = append(namespaceModels, models.NewNamespaceModelFromNamespace(ns.Name, ns.Annotations[DisplayNameAnnotation]))
 	}
 
 	return namespaceModels, nil
+}
+
+func filterAvailableNamespaces(namespaces []corev1.Namespace) []corev1.Namespace {
+	excludedExact := map[string]struct{}{
+		"default":     {},
+		"system":      {},
+		"openshift":   {},
+		"opendatahub": {},
+	}
+
+	filtered := make([]corev1.Namespace, 0, len(namespaces))
+	for _, ns := range namespaces {
+		name := ns.Name
+		if strings.HasPrefix(name, "openshift-") || strings.HasPrefix(name, "kube-") {
+			continue
+		}
+		if _, excluded := excludedExact[name]; excluded {
+			continue
+		}
+		filtered = append(filtered, ns)
+	}
+	return filtered
 }

--- a/packages/maas/bff/internal/repositories/namespace.go
+++ b/packages/maas/bff/internal/repositories/namespace.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	k8s "github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
 	corev1 "k8s.io/api/core/v1"
@@ -15,8 +16,6 @@ type NamespaceRepository struct{}
 func NewNamespaceRepository() *NamespaceRepository {
 	return &NamespaceRepository{}
 }
-
-const DisplayNameAnnotation = "openshift.io/display-name"
 
 func (r *NamespaceRepository) GetNamespaces(client k8s.KubernetesClientInterface, ctx context.Context, identity *k8s.RequestIdentity) ([]models.NamespaceModel, error) {
 
@@ -29,10 +28,17 @@ func (r *NamespaceRepository) GetNamespaces(client k8s.KubernetesClientInterface
 
 	var namespaceModels = []models.NamespaceModel{}
 	for _, ns := range namespaces {
-		namespaceModels = append(namespaceModels, models.NewNamespaceModelFromNamespace(ns.Name, ns.Annotations[DisplayNameAnnotation]))
+		namespaceModels = append(namespaceModels, models.NewNamespaceModelFromNamespace(ns.Name, namespaceDisplayName(ns.Annotations)))
 	}
 
 	return namespaceModels, nil
+}
+
+func namespaceDisplayName(annotations map[string]string) string {
+	if annotations == nil {
+		return ""
+	}
+	return annotations[constants.DisplayNameAnnotation]
 }
 
 func filterAvailableNamespaces(namespaces []corev1.Namespace) []corev1.Namespace {

--- a/packages/maas/bff/internal/repositories/namespace_test.go
+++ b/packages/maas/bff/internal/repositories/namespace_test.go
@@ -5,6 +5,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 )
 
 func TestFilterAvailableNamespaces(t *testing.T) {
@@ -15,7 +17,7 @@ func TestFilterAvailableNamespaces(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "opendatahub"}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "dora-namespace", Annotations: map[string]string{
-			DisplayNameAnnotation: "Dora Project",
+			constants.DisplayNameAnnotation: "Dora Project",
 		}}},
 	}
 
@@ -31,7 +33,21 @@ func TestFilterAvailableNamespaces(t *testing.T) {
 	if filtered[1].Name != "dora-namespace" {
 		t.Fatalf("expected second namespace dora-namespace, got %s", filtered[1].Name)
 	}
-	if filtered[1].Annotations[DisplayNameAnnotation] != "Dora Project" {
+	if filtered[1].Annotations[constants.DisplayNameAnnotation] != "Dora Project" {
 		t.Fatalf("expected display name annotation to be preserved")
+	}
+}
+
+func TestNamespaceDisplayName(t *testing.T) {
+	if got := namespaceDisplayName(nil); got != "" {
+		t.Fatalf("expected empty display name for nil annotations, got %q", got)
+	}
+	if got := namespaceDisplayName(map[string]string{}); got != "" {
+		t.Fatalf("expected empty display name for missing annotation, got %q", got)
+	}
+	if got := namespaceDisplayName(map[string]string{
+		constants.DisplayNameAnnotation: "My Project",
+	}); got != "My Project" {
+		t.Fatalf("expected My Project, got %q", got)
 	}
 }

--- a/packages/maas/bff/internal/repositories/namespace_test.go
+++ b/packages/maas/bff/internal/repositories/namespace_test.go
@@ -1,0 +1,37 @@
+package repositories
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFilterAvailableNamespaces(t *testing.T) {
+	input := []corev1.Namespace{
+		{ObjectMeta: metav1.ObjectMeta{Name: "my-project"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "openshift-ingress"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "opendatahub"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "dora-namespace", Annotations: map[string]string{
+			DisplayNameAnnotation: "Dora Project",
+		}}},
+	}
+
+	filtered := filterAvailableNamespaces(input)
+
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 namespaces, got %d", len(filtered))
+	}
+
+	if filtered[0].Name != "my-project" {
+		t.Fatalf("expected first namespace my-project, got %s", filtered[0].Name)
+	}
+	if filtered[1].Name != "dora-namespace" {
+		t.Fatalf("expected second namespace dora-namespace, got %s", filtered[1].Name)
+	}
+	if filtered[1].Annotations[DisplayNameAnnotation] != "Dora Project" {
+		t.Fatalf("expected display name annotation to be preserved")
+	}
+}

--- a/packages/maas/bff/internal/repositories/policies.go
+++ b/packages/maas/bff/internal/repositories/policies.go
@@ -159,14 +159,14 @@ func (r *PoliciesRepository) UpdatePolicy(ctx context.Context, name string, requ
 		annotations = make(map[string]string)
 	}
 	if request.DisplayName != "" {
-		annotations["openshift.io/display-name"] = request.DisplayName
+		annotations[constants.DisplayNameAnnotation] = request.DisplayName
 	} else {
-		delete(annotations, "openshift.io/display-name")
+		delete(annotations, constants.DisplayNameAnnotation)
 	}
 	if request.Description != "" {
-		annotations["openshift.io/description"] = request.Description
+		annotations[constants.DescriptionAnnotation] = request.Description
 	} else {
-		delete(annotations, "openshift.io/description")
+		delete(annotations, constants.DescriptionAnnotation)
 	}
 	existingObj.SetAnnotations(annotations)
 

--- a/packages/maas/bff/internal/repositories/repositories.go
+++ b/packages/maas/bff/internal/repositories/repositories.go
@@ -38,17 +38,24 @@ type MaaSModelRefsRepositoryInterface interface {
 	DeleteMaaSModelRef(ctx context.Context, namespace, name string, dryRun bool) error
 }
 
+// ExternalModelsRepositoryInterface defines the contract for ExternalModel list and delete operations.
+type ExternalModelsRepositoryInterface interface {
+	ListExternalModels(ctx context.Context, namespace string) ([]models.ExternalModelSummary, error)
+	DeleteExternalModel(ctx context.Context, namespace, name string) error
+}
+
 // Repositories struct is a single convenient container to hold and represent all our repositories.
 type Repositories struct {
-	HealthCheck   *HealthCheckRepository
-	User          *UserRepository
-	Namespace     *NamespaceRepository
-	APIKeys       *APIKeysRepository
-	Models        *ModelsRepository
-	Subscriptions SubscriptionsRepositoryInterface
-	Policies      PoliciesRepositoryInterface
-	MaaSModelRefs MaaSModelRefsRepositoryInterface
-	Yaml          YamlRepositoryInterface
+	HealthCheck    *HealthCheckRepository
+	User           *UserRepository
+	Namespace      *NamespaceRepository
+	APIKeys        *APIKeysRepository
+	Models         *ModelsRepository
+	Subscriptions  SubscriptionsRepositoryInterface
+	Policies       PoliciesRepositoryInterface
+	MaaSModelRefs  MaaSModelRefsRepositoryInterface
+	ExternalModels ExternalModelsRepositoryInterface
+	Yaml           YamlRepositoryInterface
 }
 
 func NewRepositories(
@@ -58,6 +65,7 @@ func NewRepositories(
 	subscriptions SubscriptionsRepositoryInterface,
 	policies PoliciesRepositoryInterface,
 	maasModelRefs MaaSModelRefsRepositoryInterface,
+	externalModels ExternalModelsRepositoryInterface,
 	yamlRepo YamlRepositoryInterface,
 ) (*Repositories, error) {
 	apiKeysRepo, err := NewAPIKeysRepository(logger, config.MaasApiUrl)
@@ -71,14 +79,15 @@ func NewRepositories(
 	}
 
 	return &Repositories{
-		HealthCheck:   NewHealthCheckRepository(),
-		User:          NewUserRepository(),
-		Namespace:     NewNamespaceRepository(),
-		APIKeys:       apiKeysRepo,
-		Models:        modelsRepo,
-		Subscriptions: subscriptions,
-		Policies:      policies,
-		MaaSModelRefs: maasModelRefs,
-		Yaml:          yamlRepo,
+		HealthCheck:    NewHealthCheckRepository(),
+		User:           NewUserRepository(),
+		Namespace:      NewNamespaceRepository(),
+		APIKeys:        apiKeysRepo,
+		Models:         modelsRepo,
+		Subscriptions:  subscriptions,
+		Policies:       policies,
+		MaaSModelRefs:  maasModelRefs,
+		ExternalModels: externalModels,
+		Yaml:           yamlRepo,
 	}, nil
 }

--- a/packages/maas/bff/internal/repositories/status_helpers.go
+++ b/packages/maas/bff/internal/repositories/status_helpers.go
@@ -1,0 +1,18 @@
+package repositories
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+// extractReadyConditionMessage returns the message from the "Ready" condition in status.conditions.
+func extractReadyConditionMessage(content map[string]interface{}) string {
+	conditions, _, _ := unstructured.NestedSlice(content, "status", "conditions")
+	for _, c := range conditions {
+		if cMap, ok := c.(map[string]interface{}); ok {
+			if condType, _ := cMap["type"].(string); condType == "Ready" {
+				if msg, _ := cMap["message"].(string); msg != "" {
+					return msg
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/packages/maas/bff/internal/repositories/status_helpers_test.go
+++ b/packages/maas/bff/internal/repositories/status_helpers_test.go
@@ -1,0 +1,25 @@
+package repositories
+
+import "testing"
+
+func TestExtractReadyConditionMessage(t *testing.T) {
+	content := map[string]interface{}{
+		"status": map[string]interface{}{
+			"phase": "Ready",
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":    "Available",
+					"message": "ignored",
+				},
+				map[string]interface{}{
+					"type":    "Ready",
+					"message": "All networking resources created successfully",
+				},
+			},
+		},
+	}
+
+	if got := extractReadyConditionMessage(content); got != "All networking resources created successfully" {
+		t.Fatalf("extractReadyConditionMessage() = %q", got)
+	}
+}

--- a/packages/maas/bff/internal/repositories/subscriptions.go
+++ b/packages/maas/bff/internal/repositories/subscriptions.go
@@ -518,21 +518,6 @@ func convertUnstructuredToAuthPolicy(obj *unstructured.Unstructured) (*models.Ma
 	return policy, nil
 }
 
-// extractReadyConditionMessage returns the message from the "Ready" condition in status.conditions.
-func extractReadyConditionMessage(content map[string]interface{}) string {
-	conditions, _, _ := unstructured.NestedSlice(content, "status", "conditions")
-	for _, c := range conditions {
-		if cMap, ok := c.(map[string]interface{}); ok {
-			if condType, _ := cMap["type"].(string); condType == "Ready" {
-				if msg, _ := cMap["message"].(string); msg != "" {
-					return msg
-				}
-			}
-		}
-	}
-	return ""
-}
-
 // --- Builder helpers: Go models -> Unstructured ---
 
 func buildSubscriptionUnstructured(name, namespace, displayName, description string, owner models.OwnerSpec, modelRefs []models.ModelSubscriptionRef, tokenMetadata *models.TokenMetadata, priority int32) *unstructured.Unstructured {

--- a/packages/maas/bff/internal/repositories/subscriptions.go
+++ b/packages/maas/bff/internal/repositories/subscriptions.go
@@ -342,8 +342,8 @@ func convertUnstructuredToSubscription(obj *unstructured.Unstructured) (*models.
 	}
 
 	annotations := obj.GetAnnotations()
-	sub.DisplayName = annotations[displayNameAnnotation]
-	sub.Description = annotations[descriptionAnnotation]
+	sub.DisplayName = annotations[constants.DisplayNameAnnotation]
+	sub.Description = annotations[constants.DescriptionAnnotation]
 
 	phase, _, _ := unstructured.NestedString(content, "status", "phase")
 	sub.Phase = phase
@@ -451,8 +451,8 @@ func convertUnstructuredToAuthPolicy(obj *unstructured.Unstructured) (*models.Ma
 	}
 
 	annotations := obj.GetAnnotations()
-	policy.DisplayName = annotations[displayNameAnnotation]
-	policy.Description = annotations[descriptionAnnotation]
+	policy.DisplayName = annotations[constants.DisplayNameAnnotation]
+	policy.Description = annotations[constants.DescriptionAnnotation]
 
 	phase, _, _ := unstructured.NestedString(content, "status", "phase")
 	policy.Phase = phase
@@ -529,10 +529,10 @@ func buildSubscriptionUnstructured(name, namespace, displayName, description str
 
 	annotations := map[string]string{}
 	if displayName != "" {
-		annotations["openshift.io/display-name"] = displayName
+		annotations[constants.DisplayNameAnnotation] = displayName
 	}
 	if description != "" {
-		annotations["openshift.io/description"] = description
+		annotations[constants.DescriptionAnnotation] = description
 	}
 	if len(annotations) > 0 {
 		obj.SetAnnotations(annotations)
@@ -561,10 +561,10 @@ func buildAuthPolicyUnstructured(name, namespace, displayName, description strin
 
 	annotations := make(map[string]string)
 	if displayName != "" {
-		annotations[displayNameAnnotation] = displayName
+		annotations[constants.DisplayNameAnnotation] = displayName
 	}
 	if description != "" {
-		annotations[descriptionAnnotation] = description
+		annotations[constants.DescriptionAnnotation] = description
 	}
 	if len(annotations) > 0 {
 		obj.SetAnnotations(annotations)
@@ -715,14 +715,14 @@ func updateSubscriptionSpec(obj *unstructured.Unstructured, displayName, descrip
 		annotations = map[string]string{}
 	}
 	if displayName != "" {
-		annotations["openshift.io/display-name"] = displayName
+		annotations[constants.DisplayNameAnnotation] = displayName
 	} else {
-		delete(annotations, "openshift.io/display-name")
+		delete(annotations, constants.DisplayNameAnnotation)
 	}
 	if description != "" {
-		annotations["openshift.io/description"] = description
+		annotations[constants.DescriptionAnnotation] = description
 	} else {
-		delete(annotations, "openshift.io/description")
+		delete(annotations, constants.DescriptionAnnotation)
 	}
 	obj.SetAnnotations(annotations)
 

--- a/packages/maas/bff/internal/testdata/crd/inference.opendatahub.io_externalmodels.yaml
+++ b/packages/maas/bff/internal/testdata/crd/inference.opendatahub.io_externalmodels.yaml
@@ -1,0 +1,250 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: externalmodels.inference.opendatahub.io
+spec:
+  group: inference.opendatahub.io
+  names:
+    kind: ExternalModel
+    listKind: ExternalModelList
+    plural: externalmodels
+    singular: externalmodel
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ExternalModel defines a client-facing model that maps to one or more
+          external providers. The model name clients use in requests is determined
+          by spec.modelName (if set) or metadata.name (default).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ExternalModelSpec defines the desired state of ExternalModel.
+            properties:
+              externalProviderRefs:
+                description: |-
+                  ExternalProviderRefs maps this model to one or more external providers.
+                  Each entry specifies the provider specific details.
+                items:
+                  description: ExternalProviderRef binds this model to a specific
+                    provider with translation config.
+                  properties:
+                    apiFormat:
+                      description: |-
+                        APIFormat determines how requests/responses are translated for this provider.
+                        Supported values:
+                          - "openai-chat": OpenAI Chat Completions API (/v1/chat/completions)
+                          - "messages": Anthropic Messages API (/v1/messages)
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    auth:
+                      description: |-
+                        Auth overrides the ExternalProvider authentication for this model-provider binding.
+                        If not set, the ExternalProvider auth is used.
+                      properties:
+                        secretRef:
+                          description: |-
+                            SecretRef references a Kubernetes Secret containing the provider API key.
+                            The Secret must be in the same namespace as the ExternalProvider
+                            and must contain a data key "api-key" with the credential value.
+                          properties:
+                            name:
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type:
+                          description: |-
+                            Type identifies the auth type for this provider.
+                            e.g. "apikey" (header based), "sigv4", etc.
+                          enum:
+                          - apikey
+                          - sigv4
+                          - oauth2
+                          type: string
+                      required:
+                      - secretRef
+                      - type
+                      type: object
+                    config:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Config holds model-specific configuration as key-value pairs.
+                        Overrides the ExternalProvider config for this model-provider binding.
+                      type: object
+                    path:
+                      description: |-
+                        Path sets the outgoing request `:path` pseudo-header for this model-provider binding.
+                        Must be a valid absolute path (e.g. "/v1/chat/completions" or
+                        "/maas-default-gateway/v1/chat/completions").
+                        Supports {key} placeholders resolved from the merged Config map.
+                      maxLength: 512
+                      minLength: 1
+                      pattern: ^/.*
+                      type: string
+                    ref:
+                      description: Ref identifies the ExternalProvider CR (must be
+                        in the same namespace).
+                      properties:
+                        name:
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    targetModel:
+                      description: |-
+                        TargetModel is the provider-specific model identifier.
+                        e.g. "gpt-4o", "anthropic.claude-3-opus", "claude-sonnet-4-5-20241022".
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    weight:
+                      default: 1
+                      description: |-
+                        Weight determines the relative traffic proportion for this provider binding.
+                        Higher weight means more traffic. Used for weighted random selection across
+                        multiple provider refs. Defaults to 1 if not set.
+                      maximum: 100
+                      minimum: 1
+                      type: integer
+                  required:
+                  - apiFormat
+                  - path
+                  - ref
+                  - targetModel
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+              modelName:
+                description: |-
+                  ModelName is the client-facing model name used in inference request bodies.
+                  Clients send this value in the "model" field of chat completion requests.
+                  Defaults to metadata.name if not set. Use this field when the desired
+                  model name contains characters not allowed in Kubernetes resource names
+                  (dots, colons, slashes, uppercase).
+                maxLength: 253
+                type: string
+            required:
+            - externalProviderRefs
+            type: object
+          status:
+            description: ExternalModelStatus defines the observed state of ExternalModel.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the model's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              httpRouteName:
+                description: |-
+                  HTTPRouteName is the name of the HTTPRoute created by the controller
+                  for this ExternalModel. Consumers (e.g., maas-controller) can read this
+                  to attach policies without assuming naming conventions.
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current reconciliation phase.
+                  Ready: all networking resources created successfully.
+                  Failed: reconciliation error (e.g., missing ExternalProvider, missing Secret).
+                  This reflects controller reconciliation state, not runtime request health.
+                enum:
+                - Pending
+                - Ready
+                - Failed
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/maas/bff/internal/testdata/crd/inference.opendatahub.io_externalproviders.yaml
+++ b/packages/maas/bff/internal/testdata/crd/inference.opendatahub.io_externalproviders.yaml
@@ -1,0 +1,191 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: externalproviders.inference.opendatahub.io
+spec:
+  group: inference.opendatahub.io
+  names:
+    kind: ExternalProvider
+    listKind: ExternalProviderList
+    plural: externalproviders
+    singular: externalprovider
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider
+      name: Provider
+      type: string
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ExternalProvider defines a connection to an external LLM provider (endpoint + credentials).
+          Multiple ExternalModel resources can reference the same ExternalProvider.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ExternalProviderSpec defines the desired state of ExternalProvider.
+            properties:
+              auth:
+                description: Auth configures how to authenticate with the provider.
+                properties:
+                  secretRef:
+                    description: |-
+                      SecretRef references a Kubernetes Secret containing the provider API key.
+                      The Secret must be in the same namespace as the ExternalProvider
+                      and must contain a data key "api-key" with the credential value.
+                    properties:
+                      name:
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type identifies the auth type for this provider.
+                      e.g. "apikey" (header based), "sigv4", etc.
+                    enum:
+                    - apikey
+                    - sigv4
+                    - oauth2
+                    type: string
+                required:
+                - secretRef
+                - type
+                type: object
+              config:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Config holds provider-specific configuration as key-value pairs.
+                  e.g., Vertex AI: {"project": "my-project", "location": "us-central1"}.
+                type: object
+              endpoint:
+                description: |-
+                  Endpoint is the FQDN of the external provider (no scheme or path).
+                  e.g. "api.openai.com", "bedrock.amazonaws.com".
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)+$
+                type: string
+              provider:
+                description: |-
+                  Provider identifies the API type for this provider.
+                  e.g. "openai", "anthropic", "azure", "aws-bedrock", "vertex".
+                maxLength: 63
+                minLength: 1
+                type: string
+            required:
+            - auth
+            - endpoint
+            - provider
+            type: object
+          status:
+            description: ExternalProviderStatus defines the observed state of ExternalProvider.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the provider's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: |-
+                  Phase represents the current reconciliation phase.
+                  Ready: all networking resources created and Secret validated.
+                  Failed: reconciliation error (e.g., missing Secret, Istio resource creation failed).
+                  This reflects controller reconciliation state, not runtime request health.
+                enum:
+                - Pending
+                - Ready
+                - Failed
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -108,7 +108,10 @@ paths:
     get:
       summary: Get Namespaces
       operationId: getNamespaces
-      description: Returns a list of namespaces accessible to the user
+      description: |
+        Returns namespaces accessible to the user. Cluster admins receive all non-system
+        namespaces. Regular users receive only OpenShift projects they can access. System
+        namespaces (for example `openshift-*`, `kube-*`, `default`, `opendatahub`) are excluded.
       responses:
         '200':
           description: List of namespaces
@@ -146,7 +149,7 @@ paths:
                 type: object
                 properties:
                   data:
-                      $ref: '#/components/schemas/ModelListResponse'
+                    $ref: '#/components/schemas/ModelListResponse'
                 required:
                   - data
               example:
@@ -1745,6 +1748,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  # ── ExternalModel Endpoints ───────────────────────────────────────────
+
+  /api/v1/externalmodel:
+    get:
+      tags: [externalmodels]
+      summary: List ExternalModels
+      operationId: listExternalModels
+      description: Returns ExternalModels enriched with referenced ExternalProvider details and companion MaaSModelRef endpoint status.
+      parameters:
+        - in: query
+          name: namespace
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ExternalModel list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ExternalModelSummary'
+
+  /api/v1/externalmodel/{namespace}/{name}:
+    delete:
+      tags: [externalmodels]
+      summary: Delete an ExternalModel
+      operationId: deleteExternalModel
+      description: Deletes an ExternalModel and its companion MaaSModelRef.
+      parameters:
+        - in: path
+          name: namespace
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ExternalModel deleted
+        '404':
+          description: ExternalModel not found
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1807,7 +1860,7 @@ components:
         contextWindow:
           type: string
           description: Context window size (from opendatahub.io/context-window annotation)
-          example: "4096"
+          example: '4096'
 
     SubscriptionInfo:
       type: object
@@ -1904,7 +1957,7 @@ components:
           displayName: Llama 2 7B Chat
           description: A large language model optimized for chat use cases
           genaiUseCase: chat
-          contextWindow: "4096"
+          contextWindow: '4096'
         kind: LLMInferenceService
         subscriptions:
           - name: premium-subscription
@@ -2238,7 +2291,7 @@ components:
         statusMessage:
           type: string
           description: Human-readable status message from the Ready condition in status.conditions
-          example: "successfully reconciled"
+          example: 'successfully reconciled'
         priority:
           type: integer
           format: int32
@@ -2323,12 +2376,12 @@ components:
         statusMessage:
           type: string
           description: Human-readable status message from the Ready condition in status.conditions
-          example: "successfully reconciled"
+          example: 'successfully reconciled'
         creationTimestamp:
           type: string
           format: date-time
           description: Timestamp when the policy was created
-          example: "2025-03-01T10:00:00Z"
+          example: '2025-03-01T10:00:00Z'
         modelRefs:
           type: array
           items:
@@ -2392,6 +2445,9 @@ components:
           enum: [Pending, Ready, Unhealthy, Failed]
           description: Current phase of the model (from status)
           example: Ready
+        statusMessage:
+          type: string
+          description: Human-readable status message from the Ready condition in status.conditions
         endpoint:
           type: string
           description: Endpoint URL for the model (from status)
@@ -2777,3 +2833,93 @@ components:
       required:
         - content
 
+    ProviderRef:
+      type: object
+      required: [providerName, weight, apiFormat, path, targetModel]
+      properties:
+        providerName:
+          type: string
+        weight:
+          type: integer
+          minimum: 1
+          maximum: 100
+        apiFormat:
+          type: string
+        path:
+          type: string
+        targetModel:
+          type: string
+        config:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional model-provider binding configuration (externalProviderRefs[].config)
+        provider:
+          $ref: '#/components/schemas/ExternalProviderDetails'
+          description: Enriched from the referenced ExternalProvider (list response only)
+
+    ExternalProviderDetails:
+      type: object
+      description: ExternalProvider fields not present on the ExternalModel providerRef
+      properties:
+        displayName:
+          type: string
+        description:
+          type: string
+        endpointUrl:
+          type: string
+        authMechanism:
+          type: string
+          enum: [apikey, sigv4, oauth2]
+        provider:
+          type: string
+          description: Provider identifier (spec.provider)
+        config:
+          type: object
+          additionalProperties:
+            type: string
+        phase:
+          type: string
+        statusMessage:
+          type: string
+          description: Human-readable status message from the Ready condition in status.conditions
+
+    ExternalModelMaaSModelRefStatus:
+      type: object
+      description: Companion MaaSModelRef status (list response only)
+      properties:
+        phase:
+          type: string
+        statusMessage:
+          type: string
+          description: Human-readable status message from the Ready condition in status.conditions
+        endpoint:
+          type: string
+          description: Published MaaS endpoint URL (status.endpoint)
+
+    ExternalModelSummary:
+      type: object
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        displayName:
+          type: string
+          description: Human-readable display name (from openshift.io/display-name annotation)
+        description:
+          type: string
+          description: Description (from openshift.io/description annotation)
+        modelName:
+          type: string
+        providerRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderRef'
+        phase:
+          type: string
+        statusMessage:
+          type: string
+          description: Human-readable status message from the Ready condition in status.conditions
+        maaSModelRef:
+          $ref: '#/components/schemas/ExternalModelMaaSModelRefStatus'


### PR DESCRIPTION
## Description

Adds MVP BFF endpoints for the External Models list page.

- Filtered `GET /api/v1/namespaces`: cluster-wide list for admins, OpenShift Projects API fallback (Forbidden-only) for regular users, filters system namespaces (`openshift-*`, `kube-*`, `default`, etc.)
- Enriched `GET /api/v1/externalmodel?namespace=`: lists ExternalModel CRs enriched with referenced ExternalProvider details and companion MaaSModelRef status (`phase`, `endpoint`, `statusMessage`)
- `DELETE /api/v1/externalmodel/{namespace}/{name}`: deletes ExternalModel CR first, then cascades companion MaaSModelRef deletion

**Deferred to follow-up** (full work preserved on local branch `maas-external-bff-full` / remote `maas-external-bff`):
- External provider HTTP CRUD
- Secrets list/create
- External model create/update
- `packages/maas/bff/testdata/bbr-e2e-export/` fixtures

## How Has This Been Tested?
Shared env vars
```
export BFF=http://localhost:8081/api/v1
```
3 mock curls (make dev-bff-federated-mock)
```
export NS=maas-models
export MODEL=gpt-4o-external
```
1. List namespaces (project selector)
```
curl -sS -H "kubeflow-userid: user@example.com" \
  "$BFF/namespaces" | jq .
```

3. List external models (enriched)
```
curl -sS -H "kubeflow-userid: user@example.com" \
  "$BFF/externalmodel?namespace=${NS}" | jq .
```

5. Delete external model (+ companion MaaSModelRef)
```
curl -sS -X DELETE \
  -H "kubeflow-userid: user@example.com" \
  "$BFF/externalmodel/${NS}/${MODEL}" | jq .
```

Verify:
```
curl -sS -H "kubeflow-userid: user@example.com" \
  "$BFF/externalmodel?namespace=${NS}" | jq '.data[] | select(.name=="'"${MODEL}"'")'
```

3 live curls (make dev-bff-federated)
```
export TOKEN=$(oc whoami -t)
export NS=<your-project>    # pick from step 1 — e.g. bbr-e2e
export MODEL=<external-model-cr-name>   # e.g. test-anthropic
```
1. List namespaces
```
curl -sS -H "x-forwarded-access-token: ${TOKEN}" \
  "$BFF/namespaces" | jq .
```

3. List external models
```
curl -sS -H "x-forwarded-access-token: ${TOKEN}" \
  "$BFF/externalmodel?namespace=${NS}" | jq .
```

5. Delete external model
```
curl -sS -X DELETE \
  -H "x-forwarded-access-token: ${TOKEN}" \
  "$BFF/externalmodel/${NS}/${MODEL}" | jq .
```

Verify:
```
curl -sS -H "x-forwarded-access-token: ${TOKEN}" \
  "$BFF/externalmodel?namespace=${NS}" | jq .
```



## Test Impact

10 new/updated `_test.go` files covering handler behavior, repository logic, and helper functions:
- `internal/api/externalmodel_handlers_test.go`
- `internal/api/namespaces_handler_test.go`
- `internal/repositories/external_helpers_test.go`, `modelref_helpers_test.go`, `namespace_test.go`, `status_helpers_test.go`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints to list and delete external models, including enriched provider details and companion status information.
  * Updated OpenAPI documentation for the new external model APIs and schemas.

* **Bug Fixes**
  * Namespace listings now use annotation-based display names consistently and better exclude system namespaces.
  * External model deletion now removes the related companion reference; modelref status messages are surfaced from Ready conditions.

* **Tests**
  * Expanded integration and unit test coverage, including repository wiring updates and Kubernetes mock improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->