### PR TITLE
RHOAIENG-72137: Remove frontend re-export shims and migrate consumers to import directly from ui-core

### DIFF
--- a/frontend/src/components/ReplicaSection.tsx
+++ b/frontend/src/components/ReplicaSection.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import NumberInputWrapper from '@odh-dashboard/ui-core/components/NumberInputWrapper';
-import { normalizeBetween } from '#~/utilities/utils';
+import { normalizeBetween } from '@odh-dashboard/ui-core/utilities';
 
 const lowerLimit = 0;
 const upperLimit = 99;

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField.tsx
@@ -7,8 +7,12 @@ import {
   HelperTextItem,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-import { trimInputOnBlur, trimInputOnPaste } from '@odh-dashboard/ui-core/utilities';
-import { containsOnlySlashes, isS3PathValid } from '#~/utilities/string';
+import {
+  containsOnlySlashes,
+  isS3PathValid,
+  trimInputOnBlur,
+  trimInputOnPaste,
+} from '@odh-dashboard/ui-core/utilities';
 import useDebounceCallback from '#~/utilities/useDebounceCallback';
 
 type ConnectionFolderPathFieldProps = {

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -14,6 +14,7 @@ import {
 } from '@odh-dashboard/model-serving/shared';
 import useGenericObjectState from '@odh-dashboard/ui-core/utilities/useGenericObjectState';
 import { useDeepCompareMemoize } from '@odh-dashboard/ui-core/hooks';
+import { containsOnlySlashes, isS3PathValid } from '@odh-dashboard/ui-core/utilities';
 import type { UpdateObjectAtPropAndValue } from '@odh-dashboard/ui-core';
 import { ConfigMapKind } from '#~/k8sTypes';
 import { NamespaceApplicationCase } from '#~/pages/projects/types';
@@ -35,7 +36,7 @@ import {
   updateInferenceService,
   updateServingRuntime,
 } from '#~/api';
-import { containsOnlySlashes, isS3PathValid, removeLeadingSlash } from '#~/utilities/string';
+import { removeLeadingSlash } from '#~/utilities/string';
 import { getNIMData, getNIMResource } from '#~/pages/modelServing/screens/projects/nim/nimUtils';
 import { Connection } from '#~/concepts/connectionTypes/types';
 import {

--- a/frontend/src/utilities/__tests__/string.spec.ts
+++ b/frontend/src/utilities/__tests__/string.spec.ts
@@ -1,6 +1,5 @@
+import { containsOnlySlashes, isS3PathValid } from '@odh-dashboard/ui-core/utilities';
 import {
-  isS3PathValid,
-  containsOnlySlashes,
   downloadString,
   removeLeadingSlash,
   containsMultipleSlashesPattern,

--- a/frontend/src/utilities/string.ts
+++ b/frontend/src/utilities/string.ts
@@ -1,5 +1,3 @@
-export { containsOnlySlashes, isS3PathValid } from '@odh-dashboard/ui-core/utilities';
-
 export const downloadString = (filename: string, data: string): void => {
   const element = document.createElement('a');
   const file = new Blob([data], { type: 'text/plain' });

--- a/frontend/src/utilities/utils.ts
+++ b/frontend/src/utilities/utils.ts
@@ -144,8 +144,6 @@ export const isHTMLInputElement = (object: unknown): object is HTMLInputElement 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   (object as Partial<HTMLInputElement>).value !== undefined;
 
-export { normalizeBetween } from '@odh-dashboard/ui-core/utilities';
-
 /**
  * @deprecated
  * modelmesh: RHOAIENG-34917, RHOAIENG-19185


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-72137

## Description

After [RHOAIENG-65083](https://redhat.atlassian.net/browse/RHOAIENG-65083) extracted shared constants and general utilities to `@odh-dashboard/ui-core`, several frontend utility files were left as one-line re-export shims to avoid updating all ~200 consumer import paths at once. This PR removes those remaining re-export shims and updates all frontend consumers to import directly from
  the ui-core package.

  The full shim files (`useDeepCompareMemoize.ts`, `useEventListener.ts`, `trimInput.ts`, `BrowserStorageContext.tsx`, `valueUnits.ts`) were already deleted in prior work. This PR handles the **partial re-exports** that remained in files with their own code:

  | File | Removed re-exports | Consumers updated |
  |------|-------------------|-------------------|
  | `frontend/src/utilities/string.ts` | `containsOnlySlashes`, `isS3PathValid` | 3 files |
  | `frontend/src/utilities/utils.ts` | `normalizeBetween` | 1 file |

  Updated consumers now import these symbols directly from `@odh-dashboard/ui-core/utilities`:

  - `frontend/src/pages/modelServing/screens/projects/utils.ts`
  - `frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField.tsx`
  - `frontend/src/components/ReplicaSection.tsx`
  - `frontend/src/utilities/__tests__/string.spec.ts`

  This is a purely mechanical change — no logic, behavior, or runtime changes. It removes one layer of import indirection.

  ## How Has This Been Tested?

  - `npm run lint` — passes
  - `npm run type-check` — passes
  - `npm run build` — passes
  - `npm run test` — all tests pass (including `string.spec.ts` which exercises the moved imports)

  ## Test Impact

  No new tests needed. This is a pure import-path refactor with no logic changes. Existing tests (`string.spec.ts`) were updated to import from `@odh-dashboard/ui-core/utilities` and continue to pass.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-65083]: https://redhat.atlassian.net/browse/RHOAIENG-65083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared string and path validation utilities under a common utility library.
  * Updated internal imports to use the centralized utility locations.
  * Removed redundant utility re-exports while preserving existing functionality and behavior.

* **Tests**
  * Updated utility test imports to align with the centralized utility structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->