### PR TITLE
RHOAIENG-72103: Add Existing Secret option to workbench env vars

### DIFF
--- a/frontend/src/api/k8s/__tests__/notebooks.spec.ts
+++ b/frontend/src/api/k8s/__tests__/notebooks.spec.ts
@@ -661,6 +661,33 @@ describe('stopNotebook', () => {
   });
 });
 describe('mergePatchUpdateNotebook', () => {
+  it('should include existingSecretEnvVars in the merge-patched notebook env array', async () => {
+    const existingNotebook = mockNotebookK8sResource({ uid });
+    const notebookData = mockStartNotebookData({
+      notebookId: existingNotebook.metadata.name,
+    });
+    notebookData.existingSecretEnvVars = [
+      {
+        name: 'API_KEY',
+        valueFrom: { secretKeyRef: { name: 'api-secret', key: 'API_KEY' } },
+      },
+    ];
+
+    k8sMergePatchResourceMock.mockResolvedValue(existingNotebook);
+
+    await mergePatchUpdateNotebook(existingNotebook, notebookData, username);
+
+    const { resource } = k8sMergePatchResourceMock.mock.calls[0][0];
+    const containerEnv = resource.spec.template.spec.containers[0].env;
+
+    // Should have NOTEBOOK_ARGS + JUPYTER_IMAGE + 1 existing secret env var
+    expect(containerEnv).toHaveLength(3);
+    expect(containerEnv[2]).toEqual({
+      name: 'API_KEY',
+      valueFrom: { secretKeyRef: { name: 'api-secret', key: 'API_KEY' } },
+    });
+  });
+
   it('should update a notebook', async () => {
     const existingNotebook = mockNotebookK8sResource({ uid });
     const notebook = assembleNotebook(
@@ -1413,6 +1440,41 @@ describe('restartNotebook', () => {
 });
 
 describe('updateNotebook', () => {
+  it('should include existingSecretEnvVars in the merged notebook env array', async () => {
+    const existingNotebook = mockNotebookK8sResource({ uid });
+    const newNotebookData = mockStartNotebookData({
+      notebookId: existingNotebook.metadata.name,
+    });
+    newNotebookData.existingSecretEnvVars = [
+      {
+        name: 'DB_HOST',
+        valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_HOST' } },
+      },
+      {
+        name: 'DB_PORT',
+        valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_PORT' } },
+      },
+    ];
+
+    k8sUpdateResourceMock.mockResolvedValue(existingNotebook);
+
+    await updateNotebook(existingNotebook, newNotebookData, username);
+
+    const { resource: mergedNotebook } = k8sUpdateResourceMock.mock.calls[0][0];
+    const containerEnv = mergedNotebook.spec.template.spec.containers[0].env;
+
+    // Should have NOTEBOOK_ARGS + JUPYTER_IMAGE + 2 existing secret env vars
+    expect(containerEnv).toHaveLength(4);
+    expect(containerEnv[2]).toEqual({
+      name: 'DB_HOST',
+      valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_HOST' } },
+    });
+    expect(containerEnv[3]).toEqual({
+      name: 'DB_PORT',
+      valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_PORT' } },
+    });
+  });
+
   it('should clear old volumes and volumeMounts to prevent lodash merge corruption', async () => {
     // Create existing notebook with multiple volumes including system volumes
     const existingNotebook = mockNotebookK8sResource({ uid });

--- a/frontend/src/api/k8s/__tests__/notebooks.spec.ts
+++ b/frontend/src/api/k8s/__tests__/notebooks.spec.ts
@@ -424,6 +424,45 @@ describe('assembleNotebook', () => {
       expect(result.metadata.annotations?.['opendatahub.io/mlflow-instance']).toBeUndefined();
     },
   );
+
+  it('should include existingSecretEnvVars in env array when provided', () => {
+    const notebookData = mockStartNotebookData({});
+    notebookData.existingSecretEnvVars = [
+      {
+        name: 'DB_HOST',
+        valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_HOST' } },
+      },
+      {
+        name: 'DB_PORT',
+        valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_PORT' } },
+      },
+    ];
+
+    const result = assembleNotebook(notebookData, 'test-user');
+    const containerEnv = result.spec.template.spec.containers[0].env;
+
+    // Should have NOTEBOOK_ARGS + JUPYTER_IMAGE + 2 existing secret env vars
+    expect(containerEnv).toHaveLength(4);
+    expect(containerEnv[2]).toEqual({
+      name: 'DB_HOST',
+      valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_HOST' } },
+    });
+    expect(containerEnv[3]).toEqual({
+      name: 'DB_PORT',
+      valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_PORT' } },
+    });
+  });
+
+  it('should not include extra env entries when existingSecretEnvVars is undefined', () => {
+    const notebookData = mockStartNotebookData({});
+    const result = assembleNotebook(notebookData, 'test-user');
+    const containerEnv = result.spec.template.spec.containers[0].env;
+
+    // Should only have NOTEBOOK_ARGS + JUPYTER_IMAGE
+    expect(containerEnv).toHaveLength(2);
+    expect(containerEnv[0].name).toBe('NOTEBOOK_ARGS');
+    expect(containerEnv[1].name).toBe('JUPYTER_IMAGE');
+  });
 });
 
 describe('createNotebook', () => {

--- a/frontend/src/api/k8s/__tests__/secrets.spec.ts
+++ b/frontend/src/api/k8s/__tests__/secrets.spec.ts
@@ -18,6 +18,7 @@ import {
   assembleSecretSA,
   createSecret,
   deleteSecret,
+  getOpaqueSecrets,
   getSecret,
   getSecretsByLabel,
   replaceSecret,
@@ -307,6 +308,32 @@ describe('replaceSecret', () => {
       },
     });
     expect(k8sUpdateResourceMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getOpaqueSecrets', () => {
+  it('should return opaque secrets for a namespace', async () => {
+    const secretMock = mockK8sResourceList([mockSecretK8sResource({})]);
+    k8sListResourceMock.mockResolvedValue(secretMock);
+    const result = await getOpaqueSecrets('test-namespace');
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: SecretModel,
+      queryOptions: { ns: 'test-namespace', queryParams: { fieldSelector: 'type=Opaque' } },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(secretMock.items);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(getOpaqueSecrets('test-namespace')).rejects.toThrow('error1');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: SecretModel,
+      queryOptions: { ns: 'test-namespace', queryParams: { fieldSelector: 'type=Opaque' } },
+    });
   });
 });
 

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -36,6 +36,7 @@ export const assembleNotebook = (
   const {
     projectName,
     notebookData,
+    existingSecretEnvVars,
     envFrom,
     image,
     volumes: formVolumes,
@@ -134,6 +135,7 @@ export const assembleNotebook = (
                   name: 'JUPYTER_IMAGE',
                   value: imageUrl,
                 },
+                ...(existingSecretEnvVars ?? []),
               ],
               envFrom,
               volumeMounts,

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -167,6 +167,17 @@ export const getSecretsByLabel = (
     ),
   ).then((result) => result.items);
 
+export const getOpaqueSecrets = (namespace: string, opts?: K8sAPIOptions): Promise<SecretKind[]> =>
+  k8sListResource<SecretKind>(
+    applyK8sAPIOptions(
+      {
+        model: SecretModel,
+        queryOptions: { ns: namespace, queryParams: { fieldSelector: 'type=Opaque' } },
+      },
+      opts,
+    ),
+  ).then((result) => result.items);
+
 export const createSecret = (data: SecretKind, opts?: K8sAPIOptions): Promise<SecretKind> =>
   k8sCreateResource<SecretKind>(
     applyK8sAPIOptions(

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -181,6 +181,8 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       dryRun,
     );
 
+    const existingSecretEnvVarsList = getExistingSecretEnvVars(envVariables);
+
     const annotations = { ...editNotebook.metadata.annotations };
     if (envFrom.length > 0) {
       annotations['notebooks.opendatahub.io/notebook-restart'] = 'true';
@@ -192,6 +194,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       ...startNotebookData,
       volumes,
       volumeMounts,
+      existingSecretEnvVars: existingSecretEnvVarsList,
       envFrom,
       connections,
       feastData,

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -32,6 +32,7 @@ import { getNotebookPVCNames } from '#~/pages/projects/pvc/utils';
 import {
   createConfigMapsAndSecretsForNotebook,
   createPvcDataForNotebook,
+  getExistingSecretEnvVars,
   updateConfigMapsAndSecretsForNotebook,
   updatePvcDataForNotebook,
 } from './service';
@@ -224,6 +225,8 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
 
     await Promise.all(restartConnectedNotebooksPromises);
 
+    const existingSecretEnvVarsList = getExistingSecretEnvVars(envVariables);
+
     const envFrom = await createConfigMapsAndSecretsForNotebook(
       projectName,
       [...envVariables],
@@ -237,6 +240,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       ...startNotebookData,
       volumes,
       volumeMounts,
+      existingSecretEnvVars: existingSecretEnvVarsList,
       envFrom: [...envFrom],
       connections,
       feastData,

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -372,7 +372,11 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   deletedSecrets={deletedSecrets}
                 />
               )}
-              <EnvironmentVariables envVariables={envVariables} setEnvVariables={setEnvVariables} />
+              <EnvironmentVariables
+                envVariables={envVariables}
+                setEnvVariables={setEnvVariables}
+                namespace={currentProject.metadata.name}
+              />
             </FormSection>
             <FormSection
               title={

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -65,6 +65,8 @@ import { useDefaultStorageClass } from './storage/useDefaultStorageClass';
 import { ConnectionsFormSection } from './connections/ConnectionsFormSection';
 import { getConnectionsFromNotebook } from './connections/utils';
 import AlertWarningText from './environmentVariables/AlertWarningText';
+import EnvVarConflictWarning from './environmentVariables/EnvVarConflictWarning';
+import { detectEnvVarConflicts } from './environmentVariables/envVarConflicts';
 import { ClusterStorageTable } from './storage/ClusterStorageTable';
 import useDefaultPvcSize from './storage/useDefaultPvcSize';
 import { defaultClusterStorage } from './storage/constants';
@@ -198,6 +200,11 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     useNotebookEnvVariables(existingNotebook, [
       ...notebookConnections.map((connection) => connection.metadata.name),
     ]);
+
+  const envVarConflicts = React.useMemo(
+    () => detectEnvVarConflicts(envVariables, notebookConnections),
+    [envVariables, notebookConnections],
+  );
 
   const notebooksUsingPVCsWithSizeChanges = React.useMemo(() => {
     const attachedPVCs = storageData.filter((storage) => storage.existingPvc !== undefined);
@@ -372,6 +379,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   deletedSecrets={deletedSecrets}
                 />
               )}
+              <EnvVarConflictWarning conflicts={envVarConflicts} />
               <EnvironmentVariables
                 envVariables={envVariables}
                 setEnvVariables={setEnvVariables}

--- a/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
@@ -1,0 +1,189 @@
+import type { EnvironmentVariable } from '@odh-dashboard/k8s-core';
+import {
+  EnvironmentVariableType,
+  EnvVariable,
+  SecretCategory,
+  ConfigMapCategory,
+} from '#~/pages/projects/types';
+import { getExistingSecretEnvVars } from '#~/pages/projects/screens/spawner/service';
+
+describe('getExistingSecretEnvVars', () => {
+  it('should return empty array when no env variables are provided', () => {
+    const result = getExistingSecretEnvVars([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when no existing secret env variables are present', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'test-key', value: 'test-value' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.CONFIG_MAP,
+        values: {
+          category: ConfigMapCategory.GENERIC,
+          data: [{ key: 'cm-key', value: 'cm-value' }],
+        },
+      },
+    ];
+
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+
+  it('should convert existing secret entries to env vars with secretKeyRef', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-existing-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'DB_HOST', value: '' },
+            { key: 'DB_PORT', value: '' },
+          ],
+        },
+      },
+    ];
+
+    const result = getExistingSecretEnvVars(envVariables);
+
+    const expected: EnvironmentVariable[] = [
+      {
+        name: 'DB_HOST',
+        valueFrom: { secretKeyRef: { name: 'my-existing-secret', key: 'DB_HOST' } },
+      },
+      {
+        name: 'DB_PORT',
+        valueFrom: { secretKeyRef: { name: 'my-existing-secret', key: 'DB_PORT' } },
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle multiple existing secrets', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY_A', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-b',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'KEY_B1', value: '' },
+            { key: 'KEY_B2', value: '' },
+          ],
+        },
+      },
+    ];
+
+    const result = getExistingSecretEnvVars(envVariables);
+
+    expect(result).toHaveLength(3);
+    expect(result).toEqual([
+      {
+        name: 'KEY_A',
+        valueFrom: { secretKeyRef: { name: 'secret-a', key: 'KEY_A' } },
+      },
+      {
+        name: 'KEY_B1',
+        valueFrom: { secretKeyRef: { name: 'secret-b', key: 'KEY_B1' } },
+      },
+      {
+        name: 'KEY_B2',
+        valueFrom: { secretKeyRef: { name: 'secret-b', key: 'KEY_B2' } },
+      },
+    ]);
+  });
+
+  it('should skip existing secret entries with no values', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: undefined,
+      },
+    ];
+
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+
+  it('should skip existing secret entries with empty data', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [],
+        },
+      },
+    ];
+
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+
+  it('should only process EXISTING secrets, ignoring GENERIC and AWS secrets', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'generic-key', value: 'generic-val' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.AWS,
+          data: [{ key: 'aws-key', value: 'aws-val' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'existing-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'EXISTING_KEY', value: '' }],
+        },
+      },
+    ];
+
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([
+      {
+        name: 'EXISTING_KEY',
+        valueFrom: { secretKeyRef: { name: 'existing-secret', key: 'EXISTING_KEY' } },
+      },
+    ]);
+  });
+
+  it('should skip existing secret entries without existingName', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY', value: '' }],
+        },
+      },
+    ];
+
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
@@ -3,9 +3,16 @@ import {
   getRelatedVersionDescription,
   checkVersionRecommended,
   getVersion,
+  isEnvVariableDataValid,
 } from '#~/pages/projects/screens/spawner/spawnerUtils';
 import { mockImageStreamK8sResource } from '#~/__mocks__/mockImageStreamK8sResource';
 import { IMAGE_ANNOTATIONS } from '#~/pages/projects/screens/spawner/const';
