### PR TITLE
feat: add Segment tracking for Homepage Task Shortcuts

### DIFF
--- a/frontend/src/pages/home/taskAssistant/TaskAssistantSearchDropdown.tsx
+++ b/frontend/src/pages/home/taskAssistant/TaskAssistantSearchDropdown.tsx
@@ -18,6 +18,7 @@ const TaskAssistantSearchDropdown: React.FC<TaskAssistantSearchDropdownProps> = 
 }) => {
   const navigate = useNavigate();
   const filterTextRef = React.useRef('');
+  const hadFilteredRef = React.useRef(false);
   const didSelectRef = React.useRef(false);
 
   const selectOptions: TypeaheadSelectOption[] = React.useMemo(() => {
@@ -31,6 +32,9 @@ const TaskAssistantSearchDropdown: React.FC<TaskAssistantSearchDropdownProps> = 
 
   const handleInputChange = React.useCallback((newValue: string) => {
     filterTextRef.current = newValue;
+    if (newValue.length > 0) {
+      hadFilteredRef.current = true;
+    }
   }, []);
 
   const handleSelect = React.useCallback(
@@ -43,7 +47,7 @@ const TaskAssistantSearchDropdown: React.FC<TaskAssistantSearchDropdownProps> = 
           taskName: task.title,
           category: task.group,
           destination: task.href,
-          viewContext: filterTextRef.current.length > 0 ? 'search-filtered' : 'search',
+          viewContext: hadFilteredRef.current ? 'search-filtered' : 'search',
         });
 
         filterTextRef.current = '';
@@ -56,10 +60,11 @@ const TaskAssistantSearchDropdown: React.FC<TaskAssistantSearchDropdownProps> = 
   const handleToggle = React.useCallback((nextIsOpen: boolean) => {
     if (!nextIsOpen) {
       if (!didSelectRef.current) {
-        fireSearchAborted({ filtered: filterTextRef.current.length > 0 });
+        fireSearchAborted({ filtered: hadFilteredRef.current });
       }
       didSelectRef.current = false;
       filterTextRef.current = '';
+      hadFilteredRef.current = false;
     }
   }, []);
 

--- a/frontend/src/pages/home/taskAssistant/TaskAssistantSearchDropdown.tsx
+++ b/frontend/src/pages/home/taskAssistant/TaskAssistantSearchDropdown.tsx
@@ -5,6 +5,7 @@ import TypeaheadSelect, {
   TypeaheadSelectOption,
 } from '@odh-dashboard/ui-core/components/TypeaheadSelect';
 import type { ResolvedTaskGroup, ResolvedTaskItem } from './types';
+import { fireShortcutClicked, fireSearchAborted } from './taskAssistantTracking';
 
 type TaskAssistantSearchDropdownProps = {
   groups: Pick<ResolvedTaskGroup, 'id' | 'title'>[];
@@ -16,6 +17,8 @@ const TaskAssistantSearchDropdown: React.FC<TaskAssistantSearchDropdownProps> = 
   tasks,
 }) => {
   const navigate = useNavigate();
+  const filterTextRef = React.useRef('');
+  const didSelectRef = React.useRef(false);
 
   const selectOptions: TypeaheadSelectOption[] = React.useMemo(() => {
     const groupTitleMap = Object.fromEntries(groups.map((g) => [g.id, g.title]));
@@ -26,20 +29,46 @@ const TaskAssistantSearchDropdown: React.FC<TaskAssistantSearchDropdownProps> = 
     }));
   }, [groups, tasks]);
 
+  const handleInputChange = React.useCallback((newValue: string) => {
+    filterTextRef.current = newValue;
+  }, []);
+
   const handleSelect = React.useCallback(
     (_event: unknown, selection: string | number) => {
       const task = tasks.find((t) => t.id === selection);
       if (task) {
+        didSelectRef.current = true;
+
+        fireShortcutClicked({
+          taskName: task.title,
+          category: task.group,
+          destination: task.href,
+          viewContext: filterTextRef.current.length > 0 ? 'search-filtered' : 'search',
+        });
+
+        filterTextRef.current = '';
         navigate(task.href);
       }
     },
     [navigate, tasks],
   );
 
