### PR TITLE
Add agentic-ci setup config for npm dependency installation

### DIFF
--- a/.agentic-ci/config.yml
+++ b/.agentic-ci/config.yml
@@ -1,0 +1,3 @@
+setup:
+  - name: Install dependencies
+    run: npm ci


### PR DESCRIPTION
## Summary
- Adds `.agentic-ci/config.yml` with a `setup` step to run `npm ci` before the agent starts in the OpenShell sandbox
- Ensures `node_modules` are available for tests, typechecks, and linting without requiring internet access from inside the sandbox

## Motivation

The autofix agent currently times out or fails on this repo because `npm install` can't reach the internet from inside the OpenShell sandbox. This config tells agentic-ci to install dependencies on the host before uploading the workdir into the sandbox.

Depends on: opendatahub-io/agentic-ci#241

## Test plan
- [ ] Verify autofix can run tests and typechecks after this change
- [ ] Confirm `node_modules/` is present inside the sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated setup step to install project dependencies consistently before CI tasks run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->