### PR TITLE
fix(dashboard-operator): report version and complete platform handshake

### DIFF
--- a/dashboard-operator/Dockerfile
+++ b/dashboard-operator/Dockerfile
@@ -14,7 +14,7 @@ COPY dashboard-operator/api/ api/
 COPY dashboard-operator/internal/ internal/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a \
-    -ldflags="-s -w -X github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller.Version=${VERSION}" \
+    -ldflags="-s -w -X 'github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller.Version=${VERSION}'" \
     -o /tmp/manager ./cmd/manager
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3

--- a/dashboard-operator/Dockerfile
+++ b/dashboard-operator/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.26 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=unknown
 
 WORKDIR /usr/src/app
 
@@ -12,7 +13,9 @@ COPY dashboard-operator/cmd/ cmd/
 COPY dashboard-operator/api/ api/
 COPY dashboard-operator/internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -ldflags="-s -w" -o /tmp/manager ./cmd/manager
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a \
+    -ldflags="-s -w -X github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller.Version=${VERSION}" \
+    -o /tmp/manager ./cmd/manager
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 

--- a/dashboard-operator/internal/controller/config.go
+++ b/dashboard-operator/internal/controller/config.go
@@ -106,3 +106,25 @@ func readDistributionConfig(ctx context.Context, cli client.Client, namespace st
 		Version: version,
 	}, nil
 }
+
+// readPlatformVersion reads the platformVersion key from the
+// chart-deployed ConfigMap. Returns ("", nil) when the ConfigMap is
+// absent or the key is missing, and ("", err) on transient read failures.
+func readPlatformVersion(ctx context.Context, cli client.Client, namespace string) (string, error) {
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{Name: distributionConfigMapName, Namespace: namespace}
+
+	if err := cli.Get(ctx, key, cm); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("failed to read platform config ConfigMap: %w", err)
+	}
+
+	if cm.Data == nil {
+		return "", nil
+	}
+
+	return cm.Data["platformVersion"], nil
+}

--- a/dashboard-operator/internal/controller/config.go
+++ b/dashboard-operator/internal/controller/config.go
@@ -111,6 +111,8 @@ func readDistributionConfig(ctx context.Context, cli client.Client, namespace st
 // chart-deployed ConfigMap. Returns ("", nil) when the ConfigMap is
 // absent or the key is missing, and ("", err) on transient read failures.
 func readPlatformVersion(ctx context.Context, cli client.Client, namespace string) (string, error) {
+	logger := log.FromContext(ctx)
+
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: distributionConfigMapName, Namespace: namespace}
 
@@ -126,5 +128,11 @@ func readPlatformVersion(ctx context.Context, cli client.Client, namespace strin
 		return "", nil
 	}
 
-	return cm.Data["platformVersion"], nil
+	version := cm.Data["platformVersion"]
+	if runeCount := utf8.RuneCountInString(version); runeCount > maxDistributionFieldLen {
+		logger.Info("Truncating platformVersion", "original_runes", runeCount)
+		version = string([]rune(version)[:maxDistributionFieldLen])
+	}
+
+	return version, nil
 }

--- a/dashboard-operator/internal/controller/config_test.go
+++ b/dashboard-operator/internal/controller/config_test.go
@@ -24,6 +24,70 @@ func configTestScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
+func TestReadPlatformVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		configMap *corev1.ConfigMap
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "configmap does not exist",
+			configMap: nil,
+			want:      "",
+		},
+		{
+			name: "platformVersion present",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: distributionConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"platformVersion": "2.20.0",
+				},
+			},
+			want: "2.20.0",
+		},
+		{
+			name: "platformVersion key missing",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: distributionConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"distribution.name": "SelfManagedRHOAI",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "nil data map",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: distributionConfigMapName, Namespace: "test-ns"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := configTestScheme(t)
+			builder := fake.NewClientBuilder().WithScheme(s)
+
+			if tt.configMap != nil {
+				builder = builder.WithObjects(tt.configMap)
+			}
+
+			cli := builder.Build()
+			got, err := readPlatformVersion(context.Background(), cli, "test-ns")
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestReadOperatorConfig(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/dashboard-operator/internal/controller/config_test.go
+++ b/dashboard-operator/internal/controller/config_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,6 +63,16 @@ func TestReadPlatformVersion(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: distributionConfigMapName, Namespace: "test-ns"},
 			},
 			want: "",
+		},
+		{
+			name: "oversized platformVersion is truncated",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: distributionConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"platformVersion": strings.Repeat("x", 300),
+				},
+			},
+			want: strings.Repeat("x", maxDistributionFieldLen),
 		},
 	}
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -154,6 +154,11 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		dashboard.Status.Distribution = dist
 	}
 
