### PR TITLE
Update MaaS API URL to use /v1/tenants

### DIFF
--- a/manifests/modular-architecture/deployment.yaml
+++ b/manifests/modular-architecture/deployment.yaml
@@ -327,6 +327,10 @@
     env:
       - name: GATEWAY_DOMAIN
         value: ""
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/manifests/modular-architecture/deployment.yaml
+++ b/manifests/modular-architecture/deployment.yaml
@@ -327,10 +327,6 @@
     env:
       - name: GATEWAY_DOMAIN
         value: ""
-      - name: POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/manifests/modular-architecture/modules-cluster-role.yaml
+++ b/manifests/modular-architecture/modules-cluster-role.yaml
@@ -3,6 +3,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: odh-dashboard-modules
 rules:
+  # DSC product type for maas-api infra namespace discovery (maas-ui)
+  - apiGroups:
+      - datasciencecluster.opendatahub.io
+    verbs:
+      - list
+    resources:
+      - datascienceclusters
   # MLflow CR auto-discovery (mlflow-ui, gen-ai-ui)
   - apiGroups:
       - mlflow.opendatahub.io

--- a/manifests/modular-architecture/modules/maas/deployment.yaml
+++ b/manifests/modular-architecture/modules/maas/deployment.yaml
@@ -146,7 +146,7 @@ spec:
           env:
             - name: GATEWAY_DOMAIN
               value: ""
-            - name: TIERS_CONFIGMAP_NS
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace

--- a/manifests/modular-architecture/modules/maas/deployment.yaml
+++ b/manifests/modular-architecture/modules/maas/deployment.yaml
@@ -146,10 +146,6 @@ spec:
           env:
             - name: GATEWAY_DOMAIN
               value: ""
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true

--- a/packages/maas/CONTRIBUTING.md
+++ b/packages/maas/CONTRIBUTING.md
@@ -71,7 +71,7 @@ MAAS_API_URL=https://maas.apps.my-cluster.example.com/maas-api make dev-start-fe
 MAAS_API_URL=https://maas.apps.my-cluster.example.com/maas-api
 ```
 
-When the BFF runs **in-cluster** without `MAAS_API_URL`, it calls the internal `maas-api` Service at `GET /v1/tenants` (service account auth), selects the tenant whose gateway name is `maas-default-gateway`, and uses `gateway.externalUrl + /maas-api` as the passthrough base URL. The deployment injects `POD_NAMESPACE` (downward API) to locate `maas-api`; optional overrides: `MAAS_API_INTERNAL_URL`, `MAAS_API_NAMESPACE`.
+When the BFF runs **in-cluster** without `MAAS_API_URL`, it locates the internal `maas-api` Service from the cluster `DataScienceCluster` product type (`status.release.name` → `odh-ai-gateway-infra` or `redhat-ai-gateway-infra`), falling back to `redhat-ai-gateway-infra` if DSC is unavailable. It then calls `GET /v1/tenants` (service account auth), selects the tenant whose gateway name is `maas-default-gateway`, and uses `gateway.externalUrl + /maas-api` as the passthrough base URL. Optional overrides: `MAAS_API_INTERNAL_URL`, `MAAS_API_NAMESPACE`.
 
 ### Kubernetes Deployment
 

--- a/packages/maas/CONTRIBUTING.md
+++ b/packages/maas/CONTRIBUTING.md
@@ -59,19 +59,19 @@ The `dev-start-federated` (and `dev-bff-federated`) targets run the BFF **outsid
 oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}'
 ```
 
-The Makefile builds `http://maas.<CLUSTER_DOMAIN>/maas-api` from that domain when `MAAS_API_URL` is unset. For this to work you must be logged into the cluster (`oc login`).
+The Makefile builds `https://maas.<CLUSTER_DOMAIN>/maas-api` from that domain when `MAAS_API_URL` is unset. For this to work you must be logged into the cluster (`oc login`).
 
 You can also set the URL explicitly via environment variable or `.env.local`:
 
 ```shell
 # environment variable
-MAAS_API_URL=http://maas.apps.my-cluster.example.com/maas-api make dev-start-federated
+MAAS_API_URL=https://maas.apps.my-cluster.example.com/maas-api make dev-start-federated
 
 # or in .env.local
-MAAS_API_URL=http://maas.apps.my-cluster.example.com/maas-api
+MAAS_API_URL=https://maas.apps.my-cluster.example.com/maas-api
 ```
 
-When the BFF runs **in-cluster** without `MAAS_API_URL`, it calls the internal `maas-api` Service at `GET /v1/tenants` (service account auth) and uses `gateway.externalUrl + /maas-api` as the passthrough base URL. The deployment injects `POD_NAMESPACE` (downward API) to locate `maas-api`; optional overrides: `MAAS_API_INTERNAL_URL`, `MAAS_API_NAMESPACE`.
+When the BFF runs **in-cluster** without `MAAS_API_URL`, it calls the internal `maas-api` Service at `GET /v1/tenants` (service account auth), selects the tenant whose gateway name is `maas-default-gateway`, and uses `gateway.externalUrl + /maas-api` as the passthrough base URL. The deployment injects `POD_NAMESPACE` (downward API) to locate `maas-api`; optional overrides: `MAAS_API_INTERNAL_URL`, `MAAS_API_NAMESPACE`.
 
 ### Kubernetes Deployment
 

--- a/packages/maas/CONTRIBUTING.md
+++ b/packages/maas/CONTRIBUTING.md
@@ -51,15 +51,15 @@ Alternatively to run in mock mode run the following from the `packages/maas` dir
 make dev-start-mock-federated
 ```
 
-#### `MAAS_API_URL` auto-detection
+#### `MAAS_API_URL` for local development
 
-The `dev-start-federated` (and `dev-bff-federated`) targets need a `MAAS_API_URL` to connect to the MaaS API. If you don't set one, the Makefile will auto-detect it by querying your cluster's ingress domain:
+The `dev-start-federated` (and `dev-bff-federated`) targets run the BFF **outside** the cluster, so in-cluster `/v1/tenants` discovery is not available. Set `MAAS_API_URL` explicitly (or let the Makefile infer it from the cluster ingress domain for convenience):
 
 ```shell
 oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}'
 ```
 
-The resulting URL is `http://maas.<CLUSTER_DOMAIN>/maas-api`. For this to work you must be logged into the cluster (`oc login`).
+The Makefile builds `http://maas.<CLUSTER_DOMAIN>/maas-api` from that domain when `MAAS_API_URL` is unset. For this to work you must be logged into the cluster (`oc login`).
 
 You can also set the URL explicitly via environment variable or `.env.local`:
 
@@ -70,6 +70,8 @@ MAAS_API_URL=http://maas.apps.my-cluster.example.com/maas-api make dev-start-fed
 # or in .env.local
 MAAS_API_URL=http://maas.apps.my-cluster.example.com/maas-api
 ```
+
+When the BFF runs **in-cluster** without `MAAS_API_URL`, it calls the internal `maas-api` Service at `GET /v1/tenants` (service account auth) and uses `gateway.externalUrl + /maas-api` as the passthrough base URL. The deployment injects `POD_NAMESPACE` (downward API) to locate `maas-api`; optional overrides: `MAAS_API_INTERNAL_URL`, `MAAS_API_NAMESPACE`.
 
 ### Kubernetes Deployment
 

--- a/packages/maas/README.md
+++ b/packages/maas/README.md
@@ -84,8 +84,8 @@ The following environment variables are used to configure the deployment and dev
 ### `MAAS_API_URL`
 
 - **Description**: Specifies the URL of the MaaS API that the BFF connects to for passthrough calls (models, API keys, subscriptions).
-- **Default Value**: *(none)* — when running in-cluster without this set, the BFF discovers the URL by calling `GET /v1/tenants` on the internal `maas-api` Service and appending `/maas-api` to `gateway.externalUrl`. Discovery failure prevents BFF startup.
-- **Example**: `MAAS_API_URL=http://maas.apps.my-cluster.example.com/maas-api`
+- **Default Value**: *(none)* — when running in-cluster without this set, the BFF discovers the URL by calling `GET /v1/tenants` on the internal `maas-api` Service, selecting the tenant with gateway `maas-default-gateway`, and appending `/maas-api` to `gateway.externalUrl`. Discovery failure prevents BFF startup.
+- **Example**: `MAAS_API_URL=https://maas.apps.my-cluster.example.com/maas-api`
 
 ### `MAAS_API_INTERNAL_URL`
 
