### PR TITLE
fix(cypress): backport e2e test reliability fixes from rhoai-3.4

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataSciencePipelines/testSchedulePipeline.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataSciencePipelines/testSchedulePipeline.yaml
@@ -2,4 +2,4 @@ pipelineName: test-scheduled-pipeline
 pipelineDescription: Pipeline scheduled via E2E
 scheduleName: test-scheduled-run
 scheduleDescription: Scheduled run created by E2E
-pipelineUrl: https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml
+pipelineUrl: https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/packages/cypress/resources/pipelines_samples/dummy_pipeline_compiled.yaml

--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -240,6 +240,22 @@ class ProjectDetails {
     return cy.findByTestId('import-pipeline-button', { timeout });
   }
 
+  private importPipelineButtonExists(): Cypress.Chainable<boolean> {
+    return cy.get('body').then(($body) => {
+      const button = $body.find('[data-testid="import-pipeline-button"]');
+      return button.length > 0;
+    });
+  }
+
+  ensureImportPipelineButtonLoaded() {
+    return this.importPipelineButtonExists().then((exists) => {
+      if (!exists) {
+        cy.log('Import Pipeline button not found, reloading page once');
+        cy.reload();
+      }
+    });
+  }
+
   findSelectPlatformButton(platform: string) {
     return cy.findByTestId(`${platform}-select-button`);
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
@@ -55,7 +55,7 @@ describe('An admin user can import and run a pipeline', { testIsolation: false }
       pipelineImportModal
         .findPipelineUrlInput()
         .type(
-          'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
+          'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/packages/cypress/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
         );
       pipelineImportModal.submit();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
@@ -10,6 +10,7 @@ import {
 import { provisionProjectForPipelines } from '#~/__tests__/cypress/cypress/utils/pipelines';
 import { retryableBefore } from '#~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '#~/__tests__/cypress/cypress/utils/uuidGenerator';
+import { waitForDspaReady } from '#~/__tests__/cypress/cypress/utils/oc_commands/dspa';
 
 const uuid = generateTestUUID();
 const projectName = `test-pipelines-prj-${uuid}`;
@@ -39,9 +40,14 @@ describe('An admin user can import and run a pipeline', { testIsolation: false }
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
 
+      cy.step('Wait for pipeline server (DSPA) to be ready');
+      waitForDspaReady(projectName);
+
+      cy.step('Ensure Import Pipeline button is loaded');
+      projectDetails.ensureImportPipelineButtonLoaded();
+
       cy.step('Import a pipeline by URL');
-      // Increasing the timeout to ~3mins so the DSPA can be loaded
-      projectDetails.findImportPipelineButton(180000).click();
+      projectDetails.findImportPipelineButton().click();
       // Fill the Import Pipeline modal
       pipelineImportModal.findPipelineNameInput().type(testPipelineName);
       pipelineImportModal.findPipelineDescriptionInput().type('Pipeline Description');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/testSchedulePipeline.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/testSchedulePipeline.cy.ts
@@ -15,6 +15,7 @@ import { provisionProjectForPipelines } from '#~/__tests__/cypress/cypress/utils
 import { retryableBefore } from '#~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '#~/__tests__/cypress/cypress/utils/uuidGenerator';
 import { deleteOpenShiftProject } from '#~/__tests__/cypress/cypress/utils/oc_commands/project';
+import { waitForDspaReady } from '#~/__tests__/cypress/cypress/utils/oc_commands/dspa';
 
 const uuid = generateTestUUID();
 const projectName = `test-dsp-schedule-prj-${uuid}`;
@@ -55,8 +56,14 @@ describe('Verify that a pipeline can be scheduled to run', { testIsolation: fals
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
 
+      cy.step('Wait for pipeline server (DSPA) to be ready');
+      waitForDspaReady(projectName);
+
+      cy.step('Ensure Import Pipeline button is loaded');
+      projectDetails.ensureImportPipelineButtonLoaded();
+
       cy.step('Import a pipeline by URL');
-      projectDetails.findImportPipelineButton(180000).click();
+      projectDetails.findImportPipelineButton().click();
       pipelineImportModal.findPipelineNameInput().type(pipelineName);
       pipelineImportModal.findPipelineDescriptionInput().type(pipelineDescription);
       pipelineImportModal.findImportPipelineRadio().click();

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelPvcDeployment.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelPvcDeployment.cy.ts
@@ -141,10 +141,12 @@ describe('Verify a model can be deployed from a PVC', () => {
 
       //Verify the model created and is running
       cy.step('Verify that the Model is running');
-      checkInferenceServiceState(testData.singleModelName, projectName, {
-        checkReady: true,
-        checkLatestDeploymentReady: true,
-      });
+      checkInferenceServiceState(
+        testData.singleModelName,
+        projectName,
+        { checkReady: true },
+        'RawDeployment',
+      );
     },
   );
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelStopStart.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelStopStart.cy.ts
@@ -91,10 +91,12 @@ describe('A model can be stopped and started', () => {
 
       //Verify the model created and is running
       cy.step('Verify that the Model is running');
-      checkInferenceServiceState(testData.singleModelName, projectName, {
-        checkReady: true,
-        checkLatestDeploymentReady: true,
-      });
+      checkInferenceServiceState(
+        testData.singleModelName,
+        projectName,
+        { checkReady: true },
+        'RawDeployment',
+      );
 
       //Stop the model with the modal
       cy.step('Stop the model');
@@ -115,12 +117,16 @@ describe('A model can be stopped and started', () => {
         .should('match', /Stopping|Stopped/);
 
       //Verify the model is stopped
-      checkInferenceServiceState(testData.singleModelName, projectName, {
-        checkReady: false,
-        checkLatestDeploymentReady: false,
-        checkStopped: true,
-        requireLoadedState: false,
-      });
+      checkInferenceServiceState(
+        testData.singleModelName,
+        projectName,
+        {
+          checkReady: false,
+          checkStopped: true,
+          requireLoadedState: false,
+        },
+        'RawDeployment',
+      );
       kServeRow.findStatusLabel('Stopped', MODEL_STATUS_TIMEOUT).should('exist');
 
       //Restart the model
@@ -129,10 +135,12 @@ describe('A model can be stopped and started', () => {
       kServeRow.findStatusLabel('Starting').should('exist');
 
       //Verify the model is running again
-      checkInferenceServiceState(testData.singleModelName, projectName, {
-        checkReady: true,
-        checkLatestDeploymentReady: true,
-      });
+      checkInferenceServiceState(
+        testData.singleModelName,
+        projectName,
+        { checkReady: true },
+        'RawDeployment',
+      );
       kServeRow
         .findStatusLabel()
         .invoke('text')

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelTokenAuth.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelTokenAuth.cy.ts
@@ -97,10 +97,12 @@ describe('A model can be deployed with token auth', () => {
 
       // Verify the model created
       cy.step('Verify that the Model is running');
-      checkInferenceServiceState(testData.singleModelName, projectName, {
-        checkReady: true,
-        checkLatestDeploymentReady: true,
-      });
+      checkInferenceServiceState(
+        testData.singleModelName,
+        projectName,
+        { checkReady: true },
+        'RawDeployment',
+      );
 
       // Verify the model is not accessible without a token
       cy.step('Verify the model is not accessible without a token');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
@@ -115,10 +115,8 @@ describe('Verify Admin Multi Model Creation and Validation using the UI', () => 
       //Verify the Model was created successfully
       cy.step('Verify that the Model is created Successfully on the backend and frontend');
       checkInferenceServiceState(testData.multiModelAdminName, projectName);
-      // Check only LatestDeploymentReady
       checkInferenceServiceState(testData.multiModelAdminName, projectName, {
         checkReady: true,
-        checkLatestDeploymentReady: false,
       });
       // Usually it takes a little longer to load the status tooltip, so it's faster to Reload the page
       cy.reload();

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -97,10 +97,12 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
 
       //Verify the model created
       cy.step('Verify that the Model is created Successfully on the backend and frontend');
-      checkInferenceServiceState(testData.singleModelAdminName, projectName, {
-        checkReady: true,
-        checkLatestDeploymentReady: true,
-      });
+      checkInferenceServiceState(
+        testData.singleModelAdminName,
+        projectName,
+        { checkReady: true },
+        'RawDeployment',
+      );
       // Note reload is required as status tooltip was not found due to a stale element
       cy.reload();
       modelServingSection.findModelMetricsLink(testData.singleModelAdminName);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
@@ -96,10 +96,12 @@ describe('Verify Model Creation and Validation using the UI', () => {
 
       //Verify the model created
       cy.step('Verify that the Model is created Successfully on the backend and frontend');
-      checkInferenceServiceState(testData.singleModelName, projectName, {
-        checkReady: true,
-        checkLatestDeploymentReady: true,
-      });
+      checkInferenceServiceState(
+        testData.singleModelName,
+        projectName,
+        { checkReady: true },
+        'RawDeployment',
+      );
       cy.reload();
       modelServingSection.findModelMetricsLink(testData.singleModelName);
       // Note reload is required as status tooltip was not found due to a stale element

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegistryDeployModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegistryDeployModel.cy.ts
@@ -183,10 +183,12 @@ describe('Verify models can be deployed from model registry', () => {
       cy.contains('Started', { timeout: 120000 }).should('be.visible');
 
       cy.step('Verify the model is deployed and started in backend');
-      checkInferenceServiceState(`${modelName}-v10`, projectName, {
-        checkReady: true,
-        checkLatestDeploymentReady: true,
-      });
+      checkInferenceServiceState(
+        `${modelName}-v10`,
+        projectName,
+        { checkReady: true },
+        'RawDeployment',
+      );
     },
   );
 });

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/dspa.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/dspa.ts
@@ -80,7 +80,9 @@ export const logDspaStatus = (projectName: string): void => {
   }).then((result) => {
     if (result.code !== 0) {
       cy.log(
-        `[DSPA] Pipeline server not ready: oc get failed (exit ${result.code}). ${result.stderr.trim()}`,
+        `[DSPA] Pipeline server not ready: oc get failed (exit ${
+          result.code
+        }). ${result.stderr.trim()}`,
       );
       return;
     }

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/dspa.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/dspa.ts
@@ -6,6 +6,15 @@ import type {
 } from '#~/__tests__/cypress/cypress/types';
 import { applyOpenShiftYaml } from './baseCommands';
 
+const DSPA_RESOURCE_NAME = 'dspa';
+
+type DspaCondition = {
+  type: string;
+  status: string;
+  reason?: string;
+  message?: string;
+};
+
 /**
  * Try to create a DSPA Secret based on the dspaSecretReplacements config
  * @param dspaSecretReplacements Dictionary with the config values
@@ -46,3 +55,58 @@ export const createDSPA = (
     const modifiedYamlContent = replacePlaceholdersInYaml(yamlContent, dspaReplacements);
     return applyOpenShiftYaml(modifiedYamlContent);
   });
+
+export const waitForDspaReady = (
+  projectName: string,
+  timeout = '600s',
+): Cypress.Chainable<CommandLineResult> => {
+  const command = `oc wait --for=condition=Ready dspa/${DSPA_RESOURCE_NAME} -n ${projectName} --timeout=${timeout}`;
+  cy.log(`Waiting for DSPA to be ready: ${command}`);
+
+  return cy
+    .exec(command, { failOnNonZeroExit: false, timeout: 610000 })
+    .then((result: CommandLineResult) => {
+      if (result.code !== 0) {
+        cy.log(`DSPA wait failed (exit ${result.code}): ${result.stderr}`);
+      } else {
+        cy.log('DSPA is ready');
+      }
+    });
+};
+
+export const logDspaStatus = (projectName: string): void => {
+  cy.exec(`oc get dspa ${DSPA_RESOURCE_NAME} -n ${projectName} -o json`, {
+    failOnNonZeroExit: false,
+  }).then((result) => {
+    if (result.code !== 0) {
+      cy.log(
+        `[DSPA] Pipeline server not ready: oc get failed (exit ${result.code}). ${result.stderr.trim()}`,
+      );
+      return;
+    }
+    try {
+      const dspa = JSON.parse(result.stdout || '{}') as {
+        status?: { conditions?: DspaCondition[] };
+      };
+      const conditions = dspa.status?.conditions ?? [];
+      const readyCondition = conditions.find((c) => c.type === 'Ready');
+      if (readyCondition?.status === 'True') {
+        cy.log('[DSPA] Pipeline server is ready.');
+        return;
+      }
+      const notReadyReasons = conditions
+        .filter((c) => c.status === 'False')
+        .map((c) => {
+          const part = [c.type, c.reason, c.message].filter(Boolean).join(': ');
+          return part || 'Unknown';
+        });
+      const reason =
+        notReadyReasons.length > 0
+          ? notReadyReasons.join('; ')
+          : readyCondition?.message || readyCondition?.reason || 'Waiting for Ready condition';
+      cy.log(`[DSPA] Pipeline server not ready: ${reason}`);
+    } catch {
+      cy.log('[DSPA] Pipeline server not ready: failed to parse DSPA status.');
+    }
+  });
+};

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
@@ -41,15 +41,14 @@ export const deleteOpenShiftProject = (
   projectName: string,
   options: { timeout?: number; wait?: boolean; ignoreNotFound?: boolean } = {},
 ): Cypress.Chainable<CommandLineResult> => {
-  const { timeout, wait = true, ignoreNotFound = false } = options;
-  const waitFlag = wait ? '' : '--wait=false';
+  const { timeout = 180000, wait = true, ignoreNotFound = false } = options;
+  const waitFlag = wait ? '--wait' : '--wait=false';
   const ignoreNotFoundFlag = ignoreNotFound ? '--ignore-not-found' : '';
   const ocCommand = `oc delete project ${projectName} ${waitFlag} ${ignoreNotFoundFlag}`.trim();
 
-  // Only apply timeout if we're waiting for the deletion
   const execOptions = {
     failOnNonZeroExit: false,
-    ...(wait && timeout && { timeout }),
+    ...(wait && { timeout }),
   };
 
   return cy.exec(ocCommand, execOptions).then((result) => {

--- a/frontend/src/__tests__/cypress/cypress/utils/projectChecker.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/projectChecker.ts
@@ -20,9 +20,29 @@ export const createCleanProject = (projectName: string): void => {
   verifyOpenShiftProjectExists(projectName).then((exists) => {
     if (exists) {
       cy.log(`Project ${projectName} already exists. Deleting it.`);
-      deleteOpenShiftProject(projectName, { wait: true });
+      deleteOpenShiftProject(projectName, { wait: true }).then(() => {
+        cy.log(`Waiting for project ${projectName} to be fully deleted...`);
+        const checkDeleted = (): Cypress.Chainable<boolean> => {
+          return verifyOpenShiftProjectExists(projectName).then(
+            (stillExists): Cypress.Chainable<boolean> => {
+              if (stillExists) {
+                cy.log(`Project ${projectName} still exists, waiting...`);
+                // eslint-disable-next-line cypress/no-unnecessary-waiting
+                cy.wait(1000);
+                return checkDeleted();
+              }
+              return cy.wrap(true);
+            },
+          );
+        };
+        checkDeleted().then(() => {
+          cy.log(`Creating project ${projectName}`);
+          createAndVerifyProject(projectName);
+        });
+      });
+    } else {
+      cy.log(`Creating project ${projectName}`);
+      createAndVerifyProject(projectName);
     }
-    cy.log(`Creating project ${projectName}`);
-    createAndVerifyProject(projectName);
   });
 };


### PR DESCRIPTION
## Summary

Backports critical Cypress e2e test reliability fixes from `rhoai-3.4` to `stable-2.x`. These fixes address persistent test failures observed in dashboard e2e test runs (Jenkins build #1843 — 3 out of 96 tests failing consistently across all retries).

### Fixes included:

1. **DSPA readiness wait** (RHOAIENG-46257, upstream PR #6405)
   - Adds `waitForDspaReady()` using `oc wait --for=condition=Ready` to properly wait for the pipeline server backend before UI interaction
   - Adds `ensureImportPipelineButtonLoaded()` to handle the race condition where DSPA is ready but UI hasn't updated
   - Replaces brittle 180s `findImportPipelineButton` timeout with proper backend polling

2. **Project deletion race condition** (RHOAIENG-46674, upstream PR #6062)
   - Fixes `createCleanProject` to poll until project is fully deleted (not just "Terminating") before creating a new one
   - Fixes `--wait` flag to be explicit instead of empty string

3. **Project deletion timeout increase** (upstream PR #7419)
   - Increases default `deleteOpenShiftProject` timeout from 60s to 180s
   - Fixes timeout always being applied when `wait=true`

4. **Model registry InferenceService condition check** (upstream PR #5085)
   - Removes `checkLatestDeploymentReady` check which only applies to Serverless/Knative mode
   - Adds explicit `'RawDeployment'` mode parameter for KServe Raw deployment tests

### Tests affected:
- `pipelines.cy.ts` — "An admin User can Import and Run a Pipeline"
- `testSchedulePipeline.cy.ts` — "Admin imports a pipeline and schedules it to run"
- `testRegistryDeployModel.cy.ts` — "Registers a model and deploys it via model registry"

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Run Jenkins e2e tests with these fixes on a RHOAI 2.25 cluster
- [ ] Verify all 3 previously-failing tests now pass