### PR TITLE
fix(ci): replace REST API artifact downloads with actions/download-artifact

### DIFF
--- a/.github/actions/cypress-build-restore/action.yml
+++ b/.github/actions/cypress-build-restore/action.yml
@@ -123,17 +123,9 @@ runs:
     # Mode: restore — download artifacts via actions/download-artifact
     # Uses internal Actions service for same-run (no REST API rate limits).
     # For cross-run (run-id specified), uses REST API with built-in retry.
-    # Priority: source run wins over current run (download current first,
-    # then source overwrites — matching the original per-package fallback).
+    # Downloads into separate directories then merges so neither download
+    # can clobber the other. Current run wins (has freshly rebuilt packages).
     # =========================================================================
-    - name: Download artifacts from current run
-      if: inputs.mode == 'restore'
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-      continue-on-error: true
-      with:
-        pattern: cypress-build-*
-        path: cypress-artifacts
-
     - name: Download artifacts from source run
       if: inputs.mode == 'restore' && inputs.run-id != ''
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -143,6 +135,24 @@ runs:
         path: cypress-artifacts
         github-token: ${{ inputs.github-token }}
         run-id: ${{ inputs.run-id }}
+
+    - name: Download artifacts from current run
+      if: inputs.mode == 'restore'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      continue-on-error: true
+      with:
+        pattern: cypress-build-*
+        path: cypress-artifacts-current
+
+    - name: Merge current-run artifacts over source-run artifacts
+      if: inputs.mode == 'restore'
+      shell: bash
+      run: |
+        if [ -d cypress-artifacts-current ]; then
+          mkdir -p cypress-artifacts
+          cp -r cypress-artifacts-current/* cypress-artifacts/ 2>/dev/null || true
+          rm -rf cypress-artifacts-current
+        fi
 
     - name: Restore artifacts to workspace
       if: inputs.mode == 'restore'

--- a/.github/actions/cypress-build-restore/action.yml
+++ b/.github/actions/cypress-build-restore/action.yml
@@ -120,108 +120,46 @@ runs:
         retention-days: 1
 
     # =========================================================================
-    # Mode: restore — download per-package artifacts via REST API (no gh dependency)
-    # Uses ?name= server-side filter so pagination is not an issue
+    # Mode: restore — download artifacts via actions/download-artifact
+    # Uses internal Actions service for same-run (no REST API rate limits).
+    # For cross-run (run-id specified), uses REST API with built-in retry.
+    # Priority: source run wins over current run (download current first,
+    # then source overwrites — matching the original per-package fallback).
     # =========================================================================
-    - name: Download and restore artifacts
-      id: download
+    - name: Download artifacts from current run
+      if: inputs.mode == 'restore'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      continue-on-error: true
+      with:
+        pattern: cypress-build-*
+        path: cypress-artifacts
+
+    - name: Download artifacts from source run
+      if: inputs.mode == 'restore' && inputs.run-id != ''
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      continue-on-error: true
+      with:
+        pattern: cypress-build-*
+        path: cypress-artifacts
+        github-token: ${{ inputs.github-token }}
+        run-id: ${{ inputs.run-id }}
+
+    - name: Restore artifacts to workspace
       if: inputs.mode == 'restore'
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
         PACKAGES_JSON: ${{ steps.discover.outputs.packages }}
-        RUN_ID: ${{ inputs.run-id }}
-        REPOSITORY: ${{ github.repository }}
       run: |
-        mkdir -p cypress-artifacts
-        DOWNLOADED=0
-        API="https://api.github.com/repos/$REPOSITORY"
-
-        download_artifact() {
-          local run_id="$1" artifact_name="$2" dest_dir="$3"
-          [ -z "$run_id" ] && return 1
-
-          local tmp_body list_http artifact_id
-          tmp_body=$(mktemp)
-          list_http=$(curl -sS -w '%{http_code}' \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -o "$tmp_body" \
-            "$API/actions/runs/$run_id/artifacts?name=$artifact_name")
-
-          if [ "$list_http" != "200" ]; then
-            echo "    API error (HTTP $list_http) listing artifacts in run $run_id"
-            rm -f "$tmp_body"
-            return 1
-          fi
-
-          artifact_id=$(jq -r '.artifacts[0].id // empty' < "$tmp_body")
-          rm -f "$tmp_body"
-          if [ -z "$artifact_id" ]; then
-            echo "    No artifact '$artifact_name' in run $run_id"
-            return 1
-          fi
-
-          mkdir -p "$dest_dir"
-          local redirect_url http_code
-          redirect_url=$(curl -sS -w '%{redirect_url}' \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -o /dev/null \
-            "$API/actions/artifacts/$artifact_id/zip")
-
-          if [ -z "$redirect_url" ]; then
-            echo "    No redirect received for artifact $artifact_id"
-            return 1
-          fi
-
-          http_code=$(curl -sS -w '%{http_code}' -L \
-            "$redirect_url" \
-            -o "$dest_dir/__artifact.zip")
-
-          if [ "$http_code" != "200" ]; then
-            echo "    Download failed (HTTP $http_code) for artifact $artifact_id"
-            rm -f "$dest_dir/__artifact.zip"
-            return 1
-          fi
-
-          unzip -qo "$dest_dir/__artifact.zip" -d "$dest_dir" && rm -f "$dest_dir/__artifact.zip"
-        }
-
-        while IFS= read -r pkg_json; do
-          workspace=$(echo "$pkg_json" | jq -r '.workspace')
-          name=$(echo "$pkg_json" | jq -r '.name')
-          artifact_name="cypress-build-$(echo "$workspace" | tr '/' '-')"
-          dest="cypress-artifacts/$artifact_name"
-
-          echo "📥 $name ($artifact_name)"
-          FETCHED=false
-          for run in "$RUN_ID" "$GITHUB_RUN_ID"; do
-            [ -z "$run" ] && continue
-            if download_artifact "$run" "$artifact_name" "$dest"; then
-              echo "  ✅ downloaded from run $run"
-              FETCHED=true
-              DOWNLOADED=$((DOWNLOADED + 1))
-              break
-            fi
-          done
-
-          if [ "$FETCHED" = "false" ]; then
-            echo "  ⚠️ not found in any run"
-          fi
-        done < <(echo "$PACKAGES_JSON" | jq -c '.[]')
-
-        echo "📦 Downloaded $DOWNLOADED artifact(s)"
-
-        # Restore to workspace structure
         while IFS= read -r pkg_json; do
           workspace=$(echo "$pkg_json" | jq -r '.workspace')
           artifact_name="cypress-build-$(echo "$workspace" | tr '/' '-')"
 
           if [ -d "cypress-artifacts/$artifact_name" ]; then
-            echo "Restoring $artifact_name → $workspace/"
+            echo "✅ Restoring $artifact_name → $workspace/"
             mkdir -p "$workspace"
             cp -r "cypress-artifacts/$artifact_name"/* "$workspace/" 2>/dev/null || true
+          else
+            echo "⚠️ No artifact found for $artifact_name"
           fi
         done < <(echo "$PACKAGES_JSON" | jq -c '.[]')
 

--- a/.github/actions/cypress-build-restore/action.yml
+++ b/.github/actions/cypress-build-restore/action.yml
@@ -123,10 +123,9 @@ runs:
     # Mode: restore — download artifacts from source and current runs
     # Source run (many artifacts): actions/download-artifact with pattern
     #   creates per-artifact subdirectories under cypress-artifacts/.
-    # Current run (few rebuilt artifacts): gh run download, which always
-    #   creates per-artifact subdirectories regardless of count.
-    #   (actions/download-artifact@v8 skips subdirectories when only one
-    #    artifact matches a pattern, breaking the restore step.)
+    # Current run (few rebuilt artifacts): REST API with explicit directory
+    #   control. Cannot use actions/download-artifact (skips subdirectories
+    #   for single-artifact matches) or gh CLI (unavailable on self-hosted).
     # =========================================================================
     - name: Download artifacts from source run
       if: inputs.mode == 'restore' && inputs.run-id != ''
@@ -143,11 +142,49 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ github.repository }}
       run: |
-        gh run download "$GITHUB_RUN_ID" \
-          --pattern "cypress-build-*" \
-          --dir cypress-artifacts \
-          2>/dev/null || echo "ℹ️ No cypress-build artifacts in current run (expected when no rebuilds needed)"
+        API="https://api.github.com/repos/$REPOSITORY"
+
+        ARTIFACTS=$(curl -sS \
+          -H "Authorization: Bearer $GH_TOKEN" \
+          -H "Accept: application/vnd.github+json" \
+          "$API/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" \
+          | jq -c '[.artifacts[] | select(.name | startswith("cypress-build-"))]')
+
+        COUNT=$(echo "$ARTIFACTS" | jq 'length')
+        if [ "$COUNT" -eq 0 ]; then
+          echo "ℹ️ No cypress-build artifacts in current run (expected when no rebuilds needed)"
+          exit 0
+        fi
+
+        echo "📥 Downloading $COUNT rebuilt artifact(s) from current run..."
+        echo "$ARTIFACTS" | jq -c '.[]' | while IFS= read -r art; do
+          art_name=$(echo "$art" | jq -r '.name')
+          art_id=$(echo "$art" | jq -r '.id')
+          dest="cypress-artifacts/$art_name"
+          mkdir -p "$dest"
+
+          redirect_url=$(curl -sS -w '%{redirect_url}' \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -o /dev/null \
+            "$API/actions/artifacts/$art_id/zip")
+
+          if [ -z "$redirect_url" ]; then
+            echo "  ⚠️ No redirect for $art_name (id=$art_id)"
+            continue
+          fi
+
+          http_code=$(curl -sS -w '%{http_code}' -L "$redirect_url" -o "$dest/__artifact.zip")
+          if [ "$http_code" = "200" ]; then
+            unzip -qo "$dest/__artifact.zip" -d "$dest" && rm -f "$dest/__artifact.zip"
+            echo "  ✅ $art_name"
+          else
+            echo "  ⚠️ Download failed (HTTP $http_code) for $art_name"
+            rm -f "$dest/__artifact.zip"
+          fi
+        done
 
     - name: Restore artifacts to workspace
       if: inputs.mode == 'restore'

--- a/.github/actions/cypress-build-restore/action.yml
+++ b/.github/actions/cypress-build-restore/action.yml
@@ -120,11 +120,13 @@ runs:
         retention-days: 1
 
     # =========================================================================
-    # Mode: restore — download artifacts via actions/download-artifact
-    # Uses internal Actions service for same-run (no REST API rate limits).
-    # For cross-run (run-id specified), uses REST API with built-in retry.
-    # Downloads into separate directories then merges so neither download
-    # can clobber the other. Current run wins (has freshly rebuilt packages).
+    # Mode: restore — download artifacts from source and current runs
+    # Source run (many artifacts): actions/download-artifact with pattern
+    #   creates per-artifact subdirectories under cypress-artifacts/.
+    # Current run (few rebuilt artifacts): gh run download, which always
+    #   creates per-artifact subdirectories regardless of count.
+    #   (actions/download-artifact@v8 skips subdirectories when only one
+    #    artifact matches a pattern, breaking the restore step.)
     # =========================================================================
     - name: Download artifacts from source run
       if: inputs.mode == 'restore' && inputs.run-id != ''
@@ -136,23 +138,16 @@ runs:
         github-token: ${{ inputs.github-token }}
         run-id: ${{ inputs.run-id }}
 
-    - name: Download artifacts from current run
-      if: inputs.mode == 'restore'
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-      continue-on-error: true
-      with:
-        pattern: cypress-build-*
-        path: cypress-artifacts-current
-
-    - name: Merge current-run artifacts over source-run artifacts
+    - name: Download rebuilt artifacts from current run
       if: inputs.mode == 'restore'
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        if [ -d cypress-artifacts-current ]; then
-          mkdir -p cypress-artifacts
-          cp -r cypress-artifacts-current/* cypress-artifacts/ 2>/dev/null || true
-          rm -rf cypress-artifacts-current
-        fi
+        gh run download "$GITHUB_RUN_ID" \
+          --pattern "cypress-build-*" \
+          --dir cypress-artifacts \
+          2>/dev/null || echo "ℹ️ No cypress-build artifacts in current run (expected when no rebuilds needed)"
 
     - name: Restore artifacts to workspace
       if: inputs.mode == 'restore'

--- a/.github/actions/cypress-build-restore/action.yml
+++ b/.github/actions/cypress-build-restore/action.yml
@@ -120,12 +120,12 @@ runs:
         retention-days: 1
 
     # =========================================================================
-    # Mode: restore — download artifacts from source and current runs
-    # Source run (many artifacts): actions/download-artifact with pattern
-    #   creates per-artifact subdirectories under cypress-artifacts/.
-    # Current run (few rebuilt artifacts): REST API with explicit directory
-    #   control. Cannot use actions/download-artifact (skips subdirectories
-    #   for single-artifact matches) or gh CLI (unavailable on self-hosted).
+    # Mode: restore — download artifacts via actions/download-artifact
+    # 1. Source run (pattern) — creates per-artifact subdirectories for 2+
+    # 2. Current run (pattern) — downloaded to temp dir
+    # 3. Shell merge — detects single-artifact flat download (v8 quirk:
+    #    patterns matching exactly one artifact extract directly to path
+    #    without a subdirectory) and wraps into correct subdirectory.
     # =========================================================================
     - name: Download artifacts from source run
       if: inputs.mode == 'restore' && inputs.run-id != ''
@@ -139,52 +139,54 @@ runs:
 
     - name: Download rebuilt artifacts from current run
       if: inputs.mode == 'restore'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      continue-on-error: true
+      with:
+        pattern: cypress-build-*
+        path: cypress-artifacts-current
+
+    - name: Merge current-run artifacts into cypress-artifacts
+      if: inputs.mode == 'restore'
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
-        REPOSITORY: ${{ github.repository }}
+        PACKAGES_JSON: ${{ steps.discover.outputs.packages }}
       run: |
-        API="https://api.github.com/repos/$REPOSITORY"
-
-        ARTIFACTS=$(curl -sS \
-          -H "Authorization: Bearer $GH_TOKEN" \
-          -H "Accept: application/vnd.github+json" \
-          "$API/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" \
-          | jq -c '[.artifacts[] | select(.name | startswith("cypress-build-"))]')
-
-        COUNT=$(echo "$ARTIFACTS" | jq 'length')
-        if [ "$COUNT" -eq 0 ]; then
-          echo "ℹ️ No cypress-build artifacts in current run (expected when no rebuilds needed)"
+        if [ ! -d cypress-artifacts-current ]; then
+          echo "ℹ️ No rebuilt artifacts in current run"
           exit 0
         fi
 
-        echo "📥 Downloading $COUNT rebuilt artifact(s) from current run..."
-        echo "$ARTIFACTS" | jq -c '.[]' | while IFS= read -r art; do
-          art_name=$(echo "$art" | jq -r '.name')
-          art_id=$(echo "$art" | jq -r '.id')
-          dest="cypress-artifacts/$art_name"
-          mkdir -p "$dest"
+        mkdir -p cypress-artifacts
 
-          redirect_url=$(curl -sS -w '%{redirect_url}' \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -o /dev/null \
-            "$API/actions/artifacts/$art_id/zip")
+        if ls -d cypress-artifacts-current/cypress-build-* 2>/dev/null | grep -q .; then
+          echo "📦 Multiple artifacts — subdirectories exist, merging directly"
+          cp -r cypress-artifacts-current/* cypress-artifacts/
+        else
+          echo "📦 Single artifact — files extracted flat (download-artifact v8 quirk)"
+          echo "   Detecting which package was rebuilt..."
 
-          if [ -z "$redirect_url" ]; then
-            echo "  ⚠️ No redirect for $art_name (id=$art_id)"
-            continue
-          fi
+          MISSING_NAME=""
+          while IFS= read -r pkg_json; do
+            workspace=$(echo "$pkg_json" | jq -r '.workspace')
+            artifact_name="cypress-build-$(echo "$workspace" | tr '/' '-')"
+            if [ ! -d "cypress-artifacts/$artifact_name" ]; then
+              MISSING_NAME="$artifact_name"
+              echo "   → Missing from source run: $artifact_name"
+              break
+            fi
+          done < <(echo "$PACKAGES_JSON" | jq -c '.[]')
 
-          http_code=$(curl -sS -w '%{http_code}' -L "$redirect_url" -o "$dest/__artifact.zip")
-          if [ "$http_code" = "200" ]; then
-            unzip -qo "$dest/__artifact.zip" -d "$dest" && rm -f "$dest/__artifact.zip"
-            echo "  ✅ $art_name"
+          if [ -n "$MISSING_NAME" ]; then
+            mkdir -p "cypress-artifacts/$MISSING_NAME"
+            cp -r cypress-artifacts-current/* "cypress-artifacts/$MISSING_NAME/"
+            echo "   ✅ Wrapped flat download into cypress-artifacts/$MISSING_NAME/"
           else
-            echo "  ⚠️ Download failed (HTTP $http_code) for $art_name"
-            rm -f "$dest/__artifact.zip"
+            echo "   ⚠️ Could not determine missing artifact name, copying flat"
+            cp -r cypress-artifacts-current/* cypress-artifacts/
           fi
-        done
+        fi
+
+        rm -rf cypress-artifacts-current
 
     - name: Restore artifacts to workspace
       if: inputs.mode == 'restore'


### PR DESCRIPTION
## Description

The `cypress-build-restore` action's restore mode used direct `curl` calls to the GitHub REST API to list and download per-package artifacts. The GITHUB_TOKEN shares a rate limit of 1,000 REST API requests per hour across all concurrent workflow runs in the repo. When 20+ `Cypress-Mock-Tests` matrix jobs each made ~18 API calls to download 9 artifacts, the limit was intermittently exhausted — producing HTTP 403 errors and failing all tests.

This replaces the custom REST API download logic with `actions/download-artifact@v8` which:
- Uses the internal Actions service channel for same-run downloads (zero REST API calls)
- Has built-in retry/backoff and digest verification for cross-run downloads
- Downloads all matching artifacts in one call via `pattern: cypress-build-*`
- Requires no `gh` CLI or REST API calls (Node.js action — works on self-hosted runners)

### Handling the download-artifact v8 single-artifact quirk

`actions/download-artifact@v8` has a documented behavior where patterns matching exactly one artifact extract files directly to the output path **without** creating a per-artifact subdirectory (regardless of `merge-multiple` setting). When multiple artifacts match, each gets its own subdirectory. The restore step relies on these subdirectories to map artifacts back to package workspaces.

To handle this, the action:
1. Downloads **source run** artifacts to `cypress-artifacts/` (typically 8-9 artifacts → subdirectories created)
2. Downloads **current run** (rebuilt) artifacts to a temp directory `cypress-artifacts-current/`
3. A merge step detects whether the temp directory has `cypress-build-*` subdirectories (multiple artifacts) or flat files (single artifact). For the single-artifact case, it identifies the missing package by comparing against the source run's subdirectories and wraps the flat files into the correct subdirectory before merging.

Current-run artifacts take precedence over source-run artifacts since they are freshly rebuilt.

## How Has This Been Tested?

- Tested via `workflow_dispatch` on the `test-cypress-e2e` branch against the self-hosted e2e cluster
- Verified the single-artifact merge handles the `@odh-dashboard/maas` rebuild case (the only package consistently missing from the triggering workflow run)
- Confirmed source-run artifacts (8 packages) download with correct subdirectory structure
- The existing `Verify builds restored` step catches any download/restore failures at runtime

See sample run https://github.com/opendatahub-io/odh-dashboard/actions/runs/29509059330

## Test Impact

No new tests needed — this is CI infrastructure. The existing verify step (`Verify builds restored`) catches any download failures at runtime.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`