### PR TITLE
feat: Add empty states for llm-d topology and routing configuration p…

### DIFF
--- a/packages/cypress/cypress/pages/llmdRoutingSettings.ts
+++ b/packages/cypress/cypress/pages/llmdRoutingSettings.ts
@@ -55,6 +55,14 @@ class LlmdRoutingSettingsPage {
     return cy.findByTestId('add-routing-config-button');
   }
 
+  findEmptyState() {
+    return cy.findByTestId('empty-routing-configurations');
+  }
+
+  findEmptyStateAddButton() {
+    return this.findEmptyState().findByTestId('add-routing-config-button');
+  }
+
   getRow(name: string) {
     return new RoutingConfigRow(
       () =>

--- a/packages/cypress/cypress/pages/llmdTopologySettings.ts
+++ b/packages/cypress/cypress/pages/llmdTopologySettings.ts
@@ -55,6 +55,22 @@ class LlmdTopologySettingsPage {
     return cy.findByTestId('add-topology-config-button');
   }
 
+  findEmptyState() {
+    return cy.findByTestId('empty-topology-configurations');
+  }
+
+  findEmptyStateAddButton() {
+    return this.findEmptyState().findByTestId('add-topology-config-button');
+  }
+
+  findEmptyStateDropdownToggle() {
+    return this.findEmptyState().findByTestId('add-topology-config-dropdown-toggle');
+  }
+
+  findEmptyStateDropdownItem(topologyType: string) {
+    return cy.findByTestId(`add-config-${topologyType}`);
+  }
+
   getRow(name: string) {
     return new TopologyConfigRow(
       () =>

--- a/packages/llmd-serving/src/settings/EmptyRoutingConfigurations.tsx
+++ b/packages/llmd-serving/src/settings/EmptyRoutingConfigurations.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { Button, EmptyState, EmptyStateBody, EmptyStateFooter } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
+
+const EmptyRoutingConfigurations: React.FC = () => (
+  <EmptyState
+    headingLevel="h2"
+    icon={PlusCircleIcon}
+    titleText="No llm-d routing configurations"
+    data-testid="empty-routing-configurations"
+  >
+    <EmptyStateBody>
+      Routing configurations define how inference traffic is scheduled and exposed when deploying
+      models with advanced routing. Add a configuration to make it available in the model serving
+      wizard.
+    </EmptyStateBody>
+    <EmptyStateFooter>
+      <Button
+        variant="primary"
+        data-testid="add-routing-config-button"
+        component={(props: React.ComponentProps<'a'>) => <Link {...props} to="add" />}
+      >
+        Add llm-d routing configuration
+      </Button>
+    </EmptyStateFooter>
+  </EmptyState>
+);
+
+export default EmptyRoutingConfigurations;

--- a/packages/llmd-serving/src/settings/EmptyTopologyConfigurations.tsx
+++ b/packages/llmd-serving/src/settings/EmptyTopologyConfigurations.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  MenuToggle,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { useNavigate } from 'react-router';
+import { TopologyType, TopologyTypeLabels } from '../types';
+
+const primaryTopologyType = TopologyType.SINGLE_NODE;
+const dropdownTopologyTypes = Object.values(TopologyType).filter((t) => t !== primaryTopologyType);
+
+const EmptyTopologyConfigurations: React.FC = () => {
+  const navigate = useNavigate();
+  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+
+  return (
+    <EmptyState
+      headingLevel="h2"
+      icon={PlusCircleIcon}
+      titleText="No llm-d topology configurations"
+      data-testid="empty-topology-configurations"
+    >
+      <EmptyStateBody>
+        Topology configurations define how llm-d workloads are composed for model serving. Add a
+        configuration to make it available in the model serving wizard.
+      </EmptyStateBody>
+      <EmptyStateFooter>
+        <Dropdown
+          isOpen={isDropdownOpen}
+          onOpenChange={setIsDropdownOpen}
+          toggle={(toggleRef) => (
+            <MenuToggle
+              ref={toggleRef}
+              variant="primary"
+              splitButtonItems={[
+                <Button
+                  key="primary-add"
+                  variant="primary"
+                  data-testid="add-topology-config-button"
+                  onClick={() => navigate(`add/${primaryTopologyType}`)}
+                >
+                  Add {TopologyTypeLabels[primaryTopologyType].toLowerCase()} configuration
+                </Button>,
+              ]}
+              aria-label="Add topology configuration"
+              onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+              data-testid="add-topology-config-dropdown-toggle"
+            />
+          )}
+        >
+          <DropdownList>
+            {dropdownTopologyTypes.map((tt) => (
+              <DropdownItem
+                key={tt}
+                data-testid={`add-config-${tt}`}
+                onClick={() => {
+                  setIsDropdownOpen(false);
+                  navigate(`add/${tt}`);
+                }}
+              >
+                Add {TopologyTypeLabels[tt].toLowerCase()} configuration
+              </DropdownItem>
+            ))}
+          </DropdownList>
+        </Dropdown>
+      </EmptyStateFooter>
+    </EmptyState>
+  );
+};
+
+export default EmptyTopologyConfigurations;

--- a/packages/llmd-serving/src/settings/RoutingConfigurationsView.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationsView.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import RoutingConfigurationsTable from './RoutingConfigurationsTable';
+import EmptyRoutingConfigurations from './EmptyRoutingConfigurations';
 import { useWatchRouterConfigs } from '../api/LLMInferenceServiceConfigs';
 
 const RoutingConfigurationsView: React.FC = () => {
@@ -16,6 +17,7 @@ const RoutingConfigurationsView: React.FC = () => {
       loaded={loaded}
       loadError={error}
       empty={loaded && configs.length === 0}
+      emptyStatePage={<EmptyRoutingConfigurations />}
       provideChildrenPadding
     >
       <RoutingConfigurationsTable configs={configs} />

--- a/packages/llmd-serving/src/settings/TopologyConfigurationsView.tsx
+++ b/packages/llmd-serving/src/settings/TopologyConfigurationsView.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import TopologyConfigurationsTable from './TopologyConfigurationsTable';
+import EmptyTopologyConfigurations from './EmptyTopologyConfigurations';
 import { useWatchTopologyConfigs } from '../api/LLMInferenceServiceConfigs';
 
 const TopologyConfigurationsView: React.FC = () => {
@@ -16,6 +17,7 @@ const TopologyConfigurationsView: React.FC = () => {
       loaded={loaded}
       loadError={error}
       empty={loaded && configs.length === 0}
+      emptyStatePage={<EmptyTopologyConfigurations />}
       provideChildrenPadding
     >
       <TopologyConfigurationsTable configs={configs} />

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
@@ -100,6 +100,26 @@ describe('LLMD Routing Admin Settings', () => {
     });
   });
 
+  describe('empty state', () => {
+    it('should show empty state when no routing configurations exist', () => {
+      initIntercepts({ configs: [] });
+      llmdRoutingSettingsPage.visit(false);
+      llmdRoutingSettingsPage.findAppTitle().should('contain', 'llm-d routing configurations');
+      llmdRoutingSettingsPage.findEmptyState().should('exist');
+      llmdRoutingSettingsPage
+        .findEmptyState()
+        .should('contain.text', 'No llm-d routing configurations');
+      llmdRoutingSettingsPage.findEmptyStateAddButton().should('exist');
+    });
+
+    it('should navigate to add page from empty state button', () => {
+      initIntercepts({ configs: [] });
+      llmdRoutingSettingsPage.visit(false);
+      llmdRoutingSettingsPage.findEmptyStateAddButton().click();
+      cy.url().should('include', '/add');
+    });
+  });
+
   describe('configurations table', () => {
     beforeEach(() => {
       initIntercepts();

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopologyAdmin.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopologyAdmin.cy.ts
@@ -80,6 +80,42 @@ describe('LLMD Topology Admin Settings', () => {
     });
   });
 
+  describe('empty state', () => {
+    it('should show empty state when no topology configurations exist', () => {
+      initIntercepts({ configs: [] });
+      llmdTopologySettingsPage.visit(false);
+      llmdTopologySettingsPage.findAppTitle().should('contain', 'llm-d topology configurations');
+      llmdTopologySettingsPage.findEmptyState().should('exist');
+      llmdTopologySettingsPage
+        .findEmptyState()
+        .should('contain.text', 'No llm-d topology configurations');
+      llmdTopologySettingsPage.findEmptyStateAddButton().should('exist');
+      llmdTopologySettingsPage.findEmptyStateDropdownToggle().should('exist');
+    });
+
+    it('should navigate to add page from empty state button', () => {
+      initIntercepts({ configs: [] });
+      llmdTopologySettingsPage.visit(false);
+      llmdTopologySettingsPage.findEmptyStateAddButton().click();
+      cy.url().should('include', '/add/workload-single-node');
+    });
+
+    it('should show dropdown with other topology types in empty state', () => {
+      initIntercepts({ configs: [] });
+      llmdTopologySettingsPage.visit(false);
+      llmdTopologySettingsPage.findEmptyStateDropdownToggle().click();
+      llmdTopologySettingsPage
+        .findEmptyStateDropdownItem('workload-multi-node-data-parallel')
+        .should('exist');
+      llmdTopologySettingsPage
+        .findEmptyStateDropdownItem('workload-single-node-pd')
+        .should('exist');
+      llmdTopologySettingsPage
+        .findEmptyStateDropdownItem('workload-multi-node-data-parallel-pd')
+        .should('exist');
+    });
+  });
+
   describe('configurations table', () => {
     beforeEach(() => {
       initIntercepts();


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

<!-- TODO: Add JIRA link if applicable -->

## Description

Adds custom empty state components for the llm-d topology configurations and routing configurations settings pages. Previously, when no `LLMInferenceServiceConfig` resources existed on the cluster, these pages displayed a generic "No Components Found" fallback from `ApplicationsPage`. Now they show purpose-built empty states with:

- **Topology configurations**: A `PlusCircleIcon` empty state with descriptive text explaining what topology configurations are, and a split button dropdown to add a configuration (defaulting to single node, with other topology types in the dropdown).
- **Routing configurations**: A `PlusCircleIcon` empty state with descriptive text explaining what routing configurations are, and a primary button to add a new routing configuration.

Both components follow the existing `EmptyCustomServingRuntime` pattern and use PatternFly `EmptyState` / `EmptyStateFooter` with `Link` for accessible navigation.

## How Has This Been Tested?

- Manually verified on a running ODH Dashboard dev server by temporarily forcing `empty={true}` on both view components to confirm the empty states render correctly with proper layout, text, and button behavior.
<img width="1408" height="711" alt="Screenshot 2026-07-13 at 3 04 40 PM" src="https://github.com/user-attachments/assets/46e8e381-ed9d-4208-903b-63f9dabf5ef7" />
<img width="1395" height="695" alt="Screenshot 2026-07-13 at 3 04 46 PM" src="https://github.com/user-attachments/assets/60f5d49a-05a0-4471-b76a-59ee1f777560" />

 
- Lint (`eslint`) and type-check (`tsc --noEmit`) pass on all changed files.
- New Cypress mock tests validate the empty states with `configs: []` intercepts.

## Test Impact

Added 5 new Cypress mock test cases across 2 test files:

- `modelServingLlmdTopologyAdmin.cy.ts` — 3 tests: empty state rendering, add button navigation, dropdown items
- `modelServingLlmdRoutingAdmin.cy.ts` — 2 tests: empty state rendering, add button navigation

Updated 2 Cypress page objects with new methods for empty state element selectors.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`