### PR TITLE
feat: Add 'Existing secret' option to workbench environment variables form

### DIFF
--- a/frontend/src/api/k8s/__tests__/notebooks.spec.ts
+++ b/frontend/src/api/k8s/__tests__/notebooks.spec.ts
@@ -1448,6 +1448,104 @@ describe('updateNotebook', () => {
   });
 });
 
+describe('assembleNotebook with env field', () => {
+  it('should include secretKeyRef entries from data.env in containers[0].env', () => {
+    const notebookData = mockStartNotebookData({});
+    notebookData.env = [
+      {
+        name: 'DB_HOST',
+        valueFrom: { secretKeyRef: { name: 'db-creds', key: 'host' } },
+      },
+      {
+        name: 'DB_PORT',
+        valueFrom: { secretKeyRef: { name: 'db-creds', key: 'port' } },
+      },
+    ];
+
+    const result = assembleNotebook(notebookData, 'test-user');
+    const containerEnv = result.spec.template.spec.containers[0].env;
+
+    // First two entries are always NOTEBOOK_ARGS and JUPYTER_IMAGE
+    expect(containerEnv[0].name).toBe('NOTEBOOK_ARGS');
+    expect(containerEnv[1].name).toBe('JUPYTER_IMAGE');
+
+    // secretKeyRef entries should appear after the system entries
+    const secretKeyRefEntries = containerEnv.filter(
+      (e) => e.valueFrom && 'secretKeyRef' in (e.valueFrom as Record<string, unknown>),
+    );
+    expect(secretKeyRefEntries).toHaveLength(2);
+    expect(secretKeyRefEntries[0]).toEqual({
+      name: 'DB_HOST',
+      valueFrom: { secretKeyRef: { name: 'db-creds', key: 'host' } },
+    });
+    expect(secretKeyRefEntries[1]).toEqual({
+      name: 'DB_PORT',
+      valueFrom: { secretKeyRef: { name: 'db-creds', key: 'port' } },
+    });
+  });
+
+  it('should handle missing env field gracefully', () => {
+    const notebookData = mockStartNotebookData({});
+    // env is undefined by default
+    const result = assembleNotebook(notebookData, 'test-user');
+    const containerEnv = result.spec.template.spec.containers[0].env;
+
+    // Should still have the two system entries
+    expect(containerEnv).toHaveLength(2);
+    expect(containerEnv[0].name).toBe('NOTEBOOK_ARGS');
+    expect(containerEnv[1].name).toBe('JUPYTER_IMAGE');
+  });
+});
+
+describe('updateNotebook env slicing', () => {
+  it('should preserve NOTEBOOK_ARGS and JUPYTER_IMAGE but clear custom env entries', async () => {
+    const existingNotebook = mockNotebookK8sResource({
+      additionalEnvs: [
+        {
+          name: 'DB_HOST',
+          valueFrom: { secretKeyRef: { name: 'db-creds', key: 'host' } },
+        },
+        {
+          name: 'API_KEY',
+          valueFrom: { secretKeyRef: { name: 'api-secret', key: 'key' } },
+        },
+      ],
+    });
+
+    const newNotebookData = mockStartNotebookData({
+      notebookId: existingNotebook.metadata.name,
+    });
+    // Add new env entries to replace the old ones
+    newNotebookData.env = [
+      {
+        name: 'NEW_VAR',
+        valueFrom: { secretKeyRef: { name: 'new-secret', key: 'val' } },
+      },
+    ];
+
+    k8sUpdateResourceMock.mockResolvedValue(existingNotebook);
+
+    await updateNotebook(existingNotebook, newNotebookData, username);
+
+    const { resource: mergedNotebook } = k8sUpdateResourceMock.mock.calls[0][0];
+    const containerEnv = mergedNotebook.spec.template.spec.containers[0].env;
+
+    // NOTEBOOK_ARGS and JUPYTER_IMAGE should still be present
+    expect(containerEnv[0].name).toBe('NOTEBOOK_ARGS');
+    expect(containerEnv[1].name).toBe('JUPYTER_IMAGE');
+
+    // Old custom entries (DB_HOST, API_KEY) should NOT be present
+    const oldEntryNames = containerEnv
+      .map((e: { name: string }) => e.name)
+      .filter((n: string) => n === 'DB_HOST' || n === 'API_KEY');
+    expect(oldEntryNames).toHaveLength(0);
+
+    // The new entry should be present
+    const newEntry = containerEnv.find((e: { name: string }) => e.name === 'NEW_VAR');
+    expect(newEntry).toBeDefined();
+  });
+});
+
 describe('getMlflowInstancePatch', () => {
   it('should return an add patch when mlflow is enabled and annotation is absent', () => {
     const notebook = mockNotebookK8sResource({});

--- a/frontend/src/api/k8s/__tests__/secrets.spec.ts
+++ b/frontend/src/api/k8s/__tests__/secrets.spec.ts
@@ -19,6 +19,7 @@ import {
   createSecret,
   deleteSecret,
   getSecret,
+  getSecrets,
   getSecretsByLabel,
   replaceSecret,
 } from '#~/api/k8s/secrets';
@@ -238,6 +239,32 @@ describe('getSecretsByLabel', () => {
       fetchOptions: { requestInit: {} },
       model: SecretModel,
       queryOptions: { ns: 'secretName', queryParams: { labelSelector: 'label' } },
+    });
+  });
+});
+
+describe('getSecrets', () => {
+  it('should list all secrets in a namespace without label filtering', async () => {
+    const secretMock = mockK8sResourceList([mockSecretK8sResource({})]);
+    k8sListResourceMock.mockResolvedValue(secretMock);
+    const result = await getSecrets('test-ns');
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: SecretModel,
+      queryOptions: { ns: 'test-ns', queryParams: {} },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(secretMock.items);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(getSecrets('test-ns')).rejects.toThrow('error1');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: SecretModel,
+      queryOptions: { ns: 'test-ns', queryParams: {} },
     });
   });
 });

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -37,6 +37,7 @@ export const assembleNotebook = (
     projectName,
     notebookData,
     envFrom,
+    env: envVars,
     image,
     volumes: formVolumes,
     volumeMounts: formVolumeMounts,
@@ -134,6 +135,7 @@ export const assembleNotebook = (
                   name: 'JUPYTER_IMAGE',
                   value: imageUrl,
                 },
+                ...(envVars || []),
               ],
               envFrom,
               volumeMounts,
