### PR TITLE
chore(gen-ai): add pgvector image env var to .env.local.example

### DIFF
--- a/packages/gen-ai/.env.local.example
+++ b/packages/gen-ai/.env.local.example
@@ -10,6 +10,9 @@ DEPLOYMENT_MODE=standalone
 # LlamaStack API URL - point to your local or remote LlamaStack instance
 LLAMA_STACK_URL=http://localhost:8321
 
+# PostgreSQL 16 base image for automatic pgvector instance provisioning
+RELATED_IMAGE_POSTGRESQL_16_IMAGE=registry.redhat.io/rhel9/postgresql-16
+
 # MaaS endpoint – provide the Kuadrant MaaS Gateway URL or direct MaaS Service URL.
 # Used by `make dev-start-maas` (passed to MaaS BFF as MAAS_API_URL) and as the
 # gen-ai BFF's guardrail availability gate.


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-68914

## Description

Add `RELATED_IMAGE_POSTGRESQL_16_IMAGE` to `.env.local.example`. Without this variable, the BFF skips pgvector auto-provisioning entirely (no default image is set). In-cluster the operator injects it via the CSV; locally, developers need it in `.env.local` for RAG to work.

## How Has This Been Tested?

Config-only change to an example env file. The variable is already consumed by the BFF; this documents it for local dev setup.

## Test Impact

Not applicable — no code changes, only a `.env.local.example` addition.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added example configuration for PostgreSQL 16.
  * Documented the PostgreSQL 16 base image used for automatic pgvector instance provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->