### PR TITLE
fix(rbac): add opentelemetry.io escalation permission to dashboard-operator role

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -603,6 +603,17 @@ rules:
     verbs:
       - get
       - list
+  # OTel Collector — gen-ai BFF creates per-namespace trace routing CRs
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -587,3 +587,14 @@ rules:
     verbs:
       - get
       - list
+  # OTel Collector — gen-ai BFF creates per-namespace trace routing CRs
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - opentelemetrycollectors
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete


### PR DESCRIPTION
## Summary

Commit 9325fd50 ("feat(gen-ai): add OTel tracing to gen-ai BFF") added `opentelemetry.io/opentelemetrycollectors` to `manifests/modular-architecture/modules-cluster-role.yaml` but did not update the dashboard-operator's own ClusterRole (`config/rbac/role.yaml`).

This causes an RBAC escalation failure when the dashboard-operator tries to deploy the operand `odh-dashboard-modules` ClusterRole:

```
user "system:serviceaccount:opendatahub:dashboard-operator" is attempting to grant RBAC permissions not currently held:
{APIGroups:["opentelemetry.io"], Resources:["opentelemetrycollectors"], Verbs:["get" "list" "create" "update" "delete"]}
```

Reported by @StevenTobin in [opendatahub-operator#3733](https://github.com/opendatahub-io/opendatahub-operator/pull/3733).

## Changes

- `config/rbac/role.yaml`: Add `opentelemetry.io/opentelemetrycollectors` escalation permission
- `charts/dashboard/templates/rbac.yaml`: Same addition to keep chart in sync

## Test plan

- [x] `TestDashboardChartRBACInSync` passes
- [ ] Dashboard-operator can deploy `odh-dashboard-modules` ClusterRole without RBAC error

Jira: [RHOAIENG-60566](https://redhat.atlassian.net/browse/RHOAIENG-60566)

[RHOAIENG-60566]: https://redhat.atlassian.net/browse/RHOAIENG-60566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automated management of OpenTelemetry collector configurations.
  * Improved support for per-namespace trace routing and lifecycle management.
  * Trace collection workflows can now create, update, and remove the required OpenTelemetry resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->