@@ -302,6 +304,10 @@ export const updateNotebook = (
 
   // clean the envFrom array in case of merging the old value again
   container.envFrom = [];
+  // Clean custom env entries (indices > 1) to prevent lodash merge from
+  // duplicating secretKeyRef entries. Indices 0 and 1 are NOTEBOOK_ARGS
+  // and JUPYTER_IMAGE, which are always present.
+  container.env = container.env.slice(0, 2);
   // clean the resources, affinity and tolerations for accelerator
   oldNotebook.spec.template.spec.tolerations = [];
   oldNotebook.spec.template.spec.affinity = {};

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -307,7 +307,9 @@ export const updateNotebook = (
   // Clean custom env entries (indices > 1) to prevent lodash merge from
   // duplicating secretKeyRef entries. Indices 0 and 1 are NOTEBOOK_ARGS
   // and JUPYTER_IMAGE, which are always present.
-  container.env = container.env.slice(0, 2);
+  // Defensive fallback: manually-crafted CRs may omit the env field entirely
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  container.env = (container.env ?? []).slice(0, 2);
   // clean the resources, affinity and tolerations for accelerator
   oldNotebook.spec.template.spec.tolerations = [];
   oldNotebook.spec.template.spec.affinity = {};

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -167,6 +167,17 @@ export const getSecretsByLabel = (
     ),
   ).then((result) => result.items);
 
+export const getSecrets = (namespace: string, opts?: K8sAPIOptions): Promise<SecretKind[]> =>
+  k8sListResource<SecretKind>(
+    applyK8sAPIOptions(
+      {
+        model: SecretModel,
+        queryOptions: { ns: namespace },
+      },
+      opts,
+    ),
+  ).then((result) => result.items);
+
 export const createSecret = (data: SecretKind, opts?: K8sAPIOptions): Promise<SecretKind> =>
   k8sCreateResource<SecretKind>(
     applyK8sAPIOptions(

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -52,6 +52,7 @@ type SpawnerFooterProps = {
   connections: Connection[];
   canEnablePipelines: boolean;
   selectedFeatureStores?: SelectedFeatureStoreConfig[];
+  hasEnvVarConflicts?: boolean;
 };
 
 const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
@@ -61,6 +62,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   connections = [],
   canEnablePipelines,
   selectedFeatureStores = [],
+  hasEnvVarConflicts = false,
 }) => {
   const [error, setError] = React.useState<K8sStatusError>();
   const {
@@ -84,6 +86,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     createInProgress ||
     !checkRequiredFieldsForNotebookStart(startNotebookData, envVariables) ||
     !isHardwareProfileValid ||
+    hasEnvVarConflicts ||
     (!isProjectScopedAvailable &&
       startNotebookData.image.imageStream?.metadata.namespace === projectName);
 

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -17,7 +17,12 @@ import {
   restartNotebook,
   updateNotebook,
 } from '#~/api';
-import { EnvVariable, StartNotebookData, StorageData } from '#~/pages/projects/types';
+import {
+  EnvVariable,
+  SecretCategory,
+  StartNotebookData,
+  StorageData,
+} from '#~/pages/projects/types';
 import { useUser } from '#~/redux/selectors';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import { ProjectSectionID } from '#~/pages/projects/screens/detail/types';
@@ -32,6 +37,7 @@ import { getNotebookPVCNames } from '#~/pages/projects/pvc/utils';
 import {
   createConfigMapsAndSecretsForNotebook,
   createPvcDataForNotebook,
+  getEnvVarsForExistingSecrets,
   updateConfigMapsAndSecretsForNotebook,
   updatePvcDataForNotebook,
 } from './service';
@@ -172,13 +178,17 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
 
     await Promise.all(restartConnectedNotebooksPromises);
 
+    const nonExistingEnvVars = envVariables.filter(
+      (ev) => ev.values?.category !== SecretCategory.EXISTING,
+    );
     const envFrom = await updateConfigMapsAndSecretsForNotebook(
       projectName,
       editNotebook,
-      envVariables,
+      nonExistingEnvVars,
       connections,
       dryRun,
     );
+    const env = getEnvVarsForExistingSecrets(envVariables);
 
     const annotations = { ...editNotebook.metadata.annotations };
     if (envFrom.length > 0) {
@@ -192,6 +202,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       volumes,
       volumeMounts,
       envFrom,
+      env,
       connections,
       feastData,
     };
@@ -224,11 +235,15 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
 
     await Promise.all(restartConnectedNotebooksPromises);
 
+    const nonExistingEnvVars = envVariables.filter(
+      (ev) => ev.values?.category !== SecretCategory.EXISTING,
+    );
     const envFrom = await createConfigMapsAndSecretsForNotebook(
       projectName,
-      [...envVariables],
+      [...nonExistingEnvVars],
       dryRun,
     );
+    const env = getEnvVarsForExistingSecrets(envVariables);
 
     const { volumes, volumeMounts } = pvcVolumeDetails;
     const feastData = generateFeastMetadata(selectedFeatureStores, undefined, false);
@@ -238,6 +253,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       volumes,
       volumeMounts,
       envFrom: [...envFrom],
+      env,
       connections,
       feastData,
     };

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -64,6 +64,8 @@ import { useNotebookEnvVariables } from './environmentVariables/useNotebookEnvVa
 import { useDefaultStorageClass } from './storage/useDefaultStorageClass';
 import { ConnectionsFormSection } from './connections/ConnectionsFormSection';
 import { getConnectionsFromNotebook } from './connections/utils';
+import { detectEnvVarConflicts } from './environmentVariables/envVarConflicts';
+import EnvVarConflictWarning from './environmentVariables/EnvVarConflictWarning';
 import AlertWarningText from './environmentVariables/AlertWarningText';
 import { ClusterStorageTable } from './storage/ClusterStorageTable';
 import useDefaultPvcSize from './storage/useDefaultPvcSize';
@@ -198,6 +200,21 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     useNotebookEnvVariables(existingNotebook, [
       ...notebookConnections.map((connection) => connection.metadata.name),
     ]);
+
+  const connectionKeysMap = React.useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const connection of notebookConnections) {
+      const name = getDisplayNameFromK8sResource(connection);
+      const keys = connection.data ? Object.keys(connection.data) : [];
+      map.set(name, keys);
+    }
+    return map;
+  }, [notebookConnections]);
+
+  const envVarConflicts = React.useMemo(
+    () => detectEnvVarConflicts(envVariables, connectionKeysMap),
+    [envVariables, connectionKeysMap],
+  );
 
   const notebooksUsingPVCsWithSizeChanges = React.useMemo(() => {
     const attachedPVCs = storageData.filter((storage) => storage.existingPvc !== undefined);
@@ -373,6 +390,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                 />
               )}
               <EnvironmentVariables envVariables={envVariables} setEnvVariables={setEnvVariables} />
+              {envVarConflicts.length > 0 && <EnvVarConflictWarning conflicts={envVarConflicts} />}
             </FormSection>
             <FormSection
               title={
@@ -494,6 +512,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   connections={notebookConnections}
                   canEnablePipelines={canEnablePipelines}
                   selectedFeatureStores={selectedFeatureStores}
+                  hasEnvVarConflicts={envVarConflicts.length > 0}
                 />
               )}
             </CanEnableElyraPipelinesCheck>

--- a/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
@@ -1,0 +1,153 @@
+import { EnvVariable, EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+import { getEnvVarsForExistingSecrets } from '#~/pages/projects/screens/spawner/service';
+
+describe('getEnvVarsForExistingSecrets', () => {
+  it('should return empty array when no existing secret variables', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'KEY1', value: 'val1' }],
+        },
+      },
+    ];
+    expect(getEnvVarsForExistingSecrets(envVariables)).toEqual([]);
+  });
+
+  it('should convert existing secret entries to secretKeyRef format', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'db-credentials',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'DB_HOST', value: '' },
+            { key: 'DB_PASSWORD', value: '' },
+          ],
+        },
+      },
+    ];
+
+    const result = getEnvVarsForExistingSecrets(envVariables);
+    expect(result).toEqual([
+      {
+        name: 'DB_HOST',
+        valueFrom: { secretKeyRef: { name: 'db-credentials', key: 'DB_HOST' } },
+      },
+      {
+        name: 'DB_PASSWORD',
+        valueFrom: { secretKeyRef: { name: 'db-credentials', key: 'DB_PASSWORD' } },
+      },
+    ]);
+  });
+
+  it('should handle multiple existing secrets', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY_A', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-b',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY_B', value: '' }],
+        },
+      },
+    ];
+
+    const result = getEnvVarsForExistingSecrets(envVariables);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('KEY_A');
+    expect(result[1].name).toBe('KEY_B');
+  });
+
+  it('should skip entries without existingName', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY', value: '' }],
+        },
+      },
+    ];
+
+    expect(getEnvVarsForExistingSecrets(envVariables)).toEqual([]);
+  });
+
+  it('should skip entries with empty key', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: '', value: '' }],
+        },
+      },
+    ];
+
+    expect(getEnvVarsForExistingSecrets(envVariables)).toEqual([]);
+  });
+
+  it('should filter mixed variables and only return existing secret entries', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'generic-secret',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'KEY1', value: 'val1' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'existing-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'EXISTING_KEY', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'aws-secret',
+        values: {
+          category: SecretCategory.AWS,
+          data: [{ key: 'AWS_KEY', value: 'aws-val' }],
+        },
+      },
+    ];
+
+    const result = getEnvVarsForExistingSecrets(envVariables);
+    expect(result).toEqual([
+      {
+        name: 'EXISTING_KEY',
+        valueFrom: { secretKeyRef: { name: 'existing-secret', key: 'EXISTING_KEY' } },
+      },
+    ]);
+  });
+
+  it('should return empty array for empty input', () => {
+    expect(getEnvVarsForExistingSecrets([])).toEqual([]);
+  });
+
+  it('should skip entries without values', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+      },
+    ];
+
+    expect(getEnvVarsForExistingSecrets(envVariables)).toEqual([]);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
@@ -5,9 +5,11 @@ import {
   getVersion,
   isHiddenOOTBImageStream,
   isBYONImageStream,
+  isEnvVariableDataValid,
 } from '#~/pages/projects/screens/spawner/spawnerUtils';
 import { mockImageStreamK8sResource } from '#~/__mocks__/mockImageStreamK8sResource';
 import { IMAGE_ANNOTATIONS } from '#~/pages/projects/screens/spawner/const';
+import { EnvironmentVariableType, SecretCategory, EnvVariable } from '#~/pages/projects/types';
 
 describe('getExistingVersionsForImageStream', () => {
   it('should handle no image tags', () => {
@@ -273,5 +275,56 @@ describe('checkVersionRecommended', () => {
     expect(getVersion(0.1)).toEqual('0.1');
     expect(getVersion(3.1, 'v')).toEqual('v3.1');
     expect(getVersion(1000.5, 'V')).toEqual('V1000.5');
+  });
+});
+
+describe('isEnvVariableDataValid', () => {
+  it('should return true for empty env variables', () => {
+    expect(isEnvVariableDataValid([])).toBe(true);
+  });
+
+  it('should return true for EXISTING entries with non-empty keys', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'DB_HOST', value: '' },
+            { key: 'DB_PORT', value: '' },
+          ],
+        },
+      },
+    ];
+    expect(isEnvVariableDataValid(envVars)).toBe(true);
+  });
+
+  it('should return false for EXISTING entries with empty keys', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: '', value: '' }],
+        },
+      },
+    ];
+    expect(isEnvVariableDataValid(envVars)).toBe(false);
+  });
+
+  it('should return false for EXISTING entries with no data', () => {
+    const envVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [],
+        },
+      },
+    ];
+    expect(isEnvVariableDataValid(envVars)).toBe(false);
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
@@ -139,7 +139,7 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
                   label={key}
                   isChecked={selectedKeys.has(key)}
                   onChange={(_event, checked) => handleKeyToggle(key, checked)}
-                  data-testid="existing-secret-key-checkbox"
+                  data-testid={`existing-secret-key-checkbox-${key}`}
                 />
               </StackItem>
             ))}

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
@@ -23,7 +23,7 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const namespace = currentProject.metadata.name;
 
-  const [secrets, loaded] = useExistingSecrets(namespace, true);
+  const [secrets, loaded, error] = useExistingSecrets(namespace, true);
 
   const selectedSecret = React.useMemo(
     () => secrets.find((s) => s.metadata.name === selectedSecretName),
@@ -64,14 +64,16 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
       if (!secret) {
         return;
       }
-      onUpdateVariable?.({ existingName: secretName });
       const allKeys = secret.data ? Object.keys(secret.data) : [];
-      onUpdate({
-        category: SecretCategory.EXISTING,
-        data: allKeys.map((key) => ({ key, value: '' })),
+      onUpdateVariable?.({
+        existingName: secretName,
+        values: {
+          category: SecretCategory.EXISTING,
+          data: allKeys.map((key) => ({ key, value: '' })),
+        },
       });
     },
-    [secrets, onUpdate, onUpdateVariable],
+    [secrets, onUpdateVariable],
   );
 
   const handleKeyToggle = React.useCallback(
@@ -97,6 +99,14 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
     },
     [env, onUpdate, secretKeys],
   );
