### PR TITLE
feat(gen-ai): add Segment tracking for playground agent lifecycle events

### DIFF
--- a/packages/gen-ai/frontend/src/app/AIAssets/components/agentprofiles/AgentProfileTableRow.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/agentprofiles/AgentProfileTableRow.tsx
@@ -11,8 +11,10 @@ import { EllipsisVIcon } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';
 import { useNavigate, useParams } from 'react-router-dom';
 import { TruncatedText } from 'mod-arch-shared';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { AgentProfileSummary } from '~/app/agentProfile/types';
 import { genAiChatPlaygroundRoute } from '~/app/utilities/routes';
+import { PLAYGROUND_AGENT_EVENTS } from '~/app/tracking/playgroundAgentTrackingConstants';
 import DeleteAgentProfileModal from './DeleteAgentProfileModal';
 import EditAgentProfileModal from './EditAgentProfileModal';
 
@@ -48,6 +50,9 @@ const AgentProfileTableRow: React.FC<AgentProfileTableRowProps> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
 
   const handleTryInPlayground = () => {
+    fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.TRY_IN_PLAYGROUND_SELECTED, {
+      agentID: profile.profileId,
+    });
     navigate({
       pathname: genAiChatPlaygroundRoute(namespace),
       search: `?agentProfileId=${encodeURIComponent(profile.profileId)}`,

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
@@ -3,6 +3,7 @@ import { MessageBox, ChatbotWelcomePrompt, WelcomePrompt } from '@patternfly/cha
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { MCPServerFromAPI, TokenInfo } from '~/app/types';
 import { ServerStatusInfo } from '~/app/hooks/useMCPServerStatuses';
+import useIsProfileDirty from '~/app/agentProfile/useIsProfileDirty';
 import useChatbotMessages, { UseChatbotMessagesReturn } from './hooks/useChatbotMessages';
 import useEmbeddedChatbotMessages from './hooks/useEmbeddedChatbotMessages';
 import { useEmbeddedMessagesConfig } from './context/EmbeddedMessagesContext';
@@ -128,6 +129,7 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
   );
 
   const embeddedConfig = useEmbeddedMessagesConfig();
+  const isProfileDirty = useIsProfileDirty(configId);
 
   const standardMessagesHook = useChatbotMessages({
     configId,
@@ -155,6 +157,7 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
     hasAudioInCurrentMessage,
     hasImageInConversation: hasImagesInConversation,
     hasAudioInConversation,
+    isProfileDirty,
   });
 
   const embeddedMessagesHook = useEmbeddedChatbotMessages({

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -7,6 +7,7 @@ import {
   fireMiscTrackingEvent,
   fireSimpleTrackingEvent,
 } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { PLAYGROUND_AGENT_EVENTS } from '~/app/tracking/playgroundAgentTrackingConstants';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import ChatbotEmptyState from '~/app/EmptyStates/NoData';
 import { GenAiContext } from '~/app/context/GenAiContext';
@@ -136,6 +137,7 @@ const ChatbotMain: React.FunctionComponent = () => {
     if (!savedSpec || !savedProfileId) {
       return;
     }
+    fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.REVERTED, { agentID: savedProfileId });
 
     // Reconstruct a minimal AgentProfile from the stored snapshot and re-apply locally —
     // no API call needed since we already have the last-saved spec.

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -25,6 +25,7 @@ import {
 import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
 import DashboardModalFooter from '@odh-dashboard/internal/concepts/dashboard/DashboardModalFooter';
 import { PLAYGROUND_MULTIMODAL_EVENTS } from '~/app/tracking/playgroundMultimodalTrackingConstants';
+import { PLAYGROUND_AGENT_EVENTS } from '~/app/tracking/playgroundAgentTrackingConstants';
 import { useUserContext } from '~/app/context/UserContext';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import { GenAiContext } from '~/app/context/GenAiContext';
@@ -302,6 +303,7 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
   const loadedProfileId = useChatbotConfigStore((s) => s.loadedProfileId);
   const loadedProfileDisplayName = useChatbotConfigStore((s) => s.loadedProfileDisplayName);
+
   const loadedProfileWarnings = useChatbotConfigStore((s) => s.loadedProfileWarnings);
   const [warningsDismissed, setWarningsDismissed] = React.useState(false);
   const [settingsTabKey, setSettingsTabKey] = React.useState<string | number>(
@@ -1006,7 +1008,13 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
                 <Button
                   variant="link"
                   isInline
-                  onClick={onOpenSaveAs}
+                  onClick={() => {
+                    fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.SAVE_COPY_SELECTED, {
+                      agentID: loadedProfileId ?? '',
+                      triggerContext: 'restriction_nudge_modal',
+                    });
+                    onOpenSaveAs?.();
+                  }}
                   style={{ textDecorationStyle: 'dotted' }}
                 >
                   Save as new agent

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -26,6 +26,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import useIsProfileDirty from '~/app/agentProfile/useIsProfileDirty';
 import RhUiUploadIcon from '~/app/images/icons/RhUiUploadIcon';
 import { AGENT_CONFIG_MANAGEMENT } from '~/odh/extensions';
@@ -41,6 +42,7 @@ import {
   selectConfigIds,
   DEFAULT_CONFIG_ID,
 } from '~/app/Chatbot/store';
+import { PLAYGROUND_AGENT_EVENTS } from '~/app/tracking/playgroundAgentTrackingConstants';
 import { UseSourceManagementReturn } from '~/app/Chatbot/hooks/useSourceManagement';
 import { UseFileManagementReturn } from '~/app/Chatbot/hooks/useFileManagement';
 import useGuardrailsEnabled from '~/app/Chatbot/hooks/useGuardrailsEnabled';
@@ -125,6 +127,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
   const isGuardrailsFeatureEnabled = useGuardrailsEnabled();
   const [agentConfigManagementEnabled] = useFeatureFlag(AGENT_CONFIG_MANAGEMENT);
   const profileApplied = useChatbotConfigStore((s) => s.profileApplied);
+  const loadedProfileId = useChatbotConfigStore((s) => s.loadedProfileId);
   const loadedProfileWarnings = useChatbotConfigStore((s) => s.loadedProfileWarnings);
   const hasWarnings = !!loadedProfileWarnings?.length;
 
@@ -509,7 +512,13 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
             ))}
           <Button
             variant={profileApplied ? 'secondary' : 'primary'}
-            onClick={onSaveAs}
+            onClick={() => {
+              fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.SAVE_COPY_SELECTED, {
+                agentID: loadedProfileId ?? '',
+                triggerContext: 'settings_drawer_button',
+              });
+              onSaveAs?.();
+            }}
             data-testid="settings-panel-save-as-button"
           >
             Save as agent

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -18,6 +18,7 @@ import {
   TextInput,
   Title,
 } from '@patternfly/react-core';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
 import useFetchAAEVectorStores from '~/app/hooks/useFetchAAEVectorStores';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
