### PR TITLE
fix: prevent cypress e2e workflow failure on push events

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -759,7 +759,9 @@ jobs:
   # ---------------------------------------------------------------------------
   e2e-tests:
     needs: [select-cluster, set-pending-status, get-test-tags, ensure-cypress-builds, build-missing-cypress]
-    if: ${{ !cancelled() && !failure() }}
+    if: >-
+      !cancelled() && !failure() &&
+      needs.select-cluster.result == 'success'
     runs-on: self-hosted
     timeout-minutes: 90
     strategy:


### PR DESCRIPTION
## Description

PR #8432 introduced `if: ${{ !cancelled() && !failure() }}` on the `e2e-tests` job to allow it to run when `build-missing-cypress` is expectedly skipped. However, this condition also evaluates to `true` when **all** dependencies are skipped — which happens when the "Test" workflow completes from a `push` event (not a `pull_request`).

In that case, GitHub tries to evaluate the matrix expression `fromJson(needs.get-test-tags.outputs.matrix)` against an empty string, causing an internal error that marks the overall workflow as `failure` instead of `skipped`.

**Evidence:**
- [Run 29335314718](https://github.com/opendatahub-io/odh-dashboard/actions/runs/29335314718) — all 8 jobs skipped, conclusion = `failure`
- [Run 29334974132](https://github.com/opendatahub-io/odh-dashboard/actions/runs/29334974132) — same pattern
- [Run 29334261943](https://github.com/opendatahub-io/odh-dashboard/actions/runs/29334261943) — same pattern
- [Run 29333416049](https://github.com/opendatahub-io/odh-dashboard/actions/runs/29333416049) — same pattern
- Pre-#8432 runs with the same trigger correctly concluded as `skipped` (e.g. [29317749200](https://github.com/opendatahub-io/odh-dashboard/actions/runs/29317749200))

**Fix:** Add `needs.select-cluster.result == 'success'` to the `e2e-tests` `if:` condition. Since `select-cluster` already gates on `pull_request` events with a successful Test workflow, this ensures `e2e-tests` skips properly on push events while still allowing `build-missing-cypress` to be skipped when no packages need rebuilding.

## How Has This Been Tested?

- Verified the logic by comparing job conditions and dependency chains before and after #8432
- Confirmed all 4 failing runs have identical pattern: all jobs skipped but workflow conclusion is `failure`
- Confirmed pre-#8432 runs with the same trigger pattern concluded as `skipped`

## Test Impact

No test changes needed — this is a workflow `if:` condition fix. The change is validated by observing that push-triggered e2e runs no longer report `failure` when all jobs skip.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test execution reliability by ensuring tests run only after the required cluster selection step completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->