### PR TITLE
Add agentsCatalog feature flag to the OdhDashboardConfig CRD

### DIFF
--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -171,6 +171,9 @@ spec:
                     mcpCatalog:
                       type: boolean
                       description: 'When true, enables the MCP (Model Context Protocol) Catalog page.'
+                    agentsCatalog:
+                      type: boolean
+                      description: 'When true, enables the Agents Catalog page.'
                     toolCalling:
                       type: boolean
                       description: 'When true, enables tool-calling configuration for supported models in the model catalog.'


### PR DESCRIPTION
## Description

Closes: https://redhat.atlassian.net/browse/RHOAIENG-75434

Adds the `agentsCatalog` boolean field to `spec.dashboardConfig` in the OdhDashboardConfig CRD so the Agents Catalog feature can be enabled via cluster config.

This mirrors the approach used for `mcpCatalog` in https://github.com/opendatahub-io/odh-dashboard/pull/7071. Frontend and backend already recognize `agentsCatalog` and default it to `false` (off by default); this change exposes the same field in the CRD schema.

## How Has This Been Tested?

- Verified the CRD schema change is limited to adding `agentsCatalog` under `spec.dashboardConfig` next to `mcpCatalog`, with a description consistent with other feature flags.
- Confirmed frontend (`concepts/areas/const.ts`) and backend (`utils/constants.ts`) already default `agentsCatalog` to `false`.

## Test Impact

No new automated tests. This is a CRD schema addition only (same scope as #7071 for `mcpCatalog`); behavior is already covered by existing area/feature-flag unit tests for `agentsCatalog`.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)