@@ -27,6 +28,7 @@ import { convertMaaSModelToAIModel, isPlaygroundModelMatchForAIModel } from '~/a
 import { serializeToAgentProfileSpec } from '~/app/agentProfile/serialize';
 import { usePromptEdited } from '~/app/Chatbot/hooks/usePromptEdited';
 import { MCPServerFromAPI } from '~/app/types/mcp';
+import { PLAYGROUND_AGENT_EVENTS } from '~/app/tracking/playgroundAgentTrackingConstants';
 
 /** Fallback ConfigMap name used only when the BFF does not return one. */
 const MCP_CONFIG_MAP_NAME_FALLBACK = 'gen-ai-aa-mcp-servers';
@@ -152,6 +154,10 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
 
       if (mode === 'save-as' || !loadedProfileId) {
         const response = await api.createAgentProfile({ spec });
+        fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.COPY_SAVED, {
+          originalAgentID: loadedProfileId ?? '',
+          newAgentID: response.profileId,
+        });
         onSaved(response.profileId, response.displayName, description.trim());
         // Set after onSaved for the same reason as the update branch below.
         useChatbotConfigStore.getState().setLoadedResourceVersion(response.resourceVersion);
@@ -162,6 +168,9 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
           id: loadedProfileId,
           spec,
           resourceVersion: loadedResourceVersion ?? '',
