### PR TITLE
feat(agent-ops): Add lifecycle quick actions to Agent Deployments list

### DIFF
--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
@@ -32,6 +32,19 @@ class AgentDeploymentTableRow extends TableRow {
   findDeleteAction(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findKebabAction('Delete');
   }
+
+  findKebab(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByRole('button', { name: /^Actions for .+ in .+$/ });
+  }
+
+  findKebabAction(name: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findKebab().then(($el) => {
+      if ($el.attr('aria-expanded') === 'false') {
+        cy.wrap($el).click();
+      }
+      return cy.get('body').findByRole('menuitem', { name });
+    });
+  }
 }
 
 class AgentDeploymentsPage {

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
@@ -119,8 +119,20 @@ class AgentDeploymentsPage {
     return cy.findByTestId('agent-runtime-endpoints-modal');
   }
 
-  findEndpointsEmptyState(): Cypress.Chainable<JQuery<HTMLElement>> {
+findEndpointsEmptyState(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findEndpointsModal().findByTestId('agent-runtime-endpoints-empty');
+  }
+
+  findDeleteModal(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-delete-modal');
+  }
+
+  findDeleteModalConfirm(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-delete-modal-confirm');
+  }
+
+  findDeleteModalCancel(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-delete-modal-cancel');
   }
 
   findEndpointField(fieldId: string): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/pages/agentDeployments.ts
@@ -141,11 +141,11 @@ findEndpointsEmptyState(): Cypress.Chainable<JQuery<HTMLElement>> {
   }
 
   findDeleteModalConfirm(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('agent-delete-modal-confirm');
+    return this.findDeleteModal().findByRole('button', { name: 'Delete' });
   }
 
   findDeleteModalCancel(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('agent-delete-modal-cancel');
+    return this.findDeleteModal().findByRole('button', { name: 'Cancel' });
   }
 
   findEndpointField(fieldId: string): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
@@ -127,11 +127,11 @@ describe('Agent Deployments', () => {
 
     const pendingRow = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'pending-agent');
     pendingRow.findStatusLabel().should('contain.text', 'Pending');
-    pendingRow.findEndpointViewButton().should('exist').and('not.be.disabled');
+    pendingRow.findEndpointViewButton().should('exist').and('be.disabled');
 
     const failedRow = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'failed-agent');
     failedRow.findStatusLabel().should('contain.text', 'Failed');
-    failedRow.findEndpointViewButton().should('exist').and('not.be.disabled');
+    failedRow.findEndpointViewButton().should('exist').and('be.disabled');
 
     const stoppedRow = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'sample-tool');
     stoppedRow.findStatusLabel().should('contain.text', 'Stopped');

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
@@ -359,4 +359,138 @@ describe('Agent Deployments', () => {
     row.findKebab().click();
     row.findViewDetailsAction().should('be.visible');
   });
+
+  it('should stop a ready deployment from the row kebab menu', () => {
+    const runtimes = mockAllRuntimes();
+
+    initIntercepts({ runtimes });
+    cy.intercept(
+      {
+        method: 'POST',
+        pathname: `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes/${TEST_NAMESPACE}/sample-support-agent/stop`,
+      },
+      {
+        statusCode: 200,
+        body: {
+          data: {
+            success: true,
+            name: 'sample-support-agent',
+            namespace: TEST_NAMESPACE,
+            action: 'stop',
+            message: 'Agent stop completed successfully',
+          },
+        },
+      },
+    ).as('stopAgent');
+
+    cy.intercept('GET', `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes*`, (req) => {
+      req.reply({
+        body: {
+          data: mockAgentRuntimesList(
+            runtimes.map((runtime) =>
+              runtime.name === 'sample-support-agent' ? { ...runtime, status: 'Stopped' } : runtime,
+            ),
+          ),
+        },
+      });
+    }).as('getAgentRuntimesAfterStop');
+
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+
+    const row = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'sample-support-agent');
+    row.findKebab().click();
+    row.findStopAction().click();
+    cy.wait('@stopAgent');
+    cy.wait('@getAgentRuntimesAfterStop');
+    row.findStatusLabel().should('contain.text', 'Stopped');
+  });
+
+  it('should restart a stopped deployment from the row kebab menu', () => {
+    const runtimes = mockAllRuntimes();
+
+    initIntercepts({ runtimes });
+    cy.intercept(
+      {
+        method: 'POST',
+        pathname: `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes/${TEST_NAMESPACE}/sample-tool/start`,
+      },
+      {
+        statusCode: 200,
+        body: {
+          data: {
+            success: true,
+            name: 'sample-tool',
+            namespace: TEST_NAMESPACE,
+            action: 'start',
+            message: 'Agent start completed successfully',
+          },
+        },
+      },
+    ).as('startAgent');
+
+    cy.intercept('GET', `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes*`, (req) => {
+      req.reply({
+        body: {
+          data: mockAgentRuntimesList(
+            runtimes.map((runtime) =>
+              runtime.name === 'sample-tool' ? { ...runtime, status: 'Ready' } : runtime,
+            ),
+          ),
+        },
+      });
+    }).as('getAgentRuntimesAfterStart');
+
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+
+    const row = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'sample-tool');
+    row.findKebab().click();
+    row.findRestartAction().click();
+    cy.wait('@startAgent');
+    cy.wait('@getAgentRuntimesAfterStart');
+    row.findStatusLabel().should('contain.text', 'Ready');
+  });
+
+  it('should open delete confirmation modal and delete a deployment on confirm', () => {
+    let runtimes = mockAllRuntimes();
+
+    initIntercepts({ runtimes });
+    cy.intercept(
+      {
+        method: 'DELETE',
+        pathname: `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes/${TEST_NAMESPACE}/failed-agent`,
+      },
+      { statusCode: 204 },
+    ).as('deleteAgent');
+
+    cy.intercept('GET', `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes*`, (req) => {
+      runtimes = runtimes.filter((runtime) => runtime.name !== 'failed-agent');
+      req.reply({ body: { data: mockAgentRuntimesList(runtimes) } });
+    }).as('getAgentRuntimesAfterDelete');
+
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+
+    const row = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'failed-agent');
+    row.findKebab().click();
+    row.findDeleteAction().click();
+    agentDeploymentsPage.findDeleteModal().should('be.visible');
+    agentDeploymentsPage.findDeleteModal().should('contain.text', 'failed-agent');
+    agentDeploymentsPage.findDeleteModalConfirm().click();
+    cy.wait('@deleteAgent');
+    cy.wait('@getAgentRuntimesAfterDelete');
+    agentDeploymentsPage.findTableRows().should('have.length', 3);
+    cy.findByTestId(`agent-runtime-row-${TEST_NAMESPACE}-failed-agent`).should('not.exist');
+  });
+
+  it('should not delete a deployment when Cancel is clicked in the delete modal', () => {
+    initIntercepts();
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+
+    const row = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'failed-agent');
+    row.findKebab().click();
+    row.findDeleteAction().click();
+    agentDeploymentsPage.findDeleteModal().should('be.visible');
+    agentDeploymentsPage.findDeleteModalCancel().click();
+    agentDeploymentsPage.findDeleteModal().should('not.exist');
+    agentDeploymentsPage.findTableRows().should('have.length', 4);
+  });
 });

--- a/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
+++ b/packages/agent-ops/frontend/src/__tests__/cypress/cypress/tests/mocked/agentDeployments/agentDeployments.cy.ts
@@ -383,6 +383,9 @@ describe('Agent Deployments', () => {
       },
     ).as('stopAgent');
 
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+    cy.wait('@getAgentRuntimes');
+
     cy.intercept('GET', `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes*`, (req) => {
       req.reply({
         body: {
@@ -394,8 +397,6 @@ describe('Agent Deployments', () => {
         },
       });
     }).as('getAgentRuntimesAfterStop');
-
-    agentDeploymentsPage.visit(TEST_NAMESPACE);
 
     const row = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'sample-support-agent');
     row.findKebab().click();
@@ -428,6 +429,9 @@ describe('Agent Deployments', () => {
       },
     ).as('startAgent');
 
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+    cy.wait('@getAgentRuntimes');
+
     cy.intercept('GET', `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes*`, (req) => {
       req.reply({
         body: {
@@ -439,8 +443,6 @@ describe('Agent Deployments', () => {
         },
       });
     }).as('getAgentRuntimesAfterStart');
-
-    agentDeploymentsPage.visit(TEST_NAMESPACE);
 
     const row = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'sample-tool');
     row.findKebab().click();
@@ -462,12 +464,13 @@ describe('Agent Deployments', () => {
       { statusCode: 204 },
     ).as('deleteAgent');
 
+    agentDeploymentsPage.visit(TEST_NAMESPACE);
+    cy.wait('@getAgentRuntimes');
+
     cy.intercept('GET', `/agent-ops/api/${CLIENT_API_VERSION}/agents/runtimes*`, (req) => {
       runtimes = runtimes.filter((runtime) => runtime.name !== 'failed-agent');
       req.reply({ body: { data: mockAgentRuntimesList(runtimes) } });
     }).as('getAgentRuntimesAfterDelete');
-
-    agentDeploymentsPage.visit(TEST_NAMESPACE);
 
     const row = agentDeploymentsPage.getRow(TEST_NAMESPACE, 'failed-agent');
     row.findKebab().click();

--- a/packages/agent-ops/frontend/src/app/api/__tests__/agentLifecycle.spec.ts
+++ b/packages/agent-ops/frontend/src/app/api/__tests__/agentLifecycle.spec.ts
@@ -67,6 +67,21 @@ describe('agentLifecycle', () => {
 
       await expect(stopAgent('')({}, lifecycleParams)).rejects.toThrow('Agent is not running');
     });
+
+    it('throws when the BFF returns the wrong action', async () => {
+      mockRestCREATE.mockResolvedValue({
+        data: {
+          success: true,
+          name: 'sample-support-agent',
+          namespace: 'agent-ops-demo',
+          action: 'start',
+          message: 'Agent start completed successfully',
+        },
+      });
+      mockIsModArchResponse.mockReturnValue(true);
+
+      await expect(stopAgent('')({}, lifecycleParams)).rejects.toThrow('Invalid response format');
+    });
   });
 
   describe('startAgent', () => {
@@ -107,6 +122,21 @@ describe('agentLifecycle', () => {
       mockIsModArchResponse.mockReturnValue(true);
 
       await expect(startAgent('')({}, lifecycleParams)).rejects.toThrow('Agent already running');
+    });
+
+    it('throws when the BFF returns the wrong action', async () => {
+      mockRestCREATE.mockResolvedValue({
+        data: {
+          success: true,
+          name: 'sample-support-agent',
+          namespace: 'agent-ops-demo',
+          action: 'stop',
+          message: 'Agent stop completed successfully',
+        },
+      });
+      mockIsModArchResponse.mockReturnValue(true);
+
+      await expect(startAgent('')({}, lifecycleParams)).rejects.toThrow('Invalid response format');
     });
   });
 

--- a/packages/agent-ops/frontend/src/app/api/__tests__/agentLifecycle.spec.ts
+++ b/packages/agent-ops/frontend/src/app/api/__tests__/agentLifecycle.spec.ts
@@ -1,0 +1,128 @@
+import { handleRestFailures, isModArchResponse, restCREATE, restDELETE } from 'mod-arch-core';
+import { deleteAgent, startAgent, stopAgent } from '~/app/api/agentLifecycle';
+
+jest.mock('~/app/utilities/const', () => ({
+  URL_PREFIX: '/agent-ops',
+  BFF_API_VERSION: 'v1',
+}));
+
+jest.mock('mod-arch-core', () => ({
+  handleRestFailures: jest.fn((promise: Promise<unknown>) => promise),
+  restCREATE: jest.fn(),
+  restDELETE: jest.fn(),
+  isModArchResponse: jest.fn(),
+}));
+
+const mockRestCREATE = jest.mocked(restCREATE);
+const mockRestDELETE = jest.mocked(restDELETE);
+const mockIsModArchResponse = jest.mocked(isModArchResponse);
+
+const lifecycleParams = {
+  namespace: 'agent-ops-demo',
+  name: 'sample-support-agent',
+};
+
+describe('agentLifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(handleRestFailures).mockImplementation((promise: Promise<unknown>) => promise);
+  });
+
+  describe('stopAgent', () => {
+    it('posts to the stop lifecycle endpoint', async () => {
+      mockRestCREATE.mockResolvedValue({
+        data: {
+          success: true,
+          name: 'sample-support-agent',
+          namespace: 'agent-ops-demo',
+          action: 'stop',
+          message: 'Agent stop completed successfully',
+        },
+      });
+      mockIsModArchResponse.mockReturnValue(true);
+
+      const result = await stopAgent('')({}, lifecycleParams);
+
+      expect(mockRestCREATE).toHaveBeenCalledWith(
+        '',
+        '/agent-ops/api/v1/agents/runtimes/agent-ops-demo/sample-support-agent/stop',
+        {},
+        {},
+        {},
+      );
+      expect(result.action).toBe('stop');
+    });
+
+    it('throws when the BFF returns success: false', async () => {
+      mockRestCREATE.mockResolvedValue({
+        data: {
+          success: false,
+          name: 'sample-support-agent',
+          namespace: 'agent-ops-demo',
+          action: 'stop',
+          message: 'Agent is not running',
+        },
+      });
+      mockIsModArchResponse.mockReturnValue(true);
+
+      await expect(stopAgent('')({}, lifecycleParams)).rejects.toThrow('Agent is not running');
+    });
+  });
+
+  describe('startAgent', () => {
+    it('posts to the start lifecycle endpoint', async () => {
+      mockRestCREATE.mockResolvedValue({
+        data: {
+          success: true,
+          name: 'sample-support-agent',
+          namespace: 'agent-ops-demo',
+          action: 'start',
+          message: 'Agent start completed successfully',
+        },
+      });
+      mockIsModArchResponse.mockReturnValue(true);
+
+      const result = await startAgent('')({}, lifecycleParams);
+
+      expect(mockRestCREATE).toHaveBeenCalledWith(
+        '',
+        '/agent-ops/api/v1/agents/runtimes/agent-ops-demo/sample-support-agent/start',
+        {},
+        {},
+        {},
+      );
+      expect(result.action).toBe('start');
+    });
+
+    it('throws when the BFF returns success: false', async () => {
+      mockRestCREATE.mockResolvedValue({
+        data: {
+          success: false,
+          name: 'sample-support-agent',
+          namespace: 'agent-ops-demo',
+          action: 'start',
+          message: 'Agent already running',
+        },
+      });
+      mockIsModArchResponse.mockReturnValue(true);
+
+      await expect(startAgent('')({}, lifecycleParams)).rejects.toThrow('Agent already running');
+    });
+  });
+
+  describe('deleteAgent', () => {
+    it('deletes the agent runtime without parsing an empty 204 body', async () => {
+      mockRestDELETE.mockResolvedValue(undefined);
+
+      await deleteAgent('')({}, lifecycleParams);
+
+      expect(mockRestDELETE).toHaveBeenCalledWith(
+        '',
+        '/agent-ops/api/v1/agents/runtimes/agent-ops-demo/sample-support-agent',
+        {},
+        {},
+        { parseJSON: false },
+      );
+    });
+  });
+});

