### PR TITLE
feat(RHOAIENG-72851): add core-bff manifest overlays

### DIFF
--- a/manifests/core-bases/base/deployment.yaml
+++ b/manifests/core-bases/base/deployment.yaml
@@ -144,6 +144,75 @@ spec:
             - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
               name: odh-ca-cert
               subPath: odh-ca-bundle.crt
+        - name: core-bff
+          image: $(core-bff-image)
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8943
+              name: core-bff
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 300m
+              memory: 512Mi
+              ephemeral-storage: 10Mi
+            limits:
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8943
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8943
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            timeoutSeconds: 15
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: proxy-tls
+              readOnly: true
+            - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
+              name: odh-trusted-ca-cert
+              subPath: odh-trusted-ca-bundle.crt
+            - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
+              name: odh-trusted-ca-cert
+              subPath: odh-trusted-ca-bundle.crt
+            - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
+              name: odh-ca-cert
+              subPath: odh-ca-bundle.crt
+            - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
+              name: odh-ca-cert
+              subPath: odh-ca-bundle.crt
+          args:
+            - '--auth-method=user_token'
+            - '--auth-token-header=x-forwarded-access-token'
+            - '--auth-token-prefix='
+            - '--port=8943'
+            - '--cert-file=/etc/tls/private/tls.crt'
+            - '--key-file=/etc/tls/private/tls.key'
+            - '--bundle-paths=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem,/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt,/etc/pki/tls/certs/odh-ca-bundle.crt,/etc/pki/tls/certs/odh-trusted-ca-bundle.crt'
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
       volumes:
         - name: proxy-tls
           secret:

--- a/manifests/core-bases/base/service.yaml
+++ b/manifests/core-bases/base/service.yaml
@@ -13,3 +13,7 @@ spec:
       protocol: TCP
       port: 8443
       targetPort: 8443
+    - name: core-bff
+      protocol: TCP
+      port: 8943
+      targetPort: 8943

--- a/manifests/odh/kustomization.yaml
+++ b/manifests/odh/kustomization.yaml
@@ -56,6 +56,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.images-jobs-async-upload
+  - name: core-bff-image
+    objref:
+      kind: ConfigMap
+      name: odh-dashboard-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.core-bff-image
 configurations:
   - params.yaml
 replacements:

--- a/manifests/odh/params.env
+++ b/manifests/odh/params.env
@@ -6,3 +6,4 @@ dashboard-url=https://www.redhat.com
 section-title=Open Data Hub
 gateway-domain=
 images-jobs-async-upload=quay.io/opendatahub/model-registry-job-async-upload:latest
+core-bff-image=quay.io/opendatahub/odh-core-bff:main

--- a/manifests/rhoai/base/deployment.yaml
+++ b/manifests/rhoai/base/deployment.yaml
@@ -18,5 +18,5 @@
   path: /spec/template/spec/serviceAccount
   value: rhods-dashboard
 - op: replace
-  path: /spec/template/spec/containers/3/env/2/value
+  path: /spec/template/spec/containers/4/env/2/value
   value: "rhods-dashboard"

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -57,6 +57,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.images-jobs-async-upload
+  - name: core-bff-image
+    objref:
+      kind: ConfigMap
+      name: rhoai-dashboard-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.core-bff-image
 configurations:
   - params.yaml
 replacements:

--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -6,3 +6,4 @@ dashboard-url=https://www.redhat.com
 section-title=OpenShift AI
 gateway-domain=
 images-jobs-async-upload=quay.io/opendatahub/model-registry-job-async-upload:latest
+core-bff-image=quay.io/opendatahub/odh-core-bff:main


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72851

## Description

Adds **core-bff** as a sidecar container in the base dashboard deployment (`core-bases/base/`), alongside `odh-dashboard` and `kube-rbac-proxy`. Core-bff will eventually replace the Fastify backend — placing it in the same pod ensures deployment continuity.

### Changes

**`manifests/core-bases/base/deployment.yaml`**
- Added `core-bff` as the third container (index 2) with:
  - Port 8943 (HTTPS), TLS cert/key from the shared `proxy-tls` secret
  - HTTPS liveness/readiness probes on `/healthcheck`
  - CA bundle mounts (odh-trusted-ca-bundle, odh-ca-bundle)
  - `POD_NAMESPACE` env from downward API
  - Security context: non-root, read-only root filesystem, all capabilities dropped

**`manifests/core-bases/base/service.yaml`**
- Added port 8943 (`core-bff`) on the shared `odh-dashboard` service

**`manifests/odh/` overlay**
- `params.env`: added `core-bff-image=quay.io/opendatahub/odh-core-bff:main`
- `kustomization.yaml`: added `core-bff-image` var referencing `odh-dashboard-params` ConfigMap

