### PR TITLE
feat(pipelines): add standalone mode and managed pipelines warning to ConfigurePipelinesServerModal

### DIFF
--- a/frontend/src/concepts/pipelines/content/DeletePipelineServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/DeletePipelineServerModal.tsx
@@ -46,12 +46,13 @@ const DeletePipelineServerModal: React.FC<DeletePipelineServerModalProps> = ({
             });
           })
           .catch((e) => {
+            const caughtError = e instanceof Error ? e : new Error(String(e));
             onBeforeClose(false);
-            setError(e);
+            setError(caughtError);
             fireFormTrackingEvent(eventName, {
               outcome: TrackingOutcome.submit,
               success: false,
-              error: e,
+              error: caughtError.message,
             });
           });
       }}

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
@@ -147,12 +147,13 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
         try {
           obj = await createPipelinesCR(effectiveNamespace, spec);
         } catch (e) {
+          const caughtError = e instanceof Error ? e : new Error(String(e));
           setFetching(false);
-          setError(e);
+          setError(caughtError);
           fireFormTrackingEvent(serverConfiguredEvent, {
             outcome: TrackingOutcome.submit,
             success: false,
-            error: e,
+            error: caughtError.message,
           });
           deleteSecret(effectiveNamespace, ExternalDatabaseSecret.NAME);
           return;
@@ -236,12 +237,13 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
         });
       })
       .catch((e) => {
+        const caughtError = e instanceof Error ? e : new Error(String(e));
         setFetching(false);
-        setError(e);
+        setError(caughtError);
         fireFormTrackingEvent(serverConfiguredEvent, {
           outcome: TrackingOutcome.submit,
           success: false,
-          error: e,
+          error: caughtError.message,
         });
       });
   };

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
@@ -118,6 +118,7 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
     setFetching(false);
     setError(undefined);
     setConfig(mergedDefaults);
