### PR TITLE
fix(rbac): update escalation permission from agent.kagenti.dev to agents.x-k8s.io

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -589,9 +589,9 @@ rules:
       - watch
   # AI agent and MCP server resources
   - apiGroups:
-      - agent.kagenti.dev
+      - agents.x-k8s.io
     resources:
-      - agentruntimes
+      - sandboxes
     verbs:
       - get
       - list

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -573,9 +573,9 @@ rules:
       - watch
   # AI agent and MCP server resources
   - apiGroups:
-      - agent.kagenti.dev
+      - agents.x-k8s.io
     resources:
-      - agentruntimes
+      - sandboxes
     verbs:
       - get
       - list


### PR DESCRIPTION
## Summary

Commit 249cae3d ("feat(agent-ops): migrate list/detail discovery to Sandbox CRs") replaced `agent.kagenti.dev/agentruntimes` with `agents.x-k8s.io/sandboxes` in `manifests/modular-architecture/modules-cluster-role.yaml`, but did not update the dashboard-operator's own ClusterRole (`config/rbac/role.yaml`).

This causes an RBAC escalation failure when the dashboard-operator tries to deploy the operand `odh-dashboard-modules` ClusterRole:

```
user "system:serviceaccount:...:dashboard-operator" is attempting to grant RBAC permissions not currently held:
{APIGroups:["agents.x-k8s.io"], Resources:["sandboxes"], Verbs:["get" "list"]}
```

This blocks the dashboard module migration PR ([opendatahub-operator#3733](https://github.com/opendatahub-io/opendatahub-operator/pull/3733)).

## Changes

- `config/rbac/role.yaml`: Replace `agent.kagenti.dev/agentruntimes` with `agents.x-k8s.io/sandboxes`
- `charts/dashboard/templates/rbac.yaml`: Same replacement to keep chart in sync

## Test plan

- [x] `TestDashboardChartRBACInSync` passes
- [ ] opendatahub-operator E2E: no RBAC escalation errors for dashboard-operator

Jira: [RHOAIENG-60566](https://redhat.atlassian.net/browse/RHOAIENG-60566)

[RHOAIENG-60566]: https://redhat.atlassian.net/browse/RHOAIENG-60566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dashboard permissions to support sandbox resources through the current agent API.
  * Removed access requirements for the previously supported agent runtime resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->