+
+  if (error) {
+    return (
+      <HelperText>
+        <HelperTextItem variant="error">Failed to load secrets</HelperTextItem>
+      </HelperText>
+    );
+  }
 
   if (loaded && secrets.length === 0) {
     return (
@@ -125,7 +135,7 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
           <Stack hasGutter>
             <StackItem>
               <Checkbox
-                id="select-all-keys"
+                id={`select-all-keys-${selectedSecretName}`}
                 label="Select all keys"
                 isChecked={allKeysSelected}
                 onChange={handleSelectAllToggle}
@@ -135,7 +145,7 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
             {secretKeys.map((key) => (
               <StackItem key={key}>
                 <Checkbox
-                  id={`key-${key}`}
+                  id={`key-${selectedSecretName}-${key}`}
                   label={key}
                   isChecked={selectedKeys.has(key)}
                   onChange={(_event, checked) => handleKeyToggle(key, checked)}

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
@@ -1,0 +1,153 @@
+import * as React from 'react';
+import { Checkbox, HelperText, HelperTextItem, Stack, StackItem } from '@patternfly/react-core';
+import TypeaheadSelect, {
+  TypeaheadSelectOption,
+} from '@odh-dashboard/ui-core/components/TypeaheadSelect';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
+import { EnvVariable, EnvVariableData, SecretCategory } from '#~/pages/projects/types';
+import { useExistingSecrets } from './useExistingSecrets';
+
+type EnvExistingSecretFieldProps = {
+  env: EnvVariableData;
+  onUpdate: (envVariableData: EnvVariableData) => void;
+  onUpdateVariable?: (partial: Partial<EnvVariable>) => void;
+  selectedSecretName?: string;
+};
+
+const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
+  env,
+  onUpdate,
+  onUpdateVariable,
+  selectedSecretName,
+}) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const namespace = currentProject.metadata.name;
+
+  const [secrets, loaded] = useExistingSecrets(namespace, true);
+
+  const selectedSecret = React.useMemo(
+    () => secrets.find((s) => s.metadata.name === selectedSecretName),
+    [secrets, selectedSecretName],
+  );
+
+  const secretKeys = React.useMemo(
+    () => (selectedSecret?.data ? Object.keys(selectedSecret.data) : []),
+    [selectedSecret],
+  );
+
+  const selectedKeys = React.useMemo(() => new Set(env.data.map((entry) => entry.key)), [env.data]);
+
+  const allKeysSelected = secretKeys.length > 0 && secretKeys.every((k) => selectedKeys.has(k));
+
+  const options: TypeaheadSelectOption[] = React.useMemo(
+    () =>
+      secrets.map(
+        (secret): TypeaheadSelectOption => ({
+          content: secret.metadata.name,
+          value: secret.metadata.name,
+          isSelected: secret.metadata.name === selectedSecretName,
+        }),
+      ),
+    [secrets, selectedSecretName],
+  );
+
+  const handleSecretSelect = React.useCallback(
+    (
+      _event:
+        | React.MouseEvent<Element, MouseEvent>
+        | React.KeyboardEvent<HTMLInputElement>
+        | undefined,
+      value: string | number,
+    ) => {
+      const secretName = String(value);
+      const secret = secrets.find((s) => s.metadata.name === secretName);
+      if (!secret) {
+        return;
+      }
+      onUpdateVariable?.({ existingName: secretName });
+      const allKeys = secret.data ? Object.keys(secret.data) : [];
+      onUpdate({
+        category: SecretCategory.EXISTING,
+        data: allKeys.map((key) => ({ key, value: '' })),
+      });
+    },
+    [secrets, onUpdate, onUpdateVariable],
+  );
+
+  const handleKeyToggle = React.useCallback(
+    (key: string, checked: boolean) => {
+      const newData = checked
+        ? [...env.data, { key, value: '' }]
+        : env.data.filter((entry) => entry.key !== key);
+      onUpdate({ ...env, data: newData });
+    },
+    [env, onUpdate],
+  );
+
+  const handleSelectAllToggle = React.useCallback(
+    (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
+      if (checked) {
+        onUpdate({
+          ...env,
+          data: secretKeys.map((key) => ({ key, value: '' })),
+        });
+      } else {
+        onUpdate({ ...env, data: [] });
+      }
+    },
+    [env, onUpdate, secretKeys],
+  );
+
+  if (loaded && secrets.length === 0) {
+    return (
+      <HelperText>
+        <HelperTextItem variant="indeterminate">
+          No existing secrets found in this namespace
+        </HelperTextItem>
+      </HelperText>
+    );
+  }
+
+  return (
+    <Stack hasGutter>
+      <StackItem data-testid="existing-secret-select">
+        <TypeaheadSelect
+          selectOptions={options}
+          onSelect={handleSecretSelect}
+          placeholder="Select a secret"
+          noOptionsFoundMessage="No matching secrets"
+          popperProps={{ appendTo: 'inline' }}
+          previewDescription={false}
+        />
+      </StackItem>
+      {selectedSecretName && secretKeys.length > 0 ? (
+        <StackItem data-testid="existing-secret-key-checkboxes">
+          <Stack hasGutter>
+            <StackItem>
+              <Checkbox
+                id="select-all-keys"
+                label="Select all keys"
+                isChecked={allKeysSelected}
+                onChange={handleSelectAllToggle}
+                data-testid="existing-secret-select-all"
+              />
+            </StackItem>
+            {secretKeys.map((key) => (
+              <StackItem key={key}>
+                <Checkbox
+                  id={`key-${key}`}
+                  label={key}
+                  isChecked={selectedKeys.has(key)}
+                  onChange={(_event, checked) => handleKeyToggle(key, checked)}
+                  data-testid="existing-secret-key-checkbox"
+                />
+              </StackItem>
+            ))}
+          </Stack>
+        </StackItem>
+      ) : null}
+    </Stack>
+  );
+};
+
+export default EnvExistingSecretField;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Checkbox, HelperText, HelperTextItem, Stack, StackItem } from '@patternfly/react-core';
+import {
+  Checkbox,
+  HelperText,
+  HelperTextItem,
+  Spinner,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import TypeaheadSelect, {
   TypeaheadSelectOption,
 } from '@odh-dashboard/ui-core/components/TypeaheadSelect';
@@ -99,6 +106,10 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
     },
     [env, onUpdate, secretKeys],
   );
+
+  if (!loaded && !error) {
+    return <Spinner size="md" />;
+  }
 
   if (error) {
     return (

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -32,9 +32,17 @@ const EnvSecret: React.FC<EnvSecretProps> = ({
 }) => (
   <EnvDataTypeField
     selection={env.category || ''}
-    onSelection={(value) =>
-      onUpdate({ ...env, category: asEnumMember(value, SecretCategory), data: [] })
-    }
+    onSelection={(value) => {
+      const newCategory = asEnumMember(value, SecretCategory);
+      if (onUpdateVariable) {
+        onUpdateVariable({
+          existingName: undefined,
+          values: { category: newCategory, data: [] },
+        });
+      } else {
+        onUpdate({ ...env, category: newCategory, data: [] });
+      }
+    }}
     options={{
       [SecretCategory.GENERIC]: {
         label: 'Key / value',

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
 import { asEnumMember } from '@odh-dashboard/foundation';
-import { EnvironmentVariableType, EnvVariableData, SecretCategory } from '#~/pages/projects/types';
+import {
+  EnvironmentVariableType,
+  EnvVariable,
+  EnvVariableData,
+  SecretCategory,
+} from '#~/pages/projects/types';
 import EnvDataTypeField from './EnvDataTypeField';
 import GenericKeyValuePairField from './GenericKeyValuePairField';
 import { EMPTY_KEY_VALUE_PAIR } from './const';
 import EnvUploadField from './EnvUploadField';
+import EnvExistingSecretField from './EnvExistingSecretField';
 
 type EnvSecretProps = {
   env?: EnvVariableData;
   onUpdate: (envVariableData: EnvVariableData) => void;
+  onUpdateVariable?: (partial: Partial<EnvVariable>) => void;
+  selectedSecretName?: string;
 };
 
 const DEFAULT_ENV: EnvVariableData = {
@@ -16,7 +24,12 @@ const DEFAULT_ENV: EnvVariableData = {
   data: [],
 };
 
-const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) => (
+const EnvSecret: React.FC<EnvSecretProps> = ({
+  env = DEFAULT_ENV,
+  onUpdate,
+  onUpdateVariable,
+  selectedSecretName,
+}) => (
   <EnvDataTypeField
     selection={env.category || ''}
     onSelection={(value) =>
@@ -40,6 +53,17 @@ const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) =>
             envVarType={EnvironmentVariableType.SECRET}
             onUpdate={(newEnvData) => onUpdate({ ...env, data: newEnvData })}
             translateValue={(value) => atob(value)}
+          />
+        ),
+      },
+      [SecretCategory.EXISTING]: {
+        label: 'Existing secret',
+        render: (
+          <EnvExistingSecretField
+            env={env}
+            onUpdate={onUpdate}
+            onUpdateVariable={onUpdateVariable}
+            selectedSecretName={selectedSecretName}
           />
         ),
       },

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -52,6 +52,7 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                 <EnvTypeSwitch
                   env={envVariable}
                   onUpdate={(envValue) => onUpdate({ ...envVariable, values: envValue })}
+                  onUpdateVariable={(partial) => onUpdate({ ...envVariable, ...partial })}
                 />
               </IndentSection>
             </StackItem>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
@@ -6,14 +6,22 @@ import EnvSecret from './EnvSecret';
 type EnvTypeSwitchProps = {
   env: EnvVariable;
   onUpdate: (envVariableData: EnvVariableData) => void;
+  onUpdateVariable?: (partial: Partial<EnvVariable>) => void;
 };
 
-const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate }) => {
+const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate, onUpdateVariable }) => {
   switch (env.type) {
     case EnvironmentVariableType.CONFIG_MAP:
       return <EnvConfigMap env={env.values} onUpdate={onUpdate} />;
     case EnvironmentVariableType.SECRET:
-      return <EnvSecret env={env.values} onUpdate={onUpdate} />;
+      return (
+        <EnvSecret
+          env={env.values}
+          onUpdate={onUpdate}
+          onUpdateVariable={onUpdateVariable}
+          selectedSecretName={env.existingName}
+        />
+      );
     default:
       return null;
   }

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Alert, ExpandableSection, List, ListItem } from '@patternfly/react-core';
+import { EnvVarConflict } from './envVarConflicts';
+
+type EnvVarConflictWarningProps = {
+  conflicts: EnvVarConflict[];
+};
+
+const EnvVarConflictWarning: React.FC<EnvVarConflictWarningProps> = ({ conflicts }) => (
+  <Alert
+    variant="warning"
+    isInline
+    title="Environment variable conflicts"
+    data-testid="env-var-conflict-warning"
+  >
+    Environment variables from different sources have conflicting names. When names conflict, only
+    one of the values is used in the workbench.
+    <ExpandableSection toggleText="Show conflicts" isIndented>
+      <List>
+        {conflicts.map((conflict) => (
+          <ListItem key={conflict.key}>
+            <strong>{conflict.key}</strong> is defined in {conflict.sources.join(' and ')}
+          </ListItem>
+        ))}
+      </List>
+    </ExpandableSection>
+  </Alert>
+);
+
+export default EnvVarConflictWarning;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Alert, ExpandableSection, List, ListItem } from '@patternfly/react-core';
 import { EnvVarConflict } from './envVarConflicts';
 

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
@@ -296,4 +296,39 @@ describe('EnvExistingSecretField', () => {
       data: [{ key: 'DB_PASSWORD', value: '' }],
     });
   });
