### PR TITLE
RHOAIENG-75893: Add Segment tracking for GPUaaS Infrastructure page

### DIFF
--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import {
   Button,
   Card,
@@ -16,6 +17,11 @@ import {
 import { SyncAltIcon } from '@patternfly/react-icons';
 import { relativeTime } from '@odh-dashboard/internal/utilities/time';
 import { INFRASTRUCTURE_SECTIONS } from '../const';
+import {
+  GPUAAS_EVENTS,
+  type PageViewedProperties,
+  type DataRefreshedProperties,
+} from '../tracking/gpuaasTrackingConstants';
 import ClusterSummaryCards from '../components/ClusterSummaryCards';
 import HardwareUsageSection from '../components/HardwareUsageSection';
 import BorrowingLendingSection from '../components/BorrowingLendingSection';
@@ -26,6 +32,41 @@ type SectionId = (typeof INFRASTRUCTURE_SECTIONS)[number]['id'];
 
 const InfrastructurePage: React.FC = () => {
   const metrics = useInfrastructureMetrics();
+  const hasTrackedPageView = React.useRef(false);
+
+  React.useEffect(() => {
+    if (metrics.loaded && !hasTrackedPageView.current) {
+      hasTrackedPageView.current = true;
+      const totalAccelerators = metrics.accelerators?.total;
+      const acceleratorsInUse = metrics.accelerators?.inUse;
+      const props: PageViewedProperties = {
+        path: '/observe-monitor/infrastructure',
+        sectionCount: INFRASTRUCTURE_SECTIONS.length,
+        hasKueueEnabled: true,
+        totalAccelerators,
+        acceleratorsInUse,
+        totalUtilizationPct:
+          totalAccelerators && totalAccelerators > 0
+            ? Math.round(((acceleratorsInUse ?? 0) / totalAccelerators) * 100)
+            : undefined,
+        avgComputeUtilPct: metrics.computeUtilization?.percentage,
+        avgMemoryUtilPct: metrics.memoryUtilization?.percentage,
+      };
+      fireMiscTrackingEvent(GPUAAS_EVENTS.PAGE_VIEWED, props);
+    }
+  }, [metrics.loaded, metrics.accelerators, metrics.computeUtilization, metrics.memoryUtilization]);
+
+  const handleRefresh = React.useCallback(() => {
+    const secondsSinceLastUpdate = metrics.lastRefreshed
+      ? Math.round((Date.now() - metrics.lastRefreshed.getTime()) / 1000)
+      : undefined;
+    metrics.refresh();
+    const props: DataRefreshedProperties = {
+      success: true,
+      secondsSinceLastUpdate,
+    };
+    fireMiscTrackingEvent(GPUAAS_EVENTS.DATA_REFRESHED, props);
+  }, [metrics]);
 
   const SECTION_COMPONENTS: Record<SectionId, React.ReactElement | null> = {
     cluster: <ClusterSummaryCards metrics={metrics} />,
@@ -42,7 +83,7 @@ const InfrastructurePage: React.FC = () => {
     >
       <FlexItem>
         <Tooltip content="Refresh page data">
-          <Button variant="plain" aria-label="Refresh page data" onClick={metrics.refresh}>
+          <Button variant="plain" aria-label="Refresh page data" onClick={handleRefresh}>
             <SyncAltIcon />
           </Button>
         </Tooltip>

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- standard page shell wrapper
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import {
   Button,
   Card,
@@ -32,6 +33,7 @@ type SectionId = (typeof INFRASTRUCTURE_SECTIONS)[number]['id'];
 
 const InfrastructurePage: React.FC = () => {
   const metrics = useInfrastructureMetrics();
+  const isKueueAvailable = useIsAreaAvailable(SupportedArea.GPUAAS_INFRASTRUCTURE).status;
   const hasTrackedPageView = React.useRef(false);
 
   React.useEffect(() => {
@@ -40,9 +42,9 @@ const InfrastructurePage: React.FC = () => {
       const totalAccelerators = metrics.accelerators?.total;
       const acceleratorsInUse = metrics.accelerators?.inUse;
       const props: PageViewedProperties = {
-        path: '/observe-monitor/infrastructure',
+        path: '/observe-and-monitor/infrastructure',
         sectionCount: INFRASTRUCTURE_SECTIONS.length,
-        hasKueueEnabled: true,
+        hasKueueEnabled: isKueueAvailable,
         totalAccelerators,
         acceleratorsInUse,
         totalUtilizationPct:
@@ -54,19 +56,27 @@ const InfrastructurePage: React.FC = () => {
       };
       fireMiscTrackingEvent(GPUAAS_EVENTS.PAGE_VIEWED, props);
     }
-  }, [metrics.loaded, metrics.accelerators, metrics.computeUtilization, metrics.memoryUtilization]);
+  }, [
+    metrics.loaded,
+    metrics.accelerators,
+    metrics.computeUtilization,
+    metrics.memoryUtilization,
+    isKueueAvailable,
+  ]);
 
   const handleRefresh = React.useCallback(() => {
     const secondsSinceLastUpdate = metrics.lastRefreshed
       ? Math.round((Date.now() - metrics.lastRefreshed.getTime()) / 1000)
       : undefined;
     metrics.refresh();
+    // Optimistic: fires before async queries settle; refresh() is fire-and-forget.
     const props: DataRefreshedProperties = {
       success: true,
       secondsSinceLastUpdate,
     };
     fireMiscTrackingEvent(GPUAAS_EVENTS.DATA_REFRESHED, props);
-  }, [metrics]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- .refresh is stable from useFetch
+  }, [metrics.lastRefreshed, metrics.refresh]);
 
   const SECTION_COMPONENTS: Record<SectionId, React.ReactElement | null> = {
     cluster: <ClusterSummaryCards metrics={metrics} />,

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -18,11 +18,7 @@ import {
 import { SyncAltIcon } from '@patternfly/react-icons';
 import { relativeTime } from '@odh-dashboard/internal/utilities/time';
 import { INFRASTRUCTURE_SECTIONS } from '../const';
-import {
-  GPUAAS_EVENTS,
-  type PageViewedProperties,
-  type DataRefreshedProperties,
-} from '../tracking/gpuaasTrackingConstants';
+import { GPUAAS_EVENTS, type PageViewedProperties } from '../tracking/gpuaasTrackingConstants';
 import ClusterSummaryCards from '../components/ClusterSummaryCards';
 import HardwareUsageSection from '../components/HardwareUsageSection';
 import BorrowingLendingSection from '../components/BorrowingLendingSection';
@@ -33,7 +29,7 @@ type SectionId = (typeof INFRASTRUCTURE_SECTIONS)[number]['id'];
 
 const InfrastructurePage: React.FC = () => {
   const metrics = useInfrastructureMetrics();
-  const isKueueAvailable = useIsAreaAvailable(SupportedArea.GPUAAS_INFRASTRUCTURE).status;
+  const isKueueAvailable = useIsAreaAvailable(SupportedArea.KUEUE).status;
   const hasTrackedPageView = React.useRef(false);
 
   React.useEffect(() => {
@@ -69,12 +65,7 @@ const InfrastructurePage: React.FC = () => {
       ? Math.round((Date.now() - metrics.lastRefreshed.getTime()) / 1000)
       : undefined;
     metrics.refresh();
-    // Optimistic: fires before async queries settle; refresh() is fire-and-forget.
-    const props: DataRefreshedProperties = {
-      success: true,
-      secondsSinceLastUpdate,
-    };
-    fireMiscTrackingEvent(GPUAAS_EVENTS.DATA_REFRESHED, props);
+    fireMiscTrackingEvent(GPUAAS_EVENTS.DATA_REFRESHED, { secondsSinceLastUpdate });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- .refresh is stable from useFetch
   }, [metrics.lastRefreshed, metrics.refresh]);
 

--- a/packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx
+++ b/packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx
@@ -3,12 +3,18 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import { GPUAAS_EVENTS } from '../../tracking/gpuaasTrackingConstants';
 import type { ClusterMetrics } from '../../hooks/useInfrastructureMetrics';
 import InfrastructurePage from '../InfrastructurePage';
 
 jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
   fireMiscTrackingEvent: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/plugin-core/areas', () => ({
+  SupportedArea: { GPUAAS_INFRASTRUCTURE: 'gpuaas-infrastructure' },
+  useIsAreaAvailable: jest.fn(),
 }));
 
 jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => {
@@ -69,11 +75,21 @@ jest.mock('../../components/ClusterQueueUtilizationSection', () => ({
 }));
 
 const mockFireMisc = jest.mocked(fireMiscTrackingEvent);
+const mockUseIsAreaAvailable = jest.mocked(useIsAreaAvailable);
 
 describe('InfrastructurePage - Tracking Events', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCurrentMetrics = { ...mockMetrics, refresh: mockRefresh };
+    mockUseIsAreaAvailable.mockReturnValue({
+      status: true,
+      devFlags: null,
+      featureFlags: null,
+      reliantAreas: null,
+      requiredComponents: null,
+      requiredCapabilities: null,
+      customCondition: () => false,
+    });
   });
 
   describe('Infrastructure Page Viewed', () => {
@@ -84,7 +100,7 @@ describe('InfrastructurePage - Tracking Events', () => {
         expect(mockFireMisc).toHaveBeenCalledWith(
           GPUAAS_EVENTS.PAGE_VIEWED,
           expect.objectContaining({
-            path: '/observe-monitor/infrastructure',
+            path: '/observe-and-monitor/infrastructure',
             sectionCount: 4,
             hasKueueEnabled: true,
             totalAccelerators: 8,

--- a/packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx
+++ b/packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx
@@ -13,7 +13,7 @@ jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', (
 }));
 
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({
-  SupportedArea: { GPUAAS_INFRASTRUCTURE: 'gpuaas-infrastructure' },
+  SupportedArea: { KUEUE: 'kueue' },
   useIsAreaAvailable: jest.fn(),
 }));
 
@@ -141,12 +141,7 @@ describe('InfrastructurePage - Tracking Events', () => {
       const refreshButton = screen.getByRole('button', { name: 'Refresh page data' });
       await user.click(refreshButton);
 
-      expect(mockFireMisc).toHaveBeenCalledWith(
-        GPUAAS_EVENTS.DATA_REFRESHED,
-        expect.objectContaining({
-          success: true,
-        }),
-      );
+      expect(mockFireMisc).toHaveBeenCalledWith(GPUAAS_EVENTS.DATA_REFRESHED, expect.any(Object));
       expect(mockRefresh).toHaveBeenCalled();
     });
 
@@ -165,7 +160,6 @@ describe('InfrastructurePage - Tracking Events', () => {
       expect(mockFireMisc).toHaveBeenCalledWith(
         GPUAAS_EVENTS.DATA_REFRESHED,
         expect.objectContaining({
-          success: true,
           secondsSinceLastUpdate: expect.any(Number),
         }),
       );

--- a/packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx
+++ b/packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { GPUAAS_EVENTS } from '../../tracking/gpuaasTrackingConstants';
+import type { ClusterMetrics } from '../../hooks/useInfrastructureMetrics';
+import InfrastructurePage from '../InfrastructurePage';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => {
+  const ApplicationsPage: React.FC<{
+    children: React.ReactNode;
+    headerAction?: React.ReactNode;
+  }> = ({ children, headerAction }) => (
+    <div data-testid="applications-page">
+      {headerAction}
+      {children}
+    </div>
+  );
+  return { __esModule: true, default: ApplicationsPage };
+});
+
+jest.mock('@odh-dashboard/internal/utilities/time', () => ({
+  relativeTime: () => 'a few seconds ago',
+}));
+
+const mockRefresh = jest.fn();
+const mockMetrics: ClusterMetrics = {
+  accelerators: { total: 8, inUse: 3 },
+  computeUtilization: { percentage: 65 },
+  memoryUtilization: { percentage: 42 },
+  hardwareUsage: null,
+  clusterLoaded: true,
+  hardwareLoaded: true,
+  loaded: true,
+  lastRefreshed: new Date(),
+  refresh: mockRefresh,
+};
+
+let mockCurrentMetrics = { ...mockMetrics };
+
+jest.mock('../../hooks/useInfrastructureMetrics', () => ({
+  __esModule: true,
+  default: () => mockCurrentMetrics,
+}));
+
+jest.mock('../../components/ClusterSummaryCards', () => ({
+  __esModule: true,
+  default: () => <div data-testid="cluster-summary" />,
+}));
+
+jest.mock('../../components/HardwareUsageSection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="hardware-usage" />,
+}));
+
+jest.mock('../../components/BorrowingLendingSection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="borrowing-lending" />,
+}));
+
+jest.mock('../../components/ClusterQueueUtilizationSection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="cluster-queue" />,
+}));
+
+const mockFireMisc = jest.mocked(fireMiscTrackingEvent);
+
+describe('InfrastructurePage - Tracking Events', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentMetrics = { ...mockMetrics, refresh: mockRefresh };
+  });
+
+  describe('Infrastructure Page Viewed', () => {
+    it('fires page-viewed event when metrics are loaded', async () => {
+      render(<InfrastructurePage />);
+
+      await waitFor(() => {
+        expect(mockFireMisc).toHaveBeenCalledWith(
+          GPUAAS_EVENTS.PAGE_VIEWED,
+          expect.objectContaining({
+            path: '/observe-monitor/infrastructure',
+            sectionCount: 4,
+            hasKueueEnabled: true,
+            totalAccelerators: 8,
+            acceleratorsInUse: 3,
+            totalUtilizationPct: 38,
+            avgComputeUtilPct: 65,
+            avgMemoryUtilPct: 42,
+          }),
+        );
+      });
+    });
+
+    it('fires page-viewed only once even if metrics update', async () => {
+      const { rerender } = render(<InfrastructurePage />);
+
+      await waitFor(() => {
+        expect(mockFireMisc).toHaveBeenCalledTimes(1);
+      });
+
+      rerender(<InfrastructurePage />);
+
+      expect(mockFireMisc).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire page-viewed when metrics are not loaded', () => {
+      mockCurrentMetrics = { ...mockMetrics, loaded: false, refresh: mockRefresh };
+      render(<InfrastructurePage />);
+
+      expect(mockFireMisc).not.toHaveBeenCalledWith(GPUAAS_EVENTS.PAGE_VIEWED, expect.anything());
+    });
+  });
+
+  describe('Infrastructure Data Refreshed', () => {
+    it('fires data-refreshed event on refresh button click', async () => {
+      const user = userEvent.setup();
+      render(<InfrastructurePage />);
+
+      const refreshButton = screen.getByRole('button', { name: 'Refresh page data' });
+      await user.click(refreshButton);
+
+      expect(mockFireMisc).toHaveBeenCalledWith(
+        GPUAAS_EVENTS.DATA_REFRESHED,
+        expect.objectContaining({
+          success: true,
+        }),
+      );
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+
+    it('includes secondsSinceLastUpdate when lastRefreshed is available', async () => {
+      const user = userEvent.setup();
+      mockCurrentMetrics = {
+        ...mockMetrics,
+        lastRefreshed: new Date(Date.now() - 30_000),
+        refresh: mockRefresh,
+      };
+      render(<InfrastructurePage />);
+
+      const refreshButton = screen.getByRole('button', { name: 'Refresh page data' });
+      await user.click(refreshButton);
+
+      expect(mockFireMisc).toHaveBeenCalledWith(
+        GPUAAS_EVENTS.DATA_REFRESHED,
+        expect.objectContaining({
+          success: true,
+          secondsSinceLastUpdate: expect.any(Number),
+        }),
+      );
+    });
+  });
+});

--- a/packages/gpuaas/src/tracking/gpuaasTrackingConstants.ts
+++ b/packages/gpuaas/src/tracking/gpuaasTrackingConstants.ts
@@ -1,0 +1,72 @@
+export const GPUAAS_EVENTS = {
+  PAGE_VIEWED: 'Infrastructure Page Viewed',
+  PAGE_INTERACTED: 'Infrastructure Page Interacted',
+  COHORT_SECTION_TOGGLED: 'Infrastructure Cohort Section Toggled',
+  BORROW_LEND_DETAIL_VIEWED: 'Infrastructure Borrow Lend Detail Viewed',
+  DATA_REFRESHED: 'Infrastructure Data Refreshed',
+  BORROW_LEND_COHORT_FILTER_SELECTED: 'Infrastructure Borrow Lend Cohort Filter Selected',
+  BORROW_LEND_QUEUE_FILTER_APPLIED: 'Infrastructure Borrow Lend Queue Filter Applied',
+} as const;
+
+export type PageViewedProperties = {
+  path: string;
+  sectionCount: number;
+  hasKueueEnabled: boolean;
+  totalAccelerators?: number;
+  acceleratorsInUse?: number;
+  totalUtilizationPct?: number;
+  avgComputeUtilPct?: number;
+  avgMemoryUtilPct?: number;
+};
+
+export type PageInteractedProperties = {
+  firstInteractionType:
+    | 'refresh'
+    | 'cohortFilter'
+    | 'queueFilter'
+    | 'cohortToggle'
+    | 'borrowLendDetail'
+    | 'trendLegendToggle';
+  secondsSincePageLoad: number;
+};
+
+// TODO: Wire when CohortAccordionGroup toggle interactions are instrumented
+export type CohortSectionToggledProperties = {
+  kueueCohortName: string;
+  kueueCohortId: string;
+  isUncohortedBucket: boolean;
+  isExpanded: boolean;
+  clusterQueueCount: number;
+  hasBorrowLendActive: boolean;
+};
+
+// TODO: Wire when BorrowLendDetailPopover is instrumented
+export type BorrowLendDetailViewedProperties = {
+  clusterQueueName: string;
+  clusterQueueId: string;
+  kueueCohortName: string;
+  direction: 'borrowed' | 'lent';
+  acceleratorCount: number;
+  acceleratorLabel: string;
+  counterpartyQueueName: string;
+};
+
+export type DataRefreshedProperties = {
+  success: boolean;
+  error?: string;
+  secondsSinceLastUpdate?: number;
+};
+
+// TODO: Wire when cohort filter dropdown is instrumented
+export type BorrowLendCohortFilterSelectedProperties = {
+  selectedCohort: string;
+  selectedCohortId: string;
+  visibleQueueCount: number;
+};
+
+// TODO: Wire when queue search field is instrumented
+export type BorrowLendQueueFilterAppliedProperties = {
+  searchQuery: string;
+  matchCount: number;
+  isEmptyResult: boolean;
+};

--- a/packages/gpuaas/src/tracking/gpuaasTrackingConstants.ts
+++ b/packages/gpuaas/src/tracking/gpuaasTrackingConstants.ts
@@ -52,7 +52,8 @@ export type BorrowLendDetailViewedProperties = {
 };
 
 export type DataRefreshedProperties = {
-  success: boolean;
+  /** Set when refresh outcome can be determined; omitted for fire-and-forget clicks. */
+  success?: boolean;
   error?: string;
   secondsSinceLastUpdate?: number;
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-75893

## Description

Adds Segment analytics tracking to the GPUaaS Infrastructure page (`packages/gpuaas`), which previously had zero instrumentation.

Per Kyle's [UX tracking proposal](https://docs.google.com/document/d/19mfjwcaQ8IusvznOx2cush5g2FZXHZjXtNKS6do7Se8/edit) (linked from [RHOAIUX-2794](https://redhat.atlassian.net/browse/RHOAIUX-2794)), this PR:

## How Has This Been Tested?

- `npx turbo run type-check --filter=@odh-dashboard/gpuaas` — passes
- `npx turbo run lint --filter=@odh-dashboard/gpuaas` — passes
- `npx jest --silent` in `packages/gpuaas` — 9 suites, 188 tests pass (including 5 new tracking tests)

## Test Impact

Added `packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx` with 5 tests:
- Page-viewed fires on metrics load with correct properties
- Page-viewed fires only once (ref guard)
- Page-viewed does not fire before metrics load
- Data-refreshed fires on refresh click
- Data-refreshed includes `secondsSinceLastUpdate`

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIUX-2794]: https://redhat.atlassian.net/browse/RHOAIUX-2794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for Infrastructure page views and “Refresh page data” actions.
  * Tracking includes computed utilization and accelerator/queue totals plus optional “seconds since last update”.
  * Introduced shared, typed tracking event names and payload fields for consistent analytics.

* **Tests**
  * Added React Testing Library coverage to confirm the page-view event fires once per load, isn’t sent before metrics are ready, and that refresh produces the correct analytics payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->