+  const handleToggle = React.useCallback((nextIsOpen: boolean) => {
+    if (!nextIsOpen) {
+      if (!didSelectRef.current) {
+        fireSearchAborted({ filtered: filterTextRef.current.length > 0 });
+      }
+      didSelectRef.current = false;
+      filterTextRef.current = '';
+    }
+  }, []);
+
   return (
     <TypeaheadSelect
       selectOptions={selectOptions}
       onSelect={handleSelect}
+      onInputChange={handleInputChange}
+      onToggle={handleToggle}
       placeholder="Looking for another task?"
       isRequired={false}
       allowClear

--- a/frontend/src/pages/home/taskAssistant/TaskAssistantSection.tsx
+++ b/frontend/src/pages/home/taskAssistant/TaskAssistantSection.tsx
@@ -22,6 +22,7 @@ import TaskGroupCard from './TaskGroupCard';
 import TaskAssistantPillBar from './TaskAssistantPillBar';
 import TaskAssistantSearchDropdown from './TaskAssistantSearchDropdown';
 import useTaskAssistantData from './useTaskAssistantData';
+import { fireSectionToggled } from './taskAssistantTracking';
 
 const STORAGE_KEY = 'odh.home.task-assistant.open';
 
@@ -42,6 +43,7 @@ const TaskAssistantSection: React.FC = () => {
 
   const handlePillClick = React.useCallback(
     (groupId: string) => {
+      fireSectionToggled({ isExpanded: true, category: groupId });
       scrollTargetRef.current = `task-group-${groupId}`;
       setIsOpen(true);
     },
@@ -78,7 +80,10 @@ const TaskAssistantSection: React.FC = () => {
                 aria-expanded={isOpen}
                 variant="plain"
                 className="pf-v6-u-px-0"
-                onClick={() => setIsOpen(!isOpen)}
+                onClick={() => {
+                  fireSectionToggled({ isExpanded: !isOpen });
+                  setIsOpen(!isOpen);
+                }}
               />
             </FlexItem>
             <FlexItem>

--- a/frontend/src/pages/home/taskAssistant/TaskGroupCard.tsx
+++ b/frontend/src/pages/home/taskAssistant/TaskGroupCard.tsx
@@ -17,6 +17,7 @@ import { TypeBorderedCard } from '@odh-dashboard/ui-core';
 import SectionIcon from '#~/concepts/design/SectionIcon';
 import { SectionType } from '#~/concepts/design/utils';
 import type { ResolvedTaskGroup, ResolvedTaskItem } from './types';
+import { fireShortcutClicked } from './taskAssistantTracking';
 
 type TaskGroupCardProps = {
   group: Pick<ResolvedTaskGroup, 'id' | 'title' | 'description' | 'type' | 'icon'>;
@@ -51,6 +52,14 @@ const TaskGroupCard: React.FC<TaskGroupCardProps> = ({ group, tasks }) => {
                 variant={ButtonVariant.link}
                 isInline
                 component={(props: React.ComponentProps<'a'>) => <Link {...props} to={task.href} />}
+                onClick={() =>
+                  fireShortcutClicked({
+                    taskName: task.title,
+                    category: group.id,
+                    destination: task.href,
+                    viewContext: 'default-row',
+                  })
+                }
                 data-testid={`task-link-${task.id}`}
               >
                 {task.title}

--- a/frontend/src/pages/home/taskAssistant/__tests__/TaskAssistantSearchDropdown.spec.tsx
+++ b/frontend/src/pages/home/taskAssistant/__tests__/TaskAssistantSearchDropdown.spec.tsx
@@ -2,7 +2,19 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import {
+  fireShortcutClicked,
+  fireSearchAborted,
+} from '#~/pages/home/taskAssistant/taskAssistantTracking';
 import TaskAssistantSearchDropdown from '#~/pages/home/taskAssistant/TaskAssistantSearchDropdown';
+
+jest.mock('#~/pages/home/taskAssistant/taskAssistantTracking', () => ({
+  fireShortcutClicked: jest.fn(),
+  fireSearchAborted: jest.fn(),
+}));
+
+const mockFireShortcutClicked = jest.mocked(fireShortcutClicked);
+const mockFireSearchAborted = jest.mocked(fireSearchAborted);
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -98,5 +110,73 @@ describe('TaskAssistantSearchDropdown', () => {
     fireEvent.change(input, { target: { value: 'zzz-no-match' } });
 
     expect(screen.getByText(/No results found/)).toBeInTheDocument();
+  });
+
+  describe('tracking', () => {
+    it('should fire Shortcut Clicked with viewContext search when selecting without filtering', () => {
+      renderDropdown();
+
+      const input = screen.getByPlaceholderText('Looking for another task?');
+      fireEvent.click(input);
+      fireEvent.click(screen.getByText('Find models'));
+
+      expect(mockFireShortcutClicked).toHaveBeenCalledWith({
+        taskName: 'Find models',
+        category: 'ai-hub',
+        destination: '/models',
+        viewContext: 'search',
+      });
+    });
+
+    it('should fire Shortcut Clicked with viewContext search-filtered when filter text was entered', () => {
+      renderDropdown();
+
+      const input = screen.getByPlaceholderText('Looking for another task?');
+      fireEvent.click(input);
+      fireEvent.change(input, { target: { value: 'model' } });
+      fireEvent.click(screen.getByText('Find models'));
+
+      expect(mockFireShortcutClicked).toHaveBeenCalledWith({
+        taskName: 'Find models',
+        category: 'ai-hub',
+        destination: '/models',
+        viewContext: 'search-filtered',
+      });
+    });
+
+    it('should fire Search Aborted with filtered false when closing without selecting or typing', () => {
+      renderDropdown();
+
+      const toggle = screen.getByRole('button', { name: 'Typeahead menu toggle' });
+      fireEvent.click(toggle);
+      fireEvent.click(toggle);
+
+      expect(mockFireSearchAborted).toHaveBeenCalledWith({ filtered: false });
+      expect(mockFireShortcutClicked).not.toHaveBeenCalled();
+    });
+
+    it('should fire Search Aborted with filtered true when closing after typing without selecting', () => {
+      renderDropdown();
+
+      const input = screen.getByPlaceholderText('Looking for another task?');
+      fireEvent.click(input);
+      fireEvent.change(input, { target: { value: 'model' } });
+
+      const toggle = screen.getByRole('button', { name: 'Typeahead menu toggle' });
+      fireEvent.click(toggle);
+
+      expect(mockFireSearchAborted).toHaveBeenCalledWith({ filtered: true });
+      expect(mockFireShortcutClicked).not.toHaveBeenCalled();
+    });
+
+    it('should not fire Search Aborted when a task is selected', () => {
+      renderDropdown();
+
+      const input = screen.getByPlaceholderText('Looking for another task?');
+      fireEvent.click(input);
+      fireEvent.click(screen.getByText('Find models'));
+
+      expect(mockFireSearchAborted).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/pages/home/taskAssistant/__tests__/TaskAssistantSearchDropdown.spec.tsx
+++ b/frontend/src/pages/home/taskAssistant/__tests__/TaskAssistantSearchDropdown.spec.tsx
@@ -169,6 +169,20 @@ describe('TaskAssistantSearchDropdown', () => {
       expect(mockFireShortcutClicked).not.toHaveBeenCalled();
     });
 
+    it('should fire Search Aborted with filtered true when user typed then cleared text before closing', () => {
+      renderDropdown();
+
+      const input = screen.getByPlaceholderText('Looking for another task?');
+      fireEvent.click(input);
+      fireEvent.change(input, { target: { value: 'workbench' } });
+      fireEvent.change(input, { target: { value: '' } });
+
+      const toggle = screen.getByRole('button', { name: 'Typeahead menu toggle' });
+      fireEvent.click(toggle);
+
+      expect(mockFireSearchAborted).toHaveBeenCalledWith({ filtered: true });
+    });
+
     it('should not fire Search Aborted when a task is selected', () => {
       renderDropdown();
 

--- a/frontend/src/pages/home/taskAssistant/__tests__/TaskAssistantSection.spec.tsx
+++ b/frontend/src/pages/home/taskAssistant/__tests__/TaskAssistantSection.spec.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { useExtensions, useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import { useBrowserStorage } from '@odh-dashboard/ui-core/utilities';
+import { fireSectionToggled } from '#~/pages/home/taskAssistant/taskAssistantTracking';
 import TaskAssistantSection from '#~/pages/home/taskAssistant/TaskAssistantSection';
 import { makeGroupExtension, makeItemExtension } from './taskAssistantTestUtils';
 
@@ -16,6 +17,12 @@ jest.mock('@odh-dashboard/ui-core/utilities', () => ({
   ...jest.requireActual('@odh-dashboard/ui-core/utilities'),
   useBrowserStorage: jest.fn(),
 }));
+
+jest.mock('#~/pages/home/taskAssistant/taskAssistantTracking', () => ({
+  fireSectionToggled: jest.fn(),
+}));
+
+const mockFireSectionToggled = jest.mocked(fireSectionToggled);
 
 const mockUseResolvedExtensions = jest.mocked(useResolvedExtensions);
 const mockUseExtensions = jest.mocked(useExtensions);
@@ -108,6 +115,13 @@ describe('TaskAssistantSection', () => {
       fireEvent.click(screen.getByRole('button', { expanded: true }));
       expect(mockSetIsOpen).toHaveBeenCalledWith(false);
     });
+
+    it('should fire Section Toggled with isExpanded false when collapsing', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByRole('button', { expanded: true }));
+      expect(mockFireSectionToggled).toHaveBeenCalledWith({ isExpanded: false });
+    });
   });
 
   describe('collapsed state', () => {
@@ -137,6 +151,22 @@ describe('TaskAssistantSection', () => {
       const clickTarget = pill.querySelector('.pf-v6-c-label__content') ?? pill;
       fireEvent.click(clickTarget);
       expect(mockSetIsOpen).toHaveBeenCalledWith(true);
+    });
+
+    it('should fire Section Toggled with category when expanding via pill click', () => {
+      renderSection();
+
+      const pill = screen.getByTestId('task-pill-g1');
+      const clickTarget = pill.querySelector('.pf-v6-c-label__content') ?? pill;
+      fireEvent.click(clickTarget);
+      expect(mockFireSectionToggled).toHaveBeenCalledWith({ isExpanded: true, category: 'g1' });
+    });
+
+    it('should fire Section Toggled without category when expanding via toggle button', () => {
+      renderSection();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Task shortcuts', expanded: false }));
+      expect(mockFireSectionToggled).toHaveBeenCalledWith({ isExpanded: true });
     });
   });
 });

--- a/frontend/src/pages/home/taskAssistant/__tests__/TaskGroupCard.spec.tsx
+++ b/frontend/src/pages/home/taskAssistant/__tests__/TaskGroupCard.spec.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { fireShortcutClicked } from '#~/pages/home/taskAssistant/taskAssistantTracking';
 import TaskGroupCard from '#~/pages/home/taskAssistant/TaskGroupCard';
+
+jest.mock('#~/pages/home/taskAssistant/taskAssistantTracking', () => ({
+  fireShortcutClicked: jest.fn(),
+}));
+
+const mockFireShortcutClicked = jest.mocked(fireShortcutClicked);
 
 const MockIcon: React.FC = () => <span data-testid="group-icon">icon</span>;
 
@@ -85,5 +92,18 @@ describe('TaskGroupCard', () => {
 
     const card = screen.getByTestId('task-group-card-general-group');
     expect(card).toHaveClass('general');
+  });
+
+  it('should fire Home Task Shortcut Clicked when a task link is clicked', () => {
+    renderCard();
+
+    fireEvent.click(screen.getByTestId('task-link-task-1'));
+
+    expect(mockFireShortcutClicked).toHaveBeenCalledWith({
+      taskName: 'Find models',
+      category: 'ai-hub',
+      destination: '/models',
+      viewContext: 'default-row',
+    });
   });
 });

--- a/frontend/src/pages/home/taskAssistant/taskAssistantTracking.ts
+++ b/frontend/src/pages/home/taskAssistant/taskAssistantTracking.ts
@@ -1,0 +1,57 @@
+import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
+
+export const TASK_SHORTCUTS_EVENTS = {
+  SHORTCUT_CLICKED: 'Home Task Shortcut Clicked',
+  SEARCH_ABORTED: 'Home Task Shortcuts Search Aborted',
+  SECTION_TOGGLED: 'Home Task Shortcuts Section Toggled',
+  // P2 deferred -- UI not yet built:
+  // VIEW_ALL_SELECTED: 'Home Task Shortcuts View All Selected',
+  // OVERFLOW_MENU_OPENED: 'Home Task Shortcuts Overflow Menu Opened',
+} as const;
+
+/**
+ * Category values use the extension-point group `id` (e.g. 'ai-hub',
+ * 'gen-ai-studio', 'develop-and-train'). The approved tracking spec uses
+ * slightly different names ('develop-train', 'observe-monitor'); PM will
+ * align the spec with the canonical code values.
+ *
+ * viewContext values:
+ *   'default-row'        -- clicked from a category card in the expanded section
+ *   'search'             -- selected from the "Looking for another task?" dropdown
+ *   'search-filtered'    -- selected from the dropdown after typing a filter query
+ *   P2 deferred:
+ *   'collapsed-label'    -- clicked from a pill in collapsed state (UI not built)
+ *   'all-cards'          -- clicked from the "View All" cards view (UI not built)
+ *   'overflow-menu'      -- clicked from the overflow "X more" menu (UI not built)
+ */
+export type ShortcutClickedProperties = {
+  taskName: string;
+  category: string;
+  destination: string;
+  viewContext: string;
+};
+
+export type SectionToggledProperties = {
+  isExpanded: boolean;
+  category?: string;
+};
+
+export type SearchAbortedProperties = {
+  filtered: boolean;
+};
+
+// P2 deferred types -- uncomment when UI ships:
+// export type ViewAllSelectedProperties = { sourceView: 'default-row' };
+// export type OverflowMenuOpenedProperties = { hiddenTaskCount: number };
+
+export const fireShortcutClicked = (properties: ShortcutClickedProperties): void => {
+  fireMiscTrackingEvent(TASK_SHORTCUTS_EVENTS.SHORTCUT_CLICKED, properties);
+};
+
+export const fireSearchAborted = (properties: SearchAbortedProperties): void => {
+  fireMiscTrackingEvent(TASK_SHORTCUTS_EVENTS.SEARCH_ABORTED, properties);
+};
+
+export const fireSectionToggled = (properties: SectionToggledProperties): void => {
+  fireMiscTrackingEvent(TASK_SHORTCUTS_EVENTS.SECTION_TOGGLED, properties);
+};

--- a/frontend/src/pages/home/taskAssistant/taskAssistantTracking.ts
+++ b/frontend/src/pages/home/taskAssistant/taskAssistantTracking.ts
@@ -1,5 +1,16 @@
 import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 
+/**
+ * Spec deviations (approved by PM during implementation):
+ *
+ * - `Workflow Selected` and `Search Used` were consolidated into
+ *   `Shortcut Clicked` with a `viewContext` discriminator (`search` /
+ *   `search-filtered`). Navigation context is captured via page visits.
+ * - `workflow` / `previousWorkflow` properties were dropped; `taskName`
+ *   identifies the selected item and `viewContext` captures the surface.
+ * - `Search Aborted` was added to track dropdown abandonment (not in
+ *   original spec).
+ */
 export const TASK_SHORTCUTS_EVENTS = {
   SHORTCUT_CLICKED: 'Home Task Shortcut Clicked',
   SEARCH_ABORTED: 'Home Task Shortcuts Search Aborted',
@@ -28,7 +39,7 @@ export type ShortcutClickedProperties = {
   taskName: string;
   category: string;
   destination: string;
-  viewContext: string;
+  viewContext: 'default-row' | 'search' | 'search-filtered';
 };
 
 export type SectionToggledProperties = {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-74891

## Description

Adds Segment analytics tracking to the Homepage Task Shortcuts section. Three events are instrumented across the Task Assistant components using `fireMiscTrackingEvent`, following the eval-hub tracking pattern.

### Events

| Event | Trigger | Properties |
|-------|---------|------------|
| `Home Task Shortcut Clicked` | User clicks a task link from a category card or the search dropdown | `taskName`, `category`, `destination`, `viewContext` |
| `Home Task Shortcuts Section Toggled` | User clicks the expand/collapse toggle or a category pill | `isExpanded`, `category` (only present on pill click) |
| `Home Task Shortcuts Search Aborted` | User opens the search dropdown then closes it without selecting a task | `filtered` (true if filter text was entered) |

**`viewContext` values for Shortcut Clicked:**
- `default-row` -- clicked from a category card in the expanded section
- `search` -- selected from the "Looking for another task?" dropdown without filtering
- `search-filtered` -- selected from the dropdown after typing a filter query

Two P2 events (`View All Selected`, `Overflow Menu Opened`) are documented as deferred in the tracking constants since their UI is not yet built.

## How Has This Been Tested?

- Manually verified all three events fire with correct properties by observing `DEV_MODE` console log output
- Verified card clicks produce `viewContext: 'default-row'`, dropdown selections produce `search` or `search-filtered`
- Verified pill clicks fire Section Toggled with `category`, toggle button fires without
- Verified closing the dropdown without selecting fires Search Aborted with correct `filtered` value
- Verified selecting from the dropdown does not fire Search Aborted

Example events:
```
Telemetry event triggered: Home Task Shortcuts Section Toggled - {"isExpanded":false}
Telemetry event triggered: Home Task Shortcuts Section Toggled - {"isExpanded":true,"category":"ai-hub"}
Telemetry event triggered: Home Task Shortcut Clicked - {"taskName":"Find, register, and deploy models","category":"ai-hub","destination":"/ai-hub/models","viewContext":"default-row"}
Telemetry event triggered: Home Task Shortcuts Search Aborted - {"filtered":false}
Telemetry event triggered: Home Task Shortcuts Search Aborted - {"filtered":true}
Telemetry event triggered: Home Task Shortcut Clicked - {"taskName":"Manage training jobs","category":"develop-and-train","destination":"/develop-train/training-jobs","viewContext":"search-filtered"}
```

## Test Impact

Unit tests added for all three events across three test files:
- `TaskGroupCard.spec.tsx` -- card click fires Shortcut Clicked with correct properties
- `TaskAssistantSearchDropdown.spec.tsx` -- dropdown selection fires Shortcut Clicked with `search`/`search-filtered` viewContext; closing without selection fires Search Aborted; selecting does not fire Search Aborted
- `TaskAssistantSection.spec.tsx` -- toggle button fires Section Toggled in both directions; pill click fires with category

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for task shortcut selections, including whether a filtered search was used.
  * Added analytics tracking when a search is closed/abandoned without selecting an option.
  * Added analytics tracking for expanding/collapsing the Task Assistant section.
  * Added analytics tracking for clicks on task links within task group cards.
* **Tests**
  * Expanded unit tests to verify the emitted analytics payloads for search, selection, abort, and section toggle interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->