### PR TITLE
Revert agentic-ci setup config (npm not available on CI runner)

### DIFF
--- a/.agentic-ci/config.yml
+++ b/.agentic-ci/config.yml
@@ -1,3 +1,0 @@
-setup:
-  - name: Install dependencies
-    run: npm ci


### PR DESCRIPTION
## Summary
Reverts #8532 — the `.agentic-ci/config.yml` with `setup: [npm ci]` causes autofix pipeline failures because the CI runner image (`quay.io/aipcc/agentic-ci/openshell`) does not have Node.js/npm installed. Setup steps run on the runner host, not inside the sandbox.

Will re-add once the runner image includes node.js or setup steps support running inside a temporary container with the sandbox image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the automated dependency installation setup step from the continuous integration configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->