### PR TITLE
RHOAIENG-71935: add workbench Kueue lifecycle E2E test

### DIFF
--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -138,6 +138,7 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
         </FlexItem>
         {statusSubtitle != null ? (
           <UnderlinedTruncateButton
+            data-testid="notebook-status-subtitle"
             content={statusSubtitle}
             color={getNotebookStatusColor(notebookStatus)}
             textDecoration={getNotebookStatusTextDecoration(notebookStatus, isStarting)}

--- a/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
@@ -13,3 +13,4 @@ updatedMemoryQuota: 8
 sectionTab: "workbenches"
 notebookImage: "code-server-notebook"
 waitingForQuotaMessage: "Waiting for quota"
+queuePositionMarker: "(position"

--- a/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
@@ -1,0 +1,14 @@
+# Kueue workbench lifecycle test data
+# Uses zero quota to force Queued state, then updates quota to allow admission
+projectName: "kueue-lifecycle-project"
+flavorName: "lifecycle-flavor"
+clusterQueueName: "lifecycle-cluster-queue"
+localQueueName: "lifecycle-queue"
+hardwareProfileName: "kueue-lifecycle-hp"
+hardwareProfileDisplayName: "Kueue Lifecycle Profile"
+cpuQuota: 0
+memoryQuota: 0
+updatedCpuQuota: 4
+updatedMemoryQuota: 8
+sectionTab: "workbenches"
+notebookImage: "code-server-notebook"

--- a/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml
@@ -12,3 +12,4 @@ updatedCpuQuota: 4
 updatedMemoryQuota: 8
 sectionTab: "workbenches"
 notebookImage: "code-server-notebook"
+waitingForQuotaMessage: "Waiting for quota"

--- a/packages/cypress/cypress/pages/workbench.ts
+++ b/packages/cypress/cypress/pages/workbench.ts
@@ -295,6 +295,10 @@ class NotebookRow extends TableRow {
     return this.find().findByTestId('notebook-status-text', { timeout });
   }
 
+  findNotebookStatusSubtitle(timeout = 10000) {
+    return this.find().findByTestId('notebook-status-subtitle', { timeout });
+  }
+
   expectStatusLabelToBe(statusValue: string, timeout?: number) {
     this.findHaveNotebookStatusText(timeout).should('have.text', statusValue);
   }

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueue.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueue.cy.ts
@@ -85,6 +85,9 @@ describe('Workbench Kueue Integration Tests', () => {
       cy.step('Submit the workbench creation');
       createSpawnerPage.findSubmitButton().click();
 
+      cy.step('Wait for notebook table to appear');
+      workbenchPage.findNotebookTable(30000).should('exist');
+
       cy.step('Wait for workbench to reach Running status');
       const notebookRow = workbenchPage.getNotebookRow(workbenchName);
       notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 300000);
@@ -109,6 +112,9 @@ describe('Workbench Kueue Integration Tests', () => {
       projectListPage.filterProjectByName(projectName);
       projectListPage.findProjectLink(projectName).click();
       projectDetails.findSectionTab(sectionTab).click();
+
+      cy.step('Wait for notebook table to appear');
+      workbenchPage.findNotebookTable(30000).should('exist');
 
       cy.step('Click on workbench status to open modal');
       const notebookRow = workbenchPage.getNotebookRow(workbenchName);

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
@@ -101,7 +101,9 @@ describe('Workbench Kueue Lifecycle Tests', () => {
         .should('contain.text', fixtureData.waitingForQuotaMessage);
 
       cy.step('Verify queue position is displayed');
-      notebookRow.findNotebookStatusSubtitle().should('contain.text', '(position');
+      notebookRow
+        .findNotebookStatusSubtitle()
+        .should('contain.text', fixtureData.queuePositionMarker);
 
       cy.step('Click on the Queued status label to open the status modal');
       notebookRow.findHaveNotebookStatusText().click();

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
@@ -1,4 +1,4 @@
-import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
+import { LDAP_ADMIN_USER } from '../../../../utils/e2eUsers';
 import {
   deleteOpenShiftProject,
   createOpenShiftProject,
@@ -60,10 +60,10 @@ describe('Workbench Kueue Lifecycle Tests', () => {
 
   it(
     'Verify workbench Kueue lifecycle: Queued → Ready after quota update',
-    { tags: ['@Sanity', '@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged'] },
+    { tags: ['@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged'] },
     () => {
       cy.step('Log into the application');
-      cy.visitWithLogin('/?devFeatureFlags=true', HTPASSWD_CLUSTER_ADMIN_USER);
+      cy.visitWithLogin('/?devFeatureFlags=true', LDAP_ADMIN_USER);
 
       cy.step(`Navigate to workbenches tab of project ${projectName}`);
       projectListPage.navigate();
@@ -93,7 +93,12 @@ describe('Workbench Kueue Lifecycle Tests', () => {
       notebookRow.expectStatusLabelToBe('Queued', 120000);
 
       cy.step('Verify status subtitle shows waiting for quota message');
-      notebookRow.findNotebookStatusSubtitle().should('contain.text', 'Waiting for quota');
+      notebookRow
+        .findNotebookStatusSubtitle()
+        .should('contain.text', fixtureData.waitingForQuotaMessage);
+
+      cy.step('Verify queue position is displayed');
+      notebookRow.findNotebookStatusSubtitle().should('contain.text', '(position');
 
       cy.step('Click on the Queued status label to open the status modal');
       notebookRow.findHaveNotebookStatusText().click();
@@ -125,7 +130,7 @@ describe('Workbench Kueue Lifecycle Tests', () => {
       cy.step('Wait for workbench to transition to Ready status');
       notebookRow.expectStatusLabelToBe('Ready', 300000);
 
-      cy.step('Verify workbench now shows Ready status');
+      cy.step('Verify hardware profile is displayed after Ready');
       notebookRow.shouldHaveHardwareProfile(testData.hardwareProfileDisplayName);
     },
   );

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
@@ -1,0 +1,132 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
+import {
+  deleteOpenShiftProject,
+  createOpenShiftProject,
+} from '../../../../utils/oc_commands/project';
+import { retryableBefore } from '../../../../utils/retryableHooks';
+import { generateTestUUID } from '../../../../utils/uuidGenerator';
+import { loadKueueWorkbenchLifecycleFixture } from '../../../../utils/dataLoader';
+import {
+  setupKueueWorkbenchResources,
+  cleanupKueueWorkbenchResources,
+  updateClusterQueueQuota,
+  type KueueWorkbenchConfig,
+} from '../../../../utils/oc_commands/kueueWorkbench';
+import { projectDetails, projectListPage } from '../../../../pages/projects';
+import {
+  workbenchPage,
+  createSpawnerPage,
+  workbenchStatusModal,
+} from '../../../../pages/workbench';
+import { selectNotebookImageWithBackendFallback } from '../../../../utils/oc_commands/imageStreams';
+import type { KueueWorkbenchLifecycleTestData } from '../../../../types';
+
+describe('Workbench Kueue Lifecycle Tests', () => {
+  let testData: KueueWorkbenchConfig;
+  let fixtureData: KueueWorkbenchLifecycleTestData;
+  let projectName: string;
+  let sectionTab: string;
+  let notebookImage: string;
+  const uuid = generateTestUUID();
+  const workbenchName = `kueue-lifecycle-wb-${uuid}`;
+
+  retryableBefore(() =>
+    loadKueueWorkbenchLifecycleFixture('e2e/kueueWorkbench/testKueueWorkbenchLifecycle.yaml').then(
+      (data) => {
+        fixtureData = data;
+        projectName = `${data.projectName}-${uuid}`;
+        sectionTab = data.sectionTab;
+        notebookImage = data.notebookImage;
+        testData = {
+          flavorName: `${data.flavorName}-${uuid}`,
+          clusterQueueName: `${data.clusterQueueName}-${uuid}`,
+          localQueueName: `${data.localQueueName}-${uuid}`,
+          hardwareProfileName: `${data.hardwareProfileName}-${uuid}`,
+          hardwareProfileDisplayName: `${data.hardwareProfileDisplayName} ${uuid}`,
+          cpuQuota: data.cpuQuota,
+          memoryQuota: data.memoryQuota,
+        };
+        return deleteOpenShiftProject(projectName, { wait: true, ignoreNotFound: true })
+          .then(() => createOpenShiftProject(projectName))
+          .then(() => setupKueueWorkbenchResources(testData, projectName));
+      },
+    ),
+  );
+
+  after(() => {
+    cleanupKueueWorkbenchResources(testData, projectName);
+    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+  });
+
+  it(
+    'Verify workbench Kueue lifecycle: Queued → Ready after quota update',
+    { tags: ['@Sanity', '@Kueue', '@Dashboard', '@Workbenches', '@Featureflagged'] },
+    () => {
+      cy.step('Log into the application');
+      cy.visitWithLogin('/?devFeatureFlags=true', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      cy.step(`Navigate to workbenches tab of project ${projectName}`);
+      projectListPage.navigate();
+      projectListPage.filterProjectByName(projectName);
+      projectListPage.findProjectLink(projectName).click();
+      projectDetails.findSectionTab(sectionTab).click();
+
+      cy.step('Click Create workbench button');
+      workbenchPage.findCreateButton().click();
+
+      cy.step('Enter workbench name');
+      createSpawnerPage.getNameInput().fill(workbenchName);
+
+      cy.step('Select a notebook image');
+      selectNotebookImageWithBackendFallback(notebookImage, createSpawnerPage);
+
+      cy.step('Verify Kueue hardware profile is pre-selected');
+      createSpawnerPage
+        .findHardwareProfileSelect()
+        .should('contain.text', testData.hardwareProfileDisplayName);
+
+      cy.step('Submit the workbench creation');
+      createSpawnerPage.findSubmitButton().click();
+
+      cy.step('Verify workbench shows Queued status');
+      const notebookRow = workbenchPage.getNotebookRow(workbenchName);
+      notebookRow.expectStatusLabelToBe('Queued', 120000);
+
+      cy.step('Verify status subtitle shows waiting for quota message');
+      notebookRow.findNotebookStatusSubtitle().should('contain.text', 'Waiting for quota');
+
+      cy.step('Click on the Queued status label to open the status modal');
+      notebookRow.findHaveNotebookStatusText().click();
+
+      cy.step('Verify status modal is visible');
+      workbenchStatusModal.find().should('be.visible');
+
+      cy.step('Verify Resources tab is visible and click it');
+      workbenchStatusModal.findResourcesTab().should('be.visible');
+      workbenchStatusModal.findResourcesTab().click();
+
+      cy.step('Verify ClusterQueue section is visible with queue name');
+      workbenchStatusModal.findClusterQueueSection().should('be.visible');
+      workbenchStatusModal.findQueueValue().should('contain.text', testData.clusterQueueName);
+
+      cy.step('Verify quotas section is visible');
+      workbenchStatusModal.findQuotasSection().should('be.visible');
+
+      cy.step('Close the status modal');
+      workbenchStatusModal.getModalCloseButton().click();
+
+      cy.step('Update the ClusterQueue quota to allow the workbench');
+      updateClusterQueueQuota(
+        testData.clusterQueueName,
+        fixtureData.updatedCpuQuota,
+        fixtureData.updatedMemoryQuota,
+      );
+
+      cy.step('Wait for workbench to transition to Ready status');
+      notebookRow.expectStatusLabelToBe('Ready', 300000);
+
+      cy.step('Verify workbench now shows Ready status');
+      notebookRow.shouldHaveHardwareProfile(testData.hardwareProfileDisplayName);
+    },
+  );
+});

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueueLifecycle.cy.ts
@@ -88,6 +88,9 @@ describe('Workbench Kueue Lifecycle Tests', () => {
       cy.step('Submit the workbench creation');
       createSpawnerPage.findSubmitButton().click();
 
+      cy.step('Wait for notebook table to appear');
+      workbenchPage.findNotebookTable(30000).should('exist');
+
       cy.step('Verify workbench shows Queued status');
       const notebookRow = workbenchPage.getNotebookRow(workbenchName);
       notebookRow.expectStatusLabelToBe('Queued', 120000);

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -132,6 +132,7 @@ export type KueueWorkbenchLifecycleTestData = KueueWorkbenchTestData & {
   updatedCpuQuota: number;
   updatedMemoryQuota: number;
   waitingForQuotaMessage: string;
+  queuePositionMarker: string;
 };
 
 export type WBControlSuiteTestData = {

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -128,6 +128,11 @@ export type KueueWorkbenchTestData = {
   notebookImage: string;
 };
 
+export type KueueWorkbenchLifecycleTestData = KueueWorkbenchTestData & {
+  updatedCpuQuota: number;
+  updatedMemoryQuota: number;
+};
+
 export type WBControlSuiteTestData = {
   controlSuiteTestNamespace: string;
   controlSuiteTestDescription: string;

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -131,6 +131,7 @@ export type KueueWorkbenchTestData = {
 export type KueueWorkbenchLifecycleTestData = KueueWorkbenchTestData & {
   updatedCpuQuota: number;
   updatedMemoryQuota: number;
+  waitingForQuotaMessage: string;
 };
 
 export type WBControlSuiteTestData = {

--- a/packages/cypress/cypress/utils/dataLoader.ts
+++ b/packages/cypress/cypress/utils/dataLoader.ts
@@ -21,6 +21,7 @@ import type {
   ResourcesFiltersTestData,
   WorkloadMetricsTestData,
   KueueWorkbenchTestData,
+  KueueWorkbenchLifecycleTestData,
   PromptManagementTestData,
   MlflowExperimentsTestData,
   ModelAsAServiceTestData,
@@ -194,6 +195,15 @@ export const loadKueueWorkbenchFixture = (
 ): Cypress.Chainable<KueueWorkbenchTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as KueueWorkbenchTestData;
+
+    return data;
+  });
+
+export const loadKueueWorkbenchLifecycleFixture = (
+  fixturePath: string,
+): Cypress.Chainable<KueueWorkbenchLifecycleTestData> =>
+  cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
+    const data = yaml.load(yamlContent) as KueueWorkbenchLifecycleTestData;
 
     return data;
   });

--- a/packages/cypress/cypress/utils/oc_commands/kueueWorkbench.ts
+++ b/packages/cypress/cypress/utils/oc_commands/kueueWorkbench.ts
@@ -160,6 +160,49 @@ export const verifyWorkloadAdmitted = (namespace: string): Cypress.Chainable<str
 };
 
 /**
+ * Updates the ClusterQueue quota to the specified CPU and memory values.
+ *
+ * @param clusterQueueName - The ClusterQueue to patch
+ * @param cpuQuota - New CPU quota value
+ * @param memoryQuota - New memory quota value (in Gi)
+ * @returns A Cypress chainable with the command result
+ */
+export const updateClusterQueueQuota = (
+  clusterQueueName: string,
+  cpuQuota: number,
+  memoryQuota: number,
+): Cypress.Chainable<CommandLineResult> => {
+  const patchJson = JSON.stringify([
+    {
+      op: 'replace',
+      path: '/spec/resourceGroups/0/flavors/0/resources/0/nominalQuota',
+      value: String(cpuQuota),
+    },
+    {
+      op: 'replace',
+      path: '/spec/resourceGroups/0/flavors/0/resources/1/nominalQuota',
+      value: `${memoryQuota}Gi`,
+    },
+  ]);
+
+  cy.log(
+    `Updating ClusterQueue ${clusterQueueName} quota: cpu=${cpuQuota}, memory=${memoryQuota}Gi`,
+  );
+  return cy
+    .exec(`oc patch clusterqueue ${clusterQueueName} --type=json -p='${patchJson}'`, {
+      failOnNonZeroExit: false,
+      timeout: 60000,
+    })
+    .then((result) => {
+      if (result.exitCode !== 0) {
+        const maskedStderr = maskSensitiveInfo(result.stderr);
+        cy.log(`Warning: Failed to update ClusterQueue quota: ${maskedStderr}`);
+      }
+      return cy.wrap(result);
+    });
+};
+
+/**
  * Cleans up all Kueue resources created for workbench testing.
  *
  * @param config - Configuration containing resource names


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-71935

## Description

Adds a Cypress E2E test that validates the full workbench Kueue lifecycle:

1. **Setup** — creates a project with Kueue label, ResourceFlavor, ClusterQueue with **zero quota**, LocalQueue, and a Kueue-enabled Hardware Profile
2. **Create workbench** — selects the Kueue hardware profile and submits
3. **Verify Queued state** — asserts the workbench shows "Queued" status label and "Waiting for quota" subtitle
4. **Inspect status modal** — opens the modal, clicks the Resources tab, verifies ClusterQueue section with queue name and quotas section
5. **Update quota** — patches the ClusterQueue to allow admission (4 CPU, 8Gi memory)
6. **Verify Ready state** — waits for the workbench to transition from Queued → Starting → Ready
7. **Cleanup** — deletes workbench, hardware profile, Kueue resources, and project

### Changes

| File | What |
|------|------|
| `testWorkbenchKueueLifecycle.cy.ts` | New lifecycle E2E test with `@Sanity` tag |
| `kueueWorkbench.ts` | New `updateClusterQueueQuota` utility (JSON patch) |
| `testKueueWorkbenchLifecycle.yaml` | Fixture with zero initial quota + update values |
| `NotebookStateStatus.tsx` | Add `data-testid="notebook-status-subtitle"` for testability |
| `workbench.ts` (page object) | Add `findNotebookStatusSubtitle()` method |
| `types.ts` | Add `KueueWorkbenchLifecycleTestData` type |
| `dataLoader.ts` | Add `loadKueueWorkbenchLifecycleFixture` loader |

## How Has This Been Tested?

Passed in jenkins `#1949`
- Lint and type-check pass for all modified files
- Test follows established patterns from the existing `testWorkbenchKueue.cy.ts`
- All assertions use page object methods (no direct `cy.findByTestId` in test)

## Test Impact

This PR **is** the test — it adds a new E2E test covering the Kueue workbench lifecycle (Queued → Ready) which was not previously covered by the existing `testWorkbenchKueue.cy.ts` (that test uses sufficient quota so the workbench goes straight to Ready).

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Added a stable UI test marker for reliably identifying the notebook status subtitle.

* **New Features**
  * Introduced Workbench Kueue lifecycle fixture loading to support quota-driven queued-to-ready flows.

* **Tests**
  * Added end-to-end coverage for Workbench Kueue lifecycle transitions, including quota updates, queued/ready status, queue position text, and hardware profile verification.
  * Improved test robustness by adding explicit waits for notebook/workbench tables to appear.

* **Chores**
  * Added Cypress helpers and types to update ClusterQueue quotas and consume lifecycle fixture data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->