**`manifests/rhoai/` overlay**
- `params.env`: added `core-bff-image=quay.io/opendatahub/odh-core-bff:main`
- `kustomization.yaml`: added `core-bff-image` var referencing `rhoai-dashboard-params` ConfigMap
- `base/deployment.yaml`: fixed container index reference (`containers/3` → `containers/4`) for gen-ai-ui's `BFF_MAAS_SERVICE_NAME` rename, since inserting core-bff at index 2 shifts the modular-architecture sidecars

**Port**: 8943 (follows the 8X43 sequence)
**Image**: `quay.io/opendatahub/odh-core-bff:main` (from Konflux onboarding [RHOAIENG-72855](https://issues.redhat.com/browse/RHOAIENG-72855) / [RHOAIENG-72856](https://issues.redhat.com/browse/RHOAIENG-72856))

## How Has This Been Tested?

### Local validation (kustomize build)

Both ODH and RHOAI overlays build successfully:

```bash
cd manifests
kustomize build odh   # ✅ core-bff container on port 8943, image resolved
kustomize build rhoai # ✅ core-bff present, gen-ai-ui BFF_MAAS_SERVICE_NAME correctly set to rhods-dashboard
```

### Cluster testing — Option A: Dashboard Operator local run

Run the dashboard-operator locally against your cluster, pointing at the manifests from this branch. The operator will render and apply the manifests including the new core-bff container.

```bash
# 1. Clone/checkout this branch
git fetch origin pull/8547/head:pr-8547
git checkout pr-8547

# 2. Scale down the ODH operator so it doesn't fight with your local run
oc scale deployment opendatahub-operator-controller-manager \
  -n openshift-operators --replicas=0

# 3. Install the Dashboard CRD (if not present)
cd dashboard-operator
oc apply -f config/crd/bases/

# 4. Run the operator locally, pointing at this branch's manifests
#    Override core-bff-image if needed
export RELATED_IMAGE_ODH_CORE_BFF_IMAGE=quay.io/opendatahub/odh-core-bff:main
go run ./cmd/manager \
  --namespace opendatahub \
  --manifests-base-path ../manifests \
  --leader-elect=false \
  --secure-metrics=false

# 5. Verify the core-bff container is running
oc get pods -n opendatahub -l deployment=odh-dashboard \
  -o jsonpath='{range .items[*].spec.containers[*]}{.name}{"\n"}{end}'

# 6. Don't forget to restore the operator when done
oc scale deployment opendatahub-operator-controller-manager \
  -n openshift-operators --replicas=1
```

> **Note**: The `core-bff-image` key is not yet registered in the dashboard-operator's `imagesMap` (`internal/controller/support.go`), so the RELATED_IMAGE env var override won't work until that follow-up is done. The operator will still use the default value from `params.env`.

### Cluster testing — Option B: Manual kustomize apply

Apply the built manifests directly, bypassing the operator. Useful when the operator is already scaled down or not installed.

```bash
# 1. Clone/checkout this branch
git fetch origin pull/8547/head:pr-8547
git checkout pr-8547

# 2. Scale down the ODH operator to prevent reconciliation
oc scale deployment opendatahub-operator-controller-manager \
  -n openshift-operators --replicas=0

# 3. Build and apply the ODH manifests
cd manifests
kustomize edit set namespace opendatahub
kustomize build odh | oc apply -f -

# 4. Wait for the rollout and verify
oc rollout status deployment/odh-dashboard -n opendatahub
oc get pods -n opendatahub -l deployment=odh-dashboard \
  -o jsonpath='{range .items[*].spec.containers[*]}{.name}{"\n"}{end}'
# Should now include: odh-dashboard, kube-rbac-proxy, core-bff, model-registry-ui, ...

# 5. Verify the core-bff container is healthy
oc get pods -n opendatahub -l deployment=odh-dashboard \
  -o jsonpath='{range .items[*].status.containerStatuses[?(@.name=="core-bff")]}{.ready}{"\n"}{end}'

# 6. Restore the operator when done
oc scale deployment opendatahub-operator-controller-manager \
  -n openshift-operators --replicas=1
```

> **Warning**: When the operator scales back up, it will reconcile the Dashboard CR and may revert your manual changes to match the operator's built-in manifests. This approach is for validation only.

## Test Impact

Manifest-only change — no application code or test code affected. CI validates `kustomize build` automatically via `.github/workflows/validate-kustomize.yml`. Full cluster validation will happen during operator integration testing.

## Follow-ups

- Register `core-bff-image` in `dashboard-operator/internal/controller/support.go` `imagesMap` so the operator can inject the image via `RELATED_IMAGE_*` env vars
- Register the related image in `dashboard-operator/charts/dashboard/values.yaml`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-72855]: https://redhat.atlassian.net/browse/RHOAIENG-72855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