### PR TITLE
feat: Add 'Existing secret' option to workbench environment variables form

### DIFF
--- a/frontend/src/api/k8s/__tests__/notebooks.spec.ts
+++ b/frontend/src/api/k8s/__tests__/notebooks.spec.ts
@@ -408,6 +408,35 @@ describe('assembleNotebook', () => {
     expect(renderResult).toStrictEqual(mockNotebookK8sResource({ uid: 'test' }));
   });
 
+  it('should include existingSecretEnvVars in containers env', () => {
+    const notebookData = mockStartNotebookData({});
+    notebookData.existingSecretEnvVars = [
+      {
+        name: 'DB_HOST',
+        valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_HOST' } },
+      },
+      {
+        name: 'DB_PORT',
+        valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_PORT' } },
+      },
+    ];
+    const result = assembleNotebook(notebookData, 'test-user');
+    const containerEnv = result.spec.template.spec.containers[0].env;
+    const secretKeyRefEntries = containerEnv.filter(
+      (e: { valueFrom?: unknown }) =>
+        e.valueFrom && typeof e.valueFrom === 'object' && 'secretKeyRef' in e.valueFrom,
+    );
+    expect(secretKeyRefEntries).toHaveLength(2);
+    expect(secretKeyRefEntries[0]).toEqual({
+      name: 'DB_HOST',
+      valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_HOST' } },
+    });
+    expect(secretKeyRefEntries[1]).toEqual({
+      name: 'DB_PORT',
+      valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_PORT' } },
+    });
+  });
+
   it('should include mlflow-instance annotation when mlflowEnabled is true', () => {
     const notebookData = mockStartNotebookData({});
     notebookData.mlflowEnabled = true;

--- a/frontend/src/api/k8s/__tests__/secrets.spec.ts
+++ b/frontend/src/api/k8s/__tests__/secrets.spec.ts
@@ -19,6 +19,7 @@ import {
   createSecret,
   deleteSecret,
   getSecret,
+  getSecrets,
   getSecretsByLabel,
   replaceSecret,
 } from '#~/api/k8s/secrets';
@@ -238,6 +239,32 @@ describe('getSecretsByLabel', () => {
       fetchOptions: { requestInit: {} },
       model: SecretModel,
       queryOptions: { ns: 'secretName', queryParams: { labelSelector: 'label' } },
+    });
+  });
+});
+
+describe('getSecrets', () => {
+  it('should return all secrets in the namespace', async () => {
+    const secretMock = mockK8sResourceList([mockSecretK8sResource({})]);
+    k8sListResourceMock.mockResolvedValue(secretMock);
+    const result = await getSecrets('test-namespace');
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: SecretModel,
+      queryOptions: { ns: 'test-namespace', queryParams: {} },
+    });
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(secretMock.items);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sListResourceMock.mockRejectedValue(mock404Error({}));
+    await expect(getSecrets('test-namespace')).rejects.toBeDefined();
+    expect(k8sListResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sListResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: SecretModel,
+      queryOptions: { ns: 'test-namespace', queryParams: {} },
     });
   });
 });

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -40,6 +40,7 @@ export const assembleNotebook = (
     image,
     volumes: formVolumes,
     volumeMounts: formVolumeMounts,
+    existingSecretEnvVars,
     connections,
     hardwareProfileOptions,
     feastData,
@@ -134,6 +135,7 @@ export const assembleNotebook = (
                   name: 'JUPYTER_IMAGE',
                   value: imageUrl,
                 },
+                ...(existingSecretEnvVars || []),
               ],
               envFrom,
               volumeMounts,
@@ -302,6 +304,8 @@ export const updateNotebook = (
 
   // clean the envFrom array in case of merging the old value again
   container.envFrom = [];
+  // clean the env array to prevent lodash merge from keeping stale secretKeyRef entries
+  container.env = [];
   // clean the resources, affinity and tolerations for accelerator
   oldNotebook.spec.template.spec.tolerations = [];
   oldNotebook.spec.template.spec.affinity = {};

--- a/frontend/src/api/k8s/secrets.ts
+++ b/frontend/src/api/k8s/secrets.ts
@@ -167,6 +167,17 @@ export const getSecretsByLabel = (
     ),
   ).then((result) => result.items);
 
+export const getSecrets = (namespace: string, opts?: K8sAPIOptions): Promise<SecretKind[]> =>
+  k8sListResource<SecretKind>(
+    applyK8sAPIOptions(
+      {
+        model: SecretModel,
+        queryOptions: { ns: namespace },
+      },
+      opts,
+    ),
+  ).then((result) => result.items);
+
 export const createSecret = (data: SecretKind, opts?: K8sAPIOptions): Promise<SecretKind> =>
   k8sCreateResource<SecretKind>(
     applyK8sAPIOptions(

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -38,6 +38,7 @@ import {
 import { checkRequiredFieldsForNotebookStart, getPvcVolumeDetails } from './spawnerUtils';
 import type { SelectedFeatureStoreConfig } from './featureStore/useWorkbenchFeatureStores';
 import { generateFeastMetadata } from './featureStore/utils';
+import { getExistingSecretEnvVars } from './environmentVariables/existingSecretUtils';
 
 type SpawnerFooterProps = {
   startNotebookData: StartNotebookData;
@@ -46,6 +47,7 @@ type SpawnerFooterProps = {
   connections: Connection[];
   canEnablePipelines: boolean;
   selectedFeatureStores?: SelectedFeatureStoreConfig[];
+  hasExistingSecretCollisions?: boolean;
 };
 
 const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
@@ -55,6 +57,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   connections = [],
   canEnablePipelines,
   selectedFeatureStores = [],
+  hasExistingSecretCollisions = false,
 }) => {
   const [error, setError] = React.useState<K8sStatusError>();
   const {
@@ -78,6 +81,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     createInProgress ||
     !checkRequiredFieldsForNotebookStart(startNotebookData, envVariables) ||
     !isHardwareProfileValid ||
+    hasExistingSecretCollisions ||
     (!isProjectScopedAvailable &&
       startNotebookData.image.imageStream?.metadata.namespace === projectName);
 
@@ -180,6 +184,8 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       dryRun,
     );
 
+    const existingSecretEnvVars = getExistingSecretEnvVars(envVariables);
+
     const annotations = { ...editNotebook.metadata.annotations };
     if (envFrom.length > 0) {
       annotations['notebooks.opendatahub.io/notebook-restart'] = 'true';
@@ -192,6 +198,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       volumes,
       volumeMounts,
       envFrom,
+      existingSecretEnvVars,
       connections,
       feastData,
     };
@@ -230,6 +237,8 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       dryRun,
     );
 
+    const existingSecretEnvVars = getExistingSecretEnvVars(envVariables);
+
     const { volumes, volumeMounts } = pvcVolumeDetails;
     const feastData = generateFeastMetadata(selectedFeatureStores, undefined, false);
 
@@ -238,6 +247,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
       volumes,
       volumeMounts,
       envFrom: [...envFrom],
+      existingSecretEnvVars,
       connections,
       feastData,
     };

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -37,7 +37,7 @@ import {
 } from '#~/pages/projects/screens/detail/notebooks/const';
 import useProjectPvcs from '#~/pages/projects/screens/detail/storage/useProjectPvcs';
 import { Connection } from '#~/concepts/connectionTypes/types';
-import { StorageData, StorageType } from '#~/pages/projects/types';
+import { SecretCategory, StorageData, StorageType } from '#~/pages/projects/types';
 import useNotebookPVCItems from '#~/pages/projects/pvc/useNotebookPVCItems';
 import { getNotebookPVCMountPathMap } from '#~/pages/projects/notebook/utils';
 import { getNotebookPVCNames } from '#~/pages/projects/pvc/utils';
@@ -64,6 +64,7 @@ import { useNotebookEnvVariables } from './environmentVariables/useNotebookEnvVa
 import { useDefaultStorageClass } from './storage/useDefaultStorageClass';
 import { ConnectionsFormSection } from './connections/ConnectionsFormSection';
 import { getConnectionsFromNotebook } from './connections/utils';
+import { detectEnvKeyCollisions } from './environmentVariables/existingSecretUtils';
 import AlertWarningText from './environmentVariables/AlertWarningText';
 import { ClusterStorageTable } from './storage/ClusterStorageTable';
 import useDefaultPvcSize from './storage/useDefaultPvcSize';
@@ -198,6 +199,15 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     useNotebookEnvVariables(existingNotebook, [
       ...notebookConnections.map((connection) => connection.metadata.name),
     ]);
+
+  const envKeyCollisions = React.useMemo(() => {
+    const existingRefs = envVariables
+      .filter((ev) => ev.values?.category === SecretCategory.EXISTING)
+      .flatMap((ev) => ev.existingSecretRefs ?? []);
+    return detectEnvKeyCollisions(existingRefs, envVariables, notebookConnections);
+  }, [envVariables, notebookConnections]);
+
+  const hasExistingSecretCollisions = envKeyCollisions.length > 0;
 
   const notebooksUsingPVCsWithSizeChanges = React.useMemo(() => {
     const attachedPVCs = storageData.filter((storage) => storage.existingPvc !== undefined);
@@ -372,7 +382,11 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   deletedSecrets={deletedSecrets}
                 />
               )}
-              <EnvironmentVariables envVariables={envVariables} setEnvVariables={setEnvVariables} />
+              <EnvironmentVariables
+                envVariables={envVariables}
+                setEnvVariables={setEnvVariables}
+                envKeyCollisions={envKeyCollisions}
+              />
             </FormSection>
             <FormSection
               title={
@@ -494,6 +508,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   connections={notebookConnections}
                   canEnablePipelines={canEnablePipelines}
                   selectedFeatureStores={selectedFeatureStores}
+                  hasExistingSecretCollisions={hasExistingSecretCollisions}
                 />
               )}
             </CanEnableElyraPipelinesCheck>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
