### PR TITLE
Sync from kubeflow/model-registry 5efe927

### DIFF
--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "27cb0f4656bc534d9c725df86b7175329ec7982e"
+    "commit": "86799a04af5d5d6906424e6c6ba1221046fecee9"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "1f97bc206f65abcf9d489ea6bf6b978967257e2e"
+    "commit": "5efe927c96fb1ca41f1091ab3da70a6936873811"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "ee7e51e55e8b260947fca2596ee62d7074d23ad4"
+    "commit": "27cb0f4656bc534d9c725df86b7175329ec7982e"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "86799a04af5d5d6906424e6c6ba1221046fecee9"
+    "commit": "1f97bc206f65abcf9d489ea6bf6b978967257e2e"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/upstream/frontend/package-lock.json
+++ b/packages/model-registry/upstream/frontend/package-lock.json
@@ -27420,9 +27420,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/agentsCatalog/agentsCatalog.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/agentsCatalog/agentsCatalog.cy.ts
@@ -218,7 +218,8 @@ describe('Agents Catalog Gallery', () => {
     initAgentsCatalogIntercepts({ agentsPerCategory: 1 });
     agentsCatalog.visit();
     agentsCatalog.findCardDetailLink('agent_templates-agent-1').click();
-    cy.url().should('include', `${agentsCatalogUrl()}/`);
+    cy.url().should('include', `${agentsCatalogUrl()}/agent_templates-agent-1/overview`);
+    cy.findByTestId('app-page-title').should('exist');
   });
 
   it('should display labels on agent cards with mapped display names', () => {

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/AgentsCatalogRoutes.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/AgentsCatalogRoutes.tsx
@@ -10,8 +10,11 @@ const AgentsCatalogRoutes: React.FC = () => (
     <Routes>
       <Route path="/*" element={<AgentsCatalogCoreLoader />}>
         <Route index element={<AgentsCatalog />} />
-        <Route path=":agentId" element={<Navigate to="overview" replace />} />
-        <Route path=":agentId/overview" element={<AgentDetailsPage />} />
+        <Route path=":agentId">
+          <Route index element={<Navigate to="overview" replace />} />
+          <Route path="overview" element={<AgentDetailsPage />} />
+          <Route path="*" element={<Navigate to="." />} />
+        </Route>
         <Route path="*" element={<Navigate to="." />} />
       </Route>
     </Routes>

--- a/packages/model-registry/upstream/frontend/src/app/routes/agentsCatalog/__tests__/agentsCatalog.spec.ts
+++ b/packages/model-registry/upstream/frontend/src/app/routes/agentsCatalog/__tests__/agentsCatalog.spec.ts
@@ -2,9 +2,11 @@ import { getAgentsCatalogDetailsRoute } from '~/app/routes/agentsCatalog/agentsC
 
 describe('agentsCatalog routes', () => {
   it('should build encoded agent details path', () => {
-    expect(getAgentsCatalogDetailsRoute('my-agent')).toBe('/ai-hub/agents/catalog/my-agent');
+    expect(getAgentsCatalogDetailsRoute('my-agent')).toBe(
+      '/ai-hub/agents/catalog/my-agent/overview',
+    );
     expect(getAgentsCatalogDetailsRoute('agent/with/slashes')).toBe(
-      '/ai-hub/agents/catalog/agent%2Fwith%2Fslashes',
+      '/ai-hub/agents/catalog/agent%2Fwith%2Fslashes/overview',
     );
   });
 });

--- a/packages/model-registry/upstream/frontend/src/app/routes/agentsCatalog/agentsCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/app/routes/agentsCatalog/agentsCatalog.ts
@@ -1,4 +1,4 @@
 export const agentsCatalogUrl = (): string => '/ai-hub/agents/catalog';
 
 export const getAgentsCatalogDetailsRoute = (agentId: string): string =>
-  `${agentsCatalogUrl()}/${encodeURIComponent(agentId)}`;
+  `${agentsCatalogUrl()}/${encodeURIComponent(agentId)}/overview`;


### PR DESCRIPTION
## Description

Sync to pull in changes from:
* https://github.com/kubeflow/model-registry/pull/2971
* https://github.com/kubeflow/model-registry/pull/2974

### Conflicts Resolved

The following conflicts were resolved during this sync:

**[#2974 - fix(ui): open agents catalog details via /overview route](https://github.com/kubeflow/model-registry/pull/2974)**
- `packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/agentsCatalog/agentsCatalog.cy.ts`
- `packages/model-registry/upstream/frontend/src/app/routes/agentsCatalog/__tests__/agentsCatalog.spec.ts`

*Nature of conflict:* Upstream paths use `/agents-catalog/.../overview` while odh-dashboard keeps the downstream `/ai-hub/agents/catalog` prefix.

*Resolution:* Kept the downstream `/ai-hub/agents/catalog` route prefix and applied the upstream `/overview` suffix (and related assertions) so route helpers and Cypress tests match the updated details navigation.

## How Has This Been Tested?

Tested by running the federated model-registry package locally, verifying existing behavior in the files this diff touches, and verifying the incoming changes.

Also ran available test scripts in `packages/model-registry/upstream/frontend`:
- `npm run test:lint`
- `npm run test:unit` (74 suites / 903 tests passed)
- `npm run test:type-check`

## Test Impact

Upstream changes include their own tests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the packaged model registry source to incorporate the latest upstream revision.
  * No changes were made to the public API or user-facing functionality.
  * Existing model registry behavior remains unchanged, with this update ensuring the package reflects the intended upstream content and remains aligned with the latest maintained source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->