+    setAdvancedSettingsExpanded(showManagedPipelinesWarning);
   };
 
   const onCancel = () => {

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
@@ -86,13 +86,10 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
   const [advancedSettingsExpanded, setAdvancedSettingsExpanded] = React.useState(
     showManagedPipelinesWarning,
   );
-  const mergedDefaults = React.useMemo(
-    () => (defaultConfig ? { ...FORM_DEFAULTS, ...defaultConfig } : FORM_DEFAULTS),
-    // Only compute once on mount — defaultConfig should not change after open
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+  const [mergedDefaults] = React.useState<PipelineServerConfigType>(() =>
+    defaultConfig ? { ...FORM_DEFAULTS, ...defaultConfig } : FORM_DEFAULTS,
   );
-  const [config, setConfig] = React.useState<PipelineServerConfigType>(mergedDefaults);
+  const [config, setConfig] = React.useState<PipelineServerConfigType>(() => mergedDefaults);
   const { registerNotification } = React.useContext(NotificationWatcherContext);
   const advancedSettingsRef = React.useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
@@ -144,102 +141,98 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
     };
 
     configureDSPipelineResourceSpec(configureConfig, effectiveNamespace)
-      .then((spec) => {
-        createPipelinesCR(effectiveNamespace, spec)
-          .then((obj: DSPipelineKind) => {
-            onBeforeClose();
+      .then(async (spec) => {
+        let obj: DSPipelineKind;
+        try {
+          obj = await createPipelinesCR(effectiveNamespace, spec);
+        } catch (e) {
+          setFetching(false);
+          setError(e);
+          fireFormTrackingEvent(serverConfiguredEvent, {
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: e,
+          });
+          deleteSecret(effectiveNamespace, ExternalDatabaseSecret.NAME);
+          return;
+        }
 
-            fireFormTrackingEvent(serverConfiguredEvent, {
-              outcome: TrackingOutcome.submit,
-              success: true,
-            });
+        onBeforeClose();
 
-            if (onSuccess) {
-              onSuccess();
-              return;
-            }
+        fireFormTrackingEvent(serverConfiguredEvent, {
+          outcome: TrackingOutcome.submit,
+          success: true,
+        });
 
-            const pollingNamespace = obj.metadata.namespace;
-            registerNotification({
-              callbackDelay: FAST_POLL_INTERVAL,
-              callback: async (signal: AbortSignal) => {
-                try {
-                  // This should emulate the logic in usePipelineNamespaceCR as much as possible
-                  const response = await listPipelinesCR(pollingNamespace, { signal });
-                  const serverLoaded = dspaLoaded([response[0], true]);
-                  const serverAllReady = isDspaAllReady([response[0], true]);
+        if (onSuccess) {
+          onSuccess();
+          return;
+        }
 
-                  if (hasServerTimedOut([response[0], true], serverLoaded)) {
-                    const errorMessage =
-                      response[0]?.status?.conditions?.find(
-                        (condition) => condition.type === 'Ready',
-                      )?.message || `${pollingNamespace} pipeline server creation timed out`;
-                    throw Error(errorMessage);
-                  }
+        const pollingNamespace = obj.metadata.namespace;
+        registerNotification({
+          callbackDelay: FAST_POLL_INTERVAL,
+          callback: async (signal: AbortSignal) => {
+            try {
+              const response = await listPipelinesCR(pollingNamespace, { signal });
+              const serverLoaded = dspaLoaded([response[0], true]);
+              const serverAllReady = isDspaAllReady([response[0], true]);
 
-                  // User deleted pipeline server while waiting
-                  if (response.length === 0) {
-                    return {
-                      status: NotificationResponseStatus.STOP,
-                    };
-                  }
+              if (hasServerTimedOut([response[0], true], serverLoaded)) {
+                const errorMessage =
+                  response[0]?.status?.conditions?.find((condition) => condition.type === 'Ready')
+                    ?.message || `${pollingNamespace} pipeline server creation timed out`;
+                throw Error(errorMessage);
+              }
 
-                  if (serverLoaded && serverAllReady) {
-                    // If we're viewing the StartingStatusModal in the same namespace, we don't need to show the notification
-                    if (startingStatusModalOpenRef?.current === pollingNamespace) {
-                      return {
-                        status: NotificationResponseStatus.STOP,
-                      };
-                    }
+              if (response.length === 0) {
+                return {
+                  status: NotificationResponseStatus.STOP,
+                };
+              }
 
-                    return {
-                      status: NotificationResponseStatus.SUCCESS,
-                      title: `Pipeline server for ${pollingNamespace} is ready.`,
-                      actions: [
-                        {
-                          title: `${pollingNamespace} pipeline server`,
-                          onClick: () => navigate(pipelinesBaseRoute(pollingNamespace)),
-                        },
-                      ],
-                    };
-                  }
-
-                  // repoll
+              if (serverLoaded && serverAllReady) {
+                if (startingStatusModalOpenRef?.current === pollingNamespace) {
                   return {
-                    status: NotificationResponseStatus.REPOLL,
-                  };
-                } catch (e) {
-                  if (startingStatusModalOpenRef?.current === pollingNamespace) {
-                    return {
-                      status: NotificationResponseStatus.STOP,
-                    };
-                  }
-                  return {
-                    status: NotificationResponseStatus.ERROR,
-                    title: `Error configuring pipeline server for ${pollingNamespace}`,
-                    message: e instanceof Error ? e.message : 'Unknown error',
-                    actions: [
-                      {
-                        title: `${pollingNamespace} pipeline server`,
-                        onClick: () => navigate(pipelinesBaseRoute(pollingNamespace)),
-                      },
-                    ],
+                    status: NotificationResponseStatus.STOP,
                   };
                 }
-              },
-            });
-          })
-          .catch((e) => {
-            setFetching(false);
-            setError(e);
-            fireFormTrackingEvent(serverConfiguredEvent, {
-              outcome: TrackingOutcome.submit,
-              success: false,
-              error: e,
-            });
-            // Cleanup created password secret
-            deleteSecret(effectiveNamespace, ExternalDatabaseSecret.NAME);
-          });
+
+                return {
+                  status: NotificationResponseStatus.SUCCESS,
+                  title: `Pipeline server for ${pollingNamespace} is ready.`,
+                  actions: [
+                    {
+                      title: `${pollingNamespace} pipeline server`,
+                      onClick: () => navigate(pipelinesBaseRoute(pollingNamespace)),
+                    },
+                  ],
+                };
+              }
+
+              return {
+                status: NotificationResponseStatus.REPOLL,
+              };
+            } catch (e) {
+              if (startingStatusModalOpenRef?.current === pollingNamespace) {
+                return {
+                  status: NotificationResponseStatus.STOP,
+                };
+              }
+              return {
+                status: NotificationResponseStatus.ERROR,
+                title: `Error configuring pipeline server for ${pollingNamespace}`,
+                message: e instanceof Error ? e.message : 'Unknown error',
+                actions: [
+                  {
+                    title: `${pollingNamespace} pipeline server`,
+                    onClick: () => navigate(pipelinesBaseRoute(pollingNamespace)),
+                  },
+                ],
+              };
+            }
+          },
+        });
       })
       .catch((e) => {
         setFetching(false);

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ConfigurePipelinesServerModal.tsx
@@ -46,6 +46,18 @@ import ManagedPipelinesSettingsSection from './ManagedPipelinesSettingsSection';
 
 type ConfigurePipelinesServerModalProps = {
   onClose: () => void;
+  /** When provided, overrides usePipelinesAPI().namespace. */
+  standaloneNamespace?: string;
+  /** Called after successful DSPA creation (standalone mode). Replaces NotificationWatcher polling. */
+  onSuccess?: () => void;
+  /** Override initial form defaults (e.g. { enableManagedPipelines: true }). */
+  defaultConfig?: Partial<PipelineServerConfigType>;
+  /** Override the modal title (default: "Configure pipeline server"). */
+  title?: string;
+  /** Override the submit button label (default: "Configure pipeline server"). */
+  submitLabel?: string;
+  /** When true, shows a warning when managed pipelines is unchecked and starts advanced settings expanded. */
+  showManagedPipelinesWarning?: boolean;
 };
 
 const FORM_DEFAULTS: PipelineServerConfigType = {
@@ -59,19 +71,37 @@ const FORM_DEFAULTS: PipelineServerConfigType = {
 const serverConfiguredEvent = 'Pipeline Server Configured';
 export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerModalProps> = ({
   onClose,
+  standaloneNamespace,
+  onSuccess,
+  defaultConfig,
+  showManagedPipelinesWarning = false,
+  title: modalTitle = 'Configure pipeline server',
+  submitLabel = 'Configure pipeline server',
 }) => {
-  const { project, namespace, startingStatusModalOpenRef } = usePipelinesAPI();
-  const [connections, loaded] = usePipelinesConnections(namespace);
+  const { namespace, startingStatusModalOpenRef } = usePipelinesAPI();
+  const effectiveNamespace = standaloneNamespace ?? namespace;
+  const [connections, loaded] = usePipelinesConnections(effectiveNamespace);
   const [fetching, setFetching] = React.useState(false);
   const [error, setError] = React.useState<Error>();
-  const [advancedSettingsExpanded, setAdvancedSettingsExpanded] = React.useState(false);
-  const [config, setConfig] = React.useState<PipelineServerConfigType>(FORM_DEFAULTS);
+  const [advancedSettingsExpanded, setAdvancedSettingsExpanded] = React.useState(
+    showManagedPipelinesWarning,
+  );
+  const mergedDefaults = React.useMemo(
+    () => (defaultConfig ? { ...FORM_DEFAULTS, ...defaultConfig } : FORM_DEFAULTS),
+    // Only compute once on mount — defaultConfig should not change after open
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const [config, setConfig] = React.useState<PipelineServerConfigType>(mergedDefaults);
   const { registerNotification } = React.useContext(NotificationWatcherContext);
   const advancedSettingsRef = React.useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
   const { dashboardConfig } = useAppContext();
-  const isManagedPipelinesAvailable =
-    dashboardConfig.spec.dashboardConfig.automl || dashboardConfig.spec.dashboardConfig.autorag;
+  // standaloneNamespace is currently only used in autorag and automl — skip the dashboardConfig
+  // check because to reach those pages the feature must already be enabled.
+  const isManagedPipelinesAvailable = standaloneNamespace
+    ? true
+    : dashboardConfig.spec.dashboardConfig.automl || dashboardConfig.spec.dashboardConfig.autorag;
 
   const databaseIsValid = config.database.useDefault
     ? true
@@ -90,7 +120,7 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
     onClose();
     setFetching(false);
     setError(undefined);
-    setConfig(FORM_DEFAULTS);
+    setConfig(mergedDefaults);
   };
 
   const onCancel = () => {
@@ -113,11 +143,21 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
       objectStorage,
     };
 
-    configureDSPipelineResourceSpec(configureConfig, project.metadata.name)
+    configureDSPipelineResourceSpec(configureConfig, effectiveNamespace)
       .then((spec) => {
-        createPipelinesCR(namespace, spec)
+        createPipelinesCR(effectiveNamespace, spec)
           .then((obj: DSPipelineKind) => {
             onBeforeClose();
+
+            fireFormTrackingEvent(serverConfiguredEvent, {
+              outcome: TrackingOutcome.submit,
+              success: true,
+            });
+
+            if (onSuccess) {
+              onSuccess();
+              return;
+            }
 
             const pollingNamespace = obj.metadata.namespace;
             registerNotification({
@@ -188,10 +228,6 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
                 }
               },
             });
-            fireFormTrackingEvent(serverConfiguredEvent, {
-              outcome: TrackingOutcome.submit,
-              success: true,
-            });
           })
           .catch((e) => {
             setFetching(false);
@@ -202,7 +238,7 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
               error: e,
             });
             // Cleanup created password secret
-            deleteSecret(project.metadata.name, ExternalDatabaseSecret.NAME);
+            deleteSecret(effectiveNamespace, ExternalDatabaseSecret.NAME);
           });
       })
       .catch((e) => {
@@ -219,7 +255,7 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
   return (
     <Modal variant="medium" isOpen onClose={onCancel}>
       <ModalHeader
-        title="Configure pipeline server"
+        title={modalTitle}
         description="Configuring a pipeline server enables you to create and manage pipelines."
       />
       <ModalBody>
@@ -273,7 +309,11 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
                     />
                   </div>
                   {isManagedPipelinesAvailable ? (
-                    <ManagedPipelinesSettingsSection setConfig={setConfig} config={config} />
+                    <ManagedPipelinesSettingsSection
+                      setConfig={setConfig}
+                      config={config}
+                      showWarning={showManagedPipelinesWarning}
+                    />
                   ) : null}
                 </div>
               </ExpandableSection>
@@ -283,7 +323,7 @@ export const ConfigurePipelinesServerModal: React.FC<ConfigurePipelinesServerMod
       </ModalBody>
       <ModalFooter>
         <DashboardModalFooter
-          submitLabel="Configure pipeline server"
+          submitLabel={submitLabel}
           onSubmit={submit}
           isSubmitLoading={fetching}
           isSubmitDisabled={!canSubmit || fetching}

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ManagedPipelinesSettingsSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ManagedPipelinesSettingsSection.tsx
@@ -51,10 +51,12 @@ const ManagedPipelinesSettingsSection: React.FC<ManagedPipelinesSettingsSectionP
   // Scroll the warning into view when it appears — it renders below the fold in the modal
   React.useEffect(() => {
     if (showRequiredError) {
-      requestAnimationFrame(() => {
+      const id = requestAnimationFrame(() => {
         alertRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
       });
+      return () => cancelAnimationFrame(id);
     }
+    return undefined;
   }, [showRequiredError]);
 
   const checkboxElement = (

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ManagedPipelinesSettingsSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ManagedPipelinesSettingsSection.tsx
@@ -5,6 +5,7 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
   DescriptionListDescription,
+  Alert,
 } from '@patternfly/react-core';
 import FormSection from '#~/components/pf-overrides/FormSection';
 import { PipelineServerConfigType } from './types';
@@ -21,7 +22,10 @@ type DescriptionVariantProps = {
   setEnableManagedPipelines: (value: boolean) => void;
 };
 
-type ManagedPipelinesSettingsSectionProps = FormVariantProps | DescriptionVariantProps;
+type ManagedPipelinesSettingsSectionProps = (FormVariantProps | DescriptionVariantProps) & {
+  /** When true, shows a warning alert when the checkbox is unchecked. */
+  showWarning?: boolean;
+};
 
 const ManagedPipelinesSettingsSection: React.FC<ManagedPipelinesSettingsSectionProps> = (props) => {
   let isChecked: boolean;
@@ -41,16 +45,40 @@ const ManagedPipelinesSettingsSection: React.FC<ManagedPipelinesSettingsSectionP
       });
   }
 
+  const showRequiredError = !isChecked && !!props.showWarning;
+  const alertRef = React.useRef<HTMLDivElement>(null);
+
+  // Scroll the warning into view when it appears — it renders below the fold in the modal
+  React.useEffect(() => {
+    if (showRequiredError) {
+      requestAnimationFrame(() => {
+        alertRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      });
+    }
+  }, [showRequiredError]);
+
   const checkboxElement = (
-    <Checkbox
-      id="managed-pipelines-checkbox"
-      data-testid="managed-pipelines-checkbox"
-      name="managed-pipelines-checkbox"
-      label="Enable AutoML and AutoRAG pipelines"
-      isChecked={isChecked}
-      onChange={onChange}
-      description="The AutoML and AutoRAG pipelines contain the steps and instructions for automated model training and RAG pattern experimentation."
-    />
+    <>
+      <Checkbox
+        id="managed-pipelines-checkbox"
+        data-testid="managed-pipelines-checkbox"
+        name="managed-pipelines-checkbox"
+        label="Enable AutoML and AutoRAG pipelines"
+        isChecked={isChecked}
+        onChange={onChange}
+        description="The AutoML and AutoRAG pipelines contain the steps and instructions for automated model training and RAG pattern experimentation."
+      />
+      {showRequiredError ? (
+        <div ref={alertRef}>
+          <Alert
+            variant="warning"
+            isInline
+            title="Deselecting this option deactivates the AutoML and AutoRAG experiences. Enable managed pipelines to use these features."
+            data-testid="managed-pipelines-required-helper-text"
+          />
+        </div>
+      ) : null}
+    </>
   );
 
   if (props.variant === 'description') {

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/ConfigurePipelinesServerModal.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/ConfigurePipelinesServerModal.spec.tsx
@@ -341,4 +341,102 @@ describe('ConfigurePipelinesServerModal', () => {
       });
     });
   });
+
+  describe('standalone mode (standaloneNamespace)', () => {
+    it('should use standaloneNamespace for API calls instead of context namespace', async () => {
+      const {
+        objectStorageIsValid,
+      } = require('#~/concepts/pipelines/content/configurePipelinesServer/utils');
+      objectStorageIsValid.mockReturnValue(true);
+
+      renderModal({
+        onClose: mockOnClose,
+        standaloneNamespace: 'standalone-ns',
+      });
+
+      const submitButton = screen.getByRole('button', { name: 'Configure pipeline server' });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockConfigureDSPipelineResourceSpec).toHaveBeenCalledWith(
+          expect.any(Object),
+          'standalone-ns',
+        );
+        expect(mockCreatePipelinesCR).toHaveBeenCalledWith('standalone-ns', expect.any(Object));
+      });
+    });
+
+    it('should call onSuccess instead of registerNotification when provided', async () => {
+      const {
+        objectStorageIsValid,
+      } = require('#~/concepts/pipelines/content/configurePipelinesServer/utils');
+      objectStorageIsValid.mockReturnValue(true);
+
+      const mockOnSuccess = jest.fn();
+
+      renderModal({
+        onClose: mockOnClose,
+        standaloneNamespace: 'standalone-ns',
+        onSuccess: mockOnSuccess,
+      });
+
+      const submitButton = screen.getByRole('button', { name: 'Configure pipeline server' });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockOnSuccess).toHaveBeenCalled();
+      });
+
+      expect(mockRegisterNotification).not.toHaveBeenCalled();
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    it('should use standaloneNamespace for deleteSecret on submission error', async () => {
+      const {
+        objectStorageIsValid,
+      } = require('#~/concepts/pipelines/content/configurePipelinesServer/utils');
+      objectStorageIsValid.mockReturnValue(true);
+
+      mockCreatePipelinesCR.mockRejectedValue(new Error('Create failed'));
+
+      renderModal({
+        onClose: mockOnClose,
+        standaloneNamespace: 'standalone-ns',
+      });
+
+      const submitButton = screen.getByRole('button', { name: 'Configure pipeline server' });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockDeleteSecret).toHaveBeenCalledWith('standalone-ns', expect.any(String));
+      });
+    });
+
+    it('should show managed pipelines section in standalone mode', () => {
+      renderModal({
+        onClose: mockOnClose,
+        standaloneNamespace: 'standalone-ns',
+      });
+
+      // Expand advanced settings to see managed pipelines
+      fireEvent.click(screen.getByText('Advanced settings'));
+
+      expect(screen.getByText('Managed pipelines')).toBeInTheDocument();
+    });
+  });
+
+  describe('defaultConfig', () => {
+    it('should pre-check managed pipelines when defaultConfig sets enableManagedPipelines', () => {
+      renderModal({
+        onClose: mockOnClose,
+        standaloneNamespace: 'standalone-ns',
+        defaultConfig: { enableManagedPipelines: true },
+      });
+
+      fireEvent.click(screen.getByText('Advanced settings'));
+
+      const checkbox = screen.getByTestId('managed-pipelines-checkbox');
+      expect(checkbox).toBeChecked();
+    });
+  });
 });

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/ConfigurePipelinesServerModal.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/ConfigurePipelinesServerModal.spec.tsx
@@ -289,7 +289,7 @@ describe('ConfigurePipelinesServerModal', () => {
       expect(mockFireFormTrackingEvent).toHaveBeenCalledWith('Pipeline Server Configured', {
         outcome: 'submit',
         success: false,
-        error,
+        error: error.message,
       });
     });
 

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/ManagedPipelinesSettingsSection.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/ManagedPipelinesSettingsSection.spec.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ManagedPipelinesSettingsSection from '#~/concepts/pipelines/content/configurePipelinesServer/ManagedPipelinesSettingsSection';
+import { PipelineServerConfigType } from '#~/concepts/pipelines/content/configurePipelinesServer/types';
+import { EMPTY_AWS_PIPELINE_DATA } from '#~/pages/projects/dataConnections/const';
+
+const baseConfig: PipelineServerConfigType = {
+  database: { useDefault: true, value: [] },
+  objectStorage: { newValue: EMPTY_AWS_PIPELINE_DATA },
+  storeYamlInKubernetes: true,
+  enableCaching: true,
+  enableManagedPipelines: false,
+};
+
+describe('ManagedPipelinesSettingsSection', () => {
+  describe('form variant', () => {
+    it('should render the checkbox unchecked by default', () => {
+      render(<ManagedPipelinesSettingsSection config={baseConfig} setConfig={jest.fn()} />);
+
+      const checkbox = screen.getByTestId('managed-pipelines-checkbox');
+      expect(checkbox).not.toBeChecked();
+      expect(checkbox).toBeEnabled();
+    });
+
+    it('should render the checkbox checked when enableManagedPipelines is true', () => {
+      render(
+        <ManagedPipelinesSettingsSection
+          config={{ ...baseConfig, enableManagedPipelines: true }}
+          setConfig={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('managed-pipelines-checkbox')).toBeChecked();
+    });
+
+    it('should toggle enableManagedPipelines when clicked', () => {
+      const setConfig = jest.fn();
+      render(<ManagedPipelinesSettingsSection config={baseConfig} setConfig={setConfig} />);
+
+      fireEvent.click(screen.getByTestId('managed-pipelines-checkbox'));
+
+      expect(setConfig).toHaveBeenCalledWith({ ...baseConfig, enableManagedPipelines: true });
+    });
+
+    it('should render section title and description', () => {
+      render(<ManagedPipelinesSettingsSection config={baseConfig} setConfig={jest.fn()} />);
+
+      expect(screen.getByText('Managed pipelines')).toBeInTheDocument();
+      expect(screen.getByText('Enable AutoML and AutoRAG pipelines')).toBeInTheDocument();
+    });
+  });
+
+  describe('description variant', () => {
+    it('should render in a description list layout', () => {
+      render(
+        <ManagedPipelinesSettingsSection
+          variant="description"
+          enableManagedPipelines={false}
+          setEnableManagedPipelines={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText('Managed pipelines')).toBeInTheDocument();
+      expect(screen.getByTestId('managed-pipelines-checkbox')).not.toBeChecked();
+    });
+
+    it('should toggle via setEnableManagedPipelines when clicked', () => {
+      const setEnableManagedPipelines = jest.fn();
+      render(
+        <ManagedPipelinesSettingsSection
+          variant="description"
+          enableManagedPipelines={false}
+          setEnableManagedPipelines={setEnableManagedPipelines}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('managed-pipelines-checkbox'));
+      expect(setEnableManagedPipelines).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/ManagedPipelinesSettingsSection.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/__tests__/ManagedPipelinesSettingsSection.spec.tsx
@@ -51,6 +51,66 @@ describe('ManagedPipelinesSettingsSection', () => {
     });
   });
 
+  describe('showWarning behavior', () => {
+    it('should show warning alert when showWarning is true and checkbox is unchecked', () => {
+      render(
+        <ManagedPipelinesSettingsSection config={baseConfig} setConfig={jest.fn()} showWarning />,
+      );
+
+      expect(screen.getByTestId('managed-pipelines-required-helper-text')).toBeInTheDocument();
+    });
+
+    it('should not show warning alert when enableManagedPipelines is true', () => {
+      render(
+        <ManagedPipelinesSettingsSection
+          config={{ ...baseConfig, enableManagedPipelines: true }}
+          setConfig={jest.fn()}
+          showWarning
+        />,
+      );
+
+      expect(
+        screen.queryByTestId('managed-pipelines-required-helper-text'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not show warning alert when showWarning is not set', () => {
+      render(<ManagedPipelinesSettingsSection config={baseConfig} setConfig={jest.fn()} />);
+
+      expect(
+        screen.queryByTestId('managed-pipelines-required-helper-text'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show warning in description variant when unchecked with showWarning', () => {
+      render(
+        <ManagedPipelinesSettingsSection
+          variant="description"
+          enableManagedPipelines={false}
+          setEnableManagedPipelines={jest.fn()}
+          showWarning
+        />,
+      );
+
+      expect(screen.getByTestId('managed-pipelines-required-helper-text')).toBeInTheDocument();
+    });
+
+    it('should not show warning in description variant when checked with showWarning', () => {
+      render(
+        <ManagedPipelinesSettingsSection
+          variant="description"
+          enableManagedPipelines
+          setEnableManagedPipelines={jest.fn()}
+          showWarning
+        />,
+      );
+
+      expect(
+        screen.queryByTestId('managed-pipelines-required-helper-text'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe('description variant', () => {
     it('should render in a description list layout', () => {
       render(


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-74829

## Description

This PR adds standalone/reusable mode to `ConfigurePipelinesServerModal` and a warning alert to `ManagedPipelinesSettingsSection`. These changes were split out of #8425 (AutoML & AutoRAG packages) so the shared modal enhancements can be reviewed independently from the new packages that consume them. Nothing in this PR is consumed outside of the packages introduced in #8425.

**ConfigurePipelinesServerModal** — new optional props for standalone reuse:
- `standaloneNamespace` — overrides `usePipelinesAPI().namespace` so the modal can create a DSPA in an arbitrary namespace
- `onSuccess` — callback after successful DSPA creation, replacing the `NotificationWatcher` polling flow
- `defaultConfig` — override initial form defaults (e.g. `{ enableManagedPipelines: true }`)
- `title` / `submitLabel` — override the modal title and submit button text
- `showManagedPipelinesWarning` — when true, starts the advanced settings expanded and shows a warning when managed pipelines is unchecked

**ManagedPipelinesSettingsSection** — new `showWarning` prop:
- Renders an inline warning alert when managed pipelines is deselected, with auto-scroll into view
- Used by the standalone modal flow to communicate that deselecting managed pipelines disables AutoML/AutoRAG

<img alt="configure_rag" src="https://github.com/user-attachments/assets/e50f9d6c-0f3b-4e01-ad16-130d54321e10" />

## How Has This Been Tested?

- Unit tests added for `ManagedPipelinesSettingsSection` (new file)
- Existing `ConfigurePipelinesServerModal` spec updated with standalone-mode coverage

## Test Impact

- New: `ManagedPipelinesSettingsSection.spec.tsx` — covers checkbox toggle, warning alert visibility, and description variant rendering
- Updated: `ConfigurePipelinesServerModal.spec.tsx` — adds test cases for the new standalone props

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standalone mode for configuring pipeline servers.
  * Enhanced the configuration modal with optional title, submit label, default configuration, and success callback.
  * Added managed-pipelines inline warning in advanced settings with auto-scroll when it appears.

* **Bug Fixes**
  * Improved namespace handling for pipeline setup and related cleanup during success and failure flows.
  * Configuration and advanced settings now reset to the selected defaults when the modal closes.

* **Tests**
  * Added unit tests covering standalone mode, defaultConfig behavior, warning visibility, and managed-pipelines interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->