@@ -59,29 +59,38 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({
     [secrets, filterValue],
   );
 
-  const handleSelect = (secret: SecretKind) => {
-    const secretName = secret.metadata.name;
-    if (selectedNames.has(secretName)) {
+  const handleSelect = React.useCallback(
+    (secret: SecretKind) => {
+      const secretName = secret.metadata.name;
+      if (selectedNames.has(secretName)) {
+        onUpdate(existingSecretRefs.filter((ref) => ref.secretName !== secretName));
+      } else {
+        const availableKeys = secret.data ? Object.keys(secret.data) : [];
+        const newRef: ExistingSecretRef = {
+          secretName,
+          allKeys: true,
+          selectedKeys: [...availableKeys],
+          availableKeys,
+        };
+        onUpdate([...existingSecretRefs, newRef]);
+      }
+    },
+    [selectedNames, existingSecretRefs, onUpdate],
+  );
+
+  const handleRemove = React.useCallback(
+    (secretName: string) => {
       onUpdate(existingSecretRefs.filter((ref) => ref.secretName !== secretName));
-    } else {
-      const availableKeys = secret.data ? Object.keys(secret.data) : [];
-      const newRef: ExistingSecretRef = {
-        secretName,
-        allKeys: true,
-        selectedKeys: [...availableKeys],
-        availableKeys,
-      };
-      onUpdate([...existingSecretRefs, newRef]);
-    }
-  };
+    },
+    [existingSecretRefs, onUpdate],
+  );
 
-  const handleRemove = (secretName: string) => {
-    onUpdate(existingSecretRefs.filter((ref) => ref.secretName !== secretName));
-  };
-
-  const handleRefUpdate = (index: number, updatedRef: ExistingSecretRef) => {
-    onUpdate(existingSecretRefs.map((ref, i) => (i === index ? updatedRef : ref)));
-  };
+  const handleRefUpdate = React.useCallback(
+    (index: number, updatedRef: ExistingSecretRef) => {
+      onUpdate(existingSecretRefs.map((ref, i) => (i === index ? updatedRef : ref)));
+    },
+    [existingSecretRefs, onUpdate],
+  );
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
@@ -1,25 +1,222 @@
 import * as React from 'react';
-import { Alert } from '@patternfly/react-core';
+import {
+  Badge,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  MenuToggle,
+  MenuToggleElement,
+  // Multi-select typeahead with checkboxes is not supported by project wrappers
+  // eslint-disable-next-line no-restricted-imports
+  Select,
+  SelectList,
+  SelectOption,
+  Spinner,
+  Stack,
+  StackItem,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  Button,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { useProjectContext } from '#~/pages/projects/ProjectDetailsContext';
 import type { ExistingSecretRef } from '#~/pages/projects/types';
+import type { EnvKeyCollision } from './existingSecretUtils';
+import { useExistingSecrets } from './useExistingSecrets';
+import ExistingSecretItem from './ExistingSecretItem';
+import ExistingSecretCollisionAlert from './ExistingSecretCollisionAlert';
 
 type EnvExistingSecretProps = {
   existingSecretRefs: ExistingSecretRef[];
   onUpdate: (refs: ExistingSecretRef[]) => void;
+  collisions?: EnvKeyCollision[];
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- stub; Task 4 will use onUpdate
-const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ existingSecretRefs, onUpdate }) => (
-  <Alert
-    variant="info"
-    isInline
-    isPlain
-    title="Existing secret selection"
-    data-testid="existing-secret-section"
-  >
-    {existingSecretRefs.length === 0
-      ? 'Select secrets from the dropdown above.'
-      : `${existingSecretRefs.length} secret(s) selected.`}
-  </Alert>
-);
+const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({
+  existingSecretRefs,
+  onUpdate,
+  collisions = [],
+}) => {
+  const { currentProject } = useProjectContext();
+  const namespace = currentProject.metadata.name;
+  const [secrets, secretsLoaded, secretsError] = useExistingSecrets(namespace);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [filterValue, setFilterValue] = React.useState('');
+  const textInputRef = React.useRef<HTMLInputElement>(null);
+
+  const selectedNames = React.useMemo(
+    () => new Set(existingSecretRefs.map((ref) => ref.secretName)),
+    [existingSecretRefs],
+  );
+
+  const filteredSecrets = React.useMemo(
+    () =>
+      secrets.filter(
+        (s) => !filterValue || s.metadata.name.toLowerCase().includes(filterValue.toLowerCase()),
+      ),
+    [secrets, filterValue],
+  );
+
+  const handleSelect = (secret: SecretKind) => {
+    const secretName = secret.metadata.name;
+    if (selectedNames.has(secretName)) {
+      onUpdate(existingSecretRefs.filter((ref) => ref.secretName !== secretName));
+    } else {
+      const availableKeys = secret.data ? Object.keys(secret.data) : [];
+      const newRef: ExistingSecretRef = {
+        secretName,
+        allKeys: true,
+        selectedKeys: [...availableKeys],
+        availableKeys,
+      };
+      onUpdate([...existingSecretRefs, newRef]);
+    }
+  };
+
+  const handleRemove = (secretName: string) => {
+    onUpdate(existingSecretRefs.filter((ref) => ref.secretName !== secretName));
+  };
+
+  const handleRefUpdate = (index: number, updatedRef: ExistingSecretRef) => {
+    onUpdate(existingSecretRefs.map((ref, i) => (i === index ? updatedRef : ref)));
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      variant="typeahead"
+      onClick={() => setIsOpen((prev) => !prev)}
+      isExpanded={isOpen}
+      isFullWidth
+      data-testid="existing-secret-select-toggle"
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={filterValue}
+          onClick={() => setIsOpen(true)}
+          onChange={(_event, value) => setFilterValue(value)}
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder={
+            selectedNames.size > 0
+              ? `${selectedNames.size} secret${selectedNames.size > 1 ? 's' : ''} selected`
+              : 'Select secrets...'
+          }
+          role="combobox"
+          aria-controls="existing-secret-select-listbox"
+          data-testid="existing-secret-typeahead-input"
+        />
+        <TextInputGroupUtilities>
+          {selectedNames.size > 0 && (
+            <Badge isRead data-testid="existing-secret-count-badge">
+              {selectedNames.size}
+            </Badge>
+          )}
+          {filterValue && (
+            <Button
+              variant="plain"
+              onClick={() => setFilterValue('')}
+              aria-label="Clear filter"
+              data-testid="existing-secret-clear-filter"
+            >
+              <TimesIcon />
+            </Button>
+          )}
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <Stack hasGutter data-testid="existing-secret-section">
+      <StackItem>
+        <FormGroup label="Secrets" isRequired fieldId="existing-secret-select">
+          {!secretsLoaded ? (
+            <Spinner size="md" data-testid="existing-secret-loading" />
+          ) : secretsError ? (
+            <HelperText>
+              <HelperTextItem variant="error" data-testid="existing-secret-error">
+                Failed to load secrets: {secretsError.message}
+              </HelperTextItem>
+            </HelperText>
+          ) : secrets.length === 0 ? (
+            <HelperText>
+              <HelperTextItem variant="indeterminate" data-testid="existing-secret-empty">
+                Your project may already have secrets, but they may be managed by Connections or
+                created by other workbenches. New secrets can be added by your platform team using
+                tools like External Secrets Operator, or you can create one using the Key / value
+                option above.
+              </HelperTextItem>
+            </HelperText>
+          ) : (
+            <Select
+              id="existing-secret-select-listbox"
+              isOpen={isOpen}
+              onOpenChange={(open) => setIsOpen(open)}
+              toggle={toggle}
+              onSelect={(_event, value) => {
+                const selected = secrets.find((s) => s.metadata.name === value);
+                if (selected) {
+                  handleSelect(selected);
+                }
+              }}
+              data-testid="existing-secret-select"
+            >
+              <SelectList>
+                {filteredSecrets.map((secret) => (
+                  <SelectOption
+                    key={secret.metadata.name}
+                    value={secret.metadata.name}
+                    hasCheckbox
+                    isSelected={selectedNames.has(secret.metadata.name)}
+                    data-testid={`existing-secret-option-${secret.metadata.name}`}
+                  >
+                    {secret.metadata.name}
+                  </SelectOption>
+                ))}
+                {filteredSecrets.length === 0 && (
+                  <SelectOption isDisabled>No secrets match the filter</SelectOption>
+                )}
+              </SelectList>
+            </Select>
+          )}
+        </FormGroup>
+      </StackItem>
+
+      {collisions.length > 0 && (
+        <StackItem>
+          <ExistingSecretCollisionAlert collisions={collisions} />
+        </StackItem>
+      )}
+
+      {existingSecretRefs.length > 0 && (
+        <StackItem>
+          <Stack hasGutter>
+            {existingSecretRefs.map((ref, index) => (
+              <StackItem key={ref.secretName}>
+                <ExistingSecretItem
+                  secretRef={ref}
+                  onUpdate={(updatedRef) => handleRefUpdate(index, updatedRef)}
+                  onRemove={() => handleRemove(ref.secretName)}
+                />
+              </StackItem>
+            ))}
+          </Stack>
+        </StackItem>
+      )}
+
+      <StackItem>
+        <HelperText>
+          <HelperTextItem data-testid="existing-secret-helper-text">
+            Environment variables are set at workbench start. If secret values change (e.g.,
+            credential rotation), restart the workbench to pick up new values.
+          </HelperTextItem>
+        </HelperText>
+      </StackItem>
+    </Stack>
+  );
+};
 
 export default EnvExistingSecret;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Alert } from '@patternfly/react-core';
