### PR TITLE
feat(RHOAIENG-76173): add Kueue Segment tracking for Workbenches

### DIFF
--- a/frontend/src/concepts/kueue/__tests__/messageUtils.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/messageUtils.spec.ts
@@ -1,10 +1,11 @@
-import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
+import { KueueWorkloadStatus, type KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
 import {
   getHumanReadableKueueMessage,
   getKueueSubStepInfo,
   getPreemptionToastBody,
   getEvictionToastBody,
   getRequeuedMessage,
+  getKueueAnalyticsSubState,
 } from '#~/concepts/kueue/messageUtils';
 
 describe('getHumanReadableKueueMessage', () => {
@@ -378,5 +379,52 @@ describe('getEvictionToastBody', () => {
     const expected = 'Workbench my-workbench was evicted from the queue.';
     expect(getEvictionToastBody('my-workbench')).toBe(expected);
     expect(getEvictionToastBody('my-workbench', '  ')).toBe(expected);
+  });
+});
+
+describe('getKueueAnalyticsSubState', () => {
+  const status = (
+    value: KueueWorkloadStatus,
+    message?: string,
+  ): KueueWorkloadStatusWithMessage => ({ status: value, message });
+
+  it.each([
+    ['none when status is missing', null, 'none'],
+    ['admitted', status(KueueWorkloadStatus.Admitted), 'admitted'],
+    ['preempted', status(KueueWorkloadStatus.Preempted), 'preempted'],
+    [
+      'queued with no message as waiting_for_quota',
+      status(KueueWorkloadStatus.Queued),
+      'waiting_for_quota',
+    ],
+    [
+      'queued quota message as waiting_for_quota',
+      status(KueueWorkloadStatus.Queued, 'insufficient unused quota'),
+      'waiting_for_quota',
+    ],
+    [
+      'queued non-quota message as waiting_for_resources',
+      status(KueueWorkloadStatus.Queued, 'waiting for pods'),
+      'waiting_for_resources',
+    ],
+    [
+      'failed queue-not-found as invalid_queue',
+      status(KueueWorkloadStatus.Failed, 'queue not found'),
+      'invalid_queue',
+    ],
+    [
+      'failed timeout as timeout',
+      status(KueueWorkloadStatus.Failed, 'admission timed out'),
+      'timeout',
+    ],
+    [
+      'inadmissible with no message as quota_exceeded',
+      status(KueueWorkloadStatus.Inadmissible),
+      'quota_exceeded',
+    ],
+    ['running as none', status(KueueWorkloadStatus.Running), 'none'],
+    ['evicted as none', status(KueueWorkloadStatus.Evicted), 'none'],
+  ] as const)('%s', (_label, input, expected) => {
+    expect(getKueueAnalyticsSubState(input)).toBe(expected);
   });
 });

--- a/frontend/src/concepts/kueue/__tests__/workbenchTracking.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/workbenchTracking.spec.ts
@@ -1,0 +1,63 @@
+import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
+import { getWorkbenchKueueTrackingProperties } from '#~/concepts/kueue/workbenchTracking';
+
+describe('getWorkbenchKueueTrackingProperties', () => {
+  it('omits queue fields when status and queue name are absent', () => {
+    expect(getWorkbenchKueueTrackingProperties({ kueueStatus: null })).toEqual({
+      primaryWorkbenchStatus: 'Stopped',
+      isKueueBlocking: false,
+      kueueSubState: 'none',
+    });
+  });
+
+  it('includes queue position/total and overrides primary status when Kueue is blocking', () => {
+    expect(
+      getWorkbenchKueueTrackingProperties({
+        kueueStatus: {
+          status: KueueWorkloadStatus.Queued,
+          queueName: 'team-queue',
+          queuePosition: 2,
+          queueTotal: 5,
+          message: 'waiting for pods',
+        },
+        isStarting: true,
+      }),
+    ).toEqual({
+      kueueQueueName: 'team-queue',
+      queuePosition: 2,
+      queueTotal: 5,
+      primaryWorkbenchStatus: 'Queued',
+      isKueueBlocking: true,
+      kueueSubState: 'waiting_for_resources',
+    });
+  });
+
+  it('uses explicit kueueQueueName and workbench flags when status is not blocking', () => {
+    expect(
+      getWorkbenchKueueTrackingProperties({
+        kueueStatus: {
+          status: KueueWorkloadStatus.Admitted,
+          queueName: 'from-status',
+        },
+        kueueQueueName: 'from-form',
+        isRunning: true,
+      }),
+    ).toEqual({
+      kueueQueueName: 'from-form',
+      primaryWorkbenchStatus: 'Ready',
+      isKueueBlocking: false,
+      kueueSubState: 'admitted',
+    });
+  });
+
+  it('prefers Stopping over other workbench flags', () => {
+    expect(
+      getWorkbenchKueueTrackingProperties({
+        kueueStatus: null,
+        isStarting: true,
+        isRunning: true,
+        isStopping: true,
+      }).primaryWorkbenchStatus,
+    ).toBe('Stopping');
+  });
+});

--- a/frontend/src/concepts/kueue/messageUtils.ts
+++ b/frontend/src/concepts/kueue/messageUtils.ts
@@ -150,6 +150,60 @@ export const getEvictionToastBody = (workbenchName: string, rawMessage?: string)
 };
 
 /**
+ * Analytics kueueSubState values from the UX tracking sheet.
+ * Mapped from KueueWorkloadStatus + existing UI message heuristics (messageUtils).
+ */
+export type KueueSubState =
+  | 'waiting_for_quota'
+  | 'waiting_for_resources'
+  | 'admitted'
+  | 'quota_exceeded'
+  | 'invalid_queue'
+  | 'timeout'
+  | 'preempted'
+  | 'none';
+
+/**
+ * Derives the Amplitude/Segment `kueueSubState` property using the same message
+ * heuristics as getHumanReadableKueueMessage. Statuses without a sheet mapping return 'none'.
+ */
+export const getKueueAnalyticsSubState = (
+  kueueStatus: KueueWorkloadStatusWithMessage | null | undefined,
+): KueueSubState => {
+  if (!kueueStatus?.status) {
+    return 'none';
+  }
+
+  const message = kueueStatus.message?.trim();
+
+  switch (kueueStatus.status) {
+    case KueueWorkloadStatus.Admitted:
+      return 'admitted';
+    case KueueWorkloadStatus.Preempted:
+      return 'preempted';
+    case KueueWorkloadStatus.Queued:
+      if (!message || QUOTA_REGEX.test(message) || FLAVOR_REGEX.test(message)) {
+        return 'waiting_for_quota';
+      }
+      return 'waiting_for_resources';
+    case KueueWorkloadStatus.Failed:
+    case KueueWorkloadStatus.Inadmissible:
+      if (message && QUEUE_NOT_FOUND_REGEX.test(message)) {
+        return 'invalid_queue';
+      }
+      if (message && TIMEOUT_REGEX.test(message)) {
+        return 'timeout';
+      }
+      if (!message || QUOTA_REGEX.test(message) || FLAVOR_REGEX.test(message)) {
+        return 'quota_exceeded';
+      }
+      return 'none';
+    default:
+      return 'none';
+  }
+};
+
+/**
  * Returns the label for the Kueue sub-step in the progress tree.
  * Adds a "Re-queued:" prefix only for the Queued state during a recovery, and appends queue position when available.
  */