+import {
+  EnvironmentVariableType,
+  SecretCategory,
+  ConfigMapCategory,
+  EnvVariable,
+} from '#~/pages/projects/types';
 
 describe('getExistingVersionsForImageStream', () => {
   it('should handle no image tags', () => {
@@ -189,5 +196,153 @@ describe('checkVersionRecommended', () => {
     expect(getVersion(0.1)).toEqual('0.1');
     expect(getVersion(3.1, 'v')).toEqual('v3.1');
     expect(getVersion(1000.5, 'V')).toEqual('V1000.5');
+  });
+});
+
+describe('isEnvVariableDataValid', () => {
+  it('should return true for empty env variables array', () => {
+    expect(isEnvVariableDataValid([])).toBe(true);
+  });
+
+  it('should return true for valid generic secret', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'MY_KEY', value: 'my-value' }],
+        },
+      },
+    ];
+    expect(isEnvVariableDataValid(envVars)).toBe(true);
+  });
+
+  it('should return true for valid generic config map', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.CONFIG_MAP,
+        values: {
+          category: ConfigMapCategory.GENERIC,
+          data: [{ key: 'MY_KEY', value: 'my-value' }],
+        },
+      },
+    ];
+    expect(isEnvVariableDataValid(envVars)).toBe(true);
+  });
+
+  it('should return false when type is null', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: null,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'MY_KEY', value: 'my-value' }],
+        },
+      },
+    ];
+    expect(isEnvVariableDataValid(envVars)).toBe(false);
+  });
+
+  it('should return false when values are missing', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+      },
+    ];
+    expect(isEnvVariableDataValid(envVars)).toBe(false);
+  });
+
+  it('should return false when data array is empty', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [],
+        },
+      },
+    ];
+    expect(isEnvVariableDataValid(envVars)).toBe(false);
+  });
+
+  describe('existing secret category', () => {
+    it('should return true when secret name is set and keys are selected', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'my-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [
+              { key: 'DB_HOST', value: '' },
+              { key: 'DB_PORT', value: '' },
+            ],
+          },
+        },
+      ];
+      expect(isEnvVariableDataValid(envVars)).toBe(true);
+    });
+
+    it('should return false when secret name is empty', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: '',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'DB_HOST', value: '' }],
+          },
+        },
+      ];
+      expect(isEnvVariableDataValid(envVars)).toBe(false);
+    });
+
+    it('should return false when secret name is not set', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'DB_HOST', value: '' }],
+          },
+        },
+      ];
+      expect(isEnvVariableDataValid(envVars)).toBe(false);
+    });
+
+    it('should return false when no keys are selected (empty data array)', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'my-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [],
+          },
+        },
+      ];
+      expect(isEnvVariableDataValid(envVars)).toBe(false);
+    });
+
+    it('should return true alongside other valid env variables', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          values: {
+            category: SecretCategory.GENERIC,
+            data: [{ key: 'INLINE_KEY', value: 'inline-value' }],
+          },
+        },
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'my-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'DB_HOST', value: '' }],
+          },
+        },
+      ];
+      expect(isEnvVariableDataValid(envVars)).toBe(true);
+    });
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
@@ -1,0 +1,183 @@
+import * as React from 'react';
+import { Checkbox, Stack, StackItem, Spinner } from '@patternfly/react-core';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { getSecret } from '#~/api';
+import { EnvVariableData, SecretCategory } from '#~/pages/projects/types';
+import TypeaheadSelect, { TypeaheadSelectOption } from '#~/components/TypeaheadSelect';
+import { useExistingSecrets } from './useExistingSecrets';
+
+type EnvExistingSecretProps = {
+  env?: EnvVariableData;
+  selectedSecretName?: string;
+  onUpdate: (data: EnvVariableData, secretName?: string) => void;
+  namespace: string;
+};
+
+const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({
+  env,
+  selectedSecretName,
+  onUpdate,
+  namespace,
+}) => {
+  const [secrets, secretsLoaded] = useExistingSecrets(namespace, true);
+  const [secretKeys, setSecretKeys] = React.useState<string[]>([]);
+  const [loadingKeys, setLoadingKeys] = React.useState(false);
+  const [currentSecretName, setCurrentSecretName] = React.useState<string>(
+    selectedSecretName ?? '',
+  );
+
+  const selectedKeys = React.useMemo(
+    () => (env?.data ?? []).map((entry) => entry.key),
+    [env?.data],
+  );
+
+  // Fetch secret keys when a secret is selected
+  React.useEffect(() => {
+    if (!currentSecretName) {
+      setSecretKeys([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingKeys(true);
+
+    getSecret(namespace, currentSecretName)
+      .then((secret: SecretKind) => {
+        if (!cancelled) {
+          setSecretKeys(Object.keys(secret.data ?? {}));
+          setLoadingKeys(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSecretKeys([]);
+          setLoadingKeys(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [namespace, currentSecretName]);
+
+  const handleSecretSelect = React.useCallback(
+    (_event: React.MouseEvent | React.KeyboardEvent | undefined, value: string | number) => {
+      const name = String(value);
+      setCurrentSecretName(name);
+      // Clear selection when secret changes
+      onUpdate(
+        {
+          category: SecretCategory.EXISTING,
+          data: [],
+        },
+        name,
+      );
+    },
+    [onUpdate],
+  );
+
+  const handleKeyToggle = React.useCallback(
+    (keyName: string, checked: boolean) => {
+      const currentKeys = new Set(selectedKeys);
+      if (checked) {
+        currentKeys.add(keyName);
+      } else {
+        currentKeys.delete(keyName);
+      }
+
+      onUpdate(
+        {
+          category: SecretCategory.EXISTING,
+          data: Array.from(currentKeys).map((k) => ({ key: k, value: '' })),
+        },
+        currentSecretName,
+      );
+    },
+    [selectedKeys, currentSecretName, onUpdate],
+  );
+
+  const handleAllKeysToggle = React.useCallback(
+    (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
+      if (checked) {
+        onUpdate(
+          {
+            category: SecretCategory.EXISTING,
+            data: secretKeys.map((k) => ({ key: k, value: '' })),
+          },
+          currentSecretName,
+        );
+      } else {
+        onUpdate(
+          {
+            category: SecretCategory.EXISTING,
+            data: [],
+          },
+          currentSecretName,
+        );
+      }
+    },
+    [secretKeys, currentSecretName, onUpdate],
+  );
+
+  const allKeysSelected =
+    secretKeys.length > 0 && secretKeys.every((k) => selectedKeys.includes(k));
+
+  const secretOptions: TypeaheadSelectOption[] = React.useMemo(
+    () =>
+      secrets.map((secret) => ({
+        value: secret.metadata.name,
+        content: secret.metadata.name,
+      })),
+    [secrets],
+  );
+
+  return (
+    <Stack hasGutter>
+      <StackItem data-testid="existing-secret-selector">
+        <TypeaheadSelect
+          selectOptions={secretOptions}
+          placeholder={secretsLoaded ? 'Select a secret' : 'Loading secrets...'}
+          onSelect={handleSecretSelect}
+          isDisabled={!secretsLoaded}
+          selected={currentSecretName || undefined}
+          dataTestId="existing-secret-typeahead"
+        />
+      </StackItem>
+      {currentSecretName && !loadingKeys && (
+        <StackItem data-testid="existing-secret-key-picker">
+          <Stack hasGutter>
+            {secretKeys.length > 0 && (
+              <StackItem>
+                <Checkbox
+                  id="all-keys-checkbox"
+                  data-testid="all-keys-checkbox"
+                  label="All keys"
+                  isChecked={allKeysSelected}
+                  onChange={handleAllKeysToggle}
+                />
+              </StackItem>
+            )}
+            {secretKeys.map((keyName) => (
+              <StackItem key={keyName}>
+                <Checkbox
+                  id={`key-checkbox-${keyName}`}
+                  data-testid={`key-checkbox-${keyName}`}
+                  label={keyName}
+                  isChecked={selectedKeys.includes(keyName)}
+                  onChange={(_event, checked) => handleKeyToggle(keyName, checked)}
+                />
+              </StackItem>
+            ))}
+          </Stack>
+        </StackItem>
+      )}
+      {currentSecretName && loadingKeys && (
+        <StackItem>
+          <Spinner size="md" data-testid="key-loading-spinner" />
+        </StackItem>
+      )}
+    </Stack>
+  );
+};
+
+export default EnvExistingSecret;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
@@ -9,7 +9,8 @@ import { useExistingSecrets } from './useExistingSecrets';
 type EnvExistingSecretProps = {
   env?: EnvVariableData;
   selectedSecretName?: string;
-  onUpdate: (data: EnvVariableData, secretName?: string) => void;
+  onUpdate: (data: EnvVariableData) => void;
+  onSecretNameChange: (name: string) => void;
   namespace: string;
 };
 
@@ -17,6 +18,7 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({
   env,
   selectedSecretName,
   onUpdate,
+  onSecretNameChange,
   namespace,
 }) => {
   const [secrets, secretsLoaded] = useExistingSecrets(namespace, true);
@@ -65,15 +67,13 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({
       const name = String(value);
       setCurrentSecretName(name);
       // Clear selection when secret changes
-      onUpdate(
-        {
-          category: SecretCategory.EXISTING,
-          data: [],
-        },
-        name,
-      );
+      onUpdate({
+        category: SecretCategory.EXISTING,
+        data: [],
+      });
+      onSecretNameChange(name);
     },
-    [onUpdate],
+    [onUpdate, onSecretNameChange],
   );
 
   const handleKeyToggle = React.useCallback(
@@ -85,38 +85,29 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({
         currentKeys.delete(keyName);
       }
 
-      onUpdate(
-        {
-          category: SecretCategory.EXISTING,
-          data: Array.from(currentKeys).map((k) => ({ key: k, value: '' })),
-        },
-        currentSecretName,
-      );
+      onUpdate({
+        category: SecretCategory.EXISTING,
+        data: Array.from(currentKeys).map((k) => ({ key: k, value: '' })),
+      });
     },
-    [selectedKeys, currentSecretName, onUpdate],
+    [selectedKeys, onUpdate],
   );
 
   const handleAllKeysToggle = React.useCallback(
     (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
       if (checked) {
-        onUpdate(
-          {
-            category: SecretCategory.EXISTING,
-            data: secretKeys.map((k) => ({ key: k, value: '' })),
-          },
-          currentSecretName,
-        );
+        onUpdate({
+          category: SecretCategory.EXISTING,
+          data: secretKeys.map((k) => ({ key: k, value: '' })),
+        });
       } else {
-        onUpdate(
-          {
-            category: SecretCategory.EXISTING,
-            data: [],
-          },
-          currentSecretName,
-        );
+        onUpdate({
+          category: SecretCategory.EXISTING,
+          data: [],
+        });
       }
     },
-    [secretKeys, currentSecretName, onUpdate],
+    [secretKeys, onUpdate],
   );
 
   const allKeysSelected =

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -5,10 +5,14 @@ import EnvDataTypeField from './EnvDataTypeField';
 import GenericKeyValuePairField from './GenericKeyValuePairField';
 import { EMPTY_KEY_VALUE_PAIR } from './const';
 import EnvUploadField from './EnvUploadField';
+import EnvExistingSecret from './EnvExistingSecret';
 
 type EnvSecretProps = {
   env?: EnvVariableData;
+  existingName?: string;
   onUpdate: (envVariableData: EnvVariableData) => void;
+  onExistingNameChange: (name: string) => void;
+  namespace: string;
 };
 
 const DEFAULT_ENV: EnvVariableData = {
@@ -16,7 +20,13 @@ const DEFAULT_ENV: EnvVariableData = {
   data: [],
 };
 
-const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) => (
+const EnvSecret: React.FC<EnvSecretProps> = ({
+  env = DEFAULT_ENV,
+  existingName,
+  onUpdate,
+  onExistingNameChange,
+  namespace,
+}) => (
   <EnvDataTypeField
     selection={env.category || ''}
     onSelection={(value) =>
@@ -40,6 +50,18 @@ const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) =>
             envVarType={EnvironmentVariableType.SECRET}
             onUpdate={(newEnvData) => onUpdate({ ...env, data: newEnvData })}
             translateValue={(value) => atob(value)}
+          />
+        ),
+      },
+      [SecretCategory.EXISTING]: {
+        label: 'Existing secret',
+        render: (
+          <EnvExistingSecret
+            env={env}
+            selectedSecretName={existingName}
+            onUpdate={onUpdate}
+            onSecretNameChange={onExistingNameChange}
+            namespace={namespace}
           />
         ),
       },

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -12,12 +12,14 @@ type EnvTypeSelectFieldProps = {
   envVariable: EnvVariable;
   onUpdate: (envVariable: EnvVariable) => void;
   onRemove: () => void;
+  namespace: string;
 };
 
 const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
   envVariable,
   onUpdate,
   onRemove,
+  namespace,
 }) => (
   <FormGroup isRequired label="Variable type" fieldId="environment-variable-type-select">
     <Split data-testid="environment-variable-field">
@@ -52,6 +54,8 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                 <EnvTypeSwitch
                   env={envVariable}
                   onUpdate={(envValue) => onUpdate({ ...envVariable, values: envValue })}
+                  onExistingNameChange={(name) => onUpdate({ ...envVariable, existingName: name })}
+                  namespace={namespace}
                 />
               </IndentSection>
             </StackItem>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
@@ -6,14 +6,29 @@ import EnvSecret from './EnvSecret';
 type EnvTypeSwitchProps = {
   env: EnvVariable;
   onUpdate: (envVariableData: EnvVariableData) => void;
+  onExistingNameChange: (name: string) => void;
+  namespace: string;
 };
 
-const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate }) => {
+const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({
+  env,
+  onUpdate,
+  onExistingNameChange,
+  namespace,
+}) => {
   switch (env.type) {
     case EnvironmentVariableType.CONFIG_MAP:
       return <EnvConfigMap env={env.values} onUpdate={onUpdate} />;
     case EnvironmentVariableType.SECRET:
-      return <EnvSecret env={env.values} onUpdate={onUpdate} />;
+      return (
+        <EnvSecret
+          env={env.values}
+          existingName={env.existingName}
+          onUpdate={onUpdate}
+          onExistingNameChange={onExistingNameChange}
+          namespace={namespace}
+        />
+      );
     default:
       return null;
   }

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Alert, ExpandableSection, List, ListItem } from '@patternfly/react-core';
+import { EnvVarConflict } from './envVarConflicts';
+
+type EnvVarConflictWarningProps = {
+  conflicts: EnvVarConflict[];
+};
+
+const EnvVarConflictWarning: React.FC<EnvVarConflictWarningProps> = ({ conflicts }) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  if (conflicts.length === 0) {
+    return null;
+  }
+
+  return (
+    <Alert
+      variant="warning"
+      isInline
+      title="Environment variable conflicts"
+      data-testid="env-var-conflict-warning"
+    >
+      Environment variables with the same key are defined in multiple sources. When variables
+      conflict, only one of the values will be used in the workbench.
+      <ExpandableSection
+        toggleText="Show conflicts"
+        onToggle={() => setIsExpanded((prev) => !prev)}
+        isExpanded={isExpanded}
+        isIndented
+      >
+        <List>
+          {conflicts.map((conflict) => (
+            <ListItem key={conflict.key} data-testid={`env-var-conflict-${conflict.key}`}>
+              <b>{conflict.key}</b> is defined in: {conflict.sources.join(', ')}
+            </ListItem>
+          ))}
+        </List>
+      </ExpandableSection>
+    </Alert>
+  );
+};
+
+export default EnvVarConflictWarning;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvironmentVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvironmentVariables.tsx
@@ -7,10 +7,12 @@ import EnvTypeSelectField from './EnvTypeSelectField';
 type EnvironmentVariablesProps = {
   envVariables: EnvVariable[];
   setEnvVariables: (envVars: EnvVariable[]) => void;
+  namespace: string;
 };
 const EnvironmentVariables: React.FC<EnvironmentVariablesProps> = ({
   envVariables,
   setEnvVariables,
+  namespace,
 }) => (
   <>
     {envVariables.map((envVariable, i) => (
@@ -27,6 +29,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesProps> = ({
           onRemove={() =>
             setEnvVariables(envVariables.filter((v, filterIndex) => filterIndex !== i))
           }
+          namespace={namespace}
         />
         {i !== envVariables.length - 1 && <Divider />}
       </React.Fragment>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
@@ -1,0 +1,326 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { k8sGetResource, k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { mockCustomSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
+import { SecretCategory } from '#~/pages/projects/types';
+import EnvExistingSecret from '#~/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sGetResource: jest.fn(),
+  k8sListResource: jest.fn(),
+}));
+
+jest.mock('#~/utilities/utils', () => ({
+  getDashboardMainContainer: jest.fn(() => undefined),
+}));
+
+const k8sGetResourceMock = jest.mocked(k8sGetResource<SecretKind>);
+const k8sListResourceMock = jest.mocked(k8sListResource<SecretKind>);
+
+const mockSecret = (name: string, keys: string[]): SecretKind => {
+  const data: Record<string, string> = {};
+  keys.forEach((key) => {
+    data[key] = btoa(`value-for-${key}`);
+  });
+  return mockCustomSecretK8sResource({
+    name,
+    namespace: 'test-ns',
+    data,
+    type: 'Opaque',
+  });
+};
+
+const openTypeaheadDropdown = () => {
+  const toggle = screen.getByTestId('existing-secret-typeahead');
+  const combobox = within(toggle).getByRole('combobox');
+  fireEvent.click(combobox);
+};
+
+describe('EnvExistingSecret', () => {
+  const mockOnUpdate = jest.fn();
+  const defaultProps = {
+    namespace: 'test-ns',
+    onUpdate: mockOnUpdate,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    k8sListResourceMock.mockResolvedValue({
+      items: [
+        mockSecret('db-credentials', ['username', 'password', 'host']),
+        mockSecret('api-keys', ['primary', 'secondary']),
+      ],
+    } as never);
+  });
+
+  it('should render the secret selector dropdown', async () => {
+    render(<EnvExistingSecret {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-selector')).toBeInTheDocument();
+    });
+  });
+
+  it('should show available secrets in the dropdown', async () => {
+    render(<EnvExistingSecret {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-typeahead')).toBeInTheDocument();
+    });
+
+    openTypeaheadDropdown();
+
+    await waitFor(() => {
+      expect(screen.getByText('db-credentials')).toBeInTheDocument();
+      expect(screen.getByText('api-keys')).toBeInTheDocument();
+    });
+  });
+
+  it('should show key picker after selecting a secret', async () => {
+    k8sGetResourceMock.mockResolvedValue(
+      mockSecret('db-credentials', ['username', 'password', 'host']),
+    );
+
+    render(<EnvExistingSecret {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-typeahead')).toBeInTheDocument();
+    });
+
+    openTypeaheadDropdown();
+
+    await waitFor(() => {
+      expect(screen.getByText('db-credentials')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('db-credentials'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-key-picker')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('key-checkbox-username')).toBeInTheDocument();
+    expect(screen.getByTestId('key-checkbox-password')).toBeInTheDocument();
+    expect(screen.getByTestId('key-checkbox-host')).toBeInTheDocument();
+  });
+
+  it('should show "All keys" checkbox in the key picker', async () => {
+    k8sGetResourceMock.mockResolvedValue(mockSecret('db-credentials', ['username', 'password']));
+
+    render(<EnvExistingSecret {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-typeahead')).toBeInTheDocument();
+    });
+
+    openTypeaheadDropdown();
+    await waitFor(() => {
+      expect(screen.getByText('db-credentials')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('db-credentials'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('all-keys-checkbox')).toBeInTheDocument();
+    });
+  });
+
+  it('should select all keys when "All keys" is checked', async () => {
+    k8sGetResourceMock.mockResolvedValue(mockSecret('db-credentials', ['username', 'password']));
+
+    render(<EnvExistingSecret {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-typeahead')).toBeInTheDocument();
+    });
+
+    openTypeaheadDropdown();
+    await waitFor(() => {
+      expect(screen.getByText('db-credentials')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('db-credentials'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('all-keys-checkbox')).toBeInTheDocument();
+    });
+
+    // PF v6 Checkbox places data-testid directly on the input element
+    fireEvent.click(screen.getByTestId('all-keys-checkbox'));
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      {
+        category: SecretCategory.EXISTING,
+        data: [
+          { key: 'username', value: '' },
+          { key: 'password', value: '' },
+        ],
+      },
+      'db-credentials',
+    );
+  });
+
+  it('should select individual keys', async () => {
+    k8sGetResourceMock.mockResolvedValue(
+      mockSecret('db-credentials', ['username', 'password', 'host']),
+    );
+
+    render(<EnvExistingSecret {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-typeahead')).toBeInTheDocument();
+    });
+
+    openTypeaheadDropdown();
+    await waitFor(() => {
+      expect(screen.getByText('db-credentials')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('db-credentials'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('key-checkbox-username')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('key-checkbox-username'));
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      {
+        category: SecretCategory.EXISTING,
+        data: [{ key: 'username', value: '' }],
+      },
+      'db-credentials',
+    );
+  });
+
+  it('should restore selected state from existing env data', async () => {
+    k8sGetResourceMock.mockResolvedValue(
+      mockSecret('db-credentials', ['username', 'password', 'host']),
+    );
+
+    render(
+      <EnvExistingSecret
+        {...defaultProps}
+        selectedSecretName="db-credentials"
+        env={{
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'username', value: '' },
+            { key: 'host', value: '' },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-key-picker')).toBeInTheDocument();
+    });
+
+    // PF v6 Checkbox data-testid is on the input element directly
+    expect(screen.getByTestId('key-checkbox-username')).toBeChecked();
+    expect(screen.getByTestId('key-checkbox-host')).toBeChecked();
+    expect(screen.getByTestId('key-checkbox-password')).not.toBeChecked();
+  });
+
+  it('should not render secret values', async () => {
+    k8sGetResourceMock.mockResolvedValue(mockSecret('db-credentials', ['username', 'password']));
+
+    render(<EnvExistingSecret {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-typeahead')).toBeInTheDocument();
+    });
+
+    openTypeaheadDropdown();
+    await waitFor(() => {
+      expect(screen.getByText('db-credentials')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('db-credentials'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-key-picker')).toBeInTheDocument();
+    });
+
+    // Ensure no secret values appear in the rendered output
+    expect(screen.queryByText('value-for-username')).not.toBeInTheDocument();
+    expect(screen.queryByText('value-for-password')).not.toBeInTheDocument();
+    expect(screen.queryByText(btoa('value-for-username'))).not.toBeInTheDocument();
+    expect(screen.queryByText(btoa('value-for-password'))).not.toBeInTheDocument();
+  });
+
+  it('should uncheck "All keys" when an individual key is deselected', async () => {
+    k8sGetResourceMock.mockResolvedValue(mockSecret('db-credentials', ['username', 'password']));
+
+    render(
+      <EnvExistingSecret
+        {...defaultProps}
+        selectedSecretName="db-credentials"
+        env={{
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'username', value: '' },
+            { key: 'password', value: '' },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('all-keys-checkbox')).toBeInTheDocument();
+    });
+
+    // All keys checkbox should be checked since all keys are selected
+    expect(screen.getByTestId('all-keys-checkbox')).toBeChecked();
+
+    // Deselect "password"
+    fireEvent.click(screen.getByTestId('key-checkbox-password'));
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      {
+        category: SecretCategory.EXISTING,
+        data: [{ key: 'username', value: '' }],
+      },
+      'db-credentials',
+    );
+  });
+
+  it('should handle empty keys in secret gracefully', async () => {
+    k8sGetResourceMock.mockResolvedValue(
+      mockCustomSecretK8sResource({
+        name: 'empty-secret',
+        namespace: 'test-ns',
+        data: {},
+        type: 'Opaque',
+      }),
+    );
+
+    k8sListResourceMock.mockResolvedValue({
+      items: [
+        mockCustomSecretK8sResource({
+          name: 'empty-secret',
+          namespace: 'test-ns',
+          data: {},
+          type: 'Opaque',
+        }),
+      ],
+    } as never);
+
+    render(<EnvExistingSecret {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-typeahead')).toBeInTheDocument();
+    });
+
+    openTypeaheadDropdown();
+    await waitFor(() => {
+      expect(screen.getByText('empty-secret')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('empty-secret'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-key-picker')).toBeInTheDocument();
+    });
+
+    // No key checkboxes or "All keys" when secret has no keys
+    expect(screen.queryByTestId('all-keys-checkbox')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
@@ -40,9 +40,11 @@ const openTypeaheadDropdown = () => {
 
 describe('EnvExistingSecret', () => {
   const mockOnUpdate = jest.fn();
+  const mockOnSecretNameChange = jest.fn();
   const defaultProps = {
     namespace: 'test-ns',
     onUpdate: mockOnUpdate,
+    onSecretNameChange: mockOnSecretNameChange,
   };
 
   beforeEach(() => {
@@ -148,16 +150,13 @@ describe('EnvExistingSecret', () => {
     // PF v6 Checkbox places data-testid directly on the input element
     fireEvent.click(screen.getByTestId('all-keys-checkbox'));
 
-    expect(mockOnUpdate).toHaveBeenCalledWith(
-      {
-        category: SecretCategory.EXISTING,
-        data: [
-          { key: 'username', value: '' },
-          { key: 'password', value: '' },
-        ],
-      },
-      'db-credentials',
-    );
+    expect(mockOnUpdate).toHaveBeenCalledWith({
+      category: SecretCategory.EXISTING,
+      data: [
+        { key: 'username', value: '' },
+        { key: 'password', value: '' },
+      ],
+    });
   });
 
   it('should select individual keys', async () => {
@@ -183,13 +182,10 @@ describe('EnvExistingSecret', () => {
 
     fireEvent.click(screen.getByTestId('key-checkbox-username'));
 
-    expect(mockOnUpdate).toHaveBeenCalledWith(
-      {
-        category: SecretCategory.EXISTING,
-        data: [{ key: 'username', value: '' }],
-      },
-      'db-credentials',
-    );
+    expect(mockOnUpdate).toHaveBeenCalledWith({
+      category: SecretCategory.EXISTING,
+      data: [{ key: 'username', value: '' }],
+    });
   });
 
   it('should restore selected state from existing env data', async () => {
@@ -274,13 +270,10 @@ describe('EnvExistingSecret', () => {
     // Deselect "password"
     fireEvent.click(screen.getByTestId('key-checkbox-password'));
 
-    expect(mockOnUpdate).toHaveBeenCalledWith(
-      {
-        category: SecretCategory.EXISTING,
-        data: [{ key: 'username', value: '' }],
-      },
-      'db-credentials',
-    );
+    expect(mockOnUpdate).toHaveBeenCalledWith({
+      category: SecretCategory.EXISTING,
+      data: [{ key: 'username', value: '' }],
+    });
   });
 
   it('should handle empty keys in secret gracefully', async () => {

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvSecret.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvSecret.spec.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { SecretCategory } from '#~/pages/projects/types';
+import EnvSecret from '#~/pages/projects/screens/spawner/environmentVariables/EnvSecret';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sGetResource: jest.fn(),
+  k8sListResource: jest.fn(),
+}));
+
+jest.mock('#~/utilities/utils', () => ({
+  getDashboardMainContainer: jest.fn(() => undefined),
+}));
+
+const k8sListResourceMock = jest.mocked(k8sListResource<SecretKind>);
+
+describe('EnvSecret', () => {
+  const mockOnUpdate = jest.fn();
+  const mockOnExistingNameChange = jest.fn();
+  const defaultProps = {
+    onUpdate: mockOnUpdate,
+    namespace: 'test-ns',
+    onExistingNameChange: mockOnExistingNameChange,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    k8sListResourceMock.mockResolvedValue({ items: [] } as never);
+  });
+
+  it('should render the data type selector', () => {
+    render(<EnvSecret {...defaultProps} />);
+    expect(screen.getByTestId('env-data-type-field')).toBeInTheDocument();
+  });
+
+  it('should show Key / value, Upload, and Existing secret options in the dropdown', () => {
+    render(<EnvSecret {...defaultProps} />);
+    const dropdown = screen.getByTestId('env-data-type-field');
+    // Open the dropdown
+    const toggle = within(dropdown).getByRole('button');
+    fireEvent.click(toggle);
+
+    expect(screen.getByText('Key / value')).toBeInTheDocument();
+    expect(screen.getByText('Upload')).toBeInTheDocument();
+    expect(screen.getByText('Existing secret')).toBeInTheDocument();
+  });
+
+  it('should render EnvExistingSecret when Existing secret category is selected', async () => {
+    render(
+      <EnvSecret
+        {...defaultProps}
+        env={{
+          category: SecretCategory.EXISTING,
+          data: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-secret-selector')).toBeInTheDocument();
+    });
+  });
+
+  it('should call onUpdate with EXISTING category when Existing secret is selected', () => {
+    render(<EnvSecret {...defaultProps} />);
+    const dropdown = screen.getByTestId('env-data-type-field');
+    const toggle = within(dropdown).getByRole('button');
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByText('Existing secret'));
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: SecretCategory.EXISTING,
+        data: [],
+      }),
+    );
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/envVarConflicts.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/envVarConflicts.spec.ts
@@ -1,0 +1,169 @@
+import {
+  EnvVariable,
+  EnvironmentVariableType,
+  SecretCategory,
+  ConfigMapCategory,
+} from '#~/pages/projects/types';
+import { Connection } from '#~/concepts/connectionTypes/types';
+import { detectEnvVarConflicts } from '#~/pages/projects/screens/spawner/environmentVariables/envVarConflicts';
+
+const makeExistingSecretEnvVar = (secretName: string, keys: string[]): EnvVariable => ({
+  type: EnvironmentVariableType.SECRET,
+  existingName: secretName,
+  values: {
+    category: SecretCategory.EXISTING,
+    data: keys.map((key) => ({ key, value: '' })),
+  },
+});
+
+const makeInlineSecretEnvVar = (keys: string[]): EnvVariable => ({
+  type: EnvironmentVariableType.SECRET,
+  values: {
+    category: SecretCategory.GENERIC,
+    data: keys.map((key) => ({ key, value: `value-${key}` })),
+  },
+});
+
+const makeConfigMapEnvVar = (keys: string[]): EnvVariable => ({
+  type: EnvironmentVariableType.CONFIG_MAP,
+  values: {
+    category: ConfigMapCategory.GENERIC,
+    data: keys.map((key) => ({ key, value: `value-${key}` })),
+  },
+});
+
+const makeConnection = (name: string, displayName: string, keys: string[]): Connection => {
+  const data: Record<string, string> = {};
+  keys.forEach((key) => {
+    data[key] = btoa(`value-${key}`);
+  });
+  return {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: {
+      name,
+      namespace: 'test-ns',
+      labels: {
+        'opendatahub.io/dashboard': 'true',
+        'opendatahub.io/managed': 'true',
+      },
+      annotations: {
+        'openshift.io/display-name': displayName,
+        'opendatahub.io/connection-type': 's3',
+      },
+    },
+    data,
+  } as unknown as Connection;
+};
+
+describe('detectEnvVarConflicts', () => {
+  it('should return empty array when there are no env variables or connections', () => {
+    const result = detectEnvVarConflicts([], []);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when there are no duplicate keys', () => {
+    const envVars: EnvVariable[] = [
+      makeExistingSecretEnvVar('s3-creds', ['AWS_ACCESS_KEY_ID']),
+      makeInlineSecretEnvVar(['MY_SECRET_KEY']),
+    ];
+    const result = detectEnvVarConflicts(envVars, []);
+    expect(result).toEqual([]);
+  });
+
+  it('should detect conflict when same key appears across two existing secrets', () => {
+    const envVars: EnvVariable[] = [
+      makeExistingSecretEnvVar('s3-creds', ['AWS_ACCESS_KEY_ID']),
+      makeExistingSecretEnvVar('backup-creds', ['AWS_ACCESS_KEY_ID']),
+    ];
+    const result = detectEnvVarConflicts(envVars, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('AWS_ACCESS_KEY_ID');
+    expect(result[0].sources).toHaveLength(2);
+    expect(result[0].sources).toContain("Secret 's3-creds'");
+    expect(result[0].sources).toContain("Secret 'backup-creds'");
+  });
+
+  it('should detect conflict when same key appears in existing secret and inline secret', () => {
+    const envVars: EnvVariable[] = [
+      makeExistingSecretEnvVar('s3-creds', ['AWS_ACCESS_KEY_ID']),
+      makeInlineSecretEnvVar(['AWS_ACCESS_KEY_ID']),
+    ];
+    const result = detectEnvVarConflicts(envVars, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('AWS_ACCESS_KEY_ID');
+    expect(result[0].sources).toContain("Secret 's3-creds'");
+    expect(result[0].sources.some((s) => s.includes('Secret'))).toBe(true);
+  });
+
+  it('should detect conflict when same key appears in existing secret and connection', () => {
+    const envVars: EnvVariable[] = [makeExistingSecretEnvVar('s3-creds', ['AWS_ACCESS_KEY_ID'])];
+    const connections: Connection[] = [
+      makeConnection('my-conn', 'My Connection', ['AWS_ACCESS_KEY_ID']),
+    ];
+    const result = detectEnvVarConflicts(envVars, connections);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('AWS_ACCESS_KEY_ID');
+    expect(result[0].sources).toContain("Secret 's3-creds'");
+    expect(result[0].sources).toContain("Connection 'My Connection'");
+  });
+
+  it('should detect conflict when same key appears in inline secret and connection', () => {
+    const envVars: EnvVariable[] = [makeInlineSecretEnvVar(['DB_PASSWORD'])];
+    const connections: Connection[] = [makeConnection('db-conn', 'DB Connection', ['DB_PASSWORD'])];
+    const result = detectEnvVarConflicts(envVars, connections);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('DB_PASSWORD');
+    expect(result[0].sources).toContain("Connection 'DB Connection'");
+  });
+
+  it('should detect conflict when same key appears in configmap and connection', () => {
+    const envVars: EnvVariable[] = [makeConfigMapEnvVar(['APP_CONFIG'])];
+    const connections: Connection[] = [
+      makeConnection('config-conn', 'Config Connection', ['APP_CONFIG']),
+    ];
+    const result = detectEnvVarConflicts(envVars, connections);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('APP_CONFIG');
+  });
+
+  it('should detect multiple conflicts across different keys', () => {
+    const envVars: EnvVariable[] = [
+      makeExistingSecretEnvVar('s3-creds', ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_KEY']),
+      makeExistingSecretEnvVar('backup-creds', ['AWS_ACCESS_KEY_ID']),
+    ];
+    const connections: Connection[] = [
+      makeConnection('my-conn', 'My Connection', ['AWS_SECRET_KEY', 'ENDPOINT']),
+    ];
+    const result = detectEnvVarConflicts(envVars, connections);
+    expect(result).toHaveLength(2);
+
+    const keyIds = result.map((c) => c.key).toSorted();
+    expect(keyIds).toEqual(['AWS_ACCESS_KEY_ID', 'AWS_SECRET_KEY']);
+  });
+
+  it('should handle env variables with no values gracefully', () => {
+    const envVars: EnvVariable[] = [{ type: null }, { type: EnvironmentVariableType.SECRET }];
+    const result = detectEnvVarConflicts(envVars, []);
+    expect(result).toEqual([]);
+  });
+
+  it('should handle connections with no data gracefully', () => {
+    const connection = makeConnection('empty-conn', 'Empty', []);
+    delete (connection as Record<string, unknown>).data;
+    const result = detectEnvVarConflicts([], [connection]);
+    expect(result).toEqual([]);
+  });
+
+  it('should detect three-way conflict across existing secret, inline secret, and connection', () => {
+    const envVars: EnvVariable[] = [
+      makeExistingSecretEnvVar('s3-creds', ['SHARED_KEY']),
+      makeInlineSecretEnvVar(['SHARED_KEY']),
+    ];
+    const connections: Connection[] = [makeConnection('my-conn', 'My Connection', ['SHARED_KEY'])];
+    const result = detectEnvVarConflicts(envVars, connections);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('SHARED_KEY');
+    expect(result[0].sources).toHaveLength(3);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretIntegration.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretIntegration.spec.ts
@@ -1,0 +1,354 @@
+import {
+  EnvVariable,
+  EnvironmentVariableType,
+  SecretCategory,
+  ConfigMapCategory,
+} from '#~/pages/projects/types';
+import { getExistingSecretEnvVars } from '#~/pages/projects/screens/spawner/service';
+import { isEnvVariableDataValid } from '#~/pages/projects/screens/spawner/spawnerUtils';
+import { detectEnvVarConflicts } from '#~/pages/projects/screens/spawner/environmentVariables/envVarConflicts';
+import { EMPTY_EXISTING_SECRET } from '#~/pages/projects/screens/spawner/environmentVariables/const';
+
+describe('Existing secret integration', () => {
+  describe('EMPTY_EXISTING_SECRET constant', () => {
+    it('should have SECRET type and EXISTING category', () => {
+      expect(EMPTY_EXISTING_SECRET.type).toBe(EnvironmentVariableType.SECRET);
+      expect(EMPTY_EXISTING_SECRET.values?.category).toBe(SecretCategory.EXISTING);
+      expect(EMPTY_EXISTING_SECRET.existingName).toBe('');
+      expect(EMPTY_EXISTING_SECRET.values?.data).toEqual([]);
+    });
+  });
+
+  describe('getExistingSecretEnvVars output structure', () => {
+    it('should produce EnvironmentVariable objects with valueFrom.secretKeyRef', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'my-db-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [
+              { key: 'DB_HOST', value: '' },
+              { key: 'DB_PORT', value: '' },
+            ],
+          },
+        },
+      ];
+
+      const result = getExistingSecretEnvVars(envVars);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        name: 'DB_HOST',
+        valueFrom: { secretKeyRef: { name: 'my-db-secret', key: 'DB_HOST' } },
+      });
+      expect(result[1]).toEqual({
+        name: 'DB_PORT',
+        valueFrom: { secretKeyRef: { name: 'my-db-secret', key: 'DB_PORT' } },
+      });
+    });
+
+    it('should handle multiple existing secrets', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'secret-a',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'KEY_A', value: '' }],
+          },
+        },
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'secret-b',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'KEY_B', value: '' }],
+          },
+        },
+      ];
+
+      const result = getExistingSecretEnvVars(envVars);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].valueFrom?.secretKeyRef?.name).toBe('secret-a');
+      expect(result[1].valueFrom?.secretKeyRef?.name).toBe('secret-b');
+    });
+
+    it('should exclude inline secrets from the output', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'my-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'API_KEY', value: '' }],
+          },
+        },
+        {
+          type: EnvironmentVariableType.SECRET,
+          values: {
+            category: SecretCategory.GENERIC,
+            data: [{ key: 'INLINE_KEY', value: 'inline-value' }],
+          },
+        },
+      ];
+
+      const result = getExistingSecretEnvVars(envVars);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('API_KEY');
+    });
+  });
+
+  describe('detectEnvVarConflicts with EXISTING secrets', () => {
+    it('should detect conflicts between two existing secrets sharing a key', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'secret-1',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'SHARED_KEY', value: '' }],
+          },
+        },
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'secret-2',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'SHARED_KEY', value: '' }],
+          },
+        },
+      ];
+
+      const conflicts = detectEnvVarConflicts(envVars, []);
+
+      expect(conflicts).toHaveLength(1);
+      expect(conflicts[0].key).toBe('SHARED_KEY');
+      expect(conflicts[0].sources).toContain("Secret 'secret-1'");
+      expect(conflicts[0].sources).toContain("Secret 'secret-2'");
+    });
+
+    it('should detect conflicts between existing secret and inline configmap', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'my-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'APP_PORT', value: '' }],
+          },
+        },
+        {
+          type: EnvironmentVariableType.CONFIG_MAP,
+          values: {
+            category: ConfigMapCategory.GENERIC,
+            data: [{ key: 'APP_PORT', value: '8080' }],
+          },
+        },
+      ];
+
+      const conflicts = detectEnvVarConflicts(envVars, []);
+
+      expect(conflicts).toHaveLength(1);
+      expect(conflicts[0].key).toBe('APP_PORT');
+      expect(conflicts[0].sources).toContain("Secret 'my-secret'");
+    });
+
+    it('should report no conflicts when keys are unique across sources', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'db-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'DB_HOST', value: '' }],
+          },
+        },
+        {
+          type: EnvironmentVariableType.SECRET,
+          values: {
+            category: SecretCategory.GENERIC,
+            data: [{ key: 'API_KEY', value: 'some-value' }],
+          },
+        },
+      ];
+
+      const conflicts = detectEnvVarConflicts(envVars, []);
+
+      expect(conflicts).toHaveLength(0);
+    });
+  });
+
+  describe('isEnvVariableDataValid for EXISTING category', () => {
+    it('should return true when existingName is set and data has entries', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'my-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'KEY_1', value: '' }],
+          },
+        },
+      ];
+
+      expect(isEnvVariableDataValid(envVars)).toBe(true);
+    });
+
+    it('should return false when existingName is empty', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: '',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'KEY_1', value: '' }],
+          },
+        },
+      ];
+
+      expect(isEnvVariableDataValid(envVars)).toBe(false);
+    });
+
+    it('should return false when data array is empty', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'my-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [],
+          },
+        },
+      ];
+
+      expect(isEnvVariableDataValid(envVars)).toBe(false);
+    });
+
+    it('should validate mixed existing and inline env vars', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'my-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'SECRET_KEY', value: '' }],
+          },
+        },
+        {
+          type: EnvironmentVariableType.SECRET,
+          values: {
+            category: SecretCategory.GENERIC,
+            data: [{ key: 'INLINE_KEY', value: 'val' }],
+          },
+        },
+      ];
+
+      expect(isEnvVariableDataValid(envVars)).toBe(true);
+    });
+
+    it('should return false when one existing var is invalid among valid ones', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'valid-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'KEY_A', value: '' }],
+          },
+        },
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: '',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'KEY_B', value: '' }],
+          },
+        },
+      ];
+
+      expect(isEnvVariableDataValid(envVars)).toBe(false);
+    });
+  });
+
+  describe('end-to-end: create, validate, convert, check conflicts', () => {
+    it('should handle a complete workflow with existing secrets', () => {
+      // Step 1: Create existing secret env vars (simulates form creation)
+      const envVars: EnvVariable[] = [
+        {
+          ...EMPTY_EXISTING_SECRET,
+          existingName: 'prod-credentials',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [
+              { key: 'USERNAME', value: '' },
+              { key: 'PASSWORD', value: '' },
+            ],
+          },
+        },
+        {
+          type: EnvironmentVariableType.SECRET,
+          values: {
+            category: SecretCategory.GENERIC,
+            data: [{ key: 'API_TOKEN', value: 'token-123' }],
+          },
+        },
+      ];
+
+      // Step 2: Validate the form data
+      expect(isEnvVariableDataValid(envVars)).toBe(true);
+
+      // Step 3: Convert to notebook CR env vars
+      const secretEnvVars = getExistingSecretEnvVars(envVars);
+      expect(secretEnvVars).toHaveLength(2);
+      expect(secretEnvVars).toEqual([
+        {
+          name: 'USERNAME',
+          valueFrom: { secretKeyRef: { name: 'prod-credentials', key: 'USERNAME' } },
+        },
+        {
+          name: 'PASSWORD',
+          valueFrom: { secretKeyRef: { name: 'prod-credentials', key: 'PASSWORD' } },
+        },
+      ]);
+
+      // Step 4: Check for conflicts (none expected)
+      const conflicts = detectEnvVarConflicts(envVars, []);
+      expect(conflicts).toHaveLength(0);
+    });
+
+    it('should detect conflicts in a mixed environment setup', () => {
+      const envVars: EnvVariable[] = [
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'aws-creds',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [
+              { key: 'AWS_ACCESS_KEY_ID', value: '' },
+              { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+            ],
+          },
+        },
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'backup-creds',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+          },
+        },
+      ];
+
+      // Validation should pass (both have names and keys)
+      expect(isEnvVariableDataValid(envVars)).toBe(true);
+
+      // But conflict detection catches the duplicate key
+      const conflicts = detectEnvVarConflicts(envVars, []);
+      expect(conflicts).toHaveLength(1);
+      expect(conflicts[0].key).toBe('AWS_ACCESS_KEY_ID');
+    });
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
@@ -1,0 +1,144 @@
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { standardUseFetchState, testHook } from '@odh-dashboard/jest-config/hooks';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { mockCustomSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
+import { useExistingSecrets } from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sListResource: jest.fn(),
+}));
+
+const k8sListResourceMock = jest.mocked(k8sListResource<SecretKind>);
+
+const mockOpaqueSecret = (
+  name: string,
+  annotations: Record<string, string> = {},
+  labels: Record<string, string> = {},
+): SecretKind =>
+  mockCustomSecretK8sResource({
+    name,
+    namespace: 'test-ns',
+    annotations,
+    labels,
+    data: { key: 'dmFsdWU=' },
+    type: 'Opaque',
+  });
+
+describe('useExistingSecrets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not fetch when enabled is false', () => {
+    const renderResult = testHook(useExistingSecrets)('test-ns', false);
+    expect(k8sListResourceMock).not.toHaveBeenCalled();
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+
+  it('should fetch and return non-connection secrets when enabled is true', async () => {
+    const plainSecret = mockOpaqueSecret('my-plain-secret');
+    const connectionSecret = mockOpaqueSecret(
+      'my-connection',
+      {
+        'opendatahub.io/connection-type': 's3',
+      },
+      {
+        'opendatahub.io/dashboard': 'true',
+      },
+    );
+
+    k8sListResourceMock.mockResolvedValue({ items: [plainSecret, connectionSecret] } as never);
+
+    const renderResult = testHook(useExistingSecrets)('test-ns', true);
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    await renderResult.waitForNextUpdate();
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([plainSecret], true));
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+
+  it('should filter out secrets with connection-type-ref annotation', async () => {
+    const plainSecret = mockOpaqueSecret('plain');
+    const connectionRefSecret = mockOpaqueSecret(
+      'conn-ref',
+      {
+        'opendatahub.io/connection-type-ref': 'some-type',
+      },
+      {
+        'opendatahub.io/dashboard': 'true',
+      },
+    );
+
+    k8sListResourceMock.mockResolvedValue({
+      items: [plainSecret, connectionRefSecret],
+    } as never);
+
+    const renderResult = testHook(useExistingSecrets)('test-ns', true);
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([plainSecret], true));
+  });
+
+  it('should filter out secrets with connection-type-protocol annotation', async () => {
+    const plainSecret = mockOpaqueSecret('plain');
+    const protocolSecret = mockOpaqueSecret('proto-conn', {
+      'opendatahub.io/connection-type-protocol': 'grpc',
+    });
+
+    k8sListResourceMock.mockResolvedValue({
+      items: [plainSecret, protocolSecret],
+    } as never);
+
+    const renderResult = testHook(useExistingSecrets)('test-ns', true);
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([plainSecret], true));
+  });
+
+  it('should return all secrets when none are connections', async () => {
+    const secret1 = mockOpaqueSecret('secret-1');
+    const secret2 = mockOpaqueSecret('secret-2');
+
+    k8sListResourceMock.mockResolvedValue({
+      items: [secret1, secret2],
+    } as never);
+
+    const renderResult = testHook(useExistingSecrets)('test-ns', true);
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([secret1, secret2], true));
+  });
+
+  it('should handle API errors', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('forbidden'));
+
+    const renderResult = testHook(useExistingSecrets)('test-ns', true);
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState([], false, new Error('forbidden')),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+
+  it('should return empty array when all secrets are connections', async () => {
+    const conn1 = mockOpaqueSecret(
+      'conn-1',
+      { 'opendatahub.io/connection-type': 's3' },
+      { 'opendatahub.io/dashboard': 'true' },
+    );
+    const conn2 = mockOpaqueSecret('conn-2', {
+      'opendatahub.io/connection-type-protocol': 'http',
+    });
+
+    k8sListResourceMock.mockResolvedValue({ items: [conn1, conn2] } as never);
+
+    const renderResult = testHook(useExistingSecrets)('test-ns', true);
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([], true));
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
@@ -1,0 +1,242 @@
+import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
+import { mockCustomSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
+import { getSecret } from '#~/api';
+import { EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+import { fetchNotebookEnvVariables } from '#~/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables';
+
+jest.mock('#~/api', () => ({
+  getConfigMap: jest.fn(),
+  getSecret: jest.fn(),
+}));
+
+const getSecretMock = jest.mocked(getSecret);
+
+describe('fetchNotebookEnvVariables', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should reconstruct existing secret references from env[].valueFrom.secretKeyRef', async () => {
+    const notebook = mockNotebookK8sResource({
+      envFrom: [],
+      additionalEnvs: [
+        {
+          name: 'DB_HOST',
+          valueFrom: {
+            secretKeyRef: { name: 'my-db-secret', key: 'DB_HOST' },
+          },
+        },
+        {
+          name: 'DB_PORT',
+          valueFrom: {
+            secretKeyRef: { name: 'my-db-secret', key: 'DB_PORT' },
+          },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    expect(result).toEqual([
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-db-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'DB_HOST', value: '' },
+            { key: 'DB_PORT', value: '' },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('should skip env entries with plain value (like NOTEBOOK_ARGS, JUPYTER_IMAGE)', async () => {
+    const notebook = mockNotebookK8sResource({
+      envFrom: [],
+      // The default mock already includes NOTEBOOK_ARGS and JUPYTER_IMAGE with value (not valueFrom)
+      additionalEnvs: [
+        {
+          name: 'MY_KEY',
+          valueFrom: {
+            secretKeyRef: { name: 'my-secret', key: 'MY_KEY' },
+          },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    // Should only include the secretKeyRef entry, not NOTEBOOK_ARGS or JUPYTER_IMAGE
+    expect(result).toEqual([
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'MY_KEY', value: '' }],
+        },
+      },
+    ]);
+  });
+
+  it('should skip env entries with non-secretKeyRef valueFrom (like fieldRef)', async () => {
+    const notebook = mockNotebookK8sResource({
+      envFrom: [],
+      additionalEnvs: [
+        {
+          name: 'NAMESPACE',
+          valueFrom: {
+            fieldRef: { fieldPath: 'metadata.namespace' },
+          },
+        },
+        {
+          name: 'SECRET_VAL',
+          valueFrom: {
+            secretKeyRef: { name: 'my-secret', key: 'SECRET_VAL' },
+          },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    expect(result).toEqual([
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'SECRET_VAL', value: '' }],
+        },
+      },
+    ]);
+  });
+
+  it('should group multiple keys from the same secret', async () => {
+    const notebook = mockNotebookK8sResource({
+      envFrom: [],
+      additionalEnvs: [
+        {
+          name: 'KEY_A',
+          valueFrom: { secretKeyRef: { name: 'shared-secret', key: 'KEY_A' } },
+        },
+        {
+          name: 'KEY_B',
+          valueFrom: { secretKeyRef: { name: 'shared-secret', key: 'KEY_B' } },
+        },
+        {
+          name: 'OTHER',
+          valueFrom: { secretKeyRef: { name: 'other-secret', key: 'OTHER' } },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    expect(result).toEqual([
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'shared-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'KEY_A', value: '' },
+            { key: 'KEY_B', value: '' },
+          ],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'other-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'OTHER', value: '' }],
+        },
+      },
+    ]);
+  });
+
+  it('should merge envFrom-based and env-based secret references', async () => {
+    const mockSecret = mockCustomSecretK8sResource({
+      name: 'envfrom-secret',
+      namespace: 'test-project',
+      data: { foo: btoa('bar') },
+      type: 'Opaque',
+    });
+
+    getSecretMock.mockResolvedValue(mockSecret);
+
+    const notebook = mockNotebookK8sResource({
+      envFrom: [{ secretRef: { name: 'envfrom-secret' } }],
+      additionalEnvs: [
+        {
+          name: 'EXISTING_KEY',
+          valueFrom: { secretKeyRef: { name: 'existing-secret', key: 'EXISTING_KEY' } },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    // Should include both the envFrom-based secret and the env-based existing secret
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      type: EnvironmentVariableType.SECRET,
+      existingName: 'envfrom-secret',
+      values: {
+        category: SecretCategory.GENERIC,
+        data: [{ key: 'foo', value: 'bar' }],
+      },
+    });
+    expect(result[1]).toEqual({
+      type: EnvironmentVariableType.SECRET,
+      existingName: 'existing-secret',
+      values: {
+        category: SecretCategory.EXISTING,
+        data: [{ key: 'EXISTING_KEY', value: '' }],
+      },
+    });
+  });
+
+  it('should return empty array when no env or envFrom entries exist', async () => {
+    const notebook = mockNotebookK8sResource({
+      envFrom: [],
+      additionalEnvs: [],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle notebook with only envFrom (existing behavior)', async () => {
+    const mockSecret = mockCustomSecretK8sResource({
+      name: 'my-secret',
+      namespace: 'test-project',
+      data: { username: btoa('admin') },
+      type: 'Opaque',
+    });
+
+    getSecretMock.mockResolvedValue(mockSecret);
+
+    const notebook = mockNotebookK8sResource({
+      envFrom: [{ secretRef: { name: 'my-secret' } }],
+      additionalEnvs: [],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    expect(result).toEqual([
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'username', value: 'admin' }],
+        },
+      },
+    ]);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/const.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/const.ts
@@ -1,6 +1,20 @@
-import { EnvVariableDataEntry } from '#~/pages/projects/types';
+import {
+  EnvVariable,
+  EnvVariableDataEntry,
+  EnvironmentVariableType,
+  SecretCategory,
+} from '#~/pages/projects/types';
 
 export const EMPTY_KEY_VALUE_PAIR: EnvVariableDataEntry = {
   key: '',
   value: '',
+};
+
+export const EMPTY_EXISTING_SECRET: EnvVariable = {
+  type: EnvironmentVariableType.SECRET,
+  existingName: '',
+  values: {
+    category: SecretCategory.EXISTING,
+    data: [],
+  },
 };

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/envVarConflicts.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/envVarConflicts.ts
@@ -1,0 +1,95 @@
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import { Connection } from '#~/concepts/connectionTypes/types';
+import { EnvVariable, EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+
+export type EnvVarConflict = {
+  key: string;
+  sources: string[];
+};
+
+type KeySource = {
+  key: string;
+  source: string;
+};
+
+const collectEnvVarKeySources = (envVariables: EnvVariable[]): KeySource[] => {
+  const keySources: KeySource[] = [];
+
+  for (const envVar of envVariables) {
+    if (!envVar.values?.data) {
+      continue;
+    }
+
+    const { category, data } = envVar.values;
+
+    for (const entry of data) {
+      if (!entry.key) {
+        continue;
+      }
+
+      let source: string;
+      if (category === SecretCategory.EXISTING && envVar.existingName) {
+        source = `Secret '${envVar.existingName}'`;
+      } else if (
+        envVar.type === EnvironmentVariableType.SECRET &&
+        category !== SecretCategory.EXISTING
+      ) {
+        source = 'Secret (inline)';
+      } else if (envVar.type === EnvironmentVariableType.CONFIG_MAP) {
+        source = 'ConfigMap (inline)';
+      } else {
+        source = 'Environment variable';
+      }
+
+      keySources.push({ key: entry.key, source });
+    }
+  }
+
+  return keySources;
+};
+
+const collectConnectionKeySources = (connections: Connection[]): KeySource[] => {
+  const keySources: KeySource[] = [];
+
+  for (const connection of connections) {
+    if (!connection.data) {
+      continue;
+    }
+
+    const displayName = getDisplayNameFromK8sResource(connection);
+    for (const key of Object.keys(connection.data)) {
+      keySources.push({ key, source: `Connection '${displayName}'` });
+    }
+  }
+
+  return keySources;
+};
+
+export const detectEnvVarConflicts = (
+  envVariables: EnvVariable[],
+  connections: Connection[],
+): EnvVarConflict[] => {
+  const allKeySources = [
+    ...collectEnvVarKeySources(envVariables),
+    ...collectConnectionKeySources(connections),
+  ];
+
+  const keyMap = new Map<string, string[]>();
+  for (const { key, source } of allKeySources) {
+    const existing = keyMap.get(key);
+    if (existing) {
+      existing.push(source);
+    } else {
+      keyMap.set(key, [source]);
+    }
+  }
+
+  const conflicts: EnvVarConflict[] = [];
+  for (const [key, sources] of keyMap) {
+    if (sources.length > 1) {
+      conflicts.push({ key, sources });
+    }
+  }
+
+  return conflicts;
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import useFetchState, {
+  FetchState,
+  NotReadyError,
+} from '@odh-dashboard/ui-core/hooks/useFetchState';
+import { getOpaqueSecrets } from '#~/api';
+import { isConnection } from '#~/concepts/connectionTypes/utils';
+
+const CONNECTION_ANNOTATION_KEYS = [
+  'opendatahub.io/connection-type',
+  'opendatahub.io/connection-type-ref',
+  'opendatahub.io/connection-type-protocol',
+] as const;
+
+const isConnectionSecret = (secret: SecretKind): boolean => {
+  if (isConnection(secret)) {
+    return true;
+  }
+  const { annotations } = secret.metadata;
+  if (!annotations) {
+    return false;
+  }
+  return CONNECTION_ANNOTATION_KEYS.some((key) => key in annotations);
+};
+
+export const useExistingSecrets = (
+  namespace: string,
+  enabled: boolean,
+): FetchState<SecretKind[]> => {
+  const callback = React.useCallback(() => {
+    if (!enabled) {
+      return Promise.reject(new NotReadyError('Not enabled'));
+    }
+    return getOpaqueSecrets(namespace).then((secrets) =>
+      secrets.filter((secret) => !isConnectionSecret(secret)),
+    );
+  }, [namespace, enabled]);
+
+  return useFetchState(callback, []);
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -13,6 +13,61 @@ import {
 import { isConnection } from '#~/concepts/connectionTypes/utils';
 import { getDeletedConfigMapOrSecretVariables, isSecretKind } from './utils';
 
+type SecretKeyRef = {
+  name: string;
+  key: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isSecretKeyRefShape = (value: unknown): value is SecretKeyRef =>
+  isRecord(value) &&
+  'name' in value &&
+  typeof value.name === 'string' &&
+  'key' in value &&
+  typeof value.key === 'string';
+
+const hasSecretKeyRef = (envEntry: {
+  name: string;
+  valueFrom?: Record<string, unknown>;
+}): envEntry is { name: string; valueFrom: { secretKeyRef: SecretKeyRef } } =>
+  envEntry.valueFrom !== undefined &&
+  'secretKeyRef' in envEntry.valueFrom &&
+  isSecretKeyRefShape(envEntry.valueFrom.secretKeyRef);
+
+const getExistingSecretEnvVarsFromEnv = (notebook: NotebookKind): EnvVariable[] => {
+  const envList = notebook.spec.template.spec.containers[0].env;
+
+  // Group entries by secret name, preserving insertion order
+  const secretKeyMap = new Map<string, string[]>();
+  for (const entry of envList) {
+    if (hasSecretKeyRef(entry)) {
+      const secretName = entry.valueFrom.secretKeyRef.name;
+      const keyName = entry.valueFrom.secretKeyRef.key;
+      const existing = secretKeyMap.get(secretName);
+      if (existing) {
+        existing.push(keyName);
+      } else {
+        secretKeyMap.set(secretName, [keyName]);
+      }
+    }
+  }
+
+  const result: EnvVariable[] = [];
+  for (const [secretName, keys] of secretKeyMap) {
+    result.push({
+      type: EnvironmentVariableType.SECRET,
+      existingName: secretName,
+      values: {
+        category: SecretCategory.EXISTING,
+        data: keys.map((key) => ({ key, value: '' })),
+      },
+    });
+  }
+  return result;
+};
+
 export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVariable[]> => {
   const envFromList = notebook.spec.template.spec.containers[0].envFrom || [];
   return Promise.all(
@@ -41,8 +96,8 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
           v: Promise<ConfigMapKind | null> | Promise<undefined> | undefined,
         ): v is Promise<SecretKind | ConfigMapKind | null> => !!v,
       ),
-  ).then((results) =>
-    results.reduce<EnvVariable[]>((acc, resource) => {
+  ).then((results) => {
+    const envFromVars = results.reduce<EnvVariable[]>((acc, resource) => {
       if (!resource) {
         return acc;
       }
@@ -70,8 +125,13 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
         return acc;
       }
       return [...acc, envVar];
-    }, []),
-  );
+    }, []);
+
+    // Also reconstruct existing secret references from env[].valueFrom.secretKeyRef
+    const existingSecretVars = getExistingSecretEnvVarsFromEnv(notebook);
+
+    return [...envFromVars, ...existingSecretVars];
+  });
 };
 
 export const useNotebookEnvVariables = (

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash-es';
 import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import type {
+  EnvironmentVariable,
   Volume,
   VolumeMount,
   PersistentVolumeClaimKind,
@@ -32,6 +33,31 @@ import { ConfigMapKind, NotebookKind } from '#~/k8sTypes';
 import { isPvcUpdateRequired } from '#~/pages/projects/screens/detail/storage/utils';
 import { fetchNotebookEnvVariables } from './environmentVariables/useNotebookEnvVariables';
 import { getDeletedConfigMapOrSecretVariables } from './environmentVariables/utils';
+
+export const getExistingSecretEnvVars = (envVariables: EnvVariable[]): EnvironmentVariable[] =>
+  envVariables
+    .filter(
+      (
+        envVar,
+      ): envVar is EnvVariable & {
+        existingName: string;
+        values: { category: SecretCategory.EXISTING; data: { key: string; value: string }[] };
+      } =>
+        envVar.values?.category === SecretCategory.EXISTING &&
+        !!envVar.existingName &&
+        !!envVar.values.data.length,
+    )
+    .flatMap((envVar) =>
+      envVar.values.data.map((entry) => ({
+        name: entry.key,
+        valueFrom: {
+          secretKeyRef: {
+            name: envVar.existingName,
+            key: entry.key,
+          },
+        },
+      })),
+    );
 
 export const createPvcDataForNotebook = async (
   projectName: string,
@@ -106,6 +132,10 @@ const getPromisesForConfigMapsAndSecrets = (
             : replaceSecret(assembleSecret(projectName, dataAsRecord, 'aws', envVar.existingName), {
                 dryRun,
               });
+        case SecretCategory.EXISTING:
+          // Existing secrets are not created/updated — they already exist in the cluster.
+          // They are handled separately via getExistingSecretEnvVars().
+          return null;
         case ConfigMapCategory.GENERIC:
         case ConfigMapCategory.UPLOAD:
           return type === 'create'

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -323,9 +323,15 @@ export const isEnvVariableDataValid = (envVariables: EnvVariable[]): boolean => 
   }
 
   const hasValidValuesForType = (
+    envVar: EnvVariable,
     values: EnvVariableDataEntry[],
     type: ConfigMapCategory | SecretCategory,
   ) => {
+    if (type === SecretCategory.EXISTING) {
+      // Existing secrets require a secret name and at least one selected key
+      return !!envVar.existingName && values.length > 0;
+    }
+
     if (values.length === 0) {
       // No entries -- they have partial form structure
       return false;
@@ -349,7 +355,7 @@ export const isEnvVariableDataValid = (envVariables: EnvVariable[]): boolean => 
       !!envVar.type &&
       !!envVar.values &&
       !!envVar.values.category &&
-      hasValidValuesForType(envVar.values.data, envVar.values.category),
+      hasValidValuesForType(envVar, envVar.values.data, envVar.values.category),
   );
 
   return isValid;

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -125,7 +125,14 @@ export enum SecretCategory {
   GENERIC = 'secret key-value',
   AWS = 'aws',
   UPLOAD = 'secret upload',
+  EXISTING = 'secret existing',
 }
+
+export type ExistingSecretRef = {
+  secretName: string;
+  selectedKeys: string[];
+  allKeys: boolean;
+};
 export enum ConfigMapCategory {
   GENERIC = 'configmap key-value',
   UPLOAD = 'configmap upload',

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -1,5 +1,6 @@
 import type {
   EnvironmentFromVariable,
+  EnvironmentVariable,
   K8sNameDescriptionFieldData,
   Volume,
   VolumeMount,
@@ -91,6 +92,7 @@ export type StartNotebookData = {
   image: ImageStreamAndVersion;
   volumes?: Volume[];
   volumeMounts?: VolumeMount[];
+  existingSecretEnvVars?: EnvironmentVariable[];
   envFrom?: EnvironmentFromVariable[];
   dashboardNamespace?: string;
   connections?: Connection[];


### PR DESCRIPTION
## Summary

Adds a third 'Existing secret' option to the workbench creation/edit form's Environment Variables section. When users select Secret type, they can now reference pre-existing Kubernetes Secrets (created by ESO, ArgoCD, or cluster admins) via a typeahead dropdown. Selected secret keys are injected as individual env[].valueFrom.secretKeyRef entries in the Notebook CR.

### Changes
- Data model: Added SecretCategory.EXISTING enum value and extended EnvVariable type
- API: Added getOpaqueSecrets() to list Opaque secrets with fieldSelector=type=Opaque
- Lazy loading: useExistingSecrets hook fetches secrets only when option is selected, filters out Connections
- UI: EnvExistingSecret component with typeahead secret picker and key selection checkboxes
- CR mutation: Create and edit flows produce secretKeyRef entries (never envFrom)
- Edit reconstruction: Reads env[].valueFrom.secretKeyRef from existing Notebook CRs
- Conflict detection: Warns about env var key collisions across existing secrets, inline secrets, and Connections

### Review Scores
- Architecture: 10.0/10
- Tests: 10.0/10
- Lint: 10.0/10
- Intent: 10.0/10
- Weighted Average: 10.0/10 (PASS)

### Test Plan
- Verify Existing secret radio option appears in Secret type selector
- Verify typeahead dropdown lists namespace Opaque secrets (excluding Connections)
- Verify key selection checkboxes appear after secret selection
- Verify Notebook CR contains correct secretKeyRef entries
- Verify edit view reconstructs existing secret references
- Verify conflict warnings for duplicate env var keys
- Run npm run test - all unit tests pass
- Run npm run type-check - no TypeScript errors
- Run npm run lint - no lint violations

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting existing Kubernetes secrets when configuring notebook environment variables.
  * Users can choose individual secret keys or select all available keys.
  * Existing secret references are preserved when creating or updating notebooks.
  * Added warnings when environment variable names conflict across secrets, configuration sources, or connections.
* **Bug Fixes**
  * Improved reconstruction of secret-based environment variables when loading existing notebooks.
  * Added validation to prevent incomplete existing-secret configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->