### PR TITLE
[Cypress-e2e] Add MCP catalog settings RBAC access control e2e 

### DIFF
--- a/packages/cypress/cypress/pages/mcpCatalogSettings.ts
+++ b/packages/cypress/cypress/pages/mcpCatalogSettings.ts
@@ -8,6 +8,10 @@ class McpCatalogSettings {
     }
   }
 
+  visitExpectDenied() {
+    cy.visit('/settings/mcp-resources/mcp-catalog', { failOnStatusCode: false });
+  }
+
   navigate() {
     this.findNavItem().click();
     this.wait();
@@ -37,6 +41,34 @@ class McpCatalogSettings {
 
   findAddSourceButton() {
     return cy.findByTestId('mcp-add-source-button-empty');
+  }
+
+  findAddSourceButtonTable() {
+    return cy.findByTestId('mcp-add-source-button');
+  }
+
+  findTable() {
+    return cy.findByTestId('mcp-catalog-source-configs-table');
+  }
+
+  findEnableToggle(sourceId: string) {
+    return cy.findByTestId(`mcp-enable-toggle-${sourceId}`);
+  }
+
+  findSourceName(sourceId: string) {
+    return cy.findByTestId(`mcp-source-name-${sourceId}`);
+  }
+
+  findSourceStatus(sourceId: string) {
+    return cy.findByTestId(`mcp-source-status-connected-${sourceId}`);
+  }
+
+  findManageSourceButton(sourceId: string) {
+    return cy.findByTestId(`mcp-manage-source-button-${sourceId}`);
+  }
+
+  findSourceActions(sourceId: string) {
+    return cy.findByTestId(`mcp-source-actions-${sourceId}`);
   }
 }
 

--- a/packages/cypress/cypress/tests/e2e/mcpCatalog/testMcpCatalogSettingsAvailable.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/mcpCatalog/testMcpCatalogSettingsAvailable.cy.ts
@@ -14,7 +14,7 @@ describe('Verify MCP Catalog Settings Access Control', () => {
       mcpCatalogSettings.navigate();
 
       cy.step('Verify add source button is visible');
-      mcpCatalogSettings.findAddSourceButton().should('be.visible');
+      mcpCatalogSettings.findAddSourceButtonTable().should('be.visible');
     },
   );
 

--- a/packages/cypress/cypress/tests/e2e/mcpCatalog/testMcpCatalogSettingsAvailable.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/mcpCatalog/testMcpCatalogSettingsAvailable.cy.ts
@@ -1,0 +1,38 @@
+import { LDAP_ADMIN_USER, LDAP_CONTRIBUTOR_USER } from '../../../utils/e2eUsers';
+import { mcpCatalogSettings } from '../../../pages/mcpCatalogSettings';
+import { pageNotfound } from '../../../pages/pageNotFound';
+
+describe('Verify MCP Catalog Settings Access Control', () => {
+  it(
+    'Admin user can access MCP catalog settings',
+    { tags: ['@Dashboard', '@McpCatalog', '@Featureflagged'] },
+    () => {
+      cy.step('Log into the application as admin with mcpCatalog flag enabled');
+      cy.visitWithLogin('/?devFeatureFlags=mcpCatalog=true', LDAP_ADMIN_USER);
+
+      cy.step('Navigate to MCP catalog settings');
+      mcpCatalogSettings.navigate();
+
+      cy.step('Verify add source button is visible');
+      mcpCatalogSettings.findAddSourceButton().should('be.visible');
+    },
+  );
+
+  it(
+    'Non-admin user cannot access MCP catalog settings',
+    { tags: ['@Dashboard', '@McpCatalog', '@Featureflagged'] },
+    () => {
+      cy.step('Log into the application as non-admin user with mcpCatalog flag enabled');
+      cy.visitWithLogin('/?devFeatureFlags=mcpCatalog=true', LDAP_CONTRIBUTOR_USER);
+
+      cy.step('Verify MCP catalog settings nav item is not visible for non-admin');
+      mcpCatalogSettings.findNavItem().should('not.exist');
+
+      cy.step('Attempt to navigate to MCP catalog settings directly');
+      mcpCatalogSettings.visitExpectDenied();
+
+      cy.step('Verify page not found is displayed');
+      pageNotfound.findPage().should('exist');
+    },
+  );
+});


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-71630

## Description
Adds E2E tests for MCP catalog admin settings page access control, covering admin access and non-admin denial.

`testMcpCatalogSettingsAvailable.cy.ts` verifies admin can navigate to MCP catalog settings and non-admin gets 404

## How Has This Been Tested?
Jenkins: 1834

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of updates

* **Tests**
  * Expanded end-to-end coverage for “MCP Catalog Settings” access control when the MCP Catalog feature is enabled.
  * Confirmed administrators can open the settings page and view the “add source” UI.
  * Confirmed non-administrators are blocked from both navigation and direct URL access, showing a “page not found” result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->