--- a/frontend/src/concepts/kueue/types.ts
+++ b/frontend/src/concepts/kueue/types.ts
@@ -24,6 +24,8 @@ export type KueueWorkloadStatusWithMessage = {
   queueName?: string;
   workloadName?: string;
   queuePosition?: number;
+  /** Pending workloads in the local queue (Visibility API items.length). */
+  queueTotal?: number;
   requeueInfo?: {
     count: number;
     requeueAt?: string;

--- a/frontend/src/concepts/kueue/workbenchTracking.ts
+++ b/frontend/src/concepts/kueue/workbenchTracking.ts
@@ -1,0 +1,121 @@
+import { getKueueStatusInfo } from '#~/concepts/kueue';
+import { getKueueAnalyticsSubState } from '#~/concepts/kueue/messageUtils';
+import {
+  KUEUE_STATUSES_OVERRIDE_WORKBENCH,
+  type KueueWorkloadStatusWithMessage,
+} from '#~/concepts/kueue/types';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '#~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
+
+/** Segment event names for Workbench analytics (lifecycle + Kueue status UX). */
+export enum WorkbenchTrackingEvent {
+  Created = 'Workbench Created',
+  Updated = 'Workbench Updated',
+  Started = 'Workbench Started',
+  Stopped = 'Workbench Stopped',
+  Deleted = 'Workbench Deleted',
+  StatusLogViewed = 'Workbench Status Log Viewed',
+  StatusModalTabSwitched = 'Workbench Status Modal Tab Switched',
+  StatusModalActionClicked = 'Workbench Status Modal Action Clicked',
+  ProgressStepExpanded = 'Workbench Progress Step Expanded',
+  StatusToastActionClicked = 'Workbench Status Toast Action Clicked',
+}
+
+export type WorkbenchKueueTrackingInput = {
+  kueueStatus: KueueWorkloadStatusWithMessage | null;
+  isStarting?: boolean;
+  isRunning?: boolean;
+  isStopping?: boolean;
+  /** Queue name when status object is not available yet (e.g. create form). */
+  kueueQueueName?: string;
+};
+
+export type WorkbenchKueueTrackingProperties = {
+  kueueQueueName?: string;
+  queuePosition?: number;
+  queueTotal?: number;
+  primaryWorkbenchStatus: string;
+  isKueueBlocking: boolean;
+  kueueSubState: string;
+};
+
+// Keep priority in sync with NotebookStatusLabel.tsx (omits Failed without notebookStatus).
+const getPrimaryWorkbenchStatus = ({
+  isStarting = false,
+  isStopping = false,
+  isRunning = false,
+  kueueStatus,
+}: WorkbenchKueueTrackingInput): string => {
+  if (isStopping) {
+    return 'Stopping';
+  }
+  if (kueueStatus?.status && KUEUE_STATUSES_OVERRIDE_WORKBENCH.includes(kueueStatus.status)) {
+    return getKueueStatusInfo(kueueStatus.status).label;
+  }
+  if (isStarting) {
+    return 'Starting';
+  }
+  if (isRunning) {
+    return 'Ready';
+  }
+  return 'Stopped';
+};
+
+export const getWorkbenchKueueTrackingProperties = (
+  input: WorkbenchKueueTrackingInput,
+): WorkbenchKueueTrackingProperties => {
+  const { kueueStatus } = input;
+  const queueName = input.kueueQueueName || kueueStatus?.queueName;
+
+  return {
+    ...(queueName && { kueueQueueName: queueName }),
+    ...(kueueStatus?.queuePosition != null && { queuePosition: kueueStatus.queuePosition }),
+    ...(kueueStatus?.queueTotal != null && { queueTotal: kueueStatus.queueTotal }),
+    primaryWorkbenchStatus: getPrimaryWorkbenchStatus(input),
+    isKueueBlocking: Boolean(
+      kueueStatus?.status && KUEUE_STATUSES_OVERRIDE_WORKBENCH.includes(kueueStatus.status),
+    ),
+    kueueSubState: getKueueAnalyticsSubState(kueueStatus),
+  };
+};
+
+export const fireWorkbenchStatusModalAction = (
+  action: string,
+  outcome: TrackingOutcome,
+  activeTab: string,
+  input: WorkbenchKueueTrackingInput,
+): void => {
+  const { primaryWorkbenchStatus, kueueSubState, isKueueBlocking } =
+    getWorkbenchKueueTrackingProperties(input);
+  fireFormTrackingEvent(WorkbenchTrackingEvent.StatusModalActionClicked, {
+    outcome,
+    action,
+    activeTab,
+    primaryWorkbenchStatus,
+    kueueSubState,
+    isKueueBlocking,
+  });
+};
+
+export const fireWorkbenchProgressStepExpanded = (
+  stepName: string,
+  kueueStatus: KueueWorkloadStatusWithMessage | null | undefined,
+): void => {
+  fireMiscTrackingEvent(WorkbenchTrackingEvent.ProgressStepExpanded, {
+    stepName,
+    kueueSubState: getKueueAnalyticsSubState(kueueStatus),
+  });
+};
+
+export const fireWorkbenchStatusToastAction = (
+  action: string,
+  kueueStatus: KueueWorkloadStatusWithMessage | null | undefined,
+): void => {
+  fireMiscTrackingEvent(WorkbenchTrackingEvent.StatusToastActionClicked, {
+    action,
+    kueueSubState: getKueueAnalyticsSubState(kueueStatus),
+  });
+};

--- a/frontend/src/concepts/kueue/workbenchTracking.ts
+++ b/frontend/src/concepts/kueue/workbenchTracking.ts
@@ -1,3 +1,4 @@
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { getKueueStatusInfo } from '#~/concepts/kueue';
 import { getKueueAnalyticsSubState } from '#~/concepts/kueue/messageUtils';
 import {
@@ -8,7 +9,6 @@ import {
   fireFormTrackingEvent,
   fireMiscTrackingEvent,
 } from '#~/concepts/analyticsTracking/segmentIOUtils';
-import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
 
 /** Segment event names for Workbench analytics (lifecycle + Kueue status UX). */
 export enum WorkbenchTrackingEvent {

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -64,6 +64,14 @@ import {
 import { getHumanReadableKueueMessage, getRequeuedMessage } from '#~/concepts/kueue/messageUtils';
 import { KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
 import EventLog from '#~/concepts/k8s/EventLog/EventLog';
+import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
+import {
+  fireWorkbenchProgressStepExpanded,
+  fireWorkbenchStatusModalAction,
+  getWorkbenchKueueTrackingProperties,
+  WorkbenchTrackingEvent,
+} from '#~/concepts/kueue/workbenchTracking';
 import NotebookStatusLabel from './NotebookStatusLabel';
 import './StartNotebookModal.scss';
 
@@ -98,6 +106,10 @@ const stepIcons: Record<EventStatus, React.ReactNode> = {
   [EventStatus.PENDING]: <OutlinedClockIcon />,
 };
 
+type StartNotebookModalButtonsContext = {
+  activeTab: string;
+};
+
 type StartNotebookModalProps = {
   notebook?: NotebookKind;
   isStarting: boolean;
@@ -108,7 +120,9 @@ type StartNotebookModalProps = {
   kueueStatus?: KueueWorkloadStatusWithMessage | null;
   containerStatuses?: PodContainerStatus[];
   onClose?: () => void;
-  buttons: React.ReactNode;
+  buttons: React.ReactNode | ((ctx: StartNotebookModalButtonsContext) => React.ReactNode);
+  /** When true, fire Workbench Status Modal Action Clicked for close. */
+  trackStatusModalActions?: boolean;
 };
 
 type SpawnStatus = {
@@ -128,6 +142,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
   containerStatuses,
   onClose,
   buttons,
+  trackStatusModalActions = false,
 }) => {
   const [spawnStatus, setSpawnStatus] = React.useState<SpawnStatus | null>(null);
   const isError = notebookStatus?.currentStatus === EventStatus.ERROR;
@@ -174,6 +189,28 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
   const { isProjectKueueEnabled, isKueueFeatureEnabled } = useKueueConfiguration(project);
   const showResourcesTab = Boolean(isKueueFeatureEnabled && isProjectKueueEnabled);
   const [activeTab, setActiveTab] = React.useState<string>(PROGRESS_TAB);
+
+  const kueueTrackingInput = React.useMemo(
+    () => ({
+      kueueStatus: kueueStatus ?? null,
+      isStarting,
+      isRunning,
+      isStopping,
+    }),
+    [kueueStatus, isStarting, isRunning, isStopping],
+  );
+
+  const handleClose = React.useCallback(() => {
+    if (trackStatusModalActions) {
+      fireWorkbenchStatusModalAction(
+        'close',
+        TrackingOutcome.cancel,
+        activeTab,
+        kueueTrackingInput,
+      );
+    }
+    onClose?.();
+  }, [trackStatusModalActions, activeTab, kueueTrackingInput, onClose]);
 
   React.useEffect(() => {
     if (!showResourcesTab && activeTab === RESOURCES_TAB) {
@@ -505,6 +542,14 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
                 next.delete(id);
                 return next;
               });
+              const parentStep = notebookProgress.find(
+                (step) => `${step.stepKind}-${step.containerName ?? ''}` === id,
+              );
+              const subStep = notebookProgress
+                .flatMap((step) => step.subSteps ?? [])
+                .find((sub) => `${sub.stepKind}-${sub.containerName ?? ''}` === id);
+              const stepName = parentStep?.label ?? subStep?.label ?? id;
+              fireWorkbenchProgressStepExpanded(stepName, kueueStatus);
             }
           }}
           onCollapse={(_, item) => {
@@ -541,7 +586,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
       appendTo={document.body}
       variant={ModalVariant.small}
       isOpen
-      onClose={onClose}
+      onClose={handleClose}
       data-testid="notebook-status-modal"
     >
       <ModalHeader
@@ -570,7 +615,21 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
           <StackItem>
             <Tabs
               activeKey={activeTab}
-              onSelect={(_ev, tabIndex) => setActiveTab(`${tabIndex}`)}
+              onSelect={(_ev, tabIndex) => {
+                const nextTab = `${tabIndex}`;
+                if (nextTab !== activeTab) {
+                  const { primaryWorkbenchStatus, kueueSubState } =
+                    getWorkbenchKueueTrackingProperties(kueueTrackingInput);
+                  fireMiscTrackingEvent(WorkbenchTrackingEvent.StatusModalTabSwitched, {
+                    progressTab: nextTab === PROGRESS_TAB,
+                    eventlogTab: nextTab === EVENT_LOG_TAB,
+                    resourcesTab: nextTab === RESOURCES_TAB,
+                    primaryWorkbenchStatus,
+                    kueueSubState,
+                  });
+                }
+                setActiveTab(nextTab);
+              }}
               aria-label="status details"
             >
               <Tab
@@ -600,7 +659,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
           </StackItem>
         </Stack>
       </ModalBody>
-      <ModalFooter>{buttons}</ModalFooter>
+      <ModalFooter>{typeof buttons === 'function' ? buttons({ activeTab }) : buttons}</ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -47,6 +47,7 @@ import {
   OutlinedClockIcon,
 } from '@patternfly/react-icons';
 import type { PodContainerStatus } from '@odh-dashboard/k8s-core';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { EventStatus, NotebookStatus } from '#~/types';
 import { EventKind, NotebookKind } from '#~/k8sTypes';
 import { useNotebookProgress, getNotebookDisplayName } from '#~/utilities/notebookControllerUtils';
@@ -65,7 +66,6 @@ import { getHumanReadableKueueMessage, getRequeuedMessage } from '#~/concepts/ku
 import { KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
 import EventLog from '#~/concepts/k8s/EventLog/EventLog';
 import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
-import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
 import {
   fireWorkbenchProgressStepExpanded,
   fireWorkbenchStatusModalAction,

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -101,7 +101,11 @@ const ProjectDetailsContextProvider: React.FC = () => {
     for (const [name, status] of Object.entries(rawKueueStatus)) {
       result[name] =
         status && name in queuePositions
-          ? { ...status, queuePosition: queuePositions[name] }
+          ? {
+              ...status,
+              queuePosition: queuePositions[name].queuePosition,
+              queueTotal: queuePositions[name].queueTotal,
+            }
           : status;
     }
     return result;

--- a/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
+++ b/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
@@ -10,6 +10,13 @@ import { deleteConfigMap, deleteNotebook, deleteSecret, isGeneratedConfigMapName
 import DeleteModal from '#~/pages/projects/components/DeleteModal';
 import { getEnvFromList } from '#~/pages/projects/pvc/utils';
 import { ConfigMapRef, SecretRef } from '#~/pages/projects/types';
+import { fireFormTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
+import {
+  getWorkbenchKueueTrackingProperties,
+  WorkbenchTrackingEvent,
+} from '#~/concepts/kueue/workbenchTracking';
 
 type DeleteNotebookModalProps = {
   notebook: NotebookKind;
@@ -19,6 +26,8 @@ type DeleteNotebookModalProps = {
 const DeleteNotebookModal: React.FC<DeleteNotebookModalProps> = ({ notebook, onClose }) => {
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
+  const { kueueStatusByNotebookName } = React.useContext(ProjectDetailsContext);
+  const kueueStatus = kueueStatusByNotebookName[notebook.metadata.name] ?? null;
 
   const onBeforeClose = (deleted: boolean) => {
     onClose(deleted);
@@ -61,9 +70,29 @@ const DeleteNotebookModal: React.FC<DeleteNotebookModalProps> = ({ notebook, onC
         ];
         Promise.all(resourcesToDelete)
           .then(() => {
+            fireFormTrackingEvent(WorkbenchTrackingEvent.Deleted, {
+              outcome: TrackingOutcome.submit,
+              success: true,
+              projectName: namespace,
+              notebookName: notebook.metadata.name,
+              ...getWorkbenchKueueTrackingProperties({
+                kueueStatus,
+                isStarting: false,
+                isRunning: false,
+                isStopping: false,
+              }),
+            });
             onBeforeClose(true);
           })
           .catch((e) => {
+            fireFormTrackingEvent(WorkbenchTrackingEvent.Deleted, {
+              outcome: TrackingOutcome.submit,
+              success: false,
+              error: e instanceof Error ? e.message : String(e),
+              projectName: namespace,
+              notebookName: notebook.metadata.name,
+              ...getWorkbenchKueueTrackingProperties({ kueueStatus }),
+            });
             setError(e);
             setIsDeleting(false);
           });

--- a/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
+++ b/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
@@ -5,13 +5,13 @@ import {
   getDisplayNameFromK8sResource,
   isGeneratedSecretName,
 } from '@odh-dashboard/k8s-core';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { NotebookKind } from '#~/k8sTypes';
 import { deleteConfigMap, deleteNotebook, deleteSecret, isGeneratedConfigMapName } from '#~/api';
 import DeleteModal from '#~/pages/projects/components/DeleteModal';
 import { getEnvFromList } from '#~/pages/projects/pvc/utils';
 import { ConfigMapRef, SecretRef } from '#~/pages/projects/types';
 import { fireFormTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
-import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import {
   getWorkbenchKueueTrackingProperties,

--- a/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
+++ b/frontend/src/pages/projects/notebook/DeleteNotebookModal.tsx
@@ -4,6 +4,7 @@ import {
   DATA_CONNECTION_PREFIX,
   getDisplayNameFromK8sResource,
   isGeneratedSecretName,
+  K8sStatusError,
 } from '@odh-dashboard/k8s-core';
 import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { NotebookKind } from '#~/k8sTypes';
@@ -88,7 +89,7 @@ const DeleteNotebookModal: React.FC<DeleteNotebookModalProps> = ({ notebook, onC
             fireFormTrackingEvent(WorkbenchTrackingEvent.Deleted, {
               outcome: TrackingOutcome.submit,
               success: false,
-              error: e instanceof Error ? e.message : String(e),
+              error: e instanceof K8sStatusError ? `k8s_${e.statusObject.code}` : 'unknown_error',
               projectName: namespace,
               notebookName: notebook.metadata.name,
               ...getWorkbenchKueueTrackingProperties({ kueueStatus }),

--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -19,6 +19,13 @@ import {
 import { getHumanReadableKueueMessage, getRequeuedMessage } from '#~/concepts/kueue/messageUtils';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import UnderlinedTruncateButton from '#~/components/UnderlinedTruncateButton';
+import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
+import {
+  fireWorkbenchStatusModalAction,
+  getWorkbenchKueueTrackingProperties,
+  WorkbenchTrackingEvent,
+} from '#~/concepts/kueue/workbenchTracking';
 import { NotebookState } from './types';
 
 type NotebookStateStatusProps = {
@@ -118,12 +125,23 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
     kueueStatus,
   });
 
+  const openStatusModal = React.useCallback(() => {
+    const { isKueueBlocking } = getWorkbenchKueueTrackingProperties({
+      kueueStatus,
+      isStarting,
+      isRunning,
+      isStopping,
+    });
+    fireMiscTrackingEvent(WorkbenchTrackingEvent.StatusLogViewed, { isKueueBlocking });
+    setStartModalOpen(true);
+  }, [kueueStatus, isStarting, isRunning, isStopping]);
+
   return (
     <>
       <Flex
         direction={{ default: isVertical ? 'column' : 'row' }}
         gap={{ default: isVertical ? 'gapXs' : 'gapMd' }}
-        onClick={() => setStartModalOpen(true)}
+        onClick={openStatusModal}
       >
         <FlexItem>
           <NotebookStatusLabel
@@ -133,7 +151,7 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
             isStopping={isStopping}
             notebookStatus={notebookStatus}
             kueueStatus={kueueStatus}
-            onClick={() => setStartModalOpen(true)}
+            onClick={openStatusModal}
           />
         </FlexItem>
         {statusSubtitle != null ? (
@@ -142,7 +160,7 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
             content={statusSubtitle}
             color={getNotebookStatusColor(notebookStatus)}
             textDecoration={getNotebookStatusTextDecoration(notebookStatus, isStarting)}
-            onClick={() => setStartModalOpen(true)}
+            onClick={openStatusModal}
           />
         ) : null}
       </Flex>
@@ -155,48 +173,81 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
           notebookStatus={notebookStatus}
           events={events}
           kueueStatus={kueueStatus}
+          trackStatusModalActions
           containerStatuses={containerStatuses}
           onClose={() => {
             setStartModalOpen(false);
           }}
-          buttons={
-            <>
-              {isStopped ? (
+          buttons={({ activeTab }) => {
+            const trackingInput = {
+              kueueStatus,
+              isStarting,
+              isRunning,
+              isStopping,
+            };
+            return (
+              <>
+                {isStopped ? (
+                  <Button
+                    data-id="start-spawn"
+                    key="start"
+                    variant="primary"
+                    onClick={() => {
+                      fireWorkbenchStatusModalAction(
+                        'Start workbench',
+                        TrackingOutcome.submit,
+                        activeTab,
+                        trackingInput,
+                      );
+                      startNotebook();
+                    }}
+                  >
+                    Start workbench
+                  </Button>
+                ) : (
+                  <Button
+                    data-id="close-spawn"
+                    key="stop"
+                    variant="primary"
+                    onClick={() => {
+                      fireWorkbenchStatusModalAction(
+                        'Stop workbench',
+                        TrackingOutcome.submit,
+                        activeTab,
+                        trackingInput,
+                      );
+                      stopNotebook();
+                    }}
+                  >
+                    Stop workbench
+                  </Button>
+                )}
                 <Button
-                  data-id="start-spawn"
-                  key="start"
-                  variant="primary"
-                  onClick={() => startNotebook()}
+                  data-id="edit-workbench"
+                  key="edit"
+                  variant="link"
+                  component={
+                    editWorkbenchHref
+                      ? (props: React.ComponentProps<'a'>) => (
+                          <Link {...props} to={editWorkbenchHref} />
+                        )
+                      : 'button'
+                  }
+                  isAriaDisabled={!notebook.metadata.namespace || !notebook.metadata.name}
+                  onClick={() => {
+                    fireWorkbenchStatusModalAction(
+                      'Edit workbench',
+                      TrackingOutcome.submit,
+                      activeTab,
+                      trackingInput,
+                    );
+                  }}
                 >
-                  Start workbench
+                  Edit workbench
                 </Button>
-              ) : (
-                <Button
-                  data-id="close-spawn"
-                  key="stop"
-                  variant="primary"
-                  onClick={() => stopNotebook()}
-                >
-                  Stop workbench
-                </Button>
-              )}
-              <Button
-                data-id="edit-workbench"
-                key="edit"
-                variant="link"
-                component={
-                  editWorkbenchHref
-                    ? (props: React.ComponentProps<'a'>) => (
-                        <Link {...props} to={editWorkbenchHref} />
-                      )
-                    : 'button'
-                }
-                isAriaDisabled={!notebook.metadata.namespace || !notebook.metadata.name}
-              >
-                Edit workbench
-              </Button>
-            </>
-          }
+              </>
+            );
+          }}
         />
       ) : null}
     </>

--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -7,6 +7,7 @@ import {
   t_global_text_color_status_warning_default as WarningColor,
 } from '@patternfly/react-tokens';
 import { useDeepCompareMemoize } from '@odh-dashboard/ui-core/hooks';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { EventStatus, NotebookStatus } from '#~/types';
 import { useNotebookStatus } from '#~/utilities/notebookControllerUtils';
 import StartNotebookModal from '#~/concepts/notebooks/StartNotebookModal';
@@ -20,7 +21,6 @@ import { getHumanReadableKueueMessage, getRequeuedMessage } from '#~/concepts/ku
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import UnderlinedTruncateButton from '#~/components/UnderlinedTruncateButton';
 import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
-import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
 import {
   fireWorkbenchStatusModalAction,
   getWorkbenchKueueTrackingProperties,

--- a/frontend/src/pages/projects/notebook/__tests__/useQueuePositions.spec.ts
+++ b/frontend/src/pages/projects/notebook/__tests__/useQueuePositions.spec.ts
@@ -81,7 +81,7 @@ describe('useQueuePositions', () => {
     await renderResult.waitForNextUpdate();
 
     expect(getPendingWorkloadsMock).toHaveBeenCalledWith('test-ns', 'user-queue');
-    expect(renderResult).hookToStrictEqual({ nb1: 1 });
+    expect(renderResult).hookToStrictEqual({ nb1: { queuePosition: 1, queueTotal: 1 } });
   });
 
   it('should fetch positions for Inadmissible workloads', async () => {
@@ -96,7 +96,7 @@ describe('useQueuePositions', () => {
 
     await renderResult.waitForNextUpdate();
 
-    expect(renderResult).hookToStrictEqual({ nb1: 2 });
+    expect(renderResult).hookToStrictEqual({ nb1: { queuePosition: 2, queueTotal: 1 } });
   });
 
   it('should return 1-indexed positions', async () => {
@@ -112,7 +112,10 @@ describe('useQueuePositions', () => {
 
     await renderResult.waitForNextUpdate();
 
-    expect(renderResult).hookToStrictEqual({ nb1: 1, nb2: 2 });
+    expect(renderResult).hookToStrictEqual({
+      nb1: { queuePosition: 1, queueTotal: 2 },
+      nb2: { queuePosition: 2, queueTotal: 2 },
+    });
   });
 
   it('should batch requests by queue name', async () => {
@@ -134,7 +137,10 @@ describe('useQueuePositions', () => {
     expect(getPendingWorkloadsMock).toHaveBeenCalledTimes(2);
     expect(getPendingWorkloadsMock).toHaveBeenCalledWith('test-ns', 'queue-a');
     expect(getPendingWorkloadsMock).toHaveBeenCalledWith('test-ns', 'queue-b');
-    expect(renderResult).hookToStrictEqual({ nb1: 1, nb2: 1 });
+    expect(renderResult).hookToStrictEqual({
+      nb1: { queuePosition: 1, queueTotal: 1 },
+      nb2: { queuePosition: 1, queueTotal: 1 },
+    });
   });
 
   it.each([

--- a/frontend/src/pages/projects/notebook/useKueueNotebookAlerts.ts
+++ b/frontend/src/pages/projects/notebook/useKueueNotebookAlerts.ts
@@ -8,6 +8,7 @@ import {
   getPreemptionToastBody,
   getEvictionToastBody,
 } from '#~/concepts/kueue/messageUtils';
+import { fireWorkbenchStatusToastAction } from '#~/concepts/kueue/workbenchTracking';
 import { NotebookState } from './types';
 
 const ALERT_STATUSES = new Set([
@@ -39,7 +40,10 @@ const fireAlert = (
   const actions = [
     {
       title: 'View details',
-      onClick: () => navigate(`/projects/${projectName}`),
+      onClick: () => {
+        fireWorkbenchStatusToastAction('View details', kueueInfo);
+        navigate(`/projects/${projectName}`);
+      },
     },
   ];
 

--- a/frontend/src/pages/projects/notebook/useQueuePositions.ts
+++ b/frontend/src/pages/projects/notebook/useQueuePositions.ts
@@ -16,18 +16,23 @@ type QueuedEntry = {
   workloadName: string;
 };
 
+export type NotebookQueueMetrics = {
+  queuePosition: number;
+  queueTotal: number;
+};
+
 /**
  * Fetches queue positions from the Kueue Visibility API for pending workloads.
- * Returns a map of notebook name → 1-indexed position in the local queue.
+ * Returns a map of notebook name → 1-indexed position and pending queue total.
  *
  * Handles 403 gracefully: when the user lacks RBAC for the Visibility API,
- * positions are silently omitted (no error, empty map).
+ * metrics are silently omitted (no error, empty map).
  */
 export const useQueuePositions = (
   namespace: string | undefined,
   kueueStatusByNotebookName: Record<string, KueueWorkloadStatusWithMessage | null>,
-): Record<string, number> => {
-  const [positions, setPositions] = React.useState<Record<string, number>>({});
+): Record<string, NotebookQueueMetrics> => {
+  const [metrics, setMetrics] = React.useState<Record<string, NotebookQueueMetrics>>({});
 
   const queuedEntries: QueuedEntry[] = React.useMemo(() => {
     const entries: QueuedEntry[] = [];
@@ -52,7 +57,7 @@ export const useQueuePositions = (
 
   React.useEffect(() => {
     if (!namespace || stableEntries.length === 0) {
-      setPositions({});
+      setMetrics({});
       return undefined;
     }
 
@@ -68,16 +73,20 @@ export const useQueuePositions = (
         byQueue.set(entry.queueName, list);
       }
 
-      const newPositions: Record<string, number> = {};
+      const newMetrics: Record<string, NotebookQueueMetrics> = {};
 
       await Promise.all(
         Array.from(byQueue.entries()).map(async ([queueName, entries]) => {
           try {
             const summary = await getPendingWorkloads(namespace, queueName);
+            const queueTotal = summary.items.length;
             for (const entry of entries) {
               const found = summary.items.find((pw) => pw.metadata.name === entry.workloadName);
               if (found != null) {
-                newPositions[entry.notebookName] = found.positionInLocalQueue + 1;
+                newMetrics[entry.notebookName] = {
+                  queuePosition: found.positionInLocalQueue + 1,
+                  queueTotal,
+                };
               }
             }
           } catch {
@@ -87,7 +96,7 @@ export const useQueuePositions = (
       );
 
       if (!cancelled && requestId === latestRequestId) {
-        setPositions(newPositions);
+        setMetrics(newMetrics);
       }
     };
 
@@ -100,5 +109,5 @@ export const useQueuePositions = (
     };
   }, [namespace, stableEntries]);
 
-  return positions;
+  return metrics;
 };

--- a/frontend/src/pages/projects/notebook/utils.ts
+++ b/frontend/src/pages/projects/notebook/utils.ts
@@ -2,9 +2,20 @@ import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { NotebookKind } from '#~/k8sTypes';
 import { fireFormTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 import {
+  getWorkbenchKueueTrackingProperties,
+  WorkbenchTrackingEvent,
+  type WorkbenchKueueTrackingInput,
+} from '#~/concepts/kueue/workbenchTracking';
+import {
   HardwarePodSpecOptionsState,
   HardwarePodSpecOptions,
 } from '#~/concepts/hardwareProfiles/types.ts';
+
+export type {
+  WorkbenchKueueTrackingInput,
+  WorkbenchKueueTrackingProperties,
+} from '#~/concepts/kueue/workbenchTracking';
+export { getWorkbenchKueueTrackingProperties } from '#~/concepts/kueue/workbenchTracking';
 
 export const hasStopAnnotation = (notebook: NotebookKind): boolean =>
   !!(
@@ -53,21 +64,27 @@ export const fireNotebookTrackingEvent = (
   action: 'started' | 'stopped',
   notebook: NotebookKind,
   podSpecOptionsState: HardwarePodSpecOptionsState<HardwarePodSpecOptions>,
+  kueueTrackingInput?: WorkbenchKueueTrackingInput,
 ): void => {
-  fireFormTrackingEvent(`Workbench ${action === 'started' ? 'Started' : 'Stopped'}`, {
-    outcome: TrackingOutcome.submit,
-    podSpecOptions: JSON.stringify({
-      hardwareProfile: podSpecOptionsState.hardwareProfile.formData.selectedProfile?.metadata.name,
-      resources: podSpecOptionsState.podSpecOptions.resources,
-      tolerations: podSpecOptionsState.podSpecOptions.tolerations,
-      nodeSelector: podSpecOptionsState.podSpecOptions.nodeSelector,
-    }),
-    lastSelectedImage:
-      notebook.metadata.annotations?.['notebooks.opendatahub.io/last-image-selection'],
-    projectName: notebook.metadata.namespace,
-    notebookName: notebook.metadata.name,
-    ...(action === 'stopped' && {
-      lastActivity: notebook.metadata.annotations?.['notebooks.kubeflow.org/last-activity'],
-    }),
-  });
+  fireFormTrackingEvent(
+    action === 'started' ? WorkbenchTrackingEvent.Started : WorkbenchTrackingEvent.Stopped,
+    {
+      outcome: TrackingOutcome.submit,
+      podSpecOptions: JSON.stringify({
+        hardwareProfile:
+          podSpecOptionsState.hardwareProfile.formData.selectedProfile?.metadata.name,
+        resources: podSpecOptionsState.podSpecOptions.resources,
+        tolerations: podSpecOptionsState.podSpecOptions.tolerations,
+        nodeSelector: podSpecOptionsState.podSpecOptions.nodeSelector,
+      }),
+      lastSelectedImage:
+        notebook.metadata.annotations?.['notebooks.opendatahub.io/last-image-selection'],
+      projectName: notebook.metadata.namespace,
+      notebookName: notebook.metadata.name,
+      ...(action === 'stopped' && {
+        lastActivity: notebook.metadata.annotations?.['notebooks.kubeflow.org/last-activity'],
+      }),
+      ...(kueueTrackingInput && getWorkbenchKueueTrackingProperties(kueueTrackingInput)),
+    },
+  );
 };

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -66,7 +66,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   canEnablePipelines,
   showOutOfDateElyraInfo,
 }) => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const { currentProject, kueueStatusByNotebookName } = React.useContext(ProjectDetailsContext);
   const editWorkbenchHref = `/projects/${currentProject.metadata.name}/spawner/${obj.notebook.metadata.name}`;
   const [isExpanded, setExpanded] = React.useState(false);
   const [notebookImage, loaded, loadError] = useNotebookImage(obj.notebook);
@@ -109,16 +109,34 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
       extraPatches,
     )
       .then(() => {
-        fireNotebookTrackingEvent('started', obj.notebook, podSpecOptionsState);
+        fireNotebookTrackingEvent('started', obj.notebook, podSpecOptionsState, {
+          kueueStatus: kueueStatusByNotebookName[notebookName] ?? null,
+          isStarting: true,
+          isRunning: false,
+          isStopping: false,
+        });
         obj.refresh().then(() => setInProgress(false));
       })
       .catch(() => {
         setInProgress(false);
       });
-  }, [obj, canEnablePipelines, podSpecOptionsState, bindingStateInfo, isMlflowAvailable]);
+  }, [
+    obj,
+    canEnablePipelines,
+    podSpecOptionsState,
+    bindingStateInfo,
+    isMlflowAvailable,
+    kueueStatusByNotebookName,
+    notebookName,
+  ]);
 
   const handleStop = React.useCallback(() => {
-    fireNotebookTrackingEvent('stopped', obj.notebook, podSpecOptionsState);
+    fireNotebookTrackingEvent('stopped', obj.notebook, podSpecOptionsState, {
+      kueueStatus: kueueStatusByNotebookName[notebookName] ?? null,
+      isStarting: false,
+      isRunning: obj.isRunning,
+      isStopping: true,
+    });
     setInProgress(true);
     stopNotebook(
       notebookName,
@@ -127,7 +145,14 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
     ).then(() => {
       obj.refresh().then(() => setInProgress(false));
     });
-  }, [podSpecOptionsState, notebookName, notebookNamespace, obj, bindingStateInfo]);
+  }, [
+    podSpecOptionsState,
+    notebookName,
+    notebookNamespace,
+    obj,
+    bindingStateInfo,
+    kueueStatusByNotebookName,
+  ]);
 
   const onStop = React.useCallback(() => {
     if (dontShowModalValue) {

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -26,6 +26,11 @@ import { Connection } from '#~/concepts/connectionTypes/types';
 import { fireFormTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 import { NotebookKind } from '#~/k8sTypes';
 import { getNotebookPVCNames } from '#~/pages/projects/pvc/utils';
+import {
+  getWorkbenchKueueTrackingProperties,
+  WorkbenchTrackingEvent,
+} from '#~/concepts/kueue/workbenchTracking';
+import { KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
 import { useExistingSecrets } from './environmentVariables/useExistingSecrets';
 import {
   createConfigMapsAndSecretsForNotebook,
@@ -59,6 +64,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   const {
     notebooks: { data: notebooks, refresh: refreshNotebooks },
     connections: { refresh: refreshConnections },
+    kueueStatusByNotebookName,
   } = React.useContext(ProjectDetailsContext);
   const { notebookName } = useParams();
   const notebookState = notebooks.find(
@@ -107,9 +113,16 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     const {
       image,
       hardwareProfileOptions: {
-        podSpecOptionsState: { podSpecOptions },
+        podSpecOptionsState: {
+          podSpecOptions,
+          hardwareProfile: { formData: hardwareProfileFormData },
+        },
       },
     } = startNotebookData;
+    const kueueStatus = kueueStatusByNotebookName[name] ?? null;
+    const kueueQueueName =
+      hardwareProfileFormData.selectedProfile?.spec.scheduling?.kueue?.localQueueName ||
+      editNotebook?.metadata.labels?.[KUEUE_QUEUE_LABEL];
     const tep: FormTrackingEventProperties = {
       containerResources: Object.entries(podSpecOptions.resources || {})
         .map(([key, value]) =>
@@ -126,9 +139,19 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       notebookName: name,
       outcome: TrackingOutcome.submit,
       success: true,
+      ...getWorkbenchKueueTrackingProperties({
+        kueueStatus,
+        kueueQueueName,
+        isStarting: true,
+        isRunning: false,
+        isStopping: false,
+      }),
     };
 
-    fireFormTrackingEvent(`Workbench ${type === 'created' ? 'Created' : 'Updated'}`, tep);
+    fireFormTrackingEvent(
+      type === 'created' ? WorkbenchTrackingEvent.Created : WorkbenchTrackingEvent.Updated,
+      tep,
+    );
 
     refreshNotebooks();
     refreshConnections();
@@ -136,7 +159,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     navigate(workbenchesHref);
   };
   const handleError = (e: K8sStatusError) => {
-    fireFormTrackingEvent('Workbench Created', {
+    fireFormTrackingEvent(WorkbenchTrackingEvent.Created, {
       outcome: TrackingOutcome.submit,
       success: false,
       error: e.message,
@@ -334,9 +357,12 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
               id="cancel-button"
               data-testid="cancel-button"
               onClick={() => {
-                fireFormTrackingEvent(`Workbench ${editNotebook ? 'Updated' : 'Created'}`, {
-                  outcome: TrackingOutcome.cancel,
-                });
+                fireFormTrackingEvent(
+                  editNotebook ? WorkbenchTrackingEvent.Updated : WorkbenchTrackingEvent.Created,
+                  {
+                    outcome: TrackingOutcome.cancel,
+                  },
+                );
                 navigate(workbenchesHref);
               }}
             >

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -50,6 +50,8 @@ type SpawnerFooterProps = {
   connections: Connection[];
   canEnablePipelines: boolean;
   selectedFeatureStores?: SelectedFeatureStoreConfig[];
+  /** Present when editing; prefer this over looking up the notebook from context. */
+  existingNotebook?: NotebookKind;
 };
 
 const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
@@ -59,6 +61,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   connections = [],
   canEnablePipelines,
   selectedFeatureStores = [],
+  existingNotebook,
 }) => {
   const [error, setError] = React.useState<K8sStatusError>();
   const {
@@ -73,7 +76,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
 
   const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
 
-  const editNotebook = notebookState?.notebook;
+  const editNotebook = existingNotebook ?? notebookState?.notebook;
   const { projectName } = startNotebookData;
   const navigate = useNavigate();
   const [createInProgress, setCreateInProgress] = React.useState(false);
@@ -159,11 +162,14 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     navigate(workbenchesHref);
   };
   const handleError = (e: K8sStatusError) => {
-    fireFormTrackingEvent(WorkbenchTrackingEvent.Created, {
-      outcome: TrackingOutcome.submit,
-      success: false,
-      error: e.message,
-    });
+    fireFormTrackingEvent(
+      editNotebook ? WorkbenchTrackingEvent.Updated : WorkbenchTrackingEvent.Created,
+      {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: `k8s_${e.statusObject.code}`,
+      },
+    );
     setError(e);
     setCreateInProgress(false);
   };
@@ -245,14 +251,15 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   };
 
   const onUpdateNotebook = async () => {
+    if (!editNotebook) {
+      return;
+    }
     handleStart();
     updateNotebookPromise(true)
       .then(() =>
         updateNotebookPromise(false)
           .then((notebook) => {
-            if (notebook) {
-              afterStart(notebook.metadata.name, 'updated');
-            }
+            afterStart(notebook?.metadata.name ?? editNotebook.metadata.name, 'updated');
           })
           .catch(handleError),
       )
@@ -320,8 +327,11 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
                     onClick={() =>
                       updateNotebookPromise(false)
                         .then((notebook) => {
-                          if (notebook) {
-                            afterStart(notebook.metadata.name, 'updated');
+                          if (editNotebook) {
+                            afterStart(
+                              notebook?.metadata.name ?? editNotebook.metadata.name,
+                              'updated',
+                            );
                           }
                         })
                         .catch(handleError)

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -161,16 +161,33 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
 
     navigate(workbenchesHref);
   };
-  const handleError = (e: K8sStatusError) => {
+  const handleError = (e: unknown) => {
+    const name = editNotebook?.metadata.name || startNotebookData.notebookData.k8sName.value;
+    const kueueQueueName =
+      startNotebookData.hardwareProfileOptions.podSpecOptionsState.hardwareProfile.formData
+        .selectedProfile?.spec.scheduling?.kueue?.localQueueName ||
+      editNotebook?.metadata.labels?.[KUEUE_QUEUE_LABEL];
+
     fireFormTrackingEvent(
       editNotebook ? WorkbenchTrackingEvent.Updated : WorkbenchTrackingEvent.Created,
       {
         outcome: TrackingOutcome.submit,
         success: false,
-        error: `k8s_${e.statusObject.code}`,
+        error: e instanceof K8sStatusError ? `k8s_${e.statusObject.code}` : 'unknown_error',
+        projectName,
+        notebookName: name,
+        ...getWorkbenchKueueTrackingProperties({
+          kueueStatus: kueueStatusByNotebookName[name] ?? null,
+          kueueQueueName,
+          isStarting: true,
+          isRunning: false,
+          isStopping: false,
+        }),
       },
     );
-    setError(e);
+    if (e instanceof K8sStatusError) {
+      setError(e);
+    }
     setCreateInProgress(false);
   };
   const handleStart = () => {

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -498,6 +498,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   connections={notebookConnections}
                   canEnablePipelines={canEnablePipelines}
                   selectedFeatureStores={selectedFeatureStores}
+                  existingNotebook={existingNotebook}
                 />
               )}
             </CanEnableElyraPipelinesCheck>


### PR DESCRIPTION
## Description

Adds Kueue Segment analytics for Workbenches per [RHOAIENG-76173](https://issues.redhat.com/browse/RHOAIENG-76173).

- **UPDATE:** extend Created / Updated / Started / Stopped / Deleted with Kueue props (`kueueQueueName`, `queuePosition`, `queueTotal`, `primaryWorkbenchStatus`, `isKueueBlocking`, `kueueSubState`).
- **NEW:** Status Log Viewed, Modal Tab Switched, Modal Action Clicked, Progress Step Expanded, Toast Action Clicked.

## How Has This Been Tested?

Manual start/stop/status-modal flows; local lint, type-check, and unit tests.

## Test Impact

Unit coverage for `getKueueSubState` and `useQueuePositions` (`queueTotal`).

[RHOAIENG-76173]: https://redhat.atlassian.net/browse/RHOAIENG-76173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Workbench analytics for notebook start/stop, status modal interactions (close/tab switch/buttons), progress expansion, create/update, delete, and status toasts.
  * Added Kueue-derived tracking properties (queue name, 1-indexed position, total pending, blocking indicator, and mapped sub-state) and updated analytics event naming to standardized constants.
  * Updated queue metrics to return per-notebook `queuePosition` (1-indexed) and `queueTotal`, enriching tracking payloads when status is available.
* **Bug Fixes**
  * Improved tracking error reporting to use Kubernetes status codes (e.g., `k8s_<code>`) for create/update and delete.
* **Tests**
  * Added coverage for Kueue sub-state mapping and Workbench tracking property derivation; updated queue metrics shape assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->