+	platformVersion, pvErr := readPlatformVersion(ctx, r.Client, r.Namespace)
+	if pvErr != nil {
+		logger.Error(pvErr, "Failed to read platform version, skipping handshake")
+	}
+
 	// Ready is the rollup condition — auto-derived by the Manager from
 	// ProvisioningSucceeded, Degraded, and ObservabilityAvailable.
 	// It is never set explicitly.
@@ -167,12 +172,20 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	result, err := r.reconcile(ctx, dashboard, cm, cfg)
 
-	dashboard.SetReleaseStatus(common.ComponentReleaseStatus{
-		Releases: []common.ComponentRelease{{
-			Name:    v1alpha1.DashboardComponentName,
-			Version: Version,
-		}},
-	})
+	releases := []common.ComponentRelease{{
+		Name:    v1alpha1.DashboardComponentName,
+		Version: Version,
+		RepoURL: "https://github.com/opendatahub-io/odh-dashboard",
+	}}
+
+	if platformVersion != "" {
+		releases = append(releases, common.ComponentRelease{
+			Name:    "platform",
+			Version: platformVersion,
+		})
+	}
+
+	dashboard.SetReleaseStatus(common.ComponentReleaseStatus{Releases: releases})
 
 	if cm.IsHappy() {
 		dashboard.Status.Phase = common.PhaseReady

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -315,6 +315,7 @@ func TestReconcile(t *testing.T) {
 
 			require.NotEmpty(t, updated.GetReleaseStatus().Releases)
 			assert.Equal(t, v1alpha1.DashboardComponentName, updated.GetReleaseStatus().Releases[0].Name)
+			assert.Equal(t, "https://github.com/opendatahub-io/odh-dashboard", updated.GetReleaseStatus().Releases[0].RepoURL)
 
 			if tt.wantModuleCount > 0 {
 				assert.Len(t, updated.Status.ModuleStatuses, tt.wantModuleCount, "module status count")
@@ -698,6 +699,7 @@ func TestReconcile_StatusContract(t *testing.T) {
 
 			require.NotEmpty(t, updated.GetReleaseStatus().Releases, "release status must be set")
 			assert.Equal(t, v1alpha1.DashboardComponentName, updated.GetReleaseStatus().Releases[0].Name)
+			assert.Equal(t, "https://github.com/opendatahub-io/odh-dashboard", updated.GetReleaseStatus().Releases[0].RepoURL)
 		})
 	}
 }
@@ -767,6 +769,103 @@ data:
 	updated := &v1alpha1.Dashboard{}
 	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
 	assert.Equal(t, "https://dashboard.apps.example.com", updated.Status.URL)