--- a/packages/agent-ops/frontend/src/app/api/agentLifecycle.ts
+++ b/packages/agent-ops/frontend/src/app/api/agentLifecycle.ts
@@ -42,13 +42,17 @@ export const stopAgent =
         opts,
       ),
     ).then((response) => {
-      if (isModArchResponse<unknown>(response) && isLifecycleResult(response.data)) {
-        if (!response.data.success) {
-          throw new Error(response.data.message || 'Stop operation failed');
-        }
-        return response.data;
+      if (
+        !isModArchResponse<unknown>(response) ||
+        !isLifecycleResult(response.data) ||
+        response.data.action !== 'stop'
+      ) {
+        throw new Error('Invalid response format');
       }
-      throw new Error('Invalid response format');
+      if (!response.data.success) {
+        throw new Error(response.data.message || 'Stop operation failed');
+      }
+      return response.data;
     });
 
 export const startAgent =
@@ -63,13 +67,17 @@ export const startAgent =
         opts,
       ),
     ).then((response) => {
-      if (isModArchResponse<unknown>(response) && isLifecycleResult(response.data)) {
-        if (!response.data.success) {
-          throw new Error(response.data.message || 'Start operation failed');
-        }
-        return response.data;
+      if (
+        !isModArchResponse<unknown>(response) ||
+        !isLifecycleResult(response.data) ||
+        response.data.action !== 'start'
+      ) {
+        throw new Error('Invalid response format');
       }
-      throw new Error('Invalid response format');
+      if (!response.data.success) {
+        throw new Error(response.data.message || 'Start operation failed');
+      }
+      return response.data;
     });
 
 export const deleteAgent =

--- a/packages/agent-ops/frontend/src/app/api/agentLifecycle.ts
+++ b/packages/agent-ops/frontend/src/app/api/agentLifecycle.ts
@@ -1,0 +1,90 @@
+import {
+  APIOptions,
+  handleRestFailures,
+  isModArchResponse,
+  restCREATE,
+  restDELETE,
+} from 'mod-arch-core';
+import { BFF_API_VERSION, URL_PREFIX } from '~/app/utilities/const';
+import type { AgentLifecycleParams, LifecycleResult } from '~/app/types/agentLifecycle';
+
+const isUnknownRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isLifecycleResult = (value: unknown): value is LifecycleResult => {
+  if (!isUnknownRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.success === 'boolean' &&
+    typeof value.name === 'string' &&
+    value.name.length > 0 &&
+    typeof value.namespace === 'string' &&
+    value.namespace.length > 0 &&
+    (value.action === 'stop' || value.action === 'start') &&
+    typeof value.message === 'string'
+  );
+};
+
+const agentRuntimeLifecyclePath = (namespace: string, name: string): string =>
+  `${URL_PREFIX}/api/${BFF_API_VERSION}/agents/runtimes/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`;
+
+export const stopAgent =
+  (hostPath = '') =>
+  (opts: APIOptions, params: AgentLifecycleParams): Promise<LifecycleResult> =>
+    handleRestFailures(
+      restCREATE(
+        hostPath,
+        `${agentRuntimeLifecyclePath(params.namespace, params.name)}/stop`,
+        {},
+        {},
+        opts,
+      ),
+    ).then((response) => {
+      if (isModArchResponse<unknown>(response) && isLifecycleResult(response.data)) {
+        if (!response.data.success) {
+          throw new Error(response.data.message || 'Stop operation failed');
+        }
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });
+
+export const startAgent =
+  (hostPath = '') =>
+  (opts: APIOptions, params: AgentLifecycleParams): Promise<LifecycleResult> =>
+    handleRestFailures(
+      restCREATE(
+        hostPath,
+        `${agentRuntimeLifecyclePath(params.namespace, params.name)}/start`,
+        {},
+        {},
+        opts,
+      ),
+    ).then((response) => {
+      if (isModArchResponse<unknown>(response) && isLifecycleResult(response.data)) {
+        if (!response.data.success) {
+          throw new Error(response.data.message || 'Start operation failed');
+        }
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });
+
+export const deleteAgent =
+  (hostPath = '') =>
+  (opts: APIOptions, params: AgentLifecycleParams): Promise<void> =>
+    handleRestFailures(
+      restDELETE(
+        hostPath,
+        agentRuntimeLifecyclePath(params.namespace, params.name),
+        {},
+        {},
+        {
+          ...opts,
+          // BFF returns 204 No Content with an empty body.
+          parseJSON: false,
+        },
+      ),
+    ).then(() => undefined);

--- a/packages/agent-ops/frontend/src/app/components/AgentDeleteModal.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentDeleteModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
+import DeleteModal from '@odh-dashboard/internal/pages/projects/components/DeleteModal';
 
 type AgentDeleteModalProps = {
   agentName: string;
@@ -13,54 +13,18 @@ const AgentDeleteModal: React.FC<AgentDeleteModalProps> = ({
   isDeleting,
   onConfirm,
   onCancel,
-}) => {
-  const titleId = React.useId();
-  const bodyId = React.useId();
-
-  return (
-    <Modal
-      variant="small"
-      isOpen
-      onClose={() => {
-        if (!isDeleting) {
-          onCancel();
-        }
-      }}
-      aria-labelledby={titleId}
-      aria-describedby={bodyId}
-      data-testid="agent-delete-modal"
-    >
-      <ModalHeader
-        title="Delete agent deployment?"
-        labelId={titleId}
-        titleIconVariant="warning"
-      />
-      <ModalBody>
-        <p id={bodyId}>
-          Are you sure you want to delete <strong>{agentName}</strong>? This action cannot be undone.
-        </p>
-      </ModalBody>
-      <ModalFooter>
-        <Button
-          variant="danger"
-          isLoading={isDeleting}
-          isDisabled={isDeleting}
-          onClick={onConfirm}
-          data-testid="agent-delete-modal-confirm"
-        >
-          Delete
-        </Button>
-        <Button
-          variant="link"
-          isDisabled={isDeleting}
-          onClick={onCancel}
-          data-testid="agent-delete-modal-cancel"
-        >
-          Cancel
-        </Button>
-      </ModalFooter>
-    </Modal>
-  );
-};
+}) => (
+  <DeleteModal
+    title="Delete agent deployment?"
+    onClose={onCancel}
+    onDelete={onConfirm}
+    deleteName={agentName}
+    deleting={isDeleting}
+    removeConfirmation
+    testId="agent-delete-modal"
+  >
+    Are you sure you want to delete <strong>{agentName}</strong>? This action cannot be undone.
+  </DeleteModal>
+);
 
 export default AgentDeleteModal;

--- a/packages/agent-ops/frontend/src/app/components/AgentDeleteModal.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentDeleteModal.tsx
@@ -17,7 +17,11 @@ const AgentDeleteModal: React.FC<AgentDeleteModalProps> = ({
   <Modal
     variant="small"
     isOpen
-    onClose={onCancel}
+    onClose={() => {
+      if (!isDeleting) {
+        onCancel();
+      }
+    }}
     aria-labelledby="delete-agent-modal-title"
     aria-describedby="delete-agent-modal-body"
     data-testid="agent-delete-modal"

--- a/packages/agent-ops/frontend/src/app/components/AgentDeleteModal.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentDeleteModal.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
+
+type AgentDeleteModalProps = {
+  agentName: string;
+  isDeleting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+const AgentDeleteModal: React.FC<AgentDeleteModalProps> = ({
+  agentName,
+  isDeleting,
+  onConfirm,
+  onCancel,
+}) => (
+  <Modal
+    variant="small"
+    isOpen
+    onClose={onCancel}
+    aria-labelledby="delete-agent-modal-title"
+    aria-describedby="delete-agent-modal-body"
+    data-testid="agent-delete-modal"
+  >
+    <ModalHeader
+      title="Delete agent deployment?"
+      labelId="delete-agent-modal-title"
+      titleIconVariant="warning"
+    />
+    <ModalBody>
+      <p id="delete-agent-modal-body">
+        Are you sure you want to delete <strong>{agentName}</strong>? This action cannot be undone.
+      </p>
+    </ModalBody>
+    <ModalFooter>
+      <Button
+        variant="danger"
+        isLoading={isDeleting}
+        isDisabled={isDeleting}
+        onClick={onConfirm}
+        data-testid="agent-delete-modal-confirm"
+      >
+        Delete
+      </Button>
+      <Button
+        variant="link"
+        isDisabled={isDeleting}
+        onClick={onCancel}
+        data-testid="agent-delete-modal-cancel"
+      >
+        Cancel
+      </Button>
+    </ModalFooter>
+  </Modal>
+);
+
+export default AgentDeleteModal;

--- a/packages/agent-ops/frontend/src/app/components/AgentDeleteModal.tsx
+++ b/packages/agent-ops/frontend/src/app/components/AgentDeleteModal.tsx
@@ -13,49 +13,54 @@ const AgentDeleteModal: React.FC<AgentDeleteModalProps> = ({
   isDeleting,
   onConfirm,
   onCancel,
-}) => (
-  <Modal
-    variant="small"
-    isOpen
-    onClose={() => {
-      if (!isDeleting) {
-        onCancel();
-      }
-    }}
-    aria-labelledby="delete-agent-modal-title"
-    aria-describedby="delete-agent-modal-body"
-    data-testid="agent-delete-modal"
-  >
-    <ModalHeader
-      title="Delete agent deployment?"
-      labelId="delete-agent-modal-title"
-      titleIconVariant="warning"
-    />
-    <ModalBody>
-      <p id="delete-agent-modal-body">
-        Are you sure you want to delete <strong>{agentName}</strong>? This action cannot be undone.
-      </p>
-    </ModalBody>
-    <ModalFooter>
-      <Button
-        variant="danger"
-        isLoading={isDeleting}
-        isDisabled={isDeleting}
-        onClick={onConfirm}
-        data-testid="agent-delete-modal-confirm"
-      >
-        Delete
-      </Button>
-      <Button
-        variant="link"
-        isDisabled={isDeleting}
-        onClick={onCancel}
-        data-testid="agent-delete-modal-cancel"
-      >
-        Cancel
-      </Button>
-    </ModalFooter>
-  </Modal>
-);
+}) => {
+  const titleId = React.useId();
+  const bodyId = React.useId();
+
+  return (
+    <Modal
+      variant="small"
+      isOpen
+      onClose={() => {
+        if (!isDeleting) {
+          onCancel();
+        }
+      }}
+      aria-labelledby={titleId}
+      aria-describedby={bodyId}
+      data-testid="agent-delete-modal"
+    >
+      <ModalHeader
+        title="Delete agent deployment?"
+        labelId={titleId}
+        titleIconVariant="warning"
+      />
+      <ModalBody>
+        <p id={bodyId}>
+          Are you sure you want to delete <strong>{agentName}</strong>? This action cannot be undone.
+        </p>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="danger"
+          isLoading={isDeleting}
+          isDisabled={isDeleting}
+          onClick={onConfirm}
+          data-testid="agent-delete-modal-confirm"
+        >
+          Delete
+        </Button>
+        <Button
+          variant="link"
+          isDisabled={isDeleting}
+          onClick={onCancel}
+          data-testid="agent-delete-modal-cancel"
+        >
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
 
 export default AgentDeleteModal;

--- a/packages/agent-ops/frontend/src/app/hooks/__tests__/useAgentLifecycleActions.spec.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/__tests__/useAgentLifecycleActions.spec.ts
@@ -49,7 +49,247 @@ describe('useAgentLifecycleActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDeleteAgent.mockResolvedValue(undefined);
+    mockStartAgent.mockResolvedValue(undefined);
+    mockStopAgent.mockResolvedValue(undefined);
     mockOnRefresh.mockResolvedValue(undefined);
+  });
+
+  describe('handleStop', () => {
+    it('should show stop error when stop mutation fails', async () => {
+      mockStopAgent.mockRejectedValue(new Error('Stop failed'));
+
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        await result.current.handleStop();
+      });
+
+      expect(mockStopAgent).toHaveBeenCalledWith(
+        {},
+        { namespace: runtime.namespace, name: runtime.name },
+      );
+      expect(mockError).toHaveBeenCalledWith('Failed to stop agent deployment', 'Stop failed');
+      expect(mockSuccess).not.toHaveBeenCalled();
+      expect(mockOnRefresh).not.toHaveBeenCalled();
+    });
+
+    it('should resolve after successful stop even when refresh fails', async () => {
+      mockOnRefresh.mockRejectedValue(new Error('Refresh failed'));
+
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        await result.current.handleStop();
+      });
+
+      expect(mockStopAgent).toHaveBeenCalledWith(
+        {},
+        { namespace: runtime.namespace, name: runtime.name },
+      );
+      expect(mockSuccess).toHaveBeenCalledWith(
+        'Agent deployment stopped',
+        `${runtime.name} has been stopped.`,
+      );
+      expect(mockError).toHaveBeenCalledWith(
+        'Failed to refresh agent deployment list',
+        'Refresh failed',
+      );
+      expect(mockOnRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('should resolve after successful stop and refresh', async () => {
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        await result.current.handleStop();
+      });
+
+      expect(mockSuccess).toHaveBeenCalledWith(
+        'Agent deployment stopped',
+        `${runtime.name} has been stopped.`,
+      );
+      expect(mockError).not.toHaveBeenCalled();
+      expect(mockOnRefresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleRestart', () => {
+    it('should show restart error when start mutation fails', async () => {
+      mockStartAgent.mockRejectedValue(new Error('Start failed'));
+
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        await result.current.handleRestart();
+      });
+
+      expect(mockStopAgent).toHaveBeenCalledWith(
+        {},
+        { namespace: runtime.namespace, name: runtime.name },
+      );
+      expect(mockStartAgent).toHaveBeenCalledWith(
+        {},
+        { namespace: runtime.namespace, name: runtime.name },
+      );
+      expect(mockError).toHaveBeenCalledWith('Failed to restart agent deployment', 'Start failed');
+      expect(mockSuccess).not.toHaveBeenCalled();
+      expect(mockOnRefresh).not.toHaveBeenCalled();
+    });
+
+    it('should show restart error when stop mutation fails', async () => {
+      mockStopAgent.mockRejectedValue(new Error('Stop failed'));
+
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        await result.current.handleRestart();
+      });
+
+      expect(mockStopAgent).toHaveBeenCalledWith(
+        {},
+        { namespace: runtime.namespace, name: runtime.name },
+      );
+      expect(mockStartAgent).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalledWith('Failed to restart agent deployment', 'Stop failed');
+      expect(mockSuccess).not.toHaveBeenCalled();
+      expect(mockOnRefresh).not.toHaveBeenCalled();
+    });
+
+    it('should resolve after successful restart even when refresh fails', async () => {
+      mockOnRefresh.mockRejectedValue(new Error('Refresh failed'));
+
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        await result.current.handleRestart();
+      });
+
+      expect(mockStopAgent).toHaveBeenCalledWith(
+        {},
+        { namespace: runtime.namespace, name: runtime.name },
+      );
+      expect(mockStartAgent).toHaveBeenCalledWith(
+        {},
+        { namespace: runtime.namespace, name: runtime.name },
+      );
+      expect(mockSuccess).toHaveBeenCalledWith(
+        'Agent deployment restarted',
+        `${runtime.name} is restarting.`,
+      );
+      expect(mockError).toHaveBeenCalledWith(
+        'Failed to refresh agent deployment list',
+        'Refresh failed',
+      );
+      expect(mockOnRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep isPending true between stop and start during restart', async () => {
+      let resolveStop: (value?: void) => void = () => undefined;
+      let resolveStart: (value?: void) => void = () => undefined;
+      const stopPromise = new Promise<void>((resolve) => {
+        resolveStop = resolve;
+      });
+      const startPromise = new Promise<void>((resolve) => {
+        resolveStart = resolve;
+      });
+      mockStopAgent.mockReturnValue(stopPromise);
+      mockStartAgent.mockReturnValue(startPromise);
+
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      let restartPromise: Promise<void> | undefined;
+      act(() => {
+        restartPromise = result.current.handleRestart();
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.isPending).toBe(true);
+
+      await act(async () => {
+        resolveStop();
+        await stopPromise;
+        await Promise.resolve();
+      });
+
+      expect(result.current.isPending).toBe(true);
+      expect(mockStartAgent).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveStart();
+        await startPromise;
+        await restartPromise;
+      });
+
+      expect(result.current.isPending).toBe(false);
+    });
+
+    it('should ignore concurrent restart requests', async () => {
+      let resolveStop: (value?: void) => void = () => undefined;
+      const stopPromise = new Promise<void>((resolve) => {
+        resolveStop = resolve;
+      });
+      mockStopAgent.mockReturnValue(stopPromise);
+
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      act(() => {
+        void result.current.handleRestart();
+        void result.current.handleRestart();
+      });
+
+      await act(async () => {
+        resolveStop();
+        await stopPromise;
+        await Promise.resolve();
+      });
+
+      expect(mockStopAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it('should resolve after successful restart and refresh', async () => {
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        await result.current.handleRestart();
+      });
+
+      expect(mockSuccess).toHaveBeenCalledWith(
+        'Agent deployment restarted',
+        `${runtime.name} is restarting.`,
+      );
+      expect(mockError).not.toHaveBeenCalled();
+      expect(mockOnRefresh).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('handleDelete', () => {

--- a/packages/agent-ops/frontend/src/app/hooks/__tests__/useAgentLifecycleActions.spec.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/__tests__/useAgentLifecycleActions.spec.ts
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { act, renderHook } from '@testing-library/react';
+import { mockAgentRuntime } from '~/__mocks__/mockAgentRuntime';
+import { useAgentLifecycleActions } from '~/app/hooks/useAgentLifecycleActions';
+
+const mockDeleteAgent = jest.fn();
+const mockStartAgent = jest.fn();
+const mockStopAgent = jest.fn();
+const mockSuccess = jest.fn();
+const mockError = jest.fn();
+const mockOnRefresh = jest.fn();
+
+jest.mock('~/app/api/agentLifecycle', () => ({
+  deleteAgent: () => (opts: unknown, params: unknown) => mockDeleteAgent(opts, params),
+  startAgent: () => (opts: unknown, params: unknown) => mockStartAgent(opts, params),
+  stopAgent: () => (opts: unknown, params: unknown) => mockStopAgent(opts, params),
+}));
+
+jest.mock('~/app/hooks/useNotification', () => ({
+  useNotification: () => ({
+    success: mockSuccess,
+    error: mockError,
+    info: jest.fn(),
+    warning: jest.fn(),
+    remove: jest.fn(),
+  }),
+}));
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+const runtime = mockAgentRuntime({
+  name: 'sample-support-agent',
+  namespace: 'agent-ops-demo',
+  status: 'Ready',
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(QueryClientProvider, { client: createTestQueryClient() }, children);
+
+describe('useAgentLifecycleActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDeleteAgent.mockResolvedValue(undefined);
+    mockOnRefresh.mockResolvedValue(undefined);
+  });
+
+  describe('handleDelete', () => {
+    it('should reject when delete mutation fails', async () => {
+      mockDeleteAgent.mockRejectedValue(new Error('Delete failed'));
+
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      await expect(result.current.handleDelete()).rejects.toThrow('Delete failed');
+
+      expect(mockError).toHaveBeenCalledWith('Failed to delete agent deployment', 'Delete failed');
+      expect(mockSuccess).not.toHaveBeenCalled();
+      expect(mockOnRefresh).not.toHaveBeenCalled();
+    });
+
+    it('should resolve after successful delete even when refresh fails', async () => {
+      mockOnRefresh.mockRejectedValue(new Error('Refresh failed'));
+
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        await result.current.handleDelete();
+      });
+
+      expect(mockDeleteAgent).toHaveBeenCalledWith(
+        {},
+        { namespace: runtime.namespace, name: runtime.name },
+      );
+      expect(mockSuccess).toHaveBeenCalledWith(
+        'Agent deployment deleted',
+        `${runtime.name} has been deleted.`,
+      );
+      expect(mockError).toHaveBeenCalledWith(
+        'Failed to refresh agent deployment list',
+        'Refresh failed',
+      );
+      expect(mockOnRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('should resolve after successful delete and refresh', async () => {
+      const { result } = renderHook(
+        () => useAgentLifecycleActions({ runtime, onRefresh: mockOnRefresh }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        await result.current.handleDelete();
+      });
+
+      expect(mockSuccess).toHaveBeenCalledWith(
+        'Agent deployment deleted',
+        `${runtime.name} has been deleted.`,
+      );
+      expect(mockError).not.toHaveBeenCalled();
+      expect(mockOnRefresh).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/agent-ops/frontend/src/app/hooks/mutations.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/mutations.ts
@@ -24,10 +24,12 @@ export function useDeployAgentMutation(
 }
 
 export function useStopAgentMutation(
+  namespace: string,
+  name: string,
   hostPath = '',
 ): UseMutationResult<LifecycleResult, Error, AgentLifecycleParams> {
   return useMutation({
-    mutationKey: ['agent-ops', 'stopAgent'],
+    mutationKey: ['agent-ops', 'stopAgent', namespace, name],
     mutationFn: async (params: AgentLifecycleParams) => {
       const apiOpts: APIOptions = {};
       return stopAgent(hostPath)(apiOpts, params);
@@ -37,10 +39,12 @@ export function useStopAgentMutation(
 }
 
 export function useStartAgentMutation(
+  namespace: string,
+  name: string,
   hostPath = '',
 ): UseMutationResult<LifecycleResult, Error, AgentLifecycleParams> {
   return useMutation({
-    mutationKey: ['agent-ops', 'startAgent'],
+    mutationKey: ['agent-ops', 'startAgent', namespace, name],
     mutationFn: async (params: AgentLifecycleParams) => {
       const apiOpts: APIOptions = {};
       return startAgent(hostPath)(apiOpts, params);
@@ -50,10 +54,12 @@ export function useStartAgentMutation(
 }
 
 export function useDeleteAgentMutation(
+  namespace: string,
+  name: string,
   hostPath = '',
 ): UseMutationResult<void, Error, AgentLifecycleParams> {
   return useMutation({
-    mutationKey: ['agent-ops', 'deleteAgent'],
+    mutationKey: ['agent-ops', 'deleteAgent', namespace, name],
     mutationFn: async (params: AgentLifecycleParams) => {
       const apiOpts: APIOptions = {};
       return deleteAgent(hostPath)(apiOpts, params);

--- a/packages/agent-ops/frontend/src/app/hooks/mutations.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/mutations.ts
@@ -1,6 +1,8 @@
 import { useMutation, type UseMutationResult } from '@tanstack/react-query';
 import type { APIOptions } from 'mod-arch-core';
+import { deleteAgent, startAgent, stopAgent } from '~/app/api/agentLifecycle';
 import { deployAgent } from '~/app/api/deployAgent';
+import type { AgentLifecycleParams, LifecycleResult } from '~/app/types/agentLifecycle';
 import type { DeployAgentRequest, DeployAgentResponse } from '~/app/types/deployAgent';
 
 /**
@@ -17,6 +19,45 @@ export function useDeployAgentMutation(
       return deployAgent(hostPath)(apiOpts, request);
     },
     // POST deploy must not auto-retry (default is false; explicit for clarity).
+    retry: false,
+  });
+}
+
+export function useStopAgentMutation(
+  hostPath = '',
+): UseMutationResult<LifecycleResult, Error, AgentLifecycleParams> {
+  return useMutation({
+    mutationKey: ['agent-ops', 'stopAgent'],
+    mutationFn: async (params: AgentLifecycleParams) => {
+      const apiOpts: APIOptions = {};
+      return stopAgent(hostPath)(apiOpts, params);
+    },
+    retry: false,
+  });
+}
+
+export function useStartAgentMutation(
+  hostPath = '',
+): UseMutationResult<LifecycleResult, Error, AgentLifecycleParams> {
+  return useMutation({
+    mutationKey: ['agent-ops', 'startAgent'],
+    mutationFn: async (params: AgentLifecycleParams) => {
+      const apiOpts: APIOptions = {};
+      return startAgent(hostPath)(apiOpts, params);
+    },
+    retry: false,
+  });
+}
+
+export function useDeleteAgentMutation(
+  hostPath = '',
+): UseMutationResult<void, Error, AgentLifecycleParams> {
+  return useMutation({
+    mutationKey: ['agent-ops', 'deleteAgent'],
+    mutationFn: async (params: AgentLifecycleParams) => {
+      const apiOpts: APIOptions = {};
+      return deleteAgent(hostPath)(apiOpts, params);
+    },
     retry: false,
   });
 }

--- a/packages/agent-ops/frontend/src/app/hooks/useAgentLifecycleActions.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useAgentLifecycleActions.ts
@@ -8,11 +8,9 @@ import { useNotification } from '~/app/hooks/useNotification';
 import type { AgentRuntime } from '~/app/types/agentRuntimes';
 import {
   getAgentRuntimeLifecycleVisibility,
+  getLifecycleErrorMessage,
   isAgentRuntimeRunning,
 } from '~/app/utilities/agentLifecycleActions';
-
-const getErrorMessage = (error: unknown): string =>
-  error instanceof Error ? error.message : 'An unexpected error occurred.';
 
 type UseAgentLifecycleActionsOptions = {
   runtime: AgentRuntime;
@@ -33,9 +31,9 @@ export const useAgentLifecycleActions = ({
   onRefresh,
 }: UseAgentLifecycleActionsOptions): UseAgentLifecycleActionsResult => {
   const notification = useNotification();
-  const stopMutation = useStopAgentMutation();
-  const startMutation = useStartAgentMutation();
-  const deleteMutation = useDeleteAgentMutation();
+  const stopMutation = useStopAgentMutation(runtime.namespace, runtime.name);
+  const startMutation = useStartAgentMutation(runtime.namespace, runtime.name);
+  const deleteMutation = useDeleteAgentMutation(runtime.namespace, runtime.name);
   const [isActionInFlight, setIsActionInFlight] = React.useState(false);
   const isActionInFlightRef = React.useRef(false);
   const mountedRef = React.useRef(true);
@@ -83,14 +81,23 @@ export const useAgentLifecycleActions = ({
       return;
     }
 
+    let stopSucceeded = false;
     try {
       try {
         if (isAgentRuntimeRunning(runtime.status)) {
           await stopMutation.mutateAsync(lifecycleParams);
+          stopSucceeded = true;
         }
         await startMutation.mutateAsync(lifecycleParams);
       } catch (error) {
-        notification.error('Failed to restart agent deployment', getErrorMessage(error));
+        notification.error('Failed to restart agent deployment', getLifecycleErrorMessage(error));
+        if (stopSucceeded) {
+          try {
+            await onRefresh();
+          } catch (refreshError) {
+            notification.error('Failed to refresh agent deployment list', getLifecycleErrorMessage(refreshError));
+          }
+        }
         return;
       }
 
@@ -99,7 +106,7 @@ export const useAgentLifecycleActions = ({
       try {
         await onRefresh();
       } catch (error) {
-        notification.error('Failed to refresh agent deployment list', getErrorMessage(error));
+        notification.error('Failed to refresh agent deployment list', getLifecycleErrorMessage(error));
       }
     } finally {
       endAction();
@@ -125,7 +132,7 @@ export const useAgentLifecycleActions = ({
       try {
         await stopMutation.mutateAsync(lifecycleParams);
       } catch (error) {
-        notification.error('Failed to stop agent deployment', getErrorMessage(error));
+        notification.error('Failed to stop agent deployment', getLifecycleErrorMessage(error));
         return;
       }
 
@@ -134,7 +141,7 @@ export const useAgentLifecycleActions = ({
       try {
         await onRefresh();
       } catch (error) {
-        notification.error('Failed to refresh agent deployment list', getErrorMessage(error));
+        notification.error('Failed to refresh agent deployment list', getLifecycleErrorMessage(error));
       }
     } finally {
       endAction();
@@ -150,7 +157,7 @@ export const useAgentLifecycleActions = ({
       try {
         await deleteMutation.mutateAsync(lifecycleParams);
       } catch (error) {
-        notification.error('Failed to delete agent deployment', getErrorMessage(error));
+        notification.error('Failed to delete agent deployment', getLifecycleErrorMessage(error));
         throw error;
       }
 
@@ -159,7 +166,7 @@ export const useAgentLifecycleActions = ({
       try {
         await onRefresh();
       } catch (error) {
-        notification.error('Failed to refresh agent deployment list', getErrorMessage(error));
+        notification.error('Failed to refresh agent deployment list', getLifecycleErrorMessage(error));
       }
     } finally {
       endAction();

--- a/packages/agent-ops/frontend/src/app/hooks/useAgentLifecycleActions.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useAgentLifecycleActions.ts
@@ -36,6 +36,16 @@ export const useAgentLifecycleActions = ({
   const stopMutation = useStopAgentMutation();
   const startMutation = useStartAgentMutation();
   const deleteMutation = useDeleteAgentMutation();
+  const [isActionInFlight, setIsActionInFlight] = React.useState(false);
+  const isActionInFlightRef = React.useRef(false);
+  const mountedRef = React.useRef(true);
+
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const lifecycleParams = React.useMemo(
     () => ({ namespace: runtime.namespace, name: runtime.name }),
@@ -47,26 +57,56 @@ export const useAgentLifecycleActions = ({
     [runtime.status],
   );
 
-  const isPending = stopMutation.isPending || startMutation.isPending || deleteMutation.isPending;
+  const isMutationPending =
+    stopMutation.isPending || startMutation.isPending || deleteMutation.isPending;
+  const isPending = isMutationPending || isActionInFlight;
+
+  const beginAction = React.useCallback(() => {
+    if (isActionInFlightRef.current || isMutationPending) {
+      return false;
+    }
+
+    isActionInFlightRef.current = true;
+    setIsActionInFlight(true);
+    return true;
+  }, [isMutationPending]);
+
+  const endAction = React.useCallback(() => {
+    isActionInFlightRef.current = false;
+    if (mountedRef.current) {
+      setIsActionInFlight(false);
+    }
+  }, []);
 
   const handleRestart = React.useCallback(async () => {
-    if (isPending) {
+    if (!beginAction()) {
       return;
     }
 
     try {
-      if (isAgentRuntimeRunning(runtime.status)) {
-        await stopMutation.mutateAsync(lifecycleParams);
+      try {
+        if (isAgentRuntimeRunning(runtime.status)) {
+          await stopMutation.mutateAsync(lifecycleParams);
+        }
+        await startMutation.mutateAsync(lifecycleParams);
+      } catch (error) {
+        notification.error('Failed to restart agent deployment', getErrorMessage(error));
+        return;
       }
-      await startMutation.mutateAsync(lifecycleParams);
-      await onRefresh();
+
       notification.success('Agent deployment restarted', `${runtime.name} is restarting.`);
-    } catch (error) {
-      await onRefresh().catch(() => undefined);
-      notification.error('Failed to restart agent deployment', getErrorMessage(error));
+
+      try {
+        await onRefresh();
+      } catch (error) {
+        notification.error('Failed to refresh agent deployment list', getErrorMessage(error));
+      }
+    } finally {
+      endAction();
     }
   }, [
-    isPending,
+    beginAction,
+    endAction,
     lifecycleParams,
     notification,
     onRefresh,
@@ -77,39 +117,54 @@ export const useAgentLifecycleActions = ({
   ]);
 
   const handleStop = React.useCallback(async () => {
-    if (isPending) {
+    if (!beginAction()) {
       return;
     }
 
     try {
-      await stopMutation.mutateAsync(lifecycleParams);
-      await onRefresh();
+      try {
+        await stopMutation.mutateAsync(lifecycleParams);
+      } catch (error) {
+        notification.error('Failed to stop agent deployment', getErrorMessage(error));
+        return;
+      }
+
       notification.success('Agent deployment stopped', `${runtime.name} has been stopped.`);
-    } catch (error) {
-      notification.error('Failed to stop agent deployment', getErrorMessage(error));
+
+      try {
+        await onRefresh();
+      } catch (error) {
+        notification.error('Failed to refresh agent deployment list', getErrorMessage(error));
+      }
+    } finally {
+      endAction();
     }
-  }, [isPending, lifecycleParams, notification, onRefresh, runtime.name, stopMutation]);
+  }, [beginAction, endAction, lifecycleParams, notification, onRefresh, runtime.name, stopMutation]);
 
   const handleDelete = React.useCallback(async () => {
-    if (isPending) {
+    if (!beginAction()) {
       return;
     }
 
     try {
-      await deleteMutation.mutateAsync(lifecycleParams);
-    } catch (error) {
-      notification.error('Failed to delete agent deployment', getErrorMessage(error));
-      throw error;
-    }
+      try {
+        await deleteMutation.mutateAsync(lifecycleParams);
+      } catch (error) {
+        notification.error('Failed to delete agent deployment', getErrorMessage(error));
+        throw error;
+      }
 
-    notification.success('Agent deployment deleted', `${runtime.name} has been deleted.`);
+      notification.success('Agent deployment deleted', `${runtime.name} has been deleted.`);
 
-    try {
-      await onRefresh();
-    } catch (error) {
-      notification.error('Failed to refresh agent deployment list', getErrorMessage(error));
+      try {
+        await onRefresh();
+      } catch (error) {
+        notification.error('Failed to refresh agent deployment list', getErrorMessage(error));
+      }
+    } finally {
+      endAction();
     }
-  }, [deleteMutation, isPending, lifecycleParams, notification, onRefresh, runtime.name]);
+  }, [beginAction, deleteMutation, endAction, lifecycleParams, notification, onRefresh, runtime.name]);
 
   return {
     visibility,

--- a/packages/agent-ops/frontend/src/app/hooks/useAgentLifecycleActions.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useAgentLifecycleActions.ts
@@ -62,6 +62,7 @@ export const useAgentLifecycleActions = ({
       await onRefresh();
       notification.success('Agent deployment restarted', `${runtime.name} is restarting.`);
     } catch (error) {
+      await onRefresh().catch(() => undefined);
       notification.error('Failed to restart agent deployment', getErrorMessage(error));
     }
   }, [
@@ -96,11 +97,17 @@ export const useAgentLifecycleActions = ({
 
     try {
       await deleteMutation.mutateAsync(lifecycleParams);
-      await onRefresh();
-      notification.success('Agent deployment deleted', `${runtime.name} has been deleted.`);
     } catch (error) {
       notification.error('Failed to delete agent deployment', getErrorMessage(error));
       throw error;
+    }
+
+    notification.success('Agent deployment deleted', `${runtime.name} has been deleted.`);
+
+    try {
+      await onRefresh();
+    } catch (error) {
+      notification.error('Failed to refresh agent deployment list', getErrorMessage(error));
     }
   }, [deleteMutation, isPending, lifecycleParams, notification, onRefresh, runtime.name]);
 

--- a/packages/agent-ops/frontend/src/app/hooks/useAgentLifecycleActions.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useAgentLifecycleActions.ts
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import {
+  useDeleteAgentMutation,
+  useStartAgentMutation,
+  useStopAgentMutation,
+} from '~/app/hooks/mutations';
+import { useNotification } from '~/app/hooks/useNotification';
+import type { AgentRuntime } from '~/app/types/agentRuntimes';
+import {
+  getAgentRuntimeLifecycleVisibility,
+  isAgentRuntimeRunning,
+} from '~/app/utilities/agentLifecycleActions';
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : 'An unexpected error occurred.';
+
+type UseAgentLifecycleActionsOptions = {
+  runtime: AgentRuntime;
+  onRefresh: () => Promise<void>;
+};
+
+type UseAgentLifecycleActionsResult = {
+  visibility: ReturnType<typeof getAgentRuntimeLifecycleVisibility>;
+  isPending: boolean;
+  isDeleting: boolean;
+  handleRestart: () => Promise<void>;
+  handleStop: () => Promise<void>;
+  handleDelete: () => Promise<void>;
+};
+
+export const useAgentLifecycleActions = ({
+  runtime,
+  onRefresh,
+}: UseAgentLifecycleActionsOptions): UseAgentLifecycleActionsResult => {
+  const notification = useNotification();
+  const stopMutation = useStopAgentMutation();
+  const startMutation = useStartAgentMutation();
+  const deleteMutation = useDeleteAgentMutation();
+
+  const lifecycleParams = React.useMemo(
+    () => ({ namespace: runtime.namespace, name: runtime.name }),
+    [runtime.namespace, runtime.name],
+  );
+
+  const visibility = React.useMemo(
+    () => getAgentRuntimeLifecycleVisibility(runtime.status),
+    [runtime.status],
+  );
+
+  const isPending = stopMutation.isPending || startMutation.isPending || deleteMutation.isPending;
+
+  const handleRestart = React.useCallback(async () => {
+    if (isPending) {
+      return;
+    }
+
+    try {
+      if (isAgentRuntimeRunning(runtime.status)) {
+        await stopMutation.mutateAsync(lifecycleParams);
+      }
+      await startMutation.mutateAsync(lifecycleParams);
+      await onRefresh();
+      notification.success('Agent deployment restarted', `${runtime.name} is restarting.`);
+    } catch (error) {
+      notification.error('Failed to restart agent deployment', getErrorMessage(error));
+    }
+  }, [
+    isPending,
+    lifecycleParams,
+    notification,
+    onRefresh,
+    runtime.name,
+    runtime.status,
+    startMutation,
+    stopMutation,
+  ]);
+
+  const handleStop = React.useCallback(async () => {
+    if (isPending) {
+      return;
+    }
+
+    try {
+      await stopMutation.mutateAsync(lifecycleParams);
+      await onRefresh();
+      notification.success('Agent deployment stopped', `${runtime.name} has been stopped.`);
+    } catch (error) {
+      notification.error('Failed to stop agent deployment', getErrorMessage(error));
+    }
+  }, [isPending, lifecycleParams, notification, onRefresh, runtime.name, stopMutation]);
+
+  const handleDelete = React.useCallback(async () => {
+    if (isPending) {
+      return;
+    }
+
+    try {
+      await deleteMutation.mutateAsync(lifecycleParams);
+      await onRefresh();
+      notification.success('Agent deployment deleted', `${runtime.name} has been deleted.`);
+    } catch (error) {
+      notification.error('Failed to delete agent deployment', getErrorMessage(error));
+      throw error;
+    }
+  }, [deleteMutation, isPending, lifecycleParams, notification, onRefresh, runtime.name]);
+
+  return {
+    visibility,
+    isPending,
+    isDeleting: deleteMutation.isPending,
+    handleRestart,
+    handleStop,
+    handleDelete,
+  };
+};

--- a/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/AgentDeploymentListPage.tsx
@@ -49,6 +49,7 @@ const AgentDeploymentListPage: React.FC = () => {
     setPageSize,
     loaded,
     error: loadError,
+    refresh,
   } = useListAgentRuntimes(namespace);
 
   const safeRuntimes = React.useMemo(
@@ -154,6 +155,7 @@ const AgentDeploymentListPage: React.FC = () => {
         onPageSizeChange={setPageSize}
         onClearFilters={clearFilters}
         discoveryMode={discoveryMode}
+        onRefresh={refresh}
         toolbarContent={
           <AgentRuntimesToolbar
             namespace={namespace}

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTable.tsx
@@ -22,6 +22,7 @@ type AgentRuntimesTableProps = {
   onPageChange: (page: number) => void;
   onPageSizeChange: (pageSize: number) => void;
   onClearFilters: () => void;
+  onRefresh: () => Promise<void>;
   toolbarContent?: React.ReactElement;
   discoveryMode?: boolean;
 };
@@ -53,6 +54,7 @@ const AgentRuntimesTable: React.FC<AgentRuntimesTableProps> = ({
   onPageChange,
   onPageSizeChange,
   onClearFilters,
+  onRefresh,
   toolbarContent,
   discoveryMode = false,
 }) => {
@@ -110,6 +112,7 @@ const AgentRuntimesTable: React.FC<AgentRuntimesTableProps> = ({
           key={getAgentRuntimeRowKey(runtime.namespace, runtime.name)}
           runtime={runtime}
           discoveryMode={discoveryMode}
+          onRefresh={onRefresh}
         />
       )}
       emptyTableView={

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
@@ -25,6 +25,7 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
 }) => {
   const [isEndpointsModalOpen, setIsEndpointsModalOpen] = React.useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
+  const [isConfirmingDelete, setIsConfirmingDelete] = React.useState(false);
   const navigate = useNavigate();
   const detailRoute = agentOpsDeploymentDetailRoute(runtime.namespace, runtime.name);
 
@@ -151,11 +152,17 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
       {isDeleteModalOpen && (
         <AgentDeleteModal
           agentName={runtime.name}
-          isDeleting={isDeleting}
+          isDeleting={isDeleting || isConfirmingDelete}
           onConfirm={() => {
+            if (isConfirmingDelete) {
+              return;
+            }
+
+            setIsConfirmingDelete(true);
             void handleDelete()
               .then(() => setIsDeleteModalOpen(false))
-              .catch(() => undefined); // error already shown via notification; modal stays open for retry
+              .catch(() => undefined) // error already shown via notification; modal stays open for retry
+              .finally(() => setIsConfirmingDelete(false));
           }}
           onCancel={() => setIsDeleteModalOpen(false)}
         />

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
 import { Button, MenuToggle, Truncate } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import AgentDeleteModal from '~/app/components/AgentDeleteModal';
 import AgentRuntimeEndpointsModal from '~/app/components/AgentRuntimeEndpointsModal';
 import AgentRuntimeStatusLabel from '~/app/components/AgentRuntimeStatusLabel';
@@ -26,7 +26,6 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
   const [isEndpointsModalOpen, setIsEndpointsModalOpen] = React.useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
   const [isConfirmingDelete, setIsConfirmingDelete] = React.useState(false);
-  const navigate = useNavigate();
   const detailRoute = agentOpsDeploymentDetailRoute(runtime.namespace, runtime.name);
 
   const { visibility, isPending, isDeleting, handleRestart, handleStop, handleDelete } =
@@ -50,7 +49,7 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
     const nextActions: IAction[] = [
       {
         title: 'View details',
-        onClick: () => navigate(detailRoute),
+        component: (props) => <Link {...props} to={detailRoute} />,
       },
     ];
 
@@ -89,7 +88,6 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
     handleRestart,
     handleStop,
     isPending,
-    navigate,
     visibility.showDelete,
     visibility.showRestart,
     visibility.showStop,
@@ -164,7 +162,11 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
               .catch(() => undefined) // error already shown via notification; modal stays open for retry
               .finally(() => setIsConfirmingDelete(false));
           }}
-          onCancel={() => setIsDeleteModalOpen(false)}
+          onCancel={() => {
+            if (!isDeleting && !isConfirmingDelete) {
+              setIsDeleteModalOpen(false);
+            }
+          }}
         />
       )}
     </>

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
@@ -2,37 +2,91 @@ import * as React from 'react';
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
 import { Button, Truncate } from '@patternfly/react-core';
 import { Link, useNavigate } from 'react-router-dom';
-import { AgentRuntime } from '~/app/types/agentRuntimes';
-import AgentRuntimeStatusLabel from '~/app/components/AgentRuntimeStatusLabel';
+import AgentDeleteModal from '~/app/components/AgentDeleteModal';
 import AgentRuntimeEndpointsModal from '~/app/components/AgentRuntimeEndpointsModal';
+import AgentRuntimeStatusLabel from '~/app/components/AgentRuntimeStatusLabel';
+import { useAgentLifecycleActions } from '~/app/hooks/useAgentLifecycleActions';
+import { AgentRuntime } from '~/app/types/agentRuntimes';
+import { getAgentRuntimeEndpointFields } from '~/app/utilities/agentRuntimeEndpoints';
 import { agentOpsDeploymentDetailRoute } from '~/app/utilities/routes';
 import { agentRuntimesColumns } from './columns';
 
 type AgentRuntimesTableRowProps = {
   runtime: AgentRuntime;
+  onRefresh: () => Promise<void>;
   discoveryMode?: boolean;
 };
 
 const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
   runtime,
+  onRefresh,
   discoveryMode = false,
 }) => {
   const [isEndpointsModalOpen, setIsEndpointsModalOpen] = React.useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
   const navigate = useNavigate();
   const detailRoute = agentOpsDeploymentDetailRoute(runtime.namespace, runtime.name);
 
-  const actions: IAction[] = React.useMemo(
-    () =>
-      discoveryMode
-        ? []
-        : [
-            {
-              title: 'View details',
-              onClick: () => navigate(detailRoute),
-            },
-          ],
-    [discoveryMode, navigate, detailRoute],
+  const { visibility, isPending, isDeleting, handleRestart, handleStop, handleDelete } =
+    useAgentLifecycleActions({ runtime, onRefresh });
+
+  const hasEndpoints = React.useMemo(
+    () => getAgentRuntimeEndpointFields(runtime).length > 0,
+    [runtime],
   );
+
+  const actions: IAction[] = React.useMemo(() => {
+    if (discoveryMode) {
+      return [];
+    }
+
+    const nextActions: IAction[] = [
+      {
+        title: 'View details',
+        onClick: () => navigate(detailRoute),
+      },
+    ];
+
+    if (visibility.showRestart) {
+      nextActions.push({
+        title: 'Restart',
+        isDisabled: isPending,
+        onClick: () => {
+          void handleRestart();
+        },
+      });
+    }
+
+    if (visibility.showStop) {
+      nextActions.push({
+        title: 'Stop',
+        isDisabled: isPending,
+        onClick: () => {
+          void handleStop();
+        },
+      });
+    }
+
+    if (visibility.showDelete) {
+      nextActions.push({
+        title: 'Delete',
+        isDisabled: isPending,
+        onClick: () => setIsDeleteModalOpen(true),
+      });
+    }
+
+    return nextActions;
+  }, [
+    discoveryMode,
+    detailRoute,
+    handleRestart,
+    handleStop,
+    isPending,
+    navigate,
+    visibility.showDelete,
+    visibility.showRestart,
+    visibility.showStop,
+  ]);
 
   return (
     <>
@@ -53,6 +107,7 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
           <Button
             variant="link"
             isInline
+            isDisabled={!hasEndpoints}
             onClick={() => setIsEndpointsModalOpen(true)}
             data-testid="agent-runtime-endpoint-view"
           >
@@ -72,6 +127,18 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
         <AgentRuntimeEndpointsModal
           runtime={runtime}
           onClose={() => setIsEndpointsModalOpen(false)}
+        />
+      )}
+      {isDeleteModalOpen && (
+        <AgentDeleteModal
+          agentName={runtime.name}
+          isDeleting={isDeleting}
+          onConfirm={() => {
+            void handleDelete()
+              .then(() => setIsDeleteModalOpen(false))
+              .catch(() => undefined); // error already shown via notification; modal stays open for retry
+          }}
+          onCancel={() => setIsDeleteModalOpen(false)}
         />
       )}
     </>

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/AgentRuntimesTableRow.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
-import { Button, Truncate } from '@patternfly/react-core';
+import { Button, MenuToggle, Truncate } from '@patternfly/react-core';
+import { EllipsisVIcon } from '@patternfly/react-icons';
 import { Link, useNavigate } from 'react-router-dom';
 import AgentDeleteModal from '~/app/components/AgentDeleteModal';
 import AgentRuntimeEndpointsModal from '~/app/components/AgentRuntimeEndpointsModal';
@@ -33,6 +34,11 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
   const hasEndpoints = React.useMemo(
     () => getAgentRuntimeEndpointFields(runtime).length > 0,
     [runtime],
+  );
+
+  const actionsToggleAriaLabel = React.useMemo(
+    () => `Actions for ${runtime.name} in ${runtime.namespace}`,
+    [runtime.name, runtime.namespace],
   );
 
   const actions: IAction[] = React.useMemo(() => {
@@ -119,7 +125,20 @@ const AgentRuntimesTableRow: React.FC<AgentRuntimesTableRowProps> = ({
         </Td>
         {!discoveryMode && (
           <Td isActionCell data-testid="agent-runtime-actions">
-            <ActionsColumn items={actions} />
+            <ActionsColumn
+              items={actions}
+              actionsToggle={({ toggleRef, onToggle, isOpen, isDisabled }) => (
+                <MenuToggle
+                  aria-label={actionsToggleAriaLabel}
+                  ref={toggleRef}
+                  onClick={(event) => onToggle(event)}
+                  isExpanded={isOpen}
+                  isDisabled={isDisabled}
+                  variant="plain"
+                  icon={<EllipsisVIcon />}
+                />
+              )}
+            />
           </Td>
         )}
       </Tr>

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTable.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTable.spec.tsx
@@ -10,6 +10,16 @@ import {
   createReadyRuntime,
 } from './agentRuntimeTestUtils';
 
+jest.mock('~/app/hooks/useAgentLifecycleActions', () => ({
+  useAgentLifecycleActions: jest.fn(() => ({
+    visibility: { showRestart: true, showStop: true, showDelete: true },
+    isPending: false,
+    handleRestart: jest.fn().mockResolvedValue(undefined),
+    handleStop: jest.fn().mockResolvedValue(undefined),
+    handleDelete: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <MemoryRouter>{children}</MemoryRouter>
 );
@@ -20,6 +30,7 @@ const defaultPaginationProps = {
   pageSize: 10,
   onPageChange: jest.fn(),
   onPageSizeChange: jest.fn(),
+  onRefresh: jest.fn().mockResolvedValue(undefined),
 };
 
 describe('AgentRuntimesTable', () => {

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
@@ -51,8 +51,11 @@ const renderRow = (runtime: AgentRuntime) =>
     </MemoryRouter>,
   );
 
-const openKebab = async (user: ReturnType<typeof userEvent.setup>) => {
-  await user.click(screen.getByRole('button', { name: 'Kebab toggle' }));
+const getActionsToggleLabel = (runtime: AgentRuntime) =>
+  `Actions for ${runtime.name} in ${runtime.namespace}`;
+
+const openKebab = async (user: ReturnType<typeof userEvent.setup>, runtime: AgentRuntime) => {
+  await user.click(screen.getByRole('button', { name: getActionsToggleLabel(runtime) }));
 };
 
 describe('AgentRuntimesTableRow', () => {
@@ -104,6 +107,26 @@ describe('AgentRuntimesTableRow', () => {
     ).toBeInTheDocument();
   });
 
+  it('should use a unique actions toggle label per runtime row', () => {
+    render(
+      <MemoryRouter>
+        <PfTable>
+          <Tbody>
+            <AgentRuntimesTableRow runtime={createReadyRuntime()} onRefresh={mockOnRefresh} />
+            <AgentRuntimesTableRow runtime={createStoppedRuntime()} onRefresh={mockOnRefresh} />
+          </Tbody>
+        </PfTable>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: getActionsToggleLabel(createReadyRuntime()) }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: getActionsToggleLabel(createStoppedRuntime()) }),
+    ).toBeInTheDocument();
+  });
+
   it('should show lifecycle actions for ready runtimes', async () => {
     const user = userEvent.setup();
     mockUseAgentLifecycleActions.mockReturnValue({
@@ -112,7 +135,7 @@ describe('AgentRuntimesTableRow', () => {
     });
     renderRow(createReadyRuntime());
 
-    await openKebab(user);
+    await openKebab(user, createReadyRuntime());
     expect(screen.getByRole('menuitem', { name: 'View details' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Restart' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Stop' })).toBeInTheDocument();
@@ -127,7 +150,7 @@ describe('AgentRuntimesTableRow', () => {
     });
     renderRow(createStoppedRuntime());
 
-    await openKebab(user);
+    await openKebab(user, createStoppedRuntime());
     expect(screen.getByRole('menuitem', { name: 'Restart' })).toBeInTheDocument();
     expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
@@ -142,7 +165,7 @@ describe('AgentRuntimesTableRow', () => {
     });
     renderRow(createReadyRuntime());
 
-    await openKebab(user);
+    await openKebab(user, createReadyRuntime());
     await user.click(screen.getByRole('menuitem', { name: 'Restart' }));
     expect(handleRestart).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId('agent-delete-modal')).not.toBeInTheDocument();
@@ -157,7 +180,7 @@ describe('AgentRuntimesTableRow', () => {
     });
     renderRow(createReadyRuntime());
 
-    await openKebab(user);
+    await openKebab(user, createReadyRuntime());
     await user.click(screen.getByRole('menuitem', { name: 'Stop' }));
     expect(handleStop).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId('agent-delete-modal')).not.toBeInTheDocument();
@@ -167,7 +190,7 @@ describe('AgentRuntimesTableRow', () => {
     const user = userEvent.setup();
     renderRow(createReadyRuntime());
 
-    await openKebab(user);
+    await openKebab(user, createReadyRuntime());
     await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
     expect(screen.getByTestId('agent-delete-modal')).toHaveTextContent('sample-support-agent');
   });
@@ -181,7 +204,7 @@ describe('AgentRuntimesTableRow', () => {
     });
     renderRow(createReadyRuntime());
 
-    await openKebab(user);
+    await openKebab(user, createReadyRuntime());
     await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
     await user.click(screen.getByTestId('agent-delete-modal-confirm'));
     expect(handleDelete).toHaveBeenCalledTimes(1);
@@ -197,7 +220,7 @@ describe('AgentRuntimesTableRow', () => {
     });
     renderRow(createReadyRuntime());
 
-    await openKebab(user);
+    await openKebab(user, createReadyRuntime());
     await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
     await user.click(screen.getByTestId('agent-delete-modal-confirm'));
     expect(handleDelete).toHaveBeenCalledTimes(1);
@@ -213,7 +236,7 @@ describe('AgentRuntimesTableRow', () => {
     });
     renderRow(createReadyRuntime());
 
-    await openKebab(user);
+    await openKebab(user, createReadyRuntime());
     await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
     expect(screen.getByTestId('agent-delete-modal')).toBeInTheDocument();
     await user.click(screen.getByTestId('agent-delete-modal-cancel'));
@@ -239,7 +262,7 @@ describe('AgentRuntimesTableRow', () => {
     });
 
     renderRow(createPendingRuntime());
-    await openKebab(user);
+    await openKebab(user, createPendingRuntime());
     expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
   });
 
@@ -251,7 +274,7 @@ describe('AgentRuntimesTableRow', () => {
     });
 
     renderRow(createFailedRuntime());
-    await openKebab(user);
+    await openKebab(user, createFailedRuntime());
     expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
   });
 
@@ -263,7 +286,7 @@ describe('AgentRuntimesTableRow', () => {
     });
     renderRow(createUnknownRuntime());
 
-    await openKebab(user);
+    await openKebab(user, createUnknownRuntime());
     expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
   });
 
@@ -284,6 +307,8 @@ describe('AgentRuntimesTableRow', () => {
 
     expect(screen.getByTestId('agent-runtime-name')).toHaveTextContent('sample-support-agent');
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Kebab toggle' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: getActionsToggleLabel(createReadyRuntime()) }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
@@ -289,40 +289,46 @@ describe('AgentRuntimesTableRow', () => {
     });
   });
 
-  it('should hide stop for pending runtimes', async () => {
+  it('should hide stop and restart for pending runtimes', async () => {
     const user = userEvent.setup();
     mockUseAgentLifecycleActions.mockReturnValue({
       ...defaultLifecycleActions,
-      visibility: { showRestart: true, showStop: false, showDelete: true },
+      visibility: { showRestart: false, showStop: false, showDelete: true },
     });
 
     renderRow(createPendingRuntime());
     await openKebab(user, createPendingRuntime());
     expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Restart' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
   });
 
-  it('should hide stop for failed runtimes', async () => {
+  it('should hide stop and restart for failed runtimes', async () => {
     const user = userEvent.setup();
     mockUseAgentLifecycleActions.mockReturnValue({
       ...defaultLifecycleActions,
-      visibility: { showRestart: true, showStop: false, showDelete: true },
+      visibility: { showRestart: false, showStop: false, showDelete: true },
     });
 
     renderRow(createFailedRuntime());
     await openKebab(user, createFailedRuntime());
     expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Restart' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
   });
 
-  it('should not show stop for unknown runtimes', async () => {
+  it('should hide stop and restart for unknown runtimes', async () => {
     const user = userEvent.setup();
     mockUseAgentLifecycleActions.mockReturnValue({
       ...defaultLifecycleActions,
-      visibility: { showRestart: true, showStop: false, showDelete: true },
+      visibility: { showRestart: false, showStop: false, showDelete: true },
     });
     renderRow(createUnknownRuntime());
 
     await openKebab(user, createUnknownRuntime());
     expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Restart' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
   });
 
   it('should hide detail navigation when discovery mode is on', () => {

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
@@ -145,7 +145,7 @@ describe('AgentRuntimesTableRow', () => {
     await openKebab(user);
     await user.click(screen.getByRole('menuitem', { name: 'Restart' }));
     expect(handleRestart).toHaveBeenCalledTimes(1);
-    expect(screen.queryByTestId('agent-stop-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('agent-delete-modal')).not.toBeInTheDocument();
   });
 
   it('should call stop handler without opening a modal', async () => {
@@ -160,7 +160,7 @@ describe('AgentRuntimesTableRow', () => {
     await openKebab(user);
     await user.click(screen.getByRole('menuitem', { name: 'Stop' }));
     expect(handleStop).toHaveBeenCalledTimes(1);
-    expect(screen.queryByTestId('agent-stop-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('agent-delete-modal')).not.toBeInTheDocument();
   });
 
   it('should open delete modal when Delete is clicked', async () => {
@@ -185,6 +185,7 @@ describe('AgentRuntimesTableRow', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
     await user.click(screen.getByTestId('agent-delete-modal-confirm'));
     expect(handleDelete).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('agent-delete-modal')).not.toBeInTheDocument();
   });
 
   it('should keep delete modal open when delete fails', async () => {

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Table as PfTable, Tbody } from '@patternfly/react-table';
 import { MemoryRouter } from 'react-router-dom';
@@ -30,6 +30,12 @@ const mockUseAgentRuntimeDetail = jest.mocked(useAgentRuntimeDetail);
 const mockUseAgentLifecycleActions = jest.mocked(useAgentLifecycleActions);
 
 const mockOnRefresh = jest.fn().mockResolvedValue(undefined);
+
+const findDeleteModalConfirmButton = () =>
+  within(screen.getByTestId('agent-delete-modal')).getByRole('button', { name: 'Delete' });
+
+const findDeleteModalCancelButton = () =>
+  within(screen.getByTestId('agent-delete-modal')).getByRole('button', { name: 'Cancel' });
 
 const defaultLifecycleActions = {
   visibility: { showRestart: true, showStop: true, showDelete: true },
@@ -206,7 +212,7 @@ describe('AgentRuntimesTableRow', () => {
 
     await openKebab(user, createReadyRuntime());
     await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
-    await user.click(screen.getByTestId('agent-delete-modal-confirm'));
+    await user.click(findDeleteModalConfirmButton());
     expect(handleDelete).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId('agent-delete-modal')).not.toBeInTheDocument();
   });
@@ -222,9 +228,38 @@ describe('AgentRuntimesTableRow', () => {
 
     await openKebab(user, createReadyRuntime());
     await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
-    await user.click(screen.getByTestId('agent-delete-modal-confirm'));
+    await user.click(findDeleteModalConfirmButton());
     expect(handleDelete).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('agent-delete-modal')).toBeInTheDocument();
+  });
+
+  it('should not submit duplicate delete requests while confirmation is in flight', async () => {
+    const user = userEvent.setup();
+    let resolveDelete: (value?: void) => void = () => undefined;
+    const deletePromise = new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    });
+    const handleDelete = jest.fn().mockReturnValue(deletePromise);
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      isDeleting: false,
+      handleDelete,
+    });
+    renderRow(createReadyRuntime());
+
+    await openKebab(user, createReadyRuntime());
+    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+    const confirmButton = findDeleteModalConfirmButton();
+    await user.click(confirmButton);
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+    expect(confirmButton).toBeDisabled();
+
+    await user.click(confirmButton);
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+
+    resolveDelete();
+    await deletePromise;
   });
 
   it('should close delete modal without deleting when Cancel is clicked', async () => {
@@ -239,7 +274,7 @@ describe('AgentRuntimesTableRow', () => {
     await openKebab(user, createReadyRuntime());
     await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
     expect(screen.getByTestId('agent-delete-modal')).toBeInTheDocument();
-    await user.click(screen.getByTestId('agent-delete-modal-cancel'));
+    await user.click(findDeleteModalCancelButton());
     expect(screen.queryByTestId('agent-delete-modal')).not.toBeInTheDocument();
     expect(handleDelete).not.toHaveBeenCalled();
   });

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/AgentRuntimesTableRow.spec.tsx
@@ -7,29 +7,53 @@ import { MemoryRouter } from 'react-router-dom';
 import { mockAgentCardDetail, mockAgentRuntimeDetail } from '~/__mocks__/mockAgentRuntime';
 import { AgentRuntime } from '~/app/types/agentRuntimes';
 import { useAgentRuntimeDetail } from '~/app/hooks/useAgentRuntimeDetail';
+import { useAgentLifecycleActions } from '~/app/hooks/useAgentLifecycleActions';
 import AgentRuntimesTableRow from '~/app/pages/agentRuntimes/AgentRuntimesTableRow';
 import {
   createFailedRuntime,
   createMockAgentRuntime,
+  createPendingRuntime,
   createReadyRuntime,
+  createStoppedRuntime,
+  createUnknownRuntime,
 } from './agentRuntimeTestUtils';
 
 jest.mock('~/app/hooks/useAgentRuntimeDetail', () => ({
   useAgentRuntimeDetail: jest.fn(),
 }));
 
+jest.mock('~/app/hooks/useAgentLifecycleActions', () => ({
+  useAgentLifecycleActions: jest.fn(),
+}));
+
 const mockUseAgentRuntimeDetail = jest.mocked(useAgentRuntimeDetail);
+const mockUseAgentLifecycleActions = jest.mocked(useAgentLifecycleActions);
+
+const mockOnRefresh = jest.fn().mockResolvedValue(undefined);
+
+const defaultLifecycleActions = {
+  visibility: { showRestart: true, showStop: true, showDelete: true },
+  isPending: false,
+  isDeleting: false,
+  handleRestart: jest.fn().mockResolvedValue(undefined),
+  handleStop: jest.fn().mockResolvedValue(undefined),
+  handleDelete: jest.fn().mockResolvedValue(undefined),
+};
 
 const renderRow = (runtime: AgentRuntime) =>
   render(
     <MemoryRouter>
       <PfTable>
         <Tbody>
-          <AgentRuntimesTableRow runtime={runtime} />
+          <AgentRuntimesTableRow runtime={runtime} onRefresh={mockOnRefresh} />
         </Tbody>
       </PfTable>
     </MemoryRouter>,
   );
+
+const openKebab = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole('button', { name: 'Kebab toggle' }));
+};
 
 describe('AgentRuntimesTableRow', () => {
   beforeEach(() => {
@@ -40,6 +64,7 @@ describe('AgentRuntimesTableRow', () => {
       undefined,
       jest.fn(),
     ]);
+    mockUseAgentLifecycleActions.mockReturnValue(defaultLifecycleActions);
   });
 
   it('should render name and namespace columns', () => {
@@ -79,15 +104,166 @@ describe('AgentRuntimesTableRow', () => {
     ).toBeInTheDocument();
   });
 
-  it('should show View details row action', async () => {
+  it('should show lifecycle actions for ready runtimes', async () => {
+    const user = userEvent.setup();
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      visibility: { showRestart: true, showStop: true, showDelete: true },
+    });
+    renderRow(createReadyRuntime());
+
+    await openKebab(user);
+    expect(screen.getByRole('menuitem', { name: 'View details' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Restart' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Stop' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('should show restart and delete without stop for stopped runtimes', async () => {
+    const user = userEvent.setup();
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      visibility: { showRestart: true, showStop: false, showDelete: true },
+    });
+    renderRow(createStoppedRuntime());
+
+    await openKebab(user);
+    expect(screen.getByRole('menuitem', { name: 'Restart' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('should call restart handler without opening a modal', async () => {
+    const user = userEvent.setup();
+    const handleRestart = jest.fn().mockResolvedValue(undefined);
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      handleRestart,
+    });
+    renderRow(createReadyRuntime());
+
+    await openKebab(user);
+    await user.click(screen.getByRole('menuitem', { name: 'Restart' }));
+    expect(handleRestart).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('agent-stop-modal')).not.toBeInTheDocument();
+  });
+
+  it('should call stop handler without opening a modal', async () => {
+    const user = userEvent.setup();
+    const handleStop = jest.fn().mockResolvedValue(undefined);
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      handleStop,
+    });
+    renderRow(createReadyRuntime());
+
+    await openKebab(user);
+    await user.click(screen.getByRole('menuitem', { name: 'Stop' }));
+    expect(handleStop).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('agent-stop-modal')).not.toBeInTheDocument();
+  });
+
+  it('should open delete modal when Delete is clicked', async () => {
     const user = userEvent.setup();
     renderRow(createReadyRuntime());
 
-    await user.click(screen.getByRole('button', { name: 'Kebab toggle' }));
-    expect(screen.getByRole('menuitem', { name: 'View details' })).toBeInTheDocument();
-    expect(screen.queryByRole('menuitem', { name: 'Restart' })).not.toBeInTheDocument();
+    await openKebab(user);
+    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    expect(screen.getByTestId('agent-delete-modal')).toHaveTextContent('sample-support-agent');
+  });
+
+  it('should call delete handler when delete modal is confirmed', async () => {
+    const user = userEvent.setup();
+    const handleDelete = jest.fn().mockResolvedValue(undefined);
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      handleDelete,
+    });
+    renderRow(createReadyRuntime());
+
+    await openKebab(user);
+    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    await user.click(screen.getByTestId('agent-delete-modal-confirm'));
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep delete modal open when delete fails', async () => {
+    const user = userEvent.setup();
+    const handleDelete = jest.fn().mockRejectedValue(new Error('Delete failed'));
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      handleDelete,
+    });
+    renderRow(createReadyRuntime());
+
+    await openKebab(user);
+    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    await user.click(screen.getByTestId('agent-delete-modal-confirm'));
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('agent-delete-modal')).toBeInTheDocument();
+  });
+
+  it('should close delete modal without deleting when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const handleDelete = jest.fn().mockResolvedValue(undefined);
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      handleDelete,
+    });
+    renderRow(createReadyRuntime());
+
+    await openKebab(user);
+    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    expect(screen.getByTestId('agent-delete-modal')).toBeInTheDocument();
+    await user.click(screen.getByTestId('agent-delete-modal-cancel'));
+    expect(screen.queryByTestId('agent-delete-modal')).not.toBeInTheDocument();
+    expect(handleDelete).not.toHaveBeenCalled();
+  });
+
+  it('should pass runtime and refresh callback to lifecycle hook', () => {
+    const runtime = createPendingRuntime();
+    renderRow(runtime);
+
+    expect(mockUseAgentLifecycleActions).toHaveBeenCalledWith({
+      runtime,
+      onRefresh: mockOnRefresh,
+    });
+  });
+
+  it('should hide stop for pending runtimes', async () => {
+    const user = userEvent.setup();
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      visibility: { showRestart: true, showStop: false, showDelete: true },
+    });
+
+    renderRow(createPendingRuntime());
+    await openKebab(user);
     expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('should hide stop for failed runtimes', async () => {
+    const user = userEvent.setup();
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      visibility: { showRestart: true, showStop: false, showDelete: true },
+    });
+
+    renderRow(createFailedRuntime());
+    await openKebab(user);
+    expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
+  });
+
+  it('should not show stop for unknown runtimes', async () => {
+    const user = userEvent.setup();
+    mockUseAgentLifecycleActions.mockReturnValue({
+      ...defaultLifecycleActions,
+      visibility: { showRestart: true, showStop: false, showDelete: true },
+    });
+    renderRow(createUnknownRuntime());
+
+    await openKebab(user);
+    expect(screen.queryByRole('menuitem', { name: 'Stop' })).not.toBeInTheDocument();
   });
 
   it('should hide detail navigation when discovery mode is on', () => {
@@ -95,7 +271,11 @@ describe('AgentRuntimesTableRow', () => {
       <MemoryRouter>
         <PfTable>
           <Tbody>
-            <AgentRuntimesTableRow runtime={createReadyRuntime()} discoveryMode />
+            <AgentRuntimesTableRow
+              runtime={createReadyRuntime()}
+              onRefresh={mockOnRefresh}
+              discoveryMode
+            />
           </Tbody>
         </PfTable>
       </MemoryRouter>,

--- a/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/agentRuntimeTestUtils.ts
+++ b/packages/agent-ops/frontend/src/app/pages/agentRuntimes/__tests__/agentRuntimeTestUtils.ts
@@ -24,3 +24,15 @@ export const createToolRuntime = (): AgentRuntime =>
     status: 'Stopped',
     type: 'tool',
   });
+
+export const createStoppedRuntime = (): AgentRuntime =>
+  mockAgentRuntime({
+    name: 'stopped-agent',
+    status: 'Stopped',
+  });
+
+export const createUnknownRuntime = (): AgentRuntime =>
+  mockAgentRuntime({
+    name: 'unknown-agent',
+    status: 'mystery',
+  });

--- a/packages/agent-ops/frontend/src/app/types/agentLifecycle.ts
+++ b/packages/agent-ops/frontend/src/app/types/agentLifecycle.ts
@@ -1,0 +1,14 @@
+export type AgentLifecycleAction = 'stop' | 'start';
+
+export type LifecycleResult = {
+  success: boolean;
+  name: string;
+  namespace: string;
+  action: AgentLifecycleAction;
+  message: string;
+};
+
+export type AgentLifecycleParams = {
+  namespace: string;
+  name: string;
+};

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/agentLifecycleActions.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/agentLifecycleActions.spec.ts
@@ -1,0 +1,72 @@
+import {
+  getAgentRuntimeLifecycleVisibility,
+  isAgentRuntimeRunning,
+} from '~/app/utilities/agentLifecycleActions';
+import {
+  AgentRuntimeDisplayStatus,
+  mapAgentRuntimeStatus,
+} from '~/app/utilities/agentRuntimeStatus';
+
+describe('agentLifecycleActions', () => {
+  describe('getAgentRuntimeLifecycleVisibility', () => {
+    it('should show restart, stop, and delete for ready runtimes', () => {
+      expect(getAgentRuntimeLifecycleVisibility('Ready')).toEqual({
+        showRestart: true,
+        showStop: true,
+        showDelete: true,
+      });
+    });
+
+    it('should show restart and delete without stop for unknown runtimes', () => {
+      expect(getAgentRuntimeLifecycleVisibility('mystery')).toEqual({
+        showRestart: true,
+        showStop: false,
+        showDelete: true,
+      });
+    });
+
+    it('should show restart and delete without stop for stopped runtimes', () => {
+      expect(getAgentRuntimeLifecycleVisibility('Stopped')).toEqual({
+        showRestart: true,
+        showStop: false,
+        showDelete: true,
+      });
+    });
+
+    it('should show restart and delete without stop for pending runtimes', () => {
+      expect(getAgentRuntimeLifecycleVisibility('Pending')).toEqual({
+        showRestart: true,
+        showStop: false,
+        showDelete: true,
+      });
+    });
+
+    it('should show restart and delete without stop for failed runtimes', () => {
+      expect(getAgentRuntimeLifecycleVisibility('Failed')).toEqual({
+        showRestart: true,
+        showStop: false,
+        showDelete: true,
+      });
+    });
+  });
+
+  describe('isAgentRuntimeRunning', () => {
+    it('should treat ready and running statuses as running', () => {
+      expect(isAgentRuntimeRunning('Ready')).toBe(true);
+      expect(isAgentRuntimeRunning('running')).toBe(true);
+    });
+
+    it('should treat unknown statuses as not running', () => {
+      expect(isAgentRuntimeRunning('mystery')).toBe(false);
+      expect(mapAgentRuntimeStatus('mystery').displayStatus).toBe(
+        AgentRuntimeDisplayStatus.Unknown,
+      );
+    });
+
+    it('should treat stopped, pending, and failed statuses as not running', () => {
+      expect(isAgentRuntimeRunning('Stopped')).toBe(false);
+      expect(isAgentRuntimeRunning('Pending')).toBe(false);
+      expect(isAgentRuntimeRunning('Failed')).toBe(false);
+    });
+  });
+});

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/agentLifecycleActions.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/agentLifecycleActions.spec.ts
@@ -33,9 +33,9 @@ describe('agentLifecycleActions', () => {
       });
     });
 
-    it('should show restart and delete without stop for pending runtimes', () => {
+    it('should hide restart for pending runtimes', () => {
       expect(getAgentRuntimeLifecycleVisibility('Pending')).toEqual({
-        showRestart: true,
+        showRestart: false,
         showStop: false,
         showDelete: true,
       });

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/agentLifecycleActions.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/agentLifecycleActions.spec.ts
@@ -1,5 +1,6 @@
 import {
   getAgentRuntimeLifecycleVisibility,
+  getLifecycleErrorMessage,
   isAgentRuntimeRunning,
 } from '~/app/utilities/agentLifecycleActions';
 import {
@@ -67,6 +68,48 @@ describe('agentLifecycleActions', () => {
       expect(isAgentRuntimeRunning('Stopped')).toBe(false);
       expect(isAgentRuntimeRunning('Pending')).toBe(false);
       expect(isAgentRuntimeRunning('Failed')).toBe(false);
+    });
+  });
+
+  describe('getLifecycleErrorMessage', () => {
+    it('should return permission message for forbidden errors', () => {
+      expect(getLifecycleErrorMessage(new Error('Forbidden'))).toBe(
+        'You do not have permission to perform this action.',
+      );
+      expect(getLifecycleErrorMessage(new Error('Error 403: Access denied'))).toBe(
+        'You do not have permission to perform this action.',
+      );
+    });
+
+    it('should return not found message for 404 errors', () => {
+      expect(getLifecycleErrorMessage(new Error('Resource not found'))).toBe(
+        'The agent deployment could not be found.',
+      );
+      expect(getLifecycleErrorMessage(new Error('404: Agent missing'))).toBe(
+        'The agent deployment could not be found.',
+      );
+    });
+
+    it('should return network message for connection errors', () => {
+      expect(getLifecycleErrorMessage(new Error('Network error'))).toBe(
+        'Unable to reach the server. Check your connection.',
+      );
+      expect(getLifecycleErrorMessage(new Error('Failed to fetch'))).toBe(
+        'Unable to reach the server. Check your connection.',
+      );
+    });
+
+    it('should return timeout message for timeout errors', () => {
+      expect(getLifecycleErrorMessage(new Error('Request timeout'))).toBe(
+        'The request timed out. Please try again.',
+      );
+    });
+
+    it('should return generic message for unknown errors', () => {
+      expect(getLifecycleErrorMessage(new Error('Something broke'))).toBe(
+        'An error occurred. Please try again.',
+      );
+      expect(getLifecycleErrorMessage('string error')).toBe('An error occurred. Please try again.');
     });
   });
 });

--- a/packages/agent-ops/frontend/src/app/utilities/__tests__/agentLifecycleActions.spec.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/__tests__/agentLifecycleActions.spec.ts
@@ -17,9 +17,9 @@ describe('agentLifecycleActions', () => {
       });
     });
 
-    it('should show restart and delete without stop for unknown runtimes', () => {
+    it('should show delete only for unknown runtimes', () => {
       expect(getAgentRuntimeLifecycleVisibility('mystery')).toEqual({
-        showRestart: true,
+        showRestart: false,
         showStop: false,
         showDelete: true,
       });
@@ -41,9 +41,9 @@ describe('agentLifecycleActions', () => {
       });
     });
 
-    it('should show restart and delete without stop for failed runtimes', () => {
+    it('should show delete only for failed runtimes', () => {
       expect(getAgentRuntimeLifecycleVisibility('Failed')).toEqual({
-        showRestart: true,
+        showRestart: false,
         showStop: false,
         showDelete: true,
       });

--- a/packages/agent-ops/frontend/src/app/utilities/agentLifecycleActions.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/agentLifecycleActions.ts
@@ -14,9 +14,10 @@ export const getAgentRuntimeLifecycleVisibility = (
 ): AgentRuntimeLifecycleVisibility => {
   const { displayStatus } = mapAgentRuntimeStatus(status);
   const showStop = displayStatus === AgentRuntimeDisplayStatus.Ready;
+  const showRestart = displayStatus !== AgentRuntimeDisplayStatus.Pending;
 
   return {
-    showRestart: true,
+    showRestart,
     showStop,
     showDelete: true,
   };

--- a/packages/agent-ops/frontend/src/app/utilities/agentLifecycleActions.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/agentLifecycleActions.ts
@@ -14,7 +14,9 @@ export const getAgentRuntimeLifecycleVisibility = (
 ): AgentRuntimeLifecycleVisibility => {
   const { displayStatus } = mapAgentRuntimeStatus(status);
   const showStop = displayStatus === AgentRuntimeDisplayStatus.Ready;
-  const showRestart = displayStatus !== AgentRuntimeDisplayStatus.Pending;
+  const showRestart =
+    displayStatus === AgentRuntimeDisplayStatus.Ready ||
+    displayStatus === AgentRuntimeDisplayStatus.Stopped;
 
   return {
     showRestart,

--- a/packages/agent-ops/frontend/src/app/utilities/agentLifecycleActions.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/agentLifecycleActions.ts
@@ -1,0 +1,28 @@
+import {
+  AgentRuntimeDisplayStatus,
+  mapAgentRuntimeStatus,
+} from '~/app/utilities/agentRuntimeStatus';
+
+export type AgentRuntimeLifecycleVisibility = {
+  showRestart: boolean;
+  showStop: boolean;
+  showDelete: boolean;
+};
+
+export const getAgentRuntimeLifecycleVisibility = (
+  status: string | undefined,
+): AgentRuntimeLifecycleVisibility => {
+  const { displayStatus } = mapAgentRuntimeStatus(status);
+  const showStop = displayStatus === AgentRuntimeDisplayStatus.Ready;
+
+  return {
+    showRestart: true,
+    showStop,
+    showDelete: true,
+  };
+};
+
+export const isAgentRuntimeRunning = (status: string | undefined): boolean => {
+  const { displayStatus } = mapAgentRuntimeStatus(status);
+  return displayStatus === AgentRuntimeDisplayStatus.Ready;
+};

--- a/packages/agent-ops/frontend/src/app/utilities/agentLifecycleActions.ts
+++ b/packages/agent-ops/frontend/src/app/utilities/agentLifecycleActions.ts
@@ -3,6 +3,29 @@ import {
   mapAgentRuntimeStatus,
 } from '~/app/utilities/agentRuntimeStatus';
 
+const extractRawMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : 'An unexpected error occurred.';
+
+export const getLifecycleErrorMessage = (error: unknown): string => {
+  const raw = extractRawMessage(error);
+  const lower = raw.toLowerCase();
+
+  if (lower.includes('forbidden') || lower.includes('403')) {
+    return 'You do not have permission to perform this action.';
+  }
+  if (lower.includes('not found') || lower.includes('404')) {
+    return 'The agent deployment could not be found.';
+  }
+  if (lower.includes('network') || lower.includes('failed to fetch')) {
+    return 'Unable to reach the server. Check your connection.';
+  }
+  if (lower.includes('timeout')) {
+    return 'The request timed out. Please try again.';
+  }
+
+  return 'An error occurred. Please try again.';
+};
+
 export type AgentRuntimeLifecycleVisibility = {
   showRestart: boolean;
   showStop: boolean;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-62721

## Description

Adds per-row lifecycle quick actions to the Agent Deployments list page so users can manage deployments without navigating to the detail view.

Each deployment row now exposes a kebab **Actions** menu with:
- **Restart** — stops the deployment if it is running, then starts it via the agent-ops BFF lifecycle endpoints
- **Stop** — shown only when the deployment status is Ready
- **Delete** — opens a confirmation modal before calling the BFF delete endpoint


### Implementation notes
- New API client (`agentLifecycle.ts`) for `POST .../stop`, `POST .../start`, and `DELETE` runtime endpoints
- `useAgentLifecycleActions` hook centralizes mutation handling, visibility rules, and refresh behavior
- `AgentDeleteModal` provides a destructive-action confirmation step for delete
- Status-aware action visibility via `getAgentRuntimeLifecycleVisibility`

## How Has This Been Tested?

- Manual testing on mock/dev environment
- Jest unit tests for API client, lifecycle visibility utilities, table row behavior, and lifecycle hook
- Cypress mock tests for stop, restart, and delete flows on the Agent Deployments list page

## Test Impact

- Added unit tests:
  - `agentLifecycle.spec.ts`
  - `agentLifecycleActions.spec.ts`
  - `AgentRuntimesTableRow.spec.tsx` (lifecycle actions)
- Added Cypress coverage in `agentDeployments.cy.ts` for row actions and delete confirmation modal
- Extended page object helpers in `agentDeployments.ts`

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added row-level lifecycle actions (Restart, Stop, Delete) for agent deployments from the row kebab menu.
  * Added a delete confirmation modal with proper loading/disable behavior and safe cancellation.
  * After lifecycle actions, the deployments list refreshes and status updates reflect the outcome.

* **Tests**
  * Expanded end-to-end coverage for restart/stop/delete flows, delete modal confirm vs cancel behavior, and status-based action visibility.
  * Added unit tests covering lifecycle visibility rules and hook behavior, including refresh and error notification handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->