### PR TITLE
refactor(core-bff): replace `interface{}` with `any` and extract header constants

### DIFF
--- a/distributions/core-bff/bff/cmd/main.go
+++ b/distributions/core-bff/bff/cmd/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/api"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/config"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
 
 	"log/slog"
 	"net/http"
@@ -150,7 +151,7 @@ func startMockPrometheus(cfg *config.EnvConfig, logger *slog.Logger) func() {
 		return nil
 	}
 	mockProm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(constants.HeaderContentType, constants.ContentTypeJSON)
 		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
 	}))
 	cfg.PrometheusHost = mockProm.URL

--- a/distributions/core-bff/bff/internal/api/app_proxy.go
+++ b/distributions/core-bff/bff/internal/api/app_proxy.go
@@ -18,9 +18,9 @@ func impersonateFromIdentity(in *http.Request, out http.Header) {
 	if !ok || identity == nil || identity.UserID == "" {
 		return
 	}
-	out.Set("Impersonate-User", identity.UserID)
+	out.Set(constants.HeaderImpersonateUser, identity.UserID)
 	for _, g := range identity.Groups {
-		out.Add("Impersonate-Group", g)
+		out.Add(constants.HeaderImpersonateGroup, g)
 	}
 }
 

--- a/distributions/core-bff/bff/internal/api/config_handler.go
+++ b/distributions/core-bff/bff/internal/api/config_handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/k8sutil"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -16,7 +17,7 @@ func (app *App) GetConfigHandler(w http.ResponseWriter, r *http.Request, _ httpr
 	ctx := r.Context()
 
 	var featureFlagOverrides map[string]bool
