### PR TITLE
feat: Add 'Existing secret' option to workbench env vars form

### DIFF
--- a/frontend/src/api/k8s/__tests__/secrets.spec.ts
+++ b/frontend/src/api/k8s/__tests__/secrets.spec.ts
@@ -19,6 +19,7 @@ import {
   createSecret,
   deleteSecret,
   getSecret,
+  getSecrets,
   getSecretsByLabel,
   replaceSecret,
 } from '#~/api/k8s/secrets';
@@ -212,6 +213,32 @@ describe('getSecret', () => {
       fetchOptions: { requestInit: {} },
       model: SecretModel,
       queryOptions: { name: 'secretName', ns: 'projectName', queryParams: {} },
+    });
+  });
+});
+
+describe('getSecrets', () => {
+  it('should list all secrets in a namespace without label selector', async () => {
+    const secretMock = mockK8sResourceList([mockSecretK8sResource({})]);
+    k8sListResourceMock.mockResolvedValue(secretMock);
+    const result = await getSecrets('test-ns');
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: SecretModel,
+      queryOptions: { ns: 'test-ns', queryParams: {} },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(secretMock.items);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(getSecrets('test-ns')).rejects.toThrow('error1');
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: SecretModel,
+      queryOptions: { ns: 'test-ns', queryParams: {} },
     });
   });
 });

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -37,6 +37,7 @@ export const assembleNotebook = (
     projectName,
     notebookData,
     envFrom,
+    existingSecretEnvVars,
     image,
     volumes: formVolumes,
     volumeMounts: formVolumeMounts,
@@ -134,6 +135,7 @@ export const assembleNotebook = (
                   name: 'JUPYTER_IMAGE',
                   value: imageUrl,
                 },
+                ...(existingSecretEnvVars || []),
               ],
               envFrom,
               volumeMounts,
@@ -302,6 +304,8 @@ export const updateNotebook = (
 
   // clean the envFrom array in case of merging the old value again
   container.envFrom = [];
+  // clean the env array to prevent merge from keeping old valueFrom entries
+  container.env = [];
   // clean the resources, affinity and tolerations for accelerator
   oldNotebook.spec.template.spec.tolerations = [];
   oldNotebook.spec.template.spec.affinity = {};

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -152,6 +152,17 @@ export const getSecret = (
     ),
   );
 
+export const getSecrets = (namespace: string, opts?: K8sAPIOptions): Promise<SecretKind[]> =>
+  k8sListResource<SecretKind>(
+    applyK8sAPIOptions(
+      {
+        model: SecretModel,
+        queryOptions: { ns: namespace },
+      },
+      opts,
+    ),
+  ).then((result) => result.items);
+
 export const getSecretsByLabel = (
   label: string,
   namespace: string,

--- a/frontend/src/pages/projects/__tests__/types.spec.ts
+++ b/frontend/src/pages/projects/__tests__/types.spec.ts
@@ -1,0 +1,7 @@
+import { SecretCategory } from '#~/pages/projects/types';
+
+describe('SecretCategory', () => {
+  it('should include EXISTING category', () => {
+    expect(SecretCategory.EXISTING).toBe('secret existing');
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -32,6 +32,7 @@ import { getNotebookPVCNames } from '#~/pages/projects/pvc/utils';
 import {
   createConfigMapsAndSecretsForNotebook,
   createPvcDataForNotebook,
+  getExistingSecretEnvVars,
   updateConfigMapsAndSecretsForNotebook,
   updatePvcDataForNotebook,
 } from './service';
@@ -185,6 +186,8 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       annotations['notebooks.opendatahub.io/notebook-restart'] = 'true';
     }
 
+    const existingSecretEnvVars = getExistingSecretEnvVars(envVariables);
+
     const { volumes, volumeMounts } = pvcVolumeDetails;
     const feastData = generateFeastMetadata(selectedFeatureStores, editNotebook, true);
     const newStartNotebookData: StartNotebookData = {
@@ -192,6 +195,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       volumes,
       volumeMounts,
       envFrom,
+      existingSecretEnvVars,
       connections,
       feastData,
     };
@@ -230,6 +234,8 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       dryRun,
     );
 
+    const existingSecretEnvVars = getExistingSecretEnvVars(envVariables);
+
     const { volumes, volumeMounts } = pvcVolumeDetails;
     const feastData = generateFeastMetadata(selectedFeatureStores, undefined, false);
 
@@ -238,6 +244,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       volumes,
       volumeMounts,
       envFrom: [...envFrom],
+      existingSecretEnvVars,
       connections,
       feastData,
     };

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -36,6 +36,7 @@ import {
   updateConfigMapsAndSecretsForNotebook,
   updatePvcDataForNotebook,
 } from './service';
+import { detectEnvVarConflicts } from './environmentVariables/envVarConflicts';
 import { checkRequiredFieldsForNotebookStart, getPvcVolumeDetails } from './spawnerUtils';
 import type { SelectedFeatureStoreConfig } from './featureStore/useWorkbenchFeatureStores';
 import { generateFeastMetadata } from './featureStore/utils';
@@ -75,10 +76,17 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   const [createInProgress, setCreateInProgress] = React.useState(false);
   const isHardwareProfileValid =
     startNotebookData.hardwareProfileOptions.validateHardwareProfileForm();
+
+  const envVarConflicts = React.useMemo(
+    () => detectEnvVarConflicts(envVariables, connections),
+    [envVariables, connections],
+  );
+
   const isButtonDisabled =
     createInProgress ||
     !checkRequiredFieldsForNotebookStart(startNotebookData, envVariables) ||
     !isHardwareProfileValid ||
+    envVarConflicts.length > 0 ||
     (!isProjectScopedAvailable &&
       startNotebookData.image.imageStream?.metadata.namespace === projectName);
 

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -64,6 +64,8 @@ import { useNotebookEnvVariables } from './environmentVariables/useNotebookEnvVa
 import { useDefaultStorageClass } from './storage/useDefaultStorageClass';
 import { ConnectionsFormSection } from './connections/ConnectionsFormSection';
 import { getConnectionsFromNotebook } from './connections/utils';
+import { detectEnvVarConflicts } from './environmentVariables/envVarConflicts';
+import EnvVarConflictAlert from './environmentVariables/EnvVarConflictAlert';
 import AlertWarningText from './environmentVariables/AlertWarningText';
 import { ClusterStorageTable } from './storage/ClusterStorageTable';
 import useDefaultPvcSize from './storage/useDefaultPvcSize';
@@ -198,6 +200,11 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     useNotebookEnvVariables(existingNotebook, [
       ...notebookConnections.map((connection) => connection.metadata.name),
     ]);
+
+  const envVarConflicts = React.useMemo(
+    () => detectEnvVarConflicts(envVariables, notebookConnections),
+    [envVariables, notebookConnections],
+  );
 
   const notebooksUsingPVCsWithSizeChanges = React.useMemo(() => {
     const attachedPVCs = storageData.filter((storage) => storage.existingPvc !== undefined);
@@ -373,6 +380,9 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                 />
               )}
               <EnvironmentVariables envVariables={envVariables} setEnvVariables={setEnvVariables} />
+              {envVarConflicts.length > 0 ? (
+                <EnvVarConflictAlert conflicts={envVarConflicts} />
+              ) : null}
             </FormSection>
             <FormSection
               title={

--- a/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/service.spec.ts
@@ -1,0 +1,89 @@
+import { EnvironmentVariableType, EnvVariable, SecretCategory } from '#~/pages/projects/types';
+import { getExistingSecretEnvVars } from '#~/pages/projects/screens/spawner/service';
+
+describe('getExistingSecretEnvVars', () => {
+  it('should convert EXISTING category entries to EnvironmentVariable array', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 's3-credentials',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [
+            { key: 'AWS_ACCESS_KEY_ID', value: '' },
+            { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+          ],
+        },
+      },
+    ];
+
+    const result = getExistingSecretEnvVars(envVariables);
+
+    expect(result).toEqual([
+      {
+        name: 'AWS_ACCESS_KEY_ID',
+        valueFrom: { secretKeyRef: { name: 's3-credentials', key: 'AWS_ACCESS_KEY_ID' } },
+      },
+      {
+        name: 'AWS_SECRET_ACCESS_KEY',
+        valueFrom: { secretKeyRef: { name: 's3-credentials', key: 'AWS_SECRET_ACCESS_KEY' } },
+      },
+    ]);
+  });
+
+  it('should return empty array when no EXISTING entries exist', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'MY_VAR', value: 'my-value' }],
+        },
+      },
+    ];
+
+    expect(getExistingSecretEnvVars(envVariables)).toEqual([]);
+  });
+
+  it('should skip EXISTING entries without existingName', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'SOME_KEY', value: '' }],
+        },
+      },
+    ];
+
+    expect(getExistingSecretEnvVars(envVariables)).toEqual([]);
+  });
+
+  it('should handle multiple EXISTING entries from different secrets', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY_A', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-b',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY_B', value: '' }],
+        },
+      },
+    ];
+
+    const result = getExistingSecretEnvVars(envVariables);
+
+    expect(result).toEqual([
+      { name: 'KEY_A', valueFrom: { secretKeyRef: { name: 'secret-a', key: 'KEY_A' } } },
+      { name: 'KEY_B', valueFrom: { secretKeyRef: { name: 'secret-b', key: 'KEY_B' } } },
+    ]);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
@@ -5,9 +5,11 @@ import {
   getVersion,
   isHiddenOOTBImageStream,
   isBYONImageStream,
+  isEnvVariableDataValid,
 } from '#~/pages/projects/screens/spawner/spawnerUtils';
 import { mockImageStreamK8sResource } from '#~/__mocks__/mockImageStreamK8sResource';
 import { IMAGE_ANNOTATIONS } from '#~/pages/projects/screens/spawner/const';