+
+  it('should call onUpdateVariable with existingName and all keys when a secret is selected from the dropdown', () => {
+    const multiSecrets = [
+      mockSecret('db-credentials', ['DB_HOST', 'DB_PASSWORD', 'DB_PORT']),
+      mockSecret('api-keys', ['API_KEY', 'API_SECRET']),
+    ];
+    mockUseExistingSecrets.mockReturnValue([multiSecrets, true, undefined, jest.fn()]);
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={defaultEnv}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+      />,
+    );
+
+    // Open the typeahead dropdown by clicking the toggle button
+    const toggleButton = screen.getByRole('button', { name: /typeahead menu toggle/i });
+    fireEvent.click(toggleButton);
+
+    // Click on the "api-keys" option in the dropdown
+    const option = screen.getByText('api-keys');
+    fireEvent.click(option);
+
+    expect(onUpdateVariable).toHaveBeenCalledWith({
+      existingName: 'api-keys',
+      values: {
+        category: SecretCategory.EXISTING,
+        data: [
+          { key: 'API_KEY', value: '' },
+          { key: 'API_SECRET', value: '' },
+        ],
+      },
+    });
+  });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
@@ -73,6 +73,34 @@ describe('EnvExistingSecretField', () => {
     expect(screen.getByTestId('existing-secret-select')).toBeInTheDocument();
   });
 
