### PR TITLE
feat: Implement Notebooks v2 Feature Flag, Manifests and Navigation Configurations

### DIFF
--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -254,3 +254,111 @@ Copy the "Request review criteria" section exactly as it appears in `.github/pul
    gh pr close <pr-number> --repo <upstream-owner>/<upstream-repo>
    ```
    **Do NOT close the PR in normal mode.** Normal sync PRs are meant to be reviewed and merged.
+
+## Package-Specific: Notebooks
+
+The notebooks package (`packages/notebooks`) syncs from `opendatahub-io/workbenches` and has unique challenges due to local ODH modifications, a Go backend, and generated TypeScript types.
+
+### Known Local ODH Modifications
+
+These files intentionally diverge from upstream. Preserve the local modifications when resolving conflicts.
+
+| File (relative to `upstream/`) | Local Modification | Why |
+|---|---|---|
+| `workspaces/frontend/src/app/pages/Workspaces/Form/WorkspaceForm.tsx` | `/* eslint-disable @cspell/spellchecker */` at line 1; `navigate(-1)` instead of `navigate('workspaces')` | cspell config doesn't resolve from upstream path; go-back behavior in federated mode |
+| `workspaces/frontend/src/odh/NotebooksWrapper.tsx` | Entire file is ODH-only | Federated module entry point with ModularArchContextProvider |
+| `workspaces/frontend/src/app/components/NamespaceSelector.tsx` | ODH-only component | Federated namespace selection UI |
+| `workspaces/frontend/src/app/pages/Workspaces/Workspaces.tsx` | NamespaceSelector integration, PF import paths | ODH federated integration |
+| `workspaces/backend/cmd/main.go` | `StaticAssetsDir` flag and config field | Frontend static asset serving in federated mode |
+| `workspaces/backend/internal/config/environment.go` | `StaticAssetsDir` struct field | Companion to main.go change |
+| `Dockerfile.workspace` | `ENV GOTOOLCHAIN=auto` in BFF build stage | UBI9 go-toolset image lags behind upstream go.mod version |
+
+### Known Conflict Patterns
+
+**CODEOWNERS-only commits** — Upstream commits touching only CODEOWNERS produce no local file changes. The script exits with "No staged changes found". Fix: manually advance the tracking commit:
+```bash
+jq --arg commit "<sha>" '.subtree.commit = $commit' packages/notebooks/package.json > packages/notebooks/package.json.tmp \
+  && mv packages/notebooks/package.json.tmp packages/notebooks/package.json \
+  && git add packages/notebooks/package.json \
+  && SKIP_LINT_HOOK=true git commit -q -m "Update @odh-dashboard/notebooks tracking to <short-sha> (CODEOWNERS only, no file changes)"
+```
+Then re-run `npm run update-subtree` (not `--continue`).
+
+**package-lock.json conflicts** — Always conflicts on dependency bumps. Clone upstream at the target commit and replace the file wholesale:
+```bash
+git clone -q --depth=1 --branch <branch> <repo-url> /tmp/nb-upstream
+cp /tmp/nb-upstream/workspaces/frontend/package-lock.json packages/notebooks/upstream/workspaces/frontend/package-lock.json
+rm -rf /tmp/nb-upstream
+```
+
+**Generated TypeScript files** — `src/generated/data-contracts.ts`, `Workspacekinds.ts`, and other files under `src/generated/` are auto-generated from the backend API. Always safe to replace from upstream wholesale.
+
+**Files stuck at intermediate commits** — When patches are rejected and files are replaced from an intermediate commit during conflict resolution, they may end up out of date with the final target. After the sync completes, verify by diffing against the upstream target:
+```bash
+git clone -q --depth=1 --branch <branch> <repo-url> /tmp/nb-check
+diff /tmp/nb-check/workspaces/frontend/src/<file> packages/notebooks/upstream/workspaces/frontend/src/<file>
+```
+Replace any stale files, re-apply local modifications from the table above, then commit.
+
+**`set -e` crash on no-op patches** — The `package-subtree.sh` script uses `set -e`. When a patch applies cleanly but produces no file changes (because files are already at the target state), `safe_git_commit_if_changes` returns exit code 2, which `set -e` treats as a failure. The script silently exits with no error message. If the sync stops after "Applying commit X/Y" with no conflict output, this is likely the cause. Workaround: temporarily add `|| commit_exit_code=$?` on the `safe_git_commit_if_changes` call line (~line 849), or advance the tracking commit past the problematic range.
+
+### Post-Sync Module Federation Patch
+
+After the sync completes, `moduleFederation.js` will be overwritten with the midstream version which lacks ODH-specific entries. Patch it to restore:
+
+1. Add `@odh-dashboard/plugin-core` as a shared singleton
+2. Set `exposes` to expose `./extensions`
+3. Set `dts: true`
+
+The required state of `moduleFederation.js` after patching:
+```js
+shared: {
+  // ... existing shared deps from midstream ...
+  '@odh-dashboard/plugin-core': {
+    singleton: true,
+    requiredVersion: '*',
+  },
+},
+exposes: {
+  './extensions': './src/odh/extensions',
+},
+// ...
+dts: true,
+```
+
+The midstream version has `exposes: {}` and `dts: false` — these must be changed. The ODH-only files in `src/odh/` (`extensions.ts`, `NotebooksWrapper.tsx`) are unaffected by the sync since they don't exist in midstream.
+
+### Post-Sync Validation
+
+After the sync completes, run these checks before creating the PR.
+
+**Step 1: Install updated dependencies** (if `mod-arch-core` or other deps were bumped):
+```bash
+cd packages/notebooks/upstream/workspaces/frontend && npm install
+```
+
+**Step 2: Go backend build**:
+```bash
+cd packages/notebooks/upstream/workspaces/backend && go build ./...
+```
+Common issues: missing constants after refactors (e.g., constants moved to `api/constants/` package), struct fields added upstream that conflict with local `StaticAssetsDir`.
+
+**Step 3: Frontend type check**:
+```bash
+cd packages/notebooks/upstream/workspaces/frontend && npx tsc --noEmit
+```
+Common issues: renamed generated types (e.g., `WorkspacekindsRedirectMessageLevel` → `V1Beta1RedirectMessageLevel`), `useGenericObjectState` tuple length changes after `mod-arch-core` bumps.
+
+**Step 4: Frontend lint**:
+```bash
+cd packages/notebooks/upstream/workspaces/frontend && npx eslint src/ --ext .ts,.tsx
+```
+Note: the root-level lint hook will report cspell errors for upstream files (cspell config path doesn't resolve from `upstream/`). These are false positives — use `SKIP_LINT_HOOK=true` when committing upstream files.
+
+### Dockerfile
+
+After syncing, check if the Go version requirement changed:
+```bash
+grep '^go ' packages/notebooks/upstream/workspaces/backend/go.mod
+```
+If the required version exceeds what's in the UBI9 `go-toolset` image (check `ARG GOLANG_BASE_IMAGE` in `Dockerfile.workspace`), ensure `ENV GOTOOLCHAIN=auto` is set in the BFF build stage.

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -57,6 +57,7 @@ export type DashboardConfig = K8sResourceCommon & {
       modelAsService: boolean;
       maasAuthPolicies: boolean;
       mlflow: boolean;
+      notebooksV2: boolean;
       mcpCatalog: boolean;
       toolCalling: boolean;
       aiAssetCustomEndpoints: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -93,6 +93,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableKueue: true,
       disableLMEval: true,
       mlflow: true,
+      notebooksV2: false,
       mcpCatalog: false,
       toolCalling: false,
       trainingJobs: true,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -51,6 +51,7 @@ export type MockDashboardConfigType = {
   hardwareProfileOrder?: string[];
   pvcSize?: string;
   mlflowPipelines?: boolean;
+  notebooksV2?: boolean;
   mcpCatalog?: boolean;
   toolCalling?: boolean;
   projectRBAC?: boolean;
@@ -75,6 +76,7 @@ export type MockDashboardConfigType = {
 
 export const mockDashboardConfig = ({
   mlflowPipelines = false,
+  notebooksV2 = false,
   projectRBAC = false,
   disableInfo = false,
   disableSupport = false,
@@ -260,6 +262,7 @@ export const mockDashboardConfig = ({
   spec: {
     dashboardConfig: {
       mlflowPipelines,
+      notebooksV2,
       projectRBAC,
       enablement: true,
       disableInfo,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -13,6 +13,7 @@ export const techPreviewFlags = {
   modelAsService: true,
   maasAuthPolicies: true,
   aiAssetCustomEndpoints: false,
+  notebooksV2: false,
   mcpCatalog: false,
   toolCalling: false,
   projectRBAC: true,
@@ -239,6 +240,9 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.MLFLOW_PIPELINES]: {
     featureFlags: ['mlflowPipelines'],
     requiredComponents: [DataScienceStackComponent.DS_PIPELINES, DataScienceStackComponent.MLFLOW],
+  },
+  [SupportedArea.NOTEBOOKS_V2]: {
+    featureFlags: ['notebooksV2'],
   },
   [SupportedArea.PROJECT_RBAC_SETTINGS]: {
     featureFlags: ['projectRBAC'],

--- a/frontend/src/concepts/projects/projectDetails/useWorkbenchesV2Tab.tsx
+++ b/frontend/src/concepts/projects/projectDetails/useWorkbenchesV2Tab.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core';
+import { isProjectDetailsTab } from '@odh-dashboard/plugin-core/extension-points';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
+import { SectionDefinition } from '#~/pages/projects/components/GenericHorizontalBar';
+import { ProjectSectionID } from '#~/pages/projects/screens/detail/types';
+
+export const useWorkbenchesV2Tab = (): SectionDefinition[] => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const projectDetailsTabExtensions = useExtensions(isProjectDetailsTab);
+  const workbenchesV2Extension = projectDetailsTabExtensions.find(
+    (tab) => tab.properties.id === ProjectSectionID.WORKBENCHES_V2,
+  )?.properties.component;
+
+  if (!workbenchesV2Extension) {
+    return [];
+  }
+
+  return [
+    {
+      id: ProjectSectionID.WORKBENCHES_V2,
+      title: 'Workbenches v2',
+      component: (
+        <LazyCodeRefComponent
+          component={workbenchesV2Extension}
+          props={{ namespace: currentProject.metadata.name }}
+        />
+      ),
+    },
+  ];
+};

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -24,6 +24,7 @@ import {
   getDisplayNameFromK8sResource,
 } from '@odh-dashboard/k8s-core';
 import { useDeploymentsTab } from '#~/concepts/projects/projectDetails/useDeploymentsTab';
+import { useWorkbenchesV2Tab } from '#~/concepts/projects/projectDetails/useWorkbenchesV2Tab';
 import ApplicationsPage from '#~/pages/ApplicationsPage';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import GenericHorizontalBar from '#~/pages/projects/components/GenericHorizontalBar';
@@ -62,6 +63,7 @@ const ProjectDetails: React.FC = () => {
   const settingsCardExtensions = useExtensions(isProjectDetailsSettingsCardExtension);
   const hasSettingsCards = settingsCardExtensions.length > 0 || biasMetricsAreaAvailable; // Bias metrics is not yet an extension
   const deploymentsTab = useDeploymentsTab();
+  const workbenchesV2Tab = useWorkbenchesV2Tab();
   const [searchParams, setSearchParams] = useSearchParams();
   const state = searchParams.get('section');
 
@@ -190,6 +192,7 @@ const ProjectDetails: React.FC = () => {
                   },
                 ]
               : []),
+            ...workbenchesV2Tab,
             ...(pipelinesEnabled
               ? [
                   {
@@ -255,6 +258,7 @@ const ProjectDetails: React.FC = () => {
           ],
           [
             workbenchEnabled,
+            workbenchesV2Tab,
             pipelinesEnabled,
             deploymentsTab,
             projectSharingEnabled,

--- a/frontend/src/pages/projects/screens/detail/types.ts
+++ b/frontend/src/pages/projects/screens/detail/types.ts
@@ -9,6 +9,7 @@ export enum ProjectSectionID {
   ROLES = 'roles',
   SETTINGS = 'settings',
   FEATURE_STORE = 'feature-store-integration',
+  WORKBENCHES_V2 = 'workbenches-v2',
 }
 
 export type ProjectSectionTitlesType = {

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -171,6 +171,9 @@ spec:
                     toolCalling:
                       type: boolean
                       description: 'When true, enables tool-calling configuration for supported models in the model catalog.'
+                    notebooksV2:
+                      type: boolean
+                      description: 'When true, enables the new notebooks v2 features.'
                     projectRBAC:
                       type: boolean
                       description: 'When true, enables project-level RBAC (Role-Based Access Control) settings.'

--- a/manifests/modular-architecture/deployment.yaml
+++ b/manifests/modular-architecture/deployment.yaml
@@ -692,3 +692,50 @@
       capabilities:
         drop:
           - ALL
+
+- op: add
+  path: /spec/template/spec/containers/-
+  value:
+    name: notebooks-ui
+    image: $(notebooks-ui-image)
+    imagePullPolicy: Always
+    livenessProbe:
+      httpGet:
+        path: /api/v1/healthcheck
+        port: 8943
+        scheme: HTTP
+      initialDelaySeconds: 30
+      timeoutSeconds: 15
+      periodSeconds: 30
+      successThreshold: 1
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /api/v1/healthcheck
+        port: 8943
+        scheme: HTTP
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+      periodSeconds: 30
+      successThreshold: 1
+      failureThreshold: 3
+    resources:
+      limits:
+        cpu: 300m
+        memory: 512Mi
+      requests:
+        cpu: 300m
+        memory: 512Mi
+    ports:
+      - containerPort: 8943
+        name: notebooks-ui
+    env:
+      - name: PORT
+        value: "8943"
+      - name: DISABLE_AUTH
+        value: "true"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL

--- a/manifests/modular-architecture/federation-configmap.yaml
+++ b/manifests/modular-architecture/federation-configmap.yaml
@@ -203,5 +203,26 @@ data:
             "namespace": "opendatahub",
             "port": 8443
         }
+      },
+      {
+          "name": "notebooks",
+          "remoteEntry": "/remoteEntry.js",
+          "authorize": true,
+          "tls": false,
+          "proxy": [
+            {
+              "path": "/workspaces/api",
+              "pathRewrite": "/api"
+            }
+          ],
+          "local": {
+            "host": "localhost",
+            "port": 8080
+          },
+          "service": {
+            "name": "odh-dashboard",
+            "namespace": "opendatahub",
+            "port": 8943
+          }
       }
     ]

--- a/manifests/modular-architecture/kustomization.yaml
+++ b/manifests/modular-architecture/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - modules-cluster-role.yaml
   - modules-cluster-role-binding.yaml
   - modules-sa-token-secret.yaml
+  - notebooks-rbac.yaml
 configMapGenerator:
   - name: modular-architecture-params
     env: params.env
@@ -84,6 +85,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.agent-ops-ui-image
+  - name: notebooks-ui-image
+    objref:
+      kind: ConfigMap
+      name: modular-architecture-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.notebooks-ui-image
 configurations:
   - params.yaml
 patchesJson6902:

--- a/manifests/modular-architecture/notebooks-rbac.yaml
+++ b/manifests/modular-architecture/notebooks-rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: notebooks-ui-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["kubeflow.org"]
+  resources: ["workspaces", "workspacekinds"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: notebooks-ui-cluster-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: odh-dashboard
+  namespace: opendatahub
+roleRef:
+  kind: ClusterRole
+  name: notebooks-ui-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: notebooks-ui-authenticated-users
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: notebooks-ui-cluster-role
+  apiGroup: rbac.authorization.k8s.io

--- a/manifests/modular-architecture/params.env
+++ b/manifests/modular-architecture/params.env
@@ -16,3 +16,5 @@ autorag-ui-image=quay.io/opendatahub/odh-mod-arch-autorag:main
 autorag-pipeline-runtime-image=
 
 agent-ops-ui-image=quay.io/opendatahub/odh-mod-arch-agent-ops:main
+
+notebooks-ui-image=quay.io/opendatahub/odh-mod-arch-notebooks:main

--- a/manifests/modular-architecture/service.yaml
+++ b/manifests/modular-architecture/service.yaml
@@ -54,3 +54,10 @@
     protocol: TCP
     port: 8843
     targetPort: 8843
+- op: add
+  path: /spec/ports/-
+  value:
+    name: notebooks-ui
+    protocol: TCP
+    port: 8943
+    targetPort: 8943

--- a/manifests/rhoai/base/kustomization.yaml
+++ b/manifests/rhoai/base/kustomization.yaml
@@ -73,5 +73,11 @@ patchesJson6902:
       version: v1
       kind: ClusterRoleBinding
       name: odh-dashboard-modules
+  - path: notebooks-rbac-patch.yaml
+    target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRoleBinding
+      name: notebooks-ui-cluster-rolebinding
 patchesStrategicMerge:
   - federation-configmap.yaml

--- a/manifests/rhoai/base/notebooks-rbac-patch.yaml
+++ b/manifests/rhoai/base/notebooks-rbac-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /subjects/0/name
+  value: rhods-dashboard
+- op: replace
+  path: /subjects/0/namespace
+  value: redhat-ods-applications

--- a/manifests/rhoai/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/odhdashboardconfig/odhdashboardconfig.yaml
@@ -9,6 +9,7 @@ spec:
   dashboardConfig:
     # Overrides only -- see blankDashboardCR
     disableTracking: false
+    notebooksV2: true
   notebookController:
     enabled: true
     pvcSize: "20Gi"

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -264,6 +264,7 @@ export type DashboardCommonConfig = {
   aiAssetCustomEndpoints?: boolean;
   mlflowPipelines?: boolean;
   mcpCatalog?: boolean;
+  notebooksV2?: boolean;
   toolCalling?: boolean;
   projectRBAC?: boolean;
   observabilityDashboard?: boolean;

--- a/packages/notebooks/Dockerfile.workspace
+++ b/packages/notebooks/Dockerfile.workspace
@@ -54,6 +54,7 @@ WORKDIR /usr/src/workspace/${UI_SOURCE_CODE}
 RUN npm ci --omit=optional --ignore-scripts
 
 # Build the module
+ARG URL_PREFIX=/notebooks
 RUN npm run build:prod
 
 # BFF build stage

--- a/packages/notebooks/Dockerfile.workspace
+++ b/packages/notebooks/Dockerfile.workspace
@@ -77,8 +77,7 @@ COPY --chown=default:root ${BFF_SOURCE_CODE} ./backend
 
 # Rewrite the go.mod to update the replace directive and download dependencies
 RUN go mod edit \
-    -replace=github.com/kubeflow/notebooks/workspaces/controller=./controller \
-    -replace=github.com/kubeflow/notebooks/workspaces/backend=./backend && \
+    -replace=github.com/kubeflow/notebooks/workspaces/controller=./controller && \
     go mod download
 
 # Copy the go source files
@@ -88,7 +87,7 @@ COPY --chown=default:root ${BFF_SOURCE_CODE}/internal/ internal/
 COPY --chown=default:root ${BFF_SOURCE_CODE}/openapi/ openapi/
 
 # Build the Go application
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o bff ./cmd
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/bff-binary ./cmd
 
 # Final stage
 FROM ${DISTROLESS_BASE_IMAGE}
@@ -96,7 +95,7 @@ FROM ${DISTROLESS_BASE_IMAGE}
 ARG UI_SOURCE_CODE
 
 WORKDIR /
-COPY --from=bff-builder /usr/src/app/bff ./
+COPY --from=bff-builder /tmp/bff-binary /bff
 COPY --from=ui-builder /usr/src/workspace/${UI_SOURCE_CODE}/dist ./static/
 USER 65532:65532
 

--- a/packages/notebooks/upstream/workspaces/frontend/src/odh/extensions.ts
+++ b/packages/notebooks/upstream/workspaces/frontend/src/odh/extensions.ts
@@ -1,57 +1,54 @@
+/* eslint-disable @cspell/spellchecker */
 import type {
   AreaExtension,
   NavExtension,
+  ProjectDetailsTab,
   RouteExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
 
-const reliantAreas = ['workbenches'];
-const PLUGIN_NOTEBOOKS = 'notebooks-plugin';
+// This must match SupportedArea.NOTEBOOKS_V2 in frontend/src/concepts/areas/types.ts
+const NOTEBOOKS_V2 = 'notebooks-v2';
 
-const extensions: (NavExtension | RouteExtension | AreaExtension)[] = [
+const extensions: (NavExtension | RouteExtension | AreaExtension | ProjectDetailsTab)[] = [
   {
     type: 'app.area',
     properties: {
-      id: PLUGIN_NOTEBOOKS,
-      reliantAreas,
-      devFlags: ['Notebooks Plugin'],
+      id: NOTEBOOKS_V2,
+      featureFlags: ['notebooksV2'],
     },
   },
   {
     type: 'app.navigation/href',
     flags: {
-      required: [PLUGIN_NOTEBOOKS],
-    },
-    properties: {
-      id: 'notebooks-kf-workspaces',
-      title: 'Workspaces',
-      href: '/notebooks/workspaces',
-      section: 'ai-hub',
-      path: '/notebooks/workspaces/*',
-      group: '1_aihub',
-    },
-  },
-  {
-    type: 'app.navigation/href',
-    flags: {
-      required: [PLUGIN_NOTEBOOKS],
+      required: [NOTEBOOKS_V2],
     },
     properties: {
       id: 'notebooks-kf-workspacekinds',
-      title: 'Workspace Kinds',
+      title: 'Workbench Templates',
       href: '/notebooks/workspacekinds',
-      section: 'ai-hub',
+      section: 'settings-environment-setup',
       path: '/notebooks/workspacekinds/*',
-      group: '1_aihub',
     },
   },
   {
     type: 'app.route',
     flags: {
-      required: [PLUGIN_NOTEBOOKS],
+      required: [NOTEBOOKS_V2],
     },
     properties: {
       path: '/notebooks/*',
       component: () => import('./NotebooksWrapper'),
+    },
+  },
+  {
+    type: 'app.project-details/tab',
+    properties: {
+      id: 'workbenches-v2',
+      title: 'Workbenches v2',
+      component: () => import('./WorkspacesProjectDetailsTab'),
+    },
+    flags: {
+      required: [NOTEBOOKS_V2],
     },
   },
 ];

--- a/packages/plugin-core/src/areas/types.ts
+++ b/packages/plugin-core/src/areas/types.ts
@@ -115,6 +115,9 @@ export enum SupportedArea {
   MLFLOW = 'mlflow',
   MLFLOW_PIPELINES = 'mlflow-pipelines',
 
+  /* Notebooks V2 (Workspaces) */
+  NOTEBOOKS_V2 = 'notebooks-v2',
+
   /* Project RBAC Settings */
   PROJECT_RBAC_SETTINGS = 'project-rbac-settings',
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
This PR implements the infrastructure needed to enable Notebooks v2 as a federated module in ODH Dashboard, gated behind the notebooksV2 feature flag.

#### Feature Flag & Area Registration

  - Add SupportedArea.NOTEBOOKS_V2 to plugin-core/src/areas/types.ts
  - Add notebooksV2 feature flag to DashboardCommonConfig in k8s-core and backend types/constants
  - Register the area in frontend/src/concepts/areas/const.ts with featureFlags: ['notebooksV2']
  - Update OdhDashboardConfig CRD schema to include notebooksV2 field
  - Enable notebooksV2: true by default in RHOAI odhdashboardconfig.yaml

 #### Manifests & RBAC

  - Add notebooks-ui container to the modular-architecture deployment (port 8943)
  - Add notebooks entry to federation-configmap.yaml with proxy config for /workspaces/api
  - Add notebooks-rbac.yaml with ClusterRole and ClusterRoleBindings for workspaces, workspacekinds, secrets, and namespaces
  - Add RHOAI overlay patch (notebooks-rbac-patch.yaml) for rhods-dashboard service account
  - Add notebooks-ui-image to params.env and kustomization variable substitution
  - Add notebooks-ui service port to service.yaml

 #### Host Navigation & Project Details

  - Add useWorkbenchesV2Tab hook to render the "Workbenches v2" tab in project details via the app.project-details/tab extension point
  - Add WORKBENCHES_V2 to ProjectSectionID enum
  - Wire workbenchesV2Tab into ProjectDetails.tsx sections

####  Plugin Extensions (ODH-only)

  - Update extensions.ts with area flag, "Workbench Templates" nav item under Settings, /notebooks/* route, and project details tab

####  Build & Package Config

  - Update Dockerfile.workspace for federated container build
 
#### Update subtree skill
- Update the `upstream-sync` skill to include Notebooks specific workarounds: extensions.ts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  - Built and deployed both dashboard and notebooks-ui images to an OpenShift cluster
  - Verified Workbench Templates nav item appears in Settings when notebooksV2 is enabled
  - Verified Workbenches v2 tab renders in project details
  - Verified /notebooks/workspacekinds route renders the workspace kinds page
  - Verified feature flag gating — extensions hidden when notebooksV2 is false
  - Backend: make test and make lint pass in midstream
  - Frontend: all unit tests pass with route prefix updates
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new **Notebooks V2** experience, including a project details tab and related feature flag.
  * Enabled the new notebooks experience in the dashboard configuration and deployment setup.
  * Added the necessary service, routing, and access configuration to surface the notebooks UI.

* **Bug Fixes**
  * Improved configuration defaults and schema support so the new notebooks setting is handled consistently across the app and manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->