+import type { ExistingSecretRef } from '#~/pages/projects/types';
+
+type EnvExistingSecretProps = {
+  existingSecretRefs: ExistingSecretRef[];
+  onUpdate: (refs: ExistingSecretRef[]) => void;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- stub; Task 4 will use onUpdate
+const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({ existingSecretRefs, onUpdate }) => (
+  <Alert
+    variant="info"
+    isInline
+    isPlain
+    title="Existing secret selection"
+    data-testid="existing-secret-section"
+  >
+    {existingSecretRefs.length === 0
+      ? 'Select secrets from the dropdown above.'
+      : `${existingSecretRefs.length} secret(s) selected.`}
+  </Alert>
+);
+
+export default EnvExistingSecret;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret.tsx
@@ -21,7 +21,7 @@ import {
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import type { SecretKind } from '@odh-dashboard/k8s-core';
-import { useProjectContext } from '#~/pages/projects/ProjectDetailsContext';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import type { ExistingSecretRef } from '#~/pages/projects/types';
 import type { EnvKeyCollision } from './existingSecretUtils';
 import { useExistingSecrets } from './useExistingSecrets';
@@ -39,7 +39,7 @@ const EnvExistingSecret: React.FC<EnvExistingSecretProps> = ({
   onUpdate,
   collisions = [],
 }) => {
-  const { currentProject } = useProjectContext();
+  const { currentProject } = React.useContext(ProjectDetailsContext);
   const namespace = currentProject.metadata.name;
   const [secrets, secretsLoaded, secretsError] = useExistingSecrets(namespace);
   const [isOpen, setIsOpen] = React.useState(false);

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -3,6 +3,7 @@ import { FormGroup, Radio, Stack, StackItem } from '@patternfly/react-core';
 import { EnvironmentVariableType, EnvVariable, SecretCategory } from '#~/pages/projects/types';
 import { useAccessReview } from '#~/api';
 import { SecretModel } from '#~/api/models';
+import type { EnvKeyCollision } from './existingSecretUtils';
 import GenericKeyValuePairField from './GenericKeyValuePairField';
 import { EMPTY_KEY_VALUE_PAIR } from './const';
 import EnvUploadField from './EnvUploadField';
@@ -11,11 +12,12 @@ import EnvExistingSecret from './EnvExistingSecret';
 type EnvSecretProps = {
   envVariable: EnvVariable;
   onUpdate: (envVariable: EnvVariable) => void;
+  envKeyCollisions?: EnvKeyCollision[];
 };
 
 const DEFAULT_VALUES: { category: SecretCategory | null; data: [] } = { category: null, data: [] };
 
-const EnvSecret: React.FC<EnvSecretProps> = ({ envVariable, onUpdate }) => {
+const EnvSecret: React.FC<EnvSecretProps> = ({ envVariable, onUpdate, envKeyCollisions }) => {
   const radioGroupName = React.useId();
   const env = envVariable.values ?? DEFAULT_VALUES;
   const { category } = env;
@@ -118,6 +120,7 @@ const EnvSecret: React.FC<EnvSecretProps> = ({ envVariable, onUpdate }) => {
                           existingSecretRefs: refs,
                         })
                       }
+                      collisions={envKeyCollisions}
                     />
                   ) : undefined
                 }

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -1,50 +1,133 @@
 import * as React from 'react';
-import { asEnumMember } from '@odh-dashboard/foundation';
-import { EnvironmentVariableType, EnvVariableData, SecretCategory } from '#~/pages/projects/types';
-import EnvDataTypeField from './EnvDataTypeField';
+import { FormGroup, Radio, Stack, StackItem } from '@patternfly/react-core';
+import { EnvironmentVariableType, EnvVariable, SecretCategory } from '#~/pages/projects/types';
+import { useAccessReview } from '#~/api';
+import { SecretModel } from '#~/api/models';
 import GenericKeyValuePairField from './GenericKeyValuePairField';
 import { EMPTY_KEY_VALUE_PAIR } from './const';
 import EnvUploadField from './EnvUploadField';
+import EnvExistingSecret from './EnvExistingSecret';
 
 type EnvSecretProps = {
-  env?: EnvVariableData;
-  onUpdate: (envVariableData: EnvVariableData) => void;
+  envVariable: EnvVariable;
+  onUpdate: (envVariable: EnvVariable) => void;
 };
 
-const DEFAULT_ENV: EnvVariableData = {
-  category: null,
-  data: [],
-};
+const DEFAULT_VALUES: { category: SecretCategory | null; data: [] } = { category: null, data: [] };
 
-const EnvSecret: React.FC<EnvSecretProps> = ({ env = DEFAULT_ENV, onUpdate }) => (
-  <EnvDataTypeField
-    selection={env.category || ''}
-    onSelection={(value) =>
-      onUpdate({ ...env, category: asEnumMember(value, SecretCategory), data: [] })
+const EnvSecret: React.FC<EnvSecretProps> = ({ envVariable, onUpdate }) => {
+  const radioGroupName = React.useId();
+  const env = envVariable.values ?? DEFAULT_VALUES;
+  const { category } = env;
+
+  const [canListSecrets, canListSecretsLoaded] = useAccessReview({
+    group: '',
+    resource: SecretModel.plural,
+    verb: 'list',
+  });
+
+  const isExistingDisabled = canListSecretsLoaded && !canListSecrets;
+
+  const handleCategoryChange = (newCategory: SecretCategory) => {
+    if (newCategory === SecretCategory.EXISTING) {
+      onUpdate({
+        ...envVariable,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: envVariable.existingSecretRefs ?? [],
+      });
+    } else {
+      onUpdate({
+        ...envVariable,
+        values: { ...env, category: newCategory, data: [] },
+      });
     }
-    options={{
-      [SecretCategory.GENERIC]: {
-        label: 'Key / value',
-        render: (
-          <GenericKeyValuePairField
-            values={env.data.length === 0 ? [EMPTY_KEY_VALUE_PAIR] : env.data}
-            onUpdate={(newEnvData) => onUpdate({ ...env, data: newEnvData })}
-            valueIsSecret
-          />
-        ),
-      },
-      [SecretCategory.UPLOAD]: {
-        label: 'Upload',
-        render: (
-          <EnvUploadField
-            envVarType={EnvironmentVariableType.SECRET}
-            onUpdate={(newEnvData) => onUpdate({ ...env, data: newEnvData })}
-            translateValue={(value) => atob(value)}
-          />
-        ),
-      },
-    }}
-  />
-);
+  };
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <FormGroup label="Data type" role="radiogroup">
+          <Stack hasGutter>
+            <StackItem>
+              <Radio
+                id={`${radioGroupName}-key-value`}
+                name={radioGroupName}
+                data-testid="secret-category-key-value"
+                label="Key / value"
+                description="Create a new key-value pair for this environment variable"
+                isChecked={category === SecretCategory.GENERIC}
+                onChange={() => handleCategoryChange(SecretCategory.GENERIC)}
+                body={
+                  category === SecretCategory.GENERIC ? (
+                    <GenericKeyValuePairField
+                      values={env.data.length === 0 ? [EMPTY_KEY_VALUE_PAIR] : env.data}
+                      onUpdate={(newEnvData) =>
+                        onUpdate({
+                          ...envVariable,
+                          values: { ...env, data: newEnvData },
+                        })
+                      }
+                      valueIsSecret
+                    />
+                  ) : undefined
+                }
+              />
+            </StackItem>
+            <StackItem>
+              <Radio
+                id={`${radioGroupName}-upload`}
+                name={radioGroupName}
+                data-testid="secret-category-upload"
+                label="Upload"
+                description="Upload environment variables from a file"
+                isChecked={category === SecretCategory.UPLOAD}
+                onChange={() => handleCategoryChange(SecretCategory.UPLOAD)}
+                body={
+                  category === SecretCategory.UPLOAD ? (
+                    <EnvUploadField
+                      envVarType={EnvironmentVariableType.SECRET}
+                      onUpdate={(newEnvData) =>
+                        onUpdate({
+                          ...envVariable,
+                          values: { ...env, data: newEnvData },
+                        })
+                      }
+                      translateValue={(value) => atob(value)}
+                    />
+                  ) : undefined
+                }
+              />
+            </StackItem>
+            <StackItem>
+              <Radio
+                id={`${radioGroupName}-existing`}
+                name={radioGroupName}
+                data-testid="secret-category-existing"
+                label="Existing secret"
+                description="Attach an available secret from this project"
+                isChecked={category === SecretCategory.EXISTING}
+                isDisabled={isExistingDisabled}
+                onChange={() => handleCategoryChange(SecretCategory.EXISTING)}
+                body={
+                  category === SecretCategory.EXISTING ? (
+                    <EnvExistingSecret
+                      existingSecretRefs={envVariable.existingSecretRefs ?? []}
+                      onUpdate={(refs) =>
+                        onUpdate({
+                          ...envVariable,
+                          existingSecretRefs: refs,
+                        })
+                      }
+                    />
+                  ) : undefined
+                }
+              />
+            </StackItem>
+          </Stack>
+        </FormGroup>
+      </StackItem>
+    </Stack>
+  );
+};
 
 export default EnvSecret;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvSecret.tsx
@@ -3,6 +3,7 @@ import { FormGroup, Radio, Stack, StackItem } from '@patternfly/react-core';
 import { EnvironmentVariableType, EnvVariable, SecretCategory } from '#~/pages/projects/types';
 import { useAccessReview } from '#~/api';
 import { SecretModel } from '#~/api/models';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import type { EnvKeyCollision } from './existingSecretUtils';
 import GenericKeyValuePairField from './GenericKeyValuePairField';
 import { EMPTY_KEY_VALUE_PAIR } from './const';
@@ -19,6 +20,8 @@ const DEFAULT_VALUES: { category: SecretCategory | null; data: [] } = { category
 
 const EnvSecret: React.FC<EnvSecretProps> = ({ envVariable, onUpdate, envKeyCollisions }) => {
   const radioGroupName = React.useId();
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const namespace = currentProject.metadata.name;
   const env = envVariable.values ?? DEFAULT_VALUES;
   const { category } = env;
 
@@ -26,6 +29,7 @@ const EnvSecret: React.FC<EnvSecretProps> = ({ envVariable, onUpdate, envKeyColl
     group: '',
     resource: SecretModel.plural,
     verb: 'list',
+    namespace,
   });
 
   const isExistingDisabled = canListSecretsLoaded && !canListSecrets;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -61,7 +61,7 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                 <IndentSection>
                   <EnvTypeSwitch
                     env={envVariable}
-                    onUpdate={(updatedEnv) => onUpdate(updatedEnv)}
+                    onUpdate={onUpdate}
                     envKeyCollisions={envKeyCollisions}
                   />
                 </IndentSection>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -58,7 +58,7 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                 <IndentSection>
                   <EnvTypeSwitch
                     env={envVariable}
-                    onUpdate={(envValue) => onUpdate({ ...envVariable, values: envValue })}
+                    onUpdate={(updatedEnv) => onUpdate(updatedEnv)}
                   />
                 </IndentSection>
               </StackItem>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSelectField.tsx
@@ -6,6 +6,7 @@ import SimpleSelect, { SimpleSelectOption } from '@odh-dashboard/ui-core/compone
 import { EnvironmentVariableType, EnvVariable } from '#~/pages/projects/types';
 import IndentSection from '#~/pages/projects/components/IndentSection';
 import { getDashboardMainContainer } from '#~/utilities/utils';
+import type { EnvKeyCollision } from './existingSecretUtils';
 import EnvTypeSwitch from './EnvTypeSwitch';
 
 const ENV_VAR_POPPER_PROPS = { appendTo: getDashboardMainContainer() };
@@ -14,12 +15,14 @@ type EnvTypeSelectFieldProps = {
   envVariable: EnvVariable;
   onUpdate: (envVariable: EnvVariable) => void;
   onRemove: () => void;
+  envKeyCollisions?: EnvKeyCollision[];
 };
 
 const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
   envVariable,
   onUpdate,
   onRemove,
+  envKeyCollisions,
 }) => {
   const selectId = React.useId().replace(/:/g, '');
 
@@ -59,6 +62,7 @@ const EnvTypeSelectField: React.FC<EnvTypeSelectFieldProps> = ({
                   <EnvTypeSwitch
                     env={envVariable}
                     onUpdate={(updatedEnv) => onUpdate(updatedEnv)}
+                    envKeyCollisions={envKeyCollisions}
                   />
                 </IndentSection>
               </StackItem>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
@@ -1,19 +1,24 @@
 import * as React from 'react';
-import { EnvironmentVariableType, EnvVariable, EnvVariableData } from '#~/pages/projects/types';
+import { EnvironmentVariableType, EnvVariable } from '#~/pages/projects/types';
 import EnvConfigMap from './EnvConfigMap';
 import EnvSecret from './EnvSecret';
 
 type EnvTypeSwitchProps = {
   env: EnvVariable;
-  onUpdate: (envVariableData: EnvVariableData) => void;
+  onUpdate: (envVariable: EnvVariable) => void;
 };
 
 const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate }) => {
   switch (env.type) {
     case EnvironmentVariableType.CONFIG_MAP:
-      return <EnvConfigMap env={env.values} onUpdate={onUpdate} />;
+      return (
+        <EnvConfigMap
+          env={env.values}
+          onUpdate={(envVariableData) => onUpdate({ ...env, values: envVariableData })}
+        />
+      );
     case EnvironmentVariableType.SECRET:
-      return <EnvSecret env={env.values} onUpdate={onUpdate} />;
+      return <EnvSecret envVariable={env} onUpdate={onUpdate} />;
     default:
       return null;
   }

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvTypeSwitch.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
 import { EnvironmentVariableType, EnvVariable } from '#~/pages/projects/types';
+import type { EnvKeyCollision } from './existingSecretUtils';
 import EnvConfigMap from './EnvConfigMap';
 import EnvSecret from './EnvSecret';
 
 type EnvTypeSwitchProps = {
   env: EnvVariable;
   onUpdate: (envVariable: EnvVariable) => void;
+  envKeyCollisions?: EnvKeyCollision[];
 };
 
-const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate }) => {
+const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate, envKeyCollisions }) => {
   switch (env.type) {
     case EnvironmentVariableType.CONFIG_MAP:
       return (
@@ -18,7 +20,9 @@ const EnvTypeSwitch: React.FC<EnvTypeSwitchProps> = ({ env, onUpdate }) => {
         />
       );
     case EnvironmentVariableType.SECRET:
-      return <EnvSecret envVariable={env} onUpdate={onUpdate} />;
+      return (
+        <EnvSecret envVariable={env} onUpdate={onUpdate} envKeyCollisions={envKeyCollisions} />
+      );
     default:
       return null;
   }

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvironmentVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/EnvironmentVariables.tsx
@@ -2,15 +2,19 @@ import * as React from 'react';
 import { Button, Divider } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { EnvVariable } from '#~/pages/projects/types';
+import type { EnvKeyCollision } from './existingSecretUtils';
 import EnvTypeSelectField from './EnvTypeSelectField';
 
 type EnvironmentVariablesProps = {
   envVariables: EnvVariable[];
   setEnvVariables: (envVars: EnvVariable[]) => void;
+  envKeyCollisions?: EnvKeyCollision[];
 };
+
 const EnvironmentVariables: React.FC<EnvironmentVariablesProps> = ({
   envVariables,
   setEnvVariables,
+  envKeyCollisions,
 }) => (
   <>
     {envVariables.map((envVariable, i) => (
@@ -27,6 +31,7 @@ const EnvironmentVariables: React.FC<EnvironmentVariablesProps> = ({
           onRemove={() =>
             setEnvVariables(envVariables.filter((v, filterIndex) => filterIndex !== i))
           }
+          envKeyCollisions={envKeyCollisions}
         />
         {i !== envVariables.length - 1 && <Divider />}
       </React.Fragment>

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretCollisionAlert.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretCollisionAlert.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Alert, List, ListItem } from '@patternfly/react-core';
+import type { EnvKeyCollision } from './existingSecretUtils';
+
+type ExistingSecretCollisionAlertProps = {
+  collisions: EnvKeyCollision[];
+};
+
+const ExistingSecretCollisionAlert: React.FC<ExistingSecretCollisionAlertProps> = ({
+  collisions,
+}) => {
+  if (collisions.length === 0) {
+    return null;
+  }
+
+  return (
+    <Alert
+      variant="warning"
+      isInline
+      title="Key name collisions across attached secrets"
+      data-testid="existing-secret-collision-alert"
+    >
+      <List>
+        {collisions.map((collision) => (
+          <ListItem key={collision.key}>
+            <strong>{collision.key}</strong> is defined in:{' '}
+            {collision.sources
+              .map((source) => `${source.name} (${source.type.replace('-', ' ')})`)
+              .join(', ')}
+          </ListItem>
+        ))}
+      </List>
+      Choose one and deselect the duplicate key to resolve the collision.
+    </Alert>
+  );
+};
+
+export default ExistingSecretCollisionAlert;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretCollisionAlert.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretCollisionAlert.tsx
@@ -25,7 +25,7 @@ const ExistingSecretCollisionAlert: React.FC<ExistingSecretCollisionAlertProps> 
           <ListItem key={collision.key}>
             <strong>{collision.key}</strong> is defined in:{' '}
             {collision.sources
-              .map((source) => `${source.name} (${source.type.replace('-', ' ')})`)
+              .map((source) => `${source.name} (${source.type.replaceAll('-', ' ')})`)
               .join(', ')}
           </ListItem>
         ))}

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretItem.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/ExistingSecretItem.tsx
@@ -1,0 +1,198 @@
+import * as React from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Checkbox,
+  ExpandableSection,
+  Flex,
+  FlexItem,
+  Icon,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
+import type { ExistingSecretRef } from '#~/pages/projects/types';
+
+type ExistingSecretItemProps = {
+  secretRef: ExistingSecretRef;
+  onUpdate: (ref: ExistingSecretRef) => void;
+  onRemove: () => void;
+};
+
+const ExistingSecretItem: React.FC<ExistingSecretItemProps> = ({
+  secretRef,
+  onUpdate,
+  onRemove,
+}) => {
+  const [isExpanded, setIsExpanded] = React.useState(!!secretRef.error || !!secretRef.missingKeys);
+  const { secretName, selectedKeys, availableKeys, allKeys, error, missingKeys } = secretRef;
+  const selectedCount = selectedKeys.length;
+  const totalCount = availableKeys.length;
+
+  const badgeContent = error ? '0 of 0 keys' : `${selectedCount} of ${totalCount} keys`;
+
+  const badgeIcon = error ? (
+    <Icon status="danger">
+      <ExclamationCircleIcon />
+    </Icon>
+  ) : missingKeys && missingKeys.length > 0 ? (
+    <Icon status="warning">
+      <ExclamationTriangleIcon />
+    </Icon>
+  ) : null;
+
+  const handleKeyToggle = (key: string, checked: boolean) => {
+    const newSelectedKeys = checked
+      ? [...selectedKeys, key]
+      : selectedKeys.filter((k) => k !== key);
+    onUpdate({
+      ...secretRef,
+      selectedKeys: newSelectedKeys,
+      allKeys:
+        newSelectedKeys.length === availableKeys.length &&
+        availableKeys.every((k) => newSelectedKeys.includes(k)),
+    });
+  };
+
+  const handleSelectAll = () => {
+    onUpdate({
+      ...secretRef,
+      selectedKeys: [...availableKeys],
+      allKeys: true,
+    });
+  };
+
+  const handleDeselectAll = () => {
+    onUpdate({
+      ...secretRef,
+      selectedKeys: [],
+      allKeys: false,
+    });
+  };
+
+  const handleRemoveMissingKeys = () => {
+    if (!missingKeys) {
+      return;
+    }
+    const cleanedKeys = selectedKeys.filter((k) => !missingKeys.includes(k));
+    onUpdate({
+      ...secretRef,
+      selectedKeys: cleanedKeys,
+      missingKeys: undefined,
+      allKeys:
+        cleanedKeys.length === availableKeys.length &&
+        availableKeys.every((k) => cleanedKeys.includes(k)),
+    });
+  };
+
+  const toggleContent = (
+    <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+      <FlexItem>{secretName}</FlexItem>
+      <FlexItem>
+        <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
+          {badgeIcon}
+          <FlexItem>
+            <Badge isRead>{badgeContent}</Badge>
+          </FlexItem>
+        </Flex>
+      </FlexItem>
+    </Flex>
+  );
+
+  return (
+    <div data-testid={`existing-secret-item-${secretName}`}>
+      <ExpandableSection
+        toggleContent={toggleContent}
+        isExpanded={isExpanded}
+        onToggle={(_event, expanded) => setIsExpanded(expanded)}
+        data-testid={`existing-secret-expand-${secretName}`}
+      >
+        <Stack hasGutter>
+          {error === 'not-found' && (
+            <StackItem>
+              <Alert
+                variant="danger"
+                isInline
+                isPlain
+                title="This secret was not found. This workbench cannot start until the missing secret is restored or removed."
+                data-testid={`secret-not-found-alert-${secretName}`}
+                actionLinks={
+                  <Button
+                    variant="link"
+                    isInline
+                    data-testid={`remove-missing-secret-${secretName}`}
+                    onClick={onRemove}
+                  >
+                    Remove this reference
+                  </Button>
+                }
+              />
+            </StackItem>
+          )}
+          {missingKeys && missingKeys.length > 0 && (
+            <StackItem>
+              <Alert
+                variant="warning"
+                isInline
+                isPlain
+                title={`${
+                  missingKeys.length
+                } previously selected key(s) not found in this secret: ${missingKeys.join(', ')}`}
+                data-testid={`secret-missing-keys-alert-${secretName}`}
+                actionLinks={
+                  <Button
+                    variant="link"
+                    isInline
+                    data-testid={`remove-missing-keys-${secretName}`}
+                    onClick={handleRemoveMissingKeys}
+                  >
+                    Remove missing keys
+                  </Button>
+                }
+              />
+            </StackItem>
+          )}
+          {!error && (
+            <StackItem>
+              <Flex spaceItems={{ default: 'spaceItemsMd' }}>
+                <FlexItem>
+                  <Button
+                    variant="link"
+                    isInline
+                    data-testid={`select-all-keys-${secretName}`}
+                    onClick={allKeys ? handleDeselectAll : handleSelectAll}
+                  >
+                    {allKeys ? 'Deselect all' : 'Select all'}
+                  </Button>
+                </FlexItem>
+                <FlexItem>
+                  {selectedCount} of {totalCount} keys selected
+                </FlexItem>
+              </Flex>
+            </StackItem>
+          )}
+          {!error && (
+            <StackItem>
+              <Stack>
+                {availableKeys.map((key) => (
+                  <StackItem key={key}>
+                    <Checkbox
+                      id={`${secretName}-key-${key}`}
+                      data-testid={`secret-key-checkbox-${secretName}-${key}`}
+                      label={key}
+                      isChecked={selectedKeys.includes(key)}
+                      onChange={(_event, checked) => handleKeyToggle(key, checked)}
+                    />
+                  </StackItem>
+                ))}
+              </Stack>
+            </StackItem>
+          )}
+        </Stack>
+      </ExpandableSection>
+    </div>
+  );
+};
+
+export default ExistingSecretItem;

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { mockCustomSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
 import {
@@ -102,5 +102,36 @@ describe('EnvExistingSecret', () => {
       <EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} collisions={collisions} />,
     );
     expect(screen.getByTestId('existing-secret-collision-alert')).toBeInTheDocument();
+  });
+
+  it('should call onUpdate with new ref when a secret is selected', async () => {
+    const secret = mockCustomSecretK8sResource({
+      name: 'db-secret',
+      namespace: 'test-ns',
+      data: { DB_HOST: 'aG9zdA==', DB_PORT: 'NTQzMg==' },
+      type: 'Opaque',
+      labels: {},
+      annotations: {},
+    });
+    useExistingSecrets.mockReturnValue([[secret], true, undefined, jest.fn()]);
+    const onUpdate = jest.fn();
+    renderWithContext(<EnvExistingSecret existingSecretRefs={[]} onUpdate={onUpdate} />);
+
+    // Open the dropdown by clicking the typeahead input
+    const input = screen.getByTestId('existing-secret-typeahead-input');
+    fireEvent.click(input);
+
+    // Select the secret option -- click the checkbox inside the PF6 SelectOption
+    const option = await screen.findByTestId('existing-secret-option-db-secret');
+    const checkbox = within(option).getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const updatedRefs = onUpdate.mock.calls[0][0] as ExistingSecretRef[];
+    expect(updatedRefs).toHaveLength(1);
+    expect(updatedRefs[0].secretName).toBe('db-secret');
+    expect(updatedRefs[0].allKeys).toBe(true);
+    expect(updatedRefs[0].selectedKeys).toEqual(expect.arrayContaining(['DB_HOST', 'DB_PORT']));
+    expect(updatedRefs[0].selectedKeys).toHaveLength(2);
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
@@ -13,9 +13,9 @@ jest.mock('../useExistingSecrets', () => ({
   useExistingSecrets: jest.fn(),
 }));
 
-const { useExistingSecrets } = jest.requireMock('../useExistingSecrets') as {
-  useExistingSecrets: jest.Mock;
-};
+const { useExistingSecrets } = jest.mocked(
+  jest.requireMock<typeof import('../useExistingSecrets')>('../useExistingSecrets'),
+);
 
 const mockContextValue = {
   currentProject: { metadata: { name: 'test-ns' } },

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { mockCustomSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
+import EnvExistingSecret from '#~/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret';
+import type { ExistingSecretRef } from '#~/pages/projects/types';
+
+jest.mock('#~/pages/projects/ProjectDetailsContext', () => ({
+  useProjectContext: jest.fn(() => ({
+    currentProject: { metadata: { name: 'test-ns' } },
+  })),
+}));
+
+jest.mock('../useExistingSecrets', () => ({
+  useExistingSecrets: jest.fn(),
+}));
+
+const { useExistingSecrets } = jest.requireMock('../useExistingSecrets') as {
+  useExistingSecrets: jest.Mock;
+};
+
+describe('EnvExistingSecret', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show loading spinner while secrets are loading', () => {
+    useExistingSecrets.mockReturnValue([[], false, undefined, jest.fn()]);
+    render(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
+    expect(screen.getByTestId('existing-secret-loading')).toBeInTheDocument();
+  });
+
+  it('should show error when secrets fail to load', () => {
+    useExistingSecrets.mockReturnValue([[], true, new Error('Forbidden'), jest.fn()]);
+    render(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
+    expect(screen.getByTestId('existing-secret-error')).toBeInTheDocument();
+    expect(screen.getByText(/Forbidden/)).toBeInTheDocument();
+  });
+
+  it('should show empty message when no eligible secrets exist', () => {
+    useExistingSecrets.mockReturnValue([[], true, undefined, jest.fn()]);
+    render(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
+    expect(screen.getByTestId('existing-secret-empty')).toBeInTheDocument();
+  });
+
+  it('should render dropdown when secrets are available', () => {
+    const secret = mockCustomSecretK8sResource({
+      name: 'test-secret',
+      namespace: 'test-ns',
+      data: { KEY: 'dmFsdWU=' },
+      type: 'Opaque',
+      labels: {},
+      annotations: {},
+    });
+    useExistingSecrets.mockReturnValue([[secret], true, undefined, jest.fn()]);
+    render(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
+    expect(screen.getByTestId('existing-secret-select-toggle')).toBeInTheDocument();
+  });
+
+  it('should render selected secret items', () => {
+    const secret = mockCustomSecretK8sResource({
+      name: 'my-secret',
+      namespace: 'test-ns',
+      data: { KEY_A: 'dmFsdWU=', KEY_B: 'dmFsdWU=' },
+      type: 'Opaque',
+      labels: {},
+      annotations: {},
+    });
+    useExistingSecrets.mockReturnValue([[secret], true, undefined, jest.fn()]);
+
+    const refs: ExistingSecretRef[] = [
+      {
+        secretName: 'my-secret',
+        allKeys: true,
+        selectedKeys: ['KEY_A', 'KEY_B'],
+        availableKeys: ['KEY_A', 'KEY_B'],
+      },
+    ];
+    render(<EnvExistingSecret existingSecretRefs={refs} onUpdate={jest.fn()} />);
+    expect(screen.getByTestId('existing-secret-item-my-secret')).toBeInTheDocument();
+  });
+
+  it('should render collision alert when collisions exist', () => {
+    useExistingSecrets.mockReturnValue([[], true, undefined, jest.fn()]);
+    const collisions = [
+      {
+        key: 'SHARED_KEY',
+        sources: [
+          { type: 'existing-secret' as const, name: 'secret-a' },
+          { type: 'existing-secret' as const, name: 'secret-b' },
+        ],
+      },
+    ];
+    render(
+      <EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} collisions={collisions} />,
+    );
+    expect(screen.getByTestId('existing-secret-collision-alert')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvExistingSecret.spec.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { mockCustomSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
+import {
+  ProjectDetailsContext,
+  ProjectDetailsContextType,
+} from '#~/pages/projects/ProjectDetailsContext';
 import EnvExistingSecret from '#~/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret';
 import type { ExistingSecretRef } from '#~/pages/projects/types';
-
-jest.mock('#~/pages/projects/ProjectDetailsContext', () => ({
-  useProjectContext: jest.fn(() => ({
-    currentProject: { metadata: { name: 'test-ns' } },
-  })),
-}));
 
 jest.mock('../useExistingSecrets', () => ({
   useExistingSecrets: jest.fn(),
@@ -19,6 +17,15 @@ const { useExistingSecrets } = jest.requireMock('../useExistingSecrets') as {
   useExistingSecrets: jest.Mock;
 };
 
+const mockContextValue = {
+  currentProject: { metadata: { name: 'test-ns' } },
+} as unknown as ProjectDetailsContextType;
+
+const renderWithContext = (ui: React.ReactElement) =>
+  render(
+    <ProjectDetailsContext.Provider value={mockContextValue}>{ui}</ProjectDetailsContext.Provider>,
+  );
+
 describe('EnvExistingSecret', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -26,20 +33,20 @@ describe('EnvExistingSecret', () => {
 
   it('should show loading spinner while secrets are loading', () => {
     useExistingSecrets.mockReturnValue([[], false, undefined, jest.fn()]);
-    render(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
+    renderWithContext(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
     expect(screen.getByTestId('existing-secret-loading')).toBeInTheDocument();
   });
 
   it('should show error when secrets fail to load', () => {
     useExistingSecrets.mockReturnValue([[], true, new Error('Forbidden'), jest.fn()]);
-    render(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
+    renderWithContext(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
     expect(screen.getByTestId('existing-secret-error')).toBeInTheDocument();
     expect(screen.getByText(/Forbidden/)).toBeInTheDocument();
   });
 
   it('should show empty message when no eligible secrets exist', () => {
     useExistingSecrets.mockReturnValue([[], true, undefined, jest.fn()]);
-    render(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
+    renderWithContext(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
     expect(screen.getByTestId('existing-secret-empty')).toBeInTheDocument();
   });
 
@@ -53,7 +60,7 @@ describe('EnvExistingSecret', () => {
       annotations: {},
     });
     useExistingSecrets.mockReturnValue([[secret], true, undefined, jest.fn()]);
-    render(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
+    renderWithContext(<EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} />);
     expect(screen.getByTestId('existing-secret-select-toggle')).toBeInTheDocument();
   });
 
@@ -76,7 +83,7 @@ describe('EnvExistingSecret', () => {
         availableKeys: ['KEY_A', 'KEY_B'],
       },
     ];
-    render(<EnvExistingSecret existingSecretRefs={refs} onUpdate={jest.fn()} />);
+    renderWithContext(<EnvExistingSecret existingSecretRefs={refs} onUpdate={jest.fn()} />);
     expect(screen.getByTestId('existing-secret-item-my-secret')).toBeInTheDocument();
   });
 
@@ -91,7 +98,7 @@ describe('EnvExistingSecret', () => {
         ],
       },
     ];
-    render(
+    renderWithContext(
       <EnvExistingSecret existingSecretRefs={[]} onUpdate={jest.fn()} collisions={collisions} />,
     );
     expect(screen.getByTestId('existing-secret-collision-alert')).toBeInTheDocument();

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvSecret.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/EnvSecret.spec.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useAccessReview } from '#~/api';
+import {
+  ProjectDetailsContext,
+  ProjectDetailsContextType,
+} from '#~/pages/projects/ProjectDetailsContext';
+import { EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+import type { EnvVariable } from '#~/pages/projects/types';
+import EnvSecret from '#~/pages/projects/screens/spawner/environmentVariables/EnvSecret';
+
+jest.mock('#~/api/useAccessReview', () => ({
+  useAccessReview: jest.fn(),
+}));
+
+jest.mock('#~/pages/projects/screens/spawner/environmentVariables/EnvExistingSecret', () => {
+  const MockEnvExistingSecret: React.FC = () => (
+    <div data-testid="env-existing-secret-mock">EnvExistingSecret</div>
+  );
+  MockEnvExistingSecret.displayName = 'MockEnvExistingSecret';
+  return { __esModule: true, default: MockEnvExistingSecret };
+});
+
+const mockUseAccessReview = jest.mocked(useAccessReview);
+
+const mockContextValue = {
+  currentProject: { metadata: { name: 'test-ns' } },
+} as unknown as ProjectDetailsContextType;
+
+const renderWithContext = (ui: React.ReactElement) =>
+  render(
+    <ProjectDetailsContext.Provider value={mockContextValue}>{ui}</ProjectDetailsContext.Provider>,
+  );
+
+describe('EnvSecret', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAccessReview.mockReturnValue([true, true]);
+  });
+
+  it('should render three radio buttons for Key/value, Upload, and Existing secret', () => {
+    const envVariable: EnvVariable = {
+      type: EnvironmentVariableType.SECRET,
+      values: { category: SecretCategory.GENERIC, data: [] },
+    };
+    renderWithContext(<EnvSecret envVariable={envVariable} onUpdate={jest.fn()} />);
+    expect(screen.getByTestId('secret-category-key-value')).toBeInTheDocument();
+    expect(screen.getByTestId('secret-category-upload')).toBeInTheDocument();
+    expect(screen.getByTestId('secret-category-existing')).toBeInTheDocument();
+  });
+
+  it('should call onUpdate with EXISTING category when Existing secret radio is clicked', () => {
+    const onUpdate = jest.fn();
+    const envVariable: EnvVariable = {
+      type: EnvironmentVariableType.SECRET,
+      values: { category: SecretCategory.GENERIC, data: [] },
+    };
+    renderWithContext(<EnvSecret envVariable={envVariable} onUpdate={onUpdate} />);
+    fireEvent.click(screen.getByTestId('secret-category-existing'));
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const updatedEnv = onUpdate.mock.calls[0][0] as EnvVariable;
+    expect(updatedEnv.values?.category).toBe(SecretCategory.EXISTING);
+  });
+
+  it('should disable existing secret radio when RBAC check denies access', () => {
+    mockUseAccessReview.mockReturnValue([false, true]);
+    const envVariable: EnvVariable = {
+      type: EnvironmentVariableType.SECRET,
+      values: { category: SecretCategory.GENERIC, data: [] },
+    };
+    renderWithContext(<EnvSecret envVariable={envVariable} onUpdate={jest.fn()} />);
+    const existingRadio = screen.getByTestId('secret-category-existing');
+    expect(existingRadio).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretItem.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretItem.spec.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ExistingSecretItem from '#~/pages/projects/screens/spawner/environmentVariables/ExistingSecretItem';
+import type { ExistingSecretRef } from '#~/pages/projects/types';
+
+describe('ExistingSecretItem', () => {
+  const defaultRef: ExistingSecretRef = {
+    secretName: 'my-secret',
+    allKeys: true,
+    selectedKeys: ['KEY_A', 'KEY_B'],
+    availableKeys: ['KEY_A', 'KEY_B'],
+  };
+
+  it('should render secret name and key count', () => {
+    const onUpdate = jest.fn();
+    const onRemove = jest.fn();
+    render(<ExistingSecretItem secretRef={defaultRef} onUpdate={onUpdate} onRemove={onRemove} />);
+    expect(screen.getByTestId('existing-secret-item-my-secret')).toBeInTheDocument();
+    expect(screen.getByText('my-secret')).toBeInTheDocument();
+    expect(screen.getByText('2 of 2 keys')).toBeInTheDocument();
+  });
+
+  it('should show danger alert for deleted secret', () => {
+    const deletedRef: ExistingSecretRef = {
+      secretName: 'gone-secret',
+      allKeys: false,
+      selectedKeys: ['KEY'],
+      availableKeys: [],
+      error: 'not-found',
+    };
+    render(<ExistingSecretItem secretRef={deletedRef} onUpdate={jest.fn()} onRemove={jest.fn()} />);
+    expect(screen.getByTestId('existing-secret-item-gone-secret')).toBeInTheDocument();
+    expect(screen.getByText(/not found/i)).toBeInTheDocument();
+  });
+
+  it('should show warning for missing keys', () => {
+    const missingRef: ExistingSecretRef = {
+      secretName: 'changed-secret',
+      allKeys: false,
+      selectedKeys: ['STILL_HERE', 'GONE_KEY'],
+      availableKeys: ['STILL_HERE', 'NEW_KEY'],
+      missingKeys: ['GONE_KEY'],
+    };
+    render(<ExistingSecretItem secretRef={missingRef} onUpdate={jest.fn()} onRemove={jest.fn()} />);
+    expect(screen.getByText(/previously selected key/i)).toBeInTheDocument();
+  });
+
+  it('should call onRemove when remove link is clicked for deleted secret', () => {
+    const onRemove = jest.fn();
+    const deletedRef: ExistingSecretRef = {
+      secretName: 'gone-secret',
+      allKeys: false,
+      selectedKeys: [],
+      availableKeys: [],
+      error: 'not-found',
+    };
+    render(<ExistingSecretItem secretRef={deletedRef} onUpdate={jest.fn()} onRemove={onRemove} />);
+    const removeLink = screen.getByTestId('remove-missing-secret-gone-secret');
+    fireEvent.click(removeLink);
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretItem.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretItem.spec.tsx
@@ -86,4 +86,50 @@ describe('ExistingSecretItem', () => {
     expect(updatedRef.selectedKeys).toEqual(['KEY_A', 'KEY_C']);
     expect(updatedRef.allKeys).toBe(false);
   });
+
+  it('should call onUpdate with all keys selected when Select all is clicked', () => {
+    const onUpdate = jest.fn();
+    const ref: ExistingSecretRef = {
+      secretName: 'partial-secret',
+      allKeys: false,
+      selectedKeys: ['KEY_A'],
+      availableKeys: ['KEY_A', 'KEY_B', 'KEY_C'],
+    };
+    render(<ExistingSecretItem secretRef={ref} onUpdate={onUpdate} onRemove={jest.fn()} />);
+
+    // Expand the section
+    const expandButton = screen.getByTestId('existing-secret-expand-partial-secret');
+    fireEvent.click(expandButton);
+
+    // Click "Select all"
+    const selectAllButton = screen.getByTestId('select-all-keys-partial-secret');
+    fireEvent.click(selectAllButton);
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const updatedRef = onUpdate.mock.calls[0][0] as ExistingSecretRef;
+    expect(updatedRef.allKeys).toBe(true);
+    expect(updatedRef.selectedKeys).toEqual(['KEY_A', 'KEY_B', 'KEY_C']);
+  });
+
+  it('should call onUpdate with missing keys removed when Remove missing keys is clicked', () => {
+    const onUpdate = jest.fn();
+    const ref: ExistingSecretRef = {
+      secretName: 'stale-secret',
+      allKeys: false,
+      selectedKeys: ['STILL_HERE', 'OLD_KEY'],
+      availableKeys: ['STILL_HERE', 'NEW_KEY'],
+      missingKeys: ['OLD_KEY'],
+    };
+    render(<ExistingSecretItem secretRef={ref} onUpdate={onUpdate} onRemove={jest.fn()} />);
+
+    // Click "Remove missing keys"
+    const removeMissingButton = screen.getByTestId('remove-missing-keys-stale-secret');
+    fireEvent.click(removeMissingButton);
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const updatedRef = onUpdate.mock.calls[0][0] as ExistingSecretRef;
+    expect(updatedRef.missingKeys).toBeUndefined();
+    expect(updatedRef.selectedKeys).not.toContain('OLD_KEY');
+    expect(updatedRef.selectedKeys).toContain('STILL_HERE');
+  });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretItem.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/ExistingSecretItem.spec.tsx
@@ -4,18 +4,20 @@ import '@testing-library/jest-dom';
 import ExistingSecretItem from '#~/pages/projects/screens/spawner/environmentVariables/ExistingSecretItem';
 import type { ExistingSecretRef } from '#~/pages/projects/types';
 
-describe('ExistingSecretItem', () => {
-  const defaultRef: ExistingSecretRef = {
-    secretName: 'my-secret',
-    allKeys: true,
-    selectedKeys: ['KEY_A', 'KEY_B'],
-    availableKeys: ['KEY_A', 'KEY_B'],
-  };
+const createDefaultRef = (): ExistingSecretRef => ({
+  secretName: 'my-secret',
+  allKeys: true,
+  selectedKeys: ['KEY_A', 'KEY_B'],
+  availableKeys: ['KEY_A', 'KEY_B'],
+});
 
+describe('ExistingSecretItem', () => {
   it('should render secret name and key count', () => {
     const onUpdate = jest.fn();
     const onRemove = jest.fn();
-    render(<ExistingSecretItem secretRef={defaultRef} onUpdate={onUpdate} onRemove={onRemove} />);
+    render(
+      <ExistingSecretItem secretRef={createDefaultRef()} onUpdate={onUpdate} onRemove={onRemove} />,
+    );
     expect(screen.getByTestId('existing-secret-item-my-secret')).toBeInTheDocument();
     expect(screen.getByText('my-secret')).toBeInTheDocument();
     expect(screen.getByText('2 of 2 keys')).toBeInTheDocument();
@@ -59,5 +61,29 @@ describe('ExistingSecretItem', () => {
     const removeLink = screen.getByTestId('remove-missing-secret-gone-secret');
     fireEvent.click(removeLink);
     expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onUpdate with correct ref when a key checkbox is toggled off', () => {
+    const onUpdate = jest.fn();
+    const ref: ExistingSecretRef = {
+      secretName: 'toggle-secret',
+      allKeys: true,
+      selectedKeys: ['KEY_A', 'KEY_B', 'KEY_C'],
+      availableKeys: ['KEY_A', 'KEY_B', 'KEY_C'],
+    };
+    render(<ExistingSecretItem secretRef={ref} onUpdate={onUpdate} onRemove={jest.fn()} />);
+
+    // Expand the section
+    const expandButton = screen.getByTestId('existing-secret-expand-toggle-secret');
+    fireEvent.click(expandButton);
+
+    // Deselect KEY_B
+    const keyBCheckbox = screen.getByTestId('secret-key-checkbox-toggle-secret-KEY_B');
+    fireEvent.click(keyBCheckbox);
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const updatedRef = onUpdate.mock.calls[0][0] as ExistingSecretRef;
+    expect(updatedRef.selectedKeys).toEqual(['KEY_A', 'KEY_C']);
+    expect(updatedRef.allKeys).toBe(false);
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretUtils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretUtils.spec.ts
@@ -1,67 +1,66 @@
 import { mockCustomSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
 import type { Connection } from '#~/concepts/connectionTypes/types';
 import { SecretCategory, EnvironmentVariableType } from '#~/pages/projects/types';
-import type { ExistingSecretRef, EnvVariable, StartNotebookData } from '#~/pages/projects/types';
+import type { ExistingSecretRef, EnvVariable } from '#~/pages/projects/types';
 import {
   filterExistingSecrets,
   getExistingSecretEnvVars,
   detectEnvKeyCollisions,
 } from '#~/pages/projects/screens/spawner/environmentVariables/existingSecretUtils';
 
-describe('Type system for existing secrets', () => {
-  it('should include EXISTING in SecretCategory', () => {
+describe('SecretCategory.EXISTING enum value', () => {
+  it('should have the expected string value', () => {
     expect(SecretCategory.EXISTING).toBe('secret existing');
   });
 
-  it('should allow ExistingSecretRef type to be used in EnvVariable', () => {
-    const ref: ExistingSecretRef = {
-      secretName: 'my-secret',
-      allKeys: true,
-      selectedKeys: ['KEY_A', 'KEY_B'],
-      availableKeys: ['KEY_A', 'KEY_B'],
-    };
-    const envVar: EnvVariable = {
-      type: EnvironmentVariableType.SECRET,
-      values: { category: SecretCategory.EXISTING, data: [] },
-      existingSecretRefs: [ref],
-    };
-    expect(envVar.existingSecretRefs).toHaveLength(1);
-    expect(envVar.existingSecretRefs?.[0].secretName).toBe('my-secret');
-  });
-
-  it('should support error and missingKeys fields on ExistingSecretRef', () => {
-    const ref: ExistingSecretRef = {
-      secretName: 'deleted-secret',
-      allKeys: false,
-      selectedKeys: ['GONE_KEY'],
-      availableKeys: [],
-      error: 'not-found',
-      missingKeys: ['GONE_KEY'],
-    };
-    expect(ref.error).toBe('not-found');
-    expect(ref.missingKeys).toEqual(['GONE_KEY']);
-  });
-
-  it('should support existingSecretEnvVars in StartNotebookData', () => {
-    const data: Pick<StartNotebookData, 'existingSecretEnvVars'> = {
-      existingSecretEnvVars: [
-        {
-          name: 'MY_VAR',
-          valueFrom: {
-            secretKeyRef: {
-              name: 'my-secret',
-              key: 'KEY_A',
-            },
+  it('should produce correct env vars when used with getExistingSecretEnvVars', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [
+          {
+            secretName: 'my-secret',
+            allKeys: true,
+            selectedKeys: ['KEY_A', 'KEY_B'],
+            availableKeys: ['KEY_A', 'KEY_B'],
           },
-        },
-      ],
-    };
-    expect(data.existingSecretEnvVars).toHaveLength(1);
-    expect(data.existingSecretEnvVars?.[0].valueFrom.secretKeyRef.name).toBe('my-secret');
+        ],
+      },
+    ];
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toHaveLength(2);
+    expect(result[0].valueFrom.secretKeyRef.name).toBe('my-secret');
+    expect(result[1].valueFrom.secretKeyRef.key).toBe('KEY_B');
+  });
+
+  it('should skip error refs when used with getExistingSecretEnvVars', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [
+          {
+            secretName: 'deleted-secret',
+            allKeys: false,
+            selectedKeys: ['GONE_KEY'],
+            availableKeys: [],
+            error: 'not-found',
+            missingKeys: ['GONE_KEY'],
+          },
+        ],
+      },
+    ];
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
   });
 });
 
 describe('filterExistingSecrets', () => {
+  it('should return empty array for empty input', () => {
+    expect(filterExistingSecrets([])).toEqual([]);
+  });
+
   it('should include Opaque secrets without Connection annotations', () => {
     const secret = mockCustomSecretK8sResource({
       name: 'plain-secret',
@@ -225,6 +224,25 @@ describe('getExistingSecretEnvVars', () => {
       {
         type: EnvironmentVariableType.SECRET,
         values: { category: SecretCategory.GENERIC, data: [{ key: 'FOO', value: 'bar' }] },
+      },
+    ];
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+
+  it('should produce no env entries for ref with empty selectedKeys', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [
+          {
+            secretName: 'empty-selection',
+            allKeys: false,
+            selectedKeys: [],
+            availableKeys: ['KEY_A', 'KEY_B'],
+          },
+        ],
       },
     ];
     const result = getExistingSecretEnvVars(envVariables);

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretUtils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretUtils.spec.ts
@@ -1,0 +1,55 @@
+import { SecretCategory, EnvironmentVariableType } from '#~/pages/projects/types';
+import type { ExistingSecretRef, EnvVariable, StartNotebookData } from '#~/pages/projects/types';
+
+describe('Type system for existing secrets', () => {
+  it('should include EXISTING in SecretCategory', () => {
+    expect(SecretCategory.EXISTING).toBe('secret existing');
+  });
+
+  it('should allow ExistingSecretRef type to be used in EnvVariable', () => {
+    const ref: ExistingSecretRef = {
+      secretName: 'my-secret',
+      allKeys: true,
+      selectedKeys: ['KEY_A', 'KEY_B'],
+      availableKeys: ['KEY_A', 'KEY_B'],
+    };
+    const envVar: EnvVariable = {
+      type: EnvironmentVariableType.SECRET,
+      values: { category: SecretCategory.EXISTING, data: [] },
+      existingSecretRefs: [ref],
+    };
+    expect(envVar.existingSecretRefs).toHaveLength(1);
+    expect(envVar.existingSecretRefs?.[0].secretName).toBe('my-secret');
+  });
+
+  it('should support error and missingKeys fields on ExistingSecretRef', () => {
+    const ref: ExistingSecretRef = {
+      secretName: 'deleted-secret',
+      allKeys: false,
+      selectedKeys: ['GONE_KEY'],
+      availableKeys: [],
+      error: 'not-found',
+      missingKeys: ['GONE_KEY'],
+    };
+    expect(ref.error).toBe('not-found');
+    expect(ref.missingKeys).toEqual(['GONE_KEY']);
+  });
+
+  it('should support existingSecretEnvVars in StartNotebookData', () => {
+    const data: Pick<StartNotebookData, 'existingSecretEnvVars'> = {
+      existingSecretEnvVars: [
+        {
+          name: 'MY_VAR',
+          valueFrom: {
+            secretKeyRef: {
+              name: 'my-secret',
+              key: 'KEY_A',
+            },
+          },
+        },
+      ],
+    };
+    expect(data.existingSecretEnvVars).toHaveLength(1);
+    expect(data.existingSecretEnvVars?.[0].valueFrom.secretKeyRef.name).toBe('my-secret');
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretUtils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/existingSecretUtils.spec.ts
@@ -1,5 +1,12 @@
+import { mockCustomSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
+import type { Connection } from '#~/concepts/connectionTypes/types';
 import { SecretCategory, EnvironmentVariableType } from '#~/pages/projects/types';
 import type { ExistingSecretRef, EnvVariable, StartNotebookData } from '#~/pages/projects/types';
+import {
+  filterExistingSecrets,
+  getExistingSecretEnvVars,
+  detectEnvKeyCollisions,
+} from '#~/pages/projects/screens/spawner/environmentVariables/existingSecretUtils';
 
 describe('Type system for existing secrets', () => {
   it('should include EXISTING in SecretCategory', () => {
@@ -51,5 +58,291 @@ describe('Type system for existing secrets', () => {
     };
     expect(data.existingSecretEnvVars).toHaveLength(1);
     expect(data.existingSecretEnvVars?.[0].valueFrom.secretKeyRef.name).toBe('my-secret');
+  });
+});
+
+describe('filterExistingSecrets', () => {
+  it('should include Opaque secrets without Connection annotations', () => {
+    const secret = mockCustomSecretK8sResource({
+      name: 'plain-secret',
+      namespace: 'test-ns',
+      data: { KEY_A: 'dmFsdWU=' },
+      type: 'Opaque',
+      labels: {},
+      annotations: {},
+    });
+    const result = filterExistingSecrets([secret]);
+    expect(result).toHaveLength(1);
+    expect(result[0].metadata.name).toBe('plain-secret');
+  });
+
+  it('should exclude non-Opaque secrets', () => {
+    const secret = mockCustomSecretK8sResource({
+      name: 'sa-token',
+      namespace: 'test-ns',
+      data: { token: 'dmFsdWU=' },
+      type: 'kubernetes.io/service-account-token',
+      labels: {},
+      annotations: {},
+    });
+    const result = filterExistingSecrets([secret]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should exclude Connection secrets with connection-type annotation', () => {
+    const secret = mockCustomSecretK8sResource({
+      name: 'conn-secret',
+      namespace: 'test-ns',
+      data: { KEY: 'dmFsdWU=' },
+      type: 'Opaque',
+      labels: { 'opendatahub.io/dashboard': 'true' },
+      annotations: {
+        'opendatahub.io/connection-type': 's3',
+      },
+    });
+    const result = filterExistingSecrets([secret]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should exclude secrets with connection-type-protocol annotation', () => {
+    const secret = mockCustomSecretK8sResource({
+      name: 'protocol-secret',
+      namespace: 'test-ns',
+      data: { KEY: 'dmFsdWU=' },
+      type: 'Opaque',
+      labels: {},
+      annotations: {
+        'opendatahub.io/connection-type-protocol': 'grpc',
+      },
+    });
+    const result = filterExistingSecrets([secret]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should exclude secrets with connection-type-ref annotation and dashboard label', () => {
+    const secret = mockCustomSecretK8sResource({
+      name: 'ref-secret',
+      namespace: 'test-ns',
+      data: { KEY: 'dmFsdWU=' },
+      type: 'Opaque',
+      labels: { 'opendatahub.io/dashboard': 'true' },
+      annotations: {
+        'opendatahub.io/connection-type-ref': 'some-type',
+      },
+    });
+    const result = filterExistingSecrets([secret]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should include dashboard-labeled Opaque secrets that are not Connections', () => {
+    const secret = mockCustomSecretK8sResource({
+      name: 'dashboard-secret',
+      namespace: 'test-ns',
+      data: { MY_KEY: 'dmFsdWU=' },
+      type: 'Opaque',
+      labels: { 'opendatahub.io/dashboard': 'true' },
+      annotations: {},
+    });
+    const result = filterExistingSecrets([secret]);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('getExistingSecretEnvVars', () => {
+  it('should convert refs with selected keys to secretKeyRef entries', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [
+          {
+            secretName: 'my-secret',
+            allKeys: false,
+            selectedKeys: ['DB_HOST', 'DB_PORT'],
+            availableKeys: ['DB_HOST', 'DB_PORT', 'DB_NAME'],
+          },
+        ],
+      },
+    ];
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([
+      { name: 'DB_HOST', valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_HOST' } } },
+      { name: 'DB_PORT', valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_PORT' } } },
+    ]);
+  });
+
+  it('should skip refs with error not-found', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [
+          {
+            secretName: 'deleted-secret',
+            allKeys: false,
+            selectedKeys: ['KEY'],
+            availableKeys: [],
+            error: 'not-found',
+          },
+        ],
+      },
+    ];
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+
+  it('should handle multiple secrets with all keys', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.EXISTING, data: [] },
+        existingSecretRefs: [
+          {
+            secretName: 'secret-a',
+            allKeys: true,
+            selectedKeys: ['A1', 'A2'],
+            availableKeys: ['A1', 'A2'],
+          },
+          {
+            secretName: 'secret-b',
+            allKeys: true,
+            selectedKeys: ['B1'],
+            availableKeys: ['B1'],
+          },
+        ],
+      },
+    ];
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({
+      name: 'A1',
+      valueFrom: { secretKeyRef: { name: 'secret-a', key: 'A1' } },
+    });
+  });
+
+  it('should ignore non-EXISTING category env variables', () => {
+    const envVariables: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        values: { category: SecretCategory.GENERIC, data: [{ key: 'FOO', value: 'bar' }] },
+      },
+    ];
+    const result = getExistingSecretEnvVars(envVariables);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('detectEnvKeyCollisions', () => {
+  it('should detect collision between two existing secrets', () => {
+    const refs: ExistingSecretRef[] = [
+      {
+        secretName: 'secret-a',
+        allKeys: true,
+        selectedKeys: ['SHARED_KEY', 'UNIQUE_A'],
+        availableKeys: ['SHARED_KEY', 'UNIQUE_A'],
+      },
+      {
+        secretName: 'secret-b',
+        allKeys: true,
+        selectedKeys: ['SHARED_KEY', 'UNIQUE_B'],
+        availableKeys: ['SHARED_KEY', 'UNIQUE_B'],
+      },
+    ];
+    const result = detectEnvKeyCollisions(refs, [], []);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('SHARED_KEY');
+    expect(result[0].sources).toHaveLength(2);
+  });
+
+  it('should detect collision between existing secret and inline secret', () => {
+    const refs: ExistingSecretRef[] = [
+      {
+        secretName: 'ext-secret',
+        allKeys: true,
+        selectedKeys: ['DB_HOST'],
+        availableKeys: ['DB_HOST'],
+      },
+    ];
+    const inlineVars: EnvVariable[] = [
+      {
+        type: EnvironmentVariableType.SECRET,
+        existingName: 'inline-secret',
+        values: {
+          category: SecretCategory.GENERIC,
+          data: [{ key: 'DB_HOST', value: 'localhost' }],
+        },
+      },
+    ];
+    const result = detectEnvKeyCollisions(refs, inlineVars, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe('DB_HOST');
+    expect(result[0].sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'existing-secret' }),
+        expect.objectContaining({ type: 'inline-secret' }),
+      ]),
+    );
+  });
+
+  it('should detect collision between existing secret and connection', () => {
+    const refs: ExistingSecretRef[] = [
+      {
+        secretName: 'ext-secret',
+        allKeys: true,
+        selectedKeys: ['AWS_ACCESS_KEY_ID'],
+        availableKeys: ['AWS_ACCESS_KEY_ID'],
+      },
+    ];
+    const connections = [
+      {
+        metadata: {
+          name: 's3-conn',
+          namespace: 'test-ns',
+          annotations: { 'openshift.io/display-name': 'My S3' },
+        },
+        data: { AWS_ACCESS_KEY_ID: 'encoded' },
+      },
+    ] as unknown as Connection[];
+    const result = detectEnvKeyCollisions(refs, [], connections);
+    expect(result).toHaveLength(1);
+    expect(result[0].sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'existing-secret' }),
+        expect.objectContaining({ type: 'connection', name: 'My S3' }),
+      ]),
+    );
+  });
+
+  it('should return empty array when no collisions', () => {
+    const refs: ExistingSecretRef[] = [
+      {
+        secretName: 'secret-a',
+        allKeys: true,
+        selectedKeys: ['UNIQUE_A'],
+        availableKeys: ['UNIQUE_A'],
+      },
+    ];
+    const result = detectEnvKeyCollisions(refs, [], []);
+    expect(result).toEqual([]);
+  });
+
+  it('should skip errored refs', () => {
+    const refs: ExistingSecretRef[] = [
+      {
+        secretName: 'deleted',
+        allKeys: false,
+        selectedKeys: ['KEY'],
+        availableKeys: [],
+        error: 'not-found',
+      },
+      {
+        secretName: 'good',
+        allKeys: true,
+        selectedKeys: ['KEY'],
+        availableKeys: ['KEY'],
+      },
+    ];
+    const result = detectEnvKeyCollisions(refs, [], []);
+    expect(result).toEqual([]);
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/fetchNotebookEnvVariables.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/fetchNotebookEnvVariables.spec.ts
@@ -1,0 +1,178 @@
+import { SecretCategory } from '#~/pages/projects/types';
+import type { NotebookKind } from '#~/k8sTypes';
+import { K8sStatusError } from '#~/api/errorUtils';
+import { fetchNotebookEnvVariables } from '#~/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables';
+
+jest.mock('#~/api', () => ({
+  ...jest.requireActual('#~/api'),
+  getConfigMap: jest.fn(),
+  getSecret: jest.fn(),
+}));
+
+const { getSecret } = jest.mocked(jest.requireMock<typeof import('#~/api')>('#~/api'));
+
+const makeNotebook = (
+  env: Array<{ name: string; value?: string; valueFrom?: unknown }> = [],
+): NotebookKind =>
+  ({
+    metadata: { namespace: 'test-ns', name: 'nb' },
+    spec: {
+      template: {
+        spec: {
+          containers: [{ env, envFrom: [] }],
+        },
+      },
+    },
+  } as unknown as NotebookKind);
+
+describe('fetchNotebookEnvVariables - secretKeyRef parsing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should parse secretKeyRef entries and group by secret name', async () => {
+    getSecret.mockResolvedValue({
+      metadata: { name: 'my-secret', namespace: 'test-ns' },
+      data: { DB_HOST: 'aG9zdA==', DB_PORT: 'NTQzMg==' },
+      kind: 'Secret',
+      apiVersion: 'v1',
+    } as never);
+
+    const notebook = makeNotebook([
+      { name: 'NOTEBOOK_ARGS', value: '--ServerApp.port=8888' },
+      { name: 'JUPYTER_IMAGE', value: 'image:tag' },
+      { name: 'DB_HOST', valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_HOST' } } },
+      { name: 'DB_PORT', valueFrom: { secretKeyRef: { name: 'my-secret', key: 'DB_PORT' } } },
+    ]);
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    const existingEntry = result.find((ev) => ev.values?.category === SecretCategory.EXISTING);
+    expect(existingEntry).toBeDefined();
+    expect(existingEntry?.existingSecretRefs).toHaveLength(1);
+
+    const ref = existingEntry?.existingSecretRefs?.[0];
+    expect(ref?.secretName).toBe('my-secret');
+    expect(ref?.selectedKeys).toEqual(['DB_HOST', 'DB_PORT']);
+    expect(ref?.availableKeys).toEqual(['DB_HOST', 'DB_PORT']);
+    expect(ref?.allKeys).toBe(true);
+  });
+
+  it('should handle 404 (deleted secret) and set error to not-found', async () => {
+    const notFoundError = new K8sStatusError({
+      kind: 'Status',
+      apiVersion: 'v1',
+      status: 'Failure',
+      message: 'secrets "gone-secret" not found',
+      reason: 'NotFound',
+      code: 404,
+    });
+    getSecret.mockRejectedValue(notFoundError);
+
+    const notebook = makeNotebook([
+      { name: 'NOTEBOOK_ARGS', value: '--ServerApp.port=8888' },
+      { name: 'KEY', valueFrom: { secretKeyRef: { name: 'gone-secret', key: 'KEY' } } },
+    ]);
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    const existingEntry = result.find((ev) => ev.values?.category === SecretCategory.EXISTING);
+    expect(existingEntry).toBeDefined();
+    expect(existingEntry?.existingSecretRefs).toHaveLength(1);
+
+    const ref = existingEntry?.existingSecretRefs?.[0];
+    expect(ref?.error).toBe('not-found');
+    expect(ref?.allKeys).toBe(false);
+    expect(ref?.availableKeys).toEqual([]);
+  });
+
+  it('should detect missing keys when secret has fewer keys than referenced', async () => {
+    getSecret.mockResolvedValue({
+      metadata: { name: 'changed-secret', namespace: 'test-ns' },
+      data: { STILL_HERE: 'dmFsdWU=' },
+      kind: 'Secret',
+      apiVersion: 'v1',
+    } as never);
+
+    const notebook = makeNotebook([
+      { name: 'NOTEBOOK_ARGS', value: '--ServerApp.port=8888' },
+      {
+        name: 'STILL_HERE',
+        valueFrom: { secretKeyRef: { name: 'changed-secret', key: 'STILL_HERE' } },
+      },
+      {
+        name: 'GONE_KEY',
+        valueFrom: { secretKeyRef: { name: 'changed-secret', key: 'GONE_KEY' } },
+      },
+    ]);
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    const existingEntry = result.find((ev) => ev.values?.category === SecretCategory.EXISTING);
+    expect(existingEntry).toBeDefined();
+
+    const ref = existingEntry?.existingSecretRefs?.[0];
+    expect(ref?.missingKeys).toEqual(['GONE_KEY']);
+    expect(ref?.allKeys).toBe(false);
+  });
+
+  it('should filter out system env names (NOTEBOOK_ARGS, JUPYTER_IMAGE)', async () => {
+    const notebook = makeNotebook([
+      { name: 'NOTEBOOK_ARGS', value: '--ServerApp.port=8888' },
+      { name: 'JUPYTER_IMAGE', value: 'image:tag' },
+    ]);
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    const existingEntry = result.find((ev) => ev.values?.category === SecretCategory.EXISTING);
+    expect(existingEntry).toBeUndefined();
+  });
+
+  it('should handle env being undefined (null guard)', async () => {
+    const notebook = {
+      metadata: { namespace: 'test-ns', name: 'nb' },
+      spec: {
+        template: {
+          spec: {
+            containers: [{ envFrom: [] }],
+          },
+        },
+      },
+    } as unknown as NotebookKind;
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    const existingEntry = result.find((ev) => ev.values?.category === SecretCategory.EXISTING);
+    expect(existingEntry).toBeUndefined();
+  });
+
+  it('should group entries from multiple secrets into separate refs', async () => {
+    getSecret
+      .mockResolvedValueOnce({
+        metadata: { name: 'secret-a', namespace: 'test-ns' },
+        data: { A1: 'dmFsdWU=' },
+        kind: 'Secret',
+        apiVersion: 'v1',
+      } as never)
+      .mockResolvedValueOnce({
+        metadata: { name: 'secret-b', namespace: 'test-ns' },
+        data: { B1: 'dmFsdWU=', B2: 'dmFsdWU=' },
+        kind: 'Secret',
+        apiVersion: 'v1',
+      } as never);
+
+    const notebook = makeNotebook([
+      { name: 'NOTEBOOK_ARGS', value: '--ServerApp.port=8888' },
+      { name: 'A1', valueFrom: { secretKeyRef: { name: 'secret-a', key: 'A1' } } },
+      { name: 'B1', valueFrom: { secretKeyRef: { name: 'secret-b', key: 'B1' } } },
+    ]);
+
+    const result = await fetchNotebookEnvVariables(notebook);
+
+    const existingEntry = result.find((ev) => ev.values?.category === SecretCategory.EXISTING);
+    expect(existingEntry).toBeDefined();
+    expect(existingEntry?.existingSecretRefs).toHaveLength(2);
+    expect(existingEntry?.existingSecretRefs?.[0].secretName).toBe('secret-a');
+    expect(existingEntry?.existingSecretRefs?.[1].secretName).toBe('secret-b');
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
@@ -1,0 +1,52 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { mockCustomSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource';
+import { useExistingSecrets } from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
+
+jest.mock('#~/api', () => ({
+  getSecrets: jest.fn(),
+}));
+
+const { getSecrets } = jest.requireMock('#~/api') as {
+  getSecrets: jest.Mock;
+};
+
+describe('useExistingSecrets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return empty array when namespace is undefined', () => {
+    const renderResult = testHook(useExistingSecrets)(undefined);
+    const [secrets, loaded] = renderResult.result.current;
+    expect(secrets).toEqual([]);
+    expect(loaded).toBe(false);
+  });
+
+  it('should fetch and filter secrets when namespace is provided', async () => {
+    const opaqueSecret = mockCustomSecretK8sResource({
+      name: 'eligible-secret',
+      namespace: 'test-ns',
+      data: { KEY: 'dmFsdWU=' },
+      type: 'Opaque',
+      labels: {},
+      annotations: {},
+    });
+    const connectionSecret = mockCustomSecretK8sResource({
+      name: 'connection-secret',
+      namespace: 'test-ns',
+      data: { KEY: 'dmFsdWU=' },
+      type: 'Opaque',
+      labels: { 'opendatahub.io/dashboard': 'true' },
+      annotations: { 'opendatahub.io/connection-type': 's3' },
+    });
+    getSecrets.mockResolvedValue([opaqueSecret, connectionSecret]);
+
+    const renderResult = testHook(useExistingSecrets)('test-ns');
+    await renderResult.waitForNextUpdate();
+
+    const [secrets, loaded] = renderResult.result.current;
+    expect(loaded).toBe(true);
+    expect(secrets).toHaveLength(1);
+    expect(secrets[0].metadata.name).toBe('eligible-secret');
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/__tests__/useExistingSecrets.spec.ts
@@ -3,6 +3,7 @@ import { mockCustomSecretK8sResource } from '#~/__mocks__/mockSecretK8sResource'
 import { useExistingSecrets } from '#~/pages/projects/screens/spawner/environmentVariables/useExistingSecrets';
 
 jest.mock('#~/api', () => ({
+  ...jest.requireActual('#~/api'),
   getSecrets: jest.fn(),
 }));
 
@@ -20,6 +21,7 @@ describe('useExistingSecrets', () => {
     const [secrets, loaded] = renderResult.result.current;
     expect(secrets).toEqual([]);
     expect(loaded).toBe(false);
+    expect(renderResult).hookToHaveUpdateCount(1);
   });
 
   it('should fetch and filter secrets when namespace is provided', async () => {
@@ -42,11 +44,30 @@ describe('useExistingSecrets', () => {
     getSecrets.mockResolvedValue([opaqueSecret, connectionSecret]);
 
     const renderResult = testHook(useExistingSecrets)('test-ns');
+    expect(renderResult).hookToHaveUpdateCount(1);
+
     await renderResult.waitForNextUpdate();
 
     const [secrets, loaded] = renderResult.result.current;
     expect(loaded).toBe(true);
     expect(secrets).toHaveLength(1);
     expect(secrets[0].metadata.name).toBe('eligible-secret');
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+
+  it('should return error when getSecrets rejects', async () => {
+    getSecrets.mockRejectedValue(new Error('Forbidden'));
+
+    const renderResult = testHook(useExistingSecrets)('test-ns');
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    await renderResult.waitForNextUpdate();
+
+    const [secrets, loaded, error] = renderResult.result.current;
+    expect(loaded).toBe(false);
+    expect(secrets).toEqual([]);
+    expect(error).toBeDefined();
+    expect(error?.message).toBe('Forbidden');
+    expect(renderResult).hookToHaveUpdateCount(2);
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/existingSecretUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/existingSecretUtils.ts
@@ -43,7 +43,7 @@ export type EnvKeyCollision = {
 
 export const detectEnvKeyCollisions = (
   existingSecretRefs: ExistingSecretRef[],
-  inlineEnvVars: EnvVariable[],
+  envVariables: EnvVariable[],
   connections: Connection[],
 ): EnvKeyCollision[] => {
   const keySourceMap = new Map<string, EnvKeyCollision['sources']>();
@@ -59,7 +59,7 @@ export const detectEnvKeyCollisions = (
     }
   }
 
-  for (const envVar of inlineEnvVars) {
+  for (const envVar of envVariables) {
     if (
       envVar.type === EnvironmentVariableType.SECRET &&
       envVar.values?.category !== SecretCategory.EXISTING &&

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/existingSecretUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/existingSecretUtils.ts
@@ -79,7 +79,8 @@ export const detectEnvKeyCollisions = (
   for (const connection of connections) {
     if (connection.data) {
       const connName =
-        connection.metadata.annotations['openshift.io/display-name'] || connection.metadata.name;
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- K8s annotations can be undefined at runtime
+        connection.metadata.annotations?.['openshift.io/display-name'] || connection.metadata.name;
       for (const key of Object.keys(connection.data)) {
         const sources = keySourceMap.get(key) ?? [];
         sources.push({ type: 'connection', name: connName });

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/existingSecretUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/existingSecretUtils.ts
@@ -1,0 +1,94 @@
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import { isConnection } from '#~/concepts/connectionTypes/utils';
+import type { Connection } from '#~/concepts/connectionTypes/types';
+import type { ExistingSecretRef, EnvVariable } from '#~/pages/projects/types';
+import { EnvironmentVariableType, SecretCategory } from '#~/pages/projects/types';
+
+export const filterExistingSecrets = (secrets: SecretKind[]): SecretKind[] =>
+  secrets.filter(
+    (secret) =>
+      secret.type === 'Opaque' &&
+      !isConnection(secret) &&
+      !secret.metadata.annotations?.['opendatahub.io/connection-type-protocol'],
+  );
+
+export const getExistingSecretEnvVars = (
+  envVariables: EnvVariable[],
+): Array<{ name: string; valueFrom: { secretKeyRef: { name: string; key: string } } }> =>
+  envVariables
+    .filter((ev) => ev.values?.category === SecretCategory.EXISTING && ev.existingSecretRefs)
+    .flatMap((ev) =>
+      (ev.existingSecretRefs ?? [])
+        .filter((ref) => !ref.error)
+        .flatMap((ref) =>
+          ref.selectedKeys.map((key) => ({
+            name: key,
+            valueFrom: {
+              secretKeyRef: {
+                name: ref.secretName,
+                key,
+              },
+            },
+          })),
+        ),
+    );
+
+export type EnvKeyCollision = {
+  key: string;
+  sources: Array<{
+    type: 'existing-secret' | 'inline-secret' | 'connection';
+    name: string;
+  }>;
+};
+
+export const detectEnvKeyCollisions = (
+  existingSecretRefs: ExistingSecretRef[],
+  inlineEnvVars: EnvVariable[],
+  connections: Connection[],
+): EnvKeyCollision[] => {
+  const keySourceMap = new Map<string, EnvKeyCollision['sources']>();
+
+  for (const ref of existingSecretRefs) {
+    if (ref.error) {
+      continue;
+    }
+    for (const key of ref.selectedKeys) {
+      const sources = keySourceMap.get(key) ?? [];
+      sources.push({ type: 'existing-secret', name: ref.secretName });
+      keySourceMap.set(key, sources);
+    }
+  }
+
+  for (const envVar of inlineEnvVars) {
+    if (
+      envVar.type === EnvironmentVariableType.SECRET &&
+      envVar.values?.category !== SecretCategory.EXISTING &&
+      envVar.values?.data
+    ) {
+      const secretName = envVar.existingName || 'inline secret';
+      for (const entry of envVar.values.data) {
+        if (entry.key) {
+          const sources = keySourceMap.get(entry.key) ?? [];
+          sources.push({ type: 'inline-secret', name: secretName });
+          keySourceMap.set(entry.key, sources);
+        }
+      }
+    }
+  }
+
+  for (const connection of connections) {
+    if (connection.data) {
+      const connName =
+        connection.metadata.annotations['openshift.io/display-name'] || connection.metadata.name;
+      for (const key of Object.keys(connection.data)) {
+        const sources = keySourceMap.get(key) ?? [];
+        sources.push({ type: 'connection', name: connName });
+        keySourceMap.set(key, sources);
+      }
+    }
+  }
+
+  return Array.from(keySourceMap.entries())
+    .filter(([, sources]) => sources.length > 1)
+    .map(([key, sources]) => ({ key, sources }));
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useExistingSecrets.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import type { SecretKind } from '@odh-dashboard/k8s-core';
+import useFetchState, { NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetchState';
+import { getSecrets } from '#~/api';
+import { filterExistingSecrets } from './existingSecretUtils';
+
+export const useExistingSecrets = (
+  namespace: string | undefined,
+): [secrets: SecretKind[], loaded: boolean, error: Error | undefined, refresh: () => void] => {
+  const callback = React.useCallback(() => {
+    if (!namespace) {
+      return Promise.reject(new NotReadyError('No namespace'));
+    }
+    return getSecrets(namespace).then(filterExistingSecrets);
+  }, [namespace]);
+
+  return useFetchState(callback, []);
+};

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -77,7 +77,9 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
   );
 
   // Process env[].valueFrom.secretKeyRef entries (NEW)
-  const envList = notebook.spec.template.spec.containers[0].env;
+  // K8s API may omit env entirely for containers with no environment variables
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const envList = notebook.spec.template.spec.containers[0].env ?? [];
   const SYSTEM_ENV_NAMES = ['NOTEBOOK_ARGS', 'JUPYTER_IMAGE'];
 
   const secretKeyRefEntries = envList.filter(

--- a/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
+++ b/frontend/src/pages/projects/screens/spawner/environmentVariables/useNotebookEnvVariables.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { SecretKind } from '@odh-dashboard/k8s-core';
 import useFetchState, { NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetchState';
-import { getConfigMap, getSecret } from '#~/api';
+import { getConfigMap, getSecret, K8sStatusError } from '#~/api';
 import { ConfigMapKind, NotebookKind } from '#~/k8sTypes';
 import { EnvVarResourceType } from '#~/types';
 import {
@@ -10,12 +10,15 @@ import {
   EnvVariable,
   SecretCategory,
 } from '#~/pages/projects/types';
+import type { ExistingSecretRef } from '#~/pages/projects/types';
 import { isConnection } from '#~/concepts/connectionTypes/utils';
 import { getDeletedConfigMapOrSecretVariables, isSecretKind } from './utils';
 
 export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVariable[]> => {
   const envFromList = notebook.spec.template.spec.containers[0].envFrom || [];
-  return Promise.all(
+
+  // Process envFrom entries (existing behavior, unchanged)
+  const envFromPromise = Promise.all(
     envFromList
       .map((envFrom) => {
         if (envFrom.configMapRef) {
@@ -71,6 +74,79 @@ export const fetchNotebookEnvVariables = (notebook: NotebookKind): Promise<EnvVa
       }
       return [...acc, envVar];
     }, []),
+  );
+
+  // Process env[].valueFrom.secretKeyRef entries (NEW)
+  const envList = notebook.spec.template.spec.containers[0].env;
+  const SYSTEM_ENV_NAMES = ['NOTEBOOK_ARGS', 'JUPYTER_IMAGE'];
+
+  const secretKeyRefEntries = envList.filter(
+    (e): e is { name: string; valueFrom: { secretKeyRef: { name: string; key: string } } } =>
+      !!e.name &&
+      !SYSTEM_ENV_NAMES.includes(e.name) &&
+      !!e.valueFrom &&
+      typeof e.valueFrom === 'object' &&
+      'secretKeyRef' in e.valueFrom &&
+      !!e.valueFrom.secretKeyRef,
+  );
+
+  // Group by secret name
+  const secretRefsByName = new Map<string, string[]>();
+  for (const entry of secretKeyRefEntries) {
+    const { name: secretName, key } = entry.valueFrom.secretKeyRef;
+    const keys = secretRefsByName.get(secretName) ?? [];
+    keys.push(key);
+    secretRefsByName.set(secretName, keys);
+  }
+
+  const secretKeyRefPromise: Promise<EnvVariable[]> =
+    secretRefsByName.size === 0
+      ? Promise.resolve([])
+      : Promise.all(
+          Array.from(secretRefsByName.entries()).map(
+            async ([secretName, selectedKeys]): Promise<ExistingSecretRef> => {
+              try {
+                const secret = await getSecret(notebook.metadata.namespace, secretName);
+                const availableKeys = secret.data ? Object.keys(secret.data) : [];
+                const missingKeys = selectedKeys.filter((k) => !availableKeys.includes(k));
+                return {
+                  secretName,
+                  allKeys:
+                    missingKeys.length === 0 &&
+                    selectedKeys.length === availableKeys.length &&
+                    selectedKeys.every((k) => availableKeys.includes(k)),
+                  selectedKeys,
+                  availableKeys,
+                  ...(missingKeys.length > 0 ? { missingKeys } : {}),
+                };
+              } catch (e) {
+                if (e instanceof K8sStatusError && e.statusObject.code === 404) {
+                  return {
+                    secretName,
+                    allKeys: false,
+                    selectedKeys,
+                    availableKeys: [],
+                    error: 'not-found',
+                  };
+                }
+                throw e;
+              }
+            },
+          ),
+        ).then((refs): EnvVariable[] =>
+          refs.length > 0
+            ? [
+                {
+                  type: EnvironmentVariableType.SECRET,
+                  values: { category: SecretCategory.EXISTING, data: [] },
+                  existingSecretRefs: refs,
+                },
+              ]
+            : [],
+        );
+
+  return Promise.all([envFromPromise, secretKeyRefPromise]).then(
+    ([envFromVars, secretKeyRefVars]) => [...envFromVars, ...secretKeyRefVars],
   );
 };
 

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -92,6 +92,8 @@ const getPromisesForConfigMapsAndSecrets = (
       );
 
       switch (envVar.values.category) {
+        case SecretCategory.EXISTING:
+          return null;
         case SecretCategory.GENERIC:
         case SecretCategory.UPLOAD:
           return type === 'create'
@@ -178,7 +180,16 @@ export const updateConfigMapsAndSecretsForNotebook = async (
     [...(connections || []).map((connection) => connection.metadata.name)],
   );
 
-  const [oldResources, newResources] = _.partition(envVariables, (envVar) => envVar.existingName);
+  // Filter out EXISTING category entries — they reference pre-existing secrets
+  // and must not be created, updated, or deleted by the dashboard
+  const managedEnvVariables = envVariables.filter(
+    (ev) => ev.values?.category !== SecretCategory.EXISTING,
+  );
+
+  const [oldResources, newResources] = _.partition(
+    managedEnvVariables,
+    (envVar) => envVar.existingName,
+  );
   const currentNames = oldResources
     .map((envVar) => envVar.existingName)
     .filter((v): v is string => !!v);

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -344,13 +344,20 @@ export const isEnvVariableDataValid = (envVariables: EnvVariable[]): boolean => 
     }
   };
 
-  const isValid = envVariables.every(
-    (envVar) =>
-      !!envVar.type &&
-      !!envVar.values &&
-      !!envVar.values.category &&
-      hasValidValuesForType(envVar.values.data, envVar.values.category),
-  );
+  const isValid = envVariables.every((envVar) => {
+    if (!envVar.type || !envVar.values || !envVar.values.category) {
+      return false;
+    }
+    // EXISTING secrets validate via existingSecretRefs, not data
+    if (envVar.values.category === SecretCategory.EXISTING) {
+      return (
+        !!envVar.existingSecretRefs &&
+        envVar.existingSecretRefs.length > 0 &&
+        envVar.existingSecretRefs.some((ref) => ref.selectedKeys.length > 0 && !ref.error)
+      );
+    }
+    return hasValidValuesForType(envVar.values.data, envVar.values.category);
+  });
 
   return isValid;
 };

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -87,6 +87,15 @@ export type StartNotebookData = {
   volumes?: Volume[];
   volumeMounts?: VolumeMount[];
   envFrom?: EnvironmentFromVariable[];
+  existingSecretEnvVars?: Array<{
+    name: string;
+    valueFrom: {
+      secretKeyRef: {
+        name: string;
+        key: string;
+      };
+    };
+  }>;
   dashboardNamespace?: string;
   connections?: Connection[];
   hardwareProfileOptions: UseAssignHardwareProfileResult<NotebookKind>;
@@ -109,10 +118,20 @@ export type EnvVariableData = {
   data: EnvVariableDataEntry[];
 };
 
+export type ExistingSecretRef = {
+  secretName: string;
+  allKeys: boolean;
+  selectedKeys: string[];
+  availableKeys: string[];
+  error?: 'not-found';
+  missingKeys?: string[];
+};
+
 export type EnvVariable = {
   type: EnvironmentVariableType | null;
   existingName?: string;
   values?: EnvVariableData;
+  existingSecretRefs?: ExistingSecretRef[];
 };
 
 export enum EnvironmentVariableType {
@@ -123,6 +142,7 @@ export enum SecretCategory {
   GENERIC = 'secret key-value',
   AWS = 'aws',
   UPLOAD = 'secret upload',
+  EXISTING = 'secret existing',
 }
 export enum ConfigMapCategory {
   GENERIC = 'configmap key-value',


### PR DESCRIPTION
## Summary

Adds a new "Existing secret" option to the workbench environment variables form, allowing users to reference pre-existing Kubernetes Secrets by key selection rather than creating new ones.

**Jira**: [RHOAIENG-72103](https://redhat.atlassian.net/browse/RHOAIENG-72103)

### Changes

- **Type system**: New `SecretCategory.EXISTING` enum value, `ExistingSecretRef` type for tracking secret/key selections
- **API layer**: `getSecrets()` function + `useExistingSecrets` data-fetching hook with RBAC-gated lazy loading
- **UI components**: Radio button selector in `EnvSecret`, typeahead multi-select dropdown in `EnvExistingSecret`, per-secret key checkbox panel in `ExistingSecretItem`
- **Notebook CR mutation**: `assembleNotebook`/`updateNotebook` wire selected keys as `env[].valueFrom.secretKeyRef` entries (never `envFrom`)
- **Edit view**: `fetchNotebookEnvVariables` parses existing `secretKeyRef` entries from Notebook CR, detects deleted secrets (404) and missing keys
- **Collision detection**: `detectEnvKeyCollisions` checks for key conflicts across existing secrets, inline secrets, and connections
- **Form validation**: `isEnvVariableDataValid` handles EXISTING category via `existingSecretRefs` validation

### Review Scores (v3 — PASS)

| Dimension | Score | Weight |
|-----------|-------|--------|
| Architecture | 8.0 | 30% |
| Tests | 7.5 | 30% |
| Lint | 9.0 | 20% |
| Intent | 9.0 | 20% |
| **Weighted Average** | **8.2** | |

### Known Minor Items for Human Review

1. Collision detection threading passes all collisions to every section (follows pre-existing pattern)
2. Radio description is truncated vs spec (cosmetic)
3. Missing RBAC-disabled popover on radio button (UX gap, not AC violation)
4. `container.env = []` clearing follows same pattern as existing `envFrom = []` but may drop manually-added env entries

## Test plan

- [x] 60 unit tests passing across 6 test suites
- [x] Type system, API layer, hook, and component tests
- [x] Edge cases: deleted secrets, missing keys, RBAC denial, empty lists, API errors
- [x] Form validation for EXISTING category
- [x] Lint clean (eslint --max-warnings 0)
- [x] TypeScript clean (tsc --noEmit)
- [ ] Manual verification of create/edit workbench flow with existing secrets
- [ ] Verify collision alerts display correctly
- [ ] Verify backward compatibility with existing workbenches

🤖 Generated with [Claude Code](https://claude.com/claude-code) via epic-codegen pipeline (3 iterations)

[RHOAIENG-72103]: https://redhat.atlassian.net/browse/RHOAIENG-72103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