@@ -114,7 +114,7 @@ CONTAINER_TOOL=docker
 IMG_UI=quay.io/<personal-registry>/mod-arch-ui:latest
 IMG_UI_STANDALONE=quay.io/<personal-registry>/mod-arch-ui-standalone:latest
 PLATFORM=linux/amd64
-MAAS_API_URL=http://maas.apps.my-cluster.example.com/maas-api
+MAAS_API_URL=https://maas.apps.my-cluster.example.com/maas-api
 ```
 
 ## Build and Push Commands

--- a/packages/maas/README.md
+++ b/packages/maas/README.md
@@ -83,9 +83,27 @@ The following environment variables are used to configure the deployment and dev
 
 ### `MAAS_API_URL`
 
-- **Description**: Specifies the URL of the MaaS API that the BFF connects to.
-- **Default Value**: *(none)* — if not set, the `dev-bff-federated` Makefile target will auto-detect it by querying the cluster's ingress domain via `oc get ingresses.config.openshift.io cluster`. The resolved URL follows the pattern `http://maas.<CLUSTER_DOMAIN>/maas-api`. When running in-cluster, the BFF performs the same auto-detection using its service account.
+- **Description**: Specifies the URL of the MaaS API that the BFF connects to for passthrough calls (models, API keys, subscriptions).
+- **Default Value**: *(none)* — when running in-cluster without this set, the BFF discovers the URL by calling `GET /v1/tenants` on the internal `maas-api` Service and appending `/maas-api` to `gateway.externalUrl`. Discovery failure prevents BFF startup.
 - **Example**: `MAAS_API_URL=http://maas.apps.my-cluster.example.com/maas-api`
+
+### `MAAS_API_INTERNAL_URL`
+
+- **Description**: Internal `maas-api` Service base URL used only for `/v1/tenants` gateway discovery (not for passthrough). Overrides namespace-based auto-detection.
+- **Default Value**: *(none)* — derived from `POD_NAMESPACE` (`opendatahub` → `odh-ai-gateway-infra`, `redhat-ods-applications` → `redhat-ai-gateway-infra`) unless `MAAS_API_NAMESPACE` is set.
+- **Example**: `MAAS_API_INTERNAL_URL=https://maas-api.odh-ai-gateway-infra.svc.cluster.local:8443`
+
+### `POD_NAMESPACE`
+
+- **Description**: Kubernetes namespace where the MaaS BFF pod is deployed. Injected by the deployment manifest (downward API) and used to locate the internal `maas-api` Service for `/v1/tenants` discovery.
+- **Default Value**: *(none in-cluster)* — set by the `maas-ui` Deployment. For local dev, `OC_PROJECT` can be used as a fallback.
+- **Example**: `POD_NAMESPACE=redhat-ods-applications`
+
+### `MAAS_API_NAMESPACE`
+
+- **Description**: Namespace of the internal `maas-api` Service when `MAAS_API_INTERNAL_URL` is not set.
+- **Default Value**: *(none)* — auto-mapped from the BFF pod namespace.
+- **Example**: `MAAS_API_NAMESPACE=redhat-ai-gateway-infra`
 
 ### Example `.env.local` File
 

--- a/packages/maas/README.md
+++ b/packages/maas/README.md
@@ -90,19 +90,13 @@ The following environment variables are used to configure the deployment and dev
 ### `MAAS_API_INTERNAL_URL`
 
 - **Description**: Internal `maas-api` Service base URL used only for `/v1/tenants` gateway discovery (not for passthrough). Overrides namespace-based auto-detection.
-- **Default Value**: *(none)* — derived from `POD_NAMESPACE` (`opendatahub` → `odh-ai-gateway-infra`, `redhat-ods-applications` → `redhat-ai-gateway-infra`) unless `MAAS_API_NAMESPACE` is set.
+- **Default Value**: *(none)* — when unset, the BFF lists the cluster `DataScienceCluster` and maps `status.release.name` to the infra namespace (`Open Data Hub` → `odh-ai-gateway-infra`; `OpenShift AI Self-Managed` / `OpenShift AI Cloud Service` → `redhat-ai-gateway-infra`). If DSC is unavailable or unrecognized, falls back to `redhat-ai-gateway-infra` unless `MAAS_API_NAMESPACE` is set.
 - **Example**: `MAAS_API_INTERNAL_URL=https://maas-api.odh-ai-gateway-infra.svc.cluster.local:8443`
-
-### `POD_NAMESPACE`
-
-- **Description**: Kubernetes namespace where the MaaS BFF pod is deployed. Injected by the deployment manifest (downward API) and used to locate the internal `maas-api` Service for `/v1/tenants` discovery.
-- **Default Value**: *(none in-cluster)* — set by the `maas-ui` Deployment. For local dev, `OC_PROJECT` can be used as a fallback.
-- **Example**: `POD_NAMESPACE=redhat-ods-applications`
 
 ### `MAAS_API_NAMESPACE`
 
-- **Description**: Namespace of the internal `maas-api` Service when `MAAS_API_INTERNAL_URL` is not set.
-- **Default Value**: *(none)* — auto-mapped from the BFF pod namespace.
+- **Description**: Namespace of the internal `maas-api` Service when `MAAS_API_INTERNAL_URL` is not set. Overrides DSC-based auto-detection.
+- **Default Value**: *(none)* — auto-resolved from DSC `status.release.name`, then `redhat-ai-gateway-infra` as fallback.
 - **Example**: `MAAS_API_NAMESPACE=redhat-ai-gateway-infra`
 
 ### Example `.env.local` File