+  it('should show loading spinner while secrets are loading', () => {
+    mockUseExistingSecrets.mockReturnValue([[], false, undefined, jest.fn()]);
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={defaultEnv}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+      />,
+    );
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('should show error state when loading secrets fails', () => {
+    mockUseExistingSecrets.mockReturnValue([[], false, new Error('Network error'), jest.fn()]);
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={defaultEnv}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+      />,
+    );
+
+    expect(screen.getByText('Failed to load secrets')).toBeInTheDocument();
+  });
+
   it('should show empty state when no secrets available', () => {
     mockUseExistingSecrets.mockReturnValue([[], true, undefined, jest.fn()]);
 

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { SecretKind } from '@odh-dashboard/k8s-core';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
@@ -136,8 +136,9 @@ describe('EnvExistingSecretField', () => {
       />,
     );
 
-    const keyCheckboxes = screen.getAllByTestId('existing-secret-key-checkbox');
-    expect(keyCheckboxes).toHaveLength(3);
+    expect(screen.getByTestId('existing-secret-key-checkbox-DB_HOST')).toBeInTheDocument();
+    expect(screen.getByTestId('existing-secret-key-checkbox-DB_PASSWORD')).toBeInTheDocument();
+    expect(screen.getByTestId('existing-secret-key-checkbox-DB_PORT')).toBeInTheDocument();
   });
 
   it('should show select-all checkbox when a secret is selected', () => {
@@ -156,5 +157,115 @@ describe('EnvExistingSecretField', () => {
     );
 
     expect(screen.getByTestId('existing-secret-select-all')).toBeInTheDocument();
+  });
+
+  it('should call onUpdate with all keys when select-all checkbox is checked', () => {
+    const envEmpty: EnvVariableData = {
+      category: SecretCategory.EXISTING,
+      data: [],
+    };
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={envEmpty}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+        selectedSecretName="db-credentials"
+      />,
+    );
+
+    const selectAllCheckbox = screen.getByTestId('existing-secret-select-all');
+    fireEvent.click(selectAllCheckbox);
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      ...envEmpty,
+      data: [
+        { key: 'DB_HOST', value: '' },
+        { key: 'DB_PASSWORD', value: '' },
+        { key: 'DB_PORT', value: '' },
+      ],
+    });
+  });
+
+  it('should call onUpdate with empty data when select-all checkbox is unchecked', () => {
+    const envWithAllKeys: EnvVariableData = {
+      category: SecretCategory.EXISTING,
+      data: [
+        { key: 'DB_HOST', value: '' },
+        { key: 'DB_PASSWORD', value: '' },
+        { key: 'DB_PORT', value: '' },
+      ],
+    };
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={envWithAllKeys}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+        selectedSecretName="db-credentials"
+      />,
+    );
+
+    const selectAllCheckbox = screen.getByTestId('existing-secret-select-all');
+    fireEvent.click(selectAllCheckbox);
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      ...envWithAllKeys,
+      data: [],
+    });
+  });
+
+  it('should call onUpdate with the key added when an individual key checkbox is checked', () => {
+    const envWithOneKey: EnvVariableData = {
+      category: SecretCategory.EXISTING,
+      data: [{ key: 'DB_HOST', value: '' }],
+    };
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={envWithOneKey}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+        selectedSecretName="db-credentials"
+      />,
+    );
+
+    const passwordCheckbox = screen.getByTestId('existing-secret-key-checkbox-DB_PASSWORD');
+    fireEvent.click(passwordCheckbox);
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      ...envWithOneKey,
+      data: [
+        { key: 'DB_HOST', value: '' },
+        { key: 'DB_PASSWORD', value: '' },
+      ],
+    });
+  });
+
+  it('should call onUpdate with the key removed when an individual key checkbox is unchecked', () => {
+    const envWithTwoKeys: EnvVariableData = {
+      category: SecretCategory.EXISTING,
+      data: [
+        { key: 'DB_HOST', value: '' },
+        { key: 'DB_PASSWORD', value: '' },
+      ],
+    };
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={envWithTwoKeys}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+        selectedSecretName="db-credentials"
+      />,
+    );
+
+    const hostCheckbox = screen.getByTestId('existing-secret-key-checkbox-DB_HOST');
+    fireEvent.click(hostCheckbox);
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      ...envWithTwoKeys,
+      data: [{ key: 'DB_PASSWORD', value: '' }],
+    });
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
+import {
+  ProjectDetailsContext,
+  ProjectDetailsContextType,
+} from '#~/pages/projects/ProjectDetailsContext';
+import { SecretCategory, EnvVariableData } from '#~/pages/projects/types';
+import { DEFAULT_LIST_FETCH_STATE } from '#~/utilities/const';
+import { useExistingSecrets } from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+import EnvExistingSecretField from '#~/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField';
+
+jest.mock('../useExistingSecrets');
+
+const mockUseExistingSecrets = jest.mocked(useExistingSecrets);
+
+const mockSecret = (name: string, keys: string[]): SecretKind => ({
+  apiVersion: 'v1',
+  kind: 'Secret',
+  type: 'Opaque',
+  metadata: { name, namespace: 'test-project', annotations: {} },
+  data: keys.reduce<Record<string, string>>((acc, k) => ({ ...acc, [k]: btoa(`value-${k}`) }), {}),
+});
+
+const currentProject = mockProjectK8sResource({ k8sName: 'test-project' });
+
+const renderWithContext = (ui: React.ReactElement) =>
+  render(
+    <ProjectDetailsContext.Provider
+      value={
+        {
+          currentProject,
+          notebooks: DEFAULT_LIST_FETCH_STATE,
+          pvcs: DEFAULT_LIST_FETCH_STATE,
+          connections: DEFAULT_LIST_FETCH_STATE,
+          serverSecrets: DEFAULT_LIST_FETCH_STATE,
+        } as unknown as ProjectDetailsContextType
+      }
+    >
+      {ui}
+    </ProjectDetailsContext.Provider>,
+  );
+
+describe('EnvExistingSecretField', () => {
+  const onUpdate = jest.fn();
+  const onUpdateVariable = jest.fn();
+  const defaultEnv: EnvVariableData = {
+    category: SecretCategory.EXISTING,
+    data: [],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseExistingSecrets.mockReturnValue([
+      [mockSecret('db-credentials', ['DB_HOST', 'DB_PASSWORD', 'DB_PORT'])],
+      true,
+      undefined,
+      jest.fn(),
+    ]);
+  });
+
+  it('should render the typeahead select for secret selection', () => {
+    renderWithContext(
+      <EnvExistingSecretField
+        env={defaultEnv}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+      />,
+    );
+
+    expect(screen.getByTestId('existing-secret-select')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no secrets available', () => {
+    mockUseExistingSecrets.mockReturnValue([[], true, undefined, jest.fn()]);
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={defaultEnv}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+      />,
+    );
+
+    expect(screen.getByText('No existing secrets found in this namespace')).toBeInTheDocument();
+  });
+
+  it('should show key checkboxes when a secret has been selected', () => {
+    const envWithSecret: EnvVariableData = {
+      category: SecretCategory.EXISTING,
+      data: [{ key: 'DB_HOST', value: '' }],
+    };
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={envWithSecret}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+        selectedSecretName="db-credentials"
+      />,
+    );
+
+    expect(screen.getByTestId('existing-secret-key-checkboxes')).toBeInTheDocument();
+  });
+
+  it('should not show key checkboxes when no secret is selected', () => {
+    renderWithContext(
+      <EnvExistingSecretField
+        env={defaultEnv}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+      />,
+    );
+
+    expect(screen.queryByTestId('existing-secret-key-checkboxes')).not.toBeInTheDocument();
+  });
+
+  it('should display all keys from selected secret as checkboxes', () => {
+    const envWithAllKeys: EnvVariableData = {
+      category: SecretCategory.EXISTING,
+      data: [
+        { key: 'DB_HOST', value: '' },
+        { key: 'DB_PASSWORD', value: '' },
+        { key: 'DB_PORT', value: '' },
+      ],
+    };
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={envWithAllKeys}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+        selectedSecretName="db-credentials"
+      />,
+    );
+
+    const keyCheckboxes = screen.getAllByTestId('existing-secret-key-checkbox');
+    expect(keyCheckboxes).toHaveLength(3);
+  });
+
+  it('should show select-all checkbox when a secret is selected', () => {
+    const envWithSecret: EnvVariableData = {
+      category: SecretCategory.EXISTING,
+      data: [{ key: 'DB_HOST', value: '' }],
+    };
+
+    renderWithContext(
+      <EnvExistingSecretField
+        env={envWithSecret}
+        onUpdate={onUpdate}
+        onUpdateVariable={onUpdateVariable}
+        selectedSecretName="db-credentials"
+      />,
+    );
+
+    expect(screen.getByTestId('existing-secret-select-all')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvSecret.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvSecret.spec.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SimpleSelect from '@odh-dashboard/ui-core/components/SimpleSelect';
+import { SecretCategory, EnvVariableData } from '#~/pages/projects/types';
+import EnvSecret from '#~/pages/projects/screens/spawner/environmentVariables/EnvSecret';
+
+jest.mock('../GenericKeyValuePairField', () => ({
+  __esModule: true,
+  default: () => <div data-testid="generic-key-value-pair-field" />,
+}));
+
+jest.mock('../EnvUploadField', () => ({
+  __esModule: true,
+  default: () => <div data-testid="env-upload-field" />,
+}));
+
+jest.mock('../EnvExistingSecretField', () => ({
+  __esModule: true,
+  default: () => <div data-testid="env-existing-secret-field" />,
+}));
+
+jest.mock('@odh-dashboard/ui-core/components/SimpleSelect', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('#~/utilities/utils', () => ({
+  getDashboardMainContainer: jest.fn(),
+}));
+
+const mockSimpleSelect = SimpleSelect as jest.Mock;
+
+describe('EnvSecret', () => {
+  const onUpdate = jest.fn();
+  const onUpdateVariable = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSimpleSelect.mockImplementation(({ options, onChange, value }) => (
+      <div data-testid="env-data-type-field">
+        <select
+          data-testid="env-secret-category-select"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          <option value="">Select one</option>
+          {options.map((option: { key: string; label: string }) => (
+            <option key={option.key} value={option.key}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    ));
+  });
+
+  it('should render all three category options (GENERIC, UPLOAD, EXISTING)', () => {
+    render(<EnvSecret onUpdate={onUpdate} onUpdateVariable={onUpdateVariable} />);
+
+    const { options } = mockSimpleSelect.mock.calls[0][0];
+    const keys = options.map((o: { key: string }) => o.key);
+
+    expect(keys).toContain(SecretCategory.GENERIC);
+    expect(keys).toContain(SecretCategory.UPLOAD);
+    expect(keys).toContain(SecretCategory.EXISTING);
+    expect(options).toHaveLength(3);
+  });
+
+  it('should render the "Key / value" label for GENERIC option', () => {
+    render(<EnvSecret onUpdate={onUpdate} onUpdateVariable={onUpdateVariable} />);
+
+    const { options } = mockSimpleSelect.mock.calls[0][0];
+    const generic = options.find((o: { key: string }) => o.key === SecretCategory.GENERIC);
+    expect(generic.label).toBe('Key / value');
+  });
+
+  it('should render the "Upload" label for UPLOAD option', () => {
+    render(<EnvSecret onUpdate={onUpdate} onUpdateVariable={onUpdateVariable} />);
+
+    const { options } = mockSimpleSelect.mock.calls[0][0];
+    const upload = options.find((o: { key: string }) => o.key === SecretCategory.UPLOAD);
+    expect(upload.label).toBe('Upload');
+  });
+
+  it('should render the "Existing secret" label for EXISTING option', () => {
+    render(<EnvSecret onUpdate={onUpdate} onUpdateVariable={onUpdateVariable} />);
+
+    const { options } = mockSimpleSelect.mock.calls[0][0];
+    const existing = options.find((o: { key: string }) => o.key === SecretCategory.EXISTING);
+    expect(existing.label).toBe('Existing secret');
+  });
+
+  it('should call onUpdateVariable to clear existingName when switching from EXISTING to another category', () => {
+    const envWithExisting: EnvVariableData = {
+      category: SecretCategory.EXISTING,
+      data: [{ key: 'DB_HOST', value: '' }],
+    };
+
+    render(
+      <EnvSecret env={envWithExisting} onUpdate={onUpdate} onUpdateVariable={onUpdateVariable} />,
+    );
+
+    const { onChange } = mockSimpleSelect.mock.calls[0][0];
+    onChange(SecretCategory.GENERIC);
+
+    expect(onUpdateVariable).toHaveBeenCalledWith({
+      existingName: undefined,
+      values: { category: SecretCategory.GENERIC, data: [] },
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should call onUpdateVariable to clear existingName when selecting EXISTING category', () => {
+    render(<EnvSecret onUpdate={onUpdate} onUpdateVariable={onUpdateVariable} />);
+
+    const { onChange } = mockSimpleSelect.mock.calls[0][0];
+    onChange(SecretCategory.EXISTING);
+
+    expect(onUpdateVariable).toHaveBeenCalledWith({
+      existingName: undefined,
+      values: { category: SecretCategory.EXISTING, data: [] },
+    });
+  });
+
+  it('should fall back to onUpdate when onUpdateVariable is not provided', () => {
+    const env: EnvVariableData = {
+      category: SecretCategory.GENERIC,
+      data: [{ key: 'KEY1', value: 'val1' }],
+    };
+
+    render(<EnvSecret env={env} onUpdate={onUpdate} />);
+
+    const { onChange } = mockSimpleSelect.mock.calls[0][0];
+    onChange(SecretCategory.UPLOAD);
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      ...env,
+      category: SecretCategory.UPLOAD,
+      data: [],
+    });
+  });
+
+  it('should render EnvExistingSecretField when EXISTING is selected', () => {
+    const envExisting: EnvVariableData = {
+      category: SecretCategory.EXISTING,
+      data: [],
+    };
+
+    render(<EnvSecret env={envExisting} onUpdate={onUpdate} onUpdateVariable={onUpdateVariable} />);
+
+    expect(screen.getByTestId('env-existing-secret-field')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvVarConflictWarning.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvVarConflictWarning.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EnvVarConflict } from '#~/pages/projects/screens/spawner/environmentVariables/envVarConflicts';
+import EnvVarConflictWarning from '#~/pages/projects/screens/spawner/environmentVariables/EnvVarConflictWarning';
+
+describe('EnvVarConflictWarning', () => {
+  it('should render warning alert with correct title', () => {
+    const conflicts: EnvVarConflict[] = [
+      { key: 'DB_HOST', sources: ["Secret 'db-creds'", "Secret 'other-creds'"] },
+    ];
+
+    render(<EnvVarConflictWarning conflicts={conflicts} />);
+
+    expect(screen.getByTestId('env-var-conflict-warning')).toBeInTheDocument();
+    expect(screen.getByText('Environment variable conflicts')).toBeInTheDocument();
+  });
+
+  it('should show conflict details in expandable section', () => {
+    const conflicts: EnvVarConflict[] = [
+      { key: 'API_KEY', sources: ["Secret 'secret-a'", "Connection 'my-conn'"] },
+    ];
+
+    render(<EnvVarConflictWarning conflicts={conflicts} />);
+
+    // Click the expandable toggle
+    fireEvent.click(screen.getByText('Show conflicts'));
+
+    expect(screen.getByText(/API_KEY/)).toBeInTheDocument();
+  });
+
+  it('should render multiple conflicts', () => {
+    const conflicts: EnvVarConflict[] = [
+      { key: 'KEY1', sources: ["Secret 'a'", "Secret 'b'"] },
+      { key: 'KEY2', sources: ["Secret 'c'", "Connection 'd'"] },
+    ];
+
+    render(<EnvVarConflictWarning conflicts={conflicts} />);
+
+    fireEvent.click(screen.getByText('Show conflicts'));
+
+    expect(screen.getByText(/KEY1/)).toBeInTheDocument();
+    expect(screen.getByText(/KEY2/)).toBeInTheDocument();
+  });
+
+  it('should show source information for each conflict', () => {
+    const conflicts: EnvVarConflict[] = [
+      { key: 'DB_HOST', sources: ["Secret 'db-creds'", "Connection 'my-conn'"] },
+    ];
+
+    render(<EnvVarConflictWarning conflicts={conflicts} />);
+
+    fireEvent.click(screen.getByText('Show conflicts'));
+
+    expect(screen.getByText(/Secret 'db-creds'/)).toBeInTheDocument();
+    expect(screen.getByText(/Connection 'my-conn'/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/envVarConflicts.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/envVarConflicts.spec.ts
@@ -1,0 +1,289 @@
+import {
+  EnvVariable,
+  EnvironmentVariableType,
+  SecretCategory,
+  ConfigMapCategory,
+} from '#~/pages/projects/types';
+import { detectEnvVarConflicts } from '#~/pages/projects/screens/spawner/environmentVariables/envVarConflicts';
+
+describe('detectEnvVarConflicts', () => {
+  it('should return empty array when no conflicts', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY_A', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-b',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY_B', value: '' }],
+        },
+      },
+    ];
+
+    expect(detectEnvVarConflicts(envVariables, new Map())).toEqual([]);
+  });
+
+  it('should detect conflict between two existing secrets', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'DB_HOST', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-b',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'DB_HOST', value: '' }],
+        },
+      },
+    ];
+
+    const conflicts = detectEnvVarConflicts(envVariables, new Map());
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].key).toBe('DB_HOST');
+    expect(conflicts[0].sources).toContain("Secret 'secret-a'");
+    expect(conflicts[0].sources).toContain("Secret 'secret-b'");
+  });
+
+  it('should detect conflict between existing secret and inline secret', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'API_KEY', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'inline-secret',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'API_KEY', value: 'some-value' }],
+        },
+      },
+    ];
+
+    const conflicts = detectEnvVarConflicts(envVariables, new Map());
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].key).toBe('API_KEY');
+  });
+
+  it('should detect conflict between existing secret and connection', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+        },
+      },
+    ];
+
+    const connectionKeys = new Map([['My S3 Connection', ['AWS_ACCESS_KEY_ID', 'AWS_SECRET']]]);
+
+    const conflicts = detectEnvVarConflicts(envVariables, connectionKeys);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].key).toBe('AWS_ACCESS_KEY_ID');
+    expect(conflicts[0].sources).toContain("Secret 'my-secret'");
+    expect(conflicts[0].sources).toContain("Connection 'My S3 Connection'");
+  });
+
+  it('should handle config map entries', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'CONFIG_VAL', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.CONFIG_MAP,
+        existingName: 'my-cm',
+        values: {
+          category: ConfigMapCategory.GENERIC,
+          data: [{ key: 'CONFIG_VAL', value: 'some-val' }],
+        },
+      },
+    ];
+
+    const conflicts = detectEnvVarConflicts(envVariables, new Map());
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].key).toBe('CONFIG_VAL');
+  });
+
+  it('should return empty array when envVariables is empty', () => {
+    expect(detectEnvVarConflicts([], new Map())).toEqual([]);
+  });
+
+  it('should skip entries with missing data', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: undefined,
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-b',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY_A', value: '' }],
+        },
+      },
+    ];
+
+    expect(detectEnvVarConflicts(envVariables, new Map())).toEqual([]);
+  });
+
+  it('should skip entries with empty key', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: '', value: 'val' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-b',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: '', value: 'other-val' }],
+        },
+      },
+    ];
+
+    expect(detectEnvVarConflicts(envVariables, new Map())).toEqual([]);
+  });
+
+  it('should use correct source labels for different categories', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-existing',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'SHARED_KEY', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-inline',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'SHARED_KEY', value: 'val' }],
+        },
+      },
+    ];
+
+    const conflicts = detectEnvVarConflicts(envVariables, new Map());
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].sources).toContain("Secret 'my-existing'");
+    expect(conflicts[0].sources).toContain("Environment variable 'my-inline'");
+  });
+
+  it('should use fallback labels when existingName is missing', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'MY_KEY', value: 'a' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.CONFIG_MAP,
+        values: {
+          category: ConfigMapCategory.GENERIC,
+          data: [{ key: 'MY_KEY', value: 'b' }],
+        },
+      },
+    ];
+
+    const conflicts = detectEnvVarConflicts(envVariables, new Map());
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].sources).toContain("Environment variable 'New secret'");
+    expect(conflicts[0].sources).toContain("Environment variable 'New config map'");
+  });
+
+  it('should detect multiple conflicts', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'KEY_1', value: '' },
+            { key: 'KEY_2', value: '' },
+          ],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-b',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'KEY_1', value: '' },
+            { key: 'KEY_2', value: '' },
+          ],
+        },
+      },
+    ];
+
+    const conflicts = detectEnvVarConflicts(envVariables, new Map());
+    expect(conflicts).toHaveLength(2);
+    expect(conflicts.map((c) => c.key)).toContain('KEY_1');
+    expect(conflicts.map((c) => c.key)).toContain('KEY_2');
+  });
+
+  it('should detect conflict across three sources', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'SHARED', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-b',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'SHARED', value: 'val' }],
+        },
+      },
+    ];
+
+    const connectionKeys = new Map([['My Connection', ['SHARED']]]);
+
+    const conflicts = detectEnvVarConflicts(envVariables, connectionKeys);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].sources).toHaveLength(3);
+    expect(conflicts[0].sources).toContain("Secret 'secret-a'");
+    expect(conflicts[0].sources).toContain("Environment variable 'secret-b'");
+    expect(conflicts[0].sources).toContain("Connection 'My Connection'");
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
@@ -1,0 +1,86 @@
+import { standardUseFetchState, testHook } from '@odh-dashboard/jest-config/hooks';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { getSecrets } from '#~/api';
+import { useExistingSecrets } from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+
+jest.mock('#~/api', () => ({
+  getSecrets: jest.fn(),
+}));
+
+const getSecretsMock = jest.mocked(getSecrets);
+
+const mockOpaqueSecret = (name: string, annotations?: Record<string, string>): SecretKind => ({
+  apiVersion: 'v1',
+  kind: 'Secret',
+  type: 'Opaque',
+  metadata: {
+    name,
+    namespace: 'test-ns',
+    annotations: annotations || {},
+  },
+  data: { key1: 'dmFsdWUx' },
+});
+
+describe('useExistingSecrets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not fetch when disabled', () => {
+    const renderResult = testHook(useExistingSecrets)('test-ns', false);
+
+    expect(getSecretsMock).not.toHaveBeenCalled();
+    expect(renderResult).hookToStrictEqual(standardUseFetchState([]));
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+
+  it('should fetch and filter secrets when enabled', async () => {
+    const secrets: SecretKind[] = [
+      mockOpaqueSecret('my-secret'),
+      mockOpaqueSecret('connection-secret', {
+        'opendatahub.io/connection-type-ref': 'some-type',
+      }),
+      mockOpaqueSecret('connection-protocol-secret', {
+        'opendatahub.io/connection-type-protocol': 'grpc',
+      }),
+      mockOpaqueSecret('legacy-aws-secret', {
+        'opendatahub.io/connection-type': 's3',
+      }),
+      {
+        ...mockOpaqueSecret('service-account-token'),
+        type: 'kubernetes.io/service-account-token',
+      },
+    ];
+
+    getSecretsMock.mockResolvedValue(secrets);
+
+    const renderResult = testHook(useExistingSecrets)('test-ns', true);
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchState([mockOpaqueSecret('my-secret')], true),
+    );
+  });
+
+  it('should keep dashboard secrets that are not Connections', async () => {
+    const secrets: SecretKind[] = [
+      {
+        ...mockOpaqueSecret('dashboard-secret'),
+        metadata: {
+          name: 'dashboard-secret',
+          namespace: 'test-ns',
+          labels: { 'opendatahub.io/dashboard': 'true' },
+          annotations: {},
+        },
+      },
+    ];
+
+    getSecretsMock.mockResolvedValue(secrets);
+
+    const renderResult = testHook(useExistingSecrets)('test-ns', true);
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current[0]).toHaveLength(1);
+    expect(renderResult.result.current[0][0].metadata.name).toBe('dashboard-secret');
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
@@ -63,6 +63,19 @@ describe('useExistingSecrets', () => {
     expect(renderResult).hookToHaveUpdateCount(2);
   });
 
+  it('should propagate error when getSecrets rejects', async () => {
+    const fetchError = new Error('Network error');
+    getSecretsMock.mockRejectedValue(fetchError);
+
+    const renderResult = testHook(useExistingSecrets)('test-ns', true);
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current[0]).toEqual([]);
+    expect(renderResult.result.current[1]).toBe(false);
+    expect(renderResult.result.current[2]).toEqual(fetchError);
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+
   it('should keep dashboard secrets that are not Connections', async () => {
     const secrets: SecretKind[] = [
       {

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
@@ -60,6 +60,7 @@ describe('useExistingSecrets', () => {
     expect(renderResult).hookToStrictEqual(
       standardUseFetchState([mockOpaqueSecret('my-secret')], true),
     );
+    expect(renderResult).hookToHaveUpdateCount(2);
   });
 
   it('should keep dashboard secrets that are not Connections', async () => {
@@ -82,5 +83,6 @@ describe('useExistingSecrets', () => {
 
     expect(renderResult.result.current[0]).toHaveLength(1);
     expect(renderResult.result.current[0][0].metadata.name).toBe('dashboard-secret');
+    expect(renderResult).hookToHaveUpdateCount(2);
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
@@ -1,0 +1,154 @@
+import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
+import { getConfigMap, getSecret } from '#~/api';
+import { EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+import { fetchNotebookEnvVariables } from '#~/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables';
+
+jest.mock('#~/api', () => ({
+  getConfigMap: jest.fn(),
+  getSecret: jest.fn(),
+}));
+
+const getConfigMapMock = jest.mocked(getConfigMap);
+const getSecretMock = jest.mocked(getSecret);
+
+describe('fetchNotebookEnvVariables', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: no envFrom resources to resolve
+    getConfigMapMock.mockRejectedValue({ statusObject: { code: 404 } });
+    getSecretMock.mockRejectedValue({ statusObject: { code: 404 } });
+  });
+
+  it('should parse secretKeyRef entries from notebook env', async () => {
+    const notebook = mockNotebookK8sResource({
+      additionalEnvs: [
+        {
+          name: 'DB_HOST',
+          valueFrom: { secretKeyRef: { name: 'db-creds', key: 'host' } },
+        },
+        {
+          name: 'DB_PORT',
+          valueFrom: { secretKeyRef: { name: 'db-creds', key: 'port' } },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    const existingSecretVars = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+    expect(existingSecretVars).toHaveLength(1);
+    expect(existingSecretVars[0]).toEqual({
+      type: EnvironmentVariableType.SECRET,
+      existingName: 'db-creds',
+      values: {
+        category: SecretCategory.EXISTING,
+        data: [
+          { key: 'host', value: '' },
+          { key: 'port', value: '' },
+        ],
+      },
+    });
+  });
+
+  it('should group keys by secret name', async () => {
+    const notebook = mockNotebookK8sResource({
+      additionalEnvs: [
+        {
+          name: 'KEY_A',
+          valueFrom: { secretKeyRef: { name: 'secret-1', key: 'a' } },
+        },
+        {
+          name: 'KEY_B',
+          valueFrom: { secretKeyRef: { name: 'secret-2', key: 'b' } },
+        },
+        {
+          name: 'KEY_C',
+          valueFrom: { secretKeyRef: { name: 'secret-1', key: 'c' } },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+    const existingSecretVars = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+
+    expect(existingSecretVars).toHaveLength(2);
+
+    const secret1 = existingSecretVars.find((v) => v.existingName === 'secret-1');
+    expect(secret1?.values?.data).toEqual([
+      { key: 'a', value: '' },
+      { key: 'c', value: '' },
+    ]);
+
+    const secret2 = existingSecretVars.find((v) => v.existingName === 'secret-2');
+    expect(secret2?.values?.data).toEqual([{ key: 'b', value: '' }]);
+  });
+
+  it('should filter out system env names (NOTEBOOK_ARGS, JUPYTER_IMAGE)', async () => {
+    // The mock already includes NOTEBOOK_ARGS and JUPYTER_IMAGE by default.
+    // Add a secretKeyRef so there's something to find.
+    const notebook = mockNotebookK8sResource({
+      additionalEnvs: [
+        {
+          name: 'APP_KEY',
+          valueFrom: { secretKeyRef: { name: 'app-secret', key: 'key' } },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+    const existingSecretVars = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+
+    // NOTEBOOK_ARGS and JUPYTER_IMAGE should not appear
+    expect(existingSecretVars).toHaveLength(1);
+    expect(existingSecretVars[0].existingName).toBe('app-secret');
+  });
+
+  it('should return empty array for notebook with no secretKeyRef entries', async () => {
+    const notebook = mockNotebookK8sResource({});
+
+    const result = await fetchNotebookEnvVariables(notebook);
+    const existingSecretVars = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+
+    expect(existingSecretVars).toHaveLength(0);
+  });
+
+  it('should handle notebook with empty env array', async () => {
+    const notebook = mockNotebookK8sResource({});
+    notebook.spec.template.spec.containers[0].env = [];
+
+    const result = await fetchNotebookEnvVariables(notebook);
+    const existingSecretVars = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+
+    expect(existingSecretVars).toHaveLength(0);
+  });
+
+  it('should handle notebook with undefined env array', async () => {
+    const notebook = mockNotebookK8sResource({});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (notebook.spec.template.spec.containers[0] as any).env = undefined;
+
+    const result = await fetchNotebookEnvVariables(notebook);
+    const existingSecretVars = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+
+    expect(existingSecretVars).toHaveLength(0);
+  });
+
+  it('should skip plain env entries (no valueFrom)', async () => {
+    const notebook = mockNotebookK8sResource({
+      additionalEnvs: [
+        { name: 'PLAIN_VAR', value: 'plain-value' },
+        {
+          name: 'SECRET_VAR',
+          valueFrom: { secretKeyRef: { name: 'my-secret', key: 'token' } },
+        },
+      ],
+    });
+
+    const result = await fetchNotebookEnvVariables(notebook);
+    const existingSecretVars = result.filter((v) => v.values?.category === SecretCategory.EXISTING);
+
+    expect(existingSecretVars).toHaveLength(1);
+    expect(existingSecretVars[0].existingName).toBe('my-secret');
+    expect(existingSecretVars[0].values?.data).toEqual([{ key: 'token', value: '' }]);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/envVarConflicts.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/envVarConflicts.ts
@@ -1,0 +1,56 @@
+import { EnvVariable, EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+
+export type EnvVarConflict = {
+  key: string;
+  sources: string[];
+};
+
+const getSourceLabel = (envVar: EnvVariable): string => {
+  if (envVar.values?.category === SecretCategory.EXISTING) {
+    return `Secret '${envVar.existingName || 'Unknown'}'`;
+  }
+  if (envVar.type === EnvironmentVariableType.SECRET) {
+    return `Environment variable '${envVar.existingName || 'New secret'}'`;
+  }
+  return `Environment variable '${envVar.existingName || 'New config map'}'`;
+};
+
+export const detectEnvVarConflicts = (
+  envVariables: EnvVariable[],
+  connectionKeys: Map<string, string[]>,
+): EnvVarConflict[] => {
+  const keyToSources = new Map<string, Set<string>>();
+
+  for (const envVar of envVariables) {
+    if (!envVar.values?.data) {
+      continue;
+    }
+    const sourceLabel = getSourceLabel(envVar);
+    for (const entry of envVar.values.data) {
+      if (!entry.key) {
+        continue;
+      }
+      const existing = keyToSources.get(entry.key) ?? new Set<string>();
+      existing.add(sourceLabel);
+      keyToSources.set(entry.key, existing);
+    }
+  }
+
+  for (const [connectionName, keys] of connectionKeys) {
+    const sourceLabel = `Connection '${connectionName}'`;
+    for (const key of keys) {
+      const existing = keyToSources.get(key) ?? new Set<string>();
+      existing.add(sourceLabel);
+      keyToSources.set(key, existing);
+    }
+  }
+
+  const conflicts: EnvVarConflict[] = [];
+  for (const [key, sources] of keyToSources) {
+    if (sources.size > 1) {
+      conflicts.push({ key, sources: Array.from(sources) });
+    }
+  }
+
+  return conflicts;
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import useFetchState, { NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetchState';
+import { getSecrets } from '#~/api';
+
+const CONNECTION_ANNOTATION_KEYS = [
+  'opendatahub.io/connection-type',
+  'opendatahub.io/connection-type-protocol',
+  'opendatahub.io/connection-type-ref',
+];
+
+const isConnectionSecret = (secret: SecretKind): boolean => {
+  const { annotations } = secret.metadata;
+  if (!annotations) {
+    return false;
+  }
+  return CONNECTION_ANNOTATION_KEYS.some((key) => key in annotations);
+};
+
+export const useExistingSecrets = (
+  namespace: string,
+  enabled: boolean,
+): [secrets: SecretKind[], loaded: boolean, error: Error | undefined, refresh: () => void] => {
+  const callback = React.useCallback(() => {
+    if (!enabled) {
+      return Promise.reject(new NotReadyError('Existing secrets not enabled'));
+    }
+    return getSecrets(namespace).then((secrets) =>
+      secrets.filter((secret) => secret.type === 'Opaque' && !isConnectionSecret(secret)),
+    );
+  }, [namespace, enabled]);
+
+  return useFetchState(callback, []);
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -13,6 +13,8 @@ import {
 import { isConnection } from '#~/concepts/connectionTypes/utils';
 import { getDeletedConfigMapOrSecretVariables, isSecretKind } from './utils';
 
+const SYSTEM_ENV_NAMES = new Set(['NOTEBOOK_ARGS', 'JUPYTER_IMAGE']);
+
 export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVariable[]> => {
   const envFromList = notebook.spec.template.spec.containers[0].envFrom || [];
 
@@ -75,8 +77,9 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
   );
 
   // Parse env[].valueFrom.secretKeyRef entries
-  const SYSTEM_ENV_NAMES = new Set(['NOTEBOOK_ARGS', 'JUPYTER_IMAGE']);
-  const envList = notebook.spec.template.spec.containers[0].env;
+  // Defensive fallback: manually-crafted CRs may omit the env field entirely
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const envList = notebook.spec.template.spec.containers[0].env ?? [];
 
   // Group by secret name
   const secretKeyRefGroups = new Map<string, string[]>();

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -15,7 +15,8 @@ import { getDeletedConfigMapOrSecretVariables, isSecretKind } from './utils';
 
 export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVariable[]> => {
   const envFromList = notebook.spec.template.spec.containers[0].envFrom || [];
-  return Promise.all(
+
+  const envFromPromise = Promise.all(
     envFromList
       .map((envFrom) => {
         if (envFrom.configMapRef) {
@@ -72,6 +73,46 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
       return [...acc, envVar];
     }, []),
   );
+
+  // Parse env[].valueFrom.secretKeyRef entries
+  const SYSTEM_ENV_NAMES = new Set(['NOTEBOOK_ARGS', 'JUPYTER_IMAGE']);
+  const envList = notebook.spec.template.spec.containers[0].env;
+
+  // Group by secret name
+  const secretKeyRefGroups = new Map<string, string[]>();
+  for (const envEntry of envList) {
+    if (SYSTEM_ENV_NAMES.has(envEntry.name) || !envEntry.valueFrom) {
+      continue;
+    }
+    const { secretKeyRef } = envEntry.valueFrom;
+    if (
+      !secretKeyRef ||
+      typeof secretKeyRef !== 'object' ||
+      !('name' in secretKeyRef) ||
+      !('key' in secretKeyRef)
+    ) {
+      continue;
+    }
+    const secretName = String(secretKeyRef.name);
+    const keyName = String(secretKeyRef.key);
+    const existing = secretKeyRefGroups.get(secretName) || [];
+    existing.push(keyName);
+    secretKeyRefGroups.set(secretName, existing);
+  }
+
+  // Convert to EnvVariable[]
+  const existingSecretVars: EnvVariable[] = Array.from(secretKeyRefGroups.entries()).map(
+    ([secretName, keys]) => ({
+      type: EnvironmentVariableType.SECRET,
+      existingName: secretName,
+      values: {
+        category: SecretCategory.EXISTING,
+        data: keys.map((key) => ({ key, value: '' })),
+      },
+    }),
+  );
+
+  return envFromPromise.then((envFromVars) => [...envFromVars, ...existingSecretVars]);
 };
 
 export const useNotebookEnvVariables = (

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash-es';
 import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import type {
+  EnvironmentVariable,
   Volume,
   VolumeMount,
   PersistentVolumeClaimKind,
@@ -32,6 +33,26 @@ import { ConfigMapKind, NotebookKind } from '#~/k8sTypes';
 import { isPvcUpdateRequired } from '#~/pages/projects/screens/detail/storage/utils';
 import { fetchNotebookEnvVariables } from './environmentVariables/useNotebookEnvVariables';
 import { getDeletedConfigMapOrSecretVariables } from './environmentVariables/utils';
+
+export const getEnvVarsForExistingSecrets = (envVariables: EnvVariable[]): EnvironmentVariable[] =>
+  envVariables
+    .filter(
+      (ev): ev is EnvVariable & { existingName: string } =>
+        ev.values?.category === SecretCategory.EXISTING && !!ev.existingName,
+    )
+    .flatMap((ev) =>
+      (ev.values?.data || [])
+        .filter((entry) => entry.key)
+        .map((entry) => ({
+          name: entry.key,
+          valueFrom: {
+            secretKeyRef: {
+              name: ev.existingName,
+              key: entry.key,
+            },
+          },
+        })),
+    );
 
 export const createPvcDataForNotebook = async (
   projectName: string,
@@ -106,6 +127,8 @@ const getPromisesForConfigMapsAndSecrets = (
             : replaceSecret(assembleSecret(projectName, dataAsRecord, 'aws', envVar.existingName), {
                 dryRun,
               });
+        case SecretCategory.EXISTING:
+          return null;
         case ConfigMapCategory.GENERIC:
         case ConfigMapCategory.UPLOAD:
           return type === 'create'
@@ -172,9 +195,12 @@ export const updateConfigMapsAndSecretsForNotebook = async (
   dryRun = false,
 ): Promise<EnvironmentFromVariable[]> => {
   const existingEnvVars = await fetchNotebookEnvVariables(notebook);
+  const existingEnvVarsFiltered = existingEnvVars.filter(
+    (ev) => ev.values?.category !== SecretCategory.EXISTING,
+  );
   const { deletedConfigMaps, deletedSecrets } = getDeletedConfigMapOrSecretVariables(
     notebook,
-    existingEnvVars,
+    existingEnvVarsFiltered,
     [...(connections || []).map((connection) => connection.metadata.name)],
   );
 
@@ -183,12 +209,12 @@ export const updateConfigMapsAndSecretsForNotebook = async (
     .map((envVar) => envVar.existingName)
     .filter((v): v is string => !!v);
 
-  const removeResources = existingEnvVars.filter(
+  const removeResources = existingEnvVarsFiltered.filter(
     (envVar) => envVar.existingName && !currentNames.includes(envVar.existingName),
   );
 
   const [typeChangeResources, updateResources] = _.partition(oldResources, (envVar) =>
-    existingEnvVars.find(
+    existingEnvVarsFiltered.find(
       (existingEnvVar) =>
         existingEnvVar.existingName === envVar.existingName &&
         existingEnvVar.values?.category !== envVar.values?.category,

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -339,6 +339,8 @@ export const isEnvVariableDataValid = (envVariables: EnvVariable[]): boolean => 
         return values.every(({ key, value }) => isValidGenericKey(key) && !!value);
       case SecretCategory.AWS:
         return isAWSValid(values);
+      case SecretCategory.EXISTING:
+        return values.every(({ key }) => !!key);
       default:
         return false;
     }

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -1,5 +1,6 @@
 import type {
   EnvironmentFromVariable,
+  EnvironmentVariable,
   K8sNameDescriptionFieldData,
   Volume,
   VolumeMount,
@@ -87,6 +88,7 @@ export type StartNotebookData = {
   volumes?: Volume[];
   volumeMounts?: VolumeMount[];
   envFrom?: EnvironmentFromVariable[];
+  env?: EnvironmentVariable[];
   dashboardNamespace?: string;
   connections?: Connection[];
   hardwareProfileOptions: UseAssignHardwareProfileResult<NotebookKind>;
@@ -120,6 +122,7 @@ export enum SecretCategory {
   GENERIC = 'secret key-value',
   AWS = 'aws',
   UPLOAD = 'secret upload',
+  EXISTING = 'existing secret',
 }
 export enum ConfigMapCategory {
   GENERIC = 'configmap key-value',


### PR DESCRIPTION
## Summary

Adds a third "Existing secret" option to the workbench environment variables form, enabling data scientists to reference pre-existing Kubernetes Secrets (created by ESO, ArgoCD, or cluster admins) without duplicating values.

### Changes

- **New `SecretCategory.EXISTING` enum value** and `StartNotebookData.env` field for secretKeyRef entries
- **`getSecrets` API function** for querying all Opaque secrets in a namespace (lazy-loaded only when "Existing secret" is selected)
- **`useExistingSecrets` hook** with Connection annotation filtering
- **`EnvExistingSecretField` component** with TypeaheadSelect for secret name and checkbox key picker (values never shown)
- **Submit flow** produces `env[].valueFrom.secretKeyRef` entries (never `envFrom`), per staff engineer directive
- **Edit view** parses existing `secretKeyRef` entries from Notebook CR and displays as opaque references
- **Cross-section conflict detection** warns before save when env var keys collide across existing secrets, inline secrets, and Connections

### Acceptance Criteria Coverage

| AC | Status |
|----|--------|
| AC1: "Existing secret" option in Secret type dropdown | ✅ |
| AC2: Namespace Opaque secrets listed (Connections filtered) | ✅ |
| AC3: "All keys" → individual secretKeyRef entries per key | ✅ |
| AC4: Specific key selection → matching secretKeyRef entries | ✅ |
| AC5: Edit view shows opaque references, allows removal | ✅ |
| AC6: Create form conflict detection with collision details | ✅ |
| AC7: Edit form conflict detection against existing env[] | ✅ |
| AC8: Existing inline secrets unchanged (purely additive) | ✅ |
| AC9: Handles manually-edited envFrom/valueFrom blocks | ✅ |

### Test Coverage

- 58+ new tests across 7 test files
- TypeScript: 0 errors, ESLint: 0 errors

## Test plan

- [ ] Verify "Existing secret" option appears in Secret type dropdown
- [ ] Verify typeahead dropdown lists non-Connection Opaque secrets
- [ ] Verify "All keys" and specific key selection produce correct secretKeyRef entries
- [ ] Verify edit view correctly displays existing secret references
- [ ] Verify conflict detection warns on duplicate env var keys
- [ ] Run `npx jest --selectProjects frontend` to verify all tests pass

Jira: [RHOAIENG-72103](https://redhat.atlassian.net/browse/RHOAIENG-72103)
Strategy: [RHAISTRAT-1699](https://redhat.atlassian.net/browse/RHAISTRAT-1699)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — epic-codegen pipeline (v5, score 9.4/10)

[RHOAIENG-72103]: https://redhat.atlassian.net/browse/RHOAIENG-72103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting existing Kubernetes secrets and mapping specific keys to notebook environment variables.
  * Added environment-variable conflict detection with expandable warnings showing affected sources.
  * Preserved existing secret references when creating or updating notebooks.
* **Bug Fixes**
  * Prevented custom environment variables from being duplicated or incorrectly retained during notebook updates.
  * Improved validation and handling of environment variable configurations.
* **Tests**
  * Added coverage for existing secrets, conflict detection, environment variable processing, and notebook updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->