### PR TITLE
Update limited-support acceptance modal microcopy

### DIFF
--- a/packages/cypress/cypress/pages/llmAcceleratorConfigs.ts
+++ b/packages/cypress/cypress/pages/llmAcceleratorConfigs.ts
@@ -50,6 +50,10 @@ class UnsupportedStatusAcceptanceModal {
     return this;
   }
 
+  findAcceptanceCheckbox() {
+    return this.find().findByTestId('unsupported-status-acceptance-checkbox');
+  }
+
   findAcceptButton() {
     return this.find().findByTestId('unsupported-status-accept-button');
   }

--- a/packages/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimesUnsupported.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimesUnsupported.cy.ts
@@ -28,7 +28,7 @@ describe('Custom serving runtimes — unsupported resource handling', () => {
     unsupportedStatusAcceptanceModal.shouldBeOpen();
     unsupportedStatusAcceptanceModal
       .find()
-      .should('contain.text', 'Enable limited support runtime');
+      .should('contain.text', 'Enable limited-support runtime?');
   });
 
   it('should dismiss modal without patching when cancel is clicked', () => {
@@ -48,6 +48,8 @@ describe('Custom serving runtimes — unsupported resource handling', () => {
     servingRuntimes.getRowById('template-unsupported-unaccepted').findEnabledToggle().click();
     unsupportedStatusAcceptanceModal.shouldBeOpen();
 
+    unsupportedStatusAcceptanceModal.findAcceptButton().should('be.disabled');
+    unsupportedStatusAcceptanceModal.findAcceptanceCheckbox().click();
     unsupportedStatusAcceptanceModal.findAcceptButton().click();
 
     cy.wait('@patchTemplate').then((interception) => {

--- a/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigs.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigs.cy.ts
@@ -63,7 +63,7 @@ describe('LLM accelerator configurations', () => {
     unsupportedStatusAcceptanceModal.shouldBeOpen();
     unsupportedStatusAcceptanceModal
       .find()
-      .should('contain.text', 'Enable limited support accelerator configuration');
+      .should('contain.text', 'Enable limited-support accelerator configuration?');
   });
 
   it('should dismiss modal without patching when cancel is clicked', () => {
@@ -80,6 +80,8 @@ describe('LLM accelerator configurations', () => {
     llmAcceleratorConfigs.getRowByName('vllm-tpu').findEnabledToggle().click();
     unsupportedStatusAcceptanceModal.shouldBeOpen();
 
+    unsupportedStatusAcceptanceModal.findAcceptButton().should('be.disabled');
+    unsupportedStatusAcceptanceModal.findAcceptanceCheckbox().click();
     unsupportedStatusAcceptanceModal.findAcceptButton().click();
 
     cy.wait('@patchConfig').then((interception) => {

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/__tests__/LlmAcceleratorConfigEnabledToggle.spec.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/__tests__/LlmAcceleratorConfigEnabledToggle.spec.tsx
@@ -123,7 +123,7 @@ describe('LlmAcceleratorConfigEnabledToggle', () => {
 
     expect(screen.getByTestId('unsupported-status-acceptance-modal')).toBeInTheDocument();
     expect(
-      screen.getByText('Enable limited support accelerator configuration'),
+      screen.getByText('Enable limited-support accelerator configuration?'),
     ).toBeInTheDocument();
     expect(mockPatchConfig).not.toHaveBeenCalled();
   });
@@ -134,6 +134,7 @@ describe('LlmAcceleratorConfigEnabledToggle', () => {
     render(<LlmAcceleratorConfigEnabledToggle config={config} />);
 
     fireEvent.click(screen.getByRole('switch'));
+    fireEvent.click(screen.getByTestId('unsupported-status-acceptance-checkbox'));
     fireEvent.click(screen.getByTestId('unsupported-status-accept-button'));
 
     await waitFor(() => {

--- a/packages/model-serving/src/components/UnsupportedStatusAcceptanceModal.tsx
+++ b/packages/model-serving/src/components/UnsupportedStatusAcceptanceModal.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Checkbox } from '@patternfly/react-core';
 import ContentModal from '@odh-dashboard/ui-core/components/ContentModal';
 
 type UnsupportedStatusAcceptanceModalProps = {
@@ -11,28 +12,45 @@ const UnsupportedStatusAcceptanceModal: React.FC<UnsupportedStatusAcceptanceModa
   resourceTypeLabel,
   onAccept,
   onClose,
-}) => (
-  <ContentModal
-    title={`Enable limited support ${resourceTypeLabel}`}
-    variant="small"
-    onClose={onClose}
-    dataTestId="unsupported-status-acceptance-modal"
-    contents={`By enabling this ${resourceTypeLabel}, you acknowledge that support coverage differs from standard support coverages.`}
-    buttonActions={[
-      {
-        label: 'Enable',
-        onClick: onAccept,
-        variant: 'primary',
-        dataTestId: 'unsupported-status-accept-button',
-      },
-      {
-        label: 'Cancel',
-        onClick: onClose,
-        variant: 'link',
-        dataTestId: 'unsupported-status-cancel-button',
-      },
-    ]}
-  />
-);
+}) => {
+  const [isChecked, setIsChecked] = React.useState(false);
+
+  return (
+    <ContentModal
+      title={`Enable limited-support ${resourceTypeLabel}?`}
+      variant="small"
+      onClose={onClose}
+      dataTestId="unsupported-status-acceptance-modal"
+      contents={
+        <>
+          The support coverage for this {resourceTypeLabel} is limited to 1 month after release.
+          <Checkbox
+            id="unsupported-status-acceptance-checkbox"
+            data-testid="unsupported-status-acceptance-checkbox"
+            label="I understand"
+            isChecked={isChecked}
+            onChange={(_event, checked) => setIsChecked(checked)}
+            className="pf-v6-u-mt-md"
+          />
+        </>
+      }
+      buttonActions={[
+        {
+          label: 'Enable',
+          onClick: onAccept,
+          variant: 'primary',
+          dataTestId: 'unsupported-status-accept-button',
+          isDisabled: !isChecked,
+        },
+        {
+          label: 'Cancel',
+          onClick: onClose,
+          variant: 'link',
+          dataTestId: 'unsupported-status-cancel-button',
+        },
+      ]}
+    />
+  );
+};
 
 export default UnsupportedStatusAcceptanceModal;

--- a/packages/model-serving/src/components/__tests__/UnsupportedStatusAcceptanceModal.spec.tsx
+++ b/packages/model-serving/src/components/__tests__/UnsupportedStatusAcceptanceModal.spec.tsx
@@ -21,7 +21,7 @@ describe('UnsupportedStatusAcceptanceModal', () => {
     );
 
     expect(
-      screen.getByText('Enable limited support accelerator configuration'),
+      screen.getByText('Enable limited-support accelerator configuration?'),
     ).toBeInTheDocument();
   });
 
@@ -34,7 +34,7 @@ describe('UnsupportedStatusAcceptanceModal', () => {
       />,
     );
 
-    expect(screen.getByText('Enable limited support runtime')).toBeInTheDocument();
+    expect(screen.getByText('Enable limited-support runtime?')).toBeInTheDocument();
   });
 
   it('should render body text with the resource type label', () => {
@@ -48,12 +48,12 @@ describe('UnsupportedStatusAcceptanceModal', () => {
 
     expect(
       screen.getByText(
-        'By enabling this accelerator configuration, you acknowledge that support coverage differs from standard support coverages.',
+        /The support coverage for this accelerator configuration is limited to 1 month after release\./,
       ),
     ).toBeInTheDocument();
   });
 
-  it('should call onAccept when Enable button is clicked', () => {
+  it('should render the I understand checkbox', () => {
     render(
       <UnsupportedStatusAcceptanceModal
         resourceTypeLabel="runtime"
@@ -62,6 +62,36 @@ describe('UnsupportedStatusAcceptanceModal', () => {
       />,
     );
 
+    expect(screen.getByTestId('unsupported-status-acceptance-checkbox')).toBeInTheDocument();
+    expect(screen.getByText('I understand')).toBeInTheDocument();
+  });
+
+  it('should have the Enable button disabled until the checkbox is checked', () => {
+    render(
+      <UnsupportedStatusAcceptanceModal
+        resourceTypeLabel="runtime"
+        onAccept={mockOnAccept}
+        onClose={mockOnClose}
+      />,
+    );
+
+    const enableButton = screen.getByTestId('unsupported-status-accept-button');
+    expect(enableButton).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('unsupported-status-acceptance-checkbox'));
+    expect(enableButton).toBeEnabled();
+  });
+
+  it('should call onAccept when Enable button is clicked after checking the checkbox', () => {
+    render(
+      <UnsupportedStatusAcceptanceModal
+        resourceTypeLabel="runtime"
+        onAccept={mockOnAccept}
+        onClose={mockOnClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('unsupported-status-acceptance-checkbox'));
     fireEvent.click(screen.getByTestId('unsupported-status-accept-button'));
     expect(mockOnAccept).toHaveBeenCalledTimes(1);
     expect(mockOnClose).not.toHaveBeenCalled();


### PR DESCRIPTION
Part of microcopy review subtask https://redhat.atlassian.net/browse/RHOAIENG-76503
Signoff epic https://redhat.atlassian.net/browse/RHOAIENG-76495
Dev epic https://redhat.atlassian.net/browse/RHOAIENG-69725

<img width="571" height="243" alt="Screenshot 2026-07-14 at 3 36 00 PM" src="https://github.com/user-attachments/assets/b22ac9f4-8248-428c-a9ce-362e668e8740" />

<img width="570" height="217" alt="Screenshot 2026-07-14 at 3 36 26 PM" src="https://github.com/user-attachments/assets/3eb30411-bcc7-419d-9136-143c14c5cfb8" />

cc @vconzola @kaedward 

## Description

Updates the unsupported status acceptance modal (shared by the accelerator configs and serving runtime templates admin pages) per UX review feedback from [this Slack thread](https://redhat-internal.slack.com/archives/C069KSM8T9N/p1783630358264019):

- **Title**: `Enable limited-support {type}?` — added hyphen (compound modifier) and question mark
- **Body**: `The support coverage for this {type} is limited to 1 month after release.` — clearer explanation of the support window
- **Checkbox**: Added "I understand" checkbox that gates the Enable button, requiring explicit acknowledgement before proceeding

These changes apply to both the accelerator configuration and serving runtime template acceptance flows.

## How Has This Been Tested?

- Unit tests updated and passing for `UnsupportedStatusAcceptanceModal` and `LlmAcceleratorConfigEnabledToggle`
- Cypress mock test assertions updated for both accelerator configs and custom serving runtimes

## Test Impact

- Updated `UnsupportedStatusAcceptanceModal.spec.tsx` — new tests for checkbox rendering, disabled-until-checked behavior
- Updated `LlmAcceleratorConfigEnabledToggle.spec.tsx` — checkbox click before accept
- Updated Cypress page object (`llmAcceleratorConfigs.ts`) with `findAcceptanceCheckbox()` method
- Updated Cypress mock tests for both `llmAcceleratorConfigs.cy.ts` and `customServingRuntimesUnsupported.cy.ts`

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “I understand” checkbox to limited-support configuration and runtime dialogs.
  * The **Enable** action remains disabled until the checkbox is selected.
  * Updated dialog messaging to clarify the limited-support period.

* **Bug Fixes**
  * Improved acceptance flow validation for unsupported configurations and runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->