+import { EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
 
 describe('getExistingVersionsForImageStream', () => {
   it('should handle no image tags', () => {
@@ -273,5 +275,52 @@ describe('checkVersionRecommended', () => {
     expect(getVersion(0.1)).toEqual('0.1');
     expect(getVersion(3.1, 'v')).toEqual('v3.1');
     expect(getVersion(1000.5, 'V')).toEqual('V1000.5');
+  });
+});
+
+describe('isEnvVariableDataValid', () => {
+  it('should return true for EXISTING category with selected keys', () => {
+    expect(
+      isEnvVariableDataValid([
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 's3-creds',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+          },
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  it('should return false for EXISTING category with no keys selected', () => {
+    expect(
+      isEnvVariableDataValid([
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 's3-creds',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [],
+          },
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it('should return false for EXISTING category with empty key name', () => {
+    expect(
+      isEnvVariableDataValid([
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 's3-creds',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: '', value: '' }],
+          },
+        },
+      ]),
+    ).toBe(false);
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/spawnerUtils.spec.ts
@@ -309,6 +309,20 @@ describe('isEnvVariableDataValid', () => {
     ).toBe(false);
   });
 
+  it('should return false for EXISTING category with undefined existingName', () => {
+    expect(
+      isEnvVariableDataValid([
+        {
+          type: EnvironmentVariableType.SECRET,
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'AWS_ACCESS_KEY_ID', value: '' }],
+          },
+        },
+      ]),
+    ).toBe(false);
+  });
+
   it('should return false for EXISTING category with empty key name', () => {
     expect(
       isEnvVariableDataValid([

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import { Checkbox, FormGroup, Spinner, Stack, StackItem } from '@patternfly/react-core';
+import TypeaheadSelect from '@odh-dashboard/ui-core/components/TypeaheadSelect';
+import type { TypeaheadSelectOption } from '@odh-dashboard/ui-core/components/TypeaheadSelect';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
+import { EnvVariableDataEntry } from '#~/pages/projects/types';
+import { useExistingSecrets } from './useExistingSecrets';
+
+type EnvExistingSecretFieldProps = {
+  secretName?: string;
+  selectedKeys: EnvVariableDataEntry[];
+  onUpdate: (data: { secretName: string; keys: EnvVariableDataEntry[] }) => void;
+};
+
+const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
+  secretName,
+  selectedKeys,
+  onUpdate,
+}) => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const namespace = currentProject.metadata.name;
+
+  const [secrets, secretsLoaded] = useExistingSecrets(namespace, true);
+
+  const selectOptions: TypeaheadSelectOption[] = React.useMemo(
+    () =>
+      secrets.map((s) => ({
+        content: s.metadata.name,
+        value: s.metadata.name,
+      })),
+    [secrets],
+  );
+
+  const selectedSecret: SecretKind | undefined = React.useMemo(
+    () => secrets.find((s) => s.metadata.name === secretName),
+    [secrets, secretName],
+  );
+
+  const secretKeys: string[] = React.useMemo(
+    () => (selectedSecret?.data ? Object.keys(selectedSecret.data) : []),
+    [selectedSecret],
+  );
+
+  const selectedKeyNames = React.useMemo(
+    () => new Set(selectedKeys.map((k) => k.key)),
+    [selectedKeys],
+  );
+
+  const allKeysSelected = secretKeys.length > 0 && secretKeys.every((k) => selectedKeyNames.has(k));
+
+  const handleSecretSelect = (_event: unknown, value: string | number) => {
+    const newSecretName = String(value);
+    const newSecret = secrets.find((s) => s.metadata.name === newSecretName);
+    const allKeys = newSecret?.data ? Object.keys(newSecret.data) : [];
+    onUpdate({
+      secretName: newSecretName,
+      keys: allKeys.map((key) => ({ key, value: '' })),
+    });
+  };
+
+  const handleSelectAllKeys = (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
+    if (!secretName) {
+      return;
+    }
+    if (checked) {
+      onUpdate({
+        secretName,
+        keys: secretKeys.map((key) => ({ key, value: '' })),
+      });
+    } else {
+      onUpdate({
+        secretName,
+        keys: [],
+      });
+    }
+  };
+
+  const handleKeyToggle = (keyName: string, checked: boolean) => {
+    if (!secretName) {
+      return;
+    }
+    const newKeys = checked
+      ? [...selectedKeys, { key: keyName, value: '' }]
+      : selectedKeys.filter((k) => k.key !== keyName);
+    onUpdate({ secretName, keys: newKeys });
+  };
+
+  if (!secretsLoaded) {
+    return <Spinner size="md" data-testid="existing-secret-loading" />;
+  }
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <FormGroup label="Secret" fieldId="existing-secret-select">
+          <TypeaheadSelect
+            dataTestId="existing-secret-select"
+            selectOptions={selectOptions}
+            selected={secretName}
+            onSelect={handleSecretSelect}
+            placeholder="Select a secret"
+            noOptionsAvailableMessage="No secrets available"
+            isRequired={false}
+          />
+        </FormGroup>
+      </StackItem>
+      {secretName && secretKeys.length > 0 ? (
+        <StackItem>
+          <FormGroup label="Keys" fieldId="existing-secret-keys">
+            <Stack hasGutter>
+              <StackItem>
+                <Checkbox
+                  id="existing-secret-select-all"
+                  data-testid="existing-secret-select-all"
+                  label="Select all keys"
+                  isChecked={allKeysSelected}
+                  onChange={handleSelectAllKeys}
+                />
+              </StackItem>
+              {secretKeys.map((keyName) => (
+                <StackItem key={keyName}>
+                  <Checkbox
+                    id={`existing-secret-key-${keyName}`}
+                    data-testid={`existing-secret-key-${keyName}`}
+                    label={keyName}
+                    isChecked={selectedKeyNames.has(keyName)}
+                    onChange={(_event, checked) => handleKeyToggle(keyName, checked)}
+                  />
+                </StackItem>
+              ))}
+            </Stack>
+          </FormGroup>
+        </StackItem>
+      ) : null}
+    </Stack>
+  );
+};
+
+export default EnvExistingSecretField;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Checkbox, FormGroup, Spinner, Stack, StackItem } from '@patternfly/react-core';
+import {
+  Checkbox,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  Spinner,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import TypeaheadSelect from '@odh-dashboard/ui-core/components/TypeaheadSelect';
 import type { TypeaheadSelectOption } from '@odh-dashboard/ui-core/components/TypeaheadSelect';
 import type { SecretKind } from '@odh-dashboard/k8s-core';
@@ -21,7 +29,7 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const namespace = currentProject.metadata.name;
 
-  const [secrets, secretsLoaded] = useExistingSecrets(namespace, true);
+  const [secrets, secretsLoaded, secretsError] = useExistingSecrets(namespace, true);
 
   const selectOptions: TypeaheadSelectOption[] = React.useMemo(
     () =>
@@ -88,6 +96,16 @@ const EnvExistingSecretField: React.FC<EnvExistingSecretFieldProps> = ({
 
   if (!secretsLoaded) {
     return <Spinner size="md" data-testid="existing-secret-loading" />;
+  }
+
+  if (secretsError && secrets.length === 0) {
+    return (
+      <HelperText data-testid="existing-secret-error">
+        <HelperTextItem variant="error">
+          Failed to load secrets. Check your permissions and try again.
+        </HelperTextItem>
+      </HelperText>
+    );
   }
 
   return (

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -9,9 +9,8 @@ import EnvExistingSecretField from './EnvExistingSecretField';
 
 type EnvSecretProps = {
   env?: EnvVariableData;
-  onUpdate: (envVariableData: EnvVariableData) => void;
+  onUpdate: (envVariableData: EnvVariableData, existingName?: string) => void;
   existingName?: string;
-  onExistingNameChange?: (name: string | undefined) => void;
 };
 
 const DEFAULT_ENV: EnvVariableData = {
@@ -19,12 +18,7 @@ const DEFAULT_ENV: EnvVariableData = {
   data: [],
 };
 
-const EnvSecret: React.FC<EnvSecretProps> = ({
-  env = DEFAULT_ENV,
-  onUpdate,
-  existingName,
-  onExistingNameChange,
-}) => (
+const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate, existingName }) => (
   <EnvDataTypeField
     selection={env.category || ''}
     onSelection={(value) =>
@@ -58,10 +52,7 @@ const EnvSecret: React.FC<EnvSecretProps> = ({
             secretName={env.category === SecretCategory.EXISTING ? existingName : undefined}
             selectedKeys={env.category === SecretCategory.EXISTING ? env.data : []}
             onUpdate={({ secretName, keys }) => {
-              if (onExistingNameChange) {
-                onExistingNameChange(secretName);
-              }
-              onUpdate({ ...env, category: SecretCategory.EXISTING, data: keys });
+              onUpdate({ ...env, category: SecretCategory.EXISTING, data: keys }, secretName);
             }}
           />
         ),

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -5,10 +5,13 @@ import EnvDataTypeField from './EnvDataTypeField';
 import GenericKeyValuePairField from './GenericKeyValuePairField';
 import { EMPTY_KEY_VALUE_PAIR } from './const';
 import EnvUploadField from './EnvUploadField';
+import EnvExistingSecretField from './EnvExistingSecretField';
 
 type EnvSecretProps = {
   env?: EnvVariableData;
   onUpdate: (envVariableData: EnvVariableData) => void;
+  existingName?: string;
+  onExistingNameChange?: (name: string | undefined) => void;
 };
 
 const DEFAULT_ENV: EnvVariableData = {
@@ -16,7 +19,12 @@ const DEFAULT_ENV: EnvVariableData = {
   data: [],
 };
 
-const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) => (
+const EnvSecret: React.FC<EnvSecretProps> = ({
+  env = DEFAULT_ENV,
+  onUpdate,
+  existingName,
+  onExistingNameChange,
+}) => (
   <EnvDataTypeField
     selection={env.category || ''}
     onSelection={(value) =>
@@ -40,6 +48,21 @@ const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) =>
             envVarType={EnvironmentVariableType.SECRET}
             onUpdate={(newEnvData) => onUpdate({ ...env, data: newEnvData })}
             translateValue={(value) => atob(value)}
+          />
+        ),
+      },
+      [SecretCategory.EXISTING]: {
+        label: 'Existing secret',
+        render: (
+          <EnvExistingSecretField
+            secretName={env.category === SecretCategory.EXISTING ? existingName : undefined}
+            selectedKeys={env.category === SecretCategory.EXISTING ? env.data : []}
+            onUpdate={({ secretName, keys }) => {
+              if (onExistingNameChange) {
+                onExistingNameChange(secretName);
+              }
+              onUpdate({ ...env, category: SecretCategory.EXISTING, data: keys });
+            }}
           />
         ),
       },

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -22,7 +22,7 @@ const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate, exis
   <EnvDataTypeField
     selection={env.category || ''}
     onSelection={(value) =>
-      onUpdate({ ...env, category: asEnumMember(value, SecretCategory), data: [] })
+      onUpdate({ ...env, category: asEnumMember(value, SecretCategory), data: [] }, undefined)
     }
     options={{
       [SecretCategory.GENERIC]: {

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -62,7 +62,7 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                       onUpdate({
                         ...envVariable,
                         values: envValue,
-                        existingName,
+                        existingName: existingName ?? envVariable.existingName,
                       })
                     }
                   />

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -59,6 +59,9 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                   <EnvTypeSwitch
                     env={envVariable}
                     onUpdate={(envValue) => onUpdate({ ...envVariable, values: envValue })}
+                    onExistingNameChange={(name) =>
+                      onUpdate({ ...envVariable, existingName: name })
+                    }
                   />
                 </IndentSection>
               </StackItem>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -62,7 +62,7 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                       onUpdate({
                         ...envVariable,
                         values: envValue,
-                        ...(existingName !== undefined ? { existingName } : {}),
+                        existingName,
                       })
                     }
                   />

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -58,9 +58,12 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                 <IndentSection>
                   <EnvTypeSwitch
                     env={envVariable}
-                    onUpdate={(envValue) => onUpdate({ ...envVariable, values: envValue })}
-                    onExistingNameChange={(name) =>
-                      onUpdate({ ...envVariable, existingName: name })
+                    onUpdate={(envValue, existingName) =>
+                      onUpdate({
+                        ...envVariable,
+                        values: envValue,
+                        ...(existingName !== undefined ? { existingName } : {}),
+                      })
                     }
                   />
                 </IndentSection>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
@@ -6,14 +6,22 @@ import EnvSecret from './EnvSecret';
 type EnvTypeSwitchProps = {
   env: EnvVariable;
   onUpdate: (envVariableData: EnvVariableData) => void;
+  onExistingNameChange?: (name: string | undefined) => void;
 };
 
-const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate }) => {
+const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate, onExistingNameChange }) => {
   switch (env.type) {
     case EnvironmentVariableType.CONFIG_MAP:
       return <EnvConfigMap env={env.values} onUpdate={onUpdate} />;
     case EnvironmentVariableType.SECRET:
-      return <EnvSecret env={env.values} onUpdate={onUpdate} />;
+      return (
+        <EnvSecret
+          env={env.values}
+          onUpdate={onUpdate}
+          existingName={env.existingName}
+          onExistingNameChange={onExistingNameChange}
+        />
+      );
     default:
       return null;
   }

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
@@ -5,23 +5,15 @@ import EnvSecret from './EnvSecret';
 
 type EnvTypeSwitchProps = {
   env: EnvVariable;
-  onUpdate: (envVariableData: EnvVariableData) => void;
-  onExistingNameChange?: (name: string | undefined) => void;
+  onUpdate: (envVariableData: EnvVariableData, existingName?: string) => void;
 };
 
-const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate, onExistingNameChange }) => {
+const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate }) => {
   switch (env.type) {
     case EnvironmentVariableType.CONFIG_MAP:
       return <EnvConfigMap env={env.values} onUpdate={onUpdate} />;
     case EnvironmentVariableType.SECRET:
-      return (
-        <EnvSecret
-          env={env.values}
-          onUpdate={onUpdate}
-          existingName={env.existingName}
-          onExistingNameChange={onExistingNameChange}
-        />
-      );
+      return <EnvSecret env={env.values} onUpdate={onUpdate} existingName={env.existingName} />;
     default:
       return null;
   }

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictAlert.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictAlert.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Alert, ExpandableSection, List, ListItem } from '@patternfly/react-core';
+import { EnvVarConflict } from './envVarConflicts';
+
+type Props = {
+  conflicts: EnvVarConflict[];
+};
+
+const sourceTypeLabel: Record<string, string> = {
+  'existing-secret': 'Existing secret',
+  'inline-secret': 'Environment variable',
+  connection: 'Connection',
+};
+
+const EnvVarConflictAlert: React.FC<Props> = ({ conflicts }) => {
+  const [showConflicts, setShowConflicts] = React.useState(false);
+
+  return (
+    <Alert
+      variant="warning"
+      isInline
+      title="Environment variable conflicts"
+      data-testid="env-var-conflict-alert"
+    >
+      The following environment variable names are used by multiple sources. Resolve these conflicts
+      before saving the workbench.
+      <ExpandableSection
+        toggleText="Show conflicts"
+        onToggle={() => setShowConflicts((prev) => !prev)}
+        isExpanded={showConflicts}
+        isIndented
+      >
+        {conflicts.map((conflict) => (
+          <div key={conflict.key} data-testid={`env-var-conflict-${conflict.key}`}>
+            <b>{conflict.key}</b> is defined in:
+            <List>
+              {conflict.sources.map((source, idx) => (
+                <ListItem key={idx}>
+                  {source.name} ({sourceTypeLabel[source.type]})
+                </ListItem>
+              ))}
+            </List>
+          </div>
+        ))}
+      </ExpandableSection>
+    </Alert>
+  );
+};
+
+export default EnvVarConflictAlert;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictAlert.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvVarConflictAlert.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Alert, ExpandableSection, List, ListItem } from '@patternfly/react-core';
 import { EnvVarConflict } from './envVarConflicts';
 
@@ -34,8 +34,8 @@ const EnvVarConflictAlert: React.FC<Props> = ({ conflicts }) => {
           <div key={conflict.key} data-testid={`env-var-conflict-${conflict.key}`}>
             <b>{conflict.key}</b> is defined in:
             <List>
-              {conflict.sources.map((source, idx) => (
-                <ListItem key={idx}>
+              {conflict.sources.map((source) => (
+                <ListItem key={`${source.type}-${source.name}`}>
                   {source.name} ({sourceTypeLabel[source.type]})
                 </ListItem>
               ))}

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
@@ -82,6 +82,13 @@ describe('EnvExistingSecretField', () => {
     expect(screen.getByTestId('existing-secret-loading')).toBeInTheDocument();
   });
 
+  it('should show error message when secrets fail to load', () => {
+    mockUseExistingSecrets.mockReturnValue([[], true, new Error('Forbidden'), jest.fn()]);
+    renderWithContext(<EnvExistingSecretField selectedKeys={[]} onUpdate={jest.fn()} />);
+    expect(screen.getByTestId('existing-secret-error')).toBeInTheDocument();
+    expect(screen.getByText(/Failed to load secrets/)).toBeInTheDocument();
+  });
+
   it('should not show the typeahead when loading', () => {
     mockUseExistingSecrets.mockReturnValue([[], false, undefined, jest.fn()]);
     renderWithContext(<EnvExistingSecretField selectedKeys={[]} onUpdate={jest.fn()} />);

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecretField.spec.tsx
@@ -1,0 +1,222 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
+import EnvExistingSecretField from '#~/pages/projects/screens/spawner/environmentVariables/EnvExistingSecretField';
+import { useExistingSecrets } from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+
+jest.mock('#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets', () => ({
+  useExistingSecrets: jest.fn(),
+}));
+
+const mockTypeaheadSelect = jest.fn((props: Record<string, unknown>) => (
+  <div data-testid={props.dataTestId as string}>
+    <button
+      data-testid="typeahead-trigger"
+      onClick={() => {
+        const onSelect = props.onSelect as (event: unknown, value: string) => void;
+        onSelect(undefined, 's3-credentials');
+      }}
+    >
+      {String(props.placeholder)}
+    </button>
+  </div>
+));
+
+jest.mock('@odh-dashboard/ui-core/components/TypeaheadSelect', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => mockTypeaheadSelect(props),
+}));
+
+const mockUseExistingSecrets = jest.mocked(useExistingSecrets);
+
+const mockSecrets: SecretKind[] = [
+  {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: { name: 's3-credentials', namespace: 'test-ns' },
+    type: 'Opaque',
+    data: {
+      AWS_ACCESS_KEY_ID: 'dGVzdA==',
+      AWS_SECRET_ACCESS_KEY: 'dGVzdA==',
+      AWS_DEFAULT_REGION: 'dGVzdA==',
+    },
+  },
+  {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: { name: 'db-password', namespace: 'test-ns' },
+    type: 'Opaque',
+    data: { DB_PASSWORD: 'dGVzdA==' },
+  },
+];
+
+const mockContextValue = {
+  currentProject: {
+    apiVersion: 'v1',
+    kind: 'Project',
+    metadata: { name: 'test-ns' },
+  },
+} as React.ComponentProps<typeof ProjectDetailsContext.Provider>['value'];
+
+const renderWithContext = (ui: React.ReactElement) =>
+  render(
+    <ProjectDetailsContext.Provider value={mockContextValue}>{ui}</ProjectDetailsContext.Provider>,
+  );
+
+describe('EnvExistingSecretField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseExistingSecrets.mockReturnValue([mockSecrets, true, undefined, jest.fn()]);
+  });
+
+  it('should render the secret typeahead dropdown', () => {
+    renderWithContext(<EnvExistingSecretField selectedKeys={[]} onUpdate={jest.fn()} />);
+    expect(screen.getByTestId('existing-secret-select')).toBeInTheDocument();
+  });
+
+  it('should show loading spinner while secrets are loading', () => {
+    mockUseExistingSecrets.mockReturnValue([[], false, undefined, jest.fn()]);
+    renderWithContext(<EnvExistingSecretField selectedKeys={[]} onUpdate={jest.fn()} />);
+    expect(screen.getByTestId('existing-secret-loading')).toBeInTheDocument();
+  });
+
+  it('should not show the typeahead when loading', () => {
+    mockUseExistingSecrets.mockReturnValue([[], false, undefined, jest.fn()]);
+    renderWithContext(<EnvExistingSecretField selectedKeys={[]} onUpdate={jest.fn()} />);
+    expect(screen.queryByTestId('existing-secret-select')).not.toBeInTheDocument();
+  });
+
+  it('should show key checkboxes when a secret is selected', () => {
+    renderWithContext(
+      <EnvExistingSecretField
+        secretName="s3-credentials"
+        selectedKeys={[
+          { key: 'AWS_ACCESS_KEY_ID', value: '' },
+          { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+          { key: 'AWS_DEFAULT_REGION', value: '' },
+        ]}
+        onUpdate={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId('existing-secret-select-all')).toBeInTheDocument();
+    expect(screen.getByTestId('existing-secret-key-AWS_ACCESS_KEY_ID')).toBeInTheDocument();
+    expect(screen.getByTestId('existing-secret-key-AWS_SECRET_ACCESS_KEY')).toBeInTheDocument();
+    expect(screen.getByTestId('existing-secret-key-AWS_DEFAULT_REGION')).toBeInTheDocument();
+  });
+
+  it('should not show key checkboxes when no secret is selected', () => {
+    renderWithContext(<EnvExistingSecretField selectedKeys={[]} onUpdate={jest.fn()} />);
+    expect(screen.queryByTestId('existing-secret-select-all')).not.toBeInTheDocument();
+  });
+
+  it('should call onUpdate when a key checkbox is toggled off', () => {
+    const onUpdate = jest.fn();
+    renderWithContext(
+      <EnvExistingSecretField
+        secretName="s3-credentials"
+        selectedKeys={[
+          { key: 'AWS_ACCESS_KEY_ID', value: '' },
+          { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+          { key: 'AWS_DEFAULT_REGION', value: '' },
+        ]}
+        onUpdate={onUpdate}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('existing-secret-key-AWS_DEFAULT_REGION'));
+    expect(onUpdate).toHaveBeenCalledWith({
+      secretName: 's3-credentials',
+      keys: [
+        { key: 'AWS_ACCESS_KEY_ID', value: '' },
+        { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+      ],
+    });
+  });
+
+  it('should call onUpdate when a key checkbox is toggled on', () => {
+    const onUpdate = jest.fn();
+    renderWithContext(
+      <EnvExistingSecretField
+        secretName="s3-credentials"
+        selectedKeys={[{ key: 'AWS_ACCESS_KEY_ID', value: '' }]}
+        onUpdate={onUpdate}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('existing-secret-key-AWS_SECRET_ACCESS_KEY'));
+    expect(onUpdate).toHaveBeenCalledWith({
+      secretName: 's3-credentials',
+      keys: [
+        { key: 'AWS_ACCESS_KEY_ID', value: '' },
+        { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+      ],
+    });
+  });
+
+  it('should call onUpdate with all keys when select-all is clicked', () => {
+    const onUpdate = jest.fn();
+    renderWithContext(
+      <EnvExistingSecretField secretName="s3-credentials" selectedKeys={[]} onUpdate={onUpdate} />,
+    );
+    fireEvent.click(screen.getByTestId('existing-secret-select-all'));
+    expect(onUpdate).toHaveBeenCalledWith({
+      secretName: 's3-credentials',
+      keys: [
+        { key: 'AWS_ACCESS_KEY_ID', value: '' },
+        { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+        { key: 'AWS_DEFAULT_REGION', value: '' },
+      ],
+    });
+  });
+
+  it('should call onUpdate with empty keys when select-all is unchecked', () => {
+    const onUpdate = jest.fn();
+    renderWithContext(
+      <EnvExistingSecretField
+        secretName="s3-credentials"
+        selectedKeys={[
+          { key: 'AWS_ACCESS_KEY_ID', value: '' },
+          { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+          { key: 'AWS_DEFAULT_REGION', value: '' },
+        ]}
+        onUpdate={onUpdate}
+      />,
+    );
+    // All keys are selected, so allKeysSelected is true; clicking unchecks
+    fireEvent.click(screen.getByTestId('existing-secret-select-all'));
+    expect(onUpdate).toHaveBeenCalledWith({
+      secretName: 's3-credentials',
+      keys: [],
+    });
+  });
+
+  it('should call onUpdate with all keys when a secret is selected from dropdown', () => {
+    const onUpdate = jest.fn();
+    renderWithContext(<EnvExistingSecretField selectedKeys={[]} onUpdate={onUpdate} />);
+    // Our mock TypeaheadSelect triggers onSelect with 's3-credentials' on click
+    fireEvent.click(screen.getByTestId('typeahead-trigger'));
+    expect(onUpdate).toHaveBeenCalledWith({
+      secretName: 's3-credentials',
+      keys: [
+        { key: 'AWS_ACCESS_KEY_ID', value: '' },
+        { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+        { key: 'AWS_DEFAULT_REGION', value: '' },
+      ],
+    });
+  });
+
+  it('should pass correct selectOptions to TypeaheadSelect', () => {
+    renderWithContext(<EnvExistingSecretField selectedKeys={[]} onUpdate={jest.fn()} />);
+    expect(mockTypeaheadSelect).toHaveBeenCalled();
+    const props = mockTypeaheadSelect.mock.calls[0][0];
+    expect(props.selectOptions).toEqual([
+      { content: 's3-credentials', value: 's3-credentials' },
+      { content: 'db-password', value: 'db-password' },
+    ]);
+  });
+
+  it('should pass the namespace from project context to useExistingSecrets', () => {
+    renderWithContext(<EnvExistingSecretField selectedKeys={[]} onUpdate={jest.fn()} />);
+    expect(mockUseExistingSecrets).toHaveBeenCalledWith('test-ns', true);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/envVarConflicts.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/envVarConflicts.spec.ts
@@ -1,0 +1,150 @@
+import { EnvironmentVariableType, EnvVariable, SecretCategory } from '#~/pages/projects/types';
+import { Connection } from '#~/concepts/connectionTypes/types';
+import { detectEnvVarConflicts } from '#~/pages/projects/screens/spawner/environmentVariables/envVarConflicts';
+
+jest.mock('@odh-dashboard/k8s-core', () => ({
+  getDisplayNameFromK8sResource: jest.fn(
+    (resource: { metadata: { annotations: Record<string, string>; name: string } }) =>
+      resource.metadata.annotations['openshift.io/display-name'] || resource.metadata.name || '',
+  ),
+}));
+
+describe('detectEnvVarConflicts', () => {
+  it('should return empty array when there are no conflicts', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'KEY_A', value: '' }],
+        },
+      },
+    ];
+
+    expect(detectEnvVarConflicts(envVariables, [])).toEqual([]);
+  });
+
+  it('should detect conflict between existing secret and connection', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'my-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'DB_HOST', value: '' }],
+        },
+      },
+    ];
+
+    const connections: Connection[] = [
+      {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: {
+          name: 'my-connection',
+          namespace: 'test-ns',
+          annotations: {
+            'openshift.io/display-name': 'My Connection',
+            'opendatahub.io/connection-type': 'postgres',
+          },
+          labels: {},
+        },
+        data: { DB_HOST: 'dGVzdA==' },
+      } as unknown as Connection,
+    ];
+
+    const conflicts = detectEnvVarConflicts(envVariables, connections);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].key).toBe('DB_HOST');
+    expect(conflicts[0].sources).toHaveLength(2);
+    expect(conflicts[0].sources).toEqual(
+      expect.arrayContaining([
+        { type: 'existing-secret', name: 'my-secret' },
+        { type: 'connection', name: 'My Connection' },
+      ]),
+    );
+  });
+
+  it('should detect conflict between two existing secrets', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-a',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'SHARED_KEY', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'secret-b',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'SHARED_KEY', value: '' }],
+        },
+      },
+    ];
+
+    const conflicts = detectEnvVarConflicts(envVariables, []);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].key).toBe('SHARED_KEY');
+  });
+
+  it('should not report connection-to-connection conflicts (handled elsewhere)', () => {
+    const connections: Connection[] = [
+      {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: {
+          name: 'conn-a',
+          namespace: 'test-ns',
+          annotations: { 'openshift.io/display-name': 'Conn A' },
+          labels: {},
+        },
+        data: { SAME_KEY: 'dGVzdA==' },
+      } as unknown as Connection,
+      {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: {
+          name: 'conn-b',
+          namespace: 'test-ns',
+          annotations: { 'openshift.io/display-name': 'Conn B' },
+          labels: {},
+        },
+        data: { SAME_KEY: 'dGVzdA==' },
+      } as unknown as Connection,
+    ];
+
+    const conflicts = detectEnvVarConflicts([], connections);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('should detect conflict between existing secret and inline secret', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'ext-secret',
+        values: {
+          category: SecretCategory.EXISTING,
+          data: [{ key: 'API_KEY', value: '' }],
+        },
+      },
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'API_KEY', value: 'some-value' }],
+        },
+      },
+    ];
+
+    const conflicts = detectEnvVarConflicts(envVariables, []);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].key).toBe('API_KEY');
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
@@ -1,0 +1,94 @@
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { isExistingSecret } from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+
+jest.mock('#~/api', () => ({
+  getSecrets: jest.fn(),
+}));
+
+describe('isExistingSecret', () => {
+  const baseSecret = (overrides: Partial<SecretKind> = {}): SecretKind =>
+    ({
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'test-secret',
+        namespace: 'test-ns',
+        annotations: {},
+        ...overrides.metadata,
+      },
+      type: 'Opaque',
+      ...overrides,
+    } as SecretKind);
+
+  it('should return true for a plain Opaque secret', () => {
+    expect(isExistingSecret(baseSecret())).toBe(true);
+  });
+
+  it('should return false for a non-Opaque secret', () => {
+    expect(isExistingSecret(baseSecret({ type: 'kubernetes.io/service-account-token' }))).toBe(
+      false,
+    );
+  });
+
+  it('should return false for a secret with connection-type annotation', () => {
+    expect(
+      isExistingSecret(
+        baseSecret({
+          metadata: {
+            name: 'conn-secret',
+            namespace: 'test-ns',
+            annotations: { 'opendatahub.io/connection-type': 's3' },
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('should return false for a secret with connection-type-protocol annotation', () => {
+    expect(
+      isExistingSecret(
+        baseSecret({
+          metadata: {
+            name: 'conn-secret',
+            namespace: 'test-ns',
+            annotations: { 'opendatahub.io/connection-type-protocol': 'https' },
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('should return false for a secret with connection-type-ref annotation', () => {
+    expect(
+      isExistingSecret(
+        baseSecret({
+          metadata: {
+            name: 'conn-secret',
+            namespace: 'test-ns',
+            annotations: { 'opendatahub.io/connection-type-ref': 'some-ref' },
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('should return true when annotations object exists but has no connection annotations', () => {
+    expect(
+      isExistingSecret(
+        baseSecret({
+          metadata: {
+            name: 'labeled-secret',
+            namespace: 'test-ns',
+            annotations: { 'some-other-annotation': 'value' },
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('should return true when metadata has no annotations', () => {
+    const secret = baseSecret();
+    delete (secret.metadata as Record<string, unknown>).annotations;
+    expect(isExistingSecret(secret)).toBe(true);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useNotebookEnvVariables.spec.ts
@@ -1,0 +1,131 @@
+import { NotebookKind } from '#~/k8sTypes';
+import { EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+import { fetchNotebookEnvVariables } from '#~/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables';
+
+jest.mock('#~/api', () => ({
+  getConfigMap: jest.fn(),
+  getSecret: jest.fn(),
+}));
+
+jest.mock('#~/concepts/connectionTypes/utils', () => ({
+  isConnection: jest.fn().mockReturnValue(false),
+}));
+
+describe('fetchNotebookEnvVariables', () => {
+  it('should parse env[].valueFrom.secretKeyRef entries into EXISTING category', async () => {
+    const notebook: NotebookKind = {
+      apiVersion: 'kubeflow.org/v1',
+      kind: 'Notebook',
+      metadata: { name: 'test-nb', namespace: 'test-ns', annotations: {}, labels: {} },
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              {
+                name: 'test',
+                image: 'test',
+                env: [
+                  { name: 'NOTEBOOK_ARGS', value: '--ServerApp.port=8888' },
+                  { name: 'JUPYTER_IMAGE', value: 'test:latest' },
+                  {
+                    name: 'AWS_ACCESS_KEY_ID',
+                    valueFrom: { secretKeyRef: { name: 's3-creds', key: 'AWS_ACCESS_KEY_ID' } },
+                  },
+                  {
+                    name: 'AWS_SECRET_ACCESS_KEY',
+                    valueFrom: { secretKeyRef: { name: 's3-creds', key: 'AWS_SECRET_ACCESS_KEY' } },
+                  },
+                  {
+                    name: 'DB_PASSWORD',
+                    valueFrom: { secretKeyRef: { name: 'db-secret', key: 'DB_PASSWORD' } },
+                  },
+                ],
+                envFrom: [],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as NotebookKind;
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    // Should group by secret name
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 's3-creds',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [
+              { key: 'AWS_ACCESS_KEY_ID', value: '' },
+              { key: 'AWS_SECRET_ACCESS_KEY', value: '' },
+            ],
+          },
+        },
+        {
+          type: EnvironmentVariableType.SECRET,
+          existingName: 'db-secret',
+          values: {
+            category: SecretCategory.EXISTING,
+            data: [{ key: 'DB_PASSWORD', value: '' }],
+          },
+        },
+      ]),
+    );
+  });
+
+  it('should exclude static env vars (NOTEBOOK_ARGS, JUPYTER_IMAGE) from parsing', async () => {
+    const notebook: NotebookKind = {
+      apiVersion: 'kubeflow.org/v1',
+      kind: 'Notebook',
+      metadata: { name: 'test-nb', namespace: 'test-ns', annotations: {}, labels: {} },
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              {
+                name: 'test',
+                image: 'test',
+                env: [
+                  { name: 'NOTEBOOK_ARGS', value: '--ServerApp.port=8888' },
+                  { name: 'JUPYTER_IMAGE', value: 'test:latest' },
+                ],
+                envFrom: [],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as NotebookKind;
+
+    const result = await fetchNotebookEnvVariables(notebook);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when env is empty and envFrom is empty', async () => {
+    const notebook: NotebookKind = {
+      apiVersion: 'kubeflow.org/v1',
+      kind: 'Notebook',
+      metadata: { name: 'test-nb', namespace: 'test-ns', annotations: {}, labels: {} },
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              {
+                name: 'test',
+                image: 'test',
+                env: [],
+                envFrom: [],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as NotebookKind;
+
+    const result = await fetchNotebookEnvVariables(notebook);
+    expect(result).toEqual([]);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/envVarConflicts.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/envVarConflicts.ts
@@ -1,0 +1,65 @@
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import { Connection } from '#~/concepts/connectionTypes/types';
+import { EnvVariable, SecretCategory } from '#~/pages/projects/types';
+
+type ConflictSource = {
+  type: 'existing-secret' | 'inline-secret' | 'connection';
+  name: string;
+};
+
+export type EnvVarConflict = {
+  key: string;
+  sources: ConflictSource[];
+};
+
+export const detectEnvVarConflicts = (
+  envVariables: EnvVariable[],
+  connections: Connection[],
+): EnvVarConflict[] => {
+  const keySourceMap = new Map<string, ConflictSource[]>();
+
+  const addSource = (key: string, source: ConflictSource) => {
+    const sources = keySourceMap.get(key) || [];
+    sources.push(source);
+    keySourceMap.set(key, sources);
+  };
+
+  // 1. Keys from existing secret references
+  envVariables
+    .filter((ev) => ev.values?.category === SecretCategory.EXISTING)
+    .forEach((ev) => {
+      (ev.values?.data || []).forEach(({ key }) => {
+        addSource(key, { type: 'existing-secret', name: ev.existingName || 'Unknown secret' });
+      });
+    });
+
+  // 2. Keys from inline secrets and configmaps
+  envVariables
+    .filter((ev) => ev.values?.category !== SecretCategory.EXISTING && ev.values?.category != null)
+    .forEach((ev) => {
+      (ev.values?.data || []).forEach(({ key }) => {
+        if (key) {
+          addSource(key, { type: 'inline-secret', name: ev.existingName || 'New variable' });
+        }
+      });
+    });
+
+  // 3. Keys from Connections
+  connections.forEach((conn) => {
+    if (conn.data) {
+      Object.keys(conn.data).forEach((key) => {
+        addSource(key, {
+          type: 'connection',
+          name: getDisplayNameFromK8sResource(conn),
+        });
+      });
+    }
+  });
+
+  // Return only conflicts involving at least one existing-secret source
+  return Array.from(keySourceMap.entries())
+    .filter(
+      ([, sources]) => sources.length > 1 && sources.some((s) => s.type === 'existing-secret'),
+    )
+    .map(([key, sources]) => ({ key, sources }));
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import useFetchState, { NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetchState';
+import { getSecrets } from '#~/api';
+
+export const isExistingSecret = (secret: SecretKind): boolean =>
+  secret.type === 'Opaque' &&
+  !secret.metadata.annotations?.['opendatahub.io/connection-type'] &&
+  !secret.metadata.annotations?.['opendatahub.io/connection-type-protocol'] &&
+  !secret.metadata.annotations?.['opendatahub.io/connection-type-ref'];
+
+export const useExistingSecrets = (
+  namespace: string,
+  enabled: boolean,
+): [secrets: SecretKind[], loaded: boolean, error: Error | undefined, refresh: () => void] => {
+  const callback = React.useCallback(() => {
+    if (!enabled) {
+      return Promise.reject(new NotReadyError('Existing secret option not selected'));
+    }
+    return getSecrets(namespace).then((secrets) => secrets.filter(isExistingSecret));
+  }, [namespace, enabled]);
+
+  return useFetchState(callback, []);
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -18,7 +18,9 @@ const STATIC_ENV_NAMES = ['NOTEBOOK_ARGS', 'JUPYTER_IMAGE'];
 export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVariable[]> => {
   const container = notebook.spec.template.spec.containers[0];
   const envFromList = container.envFrom || [];
-  const envList = container.env;
+  // Defensive: env may be absent in manually-edited Notebook CRs despite type saying otherwise
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const envList = container.env || [];
 
   // Process envFrom entries (configMapRef and secretRef)
   const envFromPromises = envFromList

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -13,36 +13,77 @@ import {
 import { isConnection } from '#~/concepts/connectionTypes/utils';
 import { getDeletedConfigMapOrSecretVariables, isSecretKind } from './utils';
 
+const STATIC_ENV_NAMES = ['NOTEBOOK_ARGS', 'JUPYTER_IMAGE'];
+
 export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVariable[]> => {
-  const envFromList = notebook.spec.template.spec.containers[0].envFrom || [];
-  return Promise.all(
-    envFromList
-      .map((envFrom) => {
-        if (envFrom.configMapRef) {
-          return getConfigMap(notebook.metadata.namespace, envFrom.configMapRef.name).catch((e) => {
-            if (e.statusObject?.code === 404) {
-              return null;
-            }
-            throw e;
-          });
-        }
-        if (envFrom.secretRef) {
-          return getSecret(notebook.metadata.namespace, envFrom.secretRef.name).catch((e) => {
-            if (e.statusObject?.code === 404) {
-              return null;
-            }
-            throw e;
-          });
-        }
-        return Promise.resolve(undefined);
-      })
-      .filter(
-        (
-          v: Promise<ConfigMapKind | null> | Promise<undefined> | undefined,
-        ): v is Promise<SecretKind | ConfigMapKind | null> => !!v,
-      ),
-  ).then((results) =>
-    results.reduce<EnvVariable[]>((acc, resource) => {
+  const container = notebook.spec.template.spec.containers[0];
+  const envFromList = container.envFrom || [];
+  const envList = container.env;
+
+  // Process envFrom entries (configMapRef and secretRef)
+  const envFromPromises = envFromList
+    .map((envFrom) => {
+      if (envFrom.configMapRef) {
+        return getConfigMap(notebook.metadata.namespace, envFrom.configMapRef.name).catch((e) => {
+          if (e.statusObject?.code === 404) {
+            return null;
+          }
+          throw e;
+        });
+      }
+      if (envFrom.secretRef) {
+        return getSecret(notebook.metadata.namespace, envFrom.secretRef.name).catch((e) => {
+          if (e.statusObject?.code === 404) {
+            return null;
+          }
+          throw e;
+        });
+      }
+      return Promise.resolve(undefined);
+    })
+    .filter(
+      (
+        v: Promise<ConfigMapKind | null> | Promise<undefined> | undefined,
+      ): v is Promise<SecretKind | ConfigMapKind | null> => !!v,
+    );
+
+  // Parse env[].valueFrom.secretKeyRef entries, excluding static env names
+  const secretKeyRefEntries = envList.filter(
+    (e) => e.valueFrom?.secretKeyRef && !STATIC_ENV_NAMES.includes(e.name),
+  );
+
+  // Group by secret name to create one EnvVariable per secret
+  const groupedBySecret = new Map<string, string[]>();
+  for (const entry of secretKeyRefEntries) {
+    const secretKeyRef = entry.valueFrom?.secretKeyRef;
+    if (
+      secretKeyRef &&
+      typeof secretKeyRef === 'object' &&
+      'name' in secretKeyRef &&
+      'key' in secretKeyRef &&
+      typeof secretKeyRef.name === 'string' &&
+      typeof secretKeyRef.key === 'string'
+    ) {
+      const keys = groupedBySecret.get(secretKeyRef.name) || [];
+      keys.push(secretKeyRef.key);
+      groupedBySecret.set(secretKeyRef.name, keys);
+    }
+  }
+
+  const existingSecretVars: EnvVariable[] = Array.from(groupedBySecret.entries()).map(
+    ([secretName, keys]) => ({
+      type: EnvironmentVariableType.SECRET,
+      existingName: secretName,
+      values: {
+        category: SecretCategory.EXISTING,
+        data: keys.map((key) => ({ key, value: '' })),
+      },
+    }),
+  );
+
+  // Combine envFrom results with existing secret env vars
+  return Promise.all(envFromPromises).then((results) => [
+    ...results.reduce<EnvVariable[]>((acc, resource) => {
       if (!resource) {
         return acc;
       }
@@ -71,7 +112,8 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
       }
       return [...acc, envVar];
     }, []),
-  );
+    ...existingSecretVars,
+  ]);
 };
 
 export const useNotebookEnvVariables = (

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash-es';
 import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import type {
+  EnvironmentVariable,
   Volume,
   VolumeMount,
   PersistentVolumeClaimKind,
@@ -32,6 +33,24 @@ import { ConfigMapKind, NotebookKind } from '#~/k8sTypes';
 import { isPvcUpdateRequired } from '#~/pages/projects/screens/detail/storage/utils';
 import { fetchNotebookEnvVariables } from './environmentVariables/useNotebookEnvVariables';
 import { getDeletedConfigMapOrSecretVariables } from './environmentVariables/utils';
+
+export const getExistingSecretEnvVars = (envVariables: EnvVariable[]): EnvironmentVariable[] =>
+  envVariables
+    .filter(
+      (ev): ev is EnvVariable & { existingName: string } =>
+        ev.values?.category === SecretCategory.EXISTING && !!ev.existingName,
+    )
+    .flatMap((ev) =>
+      (ev.values?.data || []).map((entry) => ({
+        name: entry.key,
+        valueFrom: {
+          secretKeyRef: {
+            name: ev.existingName,
+            key: entry.key,
+          },
+        },
+      })),
+    );
 
 export const createPvcDataForNotebook = async (
   projectName: string,
@@ -148,9 +167,12 @@ export const createConfigMapsAndSecretsForNotebook = async (
   envVariables: EnvVariable[],
   dryRun?: boolean,
 ): Promise<EnvironmentFromVariable[]> => {
+  const managedEnvVariables = envVariables.filter(
+    (ev) => ev.values?.category !== SecretCategory.EXISTING,
+  );
   const creatingPromises = getPromisesForConfigMapsAndSecrets(
     projectName,
-    envVariables,
+    managedEnvVariables,
     'create',
     dryRun,
   );
@@ -172,23 +194,32 @@ export const updateConfigMapsAndSecretsForNotebook = async (
   dryRun = false,
 ): Promise<EnvironmentFromVariable[]> => {
   const existingEnvVars = await fetchNotebookEnvVariables(notebook);
+  const managedEnvVariables = envVariables.filter(
+    (ev) => ev.values?.category !== SecretCategory.EXISTING,
+  );
+  const managedExistingEnvVars = existingEnvVars.filter(
+    (ev) => ev.values?.category !== SecretCategory.EXISTING,
+  );
   const { deletedConfigMaps, deletedSecrets } = getDeletedConfigMapOrSecretVariables(
     notebook,
-    existingEnvVars,
+    managedExistingEnvVars,
     [...(connections || []).map((connection) => connection.metadata.name)],
   );
 
-  const [oldResources, newResources] = _.partition(envVariables, (envVar) => envVar.existingName);
+  const [oldResources, newResources] = _.partition(
+    managedEnvVariables,
+    (envVar) => envVar.existingName,
+  );
   const currentNames = oldResources
     .map((envVar) => envVar.existingName)
     .filter((v): v is string => !!v);
 
-  const removeResources = existingEnvVars.filter(
+  const removeResources = managedExistingEnvVars.filter(
     (envVar) => envVar.existingName && !currentNames.includes(envVar.existingName),
   );
 
   const [typeChangeResources, updateResources] = _.partition(oldResources, (envVar) =>
-    existingEnvVars.find(
+    managedExistingEnvVars.find(
       (existingEnvVar) =>
         existingEnvVar.existingName === envVar.existingName &&
         existingEnvVar.values?.category !== envVar.values?.category,

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -339,6 +339,8 @@ export const isEnvVariableDataValid = (envVariables: EnvVariable[]): boolean => 
         return values.every(({ key, value }) => isValidGenericKey(key) && !!value);
       case SecretCategory.AWS:
         return isAWSValid(values);
+      case SecretCategory.EXISTING:
+        return values.length > 0 && values.every(({ key }) => !!key);
       default:
         return false;
     }

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -346,13 +346,15 @@ export const isEnvVariableDataValid = (envVariables: EnvVariable[]): boolean => 
     }
   };
 
-  const isValid = envVariables.every(
-    (envVar) =>
-      !!envVar.type &&
-      !!envVar.values &&
-      !!envVar.values.category &&
-      hasValidValuesForType(envVar.values.data, envVar.values.category),
-  );
+  const isValid = envVariables.every((envVar) => {
+    if (!envVar.type || !envVar.values || !envVar.values.category) {
+      return false;
+    }
+    if (envVar.values.category === SecretCategory.EXISTING && !envVar.existingName) {
+      return false;
+    }
+    return hasValidValuesForType(envVar.values.data, envVar.values.category);
+  });
 
   return isValid;
 };

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -1,5 +1,6 @@
 import type {
   EnvironmentFromVariable,
+  EnvironmentVariable,
   K8sNameDescriptionFieldData,
   Volume,
   VolumeMount,
@@ -87,6 +88,7 @@ export type StartNotebookData = {
   volumes?: Volume[];
   volumeMounts?: VolumeMount[];
   envFrom?: EnvironmentFromVariable[];
+  existingSecretEnvVars?: EnvironmentVariable[];
   dashboardNamespace?: string;
   connections?: Connection[];
   hardwareProfileOptions: UseAssignHardwareProfileResult<NotebookKind>;
@@ -99,6 +101,7 @@ export type {
   SecretRef,
   ConfigMapRef,
   EnvironmentFromVariable,
+  EnvironmentVariable,
   AWSDataEntry,
 } from '@odh-dashboard/k8s-core';
 
@@ -123,6 +126,7 @@ export enum SecretCategory {
   GENERIC = 'secret key-value',
   AWS = 'aws',
   UPLOAD = 'secret upload',
+  EXISTING = 'secret existing',
 }
 export enum ConfigMapCategory {
   GENERIC = 'configmap key-value',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72103

## Description

Adds a third "Existing secret" option alongside "Key / value" and "Upload" in the workbench environment variables form. Users can select a pre-existing Kubernetes Secret and pick individual keys to inject as `env[].valueFrom.secretKeyRef` entries in the Notebook CR.

**Key behaviors:**
- **Lazy loading**: Secrets are only fetched when the user selects the "Existing secret" category
- **Connection filtering**: Secrets with `opendatahub.io/connection-type`, `opendatahub.io/connection-type-protocol`, or `opendatahub.io/connection-type-ref` annotations are excluded (managed by Connections)
- **Secret values never exposed**: Only secret key names are displayed in the UI
- **Conflict detection**: Cross-source env var name collisions involving existing secrets show an alert and block submission
- **Edit view**: Parses `env[].valueFrom.secretKeyRef` entries from existing Notebook CR back into the form
- **Backward compatibility**: EXISTING entries are excluded from K8s ConfigMap/Secret resource management — they are injected directly as `env[]` entries

**Changes across 23 files (+1,278 / -48 lines):**
- New components: `EnvExistingSecretField`, `EnvVarConflictAlert`
- New hooks: `useExistingSecrets`
- New utilities: `envVarConflicts.ts`, `getExistingSecretEnvVars`
- Modified: `EnvSecret`, `EnvTypeSwitch`, `EnvTypeSelectField`, `SpawnerPage`, `SpawnerFooter`, `service.ts`, `spawnerUtils.ts`, `notebooks.ts`, `secrets.ts`, `types.ts`, `useNotebookEnvVariables.tsx`

## How Has This Been Tested?

Automated testing only — unit tests covering all new functionality:
- `service.spec.ts` — `getExistingSecretEnvVars` filtering and env var conversion
- `spawnerUtils.spec.ts` — EXISTING category validation
- `EnvExistingSecretField.spec.tsx` — component rendering, secret selection, key toggling
- `useExistingSecrets.spec.ts` — hook filtering logic
- `useNotebookEnvVariables.spec.ts` — secretKeyRef parsing from Notebook CR
- `envVarConflicts.spec.ts` — conflict detection scenarios
- `types.spec.ts` — enum value stability

Type-checking passes for all modified files.

## Test Impact

Added 7 new test files with comprehensive unit test coverage for all new components, hooks, and utilities. Existing tests are unaffected.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our [Best Practices](/docs/best-practices.md)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster

---
Generated by epic-codegen pipeline for [RHOAIENG-72103](https://redhat.atlassian.net/browse/RHOAIENG-72103)

[RHOAIENG-72103]: https://redhat.atlassian.net/browse/RHOAIENG-72103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting existing Kubernetes secrets when configuring notebook environment variables.
  * Users can choose a secret and select which keys to expose.
  * Added conflict warnings for duplicate environment variable names, with expandable details.
  * Existing secret references are preserved when updating notebooks.

* **Bug Fixes**
  * Prevented existing secrets from being incorrectly created, updated, or removed.
  * Improved validation for existing-secret environment variables.

* **Tests**
  * Added coverage for secret selection, conflict detection, validation, and notebook environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->