### PR TITLE
[Cypress-e2e] add E2E test for GPUaaS Infrastructure page

### DIFF
--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -20,8 +20,20 @@ class InfrastructurePage {
     return cy.findByTestId('app-page-title').should('have.text', 'Infrastructure');
   }
 
+  findPageSubtitle() {
+    return cy.findByTestId('app-page-description');
+  }
+
   findClusterSection() {
     return cy.findByTestId('infrastructure-cluster-section');
+  }
+
+  findHardwareUsageSection() {
+    return cy.findByTestId('infrastructure-hardware-usage-section');
+  }
+
+  findClusterQueueUtilizationSection() {
+    return cy.findByTestId('infrastructure-cluster-queue-utilization-section');
   }
 
   findTotalAcceleratorsCard() {

--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -52,10 +52,6 @@ class InfrastructurePage {
     return cy.findByTestId('infrastructure-refresh-badge');
   }
 
-  findHardwareUsageSection() {
-    return cy.findByTestId('infrastructure-hardware-usage-section');
-  }
-
   findHardwareUsageEmpty() {
     return cy.findByTestId('hardware-usage-empty');
   }

--- a/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
@@ -1,0 +1,65 @@
+import { LDAP_ADMIN_USER, LDAP_CONTRIBUTOR_USER } from '../../../utils/e2eUsers';
+import { infrastructurePage } from '../../../pages/infrastructure';
+import { isKueueUnmanaged } from '../../../utils/oc_commands/dsc';
+
+describe('GPUaaS Infrastructure Page', () => {
+  before(() => {
+    cy.step('Verify Kueue is set to Unmanaged in the DataScienceCluster');
+    isKueueUnmanaged().then((isUnmanaged) => {
+      expect(isUnmanaged).to.equal(true);
+    });
+  });
+
+  it(
+    'Verify Infrastructure page is accessible for admin users and displays expected sections',
+    { tags: ['@Dashboard', '@GPUaaS', '@Featureflagged'] },
+    () => {
+      cy.step('Log in as admin user with gpuaas feature flag enabled');
+      cy.visitWithLogin('/?devFeatureFlags=gpuaas=true', LDAP_ADMIN_USER);
+
+      cy.step('Verify Infrastructure nav item is visible under Observe & monitor');
+      infrastructurePage.findNavItem().should('be.visible');
+
+      cy.step('Click Infrastructure nav item and verify navigation');
+      infrastructurePage.findNavItem().click();
+      cy.url().should('include', '/observe-and-monitor/infrastructure');
+
+      cy.step('Verify page title and subtitle are displayed');
+      infrastructurePage.shouldHavePageTitle();
+      infrastructurePage.findPageSubtitle().should('be.visible');
+
+      cy.step('Verify Cluster section is present');
+      infrastructurePage.findClusterSection().should('exist');
+
+      cy.step('Verify Hardware usage section is present');
+      infrastructurePage.findHardwareUsageSection().should('exist');
+
+      cy.step('Verify Borrowing & lending section is present');
+      infrastructurePage.findBorrowingLendingSection().should('exist');
+
+      cy.step('Verify Cluster queue utilization section is present');
+      infrastructurePage.findClusterQueueUtilizationSection().should('exist');
+    },
+  );
+
+  it(
+    'Verify Infrastructure page is not accessible for non-admin users',
+    { tags: ['@Dashboard', '@GPUaaS', '@Featureflagged'] },
+    () => {
+      cy.step('Log in as non-admin user with gpuaas feature flag enabled');
+      cy.visitWithLogin('/?devFeatureFlags=gpuaas=true', LDAP_CONTRIBUTOR_USER);
+
+      cy.step('Verify Infrastructure nav item is NOT visible');
+      infrastructurePage.findNavItem().should('not.exist');
+
+      cy.step('Navigate directly to Infrastructure page URL');
+      cy.visitWithLogin(
+        '/observe-and-monitor/infrastructure?devFeatureFlags=gpuaas=true',
+        LDAP_CONTRIBUTOR_USER,
+      );
+
+      cy.step('Verify page does not render for non-admin');
+      infrastructurePage.shouldNotFoundPage();
+    },
+  );
+});

--- a/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
@@ -5,9 +5,7 @@ import { isKueueUnmanaged } from '../../../utils/oc_commands/dsc';
 describe('GPUaaS Infrastructure Page', () => {
   before(() => {
     cy.step('Verify Kueue is set to Unmanaged in the DataScienceCluster');
-    isKueueUnmanaged().then((isUnmanaged) => {
-      expect(isUnmanaged).to.equal(true);
-    });
+    isKueueUnmanaged().should('equal', true);
   });
 
   it(


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-75435

## Description
Smoke E2E test verifying the GPUaaS Infrastructure page is visible for admins, displays all 4 section cards, and is gated from non-admin users.

## How Has This Been Tested?
Jenkins: 1796

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for the GPUaaS Infrastructure page.
  * Verified visibility of key infrastructure sections, including cluster details, hardware usage, borrowing and lending, and queue utilization.
  * Confirmed appropriate access controls for administrators and contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->