### PR TITLE
fix(gen-ai): pass --insecure flag to ogx run command

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/k8smocks/token_k8s_client_mock.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/k8smocks/token_k8s_client_mock.go
@@ -553,7 +553,7 @@ server:
 				Replicas:  &replicas,
 				Resources: workloadResources,
 				Overrides: &ogxapi.WorkloadOverrides{
-					Command: []string{"/bin/sh", "-c", "ogx run /etc/ogx/config.yaml"},
+					Command: []string{"/bin/sh", "-c", "ogx run /etc/ogx/config.yaml --insecure"},
 					Env: []corev1.EnvVar{
 						{Name: "VLLM_TLS_VERIFY", Value: "false"},
 						{Name: "FAISS_STORE_DIR", Value: "~/.llama/faiss"},

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1696,7 +1696,7 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 				Replicas:  &replicas,
 				Resources: workloadResources,
 				Overrides: &ogxapi.WorkloadOverrides{
-					Command: []string{"/bin/sh", "-c", "ogx run /etc/ogx/config.yaml"},
+					Command: []string{"/bin/sh", "-c", "ogx run /etc/ogx/config.yaml --insecure"},
 					Env: append(envVars, corev1.EnvVar{
 						Name:  "OGX_CONFIG_DIR",
 						Value: "/opt/app-root/src/.ogx/distributions/rh/",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-76600

## Description

After upstream [ogx-ai/ogx#5603](https://github.com/ogx-ai/ogx/pull/5603) was merged, TLS is enforced by default on `ogx run`. Without `--insecure` or TLS certificates configured, the OGX server exits immediately on boot with:

> TLS required: set tls_certfile/tls_keyfile in server config or pass '--insecure' to disable.

This PR adds `--insecure` to the `ogx run` command in `InstallOGXServer` and the corresponding mock.

## How Has This Been Tested?

- `go vet` and `go fmt` pass cleanly
- `internal/integrations/kubernetes` unit tests pass
- Verified the `--insecure` flag is position-independent in the OGX CLI (`argparse`)
- Tested on an ODH cluster with latest OGX version that without `--insecure` the pod crashes with the TLS error; with it, the server starts fine

## Test Impact

No new tests needed — this is a one-token change to a command string. No existing tests assert on the command value. A proper TLS solution will be tracked in a follow-up ticket.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`