### PR TITLE
Feat(RHOAIENG-68468): notebook status modal

### DIFF
--- a/frontend/src/__mocks__/mockNotebookState.ts
+++ b/frontend/src/__mocks__/mockNotebookState.ts
@@ -8,6 +8,7 @@ type MockConfigType = {
   isStopping?: boolean;
   isStopped?: boolean;
   runningPodUid?: string;
+  containerStatuses?: NotebookState['containerStatuses'];
   refresh?: NotebookRefresh;
 };
 
@@ -23,6 +24,7 @@ export const mockNotebookState = (
       isStopping: false,
       isStopped: false,
       runningPodUid: '',
+      containerStatuses: [],
       refresh: () => Promise.resolve(),
     },
     mockConfig,

--- a/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
+++ b/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
@@ -9,6 +9,7 @@ import {
   mockInProgressStates,
 } from '#~/concepts/__tests__/mockNotebookStates';
 import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
+import { EventStatus } from '#~/types';
 
 describe('Start Notebook modal', () => {
   it('should show initial notebook startup status', async () => {
@@ -199,6 +200,29 @@ describe('Start Notebook modal', () => {
     );
 
     expect(screen.queryByTestId('notebook-latest-status')).toBeNull();
+  });
+
+  it('should NOT show spinner or helper text in error race condition (isError=true, no active spawn)', () => {
+    // Regression: error state with no active spawn should not show spinner or helper text.
+    render(
+      <StartNotebookModal
+        notebook={mockInitialStates.notebookState.notebook}
+        notebookStatus={{
+          currentStatus: EventStatus.ERROR,
+          currentEvent: 'Pod failed to start',
+          currentEventReason: 'SomeReason',
+          currentEventDescription: 'Some description',
+        }}
+        isStarting={false}
+        isStopping={false}
+        isRunning={false}
+        events={[]}
+        buttons={null}
+      />,
+    );
+
+    expect(screen.queryByTestId('notebook-latest-status')).toBeNull();
+    expect(screen.queryByText(/several minutes/i)).toBeNull();
   });
 
   it('should show stopping notebook status', async () => {

--- a/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
+++ b/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
@@ -8,12 +8,14 @@ import {
   mockInitialStates,
   mockInProgressStates,
 } from '#~/concepts/__tests__/mockNotebookStates';
+import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
 
 describe('Start Notebook modal', () => {
   it('should show initial notebook startup status', async () => {
     const mockData = mockInitialStates;
     render(
       <StartNotebookModal
+        notebook={mockData.notebookState.notebook}
         notebookStatus={mockData.notebookStatus}
         isStarting={mockData.notebookState.isStarting}
         isStopping={mockData.notebookState.isStopping}
@@ -25,35 +27,30 @@ describe('Start Notebook modal', () => {
 
     // Validate the header contents
     const header = screen.getByTestId('notebook-status-modal-header');
-    expect(header).toHaveTextContent('Workbench statusStarting');
+    expect(header).toHaveTextContent('Test Workbench statusStarting');
 
     const statusLabel = screen.getByTestId('notebook-latest-status');
     expect(statusLabel).toHaveTextContent('Waiting for server request to start');
 
-    // Validate the steps
+    // 7 top-level steps; pulling/pulled/created are collapsed sub-steps; optional problem steps filtered.
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
-    const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(13);
+    const steps = screen.getAllByRole('treeitem');
+    expect(steps).toHaveLength(7);
     expect(steps[0]).toHaveTextContent('Workbench requested');
     expect(steps[1]).toHaveTextContent('Pod created');
     expect(steps[2]).toHaveTextContent('Pod assigned');
     expect(steps[3]).toHaveTextContent('Interface added');
-    expect(steps[4]).toHaveTextContent('Pulling workbench image');
-    expect(steps[5]).toHaveTextContent('Workbench image pulled');
-    expect(steps[6]).toHaveTextContent('Workbench container created');
-    expect(steps[7]).toHaveTextContent('Workbench container started');
-    expect(steps[8]).toHaveTextContent('Pulling auth proxy');
-    expect(steps[9]).toHaveTextContent('Auth proxy pulled');
-    expect(steps[10]).toHaveTextContent('Auth proxy container created');
-    expect(steps[11]).toHaveTextContent('Auth proxy container started');
-    expect(steps[12]).toHaveTextContent('Workbench started');
+    expect(steps[4]).toHaveTextContent('Starting Workbench container');
+    expect(steps[5]).toHaveTextContent('Starting Auth proxy container');
+    expect(steps[6]).toHaveTextContent('Workbench started');
   });
 
   it('should show failed notebook startup status', async () => {
     const mockData = mockFailedStates;
     render(
       <StartNotebookModal
+        notebook={mockData.notebookState.notebook}
         notebookStatus={mockData.notebookStatus}
         isStarting={mockData.notebookState.isStarting}
         isStopping={mockData.notebookState.isStopping}
@@ -65,17 +62,17 @@ describe('Start Notebook modal', () => {
 
     // Validate the header contents
     const header = screen.getByTestId('notebook-status-modal-header');
-    expect(header).toHaveTextContent('Workbench statusFailed');
+    expect(header).toHaveTextContent('Test Workbench statusFailed');
 
     const statusLabel = screen.getByTestId('notebook-latest-status');
     expect(statusLabel).toHaveTextContent('Failed to scale-up');
     expect(screen.getByTestId('danger-NotTriggerScaleUp')).toBeTruthy();
 
-    // Validate the steps
+    // pod_problem is not filtered (ERROR state), so 8 top-level steps.
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
-    const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
+    const steps = screen.getAllByRole('treeitem');
+    expect(steps).toHaveLength(8);
     expect(steps[1]).toHaveTextContent('There was a problem with the pod');
   });
 
@@ -83,6 +80,7 @@ describe('Start Notebook modal', () => {
     const mockData = mockInProgressStates;
     render(
       <StartNotebookModal
+        notebook={mockData.notebookState.notebook}
         notebookStatus={mockData.notebookStatus}
         isStarting={mockData.notebookState.isStarting}
         isStopping={mockData.notebookState.isStopping}
@@ -94,23 +92,24 @@ describe('Start Notebook modal', () => {
 
     // Validate the header contents
     const header = screen.getByTestId('notebook-status-modal-header');
-    expect(header).toHaveTextContent('Workbench statusStarting');
+    expect(header).toHaveTextContent('Test Workbench statusStarting');
 
     const statusLabel = screen.getByTestId('notebook-latest-status');
     expect(statusLabel).toHaveTextContent('Pulling auth proxy');
 
-    // Validate the steps
+    // 8 top-level + 3 kube-rbac-proxy sub-steps (auto-expanded) = 11 visible items.
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
-    expect(screen.getAllByRole('listitem')).toHaveLength(14);
-    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(10);
-    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(4);
+    expect(screen.getAllByRole('treeitem')).toHaveLength(11);
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(7);
+    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(3);
   });
 
   it('should show completed notebook startup status', async () => {
     const mockData = mockCompletedStates;
     render(
       <StartNotebookModal
+        notebook={mockData.notebookState.notebook}
         notebookStatus={mockData.notebookStatus}
         isStarting={mockData.notebookState.isStarting}
         isStopping={mockData.notebookState.isStopping}
@@ -122,20 +121,21 @@ describe('Start Notebook modal', () => {
 
     // Validate the header contents
     const header = screen.getByTestId('notebook-status-modal-header');
-    expect(header).toHaveTextContent('Workbench statusReady');
+    expect(header).toHaveTextContent('Test Workbench statusReady');
 
-    // Validate the steps
+    // 8 top-level steps (pvc_attached surfaced by event); sub-steps collapsed, all SUCCESS.
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
-    const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
-    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(14);
+    const steps = screen.getAllByRole('treeitem');
+    expect(steps).toHaveLength(8);
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(8);
   });
 
   it('should show completed notebook startup status for standalone notebooks', async () => {
     const mockData = mockCompletedStates;
     render(
       <StartNotebookModal
+        notebook={mockData.notebookState.notebook}
         notebookStatus={mockData.notebookStatus}
         isStarting
         isStopping={mockData.notebookState.isStopping}
@@ -147,14 +147,58 @@ describe('Start Notebook modal', () => {
 
     // Validate the header contents
     const header = screen.getByTestId('notebook-status-modal-header');
-    expect(header).toHaveTextContent('Workbench statusReady');
+    expect(header).toHaveTextContent('Test Workbench statusReady');
 
-    // Validate the steps
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
-    const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(14);
-    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(14);
+    const steps = screen.getAllByRole('treeitem');
+    expect(steps).toHaveLength(8);
+    expect(screen.getAllByTestId('step-status-Success')).toHaveLength(8);
+  });
+
+  it('should show Kueue Requeued message in modal header even when isRunning is true', () => {
+    // Regression: renderLastUpdate() must not short-circuit when a Kueue override is active.
+    const mockData = mockInitialStates;
+    render(
+      <StartNotebookModal
+        notebook={mockData.notebookState.notebook}
+        notebookStatus={mockData.notebookStatus}
+        isStarting={false}
+        isStopping={false}
+        isRunning // ← pod still appears running
+        events={[]}
+        kueueStatus={{
+          status: KueueWorkloadStatus.Requeued,
+          message: 'Evicted due to timeout',
+          requeueInfo: { count: 2, requeueAt: '2026-07-15T10:05:00Z' },
+        }}
+        buttons={null}
+      />,
+    );
+
+    const statusLabel = screen.getByTestId('notebook-latest-status');
+    expect(statusLabel).toHaveTextContent('Re-queued (attempt 2');
+  });
+
+  it.each([
+    { label: 'no kueueStatus (null)', kueueStatus: null },
+    { label: 'no kueueStatus (undefined)', kueueStatus: undefined },
+  ])('should NOT show status label when isRunning=true and $label', ({ kueueStatus }) => {
+    const mockData = mockInitialStates;
+    render(
+      <StartNotebookModal
+        notebook={mockData.notebookState.notebook}
+        notebookStatus={mockData.notebookStatus}
+        isStarting={false}
+        isStopping={false}
+        isRunning
+        events={[]}
+        kueueStatus={kueueStatus}
+        buttons={null}
+      />,
+    );
+
+    expect(screen.queryByTestId('notebook-latest-status')).toBeNull();
   });
 
   it('should show stopping notebook status', async () => {
@@ -176,11 +220,11 @@ describe('Start Notebook modal', () => {
     const statusLabel = screen.getByTestId('notebook-latest-status');
     expect(statusLabel).toHaveTextContent('Shutting down the server');
 
-    // Validate the steps
+    // No notebook → no container steps; optional steps filtered → 5 total.
     const stepper = screen.getByTestId('notebook-startup-steps');
     expect(stepper).toBeTruthy();
-    const steps = screen.getAllByRole('listitem');
-    expect(steps).toHaveLength(13);
-    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(13);
+    const steps = screen.getAllByRole('treeitem');
+    expect(steps).toHaveLength(5);
+    expect(screen.getAllByTestId('step-status-Pending')).toHaveLength(5);
   });
 });

--- a/frontend/src/concepts/__tests__/mockNotebookStates.ts
+++ b/frontend/src/concepts/__tests__/mockNotebookStates.ts
@@ -184,6 +184,7 @@ const initialNotebookState: NotebookState = {
   isStopped: false,
   refresh: fauxRefresh,
   runningPodUid: '',
+  containerStatuses: [],
 };
 
 export const mockInitialStates = {
@@ -200,6 +201,7 @@ const failedNotebookState: NotebookState = {
   isStopped: false,
   runningPodUid: '1f28301b-20b0-40f7-9a9f-39c66442075e',
   refresh: fauxRefresh,
+  containerStatuses: [],
 };
 
 const failedNotebookEvents: EventKind[] = [
@@ -377,6 +379,7 @@ const inProgressNotebookState: NotebookState = {
   isStopped: false,
   runningPodUid: '59f51fb0-6c9d-4a3c-b906-4a6f1ac408e7',
   refresh: fauxRefresh,
+  containerStatuses: [],
 };
 
 const inProgressNotebookEvents: EventKind[] = [
@@ -468,7 +471,7 @@ const inProgressNotebookEvents: EventKind[] = [
     involvedObject: {
       name: 'new-pipeline-0',
     },
-    message: 'Created container new-pipeline',
+    message: 'Created container test-workbench',
     eventTime: '2025-01-22T20:18:58Z',
     metadata: {
       name: 'new-pipeline-0.181d1d33861e2a1b',
@@ -484,7 +487,7 @@ const inProgressNotebookEvents: EventKind[] = [
     involvedObject: {
       name: 'new-pipeline-0',
     },
-    message: 'Started container new-pipeline',
+    message: 'Started container test-workbench',
     eventTime: '2025-01-22T20:18:58Z',
     metadata: {
       name: 'new-pipeline-0.181d1d3386c210e4',
@@ -533,6 +536,7 @@ const completedNotebookState: NotebookState = {
   isStopped: false,
   runningPodUid: '59f51fb0-6c9d-4a3c-b906-4a6f1ac408e7',
   refresh: fauxRefresh,
+  containerStatuses: [],
 };
 
 const completedNotebookEvents: EventKind[] = [
@@ -651,7 +655,7 @@ const completedNotebookEvents: EventKind[] = [
     involvedObject: {
       name: 'new-pipeline-0',
     },
-    message: 'Created container new-pipeline',
+    message: 'Created container test-workbench',
     eventTime: '2025-01-22T20:18:58Z',
     metadata: {
       name: 'new-pipeline-0.181d1d33861e2a1b',
@@ -666,7 +670,7 @@ const completedNotebookEvents: EventKind[] = [
     involvedObject: {
       name: 'new-pipeline-0',
     },
-    message: 'Started container new-pipeline',
+    message: 'Started container test-workbench',
     eventTime: '2025-01-22T20:18:58Z',
     metadata: {
       name: 'new-pipeline-0.181d1d3386c210e4',

--- a/frontend/src/concepts/kueue/__tests__/messageUtils.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/messageUtils.spec.ts
@@ -1,6 +1,7 @@
 import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
 import {
   getHumanReadableKueueMessage,
+  getKueueSubStepInfo,
   getPreemptionToastBody,
   getEvictionToastBody,
   getRequeuedMessage,
@@ -8,24 +9,14 @@ import {
 
 describe('getHumanReadableKueueMessage', () => {
   describe('Queued status', () => {
-    it('should return quota waiting message when raw message mentions insufficient quota', () => {
+    it.each([
+      ['insufficient unused quota for cpu', 'Waiting for quota in test-queue'],
+      ["couldn't assign flavors to pod set main", 'Waiting for quota in test-queue'],
+      [undefined, 'Waiting for quota in test-queue'],
+    ])('should return quota waiting message for message %s', (rawMessage, expected) => {
       expect(
-        getHumanReadableKueueMessage(
-          KueueWorkloadStatus.Queued,
-          "couldn't assign flavors to pod set 7273a338: insufficient unused quota for cpu in flavor workbench-test-flavor",
-          'test-queue',
-        ),
-      ).toBe('Waiting for quota in test-queue');
-    });
-
-    it('should return quota waiting message when raw message mentions flavor assignment', () => {
-      expect(
-        getHumanReadableKueueMessage(
-          KueueWorkloadStatus.Queued,
-          "couldn't assign flavors to pod set main",
-          'my-queue',
-        ),
-      ).toBe('Waiting for quota in my-queue');
+        getHumanReadableKueueMessage(KueueWorkloadStatus.Queued, rawMessage, 'test-queue'),
+      ).toBe(expected);
     });
 
     it('should return generic waiting message for non-quota reasons', () => {
@@ -38,12 +29,6 @@ describe('getHumanReadableKueueMessage', () => {
       ).toBe('Waiting for available resources');
     });
 
-    it('should return quota waiting message when no raw message provided', () => {
-      expect(
-        getHumanReadableKueueMessage(KueueWorkloadStatus.Queued, undefined, 'test-queue'),
-      ).toBe('Waiting for quota in test-queue');
-    });
-
     it('should use "the queue" when queue name is not provided', () => {
       expect(getHumanReadableKueueMessage(KueueWorkloadStatus.Queued, undefined)).toBe(
         'Waiting for quota in the queue',
@@ -52,24 +37,13 @@ describe('getHumanReadableKueueMessage', () => {
   });
 
   describe('Failed status', () => {
-    it('should return queue not found message when raw message mentions queue not found', () => {
+    it.each([
+      ['ClusterQueue not found', 'Queue test-queue does not exist'],
+      ['queue does not exist', 'Queue test-queue does not exist'],
+    ])('should return queue not found message for message "%s"', (rawMessage, expected) => {
       expect(
-        getHumanReadableKueueMessage(
-          KueueWorkloadStatus.Failed,
-          'ClusterQueue not found',
-          'test-queue',
-        ),
-      ).toBe('Queue test-queue does not exist');
-    });
-
-    it('should return queue not found message when raw message mentions queue not exist', () => {
-      expect(
-        getHumanReadableKueueMessage(
-          KueueWorkloadStatus.Failed,
-          'queue does not exist',
-          'my-queue',
-        ),
-      ).toBe('Queue my-queue does not exist');
+        getHumanReadableKueueMessage(KueueWorkloadStatus.Failed, rawMessage, 'test-queue'),
+      ).toBe(expected);
     });
 
     it('should return timeout message when raw message mentions timeout', () => {
@@ -110,17 +84,10 @@ describe('getHumanReadableKueueMessage', () => {
   });
 
   describe('Preempted status', () => {
-    it('should return preemption message regardless of raw message', () => {
+    it('should always return the same fixed message regardless of raw message or queue', () => {
       expect(
-        getHumanReadableKueueMessage(
-          KueueWorkloadStatus.Preempted,
-          'Preempted by higher priority workload',
-          'test-queue',
-        ),
+        getHumanReadableKueueMessage(KueueWorkloadStatus.Preempted, 'any message', 'any-queue'),
       ).toBe('Paused by a higher-priority job');
-    });
-
-    it('should return preemption message when no raw message provided', () => {
       expect(getHumanReadableKueueMessage(KueueWorkloadStatus.Preempted)).toBe(
         'Paused by a higher-priority job',
       );
@@ -203,6 +170,23 @@ describe('getHumanReadableKueueMessage', () => {
     });
   });
 
+  describe('AdmissionCheck status', () => {
+    it('should prefix any provided message with "Waiting for admission check:"', () => {
+      expect(
+        getHumanReadableKueueMessage(KueueWorkloadStatus.AdmissionCheck, 'no GPU nodes available'),
+      ).toBe('Waiting for admission check: no GPU nodes available');
+      expect(
+        getHumanReadableKueueMessage(KueueWorkloadStatus.AdmissionCheck, 'gpu-provisioner'),
+      ).toBe('Waiting for admission check: gpu-provisioner');
+    });
+
+    it('should return generic message when no raw message provided', () => {
+      expect(getHumanReadableKueueMessage(KueueWorkloadStatus.AdmissionCheck)).toBe(
+        'Waiting for admission check to complete',
+      );
+    });
+  });
+
   describe('Requeued status', () => {
     it('should return requeued message with raw message when provided', () => {
       expect(
@@ -272,18 +256,105 @@ describe('getPreemptionToastBody', () => {
     expect(result).toContain('by a higher-priority job and has been re-queued.');
   });
 
-  it('should omit timestamp when not provided', () => {
-    const result = getPreemptionToastBody('my-workbench');
-    expect(result).toBe(
-      'Workbench my-workbench was preempted by a higher-priority job and has been re-queued.',
-    );
+  it('should omit timestamp when not provided or explicitly undefined', () => {
+    const expected =
+      'Workbench my-workbench was preempted by a higher-priority job and has been re-queued.';
+    expect(getPreemptionToastBody('my-workbench')).toBe(expected);
+    expect(getPreemptionToastBody('my-workbench', undefined)).toBe(expected);
+  });
+});
+
+describe('getKueueSubStepInfo', () => {
+  describe('Re-queued: prefix', () => {
+    it('applies prefix when recovery is true and status is Queued', () => {
+      const result = getKueueSubStepInfo(KueueWorkloadStatus.Queued, undefined, 'my-queue', true);
+      expect(result.label).toMatch(/^Re-queued:/);
+    });
+
+    it('does not apply prefix when recovery is false and status is Queued', () => {
+      const result = getKueueSubStepInfo(KueueWorkloadStatus.Queued, undefined, 'my-queue', false);
+      expect(result.label).not.toMatch(/^Re-queued:/);
+    });
+
+    it('does not apply prefix for non-Queued statuses even in recovery', () => {
+      const result = getKueueSubStepInfo(
+        KueueWorkloadStatus.Inadmissible,
+        'LocalQueue no-lq does not exist',
+        'no-lq',
+        true,
+      );
+      expect(result.label).not.toMatch(/^Re-queued:/);
+    });
+
+    it('does not double-prefix for Requeued status in recovery', () => {
+      const result = getKueueSubStepInfo(
+        KueueWorkloadStatus.Requeued,
+        'Pods were not ready in time',
+        'my-queue',
+        true,
+      );
+      expect(result.label).not.toMatch(/^Re-queued: Re-queued/);
+    });
   });
 
-  it('should omit timestamp when undefined', () => {
-    const result = getPreemptionToastBody('my-workbench', undefined);
-    expect(result).toBe(
-      'Workbench my-workbench was preempted by a higher-priority job and has been re-queued.',
-    );
+  describe('admitted statuses', () => {
+    it.each([
+      KueueWorkloadStatus.Admitted,
+      KueueWorkloadStatus.Running,
+      KueueWorkloadStatus.Complete,
+    ])('returns "Admitted to queue" label for %s', (status) => {
+      expect(getKueueSubStepInfo(status, 'some message', 'my-queue', false).label).toBe(
+        'Admitted to queue',
+      );
+    });
+  });
+
+  describe('label uses getHumanReadableKueueMessage output per status', () => {
+    it.each([
+      [
+        KueueWorkloadStatus.AdmissionCheck,
+        undefined,
+        'q',
+        'Waiting for admission check to complete',
+      ],
+      [
+        KueueWorkloadStatus.BlockedOnPreemptionGates,
+        undefined,
+        'q',
+        'Admitted but waiting for preemption gates to clear',
+      ],
+      [KueueWorkloadStatus.Inadmissible, undefined, 'q', 'Queue q does not exist'],
+      [KueueWorkloadStatus.Evicted, undefined, 'q', 'Evicted from the queue'],
+      [KueueWorkloadStatus.Preempted, undefined, 'q', 'Paused by a higher-priority job'],
+      [KueueWorkloadStatus.Requeued, undefined, 'q', 'Re-queued, waiting to retry'],
+      [KueueWorkloadStatus.Queued, undefined, 'q', 'Waiting for quota in q'],
+    ] as const)('returns human-readable label for %s', (status, message, queueName, expected) => {
+      expect(getKueueSubStepInfo(status, message, queueName, false).label).toBe(expected);
+    });
+  });
+
+  describe('queue position', () => {
+    it('appends position to label when Queued and position is provided', () => {
+      const result = getKueueSubStepInfo(
+        KueueWorkloadStatus.Queued,
+        undefined,
+        'my-queue',
+        false,
+        3,
+      );
+      expect(result.label).toContain('position 3');
+    });
+
+    it('does not append position for non-Queued statuses', () => {
+      const result = getKueueSubStepInfo(
+        KueueWorkloadStatus.Inadmissible,
+        'LocalQueue does not exist',
+        'my-queue',
+        false,
+        3,
+      );
+      expect(result.label).not.toContain('position');
+    });
   });
 });
 
@@ -303,13 +374,9 @@ describe('getEvictionToastBody', () => {
     expect(result).toBe('Workbench my-workbench was evicted: Some unexpected eviction reason');
   });
 
-  it('should return generic message when no reason', () => {
-    const result = getEvictionToastBody('my-workbench');
-    expect(result).toBe('Workbench my-workbench was evicted from the queue.');
-  });
-
-  it('should return generic message when reason is empty', () => {
-    const result = getEvictionToastBody('my-workbench', '  ');
-    expect(result).toBe('Workbench my-workbench was evicted from the queue.');
+  it('should return generic message when no reason provided or reason is blank', () => {
+    const expected = 'Workbench my-workbench was evicted from the queue.';
+    expect(getEvictionToastBody('my-workbench')).toBe(expected);
+    expect(getEvictionToastBody('my-workbench', '  ')).toBe(expected);
   });
 });

--- a/frontend/src/concepts/kueue/__tests__/messageUtils.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/messageUtils.spec.ts
@@ -163,10 +163,10 @@ describe('getHumanReadableKueueMessage', () => {
       ).toBe('Namespace does not match cluster queue selector');
     });
 
-    it('should return queue not found message when no raw message provided', () => {
+    it('should return neutral fallback message when no raw message provided', () => {
       expect(
         getHumanReadableKueueMessage(KueueWorkloadStatus.Inadmissible, undefined, 'test-queue'),
-      ).toBe('Queue test-queue does not exist');
+      ).toBe('Unable to admit workload to test-queue');
     });
   });
 
@@ -323,7 +323,7 @@ describe('getKueueSubStepInfo', () => {
         'q',
         'Admitted but waiting for preemption gates to clear',
       ],
-      [KueueWorkloadStatus.Inadmissible, undefined, 'q', 'Queue q does not exist'],
+      [KueueWorkloadStatus.Inadmissible, undefined, 'q', 'Unable to admit workload to q'],
       [KueueWorkloadStatus.Evicted, undefined, 'q', 'Evicted from the queue'],
       [KueueWorkloadStatus.Preempted, undefined, 'q', 'Paused by a higher-priority job'],
       [KueueWorkloadStatus.Requeued, undefined, 'q', 'Re-queued, waiting to retry'],

--- a/frontend/src/concepts/kueue/index.ts
+++ b/frontend/src/concepts/kueue/index.ts
@@ -24,6 +24,7 @@ const CONDITION_TYPE = {
   QuotaReserved: 'QuotaReserved',
   PodsReady: 'PodsReady',
   Admitted: 'Admitted',
+  BlockedOnPreemptionGates: 'BlockedOnPreemptionGates',
 } as const;
 
 const EVICTION_REASON = {
@@ -40,6 +41,7 @@ type ExtractedConditions = {
   Evicted: WorkloadCondition | undefined;
   Preempted: WorkloadCondition | undefined;
   Inadmissible: WorkloadCondition | undefined;
+  BlockedOnPreemptionGates: WorkloadCondition | undefined;
   Pending: WorkloadCondition | undefined;
   Running: WorkloadCondition | undefined;
   Admitted: WorkloadCondition | undefined;
@@ -80,6 +82,10 @@ const extractWorkloadConditions = (conditions: WorkloadCondition[]): ExtractedCo
         status === CONDITION_STATUS.False &&
         reason === 'Inadmissible',
     ),
+    BlockedOnPreemptionGates: conditions.find(
+      ({ type, status }) =>
+        type === CONDITION_TYPE.BlockedOnPreemptionGates && status === CONDITION_STATUS.True,
+    ),
     Pending: conditions.find(
       ({ type, status }) =>
         type === CONDITION_TYPE.QuotaReserved && status === CONDITION_STATUS.False,
@@ -93,12 +99,7 @@ const extractWorkloadConditions = (conditions: WorkloadCondition[]): ExtractedCo
   };
 };
 
-/**
- * Determines the dashboard status for an Evicted condition by inspecting its reason.
- * - reason "Preempted" → Preempted (higher-priority job displaced this one)
- * - reason "PodsReadyTimeout" with requeueState → Requeued (will retry)
- * - All other reasons → Evicted (queue stopped, deactivated, admission check, etc.)
- */
+/** Maps an Evicted condition to Preempted, Requeued, or Evicted based on its reason. */
 const resolveEvictedStatus = (
   evictedCondition: WorkloadCondition,
   workload: WorkloadKind,
@@ -121,11 +122,7 @@ const getMessageFromCondition = (condition: WorkloadCondition | undefined): stri
   return s || undefined;
 };
 
-/**
- * Finds the first True condition with a non-empty message from types
- * not handled by the known extraction logic. Ensures unknown condition types
- * always surface the raw Kueue message rather than showing blank.
- */
+/** Returns the first True condition with a message whose type is not otherwise handled. */
 const findUnknownConditionFallback = (
   conditions: WorkloadCondition[],
   extracted: ExtractedConditions,
@@ -142,17 +139,38 @@ const findUnknownConditionFallback = (
 
 /**
  * Returns Kueue status and message for a Workload from its conditions.
- * Priority: Failed → Inadmissible → Evicted/Preempted/Requeued → Succeeded → Running → Admitted → Queued → UnknownFallback.
+ * Priority: Failed → Evicted/Requeued → Inadmissible → BlockedOnPreemptionGates → Preempted → Succeeded → Running → Admitted → Queued → UnknownFallback.
  */
+type AdmissionCheckEntry = NonNullable<
+  NonNullable<WorkloadKind['status']>['admissionChecks']
+>[number];
+
+/** Returns the first blocking admission check (Pending or Retry), or undefined if none. */
+const findBlockingAdmissionCheck = (workload: WorkloadKind): AdmissionCheckEntry | undefined => {
+  const checks = workload.status?.admissionChecks;
+  return checks?.find(({ state }) => state === 'Pending' || state === 'Retry');
+};
+
 export const getKueueWorkloadStatusWithMessage = (
   workload: WorkloadKind,
 ): KueueWorkloadStatusWithMessage => {
   const conditions = workload.status?.conditions ?? [];
   const extracted = extractWorkloadConditions(conditions);
-  const { Failed, Inadmissible, Evicted, Preempted, Succeeded, Running, Admitted, Pending } =
-    extracted;
+  const {
+    Failed,
+    Inadmissible,
+    Evicted,
+    Preempted,
+    Succeeded,
+    Running,
+    Admitted,
+    Pending,
+    BlockedOnPreemptionGates,
+  } = extracted;
 
   const evictedStatus = Evicted ? resolveEvictedStatus(Evicted, workload) : undefined;
+
+  const blockingCheck = findBlockingAdmissionCheck(workload);
 
   const priority: Array<{
     condition: WorkloadCondition | undefined;
@@ -161,6 +179,7 @@ export const getKueueWorkloadStatusWithMessage = (
     { condition: Failed, status: KueueWorkloadStatus.Failed },
     { condition: Evicted, status: evictedStatus ?? KueueWorkloadStatus.Evicted },
     { condition: Inadmissible, status: KueueWorkloadStatus.Inadmissible },
+    { condition: BlockedOnPreemptionGates, status: KueueWorkloadStatus.BlockedOnPreemptionGates },
     { condition: Preempted, status: KueueWorkloadStatus.Preempted },
     { condition: Succeeded, status: KueueWorkloadStatus.Complete },
     { condition: Running, status: KueueWorkloadStatus.Running },
@@ -180,6 +199,15 @@ export const getKueueWorkloadStatusWithMessage = (
       };
     }
     return { status: KueueWorkloadStatus.Queued, message: undefined, timestamp: undefined };
+  }
+
+  // Admitted but a check is still blocking — surface AdmissionCheck for the progress tree.
+  if (matched.status === KueueWorkloadStatus.Admitted && blockingCheck != null) {
+    return {
+      status: KueueWorkloadStatus.AdmissionCheck,
+      message: blockingCheck.message || blockingCheck.name,
+      timestamp: blockingCheck.lastTransitionTime,
+    };
   }
 
   const result: KueueWorkloadStatusWithMessage = {
@@ -231,6 +259,20 @@ export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo
         label: 'Inadmissible',
         status: 'warning',
         IconComponent: ExclamationTriangleIcon,
+      };
+    case KueueWorkloadStatus.AdmissionCheck:
+      return {
+        label: 'Admission check',
+        color: 'blue',
+        IconComponent: InProgressIcon,
+        iconClassName: 'ai-u-spin',
+      };
+    case KueueWorkloadStatus.BlockedOnPreemptionGates:
+      return {
+        label: 'Blocked on preemption',
+        color: 'blue',
+        IconComponent: InProgressIcon,
+        iconClassName: 'ai-u-spin',
       };
     case KueueWorkloadStatus.Running:
       return { label: 'Running', color: 'blue', IconComponent: InProgressIcon };

--- a/frontend/src/concepts/kueue/messageUtils.ts
+++ b/frontend/src/concepts/kueue/messageUtils.ts
@@ -2,7 +2,7 @@ import { KueueWorkloadStatus, type KueueWorkloadStatusWithMessage } from './type
 
 const QUOTA_REGEX = /insufficient unused quota|quota.*exceed|exceed.*quota/i;
 const QUEUE_NOT_FOUND_REGEX =
-  /queue.*not\s*(found|exist|existing)|not\s*(found|exist|existing).*queue|clusterqueue.*not\s*(found|exist|existing)|doesn't\s+exist|does\s+not\s+exist/i;
+  /\b(?:cluster|local)?queue\b.*(?:not\s*(?:found|exist|existing)|does(?:n't| not)\s+exist)|(?:not\s*(?:found|exist|existing)|does(?:n't| not)\s+exist).*\b(?:cluster|local)?queue\b/i;
 const TIMEOUT_REGEX = /timed?\s*out|timeout/i;
 const FLAVOR_REGEX = /couldn't assign flavors|flavor/i;
 const QUEUE_STOPPED_REGEX = /clusterqueue.*stop|stop.*clusterqueue/i;
@@ -112,7 +112,10 @@ const getAdmissionCheckMessage = (rawMessage: string | undefined): string =>
     : 'Waiting for admission check to complete';
 
 const getInadmissibleMessage = (rawMessage: string | undefined, queue: string): string => {
-  if (!rawMessage || QUEUE_NOT_FOUND_REGEX.test(rawMessage)) {
+  if (!rawMessage) {
+    return `Unable to admit workload to ${queue}`;
+  }
+  if (QUEUE_NOT_FOUND_REGEX.test(rawMessage)) {
     return `Queue ${queue} does not exist`;
   }
   if (QUOTA_REGEX.test(rawMessage) || FLAVOR_REGEX.test(rawMessage)) {

--- a/frontend/src/concepts/kueue/messageUtils.ts
+++ b/frontend/src/concepts/kueue/messageUtils.ts
@@ -2,7 +2,7 @@ import { KueueWorkloadStatus, type KueueWorkloadStatusWithMessage } from './type
 
 const QUOTA_REGEX = /insufficient unused quota|quota.*exceed|exceed.*quota/i;
 const QUEUE_NOT_FOUND_REGEX =
-  /queue.*not\s*(found|exist)|not\s*(found|exist).*queue|clusterqueue.*not\s*(found|exist)/i;
+  /queue.*not\s*(found|exist|existing)|not\s*(found|exist|existing).*queue|clusterqueue.*not\s*(found|exist|existing)|doesn't\s+exist|does\s+not\s+exist/i;
 const TIMEOUT_REGEX = /timed?\s*out|timeout/i;
 const FLAVOR_REGEX = /couldn't assign flavors|flavor/i;
 const QUEUE_STOPPED_REGEX = /clusterqueue.*stop|stop.*clusterqueue/i;
@@ -34,6 +34,10 @@ export const getHumanReadableKueueMessage = (
       return message ? `Re-queued: ${message}` : 'Re-queued, waiting to retry';
     case KueueWorkloadStatus.Inadmissible:
       return getInadmissibleMessage(message, queue);
+    case KueueWorkloadStatus.AdmissionCheck:
+      return getAdmissionCheckMessage(message);
+    case KueueWorkloadStatus.BlockedOnPreemptionGates:
+      return 'Admitted but waiting for preemption gates to clear';
     default:
       return message || status;
   }
@@ -102,11 +106,13 @@ const getEvictedMessage = (rawMessage: string | undefined): string => {
   return reason ? `Evicted: ${reason}` : 'Evicted from the queue';
 };
 
+const getAdmissionCheckMessage = (rawMessage: string | undefined): string =>
+  rawMessage
+    ? `Waiting for admission check: ${rawMessage}`
+    : 'Waiting for admission check to complete';
+
 const getInadmissibleMessage = (rawMessage: string | undefined, queue: string): string => {
-  if (!rawMessage) {
-    return `Queue ${queue} does not exist`;
-  }
-  if (QUEUE_NOT_FOUND_REGEX.test(rawMessage)) {
+  if (!rawMessage || QUEUE_NOT_FOUND_REGEX.test(rawMessage)) {
     return `Queue ${queue} does not exist`;
   }
   if (QUOTA_REGEX.test(rawMessage) || FLAVOR_REGEX.test(rawMessage)) {
@@ -138,4 +144,37 @@ export const getEvictionToastBody = (workbenchName: string, rawMessage?: string)
     return `Workbench ${workbenchName} was evicted: ${reason}`;
   }
   return `Workbench ${workbenchName} was evicted from the queue.`;
+};
+
+/**
+ * Returns the label for the Kueue sub-step in the progress tree.
+ * Adds a "Re-queued:" prefix only for the Queued state during a recovery, and appends queue position when available.
+ */
+export const getKueueSubStepInfo = (
+  status: KueueWorkloadStatus,
+  message: string | undefined,
+  queueName: string | undefined,
+  isRecovery: boolean,
+  queuePosition?: number,
+): { label: string } => {
+  const admitted =
+    status === KueueWorkloadStatus.Admitted ||
+    status === KueueWorkloadStatus.Running ||
+    status === KueueWorkloadStatus.Complete;
+
+  if (admitted) {
+    return { label: 'Admitted to queue' };
+  }
+
+  const raw = getHumanReadableKueueMessage(status, message, queueName);
+
+  const withRecovery =
+    isRecovery && status === KueueWorkloadStatus.Queued ? `Re-queued: ${raw}` : raw;
+
+  const label =
+    status === KueueWorkloadStatus.Queued && queuePosition != null
+      ? `${withRecovery} (position ${queuePosition})`
+      : withRecovery;
+
+  return { label };
 };

--- a/frontend/src/concepts/kueue/types.ts
+++ b/frontend/src/concepts/kueue/types.ts
@@ -8,6 +8,10 @@ export enum KueueWorkloadStatus {
   Evicted = 'Evicted',
   Requeued = 'Requeued',
   Inadmissible = 'Inadmissible',
+  /** Admitted but one or more admission checks are still pending/retrying. */
+  AdmissionCheck = 'AdmissionCheck',
+  /** Admitted but blocked waiting for preemption gates to clear. */
+  BlockedOnPreemptionGates = 'BlockedOnPreemptionGates',
   Running = 'Running',
   Admitted = 'Admitted',
   Complete = 'Complete',

--- a/frontend/src/concepts/notebooks/StartNotebookModal.scss
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.scss
@@ -13,5 +13,10 @@
     overflow-y: auto;
     min-height: 0; // Critical for flexbox scrolling
   }
+
+  &__step-description {
+    font-size: var(--pf-t--global--font--size--sm);
+    margin: 0;
+  }
 }
 

--- a/frontend/src/concepts/notebooks/StartNotebookModal.scss
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.scss
@@ -14,9 +14,10 @@
     min-height: 0; // Critical for flexbox scrolling
   }
 
-  &__step-description {
-    font-size: var(--pf-t--global--font--size--sm);
-    margin: 0;
+  &__progress-scroll {
+    overflow-y: auto;
+    min-height: 0;
   }
+
 }
 

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -11,6 +11,9 @@ import {
   DescriptionListTerm,
   Flex,
   FlexItem,
+  HelperText,
+  HelperTextItem,
+  Icon,
   Modal,
   ModalBody,
   ModalFooter,
@@ -18,9 +21,6 @@ import {
   ModalVariant,
   Panel,
   PanelMain,
-  ProgressStep,
-  ProgressStepper,
-  ProgressStepVariant,
   Skeleton,
   Stack,
   StackItem,
@@ -28,21 +28,28 @@ import {
   Tabs,
   TabTitleText,
   Title,
+  TreeView,
+  type TreeViewDataItem,
 } from '@patternfly/react-core';
 import {
   t_global_icon_color_brand_default as BrandIconColor,
-  t_global_icon_size_font_md as InfoIconSize,
-  t_global_spacer_xs as ExtraSmallSpacerSize,
   t_global_text_color_regular as RegularColor,
   t_global_text_color_disabled as DisabledColor,
   t_global_text_color_status_danger_default as DangerColor,
-  t_global_text_color_status_info_default as InfoColor,
   t_global_text_color_status_warning_default as WarningColor,
 } from '@patternfly/react-tokens';
-import { InfoCircleIcon, InProgressIcon } from '@patternfly/react-icons';
-import { EventStatus, NotebookStatus, ProgressionStepTitles } from '#~/types';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon,
+  InProgressIcon,
+  OutlinedClockIcon,
+} from '@patternfly/react-icons';
+import type { PodContainerStatus } from '@odh-dashboard/k8s-core';
+import { EventStatus, NotebookStatus } from '#~/types';
 import { EventKind, NotebookKind } from '#~/k8sTypes';
-import { useNotebookProgress } from '#~/utilities/notebookControllerUtils';
+import { useNotebookProgress, getNotebookDisplayName } from '#~/utilities/notebookControllerUtils';
 import useClusterQueue from '#~/utilities/useClusterQueue';
 import useAssignedFlavor from '#~/utilities/useAssignedFlavor';
 import { getAllConsumedResources } from '#~/utilities/clusterQueueUtils';
@@ -64,13 +71,31 @@ const PROGRESS_TAB = 'Progress';
 const EVENT_LOG_TAB = 'Events log';
 const RESOURCES_TAB = 'Resources';
 
-const progressVariants = {
-  [EventStatus.PENDING]: ProgressStepVariant.pending,
-  [EventStatus.IN_PROGRESS]: ProgressStepVariant.pending,
-  [EventStatus.ERROR]: ProgressStepVariant.danger,
-  [EventStatus.INFO]: ProgressStepVariant.info,
-  [EventStatus.WARNING]: ProgressStepVariant.warning,
-  [EventStatus.SUCCESS]: ProgressStepVariant.success,
+const stepIcons: Record<EventStatus, React.ReactNode> = {
+  [EventStatus.SUCCESS]: (
+    <Icon status="success">
+      <CheckCircleIcon />
+    </Icon>
+  ),
+  [EventStatus.ERROR]: (
+    <Icon status="danger">
+      <ExclamationCircleIcon />
+    </Icon>
+  ),
+  [EventStatus.WARNING]: (
+    <Icon status="warning">
+      <ExclamationTriangleIcon />
+    </Icon>
+  ),
+  [EventStatus.INFO]: (
+    <Icon status="info">
+      <InfoCircleIcon />
+    </Icon>
+  ),
+  [EventStatus.IN_PROGRESS]: (
+    <InProgressIcon style={{ color: BrandIconColor.var }} className="ai-u-spin" />
+  ),
+  [EventStatus.PENDING]: <OutlinedClockIcon />,
 };
 
 type StartNotebookModalProps = {
@@ -81,6 +106,7 @@ type StartNotebookModalProps = {
   notebookStatus: NotebookStatus | null;
   events: EventKind[];
   kueueStatus?: KueueWorkloadStatusWithMessage | null;
+  containerStatuses?: PodContainerStatus[];
   onClose?: () => void;
   buttons: React.ReactNode;
 };
@@ -98,19 +124,27 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
   isStarting,
   isRunning,
   isStopping,
-  kueueStatus: kueueStatusProp,
+  kueueStatus,
+  containerStatuses,
   onClose,
   buttons,
 }) => {
   const [spawnStatus, setSpawnStatus] = React.useState<SpawnStatus | null>(null);
   const isError = notebookStatus?.currentStatus === EventStatus.ERROR;
   const isStopped = !isError && !isRunning && !isStarting && !isStopping;
-  const notebookProgress = useNotebookProgress(notebook, isRunning, isStopping, isStopped, events);
+  const notebookProgress = useNotebookProgress(
+    notebook,
+    isRunning,
+    isStopping,
+    isStopped,
+    events,
+    kueueStatus ?? null,
+    containerStatuses,
+  );
   const inProgress = !isStopped && (isStarting || isStopping || !isRunning);
   const { currentProject: project, localQueues } = React.useContext(ProjectDetailsContext);
   const { isProjectKueueEnabled, isKueueFeatureEnabled } = useKueueConfiguration(project);
   const showResourcesTab = Boolean(isKueueFeatureEnabled && isProjectKueueEnabled);
-  const kueueStatus = kueueStatusProp;
   const [activeTab, setActiveTab] = React.useState<string>(PROGRESS_TAB);
 
   React.useEffect(() => {
@@ -166,11 +200,10 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
   const renderLastUpdate = () => {
     const showKueueMessage =
       kueueStatus?.status && KUEUE_STATUSES_OVERRIDE_WORKBENCH.includes(kueueStatus.status);
-    const showKueueStatusWhenStopped = isStopped && showKueueMessage;
     if (
-      isRunning ||
+      (isRunning && !showKueueMessage) ||
       (isStopped && !showKueueMessage) ||
-      (spawnStatus?.status !== AlertVariant.danger && !inProgress && !showKueueStatusWhenStopped)
+      (spawnStatus?.status !== AlertVariant.danger && !inProgress && !showKueueMessage)
     ) {
       return null;
     }
@@ -198,9 +231,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
               kueueStatus.queueName,
             );
       kueueTitle =
-        kueueStatus.queuePosition != null &&
-        (kueueStatus.status === KueueWorkloadStatus.Queued ||
-          kueueStatus.status === KueueWorkloadStatus.Inadmissible)
+        kueueStatus.queuePosition != null && kueueStatus.status === KueueWorkloadStatus.Queued
           ? `${message} (position ${kueueStatus.queuePosition})`
           : message;
     }
@@ -366,40 +397,76 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
     );
   };
 
+  const treeData: TreeViewDataItem[] = React.useMemo(
+    () =>
+      notebookProgress.map((step) => ({
+        id: `${step.stepKind}-${step.containerName ?? ''}`,
+        name: (
+          <Flex
+            component="span"
+            gap={{ default: 'gapSm' }}
+            alignItems={{ default: 'alignItemsFlexStart' }}
+            flexWrap={{ default: 'nowrap' }}
+            data-testid={`step-status-${step.status}`}
+          >
+            <FlexItem component="span" style={{ flexShrink: 0 }}>
+              {stepIcons[step.status]}
+            </FlexItem>
+            <FlexItem component="span">
+              {step.label}
+              {step.description && (
+                <Content component="p" className="start-notebook-modal__step-description">
+                  {step.description}
+                </Content>
+              )}
+            </FlexItem>
+          </Flex>
+        ),
+        children: step.subSteps?.map((sub) => ({
+          id: `${sub.stepKind}-${sub.containerName ?? ''}`,
+          name: (
+            <Flex
+              component="span"
+              gap={{ default: 'gapSm' }}
+              alignItems={{ default: 'alignItemsFlexStart' }}
+              flexWrap={{ default: 'nowrap' }}
+              data-testid={`step-status-${sub.status}`}
+            >
+              <FlexItem component="span" style={{ flexShrink: 0 }}>
+                {stepIcons[sub.status]}
+              </FlexItem>
+              <FlexItem component="span">
+                {sub.label}
+                {sub.description && (
+                  <Content component="p" className="start-notebook-modal__step-description">
+                    {sub.description}
+                  </Content>
+                )}
+              </FlexItem>
+            </Flex>
+          ),
+        })),
+        isExpanded: step.isExpanded,
+      })),
+    [notebookProgress],
+  );
+
   const renderProgress = () => (
     <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }} style={{ height: '100%' }}>
       <FlexItem>
-        <Flex gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }}>
-          <FlexItem>
-            <InfoCircleIcon
-              style={{
-                color: InfoColor.var,
-                fontSize: InfoIconSize.var,
-                paddingTop: ExtraSmallSpacerSize.var,
-              }}
-            />
-          </FlexItem>
-          <FlexItem>
+        <HelperText>
+          <HelperTextItem variant="indeterminate" icon={<InfoCircleIcon />}>
             Steps may repeat or occur in any order, depending on the workbench&apos;s priority in
             the queue and current resource availability.
-          </FlexItem>
-        </Flex>
+          </HelperTextItem>
+        </HelperText>
       </FlexItem>
-      <FlexItem flex={{ default: 'flex_1' }} style={{ overflowY: 'scroll', minHeight: 0 }}>
-        <ProgressStepper isVertical data-testid="notebook-startup-steps">
-          {notebookProgress.map((progressStep, i) => (
-            <ProgressStep
-              key={`${progressStep.timestamp}-${i}`}
-              variant={progressVariants[progressStep.status]}
-              aria-label={progressStep.status}
-              id={`${progressStep.timestamp}`}
-              titleId={`${progressStep.timestamp}-title`}
-              data-testid={`step-status-${progressStep.status}`}
-            >
-              {ProgressionStepTitles[progressStep.step]}
-            </ProgressStep>
-          ))}
-        </ProgressStepper>
+      <FlexItem
+        flex={{ default: 'flex_1' }}
+        style={{ overflowY: 'scroll', minHeight: 0 }}
+        data-testid="notebook-startup-steps"
+      >
+        <TreeView data={treeData} hasGuides />
       </FlexItem>
     </Flex>
   );
@@ -429,7 +496,9 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
         data-testid="notebook-status-modal-header"
         title={
           <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }}>
-            <FlexItem>Workbench status</FlexItem>
+            <FlexItem>
+              {notebook ? `${getNotebookDisplayName(notebook)} status` : 'Workbench status'}
+            </FlexItem>
             <FlexItem>
               <NotebookStatusLabel
                 isStarting={isStarting && !isRunning}

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -141,6 +141,31 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
     kueueStatus ?? null,
     containerStatuses,
   );
+
+  // Server polling auto-expands IN_PROGRESS nodes; user collapse/expand is preserved.
+  const [expandedNodeIds, setExpandedNodeIds] = React.useState<Set<string>>(
+    () =>
+      new Set(
+        notebookProgress
+          .filter((s) => s.isExpanded)
+          .map((s) => `${s.stepKind}-${s.containerName ?? ''}`),
+      ),
+  );
+
+  React.useEffect(() => {
+    setExpandedNodeIds((prev) => {
+      const activeIds = notebookProgress
+        .filter((s) => s.isExpanded)
+        .map((s) => `${s.stepKind}-${s.containerName ?? ''}`);
+      if (activeIds.every((id) => prev.has(id))) {
+        return prev;
+      }
+      const next = new Set(prev);
+      activeIds.forEach((id) => next.add(id));
+      return next;
+    });
+  }, [notebookProgress]);
+
   const inProgress = isStarting || isStopping;
   const { currentProject: project, localQueues } = React.useContext(ProjectDetailsContext);
   const { isProjectKueueEnabled, isKueueFeatureEnabled } = useKueueConfiguration(project);
@@ -401,49 +426,52 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
 
   const treeData: TreeViewDataItem[] = React.useMemo(
     () =>
-      notebookProgress.map((step) => ({
-        id: `${step.stepKind}-${step.containerName ?? ''}`,
-        name: (
-          <Flex
-            component="span"
-            gap={{ default: 'gapSm' }}
-            alignItems={{ default: 'alignItemsFlexStart' }}
-            flexWrap={{ default: 'nowrap' }}
-            data-testid={`step-status-${step.status}`}
-          >
-            <FlexItem component="span" style={{ flexShrink: 0 }}>
-              {stepIcons[step.status]}
-            </FlexItem>
-            <FlexItem component="span">
-              {step.label}
-              {step.description && <Content component="small">{step.description}</Content>}
-            </FlexItem>
-          </Flex>
-        ),
-        children: step.subSteps?.map((sub) => ({
-          id: `${sub.stepKind}-${sub.containerName ?? ''}`,
+      notebookProgress.map((step) => {
+        const nodeId = `${step.stepKind}-${step.containerName ?? ''}`;
+        return {
+          id: nodeId,
           name: (
             <Flex
               component="span"
               gap={{ default: 'gapSm' }}
               alignItems={{ default: 'alignItemsFlexStart' }}
               flexWrap={{ default: 'nowrap' }}
-              data-testid={`step-status-${sub.status}`}
+              data-testid={`step-status-${step.status}`}
             >
               <FlexItem component="span" style={{ flexShrink: 0 }}>
-                {stepIcons[sub.status]}
+                {stepIcons[step.status]}
               </FlexItem>
               <FlexItem component="span">
-                {sub.label}
-                {sub.description && <Content component="small">{sub.description}</Content>}
+                {step.label}
+                {step.description && <Content component="small">{step.description}</Content>}
               </FlexItem>
             </Flex>
           ),
-        })),
-        defaultExpanded: step.isExpanded,
-        isExpanded: step.isExpanded,
-      })),
-    [notebookProgress],
+          children: step.subSteps?.map((sub) => ({
+            id: `${sub.stepKind}-${sub.containerName ?? ''}`,
+            name: (
+              <Flex
+                component="span"
+                gap={{ default: 'gapSm' }}
+                alignItems={{ default: 'alignItemsFlexStart' }}
+                flexWrap={{ default: 'nowrap' }}
+                data-testid={`step-status-${sub.status}`}
+              >
+                <FlexItem component="span" style={{ flexShrink: 0 }}>
+                  {stepIcons[sub.status]}
+                </FlexItem>
+                <FlexItem component="span">
+                  {sub.label}
+                  {sub.description && <Content component="small">{sub.description}</Content>}
+                </FlexItem>
+              </Flex>
+            ),
+          })),
+          defaultExpanded: expandedNodeIds.has(nodeId),
+          isExpanded: expandedNodeIds.has(nodeId),
+        };
+      }),
+    [notebookProgress, expandedNodeIds],
   );
 
   const renderProgress = () => (
@@ -461,7 +489,27 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
         className="start-notebook-modal__progress-scroll"
         data-testid="notebook-startup-steps"
       >
-        <TreeView data={treeData} hasGuides aria-label="Notebook startup progress" />
+        <TreeView
+          data={treeData}
+          hasGuides
+          aria-label="Notebook startup progress"
+          onExpand={(_, item) => {
+            if (item.id) {
+              const { id } = item;
+              setExpandedNodeIds((prev) => new Set([...prev, id]));
+            }
+          }}
+          onCollapse={(_, item) => {
+            if (item.id) {
+              const { id } = item;
+              setExpandedNodeIds((prev) => {
+                const next = new Set(prev);
+                next.delete(id);
+                return next;
+              });
+            }
+          }}
+        />
       </FlexItem>
     </Flex>
   );

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -142,7 +142,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
     containerStatuses,
   );
 
-  // Server polling auto-expands IN_PROGRESS nodes; user collapse/expand is preserved.
+  // Server polling auto-expands IN_PROGRESS nodes; explicit user collapse is preserved.
   const [expandedNodeIds, setExpandedNodeIds] = React.useState<Set<string>>(
     () =>
       new Set(
@@ -151,12 +151,15 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
           .map((s) => `${s.stepKind}-${s.containerName ?? ''}`),
       ),
   );
+  // Tracks nodes the user has explicitly collapsed so server polling won't re-expand them.
+  const [userCollapsedIds, setUserCollapsedIds] = React.useState<Set<string>>(new Set());
 
   React.useEffect(() => {
     setExpandedNodeIds((prev) => {
       const activeIds = notebookProgress
         .filter((s) => s.isExpanded)
-        .map((s) => `${s.stepKind}-${s.containerName ?? ''}`);
+        .map((s) => `${s.stepKind}-${s.containerName ?? ''}`)
+        .filter((id) => !userCollapsedIds.has(id));
       if (activeIds.every((id) => prev.has(id))) {
         return prev;
       }
@@ -164,7 +167,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
       activeIds.forEach((id) => next.add(id));
       return next;
     });
-  }, [notebookProgress]);
+  }, [notebookProgress, userCollapsedIds]);
 
   const inProgress = isStarting || isStopping;
   const { currentProject: project, localQueues } = React.useContext(ProjectDetailsContext);
@@ -497,6 +500,11 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
             if (item.id) {
               const { id } = item;
               setExpandedNodeIds((prev) => new Set([...prev, id]));
+              setUserCollapsedIds((prev) => {
+                const next = new Set(prev);
+                next.delete(id);
+                return next;
+              });
             }
           }}
           onCollapse={(_, item) => {
@@ -507,6 +515,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
                 next.delete(id);
                 return next;
               });
+              setUserCollapsedIds((prev) => new Set([...prev, id]));
             }
           }}
         />

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -141,7 +141,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
     kueueStatus ?? null,
     containerStatuses,
   );
-  const inProgress = !isStopped && (isStarting || isStopping || !isRunning);
+  const inProgress = isStarting || isStopping;
   const { currentProject: project, localQueues } = React.useContext(ProjectDetailsContext);
   const { isProjectKueueEnabled, isKueueFeatureEnabled } = useKueueConfiguration(project);
   const showResourcesTab = Boolean(isKueueFeatureEnabled && isProjectKueueEnabled);

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -231,7 +231,9 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
               kueueStatus.queueName,
             );
       kueueTitle =
-        kueueStatus.queuePosition != null && kueueStatus.status === KueueWorkloadStatus.Queued
+        kueueStatus.queuePosition != null &&
+        (kueueStatus.status === KueueWorkloadStatus.Queued ||
+          kueueStatus.status === KueueWorkloadStatus.Inadmissible)
           ? `${message} (position ${kueueStatus.queuePosition})`
           : message;
     }
@@ -414,11 +416,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
             </FlexItem>
             <FlexItem component="span">
               {step.label}
-              {step.description && (
-                <Content component="p" className="start-notebook-modal__step-description">
-                  {step.description}
-                </Content>
-              )}
+              {step.description && <Content component="small">{step.description}</Content>}
             </FlexItem>
           </Flex>
         ),
@@ -437,15 +435,12 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
               </FlexItem>
               <FlexItem component="span">
                 {sub.label}
-                {sub.description && (
-                  <Content component="p" className="start-notebook-modal__step-description">
-                    {sub.description}
-                  </Content>
-                )}
+                {sub.description && <Content component="small">{sub.description}</Content>}
               </FlexItem>
             </Flex>
           ),
         })),
+        defaultExpanded: step.isExpanded,
         isExpanded: step.isExpanded,
       })),
     [notebookProgress],
@@ -463,10 +458,10 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
       </FlexItem>
       <FlexItem
         flex={{ default: 'flex_1' }}
-        style={{ overflowY: 'scroll', minHeight: 0 }}
+        className="start-notebook-modal__progress-scroll"
         data-testid="notebook-startup-steps"
       >
-        <TreeView data={treeData} hasGuides />
+        <TreeView data={treeData} hasGuides aria-label="Notebook startup progress" />
       </FlexItem>
     </Flex>
   );

--- a/frontend/src/concepts/notebooks/useStopWorkbenchModal.tsx
+++ b/frontend/src/concepts/notebooks/useStopWorkbenchModal.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { stopWorkbenches } from '#~/pages/notebookController/utils';
 import useStopNotebookModalAvailability from '#~/pages/projects/notebook/useStopNotebookModalAvailability';
 import { useUser } from '#~/redux/selectors';
-import { Notebook } from '#~/types';
+import { NotebookKind } from '#~/k8sTypes';
 import useNotification from '#~/utilities/useNotification';
 
 type StopWorkbenchModalProps = {
-  notebooksToStop: Notebook[];
+  notebooksToStop: NotebookKind[];
   refresh: () => void;
 };
 

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -300,6 +300,7 @@ export type NotebookKind = K8sResourceCommon & {
     containerState?: {
       terminated?: { [key: string]: string };
     };
+    readyReplicas?: number;
   };
 };
 

--- a/frontend/src/pages/notebookController/notebookControllerContextTypes.ts
+++ b/frontend/src/pages/notebookController/notebookControllerContextTypes.ts
@@ -1,11 +1,11 @@
-import { Notebook } from '#~/types';
+import { NotebookKind } from '#~/k8sTypes';
 import { SetImpersonating } from './useImpersonationForContext';
 import { NotebookControllerTabTypes } from './const';
 import { SetCurrentAdminTab } from './useAdminTabState';
 
 export type NotebookControllerContextProps = {
   /** Current user's notebook -- set internally */
-  currentUserNotebook: Notebook | null;
+  currentUserNotebook: NotebookKind | null;
   /**
    * Requests the notebook be re-fetched now instead of waiting for polling intervals.
    * The provided speed will change the cadence future fetches are done at. Omit to reset.
@@ -37,9 +37,9 @@ export type NotebookContextStorage = {
    * Intentional state:
    *  - undefined -- not set yet (ie *we* need to load)
    *  - null -- set with no backing notebook
-   *  - Notebook -- an existing notebook
+   *  - NotebookKind -- an existing notebook
    */
-  current: Notebook | null | undefined;
+  current: NotebookKind | null | undefined;
   currentIsRunning: boolean;
   currentPodUID: string;
   currentLink: string;

--- a/frontend/src/pages/notebookController/screens/admin/StopAllServersButton.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/StopAllServersButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import StopServerModal from '#~/pages/notebookController/screens/server/StopServerModal';
-import { Notebook } from '#~/types';
+import { NotebookKind } from '#~/k8sTypes';
 import { useStopWorkbenchModal } from '#~/concepts/notebooks/useStopWorkbenchModal';
 import { useGetNotebookRoute } from '#~/utilities/useGetNotebookRoute';
 import { AdminViewUserData } from './types';
@@ -19,7 +19,7 @@ const StopAllServersButton: React.FC<StopAllServersButtonProps> = ({ users }) =>
 
   const notebooksToStop = activeServers
     .map((server) => server.notebook)
-    .filter((notebook): notebook is Notebook => !!notebook);
+    .filter((notebook): notebook is NotebookKind => !!notebook);
 
   const hasOnlyOneNotebook = notebooksToStop.length === 1;
 

--- a/frontend/src/pages/notebookController/screens/admin/types.ts
+++ b/frontend/src/pages/notebookController/screens/admin/types.ts
@@ -1,4 +1,5 @@
-import { Notebook, UsernameMap } from '#~/types';
+import { UsernameMap } from '#~/types';
+import { NotebookKind } from '#~/k8sTypes';
 
 export enum PrivilegeState {
   ADMIN = 'Admin',
@@ -22,7 +23,7 @@ export type AdminViewUserData = {
 };
 
 export type ServerStatus = {
-  notebook: Notebook | null;
+  notebook: NotebookKind | null;
   isNotebookRunning: boolean;
   forceRefresh: () => void;
 };

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -422,7 +422,7 @@ const SpawnerPage: React.FC = () => {
             spawnInProgress={startShown}
             onClose={() => {
               if (currentUserNotebook) {
-                const notebookName = currentUserNotebook.metadata.name ?? '';
+                const notebookName = currentUserNotebook.metadata.name;
                 stopNotebook(impersonatedUsername || undefined)
                   .then(() => requestNotebookRefresh())
                   .catch((e) =>

--- a/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
@@ -115,6 +115,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ spawnInProgress, on
       isStopping={false}
       notebookStatus={notebookStatus}
       events={events}
+      kueueStatus={null}
       buttons={renderButtons()}
     />
   );

--- a/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StartServerModal.tsx
@@ -113,6 +113,7 @@ const StartServerModal: React.FC<StartServerModalProps> = ({ spawnInProgress, on
       isStarting={spawnInProgress}
       isRunning={isNotebookRunning}
       isStopping={false}
+      notebook={currentUserNotebook ?? undefined}
       notebookStatus={notebookStatus}
       events={events}
       kueueStatus={null}

--- a/frontend/src/pages/notebookController/screens/server/StopServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StopServerModal.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
-import { Notebook } from '#~/types';
+import { NotebookKind } from '#~/k8sTypes';
 import useStopNotebookModalAvailability from '#~/pages/projects/notebook/useStopNotebookModalAvailability';
 import ConfirmStopModal from '#~/pages/projects/components/ConfirmStopModal.tsx';
 
 type StopServerModalProps = {
-  notebooksToStop: Notebook[];
+  notebooksToStop: NotebookKind[];
   link?: string;
   isDeleting: boolean;
   onNotebooksStop: (didStop: boolean) => void;

--- a/frontend/src/pages/notebookController/useImpersonationForContext.ts
+++ b/frontend/src/pages/notebookController/useImpersonationForContext.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { Notebook } from '#~/types';
+import { NotebookKind } from '#~/k8sTypes';
 import { useUser } from '#~/redux/selectors';
 import { NotebookContextStorage, SetNotebookState } from './notebookControllerContextTypes';
 
 export type SetImpersonating = (
-  impersonateNotebookState?: { notebook: Notebook | null; isRunning: boolean },
+  impersonateNotebookState?: { notebook: NotebookKind | null; isRunning: boolean },
   impersonateUsername?: string,
 ) => void;
 

--- a/frontend/src/pages/notebookController/utils.ts
+++ b/frontend/src/pages/notebookController/utils.ts
@@ -1,18 +1,19 @@
 import { stopNotebook } from '#~/services/notebookService';
-import { Notebook, TypedPromiseRejectedResult } from '#~/types';
+import { TypedPromiseRejectedResult } from '#~/types';
+import { NotebookKind } from '#~/k8sTypes';
 import { allSettledPromises } from '#~/utilities/allSettledPromises';
 
 export const stopWorkbenches = (
-  notebooksToStop: Notebook[],
+  notebooksToStop: NotebookKind[],
   isAdmin: boolean,
 ): Promise<
   [
-    PromiseFulfilledResult<Notebook | void>[],
+    PromiseFulfilledResult<NotebookKind | void>[],
     TypedPromiseRejectedResult<undefined>[],
-    PromiseSettledResult<Notebook | void>[],
+    PromiseSettledResult<NotebookKind | void>[],
   ]
 > =>
-  allSettledPromises<Notebook | void>(
+  allSettledPromises<NotebookKind | void>(
     notebooksToStop.map((notebook) => {
       const notebookName = notebook.metadata.name || '';
       if (!notebookName) {

--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -94,7 +94,8 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
   isVertical = true,
 }) => {
   const { kueueStatusByNotebookName } = React.useContext(ProjectDetailsContext);
-  const { notebook, isStarting, isRunning, isStopping, runningPodUid } = notebookState;
+  const { notebook, isStarting, isRunning, isStopping, runningPodUid, containerStatuses } =
+    notebookState;
   const kueueStatus = kueueStatusByNotebookName[notebook.metadata.name] ?? null;
   const editWorkbenchHref =
     notebook.metadata.namespace && notebook.metadata.name
@@ -153,6 +154,7 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
           notebookStatus={notebookStatus}
           events={events}
           kueueStatus={kueueStatus}
+          containerStatuses={containerStatuses}
           onClose={() => {
             setStartModalOpen(false);
           }}

--- a/frontend/src/pages/projects/notebook/__tests__/useKueueNotebookAlerts.spec.ts
+++ b/frontend/src/pages/projects/notebook/__tests__/useKueueNotebookAlerts.spec.ts
@@ -37,6 +37,7 @@ function notebookState(name: string, namespace = 'test-project'): NotebookState 
     isStopping: false,
     isStopped: true,
     runningPodUid: '',
+    containerStatuses: [],
     refresh: jest.fn(),
   };
 }

--- a/frontend/src/pages/projects/notebook/__tests__/useKueueStatusForNotebooks.spec.ts
+++ b/frontend/src/pages/projects/notebook/__tests__/useKueueStatusForNotebooks.spec.ts
@@ -37,6 +37,7 @@ function notebookState(name: string): NotebookState {
     isStopping: false,
     isStopped: true,
     runningPodUid: '',
+    containerStatuses: [],
     refresh: jest.fn(),
   };
 }

--- a/frontend/src/pages/projects/notebook/service.ts
+++ b/frontend/src/pages/projects/notebook/service.ts
@@ -28,7 +28,8 @@ export const getNotebooksStatus = async (
   ).then((podsPerNotebook) =>
     podsPerNotebook.reduce<NotebookDataState[]>((acc, pods, i) => {
       const isStopped = hasStopAnnotation(notebooks[i]);
-      const podsReady = pods.some((pod) => checkPodContainersReady(pod));
+      const runningPod = pods.find((pod) => checkPodContainersReady(pod));
+      const podsReady = runningPod != null;
       return [
         ...acc,
         {
@@ -37,7 +38,8 @@ export const getNotebooksStatus = async (
           isRunning: !isStopped && podsReady,
           isStopping: isStopped && podsReady,
           isStopped: isStopped && !podsReady,
-          runningPodUid: pods[0]?.metadata?.uid || '',
+          runningPodUid: runningPod?.metadata.uid ?? pods[0]?.metadata?.uid ?? '',
+          containerStatuses: runningPod?.status?.containerStatuses ?? [],
         },
       ];
     }, []),

--- a/frontend/src/pages/projects/notebook/types.ts
+++ b/frontend/src/pages/projects/notebook/types.ts
@@ -1,3 +1,4 @@
+import type { PodContainerStatus } from '@odh-dashboard/k8s-core';
 import { NotebookKind } from '#~/k8sTypes';
 
 /** The state behind the notebook status */
@@ -8,6 +9,8 @@ export type NotebookDataState = {
   isStopping: boolean;
   isStopped: boolean;
   runningPodUid: string;
+  /** Container statuses from the running pod, used for the EC3 secondary WORKBENCH_STARTED gate. */
+  containerStatuses: PodContainerStatus[];
 };
 
 /** A refresh function that can be waited on to complete the refresh and then acted on */

--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -1,8 +1,9 @@
 import type { RecursivePartial } from '@odh-dashboard/foundation';
 import axios from '#~/utilities/axios';
-import { Notebook, NotebookState, NotebookData, NotebookRunningState } from '#~/types';
+import { NotebookState, NotebookData, NotebookRunningState } from '#~/types';
+import { NotebookKind } from '#~/k8sTypes';
 
-export const getNotebook = (namespace: string, name: string): Promise<Notebook> => {
+export const getNotebook = (namespace: string, name: string): Promise<NotebookKind> => {
   const url = `/api/notebooks/${namespace}/${name}`;
   return axios
     .get(url)
@@ -15,7 +16,7 @@ export const getNotebook = (namespace: string, name: string): Promise<Notebook> 
 export const getNotebookAndStatus = (
   namespace: string,
   name: string,
-  notebook: Notebook | null,
+  notebook: NotebookKind | null,
 ): Promise<NotebookRunningState> => {
   const url = `/api/notebooks/${namespace}/${name}/status`;
 
@@ -41,7 +42,7 @@ export const getNotebookAndStatus = (
     });
 };
 
-export const enableNotebook = async (notebookData: NotebookData): Promise<Notebook> => {
+export const enableNotebook = async (notebookData: NotebookData): Promise<NotebookKind> => {
   const url = `/api/notebooks`;
 
   return axios
@@ -52,7 +53,7 @@ export const enableNotebook = async (notebookData: NotebookData): Promise<Notebo
     });
 };
 
-export const stopNotebook = (username?: string): Promise<Notebook> => {
+export const stopNotebook = (username?: string): Promise<NotebookKind> => {
   const url = `/api/notebooks`;
 
   const patch: RecursivePartial<NotebookData> = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -16,7 +16,7 @@ import { FeatureFlag } from '@odh-dashboard/plugin-core/areas';
 import { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import type { EitherNotBoth } from '@odh-dashboard/foundation';
 import { HardwarePodSpecOptions } from '#~/concepts/hardwareProfiles/types';
-import { ImageStreamKind, ImageStreamSpecTagType } from './k8sTypes';
+import { ImageStreamKind, ImageStreamSpecTagType, NotebookKind } from './k8sTypes';
 
 export type FeatureFlagProps = {
   devFeatureFlags: Record<FeatureFlag | string, boolean | undefined> | null;
@@ -306,7 +306,7 @@ export type Notebook = K8sResourceCommon & {
 };
 
 export type NotebookRunningState = {
-  notebook: Notebook | null;
+  notebook: NotebookKind | null;
   isRunning: boolean;
   podUID: string;
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -552,73 +552,35 @@ export enum NotebookState {
   Stopped = 'stopped',
 }
 
-export enum ProgressionStep {
-  WORKBENCH_REQUESTED = 'WORKBENCH_REQUESTED',
-  POD_PROBLEM = 'POD_PROBLEM',
-  POD_CREATED = 'POD_CREATED',
-  POD_ASSIGNED = 'POD_ASSIGNED',
-  PVC_ATTACHED = 'PVC_ATTACHED',
-  INTERFACE_ADDED = 'INTERFACE_ADDED',
-  PULLING_NOTEBOOK_IMAGE = 'PULLING_NOTEBOOK_IMAGE',
-  NOTEBOOK_IMAGE_PULLED = 'NOTEBOOK_IMAGE_PULLED',
-  NOTEBOOK_CONTAINER_CREATED = 'NOTEBOOK_CONTAINER_CREATED',
-  NOTEBOOK_CONTAINER_PROBLEM = 'NOTEBOOK_CONTAINER_PROBLEM',
-  NOTEBOOK_CONTAINER_STARTED = 'NOTEBOOK_CONTAINER_STARTED',
-  PULLING_AUTH_PROXY = 'PULLING_AUTH_PROXY',
-  AUTH_PROXY_PULLED = 'AUTH_PROXY_PULLED',
-  AUTH_PROXY_CONTAINER_CREATED = 'AUTH_PROXY_CONTAINER_CREATED',
-  AUTH_PROXY_CONTAINER_PROBLEM = 'AUTH_PROXY_CONTAINER_PROBLEM',
-  AUTH_PROXY_CONTAINER_STARTED = 'AUTH_PROXY_CONTAINER_STARTED',
-  WORKBENCH_STARTED = 'WORKBENCH_STARTED',
-}
+/** Step kinds for per-container progress steps. */
+export type ContainerStepKind = 'pulling' | 'pulled' | 'created' | 'started';
 
-export const ProgressionStepTitles: Record<ProgressionStep, string> = {
-  [ProgressionStep.WORKBENCH_REQUESTED]: 'Workbench requested',
-  [ProgressionStep.POD_PROBLEM]: 'There was a problem with the pod',
-  [ProgressionStep.POD_CREATED]: 'Pod created',
-  [ProgressionStep.POD_ASSIGNED]: 'Pod assigned',
-  [ProgressionStep.PVC_ATTACHED]: 'PVC attached',
-  [ProgressionStep.INTERFACE_ADDED]: 'Interface added',
-  [ProgressionStep.PULLING_NOTEBOOK_IMAGE]: 'Pulling workbench image',
-  [ProgressionStep.NOTEBOOK_IMAGE_PULLED]: 'Workbench image pulled',
-  [ProgressionStep.NOTEBOOK_CONTAINER_CREATED]: 'Workbench container created',
-  [ProgressionStep.NOTEBOOK_CONTAINER_PROBLEM]: 'There was a problem with the workbench',
-  [ProgressionStep.NOTEBOOK_CONTAINER_STARTED]: 'Workbench container started',
-  [ProgressionStep.PULLING_AUTH_PROXY]: 'Pulling auth proxy',
-  [ProgressionStep.AUTH_PROXY_PULLED]: 'Auth proxy pulled',
-  [ProgressionStep.AUTH_PROXY_CONTAINER_CREATED]: 'Auth proxy container created',
-  [ProgressionStep.AUTH_PROXY_CONTAINER_PROBLEM]: 'There was a problem with auth proxy',
-  [ProgressionStep.AUTH_PROXY_CONTAINER_STARTED]: 'Auth proxy container started',
-  [ProgressionStep.WORKBENCH_STARTED]: 'Workbench started',
-};
+/** All possible step kinds in the dynamic progress model. */
+export type NotebookProgressStepKind =
+  | ContainerStepKind
+  | 'kueue'
+  | 'pod_created'
+  | 'pod_assigned'
+  | 'pvc_attached'
+  | 'interface_added'
+  | 'pod_problem'
+  | 'container_problem'
+  | 'workbench_requested'
+  | 'workbench_started';
 
-export const AssociatedSteps: { [key in ProgressionStep]?: ProgressionStep[] } = {
-  [ProgressionStep.NOTEBOOK_CONTAINER_STARTED]: [
-    ProgressionStep.INTERFACE_ADDED,
-    ProgressionStep.PULLING_NOTEBOOK_IMAGE,
-    ProgressionStep.NOTEBOOK_IMAGE_PULLED,
-  ],
-  [ProgressionStep.AUTH_PROXY_CONTAINER_STARTED]: [
-    ProgressionStep.PULLING_AUTH_PROXY,
-    ProgressionStep.AUTH_PROXY_PULLED,
-    ProgressionStep.AUTH_PROXY_CONTAINER_CREATED,
-  ],
-  [ProgressionStep.POD_ASSIGNED]: [ProgressionStep.POD_CREATED],
-  [ProgressionStep.WORKBENCH_STARTED]: Object.values(ProgressionStep),
-};
-
-export const OptionalSteps: ProgressionStep[] = [
-  ProgressionStep.POD_PROBLEM,
-  ProgressionStep.NOTEBOOK_CONTAINER_PROBLEM,
-  ProgressionStep.AUTH_PROXY_CONTAINER_PROBLEM,
-  ProgressionStep.PVC_ATTACHED,
-];
-
+/** A single step in the notebook startup progress tree. Steps are derived from pod spec containers; Kueue and auth proxy steps only appear when active. */
 export type NotebookProgressStep = {
-  step: ProgressionStep;
+  stepKind: NotebookProgressStepKind;
+  /** Set for per-container steps (pulling / pulled / created / started / container_problem). */
+  containerName?: string;
+  label: string;
   description?: string;
   status: EventStatus;
   timestamp: number;
+  /** Child steps rendered inside this step when it acts as a collapsible parent. */
+  subSteps?: NotebookProgressStep[];
+  /** Whether the sub-steps tree is currently expanded. Managed by the modal. */
+  isExpanded?: boolean;
 };
 
 export type NotebookData = {

--- a/frontend/src/utilities/__tests__/notebookControllerUtils.spec.tsx
+++ b/frontend/src/utilities/__tests__/notebookControllerUtils.spec.tsx
@@ -504,14 +504,31 @@ describe('getNotebookEventStatus', () => {
     expect(result?.containerName).toBe('my-workbench');
   });
 
-  it('matches container by name in Started message', () => {
-    const result = getNotebookEventStatus(
-      makeEvent('Started', 'Started container kube-rbac-proxy'),
-      containerNames,
-    );
-    expect(result?.stepKind).toBe('started');
-    expect(result?.containerName).toBe('kube-rbac-proxy');
-  });
+  it.each([
+    {
+      reason: 'Started',
+      message: 'Started container kube-rbac-proxy',
+      containerName: 'kube-rbac-proxy',
+      status: EventStatus.SUCCESS,
+      labelWord: 'started',
+    },
+    {
+      reason: 'Killing',
+      message: 'Stopping container my-workbench',
+      containerName: 'my-workbench',
+      status: EventStatus.WARNING,
+      labelWord: 'stopped',
+    },
+  ])(
+    '$reason — returns started stepKind, $status, label contains "$labelWord"',
+    ({ reason, message, containerName, status, labelWord }) => {
+      const result = getNotebookEventStatus(makeEvent(reason, message), containerNames);
+      expect(result?.stepKind).toBe('started');
+      expect(result?.containerName).toBe(containerName);
+      expect(result?.status).toBe(status);
+      expect(result?.label).toContain(labelWord);
+    },
+  );
 
   it('matches auth proxy container by name in Pulling image URL (EC1)', () => {
     const result = getNotebookEventStatus(

--- a/frontend/src/utilities/__tests__/notebookControllerUtils.spec.tsx
+++ b/frontend/src/utilities/__tests__/notebookControllerUtils.spec.tsx
@@ -4,7 +4,7 @@ import type { PodContainerStatus } from '@odh-dashboard/k8s-core';
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import { NotebookControllerContext } from '#~/pages/notebookController/NotebookControllerContext';
 import { NotebookControllerContextProps } from '#~/pages/notebookController/notebookControllerContextTypes';
-import { EventStatus, Notebook } from '#~/types';
+import { EventStatus } from '#~/types';
 import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
 import { EventKind, NotebookKind } from '#~/k8sTypes';
 import {
@@ -200,7 +200,7 @@ describe('useNotebookRedirectLink', () => {
         <NotebookControllerContext.Provider
           value={
             {
-              currentUserNotebook: mockNotebookK8sResource({}) as Notebook,
+              currentUserNotebook: mockNotebookK8sResource({}),
               currentUserNotebookLink: 'test-link',
             } as NotebookControllerContextProps
           }
@@ -246,14 +246,14 @@ describe('getNotebookControllerUserState', () => {
   });
 
   it('should resolve user from opendatahub.io/username annotation', () => {
-    const notebook = mockNotebookK8sResource({ user: 'test-user' }) as Notebook;
+    const notebook = mockNotebookK8sResource({ user: 'test-user' });
     const result = getNotebookControllerUserState(notebook, 'test-user');
     expect(result).not.toBeNull();
     expect(result?.user).toBe('test-user');
   });
 
   it('should fall back to opendatahub.io/user annotation when username annotation is missing', () => {
-    const notebook = mockNotebookK8sResource({ user: 'test-user' }) as Notebook;
+    const notebook = mockNotebookK8sResource({ user: 'test-user' });
     delete (notebook.metadata.annotations as Record<string, string>)['opendatahub.io/username'];
     // Set the translated username as it would appear in a real cluster
     (notebook.metadata.annotations as Record<string, string>)['opendatahub.io/user'] =
@@ -264,7 +264,7 @@ describe('getNotebookControllerUserState', () => {
   });
 
   it('should fall back to opendatahub.io/user label for older workbenches', () => {
-    const notebook = mockNotebookK8sResource({ user: 'test-user' }) as Notebook;
+    const notebook = mockNotebookK8sResource({ user: 'test-user' });
     // Remove both user annotations to simulate an older workbench with only the label
     delete (notebook.metadata.annotations as Record<string, string>)['opendatahub.io/username'];
     delete (notebook.metadata.annotations as Record<string, string>)['opendatahub.io/user'];
@@ -279,7 +279,7 @@ describe('getNotebookControllerUserState', () => {
   });
 
   it('should handle workbenches with no annotations at all (label-only fallback)', () => {
-    const notebook = mockNotebookK8sResource({ user: 'test-user' }) as Notebook;
+    const notebook = mockNotebookK8sResource({ user: 'test-user' });
     notebook.metadata.annotations = undefined;
     notebook.metadata.labels = {
       ...notebook.metadata.labels,
@@ -291,7 +291,7 @@ describe('getNotebookControllerUserState', () => {
   });
 
   it('should return null when user cannot be resolved from any source', () => {
-    const notebook = mockNotebookK8sResource({ user: 'test-user' }) as Notebook;
+    const notebook = mockNotebookK8sResource({ user: 'test-user' });
     notebook.metadata.annotations = {};
     notebook.metadata.labels = {};
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
@@ -303,7 +303,7 @@ describe('getNotebookControllerUserState', () => {
   it('should handle long OIDC usernames (>63 chars) in annotation', () => {
     const longUsername =
       'https://keycloak-keycloak.apps.rosa.1234567890.c8l6.p3.openshiftapps.com/realms/master#someuser';
-    const notebook = mockNotebookK8sResource({ user: longUsername }) as Notebook;
+    const notebook = mockNotebookK8sResource({ user: longUsername });
     const result = getNotebookControllerUserState(notebook, longUsername);
     expect(result).not.toBeNull();
     expect(result?.user).toBe(longUsername);
@@ -462,7 +462,7 @@ describe('buildInitialProgressSteps', () => {
 });
 
 describe('getNotebookEventStatus', () => {
-  const containerNames = ['kube-rbac-proxy', 'my-workbench']; // descending length order
+  const containerNames = ['kube-rbac-proxy', 'my-workbench'];
 
   it('returns pod_created for SuccessfulCreate', () => {
     const result = getNotebookEventStatus(
@@ -523,12 +523,27 @@ describe('getNotebookEventStatus', () => {
   });
 
   it('EC1: prefers longest matching container name to avoid substring collision', () => {
-    const names = ['my-workbench-extra', 'my-workbench']; // already in descending-length order
+    const names = ['my-workbench', 'my-workbench-extra'];
     const result = getNotebookEventStatus(
       makeEvent('Created', 'Created container my-workbench-extra'),
       names,
     );
     expect(result?.containerName).toBe('my-workbench-extra');
+  });
+
+  it('EC1b: primary container is first non-auth container in pod-spec order, not the longest name', () => {
+    const names = ['wb', 'metrics-sidecar'];
+    const backoff = getNotebookEventStatus(
+      makeEvent('BackOff', 'Back-off pulling image "quay.io/example/wb:latest"', 'Warning'),
+      names,
+    );
+    expect(backoff?.containerName).toBe('wb');
+
+    const warning = getNotebookEventStatus(
+      makeEvent('FailedMount', 'Unable to mount volumes', 'Warning'),
+      names,
+    );
+    expect(warning?.containerName).toBe('wb');
   });
 
   it('EC2: returns null when no container matches (unrecognised container event)', () => {

--- a/frontend/src/utilities/__tests__/notebookControllerUtils.spec.tsx
+++ b/frontend/src/utilities/__tests__/notebookControllerUtils.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { renderHook } from '@odh-dashboard/jest-config/hooks';
+import type { PodContainerStatus } from '@odh-dashboard/k8s-core';
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import { NotebookControllerContext } from '#~/pages/notebookController/NotebookControllerContext';
 import { NotebookControllerContextProps } from '#~/pages/notebookController/notebookControllerContextTypes';
@@ -671,6 +672,30 @@ describe('useNotebookProgress', () => {
     );
     const allSubSuccess = wbStarted?.subSteps?.every((s) => s.status === EventStatus.SUCCESS);
     expect(allSubSuccess).toBe(true);
+  });
+
+  it('marks workbench_started SUCCESS when containerStatuses matched by name', () => {
+    const nb = makeNotebook(['my-wb']);
+    const containerStatuses: PodContainerStatus[] = [
+      { name: 'my-wb', ready: true, state: { running: true } },
+    ];
+    const { result } = renderHook(() =>
+      useNotebookProgress(nb, true, false, false, [], null, containerStatuses),
+    );
+    const workbenchStarted = result.current.find((s) => s.stepKind === 'workbench_started');
+    expect(workbenchStarted?.status).toBe(EventStatus.SUCCESS);
+  });
+
+  it('EC3c: does NOT mark workbench_started SUCCESS when containerStatus name does not match any spec container', () => {
+    const nb = makeNotebook(['my-wb']);
+    const containerStatuses: PodContainerStatus[] = [
+      { name: 'wrong-container', ready: true, state: { running: true } },
+    ];
+    const { result } = renderHook(() =>
+      useNotebookProgress(nb, true, false, false, [], null, containerStatuses),
+    );
+    const workbenchStarted = result.current.find((s) => s.stepKind === 'workbench_started');
+    expect(workbenchStarted?.status).toBe(EventStatus.PENDING);
   });
 
   it('EC8: empty containers list — workbench_started immediately SUCCESS when isRunning', () => {

--- a/frontend/src/utilities/__tests__/notebookControllerUtils.spec.tsx
+++ b/frontend/src/utilities/__tests__/notebookControllerUtils.spec.tsx
@@ -368,7 +368,8 @@ describe('buildInitialProgressSteps', () => {
   it('does NOT include kueue step when kueueStatus is null', () => {
     const nb = makeNotebook(['my-wb']);
     const steps = buildInitialProgressSteps(nb, false, false, null);
-    expect(steps.find((s) => s.stepKind === 'kueue')).toBeUndefined();
+    const allSteps = steps.flatMap((s) => [s, ...(s.subSteps ?? [])]);
+    expect(allSteps.find((s) => s.stepKind === 'kueue')).toBeUndefined();
   });
 
   it('includes kueue sub-step with IN_PROGRESS status when Queued', () => {

--- a/frontend/src/utilities/__tests__/notebookControllerUtils.spec.tsx
+++ b/frontend/src/utilities/__tests__/notebookControllerUtils.spec.tsx
@@ -3,12 +3,63 @@ import { renderHook } from '@odh-dashboard/jest-config/hooks';
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import { NotebookControllerContext } from '#~/pages/notebookController/NotebookControllerContext';
 import { NotebookControllerContextProps } from '#~/pages/notebookController/notebookControllerContextTypes';
-import { Notebook } from '#~/types';
+import { EventStatus, Notebook } from '#~/types';
+import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
+import { EventKind, NotebookKind } from '#~/k8sTypes';
 import {
+  buildInitialProgressSteps,
   getNotebookControllerUserState,
+  getNotebookEventStatus,
   useNotebookRedirectLink,
+  useNotebookProgress,
   usernameTranslate,
 } from '#~/utilities/notebookControllerUtils';
+
+const makeContainer = (name: string) => ({
+  name,
+  image: `quay.io/example/${name}:latest`,
+  env: [],
+  envFrom: [],
+  resources: { limits: {}, requests: {} },
+  volumeMounts: [],
+});
+
+const makeNotebook = (containerNames: string[]): NotebookKind =>
+  ({
+    apiVersion: 'kubeflow.org/v1',
+    kind: 'Notebook',
+    metadata: {
+      name: containerNames[0] ?? 'test-wb',
+      namespace: 'test-ns',
+      creationTimestamp: '2025-01-13T14:19:10Z',
+      annotations: {},
+      labels: {},
+    },
+    spec: {
+      template: {
+        spec: {
+          containers: containerNames.map(makeContainer),
+          volumes: [],
+        },
+      },
+    },
+    status: {},
+  } as unknown as NotebookKind);
+
+const makeEvent = (
+  reason: string,
+  message: string,
+  type: 'Normal' | 'Warning' = 'Normal',
+): EventKind => ({
+  apiVersion: 'v1',
+  kind: 'Event',
+  metadata: { name: `evt-${reason}`, namespace: 'test-ns' },
+  involvedObject: { name: 'pod-0' },
+  reason,
+  message,
+  type,
+  eventTime: '2025-01-22T10:00:00Z',
+});
 
 const validUnameRegex = new RegExp('^[a-z]{1}[a-z0-9-]{1,62}$');
 
@@ -256,5 +307,439 @@ describe('getNotebookControllerUserState', () => {
     expect(result).not.toBeNull();
     expect(result?.user).toBe(longUsername);
     expect(longUsername.length).toBeGreaterThan(63);
+  });
+});
+
+describe('buildInitialProgressSteps', () => {
+  it('produces minimal steps when notebook is null (no containers)', () => {
+    const steps = buildInitialProgressSteps(null, false, false, null);
+    const kinds = steps.map((s) => s.stepKind);
+    expect(kinds).toContain('workbench_requested');
+    expect(kinds).toContain('pod_created');
+    expect(kinds).toContain('pod_assigned');
+    expect(kinds).toContain('interface_added');
+    expect(kinds).toContain('workbench_started');
+    expect(steps.filter((s) => s.containerName)).toHaveLength(0);
+  });
+
+  it('sets workbench_requested to PENDING when stopping or stopped', () => {
+    const stopping = buildInitialProgressSteps(null, false, true, null);
+    expect(stopping.find((s) => s.stepKind === 'workbench_requested')?.status).toBe(
+      EventStatus.PENDING,
+    );
+    const stopped = buildInitialProgressSteps(null, true, false, null);
+    expect(stopped.find((s) => s.stepKind === 'workbench_requested')?.status).toBe(
+      EventStatus.PENDING,
+    );
+  });
+
+  it('sets workbench_requested to SUCCESS when running (not stopping/stopped)', () => {
+    const steps = buildInitialProgressSteps(null, false, false, null);
+    const requested = steps.find((s) => s.stepKind === 'workbench_requested');
+    expect(requested?.status).toBe(EventStatus.SUCCESS);
+  });
+
+  it('generates top-level started step (+ optional container_problem) per container, with pulling/pulled/created as sub-steps', () => {
+    const nb = makeNotebook(['my-wb', 'oauth-proxy']);
+    const steps = buildInitialProgressSteps(nb, false, false, null);
+    const wbSteps = steps.filter((s) => s.containerName === 'my-wb');
+    const proxySteps = steps.filter((s) => s.containerName === 'oauth-proxy');
+    expect(wbSteps).toHaveLength(2); // container_problem + started
+    expect(proxySteps).toHaveLength(2);
+    const wbStarted = wbSteps.find((s) => s.stepKind === 'started');
+    expect(wbStarted?.subSteps?.map((s) => s.stepKind)).toEqual(['pulling', 'pulled', 'created']);
+  });
+
+  it('labels primary container as Workbench and auth proxy container as Auth proxy', () => {
+    const nb = makeNotebook(['my-wb', 'kube-rbac-proxy']);
+    const steps = buildInitialProgressSteps(nb, false, false, null);
+    const wbStarted = steps.find((s) => s.stepKind === 'started' && s.containerName === 'my-wb');
+    expect(wbStarted?.subSteps?.find((s) => s.stepKind === 'pulling')?.label).toBe(
+      'Pulling Workbench image',
+    );
+    const proxyStarted = steps.find(
+      (s) => s.stepKind === 'started' && s.containerName === 'kube-rbac-proxy',
+    );
+    expect(proxyStarted?.subSteps?.find((s) => s.stepKind === 'pulling')?.label).toBe(
+      'Pulling Auth proxy image',
+    );
+  });
+
+  it('does NOT include kueue step when kueueStatus is null', () => {
+    const nb = makeNotebook(['my-wb']);
+    const steps = buildInitialProgressSteps(nb, false, false, null);
+    expect(steps.find((s) => s.stepKind === 'kueue')).toBeUndefined();
+  });
+
+  it('includes kueue sub-step with IN_PROGRESS status when Queued', () => {
+    const nb = makeNotebook(['my-wb']);
+    const steps = buildInitialProgressSteps(nb, false, false, {
+      status: KueueWorkloadStatus.Queued,
+      message: undefined,
+      queueName: 'default',
+    });
+    const podAssigned = steps.find((s) => s.stepKind === 'pod_assigned');
+    const kueue = podAssigned?.subSteps?.find((s) => s.stepKind === 'kueue');
+    expect(kueue).toBeDefined();
+    expect(kueue?.status).toBe(EventStatus.IN_PROGRESS);
+  });
+
+  it('includes kueue sub-step with SUCCESS status when Admitted', () => {
+    const nb = makeNotebook(['my-wb']);
+    const steps = buildInitialProgressSteps(nb, false, false, {
+      status: KueueWorkloadStatus.Admitted,
+    });
+    const podAssigned = steps.find((s) => s.stepKind === 'pod_assigned');
+    const kueue = podAssigned?.subSteps?.find((s) => s.stepKind === 'kueue');
+    expect(kueue?.status).toBe(EventStatus.SUCCESS);
+  });
+
+  it('includes kueue sub-step with WARNING status when Inadmissible', () => {
+    const nb = makeNotebook(['my-wb']);
+    const steps = buildInitialProgressSteps(nb, false, false, {
+      status: KueueWorkloadStatus.Inadmissible,
+      message: 'queue does not exist',
+      queueName: 'my-queue',
+    });
+    const podAssigned = steps.find((s) => s.stepKind === 'pod_assigned');
+    const kueue = podAssigned?.subSteps?.find((s) => s.stepKind === 'kueue');
+    expect(kueue?.status).toBe(EventStatus.WARNING);
+    expect(kueue?.label).toBe('Queue my-queue does not exist');
+  });
+
+  it('produces correct total count for no-containers case (EC8)', () => {
+    const steps = buildInitialProgressSteps(null, false, false, null);
+    expect(steps.map((s) => s.stepKind)).toEqual([
+      'workbench_requested',
+      'pod_problem',
+      'pod_created',
+      'pod_assigned',
+      'pvc_attached',
+      'interface_added',
+      'workbench_started',
+    ]);
+  });
+
+  it('uses restart labels for started/pulling and keeps other sub-step labels unchanged when isRecovery is true', () => {
+    const nb = makeNotebook(['my-wb']);
+    const steps = buildInitialProgressSteps(nb, false, false, null, true);
+    const wbStarted = steps.find((s) => s.stepKind === 'started' && s.containerName === 'my-wb');
+    expect(wbStarted?.label).toBe('Restarting Workbench container');
+    const subs = wbStarted?.subSteps;
+    expect(subs?.find((s) => s.stepKind === 'pulling')?.label).toBe(
+      'Pulling Workbench image (restart)',
+    );
+    expect(subs?.find((s) => s.stepKind === 'pulled')?.label).toBe('Workbench image pulled');
+    expect(subs?.find((s) => s.stepKind === 'created')?.label).toBe('Workbench container created');
+  });
+
+  it('includes kueue sub-step with IN_PROGRESS status and Running admission check label when AdmissionCheck', () => {
+    const nb = makeNotebook(['my-wb']);
+    const steps = buildInitialProgressSteps(nb, false, false, {
+      status: KueueWorkloadStatus.AdmissionCheck,
+      message: 'gpu-provisioner',
+    });
+    const podAssigned = steps.find((s) => s.stepKind === 'pod_assigned');
+    const kueue = podAssigned?.subSteps?.find((s) => s.stepKind === 'kueue');
+    expect(kueue).toBeDefined();
+    expect(kueue?.label).toBe('Waiting for admission check: gpu-provisioner');
+    expect(kueue?.status).toBe(EventStatus.IN_PROGRESS);
+  });
+
+  it('includes kueue sub-step with IN_PROGRESS status and preemption gates label when BlockedOnPreemptionGates', () => {
+    const nb = makeNotebook(['my-wb']);
+    const steps = buildInitialProgressSteps(nb, false, false, {
+      status: KueueWorkloadStatus.BlockedOnPreemptionGates,
+    });
+    const podAssigned = steps.find((s) => s.stepKind === 'pod_assigned');
+    const kueue = podAssigned?.subSteps?.find((s) => s.stepKind === 'kueue');
+    expect(kueue).toBeDefined();
+    expect(kueue?.label).toBe('Admitted but waiting for preemption gates to clear');
+    expect(kueue?.status).toBe(EventStatus.IN_PROGRESS);
+  });
+});
+
+describe('getNotebookEventStatus', () => {
+  const containerNames = ['kube-rbac-proxy', 'my-workbench']; // descending length order
+
+  it('returns pod_created for SuccessfulCreate', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('SuccessfulCreate', 'Created pod'),
+      containerNames,
+    );
+    expect(result?.stepKind).toBe('pod_created');
+    expect(result?.status).toBe(EventStatus.SUCCESS);
+  });
+
+  it('returns pod_assigned for Scheduled', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('Scheduled', 'Successfully assigned pod'),
+      containerNames,
+    );
+    expect(result?.stepKind).toBe('pod_assigned');
+    expect(result?.status).toBe(EventStatus.SUCCESS);
+  });
+
+  it('returns pvc_attached for SuccessfulAttachVolume', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('SuccessfulAttachVolume', 'Volume attached'),
+      containerNames,
+    );
+    expect(result?.stepKind).toBe('pvc_attached');
+  });
+
+  it('returns interface_added for AddedInterface', () => {
+    const result = getNotebookEventStatus(makeEvent('AddedInterface', 'Add eth0'), containerNames);
+    expect(result?.stepKind).toBe('interface_added');
+  });
+
+  it('matches container by name in Created message', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('Created', 'Created container my-workbench'),
+      containerNames,
+    );
+    expect(result?.stepKind).toBe('created');
+    expect(result?.containerName).toBe('my-workbench');
+  });
+
+  it('matches container by name in Started message', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('Started', 'Started container kube-rbac-proxy'),
+      containerNames,
+    );
+    expect(result?.stepKind).toBe('started');
+    expect(result?.containerName).toBe('kube-rbac-proxy');
+  });
+
+  it('matches auth proxy container by name in Pulling image URL (EC1)', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('Pulling', 'Pulling image "quay.io/openshift/kube-rbac-proxy:latest"'),
+      containerNames,
+    );
+    expect(result?.stepKind).toBe('pulling');
+    expect(result?.containerName).toBe('kube-rbac-proxy');
+  });
+
+  it('EC1: prefers longest matching container name to avoid substring collision', () => {
+    const names = ['my-workbench-extra', 'my-workbench']; // already in descending-length order
+    const result = getNotebookEventStatus(
+      makeEvent('Created', 'Created container my-workbench-extra'),
+      names,
+    );
+    expect(result?.containerName).toBe('my-workbench-extra');
+  });
+
+  it('EC2: returns null when no container matches (unrecognised container event)', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('Created', 'Created container unknown-sidecar'),
+      containerNames,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns pod_problem for NotTriggerScaleUp', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('NotTriggerScaleUp', 'pod did not trigger scale-up'),
+      containerNames,
+    );
+    expect(result?.stepKind).toBe('pod_problem');
+    expect(result?.status).toBe(EventStatus.ERROR);
+    expect(result?.description).toContain('Failed to scale-up');
+  });
+
+  it('returns pod_problem for FailedScheduling outside grace period', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('FailedScheduling', '0/10 nodes available', 'Warning'),
+      containerNames,
+      false,
+    );
+    expect(result?.stepKind).toBe('pod_problem');
+    expect(result?.status).toBe(EventStatus.ERROR);
+  });
+
+  it('returns a WARNING container_problem for FailedScheduling inside grace period', () => {
+    // filterEvents drops Warning events in practice; in isolation the function returns container_problem.
+    const result = getNotebookEventStatus(
+      makeEvent('FailedScheduling', '0/10 nodes available', 'Warning'),
+      containerNames,
+      true,
+    );
+    expect(result?.stepKind).toBe('container_problem');
+    expect(result?.containerName).toBe('my-workbench');
+    expect(result?.status).toBe(EventStatus.WARNING);
+  });
+
+  it('generic Warning event — returns container_problem attributed to primary container', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('FailedMount', 'Unable to attach or mount volumes', 'Warning'),
+      containerNames,
+    );
+    expect(result?.stepKind).toBe('container_problem');
+    expect(result?.containerName).toBe('my-workbench');
+    expect(result?.status).toBe(EventStatus.WARNING);
+    expect(result?.description).toBe('Issue creating workbench container');
+  });
+
+  it('returns null for unrecognised Normal events', () => {
+    const result = getNotebookEventStatus(
+      makeEvent('SomeRandomReason', 'something happened'),
+      containerNames,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('BackOff (image pull) — returns container_problem with ImagePullBackOff description', () => {
+    const result = getNotebookEventStatus(
+      makeEvent(
+        'BackOff',
+        'Back-off pulling image "quay.io/example/my-workbench:latest"',
+        'Warning',
+      ),
+      containerNames,
+    );
+    expect(result?.stepKind).toBe('container_problem');
+    expect(result?.containerName).toBe('my-workbench');
+    expect(result?.status).toBe(EventStatus.ERROR);
+    expect(result?.description).toBe('ImagePullBackOff');
+  });
+
+  it('BackOff (crash loop) — returns container_problem with CrashLoopBackOff description', () => {
+    const result = getNotebookEventStatus(
+      makeEvent(
+        'BackOff',
+        'Back-off restarting failed container my-workbench in pod test-notebook-0',
+        'Warning',
+      ),
+      containerNames,
+    );
+    expect(result?.stepKind).toBe('container_problem');
+    expect(result?.containerName).toBe('my-workbench');
+    expect(result?.status).toBe(EventStatus.ERROR);
+    expect(result?.description).toBe('CrashLoopBackOff');
+  });
+
+  it('BackOff — falls through to generic Warning handler inside grace period', () => {
+    // filterEvents drops Warning events before they reach this function in practice;
+    // in isolation with gracePeriod=true the ERROR branch is suppressed and it returns WARNING.
+    const result = getNotebookEventStatus(
+      makeEvent(
+        'BackOff',
+        'Back-off pulling image "quay.io/example/my-workbench:latest"',
+        'Warning',
+      ),
+      containerNames,
+      true, // gracePeriod
+    );
+    expect(result?.stepKind).toBe('container_problem');
+    expect(result?.containerName).toBe('my-workbench');
+    expect(result?.status).toBe(EventStatus.WARNING);
+  });
+});
+
+describe('useNotebookProgress', () => {
+  it('returns 5 steps with workbench_requested SUCCESS for no-notebook case', () => {
+    const { result } = renderHook(() => useNotebookProgress(null, false, false, false, [], null));
+    // 5 = workbench_requested + pod_created + pod_assigned + interface_added + workbench_started
+    expect(result.current).toHaveLength(5);
+    expect(result.current.find((s) => s.stepKind === 'workbench_requested')?.status).toBe(
+      EventStatus.SUCCESS,
+    );
+  });
+
+  it('returns 7 steps for a two-container notebook with no events', () => {
+    const nb = makeNotebook(['my-wb', 'kube-rbac-proxy']);
+    const { result } = renderHook(() => useNotebookProgress(nb, false, false, false, [], null));
+    // 7 = bookend + pod steps + started×2; optional problem/pvc steps filtered when PENDING
+    expect(result.current).toHaveLength(7);
+    const wbStarted = result.current.find(
+      (s) => s.stepKind === 'started' && s.containerName === 'my-wb',
+    );
+    expect(wbStarted?.subSteps).toHaveLength(3);
+  });
+
+  it('EC3: marks workbench_started SUCCESS and catches up all steps when all containers started and isRunning', () => {
+    const nb = makeNotebook(['my-wb']);
+    const events: EventKind[] = [makeEvent('Started', 'Started container my-wb')];
+    const { result } = renderHook(() => useNotebookProgress(nb, true, false, false, events, null));
+    const allSuccess = result.current.every((s) => s.status === EventStatus.SUCCESS);
+    expect(allSuccess).toBe(true);
+    const workbenchStarted = result.current.find((s) => s.stepKind === 'workbench_started');
+    expect(workbenchStarted?.status).toBe(EventStatus.SUCCESS);
+    const wbStarted = result.current.find(
+      (s) => s.stepKind === 'started' && s.containerName === 'my-wb',
+    );
+    const allSubSuccess = wbStarted?.subSteps?.every((s) => s.status === EventStatus.SUCCESS);
+    expect(allSubSuccess).toBe(true);
+  });
+
+  it('EC8: empty containers list — workbench_started immediately SUCCESS when isRunning', () => {
+    const nb = makeNotebook([]);
+    const { result } = renderHook(() => useNotebookProgress(nb, true, false, false, [], null));
+    const workbenchStarted = result.current.find((s) => s.stepKind === 'workbench_started');
+    expect(workbenchStarted?.status).toBe(EventStatus.SUCCESS);
+  });
+
+  it('no-auth-proxy notebook shows only workbench container steps', () => {
+    const nb = makeNotebook(['my-wb']); // no auth proxy sidecar
+    const { result } = renderHook(() => useNotebookProgress(nb, false, false, false, [], null));
+    const containerSteps = result.current.filter((s) => s.containerName !== undefined);
+    expect(containerSteps.every((s) => s.containerName === 'my-wb')).toBe(true);
+    expect(containerSteps).toHaveLength(1);
+    expect(containerSteps[0].stepKind).toBe('started');
+    expect(containerSteps[0].subSteps).toHaveLength(3);
+  });
+
+  it('shows pvc_attached step only when SuccessfulAttachVolume event fires', () => {
+    const nb = makeNotebook(['my-wb']);
+    const withoutEvent = renderHook(() => useNotebookProgress(nb, false, false, false, [], null))
+      .result.current;
+    expect(withoutEvent.find((s) => s.stepKind === 'pvc_attached')).toBeUndefined();
+
+    const events: EventKind[] = [makeEvent('SuccessfulAttachVolume', 'Volume attached')];
+    const withEvent = renderHook(() => useNotebookProgress(nb, false, false, false, events, null))
+      .result.current;
+    expect(withEvent.find((s) => s.stepKind === 'pvc_attached')).toBeDefined();
+  });
+
+  it.each([
+    {
+      label: 'ImagePullBackOff',
+      message: 'Back-off pulling image "quay.io/example/my-wb:latest"',
+      expectedDescription: 'ImagePullBackOff',
+    },
+    {
+      label: 'CrashLoopBackOff',
+      message: 'Back-off restarting failed container my-wb in pod test-notebook-0',
+      expectedDescription: 'CrashLoopBackOff',
+    },
+  ])(
+    'BackOff ($label) event surfaces container_problem with correct description (regression guard)',
+    ({ message, expectedDescription }) => {
+      const nb = makeNotebook(['my-wb']);
+      const events: EventKind[] = [makeEvent('BackOff', message, 'Warning')];
+      const { result } = renderHook(() =>
+        useNotebookProgress(nb, false, false, false, events, null),
+      );
+      const containerProblem = result.current.find(
+        (s) => s.stepKind === 'container_problem' && s.containerName === 'my-wb',
+      );
+      expect(containerProblem).toBeDefined();
+      expect(containerProblem?.status).toBe(EventStatus.ERROR);
+      expect(containerProblem?.description).toBe(expectedDescription);
+    },
+  );
+
+  it('shows kueue sub-step inside pod_assigned when kueueStatus is provided', () => {
+    const nb = makeNotebook(['my-wb']);
+    const { result } = renderHook(() =>
+      useNotebookProgress(nb, false, false, false, [], {
+        status: KueueWorkloadStatus.Queued,
+        queueName: 'default',
+      }),
+    );
+    const podAssigned = result.current.find((s) => s.stepKind === 'pod_assigned');
+    const kueue = podAssigned?.subSteps?.find((s) => s.stepKind === 'kueue');
+    expect(kueue).toBeDefined();
+    expect(kueue?.status).toBe(EventStatus.IN_PROGRESS);
   });
 });

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -1,23 +1,23 @@
 import * as React from 'react';
 import { AxiosError } from 'axios';
+import type { PodContainerStatus } from '@odh-dashboard/k8s-core';
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { useDeepCompareMemoize } from '@odh-dashboard/ui-core/hooks';
 import { createRoleBinding, getRoleBinding } from '#~/services/roleBindingService';
 import {
-  AssociatedSteps,
   EnvVarReducedTypeKeyValues,
   EventStatus,
   Notebook,
   NotebookControllerUserState,
   NotebookProgressStep,
+  NotebookProgressStepKind,
   NotebookStatus,
-  OptionalSteps,
-  ProgressionStep,
-  ProgressionStepTitles,
   ResourceCreator,
   ResourceGetter,
   VariableRow,
 } from '#~/types';
+import { KueueWorkloadStatus, type KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
+import { getKueueSubStepInfo } from '#~/concepts/kueue/messageUtils';
 import { NotebookControllerContext } from '#~/pages/notebookController/NotebookControllerContext';
 import { useUser } from '#~/redux/selectors';
 import { EMPTY_USER_STATE } from '#~/pages/notebookController/const';
@@ -301,167 +301,422 @@ const useLastActivity = (annotationValue?: string): Date | null => {
   return lastOpenActivity.current;
 };
 
+// Container names that identify auth-proxy sidecars.
+const AUTH_PROXY_NAMES = ['oauth-proxy', 'ose-oauth-proxy', 'kube-rbac-proxy'];
+
+const containerLabel = (name: string, notebookContainerName: string): string => {
+  if (name === notebookContainerName) {
+    return 'Workbench';
+  }
+  if (AUTH_PROXY_NAMES.includes(name)) {
+    return 'Auth proxy';
+  }
+  return name;
+};
+
+const makeContainerStep = (
+  stepKind: NotebookProgressStepKind,
+  containerName: string,
+  notebookContainerName: string,
+  labelFn: (friendly: string) => string,
+  status: EventStatus,
+  timestamp: number,
+  description?: string,
+): NotebookProgressStep => ({
+  stepKind,
+  containerName,
+  label: labelFn(containerLabel(containerName, notebookContainerName)),
+  status,
+  timestamp,
+  description,
+});
+
+const getKueueStepStatus = (status: KueueWorkloadStatus): EventStatus => {
+  switch (status) {
+    case KueueWorkloadStatus.Admitted:
+    case KueueWorkloadStatus.Running:
+    case KueueWorkloadStatus.Complete:
+      return EventStatus.SUCCESS;
+    case KueueWorkloadStatus.Failed:
+      return EventStatus.ERROR;
+    case KueueWorkloadStatus.Inadmissible:
+    case KueueWorkloadStatus.Evicted:
+    case KueueWorkloadStatus.Preempted:
+    case KueueWorkloadStatus.Requeued:
+      return EventStatus.WARNING;
+    case KueueWorkloadStatus.BlockedOnPreemptionGates:
+      return EventStatus.IN_PROGRESS;
+    case KueueWorkloadStatus.AdmissionCheck:
+      return EventStatus.IN_PROGRESS;
+    default:
+      return EventStatus.IN_PROGRESS;
+  }
+};
+
+/** True when the notebook was previously running (has a last-activity annotation). */
+export const isNotebookRestart = (notebook: NotebookKind | null): boolean =>
+  !!notebook?.metadata.annotations?.['notebooks.kubeflow.org/last-activity'];
+
+/**
+ * Builds the initial ordered step list from the notebook's pod spec containers.
+ * Auth proxy steps only appear when the sidecar is present; Kueue step only when kueueStatus is set.
+ */
+export const buildInitialProgressSteps = (
+  notebook: NotebookKind | null,
+  isStopped: boolean,
+  isStopping: boolean,
+  kueueStatus: KueueWorkloadStatusWithMessage | null,
+  isRecovery = false,
+): NotebookProgressStep[] => {
+  const steps: NotebookProgressStep[] = [];
+
+  const containers = notebook?.spec.template.spec.containers ?? [];
+  const notebookContainerName =
+    containers.find((c) => !AUTH_PROXY_NAMES.includes(c.name))?.name ?? '';
+
+  steps.push({
+    stepKind: 'workbench_requested',
+    label: 'Workbench requested',
+    status: isStopped || isStopping ? EventStatus.PENDING : EventStatus.SUCCESS,
+    timestamp: 0,
+  });
+
+  // Pod-level problem placeholder (optional — filtered out if still PENDING at end).
+  steps.push({
+    stepKind: 'pod_problem',
+    label: 'There was a problem with the pod',
+    status: EventStatus.PENDING,
+    timestamp: 0,
+  });
+
+  steps.push({
+    stepKind: 'pod_created',
+    label: 'Pod created',
+    status: EventStatus.PENDING,
+    timestamp: 0,
+  });
+
+  // Kueue admission nested as a sub-step under pod_assigned when active.
+  const podAssignedSubSteps: NotebookProgressStep[] = [];
+  if (kueueStatus) {
+    const { label: kueueLabel } = getKueueSubStepInfo(
+      kueueStatus.status,
+      kueueStatus.message,
+      kueueStatus.queueName,
+      isRecovery,
+      kueueStatus.queuePosition ?? undefined,
+    );
+    podAssignedSubSteps.push({
+      stepKind: 'kueue',
+      label: kueueLabel,
+      status: getKueueStepStatus(kueueStatus.status),
+      timestamp: 0,
+    });
+  }
+  steps.push({
+    stepKind: 'pod_assigned',
+    label: 'Pod assigned',
+    status: EventStatus.PENDING,
+    timestamp: 0,
+    ...(podAssignedSubSteps.length > 0 && {
+      subSteps: podAssignedSubSteps,
+      isExpanded: true,
+    }),
+  });
+
+  // PVC attachment (optional — filtered out if still PENDING at end).
+  steps.push({
+    stepKind: 'pvc_attached',
+    label: 'PVC attached',
+    status: EventStatus.PENDING,
+    timestamp: 0,
+  });
+
+  steps.push({
+    stepKind: 'interface_added',
+    label: 'Interface added',
+    status: EventStatus.PENDING,
+    timestamp: 0,
+  });
+
+  // pulling/pulled/created are sub-steps of the started parent so the tree stays compact.
+  containers.forEach((container) => {
+    const friendly = containerLabel(container.name, notebookContainerName);
+    const subSteps: NotebookProgressStep[] = [
+      makeContainerStep(
+        'pulling',
+        container.name,
+        notebookContainerName,
+        (f) => (isRecovery ? `Pulling ${f} image (restart)` : `Pulling ${f} image`),
+        EventStatus.PENDING,
+        0,
+      ),
+      makeContainerStep(
+        'pulled',
+        container.name,
+        notebookContainerName,
+        (f) => `${f} image pulled`,
+        EventStatus.PENDING,
+        0,
+      ),
+      makeContainerStep(
+        'created',
+        container.name,
+        notebookContainerName,
+        (f) => `${f} container created`,
+        EventStatus.PENDING,
+        0,
+      ),
+    ];
+    // Per-container problem placeholder (optional — filtered out if still PENDING).
+    steps.push({
+      stepKind: 'container_problem',
+      containerName: container.name,
+      label: `There was a problem with the ${friendly.toLowerCase()} container`,
+      status: EventStatus.PENDING,
+      timestamp: 0,
+    });
+    steps.push({
+      ...makeContainerStep(
+        'started',
+        container.name,
+        notebookContainerName,
+        (f) => (isRecovery ? `Restarting ${f} container` : `Starting ${f} container`),
+        EventStatus.PENDING,
+        0,
+      ),
+      subSteps,
+      isExpanded: false,
+    });
+  });
+
+  steps.push({
+    stepKind: 'workbench_started',
+    label: 'Workbench started',
+    status: EventStatus.PENDING,
+    timestamp: 0,
+  });
+
+  return steps;
+};
+
+// Secondary sort key when two steps share a timestamp. 'kueue' is absent — it's always a sub-step.
+/* eslint-disable @typescript-eslint/naming-convention, camelcase */
+const STEP_KIND_ORDER: Record<string, number> = {
+  workbench_requested: 0,
+  pod_problem: 1,
+  pod_created: 2,
+  pod_assigned: 3,
+  pvc_attached: 4,
+  interface_added: 5,
+  pulling: 6,
+  pulled: 7,
+  created: 8,
+  container_problem: 9,
+  started: 10,
+  workbench_started: 11,
+};
+/* eslint-enable @typescript-eslint/naming-convention, camelcase */
+
+/** Optional step kinds that are filtered from the list when their status is still PENDING. */
+const OPTIONAL_STEP_KINDS: Set<NotebookProgressStepKind> = new Set([
+  'pod_problem',
+  'container_problem',
+  'pvc_attached',
+]);
+
+const CONTAINER_EVENT_REASONS: Set<string> = new Set([
+  'Pulling',
+  'Pulled',
+  'Created',
+  'Started',
+  'Killing',
+]);
+
+/**
+ * Attempts to parse a container name directly from "Created container <name>"
+ * or "Started container <name>" event messages.
+ */
+const parseContainerNameFromMessage = (message: string): string | undefined => {
+  const match = /^(?:Created|Started) container (\S+)/.exec(message);
+  return match?.[1];
+};
+
+/**
+ * Maps a single K8s event to a NotebookProgressStep.
+ * containerNames must be sorted by descending length (longest-name-wins to avoid substring collisions).
+ * Returns null for events that cannot be meaningfully mapped.
+ */
 export const getNotebookEventStatus = (
   event: EventKind,
+  containerNames: string[],
   gracePeriod?: boolean,
-): NotebookProgressStep => {
+): NotebookProgressStep | null => {
   const timestamp = new Date(getEventTimestamp(event)).getTime();
+  const { reason, message, type } = event;
 
-  const isAuthProxyEvent =
-    event.message.includes('oauth-proxy') ||
-    event.message.includes('ose-oauth-proxy') ||
-    event.message.includes('kube-rbac-proxy');
+  if (CONTAINER_EVENT_REASONS.has(reason)) {
+    // Longest-name-wins to avoid substring collisions between container names.
+    let matchedContainer = containerNames.find((name) => message.includes(name));
 
-  if (isAuthProxyEvent) {
-    switch (event.reason) {
+    // For Created/Started, try parsing the container name directly from the message.
+    if (!matchedContainer && (reason === 'Created' || reason === 'Started')) {
+      const parsed = parseContainerNameFromMessage(message);
+      if (parsed && containerNames.includes(parsed)) {
+        matchedContainer = parsed;
+      }
+    }
+
+    if (!matchedContainer) {
+      return null;
+    }
+
+    const notebookContainerName =
+      containerNames.find((n) => !AUTH_PROXY_NAMES.includes(n)) ?? containerNames[0];
+
+    switch (reason) {
       case 'Pulling':
-        return {
-          step: ProgressionStep.PULLING_AUTH_PROXY,
-          status: EventStatus.SUCCESS,
+        return makeContainerStep(
+          'pulling',
+          matchedContainer,
+          notebookContainerName,
+          (f) => `Pulling ${f} image`,
+          EventStatus.SUCCESS,
           timestamp,
-        };
+        );
       case 'Pulled':
-        return {
-          step: ProgressionStep.AUTH_PROXY_PULLED,
-          status: EventStatus.SUCCESS,
+        return makeContainerStep(
+          'pulled',
+          matchedContainer,
+          notebookContainerName,
+          (f) => `${f} image pulled`,
+          EventStatus.SUCCESS,
           timestamp,
-        };
+        );
       case 'Created':
-        return {
-          step: ProgressionStep.AUTH_PROXY_CONTAINER_CREATED,
-          status: EventStatus.SUCCESS,
+        return makeContainerStep(
+          'created',
+          matchedContainer,
+          notebookContainerName,
+          (f) => `${f} container created`,
+          EventStatus.SUCCESS,
           timestamp,
-        };
+        );
       case 'Started':
-        return {
-          step: ProgressionStep.AUTH_PROXY_CONTAINER_STARTED,
-          status: EventStatus.SUCCESS,
+        return makeContainerStep(
+          'started',
+          matchedContainer,
+          notebookContainerName,
+          (f) => `${f} container started`,
+          EventStatus.SUCCESS,
           timestamp,
-        };
+        );
       case 'Killing':
-        return {
-          step: ProgressionStep.AUTH_PROXY_CONTAINER_STARTED,
-          status: EventStatus.WARNING,
+        return makeContainerStep(
+          'started',
+          matchedContainer,
+          notebookContainerName,
+          (f) => `${f} container started`,
+          EventStatus.WARNING,
           timestamp,
-        };
+        );
       default:
-        if (event.type === 'Warning') {
-          return {
-            step: ProgressionStep.AUTH_PROXY_CONTAINER_CREATED,
-            status: EventStatus.WARNING,
-            timestamp,
-          };
-        }
-        return {
-          step: ProgressionStep.AUTH_PROXY_CONTAINER_PROBLEM,
-          status: EventStatus.WARNING,
-          timestamp,
-        };
+        return null;
     }
   }
 
-  // For notebook-related events
-  switch (event.reason) {
+  // --- Pod-level events ---
+  switch (reason) {
     case 'SuccessfulCreate':
       return {
-        step: ProgressionStep.POD_CREATED,
+        stepKind: 'pod_created',
+        label: 'Pod created',
         status: EventStatus.SUCCESS,
         timestamp,
       };
     case 'Scheduled':
       return {
-        step: ProgressionStep.POD_ASSIGNED,
+        stepKind: 'pod_assigned',
+        label: 'Pod assigned',
         status: EventStatus.SUCCESS,
         timestamp,
       };
     case 'SuccessfulAttachVolume':
       return {
-        step: ProgressionStep.PVC_ATTACHED,
+        stepKind: 'pvc_attached',
+        label: 'PVC attached',
         status: EventStatus.SUCCESS,
         timestamp,
       };
     case 'AddedInterface':
       return {
-        step: ProgressionStep.INTERFACE_ADDED,
-        status: EventStatus.SUCCESS,
-        timestamp,
-      };
-    case 'Pulling':
-      return {
-        step: ProgressionStep.PULLING_NOTEBOOK_IMAGE,
-        status: EventStatus.SUCCESS,
-        timestamp,
-      };
-    case 'Pulled':
-      return {
-        step: ProgressionStep.NOTEBOOK_IMAGE_PULLED,
-        status: EventStatus.SUCCESS,
-        timestamp,
-      };
-    case 'Created':
-      return {
-        step: ProgressionStep.NOTEBOOK_CONTAINER_CREATED,
-        status: EventStatus.SUCCESS,
-        timestamp,
-      };
-    case 'Started':
-      return {
-        step: ProgressionStep.NOTEBOOK_CONTAINER_STARTED,
+        stepKind: 'interface_added',
+        label: 'Interface added',
         status: EventStatus.SUCCESS,
         timestamp,
       };
     case 'NotTriggerScaleUp':
       return {
-        step: ProgressionStep.POD_PROBLEM,
+        stepKind: 'pod_problem',
+        label: 'There was a problem with the pod',
         description: 'Failed to scale-up',
         status: EventStatus.ERROR,
         timestamp,
       };
     case 'TriggeredScaleUp':
       return {
-        step: ProgressionStep.POD_PROBLEM,
+        stepKind: 'pod_problem',
+        label: 'There was a problem with the pod',
         description: 'Pod triggered scale-up',
         status: EventStatus.INFO,
         timestamp,
       };
     case 'FailedCreate':
       return {
-        step: ProgressionStep.POD_PROBLEM,
+        stepKind: 'pod_problem',
+        label: 'There was a problem with the pod',
         description: 'Failed to create pod',
         status: EventStatus.ERROR,
         timestamp,
       };
     default: {
-      if (!gracePeriod && event.reason === 'FailedScheduling') {
+      if (!gracePeriod && reason === 'FailedScheduling') {
         return {
-          step: ProgressionStep.POD_PROBLEM,
+          stepKind: 'pod_problem',
+          label: 'There was a problem with the pod',
           description: 'Insufficient resources to start',
           status: EventStatus.ERROR,
           timestamp,
         };
       }
-      if (!gracePeriod && event.reason === 'BackOff') {
+      if (!gracePeriod && reason === 'BackOff') {
+        const primaryContainer =
+          containerNames.find((n) => !AUTH_PROXY_NAMES.includes(n)) ?? containerNames[0];
+        const description = message.toLowerCase().includes('pulling image')
+          ? 'ImagePullBackOff'
+          : 'CrashLoopBackOff';
         return {
-          step: ProgressionStep.NOTEBOOK_CONTAINER_PROBLEM,
-          description: 'ImagePullBackOff',
+          stepKind: 'container_problem',
+          containerName: primaryContainer,
+          label: 'There was a problem with the workbench container',
+          description,
           status: EventStatus.ERROR,
           timestamp,
         };
       }
-      if (event.type === 'Warning') {
+      if (type === 'Warning') {
+        const primaryContainer =
+          containerNames.find((n) => !AUTH_PROXY_NAMES.includes(n)) ?? containerNames[0];
         return {
-          step: ProgressionStep.NOTEBOOK_CONTAINER_PROBLEM,
+          stepKind: 'container_problem',
+          containerName: primaryContainer,
+          label: 'There was a problem with the workbench container',
           description: 'Issue creating workbench container',
           status: EventStatus.WARNING,
           timestamp,
         };
       }
-      return {
-        step: ProgressionStep.NOTEBOOK_CONTAINER_PROBLEM,
-        description: '',
-        status: EventStatus.WARNING,
-        timestamp,
-      };
+      return null;
     }
   }
 };
@@ -485,7 +740,6 @@ export const useNotebookStatus = (
       : null);
 
   if (!notebook || !lastActivity) {
-    // Notebook not started, we don't have a filter time, ignore
     return [null, []];
   }
 
@@ -494,47 +748,55 @@ export const useNotebookStatus = (
     return [null, thisInstanceEvents];
   }
 
-  // Parse the last event
   const lastItem = filteredEvents[filteredEvents.length - 1];
-  const { step, description, status } = getNotebookEventStatus(lastItem, gracePeriod);
+
+  const containerNames = notebook.spec.template.spec.containers
+    .map((c) => c.name)
+    .toSorted((a, b) => b.length - a.length);
+
+  const eventStep = getNotebookEventStatus(lastItem, containerNames, gracePeriod);
+  const statusLabel = eventStep ? eventStep.description || eventStep.label : lastItem.reason;
+  const currentStatus = eventStep?.status ?? EventStatus.WARNING;
 
   return [
     {
-      currentEvent: description || ProgressionStepTitles[step],
+      currentEvent: statusLabel,
       currentEventReason: lastItem.reason,
       currentEventDescription: lastItem.message,
-      currentStatus: status,
+      currentStatus,
     },
     thisInstanceEvents,
   ];
 };
 
-const progressionValue = (progressionStep?: ProgressionStep): number => {
-  if (!progressionStep) {
-    return 0;
-  }
-  return Object.values(ProgressionStep).indexOf(progressionStep);
-};
-
 export const compareProgressSteps = (a: NotebookProgressStep, b: NotebookProgressStep): number => {
-  const val = a.timestamp - b.timestamp;
-  return val !== 0 ? val : progressionValue(a.step) - progressionValue(b.step);
+  const timeDiff = a.timestamp - b.timestamp;
+  return timeDiff !== 0
+    ? timeDiff
+    : (STEP_KIND_ORDER[a.stepKind] ?? 99) - (STEP_KIND_ORDER[b.stepKind] ?? 99);
 };
 
+/** Returns the ordered notebook startup progress steps, derived from the pod spec containers. */
 export const useNotebookProgress = (
   notebook: NotebookKind | null,
   isRunning: boolean,
   isStopping: boolean,
   isStopped: boolean,
   events: EventKind[],
+  kueueStatus: KueueWorkloadStatusWithMessage | null,
+  containerStatuses: PodContainerStatus[] = [],
 ): NotebookProgressStep[] => {
-  const progressSteps: NotebookProgressStep[] = Object.values(ProgressionStep).map((step) => ({
-    step: ProgressionStep[step],
-    percentile: 0,
-    status: EventStatus.PENDING,
-    timestamp: 0,
-  }));
-  progressSteps[0].status = isStopped || isStopping ? EventStatus.PENDING : EventStatus.SUCCESS;
+  const isRecovery = isNotebookRestart(notebook);
+  const progressSteps = buildInitialProgressSteps(
+    notebook,
+    isStopped,
+    isStopping,
+    kueueStatus,
+    isRecovery,
+  );
+
+  const containers = notebook?.spec.template.spec.containers ?? [];
+  const containerNames = containers.map((c) => c.name).toSorted((a, b) => b.length - a.length);
 
   let progressEvents = events;
   let gracePeriod = false;
@@ -544,57 +806,149 @@ export const useNotebookProgress = (
     const lastActivity = annotationTime
       ? new Date(annotationTime)
       : new Date(notebook.metadata.creationTimestamp ?? 0);
-
     const [filteredEvents, , period] = filterEvents(events, lastActivity);
     progressEvents = filteredEvents;
     gracePeriod = period;
   }
 
+  // Search top-level steps and subSteps (pulling/pulled/created live inside started).
+  const findStepDeep = (
+    stepsArr: NotebookProgressStep[],
+    stepKind: NotebookProgressStepKind,
+    containerName?: string,
+  ): NotebookProgressStep | undefined => {
+    for (const s of stepsArr) {
+      if (s.stepKind === stepKind && s.containerName === containerName) return s;
+      if (s.subSteps) {
+        const sub = s.subSteps.find(
+          (ss) => ss.stepKind === stepKind && ss.containerName === containerName,
+        );
+        if (sub) return sub;
+      }
+    }
+    return undefined;
+  };
+
   const currentProgress = progressEvents
-    .map((event) => getNotebookEventStatus(event, gracePeriod))
+    .map((event) => getNotebookEventStatus(event, containerNames, gracePeriod))
+    .filter((s): s is NotebookProgressStep => s !== null)
     .toSorted(compareProgressSteps);
 
-  currentProgress.forEach((currentStep) => {
-    const progressStep = progressSteps.find((step) => step.step === currentStep.step);
-    if (progressStep) {
-      progressStep.status = currentStep.status;
-      progressStep.timestamp = currentStep.timestamp;
+  currentProgress.forEach((eventStep) => {
+    const match = findStepDeep(progressSteps, eventStep.stepKind, eventStep.containerName);
+    if (match) {
+      match.status = eventStep.status;
+      match.timestamp = eventStep.timestamp;
+      if (eventStep.description) {
+        match.description = eventStep.description;
+      }
     }
   });
 
-  // If the auth proxy container is started and the server is running, mark the server started step complete
-  if (
-    isRunning &&
-    progressSteps.find((p) => p.step === ProgressionStep.AUTH_PROXY_CONTAINER_STARTED)?.status ===
-      EventStatus.SUCCESS
-  ) {
-    const startedStep = progressSteps.find((p) => p.step === ProgressionStep.WORKBENCH_STARTED);
-    if (startedStep) {
-      startedStep.status = EventStatus.SUCCESS;
+  // Catch-up: pod_assigned SUCCESS → pod_created SUCCESS.
+  const podAssigned = progressSteps.find((s) => s.stepKind === 'pod_assigned');
+  if (podAssigned?.status === EventStatus.SUCCESS) {
+    const podCreated = progressSteps.find((s) => s.stepKind === 'pod_created');
+    if (podCreated?.status === EventStatus.PENDING) {
+      podCreated.status = EventStatus.SUCCESS;
     }
   }
 
-  // If milestone steps are completed, mark off associated steps
-  Object.entries(AssociatedSteps).forEach(([key, values]) => {
-    if (progressSteps.find((p) => p.step === key)?.status === EventStatus.SUCCESS) {
-      const filteredValues = values.filter((step) => !OptionalSteps.includes(step));
-      filteredValues.forEach((value) => {
-        const currentStep = progressSteps.find((p) => p.step === value);
-        if (currentStep) {
-          currentStep.status = EventStatus.SUCCESS;
+  // Catch up sub-steps when started is SUCCESS; bubble IN_PROGRESS up when sub-steps are active.
+  containers.forEach((container) => {
+    const started = progressSteps.find(
+      (s) => s.stepKind === 'started' && s.containerName === container.name,
+    );
+    if (!started) return;
+
+    if (started.status === EventStatus.SUCCESS) {
+      const subs = started.subSteps;
+      if (subs) {
+        for (let si = 0; si < subs.length; si++) {
+          if (subs[si].status === EventStatus.PENDING) {
+            subs[si].status = EventStatus.SUCCESS;
+          }
         }
-      });
+      }
+      // Also catch up interface_added — it fires before containers but may be missed.
+      const ifaceStep = progressSteps.find((s) => s.stepKind === 'interface_added');
+      if (ifaceStep?.status === EventStatus.PENDING) {
+        ifaceStep.status = EventStatus.SUCCESS;
+      }
+    } else if (started.status === EventStatus.PENDING && started.subSteps) {
+      const hasError = started.subSteps.some((sub) => sub.status === EventStatus.ERROR);
+      const hasActive = started.subSteps.some((sub) => sub.status !== EventStatus.PENDING);
+      if (hasError) {
+        started.status = EventStatus.ERROR;
+      } else if (hasActive) {
+        started.status = EventStatus.IN_PROGRESS;
+        started.isExpanded = true;
+      }
     }
   });
 
-  // Filter out pending optional steps
+  // EC3: mark workbench_started SUCCESS when all containers are started (via events or container statuses).
+  if (isRunning) {
+    const allEventStepsStarted =
+      containers.length === 0 ||
+      containers.every((container) => {
+        const startedStep = progressSteps.find(
+          (s) => s.stepKind === 'started' && s.containerName === container.name,
+        );
+        return startedStep?.status === EventStatus.SUCCESS;
+      });
+
+    const allContainerStatusesRunning =
+      containerStatuses.length > 0 &&
+      containerStatuses.every((cs) => cs.ready && cs.state?.running != null);
+
+    if (allEventStepsStarted || allContainerStatusesRunning) {
+      if (allContainerStatusesRunning && !allEventStepsStarted) {
+        containers.forEach((container) => {
+          const started = progressSteps.find(
+            (p) => p.stepKind === 'started' && p.containerName === container.name,
+          );
+          if (started) {
+            started.status = EventStatus.SUCCESS;
+            const subs = started.subSteps;
+            if (subs) {
+              for (let si = 0; si < subs.length; si++) {
+                if (subs[si].status === EventStatus.PENDING) {
+                  subs[si].status = EventStatus.SUCCESS;
+                }
+              }
+            }
+          }
+        });
+      }
+      const workbenchStarted = progressSteps.find((s) => s.stepKind === 'workbench_started');
+      if (workbenchStarted) {
+        workbenchStarted.status = EventStatus.SUCCESS;
+      }
+    }
+  }
+
+  // Once fully started, catch up any remaining PENDING steps and their sub-steps.
+  const workbenchStarted = progressSteps.find((s) => s.stepKind === 'workbench_started');
+  if (workbenchStarted?.status === EventStatus.SUCCESS) {
+    progressSteps.forEach((s, i) => {
+      if (s.status === EventStatus.PENDING && !OPTIONAL_STEP_KINDS.has(s.stepKind)) {
+        progressSteps[i].status = EventStatus.SUCCESS;
+      }
+      const subs = progressSteps[i].subSteps;
+      if (subs) {
+        for (let si = 0; si < subs.length; si++) {
+          if (subs[si].status === EventStatus.PENDING) {
+            subs[si].status = EventStatus.SUCCESS;
+          }
+        }
+      }
+    });
+  }
+
+  // Filter out optional steps that never received an event (still PENDING).
   return progressSteps.filter(
-    (notebookProgressStep) =>
-      !(
-        OptionalSteps.includes(notebookProgressStep.step) &&
-        progressSteps.find((p) => p.step === notebookProgressStep.step)?.status ===
-          EventStatus.PENDING
-      ),
+    (s) => !(OPTIONAL_STEP_KINDS.has(s.stepKind) && s.status === EventStatus.PENDING),
   );
 };
 

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -901,8 +901,10 @@ export const useNotebookProgress = (
 
     const allContainerStatusesRunning =
       containers.length > 0 &&
-      containerStatuses.length === containers.length &&
-      containerStatuses.every((cs) => cs.ready && cs.state?.running != null);
+      containers.every((container) => {
+        const cs = containerStatuses.find((s) => s.name === container.name);
+        return !!cs && cs.ready && cs.state?.running != null;
+      });
 
     if (allEventStepsStarted || allContainerStatusesRunning) {
       if (allContainerStatusesRunning && !allEventStepsStarted) {

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -756,7 +756,8 @@ export const useNotebookStatus = (
 
   const eventStep = getNotebookEventStatus(lastItem, containerNames, gracePeriod);
   const statusLabel = eventStep ? eventStep.description || eventStep.label : lastItem.reason;
-  const currentStatus = eventStep?.status ?? EventStatus.WARNING;
+  const currentStatus =
+    eventStep?.status ?? (lastItem.type === 'Warning' ? EventStatus.WARNING : EventStatus.INFO);
 
   return [
     {
@@ -899,7 +900,8 @@ export const useNotebookProgress = (
       });
 
     const allContainerStatusesRunning =
-      containerStatuses.length > 0 &&
+      containers.length > 0 &&
+      containerStatuses.length === containers.length &&
       containerStatuses.every((cs) => cs.ready && cs.state?.running != null);
 
     if (allEventStepsStarted || allContainerStatusesRunning) {

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -7,7 +7,6 @@ import { createRoleBinding, getRoleBinding } from '#~/services/roleBindingServic
 import {
   EnvVarReducedTypeKeyValues,
   EventStatus,
-  Notebook,
   NotebookControllerUserState,
   NotebookProgressStep,
   NotebookProgressStepKind,
@@ -99,7 +98,7 @@ export const classifyEnvVars = (variableRows: VariableRow[]): EnvVarReducedTypeK
   );
 
 export const getNotebookControllerUserState = (
-  notebook: Notebook | null,
+  notebook: NotebookKind | null,
   loggedInUser: string,
 ): NotebookControllerUserState | null => {
   if (!notebook) {
@@ -140,7 +139,7 @@ export const getNotebookControllerUserState = (
 };
 
 export const useSpecificNotebookUserState = (
-  notebook: Notebook | null,
+  notebook: NotebookKind | null,
 ): NotebookControllerUserState => {
   const { impersonatedUsername } = React.useContext(NotebookControllerContext);
   const { username: stateUsername } = useUser();
@@ -544,7 +543,6 @@ const parseContainerNameFromMessage = (message: string): string | undefined => {
 
 /**
  * Maps a single K8s event to a NotebookProgressStep.
- * containerNames must be sorted by descending length (longest-name-wins to avoid substring collisions).
  * Returns null for events that cannot be meaningfully mapped.
  */
 export const getNotebookEventStatus = (
@@ -556,8 +554,9 @@ export const getNotebookEventStatus = (
   const { reason, message, type } = event;
 
   if (CONTAINER_EVENT_REASONS.has(reason)) {
-    // Longest-name-wins to avoid substring collisions between container names.
-    let matchedContainer = containerNames.find((name) => message.includes(name));
+    // Longest-name-first prevents a short name from matching inside a longer sibling name.
+    const matchCandidates = containerNames.toSorted((a, b) => b.length - a.length);
+    let matchedContainer = matchCandidates.find((name) => message.includes(name));
 
     // For Created/Started, try parsing the container name directly from the message.
     if (!matchedContainer && (reason === 'Created' || reason === 'Started')) {
@@ -723,7 +722,7 @@ export const getNotebookEventStatus = (
 
 export const useNotebookStatus = (
   spawnInProgress: boolean,
-  notebook: Notebook | NotebookKind | null,
+  notebook: NotebookKind | null,
   isNotebookRunning: boolean,
   currentUserNotebookPodUID: string,
 ): [status: NotebookStatus | null, events: EventKind[]] => {
@@ -750,9 +749,7 @@ export const useNotebookStatus = (
 
   const lastItem = filteredEvents[filteredEvents.length - 1];
 
-  const containerNames = notebook.spec.template.spec.containers
-    .map((c) => c.name)
-    .toSorted((a, b) => b.length - a.length);
+  const containerNames = notebook.spec.template.spec.containers.map((c) => c.name);
 
   const eventStep = getNotebookEventStatus(lastItem, containerNames, gracePeriod);
   const statusLabel = eventStep ? eventStep.description || eventStep.label : lastItem.reason;
@@ -797,7 +794,7 @@ export const useNotebookProgress = (
   );
 
   const containers = notebook?.spec.template.spec.containers ?? [];
-  const containerNames = containers.map((c) => c.name).toSorted((a, b) => b.length - a.length);
+  const containerNames = containers.map((c) => c.name);
 
   let progressEvents = events;
   let gracePeriod = false;

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -615,7 +615,7 @@ export const getNotebookEventStatus = (
           'started',
           matchedContainer,
           notebookContainerName,
-          (f) => `${f} container started`,
+          (f) => `${f} container stopped`,
           EventStatus.WARNING,
           timestamp,
         );

--- a/packages/cypress/cypress/pages/notebookServer.ts
+++ b/packages/cypress/cypress/pages/notebookServer.ts
@@ -64,6 +64,10 @@ class NotebookServer {
     return cy.findByTestId('expand-logs');
   }
 
+  findNotebookStartupSteps() {
+    return cy.findByTestId('notebook-startup-steps');
+  }
+
   findStopServerButton() {
     return cy.findByTestId('stop-wb-button');
   }

--- a/packages/cypress/cypress/pages/workbench.ts
+++ b/packages/cypress/cypress/pages/workbench.ts
@@ -967,6 +967,10 @@ class WorkbenchStatusModal extends Modal {
     super('Workbench status');
   }
 
+  find(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('notebook-status-modal');
+  }
+
   findProgressTab() {
     return cy.findByTestId('expand-progress');
   }
@@ -975,15 +979,25 @@ class WorkbenchStatusModal extends Modal {
     return cy.findByTestId('notebook-startup-steps').find('[data-testid^="step-status-"]');
   }
 
-  getStepTitle($step: JQuery<HTMLElement>) {
-    return cy.wrap($step).find('[id$="-title"]').invoke('text');
+  findProgressStepByLabel(label: string) {
+    return cy.findByTestId('notebook-startup-steps').contains(label);
   }
 
-  assertStepSuccess($step: JQuery<HTMLElement>) {
+  findKueueSubStep() {
+    return cy.findByTestId('notebook-startup-steps').find('[id="kueue-"]');
+  }
+
+  findKueueToggle() {
     return cy
-      .wrap($step)
-      .should('have.attr', 'data-testid')
-      .and('match', /^step-status-Success/);
+      .findByTestId('notebook-startup-steps')
+      .contains('Pod assigned')
+      .closest('[role="treeitem"]')
+      .find('button')
+      .first();
+  }
+
+  findModalTitle() {
+    return cy.findByTestId('notebook-status-modal-header').find('h1,h2,h3,h4,h5,h6').first();
   }
 
   findEventlogTab() {

--- a/packages/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -158,6 +158,31 @@ describe('NotebookServer', () => {
     });
   });
 
+  it('should show per-container startup steps in the progress tree', () => {
+    // Remove last-activity so labels read "Starting …" not "Restarting …".
+    const freshNotebook = mockNotebookK8sResource({});
+    delete freshNotebook.metadata.annotations?.['notebooks.kubeflow.org/last-activity'];
+
+    cy.interceptOdh(
+      'GET /api/notebooks/openshift-ai-notebooks/:username/status',
+      { path: { username: 'jupyter-nb-test-2duser' } },
+      {
+        notebook: freshNotebook,
+        isRunning: false,
+      },
+    ).as('notebookStatus');
+
+    notebookServer.visit();
+    notebookServer.findStartServerButton().click();
+    cy.wait('@notebookStatus');
+
+    notebookServer
+      .findNotebookStartupSteps()
+      .should('be.visible')
+      .and('contain.text', 'Starting Workbench container')
+      .and('contain.text', 'Starting Auth proxy container');
+  });
+
   it('should start a workbench with params', () => {
     const existingParamEnvs: EnvironmentVariable[] = [
       {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -2915,7 +2915,7 @@ describe('Workbench page', () => {
     });
 
     it('Progress tab — Inadmissible sub-step shows "Queue {queue} does not exist"', () => {
-      // Clear the default condition message so getInadmissibleMessage falls back to 'Queue test-queue does not exist'.
+      // Set a realistic queue-not-found message so getInadmissibleMessage returns 'Queue test-queue does not exist'.
       const inadmissibleWorkload = mockWorkloadK8sResource({
         k8sName: 'workload-test-notebook',
         namespace: 'test-project',
@@ -2924,7 +2924,9 @@ describe('Workbench page', () => {
       });
       if (inadmissibleWorkload.status) {
         inadmissibleWorkload.status.conditions = inadmissibleWorkload.status.conditions?.map((c) =>
-          c.type === 'QuotaReserved' ? { ...c, message: '' } : c,
+          c.type === 'QuotaReserved'
+            ? { ...c, message: "localqueue 'test-queue' doesn't exist" }
+            : c,
         );
       }
       if (inadmissibleWorkload.metadata) {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -2864,5 +2864,334 @@ describe('Workbench page', () => {
         .should('contain.text', 'Waiting for')
         .and('not.contain.text', 'position');
     });
+
+    it('Progress tab — Kueue sub-step is visible by default and toggles collapse/expand', () => {
+      initKueueWorkloadStatus(WorkloadStatusType.Pending);
+      cy.interceptK8sList({ model: EventModel, ns: 'test-project' }, mockK8sResourceList([]));
+      workbenchPage.visit('test-project');
+      workbenchPage.getNotebookRow('Test Notebook').findHaveNotebookStatusText().click();
+      workbenchStatusModal.findProgressTab().click();
+      // Default: expanded — Kueue sub-step visible under "Pod assigned".
+      workbenchStatusModal.findKueueSubStep().should('be.visible');
+      // Click toggle to collapse.
+      workbenchStatusModal.findKueueToggle().click();
+      workbenchStatusModal.findKueueSubStep().should('not.be.visible');
+      // Click toggle again to re-expand.
+      workbenchStatusModal.findKueueToggle().click();
+      workbenchStatusModal.findKueueSubStep().should('be.visible');
+    });
+
+    it('Progress tab — Queued sub-step shows "Waiting for quota in {queue}"', () => {
+      // Clear the default condition message so getQueuedMessage falls back to 'Waiting for quota in test-queue'.
+      const queuedWorkload = mockWorkloadK8sResource({
+        k8sName: 'workload-test-notebook',
+        namespace: 'test-project',
+        ownerName: 'test-notebook',
+        mockStatus: WorkloadStatusType.Pending,
+      });
+      if (queuedWorkload.status) {
+        queuedWorkload.status.conditions = queuedWorkload.status.conditions?.map((c) =>
+          c.type === 'QuotaReserved' ? { ...c, message: '' } : c,
+        );
+      }
+      if (queuedWorkload.metadata) {
+        queuedWorkload.metadata.labels = {
+          ...queuedWorkload.metadata.labels,
+          'kueue.x-k8s.io/job-name': 'test-notebook',
+        };
+      }
+      initKueueEnabledForStatusModal();
+      cy.interceptK8sList(
+        { model: WorkloadModel, ns: 'test-project' },
+        mockK8sResourceList([queuedWorkload]),
+      );
+      cy.interceptK8sList({ model: EventModel, ns: 'test-project' }, mockK8sResourceList([]));
+      workbenchPage.visit('test-project');
+      workbenchPage.getNotebookRow('Test Notebook').findHaveNotebookStatusText().click();
+      workbenchStatusModal.findProgressTab().click();
+      workbenchStatusModal
+        .findProgressStepByLabel('Waiting for quota in test-queue')
+        .should('exist');
+    });
+
+    it('Progress tab — Inadmissible sub-step shows "Queue {queue} does not exist"', () => {
+      // Clear the default condition message so getInadmissibleMessage falls back to 'Queue test-queue does not exist'.
+      const inadmissibleWorkload = mockWorkloadK8sResource({
+        k8sName: 'workload-test-notebook',
+        namespace: 'test-project',
+        ownerName: 'test-notebook',
+        mockStatus: WorkloadStatusType.Inadmissible,
+      });
+      if (inadmissibleWorkload.status) {
+        inadmissibleWorkload.status.conditions = inadmissibleWorkload.status.conditions?.map((c) =>
+          c.type === 'QuotaReserved' ? { ...c, message: '' } : c,
+        );
+      }
+      if (inadmissibleWorkload.metadata) {
+        inadmissibleWorkload.metadata.labels = {
+          ...inadmissibleWorkload.metadata.labels,
+          'kueue.x-k8s.io/job-name': 'test-notebook',
+        };
+      }
+      initKueueEnabledForStatusModal();
+      cy.interceptK8sList(
+        { model: WorkloadModel, ns: 'test-project' },
+        mockK8sResourceList([inadmissibleWorkload]),
+      );
+      cy.interceptK8sList({ model: EventModel, ns: 'test-project' }, mockK8sResourceList([]));
+      workbenchPage.visit('test-project');
+      workbenchPage.getNotebookRow('Test Notebook').findHaveNotebookStatusText().click();
+      workbenchStatusModal.findProgressTab().click();
+      workbenchStatusModal
+        .findProgressStepByLabel('Queue test-queue does not exist')
+        .should('exist');
+    });
+
+    it('Progress tab — modal title shows workbench display name', () => {
+      initKueueEnabledForStatusModal();
+      workbenchPage.visit('test-project');
+      workbenchPage.getNotebookRow('Test Notebook').findHaveNotebookStatusText().click();
+      // Title should be "{displayName} status", not the hardcoded "Workbench status".
+      workbenchStatusModal
+        .find()
+        .findByTestId('notebook-status-modal-header')
+        .should('contain.text', 'Test Notebook status');
+    });
+
+    it('Progress tab — no auth proxy container means no Auth proxy steps', () => {
+      const notebookNoAuthProxy = mockNotebookK8sResource({
+        lastImageSelection: 'test-imagestream:1.2',
+        opts: {
+          metadata: {
+            name: 'test-notebook',
+            labels: {
+              'opendatahub.io/notebook-image': 'true',
+              'kueue.x-k8s.io/queue-name': 'test-queue',
+            },
+            annotations: { 'opendatahub.io/image-display-name': 'Test image' },
+          },
+        },
+      });
+      // _.merge keeps array entries by index, so explicitly filter out auth proxy containers.
+      notebookNoAuthProxy.spec.template.spec.containers =
+        notebookNoAuthProxy.spec.template.spec.containers.filter(
+          (c) => !['kube-rbac-proxy', 'oauth-proxy', 'ose-oauth-proxy'].includes(c.name),
+        );
+      initIntercepts({ notebooks: [notebookNoAuthProxy] });
+      cy.interceptK8sList({ model: EventModel, ns: 'test-project' }, mockK8sResourceList([]));
+      workbenchPage.visit('test-project');
+      workbenchPage.getNotebookRow('Test Notebook').findHaveNotebookStatusText().click();
+      workbenchStatusModal.findProgressTab().click();
+      workbenchStatusModal.findProgressStepByLabel('Auth proxy').should('not.exist');
+    });
+
+    it('Progress tab — AdmissionCheck status surfaces check label', () => {
+      // Uses WorkloadStatusType.Admitted so the Admitted condition is present;
+      // the blocking admission check then promotes the status to AdmissionCheck.
+      const workloadWithAdmissionCheck = mockWorkloadK8sResource({
+        k8sName: 'workload-test-notebook',
+        namespace: 'test-project',
+        ownerName: 'test-notebook',
+        mockStatus: WorkloadStatusType.Admitted,
+      });
+      if (workloadWithAdmissionCheck.status) {
+        workloadWithAdmissionCheck.status.admissionChecks = [
+          {
+            name: 'gpu-check',
+            message: 'Waiting for GPU resource assignment',
+            state: 'Pending',
+            lastTransitionTime: '2024-01-15T10:00:00Z',
+          },
+        ];
+      }
+      if (workloadWithAdmissionCheck.metadata) {
+        workloadWithAdmissionCheck.metadata.labels = {
+          ...workloadWithAdmissionCheck.metadata.labels,
+          'kueue.x-k8s.io/job-name': 'test-notebook',
+        };
+      }
+      initKueueEnabledForStatusModal();
+      cy.interceptK8sList(
+        { model: WorkloadModel, ns: 'test-project' },
+        mockK8sResourceList([workloadWithAdmissionCheck]),
+      );
+      cy.interceptK8sList({ model: EventModel, ns: 'test-project' }, mockK8sResourceList([]));
+      workbenchPage.visit('test-project');
+      workbenchPage.getNotebookRow('Test Notebook').findHaveNotebookStatusText().click();
+      workbenchStatusModal.findProgressTab().click();
+      workbenchStatusModal.findProgressStepByLabel('Waiting for admission check').should('exist');
+    });
+
+    it('Requeued — table badge shows Requeued and modal header and progress sub-step are correct', () => {
+      const requeuedWorkload = mockWorkloadK8sResource({
+        k8sName: 'workload-test-notebook',
+        namespace: 'test-project',
+        ownerName: 'test-notebook',
+        mockStatus: WorkloadStatusType.Evicted,
+        evictionReason: 'PodsReadyTimeout',
+        requeueState: { count: 2, requeueAt: '2026-07-15T10:05:00Z' },
+      });
+      if (requeuedWorkload.metadata) {
+        requeuedWorkload.metadata.labels = {
+          ...requeuedWorkload.metadata.labels,
+          'kueue.x-k8s.io/job-name': 'test-notebook',
+        };
+      }
+      initKueueEnabledForStatusModal();
+      cy.interceptK8sList(
+        { model: WorkloadModel, ns: 'test-project' },
+        mockK8sResourceList([requeuedWorkload]),
+      );
+      cy.interceptK8sList({ model: EventModel, ns: 'test-project' }, mockK8sResourceList([]));
+      workbenchPage.visit('test-project');
+      workbenchPage
+        .getNotebookRow('Test Notebook')
+        .findHaveNotebookStatusText()
+        .should('have.text', 'Requeued')
+        .click();
+      workbenchStatusModal.find().should('contain.text', 'attempt 2');
+      workbenchStatusModal.findProgressTab().click();
+      workbenchStatusModal.findProgressStepByLabel('Re-queued').should('exist');
+    });
+
+    it('Progress tab — BlockedOnPreemptionGates sub-step shows in-progress label', () => {
+      const blockedWorkload = mockWorkloadK8sResource({
+        k8sName: 'workload-test-notebook',
+        namespace: 'test-project',
+        ownerName: 'test-notebook',
+        mockStatus: WorkloadStatusType.Admitted,
+      });
+      if (blockedWorkload.status) {
+        blockedWorkload.status.conditions = [
+          ...(blockedWorkload.status.conditions ?? []),
+          {
+            lastTransitionTime: '2024-01-15T10:00:00Z',
+            message: 'Waiting for preemption gates to clear',
+            reason: 'BlockedOnPreemptionGates',
+            status: 'True',
+            type: 'BlockedOnPreemptionGates',
+          },
+        ];
+      }
+      if (blockedWorkload.metadata) {
+        blockedWorkload.metadata.labels = {
+          ...blockedWorkload.metadata.labels,
+          'kueue.x-k8s.io/job-name': 'test-notebook',
+        };
+      }
+      initKueueEnabledForStatusModal();
+      cy.interceptK8sList(
+        { model: WorkloadModel, ns: 'test-project' },
+        mockK8sResourceList([blockedWorkload]),
+      );
+      cy.interceptK8sList({ model: EventModel, ns: 'test-project' }, mockK8sResourceList([]));
+      workbenchPage.visit('test-project');
+      workbenchPage.getNotebookRow('Test Notebook').findHaveNotebookStatusText().click();
+      workbenchStatusModal.findProgressTab().click();
+      workbenchStatusModal
+        .findProgressStepByLabel('Admitted but waiting for preemption gates to clear')
+        .should('exist');
+    });
+  });
+
+  describe('Progress tab — warning events surface container_problem step', () => {
+    const makeEvent = (
+      name: string,
+      reason: string,
+      message: string,
+      type: 'Normal' | 'Warning' = 'Normal',
+    ) => ({
+      apiVersion: 'v1',
+      kind: 'Event',
+      metadata: { name, namespace: 'test-project', uid: `${name}-uid` },
+      involvedObject: { name: 'test-notebook', kind: 'StatefulSet' },
+      lastTimestamp: '2024-01-15T10:00:00Z',
+      eventTime: '2024-01-15T10:00:00Z',
+      type,
+      reason,
+      message,
+    });
+
+    const podLifecycleEvents = () => [
+      makeEvent('ev-create', 'SuccessfulCreate', 'Created pod test-notebook-0'),
+      makeEvent('ev-schedule', 'Scheduled', 'Successfully assigned test-notebook-0 to node-1'),
+      makeEvent('ev-iface', 'AddedInterface', 'Add eth0'),
+    ];
+
+    it('BackOff (ImagePullBackOff) — first-time start with unavailable image tag', () => {
+      // No last-activity annotation → first-time start; isRunning=false so steps stay event-driven.
+      const freshNotebook = mockNotebookK8sResource({
+        lastImageSelection: 'test-imagestream:1.2',
+        opts: {
+          metadata: {
+            name: 'test-notebook',
+            labels: { 'opendatahub.io/notebook-image': 'true' },
+            annotations: { 'opendatahub.io/image-display-name': 'Test image' },
+          },
+        },
+      });
+      delete freshNotebook.metadata.annotations?.['notebooks.kubeflow.org/last-activity'];
+      initIntercepts({ notebooks: [freshNotebook] });
+      cy.interceptK8sList(
+        PodModel,
+        mockK8sResourceList([mockPodK8sResource({ isRunning: false })]),
+      );
+      cy.interceptK8sList(
+        { model: EventModel, ns: 'test-project' },
+        mockK8sResourceList([
+          ...podLifecycleEvents(),
+          makeEvent(
+            'ev-backoff',
+            'BackOff',
+            'Back-off pulling image "quay.io/rhoai/workbench-images:pytorch-2024.1"',
+            'Warning',
+          ),
+        ]),
+      );
+      workbenchPage.visit('test-project');
+      workbenchPage.getNotebookRow('Test Notebook').findHaveNotebookStatusText().click();
+      workbenchStatusModal.findProgressTab().click();
+      workbenchStatusModal.findProgressStepByLabel('Workbench requested').should('exist');
+      workbenchStatusModal.findProgressStepByLabel('Pod created').should('exist');
+      workbenchStatusModal.findProgressStepByLabel('Pod assigned').should('exist');
+      workbenchStatusModal.findProgressStepByLabel('Starting Workbench container').should('exist');
+      workbenchStatusModal
+        .findProgressStepByLabel('There was a problem with the workbench container')
+        .should('exist');
+    });
+
+    it('FailedMount — workbench restart while PVC is still detaching from previous pod', () => {
+      // last-activity annotation present → restart; PVC multi-attach until old pod releases the lock.
+      initIntercepts({});
+      cy.interceptK8sList(
+        PodModel,
+        mockK8sResourceList([mockPodK8sResource({ isRunning: false })]),
+      );
+      cy.interceptK8sList(
+        { model: EventModel, ns: 'test-project' },
+        mockK8sResourceList([
+          ...podLifecycleEvents(),
+          makeEvent(
+            'ev-mount',
+            'FailedMount',
+            'Unable to attach or mount volumes: multi-attach error for volume "pvc-abc123": ' +
+              "Volume is already exclusively attached to one node and can't be attached to another",
+            'Warning',
+          ),
+        ]),
+      );
+      workbenchPage.visit('test-project');
+      workbenchPage.getNotebookRow('Test Notebook').findHaveNotebookStatusText().click();
+      workbenchStatusModal.findProgressTab().click();
+      workbenchStatusModal.findProgressStepByLabel('Workbench requested').should('exist');
+      workbenchStatusModal.findProgressStepByLabel('Pod created').should('exist');
+      workbenchStatusModal.findProgressStepByLabel('Pod assigned').should('exist');
+      workbenchStatusModal
+        .findProgressStepByLabel('Restarting Workbench container')
+        .should('exist');
+      workbenchStatusModal
+        .findProgressStepByLabel('There was a problem with the workbench container')
+        .should('exist');
+    });
   });
 });


### PR DESCRIPTION
Closes [RHOAIENG-68468](https://issues.redhat.com/browse/RHOAIENG-68468)

## Description
https://github.com/user-attachments/assets/43bc3213-37e1-42c3-a78f-29759ef2f521

Via the Create workbench Flow

https://github.com/user-attachments/assets/b30e335a-64a9-48e5-b55a-b1981a4d531a



Replaces the hardcoded 17-step progress stepper in the notebook startup modal with a dynamic, tree-based view derived from the actual pod spec.

**Progress tree (was: ProgressStepper → now: TreeView)**
- Steps are built from the notebook's `spec.containers` at runtime — auth proxy steps only appear when the sidecar is present, Kueue admission only appears when Kueue is active
- Pulling / pulled / created are nested as collapsible sub-steps under each container's "started" row, keeping the top level clean
- Auto-expands a container's sub-steps while they are in progress, collapses once done

**Kueue integration**
- Kueue admission is a sub-step under "Pod assigned" with a live label (queue name, position, admission check name, preemption gate state)
- `Re-queued:` prefix only applies to the `Queued` state during a recovery — not every Kueue state
- Queue position appended to the label when the Visibility API returns a position
- `Inadmissible` sub-step shows "Queue X does not exist" when the queue name isn't found (uses the same logic as the existing modal header, now surfaced in the tree)
- Modal header shows the retry attempt count (e.g. "attempt 2") for `Requeued` workloads, even when the pod is still technically running

**Event attribution fixes**
- `BackOff` events are attributed to the workbench container with a dynamic description (`ImagePullBackOff` vs `CrashLoopBackOff`) based on the event message
- Generic `Warning` events (e.g. `FailedMount`, `NetworkNotReady`) are attributed to the primary container so they surface in the tree instead of being silently dropped
- `BlockedOnPreemptionGates` status correctly mapped to `IN_PROGRESS` (was `WARNING`)

**Other fixes**
- Modal title now shows the workbench display name (`<name> status`) instead of the hardcoded "Workbench status"
- `runningPodUid` in `service.ts` uses the running pod's UID consistently with `containerStatuses`
- `PENDING` icon changed from ⊗ (`PendingIcon`) to 🕐 (`OutlinedClockIcon`) — better visual for "not started yet"
- TreeView uses the controlled `isExpanded` prop instead of remounting on every toggle

## How Has This Been Tested?

Tested via Cypress mock tests and unit tests (see Test Impact below). Cluster testing pending — to verify:
- Progress tree steps match actual pod events as they arrive
- Auth proxy steps appear only when `kube-rbac-proxy` is in the spec
- Kueue sub-step label updates as the workload moves through Queued → AdmissionCheck → Admitted
- `Re-queued` header shows correct attempt count; sub-step label shows queue name and position
- `BackOff` and `FailedMount` events surface the warning step correctly

## Test Impact

**Unit tests** (`notebookControllerUtils.spec.tsx`, `messageUtils.spec.ts`, `StartNotebookModal.spec.tsx`)
- Dynamic step generation (container counts, sub-step nesting, optional step filtering)
- Event attribution for `BackOff` (image pull and crash loop variants) and `FailedMount`; grace period suppression behavior
- `getKueueSubStepInfo` covering all Kueue statuses, recovery prefix, queue position
- `renderLastUpdate` regression — Kueue message shows even when `isRunning=true`

**Cypress mock tests** (`workbench.cy.ts`)
- Kueue sub-step expand/collapse in the progress tree
- `AdmissionCheck`, `Requeued`, `BlockedOnPreemptionGates`, `Queued`, `Inadmissible` sub-step labels
- No auth proxy steps when the sidecar is absent
- `BackOff` on a first-time start and `FailedMount` on a restart both surface the warning step

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-68468]: https://redhat.atlassian.net/browse/RHOAIENG-68468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Redesigned Workbench/Notebook startup progress into an expandable hierarchical tree with icons, labels, descriptions, and a progress warning.
  * Expanded Kueue status messaging to include **Admission Check** and **Blocked on preemption gates**, plus improved **Re-queued** labeling (attempts and queue position where applicable).

* **Bug Fixes**
  * Improved container-aware progress by deriving displayed state from the selected running pod/container and passing through container status details.

* **Tests**
  * Updated and expanded unit and Cypress coverage for the new progress tree, Kueue scenarios (including race-condition suppressions), and per-container startup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->