### PR TITLE
feat(mlflow-embedded): add MCP Registry tab to MCP servers page

### DIFF
--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -36,7 +36,6 @@ export const devTemporaryFeatureFlags = {
   nimWizard: false,
   agentOpsDeploy: false,
   agentsCatalog: false,
-  roleManagement: false,
   mcpRegistry: false,
 } satisfies Partial<DashboardCommonConfig>;
 

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -36,6 +36,8 @@ export const devTemporaryFeatureFlags = {
   nimWizard: false,
   agentOpsDeploy: false,
   agentsCatalog: false,
+  roleManagement: false,
+  mcpRegistry: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Group 1: Core Dashboard Features
@@ -249,6 +251,10 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.MLFLOW_PIPELINES]: {
     featureFlags: ['mlflowPipelines'],
     requiredComponents: [DataScienceStackComponent.DS_PIPELINES, DataScienceStackComponent.MLFLOW],
+  },
+  [SupportedArea.MCP_REGISTRY]: {
+    featureFlags: ['mcpRegistry'],
+    requiredComponents: [DataScienceStackComponent.MLFLOW],
   },
   [SupportedArea.PROJECT_RBAC_SETTINGS]: {
     featureFlags: ['projectRBAC'],

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -293,6 +293,7 @@ export type DashboardCommonConfig = {
   aiAssetCustomEndpoints?: boolean;
   mlflowPipelines?: boolean;
   mcpCatalog?: boolean;
+  mcpRegistry?: boolean;
   toolCalling?: boolean;
   projectRBAC?: boolean;
   observabilityDashboard?: boolean;

--- a/packages/mlflow-embedded/extensions.ts
+++ b/packages/mlflow-embedded/extensions.ts
@@ -2,6 +2,7 @@ import type {
   AreaExtension,
   HrefNavItemExtension,
   RouteExtension,
+  TabRouteTabExtension,
   TaskItemExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
 import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
@@ -21,7 +22,13 @@ import { PROMPT_MANAGEMENT_PAGE_TITLE } from './shared/const';
 /**
  * MLflow host-side extensions.
  */
-const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension | TaskItemExtension)[] = [
+const extensions: (
+  | AreaExtension
+  | HrefNavItemExtension
+  | RouteExtension
+  | TabRouteTabExtension
+  | TaskItemExtension
+)[] = [
   {
     type: 'app.area',
     properties: {
@@ -77,6 +84,21 @@ const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension | TaskI
     properties: {
       path: globPromptManagementAll,
       component: () => import('./prompts/GlobalMLflowPromptManagementRoutes'),
+    },
+  },
+  {
+    type: 'app.tab-route/tab',
+    flags: {
+      required: [SupportedArea.MLFLOW, SupportedArea.MCP_CATALOG, SupportedArea.MCP_REGISTRY],
+    },
+    properties: {
+      pageId: 'mcp-servers-tab-page',
+      id: 'registry',
+      title: 'Registry',
+      singleTabTitle: 'Registry',
+      objectType: 'mcp-catalog',
+      component: () => import('./mcp-registry/MlflowMcpRegistryTabContent'),
+      group: '1b_registry',
     },
   },
   {

--- a/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx
+++ b/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx
@@ -1,0 +1,100 @@
+import React, { useMemo } from 'react';
+import {
+  Bullseye,
+  Content,
+  Flex,
+  FlexItem,
+  PageSection,
+  Spinner,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { Navigate, useSearchParams } from 'react-router-dom';
+import { loadRemote } from '@module-federation/runtime';
+import { LazyCodeRefComponent } from '@odh-dashboard/plugin-core';
+import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { getStoredPreferredProject } from '@odh-dashboard/internal/concepts/projects/getStoredPreferredProject';
+import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/ProjectIconWithSize';
+import { IconSize } from '@odh-dashboard/internal/types';
+import ProjectSelectorNavigator from '@odh-dashboard/internal/concepts/projects/ProjectSelectorNavigator';
+import { WORKSPACE_QUERY_PARAM } from '@odh-dashboard/internal/routes/pipelines/mlflow';
+import MLflowUnavailable from '../shared/MLflowUnavailable';
+
+const MCP_REGISTRY_BASENAME = '/ai-hub/mcp-servers/registry';
+
+const mcpRegistryBaseRoute = (namespace?: string): string => {
+  if (!namespace) {
+    return MCP_REGISTRY_BASENAME;
+  }
+  return `${MCP_REGISTRY_BASENAME}?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(namespace)}`;
+};
+
+const MlflowMcpRegistryTabContent: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const workspace = searchParams.get(WORKSPACE_QUERY_PARAM) ?? '';
+  const { projects, preferredProject } = React.useContext(ProjectsContext);
+  const storedProject = getStoredPreferredProject(projects);
+
+  const loadWrapper = useMemo(
+    () => () =>
+      loadRemote<{ default: React.ComponentType }>('mlflowEmbedded/MlflowMcpRegistryWrapper')
+        .then((mod) => mod ?? { default: MLflowUnavailable })
+        .catch(() => ({ default: MLflowUnavailable })),
+    [],
+  );
+
+  if (!workspace && projects.length > 0) {
+    const defaultProject = storedProject ?? preferredProject ?? projects[0];
+    return <Navigate to={mcpRegistryBaseRoute(defaultProject.metadata.name)} replace />;
+  }
+
+  return (
+    <>
+      <PageSection hasBodyWrapper={false}>
+        <Stack hasGutter>
+          <StackItem>
+            <Content component="p">
+              Browse and manage registered MCP servers and access bindings.
+            </Content>
+          </StackItem>
+          <StackItem>
+            <Flex
+              spaceItems={{ default: 'spaceItemsXs' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+            >
+              <ProjectIconWithSize size={IconSize.XXL} />
+              <Flex
+                spaceItems={{ default: 'spaceItemsSm' }}
+                alignItems={{ default: 'alignItemsCenter' }}
+              >
+                <FlexItem>
+                  <Bullseye>Project</Bullseye>
+                </FlexItem>
+                <FlexItem>
+                  <ProjectSelectorNavigator
+                    getRedirectPath={mcpRegistryBaseRoute}
+                    queryParamNamespace={WORKSPACE_QUERY_PARAM}
+                  />
+                </FlexItem>
+              </Flex>
+            </Flex>
+          </StackItem>
+        </Stack>
+      </PageSection>
+      <LazyCodeRefComponent
+        key={workspace}
+        component={loadWrapper}
+        props={{ basename: MCP_REGISTRY_BASENAME, onBreadcrumbChange: () => undefined }}
+        fallback={
+          <PageSection hasBodyWrapper={false}>
+            <Bullseye>
+              <Spinner />
+            </Bullseye>
+          </PageSection>
+        }
+      />
+    </>
+  );
+};
+
+export default MlflowMcpRegistryTabContent;

--- a/packages/plugin-core/src/areas/types.ts
+++ b/packages/plugin-core/src/areas/types.ts
@@ -109,6 +109,9 @@ export enum SupportedArea {
   MLFLOW = 'mlflow',
   MLFLOW_PIPELINES = 'mlflow-pipelines',
 
+  /* MCP Registry */
+  MCP_REGISTRY = 'mcp-registry',
+
   /* GPUaaS */
   GPUAAS_INFRASTRUCTURE = 'gpuaas-infrastructure',
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-65782
Depends on https://github.com/opendatahub-io/mlflow/pull/338

## Description

Embeds the MLflow MCP Registry UI as a new **Registry** tab on the MCP servers tabbed page (`/ai-hub/mcp-servers`), positioned between the existing Catalog and Deployments tabs.

The tab:
- Loads `MlflowMcpRegistryWrapper` from the `mlflowEmbedded` Module Federation remote (exposed by [opendatahub-io/mlflow#338](https://github.com/opendatahub-io/mlflow/pull/338))
- Includes a project selector with auto-redirect to the preferred/stored project (matching the Deployments tab pattern)
- Shows a description line and project icon consistent with the Deployments tab layout
- Falls back to the `MLflowUnavailable` empty state if the federated wrapper cannot be loaded

Adds a new `mcpRegistry` feature flag (default `false`) gated behind a new `MCP_REGISTRY` SupportedArea, so the tab remains hidden until explicitly enabled. The tab requires all three flags: `MLFLOW`, `MCP_CATALOG`, and `MCP_REGISTRY`.

<img width="1492" height="810" alt="Screenshot 2026-07-16 at 11 06 31 PM" src="https://github.com/user-attachments/assets/b41a7523-4630-4a90-b8c5-eb3cdf216f8b" />

<img width="1492" height="810" alt="Screenshot 2026-07-16 at 11 06 55 PM" src="https://github.com/user-attachments/assets/faa6115b-aa80-4ead-a5de-aa80eefb48ee" />

### Changes

| File | Change |
|---|---|
| `packages/plugin-core/src/areas/types.ts` | Add `MCP_REGISTRY` to `SupportedArea` enum |
| `packages/k8s-core/src/k8sTypes.ts` | Add `mcpRegistry` to `DashboardCommonConfig` |
| `frontend/src/concepts/areas/const.ts` | Add `mcpRegistry: false` to `techPreviewFlags` and area config |
| `packages/mlflow-embedded/extensions.ts` | Add `app.tab-route/tab` extension for the Registry tab |
| `packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx` | New tab content component |

## How Has This Been Tested?

- Ran MLflow federated dev server (`yarn start:federated` on `mcp-registry-ui` branch) alongside the dashboard dev server
- Enabled `mcpCatalog` and `mcpRegistry` feature flags via dev overrides
- Verified:
  - Registry tab appears between Catalog and Deployments
  - Project selector auto-selects the preferred project on initial load
  - Embedded MLflow MCP Registry UI loads with Access Bindings and Servers sub-tabs
  - Server cards render with data from the MLflow backend
  - Clicking a server card navigates to the detail page within the embedded UI
  - Tab selection persists across navigation
  - Tab is hidden when `mcpRegistry` flag is disabled

## Test Impact

No tests added. The `mlflow-embedded` package has no existing test infrastructure (no jest config, no test scripts). The new component is a thin integration layer — declarative wiring between the project selector, auto-redirect logic, and the `loadRemote` federated wrapper. All business logic lives in the upstream MLflow wrapper.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **MCP Registry** supported area and gated it behind a new temporary feature flag, requiring MLflow configuration.
  * Added a **Registry** tab under MCP Servers, with navigation gated to the required areas.
  * Implemented workspace-aware routing, project selection, and automatic redirection to the default project when applicable.
  * Added loading feedback and an unavailable-state fallback for the Registry tab content.
* **Platform Updates**
  * Extended shared dashboard configuration with an optional `mcpRegistry` flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->