### PR TITLE
RHOAIENG-72365: Move token table components to @odh-dashboard/model-serving-shared

### DIFF
--- a/frontend/src/concepts/modelServingKServe/ServingRuntimeTokensTable.tsx
+++ b/frontend/src/concepts/modelServingKServe/ServingRuntimeTokensTable.tsx
@@ -4,8 +4,8 @@ import {
   isInferenceServiceKind,
   ServingRuntimeKind,
 } from '@odh-dashboard/model-serving/shared';
+import { TokensDescriptionItem } from '@odh-dashboard/model-serving/shared/components';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
-import { TokensDescriptionItem } from '#~/concepts/modelServing/ModelRow/TokensDescriptionItem';
 
 type ServingRuntimeTokensTableProps = {
   obj: ServingRuntimeKind | InferenceServiceKind;

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRowExpandedSection.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRowExpandedSection.tsx
@@ -13,13 +13,13 @@ import {
 } from '@patternfly/react-core';
 import { formatMemory } from '@odh-dashboard/ui-core/utilities';
 import type { SupportedModelFormats, ContainerResources } from '@odh-dashboard/k8s-core';
-import { TokensDescriptionItem } from '@odh-dashboard/internal/concepts/modelServing/ModelRow/TokensDescriptionItem';
 import type { CrPathConfig } from '@odh-dashboard/hardware-profiles/shared';
 import {
   useAssignHardwareProfile,
   MODEL_SERVING_VISIBILITY,
 } from '@odh-dashboard/hardware-profiles/shared';
 import HardwareProfileNameValue from './HardwareProfileNameValue';
+import { TokensDescriptionItem } from '../../../shared/components';
 import { isDeploymentAuthEnabled, useDeploymentAuthTokens } from '../../../concepts/auth';
 import { useResolvedDeploymentExtension } from '../../../concepts/extensionUtils';
 import { type Deployment, isModelServingAuthExtension } from '../../../../extension-points';

--- a/packages/model-serving/src/shared/components/ServingRuntimeTokenTableRow.tsx
+++ b/packages/model-serving/src/shared/components/ServingRuntimeTokenTableRow.tsx
@@ -3,7 +3,7 @@ import { Td, Tr } from '@patternfly/react-table';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import type { SecretKind } from '@odh-dashboard/k8s-core';
 import { ResourceNameTooltip } from '@odh-dashboard/ui-core';
-import { ServingRuntimeTokenDisplay } from '@odh-dashboard/model-serving/shared/components';
+import ServingRuntimeTokenDisplay from './ServingRuntimeTokenDisplay';
 
 type ServingRuntimeTokenTableRowProps = {
   obj: SecretKind;

--- a/packages/model-serving/src/shared/components/TokensDescriptionItem.tsx
+++ b/packages/model-serving/src/shared/components/TokensDescriptionItem.tsx
@@ -3,19 +3,18 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import type { SecretKind } from '@odh-dashboard/k8s-core';
 import { Table, SortableData } from '@odh-dashboard/ui-core';
-import { ColumnField } from '#~/pages/modelServing/screens/global/data';
 import ServingRuntimeTokenTableRow from './ServingRuntimeTokenTableRow';
 
 export const tokenColumns: SortableData<SecretKind>[] = [
   {
-    field: ColumnField.Name,
+    field: 'name',
     label: 'Token name',
     width: 20,
     sortable: (a, b) =>
       getDisplayNameFromK8sResource(a).localeCompare(getDisplayNameFromK8sResource(b)),
   },
   {
-    field: ColumnField.Token,
+    field: 'token',
     label: 'Token secret',
     width: 80,
     sortable: false,

--- a/packages/model-serving/src/shared/components/index.ts
+++ b/packages/model-serving/src/shared/components/index.ts
@@ -2,3 +2,5 @@ export { ModelStatusIcon } from './ModelStatusIcon';
 export { default as ServingRuntimeVersionLabel } from './ServingRuntimeVersionLabel';
 export { default as ModelServingPlatformSelectErrorAlert } from './ModelServingPlatformSelectErrorAlert';
 export { default as ServingRuntimeTokenDisplay } from './ServingRuntimeTokenDisplay';
+export { default as ServingRuntimeTokenTableRow } from './ServingRuntimeTokenTableRow';
+export { TokensDescriptionItem, tokenColumns } from './TokensDescriptionItem';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-72365

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Moves `TokensDescriptionItem` and `ServingRuntimeTokenTableRow` from `@odh-dashboard/internal` (`frontend/src/concepts/modelServing/ModelRow/`) to `@odh-dashboard/model-serving/shared/components` as subpath exports.

  These are pure presentational components — they receive `SecretKind[]` as props and render a token table. No API calls or data fetching.

  | Category | Items |
  |----------|-------|
  | **Components** | `TokensDescriptionItem`, `ServingRuntimeTokenTableRow` |
  | **Exported constant** | `tokenColumns` |

  ### Additional change

  The `ColumnField` enum import (`ColumnField.Name`, `ColumnField.Token`) has been replaced with inline string literals (`'name'`, `'token'`) in `TokensDescriptionItem`. The `ColumnField` enum in `pages/modelServing/screens/global/data.ts` contains 10 unrelated values and imports `getInferenceServiceStoppedStatus` from deep internal
  code — it cannot be moved. The two values used by the token component are arbitrary column identifiers, not shared constants.

  ### Consumer updates

  | Consumer | Old import | New import |
  |----------|-----------|------------|
  | `frontend/src/concepts/modelServingKServe/ServingRuntimeTokensTable.tsx` | `#~/concepts/modelServing/ModelRow/TokensDescriptionItem` | `@odh-dashboard/model-serving/shared/components` |
  | `packages/model-serving/src/components/deployments/row/DeploymentsTableRowExpandedSection.tsx` | `@odh-dashboard/internal/concepts/modelServing/ModelRow/TokensDescriptionItem` | `../../../shared/components` (package-internal relative) |

  After these changes, the shared components depend only on `@odh-dashboard/k8s-core`, `@odh-dashboard/ui-core`, and `@patternfly/*` — all already allowed dependencies of `model-serving/shared`. No dependency on `@odh-dashboard/internal`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  - `npm run lint` — passes with 0 errors
  - `npm run type-check` — all 27 packages pass
  - `npm run test:unit` (via `npx turbo run test-unit --force`) — 16/16 packages pass, 5,296 tests pass
  - `npm run build` — compiles with 0 errors

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No new tests added. This is a pure move/re-export refactor with no behavioral changes. Existing tests (`DeploymentsTableRowExpandedSection.spec.tsx`, `DeploymentsTableRow.spec.tsx`) continue to pass and validate the component through its new import path.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated token table UI pieces and related helpers under the shared model-serving exports to improve reuse and consistency across views.
  * Updated token table consumers to use the shared components where applicable.
  * Standardized the token column field identifiers to literal `name`/`token` keys while preserving the existing sorting behavior.
  * Extended shared component exports to include the token table row display and token column definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->