--- a/packages/maas/bff/cmd/main.go
+++ b/packages/maas/bff/cmd/main.go
@@ -51,9 +51,8 @@ func main() {
 
 	// MaaS
 	flag.StringVar(&cfg.MaasApiUrl, "maas-api-url", getEnvAsString("MAAS_API_URL", ""), "The URL of the MaaS Gateway API")
-	flag.StringVar(&cfg.PodNamespace, "pod-namespace", getEnvAsString("POD_NAMESPACE", getEnvAsString("OC_PROJECT", "opendatahub")), "Kubernetes namespace where the BFF pod is deployed (used to locate internal maas-api)")
 	flag.StringVar(&cfg.MaasApiInternalUrl, "maas-api-internal-url", getEnvAsString("MAAS_API_INTERNAL_URL", ""), "Internal maas-api Service URL for /v1/tenants discovery (e.g. https://maas-api.odh-ai-gateway-infra.svc.cluster.local:8443)")
-	flag.StringVar(&cfg.MaasApiNamespace, "maas-api-namespace", getEnvAsString("MAAS_API_NAMESPACE", ""), "Namespace of the internal maas-api Service when MAAS_API_INTERNAL_URL is not set")
+	flag.StringVar(&cfg.MaasApiNamespace, "maas-api-namespace", getEnvAsString("MAAS_API_NAMESPACE", ""), "Namespace of the internal maas-api Service when MAAS_API_INTERNAL_URL is not set (overrides DSC-based detection)")
 	flag.StringVar(&cfg.MaaSSubscriptionNamespace, "maas-subscription-namespace", getEnvAsString("MAAS_SUBSCRIPTION_NAMESPACE", "models-as-a-service"), "Namespace for MaaSSubscription and MaaSAuthPolicy resources")
 
 	flag.Parse()

--- a/packages/maas/bff/cmd/main.go
+++ b/packages/maas/bff/cmd/main.go
@@ -53,6 +53,9 @@ func main() {
 	flag.StringVar(&cfg.GatewayNamespace, "gateway-namespace", getEnvAsString("GATEWAY_NAMESPACE", "openshift-ingress"), "Namespace where the MaaS Gateway is deployed in")
 	flag.StringVar(&cfg.GatewayName, "gateway-name", getEnvAsString("GATEWAY_NAME", "maas-default-gateway"), "The names of the MaaS Gateway")
 	flag.StringVar(&cfg.MaasApiUrl, "maas-api-url", getEnvAsString("MAAS_API_URL", ""), "The URL of the MaaS API")
+	flag.StringVar(&cfg.PodNamespace, "pod-namespace", getEnvAsString("POD_NAMESPACE", getEnvAsString("OC_PROJECT", "opendatahub")), "Kubernetes namespace where the BFF pod is deployed (used to locate internal maas-api)")
+	flag.StringVar(&cfg.MaasApiInternalUrl, "maas-api-internal-url", getEnvAsString("MAAS_API_INTERNAL_URL", ""), "Internal maas-api Service URL for /v1/tenants discovery (e.g. https://maas-api.odh-ai-gateway-infra.svc.cluster.local:8443)")
+	flag.StringVar(&cfg.MaasApiNamespace, "maas-api-namespace", getEnvAsString("MAAS_API_NAMESPACE", ""), "Namespace of the internal maas-api Service when MAAS_API_INTERNAL_URL is not set")
 	flag.StringVar(&cfg.MaaSSubscriptionNamespace, "maas-subscription-namespace", getEnvAsString("MAAS_SUBSCRIPTION_NAMESPACE", "models-as-a-service"), "Namespace for MaaSSubscription and MaaSAuthPolicy resources")
 
 	flag.Parse()

--- a/packages/maas/bff/cmd/main.go
+++ b/packages/maas/bff/cmd/main.go
@@ -50,9 +50,7 @@ func main() {
 	flag.BoolVar(&cfg.FederatedPlatform, "federated-platform", false, "DEPRECATED: Use -deployment-mode=federated instead")
 
 	// MaaS
-	flag.StringVar(&cfg.GatewayNamespace, "gateway-namespace", getEnvAsString("GATEWAY_NAMESPACE", "openshift-ingress"), "Namespace where the MaaS Gateway is deployed in")
-	flag.StringVar(&cfg.GatewayName, "gateway-name", getEnvAsString("GATEWAY_NAME", "maas-default-gateway"), "The names of the MaaS Gateway")
-	flag.StringVar(&cfg.MaasApiUrl, "maas-api-url", getEnvAsString("MAAS_API_URL", ""), "The URL of the MaaS API")
+	flag.StringVar(&cfg.MaasApiUrl, "maas-api-url", getEnvAsString("MAAS_API_URL", ""), "The URL of the MaaS Gateway API")
 	flag.StringVar(&cfg.PodNamespace, "pod-namespace", getEnvAsString("POD_NAMESPACE", getEnvAsString("OC_PROJECT", "opendatahub")), "Kubernetes namespace where the BFF pod is deployed (used to locate internal maas-api)")
 	flag.StringVar(&cfg.MaasApiInternalUrl, "maas-api-internal-url", getEnvAsString("MAAS_API_INTERNAL_URL", ""), "Internal maas-api Service URL for /v1/tenants discovery (e.g. https://maas-api.odh-ai-gateway-infra.svc.cluster.local:8443)")
 	flag.StringVar(&cfg.MaasApiNamespace, "maas-api-namespace", getEnvAsString("MAAS_API_NAMESPACE", ""), "Namespace of the internal maas-api Service when MAAS_API_INTERNAL_URL is not set")

--- a/packages/maas/bff/internal/api/api_keys_handlers_test.go
+++ b/packages/maas/bff/internal/api/api_keys_handlers_test.go
@@ -344,8 +344,6 @@ var _ = Describe("APIKeysHandlers", Ordered, func() {
 			envConfig := config.EnvConfig{
 				AllowedOrigins:            []string{"*"},
 				AuthMethod:                config.AuthMethodInternal,
-				GatewayNamespace:          "openshift-ingress",
-				GatewayName:               "maas-default-gateway",
 				MockHTTPClient:            true,
 				MaasApiUrl:                failSearchServer.URL,
 				MaaSSubscriptionNamespace: "maas-system",

--- a/packages/maas/bff/internal/api/app.go
+++ b/packages/maas/bff/internal/api/app.go
@@ -139,17 +139,12 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		maasFakeServer = maas.CreateMaasFakeServer()
 		logger.Info("MaaS Fake API Server is running", "url", maasFakeServer.URL)
 		cfg.MaasApiUrl = maasFakeServer.URL
-	} else {
-		// Fallback to discovery of MaaS API url, when not provided via envvar, or cmd flags
-		if cfg.MaasApiUrl == "" {
-			clusterDomain, err := helper.GetClusterDomainUsingServiceAccount(context.Background(), logger)
-			if err != nil {
-				logger.Error("Failed to auto-discover cluster domain, MaaS API URL will be unavailable", "error", err)
-			} else {
-				cfg.MaasApiUrl = fmt.Sprintf("https://maas.%s/maas-api", clusterDomain)
-				logger.Info("Using automatically discovered MaaS URL", "url", cfg.MaasApiUrl)
-			}
+	} else if cfg.MaasApiUrl == "" {
+		discoveredURL, err := helper.DiscoverMaasApiURL(context.Background(), cfg, logger, rootCAs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to discover MaaS API URL via /v1/tenants: %w", err)
 		}
+		cfg.MaasApiUrl = discoveredURL
 	}
 
 	if err != nil {

--- a/packages/maas/bff/internal/api/test_utils.go
+++ b/packages/maas/bff/internal/api/test_utils.go
@@ -46,8 +46,6 @@ func setupApiTest[T any](method, url string, body interface{}, k8Factory kuberne
 	envConfig := config.EnvConfig{
 		AllowedOrigins:            []string{"*"},
 		AuthMethod:                config.AuthMethodInternal,
-		GatewayNamespace:          "openshift-ingress",
-		GatewayName:               "maas-default-gateway",
 		MockHTTPClient:            true,
 		MaasApiUrl:                maasFakeServer.URL,
 		MaaSSubscriptionNamespace: "maas-system",

--- a/packages/maas/bff/internal/api/user_handler_test.go
+++ b/packages/maas/bff/internal/api/user_handler_test.go
@@ -22,11 +22,9 @@ const (
 )
 
 var envConfig = config.EnvConfig{
-	AllowedOrigins:   []string{"*"},
-	AuthMethod:       "internal",
-	GatewayNamespace: "openshift-ingress",
-	GatewayName:      "maas-default-gateway",
-	MockHTTPClient:   true,
+	AllowedOrigins: []string{"*"},
+	AuthMethod:     "internal",
+	MockHTTPClient: true,
 }
 
 var _ = Describe("TestUserHandler", func() {

--- a/packages/maas/bff/internal/config/environment.go
+++ b/packages/maas/bff/internal/config/environment.go
@@ -119,8 +119,6 @@ type EnvConfig struct {
 	FederatedPlatform bool
 
 	// MaaS
-	GatewayNamespace          string
-	GatewayName               string
 	PodNamespace              string
 	MaasApiUrl                string
 	MaasApiInternalUrl        string

--- a/packages/maas/bff/internal/config/environment.go
+++ b/packages/maas/bff/internal/config/environment.go
@@ -121,6 +121,9 @@ type EnvConfig struct {
 	// MaaS
 	GatewayNamespace          string
 	GatewayName               string
+	PodNamespace              string
 	MaasApiUrl                string
+	MaasApiInternalUrl        string
+	MaasApiNamespace          string
 	MaaSSubscriptionNamespace string
 }

--- a/packages/maas/bff/internal/config/environment.go
+++ b/packages/maas/bff/internal/config/environment.go
@@ -119,7 +119,6 @@ type EnvConfig struct {
 	FederatedPlatform bool
 
 	// MaaS
-	PodNamespace              string
 	MaasApiUrl                string
 	MaasApiInternalUrl        string
 	MaasApiNamespace          string

--- a/packages/maas/bff/internal/constants/gvr.go
+++ b/packages/maas/bff/internal/constants/gvr.go
@@ -50,4 +50,10 @@ var (
 		Version:  "v1",
 		Resource: "groups",
 	}
+
+	DataScienceClusterGvr = schema.GroupVersionResource{
+		Group:    "datasciencecluster.opendatahub.io",
+		Version:  "v2",
+		Resource: "datascienceclusters",
+	}
 )

--- a/packages/maas/bff/internal/helpers/k8s.go
+++ b/packages/maas/bff/internal/helpers/k8s.go
@@ -1,16 +1,9 @@
 package helper
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"log/slog"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clientRest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -32,34 +25,4 @@ func BuildScheme() (*runtime.Scheme, error) {
 	}
 
 	return scheme, nil
-}
-
-// GetClusterDomainUsingServiceAccount retrieves cluster domain using the pod's service account
-func GetClusterDomainUsingServiceAccount(ctx context.Context, logger *slog.Logger) (string, error) {
-	cfg, err := clientRest.InClusterConfig()
-	if err != nil {
-		return "", err
-	}
-
-	client, err := dynamic.NewForConfig(cfg)
-	if err != nil {
-		return "", err
-	}
-
-	gvr := schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "ingresses"}
-	result, err := client.Resource(gvr).Get(ctx, "cluster", v1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	domain, found, err := unstructured.NestedString(result.Object, "spec", "domain")
-	if err != nil {
-		return "", err
-	}
-
-	if !found {
-		return "", errors.New("invalid ingress config: cluster domain not found")
-	}
-
-	return domain, nil
 }

--- a/packages/maas/bff/internal/helpers/maas_discovery.go
+++ b/packages/maas/bff/internal/helpers/maas_discovery.go
@@ -14,7 +14,11 @@ import (
 	"time"
 
 	"github.com/opendatahub-io/maas-library/bff/internal/config"
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
 	clientRest "k8s.io/client-go/rest"
 )
 
@@ -22,22 +26,79 @@ const (
 	maasAPIServiceName     = "maas-api"
 	maasAPIServicePort     = 8443
 	maasDefaultGatewayName = "maas-default-gateway"
+
+	// OdhPlatformType values mirrored from the dashboard backend (status.release.name).
+	releaseOpenDataHub      = "Open Data Hub"
+	releaseSelfManagedRHOAI = "OpenShift AI Self-Managed"
+	releaseManagedRHOAI     = "OpenShift AI Cloud Service"
+
+	infraNamespaceODH   = "odh-ai-gateway-infra"
+	infraNamespaceRHOAI = "redhat-ai-gateway-infra"
 )
 
-var dashboardToInfraNamespace = map[string]string{
-	"opendatahub":             "odh-ai-gateway-infra",
-	"redhat-ods-applications": "redhat-ai-gateway-infra",
+// InfraNamespaceFromReleaseName maps DSC status.release.name to the maas-api infra namespace.
+// The bool is false when the release name is unrecognized.
+func InfraNamespaceFromReleaseName(releaseName string) (string, bool) {
+	switch strings.TrimSpace(releaseName) {
+	case releaseSelfManagedRHOAI, releaseManagedRHOAI:
+		return infraNamespaceRHOAI, true
+	case releaseOpenDataHub:
+		return infraNamespaceODH, true
+	default:
+		return "", false
+	}
 }
 
-// ResolveMaasApiInfraNamespace maps the BFF pod namespace to the maas-api infrastructure namespace.
-func ResolveMaasApiInfraNamespace(podNamespace, override string) string {
-	if override != "" {
-		return override
+// FetchDSCReleaseName lists DataScienceClusters (cluster-scoped), takes the first item,
+// and returns status.release.name.
+func FetchDSCReleaseName(ctx context.Context, client dynamic.Interface) (string, error) {
+	list, err := client.Resource(constants.DataScienceClusterGvr).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("list DataScienceClusters: %w", err)
 	}
-	if infra, ok := dashboardToInfraNamespace[podNamespace]; ok {
-		return infra
+	if len(list.Items) == 0 {
+		return "", fmt.Errorf("no DataScienceCluster found")
 	}
-	return podNamespace
+
+	name, found, err := unstructured.NestedString(list.Items[0].Object, "status", "release", "name")
+	if err != nil {
+		return "", fmt.Errorf("read status.release.name: %w", err)
+	}
+	if !found || strings.TrimSpace(name) == "" {
+		return "", fmt.Errorf("DataScienceCluster has empty status.release.name")
+	}
+	return name, nil
+}
+
+// ResolveMaasApiNamespace resolves the maas-api infrastructure namespace.
+// Order: cfg.MaasApiNamespace override, DSC status.release.name, then infraNamespaceRHOAI.
+func ResolveMaasApiNamespace(ctx context.Context, cfg config.EnvConfig, logger *slog.Logger, dynClient dynamic.Interface) string {
+	if cfg.MaasApiNamespace != "" {
+		return cfg.MaasApiNamespace
+	}
+
+	if dynClient != nil {
+		releaseName, err := FetchDSCReleaseName(ctx, dynClient)
+		if err != nil {
+			logger.Warn("Failed to read DSC product type for maas-api namespace; falling back to RHOAI infra namespace",
+				"error", err,
+				"namespace", infraNamespaceRHOAI)
+		} else if ns, ok := InfraNamespaceFromReleaseName(releaseName); ok {
+			logger.Info("Resolved maas-api namespace from DSC release",
+				"release", releaseName,
+				"namespace", ns)
+			return ns
+		} else {
+			logger.Warn("Unrecognized DSC release.name; falling back to RHOAI infra namespace",
+				"release", releaseName,
+				"namespace", infraNamespaceRHOAI)
+		}
+	} else {
+		logger.Warn("No dynamic client for DSC product type; falling back to RHOAI infra namespace",
+			"namespace", infraNamespaceRHOAI)
+	}
+
+	return infraNamespaceRHOAI
 }
 
 // ResolveMaasApiInternalURL builds the internal maas-api Service base URL for /v1/tenants discovery.
@@ -46,15 +107,7 @@ func ResolveMaasApiInternalURL(cfg config.EnvConfig) (string, error) {
 		return strings.TrimSuffix(cfg.MaasApiInternalUrl, "/"), nil
 	}
 
-	namespace := cfg.MaasApiNamespace
-	if namespace == "" {
-		podNamespace := strings.TrimSpace(cfg.PodNamespace)
-		if podNamespace == "" {
-			return "", fmt.Errorf("maas-api namespace unresolved: set POD_NAMESPACE, MAAS_API_NAMESPACE, or MAAS_API_INTERNAL_URL")
-		}
-		namespace = ResolveMaasApiInfraNamespace(podNamespace, "")
-	}
-
+	namespace := strings.TrimSpace(cfg.MaasApiNamespace)
 	if namespace == "" {
 		return "", fmt.Errorf("maas-api namespace is empty; set MAAS_API_NAMESPACE or MAAS_API_INTERNAL_URL")
 	}
@@ -71,6 +124,19 @@ func DiscoverMaasApiURL(ctx context.Context, cfg config.EnvConfig, logger *slog.
 	}
 	if restCfg.BearerToken == "" {
 		return "", fmt.Errorf("in-cluster config has no bearer token for maas-api tenant discovery")
+	}
+
+	// When internal URL/namespace are not overridden, resolve infra NS from DSC product type.
+	if cfg.MaasApiInternalUrl == "" && cfg.MaasApiNamespace == "" {
+		dynClient, dynErr := dynamic.NewForConfig(restCfg)
+		if dynErr != nil {
+			logger.Warn("Failed to create dynamic client for DSC product type; falling back to RHOAI infra namespace",
+				"error", dynErr,
+				"namespace", infraNamespaceRHOAI)
+			cfg.MaasApiNamespace = ResolveMaasApiNamespace(ctx, cfg, logger, nil)
+		} else {
+			cfg.MaasApiNamespace = ResolveMaasApiNamespace(ctx, cfg, logger, dynClient)
+		}
 	}
 
 	return discoverMaasApiURLWithToken(ctx, cfg, logger, rootCAs, restCfg.BearerToken)

--- a/packages/maas/bff/internal/helpers/maas_discovery.go
+++ b/packages/maas/bff/internal/helpers/maas_discovery.go
@@ -1,0 +1,155 @@
+package helper
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/config"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+	clientRest "k8s.io/client-go/rest"
+)
+
+const (
+	maasAPIServiceName = "maas-api"
+	maasAPIServicePort = 8443
+)
+
+var dashboardToInfraNamespace = map[string]string{
+	"opendatahub":             "odh-ai-gateway-infra",
+	"redhat-ods-applications": "redhat-ai-gateway-infra",
+}
+
+// ResolveMaasApiInfraNamespace maps the BFF pod namespace to the maas-api infrastructure namespace.
+func ResolveMaasApiInfraNamespace(podNamespace, override string) string {
+	if override != "" {
+		return override
+	}
+	if infra, ok := dashboardToInfraNamespace[podNamespace]; ok {
+		return infra
+	}
+	return podNamespace
+}
+
+// ResolveMaasApiInternalURL builds the internal maas-api Service base URL for /v1/tenants discovery.
+func ResolveMaasApiInternalURL(cfg config.EnvConfig) (string, error) {
+	if cfg.MaasApiInternalUrl != "" {
+		return strings.TrimSuffix(cfg.MaasApiInternalUrl, "/"), nil
+	}
+
+	namespace := cfg.MaasApiNamespace
+	if namespace == "" {
+		podNamespace := strings.TrimSpace(cfg.PodNamespace)
+		if podNamespace == "" {
+			return "", fmt.Errorf("maas-api namespace unresolved: set POD_NAMESPACE, MAAS_API_NAMESPACE, or MAAS_API_INTERNAL_URL")
+		}
+		namespace = ResolveMaasApiInfraNamespace(podNamespace, "")
+	}
+
+	if namespace == "" {
+		return "", fmt.Errorf("maas-api namespace is empty; set MAAS_API_NAMESPACE or MAAS_API_INTERNAL_URL")
+	}
+
+	return fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", maasAPIServiceName, namespace, maasAPIServicePort), nil
+}
+
+// DiscoverMaasApiURL calls GET /v1/tenants on the internal maas-api Service and returns
+// the external gateway URL with /maas-api suffix for passthrough calls.
+func DiscoverMaasApiURL(ctx context.Context, cfg config.EnvConfig, logger *slog.Logger, rootCAs *x509.CertPool) (string, error) {
+	internalURL, err := ResolveMaasApiInternalURL(cfg)
+	if err != nil {
+		return "", err
+	}
+
+	restCfg, err := clientRest.InClusterConfig()
+	if err != nil {
+		return "", fmt.Errorf("load in-cluster config for maas-api tenant discovery: %w", err)
+	}
+	if restCfg.BearerToken == "" {
+		return "", fmt.Errorf("in-cluster config has no bearer token for maas-api tenant discovery")
+	}
+
+	tenantsURL, err := url.JoinPath(internalURL, "v1", "tenants")
+	if err != nil {
+		return "", fmt.Errorf("build tenants discovery URL: %w", err)
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:            rootCAs,
+			InsecureSkipVerify: cfg.InsecureSkipVerify,
+		},
+	}
+	client := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: transport,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tenantsURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create tenants discovery request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+restCfg.BearerToken)
+	req.Header.Set("Accept", "application/json")
+
+	logger.Info("Discovering MaaS API URL via /v1/tenants", "internalURL", internalURL)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("call maas-api GET /v1/tenants at %s: %w", tenantsURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("read maas-api /v1/tenants response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("maas-api GET /v1/tenants returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var tenantsResp models.TenantsResponse
+	if err := json.Unmarshal(body, &tenantsResp); err != nil {
+		return "", fmt.Errorf("parse maas-api /v1/tenants response: %w", err)
+	}
+
+	maasApiURL, err := MaasApiURLFromTenantsResponse(tenantsResp)
+	if err != nil {
+		return "", err
+	}
+
+	logger.Info("Discovered MaaS API URL from /v1/tenants",
+		"tenant", tenantsResp.Tenants[0].Name,
+		"gateway", tenantsResp.Tenants[0].Gateway.Name,
+		"url", maasApiURL)
+
+	return maasApiURL, nil
+}
+
+// MaasApiURLFromTenantsResponse builds the passthrough MaaS API base URL from a /v1/tenants response.
+func MaasApiURLFromTenantsResponse(resp models.TenantsResponse) (string, error) {
+	if len(resp.Tenants) == 0 {
+		return "", fmt.Errorf("maas-api /v1/tenants returned no tenants")
+	}
+
+	externalURL := strings.TrimSpace(resp.Tenants[0].Gateway.ExternalURL)
+	if externalURL == "" {
+		return "", fmt.Errorf("maas-api /v1/tenants returned empty gateway.externalUrl")
+	}
+
+	maasApiURL, err := url.JoinPath(externalURL, "maas-api")
+	if err != nil {
+		return "", fmt.Errorf("build MaaS API URL from externalUrl %q: %w", externalURL, err)
+	}
+
+	return maasApiURL, nil
+}

--- a/packages/maas/bff/internal/helpers/maas_discovery.go
+++ b/packages/maas/bff/internal/helpers/maas_discovery.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	maasAPIServiceName = "maas-api"
-	maasAPIServicePort = 8443
+	maasAPIServiceName     = "maas-api"
+	maasAPIServicePort     = 8443
+	maasDefaultGatewayName = "maas-default-gateway"
 )
 
 var dashboardToInfraNamespace = map[string]string{
@@ -64,17 +65,23 @@ func ResolveMaasApiInternalURL(cfg config.EnvConfig) (string, error) {
 // DiscoverMaasApiURL calls GET /v1/tenants on the internal maas-api Service and returns
 // the external gateway URL with /maas-api suffix for passthrough calls.
 func DiscoverMaasApiURL(ctx context.Context, cfg config.EnvConfig, logger *slog.Logger, rootCAs *x509.CertPool) (string, error) {
-	internalURL, err := ResolveMaasApiInternalURL(cfg)
-	if err != nil {
-		return "", err
-	}
-
 	restCfg, err := clientRest.InClusterConfig()
 	if err != nil {
 		return "", fmt.Errorf("load in-cluster config for maas-api tenant discovery: %w", err)
 	}
 	if restCfg.BearerToken == "" {
 		return "", fmt.Errorf("in-cluster config has no bearer token for maas-api tenant discovery")
+	}
+
+	return discoverMaasApiURLWithToken(ctx, cfg, logger, rootCAs, restCfg.BearerToken)
+}
+
+// discoverMaasApiURLWithToken performs /v1/tenants discovery using an explicit bearer token.
+// Separated from DiscoverMaasApiURL so unit tests can exercise the HTTP path without in-cluster config.
+func discoverMaasApiURLWithToken(ctx context.Context, cfg config.EnvConfig, logger *slog.Logger, rootCAs *x509.CertPool, bearerToken string) (string, error) {
+	internalURL, err := ResolveMaasApiInternalURL(cfg)
+	if err != nil {
+		return "", err
 	}
 
 	tenantsURL, err := url.JoinPath(internalURL, "v1", "tenants")
@@ -97,7 +104,7 @@ func DiscoverMaasApiURL(ctx context.Context, cfg config.EnvConfig, logger *slog.
 	if err != nil {
 		return "", fmt.Errorf("create tenants discovery request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+restCfg.BearerToken)
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
 	req.Header.Set("Accept", "application/json")
 
 	logger.Info("Discovering MaaS API URL via /v1/tenants", "internalURL", internalURL)
@@ -122,34 +129,45 @@ func DiscoverMaasApiURL(ctx context.Context, cfg config.EnvConfig, logger *slog.
 		return "", fmt.Errorf("parse maas-api /v1/tenants response: %w", err)
 	}
 
-	maasApiURL, err := MaasApiURLFromTenantsResponse(tenantsResp)
+	tenant, maasApiURL, err := MaasApiURLFromTenantsResponse(tenantsResp)
 	if err != nil {
 		return "", err
 	}
 
 	logger.Info("Discovered MaaS API URL from /v1/tenants",
-		"tenant", tenantsResp.Tenants[0].Name,
-		"gateway", tenantsResp.Tenants[0].Gateway.Name,
+		"tenant", tenant.Name,
+		"gateway", tenant.Gateway.Name,
 		"url", maasApiURL)
 
 	return maasApiURL, nil
 }
 
-// MaasApiURLFromTenantsResponse builds the passthrough MaaS API base URL from a /v1/tenants response.
-func MaasApiURLFromTenantsResponse(resp models.TenantsResponse) (string, error) {
+// MaasApiURLFromTenantsResponse finds the maas-default-gateway tenant and builds the passthrough MaaS API base URL.
+func MaasApiURLFromTenantsResponse(resp models.TenantsResponse) (models.TenantInfo, string, error) {
 	if len(resp.Tenants) == 0 {
-		return "", fmt.Errorf("maas-api /v1/tenants returned no tenants")
+		return models.TenantInfo{}, "", fmt.Errorf("maas-api /v1/tenants returned no tenants")
 	}
 
-	externalURL := strings.TrimSpace(resp.Tenants[0].Gateway.ExternalURL)
+	var matched *models.TenantInfo
+	for i := range resp.Tenants {
+		if resp.Tenants[i].Gateway.Name == maasDefaultGatewayName {
+			matched = &resp.Tenants[i]
+			break
+		}
+	}
+	if matched == nil {
+		return models.TenantInfo{}, "", fmt.Errorf("maas-api /v1/tenants returned no tenant with gateway %q", maasDefaultGatewayName)
+	}
+
+	externalURL := strings.TrimSpace(matched.Gateway.ExternalURL)
 	if externalURL == "" {
-		return "", fmt.Errorf("maas-api /v1/tenants returned empty gateway.externalUrl")
+		return models.TenantInfo{}, "", fmt.Errorf("maas-api /v1/tenants returned empty gateway.externalUrl for %q", maasDefaultGatewayName)
 	}
 
 	maasApiURL, err := url.JoinPath(externalURL, "maas-api")
 	if err != nil {
-		return "", fmt.Errorf("build MaaS API URL from externalUrl %q: %w", externalURL, err)
+		return models.TenantInfo{}, "", fmt.Errorf("build MaaS API URL from externalUrl %q: %w", externalURL, err)
 	}
 
-	return maasApiURL, nil
+	return *matched, maasApiURL, nil
 }

--- a/packages/maas/bff/internal/helpers/maas_discovery_test.go
+++ b/packages/maas/bff/internal/helpers/maas_discovery_test.go
@@ -1,6 +1,13 @@
 package helper
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/opendatahub-io/maas-library/bff/internal/config"
@@ -79,35 +86,120 @@ func TestResolveMaasApiInternalURL(t *testing.T) {
 }
 
 func TestMaasApiURLFromTenantsResponse(t *testing.T) {
-	got, err := MaasApiURLFromTenantsResponse(models.TenantsResponse{
-		Tenants: []models.TenantInfo{{
-			Name: "models-as-a-service",
-			Gateway: models.GatewayMetadata{
-				ExternalURL: "https://maas.custom.example.com",
+	gotTenant, gotURL, err := MaasApiURLFromTenantsResponse(models.TenantsResponse{
+		Tenants: []models.TenantInfo{
+			{
+				Name: "other-tenant",
+				Gateway: models.GatewayMetadata{
+					Name:        "other-gateway",
+					ExternalURL: "https://other.example.com",
+				},
 			},
-		}},
+			{
+				Name: "models-as-a-service",
+				Gateway: models.GatewayMetadata{
+					Name:        maasDefaultGatewayName,
+					ExternalURL: "https://maas.custom.example.com",
+				},
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if gotTenant.Name != "models-as-a-service" {
+		t.Fatalf("tenant = %q, want models-as-a-service", gotTenant.Name)
+	}
 	want := "https://maas.custom.example.com/maas-api"
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	if gotURL != want {
+		t.Fatalf("got %q, want %q", gotURL, want)
 	}
 }
 
 func TestMaasApiURLFromTenantsResponse_EmptyTenants(t *testing.T) {
-	_, err := MaasApiURLFromTenantsResponse(models.TenantsResponse{Tenants: []models.TenantInfo{}})
+	_, _, err := MaasApiURLFromTenantsResponse(models.TenantsResponse{Tenants: []models.TenantInfo{}})
 	if err == nil {
 		t.Fatal("expected error for empty tenants")
 	}
 }
 
+func TestMaasApiURLFromTenantsResponse_MissingDefaultGateway(t *testing.T) {
+	_, _, err := MaasApiURLFromTenantsResponse(models.TenantsResponse{
+		Tenants: []models.TenantInfo{{
+			Name: "t",
+			Gateway: models.GatewayMetadata{
+				Name:        "not-the-default",
+				ExternalURL: "https://maas.example.com",
+			},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected error when maas-default-gateway is missing")
+	}
+}
+
 func TestMaasApiURLFromTenantsResponse_MissingExternalURL(t *testing.T) {
-	_, err := MaasApiURLFromTenantsResponse(models.TenantsResponse{
-		Tenants: []models.TenantInfo{{Name: "t", Gateway: models.GatewayMetadata{}}},
+	_, _, err := MaasApiURLFromTenantsResponse(models.TenantsResponse{
+		Tenants: []models.TenantInfo{{
+			Name:    "t",
+			Gateway: models.GatewayMetadata{Name: maasDefaultGatewayName},
+		}},
 	})
 	if err == nil {
 		t.Fatal("expected error for missing externalUrl")
 	}
+}
+
+func TestDiscoverMaasApiURLWithToken_HTTP(t *testing.T) {
+	const token = "test-sa-token"
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/tenants" {
+				t.Errorf("path = %q, want /v1/tenants", r.URL.Path)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+				t.Errorf("Authorization = %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(models.TenantsResponse{
+				Tenants: []models.TenantInfo{{
+					Name: "models-as-a-service",
+					Gateway: models.GatewayMetadata{
+						Name:        maasDefaultGatewayName,
+						ExternalURL: "https://maas.apps.example.com",
+					},
+				}},
+			})
+		}))
+		defer server.Close()
+
+		got, err := discoverMaasApiURLWithToken(context.Background(), config.EnvConfig{
+			MaasApiInternalUrl: server.URL,
+		}, logger, nil, token)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "https://maas.apps.example.com/maas-api"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("non-200 status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		_, err := discoverMaasApiURLWithToken(context.Background(), config.EnvConfig{
+			MaasApiInternalUrl: server.URL,
+		}, logger, nil, token)
+		if err == nil {
+			t.Fatal("expected error for non-200 response")
+		}
+		if !strings.Contains(err.Error(), "503") {
+			t.Fatalf("error %q should mention status 503", err)
+		}
+	})
 }

--- a/packages/maas/bff/internal/helpers/maas_discovery_test.go
+++ b/packages/maas/bff/internal/helpers/maas_discovery_test.go
@@ -11,30 +11,153 @@ import (
 	"testing"
 
 	"github.com/opendatahub-io/maas-library/bff/internal/config"
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
-func TestResolveMaasApiInfraNamespace(t *testing.T) {
+func TestInfraNamespaceFromReleaseName(t *testing.T) {
 	tests := []struct {
-		name         string
-		podNamespace string
-		override     string
-		want         string
+		name        string
+		releaseName string
+		wantNS      string
+		wantOK      bool
 	}{
-		{name: "ODH mapping", podNamespace: "opendatahub", want: "odh-ai-gateway-infra"},
-		{name: "RHOAI mapping", podNamespace: "redhat-ods-applications", want: "redhat-ai-gateway-infra"},
-		{name: "override wins", podNamespace: "opendatahub", override: "custom-ns", want: "custom-ns"},
-		{name: "unknown pod namespace passthrough", podNamespace: "my-ns", want: "my-ns"},
+		{name: "Open Data Hub", releaseName: releaseOpenDataHub, wantNS: infraNamespaceODH, wantOK: true},
+		{name: "Self-Managed RHOAI", releaseName: releaseSelfManagedRHOAI, wantNS: infraNamespaceRHOAI, wantOK: true},
+		{name: "Managed RHOAI", releaseName: releaseManagedRHOAI, wantNS: infraNamespaceRHOAI, wantOK: true},
+		{name: "trims whitespace", releaseName: "  " + releaseOpenDataHub + "  ", wantNS: infraNamespaceODH, wantOK: true},
+		{name: "unknown", releaseName: "Something Else", wantNS: "", wantOK: false},
+		{name: "empty", releaseName: "", wantNS: "", wantOK: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ResolveMaasApiInfraNamespace(tt.podNamespace, tt.override)
-			if got != tt.want {
-				t.Fatalf("ResolveMaasApiInfraNamespace() = %q, want %q", got, tt.want)
+			gotNS, gotOK := InfraNamespaceFromReleaseName(tt.releaseName)
+			if gotNS != tt.wantNS || gotOK != tt.wantOK {
+				t.Fatalf("InfraNamespaceFromReleaseName(%q) = (%q, %v), want (%q, %v)",
+					tt.releaseName, gotNS, gotOK, tt.wantNS, tt.wantOK)
 			}
 		})
 	}
+}
+
+func newFakeDSCDynamicClient(t *testing.T, objs ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		constants.DataScienceClusterGvr: "DataScienceClusterList",
+	})
+	ctx := context.Background()
+	for _, obj := range objs {
+		_, err := client.Resource(constants.DataScienceClusterGvr).Create(ctx, obj, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("test setup: failed to seed DSC %q: %v", obj.GetName(), err)
+		}
+	}
+	return client
+}
+
+func newDSCObj(name, releaseName string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   constants.DataScienceClusterGvr.Group,
+		Version: constants.DataScienceClusterGvr.Version,
+		Kind:    "DataScienceCluster",
+	})
+	obj.SetName(name)
+	if releaseName != "" {
+		_ = unstructured.SetNestedField(obj.Object, map[string]any{
+			"name": releaseName,
+		}, "status", "release")
+	}
+	return obj
+}
+
+func TestFetchDSCReleaseName(t *testing.T) {
+	t.Run("returns first DSC release name", func(t *testing.T) {
+		client := newFakeDSCDynamicClient(t, newDSCObj("default-dsc", releaseSelfManagedRHOAI))
+		got, err := FetchDSCReleaseName(context.Background(), client)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != releaseSelfManagedRHOAI {
+			t.Fatalf("got %q, want %q", got, releaseSelfManagedRHOAI)
+		}
+	})
+
+	t.Run("error when no DSC", func(t *testing.T) {
+		client := newFakeDSCDynamicClient(t)
+		_, err := FetchDSCReleaseName(context.Background(), client)
+		if err == nil {
+			t.Fatal("expected error when no DataScienceCluster exists")
+		}
+	})
+
+	t.Run("error when release name empty", func(t *testing.T) {
+		client := newFakeDSCDynamicClient(t, newDSCObj("default-dsc", ""))
+		_, err := FetchDSCReleaseName(context.Background(), client)
+		if err == nil {
+			t.Fatal("expected error for empty status.release.name")
+		}
+	})
+}
+
+func TestResolveMaasApiNamespace(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("override wins over DSC", func(t *testing.T) {
+		client := newFakeDSCDynamicClient(t, newDSCObj("default-dsc", releaseOpenDataHub))
+		got := ResolveMaasApiNamespace(context.Background(), config.EnvConfig{
+			MaasApiNamespace: "custom-infra",
+		}, logger, client)
+		if got != "custom-infra" {
+			t.Fatalf("got %q, want custom-infra", got)
+		}
+	})
+
+	t.Run("uses DSC ODH release", func(t *testing.T) {
+		client := newFakeDSCDynamicClient(t, newDSCObj("default-dsc", releaseOpenDataHub))
+		got := ResolveMaasApiNamespace(context.Background(), config.EnvConfig{}, logger, client)
+		if got != infraNamespaceODH {
+			t.Fatalf("got %q, want %q", got, infraNamespaceODH)
+		}
+	})
+
+	t.Run("uses DSC RHOAI release", func(t *testing.T) {
+		client := newFakeDSCDynamicClient(t, newDSCObj("default-dsc", releaseManagedRHOAI))
+		got := ResolveMaasApiNamespace(context.Background(), config.EnvConfig{}, logger, client)
+		if got != infraNamespaceRHOAI {
+			t.Fatalf("got %q, want %q", got, infraNamespaceRHOAI)
+		}
+	})
+
+	t.Run("falls back to RHOAI when DSC missing", func(t *testing.T) {
+		client := newFakeDSCDynamicClient(t)
+		got := ResolveMaasApiNamespace(context.Background(), config.EnvConfig{}, logger, client)
+		if got != infraNamespaceRHOAI {
+			t.Fatalf("got %q, want %q", got, infraNamespaceRHOAI)
+		}
+	})
+
+	t.Run("falls back to RHOAI when release unrecognized", func(t *testing.T) {
+		client := newFakeDSCDynamicClient(t, newDSCObj("default-dsc", "Unknown Product"))
+		got := ResolveMaasApiNamespace(context.Background(), config.EnvConfig{}, logger, client)
+		if got != infraNamespaceRHOAI {
+			t.Fatalf("got %q, want %q", got, infraNamespaceRHOAI)
+		}
+	})
+
+	t.Run("falls back to RHOAI when dynClient nil", func(t *testing.T) {
+		got := ResolveMaasApiNamespace(context.Background(), config.EnvConfig{}, logger, nil)
+		if got != infraNamespaceRHOAI {
+			t.Fatalf("got %q, want %q", got, infraNamespaceRHOAI)
+		}
+	})
 }
 
 func TestResolveMaasApiInternalURL(t *testing.T) {
@@ -64,23 +187,10 @@ func TestResolveMaasApiInternalURL(t *testing.T) {
 		}
 	})
 
-	t.Run("maps POD_NAMESPACE to infra namespace", func(t *testing.T) {
-		got, err := ResolveMaasApiInternalURL(config.EnvConfig{
-			PodNamespace: "opendatahub",
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := "https://maas-api.odh-ai-gateway-infra.svc.cluster.local:8443"
-		if got != want {
-			t.Fatalf("got %q, want %q", got, want)
-		}
-	})
-
-	t.Run("requires POD_NAMESPACE when no override", func(t *testing.T) {
+	t.Run("requires namespace when no override", func(t *testing.T) {
 		_, err := ResolveMaasApiInternalURL(config.EnvConfig{})
 		if err == nil {
-			t.Fatal("expected error when POD_NAMESPACE and overrides are unset")
+			t.Fatal("expected error when MAAS_API_NAMESPACE and MAAS_API_INTERNAL_URL are unset")
 		}
 	})
 }

--- a/packages/maas/bff/internal/helpers/maas_discovery_test.go
+++ b/packages/maas/bff/internal/helpers/maas_discovery_test.go
@@ -1,0 +1,113 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/config"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+func TestResolveMaasApiInfraNamespace(t *testing.T) {
+	tests := []struct {
+		name         string
+		podNamespace string
+		override     string
+		want         string
+	}{
+		{name: "ODH mapping", podNamespace: "opendatahub", want: "odh-ai-gateway-infra"},
+		{name: "RHOAI mapping", podNamespace: "redhat-ods-applications", want: "redhat-ai-gateway-infra"},
+		{name: "override wins", podNamespace: "opendatahub", override: "custom-ns", want: "custom-ns"},
+		{name: "unknown pod namespace passthrough", podNamespace: "my-ns", want: "my-ns"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveMaasApiInfraNamespace(tt.podNamespace, tt.override)
+			if got != tt.want {
+				t.Fatalf("ResolveMaasApiInfraNamespace() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveMaasApiInternalURL(t *testing.T) {
+	t.Run("full override", func(t *testing.T) {
+		got, err := ResolveMaasApiInternalURL(config.EnvConfig{
+			MaasApiInternalUrl: "https://maas-api.custom.svc.cluster.local:8443/",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "https://maas-api.custom.svc.cluster.local:8443"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("namespace override", func(t *testing.T) {
+		got, err := ResolveMaasApiInternalURL(config.EnvConfig{
+			MaasApiNamespace: "redhat-ai-gateway-infra",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "https://maas-api.redhat-ai-gateway-infra.svc.cluster.local:8443"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("maps POD_NAMESPACE to infra namespace", func(t *testing.T) {
+		got, err := ResolveMaasApiInternalURL(config.EnvConfig{
+			PodNamespace: "opendatahub",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "https://maas-api.odh-ai-gateway-infra.svc.cluster.local:8443"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("requires POD_NAMESPACE when no override", func(t *testing.T) {
+		_, err := ResolveMaasApiInternalURL(config.EnvConfig{})
+		if err == nil {
+			t.Fatal("expected error when POD_NAMESPACE and overrides are unset")
+		}
+	})
+}
+
+func TestMaasApiURLFromTenantsResponse(t *testing.T) {
+	got, err := MaasApiURLFromTenantsResponse(models.TenantsResponse{
+		Tenants: []models.TenantInfo{{
+			Name: "models-as-a-service",
+			Gateway: models.GatewayMetadata{
+				ExternalURL: "https://maas.custom.example.com",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://maas.custom.example.com/maas-api"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestMaasApiURLFromTenantsResponse_EmptyTenants(t *testing.T) {
+	_, err := MaasApiURLFromTenantsResponse(models.TenantsResponse{Tenants: []models.TenantInfo{}})
+	if err == nil {
+		t.Fatal("expected error for empty tenants")
+	}
+}
+
+func TestMaasApiURLFromTenantsResponse_MissingExternalURL(t *testing.T) {
+	_, err := MaasApiURLFromTenantsResponse(models.TenantsResponse{
+		Tenants: []models.TenantInfo{{Name: "t", Gateway: models.GatewayMetadata{}}},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing externalUrl")
+	}
+}

--- a/packages/maas/bff/internal/integrations/maas/maas_fake_server.go
+++ b/packages/maas/bff/internal/integrations/maas/maas_fake_server.go
@@ -21,6 +21,10 @@ func CreateMaasFakeServer() *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
+			if r.URL.Path == "/v1/tenants" {
+				sendFakeResponse("tenants-response.json", http.StatusOK, w)
+				return
+			}
 			if r.URL.Path == "/v1/models" {
 				sendFakeResponse("maas-models-list.json", http.StatusOK, w)
 				return

--- a/packages/maas/bff/internal/integrations/maas/testdata/tenants-response.json
+++ b/packages/maas/bff/internal/integrations/maas/testdata/tenants-response.json
@@ -1,0 +1,14 @@
+{
+  "tenants": [
+    {
+      "name": "models-as-a-service",
+      "gateway": {
+        "name": "maas-default-gateway",
+        "namespace": "openshift-ingress",
+        "protocol": "https",
+        "externalUrl": "https://maas.apps.cluster.example.com",
+        "port": 443
+      }
+    }
+  ]
+}

--- a/packages/maas/bff/internal/models/tenant.go
+++ b/packages/maas/bff/internal/models/tenant.go
@@ -1,0 +1,21 @@
+package models
+
+// TenantsResponse is the response from maas-api GET /v1/tenants.
+type TenantsResponse struct {
+	Tenants []TenantInfo `json:"tenants"`
+}
+
+// TenantInfo contains tenant identification and gateway metadata.
+type TenantInfo struct {
+	Name    string          `json:"name"`
+	Gateway GatewayMetadata `json:"gateway"`
+}
+
+// GatewayMetadata contains gateway connection details from the MaaS API.
+type GatewayMetadata struct {
+	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
+	Protocol    string `json:"protocol"`
+	ExternalURL string `json:"externalUrl"`
+	Port        int64  `json:"port"`
+}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-69335
## Description
- Replaced cluster-ingress URL guessing with in-cluster GET /v1/tenants discovery on the internal maas-api Service, using the BFF service account token to resolve the real gateway externalUrl.
- Set passthrough MaasApiUrl to externalUrl + /maas-api; BFF startup fails if discovery fails and MAAS_API_URL is not set.
- Added POD_NAMESPACE (downward API) to the maas-ui deployment to map ODH/RHOAI namespaces to maas-api infra namespaces; removed duplicate TIERS_CONFIGMAP_NS.
- Added optional overrides (MAAS_API_INTERNAL_URL, MAAS_API_NAMESPACE, MAAS_API_URL), unit tests, and updated README/CONTRIBUTING docs.

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Tested with the image from this PR set as the image for maas-ui on my cluster and added the env var for POD_NAMESPACE
rolling out new pods shows 
```bash
time=2026-07-16T17:49:11.274Z level=INFO msg="Discovering MaaS API URL via /v1/tenants" internalURL=https://maas-api.redhat-ai-gateway-infra.svc.cluster.local:8443
time=2026-07-16T17:49:11.301Z level=INFO msg="Discovered MaaS API URL from /v1/tenants" tenant=models-as-a-service gateway=maas-default-gateway url=http://<maas-gateway-url>/maas-api
```
The API Keys page and operations were working as well.
Going to try out the PR image built here to see how it's working
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
new golang tests
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MaaS BFF now discovers the MaaS API endpoint via internal tenant discovery (`GET /v1/tenants`) and the `maas-default-gateway` external URL when `MAAS_API_URL` is not set.
  * Added configuration for pod namespace and internal MaaS API lookup/target namespaces; manifests now provide `POD_NAMESPACE`.
  * Extended ClusterRole permissions to list `datadscienceclusters`.

* **Bug Fixes**
  * Startup now stops with a clear error if discovery fails.

* **Documentation**
  * Updated MAAS contributing/development guidance and environment-variable descriptions for the new discovery behavior and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->