### PR TITLE
Backport/tfa fixes

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataSciencePipelines/testSchedulePipeline.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataSciencePipelines/testSchedulePipeline.yaml
@@ -1,5 +1,5 @@
 pipelineName: test-scheduled-pipeline
-pipelineDescription: Pipeline scheduled via E2E
+pipelineDescription: 'Pipeline scheduled via E2E'
 scheduleName: test-scheduled-run
-scheduleDescription: Scheduled run created by E2E
-pipelineUrl: https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml
+scheduleDescription: 'Scheduled run created by E2E'
+pipelineUrl: https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/packages/cypress/resources/pipelines_samples/dummy_pipeline_compiled.yaml

--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/modelRegistry/testModelRegistry.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/modelRegistry/testModelRegistry.yaml
@@ -1,43 +1,43 @@
 # Comprehensive test data for all model registry tests
-registryNamePrefix: "test-model-registry"
-createRegistryName: "e2e-test-registry"
+registryNamePrefix: 'test-model-registry'
+createRegistryName: 'e2e-test-registry'
 
 # Model Registry Operator Configuration
-operatorDeploymentName: "model-registry-operator-controller-manager"
+operatorDeploymentName: 'model-registry-operator-controller-manager'
 
 # First model (Object Storage)
-objectStorageModelName: "test-object-storage-model"
-objectStorageModelDescription: "E2E test model using object storage"
-version1Name: "v1.0"
-version1Description: "First version of the object storage test model"
-modelFormatOnnx: "onnx"
-formatVersion1_0: "1.0"
-objectStorageEndpoint: "http://minio.example.com:9000"
-objectStorageBucket: "test-models"
-objectStorageRegion: "us-east-1"
-objectStoragePath: "models/test-model/v1.0"
-modelOpenVinoPath: "kserve-openvino-test/openvino-example-model"
+objectStorageModelName: 'test-obj-model'
+objectStorageModelDescription: 'E2E test model using object storage'
+version1Name: 'v1.0'
+version1Description: 'First version of the object storage test model'
+modelFormatOnnx: 'onnx'
+formatVersion1_0: '1.0'
+objectStorageEndpoint: 'http://minio.example.com:9000'
+objectStorageBucket: 'test-models'
+objectStorageRegion: 'us-east-1'
+objectStoragePath: 'models/test-model/v1.0'
+modelOpenVinoPath: 'kserve-openvino-test/openvino-example-model'
 
 # Second model (URI)
-uriModelName: "test-uri-model"
-uriModelDescription: "E2E test model using URI"
-uriVersion1Description: "First version of the URI test model"
-modelFormatPytorch: "pytorch"
-formatVersion2_0: "2.0"
-uriPrimary: "s3://test-bucket/models/pytorch-model?endpoint=http%3A%2F%2Fminio.example.com%3A9000&defaultRegion=us-east-1"
+uriModelName: 'test-uri-model'
+uriModelDescription: 'E2E test model using URI'
+uriVersion1Description: 'First version of the URI test model'
+modelFormatPytorch: 'pytorch'
+formatVersion2_0: '2.0'
+uriPrimary: 's3://test-bucket/models/pytorch-model?endpoint=http%3A%2F%2Fminio.example.com%3A9000&defaultRegion=us-east-1'
 
 # New version registration (Versions view)
-version2Name: "v2.0"
-version2Description: "Second version registered via versions view"
-modelFormatTensorflow: "tensorflow"
-formatVersion3_0: "3.0"
-uriVersion2: "s3://test-bucket/models/tensorflow-model-v2?endpoint=http%3A%2F%2Fminio.example.com%3A9000&defaultRegion=us-east-1"
+version2Name: 'v2.0'
+version2Description: 'Second version registered via versions view'
+modelFormatTensorflow: 'tensorflow'
+formatVersion3_0: '3.0'
+uriVersion2: 's3://test-bucket/models/tensorflow-model-v2?endpoint=http%3A%2F%2Fminio.example.com%3A9000&defaultRegion=us-east-1'
 
-newNameSuffix: "-edited"
-newDescription: "Updated description for e2e test"
-deployProjectNamePrefix: "test-deploy-project"
+newNameSuffix: '-edited'
+newDescription: 'Updated description for e2e test'
+deployProjectNamePrefix: 'test-deploy-prj'
 
 # Permissions management configuration
