### PR TITLE
Fix protobuf registration panic in gen-ai BFF Konflux build

### DIFF
--- a/packages/gen-ai/Dockerfile.workspace
+++ b/packages/gen-ai/Dockerfile.workspace
@@ -93,6 +93,7 @@ COPY --from=ui-builder /usr/src/workspace/${UI_SOURCE_CODE}/dist ./static/
 USER 65532:65532
 
 # Set environment variables
+ENV GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn
 # Expose port 8080
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- Add `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn` to `packages/gen-ai/Dockerfile.workspace`

## Problem
The `mlflow-go` SDK vendors OTEL trace protos at `internal/gen/otelpb/trace.pb.go`, which collide with the canonical `go.opentelemetry.io/proto/otlp/trace/v1` import. Go's protobuf runtime panics on duplicate file registration:

```
panic: proto: file "opentelemetry/proto/trace/v1/trace.proto" is already registered
previously from: "github.com/opendatahub-io/mlflow-go/internal/gen/otelpb"
currently from: "go.opentelemetry.io/proto/otlp/trace/v1"
```

The standalone `packages/gen-ai/Dockerfile` already has this env var (line 51), but `Dockerfile.workspace` (used by Konflux via `.tekton/odh-mod-arch-gen-ai-push.yaml`) does not.

## Fix
One-line addition of `ENV GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn` to suppress the panic until the upstream fix (removing vendored protos from `opendatahub-io/mlflow-go`) is merged.

## Test plan
- [ ] Konflux build for `odh-mod-arch-gen-ai` completes without protobuf registration panic
- [ ] Gen-ai BFF starts and serves requests normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility by handling duplicate protocol buffer registrations as warnings instead of application errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->