### PR TITLE
fix: suppress What's New modal in Cypress E2E tests

### DIFF
--- a/packages/cypress/cypress/support/e2e.ts
+++ b/packages/cypress/cypress/support/e2e.ts
@@ -109,6 +109,11 @@ Cypress.Keyboard.defaults({
   keystrokeDelay: 0,
 });
 
+// Suppress the "What's New" auto-launch modal in all Cypress tests
+Cypress.on('window:before:load', (win) => {
+  win.localStorage.setItem('odh-whats-new-3.5-seen', JSON.stringify(true));
+});
+
 // Disable polling in mock tests by injecting window globals before app code runs
 if (Cypress.env('MOCK')) {
   Cypress.on('window:before:load', (win) => {
@@ -117,7 +122,6 @@ if (Cypress.env('MOCK')) {
       FAST_POLL_INTERVAL: 999999,
       WS_HOSTNAME: 'localhost:9002',
     });
-    win.localStorage.setItem('odh-whats-new-3.5-seen', JSON.stringify(true));
   });
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-76170

## Description

The "What's New in 3.5" guided tour modal (merged in #8568) auto-launches 1.5s after page load for users who haven't seen it. In Cypress E2E tests running on the live `dash-e2e-int` cluster, `localStorage` is clean so the modal auto-launches and its `<ModalFooter>` covers page elements — causing `cy.type()` failures in the Create Project test.

The existing suppression in `e2e.ts` only applied inside the `if (Cypress.env('MOCK'))` block. This PR moves the `localStorage.setItem('odh-whats-new-3.5-seen', true)` call to a separate `window:before:load` handler **outside** the MOCK block so it fires for both mock and E2E tests.

## How Has This Been Tested?

- Verified that the `window:before:load` handler fires before every `cy.visit()` in both mock and E2E modes
- All 67 Cypress mock test groups passed on #8568 with the MOCK-scoped version; this change extends coverage to E2E
- Unit tests for `WhatsNewModal` continue to pass (9/9)

## Test Impact

No new tests — this is a test infrastructure fix. The existing Cypress E2E suite validates the fix by no longer having the modal overlay interfere with test interactions.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the “What’s New” modal from automatically appearing during end-to-end test sessions.
  * Preserved mock-specific browser setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->