### PR TITLE
RHOAIENG-75738: Fix model nodes showing hourglass after run completes

### DIFF
--- a/packages/automl/frontend/src/app/topology/__tests__/buildStageMapTopology.spec.ts
+++ b/packages/automl/frontend/src/app/topology/__tests__/buildStageMapTopology.spec.ts
@@ -473,5 +473,19 @@ describe('buildStageMapTopology', () => {
         expect(n.data?.runStatus).toBe(RunStatus.InProgress);
       });
     });
+
+    it('should use terminalFallback for placeholder models when run is complete but component has no status', () => {
+      const stageMap = makeStageMap([
+        makeComponent('training', [makeStage('model_selection'), makeStage('refit_full')]),
+      ]);
+
+      const nodes = buildStageMapTopology(stageMap, undefined, 'SUCCEEDED');
+      const modelNodes = nodes.filter(
+        (n) => n.id.includes('__model__') && n.type !== 'DEFAULT_SPACER_NODE',
+      );
+      modelNodes.forEach((n) => {
+        expect(n.data?.runStatus).toBe(RunStatus.Succeeded);
+      });
+    });
   });
 });

--- a/packages/automl/frontend/src/app/topology/buildStageMapTopology.ts
+++ b/packages/automl/frontend/src/app/topology/buildStageMapTopology.ts
@@ -258,7 +258,7 @@ export const buildStageMapTopology = (
       const branchStatus = isPlaceholder
         ? componentStatus === RunStatus.Succeeded
           ? RunStatus.InProgress
-          : componentStatus
+          : componentStatus ?? terminalFallback
         : resolveStageRunStatus(
             modelSelectionStage ?? { id: BRANCHING_STAGE_ID, description: '' },
             componentStatus,


### PR DESCRIPTION

https://redhat.atlassian.net/browse/RHOAIENG-75738

Placeholder Model 1/Model 2 nodes bypassed the terminalFallback used by all other nodes, causing them to stay as Pending (hourglass) when the run finished but the component had no explicit status.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Placeholder model nodes now correctly inherit the final run status when no explicit component status is available, improving status display consistency in topology views.
  * Added test coverage to verify placeholder nodes resolve to a succeeded status in completed runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->