+}
+
+func TestReconcile_PlatformVersionHandshake(t *testing.T) {
+	tests := []struct {
+		name                string
+		platformConfigMap   *corev1.ConfigMap
+		wantPlatformVersion string
+	}{
+		{
+			name:                "no platform config — no platform release entry",
+			platformConfigMap:   nil,
+			wantPlatformVersion: "",
+		},
+		{
+			name: "platformVersion present — echoed to status",
+			platformConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "opendatahub-dashboard-config",
+					Namespace: testNamespace,
+				},
+				Data: map[string]string{
+					"platformVersion": "2.20.0",
+				},
+			},
+			wantPlatformVersion: "2.20.0",
+		},
+		{
+			name: "platformVersion key absent — no platform release entry",
+			platformConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "opendatahub-dashboard-config",
+					Namespace: testNamespace,
+				},
+				Data: map[string]string{
+					"distribution.name": "SelfManagedRHOAI",
+				},
+			},
+			wantPlatformVersion: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := testScheme(t)
+
+			dashboard := &v1alpha1.Dashboard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       v1alpha1.DashboardInstanceName,
+					Generation: 1,
+					Finalizers: []string{"components.platform.opendatahub.io/cleanup"},
+				},
+			}
+
+			builder := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(dashboard).
+				WithStatusSubresource(dashboard).
+				WithObjects(admittedRoute(testNamespace))
+
+			if tt.platformConfigMap != nil {
+				builder = builder.WithObjects(tt.platformConfigMap)
+			}
+
+			cli := builder.Build()
+
+			r := &ctrlpkg.DashboardReconciler{
+				Client:                cli,
+				Scheme:                s,
+				ManifestsBasePath:     createMinimalManifests(t),
+				Platform:              cluster.OpenDataHub,
+				Namespace:             testNamespace,
+				ApplicationsNamespace: testNamespace,
+			}
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+			})
+			require.NoError(t, err)
+
+			updated := &v1alpha1.Dashboard{}
+			require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
+
+			var platformVersion string
+			for _, r := range updated.GetReleaseStatus().Releases {
+				if r.Name == "platform" {
+					platformVersion = r.Version
+					break
+				}
+			}
+			assert.Equal(t, tt.wantPlatformVersion, platformVersion)
+
+			if tt.wantPlatformVersion != "" {
+				require.GreaterOrEqual(t, len(updated.GetReleaseStatus().Releases), 2,
+					"should have both dashboard and platform release entries")
+			}
+		})
+	}
 }
 
 func boolPtr(b bool) *bool {


### PR DESCRIPTION
## Summary

- **Fix `version: unknown`**: Inject `controller.Version` via `-ldflags` in the Dockerfile so container builds report the actual git-derived version instead of `"unknown"`.
- **Add `repoUrl`**: Include `repoUrl` in the dashboard component release entry as required by the [Module Handler Developer Guide](https://gitlab.cee.redhat.com/data-hub/odh-modularisation-docs/-/blob/main/Module%20Handler%20Developer%20Guide.md).
- **Complete platform version handshake**: Read `platformVersion` from the `opendatahub-dashboard-config` ConfigMap (injected by the ODH Operator) and echo it back as a `releases[name="platform"]` entry on the Dashboard CR status. This satisfies the module readiness contract checked by the ODH Operator's `ModuleReadinessChecker`.

### Before
```yaml
status:
  releases:
  - name: dashboard
    version: unknown
```

### After
```yaml
status:
  releases:
  - name: dashboard
    version: "v1.2.3"
    repoUrl: "https://github.com/opendatahub-io/odh-dashboard"
  - name: platform
    version: "2.20.0"
```

### Note
The Tekton/Konflux CI pipelines should be updated to pass `--build-arg VERSION=<tag>` when building the Dockerfile for production images. Without that, the Dockerfile defaults to `VERSION=unknown` (same as today). The `make build` target already injects the version correctly.

Ref: https://github.com/opendatahub-io/opendatahub-operator/pull/3733#issuecomment-4994316296

## Test plan

- [x] `make build` passes with version injected via ldflags
- [x] `make test` — all existing and new tests pass
- [x] `make lint` — 0 issues
- [ ] Verify on cluster that Dashboard CR status shows correct version and platform handshake entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard release status now conditionally includes a platform component version when available from cluster configuration.
  * Dashboard release version can be injected at build time and reported in release status.
  * Release status assertions now include the dashboard repository URL.

* **Bug Fixes**
  * Platform version retrieval failures no longer block reconciliation; the controller logs the issue and continues without the platform handshake.
  * Platform version values are safely handled, including truncation to the supported length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->