### PR TITLE
feat(RHOAIENG-74851): add admin settings link to MCP catalog empty state

### DIFF
--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/mcpCatalog/McpCatalogCoreLoader.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/mcpCatalog/McpCatalogCoreLoader.d.ts
@@ -1,3 +1,8 @@
 import * as React from 'react';
-declare const McpCatalogCoreLoader: React.FC;
+type McpCatalogCoreLoaderProps = {
+    customAction?: React.ReactNode;
+    customEmptyStateTitle?: string;
+    customEmptyStateDescription?: React.ReactNode;
+};
+declare const McpCatalogCoreLoader: React.FC<McpCatalogCoreLoaderProps>;
 export default McpCatalogCoreLoader;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/components/OdhMcpCatalogCoreLoader.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/components/OdhMcpCatalogCoreLoader.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+/**
+ * ODH-specific override of McpCatalogCoreLoader that includes admin user detection
+ * for showing the appropriate action link in empty states:
+ * - Admin users see "Go to MCP catalog sources" link
+ * - Non-admin users see "Who's my administrator" link
+ */
+declare const OdhMcpCatalogCoreLoader: React.FC;
+export default OdhMcpCatalogCoreLoader;

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/mcpCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/mcpCatalog.ts
@@ -78,6 +78,14 @@ class McpCatalog {
   findEmptyState() {
     return cy.findByTestId('empty-mcp-catalog-state');
   }
+
+  findEmptyStateTitle() {
+    return this.findEmptyState().find('.pf-v6-c-empty-state__title-text');
+  }
+
+  findEmptyStateWhosMyAdminLink() {
+    return this.findEmptyState().contains("Who's my administrator?");
+  }
 }
 
 class McpServerDetails {

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalog/mcpCatalog.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalog/mcpCatalog.cy.ts
@@ -73,7 +73,7 @@ describe('MCP Catalog Page', () => {
 });
 
 describe('MCP Catalog Empty State', () => {
-  it('should show empty state when no sources are configured', () => {
+  beforeEach(() => {
     cy.interceptApi(
       `GET /api/:apiVersion/model_catalog/sources`,
       {
@@ -93,8 +93,13 @@ describe('MCP Catalog Empty State', () => {
       { method: 'GET', pathname: MCP_FILTER_OPTIONS_PATH },
       mockModArchResponse(mockMcpCatalogFilterOptions()),
     );
+  });
+
+  it("should show non-admin empty state with Who's my administrator link when no sources are configured", () => {
     mcpCatalog.visit();
     mcpCatalog.findEmptyState().should('be.visible');
+    mcpCatalog.findEmptyStateTitle().should('contain.text', 'MCP catalog configuration required');
+    mcpCatalog.findEmptyStateWhosMyAdminLink().should('exist');
   });
 });
 

--- a/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalog/McpCatalogCoreLoader.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalog/McpCatalogCoreLoader.tsx
@@ -15,7 +15,17 @@ import { EmptyCatalogState } from '~/app/shared/components/catalog';
 import { hasSourcesWithModels } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { MCP_CATALOG_TITLE, MCP_CATALOG_DESCRIPTION } from '~/app/pages/mcpCatalog/const';
 
-const McpCatalogCoreLoader: React.FC = () => {
+type McpCatalogCoreLoaderProps = {
+  customAction?: React.ReactNode;
+  customEmptyStateTitle?: string;
+  customEmptyStateDescription?: React.ReactNode;
+};
+
+const McpCatalogCoreLoader: React.FC<McpCatalogCoreLoaderProps> = ({
+  customAction,
+  customEmptyStateTitle,
+  customEmptyStateDescription,
+}) => {
   const { catalogSources, catalogSourcesLoaded, catalogSourcesLoadError } =
     React.useContext(McpCatalogContext);
   const { isMUITheme } = useThemeContext();
@@ -70,16 +80,22 @@ const McpCatalogCoreLoader: React.FC = () => {
         emptyStatePage={
           <EmptyCatalogState
             testid="empty-mcp-catalog-state"
-            title="MCP catalog configuration required"
+            title={
+              customEmptyStateTitle ??
+              (isMUITheme ? 'Deploy an MCP catalog' : 'MCP catalog configuration required')
+            }
             description={
-              isMUITheme
+              customEmptyStateDescription ??
+              (isMUITheme
                 ? 'To discover MCP servers, follow the instructions in the docs below.'
-                : 'There are no MCP sources to display. Request that your administrator configure MCP sources for the catalog.'
+                : 'There are no MCP sources to display. Request that your administrator configure MCP sources for the catalog.')
             }
             headerIcon={() => (
               <img src={typedEmptyImage(ProjectObjectType.modelRegistrySettings)} alt="" />
             )}
-            primaryAction={isMUITheme ? <KubeflowDocs /> : <WhosMyAdministrator />}
+            primaryAction={
+              customAction ?? (isMUITheme ? <KubeflowDocs /> : <WhosMyAdministrator />)
+            }
           />
         }
         headerContent={null}

--- a/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalog/McpCatalogRoutes.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalog/McpCatalogRoutes.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { McpCatalogContextProvider } from '~/app/context/mcpCatalog/McpCatalogContext';
-import McpCatalogCoreLoader from './McpCatalogCoreLoader';
+import OdhMcpCatalogCoreLoader from '~/odh/components/OdhMcpCatalogCoreLoader';
 import McpCatalog from './screens/McpCatalog';
 import McpServerDetailsPage from './screens/McpServerDetailsPage';
 
 const McpCatalogRoutes: React.FC = () => (
   <McpCatalogContextProvider>
     <Routes>
-      <Route path="/*" element={<McpCatalogCoreLoader />}>
+      <Route path="/*" element={<OdhMcpCatalogCoreLoader />}>
         <Route index element={<McpCatalog />} />
         <Route path=":serverId" element={<McpServerDetailsPage />} />
         <Route path="*" element={<Navigate to="." />} />

--- a/packages/model-registry/upstream/frontend/src/odh/components/OdhMcpCatalogCoreLoader.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/OdhMcpCatalogCoreLoader.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Bullseye } from '@patternfly/react-core';
+import { useResolvedExtensions, useExtensions } from '@odh-dashboard/plugin-core';
+import McpCatalogCoreLoader from '~/app/pages/mcpCatalog/McpCatalogCoreLoader';
+import { isAdminCheckExtension, isMcpCatalogSettingsUrlExtension } from '~/odh/extension-points';
+import { mcpCatalogSettingsUrl } from '~/app/routes/mcpCatalogSettings/mcpCatalogSettings';
+
+const ADMIN_EMPTY_STATE_TITLE = 'Configure MCP sources';
+
+/**
+ * ODH-specific override of McpCatalogCoreLoader that includes admin user detection
+ * for showing the appropriate action link in empty states:
+ * - Admin users see "Go to MCP catalog sources" link
+ * - Non-admin users see "Who's my administrator" link
+ */
+const OdhMcpCatalogCoreLoader: React.FC = () => {
+  const [adminCheckExtensions, adminCheckExtensionsLoaded] =
+    useResolvedExtensions(isAdminCheckExtension);
+  const mcpCatalogSettingsUrlExtensions = useExtensions(isMcpCatalogSettingsUrlExtension);
+
+  const getMcpCatalogSettingsUrl = (): string => {
+    if (mcpCatalogSettingsUrlExtensions.length > 0) {
+      return mcpCatalogSettingsUrlExtensions[0].properties.url;
+    }
+    return mcpCatalogSettingsUrl();
+  };
+
+  const mcpCatalogSettingsTitle =
+    mcpCatalogSettingsUrlExtensions.length > 0
+      ? mcpCatalogSettingsUrlExtensions[0].properties.title
+      : '';
+
+  const adminEmptyStateDescription = (
+    <>
+      There are no MCP sources to display. To add MCP servers to the catalog, add MCP sources to the{' '}
+      <b>{mcpCatalogSettingsTitle}</b> page. If you&apos;ve already added sources, ensure that
+      filters are not restricting all servers from appearing in the catalog.
+    </>
+  );
+
+  const adminAction = (
+    <Link to={getMcpCatalogSettingsUrl()}>
+      Go to <b>{mcpCatalogSettingsTitle}</b>
+    </Link>
+  );
+
+  if (!adminCheckExtensionsLoaded) {
+    return <Bullseye>Loading...</Bullseye>;
+  }
+
+  if (adminCheckExtensions.length > 0) {
+    const AdminCheckComponent = adminCheckExtensions[0].properties.component.default;
+    return (
+      <AdminCheckComponent>
+        {(isAdmin: boolean, loaded: boolean) => {
+          if (!loaded) {
+            return <Bullseye>Loading...</Bullseye>;
+          }
+          if (isAdmin) {
+            return (
+              <McpCatalogCoreLoader
+                customAction={adminAction}
+                customEmptyStateTitle={ADMIN_EMPTY_STATE_TITLE}
+                customEmptyStateDescription={adminEmptyStateDescription}
+              />
+            );
+          }
+          return <McpCatalogCoreLoader />;
+        }}
+      </AdminCheckComponent>
+    );
+  }
+
+  return <McpCatalogCoreLoader />;
+};
+
+export default OdhMcpCatalogCoreLoader;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-74851

## Description

Updates the MCP catalog empty state to show an admin-specific "Go to **MCP catalog sources**" link for admin users, following the same pattern as the model catalog (`OdhModelCatalogCoreLoader`).

**Changes:**
- **`McpCatalogCoreLoader`** — Added optional props (`customAction`, `customEmptyStateTitle`, `customEmptyStateDescription`) to allow the ODH wrapper to override empty state content, matching `ModelCatalogCoreLoader`'s interface
- **`OdhMcpCatalogCoreLoader`** (new) — ODH-specific wrapper that uses the existing `isAdminCheckExtension` and `isMcpCatalogSettingsUrlExtension` extension points to:
  - Show "Go to **MCP catalog sources**" link for admins
  - Show "Who's my administrator?" popover for non-admins
- **`McpCatalogRoutes`** — Switched from `McpCatalogCoreLoader` to `OdhMcpCatalogCoreLoader`
- **Cypress tests** — Added page object helpers and a mocked test for the non-admin empty state

The infrastructure (extension point `mcp-catalog.settings/url`, `McpCatalogSettingsRoutesWrapper`, settings nav/route) was already merged on `main`.

<img width="1096" height="450" alt="Screenshot 2026-07-13 at 9 14 17 PM" src="https://github.com/user-attachments/assets/31fdce67-a76b-4088-8599-367e24b73b30" />
<img width="1126" height="419" alt="Screenshot 2026-07-13 at 9 34 24 PM" src="https://github.com/user-attachments/assets/a145a812-bcc1-48dc-b1db-c7de73293025" />


## How Has This Been Tested?

- Ran `npx eslint` on all changed files — passes
- Ran `npx tsc --noEmit` on model-registry package — passes
- Ran `npx jest` for MCP catalog tests — all 59 tests pass
- Verified the non-admin empty state Cypress test asserts correct title and "Who's my administrator?" link

## Test Impact

Added a Cypress mocked test for the non-admin MCP catalog empty state, verifying the title shows "MCP catalog configuration required" and the "Who's my administrator?" link is present. Admin-path testing requires the host-level admin check extension and is covered by host-level Cypress tests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)