### PR TITLE
fix(dashboard-operator): rename VERSION build arg to OPERATOR_VERSION

### DIFF
--- a/dashboard-operator/Dockerfile
+++ b/dashboard-operator/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.26 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG VERSION=unknown
+ARG OPERATOR_VERSION=unknown
 
 WORKDIR /usr/src/app
 
@@ -14,7 +14,7 @@ COPY dashboard-operator/api/ api/
 COPY dashboard-operator/internal/ internal/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a \
-    -ldflags="-s -w -X 'github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller.Version=${VERSION}'" \
+    -ldflags="-s -w -X 'github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller.Version=${OPERATOR_VERSION}'" \
     -o /tmp/manager ./cmd/manager
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -86,7 +86,7 @@ check-chart-crds:
 
 .PHONY: docker-build
 docker-build: ## Build container image (run from repo root).
-	docker build -t $(IMG) -f Dockerfile ..
+	docker build --build-arg OPERATOR_VERSION=$(SAFE_VERSION) -t $(IMG) -f Dockerfile ..
 
 .PHONY: docker-push
 docker-push: ## Push container image.


### PR DESCRIPTION
## Summary

- Rename `ARG VERSION` to `ARG OPERATOR_VERSION` in `dashboard-operator/Dockerfile` to avoid collision with the `VERSION` environment variable baked into the `go-toolset` base image (`VERSION=1.26.5`). The downstream `Dockerfile.konflux.dashboard-operator` uses `go-toolset`, and `ARG VERSION` is silently shadowed by `ENV VERSION` during `RUN`, causing the ldflags injection to embed `1.26.5` instead of the intended version tag.
- Pass `--build-arg OPERATOR_VERSION=$(SAFE_VERSION)` in the Makefile `docker-build` target so `make docker-build` injects the git-derived version.

Found during manual testing of [red-hat-data-services/odh-dashboard#2202](https://github.com/red-hat-data-services/odh-dashboard/pull/2202).

## Test plan

- [x] `podman build --build-arg OPERATOR_VERSION=v3.5.0-test` — verified `v3.5.0-test` appears in the compiled binary
- [x] `podman build` (no `--build-arg`) — verified default `unknown` is used
- [x] Tested with both `dashboard-operator/Dockerfile` and `Dockerfile.konflux.dashboard-operator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker images now receive and display the intended operator version during builds.
  * Improved consistency between release versioning and container image metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->