### PR TITLE
fix(llmd-serving): wire topology config selection into deployment ass…

### DIFF
--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -299,7 +299,9 @@ const extensions: (
   | WizardFieldApplyExtension<AdvancedRoutingFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<AdvancedRoutingFieldData, LLMdDeployment>
   | WizardFieldApplyExtension<GatewaySelectFieldData, LLMdDeployment>
+  | WizardFieldApplyExtension<CustomTopologyConfigFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<GatewaySelectFieldData, LLMdDeployment>
+  | WizardFieldExtractorExtension<CustomTopologyConfigFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<{ method: string }, LLMdDeployment>
   | HrefNavItemExtension
   | RouteExtension
@@ -500,6 +502,8 @@ const extensions: (
   gatewaySelectFieldExtension,
   gatewaySelectApplyExtension,
   gatewaySelectExtractorExtension,
+  topologyConfigApplyExtension,
+  topologyConfigExtractorExtension,
   deploymentMethodExtractorExtensionLllmdOnly,
   deploymentMethodExtractorExtensionvLLMOnMaaS,
   {

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -299,9 +299,7 @@ const extensions: (
   | WizardFieldApplyExtension<AdvancedRoutingFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<AdvancedRoutingFieldData, LLMdDeployment>
   | WizardFieldApplyExtension<GatewaySelectFieldData, LLMdDeployment>
-  | WizardFieldApplyExtension<CustomTopologyConfigFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<GatewaySelectFieldData, LLMdDeployment>
-  | WizardFieldExtractorExtension<CustomTopologyConfigFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<{ method: string }, LLMdDeployment>
   | HrefNavItemExtension
   | RouteExtension
@@ -502,8 +500,6 @@ const extensions: (
   gatewaySelectFieldExtension,
   gatewaySelectApplyExtension,
   gatewaySelectExtractorExtension,
-  topologyConfigApplyExtension,
-  topologyConfigExtractorExtension,
   deploymentMethodExtractorExtensionLllmdOnly,
   deploymentMethodExtractorExtensionvLLMOnMaaS,
   {

--- a/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
+++ b/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
@@ -251,13 +251,17 @@ export const CustomTopologyConfigFieldWizardField: CustomTopologyConfigFieldType
         return existingFieldData;
       }
       const topologyType = dependencies?.topologyType?.topologyType;
-      if (topologyType && topologyType !== TopologyType.SINGLE_NODE) {
+      if (!topologyType) {
+        return { selectedConfig: TOPOLOGY_CONFIG_DEFAULT };
+      }
+      if (topologyType !== TopologyType.SINGLE_NODE) {
         const configs = getFilteredConfigs(externalData?.configsByTopology, topologyType);
         if (configs.length > 0) {
           return { selectedConfig: configs[0] };
         }
+        return { selectedConfig: undefined };
       }
-      return { selectedConfig: undefined };
+      return { selectedConfig: TOPOLOGY_CONFIG_DEFAULT };
     },
     validationSchema: z.object({
       selectedConfig: z.union([

--- a/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
+++ b/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
@@ -244,8 +244,21 @@ export const CustomTopologyConfigFieldWizardField: CustomTopologyConfigFieldType
     setFieldData: (value: CustomTopologyConfigFieldData) => value,
     getInitialFieldData: (
       existingFieldData?: CustomTopologyConfigFieldData,
-    ): CustomTopologyConfigFieldData =>
-      existingFieldData ?? { selectedConfig: TOPOLOGY_CONFIG_DEFAULT },
+      externalData?: TopologyTypeExternalData,
+      dependencies?: CustomTopologyConfigDependencies,
+    ): CustomTopologyConfigFieldData => {
+      if (existingFieldData) {
+        return existingFieldData;
+      }
+      const topologyType = dependencies?.topologyType?.topologyType;
+      if (topologyType && topologyType !== TopologyType.SINGLE_NODE) {
+        const configs = getFilteredConfigs(externalData?.configsByTopology, topologyType);
+        if (configs.length > 0) {
+          return { selectedConfig: configs[0] };
+        }
+      }
+      return { selectedConfig: undefined };
+    },
     validationSchema: z.object({
       selectedConfig: z.union([
         z.custom<LLMInferenceServiceConfigKind>(

--- a/packages/llmd-serving/src/wizardFields/__tests__/CustomTopologyConfigField.spec.ts
+++ b/packages/llmd-serving/src/wizardFields/__tests__/CustomTopologyConfigField.spec.ts
@@ -1,0 +1,124 @@
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { TopologyType } from '../../types';
+import { CustomTopologyConfigFieldWizardField } from '../CustomTopologyConfigField';
+import type { TopologyTypeExternalData } from '../TopologyTypeField';
+import type { CustomTopologyConfigFieldData } from '../CustomTopologyConfigField';
+
+const { getInitialFieldData } = CustomTopologyConfigFieldWizardField.reducerFunctions;
+
+const mockMultiNodeConfig = mockLLMInferenceServiceConfigK8sResource({
+  name: 'multi-node-config-1',
+  displayName: 'Multi-node Config 1',
+  topologyType: TopologyType.MULTI_NODE,
+});
+
+const mockMultiNodeConfig2 = mockLLMInferenceServiceConfigK8sResource({
+  name: 'multi-node-config-2',
+  displayName: 'Multi-node Config 2',
+  topologyType: TopologyType.MULTI_NODE,
+});
+
+const mockSingleNodePdConfig = mockLLMInferenceServiceConfigK8sResource({
+  name: 'single-node-pd-config',
+  displayName: 'Single Node P/D Config',
+  topologyType: TopologyType.SINGLE_NODE_DISAGGREGATED,
+});
+
+const emptyConfigsByTopology: Record<
+  TopologyType,
+  ReturnType<typeof mockLLMInferenceServiceConfigK8sResource>[]
+> = {
+  [TopologyType.SINGLE_NODE]: [],
+  [TopologyType.MULTI_NODE]: [],
+  [TopologyType.SINGLE_NODE_DISAGGREGATED]: [],
+  [TopologyType.MULTI_NODE_DISAGGREGATED]: [],
+};
+
+const buildExternalData = (
+  overrides: Partial<typeof emptyConfigsByTopology> = {},
+): TopologyTypeExternalData => ({
+  configsByTopology: Object.assign({}, emptyConfigsByTopology, overrides),
+});
+
+describe('CustomTopologyConfigField getInitialFieldData', () => {
+  it('should return existing field data when provided (edit flow)', () => {
+    const existing: CustomTopologyConfigFieldData = { selectedConfig: mockMultiNodeConfig };
+    const externalData = buildExternalData({
+      [TopologyType.MULTI_NODE]: [mockMultiNodeConfig],
+    });
+    const deps = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
+
+    const result = getInitialFieldData(existing, externalData, deps);
+
+    expect(result).toBe(existing);
+  });
+
+  it('should return existing field data with configRef when provided (edit extractor)', () => {
+    const existing: CustomTopologyConfigFieldData = { configRef: 'some-config' };
+    const result = getInitialFieldData(existing);
+
+    expect(result).toBe(existing);
+  });
+
+  it('should auto-select first config for multi-node topology', () => {
+    const externalData = buildExternalData({
+      [TopologyType.MULTI_NODE]: [mockMultiNodeConfig, mockMultiNodeConfig2],
+    });
+    const deps = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
+
+    const result = getInitialFieldData(undefined, externalData, deps);
+
+    expect(result).toEqual({ selectedConfig: mockMultiNodeConfig });
+  });
+
+  it('should auto-select first config for single-node disaggregated topology', () => {
+    const externalData = buildExternalData({
+      [TopologyType.SINGLE_NODE_DISAGGREGATED]: [mockSingleNodePdConfig],
+    });
+    const deps = {
+      topologyType: { topologyType: TopologyType.SINGLE_NODE_DISAGGREGATED },
+    };
+
+    const result = getInitialFieldData(undefined, externalData, deps);
+
+    expect(result).toEqual({ selectedConfig: mockSingleNodePdConfig });
+  });
+
+  it('should return undefined selectedConfig for single-node topology', () => {
+    const externalData = buildExternalData({});
+    const deps = { topologyType: { topologyType: TopologyType.SINGLE_NODE } };
+
+    const result = getInitialFieldData(undefined, externalData, deps);
+
+    expect(result).toEqual({ selectedConfig: undefined });
+  });
+
+  it('should return undefined selectedConfig when no configs exist for the topology type', () => {
+    const externalData = buildExternalData({
+      [TopologyType.MULTI_NODE]: [],
+    });
+    const deps = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
+
+    const result = getInitialFieldData(undefined, externalData, deps);
+
+    expect(result).toEqual({ selectedConfig: undefined });
+  });
+
+  it('should return undefined selectedConfig when dependencies are undefined', () => {
+    const externalData = buildExternalData({
+      [TopologyType.MULTI_NODE]: [mockMultiNodeConfig],
+    });
+
+    const result = getInitialFieldData(undefined, externalData, undefined);
+
+    expect(result).toEqual({ selectedConfig: undefined });
+  });
+
+  it('should return undefined selectedConfig when external data is undefined', () => {
+    const deps = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
+
+    const result = getInitialFieldData(undefined, undefined, deps);
+
+    expect(result).toEqual({ selectedConfig: undefined });
+  });
+});

--- a/packages/llmd-serving/src/wizardFields/__tests__/CustomTopologyConfigField.spec.ts
+++ b/packages/llmd-serving/src/wizardFields/__tests__/CustomTopologyConfigField.spec.ts
@@ -84,13 +84,13 @@ describe('CustomTopologyConfigField getInitialFieldData', () => {
     expect(result).toEqual({ selectedConfig: mockSingleNodePdConfig });
   });
 
-  it('should return undefined selectedConfig for single-node topology', () => {
+  it('should return default selectedConfig for single-node topology', () => {
     const externalData = buildExternalData({});
     const deps = { topologyType: { topologyType: TopologyType.SINGLE_NODE } };
 
     const result = getInitialFieldData(undefined, externalData, deps);
 
-    expect(result).toEqual({ selectedConfig: undefined });
+    expect(result).toEqual({ selectedConfig: 'default' });
   });
 
   it('should return undefined selectedConfig when no configs exist for the topology type', () => {
@@ -104,17 +104,17 @@ describe('CustomTopologyConfigField getInitialFieldData', () => {
     expect(result).toEqual({ selectedConfig: undefined });
   });
 
-  it('should return undefined selectedConfig when dependencies are undefined', () => {
+  it('should return default selectedConfig when dependencies are undefined', () => {
     const externalData = buildExternalData({
       [TopologyType.MULTI_NODE]: [mockMultiNodeConfig],
     });
 
     const result = getInitialFieldData(undefined, externalData, undefined);
 
-    expect(result).toEqual({ selectedConfig: undefined });
+    expect(result).toEqual({ selectedConfig: 'default' });
   });
 
-  it('should return undefined selectedConfig when external data is undefined', () => {
+  it('should return undefined selectedConfig when external data is undefined for non-single-node', () => {
     const deps = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
 
     const result = getInitialFieldData(undefined, undefined, deps);


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-66855
https://issues.redhat.com/browse/RHOAIENG-76493

## Description

Fixes two related bugs in the llm-d topology config deployment flow:

### [RHOAIENG-66855](https://redhat.atlassian.net/browse/RHOAIENG-66855) — Topology config selection silently dropped during deployment

The `CustomTopologyConfigField` stores the user's selected topology configuration in the wizard state, but no `WizardFieldApplyExtension` existed to map it into the deployment resource. This meant the `selectedConfig` was never applied — no `LLMInferenceServiceConfig` was created alongside the `LLMInferenceService`, `baseRef` was never set, and the operator defaulted to its generic config (CUDA image). This is the root cause of AMD hardware profiles getting the wrong vLLM image.

**Fix:** Added `applyTopologyConfigData` / `extractTopologyConfigData` functions and registered them as `WizardFieldApplyExtension` and `WizardFieldExtractorExtension` in the llmd-serving extensions, following the same pattern as the existing gateway field extensions. When a topology config is selected, it is cloned as the deployment's `LLMInferenceServiceConfig` with the correct `baseRef` and template annotations. When "Single node (default)" is selected, the server and baseRef are cleared.

### [RHOAIENG-76493](https://redhat.atlassian.net/browse/RHOAIENG-76493) — Auto-select doesn't persist when switching topology types

When switching from "Single node" to another topology type (e.g. "Multi-node"), the auto-select `useEffect` fired correctly but the selection was immediately overwritten by the wizard framework's dependency-change reset cycle (`shouldResetOnDependencyChange` → `clearFieldData` + `initFieldData`).

**Fix:** Moved auto-selection logic from the component's `useEffect` into `getInitialFieldData`, which is called during the `initFieldData` dispatch. The `getInitialFieldData` signature already supports `externalData` and `dependencies` parameters — we now use them to auto-select the first available config for non-single-node topologies.

## How Has This Been Tested?
for [RHOAIENG-66855](https://redhat.atlassian.net/browse/RHOAIENG-66855) 
<img width="970" height="652" alt="Screenshot 2026-07-14 at 2 35 14 PM" src="https://github.com/user-attachments/assets/630daaf2-68e7-42b3-8e53-ad339ee9601b" />
<img width="941" height="89" alt="Screenshot 2026-07-14 at 2 37 01 PM" src="https://github.com/user-attachments/assets/683a303b-dee7-4d19-8bc4-c22556d186fd" />
<img width="910" height="94" alt="Screenshot 2026-07-14 at 2 37 36 PM" src="https://github.com/user-attachments/assets/cedf0cb6-174d-4dd1-8149-4b1db34262ec" />
<img width="886" height="88" alt="Screenshot 2026-07-14 at 2 39 27 PM" src="https://github.com/user-attachments/assets/9c9ca6b1-737e-4e46-b7c8-803739d47193" />

For [RHOAIENG-76493](https://redhat.atlassian.net/browse/RHOAIENG-76493)

https://github.com/user-attachments/assets/a85ac462-b4c2-4285-bdfe-cb9a9be35bdf


- **Unit tests**: 11 new tests covering apply (9 cases) and extract (2 cases) — config selection, annotation preservation, server clearing, scheduler behavior, immutability, config switching
- **All existing tests pass**: 165/165 tests across 15 suites in `llmd-serving`
- **Type-check**: passes cleanly
- **Lint**: 0 errors (8 pre-existing warnings unrelated to this change)
- **Manual UI testing** on a live cluster:
  - Verified selecting a single-node topology config creates `LLMInferenceServiceConfig` with correct `baseRef` and `template-name` annotation
  - Verified "Single node (default)" does NOT create an `LLMInferenceServiceConfig`
  - Verified switching topology types auto-selects the first available config (persists in dropdown)
  - Verified switching back to single-node resets to "Single node (default)"

## Test Impact

**Added:** `packages/llmd-serving/src/wizardFields/__tests__/topologyConfigApplyExtract.spec.ts`
- 9 test cases for `applyTopologyConfigData` (set server/baseRef, preserve annotations, clear on undefined, scheduler behavior, immutability, config switching)
- 2 test cases for `extractTopologyConfigData` (extract server, return undefined when no server)

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-66855]: https://redhat.atlassian.net/browse/RHOAIENG-66855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-76493]: https://redhat.atlassian.net/browse/RHOAIENG-76493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for applying and extracting custom topology configurations in wizard fields.
  * Custom topology configuration fields now initialize with the first available configuration for applicable topology types.

* **Bug Fixes**
  * Improved initial configuration selection while preserving existing selections during edits.
  * Prevented configuration selection from changing unexpectedly after loading completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->