### PR TITLE
Feat(RHOAIENG-72327):Cluster queue utilisation cohort accordion

### DIFF
--- a/frontend/src/__mocks__/mockClusterQueueK8sResource.ts
+++ b/frontend/src/__mocks__/mockClusterQueueK8sResource.ts
@@ -8,6 +8,12 @@ type MockResourceConfigType = {
   hasResourceGroups?: boolean;
   isCpuOverQuota?: boolean;
   isMemoryOverQuota?: boolean;
+  gpuFlavorName?: string;
+  gpuNominalQuota?: number;
+  gpuUsed?: number;
+  gpuBorrowed?: number;
+  admittedWorkloads?: number;
+  pendingWorkloads?: number;
 };
 
 export const mockClusterQueueK8sResource = ({
@@ -16,6 +22,12 @@ export const mockClusterQueueK8sResource = ({
   hasResourceGroups = true,
   isCpuOverQuota = false,
   isMemoryOverQuota = false,
+  gpuFlavorName,
+  gpuNominalQuota = 8,
+  gpuUsed = 0,
+  gpuBorrowed = 0,
+  admittedWorkloads = 0,
+  pendingWorkloads = 0,
 }: MockResourceConfigType): ClusterQueueKind => ({
   apiVersion: 'kueue.x-k8s.io/v1beta2',
   kind: 'ClusterQueue',
@@ -50,12 +62,30 @@ export const mockClusterQueueK8sResource = ({
               },
             ],
           },
+          ...(gpuFlavorName
+            ? [
+                {
+                  coveredResources: ['nvidia.com/gpu' as ContainerResourceAttributes],
+                  flavors: [
+                    {
+                      name: gpuFlavorName,
+                      resources: [
+                        {
+                          name: 'nvidia.com/gpu' as ContainerResourceAttributes,
+                          nominalQuota: String(gpuNominalQuota),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ]
+            : []),
         ]
       : [],
     stopPolicy: 'None',
   },
   status: {
-    admittedWorkloads: 0,
+    admittedWorkloads,
     conditions: [
       {
         lastTransitionTime: '2024-02-22T17:26:19Z',
@@ -98,8 +128,22 @@ export const mockClusterQueueK8sResource = ({
           },
         ],
       },
+      ...(gpuFlavorName
+        ? [
+            {
+              name: gpuFlavorName,
+              resources: [
+                {
+                  name: 'nvidia.com/gpu' as ContainerResourceAttributes,
+                  borrowed: String(gpuBorrowed),
+                  total: String(gpuUsed),
+                },
+              ],
+            },
+          ]
+        : []),
     ],
-    pendingWorkloads: 0,
+    pendingWorkloads,
     reservingWorkloads: 0,
   },
 });

--- a/frontend/src/__mocks__/mockResourceFlavorK8sResource.ts
+++ b/frontend/src/__mocks__/mockResourceFlavorK8sResource.ts
@@ -1,0 +1,23 @@
+import { ResourceFlavorKind } from '@odh-dashboard/internal/k8sTypes';
+import { genUID } from '#~/__mocks__/mockUtils';
+
+type MockResourceFlavorConfigType = {
+  name?: string;
+  gpuProduct?: string;
+};
+
+export const mockResourceFlavorK8sResource = ({
+  name = 'test-gpu-flavor',
+  gpuProduct,
+}: MockResourceFlavorConfigType = {}): ResourceFlavorKind => ({
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
+  kind: 'ResourceFlavor',
+  metadata: {
+    creationTimestamp: '2024-02-22T17:26:19Z',
+    name,
+    uid: genUID('resourceflavor'),
+  },
+  spec: {
+    nodeLabels: gpuProduct ? { 'nvidia.com/gpu.product': gpuProduct } : {},
+  },
+});

--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -82,7 +82,7 @@ class InfrastructurePage {
   }
 
   findCQUtilizationSubtitle() {
-    return cy.findByTestId('cq-utilization-subtitle');
+    return cy.findByTestId('infrastructure-cluster-queue-utilization-description');
   }
 
   findCQUtilizationEmptyState() {

--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -72,6 +72,91 @@ class InfrastructurePage {
     return cy.findByTestId('borrowing-lending-count-label');
   }
 
+  findCQUtilizationSection() {
+    return cy.findByTestId('infrastructure-cluster-queue-utilization-section');
+  }
+
+  scrollToCQUtilizationSection() {
+    this.findCQUtilizationSection().scrollIntoView();
+    return this;
+  }
+
+  findCQUtilizationSubtitle() {
+    return cy.findByTestId('cq-utilization-subtitle');
+  }
+
+  findCQUtilizationEmptyState() {
+    return cy.findByTestId('cq-utilization-empty');
+  }
+
+  findCQUtilizationError() {
+    return cy.findByTestId('cq-utilization-error');
+  }
+
+  findCohortAccordion(cohortName: string) {
+    return cy.findByTestId(`cohort-accordion-${cohortName}`);
+  }
+
+  findCohortBorrowLendBadge() {
+    return cy.findByTestId('cohort-borrow-lend-badge');
+  }
+
+  findCohortUnallocatedBorrowable() {
+    return cy.findByTestId('cohort-unallocated-borrowable');
+  }
+
+  findCQCard(cqName: string) {
+    return cy.get(`[data-testid="cq-card-${cqName}"]`);
+  }
+
+  findCQBorrowBadge() {
+    return cy.findByTestId('cq-borrowed-badge');
+  }
+
+  findCQLendBadge() {
+    return cy.findByTestId('cq-lent-badge');
+  }
+
+  findCQWorkloadCounts() {
+    return cy.findByTestId('cq-workload-counts');
+  }
+
+  findHardwareModelBadge(modelName: string) {
+    return cy.findByTestId(`hardware-model-badge-${modelName}`);
+  }
+
+  findAcceleratorDonutChart() {
+    return cy.findByTestId('accelerator-donut-chart');
+  }
+
+  findAcceleratorDonutChartInCard(cqName: string) {
+    return this.findCQCard(cqName).findByTestId('accelerator-donut-chart');
+  }
+
+  findDcgmComputeDonutInCard(cqName: string) {
+    return this.findCQCard(cqName).findByTestId('dcgm-compute-donut');
+  }
+
+  findDcgmMemoryDonutInCard(cqName: string) {
+    return this.findCQCard(cqName).findByTestId('dcgm-memory-donut');
+  }
+
+  findCQLendBadgeInCard(cqName: string) {
+    return this.findCQCard(cqName).find('[data-testid="cq-lent-badge"]');
+  }
+
+  findCQBorrowBadgeInCard(cqName: string) {
+    return this.findCQCard(cqName).find('[data-testid="cq-borrowed-badge"]');
+  }
+
+  findWorkloadCountsInCard(cqName: string) {
+    return this.findCQCard(cqName).find('[data-testid="cq-workload-counts"]');
+  }
+
+  findOpenPopover() {
+    return cy.findByRole('dialog');
+  }
+
   private wait() {
     this.shouldHavePageTitle();
     cy.testA11y();

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -4,10 +4,10 @@ import { mockComponents } from '@odh-dashboard/internal/__mocks__/mockComponents
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
 import { mockClusterQueueK8sResource } from '@odh-dashboard/internal/__mocks__/mockClusterQueueK8sResource';
 import { mockCohortK8sResource } from '@odh-dashboard/internal/__mocks__/mockCohortK8sResource';
-import type { ClusterQueueKind, CohortKind } from '@odh-dashboard/internal/k8sTypes';
+import { mockResourceFlavorK8sResource } from '@odh-dashboard/internal/__mocks__/mockResourceFlavorK8sResource';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { ClusterQueueModel, CohortModel, ResourceFlavorModel } from '../../../utils/models';
 import { asClusterAdminUser, asProjectAdminUser } from '../../../utils/mockUsers';
-import { ClusterQueueModel, CohortModel } from '../../../utils/models';
 import { infrastructurePage } from '../../../pages/infrastructure';
 
 const mockPrometheusResponse = (value: string) => ({
@@ -46,6 +46,14 @@ const mockNodeLabelResponse = (models: { label: string; count: string }[]) => ({
   status: 'success',
 });
 
+const mockPrometheusResponseWithModel = (modelName: string, value: string) => ({
+  data: {
+    result: [{ metric: { modelName }, value: [Date.now() / 1000, value] }],
+    resultType: 'vector',
+  },
+  status: 'success',
+});
+
 const NOW_S = Math.floor(Date.now() / 1000);
 const ONE_HOUR_S = 3600;
 
@@ -76,8 +84,11 @@ type InitInterceptsOptions = {
   hasDcgm?: boolean;
   hasHardwareModels?: boolean;
   hasNodeLabels?: boolean;
-  clusterQueues?: ClusterQueueKind[];
-  cohorts?: CohortKind[];
+  /** When set, per-model DCGM queries return data keyed by this model name. */
+  dcgmModelName?: string;
+  clusterQueues?: Parameters<typeof mockClusterQueueK8sResource>[0][];
+  cohortNames?: string[];
+  resourceFlavors?: Parameters<typeof mockResourceFlavorK8sResource>[0][];
   hasChartData?: boolean;
 };
 
@@ -107,8 +118,10 @@ const initIntercepts = ({
   hasDcgm = true,
   hasHardwareModels = true,
   hasNodeLabels = false,
-  clusterQueues = [mockClusterQueueK8sResource({ name: 'test-cq' })],
-  cohorts = [mockCohortK8sResource({ name: 'test-cohort' })],
+  dcgmModelName,
+  clusterQueues = [{ name: 'test-cq' }],
+  cohortNames = ['test-cohort'],
+  resourceFlavors = [],
   hasChartData = false,
 }: InitInterceptsOptions = {}) => {
   cy.interceptOdh(
@@ -123,11 +136,22 @@ const initIntercepts = ({
   );
   cy.interceptOdh('GET /api/config', mockDashboardConfig({ gpuaas }));
   cy.interceptOdh('GET /api/components', null, mockComponents());
-  cy.interceptK8sList(ClusterQueueModel, mockK8sResourceList(clusterQueues));
-  cy.interceptK8sList(CohortModel, mockK8sResourceList(cohorts));
+
+  cy.interceptK8sList(
+    ClusterQueueModel,
+    mockK8sResourceList(clusterQueues.map((opts) => mockClusterQueueK8sResource(opts))),
+  );
+  cy.interceptK8sList(
+    CohortModel,
+    mockK8sResourceList(cohortNames.map((name) => mockCohortK8sResource({ name }))),
+  );
+  cy.interceptK8sList(
+    ResourceFlavorModel,
+    mockK8sResourceList(resourceFlavors.map((opts) => mockResourceFlavorK8sResource(opts))),
+  );
 
   cy.interceptOdh('POST /api/prometheus/query', (req) => {
-    const query = req.body.query as string;
+    const { query } = req.body;
 
     // Hardware usage per-model queries (must come before generic DCGM checks
     // since they also contain DCGM_FI_PROF_GR_ENGINE_ACTIVE).
@@ -161,12 +185,20 @@ const initIntercepts = ({
     } else if (query.includes('DCGM_FI_PROF_GR_ENGINE_ACTIVE')) {
       req.reply({
         code: 200,
-        response: hasDcgm ? mockPrometheusResponse('79.5') : mockEmptyPrometheusResponse(),
+        response: hasDcgm
+          ? dcgmModelName && query.includes('modelName')
+            ? mockPrometheusResponseWithModel(dcgmModelName, '30')
+            : mockPrometheusResponse('79.5')
+          : mockEmptyPrometheusResponse(),
       });
     } else if (query.includes('DCGM_FI_DEV_FB_USED')) {
       req.reply({
         code: 200,
-        response: hasDcgm ? mockPrometheusResponse('83.2') : mockEmptyPrometheusResponse(),
+        response: hasDcgm
+          ? dcgmModelName && query.includes('modelName')
+            ? mockPrometheusResponseWithModel(dcgmModelName, '35')
+            : mockPrometheusResponse('83.2')
+          : mockEmptyPrometheusResponse(),
       });
     } else if (query.includes('kube_node_labels')) {
       req.reply({
@@ -185,9 +217,7 @@ const initIntercepts = ({
       req.reply(
         makePrometheusRangeResponse(
           hasChartData
-            ? clusterQueues.map((cq) =>
-                makeRangeResult(cq.metadata?.name ?? '', [2, -1, 3, 0, 2, -2, 1]),
-              )
+            ? clusterQueues.map((opts) => makeRangeResult(opts.name ?? '', [2, -1, 3, 0, 2, -2, 1]))
             : [],
         ),
       );
@@ -206,29 +236,25 @@ describe('GPUaaS Infrastructure Page', () => {
     infrastructurePage.shouldNotFoundPage();
   });
 
-  it('should not exist when Kueue is not installed', () => {
-    asClusterAdminUser();
-    initIntercepts({ isKueueInstalled: false });
-    infrastructurePage.visit(false);
-    infrastructurePage.findNavItem().should('not.exist');
-    infrastructurePage.shouldNotFoundPage();
+  (
+    [
+      ['Kueue is not installed', { isKueueInstalled: false }],
+      ['the gpuaas feature flag is disabled', { gpuaas: false }],
+    ] as [string, InitInterceptsOptions][]
+  ).forEach(([description, opts]) => {
+    it(`page does not exist when ${description}`, () => {
+      asClusterAdminUser();
+      initIntercepts(opts);
+      infrastructurePage.visit(false);
+      infrastructurePage.findNavItem().should('not.exist');
+      infrastructurePage.shouldNotFoundPage();
+    });
   });
 
-  it('should not exist when the gpuaas feature flag is disabled', () => {
-    asClusterAdminUser();
-    initIntercepts({ gpuaas: false });
-    infrastructurePage.visit(false);
-    infrastructurePage.findNavItem().should('not.exist');
-    infrastructurePage.shouldNotFoundPage();
-  });
-
-  describe('with GPU data available', () => {
-    beforeEach(() => {
+  describe('cluster summary cards', () => {
+    it('should display correct card data and refresh badge when GPU data is available', () => {
       asClusterAdminUser();
       initIntercepts({ hasAccelerators: true, hasDcgm: true });
-    });
-
-    it('should display cluster section with correct card data and refresh badge', () => {
       infrastructurePage.visit();
       infrastructurePage.findClusterSection().should('exist');
       infrastructurePage.findTotalAcceleratorsCard().should('contain.text', '11/16');
@@ -238,15 +264,10 @@ describe('GPUaaS Infrastructure Page', () => {
       infrastructurePage.findRefreshBadge().should('exist');
       infrastructurePage.findRefreshBadge().should('contain.text', 'Last update');
     });
-  });
 
-  describe('with no accelerators', () => {
-    beforeEach(() => {
+    it('should display empty states when no accelerators are present', () => {
       asClusterAdminUser();
       initIntercepts({ hasAccelerators: false, hasDcgm: false });
-    });
-
-    it('should display empty states for all cards', () => {
       infrastructurePage.visit();
       infrastructurePage
         .findTotalAcceleratorsCard()
@@ -258,15 +279,10 @@ describe('GPUaaS Infrastructure Page', () => {
         .findMemoryUtilizationCard()
         .should('contain.text', 'Utilization metrics unavailable');
     });
-  });
 
-  describe('with accelerators but no DCGM', () => {
-    beforeEach(() => {
+    it('should show accelerator data but empty utilization cards when DCGM is unavailable', () => {
       asClusterAdminUser();
       initIntercepts({ hasAccelerators: true, hasDcgm: false });
-    });
-
-    it('should show accelerator data but empty utilization cards', () => {
       infrastructurePage.visit();
       infrastructurePage.findTotalAcceleratorsCard().should('contain.text', '11/16');
       infrastructurePage
@@ -321,19 +337,17 @@ describe('GPUaaS Infrastructure Page', () => {
   });
 
   describe('Borrowing & lending chart', () => {
-    const cohort1 = mockCohortK8sResource({ name: 'cohort-inference' });
-    const cq1 = mockClusterQueueK8sResource({
-      name: 'cq-inference',
-      cohortName: 'cohort-inference',
-    });
-    const cq2 = mockClusterQueueK8sResource({
-      name: 'cq-training',
-      cohortName: 'cohort-inference',
-    });
+    const cq1Opts = { name: 'cq-inference', cohortName: 'cohort-inference' };
+    const cq2Opts = { name: 'cq-training', cohortName: 'cohort-inference' };
+    const cohortName = 'cohort-inference';
 
     it('renders the chart, cohort filter, and CQ filter when data is present', () => {
       asClusterAdminUser();
-      initIntercepts({ hasChartData: true, clusterQueues: [cq1, cq2], cohorts: [cohort1] });
+      initIntercepts({
+        hasChartData: true,
+        clusterQueues: [cq1Opts, cq2Opts],
+        cohortNames: [cohortName],
+      });
       infrastructurePage.visit();
 
       infrastructurePage.findBorrowingLendingChart().should('exist');
@@ -358,9 +372,233 @@ describe('GPUaaS Infrastructure Page', () => {
 
     it('shows empty state when Prometheus returns no data', () => {
       asClusterAdminUser();
-      initIntercepts({ hasChartData: false, clusterQueues: [cq1], cohorts: [cohort1] });
+      initIntercepts({ hasChartData: false, clusterQueues: [cq1Opts], cohortNames: [cohortName] });
       infrastructurePage.visit();
       infrastructurePage.findBorrowingLendingEmptyState().should('exist');
+    });
+  });
+
+  describe('Cluster queue utilization section', () => {
+    beforeEach(() => {
+      asClusterAdminUser();
+    });
+
+    it('should show empty state when no GPU CQs exist or all are CPU-only', () => {
+      // Stage 1: no cluster queues at all
+      initIntercepts({ clusterQueues: [], cohortNames: [], resourceFlavors: [] });
+      infrastructurePage.visit();
+      infrastructurePage
+        .findCQUtilizationEmptyState()
+        .should('exist')
+        .should('contain.text', 'No accelerator cluster queues found');
+
+      // Stage 2: only CPU-only CQ — same empty state
+      initIntercepts({
+        clusterQueues: [
+          {
+            name: 'cq-cpu-only',
+            cohortName: 'cohort-1',
+            gpuFlavorName: undefined,
+            hasResourceGroups: true,
+          },
+        ],
+        cohortNames: ['cohort-1'],
+        resourceFlavors: [],
+      });
+      infrastructurePage.visit();
+      infrastructurePage.findCQUtilizationEmptyState().should('exist');
+    });
+
+    it('should render CQ card with subtitle, hardware badge, donut, workload counts, and cohort accordion', () => {
+      initIntercepts({
+        clusterQueues: [
+          {
+            name: 'cq-gpu',
+            cohortName: 'cohort-1',
+            gpuFlavorName: 'a100-flavor',
+            gpuNominalQuota: 8,
+            gpuUsed: 5,
+            admittedWorkloads: 2,
+            pendingWorkloads: 1,
+          },
+        ],
+        cohortNames: ['cohort-1'],
+        resourceFlavors: [{ name: 'a100-flavor', gpuProduct: 'NVIDIA A100' }],
+      });
+      infrastructurePage.visit();
+      infrastructurePage
+        .findCQUtilizationSubtitle()
+        .should('contain.text', 'Cluster queue accelerator utilization grouped by Kueue cohort.');
+      infrastructurePage.findCohortAccordion('cohort-1').should('exist');
+      infrastructurePage.findCQCard('cq-gpu').should('exist');
+      infrastructurePage.findHardwareModelBadge('NVIDIA A100').should('exist');
+      infrastructurePage.findAcceleratorDonutChart().should('exist');
+      infrastructurePage
+        .findCQWorkloadCounts()
+        .should('contain.text', '2 active workloads · 1 pending');
+    });
+
+    it('should render two CQ cards with DCGM utilization columns when telemetry is available', () => {
+      initIntercepts({
+        clusterQueues: [
+          {
+            name: 'notebook-queues',
+            cohortName: 'research-sandbox',
+            gpuFlavorName: 'mi300x-flavor',
+            gpuNominalQuota: 6,
+            gpuUsed: 2,
+            admittedWorkloads: 2,
+            pendingWorkloads: 2,
+          },
+          {
+            name: 'experiment-queues',
+            cohortName: 'research-sandbox',
+            gpuFlavorName: 'mi300x-flavor',
+            gpuNominalQuota: 4,
+            gpuUsed: 0,
+            admittedWorkloads: 0,
+            pendingWorkloads: 1,
+          },
+        ],
+        cohortNames: ['research-sandbox'],
+        resourceFlavors: [{ name: 'mi300x-flavor', gpuProduct: 'AMD MI300X' }],
+        dcgmModelName: 'AMD MI300X',
+      });
+      infrastructurePage.visit();
+      infrastructurePage.scrollToCQUtilizationSection();
+      infrastructurePage.findCohortAccordion('research-sandbox').should('exist');
+      infrastructurePage.findCQCard('notebook-queues').should('exist');
+      infrastructurePage.findCQCard('experiment-queues').should('exist');
+      // Scope to one card since both share the same model badge testid
+      infrastructurePage
+        .findCQCard('notebook-queues')
+        .findByTestId('hardware-model-badge-AMD MI300X')
+        .should('exist');
+      infrastructurePage.findAcceleratorDonutChartInCard('notebook-queues').should('exist');
+      infrastructurePage.findAcceleratorDonutChartInCard('experiment-queues').should('exist');
+    });
+
+    describe('borrow-lend donut state', () => {
+      // a100-train-queues: 6 nominal, 4 used → lends 2; burst-training: 8 nominal, 10 used, 2 borrowed
+      const COHORT = 'ml-training-cohort';
+      const FLAVOR = 'a100-flavor';
+
+      beforeEach(() => {
+        initIntercepts({
+          clusterQueues: [
+            {
+              name: 'a100-train-queues',
+              cohortName: COHORT,
+              gpuFlavorName: FLAVOR,
+              gpuNominalQuota: 6,
+              gpuUsed: 4,
+              admittedWorkloads: 1,
+              pendingWorkloads: 2,
+            },
+            {
+              name: 'burst-training',
+              cohortName: COHORT,
+              gpuFlavorName: FLAVOR,
+              gpuNominalQuota: 8,
+              gpuUsed: 10,
+              gpuBorrowed: 2,
+              admittedWorkloads: 2,
+              pendingWorkloads: 2,
+            },
+          ],
+          cohortNames: [COHORT],
+          resourceFlavors: [{ name: FLAVOR, gpuProduct: 'NVIDIA A100' }],
+          dcgmModelName: 'NVIDIA A100',
+        });
+        infrastructurePage.visit();
+        infrastructurePage.scrollToCQUtilizationSection();
+      });
+
+      it('shows lend/borrow badges, workload counts, all chart columns, and per-model badge popovers', () => {
+        // Cohort-level badges
+        infrastructurePage.findCohortAccordion(COHORT).should('exist');
+        infrastructurePage.findCohortBorrowLendBadge().should('exist');
+        infrastructurePage
+          .findCohortUnallocatedBorrowable()
+          .should('contain.text', '2 unallocated, borrowable');
+
+        // Lender card
+        infrastructurePage
+          .findCQLendBadgeInCard('a100-train-queues')
+          .should('contain.text', '2 lent');
+        infrastructurePage
+          .findWorkloadCountsInCard('a100-train-queues')
+          .should('contain.text', '1 active workload · 2 pending');
+        infrastructurePage.findAcceleratorDonutChartInCard('a100-train-queues').should('exist');
+        infrastructurePage
+          .findCQCard('a100-train-queues')
+          .should('contain.text', 'Accelerator compute utilization')
+          .should('contain.text', 'Accelerator memory utilization');
+
+        // Lent badge popover: shows counterpart CQ and per-model lent count
+        infrastructurePage.findCQLendBadgeInCard('a100-train-queues').click();
+        infrastructurePage
+          .findOpenPopover()
+          .should('contain.text', 'Lent capacity')
+          .should('contain.text', 'burst-training')
+          .should('contain.text', '2 × NVIDIA A100');
+        cy.get('body').type('{esc}');
+
+        // Borrower card
+        infrastructurePage
+          .findCQBorrowBadgeInCard('burst-training')
+          .should('contain.text', '+2 borrowed');
+        infrastructurePage
+          .findWorkloadCountsInCard('burst-training')
+          .should('contain.text', '2 active workloads · 2 pending');
+        infrastructurePage.findAcceleratorDonutChartInCard('burst-training').should('exist');
+        infrastructurePage
+          .findCQCard('burst-training')
+          .should('contain.text', 'Accelerator compute utilization')
+          .should('contain.text', 'Accelerator memory utilization');
+
+        // Borrowed badge popover: shows counterpart CQ and per-model borrowed count
+        infrastructurePage.findCQBorrowBadgeInCard('burst-training').click();
+        infrastructurePage
+          .findOpenPopover()
+          .should('contain.text', 'Borrowed capacity')
+          .should('contain.text', 'a100-train-queues')
+          .should('contain.text', '2 × NVIDIA A100');
+        cy.get('body').type('{esc}');
+      });
+
+      it('shows per-model breakdown in donut segment hover tooltip', () => {
+        // Total accelerators — Own segment
+        infrastructurePage
+          .findAcceleratorDonutChartInCard('a100-train-queues')
+          .find('svg path')
+          .first()
+          .trigger('mouseover', { force: true });
+        infrastructurePage
+          .findCQCard('a100-train-queues')
+          .should('contain.text', 'NVIDIA A100: 4/6 in use');
+
+        // Total accelerators — Lent segment
+        infrastructurePage
+          .findAcceleratorDonutChartInCard('a100-train-queues')
+          .find('svg path')
+          .eq(1)
+          .trigger('mouseover', { force: true });
+        infrastructurePage
+          .findCQCard('a100-train-queues')
+          .should('contain.text', '2 GPUs lent')
+          .should('contain.text', 'NVIDIA A100: 2 lent');
+
+        // DCGM compute — Lent segment
+        infrastructurePage
+          .findDcgmComputeDonutInCard('a100-train-queues')
+          .find('svg path')
+          .eq(1)
+          .trigger('mouseover', { force: true });
+        infrastructurePage
+          .findCQCard('a100-train-queues')
+          .should('contain.text', 'NVIDIA A100: 30% lent');
+      });
     });
   });
 });

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -599,6 +599,43 @@ describe('GPUaaS Infrastructure Page', () => {
           .findCQCard('a100-train-queues')
           .should('contain.text', 'NVIDIA A100: 30% lent');
       });
+
+      describe('pure borrower CQ (nominal=0, used>0)', () => {
+        const PURE_BORROWER_COHORT = 'burst-cohort';
+        const PURE_BORROWER_FLAVOR = 'h100-flavor';
+
+        beforeEach(() => {
+          initIntercepts({
+            clusterQueues: [
+              {
+                name: 'pure-borrower-cq',
+                cohortName: PURE_BORROWER_COHORT,
+                gpuFlavorName: PURE_BORROWER_FLAVOR,
+                gpuNominalQuota: 0,
+                gpuUsed: 6,
+                admittedWorkloads: 1,
+                pendingWorkloads: 0,
+              },
+            ],
+            cohortNames: [PURE_BORROWER_COHORT],
+            resourceFlavors: [{ name: PURE_BORROWER_FLAVOR, gpuProduct: 'NVIDIA H100' }],
+            dcgmModelName: 'NVIDIA H100',
+          });
+          infrastructurePage.visit();
+        });
+
+        it('renders the CQ card with all 3 chart columns and a fully-filled borrowed donut', () => {
+          infrastructurePage.findAcceleratorDonutChartInCard('pure-borrower-cq').should('exist');
+          infrastructurePage
+            .findCQCard('pure-borrower-cq')
+            .findByText('+6 borrowed')
+            .should('exist');
+          infrastructurePage
+            .findCQCard('pure-borrower-cq')
+            .should('contain.text', 'Accelerator compute utilization')
+            .should('contain.text', 'Accelerator memory utilization');
+        });
+      });
     });
   });
 });

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -597,7 +597,7 @@ describe('GPUaaS Infrastructure Page', () => {
           .trigger('mouseover', { force: true });
         infrastructurePage
           .findCQCard('a100-train-queues')
-          .should('contain.text', 'NVIDIA A100: 30% lent');
+          .should('contain.text', 'NVIDIA A100: 30% utilization');
       });
 
       describe('pure borrower CQ (nominal=0, used>0)', () => {

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -153,10 +153,10 @@ const initIntercepts = ({
   cy.interceptOdh('POST /api/prometheus/query', (req) => {
     const { query } = req.body;
 
-    // Hardware usage per-model queries (must come before generic DCGM checks
-    // since they also contain DCGM_FI_PROF_GR_ENGINE_ACTIVE).
-    // Match on 'modelName' which is alphanumeric and survives encodeURIComponent.
+    // DCGM per-model queries must come before the generic 'modelName' check because
+    // they contain both 'DCGM_FI_*' and 'modelName' in the same query string.
     if (query.includes('modelName') && query.includes('pod')) {
+      // Hardware usage per-model (pod-level resource requests).
       req.reply({
         code: 200,
         response:
@@ -164,7 +164,31 @@ const initIntercepts = ({
             ? mockHardwareModelResponse(MOCK_HARDWARE_IN_USE)
             : mockEmptyPrometheusResponse(),
       });
+    } else if (query.includes('DCGM_FI_PROF_GR_ENGINE_ACTIVE')) {
+      // Per-model query: return model-keyed data; aggregate query: return single value.
+      req.reply({
+        code: 200,
+        response: hasDcgm
+          ? query.includes('modelName')
+            ? dcgmModelName
+              ? mockPrometheusResponseWithModel(dcgmModelName, '30')
+              : mockHardwareModelResponse(MOCK_HARDWARE_MODELS)
+            : mockPrometheusResponse('79.5')
+          : mockEmptyPrometheusResponse(),
+      });
+    } else if (query.includes('DCGM_FI_DEV_FB_USED')) {
+      req.reply({
+        code: 200,
+        response: hasDcgm
+          ? query.includes('modelName')
+            ? dcgmModelName
+              ? mockPrometheusResponseWithModel(dcgmModelName, '35')
+              : mockHardwareModelResponse(MOCK_HARDWARE_IN_USE)
+            : mockPrometheusResponse('83.2')
+          : mockEmptyPrometheusResponse(),
+      });
     } else if (query.includes('modelName')) {
+      // Generic hardware model count query (no DCGM, no pod filter).
       req.reply({
         code: 200,
         response:
@@ -181,24 +205,6 @@ const initIntercepts = ({
       req.reply({
         code: 200,
         response: hasAccelerators ? mockPrometheusResponse('11') : mockEmptyPrometheusResponse(),
-      });
-    } else if (query.includes('DCGM_FI_PROF_GR_ENGINE_ACTIVE')) {
-      req.reply({
-        code: 200,
-        response: hasDcgm
-          ? dcgmModelName && query.includes('modelName')
-            ? mockPrometheusResponseWithModel(dcgmModelName, '30')
-            : mockPrometheusResponse('79.5')
-          : mockEmptyPrometheusResponse(),
-      });
-    } else if (query.includes('DCGM_FI_DEV_FB_USED')) {
-      req.reply({
-        code: 200,
-        response: hasDcgm
-          ? dcgmModelName && query.includes('modelName')
-            ? mockPrometheusResponseWithModel(dcgmModelName, '35')
-            : mockPrometheusResponse('83.2')
-          : mockEmptyPrometheusResponse(),
       });
     } else if (query.includes('kube_node_labels')) {
       req.reply({

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test-unit": "jest --silent"
   },
   "exports": {
     "./extensions": "./extensions.ts"

--- a/packages/gpuaas/src/components/AcceleratorDonutChart.tsx
+++ b/packages/gpuaas/src/components/AcceleratorDonutChart.tsx
@@ -1,0 +1,181 @@
+import * as React from 'react';
+import { Bullseye } from '@patternfly/react-core';
+import {
+  ChartDonut,
+  ChartDonutThreshold,
+  ChartDonutUtilization,
+} from '@patternfly/react-charts/victory';
+import {
+  chart_color_black_300 as chartColorGray,
+  chart_color_blue_300 as chartColorBlue,
+  chart_color_purple_100 as chartColorPurple,
+  chart_color_orange_100 as chartColorOrange,
+} from '@patternfly/react-tokens';
+import { SUBTITLE_LABEL, TITLE_LABEL } from './ClusterQueueChartComponents';
+import {
+  AcceleratorDonutConfig,
+  AcceleratorDonutType,
+  AcceleratorSegment,
+  buildAcceleratorBorrowedLines,
+  buildAcceleratorLentLines,
+  buildAcceleratorOwnLines,
+} from '../utils/clusterQueueUtils';
+import { CQ_DONUT_INNER_RADIUS, CQ_DONUT_SIZE } from '../const';
+import { ModelGpuCount } from '../utils/hardwareModels';
+
+type AcceleratorDonutChartProps = {
+  config: AcceleratorDonutConfig;
+  cqName: string;
+  perModelGpus?: ModelGpuCount[];
+};
+
+const AcceleratorDonutChart: React.FC<AcceleratorDonutChartProps> = ({
+  config,
+  cqName,
+  perModelGpus = [],
+}) => {
+  if (config.type === AcceleratorDonutType.None) {
+    return null;
+  }
+
+  if (config.type === AcceleratorDonutType.BorrowLend) {
+    if (config.isBorrowing) {
+      const nonZeroSegments = config.segments.filter((s) => s.y > 0);
+      const totalSlots = nonZeroSegments.reduce((sum, s) => sum + s.y, 0);
+      const borrowedSlots =
+        nonZeroSegments.find((s) => s.x === AcceleratorSegment.Borrowed)?.y ?? 0;
+      const borrowedPct = totalSlots > 0 ? (borrowedSlots / totalSlots) * 100 : 0;
+
+      const borrowedTooltip = [
+        `Total borrowed in use: ${Math.round(borrowedPct)}%`,
+        buildAcceleratorBorrowedLines(perModelGpus),
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+      const ownUsed = config.used - borrowedSlots;
+      const ownBorrowedTooltip = [
+        `Total owned in use: ${ownUsed}`,
+        buildAcceleratorOwnLines(perModelGpus),
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+      return (
+        <Bullseye
+          data-testid="accelerator-donut-chart"
+          style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }}
+        >
+          <ChartDonutThreshold
+            ariaTitle={`Accelerator utilization: ${config.title} (borrowed)`}
+            constrainToVisibleArea
+            data={[{ x: AcceleratorSegment.Own, y: 100 }]}
+            colorScale={[chartColorBlue.value]}
+            height={CQ_DONUT_SIZE}
+            width={CQ_DONUT_SIZE}
+            name={`accelerators-${cqName}`}
+            labels={() => ownBorrowedTooltip}
+          >
+            <ChartDonutUtilization
+              data={{ x: AcceleratorSegment.Borrowed, y: borrowedPct }}
+              thresholds={[{ value: 0, color: chartColorOrange.value }]}
+              labels={({ datum }) =>
+                datum.x === AcceleratorSegment.Borrowed ? borrowedTooltip : ''
+              }
+              title={config.title}
+              subTitle={'Accelerators\nin use'}
+              titleComponent={TITLE_LABEL}
+              subTitleComponent={SUBTITLE_LABEL}
+            />
+          </ChartDonutThreshold>
+        </Bullseye>
+      );
+    }
+
+    // Lent: proportional ring — Own (blue) + Lent (purple).
+    const colorMap: Record<string, string> = {
+      [AcceleratorSegment.Own]: chartColorBlue.value,
+      [AcceleratorSegment.Lent]: chartColorPurple.value,
+    };
+    const visibleSegments = config.segments.filter((seg) => seg.y > 0);
+    const chartData =
+      visibleSegments.length > 0
+        ? visibleSegments
+        : [{ x: AcceleratorSegment.NoData, y: config.nominal }];
+    const chartColorScale =
+      visibleSegments.length > 0
+        ? visibleSegments.map((seg) => colorMap[seg.x] ?? chartColorGray.value)
+        : [chartColorGray.value];
+
+    const ownTooltip = [
+      `Total owned in use: ${config.used}`,
+      buildAcceleratorOwnLines(perModelGpus),
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const lentCount = config.segments.find((s) => s.x === AcceleratorSegment.Lent)?.y ?? 0;
+    const lentTooltip = [`${lentCount} GPUs lent`, buildAcceleratorLentLines(perModelGpus)]
+      .filter(Boolean)
+      .join('\n');
+
+    return (
+      <Bullseye
+        data-testid="accelerator-donut-chart"
+        style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }}
+      >
+        <ChartDonut
+          ariaTitle={`Accelerator utilization: ${config.title} (lent)`}
+          constrainToVisibleArea
+          data={chartData}
+          colorScale={chartColorScale}
+          labels={({ datum }) => (datum.x === AcceleratorSegment.Own ? ownTooltip : lentTooltip)}
+          height={CQ_DONUT_SIZE}
+          width={CQ_DONUT_SIZE}
+          innerRadius={CQ_DONUT_INNER_RADIUS}
+          title={config.title}
+          subTitle={'Accelerators\nin use'}
+          titleComponent={TITLE_LABEL}
+          subTitleComponent={SUBTITLE_LABEL}
+          name={`accelerators-${cqName}`}
+        />
+      </Bullseye>
+    );
+  }
+
+  // Normal: single ChartDonutUtilization.
+  const normalTooltip = [
+    `Accelerators in use: ${config.percentage}%`,
+    buildAcceleratorOwnLines(perModelGpus),
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return (
+    <Bullseye
+      data-testid="accelerator-donut-chart"
+      style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }}
+    >
+      <ChartDonutUtilization
+        ariaTitle={`Accelerator utilization: ${config.used}/${config.nominal} (${config.percentage}%)`}
+        constrainToVisibleArea
+        data={{ x: 'Accelerators in use', y: config.percentage }}
+        height={CQ_DONUT_SIZE}
+        width={CQ_DONUT_SIZE}
+        innerRadius={CQ_DONUT_INNER_RADIUS}
+        labels={({ datum }) =>
+          datum.x === 'Accelerators in use'
+            ? normalTooltip
+            : `Available: ${100 - config.percentage}%`
+        }
+        title={config.title}
+        subTitle={'Accelerators\nin use'}
+        titleComponent={TITLE_LABEL}
+        subTitleComponent={SUBTITLE_LABEL}
+        name={`accelerators-${cqName}`}
+      />
+    </Bullseye>
+  );
+};
+
+export default AcceleratorDonutChart;

--- a/packages/gpuaas/src/components/AcceleratorDonutChart.tsx
+++ b/packages/gpuaas/src/components/AcceleratorDonutChart.tsx
@@ -54,9 +54,10 @@ const AcceleratorDonutChart: React.FC<AcceleratorDonutChartProps> = ({
         .join('\n');
 
       const ownUsed = config.used - borrowedSlots;
+      // Pure borrowers have no owned capacity, skip per-model breakdown to avoid "6/0 in use" output
       const ownBorrowedTooltip = [
         `Total owned in use: ${ownUsed}`,
-        buildAcceleratorOwnLines(perModelGpus),
+        ownUsed > 0 ? buildAcceleratorOwnLines(perModelGpus) : null,
       ]
         .filter(Boolean)
         .join('\n');
@@ -69,7 +70,7 @@ const AcceleratorDonutChart: React.FC<AcceleratorDonutChartProps> = ({
           <ChartDonutThreshold
             ariaTitle={`Accelerator utilization: ${config.title} (borrowed)`}
             constrainToVisibleArea
-            data={[{ x: AcceleratorSegment.Own, y: 100 }]}
+            data={[{ x: AcceleratorSegment.Own, y: ownUsed > 0 ? 100 : 0 }]}
             colorScale={[chartColorBlue.value]}
             height={CQ_DONUT_SIZE}
             width={CQ_DONUT_SIZE}

--- a/packages/gpuaas/src/components/ClusterQueueCard.tsx
+++ b/packages/gpuaas/src/components/ClusterQueueCard.tsx
@@ -1,0 +1,208 @@
+import * as React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Content,
+  ContentVariants,
+  Flex,
+  FlexItem,
+  Label,
+  LabelGroup,
+} from '@patternfly/react-core';
+import {
+  chart_color_blue_300 as chartColorBlue,
+  chart_color_purple_100 as chartColorPurple,
+  chart_color_orange_100 as chartColorOrange,
+} from '@patternfly/react-tokens';
+import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import AcceleratorDonutChart from './AcceleratorDonutChart';
+import {
+  BorrowLendBadge,
+  ChartColumn,
+  DcgmDonut,
+  PerModelDcgmData,
+} from './ClusterQueueChartComponents';
+import { ModelGpuCount } from '../utils/hardwareModels';
+import {
+  AcceleratorDonutType,
+  AcceleratorSegment,
+  formatWorkloadCounts,
+  getAcceleratorDonutConfig,
+  getBorrowLendBadgeState,
+  getBorrowLendInfo,
+  isInCohort,
+} from '../utils/clusterQueueUtils';
+
+type ClusterQueueCardProps = {
+  cq: ClusterQueueKind;
+  hardwareModels: string[];
+  perModelGpus?: ModelGpuCount[];
+  counterpartCQNames?: string[];
+  /** True when the DCGM service is present; controls whether the two chart columns render at all. */
+  dcgmAvailable?: boolean;
+  computeUtilization?: number | null;
+  memoryUtilization?: number | null;
+  perModelComputeDcgm?: PerModelDcgmData[];
+  perModelMemoryDcgm?: PerModelDcgmData[];
+};
+
+const LEGEND_COLORS: Record<string, string> = {
+  [AcceleratorSegment.Own]: chartColorBlue.value,
+  [AcceleratorSegment.Borrowed]: chartColorOrange.value,
+  [AcceleratorSegment.Lent]: chartColorPurple.value,
+};
+
+const ClusterQueueCard: React.FC<ClusterQueueCardProps> = ({
+  cq,
+  hardwareModels,
+  perModelGpus = [],
+  counterpartCQNames = [],
+  dcgmAvailable = false,
+  computeUtilization,
+  memoryUtilization,
+  perModelComputeDcgm = [],
+  perModelMemoryDcgm = [],
+}) => {
+  const name = cq.metadata?.name ?? '';
+  const admitted = cq.status?.admittedWorkloads ?? 0;
+  const pending = cq.status?.pendingWorkloads ?? 0;
+  const cqIsInCohort = isInCohort(cq);
+
+  const donutConfig = getAcceleratorDonutConfig(cq, cqIsInCohort);
+  const { borrowing, lending, lentCount, borrowedCount } = getBorrowLendBadgeState(donutConfig);
+
+  const borrowLendInfo = getBorrowLendInfo(donutConfig);
+  const legendSeriesNames =
+    donutConfig.type === AcceleratorDonutType.BorrowLend
+      ? donutConfig.isBorrowing
+        ? [AcceleratorSegment.Own, AcceleratorSegment.Borrowed]
+        : [AcceleratorSegment.Own, AcceleratorSegment.Lent]
+      : [];
+  const legendItems = legendSeriesNames.map((seriesName) => ({
+    name: seriesName,
+    color: LEGEND_COLORS[seriesName],
+  }));
+
+  return (
+    <Card isCompact data-testid={`cq-card-${name}`}>
+      <CardTitle>
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          flexWrap={{ default: 'wrap' }}
+          spaceItems={{ default: 'spaceItemsSm' }}
+        >
+          <FlexItem>{name}</FlexItem>
+          {hardwareModels.length > 0 && (
+            <FlexItem>
+              <LabelGroup>
+                {hardwareModels.map((model) => (
+                  <Label
+                    key={model}
+                    color="blue"
+                    variant="outline"
+                    isCompact
+                    data-testid={`hardware-model-badge-${model}`}
+                  >
+                    {model}
+                  </Label>
+                ))}
+              </LabelGroup>
+            </FlexItem>
+          )}
+          {lending && cqIsInCohort && (
+            <FlexItem>
+              <BorrowLendBadge
+                type="lent"
+                count={lentCount}
+                models={hardwareModels}
+                perModelGpus={perModelGpus}
+                counterpartCQNames={counterpartCQNames}
+              />
+            </FlexItem>
+          )}
+          {borrowing && (
+            <FlexItem>
+              <BorrowLendBadge
+                type="borrowed"
+                count={borrowedCount}
+                models={hardwareModels}
+                perModelGpus={perModelGpus}
+                counterpartCQNames={counterpartCQNames}
+              />
+            </FlexItem>
+          )}
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+          <FlexItem>
+            <Content component={ContentVariants.small} data-testid="cq-workload-counts">
+              {formatWorkloadCounts(admitted, pending)}
+            </Content>
+          </FlexItem>
+          <FlexItem>
+            <Flex
+              flexWrap={{ default: 'nowrap' }}
+              justifyContent={{ default: 'justifyContentSpaceEvenly' }}
+              spaceItems={{ default: 'spaceItemsNone' }}
+              style={{ overflowX: 'auto', overflowY: 'hidden' }}
+            >
+              <ChartColumn label="Total accelerators">
+                <AcceleratorDonutChart
+                  config={donutConfig}
+                  cqName={name}
+                  perModelGpus={perModelGpus}
+                />
+              </ChartColumn>
+              {dcgmAvailable && (
+                <ChartColumn label="Accelerator compute utilization">
+                  <DcgmDonut
+                    percentage={computeUtilization}
+                    ariaLabel="Accelerator compute utilization"
+                    borrowLendInfo={borrowLendInfo}
+                    perModelData={perModelComputeDcgm}
+                    testId="dcgm-compute-donut"
+                  />
+                </ChartColumn>
+              )}
+              {dcgmAvailable && (
+                <ChartColumn label="Accelerator memory utilization">
+                  <DcgmDonut
+                    percentage={memoryUtilization}
+                    ariaLabel="Accelerator memory utilization"
+                    borrowLendInfo={borrowLendInfo}
+                    perModelData={perModelMemoryDcgm}
+                    testId="dcgm-memory-donut"
+                  />
+                </ChartColumn>
+              )}
+            </Flex>
+          </FlexItem>
+
+          {legendItems.length > 0 && (
+            <FlexItem>
+              <Flex
+                justifyContent={{ default: 'justifyContentCenter' }}
+                spaceItems={{ default: 'spaceItemsMd' }}
+              >
+                {legendItems.map((item) => (
+                  <FlexItem key={item.name}>
+                    <Content
+                      component={ContentVariants.small}
+                      data-testid={`legend-item-${item.name.toLowerCase()}`}
+                    >
+                      <span style={{ color: item.color }}>&#9679;</span> {item.name}
+                    </Content>
+                  </FlexItem>
+                ))}
+              </Flex>
+            </FlexItem>
+          )}
+        </Flex>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default ClusterQueueCard;

--- a/packages/gpuaas/src/components/ClusterQueueChartComponents.tsx
+++ b/packages/gpuaas/src/components/ClusterQueueChartComponents.tsx
@@ -107,7 +107,7 @@ export const BorrowLendBadge: React.FC<BorrowLendBadgeProps> = ({
         .filter((m) => (m.borrowed ?? 0) > 0)
         .map((m) => (
           <Content key={m.model} component={ContentVariants.small}>
-            {m.borrowed} × {m.model}
+            {m.borrowed ?? 0} × {m.model}
           </Content>
         ))
     : perModelGpus

--- a/packages/gpuaas/src/components/ClusterQueueChartComponents.tsx
+++ b/packages/gpuaas/src/components/ClusterQueueChartComponents.tsx
@@ -22,7 +22,6 @@ import {
   chart_color_blue_300 as chartColorBlue,
   chart_color_purple_100 as chartColorPurple,
   chart_color_orange_100 as chartColorOrange,
-  t_global_text_color_100 as textColor,
 } from '@patternfly/react-tokens';
 import {
   AcceleratorSegment,
@@ -67,8 +66,8 @@ const SEGMENT_COLORS: Record<string, string> = {
   [AcceleratorSegment.NoData]: chartColorGray.value,
 };
 
-export const TITLE_LABEL = <ChartLabel style={{ fontSize: 18, fill: textColor.value }} />;
-export const SUBTITLE_LABEL = <ChartLabel style={{ fontSize: 13, fill: textColor.value }} />;
+export const TITLE_LABEL = <ChartLabel style={{ fontSize: 18, fill: 'currentColor' }} />;
+export const SUBTITLE_LABEL = <ChartLabel style={{ fontSize: 13, fill: 'currentColor' }} />;
 
 export const ChartColumn: React.FC<{ label: string; children: React.ReactNode }> = ({
   label,

--- a/packages/gpuaas/src/components/ClusterQueueChartComponents.tsx
+++ b/packages/gpuaas/src/components/ClusterQueueChartComponents.tsx
@@ -1,0 +1,281 @@
+import * as React from 'react';
+import {
+  Bullseye,
+  Content,
+  ContentVariants,
+  Flex,
+  FlexItem,
+  Label,
+  Popover,
+  Spinner,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import {
+  ChartDonut,
+  ChartDonutThreshold,
+  ChartDonutUtilization,
+  ChartLabel,
+} from '@patternfly/react-charts/victory';
+import {
+  chart_color_black_300 as chartColorGray,
+  chart_color_blue_300 as chartColorBlue,
+  chart_color_purple_100 as chartColorPurple,
+  chart_color_orange_100 as chartColorOrange,
+  t_global_text_color_100 as textColor,
+} from '@patternfly/react-tokens';
+import {
+  AcceleratorSegment,
+  BorrowLendInfo,
+  PerModelDcgmData,
+  buildDcgmBorrowedTooltip,
+  buildDcgmLentTooltip,
+  buildDcgmOwnTooltip,
+  computeDcgmSplitData,
+} from '../utils/clusterQueueUtils';
+import { ModelGpuCount } from '../utils/hardwareModels';
+import { CQ_DONUT_INNER_RADIUS, CQ_DONUT_SIZE } from '../const';
+
+export type { BorrowLendInfo, PerModelDcgmData };
+
+type BorrowLendBadgeProps = {
+  type: 'borrowed' | 'lent';
+  count: number;
+  models: string[];
+  perModelGpus?: ModelGpuCount[];
+  counterpartCQNames?: string[];
+};
+
+type DcgmDonutProps = {
+  /**
+   * null      = data loading (show spinner)
+   * undefined = data loaded but unavailable for this model (show 0% ring)
+   * number    = loaded value to render
+   */
+  percentage: number | null | undefined;
+  ariaLabel: string;
+  borrowLendInfo?: BorrowLendInfo;
+  /** Per-GPU-model utilization for richer hover tooltips in lent/borrowed state. */
+  perModelData?: PerModelDcgmData[];
+  testId?: string;
+};
+
+const SEGMENT_COLORS: Record<string, string> = {
+  [AcceleratorSegment.Own]: chartColorBlue.value,
+  [AcceleratorSegment.Lent]: chartColorPurple.value,
+  [AcceleratorSegment.Available]: chartColorGray.value,
+  [AcceleratorSegment.NoData]: chartColorGray.value,
+};
+
+export const TITLE_LABEL = <ChartLabel style={{ fontSize: 18, fill: textColor.value }} />;
+export const SUBTITLE_LABEL = <ChartLabel style={{ fontSize: 13, fill: textColor.value }} />;
+
+export const ChartColumn: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <FlexItem style={{ width: CQ_DONUT_SIZE, flexShrink: 0, textAlign: 'center' }}>
+    <Stack>
+      <StackItem>
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          justifyContent={{ default: 'justifyContentCenter' }}
+          style={{ minHeight: '2.8em' }}
+        >
+          <FlexItem>
+            <Content component={ContentVariants.small}>{label}</Content>
+          </FlexItem>
+        </Flex>
+      </StackItem>
+      <StackItem>{children}</StackItem>
+    </Stack>
+  </FlexItem>
+);
+
+export const BorrowLendBadge: React.FC<BorrowLendBadgeProps> = ({
+  type,
+  count,
+  models,
+  perModelGpus = [],
+  counterpartCQNames = [],
+}) => {
+  const isBorrowed = type === 'borrowed';
+  const directionLabel = isBorrowed ? 'From' : 'To';
+
+  const perModelRows = isBorrowed
+    ? perModelGpus
+        .filter((m) => (m.borrowed ?? 0) > 0)
+        .map((m) => (
+          <Content key={m.model} component={ContentVariants.small}>
+            {m.borrowed} × {m.model}
+          </Content>
+        ))
+    : perModelGpus
+        .filter((m) => m.nominal - m.used > 0)
+        .map((m) => (
+          <Content key={m.model} component={ContentVariants.small}>
+            {m.nominal - m.used} × {m.model}
+          </Content>
+        ));
+
+  const fallbackRow = (
+    <Content component={ContentVariants.small}>
+      {count} × {models.length > 0 ? models.join(', ') : count === 1 ? 'GPU' : 'GPUs'}
+    </Content>
+  );
+
+  return (
+    <Popover
+      headerContent={isBorrowed ? 'Borrowed capacity' : 'Lent capacity'}
+      bodyContent={
+        <Stack hasGutter>
+          {counterpartCQNames.length > 0 && (
+            <StackItem>
+              {counterpartCQNames.map((cqName) => (
+                <Content key={cqName} component={ContentVariants.small}>
+                  {directionLabel}: <strong>{cqName}</strong>
+                </Content>
+              ))}
+            </StackItem>
+          )}
+          <StackItem>{perModelRows.length > 0 ? perModelRows : fallbackRow}</StackItem>
+        </Stack>
+      }
+    >
+      <Label
+        color={isBorrowed ? 'orange' : 'purple'}
+        isCompact
+        onClick={() => undefined}
+        data-testid={`cq-${type}-badge`}
+      >
+        {isBorrowed ? `+${count} borrowed` : `${count} lent`}
+      </Label>
+    </Popover>
+  );
+};
+
+export const DcgmDonut: React.FC<DcgmDonutProps> = ({
+  percentage,
+  ariaLabel,
+  borrowLendInfo,
+  perModelData = [],
+  testId,
+}) => {
+  if (percentage === null) {
+    return (
+      <Bullseye style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }} data-testid={testId}>
+        <Spinner size="md" aria-label={`Loading ${ariaLabel}`} />
+      </Bullseye>
+    );
+  }
+
+  if (percentage === undefined) {
+    return (
+      <Bullseye style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }} data-testid={testId}>
+        <ChartDonutUtilization
+          ariaTitle={`${ariaLabel}: 0%`}
+          constrainToVisibleArea
+          data={{ x: ariaLabel, y: 0 }}
+          height={CQ_DONUT_SIZE}
+          width={CQ_DONUT_SIZE}
+          innerRadius={CQ_DONUT_INNER_RADIUS}
+          labels={() => 'No telemetry data'}
+          title="0%"
+          subTitle="utilization"
+          titleComponent={TITLE_LABEL}
+          subTitleComponent={SUBTITLE_LABEL}
+          name={`dcgm-${ariaLabel}`}
+        />
+      </Bullseye>
+    );
+  }
+
+  if (borrowLendInfo) {
+    if (borrowLendInfo.isBorrowing) {
+      const fillPct = Math.min(percentage, 99.9); // avoid full-circle SVG edge case at 100
+      return (
+        <Bullseye style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }} data-testid={testId}>
+          <ChartDonutThreshold
+            ariaTitle={`${ariaLabel} (borrowed)`}
+            constrainToVisibleArea
+            data={[{ x: AcceleratorSegment.Own, y: 100 }]}
+            colorScale={[chartColorBlue.value]}
+            height={CQ_DONUT_SIZE}
+            width={CQ_DONUT_SIZE}
+            name={`dcgm-${ariaLabel}`}
+            labels={() => buildDcgmOwnTooltip(percentage, perModelData)}
+          >
+            <ChartDonutUtilization
+              data={{ x: AcceleratorSegment.Borrowed, y: fillPct }}
+              thresholds={[{ value: 0, color: chartColorOrange.value }]}
+              labels={({ datum }) =>
+                datum.x === AcceleratorSegment.Borrowed
+                  ? buildDcgmBorrowedTooltip(datum.y, perModelData)
+                  : `Own: ${Math.round(datum.y)}%`
+              }
+              title={`${Math.round(percentage)}%`}
+              subTitle="utilization"
+              titleComponent={TITLE_LABEL}
+              subTitleComponent={SUBTITLE_LABEL}
+            />
+          </ChartDonutThreshold>
+        </Bullseye>
+      );
+    }
+
+    // Lent: proportional ring — Own / Lent / Available segments.
+    const { chartData } = computeDcgmSplitData(percentage, borrowLendInfo);
+    // Map colors by segment name so filtering zero-value segments doesn't shift colors.
+    const chartColorScale = chartData.map((d) => SEGMENT_COLORS[d.x] ?? chartColorGray.value);
+
+    return (
+      <Bullseye style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }} data-testid={testId}>
+        <ChartDonut
+          ariaTitle={`${ariaLabel} (lent)`}
+          constrainToVisibleArea
+          data={chartData}
+          colorScale={chartColorScale}
+          labels={({ datum }) => {
+            if (datum.x === AcceleratorSegment.Available || datum.x === AcceleratorSegment.NoData) {
+              return `Available: ${Math.round(datum.y)}%`;
+            }
+            if (datum.x === AcceleratorSegment.Lent) {
+              return buildDcgmLentTooltip(datum.y, perModelData);
+            }
+            return `Own: ${Math.round(datum.y)}%`;
+          }}
+          height={CQ_DONUT_SIZE}
+          width={CQ_DONUT_SIZE}
+          innerRadius={CQ_DONUT_INNER_RADIUS}
+          title={`${Math.round(percentage)}%`}
+          subTitle="utilization"
+          titleComponent={TITLE_LABEL}
+          subTitleComponent={SUBTITLE_LABEL}
+          name={`dcgm-${ariaLabel}`}
+        />
+      </Bullseye>
+    );
+  }
+
+  // Normal single-colour utilisation ring.
+  return (
+    <Bullseye style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }} data-testid={testId}>
+      <ChartDonutUtilization
+        ariaTitle={ariaLabel}
+        constrainToVisibleArea
+        data={{ x: ariaLabel, y: percentage }}
+        height={CQ_DONUT_SIZE}
+        width={CQ_DONUT_SIZE}
+        innerRadius={CQ_DONUT_INNER_RADIUS}
+        labels={({ datum }) =>
+          datum.x === ariaLabel ? `${ariaLabel}: ${percentage}%` : `Available: ${100 - percentage}%`
+        }
+        title={`${percentage}%`}
+        subTitle="utilization"
+        titleComponent={TITLE_LABEL}
+        subTitleComponent={SUBTITLE_LABEL}
+        name={`dcgm-${ariaLabel}`}
+      />
+    </Bullseye>
+  );
+};

--- a/packages/gpuaas/src/components/ClusterQueueUtilizationSection.tsx
+++ b/packages/gpuaas/src/components/ClusterQueueUtilizationSection.tsx
@@ -45,14 +45,6 @@ const ClusterQueueUtilizationSection: React.FC = () => {
     [allAcceleratorCQs, resourceFlavorsState.data],
   );
 
-  if (!loaded) {
-    return (
-      <Bullseye data-testid="cq-utilization-loading">
-        <Spinner />
-      </Bullseye>
-    );
-  }
-
   if (error) {
     return (
       <EmptyState
@@ -64,6 +56,14 @@ const ClusterQueueUtilizationSection: React.FC = () => {
       >
         <EmptyStateBody>{error.message}</EmptyStateBody>
       </EmptyState>
+    );
+  }
+
+  if (!loaded) {
+    return (
+      <Bullseye data-testid="cq-utilization-loading">
+        <Spinner />
+      </Bullseye>
     );
   }
 

--- a/packages/gpuaas/src/components/ClusterQueueUtilizationSection.tsx
+++ b/packages/gpuaas/src/components/ClusterQueueUtilizationSection.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import {
+  Bullseye,
+  Content,
+  ContentVariants,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Spinner,
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+import CohortAccordionGroup from './CohortAccordionGroup';
+import useCohorts from '../hooks/useCohorts';
+import useCQDcgmMetrics from '../hooks/useCQDcgmMetrics';
+import useResourceFlavors from '../hooks/useResourceFlavors';
+import { filterAcceleratorCQs } from '../utils/clusterQueueUtils';
+import { resolveHardwareModels, resolvePerModelGpuCounts } from '../utils/hardwareModels';
+
+const ClusterQueueUtilizationSection: React.FC = () => {
+  const cohortsState = useCohorts();
+  const resourceFlavorsState = useResourceFlavors();
+  const dcgmMetrics = useCQDcgmMetrics();
+
+  const loaded = cohortsState.loaded && resourceFlavorsState.loaded && dcgmMetrics.loaded;
+  const error = cohortsState.error ?? resourceFlavorsState.error;
+
+  const acceleratorCohorts = React.useMemo(
+    () =>
+      cohortsState.data.filter(
+        (cohort) => filterAcceleratorCQs(cohort.memberClusterQueues).length > 0,
+      ),
+    [cohortsState.data],
+  );
+
+  const allAcceleratorCQs = React.useMemo(
+    () => acceleratorCohorts.flatMap((c) => filterAcceleratorCQs(c.memberClusterQueues)),
+    [acceleratorCohorts],
+  );
+
+  const hardwareModelsByCQ = React.useMemo(
+    () => resolveHardwareModels(allAcceleratorCQs, resourceFlavorsState.data),
+    [allAcceleratorCQs, resourceFlavorsState.data],
+  );
+
+  const perModelGpusByCQ = React.useMemo(
+    () => resolvePerModelGpuCounts(allAcceleratorCQs, resourceFlavorsState.data),
+    [allAcceleratorCQs, resourceFlavorsState.data],
+  );
+
+  if (!loaded) {
+    return (
+      <Bullseye data-testid="cq-utilization-loading">
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        headingLevel="h4"
+        icon={CubesIcon}
+        titleText="Error loading cluster queue data"
+        variant={EmptyStateVariant.sm}
+        data-testid="cq-utilization-error"
+      >
+        <EmptyStateBody>{error.message}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  if (acceleratorCohorts.length === 0) {
+    return (
+      <EmptyState
+        headingLevel="h4"
+        icon={CubesIcon}
+        titleText="No accelerator cluster queues found"
+        variant={EmptyStateVariant.sm}
+        data-testid="cq-utilization-empty"
+      >
+        <EmptyStateBody>
+          No cluster queues with accelerator resources were detected. Configure cluster queues with
+          GPU resource quotas to see utilization here.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <>
+      <Content component={ContentVariants.p} data-testid="cq-utilization-subtitle">
+        Cluster queue accelerator utilization grouped by Kueue cohort.
+      </Content>
+      <CohortAccordionGroup
+        cohorts={acceleratorCohorts}
+        hardwareModelsByCQ={hardwareModelsByCQ}
+        perModelGpusByCQ={perModelGpusByCQ}
+        dcgmByModel={dcgmMetrics.dcgmAvailable ? dcgmMetrics.byModel : undefined}
+      />
+    </>
+  );
+};
+
+export default ClusterQueueUtilizationSection;

--- a/packages/gpuaas/src/components/ClusterQueueUtilizationSection.tsx
+++ b/packages/gpuaas/src/components/ClusterQueueUtilizationSection.tsx
@@ -1,14 +1,12 @@
-import * as React from 'react';
 import {
   Bullseye,
-  Content,
-  ContentVariants,
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
   Spinner,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import CohortAccordionGroup from './CohortAccordionGroup';
 import useCohorts from '../hooks/useCohorts';
 import useCQDcgmMetrics from '../hooks/useCQDcgmMetrics';
@@ -87,17 +85,12 @@ const ClusterQueueUtilizationSection: React.FC = () => {
   }
 
   return (
-    <>
-      <Content component={ContentVariants.p} data-testid="cq-utilization-subtitle">
-        Cluster queue accelerator utilization grouped by Kueue cohort.
-      </Content>
-      <CohortAccordionGroup
-        cohorts={acceleratorCohorts}
-        hardwareModelsByCQ={hardwareModelsByCQ}
-        perModelGpusByCQ={perModelGpusByCQ}
-        dcgmByModel={dcgmMetrics.dcgmAvailable ? dcgmMetrics.byModel : undefined}
-      />
-    </>
+    <CohortAccordionGroup
+      cohorts={acceleratorCohorts}
+      hardwareModelsByCQ={hardwareModelsByCQ}
+      perModelGpusByCQ={perModelGpusByCQ}
+      dcgmByModel={dcgmMetrics.dcgmAvailable ? dcgmMetrics.byModel : undefined}
+    />
   );
 };
 

--- a/packages/gpuaas/src/components/CohortAccordionGroup.tsx
+++ b/packages/gpuaas/src/components/CohortAccordionGroup.tsx
@@ -1,0 +1,170 @@
+import * as React from 'react';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionToggle,
+  Content,
+  ContentVariants,
+  Flex,
+  FlexItem,
+  Grid,
+  GridItem,
+  Label,
+} from '@patternfly/react-core';
+import ClusterQueueCard from './ClusterQueueCard';
+import { CQDcgmResult, UnifiedCohort } from '../types';
+import { ModelGpuCount } from '../utils/hardwareModels';
+import {
+  filterAcceleratorCQs,
+  getCohortTotalAccelerators,
+  getCohortUnallocatedBorrowable,
+  getCounterpartCQNames,
+  isCohortBorrowLendActive,
+  resolveCQDcgmUtilization,
+  resolvePerModelDcgmData,
+} from '../utils/clusterQueueUtils';
+
+type CohortAccordionGroupProps = {
+  cohorts: UnifiedCohort[];
+  hardwareModelsByCQ: Map<string, string[]>;
+  perModelGpusByCQ: Map<string, ModelGpuCount[]>;
+  /** Per-GPU-model DCGM metrics. Undefined = DCGM unavailable, hide the chart columns. */
+  dcgmByModel?: Map<string, CQDcgmResult>;
+};
+
+const CohortAccordionGroup: React.FC<CohortAccordionGroupProps> = ({
+  cohorts,
+  hardwareModelsByCQ,
+  perModelGpusByCQ,
+  dcgmByModel,
+}) => {
+  const [expanded, setExpanded] = React.useState<Set<string>>(
+    () => new Set(cohorts.map((c) => c.name)),
+  );
+
+  const toggleAccordion = (cohortName: string) => {
+    setExpanded((prev) => {
+      const expandedCohortNames = new Set(prev);
+      if (expandedCohortNames.has(cohortName)) {
+        expandedCohortNames.delete(cohortName);
+      } else {
+        expandedCohortNames.add(cohortName);
+      }
+      return expandedCohortNames;
+    });
+  };
+
+  return (
+    <Accordion asDefinitionList={false} isBordered={false} togglePosition="start">
+      {cohorts.map((cohort) => {
+        const acceleratorCQs = filterAcceleratorCQs(cohort.memberClusterQueues);
+        const total = getCohortTotalAccelerators(cohort);
+        const unallocatedBorrowable = getCohortUnallocatedBorrowable(cohort);
+        const borrowLendActive = isCohortBorrowLendActive(cohort);
+        const isExpanded = expanded.has(cohort.name);
+        const cohortLabel = cohort.name || 'Not in a cohort';
+
+        return (
+          <AccordionItem
+            key={cohort.name || 'standalone'}
+            isExpanded={isExpanded}
+            data-testid={`cohort-accordion-${cohort.name}`}
+          >
+            <AccordionToggle
+              onClick={() => toggleAccordion(cohort.name)}
+              id={`cohort-toggle-${cohort.name}`}
+            >
+              <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                spaceItems={{ default: 'spaceItemsSm' }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <FlexItem>
+                  {cohortLabel}
+                  <Content component={ContentVariants.small} style={{ display: 'inline' }}>
+                    {` · ${total} total accelerators`}
+                    {unallocatedBorrowable > 0 && (
+                      <Content
+                        component={ContentVariants.small}
+                        style={{ display: 'inline' }}
+                        data-testid="cohort-unallocated-borrowable"
+                      >
+                        {` · ${unallocatedBorrowable} unallocated, borrowable`}
+                      </Content>
+                    )}
+                  </Content>
+                </FlexItem>
+                {borrowLendActive && (
+                  <FlexItem>
+                    <Label color="purple" isCompact data-testid="cohort-borrow-lend-badge">
+                      Borrow / lend active
+                    </Label>
+                  </FlexItem>
+                )}
+              </Flex>
+            </AccordionToggle>
+
+            <AccordionContent id={`cohort-content-${cohort.name}`}>
+              {cohort.state === 'standalone' && (
+                <Content component={ContentVariants.small}>
+                  Cluster queues not assigned to a Kueue cohort.
+                </Content>
+              )}
+              {acceleratorCQs.length > 0 ? (
+                <Grid hasGutter>
+                  {acceleratorCQs.map((cq) => {
+                    const cqName = cq.metadata?.name ?? '';
+                    const models = hardwareModelsByCQ.get(cqName) ?? [];
+                    const perModelGpus = perModelGpusByCQ.get(cqName) ?? [];
+
+                    const dcgmAvailable = dcgmByModel !== undefined;
+                    const { computeUtilization, memoryUtilization } =
+                      dcgmAvailable && models.length > 0
+                        ? resolveCQDcgmUtilization(models, dcgmByModel)
+                        : { computeUtilization: undefined, memoryUtilization: undefined };
+
+                    const { compute: perModelComputeDcgm, memory: perModelMemoryDcgm } =
+                      resolvePerModelDcgmData(models, dcgmByModel);
+
+                    // 1 card → full width; 2+ → half each so they always fill the row
+                    const span = acceleratorCQs.length === 1 ? 12 : 6;
+
+                    // Use all member CQs (not just accelerator-filtered ones) so borrowing CQs
+                    // with nominal=0 GPU quota are still found as counterparts.
+                    const counterpartCQNames = getCounterpartCQNames(
+                      cq,
+                      cohort.memberClusterQueues,
+                    );
+
+                    return (
+                      <GridItem key={cqName} span={span}>
+                        <ClusterQueueCard
+                          cq={cq}
+                          hardwareModels={models}
+                          perModelGpus={perModelGpus}
+                          counterpartCQNames={counterpartCQNames}
+                          dcgmAvailable={dcgmAvailable}
+                          computeUtilization={computeUtilization}
+                          memoryUtilization={memoryUtilization}
+                          perModelComputeDcgm={perModelComputeDcgm}
+                          perModelMemoryDcgm={perModelMemoryDcgm}
+                        />
+                      </GridItem>
+                    );
+                  })}
+                </Grid>
+              ) : (
+                <Content component={ContentVariants.small}>
+                  No accelerator cluster queues in this cohort.
+                </Content>
+              )}
+            </AccordionContent>
+          </AccordionItem>
+        );
+      })}
+    </Accordion>
+  );
+};
+
+export default CohortAccordionGroup;

--- a/packages/gpuaas/src/components/CohortAccordionGroup.tsx
+++ b/packages/gpuaas/src/components/CohortAccordionGroup.tsx
@@ -78,7 +78,6 @@ const CohortAccordionGroup: React.FC<CohortAccordionGroupProps> = ({
               <Flex
                 alignItems={{ default: 'alignItemsCenter' }}
                 spaceItems={{ default: 'spaceItemsSm' }}
-                onClick={(e) => e.stopPropagation()}
               >
                 <FlexItem>
                   {cohortLabel}

--- a/packages/gpuaas/src/components/CohortAccordionGroup.tsx
+++ b/packages/gpuaas/src/components/CohortAccordionGroup.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionToggle,
+  Card,
+  CardBody,
+  CardExpandableContent,
+  CardHeader,
   Content,
   ContentVariants,
   Flex,
@@ -11,6 +11,9 @@ import {
   Grid,
   GridItem,
   Label,
+  Stack,
+  StackItem,
+  Title,
 } from '@patternfly/react-core';
 import ClusterQueueCard from './ClusterQueueCard';
 import { CQDcgmResult, UnifiedCohort } from '../types';
@@ -43,20 +46,20 @@ const CohortAccordionGroup: React.FC<CohortAccordionGroupProps> = ({
     () => new Set(cohorts.map((c) => c.name)),
   );
 
-  const toggleAccordion = (cohortName: string) => {
+  const toggleCohort = (cohortName: string) => {
     setExpanded((prev) => {
-      const expandedCohortNames = new Set(prev);
-      if (expandedCohortNames.has(cohortName)) {
-        expandedCohortNames.delete(cohortName);
+      const next = new Set(prev);
+      if (next.has(cohortName)) {
+        next.delete(cohortName);
       } else {
-        expandedCohortNames.add(cohortName);
+        next.add(cohortName);
       }
-      return expandedCohortNames;
+      return next;
     });
   };
 
   return (
-    <Accordion asDefinitionList={false} isBordered={false} togglePosition="start">
+    <Stack hasGutter>
       {cohorts.map((cohort) => {
         const acceleratorCQs = filterAcceleratorCQs(cohort.memberClusterQueues);
         const total = getCohortTotalAccelerators(cohort);
@@ -66,103 +69,120 @@ const CohortAccordionGroup: React.FC<CohortAccordionGroupProps> = ({
         const cohortLabel = cohort.name || 'Not in a cohort';
 
         return (
-          <AccordionItem
-            key={cohort.name || 'standalone'}
-            isExpanded={isExpanded}
-            data-testid={`cohort-accordion-${cohort.name}`}
-          >
-            <AccordionToggle
-              onClick={() => toggleAccordion(cohort.name)}
-              id={`cohort-toggle-${cohort.name}`}
+          <StackItem key={cohort.name || 'standalone'}>
+            <Card
+              isExpanded={isExpanded}
+              variant="secondary"
+              data-testid={`cohort-accordion-${cohort.name}`}
             >
-              <Flex
-                alignItems={{ default: 'alignItemsCenter' }}
-                spaceItems={{ default: 'spaceItemsSm' }}
+              <CardHeader
+                onExpand={() => toggleCohort(cohort.name)}
+                toggleButtonProps={{
+                  id: `cohort-toggle-${cohort.name}`,
+                  'aria-label': isExpanded ? `Collapse ${cohortLabel}` : `Expand ${cohortLabel}`,
+                  'aria-expanded': isExpanded,
+                }}
               >
-                <FlexItem>
-                  {cohortLabel}
-                  <Content component={ContentVariants.small} style={{ display: 'inline' }}>
-                    {` · ${total} total accelerators`}
-                    {unallocatedBorrowable > 0 && (
-                      <Content
-                        component={ContentVariants.small}
-                        style={{ display: 'inline' }}
-                        data-testid="cohort-unallocated-borrowable"
-                      >
-                        {` · ${unallocatedBorrowable} unallocated, borrowable`}
+                <Stack hasGutter>
+                  <StackItem>
+                    <Flex
+                      alignItems={{ default: 'alignItemsCenter' }}
+                      spaceItems={{ default: 'spaceItemsSm' }}
+                    >
+                      <FlexItem>
+                        <Title headingLevel="h3">{cohortLabel}</Title>
+                      </FlexItem>
+                      <FlexItem>
+                        <Content component={ContentVariants.small}>
+                          {`${total} total accelerators`}
+                        </Content>
+                      </FlexItem>
+                      {unallocatedBorrowable > 0 && (
+                        <FlexItem>
+                          <Content
+                            component={ContentVariants.small}
+                            data-testid="cohort-unallocated-borrowable"
+                          >
+                            {`· ${unallocatedBorrowable} unallocated, borrowable`}
+                          </Content>
+                        </FlexItem>
+                      )}
+                      {borrowLendActive && (
+                        <FlexItem>
+                          <Label color="purple" isCompact data-testid="cohort-borrow-lend-badge">
+                            Borrow / lend active
+                          </Label>
+                        </FlexItem>
+                      )}
+                    </Flex>
+                  </StackItem>
+                  {cohort.state === 'standalone' && (
+                    <StackItem>
+                      <Content component={ContentVariants.small}>
+                        Cluster queues not assigned to a Kueue cohort.
                       </Content>
-                    )}
-                  </Content>
-                </FlexItem>
-                {borrowLendActive && (
-                  <FlexItem>
-                    <Label color="purple" isCompact data-testid="cohort-borrow-lend-badge">
-                      Borrow / lend active
-                    </Label>
-                  </FlexItem>
-                )}
-              </Flex>
-            </AccordionToggle>
+                    </StackItem>
+                  )}
+                </Stack>
+              </CardHeader>
 
-            <AccordionContent id={`cohort-content-${cohort.name}`}>
-              {cohort.state === 'standalone' && (
-                <Content component={ContentVariants.small}>
-                  Cluster queues not assigned to a Kueue cohort.
-                </Content>
-              )}
-              {acceleratorCQs.length > 0 ? (
-                <Grid hasGutter>
-                  {acceleratorCQs.map((cq) => {
-                    const cqName = cq.metadata?.name ?? '';
-                    const models = hardwareModelsByCQ.get(cqName) ?? [];
-                    const perModelGpus = perModelGpusByCQ.get(cqName) ?? [];
+              <CardExpandableContent>
+                <CardBody>
+                  {acceleratorCQs.length > 0 ? (
+                    <Grid hasGutter>
+                      {acceleratorCQs.map((cq) => {
+                        const cqName = cq.metadata?.name ?? '';
+                        const models = hardwareModelsByCQ.get(cqName) ?? [];
+                        const perModelGpus = perModelGpusByCQ.get(cqName) ?? [];
 
-                    const dcgmAvailable = dcgmByModel !== undefined;
-                    const { computeUtilization, memoryUtilization } =
-                      dcgmAvailable && models.length > 0
-                        ? resolveCQDcgmUtilization(models, dcgmByModel)
-                        : { computeUtilization: undefined, memoryUtilization: undefined };
+                        const dcgmAvailable = dcgmByModel !== undefined;
+                        const { computeUtilization, memoryUtilization } =
+                          dcgmAvailable && models.length > 0
+                            ? resolveCQDcgmUtilization(models, dcgmByModel)
+                            : { computeUtilization: undefined, memoryUtilization: undefined };
 
-                    const { compute: perModelComputeDcgm, memory: perModelMemoryDcgm } =
-                      resolvePerModelDcgmData(models, dcgmByModel);
+                        const { compute: perModelComputeDcgm, memory: perModelMemoryDcgm } =
+                          resolvePerModelDcgmData(models, dcgmByModel);
 
-                    // 1 card → full width; 2+ → half each so they always fill the row
-                    const span = acceleratorCQs.length === 1 ? 12 : 6;
+                        // 1 card → full width; 2+ → half each so they always fill the row
+                        const span = acceleratorCQs.length === 1 ? 12 : 6;
 
-                    // Use all member CQs (not just accelerator-filtered ones) so borrowing CQs
-                    // with nominal=0 GPU quota are still found as counterparts.
-                    const counterpartCQNames = getCounterpartCQNames(
-                      cq,
-                      cohort.memberClusterQueues,
-                    );
+                        // Use all member CQs (not just accelerator-filtered ones) so borrowing CQs
+                        // with nominal=0 GPU quota are still found as counterparts.
+                        const counterpartCQNames = getCounterpartCQNames(
+                          cq,
+                          cohort.memberClusterQueues,
+                        );
 
-                    return (
-                      <GridItem key={cqName} span={span}>
-                        <ClusterQueueCard
-                          cq={cq}
-                          hardwareModels={models}
-                          perModelGpus={perModelGpus}
-                          counterpartCQNames={counterpartCQNames}
-                          dcgmAvailable={dcgmAvailable}
-                          computeUtilization={computeUtilization}
-                          memoryUtilization={memoryUtilization}
-                          perModelComputeDcgm={perModelComputeDcgm}
-                          perModelMemoryDcgm={perModelMemoryDcgm}
-                        />
-                      </GridItem>
-                    );
-                  })}
-                </Grid>
-              ) : (
-                <Content component={ContentVariants.small}>
-                  No accelerator cluster queues in this cohort.
-                </Content>
-              )}
-            </AccordionContent>
-          </AccordionItem>
+                        return (
+                          <GridItem key={cqName} span={span}>
+                            <ClusterQueueCard
+                              cq={cq}
+                              hardwareModels={models}
+                              perModelGpus={perModelGpus}
+                              counterpartCQNames={counterpartCQNames}
+                              dcgmAvailable={dcgmAvailable}
+                              computeUtilization={computeUtilization}
+                              memoryUtilization={memoryUtilization}
+                              perModelComputeDcgm={perModelComputeDcgm}
+                              perModelMemoryDcgm={perModelMemoryDcgm}
+                            />
+                          </GridItem>
+                        );
+                      })}
+                    </Grid>
+                  ) : (
+                    <Content component={ContentVariants.small}>
+                      No accelerator cluster queues in this cohort.
+                    </Content>
+                  )}
+                </CardBody>
+              </CardExpandableContent>
+            </Card>
+          </StackItem>
         );
       })}
-    </Accordion>
+    </Stack>
   );
 };
 

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -3,14 +3,30 @@ export const INFRASTRUCTURE_REFRESH_INTERVAL = 30_000;
 export const TREND_REFRESH_INTERVAL = 5 * 60 * 1000;
 
 export const INFRASTRUCTURE_SECTIONS = [
-  { id: 'cluster', title: 'Cluster', description: undefined },
-  { id: 'hardware-usage', title: 'Hardware usage', description: undefined },
+  {
+    id: 'cluster',
+    title: 'Cluster',
+    description: 'Cluster-wide accelerator allocation and average compute and memory utilization.',
+    isPlain: true,
+  },
+  {
+    id: 'hardware-usage',
+    title: 'Hardware usage',
+    description: 'Accelerator counts by hardware type, in use and available.',
+    isPlain: false,
+  },
   {
     id: 'borrowing-lending',
     title: 'Borrowing & lending',
     description: 'Seven-day trend of borrow and lend activity by cluster queue.',
+    isPlain: false,
   },
-  { id: 'cluster-queue-utilization', title: 'Cluster queue utilization', description: undefined },
+  {
+    id: 'cluster-queue-utilization',
+    title: 'Cluster queue utilization',
+    description: 'Cluster queue accelerator utilization grouped by Kueue cohort.',
+    isPlain: true,
+  },
 ] as const;
 
 export const ACCELERATOR_RESOURCE_REGEX =

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -50,6 +50,17 @@ export const PROMQL_HARDWARE_IN_USE = `query=${encodeURIComponent(
 export const PROMQL_HARDWARE_NODE_LABELS = `query=${encodeURIComponent(
   'count by (label_nvidia_com_gpu_product, label_amd_com_gpu_product, label_habana_ai_gaudi, label_intel_com_gpu_product)(kube_node_labels{label_nvidia_com_gpu_product!=""} or kube_node_labels{label_amd_com_gpu_product!=""} or kube_node_labels{label_habana_ai_gaudi!=""} or kube_node_labels{label_intel_com_gpu_product!=""})',
 )}`;
+export const PROMQL_COMPUTE_BY_MODEL = `query=${encodeURIComponent(
+  'avg by (modelName) (avg_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE[30m])) * 100',
+)}`;
+
+export const PROMQL_MEMORY_BY_MODEL = `query=${encodeURIComponent(
+  'avg by (modelName) (DCGM_FI_DEV_FB_USED / (DCGM_FI_DEV_FB_USED + DCGM_FI_DEV_FB_FREE)) * 100',
+)}`;
+
+/** Shared dimensions for all CQ accelerator donut charts (Total, Compute, Memory columns). */
+export const CQ_DONUT_SIZE = 175;
+export const CQ_DONUT_INNER_RADIUS = 76;
 
 export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 export const CHART_HEIGHT = 400;

--- a/packages/gpuaas/src/hooks/__tests__/useCQDcgmMetrics.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useCQDcgmMetrics.spec.ts
@@ -1,0 +1,60 @@
+import { parseByModel } from '../useCQDcgmMetrics';
+
+type MockResponse = Parameters<typeof parseByModel>[0];
+
+const makeResponse = (results: Array<{ modelName?: string; value: string }>): MockResponse =>
+  ({
+    data: {
+      result: results.map(({ modelName, value }) => ({
+        metric: modelName ? { modelName } : {},
+        value: [0, value],
+      })),
+    },
+  } as MockResponse);
+
+describe('parseByModel', () => {
+  it('returns empty map for null response', () => {
+    expect(parseByModel(null).size).toBe(0);
+  });
+
+  it('returns empty map when result array is empty', () => {
+    expect(parseByModel(makeResponse([])).size).toBe(0);
+  });
+
+  it('ignores entries missing modelName label', () => {
+    const response = makeResponse([{ value: '50' }]);
+    expect(parseByModel(response).size).toBe(0);
+  });
+
+  it.each([
+    ['42.7', 43],
+    ['18.0', 18],
+    ['99.5', 100],
+    ['0.4', 0],
+  ])('rounds value "%s" → %d', (raw, rounded) => {
+    const map = parseByModel(makeResponse([{ modelName: 'Tesla T4', value: raw }]));
+    expect(map.get('tesla t4')).toBe(rounded);
+  });
+
+  it('ignores NaN values', () => {
+    const map = parseByModel(makeResponse([{ modelName: 'bad-model', value: 'not-a-number' }]));
+    expect(map.size).toBe(0);
+  });
+
+  it('normalises modelName keys — DCGM space format → lowercase with spaces', () => {
+    const map = parseByModel(makeResponse([{ modelName: 'NVIDIA A100-SXM4-80GB', value: '42' }]));
+    expect(map.has('nvidia a100 sxm4 80gb')).toBe(true);
+    expect(map.get('nvidia a100 sxm4 80gb')).toBe(42);
+  });
+
+  it('parses multiple models into the same map', () => {
+    const map = parseByModel(
+      makeResponse([
+        { modelName: 'Tesla T4', value: '30' },
+        { modelName: 'NVIDIA A100', value: '75' },
+      ]),
+    );
+    expect(map.get('tesla t4')).toBe(30);
+    expect(map.get('nvidia a100')).toBe(75);
+  });
+});

--- a/packages/gpuaas/src/hooks/__tests__/useCQDcgmMetrics.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useCQDcgmMetrics.spec.ts
@@ -58,3 +58,22 @@ describe('parseByModel', () => {
     expect(map.get('nvidia a100')).toBe(75);
   });
 });
+
+describe('byModel asymmetric coverage', () => {
+  const computeMap = parseByModel(makeResponse([{ modelName: 'NVIDIA A100', value: '72' }]));
+  const memoryMap = parseByModel(makeResponse([])); // memory has no A100 entry
+
+  it.each([
+    // settled=true: absent model → undefined ("No telemetry data"), not null (spinner)
+    [true, 72, undefined],
+    // settled=false: still loading → null (spinner) for both
+    [false, null, null],
+  ])('settled=%s → compute=%s, memory=%s', (settled, expectedCompute, expectedMemory) => {
+    const entry = {
+      computePercentage: settled ? computeMap.get('nvidia a100') : null,
+      memoryPercentage: settled ? memoryMap.get('nvidia a100') : null,
+    };
+    expect(entry.computePercentage).toBe(expectedCompute);
+    expect(entry.memoryPercentage).toBe(expectedMemory);
+  });
+});

--- a/packages/gpuaas/src/hooks/useCQDcgmMetrics.ts
+++ b/packages/gpuaas/src/hooks/useCQDcgmMetrics.ts
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import usePrometheusQuery from '@odh-dashboard/internal/api/prometheus/usePrometheusQuery';
+import { PrometheusQueryResponse } from '@odh-dashboard/internal/types';
+import { CQDcgmResult } from '../types';
+import {
+  INFRASTRUCTURE_REFRESH_INTERVAL,
+  PROMQL_COMPUTE_BY_MODEL,
+  PROMQL_MEMORY_BY_MODEL,
+} from '../const';
+import { normalizeModelName } from '../utils/clusterQueueUtils';
+
+export type { CQDcgmResult };
+
+const PROMETHEUS_API = '/api/prometheus/query';
+
+type ByModelResponse = PrometheusQueryResponse<{ metric?: { modelName?: string } }>;
+
+export const parseByModel = (response: ByModelResponse | null): Map<string, number> => {
+  const out = new Map<string, number>();
+  if (!response?.data.result) {
+    return out;
+  }
+  for (const { metric, value } of response.data.result) {
+    const { modelName } = metric ?? {};
+    if (!modelName) {
+      continue;
+    }
+    const pct = Math.round(parseFloat(value[1]));
+    if (!Number.isNaN(pct)) {
+      out.set(normalizeModelName(modelName), pct);
+    }
+  }
+  return out;
+};
+
+type CQDcgmMetricsReturn = {
+  /** Map from GPU model name → per-model DCGM utilization */
+  byModel: Map<string, CQDcgmResult>;
+  loaded: boolean;
+  dcgmAvailable: boolean;
+};
+
+/**
+ * Fetches per-GPU-model DCGM compute and memory utilization in two scalar
+ * Prometheus queries (one for compute, one for memory), both of which return
+ * all model names at once.  This avoids calling hooks in a loop.
+ */
+const useCQDcgmMetrics = (refreshRate = INFRASTRUCTURE_REFRESH_INTERVAL): CQDcgmMetricsReturn => {
+  const fetchOptions = React.useMemo(() => ({ refreshRate }), [refreshRate]);
+
+  const computeState = usePrometheusQuery<ByModelResponse>(
+    PROMETHEUS_API,
+    PROMQL_COMPUTE_BY_MODEL,
+    fetchOptions,
+  );
+  const memoryState = usePrometheusQuery<ByModelResponse>(
+    PROMETHEUS_API,
+    PROMQL_MEMORY_BY_MODEL,
+    fetchOptions,
+  );
+
+  const loaded =
+    (computeState.loaded || !!computeState.error) && (memoryState.loaded || !!memoryState.error);
+
+  const byModel = React.useMemo((): Map<string, CQDcgmResult> => {
+    const computeMap = parseByModel(computeState.data);
+    const memoryMap = parseByModel(memoryState.data);
+
+    const allModels = new Set([...computeMap.keys(), ...memoryMap.keys()]);
+    const result = new Map<string, CQDcgmResult>();
+    for (const model of allModels) {
+      result.set(model, {
+        computePercentage: computeMap.get(model) ?? null,
+        memoryPercentage: memoryMap.get(model) ?? null,
+      });
+    }
+    return result;
+  }, [computeState.data, memoryState.data]);
+
+  const dcgmAvailable = byModel.size > 0;
+
+  return { byModel, loaded, dcgmAvailable };
+};
+
+export default useCQDcgmMetrics;

--- a/packages/gpuaas/src/hooks/useCQDcgmMetrics.ts
+++ b/packages/gpuaas/src/hooks/useCQDcgmMetrics.ts
@@ -62,6 +62,9 @@ const useCQDcgmMetrics = (refreshRate = INFRASTRUCTURE_REFRESH_INTERVAL): CQDcgm
   const loaded =
     (computeState.loaded || !!computeState.error) && (memoryState.loaded || !!memoryState.error);
 
+  const computeSettled = computeState.loaded || !!computeState.error;
+  const memorySettled = memoryState.loaded || !!memoryState.error;
+
   const byModel = React.useMemo((): Map<string, CQDcgmResult> => {
     const computeMap = parseByModel(computeState.data);
     const memoryMap = parseByModel(memoryState.data);
@@ -70,12 +73,13 @@ const useCQDcgmMetrics = (refreshRate = INFRASTRUCTURE_REFRESH_INTERVAL): CQDcgm
     const result = new Map<string, CQDcgmResult>();
     for (const model of allModels) {
       result.set(model, {
-        computePercentage: computeMap.get(model) ?? null,
-        memoryPercentage: memoryMap.get(model) ?? null,
+        // undefined (→ "No telemetry data") once settled; null (→ spinner) while loading
+        computePercentage: computeSettled ? computeMap.get(model) : null,
+        memoryPercentage: memorySettled ? memoryMap.get(model) : null,
       });
     }
     return result;
-  }, [computeState.data, memoryState.data]);
+  }, [computeState.data, memoryState.data, computeSettled, memorySettled]);
 
   const dcgmAvailable = byModel.size > 0;
 

--- a/packages/gpuaas/src/hooks/useResourceFlavors.ts
+++ b/packages/gpuaas/src/hooks/useResourceFlavors.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { ResourceFlavorKind } from '@odh-dashboard/internal/k8sTypes';
+import useFetch, { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
+import { listResourceFlavors } from '@odh-dashboard/internal/api/k8s/resourceFlavors';
+import { INFRASTRUCTURE_REFRESH_INTERVAL } from '../const';
+
+const useResourceFlavors = (
+  refreshRate = INFRASTRUCTURE_REFRESH_INTERVAL,
+): FetchStateObject<ResourceFlavorKind[]> =>
+  useFetch<ResourceFlavorKind[]>(
+    React.useCallback(async () => listResourceFlavors(), []),
+    [],
+    { refreshRate },
+  );
+
+export default useResourceFlavors;

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   StackItem,
   Tooltip,
+  Title,
 } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
 import { relativeTime } from '@odh-dashboard/internal/utilities/time';
@@ -64,16 +65,20 @@ const InfrastructurePage: React.FC = () => {
       headerAction={headerAction}
     >
       <Stack hasGutter>
-        {INFRASTRUCTURE_SECTIONS.map(({ id, title, description }) => (
+        {INFRASTRUCTURE_SECTIONS.map(({ id, title, description, isPlain }) => (
           <StackItem key={id}>
             <Stack hasGutter>
               <StackItem>
-                <Content component="h2">{title}</Content>
-                {description && <Content component="p">{description}</Content>}
+                <Title headingLevel="h2" data-testid={`infrastructure-${id}-title`}>
+                  {title}
+                </Title>
+                <Content component="p" data-testid={`infrastructure-${id}-description`}>
+                  {description}
+                </Content>
               </StackItem>
               <StackItem>
-                <Card data-testid={`infrastructure-${id}-section`}>
-                  <CardBody>{SECTION_COMPONENTS[id]}</CardBody>
+                <Card isPlain={isPlain} data-testid={`infrastructure-${id}-section`}>
+                  {isPlain ? SECTION_COMPONENTS[id] : <CardBody>{SECTION_COMPONENTS[id]}</CardBody>}
                 </Card>
               </StackItem>
             </Stack>

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -18,6 +18,7 @@ import { INFRASTRUCTURE_SECTIONS } from '../const';
 import ClusterSummaryCards from '../components/ClusterSummaryCards';
 import HardwareUsageSection from '../components/HardwareUsageSection';
 import BorrowingLendingSection from '../components/BorrowingLendingSection';
+import ClusterQueueUtilizationSection from '../components/ClusterQueueUtilizationSection';
 import useInfrastructureMetrics from '../hooks/useInfrastructureMetrics';
 
 type SectionId = (typeof INFRASTRUCTURE_SECTIONS)[number]['id'];
@@ -29,7 +30,7 @@ const InfrastructurePage: React.FC = () => {
     cluster: <ClusterSummaryCards metrics={metrics} />,
     'hardware-usage': <HardwareUsageSection metrics={metrics} />,
     'borrowing-lending': <BorrowingLendingSection />,
-    'cluster-queue-utilization': null,
+    'cluster-queue-utilization': <ClusterQueueUtilizationSection />,
   };
 
   const headerAction = metrics.lastRefreshed ? (

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -21,7 +21,8 @@ export type UnifiedCohort = {
   effectivePool: FlavorQuota[];
 };
 
+/** null = still loading; undefined = loaded but no telemetry data for this model */
 export type CQDcgmResult = {
-  computePercentage: number | null;
-  memoryPercentage: number | null;
+  computePercentage: number | null | undefined;
+  memoryPercentage: number | null | undefined;
 };

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -20,3 +20,8 @@ export type UnifiedCohort = {
   memberClusterQueues: ClusterQueueKind[];
   effectivePool: FlavorQuota[];
 };
+
+export type CQDcgmResult = {
+  computePercentage: number | null;
+  memoryPercentage: number | null;
+};

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
@@ -17,6 +17,7 @@ import {
   isCohortBorrowLendActive,
   getAcceleratorDonutConfig,
   getBorrowLendBadgeState,
+  getBorrowLendInfo,
   getCounterpartCQNames,
   formatWorkloadCounts,
   normalizeModelName,
@@ -221,13 +222,23 @@ describe('filterAcceleratorCQs', () => {
 });
 
 describe('getCohortTotalAccelerators', () => {
-  it('sums nominal quota across all member CQs', () => {
-    const cohort = makeCohort([makeGpuCQ('a', { nominal: 8 }), makeGpuCQ('b', { nominal: 16 })]);
-    expect(getCohortTotalAccelerators(cohort)).toBe(24);
-  });
-
-  it('returns 0 for empty cohort', () => {
-    expect(getCohortTotalAccelerators(makeCohort([]))).toBe(0);
+  it.each([
+    ['empty cohort', [], 0],
+    ['all normal CQs', [{ nominal: 8 }, { nominal: 16 }], 24],
+    // Mixed: cq-burst borrows from cq-train's pool — physical total is still 8, not 10
+    [
+      'mixed — pure borrower not double-counted',
+      [
+        { nominal: 8, used: 6 },
+        { nominal: 0, used: 2 },
+      ],
+      8,
+    ],
+    // Pure-borrower-only: no owned quota, fall back to active usage so header is not 0
+    ['pure-borrower-only — falls back to used', [{ nominal: 0, used: 6 }], 6],
+  ] as const)('%s', (_label, cqOpts, expected) => {
+    const cohort = makeCohort(cqOpts.map((opts, i) => makeGpuCQ(`cq-${i}`, opts)));
+    expect(getCohortTotalAccelerators(cohort)).toBe(expected);
   });
 });
 
@@ -459,6 +470,35 @@ describe('getBorrowLendBadgeState', () => {
     const config = getAcceleratorDonutConfig(cq, inCohort);
     expect(getBorrowLendBadgeState(config)).toEqual(expected);
   });
+});
+
+describe('getBorrowLendInfo', () => {
+  it('returns undefined for a Normal donut', () => {
+    const config = getAcceleratorDonutConfig(makeGpuCQ('cq', { nominal: 8, used: 4 }));
+    expect(getBorrowLendInfo(config)).toBeUndefined();
+  });
+
+  it.each([
+    // Pure borrower: nominal=0 set to used as rendering trick — Own segment absent → ownRatio must be 0
+    ['pure borrower', makeGpuCQ('burst-cq', { nominal: 0, used: 6 }), true, 0],
+    // Regular borrower: nominal=8, used=10, borrowed=2 → ownUsed=8, ownRatio=8/10=0.8
+    [
+      'regular borrower',
+      makeGpuCQWithCohort('cq', 'cohort', { nominal: 8, used: 10, borrowed: 2 }),
+      true,
+      0.8,
+    ],
+    // Lender: nominal=8, used=4 → ownRatio=4/8=0.5
+    ['lender', makeGpuCQWithCohort('cq', 'cohort', { nominal: 8, used: 4 }), false, 0.5],
+  ] as const)(
+    '%s — isBorrowing=%s, ownRatio≈%s',
+    (_label, cq, expectedIsBorrowing, expectedRatio) => {
+      const config = getAcceleratorDonutConfig(cq, true);
+      const info = getBorrowLendInfo(config);
+      expect(info?.isBorrowing).toBe(expectedIsBorrowing);
+      expect(info?.ownRatio).toBeCloseTo(expectedRatio);
+    },
+  );
 });
 
 describe('resolveCQDcgmUtilization', () => {

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
@@ -1,0 +1,503 @@
+import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { CQDcgmResult, UnifiedCohort } from '../../types';
+import {
+  AcceleratorDonutType,
+  AcceleratorSegment,
+  isAcceleratorResource,
+  getCQNominalAccelerators,
+  getCQUsedAccelerators,
+  getAcceleratorBorrowedCount,
+  getAcceleratorLentCount,
+  isAcceleratorBorrowing,
+  isAcceleratorLending,
+  isInCohort,
+  filterAcceleratorCQs,
+  getCohortTotalAccelerators,
+  getCohortUnallocatedBorrowable,
+  isCohortBorrowLendActive,
+  getAcceleratorDonutConfig,
+  getBorrowLendBadgeState,
+  getCounterpartCQNames,
+  formatWorkloadCounts,
+  normalizeModelName,
+  resolveCQDcgmUtilization,
+} from '../clusterQueueUtils';
+
+const makeGpuCQ = (
+  name: string,
+  {
+    nominal = 8,
+    used = 0,
+    borrowed = 0,
+  }: { nominal?: number; used?: number; borrowed?: number } = {},
+): ClusterQueueKind =>
+  ({
+    apiVersion: 'kueue.x-k8s.io/v1beta2',
+    kind: 'ClusterQueue',
+    metadata: { name },
+    spec: {
+      resourceGroups: [
+        {
+          coveredResources: ['nvidia.com/gpu'],
+          flavors: [
+            {
+              name: 'gpu-flavor',
+              resources: [{ name: 'nvidia.com/gpu', nominalQuota: String(nominal) }],
+            },
+          ],
+        },
+      ],
+    },
+    status: {
+      admittedWorkloads: 0,
+      pendingWorkloads: 0,
+      reservingWorkloads: 0,
+      conditions: [],
+      flavorsReservation: [],
+      flavorsUsage: [
+        {
+          name: 'gpu-flavor',
+          resources: [
+            {
+              name: 'nvidia.com/gpu',
+              total: String(used),
+              borrowed: String(borrowed),
+            },
+          ],
+        },
+      ],
+    },
+  } as unknown as ClusterQueueKind);
+
+const makeCpuOnlyCQ = (name: string): ClusterQueueKind =>
+  ({
+    apiVersion: 'kueue.x-k8s.io/v1beta2',
+    kind: 'ClusterQueue',
+    metadata: { name },
+    spec: {
+      resourceGroups: [
+        {
+          coveredResources: ['cpu'],
+          flavors: [{ name: 'cpu-flavor', resources: [{ name: 'cpu', nominalQuota: '100' }] }],
+        },
+      ],
+    },
+    status: { admittedWorkloads: 0, pendingWorkloads: 0, flavorsUsage: [] },
+  } as unknown as ClusterQueueKind);
+
+const makeCohort = (
+  cqs: ClusterQueueKind[],
+  state: UnifiedCohort['state'] = 'implicit',
+): UnifiedCohort => ({
+  name: 'test-cohort',
+  state,
+  memberClusterQueues: cqs,
+  effectivePool: [],
+});
+
+const makeGpuCQWithCohort = (
+  name: string,
+  cohortName: string,
+  opts: Parameters<typeof makeGpuCQ>[1] = {},
+): ClusterQueueKind => {
+  const cq = makeGpuCQ(name, opts);
+  return { ...cq, spec: { ...cq.spec, cohortName } } as unknown as ClusterQueueKind;
+};
+
+const makeMap = (entries: Record<string, CQDcgmResult>): Map<string, CQDcgmResult> =>
+  new Map(Object.entries(entries));
+
+// GPU model name constants used across resolveCQDcgmUtilization tests.
+// NFD label format uses dashes; DCGM metric labels use spaces (post-normalization).
+const TESLA_T4_NFD = 'Tesla-T4';
+const TESLA_T4_DCGM = 'tesla t4';
+
+const NO_UTILIZATION_DATA = { computeUtilization: undefined, memoryUtilization: undefined };
+
+describe('isAcceleratorResource', () => {
+  it.each([
+    ['nvidia.com/gpu', true],
+    ['nvidia.com/mig.1g.5gb', true],
+    ['amd.com/gpu', true],
+    ['habana.ai/gaudi', true],
+    ['cpu', false],
+    ['memory', false],
+    ['requests.cpu', false],
+  ])('"%s" → %s', (name, expected) => {
+    expect(isAcceleratorResource(name)).toBe(expected);
+  });
+});
+
+describe('getCQNominalAccelerators', () => {
+  it('returns 0 for CQ with no GPU resources', () => {
+    expect(getCQNominalAccelerators(makeCpuOnlyCQ('cq'))).toBe(0);
+  });
+
+  it('sums GPU quota from all flavors', () => {
+    expect(getCQNominalAccelerators(makeGpuCQ('cq', { nominal: 8 }))).toBe(8);
+  });
+});
+
+describe('getCQUsedAccelerators', () => {
+  it('returns 0 when no flavorsUsage present', () => {
+    const cq = makeGpuCQ('cq');
+    cq.status = { ...cq.status, flavorsUsage: [] } as ClusterQueueKind['status'];
+    expect(getCQUsedAccelerators(cq)).toBe(0);
+  });
+
+  it('returns GPU units in use', () => {
+    expect(getCQUsedAccelerators(makeGpuCQ('cq', { used: 5 }))).toBe(5);
+  });
+
+  it('ignores CPU resources', () => {
+    const cq = makeCpuOnlyCQ('cq');
+    expect(getCQUsedAccelerators(cq)).toBe(0);
+  });
+});
+
+describe('getAcceleratorBorrowedCount', () => {
+  it.each([
+    [4, 0, 0],
+    [10, 2, 2],
+  ])('used=%d borrowed=%d → %d', (used, borrowed, expected) => {
+    expect(getAcceleratorBorrowedCount(makeGpuCQ('cq', { nominal: 8, used, borrowed }))).toBe(
+      expected,
+    );
+  });
+});
+
+describe('getAcceleratorLentCount', () => {
+  it.each([
+    [8, 0, 0, 'fully used'],
+    [3, 0, 5, 'unused capacity'],
+    [10, 2, 0, 'over quota floored at 0'],
+  ])('used=%d borrowed=%d → %d (%s)', (used, borrowed, expected) => {
+    expect(getAcceleratorLentCount(makeGpuCQ('cq', { nominal: 8, used, borrowed }))).toBe(expected);
+  });
+});
+
+describe('isInCohort', () => {
+  it.each([
+    ['CQ with cohortName set', makeGpuCQWithCohort('cq', 'my-cohort'), true],
+    ['CQ without cohortName', makeGpuCQ('cq'), false],
+  ] as const)('%s → %s', (_label, cq, expected) => {
+    expect(isInCohort(cq)).toBe(expected);
+  });
+});
+
+describe('isAcceleratorBorrowing / isAcceleratorLending', () => {
+  it('detects borrowing', () => {
+    expect(isAcceleratorBorrowing(makeGpuCQ('cq', { nominal: 8, used: 10, borrowed: 2 }))).toBe(
+      true,
+    );
+    expect(isAcceleratorBorrowing(makeGpuCQ('cq', { nominal: 8, used: 4 }))).toBe(false);
+  });
+
+  it('detects lending (unused capacity)', () => {
+    expect(isAcceleratorLending(makeGpuCQ('cq', { nominal: 8, used: 3 }))).toBe(true);
+    expect(isAcceleratorLending(makeGpuCQ('cq', { nominal: 8, used: 8 }))).toBe(false);
+  });
+});
+
+describe('filterAcceleratorCQs', () => {
+  it('excludes CPU-only CQs and retains GPU CQs', () => {
+    const cqs = [makeGpuCQ('gpu-cq'), makeCpuOnlyCQ('cpu-cq'), makeGpuCQ('gpu-cq-2')];
+    expect(filterAcceleratorCQs(cqs).map((c) => c.metadata?.name)).toEqual(['gpu-cq', 'gpu-cq-2']);
+  });
+
+  it('returns empty array when all CQs are CPU-only', () => {
+    expect(filterAcceleratorCQs([makeCpuOnlyCQ('cq')])).toHaveLength(0);
+  });
+});
+
+describe('getCohortTotalAccelerators', () => {
+  it('sums nominal quota across all member CQs', () => {
+    const cohort = makeCohort([makeGpuCQ('a', { nominal: 8 }), makeGpuCQ('b', { nominal: 16 })]);
+    expect(getCohortTotalAccelerators(cohort)).toBe(24);
+  });
+
+  it('returns 0 for empty cohort', () => {
+    expect(getCohortTotalAccelerators(makeCohort([]))).toBe(0);
+  });
+});
+
+describe('getCohortUnallocatedBorrowable', () => {
+  it('sums unused capacity across member CQs', () => {
+    const cohort = makeCohort([
+      makeGpuCQ('a', { nominal: 8, used: 5 }), // lent: 3
+      makeGpuCQ('b', { nominal: 8, used: 8 }), // lent: 0
+    ]);
+    expect(getCohortUnallocatedBorrowable(cohort)).toBe(3);
+  });
+
+  it('returns 0 for a standalone group even if CQs have spare capacity', () => {
+    const cohort = makeCohort([makeGpuCQ('a', { nominal: 8, used: 3 })], 'standalone');
+    expect(getCohortUnallocatedBorrowable(cohort)).toBe(0);
+  });
+});
+
+describe('isCohortBorrowLendActive', () => {
+  it.each([
+    ['borrowing CQ', makeCohort([makeGpuCQ('a', { nominal: 8, used: 10, borrowed: 2 })]), true],
+    ['lending CQ (unused capacity)', makeCohort([makeGpuCQ('a', { nominal: 8, used: 3 })]), true],
+    ['fully used, no borrowing', makeCohort([makeGpuCQ('a', { nominal: 8, used: 8 })]), false],
+    ['empty cohort', makeCohort([]), false],
+  ] as const)('%s → %s', (_label, cohort, expected) => {
+    expect(isCohortBorrowLendActive(cohort)).toBe(expected);
+  });
+
+  it('returns false for a standalone group even if CQs have spare capacity or borrow', () => {
+    const cohort = makeCohort(
+      [
+        makeGpuCQ('a', { nominal: 8, used: 3 }),
+        makeGpuCQ('b', { nominal: 8, used: 10, borrowed: 2 }),
+      ],
+      'standalone',
+    );
+    expect(isCohortBorrowLendActive(cohort)).toBe(false);
+  });
+});
+
+describe('getCounterpartCQNames', () => {
+  it('lender sees names of borrowing siblings', () => {
+    const lender = makeGpuCQ('lender', { nominal: 8, used: 3 });
+    const borrower = makeGpuCQ('borrower', { nominal: 8, used: 10, borrowed: 2 });
+    const other = makeGpuCQ('other', { nominal: 8, used: 8 });
+    expect(getCounterpartCQNames(lender, [lender, borrower, other])).toEqual(['borrower']);
+  });
+
+  it('borrower sees names of lending siblings', () => {
+    const borrower = makeGpuCQ('borrower', { nominal: 8, used: 10, borrowed: 2 });
+    const lender = makeGpuCQ('lender', { nominal: 8, used: 3 });
+    const other = makeGpuCQ('other', { nominal: 8, used: 8 });
+    expect(getCounterpartCQNames(borrower, [borrower, lender, other])).toEqual(['lender']);
+  });
+
+  it.each([
+    [
+      'siblings present but no borrow-lend activity',
+      [makeGpuCQ('sibling', { nominal: 8, used: 8 })],
+    ],
+    ['no siblings at all', []],
+  ] as const)('returns empty array — %s', (_label, siblings) => {
+    const cq = makeGpuCQ('cq', { nominal: 8, used: 8 });
+    expect(getCounterpartCQNames(cq, [cq, ...siblings])).toEqual([]);
+  });
+});
+
+describe('normalizeModelName', () => {
+  it.each([
+    ['NVIDIA-A100-SXM4-80GB', 'nvidia a100 sxm4 80gb'],
+    ['NVIDIA A100-SXM4-80GB', 'nvidia a100 sxm4 80gb'],
+    ['Tesla-T4', 'tesla t4'],
+    ['Tesla T4', 'tesla t4'],
+    ['  NVIDIA  A100  ', 'nvidia a100'],
+    ['lowercase-model', 'lowercase model'],
+    ['AMD_MI300X', 'amd mi300x'],
+    ['AMD_Instinct_MI300X', 'amd instinct mi300x'],
+  ])('"%s" → "%s"', (input, expected) => {
+    expect(normalizeModelName(input)).toBe(expected);
+  });
+});
+
+describe('formatWorkloadCounts', () => {
+  it.each([
+    [0, 0, '0 active workloads · 0 pending'],
+    [1, 0, '1 active workload · 0 pending'],
+    [2, 5, '2 active workloads · 5 pending'],
+    [0, 10, '0 active workloads · 10 pending'],
+  ])('(%d admitted, %d pending) → "%s"', (admitted, pending, expected) => {
+    expect(formatWorkloadCounts(admitted, pending)).toBe(expected);
+  });
+});
+
+describe('getAcceleratorDonutConfig', () => {
+  it('returns type=none when CQ has no GPU quota', () => {
+    expect(getAcceleratorDonutConfig(makeCpuOnlyCQ('cq'))).toEqual({
+      type: AcceleratorDonutType.None,
+    });
+  });
+
+  describe('normal state — fully utilised, no borrowing', () => {
+    it.each([
+      [8, 8, '8/8'],
+      [16, 16, '16/16'],
+    ])('nominal=%d used=%d → title="%s" percentage=100', (nominal, used, title) => {
+      const config = getAcceleratorDonutConfig(makeGpuCQ('cq', { nominal, used }));
+      expect(config.type).toBe(AcceleratorDonutType.Normal);
+      if (config.type === AcceleratorDonutType.Normal) {
+        expect(config.percentage).toBe(100);
+        expect(config.title).toBe(title);
+        expect(config.used).toBe(used);
+        expect(config.nominal).toBe(nominal);
+      }
+    });
+  });
+
+  describe('lending state — used < nominal', () => {
+    it.each([
+      // [nominal, used, expectedOwnUsed, expectedLent]
+      [8, 3, 3, 5],
+      [8, 0, 0, 8],
+    ])('nominal=%d used=%d → segments Own=%d Lent=%d', (nominal, used, ownUsed, lent) => {
+      const config = getAcceleratorDonutConfig(makeGpuCQ('cq', { nominal, used }));
+      expect(config.type).toBe(AcceleratorDonutType.BorrowLend);
+      if (config.type === AcceleratorDonutType.BorrowLend) {
+        expect(config.isBorrowing).toBe(false);
+        expect(config.stateLabel).toBe(AcceleratorSegment.Lent);
+        expect(config.segments).toEqual([
+          { x: AcceleratorSegment.Own, y: ownUsed },
+          { x: AcceleratorSegment.Lent, y: lent },
+        ]);
+      }
+    });
+  });
+
+  describe('standalone CQ (inCohort=false) — borrow-lend suppressed to normal', () => {
+    it.each([
+      // [description, cqOpts, expectedPercentage]
+      // Math.round(3/8 * 100) = 38
+      ['lending CQ', { nominal: 8, used: 3 }, 38],
+      // used=8 equals nominal=8; borrowed=2 suppressed → 100%
+      ['borrowing CQ', { nominal: 8, used: 8, borrowed: 2 }, 100],
+    ] as const)('%s → type=normal percentage=%d', (_label, cqOpts, expectedPercentage) => {
+      const config = getAcceleratorDonutConfig(makeGpuCQ('cq', cqOpts), false);
+      expect(config.type).toBe(AcceleratorDonutType.Normal);
+      if (config.type === AcceleratorDonutType.Normal) {
+        expect(config.percentage).toBe(expectedPercentage);
+      }
+    });
+  });
+
+  describe('borrowing state — borrowed > 0', () => {
+    it.each([
+      // [nominal, used, borrowed, expectedOwnUsed, expectedAvailable]
+      [8, 10, 2, 8, 0],
+      [8, 6, 2, 4, 4],
+    ])(
+      'nominal=%d used=%d borrowed=%d → segments Own=%d Available=%d',
+      (nominal, used, borrowed, ownUsed, available) => {
+        const config = getAcceleratorDonutConfig(makeGpuCQ('cq', { nominal, used, borrowed }));
+        expect(config.type).toBe(AcceleratorDonutType.BorrowLend);
+        if (config.type === AcceleratorDonutType.BorrowLend) {
+          expect(config.isBorrowing).toBe(true);
+          expect(config.stateLabel).toBe(AcceleratorSegment.Borrowed);
+          expect(config.segments).toEqual([
+            { x: AcceleratorSegment.Own, y: ownUsed },
+            { x: AcceleratorSegment.Borrowed, y: borrowed },
+            { x: AcceleratorSegment.Available, y: available },
+          ]);
+        }
+      },
+    );
+  });
+});
+
+describe('getBorrowLendBadgeState', () => {
+  it.each([
+    [
+      'fully utilised (type=normal)',
+      { nominal: 8, used: 8 },
+      true,
+      { borrowing: false, lending: false, lentCount: 0, borrowedCount: 0 },
+    ],
+    [
+      'lending CQ',
+      { nominal: 8, used: 3 },
+      true,
+      { borrowing: false, lending: true, lentCount: 5, borrowedCount: 0 },
+    ],
+    [
+      'borrowing CQ',
+      { nominal: 8, used: 10, borrowed: 2 },
+      true,
+      { borrowing: true, lending: false, lentCount: 0, borrowedCount: 2 },
+    ],
+    [
+      'lending suppressed by inCohort=false',
+      { nominal: 8, used: 3 },
+      false,
+      { borrowing: false, lending: false, lentCount: 0, borrowedCount: 0 },
+    ],
+  ] as const)('%s', (_label, cqOpts, inCohort, expected) => {
+    const config = getAcceleratorDonutConfig(makeGpuCQ('cq', cqOpts), inCohort);
+    expect(getBorrowLendBadgeState(config)).toEqual(expected);
+  });
+});
+
+describe('resolveCQDcgmUtilization', () => {
+  it('returns both undefined when models array is empty', () => {
+    const map = makeMap({ [TESLA_T4_DCGM]: { computePercentage: 10, memoryPercentage: 20 } });
+    expect(resolveCQDcgmUtilization([], map)).toEqual(NO_UTILIZATION_DATA);
+  });
+
+  it.each([
+    [[TESLA_T4_NFD], {}],
+    [['NVIDIA-A100', 'unknown-gpu'], {}],
+  ] as const)('returns both undefined for unmatched models', (models, mapEntries) => {
+    expect(resolveCQDcgmUtilization([...models], makeMap(mapEntries))).toEqual(NO_UTILIZATION_DATA);
+  });
+
+  it('resolves a single model — NFD dash format normalised to DCGM space format', () => {
+    const map = makeMap({ [TESLA_T4_DCGM]: { computePercentage: 30, memoryPercentage: 60 } });
+    expect(resolveCQDcgmUtilization([TESLA_T4_NFD], map)).toEqual({
+      computeUtilization: 30,
+      memoryUtilization: 60,
+    });
+  });
+
+  it('averages compute and memory across multiple models', () => {
+    const map = makeMap({
+      'model a': { computePercentage: 20, memoryPercentage: 40 },
+      'model b': { computePercentage: 40, memoryPercentage: 60 },
+    });
+    expect(resolveCQDcgmUtilization(['model-a', 'model-b'], map)).toEqual({
+      computeUtilization: 30,
+      memoryUtilization: 50,
+    });
+  });
+
+  it('rounds averages (Math.round)', () => {
+    const map = makeMap({
+      'model a': { computePercentage: 1, memoryPercentage: 1 },
+      'model b': { computePercentage: 2, memoryPercentage: 2 },
+    });
+    // avg = 1.5 → Math.round(1.5) = 2
+    expect(resolveCQDcgmUtilization(['model-a', 'model-b'], map)).toEqual({
+      computeUtilization: 2,
+      memoryUtilization: 2,
+    });
+  });
+
+  it.each([
+    [
+      'compute null → computeUtilization null, memoryUtilization number',
+      { computePercentage: null, memoryPercentage: 20 } satisfies CQDcgmResult,
+      { computeUtilization: null, memoryUtilization: 20 },
+    ],
+    [
+      'memory null → computeUtilization number, memoryUtilization null',
+      { computePercentage: 50, memoryPercentage: null } satisfies CQDcgmResult,
+      { computeUtilization: 50, memoryUtilization: null },
+    ],
+    [
+      'both null → both null',
+      { computePercentage: null, memoryPercentage: null } satisfies CQDcgmResult,
+      { computeUtilization: null, memoryUtilization: null },
+    ],
+  ])('null percentages — metric not yet loaded: %s', (_label, dcgmEntry, expected) => {
+    const map = makeMap({ [TESLA_T4_DCGM]: dcgmEntry });
+    expect(resolveCQDcgmUtilization([TESLA_T4_NFD], map)).toEqual(expected);
+  });
+
+  it('averages only non-null values when models are partially loaded', () => {
+    const map = makeMap({
+      [TESLA_T4_DCGM]: { computePercentage: 40, memoryPercentage: null },
+      'nvidia a100': { computePercentage: null, memoryPercentage: 60 },
+    });
+    expect(resolveCQDcgmUtilization([TESLA_T4_NFD, 'NVIDIA-A100'], map)).toEqual({
+      computeUtilization: 40,
+      memoryUtilization: 60,
+    });
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
@@ -327,9 +327,25 @@ describe('formatWorkloadCounts', () => {
 });
 
 describe('getAcceleratorDonutConfig', () => {
-  it('returns type=none when CQ has no GPU quota', () => {
+  it('returns type=none when CQ has no GPU quota and no usage', () => {
     expect(getAcceleratorDonutConfig(makeCpuOnlyCQ('cq'))).toEqual({
       type: AcceleratorDonutType.None,
+    });
+  });
+
+  describe('pure borrower — nominal=0, used>0', () => {
+    it.each([
+      [3, '3'],
+      [6, '6'],
+    ])('used=%d → title="%s" single Borrowed segment', (used, title) => {
+      const config = getAcceleratorDonutConfig(makeGpuCQ('burst-cq', { nominal: 0, used }));
+      expect(config.type).toBe(AcceleratorDonutType.BorrowLend);
+      if (config.type === AcceleratorDonutType.BorrowLend) {
+        expect(config.isBorrowing).toBe(true);
+        expect(config.title).toBe(title);
+        expect(config.stateLabel).toBe(AcceleratorSegment.Borrowed);
+        expect(config.segments).toEqual([{ x: AcceleratorSegment.Borrowed, y: used }]);
+      }
     });
   });
 
@@ -490,13 +506,13 @@ describe('resolveCQDcgmUtilization', () => {
   });
 
   it.each([null, undefined] as const)(
-    'skips %s percentage when averaging (null = loading, undefined = no telemetry)',
+    'skips %s percentage when averaging — absent dimension returns undefined (no-telemetry ring)',
     (noData) => {
       const computeAbsent = makeMap({
         [TESLA_T4_DCGM]: { computePercentage: noData, memoryPercentage: 20 },
       });
       expect(resolveCQDcgmUtilization([TESLA_T4_NFD], computeAbsent)).toEqual({
-        computeUtilization: null,
+        computeUtilization: undefined,
         memoryUtilization: 20,
       });
 
@@ -505,15 +521,15 @@ describe('resolveCQDcgmUtilization', () => {
       });
       expect(resolveCQDcgmUtilization([TESLA_T4_NFD], memoryAbsent)).toEqual({
         computeUtilization: 50,
-        memoryUtilization: null,
+        memoryUtilization: undefined,
       });
 
       const bothAbsent = makeMap({
         [TESLA_T4_DCGM]: { computePercentage: noData, memoryPercentage: noData },
       });
       expect(resolveCQDcgmUtilization([TESLA_T4_NFD], bothAbsent)).toEqual({
-        computeUtilization: null,
-        memoryUtilization: null,
+        computeUtilization: undefined,
+        memoryUtilization: undefined,
       });
     },
   );

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
@@ -307,10 +307,11 @@ describe('normalizeModelName', () => {
 
 describe('formatWorkloadCounts', () => {
   it.each([
-    [0, 0, '0 active workloads · 0 pending'],
-    [1, 0, '1 active workload · 0 pending'],
-    [2, 5, '2 active workloads · 5 pending'],
-    [0, 10, '0 active workloads · 10 pending'],
+    [0, 0, '0 active workloads · 0 pending workloads'],
+    [1, 0, '1 active workload · 0 pending workloads'],
+    [2, 5, '2 active workloads · 5 pending workloads'],
+    [0, 1, '0 active workloads · 1 pending workload'],
+    [0, 10, '0 active workloads · 10 pending workloads'],
   ])('(%d admitted, %d pending) → "%s"', (admitted, pending, expected) => {
     expect(formatWorkloadCounts(admitted, pending)).toBe(expected);
   });
@@ -474,26 +475,34 @@ describe('resolveCQDcgmUtilization', () => {
     });
   });
 
-  it.each([
-    [
-      'compute null → computeUtilization null, memoryUtilization number',
-      { computePercentage: null, memoryPercentage: 20 } satisfies CQDcgmResult,
-      { computeUtilization: null, memoryUtilization: 20 },
-    ],
-    [
-      'memory null → computeUtilization number, memoryUtilization null',
-      { computePercentage: 50, memoryPercentage: null } satisfies CQDcgmResult,
-      { computeUtilization: 50, memoryUtilization: null },
-    ],
-    [
-      'both null → both null',
-      { computePercentage: null, memoryPercentage: null } satisfies CQDcgmResult,
-      { computeUtilization: null, memoryUtilization: null },
-    ],
-  ])('null percentages — metric not yet loaded: %s', (_label, dcgmEntry, expected) => {
-    const map = makeMap({ [TESLA_T4_DCGM]: dcgmEntry });
-    expect(resolveCQDcgmUtilization([TESLA_T4_NFD], map)).toEqual(expected);
-  });
+  it.each([null, undefined] as const)(
+    'skips %s percentage when averaging (null = loading, undefined = no telemetry)',
+    (noData) => {
+      const computeAbsent = makeMap({
+        [TESLA_T4_DCGM]: { computePercentage: noData, memoryPercentage: 20 },
+      });
+      expect(resolveCQDcgmUtilization([TESLA_T4_NFD], computeAbsent)).toEqual({
+        computeUtilization: null,
+        memoryUtilization: 20,
+      });
+
+      const memoryAbsent = makeMap({
+        [TESLA_T4_DCGM]: { computePercentage: 50, memoryPercentage: noData },
+      });
+      expect(resolveCQDcgmUtilization([TESLA_T4_NFD], memoryAbsent)).toEqual({
+        computeUtilization: 50,
+        memoryUtilization: null,
+      });
+
+      const bothAbsent = makeMap({
+        [TESLA_T4_DCGM]: { computePercentage: noData, memoryPercentage: noData },
+      });
+      expect(resolveCQDcgmUtilization([TESLA_T4_NFD], bothAbsent)).toEqual({
+        computeUtilization: null,
+        memoryUtilization: null,
+      });
+    },
+  );
 
   it('averages only non-null values when models are partially loaded', () => {
     const map = makeMap({

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
@@ -194,8 +194,13 @@ describe('isAcceleratorBorrowing / isAcceleratorLending', () => {
   });
 
   it('detects lending (unused capacity)', () => {
-    expect(isAcceleratorLending(makeGpuCQ('cq', { nominal: 8, used: 3 }))).toBe(true);
-    expect(isAcceleratorLending(makeGpuCQ('cq', { nominal: 8, used: 8 }))).toBe(false);
+    expect(
+      isAcceleratorLending(makeGpuCQWithCohort('cq', 'cohort-a', { nominal: 8, used: 3 })),
+    ).toBe(true);
+    expect(
+      isAcceleratorLending(makeGpuCQWithCohort('cq', 'cohort-a', { nominal: 8, used: 8 })),
+    ).toBe(false);
+    expect(isAcceleratorLending(makeGpuCQ('cq', { nominal: 8, used: 3 }))).toBe(false); // standalone CQs cannot lend
   });
 });
 
@@ -244,7 +249,11 @@ describe('getCohortUnallocatedBorrowable', () => {
 describe('isCohortBorrowLendActive', () => {
   it.each([
     ['borrowing CQ', makeCohort([makeGpuCQ('a', { nominal: 8, used: 10, borrowed: 2 })]), true],
-    ['lending CQ (unused capacity)', makeCohort([makeGpuCQ('a', { nominal: 8, used: 3 })]), true],
+    [
+      'lending CQ (unused capacity)',
+      makeCohort([makeGpuCQWithCohort('a', 'test-cohort', { nominal: 8, used: 3 })]),
+      true,
+    ],
     ['fully used, no borrowing', makeCohort([makeGpuCQ('a', { nominal: 8, used: 8 })]), false],
     ['empty cohort', makeCohort([]), false],
   ] as const)('%s → %s', (_label, cohort, expected) => {
@@ -273,7 +282,7 @@ describe('getCounterpartCQNames', () => {
 
   it('borrower sees names of lending siblings', () => {
     const borrower = makeGpuCQ('borrower', { nominal: 8, used: 10, borrowed: 2 });
-    const lender = makeGpuCQ('lender', { nominal: 8, used: 3 });
+    const lender = makeGpuCQWithCohort('lender', 'test-cohort', { nominal: 8, used: 3 });
     const other = makeGpuCQ('other', { nominal: 8, used: 8 });
     expect(getCounterpartCQNames(borrower, [borrower, lender, other])).toEqual(['lender']);
   });
@@ -346,7 +355,9 @@ describe('getAcceleratorDonutConfig', () => {
       [8, 3, 3, 5],
       [8, 0, 0, 8],
     ])('nominal=%d used=%d → segments Own=%d Lent=%d', (nominal, used, ownUsed, lent) => {
-      const config = getAcceleratorDonutConfig(makeGpuCQ('cq', { nominal, used }));
+      const config = getAcceleratorDonutConfig(
+        makeGpuCQWithCohort('cq', 'test-cohort', { nominal, used }),
+      );
       expect(config.type).toBe(AcceleratorDonutType.BorrowLend);
       if (config.type === AcceleratorDonutType.BorrowLend) {
         expect(config.isBorrowing).toBe(false);
@@ -426,7 +437,10 @@ describe('getBorrowLendBadgeState', () => {
       { borrowing: false, lending: false, lentCount: 0, borrowedCount: 0 },
     ],
   ] as const)('%s', (_label, cqOpts, inCohort, expected) => {
-    const config = getAcceleratorDonutConfig(makeGpuCQ('cq', cqOpts), inCohort);
+    const cq = inCohort
+      ? makeGpuCQWithCohort('cq', 'test-cohort', cqOpts)
+      : makeGpuCQ('cq', cqOpts);
+    const config = getAcceleratorDonutConfig(cq, inCohort);
     expect(getBorrowLendBadgeState(config)).toEqual(expected);
   });
 });

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
@@ -208,6 +208,11 @@ describe('filterAcceleratorCQs', () => {
   it('returns empty array when all CQs are CPU-only', () => {
     expect(filterAcceleratorCQs([makeCpuOnlyCQ('cq')])).toHaveLength(0);
   });
+
+  it('includes a pure-borrower CQ with nominal=0 but active GPU usage', () => {
+    const pureBorrower = makeGpuCQ('burst-cq', { nominal: 0, used: 3 });
+    expect(filterAcceleratorCQs([pureBorrower]).map((c) => c.metadata?.name)).toEqual(['burst-cq']);
+  });
 });
 
 describe('getCohortTotalAccelerators', () => {

--- a/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
@@ -1,0 +1,181 @@
+import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/internal/k8sTypes';
+import { resolveHardwareModels, resolvePerModelGpuCounts } from '../hardwareModels';
+
+const makeGpuCQ = (
+  name: string,
+  flavorName: string,
+  {
+    nominal = 8,
+    used = 0,
+    borrowed,
+  }: { nominal?: number | string; used?: number | string; borrowed?: number | string } = {},
+): ClusterQueueKind =>
+  ({
+    apiVersion: 'kueue.x-k8s.io/v1beta2',
+    kind: 'ClusterQueue',
+    metadata: { name },
+    spec: {
+      resourceGroups: [
+        {
+          coveredResources: ['nvidia.com/gpu'],
+          flavors: [
+            {
+              name: flavorName,
+              resources: [{ name: 'nvidia.com/gpu', nominalQuota: String(nominal) }],
+            },
+          ],
+        },
+      ],
+    },
+    status: {
+      admittedWorkloads: 0,
+      pendingWorkloads: 0,
+      reservingWorkloads: 0,
+      conditions: [],
+      flavorsReservation: [],
+      flavorsUsage: [
+        {
+          name: flavorName,
+          resources: [
+            {
+              name: 'nvidia.com/gpu',
+              total: String(used),
+              ...(borrowed !== undefined && { borrowed: String(borrowed) }),
+            },
+          ],
+        },
+      ],
+    },
+  } as unknown as ClusterQueueKind);
+
+const makeRF = (name: string, gpuProduct?: string): ResourceFlavorKind =>
+  ({
+    apiVersion: 'kueue.x-k8s.io/v1beta2',
+    kind: 'ResourceFlavor',
+    metadata: { name },
+    spec: {
+      nodeLabels: gpuProduct ? { 'nvidia.com/gpu.product': gpuProduct } : {},
+    },
+  } as unknown as ResourceFlavorKind);
+
+describe('resolveHardwareModels', () => {
+  it('returns GPU product label for a CQ whose flavor has the label', () => {
+    const cq = makeGpuCQ('cq-a', 'a100-flavor');
+    const rf = makeRF('a100-flavor', 'NVIDIA A100');
+    const result = resolveHardwareModels([cq], [rf]);
+    expect(result.get('cq-a')).toEqual(['NVIDIA A100']);
+  });
+
+  it('returns empty array when flavor has no gpu.product label', () => {
+    const cq = makeGpuCQ('cq-b', 'generic-flavor');
+    const rf = makeRF('generic-flavor'); // no gpuProduct
+    const result = resolveHardwareModels([cq], [rf]);
+    expect(result.get('cq-b')).toEqual([]);
+  });
+
+  it('returns empty array for a CQ with no resourceGroups', () => {
+    const cq = {
+      metadata: { name: 'cq-empty' },
+      spec: { resourceGroups: [] },
+      status: {},
+    } as unknown as ClusterQueueKind;
+    const result = resolveHardwareModels([cq], []);
+    expect(result.get('cq-empty')).toEqual([]);
+  });
+
+  it('deduplicates models when multiple flavors share the same product label', () => {
+    const cq = {
+      metadata: { name: 'cq-dup' },
+      spec: {
+        resourceGroups: [
+          {
+            coveredResources: ['nvidia.com/gpu'],
+            flavors: [
+              {
+                name: 'flavor-1',
+                resources: [{ name: 'nvidia.com/gpu', nominalQuota: '4' }],
+              },
+              {
+                name: 'flavor-2',
+                resources: [{ name: 'nvidia.com/gpu', nominalQuota: '4' }],
+              },
+            ],
+          },
+        ],
+      },
+      status: { admittedWorkloads: 0, pendingWorkloads: 0, flavorsUsage: [] },
+    } as unknown as ClusterQueueKind;
+    const rf1 = makeRF('flavor-1', 'NVIDIA H100');
+    const rf2 = makeRF('flavor-2', 'NVIDIA H100');
+    const result = resolveHardwareModels([cq], [rf1, rf2]);
+    expect(result.get('cq-dup')).toEqual(['NVIDIA H100']);
+  });
+});
+
+describe('resolvePerModelGpuCounts', () => {
+  it('returns nominal, used, borrowed for a CQ with a labelled flavor', () => {
+    const cq = makeGpuCQ('cq-a', 'a100-flavor', { nominal: 8, used: 3, borrowed: 1 });
+    const rf = makeRF('a100-flavor', 'NVIDIA A100');
+    const result = resolvePerModelGpuCounts([cq], [rf]);
+    expect(result.get('cq-a')).toEqual([
+      { model: 'NVIDIA A100', nominal: 8, used: 3, borrowed: 1 },
+    ]);
+  });
+
+  it('sets borrowed to undefined when the usage entry has no borrowed field', () => {
+    const cq = makeGpuCQ('cq-b', 'a100-flavor', { nominal: 4, used: 2 });
+    const rf = makeRF('a100-flavor', 'NVIDIA A100');
+    const result = resolvePerModelGpuCounts([cq], [rf]);
+    expect(result.get('cq-b')).toEqual([
+      { model: 'NVIDIA A100', nominal: 4, used: 2, borrowed: undefined },
+    ]);
+  });
+
+  it('skips flavors with no matching ResourceFlavor or no gpu.product label', () => {
+    const cq = makeGpuCQ('cq-c', 'unknown-flavor', { nominal: 8, used: 0 });
+    const rf = makeRF('unknown-flavor'); // no gpuProduct
+    const result = resolvePerModelGpuCounts([cq], [rf]);
+    expect(result.get('cq-c')).toEqual([]);
+  });
+
+  it.each([
+    ['plain integer string', '8', 8],
+    ['zero string', '0', 0],
+  ])('parses nominalQuota as k8s quantity: %s', (_label, quantityStr, expected) => {
+    const cq = makeGpuCQ('cq-qty', 'a100-flavor', { nominal: quantityStr });
+    const rf = makeRF('a100-flavor', 'NVIDIA A100');
+    const result = resolvePerModelGpuCounts([cq], [rf]);
+    expect(result.get('cq-qty')?.[0].nominal).toBe(expected);
+  });
+
+  it('returns empty counts for a CQ with no GPU resource groups', () => {
+    const cq = {
+      metadata: { name: 'cpu-only' },
+      spec: {
+        resourceGroups: [
+          {
+            coveredResources: ['cpu'],
+            flavors: [{ name: 'cpu-flavor', resources: [{ name: 'cpu', nominalQuota: '100' }] }],
+          },
+        ],
+      },
+      status: { admittedWorkloads: 0, pendingWorkloads: 0, flavorsUsage: [] },
+    } as unknown as ClusterQueueKind;
+    const result = resolvePerModelGpuCounts([cq], []);
+    expect(result.get('cpu-only')).toEqual([]);
+  });
+
+  it('handles multiple CQs independently', () => {
+    const cq1 = makeGpuCQ('cq-1', 'a100-flavor', { nominal: 8, used: 2 });
+    const cq2 = makeGpuCQ('cq-2', 'h100-flavor', { nominal: 4, used: 4, borrowed: 2 });
+    const rf1 = makeRF('a100-flavor', 'NVIDIA A100');
+    const rf2 = makeRF('h100-flavor', 'NVIDIA H100');
+    const result = resolvePerModelGpuCounts([cq1, cq2], [rf1, rf2]);
+    expect(result.get('cq-1')).toEqual([
+      { model: 'NVIDIA A100', nominal: 8, used: 2, borrowed: undefined },
+    ]);
+    expect(result.get('cq-2')).toEqual([
+      { model: 'NVIDIA H100', nominal: 4, used: 4, borrowed: 2 },
+    ]);
+  });
+});

--- a/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
@@ -113,22 +113,19 @@ describe('resolveHardwareModels', () => {
 });
 
 describe('resolvePerModelGpuCounts', () => {
-  it('returns nominal, used, borrowed for a CQ with a labelled flavor', () => {
-    const cq = makeGpuCQ('cq-a', 'a100-flavor', { nominal: 8, used: 3, borrowed: 1 });
-    const rf = makeRF('a100-flavor', 'NVIDIA A100');
-    const result = resolvePerModelGpuCounts([cq], [rf]);
-    expect(result.get('cq-a')).toEqual([
+  it.each([
+    [
+      { nominal: 8, used: 3, borrowed: 1 },
       { model: 'NVIDIA A100', nominal: 8, used: 3, borrowed: 1 },
-    ]);
-  });
-
-  it('sets borrowed to undefined when the usage entry has no borrowed field', () => {
-    const cq = makeGpuCQ('cq-b', 'a100-flavor', { nominal: 4, used: 2 });
-    const rf = makeRF('a100-flavor', 'NVIDIA A100');
-    const result = resolvePerModelGpuCounts([cq], [rf]);
-    expect(result.get('cq-b')).toEqual([
+    ],
+    [
+      { nominal: 4, used: 2 },
       { model: 'NVIDIA A100', nominal: 4, used: 2, borrowed: undefined },
-    ]);
+    ],
+  ])('resolves per-model counts: %o', (overrides, expected) => {
+    const cq = makeGpuCQ('cq-a', 'a100-flavor', overrides);
+    const rf = makeRF('a100-flavor', 'NVIDIA A100');
+    expect(resolvePerModelGpuCounts([cq], [rf]).get('cq-a')).toEqual([expected]);
   });
 
   it('skips flavors with no matching ResourceFlavor or no gpu.product label', () => {
@@ -163,6 +160,44 @@ describe('resolvePerModelGpuCounts', () => {
     } as unknown as ClusterQueueKind;
     const result = resolvePerModelGpuCounts([cq], []);
     expect(result.get('cpu-only')).toEqual([]);
+  });
+
+  it('aggregates counts when two flavors resolve to the same GPU model', () => {
+    const cq = {
+      metadata: { name: 'cq-multi' },
+      spec: {
+        resourceGroups: [
+          {
+            coveredResources: ['nvidia.com/gpu'],
+            flavors: [
+              { name: 'a100-small', resources: [{ name: 'nvidia.com/gpu', nominalQuota: '4' }] },
+              { name: 'a100-large', resources: [{ name: 'nvidia.com/gpu', nominalQuota: '8' }] },
+            ],
+          },
+        ],
+      },
+      status: {
+        admittedWorkloads: 0,
+        pendingWorkloads: 0,
+        flavorsUsage: [
+          {
+            name: 'a100-small',
+            resources: [{ name: 'nvidia.com/gpu', total: '2', borrowed: '1' }],
+          },
+          {
+            name: 'a100-large',
+            resources: [{ name: 'nvidia.com/gpu', total: '4', borrowed: '2' }],
+          },
+        ],
+      },
+    } as unknown as ClusterQueueKind;
+    const rf1 = makeRF('a100-small', 'NVIDIA A100');
+    const rf2 = makeRF('a100-large', 'NVIDIA A100');
+
+    const result = resolvePerModelGpuCounts([cq], [rf1, rf2]);
+    expect(result.get('cq-multi')).toEqual([
+      { model: 'NVIDIA A100', nominal: 12, used: 6, borrowed: 3 },
+    ]);
   });
 
   it('handles multiple CQs independently', () => {

--- a/packages/gpuaas/src/utils/borrowingLendingChart.ts
+++ b/packages/gpuaas/src/utils/borrowingLendingChart.ts
@@ -1,4 +1,5 @@
 import { ChartThemeColor, getTheme } from '@patternfly/react-charts/victory';
+import { chart_color_black_300 as chartColorGray } from '@patternfly/react-tokens';
 import { CQMetricSeries } from '../hooks/useBorrowingLendingMetrics';
 import {
   CURSOR_GAP,
@@ -116,7 +117,9 @@ export const buildColorByName = (
       .filter((s) => !hiddenSeries.has(s.cqName))
       .map((s, i) => [
         s.cqName,
-        CHART_COLOR_SCALE.length > 0 ? CHART_COLOR_SCALE[i % CHART_COLOR_SCALE.length] : '#aaa',
+        CHART_COLOR_SCALE.length > 0
+          ? CHART_COLOR_SCALE[i % CHART_COLOR_SCALE.length]
+          : chartColorGray.value,
       ]),
   );
 

--- a/packages/gpuaas/src/utils/clusterQueueUtils.ts
+++ b/packages/gpuaas/src/utils/clusterQueueUtils.ts
@@ -109,9 +109,9 @@ export const isAcceleratorLending = (cq: ClusterQueueKind): boolean =>
 /** True when the CQ belongs to a Kueue cohort and can participate in borrow/lend. */
 export const isInCohort = (cq: ClusterQueueKind): boolean => !!cq.spec.cohortName;
 
-/** Filters to CQs that have at least one GPU resource declared in their quota. */
+/** Filters to CQs with non-zero accelerator quota or active usage (includes pure borrowers). */
 export const filterAcceleratorCQs = (cqs: ClusterQueueKind[]): ClusterQueueKind[] =>
-  cqs.filter((cq) => getCQNominalAccelerators(cq) > 0);
+  cqs.filter((cq) => getCQNominalAccelerators(cq) > 0 || getCQUsedAccelerators(cq) > 0);
 
 /** Sum of nominal GPU quota across all member CQs in the cohort. */
 export const getCohortTotalAccelerators = (cohort: UnifiedCohort): number =>

--- a/packages/gpuaas/src/utils/clusterQueueUtils.ts
+++ b/packages/gpuaas/src/utils/clusterQueueUtils.ts
@@ -270,7 +270,9 @@ export const computeDcgmSplitData = (
 
 /** Formats the active/pending workload count line shown on a CQ card. */
 export const formatWorkloadCounts = (admitted: number, pending: number): string =>
-  `${admitted} active workload${admitted !== 1 ? 's' : ''} · ${pending} pending`;
+  `${admitted} active workload${admitted !== 1 ? 's' : ''} · ${pending} pending workload${
+    pending !== 1 ? 's' : ''
+  }`;
 
 /**
  * Normalises a GPU model name so NFD node-label format ("NVIDIA-A100-SXM4-80GB" or "AMD_MI300X")
@@ -304,10 +306,10 @@ export const resolveCQDcgmUtilization = (
 
   const computeValues = dcgmEntries
     .map((e) => e.computePercentage)
-    .filter((v): v is number => v !== null);
+    .filter((v): v is number => v != null);
   const memoryValues = dcgmEntries
     .map((e) => e.memoryPercentage)
-    .filter((v): v is number => v !== null);
+    .filter((v): v is number => v != null);
 
   const avg = (values: number[]): number =>
     Math.round(values.reduce((a, b) => a + b, 0) / values.length);
@@ -342,10 +344,10 @@ export const resolvePerModelDcgmData = (
     if (!entry) {
       continue;
     }
-    if (entry.computePercentage !== null) {
+    if (entry.computePercentage != null) {
       compute.push({ model, pct: entry.computePercentage });
     }
-    if (entry.memoryPercentage !== null) {
+    if (entry.memoryPercentage != null) {
       memory.push({ model, pct: entry.memoryPercentage });
     }
   }

--- a/packages/gpuaas/src/utils/clusterQueueUtils.ts
+++ b/packages/gpuaas/src/utils/clusterQueueUtils.ts
@@ -113,12 +113,21 @@ export const isInCohort = (cq: ClusterQueueKind): boolean => !!cq.spec.cohortNam
 export const filterAcceleratorCQs = (cqs: ClusterQueueKind[]): ClusterQueueKind[] =>
   cqs.filter((cq) => getCQNominalAccelerators(cq) > 0 || getCQUsedAccelerators(cq) > 0);
 
-/** Sum of GPU quota across all member CQs. Pure borrowers (nominal=0) contribute their used count. */
-export const getCohortTotalAccelerators = (cohort: UnifiedCohort): number =>
-  cohort.memberClusterQueues.reduce((sum, cq) => {
-    const nominal = getCQNominalAccelerators(cq);
-    return sum + (nominal > 0 ? nominal : getCQUsedAccelerators(cq));
-  }, 0);
+/**
+ * Total GPUs shown in the cohort header.
+ * Normally this is the sum of each CQ's nominal quota.
+ * For cohorts where every CQ is a pure borrower (nominal=0), falls back to active usage
+ * so the header doesn't show a misleading 0.
+ */
+export const getCohortTotalAccelerators = (cohort: UnifiedCohort): number => {
+  const nominalTotal = cohort.memberClusterQueues.reduce(
+    (sum, cq) => sum + getCQNominalAccelerators(cq),
+    0,
+  );
+  return nominalTotal > 0
+    ? nominalTotal
+    : cohort.memberClusterQueues.reduce((sum, cq) => sum + getCQUsedAccelerators(cq), 0);
+};
 
 /** Sum of unused GPU capacity across member CQs — how much the cohort can lend out.
  *  Returns 0 for standalone (non-cohort) groups since they cannot participate in lending. */
@@ -244,15 +253,19 @@ export const getBorrowLendBadgeState = (config: AcceleratorDonutConfig): BorrowL
  * Derives the borrow-lend split ratio from the donut config.
  * Returns undefined when the CQ is neither borrowing nor lending.
  *
- * - Borrowing: own = nominal GPUs out of (nominal + borrowed) total in use.
+ * - Borrowing: own = Own segment slots out of total used (0 for pure borrowers).
  * - Lending:   own = used GPUs out of nominal total quota.
+ *
+ * ownRatio is derived from segments rather than nominal/used to handle pure borrowers
+ * correctly — they set nominal=used as a rendering trick, which would give ownRatio=1
+ * (100% owned) if we used nominal/used directly.
  */
 export const getBorrowLendInfo = (config: AcceleratorDonutConfig): BorrowLendInfo | undefined => {
   if (config.type !== AcceleratorDonutType.BorrowLend) {
     return undefined;
   }
   const ownRatio = config.isBorrowing
-    ? config.nominal / (config.used || 1)
+    ? (config.segments.find((s) => s.x === AcceleratorSegment.Own)?.y ?? 0) / (config.used || 1)
     : config.used / (config.nominal || 1);
   return { isBorrowing: config.isBorrowing, ownRatio };
 };
@@ -373,14 +386,17 @@ export const resolvePerModelDcgmData = (
 };
 
 export const buildDcgmLentTooltip = (lentPct: number, data: PerModelDcgmData[]): string =>
-  [`Total lent in use: ${Math.round(lentPct)}%`, ...data.map((d) => `${d.model}: ${d.pct}% lent`)]
+  [
+    `Total lent in use: ${Math.round(lentPct)}%`,
+    ...data.map((d) => `${d.model}: ${d.pct}% utilization`),
+  ]
     .filter(Boolean)
     .join('\n');
 
 export const buildDcgmBorrowedTooltip = (borrowedPct: number, data: PerModelDcgmData[]): string =>
   [
     `Total borrowed in use: ${Math.round(borrowedPct)}%`,
-    ...data.map((d) => `${d.model}: ${d.pct}% borrowed`),
+    ...data.map((d) => `${d.model}: ${d.pct}% utilization`),
   ]
     .filter(Boolean)
     .join('\n');

--- a/packages/gpuaas/src/utils/clusterQueueUtils.ts
+++ b/packages/gpuaas/src/utils/clusterQueueUtils.ts
@@ -113,9 +113,12 @@ export const isInCohort = (cq: ClusterQueueKind): boolean => !!cq.spec.cohortNam
 export const filterAcceleratorCQs = (cqs: ClusterQueueKind[]): ClusterQueueKind[] =>
   cqs.filter((cq) => getCQNominalAccelerators(cq) > 0 || getCQUsedAccelerators(cq) > 0);
 
-/** Sum of nominal GPU quota across all member CQs in the cohort. */
+/** Sum of GPU quota across all member CQs. Pure borrowers (nominal=0) contribute their used count. */
 export const getCohortTotalAccelerators = (cohort: UnifiedCohort): number =>
-  cohort.memberClusterQueues.reduce((sum, cq) => sum + getCQNominalAccelerators(cq), 0);
+  cohort.memberClusterQueues.reduce((sum, cq) => {
+    const nominal = getCQNominalAccelerators(cq);
+    return sum + (nominal > 0 ? nominal : getCQUsedAccelerators(cq));
+  }, 0);
 
 /** Sum of unused GPU capacity across member CQs — how much the cohort can lend out.
  *  Returns 0 for standalone (non-cohort) groups since they cannot participate in lending. */
@@ -159,11 +162,25 @@ export const getAcceleratorDonutConfig = (
   inCohort = true,
 ): AcceleratorDonutConfig => {
   const nominal = getCQNominalAccelerators(cq);
-  if (nominal === 0) {
-    return { type: AcceleratorDonutType.None };
-  }
-
   const used = getCQUsedAccelerators(cq);
+
+  if (nominal === 0) {
+    if (used === 0 || !inCohort) {
+      return { type: AcceleratorDonutType.None };
+    }
+    // Pure borrower: no owned quota but actively using borrowed GPUs from the cohort pool.
+    // Standalone CQs (inCohort=false) cannot borrow, so they fall through to None above.
+    // nominal is set to used so the donut renders as fully filled with the borrowed segment.
+    return {
+      type: AcceleratorDonutType.BorrowLend,
+      used,
+      nominal: used,
+      title: `${used}`,
+      isBorrowing: true,
+      stateLabel: AcceleratorSegment.Borrowed,
+      segments: [{ x: AcceleratorSegment.Borrowed, y: used }],
+    };
+  }
   const borrowed = getAcceleratorBorrowedCount(cq);
   const borrowing = isAcceleratorBorrowing(cq);
   const lending = isAcceleratorLending(cq);
@@ -315,8 +332,8 @@ export const resolveCQDcgmUtilization = (
     Math.round(values.reduce((a, b) => a + b, 0) / values.length);
 
   return {
-    computeUtilization: computeValues.length > 0 ? avg(computeValues) : null,
-    memoryUtilization: memoryValues.length > 0 ? avg(memoryValues) : null,
+    computeUtilization: computeValues.length > 0 ? avg(computeValues) : undefined,
+    memoryUtilization: memoryValues.length > 0 ? avg(memoryValues) : undefined,
   };
 };
 

--- a/packages/gpuaas/src/utils/clusterQueueUtils.ts
+++ b/packages/gpuaas/src/utils/clusterQueueUtils.ts
@@ -104,7 +104,7 @@ export const isAcceleratorBorrowing = (cq: ClusterQueueKind): boolean =>
   getAcceleratorBorrowedCount(cq) > 0;
 
 export const isAcceleratorLending = (cq: ClusterQueueKind): boolean =>
-  getAcceleratorLentCount(cq) > 0;
+  isInCohort(cq) && getAcceleratorLentCount(cq) > 0;
 
 /** True when the CQ belongs to a Kueue cohort and can participate in borrow/lend. */
 export const isInCohort = (cq: ClusterQueueKind): boolean => !!cq.spec.cohortName;

--- a/packages/gpuaas/src/utils/clusterQueueUtils.ts
+++ b/packages/gpuaas/src/utils/clusterQueueUtils.ts
@@ -1,0 +1,390 @@
+import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import parseK8sQuantity from './parseK8sQuantity';
+import { ModelGpuCount } from './hardwareModels';
+import { ACCELERATOR_RESOURCE_REGEX } from '../const';
+import { CQDcgmResult, UnifiedCohort } from '../types';
+
+export enum AcceleratorSegment {
+  Own = 'Own',
+  Lent = 'Lent',
+  Borrowed = 'Borrowed',
+  Available = 'Available',
+  NoData = 'No data',
+}
+
+export enum AcceleratorDonutType {
+  None = 'none',
+  Normal = 'normal',
+  BorrowLend = 'borrow-lend',
+}
+
+export type AcceleratorDonutConfig =
+  | { type: AcceleratorDonutType.None }
+  | {
+      type: AcceleratorDonutType.Normal;
+      used: number;
+      nominal: number;
+      title: string;
+      percentage: number;
+    }
+  | {
+      type: AcceleratorDonutType.BorrowLend;
+      used: number;
+      nominal: number;
+      title: string;
+      isBorrowing: boolean;
+      stateLabel: AcceleratorSegment.Borrowed | AcceleratorSegment.Lent;
+      segments: Array<{ x: string; y: number }>;
+    };
+
+/**
+ * Fraction of total in-use GPUs attributed to "own" allocation.
+ * Used by DcgmDonut to split the utilisation ring proportionally.
+ */
+export type BorrowLendInfo = {
+  isBorrowing: boolean;
+  ownRatio: number;
+};
+
+export type CQDcgmUtilization = {
+  /** null = DCGM knows the model but data hasn't loaded yet (transient spinner) */
+  computeUtilization: number | null | undefined;
+  /** null = DCGM knows the model but data hasn't loaded yet (transient spinner) */
+  memoryUtilization: number | null | undefined;
+};
+
+const ACCELERATOR_RE = new RegExp(ACCELERATOR_RESOURCE_REGEX);
+
+export const isAcceleratorResource = (resourceName: string): boolean =>
+  ACCELERATOR_RE.test(resourceName);
+
+/** Returns the total nominal GPU quota declared in spec.resourceGroups. */
+export const getCQNominalAccelerators = (cq: ClusterQueueKind): number =>
+  (cq.spec.resourceGroups ?? []).reduce(
+    (total, rg) =>
+      total +
+      rg.flavors.reduce(
+        (sum, f) =>
+          sum +
+          f.resources
+            .filter((r) => isAcceleratorResource(r.name))
+            .reduce((s, r) => s + parseK8sQuantity(r.nominalQuota), 0),
+        0,
+      ),
+    0,
+  );
+
+/** Returns total GPU units currently in use (from status.flavorsUsage[].resources[].total). */
+export const getCQUsedAccelerators = (cq: ClusterQueueKind): number =>
+  (cq.status?.flavorsUsage ?? []).reduce(
+    (total, flavor) =>
+      total +
+      flavor.resources
+        .filter((r) => isAcceleratorResource(r.name))
+        .reduce((sum, r) => sum + parseK8sQuantity(r.total), 0),
+    0,
+  );
+
+/** Returns GPU units borrowed from the cohort (status.flavorsUsage[].resources[].borrowed). */
+export const getAcceleratorBorrowedCount = (cq: ClusterQueueKind): number =>
+  (cq.status?.flavorsUsage ?? []).reduce(
+    (total, flavor) =>
+      total +
+      flavor.resources
+        .filter((r) => isAcceleratorResource(r.name))
+        .reduce((sum, r) => sum + parseK8sQuantity(r.borrowed), 0),
+    0,
+  );
+
+/** Returns GPU units unused and available for other CQs to borrow. Floored at 0. */
+export const getAcceleratorLentCount = (cq: ClusterQueueKind): number =>
+  Math.max(0, getCQNominalAccelerators(cq) - getCQUsedAccelerators(cq));
+
+export const isAcceleratorBorrowing = (cq: ClusterQueueKind): boolean =>
+  getAcceleratorBorrowedCount(cq) > 0;
+
+export const isAcceleratorLending = (cq: ClusterQueueKind): boolean =>
+  getAcceleratorLentCount(cq) > 0;
+
+/** True when the CQ belongs to a Kueue cohort and can participate in borrow/lend. */
+export const isInCohort = (cq: ClusterQueueKind): boolean => !!cq.spec.cohortName;
+
+/** Filters to CQs that have at least one GPU resource declared in their quota. */
+export const filterAcceleratorCQs = (cqs: ClusterQueueKind[]): ClusterQueueKind[] =>
+  cqs.filter((cq) => getCQNominalAccelerators(cq) > 0);
+
+/** Sum of nominal GPU quota across all member CQs in the cohort. */
+export const getCohortTotalAccelerators = (cohort: UnifiedCohort): number =>
+  cohort.memberClusterQueues.reduce((sum, cq) => sum + getCQNominalAccelerators(cq), 0);
+
+/** Sum of unused GPU capacity across member CQs — how much the cohort can lend out.
+ *  Returns 0 for standalone (non-cohort) groups since they cannot participate in lending. */
+export const getCohortUnallocatedBorrowable = (cohort: UnifiedCohort): number =>
+  cohort.state === 'standalone'
+    ? 0
+    : cohort.memberClusterQueues.reduce((sum, cq) => sum + getAcceleratorLentCount(cq), 0);
+
+/** True if any member CQ in the cohort is currently borrowing or lending GPU resources.
+ *  Always false for standalone groups since they cannot exchange quota. */
+export const isCohortBorrowLendActive = (cohort: UnifiedCohort): boolean =>
+  cohort.state !== 'standalone' &&
+  cohort.memberClusterQueues.some((cq) => isAcceleratorBorrowing(cq) || isAcceleratorLending(cq));
+
+/**
+ * Returns the names of sibling CQs that are on the other side of a borrow/lend relationship.
+ * For a lending CQ → names of CQs currently borrowing.
+ * For a borrowing CQ → names of CQs currently lending (from whom capacity flows).
+ */
+export const getCounterpartCQNames = (
+  cq: ClusterQueueKind,
+  siblingsInCohort: ClusterQueueKind[],
+): string[] => {
+  const cqName = cq.metadata?.name ?? '';
+  const siblings = siblingsInCohort.filter((s) => s.metadata?.name !== cqName);
+  const check = isAcceleratorBorrowing(cq) ? isAcceleratorLending : isAcceleratorBorrowing;
+  return siblings
+    .filter(check)
+    .map((s) => s.metadata?.name ?? '')
+    .filter(Boolean);
+};
+
+/**
+ * Derives the donut chart config for a ClusterQueue's accelerator utilization.
+ * Returns 'none' when the CQ has no accelerator quota.
+ * Returns 'borrow-lend' when the CQ is borrowing or lending GPU resources AND belongs to a cohort.
+ * Returns 'normal' otherwise (including standalone CQs which cannot exchange quota).
+ */
+export const getAcceleratorDonutConfig = (
+  cq: ClusterQueueKind,
+  inCohort = true,
+): AcceleratorDonutConfig => {
+  const nominal = getCQNominalAccelerators(cq);
+  if (nominal === 0) {
+    return { type: AcceleratorDonutType.None };
+  }
+
+  const used = getCQUsedAccelerators(cq);
+  const borrowed = getAcceleratorBorrowedCount(cq);
+  const borrowing = isAcceleratorBorrowing(cq);
+  const lending = isAcceleratorLending(cq);
+
+  if (inCohort && (borrowing || lending)) {
+    const ownUsed = Math.max(0, used - borrowed);
+    const lent = Math.max(0, nominal - ownUsed);
+    const available = Math.max(0, nominal - ownUsed - (borrowing ? 0 : lent));
+
+    return {
+      type: AcceleratorDonutType.BorrowLend,
+      used,
+      nominal,
+      title: `${used}/${nominal}`,
+      isBorrowing: borrowing,
+      stateLabel: borrowing ? AcceleratorSegment.Borrowed : AcceleratorSegment.Lent,
+      segments: borrowing
+        ? [
+            { x: AcceleratorSegment.Own, y: ownUsed },
+            { x: AcceleratorSegment.Borrowed, y: borrowed },
+            { x: AcceleratorSegment.Available, y: available },
+          ]
+        : [
+            { x: AcceleratorSegment.Own, y: ownUsed },
+            { x: AcceleratorSegment.Lent, y: lent },
+          ],
+    };
+  }
+
+  return {
+    type: AcceleratorDonutType.Normal,
+    used,
+    nominal,
+    title: `${used}/${nominal}`,
+    percentage: Math.round((used / nominal) * 100),
+  };
+};
+
+export type BorrowLendBadgeState = {
+  borrowing: boolean;
+  lending: boolean;
+  lentCount: number;
+  borrowedCount: number;
+};
+
+/** Derives the badge visibility and counts for the borrow/lend badges on a CQ card. */
+export const getBorrowLendBadgeState = (config: AcceleratorDonutConfig): BorrowLendBadgeState => ({
+  borrowing: config.type === AcceleratorDonutType.BorrowLend && config.isBorrowing,
+  lending: config.type === AcceleratorDonutType.BorrowLend && !config.isBorrowing,
+  lentCount:
+    config.type === AcceleratorDonutType.BorrowLend && !config.isBorrowing
+      ? config.segments.find((s) => s.x === AcceleratorSegment.Lent)?.y ?? 0
+      : 0,
+  borrowedCount:
+    config.type === AcceleratorDonutType.BorrowLend && config.isBorrowing
+      ? config.segments.find((s) => s.x === AcceleratorSegment.Borrowed)?.y ?? 0
+      : 0,
+});
+
+/**
+ * Derives the borrow-lend split ratio from the donut config.
+ * Returns undefined when the CQ is neither borrowing nor lending.
+ *
+ * - Borrowing: own = nominal GPUs out of (nominal + borrowed) total in use.
+ * - Lending:   own = used GPUs out of nominal total quota.
+ */
+export const getBorrowLendInfo = (config: AcceleratorDonutConfig): BorrowLendInfo | undefined => {
+  if (config.type !== AcceleratorDonutType.BorrowLend) {
+    return undefined;
+  }
+  const ownRatio = config.isBorrowing
+    ? config.nominal / (config.used || 1)
+    : config.used / (config.nominal || 1);
+  return { isBorrowing: config.isBorrowing, ownRatio };
+};
+
+/**
+ * Computes the Victory chart data array for a DCGM donut in borrow-lend mode.
+ * Clamps the remainder so the ring stays on a 0–100% scale.
+ */
+export const computeDcgmSplitData = (
+  percentage: number,
+  { isBorrowing, ownRatio }: BorrowLendInfo,
+): {
+  chartData: Array<{ x: string; y: number }>;
+  splitLabel: AcceleratorSegment.Borrowed | AcceleratorSegment.Lent;
+} => {
+  const splitLabel = isBorrowing ? AcceleratorSegment.Borrowed : AcceleratorSegment.Lent;
+  const ownPct = percentage * ownRatio;
+  const splitPct = percentage * (1 - ownRatio);
+  // Remainder keeps the ring at 100% scale; clamped so >100% utilisation fills the ring completely.
+  const remainingPct = Math.max(0, 100 - ownPct - splitPct);
+
+  // Victory renders y:0 slices as a degenerate path (tiny visible line), so filter them out.
+  const rawData = [
+    { x: AcceleratorSegment.Own, y: ownPct },
+    { x: splitLabel, y: splitPct },
+    { x: AcceleratorSegment.Available, y: remainingPct },
+  ].filter((d) => d.y > 0);
+
+  const chartData = rawData.length === 0 ? [{ x: AcceleratorSegment.NoData, y: 100 }] : rawData;
+  return { chartData, splitLabel };
+};
+
+/** Formats the active/pending workload count line shown on a CQ card. */
+export const formatWorkloadCounts = (admitted: number, pending: number): string =>
+  `${admitted} active workload${admitted !== 1 ? 's' : ''} · ${pending} pending`;
+
+/**
+ * Normalises a GPU model name so NFD node-label format ("NVIDIA-A100-SXM4-80GB" or "AMD_MI300X")
+ * and DCGM metric label format ("NVIDIA A100-SXM4-80GB") map to the same key.
+ */
+export const normalizeModelName = (name: string): string =>
+  name.toLowerCase().replace(/[-_]/g, ' ').replace(/\s+/g, ' ').trim();
+
+/**
+ * Resolves per-CQ DCGM utilization by averaging across all GPU models the CQ owns.
+ *
+ * - `undefined` means the model is not in DCGM's data (N/A ring)
+ * - `null` means the model is known to DCGM but the metric hasn't arrived yet (spinner)
+ * - `number` is the averaged percentage
+ */
+export const resolveCQDcgmUtilization = (
+  models: string[],
+  dcgmByModel: Map<string, CQDcgmResult>,
+): CQDcgmUtilization => {
+  if (models.length === 0) {
+    return { computeUtilization: undefined, memoryUtilization: undefined };
+  }
+
+  const dcgmEntries = models
+    .map((m) => dcgmByModel.get(normalizeModelName(m)))
+    .filter((e): e is CQDcgmResult => e !== undefined);
+
+  if (dcgmEntries.length === 0) {
+    return { computeUtilization: undefined, memoryUtilization: undefined };
+  }
+
+  const computeValues = dcgmEntries
+    .map((e) => e.computePercentage)
+    .filter((v): v is number => v !== null);
+  const memoryValues = dcgmEntries
+    .map((e) => e.memoryPercentage)
+    .filter((v): v is number => v !== null);
+
+  const avg = (values: number[]): number =>
+    Math.round(values.reduce((a, b) => a + b, 0) / values.length);
+
+  return {
+    computeUtilization: computeValues.length > 0 ? avg(computeValues) : null,
+    memoryUtilization: memoryValues.length > 0 ? avg(memoryValues) : null,
+  };
+};
+
+export type PerModelDcgmData = { model: string; pct: number };
+
+/**
+ * Returns per-model DCGM utilization arrays for a CQ's hardware models, used to
+ * build per-model tooltip lines in the DCGM lent/borrowed donut charts.
+ * Accepts an optional map so callers can pass `dcgmByModel` directly regardless of
+ * whether DCGM is available, and always get a safe `{ compute, memory }` result.
+ */
+export const resolvePerModelDcgmData = (
+  models: string[],
+  dcgmByModel: Map<string, CQDcgmResult> | undefined,
+): { compute: PerModelDcgmData[]; memory: PerModelDcgmData[] } => {
+  if (!dcgmByModel) {
+    return { compute: [], memory: [] };
+  }
+
+  const compute: PerModelDcgmData[] = [];
+  const memory: PerModelDcgmData[] = [];
+
+  for (const model of models) {
+    const entry = dcgmByModel.get(normalizeModelName(model));
+    if (!entry) {
+      continue;
+    }
+    if (entry.computePercentage !== null) {
+      compute.push({ model, pct: entry.computePercentage });
+    }
+    if (entry.memoryPercentage !== null) {
+      memory.push({ model, pct: entry.memoryPercentage });
+    }
+  }
+
+  return { compute, memory };
+};
+
+export const buildDcgmLentTooltip = (lentPct: number, data: PerModelDcgmData[]): string =>
+  [`Total lent in use: ${Math.round(lentPct)}%`, ...data.map((d) => `${d.model}: ${d.pct}% lent`)]
+    .filter(Boolean)
+    .join('\n');
+
+export const buildDcgmBorrowedTooltip = (borrowedPct: number, data: PerModelDcgmData[]): string =>
+  [
+    `Total borrowed in use: ${Math.round(borrowedPct)}%`,
+    ...data.map((d) => `${d.model}: ${d.pct}% borrowed`),
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+export const buildDcgmOwnTooltip = (ownPct: number, data: PerModelDcgmData[]): string =>
+  [
+    `Total owned in use: ${Math.round(ownPct)}%`,
+    ...data.map((d) => `${d.model}: ${d.pct}% utilization`),
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+export const buildAcceleratorOwnLines = (gpus: ModelGpuCount[]): string =>
+  gpus.map((m) => `${m.model}: ${m.used}/${m.nominal} in use`).join('\n');
+
+export const buildAcceleratorLentLines = (gpus: ModelGpuCount[]): string =>
+  gpus
+    .filter((m) => m.nominal - m.used > 0)
+    .map((m) => `${m.model}: ${m.nominal - m.used} lent`)
+    .join('\n');
+
+export const buildAcceleratorBorrowedLines = (gpus: ModelGpuCount[]): string =>
+  gpus
+    .filter((m) => (m.borrowed ?? 0) > 0)
+    .map((m) => `${m.model}: +${m.borrowed ?? 0} borrowed`)
+    .join('\n');

--- a/packages/gpuaas/src/utils/hardwareModels.ts
+++ b/packages/gpuaas/src/utils/hardwareModels.ts
@@ -1,4 +1,15 @@
 import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/internal/k8sTypes';
+import parseK8sQuantity from './parseK8sQuantity';
+import { ACCELERATOR_RESOURCE_REGEX } from '../const';
+
+const ACCELERATOR_RE = new RegExp(ACCELERATOR_RESOURCE_REGEX);
+
+export type ModelGpuCount = {
+  model: string;
+  used: number;
+  nominal: number;
+  borrowed?: number;
+};
 
 const GPU_PRODUCT_LABELS = [
   'nvidia.com/gpu.product',
@@ -41,6 +52,56 @@ export const resolveHardwareModels = (
     const cqName = cq.metadata?.name ?? '';
     if (cqName) {
       result.set(cqName, [...models]);
+    }
+  }
+
+  return result;
+};
+
+/** Returns a map of CQ name → per-model GPU counts (nominal, used, borrowed). */
+export const resolvePerModelGpuCounts = (
+  clusterQueues: ClusterQueueKind[],
+  resourceFlavors: ResourceFlavorKind[],
+): Map<string, ModelGpuCount[]> => {
+  const flavorMap = new Map(resourceFlavors.map((rf) => [rf.metadata?.name ?? '', rf]));
+
+  const result = new Map<string, ModelGpuCount[]>();
+
+  for (const cq of clusterQueues) {
+    const counts: ModelGpuCount[] = [];
+
+    for (const rg of cq.spec.resourceGroups ?? []) {
+      for (const flavor of rg.flavors) {
+        const rf = flavorMap.get(flavor.name);
+        let model: string | undefined;
+        for (const label of GPU_PRODUCT_LABELS) {
+          const value = rf?.spec.nodeLabels?.[label];
+          if (value) {
+            model = value;
+            break;
+          }
+        }
+        if (!model) {
+          continue;
+        }
+
+        const nominalRes = flavor.resources.find((r) => ACCELERATOR_RE.test(r.name));
+        const usageEntry = cq.status?.flavorsUsage?.find((f) => f.name === flavor.name);
+        const usedRes = usageEntry?.resources.find((r) => ACCELERATOR_RE.test(r.name));
+
+        counts.push({
+          model,
+          nominal: parseK8sQuantity(nominalRes?.nominalQuota ?? '0'),
+          used: parseK8sQuantity(usedRes?.total ?? '0'),
+          borrowed:
+            usedRes?.borrowed !== undefined ? parseK8sQuantity(usedRes.borrowed) : undefined,
+        });
+      }
+    }
+
+    const cqName = cq.metadata?.name ?? '';
+    if (cqName) {
+      result.set(cqName, counts);
     }
   }
 

--- a/packages/gpuaas/src/utils/hardwareModels.ts
+++ b/packages/gpuaas/src/utils/hardwareModels.ts
@@ -68,7 +68,7 @@ export const resolvePerModelGpuCounts = (
   const result = new Map<string, ModelGpuCount[]>();
 
   for (const cq of clusterQueues) {
-    const counts: ModelGpuCount[] = [];
+    const countsByModel = new Map<string, ModelGpuCount>();
 
     for (const rg of cq.spec.resourceGroups ?? []) {
       for (const flavor of rg.flavors) {
@@ -89,19 +89,27 @@ export const resolvePerModelGpuCounts = (
         const usageEntry = cq.status?.flavorsUsage?.find((f) => f.name === flavor.name);
         const usedRes = usageEntry?.resources.find((r) => ACCELERATOR_RE.test(r.name));
 
-        counts.push({
-          model,
-          nominal: parseK8sQuantity(nominalRes?.nominalQuota ?? '0'),
-          used: parseK8sQuantity(usedRes?.total ?? '0'),
-          borrowed:
-            usedRes?.borrowed !== undefined ? parseK8sQuantity(usedRes.borrowed) : undefined,
-        });
+        const nominal = parseK8sQuantity(nominalRes?.nominalQuota ?? '0');
+        const used = parseK8sQuantity(usedRes?.total ?? '0');
+        const borrowed =
+          usedRes?.borrowed !== undefined ? parseK8sQuantity(usedRes.borrowed) : undefined;
+
+        const existing = countsByModel.get(model);
+        if (existing) {
+          existing.nominal += nominal;
+          existing.used += used;
+          if (borrowed !== undefined) {
+            existing.borrowed = (existing.borrowed ?? 0) + borrowed;
+          }
+        } else {
+          countsByModel.set(model, { model, nominal, used, borrowed });
+        }
       }
     }
 
     const cqName = cq.metadata?.name ?? '';
     if (cqName) {
-      result.set(cqName, counts);
+      result.set(cqName, [...countsByModel.values()]);
     }
   }
 


### PR DESCRIPTION
Closes [RHOAIENG-72327](https://issues.redhat.com/browse/RHOAIENG-72327)

## Description

For borrow and lend

https://github.com/user-attachments/assets/3de965ea-f366-4120-b89c-bf1ebb3f8c58

On Training cluster:  

https://github.com/user-attachments/assets/227b1c6a-895e-49f3-9c07-ce0c3b9f08d8


Adds the **Cluster queue utilization** section to the Infrastructure page — a per-cohort accordion where each cohort expands to show a row of CQ cards, each with three donut charts and borrow/lend state.

**Data fetching** (`ClusterQueueUtilizationSection.tsx`)
- Fetches cohorts, ResourceFlavors, and DCGM Prometheus metrics in parallel via three hooks
- Shows a spinner until all three sources are loaded to avoid layout shifts

**Cohort accordion** (`CohortAccordionGroup.tsx`)
- One accordion per cohort, all expanded by default
- Header shows cohort name, total accelerator count, unallocated-borrowable count, and a "Borrow / lend active" badge when any member CQ is exchanging quota
- Standalone CQs (no Kueue cohort assigned) are grouped under a single "Not in a cohort" accordion

**CQ card** (`ClusterQueueCard.tsx`, `AcceleratorDonutChart.tsx`, `ClusterQueueChartComponents.tsx`)

Each card contains:
- CQ name + outlined GPU model badges (e.g., `NVIDIA A100`)
- Lent/borrowed badge — clickable, opens a Popover with the counterpart CQ name and per-model GPU breakdown ("N × Model")
- Active workload count and pending count
- Three chart columns (DCGM columns only render when the DCGM exporter is present):
  - **Total accelerators** — `ChartDonutUtilization` (normal), `ChartDonut` proportional segments (lent: own blue + lent purple), or `ChartDonutThreshold` nested rings (borrowed: own outer blue + borrowed inner orange)
  - **Accelerator compute utilization** — same three variants driven by `DCGM_FI_PROF_GR_ENGINE_ACTIVE` per model
  - **Accelerator memory utilization** — same three variants driven by `DCGM_FI_DEV_FB_USED` per model
- Hover tooltips on chart segments show per-model GPU breakdown
- Own/Lent or Own/Borrowed color legend below the charts in borrow-lend state

**Business logic** (`clusterQueueUtils.ts`, `hardwareModels.ts`)
- `getAcceleratorDonutConfig` derives which donut variant to render from `status.flavorsUsage`
- `resolveCQDcgmUtilization` averages per-model DCGM percentages across all GPU models a CQ owns
- `normalizeModelName` bridges NFD label format (`NVIDIA-A100-SXM4-80GB`, `AMD_MI300X`) and DCGM metric label format (`NVIDIA A100-SXM4-80GB`) — handles both dashes and underscores as separators
- `resolvePerModelGpuCounts` extracts per-model nominal/used/borrowed counts for the badge popover

## How Has This Been Tested?

Manually tested on a cluster with Kueue and GPU cluster queues in cohorts:
- Accordion expands/collapses per cohort; standalone CQs appear under "Not in a cohort"
- Normal donut shows used/nominal; lent donut shows own (blue) + lent (purple) segments; borrowed donut shows outer blue ring + inner orange fill
- Hover tooltips on donut segments show per-model breakdown (e.g., "NVIDIA A100: 4/6 in use")
- Lent/borrowed badge click opens Popover with counterpart CQ name and "N × Model" count
- DCGM columns appear when the DCGM exporter is running, hidden when it is not

## Test Impact

**Unit tests** (`clusterQueueUtils.spec.ts`, `hardwareModels.spec.ts`, `useCQDcgmMetrics.spec.ts`) — 90 tests covering:
- Donut config derivation for all three variants (normal, lent, borrowed)
- DCGM utilization averaging, per-model data resolution, tooltip builders
- `normalizeModelName` including underscore-separated AMD/Intel GPU label formats
- `resolvePerModelGpuCounts` with nominal/used/borrowed parsing via `parseK8sQuantity`
- `parseByModel` Prometheus response parsing and `useCQDcgmMetrics` hook loading states

**Cypress mock tests** (`infrastructure.cy.ts`) — covering:
- Empty state when no GPU CQs exist or all are CPU-only
- CQ card renders subtitle, hardware badge, donut, workload counts, and cohort accordion
- Two CQ cards with DCGM utilization columns when telemetry is available
- Lent/borrowed badges, workload counts, all three chart columns in borrow-lend state
- Badge click Popover: counterpart CQ name and per-model GPU breakdown
- Donut segment hover tooltip: per-model breakdown for own/lent segments

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-72327]: https://redhat.atlassian.net/browse/RHOAIENG-72327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Cluster Queue Utilization section to the Infrastructure page with cohort accordions and cluster queue cards, including workload counts and accelerator donuts (plus optional DCGM compute/memory donuts).
  * Introduced new GPUaaS UI components and hooks to power utilization, badges, and model-aware tooltips.
* **Bug Fixes**
  * Improved handling and display semantics for DCGM availability, including “no data” vs “loading” behavior.
* **Tests / Chores**
  * Refreshed Cypress mocks/tests to be model-driven, added unit tests for DCGM parsing and GPU/model aggregation, and expanded Jest/unit test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->