-	if flagsHeader := r.Header.Get("x-odh-feature-flags"); flagsHeader != "" {
+	if flagsHeader := r.Header.Get(constants.HeaderFeatureFlags); flagsHeader != "" {
 		featureFlagOverrides = make(map[string]bool)
 		if err := json.Unmarshal([]byte(flagsHeader), &featureFlagOverrides); err != nil {
 			// Silently ignore malformed header
@@ -32,7 +33,7 @@ func (app *App) GetConfigHandler(w http.ResponseWriter, r *http.Request, _ httpr
 		return
 	}
 
-	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set(constants.HeaderCacheControl, constants.CacheControlNo)
 	if err := app.WriteJSON(w, http.StatusOK, config, nil); err != nil {
 		app.serverErrorResponse(w, r, err)
 	}

--- a/distributions/core-bff/bff/internal/api/dashboard_config_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/dashboard_config_handler_test.go
@@ -146,15 +146,15 @@ func TestGetDashboardConfigByName_WrongNamespace_Returns403(t *testing.T) {
 
 func newFakeDynWithDashboardCR() *dynamicfake.FakeDynamicClient {
 	cr := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "opendatahub.io/v1alpha",
 			"kind":       "OdhDashboardConfig",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "odh-dashboard-config",
 				"namespace": "dash-ns",
 			},
-			"spec": map[string]interface{}{
-				"dashboardConfig": map[string]interface{}{
+			"spec": map[string]any{
+				"dashboardConfig": map[string]any{
 					"disableKServe": false,
 				},
 			},
@@ -198,7 +198,7 @@ func TestGetDashboardConfigByName_Success(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err := json.Unmarshal(rr.Body.Bytes(), &body)
 	require.NoError(t, err)
 	assert.Equal(t, "OdhDashboardConfig", body["kind"])
@@ -236,11 +236,11 @@ func TestPatchDashboardConfigByName_Success(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err := json.Unmarshal(rr.Body.Bytes(), &body)
 	require.NoError(t, err)
 
-	spec := body["spec"].(map[string]interface{})
-	dc := spec["dashboardConfig"].(map[string]interface{})
+	spec := body["spec"].(map[string]any)
+	dc := spec["dashboardConfig"].(map[string]any)
 	assert.Equal(t, true, dc["disableKServe"])
 }

--- a/distributions/core-bff/bff/internal/api/helpers.go
+++ b/distributions/core-bff/bff/internal/api/helpers.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
 )
 
 // Envelope wraps API response data with optional metadata.
@@ -32,7 +34,7 @@ func (app *App) WriteJSON(w http.ResponseWriter, status int, data any, headers h
 		w.Header()[key] = value
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(constants.HeaderContentType, constants.ContentTypeJSON)
 	w.WriteHeader(status)
 	_, err = w.Write(js)
 

--- a/distributions/core-bff/bff/internal/api/middleware.go
+++ b/distributions/core-bff/bff/internal/api/middleware.go
@@ -19,7 +19,7 @@ func (app *App) RecoverPanic(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if err := recover(); err != nil {
-				w.Header().Set("Connection", "close")
+				w.Header().Set(constants.HeaderConnection, constants.ConnectionClose)
 				app.serverErrorResponse(w, r, fmt.Errorf("%s", err))
 				app.logger.Error("Recovered from panic", slog.String("stack_trace", string(debug.Stack())))
 			}
@@ -34,8 +34,8 @@ func (app *App) EnableCORS(next http.Handler) http.Handler {
 		return next
 	}
 
-	allowedHeaders := []string{"Content-Type", "Authorization", "X-Forwarded-Access-Token", "x-odh-feature-flags"}
-	if h := app.config.AuthTokenHeader; h != "" && h != "Authorization" && h != "X-Forwarded-Access-Token" {
+	allowedHeaders := []string{constants.HeaderContentType, constants.HeaderAuthorization, constants.HeaderForwardedToken, constants.HeaderFeatureFlags}
+	if h := app.config.AuthTokenHeader; h != "" && h != constants.HeaderAuthorization && h != constants.HeaderForwardedToken {
 		allowedHeaders = append(allowedHeaders, h)
 	}
 

--- a/distributions/core-bff/bff/internal/api/model_serving_proxy.go
+++ b/distributions/core-bff/bff/internal/api/model_serving_proxy.go
@@ -20,7 +20,7 @@ const (
 func (app *App) initModelServingProxy() error {
 	if app.config.MockK8Client {
 		app.modelServingProxy = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set(constants.HeaderContentType, constants.ContentTypeJSON)
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"mock":true}`)) //nolint:errcheck // mock-only handler
 		})
@@ -55,7 +55,7 @@ func (app *App) initModelServingProxy() error {
 				// before requests reach this handler. Defensive fallback omits the header.
 				return ""
 			}
-			return "Bearer " + identity.ResolveToken(app.devFallbackToken)
+			return k8s.BearerTokenPrefix + identity.ResolveToken(app.devFallbackToken)
 		},
 		StripHeaders:       proxy.SensitiveIngressHeaders(app.config.AuthTokenHeader),
 		ModifyResponse:     ssrf.NewRedirectValidator(app.logger),

--- a/distributions/core-bff/bff/internal/api/openapi_handler.go
+++ b/distributions/core-bff/bff/internal/api/openapi_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
 	openapispec "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/openapi"
 )
 
@@ -49,10 +50,10 @@ func NewOpenAPIHandler(logger *slog.Logger) (*OpenAPIHandler, error) {
 // OpenAPI endpoints use permissive CORS (Allow-Origin: *) intentionally - they serve
 // public developer documentation and must be accessible from Swagger UI on any origin.
 func (h *OpenAPIHandler) HandleOpenAPIJSON(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set(constants.HeaderContentType, constants.ContentTypeJSON)
+	w.Header().Set(constants.HeaderAccessControlOrigin, constants.AllowedOriginAll)
+	w.Header().Set(constants.HeaderAccessControlMethod, constants.AllowedMethodsReadOnly)
+	w.Header().Set(constants.HeaderAccessControlHeader, constants.HeaderContentType)
 
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -85,10 +86,10 @@ func (h *OpenAPIHandler) HandleOpenAPIJSON(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *OpenAPIHandler) HandleOpenAPIYAML(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Header().Set("Content-Type", "text/yaml")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set(constants.HeaderContentType, constants.ContentTypeYAML)
+	w.Header().Set(constants.HeaderAccessControlOrigin, constants.AllowedOriginAll)
+	w.Header().Set(constants.HeaderAccessControlMethod, constants.AllowedMethodsReadOnly)
+	w.Header().Set(constants.HeaderAccessControlHeader, constants.HeaderContentType)
 
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -102,8 +103,8 @@ func (h *OpenAPIHandler) HandleOpenAPIYAML(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *OpenAPIHandler) HandleSwaggerUI(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Header().Set("Content-Type", "text/html")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set(constants.HeaderContentType, constants.ContentTypeHTML)
+	w.Header().Set(constants.HeaderAccessControlOrigin, constants.AllowedOriginAll)
 
 	html := `<!DOCTYPE html>
 <html lang="en">

--- a/distributions/core-bff/bff/internal/api/openshift_user.go
+++ b/distributions/core-bff/bff/internal/api/openshift_user.go
@@ -41,14 +41,14 @@ func (app *App) resolveUserViaOpenShiftAPI(ctx context.Context, client k8s.Kuber
 	return username, groups, nil
 }
 
-func unstructuredString(obj map[string]interface{}, keys ...string) (string, bool) {
+func unstructuredString(obj map[string]any, keys ...string) (string, bool) {
 	current := obj
 	for i, key := range keys {
 		if i == len(keys)-1 {
 			val, ok := current[key].(string)
 			return val, ok
 		}
-		next, ok := current[key].(map[string]interface{})
+		next, ok := current[key].(map[string]any)
 		if !ok {
 			return "", false
 		}
@@ -57,12 +57,12 @@ func unstructuredString(obj map[string]interface{}, keys ...string) (string, boo
 	return "", false
 }
 
-func unstructuredStringSlice(obj map[string]interface{}, key string) []string {
+func unstructuredStringSlice(obj map[string]any, key string) []string {
 	raw, ok := obj[key]
 	if !ok {
 		return nil
 	}
-	slice, ok := raw.([]interface{})
+	slice, ok := raw.([]any)
 	if !ok {
 		return nil
 	}

--- a/distributions/core-bff/bff/internal/api/openshift_user_test.go
+++ b/distributions/core-bff/bff/internal/api/openshift_user_test.go
@@ -22,7 +22,7 @@ import (
 // ─── unstructuredString tests ───────────────────────────────────────────────
 
 func TestUnstructuredString_TopLevelKey(t *testing.T) {
-	obj := map[string]interface{}{
+	obj := map[string]any{
 		"name": "test-user",
 	}
 	val, ok := unstructuredString(obj, "name")
@@ -31,8 +31,8 @@ func TestUnstructuredString_TopLevelKey(t *testing.T) {
 }
 
 func TestUnstructuredString_NestedKey(t *testing.T) {
-	obj := map[string]interface{}{
-		"metadata": map[string]interface{}{
+	obj := map[string]any{
+		"metadata": map[string]any{
 			"name": "test-user",
 		},
 	}
@@ -42,8 +42,8 @@ func TestUnstructuredString_NestedKey(t *testing.T) {
 }
 
 func TestUnstructuredString_MissingKey(t *testing.T) {
-	obj := map[string]interface{}{
-		"metadata": map[string]interface{}{},
+	obj := map[string]any{
+		"metadata": map[string]any{},
 	}
 	val, ok := unstructuredString(obj, "metadata", "name")
 	assert.False(t, ok)
@@ -51,7 +51,7 @@ func TestUnstructuredString_MissingKey(t *testing.T) {
 }
 
 func TestUnstructuredString_MissingIntermediateKey(t *testing.T) {
-	obj := map[string]interface{}{
+	obj := map[string]any{
 		"other": "value",
 	}
 	val, ok := unstructuredString(obj, "metadata", "name")
@@ -60,7 +60,7 @@ func TestUnstructuredString_MissingIntermediateKey(t *testing.T) {
 }
 
 func TestUnstructuredString_NonStringValue(t *testing.T) {
-	obj := map[string]interface{}{
+	obj := map[string]any{
 		"count": 42,
 	}
 	val, ok := unstructuredString(obj, "count")
@@ -69,7 +69,7 @@ func TestUnstructuredString_NonStringValue(t *testing.T) {
 }
 
 func TestUnstructuredString_EmptyKeys(t *testing.T) {
-	obj := map[string]interface{}{
+	obj := map[string]any{
 		"name": "test",
 	}
 	val, ok := unstructuredString(obj)
@@ -80,21 +80,21 @@ func TestUnstructuredString_EmptyKeys(t *testing.T) {
 // ─── unstructuredStringSlice tests ──────────────────────────────────────────
 
 func TestUnstructuredStringSlice_ValidSlice(t *testing.T) {
-	obj := map[string]interface{}{
-		"groups": []interface{}{"admin", "users", "editors"},
+	obj := map[string]any{
+		"groups": []any{"admin", "users", "editors"},
 	}
 	result := unstructuredStringSlice(obj, "groups")
 	assert.Equal(t, []string{"admin", "users", "editors"}, result)
 }
 
 func TestUnstructuredStringSlice_MissingKey(t *testing.T) {
-	obj := map[string]interface{}{}
+	obj := map[string]any{}
 	result := unstructuredStringSlice(obj, "groups")
 	assert.Nil(t, result)
 }
 
 func TestUnstructuredStringSlice_NotASlice(t *testing.T) {
-	obj := map[string]interface{}{
+	obj := map[string]any{
 		"groups": "not-a-slice",
 	}
 	result := unstructuredStringSlice(obj, "groups")
@@ -102,16 +102,16 @@ func TestUnstructuredStringSlice_NotASlice(t *testing.T) {
 }
 
 func TestUnstructuredStringSlice_MixedTypes(t *testing.T) {
-	obj := map[string]interface{}{
-		"groups": []interface{}{"admin", 42, "users", true},
+	obj := map[string]any{
+		"groups": []any{"admin", 42, "users", true},
 	}
 	result := unstructuredStringSlice(obj, "groups")
 	assert.Equal(t, []string{"admin", "users"}, result)
 }
 
 func TestUnstructuredStringSlice_EmptySlice(t *testing.T) {
-	obj := map[string]interface{}{
-		"groups": []interface{}{},
+	obj := map[string]any{
+		"groups": []any{},
 	}
 	result := unstructuredStringSlice(obj, "groups")
 	assert.Equal(t, []string{}, result)
@@ -136,13 +136,13 @@ func TestResolveUserViaOpenShiftAPI_XKSReturnsEarly(t *testing.T) {
 // construction, dynamic Get, unstructured parsing of username and groups).
 func TestResolveUserViaOpenShiftAPI_OpenShiftResolvesUser(t *testing.T) {
 	userObj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "user.openshift.io/v1",
 			"kind":       "User",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "~",
 			},
-			"groups": []interface{}{"dev-team", "editors"},
+			"groups": []any{"dev-team", "editors"},
 		},
 	}
 

--- a/distributions/core-bff/bff/internal/api/serving_runtime_handler.go
+++ b/distributions/core-bff/bff/internal/api/serving_runtime_handler.go
@@ -14,7 +14,7 @@ import (
 // CreateServingRuntimeHandler handles POST /api/v1/servingRuntimes.
 // Creates a ServingRuntime CR in the specified namespace.
 func (app *App) CreateServingRuntimeHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	var body map[string]interface{}
+	var body map[string]any
 	if err := app.ReadJSON(w, r, &body); err != nil {
 		app.badRequestResponse(w, r, err)
 		return
@@ -50,12 +50,12 @@ func (app *App) CreateServingRuntimeHandler(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-func extractNamespaceFromBody(body map[string]interface{}) (string, error) {
+func extractNamespaceFromBody(body map[string]any) (string, error) {
 	metadata, ok := body["metadata"]
 	if !ok {
 		return "", errors.New("missing metadata in request body")
 	}
-	metaMap, ok := metadata.(map[string]interface{})
+	metaMap, ok := metadata.(map[string]any)
 	if !ok {
 		return "", errors.New("metadata must be an object")
 	}

--- a/distributions/core-bff/bff/internal/api/serving_runtime_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/serving_runtime_handler_test.go
@@ -23,7 +23,7 @@ func TestCreateServingRuntime_MissingMetadata(t *testing.T) {
 	})
 	admin := k8mocks.DefaultTestUsers[0]
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"apiVersion": "serving.kserve.io/v1alpha1",
 		"kind":       "ServingRuntime",
 	}
@@ -50,10 +50,10 @@ func TestCreateServingRuntime_MissingNamespace(t *testing.T) {
 	})
 	admin := k8mocks.DefaultTestUsers[0]
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"apiVersion": "serving.kserve.io/v1alpha1",
 		"kind":       "ServingRuntime",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name": "test-runtime",
 		},
 	}
@@ -80,10 +80,10 @@ func TestCreateServingRuntime_DisallowedNamespace(t *testing.T) {
 	})
 	admin := k8mocks.DefaultTestUsers[0]
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"apiVersion": "serving.kserve.io/v1alpha1",
 		"kind":       "ServingRuntime",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "test-runtime",
 			"namespace": "some-other-ns",
 		},
@@ -147,10 +147,10 @@ func TestCreateServingRuntime_EmptyNamespaceString(t *testing.T) {
 	})
 	admin := k8mocks.DefaultTestUsers[0]
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"apiVersion": "serving.kserve.io/v1alpha1",
 		"kind":       "ServingRuntime",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "test-runtime",
 			"namespace": "",
 		},
@@ -181,16 +181,16 @@ func TestCreateServingRuntime_Success(t *testing.T) {
 	})
 	admin := k8mocks.DefaultTestUsers[0]
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"apiVersion": "serving.kserve.io/v1alpha1",
 		"kind":       "ServingRuntime",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "test-runtime",
 			"namespace": ns,
 		},
-		"spec": map[string]interface{}{
-			"supportedModelFormats": []interface{}{
-				map[string]interface{}{"name": "openvino_ir", "version": "opset1"},
+		"spec": map[string]any{
+			"supportedModelFormats": []any{
+				map[string]any{"name": "openvino_ir", "version": "opset1"},
 			},
 		},
 	}
@@ -210,10 +210,10 @@ func TestCreateServingRuntime_Success(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(rr.Body.Bytes(), &result)
 	require.NoError(t, err)
-	meta, _ := result["metadata"].(map[string]interface{})
+	meta, _ := result["metadata"].(map[string]any)
 	assert.Equal(t, "test-runtime", meta["name"])
 	assert.Equal(t, ns, meta["namespace"])
 }
@@ -227,16 +227,16 @@ func TestCreateServingRuntime_DryRun(t *testing.T) {
 	})
 	admin := k8mocks.DefaultTestUsers[0]
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"apiVersion": "serving.kserve.io/v1alpha1",
 		"kind":       "ServingRuntime",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "dryrun-runtime",
 			"namespace": ns,
 		},
-		"spec": map[string]interface{}{
-			"supportedModelFormats": []interface{}{
-				map[string]interface{}{"name": "openvino_ir", "version": "opset1"},
+		"spec": map[string]any{
+			"supportedModelFormats": []any{
+				map[string]any{"name": "openvino_ir", "version": "opset1"},
 			},
 		},
 	}
@@ -256,10 +256,10 @@ func TestCreateServingRuntime_DryRun(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(rr.Body.Bytes(), &result)
 	require.NoError(t, err)
-	meta, _ := result["metadata"].(map[string]interface{})
+	meta, _ := result["metadata"].(map[string]any)
 	assert.Equal(t, "dryrun-runtime", meta["name"])
 
 	// Verify the object was not actually persisted.
@@ -270,47 +270,47 @@ func TestCreateServingRuntime_DryRun(t *testing.T) {
 func TestExtractNamespaceFromBody(t *testing.T) {
 	tests := []struct {
 		name    string
-		body    map[string]interface{}
+		body    map[string]any
 		want    string
 		wantErr bool
 	}{
 		{
 			name: "valid namespace",
-			body: map[string]interface{}{
-				"metadata": map[string]interface{}{"namespace": "test-ns"},
+			body: map[string]any{
+				"metadata": map[string]any{"namespace": "test-ns"},
 			},
 			want: "test-ns",
 		},
 		{
 			name:    "missing metadata",
-			body:    map[string]interface{}{},
+			body:    map[string]any{},
 			wantErr: true,
 		},
 		{
 			name: "metadata not an object",
-			body: map[string]interface{}{
+			body: map[string]any{
 				"metadata": "not-a-map",
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing namespace key",
-			body: map[string]interface{}{
-				"metadata": map[string]interface{}{"name": "test"},
+			body: map[string]any{
+				"metadata": map[string]any{"name": "test"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "empty namespace string",
-			body: map[string]interface{}{
-				"metadata": map[string]interface{}{"namespace": ""},
+			body: map[string]any{
+				"metadata": map[string]any{"namespace": ""},
 			},
 			wantErr: true,
 		},
 		{
 			name: "namespace not a string",
-			body: map[string]interface{}{
-				"metadata": map[string]interface{}{"namespace": 123},
+			body: map[string]any{
+				"metadata": map[string]any{"namespace": 123},
 			},
 			wantErr: true,
 		},

--- a/distributions/core-bff/bff/internal/constants/headers.go
+++ b/distributions/core-bff/bff/internal/constants/headers.go
@@ -1,0 +1,33 @@
+package constants
+
+const (
+	HeaderAuthorization       = "Authorization"
+	HeaderContentType         = "Content-Type"
+	HeaderAccept              = "Accept"
+	HeaderOrigin              = "Origin"
+	HeaderHost                = "Host"
+	HeaderLocation            = "Location"
+	HeaderConnection          = "Connection"
+	HeaderCacheControl        = "Cache-Control"
+	HeaderCookie              = "Cookie"
+	HeaderSetCookie           = "Set-Cookie"
+	HeaderProxyAuthorization  = "Proxy-Authorization"
+	HeaderSecWebSocketProto   = "Sec-WebSocket-Protocol"
+	HeaderImpersonateUser     = "Impersonate-User"
+	HeaderImpersonateGroup    = "Impersonate-Group"
+	HeaderForwardedToken      = "X-Forwarded-Access-Token" //nolint:gosec // G101: header name, not a credential
+	HeaderFeatureFlags        = "x-odh-feature-flags"
+	HeaderAccessControlOrigin = "Access-Control-Allow-Origin"
+	HeaderAccessControlMethod = "Access-Control-Allow-Methods"
+	HeaderAccessControlHeader = "Access-Control-Allow-Headers"
+
+	ContentTypeJSON = "application/json"
+	ContentTypeYAML = "text/yaml"
+	ContentTypeHTML = "text/html"
+
+	AllowedMethodsReadOnly = "GET, OPTIONS"
+	AllowedOriginAll       = "*"
+
+	ConnectionClose = "close"
+	CacheControlNo  = "no-cache"
+)

--- a/distributions/core-bff/bff/internal/helpers/logging.go
+++ b/distributions/core-bff/bff/internal/helpers/logging.go
@@ -27,11 +27,11 @@ func GetContextLogger(ctx context.Context) *slog.Logger {
 }
 
 var sensitiveHeaders = []string{
-	"Authorization",
-	"Cookie",
-	"Set-Cookie",
-	"Proxy-Authorization",
-	"X-Forwarded-Access-Token",
+	constants.HeaderAuthorization,
+	constants.HeaderCookie,
+	constants.HeaderSetCookie,
+	constants.HeaderProxyAuthorization,
+	constants.HeaderForwardedToken,
 }
 
 func isSensitiveHeader(h string) bool {

--- a/distributions/core-bff/bff/internal/integrations/bffclient/client.go
+++ b/distributions/core-bff/bff/internal/integrations/bffclient/client.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
 )
 
 // BFFClientInterface defines the interface for inter-BFF communication
@@ -151,9 +153,9 @@ func (c *HTTPBFFClient) buildRequest(ctx context.Context, method, path string, b
 	}
 
 	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(constants.HeaderContentType, constants.ContentTypeJSON)
 	}
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set(constants.HeaderAccept, constants.ContentTypeJSON)
 
 	authHeader := c.authTokenHeader
 	if authHeader == "" {
@@ -164,7 +166,7 @@ func (c *HTTPBFFClient) buildRequest(ctx context.Context, method, path string, b
 	}
 
 	for key, value := range c.customHeaders {
-		if strings.EqualFold(key, authHeader) || strings.EqualFold(key, "Authorization") {
+		if strings.EqualFold(key, authHeader) || strings.EqualFold(key, constants.HeaderAuthorization) {
 			continue
 		}
 		req.Header.Set(key, value)

--- a/distributions/core-bff/bff/internal/integrations/httpclient/http.go
+++ b/distributions/core-bff/bff/internal/integrations/httpclient/http.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 
 	"github.com/google/uuid"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/helpers"
 )
 
@@ -91,7 +92,7 @@ func (c *HTTPClient) doRequest(ctx context.Context, method, url string, body io.
 	}
 
 	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(constants.HeaderContentType, constants.ContentTypeJSON)
 	}
 
 	c.applyHeaders(req)

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_nim.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_nim.go
@@ -41,14 +41,14 @@ func createNIMTestData(ctx context.Context, k8sClient k8sclient.Interface, dynCl
 		return fmt.Errorf("failed to create NIM config map: %w", err)
 	}
 
-	account := &unstructured.Unstructured{Object: map[string]interface{}{
+	account := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "nim.opendatahub.io/v1",
 		"kind":       "Account",
-		"metadata":   map[string]interface{}{"name": models.NIMAccountName, "namespace": ns},
-		"spec":       map[string]interface{}{"apiKeySecret": map[string]interface{}{"name": "nvidia-nim-access"}},
-		"status": map[string]interface{}{
-			"nimPullSecret": map[string]interface{}{"name": "nim-pull-secret"},
-			"nimConfig":     map[string]interface{}{"name": "nim-config"},
+		"metadata":   map[string]any{"name": models.NIMAccountName, "namespace": ns},
+		"spec":       map[string]any{"apiKeySecret": map[string]any{"name": "nvidia-nim-access"}},
+		"status": map[string]any{
+			"nimPullSecret": map[string]any{"name": "nim-pull-secret"},
+			"nimConfig":     map[string]any{"name": "nim-config"},
 		},
 	}}
 	_, err = dynClient.Resource(models.NIMAccountGVR).Namespace(ns).Create(ctx, account, metav1.CreateOptions{})

--- a/distributions/core-bff/bff/internal/maputil/maputil.go
+++ b/distributions/core-bff/bff/internal/maputil/maputil.go
@@ -5,18 +5,18 @@ import "encoding/json"
 // DeepMerge recursively merges overrides into defaults.
 // Override values take precedence. Maps are merged recursively.
 // Nested maps from defaults are deep-copied so the original defaults are never mutated.
-func DeepMerge(defaults, overrides map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{}, len(defaults))
+func DeepMerge(defaults, overrides map[string]any) map[string]any {
+	result := make(map[string]any, len(defaults))
 	for k, v := range defaults {
-		if vMap, ok := v.(map[string]interface{}); ok {
+		if vMap, ok := v.(map[string]any); ok {
 			result[k] = DeepCopyMap(vMap)
 		} else {
 			result[k] = v
 		}
 	}
 	for k, v := range overrides {
-		if vMap, ok := v.(map[string]interface{}); ok {
-			if dMap, ok := result[k].(map[string]interface{}); ok {
+		if vMap, ok := v.(map[string]any); ok {
+			if dMap, ok := result[k].(map[string]any); ok {
 				result[k] = DeepMerge(dMap, vMap)
 				continue
 			}
@@ -43,13 +43,13 @@ func DeepCopyMap(m map[string]any) map[string]any {
 	return cp
 }
 
-// ToUnstructuredMap converts a typed Go struct to a map[string]interface{} via JSON round-trip.
-func ToUnstructuredMap(obj interface{}) (map[string]interface{}, error) {
+// ToUnstructuredMap converts a typed Go struct to a map[string]any via JSON round-trip.
+func ToUnstructuredMap(obj any) (map[string]any, error) {
 	data, err := json.Marshal(obj)
 	if err != nil {
 		return nil, err
 	}
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, err
 	}

--- a/distributions/core-bff/bff/internal/models/nim.go
+++ b/distributions/core-bff/bff/internal/models/nim.go
@@ -33,7 +33,7 @@ var NIMResourceMap = map[string]NIMResourceMapping{
 
 // NIMServingResourceResponse wraps the result of a cross-resource NIM lookup.
 type NIMServingResourceResponse struct {
-	Body interface{} `json:"body"`
+	Body any `json:"body"`
 }
 
 // NIMIntegrationStatus represents the status of a NIM integration.

--- a/distributions/core-bff/bff/internal/proxy/factory.go
+++ b/distributions/core-bff/bff/internal/proxy/factory.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/ssrf"
 )
 
@@ -72,17 +73,17 @@ func (cfg ProxyConfig) rewriteFunc() func(*httputil.ProxyRequest) {
 }
 
 func rewriteAuthHeader(pr *httputil.ProxyRequest, authHeaderFn func(*http.Request) string) {
-	pr.Out.Header.Del("Authorization")
+	pr.Out.Header.Del(constants.HeaderAuthorization)
 	if authHeaderFn != nil {
 		if authValue := authHeaderFn(pr.In); authValue != "" {
-			pr.Out.Header.Set("Authorization", authValue)
+			pr.Out.Header.Set(constants.HeaderAuthorization, authValue)
 		}
 	}
 }
 
 func stripImpersonationHeaders(h http.Header) {
-	h.Del("Impersonate-User")
-	h.Del("Impersonate-Group")
+	h.Del(constants.HeaderImpersonateUser)
+	h.Del(constants.HeaderImpersonateGroup)
 	for key := range h {
 		if strings.HasPrefix(strings.ToLower(key), "impersonate-extra-") {
 			h.Del(key)

--- a/distributions/core-bff/bff/internal/proxy/ws_proxy.go
+++ b/distributions/core-bff/bff/internal/proxy/ws_proxy.go
@@ -48,7 +48,7 @@ func originChecker(allowedOrigins []string) func(*http.Request) bool {
 		allowed[strings.TrimRight(o, "/")] = true
 	}
 	return func(r *http.Request) bool {
-		origin := r.Header.Get("Origin")
+		origin := r.Header.Get(constants.HeaderOrigin)
 		if origin == "" {
 			return false
 		}
@@ -60,7 +60,7 @@ func originChecker(allowedOrigins []string) func(*http.Request) bool {
 // matches the request's Host. This is the default when ALLOWED_ORIGINS is
 // unset, so WebSockets work out of the box without opening cross-origin access.
 func sameOriginCheck(r *http.Request) bool {
-	origin := r.Header.Get("Origin")
+	origin := r.Header.Get(constants.HeaderOrigin)
 	if origin == "" {
 		return false
 	}
@@ -157,9 +157,9 @@ func dialK8sWebSocket(targetWSURL string, tlsConfig *tls.Config, token string, t
 	}
 
 	dialHeaders := http.Header{}
-	dialHeaders.Set("Host", targetURL.Host)
-	dialHeaders.Set("Origin", targetURL.Scheme+"://"+targetURL.Host)
-	dialHeaders.Set("Authorization", k8s.BearerTokenPrefix+token)
+	dialHeaders.Set(constants.HeaderHost, targetURL.Host)
+	dialHeaders.Set(constants.HeaderOrigin, targetURL.Scheme+"://"+targetURL.Host)
+	dialHeaders.Set(constants.HeaderAuthorization, k8s.BearerTokenPrefix+token)
 
 	return dialer.Dial(targetWSURL, dialHeaders)
 }
@@ -176,7 +176,7 @@ func negotiatedSubprotocolHeader(targetConn *websocket.Conn, clientSubprotocols 
 	for _, csp := range clientSubprotocols {
 		if csp == sp {
 			h := http.Header{}
-			h.Set("Sec-WebSocket-Protocol", sp)
+			h.Set(constants.HeaderSecWebSocketProto, sp)
 			return h
 		}
 	}

--- a/distributions/core-bff/bff/internal/repositories/allowed_users.go
+++ b/distributions/core-bff/bff/internal/repositories/allowed_users.go
@@ -68,14 +68,14 @@ func (r *AllowedUsersRepository) GetAllowedUsers(ctx context.Context, namespace 
 	return result, nil
 }
 
-func parseNotebookUser(obj map[string]interface{}) *models.AllowedUser {
-	metadata, ok := obj["metadata"].(map[string]interface{})
+func parseNotebookUser(obj map[string]any) *models.AllowedUser {
+	metadata, ok := obj["metadata"].(map[string]any)
 	if !ok {
 		return nil
 	}
 
-	annotations, _ := metadata["annotations"].(map[string]interface{})
-	labels, _ := metadata["labels"].(map[string]interface{})
+	annotations, _ := metadata["annotations"].(map[string]any)
+	labels, _ := metadata["labels"].(map[string]any)
 
 	username := decodeNotebookUsername(annotations)
 	if username == "" {
@@ -89,14 +89,14 @@ func parseNotebookUser(obj map[string]interface{}) *models.AllowedUser {
 	}
 }
 
-func notebookPrivilege(labels map[string]interface{}) string {
+func notebookPrivilege(labels map[string]any) string {
 	if userType, _ := labels[labelUserType].(string); userType == "admin" {
 		return models.PrivilegeAdmin
 	}
 	return models.PrivilegeUser
 }
 
-func notebookLastActivity(annotations map[string]interface{}) string {
+func notebookLastActivity(annotations map[string]any) string {
 	if la, ok := annotations[annotationLastActivity].(string); ok && la != "" {
 		return la
 	}
@@ -108,7 +108,7 @@ func notebookLastActivity(annotations map[string]interface{}) string {
 
 const kubeSafePrefix = "b64:"
 
-func decodeNotebookUsername(annotations map[string]interface{}) string {
+func decodeNotebookUsername(annotations map[string]any) string {
 	raw, _ := annotations[annotationUsername].(string)
 	if raw == "" {
 		return ""

--- a/distributions/core-bff/bff/internal/repositories/allowed_users_test.go
+++ b/distributions/core-bff/bff/internal/repositories/allowed_users_test.go
@@ -18,17 +18,17 @@ import (
 
 func fakeNotebook(name, namespace, username, userType, lastActivity string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "kubeflow.org/v1",
 			"kind":       "Notebook",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      name,
 				"namespace": namespace,
-				"annotations": map[string]interface{}{
+				"annotations": map[string]any{
 					"opendatahub.io/username":              username,
 					"notebooks.kubeflow.org/last-activity": lastActivity,
 				},
-				"labels": map[string]interface{}{
+				"labels": map[string]any{
 					"opendatahub.io/user-type": userType,
 				},
 			},
@@ -102,7 +102,7 @@ func TestGetAllowedUsers_NilClient_ReturnsEmpty(t *testing.T) {
 }
 
 func TestDecodeNotebookUsername_Plain(t *testing.T) {
-	annotations := map[string]interface{}{
+	annotations := map[string]any{
 		"opendatahub.io/username": "user@example.com",
 	}
 	assert.Equal(t, "user@example.com", decodeNotebookUsername(annotations))
@@ -110,7 +110,7 @@ func TestDecodeNotebookUsername_Plain(t *testing.T) {
 
 func TestDecodeNotebookUsername_B64Encoded(t *testing.T) {
 	encoded := kubeSafePrefix + base64.StdEncoding.EncodeToString([]byte("user@example.com"))
-	annotations := map[string]interface{}{
+	annotations := map[string]any{
 		"opendatahub.io/username": encoded,
 	}
 	assert.Equal(t, "user@example.com", decodeNotebookUsername(annotations))
@@ -118,5 +118,5 @@ func TestDecodeNotebookUsername_B64Encoded(t *testing.T) {
 
 func TestDecodeNotebookUsername_Empty(t *testing.T) {
 	assert.Equal(t, "", decodeNotebookUsername(nil))
-	assert.Equal(t, "", decodeNotebookUsername(map[string]interface{}{}))
+	assert.Equal(t, "", decodeNotebookUsername(map[string]any{}))
 }

--- a/distributions/core-bff/bff/internal/repositories/auth.go
+++ b/distributions/core-bff/bff/internal/repositories/auth.go
@@ -46,7 +46,7 @@ func (r *AuthRepository) GetAuth(ctx context.Context) (*AuthConfig, error) {
 		return nil, classifyAuthError(err)
 	}
 
-	spec, ok := result.Object["spec"].(map[string]interface{})
+	spec, ok := result.Object["spec"].(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("auth CR has missing or invalid spec")
 	}
@@ -64,8 +64,8 @@ func classifyAuthError(err error) error {
 	return fmt.Errorf("failed to get auth config: %w", err)
 }
 
-func extractStringSlice(m map[string]interface{}, key string) []string {
-	raw, ok := m[key].([]interface{})
+func extractStringSlice(m map[string]any, key string) []string {
+	raw, ok := m[key].([]any)
 	if !ok {
 		return nil
 	}

--- a/distributions/core-bff/bff/internal/repositories/auth_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/auth_integration_test.go
@@ -18,20 +18,20 @@ import (
 func newFakeDynClientWithAuth(allowedGroups []string) *dynamicfake.FakeDynamicClient {
 	scheme := runtime.NewScheme()
 
-	adminGroups := []interface{}{"odh-admins"}
-	allowed := make([]interface{}, len(allowedGroups))
+	adminGroups := []any{"odh-admins"}
+	allowed := make([]any, len(allowedGroups))
 	for i, g := range allowedGroups {
 		allowed[i] = g
 	}
 
 	authCR := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "services.platform.opendatahub.io/v1alpha1",
 			"kind":       "Auth",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "auth",
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"adminGroups":   adminGroups,
 				"allowedGroups": allowed,
 			},
@@ -91,10 +91,10 @@ func TestGetAuth_CRDAbsent_ReturnsNil(t *testing.T) {
 func TestGetAuth_MalformedSpec_ReturnsError(t *testing.T) {
 	scheme := runtime.NewScheme()
 	cr := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "services.platform.opendatahub.io/v1alpha1",
 			"kind":       "Auth",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "auth",
 			},
 		},

--- a/distributions/core-bff/bff/internal/repositories/auth_test.go
+++ b/distributions/core-bff/bff/internal/repositories/auth_test.go
@@ -26,20 +26,20 @@ func TestGetAuth_ErrorClassification(t *testing.T) {
 }
 
 func TestGetAuth_ParsesAuthConfig(t *testing.T) {
-	spec := map[string]interface{}{
-		"adminGroups":   []interface{}{"admin-group-1", "admin-group-2"},
-		"allowedGroups": []interface{}{models.SystemAuthenticated, "allowed-group"},
+	spec := map[string]any{
+		"adminGroups":   []any{"admin-group-1", "admin-group-2"},
+		"allowedGroups": []any{models.SystemAuthenticated, "allowed-group"},
 	}
 
 	auth := &AuthConfig{}
-	if groups, ok := spec["adminGroups"].([]interface{}); ok {
+	if groups, ok := spec["adminGroups"].([]any); ok {
 		for _, g := range groups {
 			if s, ok := g.(string); ok {
 				auth.AdminGroups = append(auth.AdminGroups, s)
 			}
 		}
 	}
-	if groups, ok := spec["allowedGroups"].([]interface{}); ok {
+	if groups, ok := spec["allowedGroups"].([]any); ok {
 		for _, g := range groups {
 			if s, ok := g.(string); ok {
 				auth.AllowedGroups = append(auth.AllowedGroups, s)
@@ -52,10 +52,10 @@ func TestGetAuth_ParsesAuthConfig(t *testing.T) {
 }
 
 func TestGetAuth_EmptySpec(t *testing.T) {
-	spec := map[string]interface{}{}
+	spec := map[string]any{}
 
 	auth := &AuthConfig{}
-	if groups, ok := spec["adminGroups"].([]interface{}); ok {
+	if groups, ok := spec["adminGroups"].([]any); ok {
 		for _, g := range groups {
 			if s, ok := g.(string); ok {
 				auth.AdminGroups = append(auth.AdminGroups, s)

--- a/distributions/core-bff/bff/internal/repositories/cluster_settings.go
+++ b/distributions/core-bff/bff/internal/repositories/cluster_settings.go
@@ -78,16 +78,16 @@ func (r *ClusterSettingsRepository) BuildDashboardConfigPatch(
 		return nil, fmt.Errorf("currentConfig must not be nil")
 	}
 
-	patch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"dashboardConfig": map[string]interface{}{
+	patch := map[string]any{
+		"spec": map[string]any{
+			"dashboardConfig": map[string]any{
 				"disableKServe": !settings.ModelServingPlatformEnabled.KServe,
 				"disableLLMd":   !settings.ModelServingPlatformEnabled.LLMd,
 			},
 		},
 	}
 
-	modelServing := map[string]interface{}{}
+	modelServing := map[string]any{}
 	if settings.IsDistributedInferencingDefault != nil {
 		modelServing["isLLMdDefault"] = *settings.IsDistributedInferencingDefault
 	}
@@ -99,7 +99,7 @@ func (r *ClusterSettingsRepository) BuildDashboardConfigPatch(
 		modelServing["deploymentStrategy"] = settings.DefaultDeploymentStrategy
 	}
 	if len(modelServing) > 0 {
-		patch["spec"].(map[string]interface{})["modelServing"] = modelServing
+		patch["spec"].(map[string]any)["modelServing"] = modelServing
 	}
 
 	currentPVC := currentPVCSize(currentConfig)
@@ -109,7 +109,7 @@ func (r *ClusterSettingsRepository) BuildDashboardConfigPatch(
 			isJupyterEnabled = currentConfig.Spec.NotebookController.Enabled
 		}
 		pvcStr := fmt.Sprintf("%dGi", settings.PVCSize)
-		patch["spec"].(map[string]interface{})["notebookController"] = map[string]interface{}{
+		patch["spec"].(map[string]any)["notebookController"] = map[string]any{
 			"enabled": isJupyterEnabled,
 			"pvcSize": pvcStr,
 		}

--- a/distributions/core-bff/bff/internal/repositories/components.go
+++ b/distributions/core-bff/bff/internal/repositories/components.go
@@ -30,20 +30,20 @@ func NewComponentsRepository(saDynClient dynamic.Interface, saClientset kubernet
 func (r *ComponentsRepository) ListComponents(
 	ctx context.Context,
 	namespace string, installedOnly bool,
-) ([]map[string]interface{}, error) {
+) ([]map[string]any, error) {
 	if r.saDynClient == nil {
-		return []map[string]interface{}{}, nil
+		return []map[string]any{}, nil
 	}
 
 	list, err := r.saDynClient.Resource(models.OdhApplicationGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		if k8sutil.IsResourceUnavailable(err) {
-			return []map[string]interface{}{}, nil
+			return []map[string]any{}, nil
 		}
 		return nil, fmt.Errorf("failed to list components: %w", err)
 	}
 
-	result := make([]map[string]interface{}, 0, len(list.Items))
+	result := make([]map[string]any, 0, len(list.Items))
 	for _, item := range list.Items {
 		if installedOnly && !isShownOnEnabledPage(item) {
 			continue
@@ -83,7 +83,7 @@ func (r *ComponentsRepository) RemoveComponent(ctx context.Context, namespace, a
 }
 
 func isShownOnEnabledPage(item unstructured.Unstructured) bool {
-	spec, ok := item.Object["spec"].(map[string]interface{})
+	spec, ok := item.Object["spec"].(map[string]any)
 	if !ok {
 		return false
 	}

--- a/distributions/core-bff/bff/internal/repositories/components_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/components_integration_test.go
@@ -33,14 +33,14 @@ func newFakeDynClientWithApps(apps ...*unstructured.Unstructured) *dynamicfake.F
 
 func odhApp(name string, shownOnEnabledPage bool) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "dashboard.opendatahub.io/v1",
 			"kind":       "OdhApplication",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      name,
 				"namespace": "test-ns",
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"shownOnEnabledPage": shownOnEnabledPage,
 			},
 		},
@@ -58,7 +58,7 @@ func TestListComponents_InstalledOnly_FiltersCorrectly(t *testing.T) {
 		result, err := repo.ListComponents(context.Background(), "test-ns", true)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
-		meta := result[0]["metadata"].(map[string]interface{})
+		meta := result[0]["metadata"].(map[string]any)
 		assert.Equal(t, "visible-app", meta["name"])
 	})
 

--- a/distributions/core-bff/bff/internal/repositories/dashboard_config.go
+++ b/distributions/core-bff/bff/internal/repositories/dashboard_config.go
@@ -70,7 +70,7 @@ func (r *DashboardConfigRepository) GetDashboardConfig(
 func (r *DashboardConfigRepository) GetRawDashboardConfig(
 	ctx context.Context,
 	namespace, name string,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	if r.saDynClient == nil {
 		return nil, fmt.Errorf("service account dynamic client not available")
 	}
@@ -86,7 +86,7 @@ func (r *DashboardConfigRepository) GetRawDashboardConfig(
 func (r *DashboardConfigRepository) PatchRawDashboardConfig(
 	ctx context.Context,
 	namespace, name string, patchData []byte, patchType types.PatchType,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	if r.saDynClient == nil {
 		return nil, fmt.Errorf("service account dynamic client not available")
 	}
@@ -104,7 +104,7 @@ func (r *DashboardConfigRepository) PatchRawDashboardConfig(
 func (r *DashboardConfigRepository) fetchOrCreateDashboardCR(
 	ctx context.Context,
 	namespace, name string,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	if r.saDynClient == nil {
 		return nil, fmt.Errorf("service account dynamic client not available")
 	}
@@ -121,7 +121,7 @@ func (r *DashboardConfigRepository) fetchOrCreateDashboardCR(
 	return r.autoCreateDashboardCR(ctx, namespace, name)
 }
 
-func (r *DashboardConfigRepository) handleFetchError(err error, namespace, name string) (map[string]interface{}, error) {
+func (r *DashboardConfigRepository) handleFetchError(err error, namespace, name string) (map[string]any, error) {
 	if k8sutil.IsDiscoveryError(err) {
 		slog.Debug("OdhDashboardConfig CRD not installed, using defaults",
 			slog.String("namespace", namespace), slog.String("name", name))
@@ -133,28 +133,28 @@ func (r *DashboardConfigRepository) handleFetchError(err error, namespace, name 
 func (r *DashboardConfigRepository) autoCreateDashboardCR(
 	ctx context.Context,
 	namespace, name string,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	// Deliberately sparse: omit spec.dashboardConfig so code-level defaults apply at read time.
 	defaultCR := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "opendatahub.io/v1alpha",
 			"kind":       "OdhDashboardConfig",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      name,
 				"namespace": namespace,
-				"labels": map[string]interface{}{
+				"labels": map[string]any{
 					"opendatahub.io/dashboard": "true",
 				},
 			},
-			"spec": map[string]interface{}{
-				"notebookController": map[string]interface{}{
+			"spec": map[string]any{
+				"notebookController": map[string]any{
 					"enabled": true,
 				},
-				"templateOrder": []interface{}{},
-				"genAiStudioConfig": map[string]interface{}{
-					"aiAssetCustomEndpoints": map[string]interface{}{
+				"templateOrder": []any{},
+				"genAiStudioConfig": map[string]any{
+					"aiAssetCustomEndpoints": map[string]any{
 						"externalProviders": false,
-						"clusterDomains":    []interface{}{},
+						"clusterDomains":    []any{},
 					},
 				},
 			},

--- a/distributions/core-bff/bff/internal/repositories/dashboard_config_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/dashboard_config_integration_test.go
@@ -21,15 +21,15 @@ func newFakeDynClientWithDashboardConfig(disableProjects bool) *dynamicfake.Fake
 	scheme := runtime.NewScheme()
 
 	cr := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "opendatahub.io/v1alpha",
 			"kind":       "OdhDashboardConfig",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "odh-dashboard-config",
 				"namespace": "test-ns",
 			},
-			"spec": map[string]interface{}{
-				"dashboardConfig": map[string]interface{}{
+			"spec": map[string]any{
+				"dashboardConfig": map[string]any{
 					"disableProjects": disableProjects,
 					"disableKServe":   true,
 				},
@@ -119,19 +119,19 @@ func TestGetDashboardConfig_AutoCreatesWhenInstanceMissing(t *testing.T) {
 
 	// Persisted CR is deliberately sparse (no spec.dashboardConfig).
 	// Defaults are applied at read time via deepMerge, not persisted.
-	spec, ok := persisted.Object["spec"].(map[string]interface{})
+	spec, ok := persisted.Object["spec"].(map[string]any)
 	require.True(t, ok, "persisted CR should have spec")
 
 	_, hasDC := spec["dashboardConfig"]
 	assert.False(t, hasDC, "persisted CR should NOT contain spec.dashboardConfig")
 
-	nc, ok := spec["notebookController"].(map[string]interface{})
+	nc, ok := spec["notebookController"].(map[string]any)
 	require.True(t, ok, "persisted CR should have spec.notebookController")
 	assert.Equal(t, true, nc["enabled"])
 
-	gasc, ok := spec["genAiStudioConfig"].(map[string]interface{})
+	gasc, ok := spec["genAiStudioConfig"].(map[string]any)
 	require.True(t, ok, "persisted CR should have spec.genAiStudioConfig")
-	endpoints, ok := gasc["aiAssetCustomEndpoints"].(map[string]interface{})
+	endpoints, ok := gasc["aiAssetCustomEndpoints"].(map[string]any)
 	require.True(t, ok, "genAiStudioConfig should have aiAssetCustomEndpoints")
 	assert.Equal(t, false, endpoints["externalProviders"])
 }

--- a/distributions/core-bff/bff/internal/repositories/dashboard_config_overrides.go
+++ b/distributions/core-bff/bff/internal/repositories/dashboard_config_overrides.go
@@ -13,12 +13,12 @@ import (
 
 // applyFeatureLockouts forces specific flags that must not be changed by CRD values.
 // Matches backend/src/utils/resourceUtils.ts applyFeatureLockouts().
-func applyFeatureLockouts(config map[string]interface{}) {
-	spec, ok := config["spec"].(map[string]interface{})
+func applyFeatureLockouts(config map[string]any) {
+	spec, ok := config["spec"].(map[string]any)
 	if !ok {
 		return
 	}
-	dc, ok := spec["dashboardConfig"].(map[string]interface{})
+	dc, ok := spec["dashboardConfig"].(map[string]any)
 	if !ok {
 		return
 	}
@@ -26,12 +26,12 @@ func applyFeatureLockouts(config map[string]interface{}) {
 	dc["mlflow"] = true
 }
 
-func applyFeatureFlagOverrides(config map[string]interface{}, overrides map[string]bool) {
-	spec, ok := config["spec"].(map[string]interface{})
+func applyFeatureFlagOverrides(config map[string]any, overrides map[string]bool) {
+	spec, ok := config["spec"].(map[string]any)
 	if !ok {
 		return
 	}
-	dc, ok := spec["dashboardConfig"].(map[string]interface{})
+	dc, ok := spec["dashboardConfig"].(map[string]any)
 	if !ok {
 		return
 	}
@@ -41,12 +41,12 @@ func applyFeatureFlagOverrides(config map[string]interface{}, overrides map[stri
 }
 
 // applyXKSOverrides disables OpenShift-dependent features for XKS platform deployments.
-func applyXKSOverrides(config map[string]interface{}) {
-	spec, ok := config["spec"].(map[string]interface{})
+func applyXKSOverrides(config map[string]any) {
+	spec, ok := config["spec"].(map[string]any)
 	if !ok {
 		return
 	}
-	dc, ok := spec["dashboardConfig"].(map[string]interface{})
+	dc, ok := spec["dashboardConfig"].(map[string]any)
 	if !ok {
 		return
 	}
@@ -59,7 +59,7 @@ func applyXKSOverrides(config map[string]interface{}) {
 	dc["mlflow"] = false
 }
 
-func blankDefaults() (map[string]interface{}, error) {
+func blankDefaults() (map[string]any, error) {
 	defaultsMap, err := maputil.ToUnstructuredMap(models.BlankDashboardCR)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert defaults: %w", err)

--- a/distributions/core-bff/bff/internal/repositories/dashboard_config_test.go
+++ b/distributions/core-bff/bff/internal/repositories/dashboard_config_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func TestDeepMerge_OverridesTakePrecedence(t *testing.T) {
-	defaults := map[string]interface{}{
+	defaults := map[string]any{
 		"a": "default",
 		"b": "default",
 	}
-	overrides := map[string]interface{}{
+	overrides := map[string]any{
 		"a": "override",
 	}
 
@@ -27,18 +27,18 @@ func TestDeepMerge_OverridesTakePrecedence(t *testing.T) {
 }
 
 func TestDeepMerge_NestedMaps(t *testing.T) {
-	defaults := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"dashboardConfig": map[string]interface{}{
+	defaults := map[string]any{
+		"spec": map[string]any{
+			"dashboardConfig": map[string]any{
 				"enablement":    true,
 				"disableInfo":   false,
 				"disableKServe": false,
 			},
 		},
 	}
-	overrides := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"dashboardConfig": map[string]interface{}{
+	overrides := map[string]any{
+		"spec": map[string]any{
+			"dashboardConfig": map[string]any{
 				"disableKServe": true,
 			},
 		},
@@ -46,16 +46,16 @@ func TestDeepMerge_NestedMaps(t *testing.T) {
 
 	result := maputil.DeepMerge(defaults, overrides)
 
-	spec := result["spec"].(map[string]interface{})
-	dc := spec["dashboardConfig"].(map[string]interface{})
+	spec := result["spec"].(map[string]any)
+	dc := spec["dashboardConfig"].(map[string]any)
 	assert.Equal(t, true, dc["enablement"])
 	assert.Equal(t, false, dc["disableInfo"])
 	assert.Equal(t, true, dc["disableKServe"])
 }
 
 func TestDeepMerge_OverrideDoesNotMutateDefaults(t *testing.T) {
-	defaults := map[string]interface{}{"key": "original"}
-	overrides := map[string]interface{}{"key": "changed"}
+	defaults := map[string]any{"key": "original"}
+	overrides := map[string]any{"key": "changed"}
 
 	_ = maputil.DeepMerge(defaults, overrides)
 
@@ -63,28 +63,28 @@ func TestDeepMerge_OverrideDoesNotMutateDefaults(t *testing.T) {
 }
 
 func TestDeepMerge_NestedDefaultsNotMutated(t *testing.T) {
-	defaults := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"nested": map[string]interface{}{
+	defaults := map[string]any{
+		"spec": map[string]any{
+			"nested": map[string]any{
 				"flag": false,
 			},
 		},
 	}
 
-	result := maputil.DeepMerge(defaults, map[string]interface{}{})
+	result := maputil.DeepMerge(defaults, map[string]any{})
 
 	// Mutate the result's nested map
-	result["spec"].(map[string]interface{})["nested"].(map[string]interface{})["flag"] = true
+	result["spec"].(map[string]any)["nested"].(map[string]any)["flag"] = true
 
 	// Original defaults must be unchanged
-	nested := defaults["spec"].(map[string]interface{})["nested"].(map[string]interface{})
+	nested := defaults["spec"].(map[string]any)["nested"].(map[string]any)
 	assert.Equal(t, false, nested["flag"])
 }
 
 func TestApplyFeatureLockouts(t *testing.T) {
-	config := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"dashboardConfig": map[string]interface{}{
+	config := map[string]any{
+		"spec": map[string]any{
+			"dashboardConfig": map[string]any{
 				"disableFineTuning": false,
 				"mlflow":            false,
 				"disableKServe":     false,
@@ -94,22 +94,22 @@ func TestApplyFeatureLockouts(t *testing.T) {
 
 	applyFeatureLockouts(config)
 
-	dc := config["spec"].(map[string]interface{})["dashboardConfig"].(map[string]interface{})
+	dc := config["spec"].(map[string]any)["dashboardConfig"].(map[string]any)
 	assert.Equal(t, true, dc["disableFineTuning"])
 	assert.Equal(t, true, dc["mlflow"])
 	assert.Equal(t, false, dc["disableKServe"])
 }
 
 func TestApplyFeatureLockouts_MissingSpec(t *testing.T) {
-	config := map[string]interface{}{}
+	config := map[string]any{}
 	applyFeatureLockouts(config)
 	// Should not panic
 }
 
 func TestApplyFeatureFlagOverrides(t *testing.T) {
-	config := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"dashboardConfig": map[string]interface{}{
+	config := map[string]any{
+		"spec": map[string]any{
+			"dashboardConfig": map[string]any{
 				"disableKServe": false,
 				"enablement":    true,
 			},
@@ -123,16 +123,16 @@ func TestApplyFeatureFlagOverrides(t *testing.T) {
 
 	applyFeatureFlagOverrides(config, overrides)
 
-	dc := config["spec"].(map[string]interface{})["dashboardConfig"].(map[string]interface{})
+	dc := config["spec"].(map[string]any)["dashboardConfig"].(map[string]any)
 	assert.Equal(t, true, dc["disableKServe"])
 	assert.Equal(t, true, dc["newFlag"])
 	assert.Equal(t, true, dc["enablement"])
 }
 
 func TestApplyXKSOverrides(t *testing.T) {
-	config := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"dashboardConfig": map[string]interface{}{
+	config := map[string]any{
+		"spec": map[string]any{
+			"dashboardConfig": map[string]any{
 				"enablement":             true,
 				"disableProjects":        false,
 				"disableBYONImageStream": false,
@@ -147,7 +147,7 @@ func TestApplyXKSOverrides(t *testing.T) {
 
 	applyXKSOverrides(config)
 
-	dc := config["spec"].(map[string]interface{})["dashboardConfig"].(map[string]interface{})
+	dc := config["spec"].(map[string]any)["dashboardConfig"].(map[string]any)
 	assert.Equal(t, false, dc["enablement"])
 	assert.Equal(t, true, dc["disableProjects"])
 	assert.Equal(t, true, dc["disableBYONImageStream"])
@@ -159,9 +159,9 @@ func TestApplyXKSOverrides(t *testing.T) {
 }
 
 func TestLockoutsAndXKSOverridesCannotBeOverriddenByHeaders(t *testing.T) {
-	config := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"dashboardConfig": map[string]interface{}{
+	config := map[string]any{
+		"spec": map[string]any{
+			"dashboardConfig": map[string]any{
 				"enablement":        true,
 				"disableFineTuning": false,
 				"mlflow":            true,
@@ -184,7 +184,7 @@ func TestLockoutsAndXKSOverridesCannotBeOverriddenByHeaders(t *testing.T) {
 	applyFeatureLockouts(config)
 	applyXKSOverrides(config)
 
-	dc := config["spec"].(map[string]interface{})["dashboardConfig"].(map[string]interface{})
+	dc := config["spec"].(map[string]any)["dashboardConfig"].(map[string]any)
 	assert.Equal(t, true, dc["disableFineTuning"])
 	assert.Equal(t, false, dc["enablement"])
 	assert.Equal(t, false, dc["mlflow"])
@@ -203,7 +203,7 @@ func TestHandleFetchError_DiscoveryErrorReturnsDefaults(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, result, "discovery error should return blank defaults, not nil")
-	spec, ok := result["spec"].(map[string]interface{})
+	spec, ok := result["spec"].(map[string]any)
 	require.True(t, ok, "defaults should have a spec")
 	_, hasDC := spec["dashboardConfig"]
 	assert.True(t, hasDC, "defaults should have dashboardConfig in spec")

--- a/distributions/core-bff/bff/internal/repositories/namespace_mutation.go
+++ b/distributions/core-bff/bff/internal/repositories/namespace_mutation.go
@@ -54,8 +54,8 @@ type namespacePatch struct {
 }
 
 type namespacePatchMetadata struct {
-	Labels      map[string]interface{} `json:"labels,omitempty"`
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
+	Labels      map[string]any `json:"labels,omitempty"`
+	Annotations map[string]any `json:"annotations,omitempty"`
 }
 
 func buildMutationPatch(appCase models.NamespaceApplicationCase) (*namespacePatch, error) {
@@ -63,7 +63,7 @@ func buildMutationPatch(appCase models.NamespaceApplicationCase) (*namespacePatc
 	case models.KServePromotion:
 		return &namespacePatch{
 			Metadata: namespacePatchMetadata{
-				Labels: map[string]interface{}{
+				Labels: map[string]any{
 					models.LabelModelMeshEnabled: "false",
 				},
 			},
@@ -72,7 +72,7 @@ func buildMutationPatch(appCase models.NamespaceApplicationCase) (*namespacePatc
 	case models.KServeNIMPromotion:
 		return &namespacePatch{
 			Metadata: namespacePatchMetadata{
-				Annotations: map[string]interface{}{
+				Annotations: map[string]any{
 					models.AnnotationNIMSupport: "true",
 				},
 			},
@@ -81,10 +81,10 @@ func buildMutationPatch(appCase models.NamespaceApplicationCase) (*namespacePatc
 	case models.ResetModelServingPlatform:
 		return &namespacePatch{
 			Metadata: namespacePatchMetadata{
-				Labels: map[string]interface{}{
+				Labels: map[string]any{
 					models.LabelModelMeshEnabled: nil,
 				},
-				Annotations: map[string]interface{}{
+				Annotations: map[string]any{
 					models.AnnotationNIMSupport: nil,
 				},
 			},

--- a/distributions/core-bff/bff/internal/repositories/nim.go
+++ b/distributions/core-bff/bff/internal/repositories/nim.go
@@ -42,7 +42,7 @@ func (r *NIMRepository) GetNIMAccount(ctx context.Context, namespace string) (*u
 // GetNIMServingResource performs the cross-resource lookup for a NIM serving resource.
 // It fetches the NIM Account CR, resolves the resource name from it, then fetches the
 // Secret or ConfigMap.
-func (r *NIMRepository) GetNIMServingResource(ctx context.Context, namespace, nimResource string) (interface{}, error) {
+func (r *NIMRepository) GetNIMServingResource(ctx context.Context, namespace, nimResource string) (any, error) {
 	mapping, ok := models.NIMResourceMap[nimResource]
 	if !ok {
 		return nil, &models.NIMNotFoundError{Reason: fmt.Sprintf("invalid NIM resource type %q", nimResource)}
@@ -65,8 +65,8 @@ func (r *NIMRepository) GetNIMServingResource(ctx context.Context, namespace, ni
 }
 
 // fetchNIMResource fetches a Secret or ConfigMap by type and name.
-func (r *NIMRepository) fetchNIMResource(ctx context.Context, resourceType, namespace, name string) (interface{}, error) {
-	var result interface{}
+func (r *NIMRepository) fetchNIMResource(ctx context.Context, resourceType, namespace, name string) (any, error) {
+	var result any
 	var err error
 
 	switch resourceType {
@@ -128,18 +128,18 @@ func (r *NIMRepository) CreateNIMAccount(ctx context.Context, namespace string, 
 
 	if account == nil {
 		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": "nim.opendatahub.io/v1",
 				"kind":       models.NIMAccountKind,
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      models.NIMAccountName,
 					"namespace": namespace,
-					"labels": map[string]interface{}{
+					"labels": map[string]any{
 						models.NIMManagedLabel: "true",
 					},
 				},
-				"spec": map[string]interface{}{
-					"apiKeySecret": map[string]interface{}{
+				"spec": map[string]any{
+					"apiKeySecret": map[string]any{
 						"name": models.NIMSecretName,
 					},
 				},
@@ -222,7 +222,7 @@ func deriveStatusFromAccount(account *unstructured.Unstructured) *models.NIMInte
 
 	var errorMessages []string
 	for _, c := range conditions {
-		cond, ok := c.(map[string]interface{})
+		cond, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/distributions/core-bff/bff/internal/repositories/nim_test.go
+++ b/distributions/core-bff/bff/internal/repositories/nim_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestDeriveStatusFromAccount_NoConditions(t *testing.T) {
 	account := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "nim.opendatahub.io/v1",
 			"kind":       "Account",
-			"metadata":   map[string]interface{}{"name": "odh-nim-account"},
+			"metadata":   map[string]any{"name": "odh-nim-account"},
 		},
 	}
 
@@ -26,17 +26,17 @@ func TestDeriveStatusFromAccount_NoConditions(t *testing.T) {
 
 func TestDeriveStatusFromAccount_EnabledWithValidKey(t *testing.T) {
 	account := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "nim.opendatahub.io/v1",
 			"kind":       "Account",
-			"metadata":   map[string]interface{}{"name": "odh-nim-account"},
-			"status": map[string]interface{}{
-				"conditions": []interface{}{
-					map[string]interface{}{
+			"metadata":   map[string]any{"name": "odh-nim-account"},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
 						"type":   "AccountStatus",
 						"status": "True",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"type":   "APIKeyValidation",
 						"status": "True",
 					},
@@ -58,18 +58,18 @@ func TestDeriveStatusFromAccount_EnabledWithValidKey(t *testing.T) {
 
 func TestDeriveStatusFromAccount_DisabledWithError(t *testing.T) {
 	account := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "nim.opendatahub.io/v1",
 			"kind":       "Account",
-			"metadata":   map[string]interface{}{"name": "odh-nim-account"},
-			"status": map[string]interface{}{
-				"conditions": []interface{}{
-					map[string]interface{}{
+			"metadata":   map[string]any{"name": "odh-nim-account"},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
 						"type":    "AccountStatus",
 						"status":  "False",
 						"message": "API key expired",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"type":   "APIKeyValidation",
 						"status": "False",
 					},

--- a/distributions/core-bff/bff/internal/repositories/prometheus.go
+++ b/distributions/core-bff/bff/internal/repositories/prometheus.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
 	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
 )
@@ -80,7 +81,7 @@ func (r *PrometheusRepository) Query(ctx context.Context, token, query, queryTyp
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Prometheus request: %w", err)
 	}
-	req.Header.Set("Authorization", k8s.BearerTokenPrefix+token)
+	req.Header.Set(constants.HeaderAuthorization, k8s.BearerTokenPrefix+token)
 
 	resp, err := r.httpClient.Do(req)
 	if err != nil {

--- a/distributions/core-bff/bff/internal/ssrf/ssrf.go
+++ b/distributions/core-bff/bff/internal/ssrf/ssrf.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
 )
 
 // ErrSSRFBlocked is returned when a request is blocked by SSRF validation.
@@ -77,7 +79,7 @@ func NewRedirectValidator(logger *slog.Logger) func(*http.Response) error {
 		if resp.StatusCode < 300 || resp.StatusCode >= 400 {
 			return nil
 		}
-		location := resp.Header.Get("Location")
+		location := resp.Header.Get(constants.HeaderLocation)
 		if location == "" {
 			return nil
 		}


### PR DESCRIPTION
FUP of https://redhat.atlassian.net/browse/RHOAIENG-67106

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Two Go housekeeping improvements in the Core BFF:

1. **`interface{}` -> `any`**: Replaced all occurrences of `interface{}` with the idiomatic `any` alias (Go 1.18+). Pure cosmetic change - `any` is a built-in alias for `interface{}` with zero behavioral difference. Covers `map[string]interface{}`, `[]interface{}`, and standalone `interface{}` usages across 38 files.

2. **Extract HTTP header constants**: Created `internal/constants/headers.go` with reusable constants for HTTP header keys (`HeaderAuthorization`, `HeaderContentType`, etc.), content type values (`ContentTypeJSON`, `ContentTypeYAML`, `ContentTypeHTML`), and common header values (`AllowedMethodsReadOnly`, `AllowedOriginAll`, `ConnectionClose`, `CacheControlNo`). Updated all production code to use these constants instead of hardcoded string literals. Also fixed a hardcoded `"Bearer "` in `model_serving_proxy.go` to use the existing `k8s.BearerTokenPrefix` constant.

No functional changes. All existing tests pass without modification.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `make fmt` - passed
- `make lint` - passed
- `make test` - passed (includes `go vet`, unit tests, and envtest integration tests)
- `make build` - passed

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

No new tests needed - this is a pure refactor with no behavioral changes. All existing tests pass unmodified.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized HTTP headers and content types across API responses, requests, proxies, and integrations.
  * Improved consistency for authentication, impersonation, CORS, caching, WebSocket, and redirect handling.
  * Prevented potential dashboard configuration errors when expected configuration sections are missing.

* **Refactor**
  * Modernized internal data handling without changing existing functionality or user-facing workflows.

* **Tests**
  * Updated coverage and test fixtures to verify dashboard configuration and resource-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->