### PR TITLE
feat(gen-ai): add Segment tracking events for Playground Tracing

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
@@ -233,6 +233,8 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
         placeholderContent={placeholderBotContentProp ?? PLACEHOLDER_BOT_CONTENT}
         hasImagesInConversation={hasImagesInConversation}
         onViewTrace={onViewTrace}
+        compareMode={isCompareMode}
+        configID={configIndex === 0 ? 'default' : String(configIndex)}
       />
     </MessageBox>
   );

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMessagesList.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMessagesList.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Button, Stack, StackItem } from '@patternfly/react-core';
 import { Message, MessageProps as PFMessageProps } from '@patternfly/chatbot';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import botAvatar from '~/app/bgimages/bot_avatar.svg';
 import { ChatbotMessageProps } from '~/app/Chatbot/hooks/useChatbotMessages';
 import { ChatbotMessagesMetrics } from '~/app/Chatbot/ChatbotMessagesMetrics';
 import ChatbotErrorAlert from '~/app/Chatbot/components/ChatbotErrorAlert';
 import ChatbotFileSearchResults from '~/app/Chatbot/ChatbotFileSearchResults';
+import { PLAYGROUND_TRACING_EVENTS } from '~/app/tracking/playgroundTracingTrackingConstants';
 import './ChatbotMessagesList.scss';
 
 type ChatbotMessagesListProps = {
@@ -20,6 +22,10 @@ type ChatbotMessagesListProps = {
   hasImagesInConversation?: boolean;
   /** Called when the user clicks "View trace" on a bot message with a traceId */
   onViewTrace?: (traceId: string) => void;
+  /** Whether compare mode is active */
+  compareMode?: boolean;
+  /** Config ID string for tracking: 'default', '1', or '2' */
+  configID?: string;
 };
 
 const CITATION_REGEX = /\{\{citation:(\d+)\}\}/g;
@@ -36,6 +42,8 @@ const ChatbotMessagesList: React.FC<ChatbotMessagesListProps> = ({
   placeholderContent,
   hasImagesInConversation = false,
   onViewTrace,
+  compareMode = false,
+  configID = 'default',
 }) => {
   const [expandedCitation, setExpandedCitation] = React.useState<{
     messageId: string;
@@ -116,7 +124,15 @@ const ChatbotMessagesList: React.FC<ChatbotMessagesListProps> = ({
                   <Button
                     variant="link"
                     isInline
-                    onClick={() => onViewTrace(traceId)}
+                    onClick={() => {
+                      fireMiscTrackingEvent(PLAYGROUND_TRACING_EVENTS.TRACE_VIEW_OPENED, {
+                        source: 'message_button',
+                        traceId,
+                        compareMode,
+                        configID,
+                      });
+                      onViewTrace(traceId);
+                    }}
                     data-testid="view-trace-link"
                   >
                     View trace

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -26,6 +26,7 @@ import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTrack
 import DashboardModalFooter from '@odh-dashboard/internal/concepts/dashboard/DashboardModalFooter';
 import { PLAYGROUND_MULTIMODAL_EVENTS } from '~/app/tracking/playgroundMultimodalTrackingConstants';
 import { PLAYGROUND_AGENT_EVENTS } from '~/app/tracking/playgroundAgentTrackingConstants';
+import { PLAYGROUND_TRACING_EVENTS } from '~/app/tracking/playgroundTracingTrackingConstants';
 import { useUserContext } from '~/app/context/UserContext';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import { GenAiContext } from '~/app/context/GenAiContext';
@@ -1135,7 +1136,13 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
               isOpen={!!selectedTraceId}
               traceId={selectedTraceId || ''}
               workspace={namespace?.name}
-              onClose={() => setSelectedTraceId(null)}
+              onClose={() => {
+                fireMiscTrackingEvent(PLAYGROUND_TRACING_EVENTS.TRACE_VIEW_CLOSED, {
+                  traceId: selectedTraceId ?? undefined,
+                  compareMode: isCompareMode,
+                });
+                setSelectedTraceId(null);
+              }}
             >
               <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
                 {/* Single mode header */}

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
@@ -16,8 +16,12 @@ import {
   Switch,
 } from '@patternfly/react-core';
 import { ArrowLeftIcon } from '@patternfly/react-icons';
-import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
+import { PLAYGROUND_TRACING_EVENTS } from '~/app/tracking/playgroundTracingTrackingConstants';
 import { GenAiContext } from '~/app/context/GenAiContext';
 import {
   AIModel,
@@ -609,7 +613,13 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
                   </>
                 }
                 isChecked={enableTracing}
-                onChange={(_event, checked) => setEnableTracing(checked)}
+                onChange={(_event, checked) => {
+                  setEnableTracing(checked);
+                  fireMiscTrackingEvent(PLAYGROUND_TRACING_EVENTS.CONFIGURE_TRACING_TOGGLED, {
+                    isEnabled: checked,
+                    source: 'configure_playground_modal',
+                  });
+                }}
                 aria-label="Toggle tracing for this playground"
                 data-testid="enable-tracing-switch"
               />

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
@@ -23,6 +23,7 @@ import { mockGenAiContextValue } from '~/__mocks__/mockGenAiContext';
 
 jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
   fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
 }));
 
 jest.mock('~/app/Chatbot/hooks/useGuardrailsEnabled');

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
@@ -509,6 +509,7 @@ const useChatbotMessages = ({
             ? 'unsaved_changes'
             : 'saved'
           : 'temporary_session',
+        tracingEnabled: !!isTracingEnabled,
       });
 
       if (!apiAvailable) {

--- a/packages/gen-ai/frontend/src/app/tracking/playgroundTracingTrackingConstants.ts
+++ b/packages/gen-ai/frontend/src/app/tracking/playgroundTracingTrackingConstants.ts
@@ -1,0 +1,22 @@
+export const PLAYGROUND_TRACING_EVENTS = {
+  CONFIGURE_TRACING_TOGGLED: 'Playground Configure Tracing Toggled',
+  TRACE_VIEW_OPENED: 'Playground Trace View Opened',
+  TRACE_VIEW_CLOSED: 'Playground Trace View Closed',
+} as const;
+
+export type ConfigureTracingToggledProperties = {
+  isEnabled: boolean;
+  source: 'configure_playground_modal';
+};
+
+export type TraceViewOpenedProperties = {
+  source: 'message_button' | 'kebab_menu';
+  traceId: string;
+  compareMode: boolean;
+  configID: string;
+};
+
+export type TraceViewClosedProperties = {
+  traceId?: string;
+  compareMode: boolean;
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72216

## Description

Adds Segment tracking events for Playground Tracing per the [event tracking spec](https://docs.google.com/document/d/1F324O2wesYGsm7mv7D0DZIsGBxUFFmGtzAEOZxVDjD4/edit?tab=t.85wpyn1ymwci#heading=h.5u17fqgutkm0).

**Events implemented:**

| ID | Event Name | Trigger | Properties |
|----|-----------|---------|------------|
| U1 | Playground Query Submitted *(update)* | User submits a query | Added `tracingEnabled: boolean` |
| E1 | Playground Configure Tracing Toggled | User toggles "Enable tracing" switch in Configure playground modal | `isEnabled`, `source` |
| E2 | Playground Trace View Opened | User clicks "View trace" link below a bot message | `source`, `traceId`, `compareMode`, `configID` |
| E3 | Playground Trace View Closed | User clicks the close button on the trace drawer | `traceId`, `compareMode` |

**Events NOT included (out of scope):**

Events E4–E9 (Trace Drawer Expanded, Compare Chat Switched, Span Detail Tab Switched, Span Selected, Breakdown View Switched, Span Link Opened) all interact with UI rendered inside the MLflow embedded component, which is loaded remotely via Module Federation from the MLflow server. Tracking these requires changes to the MLflow embedded component to expose callback props. The kebab menu "View tracing" entry point (E2 `source: 'kebab_menu'`) does not exist in the UI yet.

## How Has This Been Tested?

- Type-check passes (`tsc --noEmit`)
- ESLint passes on all changed files
- All 1736 unit tests pass (112 suites)

## Test Impact

No new tests added. The tracking functions are globally mocked in `jest.setup.ts`, so existing tests continue to pass. The new events use `fireMiscTrackingEvent` which is a fire-and-forget call with no side effects on component behavior — the tracking calls don't affect render output or state.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved tracking for tracing-related actions, including enabling or disabling tracing and opening or closing trace views.
  - Trace activity now records relevant comparison and configuration context.
  - Query submission tracking now reflects whether tracing is enabled.
- **Tests**
  - Updated configuration modal test coverage to support tracing interaction tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->