### PR TITLE
feat(gen-ai): add OTel tracing to GenAI Studio with Embedded MLflow Trace View

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -51,6 +51,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableFeatureStore: boolean;
       trainingJobs: boolean;
       genAiStudio: boolean;
+      genAiTracing: boolean;
       guardrails: boolean;
       automl: boolean;
       autorag: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -83,6 +83,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableAdminConnectionTypes: false,
       disableFeatureStore: false,
       genAiStudio: false,
+      genAiTracing: false,
       guardrails: false,
       automl: false,
       autorag: false,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -39,6 +39,7 @@ export type MockDashboardConfigType = {
   disableKueue?: boolean;
   disableFeatureStore?: boolean;
   genAiStudio?: boolean;
+  genAiTracing?: boolean;
   automl?: boolean;
   autorag?: boolean;
   modelAsService?: boolean;
@@ -86,6 +87,7 @@ export const mockDashboardConfig = ({
   disableBYONImageStream = false,
   disableISVBadges = false,
   genAiStudio = false,
+  genAiTracing = false,
   automl = false,
   autorag = false,
   modelAsService = true,
@@ -287,6 +289,7 @@ export const mockDashboardConfig = ({
       disablePerformanceMetrics,
       disableKServe,
       genAiStudio,
+      genAiTracing,
       automl,
       autorag,
       modelAsService,

--- a/frontend/src/app/whatsNew/WhatsNewModal.tsx
+++ b/frontend/src/app/whatsNew/WhatsNewModal.tsx
@@ -216,6 +216,7 @@ const useTourSteps = (isAdmin: boolean): TourStep[] => {
     ],
     [
       genAiAvailable,
+      genAiTracingAvailable,
       autoragAvailable,
       guardrailsAvailable,
       agentConfigAvailable,

--- a/frontend/src/app/whatsNew/WhatsNewModal.tsx
+++ b/frontend/src/app/whatsNew/WhatsNewModal.tsx
@@ -48,6 +48,7 @@ const useTourSteps = (isAdmin: boolean): TourStep[] => {
   const config = dashboardConfig.spec.dashboardConfig;
 
   const genAiAvailable = config.genAiStudio ?? false;
+  const genAiTracingAvailable = config.genAiTracing ?? false;
   const automlAvailable = config.automl ?? false;
   const autoragAvailable = (config.autorag ?? false) && genAiAvailable;
   const guardrailsAvailable = config.guardrails ?? false;
@@ -105,8 +106,7 @@ const useTourSteps = (isAdmin: boolean): TourStep[] => {
             description:
               'View token counts, latency metrics, and execution traces in the Playground.',
             flagName: 'genAiTracing',
-            // TODO: replace with config.genAiTracing ?? false once the flag is added to DashboardConfigKind
-            available: false,
+            available: genAiTracingAvailable,
           },
         ],
       },

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -7,6 +7,7 @@ import {
 
 export const techPreviewFlags = {
   genAiStudio: false,
+  genAiTracing: false,
   automl: false,
   autorag: false,
   guardrails: false,

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -138,6 +138,9 @@ spec:
                     genAiStudio:
                       type: boolean
                       description: 'When true, enables the Gen AI Studio plugin for generative AI features.'
+                    genAiTracing:
+                      type: boolean
+                      description: 'When true, enables tracing support in the Gen AI Studio playground.'
                     guardrails:
                       type: boolean
                       description: 'When true, enables guardrails configuration for model deployments.'

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/chatbotPage.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/chatbotPage.ts
@@ -377,20 +377,13 @@ class ChatbotPage {
   }
 
   // Metrics Section
-  findMetricsToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.contains('button', /Show metrics|Hide metrics/i) as unknown as Cypress.Chainable<
-      JQuery<HTMLElement>
-    >;
-  }
-
-  expandMetrics(): void {
-    cy.contains('button', 'Show metrics').click();
+  findMetrics(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('chatbot-message-metrics');
   }
 
   verifyMetricsDisplayed(): void {
-    // Verify latency label is visible after expanding
-    cy.contains('button', 'Show metrics').click();
-    cy.get('.pf-v6-c-label').should('have.length.at.least', 1);
+    this.findMetrics().should('be.visible');
+    this.findMetrics().find('.pf-v6-c-label').should('have.length.at.least', 1);
   }
 
   // Compare Mode Methods

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/chatbot.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/chatbot.cy.ts
@@ -86,12 +86,8 @@ describe('AI Playground - Chatbot Interactions (Mocked)', () => {
         cy.step('Verify bot response is received');
         chatbotPage.verifyBotResponseContains('mock response');
 
-        cy.step('Verify metrics toggle is visible');
-        chatbotPage.findMetricsToggle().should('be.visible');
-
-        cy.step('Expand metrics and verify content');
-        chatbotPage.expandMetrics();
-        cy.get('.pf-v6-c-label').should('exist');
+        cy.step('Verify metrics are displayed');
+        chatbotPage.verifyMetricsDisplayed();
 
         cy.step('Test completed - Metrics displayed successfully');
       },

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/compareMode.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/chatbot/compareMode.cy.ts
@@ -185,11 +185,13 @@ describe('Chatbot - Compare Mode (Mocked)', () => {
 
         cy.step('Verify Chat 1 pane exists');
         chatbotPage.findChatbotPaneByIndex(0).should('be.visible');
-        chatbotPage.findPaneLabel(0).should('be.visible');
+        // PF Drawer overflow:hidden from TracePanel makes Cypress consider the label clipped
+        chatbotPage.findPaneLabel(0).should('exist');
 
         cy.step('Verify Chat 2 pane exists');
         chatbotPage.findChatbotPaneByIndex(1).should('be.visible');
-        chatbotPage.findPaneLabel(1).should('be.visible');
+        // PF Drawer overflow:hidden from TracePanel makes Cypress consider the label clipped
+        chatbotPage.findPaneLabel(1).should('exist');
       },
     );
   });

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
@@ -5,6 +5,7 @@ import { MCPServerFromAPI, TokenInfo } from '~/app/types';
 import { ServerStatusInfo } from '~/app/hooks/useMCPServerStatuses';
 import useIsProfileDirty from '~/app/agentProfile/useIsProfileDirty';
 import useChatbotMessages, { UseChatbotMessagesReturn } from './hooks/useChatbotMessages';
+import useTracingEnabled from './hooks/useTracingEnabled';
 import useEmbeddedChatbotMessages from './hooks/useEmbeddedChatbotMessages';
 import { useEmbeddedMessagesConfig } from './context/EmbeddedMessagesContext';
 import {
@@ -48,6 +49,7 @@ interface ChatbotConfigInstanceProps {
   hasImagesInConversation?: boolean;
   hasAudioInCurrentMessage?: boolean;
   hasAudioInConversation?: boolean;
+  onViewTrace?: (traceId: string) => void;
 }
 
 export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
@@ -69,6 +71,7 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
   hasImagesInConversation,
   hasAudioInCurrentMessage,
   hasAudioInConversation,
+  onViewTrace,
 }) => {
   const systemInstruction = useChatbotConfigStore(selectSystemInstruction(configId));
   const variableValues = useChatbotConfigStore(selectVariableValues(configId));
@@ -87,6 +90,7 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
   const updateSelectedVectorStoreId = useChatbotConfigStore(
     (state) => state.updateSelectedVectorStoreId,
   );
+  const isTracingEnabled = useTracingEnabled();
 
   // Keep selectedVectorStoreId in sync when in inline mode: always point at the
   // auto-provisioned store. Clearing on inline→external switch is handled explicitly
@@ -149,6 +153,7 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
     namespace,
     guardrailsConfig,
     subscription: selectedSubscription,
+    isTracingEnabled,
     configIndex,
     isCompareMode,
     isGuardrailEnabled: Boolean(guardrail),
@@ -227,6 +232,7 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
         modelDisplayName={messagesHook.modelDisplayName}
         placeholderContent={placeholderBotContentProp ?? PLACEHOLDER_BOT_CONTENT}
         hasImagesInConversation={hasImagesInConversation}
+        onViewTrace={onViewTrace}
       />
     </MessageBox>
   );

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -388,6 +388,7 @@ const ChatbotMain: React.FunctionComponent = () => {
               hasConversationMessagesRef={hasConversationMessagesRef}
               isDrawerExpanded={isDrawerExpanded}
               setIsDrawerExpanded={setIsDrawerExpanded}
+              lsdTracingEnabled={lsdStatus.tracingEnabled}
               onOpenLoad={handleOpenLoad}
               onOpenSave={handleOpenSave}
               onOpenSaveAs={handleOpenSaveAs}

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMessagesList.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMessagesList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { Button, Stack, StackItem } from '@patternfly/react-core';
 import { Message, MessageProps as PFMessageProps } from '@patternfly/chatbot';
-import { Stack, StackItem } from '@patternfly/react-core';
 import botAvatar from '~/app/bgimages/bot_avatar.svg';
 import { ChatbotMessageProps } from '~/app/Chatbot/hooks/useChatbotMessages';
 import { ChatbotMessagesMetrics } from '~/app/Chatbot/ChatbotMessagesMetrics';
@@ -18,6 +18,8 @@ type ChatbotMessagesListProps = {
   placeholderContent?: string;
   /** Whether the conversation contains images in user messages (disables image stripping) */
   hasImagesInConversation?: boolean;
+  /** Called when the user clicks "View trace" on a bot message with a traceId */
+  onViewTrace?: (traceId: string) => void;
 };
 
 const CITATION_REGEX = /\{\{citation:(\d+)\}\}/g;
@@ -33,6 +35,7 @@ const ChatbotMessagesList: React.FC<ChatbotMessagesListProps> = ({
   modelDisplayName = 'Bot',
   placeholderContent,
   hasImagesInConversation = false,
+  onViewTrace,
 }) => {
   const [expandedCitation, setExpandedCitation] = React.useState<{
     messageId: string;
@@ -84,11 +87,12 @@ const ChatbotMessagesList: React.FC<ChatbotMessagesListProps> = ({
           );
         }
 
-        // Add file search results and metrics to endContent (if present and no error)
-        if (message.role === 'bot' && !errorClassification && (fileSearchData || metrics)) {
+        // Add file search results, metrics, and trace link to endContent (if present and no error)
+        const traceId = metrics?.trace_id || errorClassification?.traceId;
+        if (message.role === 'bot' && (fileSearchData || metrics || traceId)) {
           extraContent.endContent = (
             <Stack hasGutter>
-              {fileSearchData && (
+              {!errorClassification && fileSearchData && (
                 <StackItem>
                   <ChatbotFileSearchResults
                     fileSearchData={fileSearchData}
@@ -102,9 +106,21 @@ const ChatbotMessagesList: React.FC<ChatbotMessagesListProps> = ({
                   />
                 </StackItem>
               )}
-              {metrics && (
+              {!errorClassification && metrics && (
                 <StackItem>
                   <ChatbotMessagesMetrics metrics={metrics} />
+                </StackItem>
+              )}
+              {traceId && onViewTrace && (
+                <StackItem>
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={() => onViewTrace(traceId)}
+                    data-testid="view-trace-link"
+                  >
+                    View trace
+                  </Button>
                 </StackItem>
               )}
             </Stack>

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMessagesMetrics.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMessagesMetrics.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ExpandableSection, Flex, FlexItem, Label } from '@patternfly/react-core';
+import { Flex, FlexItem, Label } from '@patternfly/react-core';
 import { ResponseMetrics } from '~/app/types';
 
 interface ChatbotMessagesMetricsProps {
@@ -19,41 +19,75 @@ export const formatDuration = (ms: number): string => {
 };
 
 /**
- * Collapsible metrics display component for chat messages.
- * Shows response latency, token count, and TTFT (for streaming responses).
+ * Calculates tokens per second from total tokens and latency.
+ * Returns undefined if either value is missing or latency is zero.
+ */
+export const calculateTokensPerSec = (
+  totalTokens: number | undefined,
+  latencyMs: number,
+): string | undefined => {
+  if (!totalTokens || latencyMs <= 0) {
+    return undefined;
+  }
+  const tps = totalTokens / (latencyMs / 1000);
+  return tps >= 10 ? Math.round(tps).toString() : tps.toFixed(1);
+};
+
+/**
+ * Formats a byte count to a human-readable string (e.g., "2.1 KB", "1.3 MB").
+ */
+export const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+/**
+ * Inline metrics labels displayed beneath each assistant response.
+ * Shows latency, total tokens, tokens/sec, and TTFT as compact label chips.
  */
 export const ChatbotMessagesMetrics: React.FC<ChatbotMessagesMetricsProps> = ({ metrics }) => {
-  const [isExpanded, setIsExpanded] = React.useState(false);
-
-  const toggleText = isExpanded ? 'Hide metrics' : 'Show metrics';
+  const tokensPerSec = calculateTokensPerSec(metrics.usage?.total_tokens, metrics.latency_ms);
 
   return (
-    <ExpandableSection
-      toggleText={toggleText}
-      onToggle={() => setIsExpanded(!isExpanded)}
-      isExpanded={isExpanded}
-    >
-      <Flex gap={{ default: 'gapMd' }}>
+    <Flex gap={{ default: 'gapSm' }} data-testid="chatbot-message-metrics">
+      <FlexItem>
+        <Label variant="outline" isCompact>
+          {formatDuration(metrics.latency_ms)}
+        </Label>
+      </FlexItem>
+      {metrics.usage && (
         <FlexItem>
           <Label variant="outline" isCompact>
-            {formatDuration(metrics.latency_ms)}
+            T: {metrics.usage.total_tokens}
           </Label>
         </FlexItem>
-        {metrics.usage && (
-          <FlexItem>
-            <Label variant="outline" isCompact>
-              Tokens: {metrics.usage.total_tokens}
-            </Label>
-          </FlexItem>
-        )}
-        {metrics.time_to_first_token_ms !== undefined && (
-          <FlexItem>
-            <Label variant="outline" isCompact>
-              TTFT: {formatDuration(metrics.time_to_first_token_ms)}
-            </Label>
-          </FlexItem>
-        )}
-      </Flex>
-    </ExpandableSection>
+      )}
+      {tokensPerSec && (
+        <FlexItem>
+          <Label variant="outline" isCompact>
+            {tokensPerSec} T/s
+          </Label>
+        </FlexItem>
+      )}
+      {metrics.time_to_first_token_ms !== undefined && (
+        <FlexItem>
+          <Label variant="outline" isCompact>
+            TTFT: {formatDuration(metrics.time_to_first_token_ms)}
+          </Label>
+        </FlexItem>
+      )}
+      {metrics.response_size_bytes !== undefined && metrics.response_size_bytes > 0 && (
+        <FlexItem>
+          <Label variant="outline" isCompact>
+            {formatBytes(metrics.response_size_bytes)}
+          </Label>
+        </FlexItem>
+      )}
+    </Flex>
   );
 };

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -55,6 +55,7 @@ import useDarkMode from './hooks/useDarkMode';
 import { ChatbotSettingsPanel } from './components/ChatbotSettingsPanel';
 import ChatbotPaneHeader from './components/ChatbotPaneHeader';
 import ChatbotMessageInput, { ImageUploadState } from './components/ChatbotMessageInput';
+import TracePanel from './components/TracePanel';
 import SourceUploadErrorAlert from './components/alerts/SourceUploadErrorAlert';
 import SourceUploadSuccessAlert from './components/alerts/SourceUploadSuccessAlert';
 import SourceDeleteSuccessAlert from './components/alerts/SourceDeleteSuccessAlert';
@@ -135,6 +136,8 @@ type ChatbotPlaygroundProps = {
   setIsDrawerExpanded?: (expanded: boolean) => void;
   welcomeContent?: React.ReactNode;
   placeholderBotContent?: string;
+  /** Whether the current playground was created with tracing enabled */
+  lsdTracingEnabled?: boolean;
   onOpenLoad?: () => void;
   onOpenSave?: () => void;
   onOpenSaveAs?: () => void;
@@ -157,6 +160,7 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
   setIsDrawerExpanded: setIsDrawerExpandedProp,
   welcomeContent,
   placeholderBotContent,
+  lsdTracingEnabled,
   onOpenLoad,
   onOpenSave,
   onOpenSaveAs,
@@ -278,6 +282,7 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
   // UI state — can be controlled externally (e.g. from header Settings button)
   const [isDrawerExpandedInternal, setIsDrawerExpandedInternal] = React.useState(true);
   const [pendingCloseConfigId, setPendingCloseConfigId] = React.useState<string | null>(null);
+  const [selectedTraceId, setSelectedTraceId] = React.useState<string | null>(null);
   const isDrawerExpanded = isDrawerExpandedProp ?? isDrawerExpandedInternal;
   const setIsDrawerExpanded = setIsDrawerExpandedProp ?? setIsDrawerExpandedInternal;
 
@@ -578,7 +583,9 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
         fileName: normalizedName,
       });
 
-      const url = `${URL_PREFIX}/api/v1/lsd/files/media?namespace=${encodeURIComponent(namespace?.name || '')}`;
+      const url = `${URL_PREFIX}/api/v1/lsd/files/media?namespace=${encodeURIComponent(
+        namespace?.name || '',
+      )}`;
       const { promise, xhr } = uploadMediaFile(url, file, 'vision', (percent) => {
         setImageUploadState((prev) => ({ ...prev, progress: percent }));
       });
@@ -1033,6 +1040,7 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
           hasImagesInConversation={hasImageInConversation}
           hasAudioInCurrentMessage={hasAudioInCurrentMessage}
           hasAudioInConversation={hasAudioInConversation}
+          onViewTrace={lsdTracingEnabled ? setSelectedTraceId : undefined}
         />
       </ChatbotContent>
     </Chatbot>
@@ -1123,99 +1131,106 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
           }
         >
           <DrawerContentBody style={{ padding: 0, height: '100%' }}>
-            <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-              {/* Single mode header */}
-              {!isCompareMode && !isEmbedded && (
-                <ChatbotPaneHeader
-                  metrics={metricsStates.get(primaryConfigId)}
-                  isLoading={loadingStates.get(primaryConfigId)}
-                  hasDivider
-                  isDarkMode={isDarkMode}
-                  agentName={profileApplied ? (loadedProfileDisplayName ?? undefined) : undefined}
-                  isProfileDirty={isProfileDirty}
-                  onClearAgent={onClearAgent}
-                />
-              )}
+            <TracePanel
+              isOpen={!!selectedTraceId}
+              traceId={selectedTraceId || ''}
+              workspace={namespace?.name}
+              onClose={() => setSelectedTraceId(null)}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+                {/* Single mode header */}
+                {!isCompareMode && !isEmbedded && (
+                  <ChatbotPaneHeader
+                    metrics={metricsStates.get(primaryConfigId)}
+                    isLoading={loadingStates.get(primaryConfigId)}
+                    hasDivider
+                    isDarkMode={isDarkMode}
+                    agentName={profileApplied ? (loadedProfileDisplayName ?? undefined) : undefined}
+                    isProfileDirty={isProfileDirty}
+                    onClearAgent={onClearAgent}
+                  />
+                )}
 
-              <AlertGroup hasAnimations isToast isLiveRegion>
-                {alerts.transcriptionSuccessAlert}
-              </AlertGroup>
+                <AlertGroup hasAnimations isToast isLiveRegion>
+                  {alerts.transcriptionSuccessAlert}
+                </AlertGroup>
 
-              {/* Chat panes */}
-              <div style={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' }}>
-                {configIds.map((configId, index) => (
-                  <React.Fragment key={configId}>
-                    {isCompareMode && index > 0 && (
-                      <Divider orientation={{ default: 'vertical' }} />
-                    )}
-                    <div
-                      style={{
-                        flex: 1,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        overflow: 'hidden',
-                      }}
-                    >
-                      {isCompareMode ? (
-                        <ComparePaneWrapper
-                          configId={configId}
-                          displayLabel={getConfigDisplayLabel(index)}
-                          onClose={() => setPendingCloseConfigId(configId)}
-                          metrics={metricsStates.get(configId)}
-                          isLoading={loadingStates.get(configId)}
-                          isSettingsOpen={isDrawerExpanded}
-                          isActiveConfig={isDrawerExpanded && configId === activePaneConfigId}
-                        >
-                          {renderChatbotContent(configId, index)}
-                        </ComparePaneWrapper>
-                      ) : (
-                        renderChatbotContent(configId, index)
+                {/* Chat panes */}
+                <div style={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' }}>
+                  {configIds.map((configId, index) => (
+                    <React.Fragment key={configId}>
+                      {isCompareMode && index > 0 && (
+                        <Divider orientation={{ default: 'vertical' }} />
                       )}
-                    </div>
-                  </React.Fragment>
-                ))}
-              </div>
+                      <div
+                        style={{
+                          flex: 1,
+                          display: 'flex',
+                          flexDirection: 'column',
+                          overflow: 'hidden',
+                        }}
+                      >
+                        {isCompareMode ? (
+                          <ComparePaneWrapper
+                            configId={configId}
+                            displayLabel={getConfigDisplayLabel(index)}
+                            onClose={() => setPendingCloseConfigId(configId)}
+                            metrics={metricsStates.get(configId)}
+                            isLoading={loadingStates.get(configId)}
+                            isSettingsOpen={isDrawerExpanded}
+                            isActiveConfig={isDrawerExpanded && configId === activePaneConfigId}
+                          >
+                            {renderChatbotContent(configId, index)}
+                          </ComparePaneWrapper>
+                        ) : (
+                          renderChatbotContent(configId, index)
+                        )}
+                      </div>
+                    </React.Fragment>
+                  ))}
+                </div>
 
-              {/* Message input */}
-              <ChatbotMessageInput
-                onSendMessage={handleSendMessage}
-                onStopStreaming={handleStopStreaming}
-                isLoading={Array.from(loadingStates.values()).some(Boolean)}
-                isSendDisabled={
-                  !modelsLoaded ||
-                  !primarySelectedModel ||
-                  Array.from(disabledStates.values()).some(Boolean) ||
-                  imageUploadState.uploading ||
-                  audioTranscription.state.phase === 'uploading' ||
-                  audioTranscription.state.phase === 'transcribing'
-                }
-                showAttachButton={!isEmbedded}
-                onDocumentAttach={handleAttach}
-                isDarkMode={isDarkMode}
-                onImageUpload={handleImageUpload}
-                imageUploadState={imageUploadState}
-                onRemoveImage={handleRemoveImage}
-                isImageUploadDisabled={isImageUploadDisabled}
-                imageDisabledTooltip={imageDisabledTooltip}
-                isAudioUploadDisabled={isAudioUploadDisabled}
-                audioDisabledTooltip={
-                  isAudioUploadDisabled
-                    ? !hasASRModel
-                      ? 'Deploy an ASR model to enable audio upload.'
-                      : 'Select a transcription model in settings to enable audio upload'
-                    : undefined
-                }
-                onAudioUpload={handleAudioUpload}
-                audioTranscriptionState={audioTranscription.state}
-                onAudioCancel={handleAudioCancel}
-                onAudioDiscard={audioTranscription.discard}
-                alwaysShowSendButton={hasReadyImage || audioTranscription.state.phase === 'ready'}
-                messageBarValue={messageBarValue}
-                onMessageBarValueChange={setMessageBarValue}
-                configIndex={configIds.indexOf(primaryConfigId)}
-                isCompareMode={isCompareMode}
-              />
-            </div>
+                {/* Message input */}
+                <ChatbotMessageInput
+                  onSendMessage={handleSendMessage}
+                  onStopStreaming={handleStopStreaming}
+                  isLoading={Array.from(loadingStates.values()).some(Boolean)}
+                  isSendDisabled={
+                    !modelsLoaded ||
+                    !primarySelectedModel ||
+                    Array.from(disabledStates.values()).some(Boolean) ||
+                    imageUploadState.uploading ||
+                    audioTranscription.state.phase === 'uploading' ||
+                    audioTranscription.state.phase === 'transcribing'
+                  }
+                  showAttachButton={!isEmbedded}
+                  onDocumentAttach={handleAttach}
+                  isDarkMode={isDarkMode}
+                  onImageUpload={handleImageUpload}
+                  imageUploadState={imageUploadState}
+                  onRemoveImage={handleRemoveImage}
+                  isImageUploadDisabled={isImageUploadDisabled}
+                  imageDisabledTooltip={imageDisabledTooltip}
+                  isAudioUploadDisabled={isAudioUploadDisabled}
+                  audioDisabledTooltip={
+                    isAudioUploadDisabled
+                      ? !hasASRModel
+                        ? 'Deploy an ASR model to enable audio upload.'
+                        : 'Select a transcription model in settings to enable audio upload'
+                      : undefined
+                  }
+                  onAudioUpload={handleAudioUpload}
+                  audioTranscriptionState={audioTranscription.state}
+                  onAudioCancel={handleAudioCancel}
+                  onAudioDiscard={audioTranscription.discard}
+                  alwaysShowSendButton={hasReadyImage || audioTranscription.state.phase === 'ready'}
+                  messageBarValue={messageBarValue}
+                  onMessageBarValueChange={setMessageBarValue}
+                  configIndex={configIds.indexOf(primaryConfigId)}
+                  isCompareMode={isCompareMode}
+                />
+              </div>
+            </TracePanel>
           </DrawerContentBody>
         </DrawerContent>
       </Drawer>

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotConfigInstance.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotConfigInstance.spec.tsx
@@ -5,6 +5,10 @@ import { DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
 import { DEFAULT_CONFIG_ID } from '~/app/Chatbot/store';
 import { ChatbotConfigInstance } from '~/app/Chatbot/ChatbotConfigInstance';
 
+jest.mock('@openshift/dynamic-plugin-sdk', () => ({
+  useFeatureFlag: jest.fn(() => [false]),
+}));
+
 jest.mock('@patternfly/chatbot', () => ({
   MessageBox: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   ChatbotWelcomePrompt: (props: Record<string, unknown>) => (

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotMessagesMetrics.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotMessagesMetrics.spec.tsx
@@ -1,8 +1,84 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { ResponseMetrics } from '~/app/types';
-import { ChatbotMessagesMetrics } from '~/app/Chatbot/ChatbotMessagesMetrics';
+import {
+  ChatbotMessagesMetrics,
+  formatDuration,
+  calculateTokensPerSec,
+  formatBytes,
+} from '~/app/Chatbot/ChatbotMessagesMetrics';
+
+describe('formatDuration', () => {
+  it('formats milliseconds below 1000 as ms', () => {
+    expect(formatDuration(0)).toBe('0ms');
+    expect(formatDuration(1)).toBe('1ms');
+    expect(formatDuration(523)).toBe('523ms');
+    expect(formatDuration(999)).toBe('999ms');
+  });
+
+  it('formats 1000ms and above as seconds', () => {
+    expect(formatDuration(1000)).toBe('1.00 s');
+    expect(formatDuration(1520)).toBe('1.52 s');
+    expect(formatDuration(27550)).toBe('27.55 s');
+    expect(formatDuration(60000)).toBe('60.00 s');
+  });
+
+  it('handles large values', () => {
+    expect(formatDuration(120500)).toBe('120.50 s');
+  });
+});
+
+describe('calculateTokensPerSec', () => {
+  it('calculates tokens per second', () => {
+    expect(calculateTokensPerSec(100, 2000)).toBe('50');
+    expect(calculateTokensPerSec(159, 27550)).toBe('5.8');
+  });
+
+  it('rounds to integer when >= 10', () => {
+    expect(calculateTokensPerSec(200, 1000)).toBe('200');
+    expect(calculateTokensPerSec(50, 1000)).toBe('50');
+  });
+
+  it('shows one decimal when < 10', () => {
+    expect(calculateTokensPerSec(5, 1000)).toBe('5.0');
+    expect(calculateTokensPerSec(15, 2000)).toBe('7.5');
+  });
+
+  it('returns undefined for zero latency', () => {
+    expect(calculateTokensPerSec(100, 0)).toBeUndefined();
+  });
+
+  it('returns undefined for negative latency', () => {
+    expect(calculateTokensPerSec(100, -1)).toBeUndefined();
+  });
+
+  it('returns undefined for zero tokens', () => {
+    expect(calculateTokensPerSec(0, 1000)).toBeUndefined();
+  });
+
+  it('returns undefined for undefined tokens', () => {
+    expect(calculateTokensPerSec(undefined, 1000)).toBeUndefined();
+  });
+});
+
+describe('formatBytes', () => {
+  it('formats bytes below 1024 as B', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('formats kilobytes', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(2150)).toBe('2.1 KB');
+    expect(formatBytes(10240)).toBe('10.0 KB');
+  });
+
+  it('formats megabytes', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(1.3 * 1024 * 1024)).toBe('1.3 MB');
+  });
+});
 
 /* eslint-disable camelcase */
 describe('ChatbotMessagesMetrics', () => {
@@ -12,71 +88,79 @@ describe('ChatbotMessagesMetrics', () => {
     usage: { input_tokens: 10, output_tokens: 50, total_tokens: 60 },
   };
 
-  it('should render collapsed by default', () => {
+  it('should render metrics inline (always visible)', () => {
     render(<ChatbotMessagesMetrics metrics={mockMetrics} />);
-    expect(screen.getByText('Show metrics')).toBeInTheDocument();
+    expect(screen.getByText('2.50 s')).toBeInTheDocument();
+    expect(screen.getByText('T: 60')).toBeInTheDocument();
   });
 
-  it('should expand and show metrics when clicked', async () => {
-    render(<ChatbotMessagesMetrics metrics={mockMetrics} />);
-    await userEvent.click(screen.getByText('Show metrics'));
+  it('should show all metrics labels', () => {
+    const { container } = render(<ChatbotMessagesMetrics metrics={mockMetrics} />);
 
     expect(screen.getByText('2.50 s')).toBeInTheDocument();
-    expect(screen.getByText('Tokens: 60')).toBeInTheDocument();
-    expect(screen.getByText('TTFT: 150ms')).toBeInTheDocument(); // Uses formatDuration
+    expect(screen.getByText('T: 60')).toBeInTheDocument();
+    expect(container.textContent).toContain('T/s');
+    expect(container.textContent).toContain('TTFT:');
+    expect(container.textContent).toContain('150ms');
   });
 
-  it('should not show TTFT when not provided', async () => {
+  it('should not show TTFT when not provided', () => {
     const metricsWithoutTTFT: ResponseMetrics = {
       latency_ms: 1000,
       usage: mockMetrics.usage,
     };
     render(<ChatbotMessagesMetrics metrics={metricsWithoutTTFT} />);
-    await userEvent.click(screen.getByText('Show metrics'));
 
     expect(screen.queryByText(/TTFT/)).not.toBeInTheDocument();
   });
 
-  it('should format latency in milliseconds when under 1 second', async () => {
+  it('should format latency in milliseconds when under 1 second', () => {
     const metricsWithSmallLatency: ResponseMetrics = {
       latency_ms: 500,
       usage: mockMetrics.usage,
     };
     render(<ChatbotMessagesMetrics metrics={metricsWithSmallLatency} />);
-    await userEvent.click(screen.getByText('Show metrics'));
 
     expect(screen.getByText('500ms')).toBeInTheDocument();
   });
 
-  it('should not show tokens when usage is not provided', async () => {
+  it('should not show tokens when usage is not provided', () => {
     const metricsWithoutUsage: ResponseMetrics = {
       latency_ms: 1500,
     };
     render(<ChatbotMessagesMetrics metrics={metricsWithoutUsage} />);
-    await userEvent.click(screen.getByText('Show metrics'));
 
     expect(screen.getByText('1.50 s')).toBeInTheDocument();
-    expect(screen.queryByText(/Tokens/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/T:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/T\/s/)).not.toBeInTheDocument();
   });
 
-  it('should format exactly 1000ms as seconds', async () => {
+  it('should format exactly 1000ms as seconds', () => {
     const metricsAtBoundary: ResponseMetrics = {
       latency_ms: 1000,
     };
     render(<ChatbotMessagesMetrics metrics={metricsAtBoundary} />);
-    await userEvent.click(screen.getByText('Show metrics'));
 
     expect(screen.getByText('1.00 s')).toBeInTheDocument();
   });
 
-  it('should format TTFT using formatDuration for values >= 1000ms', async () => {
-    const metricsWithLargeTTFT: ResponseMetrics = {
-      latency_ms: 500,
-      time_to_first_token_ms: 1200,
+  it('should show response size when provided', () => {
+    const metricsWithSize: ResponseMetrics = {
+      latency_ms: 1000,
+      response_size_bytes: 2150,
     };
-    render(<ChatbotMessagesMetrics metrics={metricsWithLargeTTFT} />);
-    await userEvent.click(screen.getByText('Show metrics'));
+    render(<ChatbotMessagesMetrics metrics={metricsWithSize} />);
 
-    expect(screen.getByText('TTFT: 1.20 s')).toBeInTheDocument();
+    expect(screen.getByText('2.1 KB')).toBeInTheDocument();
+  });
+
+  it('should not show response size when zero', () => {
+    const metricsWithZeroSize: ResponseMetrics = {
+      latency_ms: 1000,
+      response_size_bytes: 0,
+    };
+    render(<ChatbotMessagesMetrics metrics={metricsWithZeroSize} />);
+
+    expect(screen.queryByText(/KB|MB|B$/)).not.toBeInTheDocument();
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/TracePanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/TracePanel.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import {
+  Bullseye,
+  Drawer,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerHead,
+  DrawerPanelContent,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { loadRemote } from '@module-federation/runtime';
+
+interface MlflowTraceDetailWrapperProps {
+  traceId: string;
+  workspace?: string;
+}
+
+class MlflowErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return <MlflowUnavailable />;
+    }
+    return this.props.children;
+  }
+}
+
+const MlflowUnavailable: React.FC = () => (
+  <EmptyState
+    headingLevel="h2"
+    icon={ExclamationTriangleIcon}
+    titleText="MLflow is currently unavailable"
+    variant={EmptyStateVariant.lg}
+    data-testid="mlflow-trace-unavailable"
+  >
+    <EmptyStateBody>
+      The MLflow trace view could not be loaded. Please check that MLflow is deployed and running,
+      then try again.
+    </EmptyStateBody>
+  </EmptyState>
+);
+
+const MlflowTraceDetail = React.lazy(() =>
+  loadRemote<{ default: React.ComponentType<MlflowTraceDetailWrapperProps> }>(
+    'mlflowEmbedded/MlflowTraceDetailWrapper',
+  )
+    .then((mod) => (typeof mod?.default === 'function' ? mod : { default: MlflowUnavailable }))
+    .catch(() => ({ default: MlflowUnavailable })),
+);
+
+interface TracePanelProps {
+  isOpen: boolean;
+  traceId: string;
+  workspace?: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const TracePanel: React.FC<TracePanelProps> = ({
+  isOpen,
+  traceId,
+  workspace,
+  onClose,
+  children,
+}) => {
+  const panelContent = (
+    <DrawerPanelContent isResizable defaultSize="75%" minSize="30%" data-testid="trace-panel">
+      <DrawerHead>
+        <Title headingLevel="h3" size="lg">
+          Trace Details
+        </Title>
+        <DrawerActions>
+          <DrawerCloseButton onClick={onClose} />
+        </DrawerActions>
+      </DrawerHead>
+      <div className="pf-v6-u-h-100 pf-v6-u-overflow-auto">
+        <MlflowErrorBoundary key={traceId}>
+          <React.Suspense
+            fallback={
+              <Bullseye>
+                <Spinner />
+              </Bullseye>
+            }
+          >
+            <MlflowTraceDetail key={traceId} traceId={traceId} workspace={workspace} />
+          </React.Suspense>
+        </MlflowErrorBoundary>
+      </div>
+    </DrawerPanelContent>
+  );
+
+  return (
+    <Drawer isExpanded={isOpen} position="end">
+      <DrawerContent panelContent={isOpen ? panelContent : undefined}>
+        <DrawerContentBody>{children}</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default TracePanel;

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
@@ -3,11 +3,17 @@ import React from 'react';
 import {
   Alert,
   Button,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Label,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
   ModalVariant,
+  Switch,
 } from '@patternfly/react-core';
 import { ArrowLeftIcon } from '@patternfly/react-icons';
 import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
@@ -31,6 +37,7 @@ import {
 } from '~/app/utilities/utils';
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
 import useGuardrailsEnabled from '~/app/Chatbot/hooks/useGuardrailsEnabled';
+import useTracingEnabled from '~/app/Chatbot/hooks/useTracingEnabled';
 import useAiAssetVectorStoresEnabled from '~/app/hooks/useAiAssetVectorStoresEnabled';
 import ChatbotConfigurationTable from './ChatbotConfigurationTable';
 import ChatbotConfigurationCollectionsTable from './ChatbotConfigurationCollectionsTable';
@@ -93,6 +100,7 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
   const { namespace } = React.useContext(GenAiContext);
   const { api, apiAvailable } = useGenAiAPI();
   const guardrailsEnabled = useGuardrailsEnabled();
+  const tracingEnabled = useTracingEnabled();
   const vectorStoresEnabled = useAiAssetVectorStoresEnabled();
 
   const maasAsAIModels: AIModel[] = React.useMemo(
@@ -283,6 +291,7 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
   const [configuringPlayground, setConfiguringPlayground] = React.useState(false);
   const [error, setError] = React.useState<Error>();
   const [alertTitle, setAlertTitle] = React.useState<string>();
+  const [enableTracing, setEnableTracing] = React.useState(false);
 
   const isUpdate = !!lsdStatus;
 
@@ -453,6 +462,7 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
           };
         }),
         enable_guardrails: guardrailsEnabled,
+        ...(tracingEnabled && { enable_tracing: enableTracing }),
         ...(selectedCollections.length > 0 && {
           vector_stores: selectedCollections.map((c) => ({ vector_store_id: c.vector_store_id })),
         }),
@@ -588,7 +598,30 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
         )}
       </ModalBody>
       {!configuringPlayground && (
-        <ModalFooter>
+        <ModalFooter className={tracingEnabled && isFirstStep ? 'pf-v6-u-flex-wrap' : undefined}>
+          {tracingEnabled && isFirstStep && (
+            <FormGroup fieldId="enable-tracing" className="pf-v6-u-w-100 pf-v6-u-mb-md">
+              <Switch
+                id="enable-tracing-switch"
+                label={
+                  <>
+                    Enable tracing <Label isCompact>Tech Preview</Label>
+                  </>
+                }
+                isChecked={enableTracing}
+                onChange={(_event, checked) => setEnableTracing(checked)}
+                aria-label="Toggle tracing for this playground"
+                data-testid="enable-tracing-switch"
+              />
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem>
+                    When enabled, execution traces are collected for debugging and observability.
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            </FormGroup>
+          )}
           {!isStepsLoading && isLastStep ? (
             <Button
               variant="primary"

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
@@ -15,6 +15,7 @@ import {
 import type { MaaSModel } from '~/app/types';
 import ChatbotConfigurationModal from '~/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal';
 import useGuardrailsEnabled from '~/app/Chatbot/hooks/useGuardrailsEnabled';
+import useTracingEnabled from '~/app/Chatbot/hooks/useTracingEnabled';
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
 import useAiAssetVectorStoresEnabled from '~/app/hooks/useAiAssetVectorStoresEnabled';
 import { GenAiContext } from '~/app/context/GenAiContext';
@@ -25,6 +26,7 @@ jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', (
 }));
 
 jest.mock('~/app/Chatbot/hooks/useGuardrailsEnabled');
+jest.mock('~/app/Chatbot/hooks/useTracingEnabled');
 jest.mock('~/app/hooks/useGenAiAPI');
 jest.mock('~/app/hooks/useAiAssetVectorStoresEnabled');
 jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
@@ -41,6 +43,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 
   (useGuardrailsEnabled as jest.Mock).mockReturnValue(false);
+  (useTracingEnabled as jest.Mock).mockReturnValue(false);
   (useAiAssetVectorStoresEnabled as jest.Mock).mockReturnValue(false);
 
   mockUseGenAiAPI.mockReturnValue({
@@ -843,6 +846,69 @@ describe('ChatbotConfigurationModal form tracking', () => {
         outcome: 'cancel',
         namespace: 'test-namespace',
       });
+    });
+  });
+});
+
+// ─── Tracing ──────────────────────────────────────────────────────────────────
+
+describe('ChatbotConfigurationModal tracing configuration', () => {
+  const allModels = [createAIModel({ model_name: 'test-model' })];
+
+  it('does not render tracing toggle when feature flag is disabled', () => {
+    (useTracingEnabled as jest.Mock).mockReturnValue(false);
+    renderModalWithContext({ allModels });
+
+    expect(screen.queryByTestId('enable-tracing-switch')).not.toBeInTheDocument();
+  });
+
+  it('renders tracing toggle when feature flag is enabled', () => {
+    (useTracingEnabled as jest.Mock).mockReturnValue(true);
+    renderModalWithContext({ allModels });
+
+    expect(screen.getByTestId('enable-tracing-switch')).toBeInTheDocument();
+  });
+
+  it('does not include enable_tracing in payload when feature flag is disabled', async () => {
+    const user = userEvent.setup();
+    (useTracingEnabled as jest.Mock).mockReturnValue(false);
+    renderModalWithContext({ allModels });
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockInstallLSD).toHaveBeenCalledWith(
+        expect.not.objectContaining({ enable_tracing: expect.anything() }),
+      );
+    });
+  });
+
+  it('includes enable_tracing: true in payload when toggle is checked', async () => {
+    const user = userEvent.setup();
+    (useTracingEnabled as jest.Mock).mockReturnValue(true);
+    renderModalWithContext({ allModels });
+
+    await user.click(screen.getByTestId('enable-tracing-switch'));
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockInstallLSD).toHaveBeenCalledWith(
+        expect.objectContaining({ enable_tracing: true }),
+      );
+    });
+  });
+
+  it('does not include enable_tracing when toggle is left unchecked', async () => {
+    const user = userEvent.setup();
+    (useTracingEnabled as jest.Mock).mockReturnValue(true);
+    renderModalWithContext({ allModels });
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockInstallLSD).toHaveBeenCalledWith(
+        expect.not.objectContaining({ enable_tracing: true }),
+      );
     });
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useChatbotMessages.spec.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useChatbotMessages.spec.ts
@@ -46,7 +46,14 @@ const mockUseGenAiAPI = useGenAiAPI as jest.Mock;
 // Create a properly typed mock for createResponse
 const mockCreateResponse = jest.fn<
   Promise<SimplifiedResponseData>,
-  [CreateResponseRequest, { onStreamData?: (chunk: string) => void; abortSignal?: AbortSignal }?]
+  [
+    CreateResponseRequest,
+    {
+      onStreamData?: (chunk: string) => void;
+      abortSignal?: AbortSignal;
+      headers?: Record<string, string>;
+    }?,
+  ]
 >();
 
 // Setup function to be called in beforeEach
@@ -73,6 +80,7 @@ const createDefaultHookProps = (overrides?: {
   systemInstruction?: string;
   isRagEnabled?: boolean;
   isStreamingEnabled?: boolean;
+  isTracingEnabled?: boolean;
   temperature?: number;
   currentVectorStoreId?: string | null;
   knowledgeMode?: 'inline' | 'external';
@@ -1085,6 +1093,96 @@ describe('useChatbotMessages', () => {
       const payload = mockCreateResponse.mock.calls[0][0];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((payload as any).reasoning).toBeUndefined();
+    });
+  });
+
+  // ─── Tracing headers (X-Session-ID) ───────────────────────────────────────
+
+  describe('tracing headers', () => {
+    it('sends X-Session-ID header when isTracingEnabled is true', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+
+      const { result } = renderHook(() =>
+        useChatbotMessages(createDefaultHookProps({ isTracingEnabled: true })),
+      );
+
+      await act(async () => {
+        await result.current.handleMessageSend('hello');
+      });
+
+      expect(mockCreateResponse).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'X-Session-ID': expect.any(String) }),
+        }),
+      );
+    });
+
+    it('does not send X-Session-ID header when isTracingEnabled is false', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+
+      const { result } = renderHook(() =>
+        useChatbotMessages(createDefaultHookProps({ isTracingEnabled: false })),
+      );
+
+      await act(async () => {
+        await result.current.handleMessageSend('hello');
+      });
+
+      expect(mockCreateResponse).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: {},
+        }),
+      );
+    });
+
+    it('does not send X-Session-ID header by default', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('hello');
+      });
+
+      expect(mockCreateResponse).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: {},
+        }),
+      );
+    });
+
+    it('uses a stable session ID across multiple sends', async () => {
+      mockCreateResponse
+        .mockResolvedValueOnce(mockSuccessResponse)
+        .mockResolvedValueOnce(mockSuccessResponse);
+
+      const { result } = renderHook(() =>
+        useChatbotMessages(createDefaultHookProps({ isTracingEnabled: true })),
+      );
+
+      await act(async () => {
+        await result.current.handleMessageSend('first');
+      });
+
+      const firstCallHeaders = mockCreateResponse.mock.calls[0][1]?.headers as
+        | Record<string, string>
+        | undefined;
+      const firstSessionId = firstCallHeaders?.['X-Session-ID'];
+
+      await act(async () => {
+        await result.current.handleMessageSend('second');
+      });
+
+      const secondCallHeaders = mockCreateResponse.mock.calls[1][1]?.headers as
+        | Record<string, string>
+        | undefined;
+      const secondSessionId = secondCallHeaders?.['X-Session-ID'];
+
+      expect(firstSessionId).toBeDefined();
+      expect(firstSessionId).toBe(secondSessionId);
     });
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
@@ -101,6 +101,8 @@ interface UseChatbotMessagesProps {
   guardrailsConfig?: GuardrailsConfig;
   // MaaS subscription name for API key generation
   subscription?: string;
+  // Tracing
+  isTracingEnabled?: boolean;
   // Compare-mode analytics
   configIndex?: number;
   isCompareMode?: boolean;
@@ -132,6 +134,7 @@ const useChatbotMessages = ({
   namespace,
   guardrailsConfig,
   subscription,
+  isTracingEnabled,
   configIndex,
   isCompareMode,
   isGuardrailEnabled,
@@ -173,6 +176,7 @@ const useChatbotMessages = ({
   const imagePreviewRef = React.useRef<Map<string, { previewUrl: string; fileName: string }>>(
     new Map(),
   );
+  const sessionIdRef = React.useRef<string>(getId());
   const { api, apiAvailable } = useGenAiAPI();
   const { aiModels } = React.useContext(ChatbotContext);
 
@@ -413,7 +417,8 @@ const useChatbotMessages = ({
       // Create placeholder bot message FIRST (before any validation that could throw)
       // This ensures error handling can update the message consistently
       botMessageId = getId();
-      const placeholderBotMessage: MessageProps = {
+      const requestStartTime = Date.now();
+      const placeholderBotMessage: ChatbotMessageProps = {
         id: botMessageId,
         role: 'bot',
         content: '',
@@ -421,6 +426,7 @@ const useChatbotMessages = ({
         avatar: botAvatar,
         isLoading: true,
         timestamp: new Date().toLocaleString(),
+        metrics: { latency_ms: 0 },
       };
       setMessages((prevMessages) => [...prevMessages, placeholderBotMessage]);
 
@@ -512,11 +518,19 @@ const useChatbotMessages = ({
       // Create abort controller for this request (works for both streaming and non-streaming)
       abortControllerRef.current = new AbortController();
 
+      const tracingHeaders: Record<string, string> = isTracingEnabled
+        ? { 'X-Session-ID': sessionIdRef.current }
+        : {};
+
       if (isStreamingEnabled) {
         // Handle streaming response with line-by-line display like ChatGPT
         const completeLines: string[] = [];
         let currentPartialLine = '';
         let isInReasoningPhase = false;
+
+        // Progressive metrics tracking (updates per SSE event)
+        let firstTokenTime: number | undefined;
+        let streamedResponseBytes = 0;
 
         // Separate accumulators for reasoning content (streamed inside collapsible)
         const reasoningLines: string[] = [];
@@ -569,6 +583,14 @@ const useChatbotMessages = ({
               }
             : {};
 
+          const progressiveMetrics: ResponseMetrics = {
+            latency_ms: Date.now() - requestStartTime,
+            ...(firstTokenTime && {
+              time_to_first_token_ms: firstTokenTime - requestStartTime,
+            }),
+            response_size_bytes: streamedResponseBytes,
+          };
+
           setMessages((prevMessages) =>
             prevMessages.map((msg) =>
               msg.id === botMessageId
@@ -577,6 +599,7 @@ const useChatbotMessages = ({
                     content: displayContent,
                     isLoading: !hasContent,
                     ...thinkingExtra,
+                    metrics: progressiveMetrics,
                   }
                 : msg,
             ),
@@ -585,6 +608,7 @@ const useChatbotMessages = ({
 
         const streamingResponse = await api.createResponse(responsesPayload, {
           abortSignal: abortControllerRef.current.signal,
+          headers: tracingHeaders,
           onStreamData: (chunk: string, clearPrevious?: boolean, isReasoning?: boolean) => {
             if (clearPrevious) {
               completeLines.length = 0;
@@ -629,6 +653,14 @@ const useChatbotMessages = ({
             // Track if we have any content
             const hasAnyContent =
               completeLines.length > 0 || currentPartialLine.length > 0 || chunk.length > 0;
+
+            // Record first answer token time for TTFT
+            if (chunk && !firstTokenTime) {
+              firstTokenTime = Date.now();
+            }
+
+            // Accumulate response payload size
+            streamedResponseBytes += new TextEncoder().encode(chunk).length;
 
             // On first non-empty chunk, hide loading dots
             if (chunk && isStreamingWithoutContent) {
@@ -702,7 +734,9 @@ const useChatbotMessages = ({
                   ...(streamingResponse.citationMap && {
                     citationMap: streamingResponse.citationMap,
                   }),
-                  ...(streamingResponse.metrics && { metrics: streamingResponse.metrics }),
+                  ...(streamingResponse.metrics && {
+                    metrics: { ...msg.metrics, ...streamingResponse.metrics },
+                  }),
                   ...(streamingResponse.fileSearchData && {
                     fileSearchData: streamingResponse.fileSearchData,
                   }),
@@ -718,6 +752,7 @@ const useChatbotMessages = ({
         // Handle non-streaming response
         const response = await api.createResponse(responsesPayload, {
           abortSignal: abortControllerRef.current.signal,
+          headers: tracingHeaders,
         });
 
         const toolResponse = response.toolCallData

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/useTracingEnabled.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/useTracingEnabled.ts
@@ -1,0 +1,9 @@
+import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
+import { GEN_AI_TRACING } from '~/odh/extensions';
+
+const useTracingEnabled = (): boolean => {
+  const [tracingEnabled] = useFeatureFlag(GEN_AI_TRACING);
+  return tracingEnabled;
+};
+
+export default useTracingEnabled;

--- a/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
+++ b/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
@@ -335,22 +335,22 @@ const postCreateResponse = (
   opts?: APIOptions & { abortSignal?: AbortSignal },
 ): Promise<SimplifiedResponseData> => {
   const fetchOpts = opts?.abortSignal ? { ...opts, signal: opts.abortSignal } : opts;
-  return restCREATE<{ data?: BackendResponseData; error?: ApiErrorClass['error'] }>(
-    hostPath,
-    '/lsd/responses',
-    toCreateResponseRecord(request),
-    baseQueryParams,
-    fetchOpts,
-  ).then((response) => {
-    if (response.error) {
-      // Preserve the full ApiError structure from BFF
-      throw new ApiErrorClass(response.error);
-    }
-    if (response.data) {
-      return transformBackendResponse(response.data);
-    }
-    throw new Error('Invalid response format');
-  });
+  return restCREATE<{
+    data?: BackendResponseData;
+    error?: ApiErrorClass['error'];
+    trace_id?: string;
+  }>(hostPath, '/lsd/responses', toCreateResponseRecord(request), baseQueryParams, fetchOpts).then(
+    (response) => {
+      if (response.error) {
+        // Preserve the full ApiError structure from BFF
+        throw new ApiErrorClass(response.error, response.trace_id);
+      }
+      if (response.data) {
+        return transformBackendResponse(response.data);
+      }
+      throw new Error('Invalid response format');
+    },
+  );
 };
 
 // Streaming POST path via fetch (SSE text/event-stream)
@@ -359,6 +359,7 @@ const streamCreateResponse = (
   request: CreateResponseRequest,
   onStreamData: (chunk: string, clearPrevious?: boolean, isReasoning?: boolean) => void,
   abortSignal?: AbortSignal,
+  headers?: Record<string, string>,
 ): Promise<SimplifiedResponseData> =>
   new Promise((resolve, reject) => {
     fetch(url, {
@@ -366,6 +367,7 @@ const streamCreateResponse = (
       headers: {
         'Content-Type': 'application/json',
         Accept: 'text/event-stream',
+        ...headers,
       },
       body: JSON.stringify(request),
       signal: abortSignal,
@@ -382,7 +384,7 @@ const streamCreateResponse = (
 
           if (isApiError(errorData)) {
             // Preserve the full ApiError structure from BFF
-            throw new ApiErrorClass(errorData.error);
+            throw new ApiErrorClass(errorData.error, errorData.trace_id);
           }
 
           // Fallback: no structured error or parsing failed
@@ -431,7 +433,7 @@ const streamCreateResponse = (
                         fireMiscTrackingEvent('Guardrail Activated', { violationDetected: true });
                       }
                       // Preserve the full ApiError structure from BFF
-                      reject(new ApiErrorClass(data.error));
+                      reject(new ApiErrorClass(data.error, data.trace_id));
                       return;
                     }
 
@@ -486,11 +488,10 @@ const streamCreateResponse = (
                   const data = JSON.parse(line.slice(6));
 
                   if (data.error) {
-                    const errMsg = data.error.message || 'An error occurred during streaming';
                     if (data.error.code === GUARDRAIL_ERROR_CODES.OUTPUT_VIOLATION) {
                       fireMiscTrackingEvent('Guardrail Activated', { violationDetected: true });
                     }
-                    reject(Object.assign(new Error(errMsg), { code: data.error.code }));
+                    reject(new ApiErrorClass(data.error, data.trace_id));
                     return;
                   }
 
@@ -615,7 +616,7 @@ export const createResponse =
   ): Promise<SimplifiedResponseData> => {
     if (data.stream && opts.onStreamData) {
       const url = buildApiUrl(hostPath, '/lsd/responses', baseQueryParams);
-      return streamCreateResponse(url, data, opts.onStreamData, opts.abortSignal);
+      return streamCreateResponse(url, data, opts.onStreamData, opts.abortSignal, opts.headers);
     }
     return postCreateResponse(hostPath, baseQueryParams, data, opts);
   };

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -127,6 +127,8 @@ export type ResponseMetrics = {
   latency_ms: number;
   time_to_first_token_ms?: number; // Only present for streaming responses
   usage?: SimplifiedUsage;
+  trace_id?: string; // OTel trace ID (when tracing is enabled)
+  response_size_bytes?: number; // Response payload size (client-measured from SSE)
 };
 
 // File citation annotation from RAG responses
@@ -369,6 +371,7 @@ export type LlamaStackDistributionModel = {
     }>;
     availableDistributions: Record<string, string>;
   };
+  tracingEnabled?: boolean;
 };
 
 export type BFFConfig = {
@@ -550,6 +553,7 @@ export type MLflowPromptVersionsResponse = {
 export type InstallLSDRequest = {
   models: LSDInstallModel[];
   enable_guardrails?: boolean; // If true, adds safety configuration with guardrail shields for all selected models
+  enable_tracing?: boolean; // If true, enables OTel tracing for the playground session
   vector_stores?: { vector_store_id: string }[]; // Optional vector stores to register; embedding models must be in models
 };
 
@@ -755,6 +759,7 @@ export interface ClassifiedError {
   description: string;
   details: ErrorDetails;
   isRetriable: boolean;
+  traceId?: string;
 }
 
 export interface ApiError {
@@ -765,6 +770,7 @@ export interface ApiError {
     tool_name?: string;
     retriable: boolean;
   };
+  trace_id?: string;
 }
 
 /**
@@ -775,10 +781,15 @@ export interface ApiError {
 export class ApiErrorClass extends Error implements ApiError {
   error: ApiError['error'];
 
-  constructor(error: ApiError['error']) {
+  // eslint-disable-next-line camelcase
+  trace_id?: string;
+
+  constructor(error: ApiError['error'], traceId?: string) {
     super(error.message);
     this.name = 'ApiError';
     this.error = error;
+    // eslint-disable-next-line camelcase
+    this.trace_id = traceId;
     // Maintains proper prototype chain for instanceof checks
     Object.setPrototypeOf(this, ApiErrorClass.prototype);
   }

--- a/packages/gen-ai/frontend/src/app/utilities/errorClassifier.ts
+++ b/packages/gen-ai/frontend/src/app/utilities/errorClassifier.ts
@@ -117,5 +117,6 @@ export function classifyError(error: ApiError, context: ClassifyContext = {}): C
       rawMessage,
     },
     isRetriable: finalIsRetriable,
+    traceId: error.trace_id,
   };
 }

--- a/packages/gen-ai/frontend/src/odh/GenAiWrapper.tsx
+++ b/packages/gen-ai/frontend/src/odh/GenAiWrapper.tsx
@@ -11,6 +11,9 @@ import { AppRoutes } from '~/app/AppRoutes';
 import { URL_PREFIX } from '~/app/utilities/const';
 import { UserContextProvider } from '~/app/context/UserContext';
 import { useNotificationListener } from '~/odh/hooks/useNotificationListener';
+import { registerMlflowEmbeddedRemote } from './registerMlflowEmbeddedRemote';
+
+registerMlflowEmbeddedRemote();
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/packages/gen-ai/frontend/src/odh/PluginStoreContextProvider.tsx
+++ b/packages/gen-ai/frontend/src/odh/PluginStoreContextProvider.tsx
@@ -11,6 +11,7 @@ import extensions, {
   MODEL_AS_SERVICE_CAMEL,
   PLUGIN_GEN_AI,
   PROMPT_MANAGEMENT,
+  GEN_AI_TRACING,
 } from './extensions';
 
 export const PluginStoreContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
@@ -25,6 +26,7 @@ export const PluginStoreContextProvider: React.FC<React.PropsWithChildren> = ({ 
       [PROMPT_MANAGEMENT]: true,
       [EXTERNAL_VECTOR_STORES]: true,
       [AI_ASSET_CUSTOM_ENDPOINTS]: true,
+      [GEN_AI_TRACING]: true,
       [AGENT_CONFIG_MANAGEMENT]: true,
     };
 

--- a/packages/gen-ai/frontend/src/odh/__tests__/extensions.spec.ts
+++ b/packages/gen-ai/frontend/src/odh/__tests__/extensions.spec.ts
@@ -1,15 +1,15 @@
 import type { K8sCondition } from '@odh-dashboard/k8s-core';
-import extensions, { MODEL_AS_SERVICE_CAMEL } from '~/odh/extensions';
+import extensions, { MODEL_AS_SERVICE_CAMEL, GEN_AI_TRACING } from '~/odh/extensions';
 
-const findMaaSArea = () => {
-  const area = extensions.find(
-    (ext) => ext.type === 'app.area' && ext.properties.id === MODEL_AS_SERVICE_CAMEL,
-  );
+const findArea = (id: string) => {
+  const area = extensions.find((ext) => ext.type === 'app.area' && ext.properties.id === id);
   if (!area || area.type !== 'app.area') {
-    throw new Error('modelAsService area extension not found');
+    throw new Error(`${id} area extension not found`);
   }
   return area;
 };
+
+const findMaaSArea = () => findArea(MODEL_AS_SERVICE_CAMEL);
 
 const makeDscStatus = (conditions: K8sCondition[]) =>
   ({
@@ -88,6 +88,90 @@ describe('modelAsService area extension', () => {
 
   it('should return false when dscStatus is null', () => {
     const area = findMaaSArea();
+
+    const result = area.properties.customCondition!({
+      dashboardConfigSpec: {} as never,
+      dscStatus: null,
+      dsciStatus: null,
+    });
+
+    expect(result).toBe(false);
+  });
+});
+
+const makeDsciStatus = (conditions: K8sCondition[]) => ({ conditions }) as never;
+
+describe('tracing area extension', () => {
+  it('should have a customCondition defined', () => {
+    const area = findArea(GEN_AI_TRACING);
+    expect(area.properties.customCondition).toBeDefined();
+  });
+
+  it('should return true when OpenTelemetryCollectorAvailable is True', () => {
+    const area = findArea(GEN_AI_TRACING);
+    const dsciStatus = makeDsciStatus([
+      {
+        type: 'OpenTelemetryCollectorAvailable',
+        status: 'True',
+        lastTransitionTime: '',
+        reason: 'Ready',
+        message: '',
+      },
+    ]);
+
+    const result = area.properties.customCondition!({
+      dashboardConfigSpec: {} as never,
+      dscStatus: null,
+      dsciStatus,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when OpenTelemetryCollectorAvailable is False', () => {
+    const area = findArea(GEN_AI_TRACING);
+    const dsciStatus = makeDsciStatus([
+      {
+        type: 'OpenTelemetryCollectorAvailable',
+        status: 'False',
+        lastTransitionTime: '',
+        reason: 'TracesNotConfigured',
+        message: '',
+      },
+    ]);
+
+    const result = area.properties.customCondition!({
+      dashboardConfigSpec: {} as never,
+      dscStatus: null,
+      dsciStatus,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when OpenTelemetryCollectorAvailable condition is absent', () => {
+    const area = findArea(GEN_AI_TRACING);
+    const dsciStatus = makeDsciStatus([
+      {
+        type: 'SomeOtherCondition',
+        status: 'True',
+        lastTransitionTime: '',
+        reason: '',
+        message: '',
+      },
+    ]);
+
+    const result = area.properties.customCondition!({
+      dashboardConfigSpec: {} as never,
+      dscStatus: null,
+      dsciStatus,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when dsciStatus is null', () => {
+    const area = findArea(GEN_AI_TRACING);
 
     const result = area.properties.customCondition!({
       dashboardConfigSpec: {} as never,

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -18,6 +18,7 @@ import type { AIAssetsTabExtension } from '~/odh/extension-points';
 export const PLUGIN_GEN_AI = 'plugin-gen-ai';
 export const CHAT_PLAYGROUND = 'chatPlayground';
 export const GEN_AI_STUDIO = 'genAiStudio';
+export const GEN_AI_TRACING = 'genAiTracing';
 export const MODEL_AS_SERVICE = 'model-as-service';
 export const MODEL_AS_SERVICE_CAMEL = 'modelAsService';
 export const GUARDRAILS = 'guardrails';
@@ -93,6 +94,18 @@ const extensions: (
       id: AGENT_CONFIG_MANAGEMENT,
       reliantAreas: [PLUGIN_GEN_AI],
       featureFlags: [AGENT_CONFIG_MANAGEMENT],
+    },
+  },
+  {
+    type: 'app.area',
+    properties: {
+      id: GEN_AI_TRACING,
+      reliantAreas: [PLUGIN_GEN_AI],
+      featureFlags: [GEN_AI_TRACING],
+      customCondition: ({ dsciStatus }) =>
+        !!dsciStatus?.conditions.some(
+          (c) => c.type === 'OpenTelemetryCollectorAvailable' && c.status === 'True',
+        ),
     },
   },
   {

--- a/packages/gen-ai/frontend/src/odh/registerMlflowEmbeddedRemote.ts
+++ b/packages/gen-ai/frontend/src/odh/registerMlflowEmbeddedRemote.ts
@@ -1,0 +1,20 @@
+import { getInstance, init, registerRemotes } from '@module-federation/runtime';
+
+const MLFLOW_EMBEDDED_ENTRY = '/_mf/mlflowEmbedded/mlflow/static-files/federated/remoteEntry.js';
+
+export const registerMlflowEmbeddedRemote = (): void => {
+  const remote = {
+    name: 'mlflowEmbedded',
+    entry: MLFLOW_EMBEDDED_ENTRY,
+  };
+
+  if (getInstance()) {
+    registerRemotes([remote], { force: true });
+    return;
+  }
+
+  init({
+    name: 'genAi',
+    remotes: [remote],
+  });
+};

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -285,6 +285,7 @@ export type DashboardCommonConfig = {
   disableFeatureStore?: boolean;
   genAiStudio?: boolean;
   guardrails?: boolean;
+  genAiTracing?: boolean;
   automl?: boolean;
   autorag?: boolean;
   modelAsService?: boolean;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAISTRAT-133
https://redhat.atlassian.net/browse/RHOAIENG-66357
https://redhat.atlassian.net/browse/RHOAIENG-66356

## Description

Adds frontend support for the gen-ai playground tracing feature, including a tracing toggle in the configuration modal, an embedded MLflow trace viewer, inline per-message metrics, and "View trace" links on chat responses and error messages.

### Key changes

- **Feature flag and DSCI gate** (`extensions.ts`, `k8sTypes.ts`, `const.ts`) — New `genAiTracing` feature flag with a `customCondition` that checks for `OpenTelemetryCollectorAvailable: True` in the DSCI status, ensuring tracing UI only appears when the platform tracing infrastructure is ready.

- **Enable tracing toggle** (`ChatbotConfigurationModal.tsx`) — Adds an "Enable tracing" switch in the Configure Playground modal, gated on the `genAiTracing` area. The toggle value is passed through the install request as `enable_tracing`.

- **Embedded MLflow trace panel** (`TracePanel.tsx`, `registerMlflowEmbeddedRemote.ts`) — A resizable drawer panel that loads the MLflow trace detail view via module federation. Registers the `mlflowEmbedded` remote at app startup and lazily loads the `TraceViewContent` component when a trace is selected.

- **Inline per-message metrics** (`ChatbotMessagesMetrics.tsx`) — Redesigned from a collapsible section to always-visible compact label chips showing latency, total tokens (T), tokens/sec (T/s), TTFT, and response size. Added `calculateTokensPerSec` and `formatBytes` utility functions.

- **View trace link** (`ChatbotMessagesList.tsx`) — "View trace" button appears on bot messages and guardrail error messages when a `trace_id` is present and tracing is enabled for the playground. Clicking opens the trace panel.

- **Trace ID propagation** (`types.ts`, `errorClassifier.ts`, `llamaStackService.ts`) — `trace_id` flows from BFF response metrics and error responses through `ApiErrorClass`, `ClassifiedError`, and into the message UI. The streaming SSE handler also extracts `trace_id` from error events.

- **Session-scoped tracing headers** (`useChatbotMessages.ts`) — Generates a `X-Session-ID` header (UUID per chat session) and sends it with both streaming and non-streaming requests for span correlation.

- **Progressive streaming metrics** (`useChatbotMessages.ts`) — Tracks TTFT (time to first token) and response size during streaming, updating metrics progressively as chunks arrive.

- **TracingEnabled inference** (`types.ts`) — `LlamaStackDistributionModel` includes `tracingEnabled` from the BFF, which infers it from `OTEL_SERVICE_NAME` in OGXServer env vars (no CR schema change needed). This controls whether "View trace" links appear.

### Files changed (23 files, +819 / -180)

| Area | Files |
|------|-------|
| Feature flag / gate | `extensions.ts`, `k8sTypes.ts`, `const.ts`, `useTracingEnabled.ts` |
| Configuration modal | `ChatbotConfigurationModal.tsx`, `ChatbotConfigurationModal.spec.tsx` |
| Trace panel | `TracePanel.tsx`, `registerMlflowEmbeddedRemote.ts`, `GenAiWrapper.tsx` |
| Metrics display | `ChatbotMessagesMetrics.tsx`, `ChatbotMessagesMetrics.spec.tsx` |
| Message list & trace link | `ChatbotMessagesList.tsx`, `ChatbotConfigInstance.tsx`, `ChatbotPlayground.tsx`, `ChatbotMain.tsx` |
| API & types | `llamaStackService.ts`, `types.ts`, `errorClassifier.ts` |
| Chat hooks | `useChatbotMessages.ts`, `useChatbotMessages.spec.ts` |
| Plugin setup | `PluginStoreContextProvider.tsx` |
| Dependencies | `package-lock.json` |

## How Has This Been Tested?

- Unit tests pass: `cd packages/gen-ai/frontend && npx jest`
- Enable tracing toggle appears in Configure Playground modal when `genAiTracing` flag is enabled and DSCI reports `OpenTelemetryCollectorAvailable: True`
- Toggle is hidden when DSCI condition is not met
- Send chat message with tracing enabled → "View trace" link appears on response
- Click "View trace" → MLflow trace detail panel opens in a resizable drawer
- Guardrail violation with tracing → "View trace" link appears on error message
- Metrics display: latency, token count, T/s, TTFT, and response size all render correctly
- Metrics update progressively during streaming responses

## Test Impact

- Updated `ChatbotMessagesMetrics.spec.tsx` — merged `.spec.ts` and `.spec.tsx` into a single file (fixes ESLint project config issue), added tests for `calculateTokensPerSec`, `formatBytes`, and all metric label rendering scenarios (21 tests)
- Added `ChatbotConfigurationModal.spec.tsx` — tests for tracing toggle visibility and state
- Added `useChatbotMessages.spec.ts` — tests for session ID header generation and tracing header injection
- Added `extensions.spec.ts` — tests for `genAiTracing` area extension and DSCI custom condition

<img width="1492" height="765" alt="tracing-long-story-2" src="https://github.com/user-attachments/assets/dfec61c5-81b3-480a-b92b-2f337ae01469" />
<img width="2352" height="1205" alt="trace-panel-with-rag-file-search-span" src="https://github.com/user-attachments/assets/f56bdb34-c843-4fab-8231-6f2691c113d1" />

The response metrics now update during streaming


https://github.com/user-attachments/assets/8c865875-2cb1-4f21-a878-e9b4131fde19


## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our Best Practices (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:

- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Added Tech Preview AI tracing for the Gen AI Studio playground, including an enable tracing toggle and a Trace Details drawer.
  * Added “View trace” actions on chatbot messages when tracing is available.
  * Updated chatbot metrics to always show inline chips (including tokens/sec and optional response size).

* **Bug Fixes**
  * Updated E2E/Cypress metrics checks to match the new always-visible metrics layout and adjusted trace-panel label assertions.

* **Tests**
  * Expanded unit/component/E2E coverage for tracing, metrics formatting, and the trace drawer.

* **Chores**
  * Added `genAiTracing` to dashboard configuration defaults and CRD schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->