+        });
+        fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.SAVED, {
+          agentID: loadedProfileId,
         });
         onSaved(loadedProfileId, response.displayName, description.trim());
         // Set after onSaved: applyAgentProfile (called inside onSaved) resets the store

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
@@ -111,6 +111,7 @@ interface UseChatbotMessagesProps {
   hasAudioInCurrentMessage?: boolean;
   hasImageInConversation?: boolean;
   hasAudioInConversation?: boolean;
+  isProfileDirty?: boolean;
 }
 
 const useChatbotMessages = ({
@@ -139,6 +140,7 @@ const useChatbotMessages = ({
   hasAudioInCurrentMessage,
   hasImageInConversation,
   hasAudioInConversation,
+  isProfileDirty,
 }: UseChatbotMessagesProps): UseChatbotMessagesReturn => {
   const [messages, setMessages] = React.useState<ChatbotMessageProps[]>([]);
   const [isMessageSendButtonDisabled, setIsMessageSendButtonDisabled] = React.useState(false);
@@ -496,7 +498,11 @@ const useChatbotMessages = ({
         hasAudio,
         modality,
         hasLoadedAgent: profileApplied,
-        agentSavedState: profileApplied ? 'saved' : 'temporary_session',
+        agentSavedState: profileApplied
+          ? isProfileDirty
+            ? 'unsaved_changes'
+            : 'saved'
+          : 'temporary_session',
       });
 
       if (!apiAvailable) {

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
@@ -40,6 +40,7 @@ import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import { useChatbotConfigStore } from '~/app/Chatbot/store';
 import { StreamingThinkingSection } from '~/app/Chatbot/components/StreamingThinkingSection';
+import { PLAYGROUND_AGENT_EVENTS } from '~/app/tracking/playgroundAgentTrackingConstants';
 
 export type GuardrailsConfig = {
   enabled: boolean;
@@ -476,6 +477,7 @@ const useChatbotMessages = ({
         return 'text';
       })();
 
+      const { profileApplied } = useChatbotConfigStore.getState();
       fireMiscTrackingEvent('Playground Query Submitted', {
         configID: configIndex ?? 0,
         compareMode: isCompareMode ?? false,
@@ -493,6 +495,8 @@ const useChatbotMessages = ({
         hasImage,
         hasAudio,
         modality,
+        hasLoadedAgent: profileApplied,
+        agentSavedState: profileApplied ? 'saved' : 'temporary_session',
       });
 
       if (!apiAvailable) {
@@ -790,6 +794,15 @@ const useChatbotMessages = ({
 
       if (apiError.error.code === GUARDRAIL_ERROR_CODES.INPUT_VIOLATION) {
         fireMiscTrackingEvent('Guardrail Activated', { violationDetected: true });
+        fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.CHAT_BLOCKED, {
+          agentID: useChatbotConfigStore.getState().loadedProfileId ?? '',
+          blockType: 'input',
+        });
+      } else if (apiError.error.code === GUARDRAIL_ERROR_CODES.OUTPUT_VIOLATION) {
+        fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.CHAT_BLOCKED, {
+          agentID: useChatbotConfigStore.getState().loadedProfileId ?? '',
+          blockType: 'output',
+        });
       }
 
       // Check if this was a user-initiated stop (stop button, not clear conversation)

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -197,14 +197,14 @@ const useAgentProfileUrlParam = ({
 
         setLoading(false);
       })
-      .catch((err: Error) => {
+      .catch((err: unknown) => {
         if (cancelled) {
           return;
         }
         appliedProfileId.current = null; // allow retry if caller re-mounts
-        setError(err);
+        setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
-        const message = err.message.toLowerCase();
+        const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
         const failureReason = message.includes('timeout')
           ? 'timeout'
           : message.includes('not found') || message.includes('404')

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -1,12 +1,21 @@
 import * as React from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import { GenAiContext } from '~/app/context/GenAiContext';
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
 import { MCPServerFromAPI } from '~/app/types/mcp';
 import { DEFAULT_CONFIG_ID, useChatbotConfigStore } from '~/app/Chatbot/store';
+import {
+  PLAYGROUND_AGENT_EVENTS,
+  ConfigurationUnavailableProperties,
+} from '~/app/tracking/playgroundAgentTrackingConstants';
 import { deserializeAgentProfile } from './deserialize';
-import { buildValidationWarnings, validateAgentProfileAsync } from './validateAgentProfile';
+import {
+  buildValidationWarnings,
+  validateAgentProfileAsync,
+  ValidationWarning,
+} from './validateAgentProfile';
 
 const AGENT_PROFILE_ID_PARAM = 'agentProfileId';
 
@@ -107,6 +116,7 @@ const useAgentProfileUrlParam = ({
           profile.spec.description,
         );
         setLoadedResourceVersion(profile.metadata.resourceVersion);
+        fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.LOADED, { agentID: agentProfileId });
 
         // Sync warnings are set immediately so the OpenAgentProfileModal can show
         // the alert (and bypass localStorage) as soon as the profile is applied.
@@ -157,6 +167,34 @@ const useAgentProfileUrlParam = ({
         setLoadedProfileSpec(profile.spec);
         setLoadedProfilePrompt(asyncResult.resolvedPrompt ?? null);
 
+        const tabToMissingComponent = (
+          w: ValidationWarning,
+        ): ConfigurationUnavailableProperties['missingComponents'][number] | null => {
+          if (w.tab === 'model') {
+            return 'model';
+          }
+          if (w.tab === 'mcp') {
+            return 'mcp_server';
+          }
+          if (w.tab === 'knowledge') {
+            return 'vector_store';
+          }
+          return null;
+        };
+        const missingComponents = [
+          ...new Set(
+            allWarnings
+              .map(tabToMissingComponent)
+              .filter((c): c is NonNullable<typeof c> => c !== null),
+          ),
+        ];
+        if (missingComponents.length > 0) {
+          fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.CONFIGURATION_UNAVAILABLE, {
+            agentID: agentProfileId,
+            missingComponents: missingComponents.join(','),
+          });
+        }
+
         setLoading(false);
       })
       .catch((err: Error) => {
@@ -166,6 +204,20 @@ const useAgentProfileUrlParam = ({
         appliedProfileId.current = null; // allow retry if caller re-mounts
         setError(err);
         setLoading(false);
+        const message = err.message.toLowerCase();
+        const failureReason = message.includes('timeout')
+          ? 'timeout'
+          : message.includes('not found') || message.includes('404')
+            ? 'dependency_missing'
+            : message.includes('auth') ||
+                message.includes('unauthorized') ||
+                message.includes('forbidden')
+              ? 'auth_error'
+              : 'unknown';
+        fireMiscTrackingEvent(PLAYGROUND_AGENT_EVENTS.LOAD_INTERRUPTED, {
+          agentID: agentProfileId,
+          failureReason,
+        });
       });
 
     return () => {

--- a/packages/gen-ai/frontend/src/app/tracking/playgroundAgentTrackingConstants.ts
+++ b/packages/gen-ai/frontend/src/app/tracking/playgroundAgentTrackingConstants.ts
@@ -1,0 +1,60 @@
+export const PLAYGROUND_AGENT_EVENTS = {
+  TRY_IN_PLAYGROUND_SELECTED: 'Playground Agent Try In Playground Selected',
+  LOADED: 'Playground Agent Loaded',
+  SAVED: 'Playground Agent Saved',
+  REVERTED: 'Playground Agent Reverted',
+
+  SAVE_COPY_SELECTED: 'Playground Agent Save Copy Selected',
+  COPY_SAVED: 'Playground Agent Copy Saved',
+  LOAD_INTERRUPTED: 'Playground Agent Load Interrupted',
+  CONFIGURATION_UNAVAILABLE: 'Playground Agent Configuration Unavailable',
+  CHAT_BLOCKED: 'Playground Agent Chat Blocked',
+  QUERY_SUBMITTED: 'Playground Query Submitted',
+} as const;
+
+export type TryInPlaygroundSelectedProperties = {
+  agentID: string;
+};
+
+export type AgentLoadedProperties = {
+  agentID: string;
+};
+
+export type AgentSavedProperties = {
+  agentID: string;
+  modifiedProperties?: string[];
+};
+
+export type AgentRevertedProperties = {
+  agentID: string;
+};
+
+export type SaveCopySelectedProperties = {
+  agentID: string;
+  triggerContext: 'settings_drawer_button' | 'save_modal_fork_button' | 'restriction_nudge_modal';
+};
+
+export type CopySavedProperties = {
+  originalAgentID: string;
+  newAgentID: string;
+};
+
+export type LoadInterruptedProperties = {
+  agentID: string;
+  failureReason: 'dependency_missing' | 'timeout' | 'auth_error' | 'corrupted_config' | 'unknown';
+};
+
+export type ConfigurationUnavailableProperties = {
+  agentID: string;
+  missingComponents: string;
+};
+
+export type ChatBlockedProperties = {
+  agentID: string;
+  blockType: 'input' | 'output';
+};
+
+export type QuerySubmittedProperties = {
+  hasLoadedAgent: boolean;
+  agentSavedState: 'saved' | 'unsaved_changes' | 'temporary_session';
+};


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-70789

## Description

Adds Segment analytics tracking for the agent playground lifecycle in the gen-ai package. Introduces a new constants file with typed event definitions and wires tracking calls across the relevant components.

**New file:** `playgroundAgentTrackingConstants.ts` — event name strings and TypeScript property types for all new events.

**Events added:**

| Event | Where |
|---|---|
| `Playground Agent Try In Playground Selected` | `AgentProfileTableRow` — "Try in Playground" button |
| `Playground Agent Loaded` | `useAgentProfileUrlParam` — after profile applied |
| `Playground Agent Saved` | `SaveAgentProfileModal` — successful overwrite save |
| `Playground Agent Reverted` | `ChatbotMain` — "Reset to last saved" confirmed |
| `Playground Agent Save Copy Selected` | `ChatbotSettingsPanel` (drawer button) and `ChatbotPlayground` (restriction nudge) |
| `Playground Agent Copy Saved` | `SaveAgentProfileModal` — successful save-as |
| `Playground Agent Load Interrupted` | `useAgentProfileUrlParam` — fetch failure |
| `Playground Agent Configuration Unavailable` | `useAgentProfileUrlParam` — after validation warnings, fires once with deduplicated `missingComponents` string |
| `Playground Agent Chat Blocked` | `useChatbotMessages` — guardrail input/output violations |
| `Playground Query Submitted` (extended) | `useChatbotMessages` — adds `hasLoadedAgent` and `agentSavedState` to existing event |

## How Has This Been Tested?

Manually tested and reviewed by the developer.

## Test Impact

Tracking calls are side-effect only with no impact on component logic or rendering. No new unit tests added; existing tracking specs (e.g. `GuardrailsPanel.tracking.spec.tsx`) serve as the pattern reference.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for key AI Playground actions, including loading, saving, copying, reverting, and trying agents.
  * Added tracking for chat submissions, blocked messages, configuration issues, and interrupted agent loading.
  * Captured additional context such as agent IDs, save state, trigger location, missing components, and failure reasons.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->