-permissionsRegistryNamePrefix: "test-mr-permissions-registry"
-testProjectNamePrefix: "test-mr-permissions-project"
-rhodsUsersGroup: "rhods-users"
+permissionsRegistryNamePrefix: 'test-mr-permissions-registry'
+testProjectNamePrefix: 'test-mr-permissions-project'
+rhodsUsersGroup: 'rhods-users'

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/pvc-loader-pod.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/pvc-loader-pod.yaml
@@ -12,6 +12,14 @@ spec:
     - name: s3-downloader
       image: amazon/aws-cli
       command: ["/bin/bash", "-c"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
       args:
         - |
           set -e

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
@@ -49,7 +49,7 @@ describe('An admin user can import and run a pipeline', { testIsolation: false }
       pipelineImportModal
         .findPipelineUrlInput()
         .type(
-          'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
+          'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/packages/cypress/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
         );
       pipelineImportModal.submit();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegistryDeployModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegistryDeployModel.cy.ts
@@ -22,7 +22,10 @@ import { kserveModal, modelServingGlobal } from '#~/__tests__/cypress/cypress/pa
 import { checkInferenceServiceState } from '#~/__tests__/cypress/cypress/utils/oc_commands/modelServing';
 import { projectDetails } from '#~/__tests__/cypress/cypress/pages/projects';
 import { createCleanProject } from '#~/__tests__/cypress/cypress/utils/projectChecker';
-import { deleteOpenShiftProject } from '#~/__tests__/cypress/cypress/utils/oc_commands/project';
+import {
+  clearStuckProjectInferenceServices,
+  deleteOpenShiftProject,
+} from '#~/__tests__/cypress/cypress/utils/oc_commands/project';
 import { AWS_BUCKETS } from '#~/__tests__/cypress/cypress/utils/s3Buckets';
 
 describe('Verify models can be deployed from model registry', () => {
@@ -62,11 +65,16 @@ describe('Verify models can be deployed from model registry', () => {
     cy.clearCookies();
     cy.clearLocalStorage();
 
+    cy.step('Clear registry-deployed InferenceService finalizers');
+    clearStuckProjectInferenceServices(projectName);
+
     cy.step('Clean up model registry components');
     cleanupModelRegistryComponents([modelName], registryName);
 
     cy.step('Delete the test project');
-    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+    clearStuckProjectInferenceServices(projectName).then(() => {
+      deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+    });
 
     cy.step('Delete the SQL database');
     deleteModelRegistryDatabase();
@@ -175,18 +183,18 @@ describe('Verify models can be deployed from model registry', () => {
 
       cy.step('Submit the deployment');
       kserveModal.findSubmitButton().click();
-
-      // Check deployment link and verify status in deployments view
-      modelRegistry.navigate();
-      cy.contains('1 deployment').should('be.visible').click();
       cy.contains(modelName, { timeout: 30000 }).should('be.visible');
-      cy.contains('Started', { timeout: 120000 }).should('be.visible');
 
       cy.step('Verify the model is deployed and started in backend');
       checkInferenceServiceState(`${modelName}-v10`, projectName, {
         checkReady: true,
         checkLatestDeploymentReady: true,
       });
+
+      // Check deployment link and verify status in deployments view
+      modelRegistry.navigate();
+      cy.contains('1 deployment').should('be.visible').click();
+      cy.contains('Started', { timeout: 120000 }).should('be.visible');
     },
   );
 });

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
@@ -53,7 +53,7 @@ export const deleteOpenShiftProject = (
   };
 
   return cy.exec(ocCommand, execOptions).then((result) => {
-    if (result.code !== 0) {
+    if (result.code !== 0 && !(ignoreNotFound && result.stderr.includes('not found'))) {
       cy.log(`ERROR deleting ${projectName} Project
                 stdout: ${result.stdout}
                 stderr: ${result.stderr}`);
@@ -61,6 +61,70 @@ export const deleteOpenShiftProject = (
     }
     return result;
   });
+};
+
+const sanitizeK8sName = (name: string): string => name.replace(/[^a-zA-Z0-9_-]/g, '');
+
+/**
+ * Clears model-registry finalizers on InferenceServices that block project deletion.
+ * Registry-deployed models attach `modelregistry.opendatahub.io/finalizer`.
+ */
+export const clearStuckProjectInferenceServices = (
+  projectName: string,
+): Cypress.Chainable<CommandLineResult> => {
+  const ns = sanitizeK8sName(projectName);
+  const listCommand = `oc get inferenceservice -n ${ns} -o jsonpath='{.items[*].metadata.name}'`;
+  const patchDeleteCommand = `for is in $(oc get inferenceservice -n ${ns} -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do oc patch inferenceservice "$is" -n ${ns} --type=merge -p '{"metadata":{"finalizers":[]}}' || true; oc delete inferenceservice "$is" -n ${ns} --ignore-not-found --wait=false || true; done; true`;
+
+  cy.log(`Clearing stuck InferenceServices in project ${projectName}`);
+  return cy.exec(listCommand, { failOnNonZeroExit: false }).then((listResult) => {
+    const names = listResult.stdout.trim();
+    if (names) {
+      cy.log(`Found InferenceServices to clear in ${projectName}: ${names}`);
+    }
+    return cy.exec(patchDeleteCommand, { failOnNonZeroExit: false }).then((result) => {
+      if (result.stderr) {
+        cy.log(`clearStuckProjectInferenceServices stderr: ${result.stderr}`);
+      }
+      return result;
+    });
+  });
+};
+
+/**
+ * Poll until a project no longer exists (handles lingering Terminating state).
+ */
+export const waitForProjectDeletion = (
+  projectName: string,
+  maxAttempts = 300,
+): Cypress.Chainable<void> => {
+  let attempts = 0;
+
+  const checkDeleted = (): Cypress.Chainable<void> =>
+    verifyOpenShiftProjectExists(projectName).then((stillExists) => {
+      if (!stillExists) {
+        return cy.wrap(undefined as void);
+      }
+      attempts += 1;
+      if (attempts >= maxAttempts) {
+        throw new Error(
+          `Project ${projectName} still exists after ${maxAttempts} seconds (may be stuck terminating)`,
+        );
+      }
+      cy.log(`Project ${projectName} still exists, waiting... (${attempts}/${maxAttempts})`);
+      // Re-clear MR finalizers while Terminating; a single pre-delete pass is not always enough.
+      const retryClear =
+        attempts === 1 || attempts % 10 === 0
+          ? clearStuckProjectInferenceServices(projectName)
+          : cy.wrap({ code: 0, stdout: '', stderr: '' } as CommandLineResult);
+      return retryClear.then(() => {
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(1000);
+        return checkDeleted();
+      });
+    });
+
+  return checkDeleted();
 };
 
 /**

--- a/frontend/src/__tests__/cypress/cypress/utils/projectChecker.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/projectChecker.ts
@@ -2,6 +2,8 @@ import {
   verifyOpenShiftProjectExists,
   deleteOpenShiftProject,
   createOpenShiftProject,
+  clearStuckProjectInferenceServices,
+  waitForProjectDeletion,
 } from '#~/__tests__/cypress/cypress/utils/oc_commands/project';
 
 export const createAndVerifyProject = (projectName: string): void => {
@@ -16,13 +18,27 @@ export const createAndVerifyProject = (projectName: string): void => {
   });
 };
 
+const deleteProjectAndWait = (projectName: string): void => {
+  clearStuckProjectInferenceServices(projectName).then(() => {
+    // --wait=false avoids cy.exec 60s timeout when deletion is blocked by finalizers
+    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true }).then(() => {
+      cy.log(`Waiting for project ${projectName} to be fully deleted...`);
+      waitForProjectDeletion(projectName).then(() => {
+        cy.log(`Creating project ${projectName}`);
+        createAndVerifyProject(projectName);
+      });
+    });
+  });
+};
+
 export const createCleanProject = (projectName: string): void => {
   verifyOpenShiftProjectExists(projectName).then((exists) => {
     if (exists) {
       cy.log(`Project ${projectName} already exists. Deleting it.`);
-      deleteOpenShiftProject(projectName, { wait: true });
+      deleteProjectAndWait(projectName);
+    } else {
+      cy.log(`Creating project ${projectName}`);
+      createAndVerifyProject(projectName);
     }
-    cy.log(`Creating project ${projectName}`);
-    createAndVerifyProject(projectName);
   });
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes E2E tests in 2.25 TFA which are failing with Test Maintain.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
job/components/job/dashboard/job/dashboard-e2e-tests/1865/Test_20Reports/
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
