### PR TITLE
Enable mlflowPipelines feature flag by default

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -78,7 +78,7 @@ export type MockDashboardConfigType = {
 };
 
 export const mockDashboardConfig = ({
-  mlflowPipelines = false,
+  mlflowPipelines = true,
   projectRBAC = false,
   disableInfo = false,
   disableSupport = false,

--- a/frontend/src/api/pipelines/__tests__/errorUtils.spec.ts
+++ b/frontend/src/api/pipelines/__tests__/errorUtils.spec.ts
@@ -31,10 +31,9 @@ describe('handlePipelineFailures', () => {
     ).rejects.toThrow('error');
   });
 
-  it('should re-throw plain Error instances', async () => {
-    await expect(handlePipelineFailures(Promise.reject(new Error('error')))).rejects.toThrow(
-      'error',
-    );
+  it('should re-throw the same Error instance', async () => {
+    const original = new Error('error');
+    await expect(handlePipelineFailures(Promise.reject(original))).rejects.toBe(original);
   });
 
   it('should wrap non-Error rejections in a generic message', async () => {

--- a/frontend/src/api/pipelines/__tests__/errorUtils.spec.ts
+++ b/frontend/src/api/pipelines/__tests__/errorUtils.spec.ts
@@ -31,8 +31,14 @@ describe('handlePipelineFailures', () => {
     ).rejects.toThrow('error');
   });
 
-  it('should handle other errors', async () => {
+  it('should re-throw plain Error instances', async () => {
     await expect(handlePipelineFailures(Promise.reject(new Error('error')))).rejects.toThrow(
+      'error',
+    );
+  });
+
+  it('should wrap non-Error rejections in a generic message', async () => {
+    await expect(handlePipelineFailures(Promise.reject('string error'))).rejects.toThrow(
       'Error communicating with pipeline server',
     );
   });

--- a/frontend/src/api/pipelines/errorUtils.ts
+++ b/frontend/src/api/pipelines/errorUtils.ts
@@ -29,7 +29,13 @@ const isGrpcErrorKF = (e: unknown): e is GrpcErrorKF => {
   }
   const obj: Record<string, unknown> = e;
   return (
-    typeof obj.code === 'number' && obj.code !== 0 && !('run_id' in e) && !('recurring_run_id' in e)
+    typeof obj.code === 'number' &&
+    obj.code !== 0 &&
+    typeof obj.message === 'string' &&
+    !('error' in e) &&
+    !('details' in e) &&
+    !('run_id' in e) &&
+    !('recurring_run_id' in e)
   );
 };
 
@@ -41,11 +47,11 @@ const isErrorDetailsKF = (result: unknown): result is ResultErrorKF =>
 export const handlePipelineFailures = <T>(promise: Promise<T>): Promise<T> =>
   promise
     .then((result) => {
-      if (isGrpcErrorKF(result)) {
-        throw new Error(result.message);
-      }
       if (isErrorKF(result)) {
         throw result;
+      }
+      if (isGrpcErrorKF(result)) {
+        throw new Error(result.message);
       }
       if (isErrorDetailsKF(result)) {
         const errorKF: ErrorKF = {
@@ -74,6 +80,10 @@ export const handlePipelineFailures = <T>(promise: Promise<T>): Promise<T> =>
       // on the next poll — no error message is shown to the user.
       if (e instanceof ProxyTransientError) {
         throw new NotReadyError('Pipeline server route is not yet available');
+      }
+
+      if (e instanceof Error) {
+        throw e;
       }
 
       // eslint-disable-next-line no-console

--- a/frontend/src/api/pipelines/errorUtils.ts
+++ b/frontend/src/api/pipelines/errorUtils.ts
@@ -17,6 +17,22 @@ type ResultErrorKF = {
 const isErrorKF = (e: unknown): e is ErrorKF =>
   typeof e === 'object' && e !== null && ['error', 'code', 'message'].every((key) => key in e);
 
+type GrpcErrorKF = {
+  code: number;
+  message: string;
+  details?: unknown[];
+};
+
+const isGrpcErrorKF = (e: unknown): e is GrpcErrorKF => {
+  if (typeof e !== 'object' || e === null || !('code' in e) || !('message' in e)) {
+    return false;
+  }
+  const obj: Record<string, unknown> = e;
+  return (
+    typeof obj.code === 'number' && obj.code !== 0 && !('run_id' in e) && !('recurring_run_id' in e)
+  );
+};
+
 const isErrorDetailsKF = (result: unknown): result is ResultErrorKF =>
   typeof result === 'object' &&
   result !== null &&
@@ -25,6 +41,9 @@ const isErrorDetailsKF = (result: unknown): result is ResultErrorKF =>
 export const handlePipelineFailures = <T>(promise: Promise<T>): Promise<T> =>
   promise
     .then((result) => {
+      if (isGrpcErrorKF(result)) {
+        throw new Error(result.message);
+      }
       if (isErrorKF(result)) {
         throw result;
       }

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -31,7 +31,7 @@ export const techPreviewFlags = {
 export const devTemporaryFeatureFlags = {
   disableKueue: true,
   disableProjectScoped: true,
-  mlflowPipelines: false,
+  mlflowPipelines: true,
   nimWizard: false,
   agentOpsDeploy: false,
   agentsCatalog: false,

--- a/frontend/src/concepts/pipelines/content/createRun/RunPageFooter.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunPageFooter.tsx
@@ -60,7 +60,6 @@ const RunPageFooter: React.FC<RunPageFooterProps> = ({ data, contextPath }) => {
 
                 handleSubmit(data, api, isMlflowAvailable)
                   .then((resource) => {
-                    fireFormTrackingEvent(eventName, properties);
                     const detailsPath = isRunSchedule(resource)
                       ? resource.recurring_run_id
                       : resource.run_id;
@@ -69,6 +68,7 @@ const RunPageFooter: React.FC<RunPageFooterProps> = ({ data, contextPath }) => {
                       throw new Error('Run was created but no identifier was returned.');
                     }
 
+                    fireFormTrackingEvent(eventName, properties);
                     navigate(`${contextPath}/${detailsPath}`);
                   })
                   .catch((e) => {

--- a/frontend/src/concepts/pipelines/content/createRun/RunPageFooter.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunPageFooter.tsx
@@ -65,6 +65,10 @@ const RunPageFooter: React.FC<RunPageFooterProps> = ({ data, contextPath }) => {
                       ? resource.recurring_run_id
                       : resource.run_id;
 
+                    if (!detailsPath) {
+                      throw new Error('Run was created but no identifier was returned.');
+                    }
+
                     navigate(`${contextPath}/${detailsPath}`);
                   })
                   .catch((e) => {

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowMlflowExperiment.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowMlflowExperiment.tsx
@@ -8,8 +8,10 @@ import { mlflowExperimentRoute } from '#~/routes/pipelines/mlflow';
 import { MlflowTrackingEvents } from '#~/concepts/mlflow/const';
 import { NoRunContent } from '#~/concepts/pipelines/content/tables/renderUtils';
 import { MlflowExperimentData } from '#~/concepts/mlflow/types';
-import { getMlflowExperimentNameFromRun } from '#~/concepts/pipelines/content/tables/pipelineRun/utils';
-import { isPipelineRun } from '#~/concepts/pipelines/content/utils';
+import {
+  getMlflowExperimentNameFromRun,
+  getMlflowPluginOutput,
+} from '#~/concepts/pipelines/content/tables/pipelineRun/utils';
 import { fireLinkTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 
 type PipelineRunTableRowMlflowExperimentProps = {
@@ -24,9 +26,7 @@ const PipelineRunTableRowMlflowExperiment: React.FC<PipelineRunTableRowMlflowExp
   const { namespace } = usePipelinesAPI();
 
   const experimentName = getMlflowExperimentNameFromRun(run);
-  const experimentIdFromOutput = isPipelineRun(run)
-    ? run.plugins_output?.mlflow?.entries.experiment_id?.value
-    : undefined;
+  const experimentIdFromOutput = getMlflowPluginOutput(run)?.entries.experiment_id?.value;
   const experimentId =
     experimentIdFromOutput ??
     (experimentName ? mlflow.experiments.find((e) => e.name === experimentName)?.id : undefined);

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/__tests__/utils.spec.ts
@@ -6,6 +6,7 @@ import {
   filterByMlflowExperiment,
   getMlflowExperimentId,
   getMlflowExperimentNameFromRun,
+  getMlflowPluginOutput,
   getMlflowRunId,
 } from '#~/concepts/pipelines/content/tables/pipelineRun/utils';
 
@@ -96,6 +97,72 @@ describe('getMlflowExperimentNameFromRun', () => {
       plugins_input: { mlflow: { experiment_name: '' } },
     });
     expect(getMlflowExperimentNameFromRun(run)).toBeUndefined();
+  });
+
+  it('should return experiment name when plugins_output uses uppercase MLflow key', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        MLflow: {
+          entries: { experiment_name: { value: 'KFP-Default' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+    });
+    expect(getMlflowExperimentNameFromRun(run)).toBe('KFP-Default');
+  });
+});
+
+describe('getMlflowPluginOutput', () => {
+  it('should return output when key is lowercase mlflow', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        mlflow: {
+          entries: { experiment_name: { value: 'test' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+    });
+    expect(getMlflowPluginOutput(run)?.entries.experiment_name?.value).toBe('test');
+  });
+
+  it('should return output when key is uppercase MLflow (KFP API casing)', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        MLflow: {
+          entries: { experiment_name: { value: 'test' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+    });
+    expect(getMlflowPluginOutput(run)?.entries.experiment_name?.value).toBe('test');
+  });
+
+  it('should prefer lowercase mlflow over uppercase MLflow', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        mlflow: {
+          entries: { experiment_name: { value: 'lowercase' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+        MLflow: {
+          entries: { experiment_name: { value: 'uppercase' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+    });
+    expect(getMlflowPluginOutput(run)?.entries.experiment_name?.value).toBe('lowercase');
+  });
+
+  it('should return undefined for recurring runs', () => {
+    const run = buildMockRecurringRunKF({
+      plugins_input: { mlflow: { experiment_name: 'test' } },
+    });
+    expect(getMlflowPluginOutput(run)).toBeUndefined();
+  });
+
+  it('should return undefined when no plugins_output', () => {
+    const run = buildMockRunKF({});
+    expect(getMlflowPluginOutput(run)).toBeUndefined();
   });
 });
 
@@ -225,6 +292,18 @@ describe('getMlflowExperimentId', () => {
     });
     expect(getMlflowExperimentId(run)).toBe('failed-exp');
   });
+
+  it('returns experiment_id when plugins_output uses uppercase MLflow key', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        MLflow: {
+          entries: { experiment_id: { value: '99' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+    });
+    expect(getMlflowExperimentId(run)).toBe('99');
+  });
 });
 
 describe('getMlflowRunId', () => {
@@ -274,5 +353,17 @@ describe('getMlflowRunId', () => {
       },
     });
     expect(getMlflowRunId(run)).toBe('partial-id');
+  });
+
+  it('returns root_run_id when plugins_output uses uppercase MLflow key', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        MLflow: {
+          entries: { root_run_id: { value: 'uppercase-id' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+    });
+    expect(getMlflowRunId(run)).toBe('uppercase-id');
   });
 });

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/utils.ts
@@ -1,16 +1,33 @@
 import { Artifact } from '#~/third_party/mlmd';
 import { getArtifactModelData } from '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils';
-import { PipelineRecurringRunKF, PipelineRunKF } from '#~/concepts/pipelines/kfTypes';
+import {
+  PluginOutputKF,
+  PipelineRecurringRunKF,
+  PipelineRunKF,
+} from '#~/concepts/pipelines/kfTypes';
 import { isPipelineRun } from '#~/concepts/pipelines/content/utils';
 
 export const ALL_RUNS_METRICS_COLUMNS_STORAGE_KEY = 'all-runs-metrics-columns';
 
+export const getMlflowPluginOutput = (
+  run: PipelineRunKF | PipelineRecurringRunKF,
+): PluginOutputKF | undefined => {
+  if (!isPipelineRun(run)) {
+    return undefined;
+  }
+  const output = run.plugins_output;
+  if (!output) {
+    return undefined;
+  }
+  // ODH/RHOAI returns "MLflow"; upstream KFP returns "mlflow"
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  return output.MLflow || output.mlflow;
+};
+
 export const getMlflowExperimentNameFromRun = (
   run: PipelineRunKF | PipelineRecurringRunKF,
 ): string | undefined => {
-  const outputName = isPipelineRun(run)
-    ? run.plugins_output?.mlflow?.entries.experiment_name?.value
-    : undefined;
+  const outputName = getMlflowPluginOutput(run)?.entries.experiment_name?.value;
   const name = outputName ?? run.plugins_input?.mlflow?.experiment_name;
   return typeof name === 'string' ? name.trim() || undefined : undefined;
 };
@@ -38,7 +55,7 @@ export const isPipelineRunRegistered = (artifact: Artifact[]): boolean => {
 };
 
 export const getMlflowExperimentId = (run: PipelineRunKF): string | undefined => {
-  const outputEntry = run.plugins_output?.mlflow?.entries;
+  const outputEntry = getMlflowPluginOutput(run)?.entries;
   const outputId = outputEntry?.experiment_id?.value;
   if (outputId != null) {
     return String(outputId);
@@ -53,7 +70,7 @@ export const getMlflowExperimentId = (run: PipelineRunKF): string | undefined =>
 // root_run_id is only populated in plugins_output after the backend creates the MLflow run.
 // Unlike experiment_id, there is no plugins_input equivalent to fall back to.
 export const getMlflowRunId = (run: PipelineRunKF): string | undefined => {
-  const outputEntry = run.plugins_output?.mlflow?.entries;
+  const outputEntry = getMlflowPluginOutput(run)?.entries;
   const outputId = outputEntry?.root_run_id?.value;
   if (outputId != null) {
     return String(outputId);

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/utils.ts
@@ -19,9 +19,9 @@ export const getMlflowPluginOutput = (
   if (!output) {
     return undefined;
   }
-  // ODH/RHOAI returns "MLflow"; upstream KFP returns "mlflow"
+  // ODH/RHOAI returns "MLflow"; upstream KFP returns "mlflow" — prefer lowercase when both are present
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  return output.MLflow || output.mlflow;
+  return output.mlflow || output.MLflow;
 };
 
 export const getMlflowExperimentNameFromRun = (

--- a/packages/cypress/cypress/tests/mocked/pipelines/intercepts.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/intercepts.ts
@@ -10,9 +10,11 @@ import {
   ProjectModel,
   RouteModel,
 } from '../../../utils/models';
+import { interceptMlflowStatus } from '../../../utils/mlflowUtils';
 
 export const configIntercept = (): void => {
   cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
+  interceptMlflowStatus(false);
 };
 
 export const projectsIntercept = (


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-58541

  ## Description

  Enable the `mlflowPipelines` feature flag by default. The flag was introduced as a dev-temporary gate while the MLflow pipelines integration was under development. The feature is now ready for general use — this flips the default from `false` to `true` so it no longer requires explicit opt-in via the dashboard config CR.

  ## How Has This Been Tested?

  - Verified all references to `mlflowPipelines` across the codebase, only two defaults existed

  ## Test Impact

  No new tests needed. Existing Cypress tests already cover both `mlflowPipelines: true` and `mlflowPipelines: false` scenarios explicitly via mock overrides. The change only affects the default when no explicit value is provided.

  ## Request review criteria:

  Self checklist (all need to be checked):
  - [x] The developer has manually tested the changes and verified that the changes work
  - [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
  - [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
  - [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

  After the PR is posted & before it merges:
  - [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled MLflow Pipelines by default in development feature flags and the mock dashboard configuration.
* **Bug Fixes**
  * Improved pipeline failure handling for clearer messaging with gRPC-shaped errors and consistent rethrows for existing `Error` instances.
  * Added Run page validation to prevent navigation/tracking when the run identifier is missing.
* **Improvements**
  * More reliable MLflow experiment/run ID extraction by supporting both `mlflow` and `MLflow` plugin output casing.
* **Tests**
  * Expanded unit coverage for MLflow casing scenarios and updated Cypress pipeline mocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->