### PR TITLE
feat: add Segment tracking for the What's New guided tour

### DIFF
--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -156,7 +156,7 @@ const HeaderTools: React.FC<Props> = ({ onNotificationsClick, ...devFeatureFlags
               <Button
                 variant="plain"
                 aria-label="What's new"
-                onClick={openWhatsNewTour}
+                onClick={() => openWhatsNewTour('masthead')}
                 data-testid="whats-new-button"
               >
                 <LightBulbIcon style={{ fontSize: 'var(--pf-t--global--font--size--lg)' }} />

--- a/frontend/src/app/whatsNew/WhatsNewModal.tsx
+++ b/frontend/src/app/whatsNew/WhatsNewModal.tsx
@@ -21,11 +21,14 @@ import { ExternalLinkAltIcon, ExclamationTriangleIcon } from '@patternfly/react-
 import { useBrowserStorage } from '@odh-dashboard/ui-core/utilities';
 import { useAppContext } from '#~/app/AppContext';
 import { useUser } from '#~/redux/selectors';
-import type { GuidedTourDismissMethod, GuidedTourEntryPoint } from './tracking/guidedTourTracking';
+import {
+  TOUR_SEEN_STORAGE_KEY,
+  type GuidedTourDismissMethod,
+  type GuidedTourEntryPoint,
+} from './tracking/guidedTourTracking';
 import { useGuidedTourTracking } from './tracking/useGuidedTourTracking';
 import { useWhatsNewTourListener } from './whatsNewEvent';
 
-const STORAGE_KEY = 'odh-whats-new-3.5-seen';
 const DEFAULT_DOC_URL =
   'https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.5';
 
@@ -266,7 +269,7 @@ const findNavElement = (step: TourStep): HTMLElement | null => {
 
 const WhatsNewModal: React.FC = () => {
   const { isAdmin } = useUser();
-  const [seen, setSeen] = useBrowserStorage<boolean>(STORAGE_KEY, false);
+  const [seen, setSeen] = useBrowserStorage<boolean>(TOUR_SEEN_STORAGE_KEY, false);
   const [isOpen, setIsOpen] = React.useState(false);
   const [showWelcome, setShowWelcome] = React.useState(true);
   const [stepIndex, setStepIndex] = React.useState(0);
@@ -469,6 +472,8 @@ const WhatsNewModal: React.FC = () => {
   }
 
   // ── Completion screen ──
+  // User has finished every step; both the footer Close and the modal X count as
+  // Completed (not Dismissed). Dismissed is only for exiting before the summary.
   if (stepIndex >= tourSteps.length) {
     return (
       <Modal
@@ -476,7 +481,7 @@ const WhatsNewModal: React.FC = () => {
         variant={ModalVariant.small}
         isOpen
         aria-labelledby="whats-new-done-title"
-        onClose={() => handleDismiss('modal_close')}
+        onClose={handleComplete}
       >
         <ModalHeader title="You're ready to go!" labelId="whats-new-done-title" />
         <ModalBody>
@@ -649,7 +654,8 @@ const WhatsNewModal: React.FC = () => {
   if (targetEl) {
     return (
       <>
-        <Backdrop onClick={() => handleDismiss('popover_close')} />
+        {/* Visual only — outside clicks are handled by Popover shouldClose to avoid double dismiss telemetry. */}
+        <Backdrop />
         <Popover
           data-testid="nav-tour-popover"
           isVisible

--- a/frontend/src/app/whatsNew/WhatsNewModal.tsx
+++ b/frontend/src/app/whatsNew/WhatsNewModal.tsx
@@ -294,14 +294,26 @@ const WhatsNewModal: React.FC = () => {
     return tourSteps.length;
   }, [tourPath, tourSteps]);
 
+  const autoLaunchTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelAutoLaunch = React.useCallback(() => {
+    if (autoLaunchTimerRef.current !== null) {
+      clearTimeout(autoLaunchTimerRef.current);
+      autoLaunchTimerRef.current = null;
+    }
+  }, []);
+
   const openTour = React.useCallback(
     (entryPoint: GuidedTourEntryPoint, isReturningUser: boolean) => {
+      // Manual opens (masthead / task assistant) must cancel a pending auto-launch
+      // so we don't reset the session and emit a duplicate Started event.
+      cancelAutoLaunch();
       beginSession(entryPoint, isReturningUser);
       setShowWelcome(true);
       setStepIndex(0);
       setIsOpen(true);
     },
-    [beginSession],
+    [beginSession, cancelAutoLaunch],
   );
 
   const openTourRef = React.useRef(openTour);
@@ -311,8 +323,16 @@ const WhatsNewModal: React.FC = () => {
 
   React.useEffect(() => {
     if (!seen) {
-      const timer = setTimeout(() => openTourRef.current('auto-launch', false), 1500);
-      return () => clearTimeout(timer);
+      autoLaunchTimerRef.current = setTimeout(() => {
+        autoLaunchTimerRef.current = null;
+        openTourRef.current('auto-launch', false);
+      }, 1500);
+      return () => {
+        if (autoLaunchTimerRef.current !== null) {
+          clearTimeout(autoLaunchTimerRef.current);
+          autoLaunchTimerRef.current = null;
+        }
+      };
     }
     return undefined;
   }, [seen]);

--- a/frontend/src/app/whatsNew/WhatsNewModal.tsx
+++ b/frontend/src/app/whatsNew/WhatsNewModal.tsx
@@ -21,6 +21,8 @@ import { ExternalLinkAltIcon, ExclamationTriangleIcon } from '@patternfly/react-
 import { useBrowserStorage } from '@odh-dashboard/ui-core/utilities';
 import { useAppContext } from '#~/app/AppContext';
 import { useUser } from '#~/redux/selectors';
+import type { GuidedTourDismissMethod, GuidedTourEntryPoint } from './tracking/guidedTourTracking';
+import { useGuidedTourTracking } from './tracking/useGuidedTourTracking';
 import { useWhatsNewTourListener } from './whatsNewEvent';
 
 const STORAGE_KEY = 'odh-whats-new-3.5-seen';
@@ -35,6 +37,7 @@ type NewIn35Feature = {
 };
 
 type TourStep = {
+  id: string;
   title: string;
   description: string;
   navSelector: string;
@@ -64,6 +67,7 @@ const useTourSteps = (isAdmin: boolean): TourStep[] => {
   return React.useMemo<TourStep[]>(
     () => [
       {
+        id: 'projects',
         title: 'Projects',
         description:
           'Organize your AI work into projects. Each project groups workbenches, pipelines, model servers, and cluster storage so your team can collaborate in one place.',
@@ -73,6 +77,7 @@ const useTourSteps = (isAdmin: boolean): TourStep[] => {
         newFeatures: [],
       },
       {
+        id: 'gen-ai-studio',
         title: 'Gen AI studio',
         description:
           'Build and experiment with generative AI applications. Test models and prompts in the Playground, manage API keys, build retrieval-augmented generation (RAG) pipelines, and adjust model parameters.',
@@ -111,6 +116,7 @@ const useTourSteps = (isAdmin: boolean): TourStep[] => {
         ],
       },
       {
+        id: 'develop-and-train',
         title: 'Develop & train',
         description:
           'Build and train models using workbenches, pipelines, and distributed training jobs. Launch Jupyter notebooks, submit Ray jobs, or run automated experiments.',
@@ -127,6 +133,7 @@ const useTourSteps = (isAdmin: boolean): TourStep[] => {
         ],
       },
       {
+        id: 'ai-hub',
         title: 'AI hub',
         description:
           'Discover pre-built models, MCP servers, and agents from a central catalog. Browse, filter, and deploy assets directly to your project.',
@@ -164,6 +171,7 @@ const useTourSteps = (isAdmin: boolean): TourStep[] => {
         ],
       },
       {
+        id: 'observe-and-monitor',
         title: 'Observe & monitor',
         description:
           'Track workload metrics and resource utilization across your projects. Monitor GPU usage, queue wait times, and distributed workload performance.',
@@ -182,6 +190,7 @@ const useTourSteps = (isAdmin: boolean): TourStep[] => {
       ...(isAdmin
         ? [
             {
+              id: 'settings',
               title: 'Settings',
               description:
                 'Configure cluster-wide settings including storage classes, hardware profiles, serving runtimes, connection types, and user access management.',
@@ -263,43 +272,118 @@ const WhatsNewModal: React.FC = () => {
   const [stepIndex, setStepIndex] = React.useState(0);
   const tourSteps = useTourSteps(isAdmin);
   const [targetEl, setTargetEl] = React.useState<HTMLElement | null>(null);
+  const {
+    beginSession,
+    selectPath,
+    trackStepView,
+    trackLearnMore,
+    trackSummaryDocs,
+    dismiss,
+    complete,
+    resetSession,
+    tourPath,
+  } = useGuidedTourTracking(isAdmin);
+
+  const pathStepCount = React.useMemo(() => {
+    if (tourPath === 'new-features-only') {
+      return tourSteps.filter((step) => step.newFeatures.length > 0).length;
+    }
+    return tourSteps.length;
+  }, [tourPath, tourSteps]);
+
+  const openTour = React.useCallback(
+    (entryPoint: GuidedTourEntryPoint, isReturningUser: boolean) => {
+      beginSession(entryPoint, isReturningUser);
+      setShowWelcome(true);
+      setStepIndex(0);
+      setIsOpen(true);
+    },
+    [beginSession],
+  );
+
+  const openTourRef = React.useRef(openTour);
+  openTourRef.current = openTour;
+  const seenRef = React.useRef(seen);
+  seenRef.current = seen;
 
   React.useEffect(() => {
     if (!seen) {
-      const timer = setTimeout(() => setIsOpen(true), 1500);
+      const timer = setTimeout(() => openTourRef.current('auto-launch', false), 1500);
       return () => clearTimeout(timer);
     }
     return undefined;
   }, [seen]);
 
   useWhatsNewTourListener(
-    React.useCallback(() => {
-      setShowWelcome(true);
-      setStepIndex(0);
-      setIsOpen(true);
+    React.useCallback((entryPoint) => {
+      openTourRef.current(entryPoint, seenRef.current);
     }, []),
   );
 
-  const close = React.useCallback(() => {
+  const closeUi = React.useCallback(() => {
     setIsOpen(false);
     setSeen(true);
     setShowWelcome(true);
     setStepIndex(0);
-  }, [setSeen]);
+    resetSession();
+  }, [resetSession, setSeen]);
+
+  const getDismissLocation = React.useCallback((): {
+    dismissStepId: string;
+    dismissStepIndex: number;
+  } => {
+    if (showWelcome) {
+      return { dismissStepId: 'welcome', dismissStepIndex: -1 };
+    }
+    if (stepIndex >= tourSteps.length) {
+      return { dismissStepId: 'summary', dismissStepIndex: tourSteps.length };
+    }
+    return {
+      dismissStepId: tourSteps[stepIndex]?.id ?? 'unknown',
+      dismissStepIndex: stepIndex,
+    };
+  }, [showWelcome, stepIndex, tourSteps]);
+
+  const handleDismiss = React.useCallback(
+    (dismissMethod: GuidedTourDismissMethod) => {
+      const { dismissStepId, dismissStepIndex } = getDismissLocation();
+      dismiss({
+        dismissMethod,
+        dismissStepId,
+        dismissStepIndex,
+        pathStepCount,
+      });
+      closeUi();
+    },
+    [closeUi, dismiss, getDismissLocation, pathStepCount],
+  );
+
+  const handleComplete = React.useCallback(() => {
+    complete(pathStepCount);
+    closeUi();
+  }, [closeUi, complete, pathStepCount]);
 
   const startTour = React.useCallback(() => {
+    selectPath('full');
     setShowWelcome(false);
     setStepIndex(0);
-  }, []);
+  }, [selectPath]);
 
   const startWhatsNew = React.useCallback(() => {
+    selectPath('new-features-only');
     const firstWithFeatures = tourSteps.findIndex((s) => s.newFeatures.length > 0);
     setShowWelcome(false);
     setStepIndex(firstWithFeatures >= 0 ? firstWithFeatures : 0);
-  }, [tourSteps]);
+  }, [selectPath, tourSteps]);
 
   const currentStep = !showWelcome ? tourSteps[stepIndex] ?? null : null;
   const [targetReady, setTargetReady] = React.useState(false);
+
+  React.useEffect(() => {
+    if (currentStep) {
+      trackStepView(currentStep);
+    }
+  }, [currentStep, trackStepView]);
 
   React.useEffect(() => {
     if (!isOpen || !currentStep) {
@@ -340,7 +424,7 @@ const WhatsNewModal: React.FC = () => {
         variant={ModalVariant.medium}
         isOpen
         aria-labelledby="whats-new-modal-title"
-        onClose={close}
+        onClose={() => handleDismiss('modal_close')}
       >
         <ModalHeader
           title="Welcome to the new OpenShift AI 3.5 experience!"
@@ -370,7 +454,11 @@ const WhatsNewModal: React.FC = () => {
               </Button>
             </FlexItem>
             <FlexItem>
-              <Button data-testid="whats-new-skip-tour" variant="link" onClick={close}>
+              <Button
+                data-testid="whats-new-skip-tour"
+                variant="link"
+                onClick={() => handleDismiss('skip_button')}
+              >
                 Skip tour
               </Button>
             </FlexItem>
@@ -388,7 +476,7 @@ const WhatsNewModal: React.FC = () => {
         variant={ModalVariant.small}
         isOpen
         aria-labelledby="whats-new-done-title"
-        onClose={close}
+        onClose={() => handleDismiss('modal_close')}
       >
         <ModalHeader title="You're ready to go!" labelId="whats-new-done-title" />
         <ModalBody>
@@ -403,6 +491,7 @@ const WhatsNewModal: React.FC = () => {
               rel="noopener noreferrer"
               icon={<ExternalLinkAltIcon />}
               iconPosition="end"
+              onClick={() => trackSummaryDocs(DEFAULT_DOC_URL)}
             >
               documentation
             </Button>
@@ -421,7 +510,7 @@ const WhatsNewModal: React.FC = () => {
               </Button>
             </FlexItem>
             <FlexItem>
-              <Button data-testid="whats-new-done-close" variant="primary" onClick={close}>
+              <Button data-testid="whats-new-done-close" variant="primary" onClick={handleComplete}>
                 Close
               </Button>
             </FlexItem>
@@ -440,6 +529,7 @@ const WhatsNewModal: React.FC = () => {
   const learnMoreUrl = currentStep.docUrl ?? DEFAULT_DOC_URL;
   const unavailableFeatures = currentStep.newFeatures.filter((f) => !f.available);
   const sectionUnavailable = !currentStep.sectionAvailable;
+  const presentationType = targetEl ? 'popover' : 'modal';
 
   const stepBody = (
     <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
@@ -463,6 +553,7 @@ const WhatsNewModal: React.FC = () => {
           rel="noopener noreferrer"
           icon={<ExternalLinkAltIcon />}
           iconPosition="end"
+          onClick={() => trackLearnMore(currentStep.id, learnMoreUrl, presentationType)}
         >
           Learn more
         </Button>
@@ -533,7 +624,11 @@ const WhatsNewModal: React.FC = () => {
           </Button>
         </FlexItem>
         <FlexItem>
-          <Button data-testid="tour-step-skip" variant="link" onClick={close}>
+          <Button
+            data-testid="tour-step-skip"
+            variant="link"
+            onClick={() => handleDismiss('skip_button')}
+          >
             Skip tour
           </Button>
         </FlexItem>
@@ -554,11 +649,11 @@ const WhatsNewModal: React.FC = () => {
   if (targetEl) {
     return (
       <>
-        <Backdrop onClick={close} />
+        <Backdrop onClick={() => handleDismiss('popover_close')} />
         <Popover
           data-testid="nav-tour-popover"
           isVisible
-          shouldClose={() => close()}
+          shouldClose={() => handleDismiss('popover_close')}
           position="right"
           triggerRef={() => targetEl}
           headerContent={currentStep.title}
@@ -578,7 +673,7 @@ const WhatsNewModal: React.FC = () => {
       variant={ModalVariant.medium}
       isOpen
       aria-labelledby="whats-new-step-title"
-      onClose={close}
+      onClose={() => handleDismiss('modal_close')}
     >
       <ModalHeader title={currentStep.title} labelId="whats-new-step-title" />
       <ModalBody>{stepBody}</ModalBody>

--- a/frontend/src/app/whatsNew/__tests__/WhatsNewModal.spec.tsx
+++ b/frontend/src/app/whatsNew/__tests__/WhatsNewModal.spec.tsx
@@ -9,7 +9,14 @@ import { useAppContext } from '#~/app/AppContext';
 import { mockDashboardConfig } from '#~/__mocks__';
 import type { BuildStatus } from '#~/types';
 import type { StorageClassKind } from '#~/k8sTypes';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '#~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
 import WhatsNewModal from '#~/app/whatsNew/WhatsNewModal';
+import { GUIDED_TOUR_EVENTS } from '#~/app/whatsNew/tracking/guidedTourTracking';
+import { openWhatsNewTour } from '#~/app/whatsNew/whatsNewEvent';
 
 jest.mock('#~/app/AppContext', () => ({
   __esModule: true,
@@ -26,9 +33,16 @@ jest.mock('@odh-dashboard/ui-core/utilities', () => ({
   useBrowserStorage: jest.fn(),
 }));
 
+jest.mock('#~/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
 const useAppContextMock = jest.mocked(useAppContext);
 const useUserMock = jest.mocked(useUser);
 const mockUseBrowserStorage = jest.mocked(useBrowserStorage);
+const mockFireFormTrackingEvent = jest.mocked(fireFormTrackingEvent);
+const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
 
 const mockSetSeen = jest.fn();
 
@@ -222,6 +236,142 @@ describe('WhatsNewModal', () => {
 
       expect(screen.getByText("You're ready to go!")).toBeInTheDocument();
       expect(screen.getByText('documentation')).toBeInTheDocument();
+    });
+  });
+
+  describe('segment tracking', () => {
+    it('should fire Guided Tour Started as a form event on auto-launch', () => {
+      useAppContextMock.mockReturnValue(buildAppContext());
+      useUserMock.mockReturnValue(regularUser);
+
+      render(<WhatsNewModal />);
+      openWelcomeModal();
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(GUIDED_TOUR_EVENTS.STARTED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        entryPoint: 'auto-launch',
+        tourVersion: '3.5',
+        tourVariant: 'non-admin',
+        isReturningUser: false,
+        roleType: 'Data Scientist',
+      });
+    });
+
+    it('should fire Dismissed as a form cancel when skipping from welcome', () => {
+      useAppContextMock.mockReturnValue(buildAppContext());
+      useUserMock.mockReturnValue(adminUser);
+
+      render(<WhatsNewModal />);
+      openWelcomeModal();
+      mockFireFormTrackingEvent.mockClear();
+
+      fireEvent.click(screen.getByText('Skip tour'));
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+        GUIDED_TOUR_EVENTS.DISMISSED,
+        expect.objectContaining({
+          outcome: TrackingOutcome.cancel,
+          entryPoint: 'auto-launch',
+          tourVariant: 'admin',
+          dismissStepId: 'welcome',
+          dismissStepIndex: -1,
+          dismissMethod: 'skip_button',
+          stepsViewed: 0,
+        }),
+      );
+      expect(mockFireFormTrackingEvent).not.toHaveBeenCalledWith(
+        GUIDED_TOUR_EVENTS.PATH_SELECTED,
+        expect.anything(),
+      );
+    });
+
+    it('should fire Path Selected and Completed as form events', () => {
+      useAppContextMock.mockReturnValue(buildAppContext());
+      useUserMock.mockReturnValue(regularUser);
+
+      render(<WhatsNewModal />);
+      openWelcomeModal();
+      startTourAndWait('Start tour');
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(GUIDED_TOUR_EVENTS.PATH_SELECTED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        tourPath: 'full',
+        tourVersion: '3.5',
+        tourVariant: 'non-admin',
+        entryPoint: 'auto-launch',
+      });
+
+      for (let i = 0; i < 5; i++) {
+        fireEvent.click(screen.getByText('Next'));
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+      }
+
+      mockFireFormTrackingEvent.mockClear();
+      fireEvent.click(screen.getByTestId('whats-new-done-close'));
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+        GUIDED_TOUR_EVENTS.COMPLETED,
+        expect.objectContaining({
+          outcome: TrackingOutcome.submit,
+          success: true,
+          tourPath: 'full',
+          entryPoint: 'auto-launch',
+          tourVariant: 'non-admin',
+          stepsViewed: 5,
+          totalSteps: 5,
+        }),
+      );
+      expect(mockFireFormTrackingEvent).not.toHaveBeenCalledWith(
+        GUIDED_TOUR_EVENTS.DISMISSED,
+        expect.anything(),
+      );
+    });
+
+    it('should fire Started with masthead entry point on manual reopen', () => {
+      mockUseBrowserStorage.mockReturnValue([true, mockSetSeen]);
+      useAppContextMock.mockReturnValue(buildAppContext());
+      useUserMock.mockReturnValue(regularUser);
+
+      render(<WhatsNewModal />);
+      act(() => {
+        openWhatsNewTour('masthead');
+      });
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(GUIDED_TOUR_EVENTS.STARTED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        entryPoint: 'masthead',
+        tourVersion: '3.5',
+        tourVariant: 'non-admin',
+        isReturningUser: true,
+        roleType: 'Data Scientist',
+      });
+    });
+
+    it('should fire Learn More with Amplitude plan property names', () => {
+      useAppContextMock.mockReturnValue(buildAppContext());
+      useUserMock.mockReturnValue(regularUser);
+
+      render(<WhatsNewModal />);
+      openWelcomeModal();
+      startTourAndWait('Start tour');
+      mockFireMiscTrackingEvent.mockClear();
+
+      fireEvent.click(screen.getByText('Learn more'));
+
+      expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(
+        GUIDED_TOUR_EVENTS.LEARN_MORE_CLICKED,
+        expect.objectContaining({
+          stepId: 'projects',
+          destinationUrl: expect.any(String),
+          tourPath: 'full',
+          presentationType: 'modal',
+        }),
+      );
     });
   });
 });

--- a/frontend/src/app/whatsNew/__tests__/WhatsNewModal.spec.tsx
+++ b/frontend/src/app/whatsNew/__tests__/WhatsNewModal.spec.tsx
@@ -316,6 +316,28 @@ describe('WhatsNewModal', () => {
       );
     });
 
+    it('should include tourPath on Dismissed after a path is selected', () => {
+      useAppContextMock.mockReturnValue(buildAppContext());
+      useUserMock.mockReturnValue(regularUser);
+
+      render(<WhatsNewModal />);
+      openWelcomeModal();
+      startTourAndWait('Start tour');
+      mockFireFormTrackingEvent.mockClear();
+
+      fireEvent.click(screen.getByTestId('tour-step-skip'));
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+        GUIDED_TOUR_EVENTS.DISMISSED,
+        expect.objectContaining({
+          outcome: TrackingOutcome.cancel,
+          tourPath: 'full',
+          dismissMethod: 'skip_button',
+          dismissStepId: 'projects',
+        }),
+      );
+    });
+
     it('should fire Path Selected and Completed as form events', () => {
       useAppContextMock.mockReturnValue(buildAppContext());
       useUserMock.mockReturnValue(regularUser);

--- a/frontend/src/app/whatsNew/__tests__/WhatsNewModal.spec.tsx
+++ b/frontend/src/app/whatsNew/__tests__/WhatsNewModal.spec.tsx
@@ -331,6 +331,48 @@ describe('WhatsNewModal', () => {
       );
     });
 
+    it('should fire Completed (not Dismissed) when closing the summary modal via X', () => {
+      useAppContextMock.mockReturnValue(buildAppContext());
+      useUserMock.mockReturnValue(regularUser);
+
+      render(<WhatsNewModal />);
+      openWelcomeModal();
+      startTourAndWait('Start tour');
+
+      for (let i = 0; i < 5; i++) {
+        fireEvent.click(screen.getByText('Next'));
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+      }
+
+      expect(screen.getByText("You're ready to go!")).toBeInTheDocument();
+      mockFireFormTrackingEvent.mockClear();
+
+      // PatternFly modal X (not the footer Close button) — still Completed, not abandon.
+      const modalCloseButtons = screen.getAllByRole('button', { name: /^close$/i });
+      const modalX = modalCloseButtons.find(
+        (button) => button.getAttribute('data-testid') !== 'whats-new-done-close',
+      );
+      if (!modalX) {
+        throw new Error('Expected PatternFly modal close (X) button');
+      }
+      fireEvent.click(modalX);
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+        GUIDED_TOUR_EVENTS.COMPLETED,
+        expect.objectContaining({
+          outcome: TrackingOutcome.submit,
+          success: true,
+          tourPath: 'full',
+        }),
+      );
+      expect(mockFireFormTrackingEvent).not.toHaveBeenCalledWith(
+        GUIDED_TOUR_EVENTS.DISMISSED,
+        expect.anything(),
+      );
+    });
+
     it('should fire Started with masthead entry point on manual reopen', () => {
       mockUseBrowserStorage.mockReturnValue([true, mockSetSeen]);
       useAppContextMock.mockReturnValue(buildAppContext());

--- a/frontend/src/app/whatsNew/__tests__/WhatsNewModal.spec.tsx
+++ b/frontend/src/app/whatsNew/__tests__/WhatsNewModal.spec.tsx
@@ -258,6 +258,36 @@ describe('WhatsNewModal', () => {
       });
     });
 
+    it('should cancel pending auto-launch when the tour is opened manually', () => {
+      useAppContextMock.mockReturnValue(buildAppContext());
+      useUserMock.mockReturnValue(regularUser);
+
+      render(<WhatsNewModal />);
+
+      // Open from masthead before the 1.5s auto-launch timer fires.
+      act(() => {
+        jest.advanceTimersByTime(500);
+        openWhatsNewTour('masthead');
+      });
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledTimes(1);
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+        GUIDED_TOUR_EVENTS.STARTED,
+        expect.objectContaining({ entryPoint: 'masthead' }),
+      );
+
+      // Auto-launch timer would have fired by now — must not start a second session.
+      act(() => {
+        jest.advanceTimersByTime(1500);
+      });
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledTimes(1);
+      expect(mockFireFormTrackingEvent).not.toHaveBeenCalledWith(
+        GUIDED_TOUR_EVENTS.STARTED,
+        expect.objectContaining({ entryPoint: 'auto-launch' }),
+      );
+    });
+
     it('should fire Dismissed as a form cancel when skipping from welcome', () => {
       useAppContextMock.mockReturnValue(buildAppContext());
       useUserMock.mockReturnValue(adminUser);

--- a/frontend/src/app/whatsNew/tracking/guidedTourTracking.ts
+++ b/frontend/src/app/whatsNew/tracking/guidedTourTracking.ts
@@ -16,6 +16,9 @@ export const GUIDED_TOUR_EVENTS = {
 
 export const TOUR_VERSION = '3.5';
 
+/** Bump with TOUR_VERSION each release so first-visit auto-launch resets. */
+export const TOUR_SEEN_STORAGE_KEY = `odh-whats-new-${TOUR_VERSION}-seen`;
+
 export type GuidedTourEntryPoint = 'auto-launch' | 'masthead' | 'home-task-assistant';
 export type GuidedTourPath = 'full' | 'new-features-only';
 export type GuidedTourDismissMethod = 'skip_button' | 'modal_close' | 'popover_close';

--- a/frontend/src/app/whatsNew/tracking/guidedTourTracking.ts
+++ b/frontend/src/app/whatsNew/tracking/guidedTourTracking.ts
@@ -99,8 +99,7 @@ export const trackGuidedTourDismissed = (args: {
   fireFormTrackingEvent(GUIDED_TOUR_EVENTS.DISMISSED, {
     outcome: TrackingOutcome.cancel,
     ...formSessionProps(args.isAdmin, args.entryPoint),
-    // Amplitude plan names this field tourMode (same values as tourPath).
-    ...(args.tourPath ? { tourMode: args.tourPath } : {}),
+    ...(args.tourPath ? { tourPath: args.tourPath } : {}),
     dismissStepId: args.dismissStepId,
     dismissStepIndex: args.dismissStepIndex,
     dismissMethod: args.dismissMethod,

--- a/frontend/src/app/whatsNew/tracking/guidedTourTracking.ts
+++ b/frontend/src/app/whatsNew/tracking/guidedTourTracking.ts
@@ -1,0 +1,141 @@
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '#~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
+
+/** Event names from the Guided Tour Amplitude tracking plan. */
+export const GUIDED_TOUR_EVENTS = {
+  STARTED: 'Guided Tour Started',
+  PATH_SELECTED: 'Guided Tour Path Selected',
+  COMPLETED: 'Guided Tour Completed',
+  LEARN_MORE_CLICKED: 'Guided Tour Learn More Clicked',
+  SUMMARY_DOCS_CLICKED: 'Documentation Link Clicked in Summary',
+  DISMISSED: 'Guided Tour Dismissed',
+} as const;
+
+export const TOUR_VERSION = '3.5';
+
+export type GuidedTourEntryPoint = 'auto-launch' | 'masthead' | 'home-task-assistant';
+export type GuidedTourPath = 'full' | 'new-features-only';
+export type GuidedTourDismissMethod = 'skip_button' | 'modal_close' | 'popover_close';
+export type GuidedTourPresentationType = 'modal' | 'popover';
+
+const getTourVariant = (isAdmin: boolean): 'admin' | 'non-admin' =>
+  isAdmin ? 'admin' : 'non-admin';
+
+const getRoleType = (isAdmin: boolean): string => (isAdmin ? 'AI Admin' : 'Data Scientist');
+
+/** Shared fields on every guided-tour form event. */
+const formSessionProps = (isAdmin: boolean, entryPoint: GuidedTourEntryPoint) => ({
+  tourVersion: TOUR_VERSION,
+  tourVariant: getTourVariant(isAdmin),
+  entryPoint,
+});
+
+/** Form event — tour session becomes active. */
+export const trackGuidedTourStarted = (
+  entryPoint: GuidedTourEntryPoint,
+  isAdmin: boolean,
+  isReturningUser: boolean,
+): void => {
+  fireFormTrackingEvent(GUIDED_TOUR_EVENTS.STARTED, {
+    outcome: TrackingOutcome.submit,
+    success: true,
+    ...formSessionProps(isAdmin, entryPoint),
+    isReturningUser,
+    roleType: getRoleType(isAdmin),
+  });
+};
+
+/** Form event — user chose full vs new-features-only path. */
+export const trackGuidedTourPathSelected = (
+  tourPath: GuidedTourPath,
+  entryPoint: GuidedTourEntryPoint,
+  isAdmin: boolean,
+): void => {
+  fireFormTrackingEvent(GUIDED_TOUR_EVENTS.PATH_SELECTED, {
+    outcome: TrackingOutcome.submit,
+    success: true,
+    ...formSessionProps(isAdmin, entryPoint),
+    tourPath,
+  });
+};
+
+/** Form event — user finished the tour via summary Close. */
+export const trackGuidedTourCompleted = (args: {
+  tourPath: GuidedTourPath;
+  entryPoint: GuidedTourEntryPoint;
+  isAdmin: boolean;
+  stepsViewed: number;
+  totalSteps: number;
+  hadUnavailableFeatures: boolean;
+}): void => {
+  fireFormTrackingEvent(GUIDED_TOUR_EVENTS.COMPLETED, {
+    outcome: TrackingOutcome.submit,
+    success: true,
+    ...formSessionProps(args.isAdmin, args.entryPoint),
+    tourPath: args.tourPath,
+    stepsViewed: args.stepsViewed,
+    totalSteps: args.totalSteps,
+    hadUnavailableFeatures: args.hadUnavailableFeatures,
+  });
+};
+
+/** Form event — user exited before completion. */
+export const trackGuidedTourDismissed = (args: {
+  entryPoint: GuidedTourEntryPoint;
+  isAdmin: boolean;
+  tourPath?: GuidedTourPath;
+  dismissStepId: string;
+  dismissStepIndex: number;
+  dismissMethod: GuidedTourDismissMethod;
+  stepsViewed: number;
+  totalSteps: number;
+}): void => {
+  fireFormTrackingEvent(GUIDED_TOUR_EVENTS.DISMISSED, {
+    outcome: TrackingOutcome.cancel,
+    ...formSessionProps(args.isAdmin, args.entryPoint),
+    // Amplitude plan names this field tourMode (same values as tourPath).
+    ...(args.tourPath ? { tourMode: args.tourPath } : {}),
+    dismissStepId: args.dismissStepId,
+    dismissStepIndex: args.dismissStepIndex,
+    dismissMethod: args.dismissMethod,
+    stepsViewed: args.stepsViewed,
+    totalSteps: args.totalSteps,
+  });
+};
+
+/**
+ * Learn more on a tour step.
+ * Uses misc (not link) because LinkTrackingEventProperties cannot carry the
+ * Amplitude plan fields (stepId, destinationUrl, tourPath, presentationType).
+ */
+export const trackGuidedTourLearnMoreClicked = (args: {
+  stepId: string;
+  destinationUrl: string;
+  tourPath: GuidedTourPath;
+  presentationType: GuidedTourPresentationType;
+}): void => {
+  fireMiscTrackingEvent(GUIDED_TOUR_EVENTS.LEARN_MORE_CLICKED, {
+    stepId: args.stepId,
+    destinationUrl: args.destinationUrl,
+    tourPath: args.tourPath,
+    presentationType: args.presentationType,
+  });
+};
+
+/**
+ * Documentation link on the summary step.
+ * Uses misc for the same reason as Learn More — plan fields do not fit the link schema.
+ */
+export const trackGuidedTourSummaryDocsClicked = (args: {
+  destinationUrl: string;
+  tourPath: GuidedTourPath;
+}): void => {
+  fireMiscTrackingEvent(GUIDED_TOUR_EVENTS.SUMMARY_DOCS_CLICKED, {
+    linkType: 'documentation',
+    destinationUrl: args.destinationUrl,
+    tourPath: args.tourPath,
+  });
+};

--- a/frontend/src/app/whatsNew/tracking/useGuidedTourTracking.ts
+++ b/frontend/src/app/whatsNew/tracking/useGuidedTourTracking.ts
@@ -1,0 +1,153 @@
+import React from 'react';
+import {
+  trackGuidedTourCompleted,
+  trackGuidedTourDismissed,
+  trackGuidedTourLearnMoreClicked,
+  trackGuidedTourPathSelected,
+  trackGuidedTourStarted,
+  trackGuidedTourSummaryDocsClicked,
+  type GuidedTourDismissMethod,
+  type GuidedTourEntryPoint,
+  type GuidedTourPath,
+  type GuidedTourPresentationType,
+} from './guidedTourTracking';
+
+type TourStepLike = {
+  id: string;
+  sectionAvailable: boolean;
+  newFeatures: { available: boolean }[];
+};
+
+type DismissArgs = {
+  dismissMethod: GuidedTourDismissMethod;
+  dismissStepId: string;
+  dismissStepIndex: number;
+  pathStepCount: number;
+};
+
+/**
+ * Holds tour-session state and fires Segment events via guidedTourTracking helpers.
+ * WhatsNewModal should not import Segment utilities directly.
+ */
+export const useGuidedTourTracking = (
+  isAdmin: boolean,
+): {
+  beginSession: (entryPoint: GuidedTourEntryPoint, isReturningUser: boolean) => void;
+  selectPath: (tourPath: GuidedTourPath) => void;
+  trackStepView: (step: TourStepLike) => void;
+  trackLearnMore: (
+    stepId: string,
+    destinationUrl: string,
+    presentationType: GuidedTourPresentationType,
+  ) => void;
+  trackSummaryDocs: (destinationUrl: string) => void;
+  dismiss: (args: DismissArgs) => void;
+  complete: (pathStepCount: number) => void;
+  resetSession: () => void;
+  tourPath: GuidedTourPath | undefined;
+} => {
+  const [tourPath, setTourPath] = React.useState<GuidedTourPath | undefined>();
+  const entryPointRef = React.useRef<GuidedTourEntryPoint>('auto-launch');
+  const viewedStepIdsRef = React.useRef<Set<string>>(new Set());
+  const hadUnavailableFeaturesRef = React.useRef(false);
+
+  const resetSession = React.useCallback(() => {
+    setTourPath(undefined);
+    viewedStepIdsRef.current = new Set();
+    hadUnavailableFeaturesRef.current = false;
+  }, []);
+
+  const beginSession = React.useCallback(
+    (entryPoint: GuidedTourEntryPoint, isReturningUser: boolean) => {
+      entryPointRef.current = entryPoint;
+      resetSession();
+      trackGuidedTourStarted(entryPoint, isAdmin, isReturningUser);
+    },
+    [isAdmin, resetSession],
+  );
+
+  const selectPath = React.useCallback(
+    (path: GuidedTourPath) => {
+      setTourPath(path);
+      trackGuidedTourPathSelected(path, entryPointRef.current, isAdmin);
+    },
+    [isAdmin],
+  );
+
+  const trackStepView = React.useCallback((step: TourStepLike) => {
+    viewedStepIdsRef.current.add(step.id);
+    if (!step.sectionAvailable || step.newFeatures.some((feature) => !feature.available)) {
+      hadUnavailableFeaturesRef.current = true;
+    }
+  }, []);
+
+  const trackLearnMore = React.useCallback(
+    (stepId: string, destinationUrl: string, presentationType: GuidedTourPresentationType) => {
+      if (!tourPath) {
+        return;
+      }
+      trackGuidedTourLearnMoreClicked({
+        stepId,
+        destinationUrl,
+        tourPath,
+        presentationType,
+      });
+    },
+    [tourPath],
+  );
+
+  const trackSummaryDocs = React.useCallback(
+    (destinationUrl: string) => {
+      if (!tourPath) {
+        return;
+      }
+      trackGuidedTourSummaryDocsClicked({ destinationUrl, tourPath });
+    },
+    [tourPath],
+  );
+
+  const dismiss = React.useCallback(
+    ({ dismissMethod, dismissStepId, dismissStepIndex, pathStepCount }: DismissArgs) => {
+      trackGuidedTourDismissed({
+        entryPoint: entryPointRef.current,
+        isAdmin,
+        tourPath,
+        dismissStepId,
+        dismissStepIndex,
+        dismissMethod,
+        stepsViewed: viewedStepIdsRef.current.size,
+        totalSteps: pathStepCount,
+      });
+    },
+    [isAdmin, tourPath],
+  );
+
+  const complete = React.useCallback(
+    (pathStepCount: number) => {
+      if (!tourPath) {
+        return;
+      }
+      trackGuidedTourCompleted({
+        tourPath,
+        entryPoint: entryPointRef.current,
+        isAdmin,
+        stepsViewed: viewedStepIdsRef.current.size,
+        totalSteps: pathStepCount,
+        hadUnavailableFeatures: hadUnavailableFeaturesRef.current,
+      });
+    },
+    [isAdmin, tourPath],
+  );
+
+  return {
+    beginSession,
+    selectPath,
+    trackStepView,
+    trackLearnMore,
+    trackSummaryDocs,
+    dismiss,
+    complete,
+    resetSession,
+    tourPath,
+  };
+};

--- a/frontend/src/app/whatsNew/whatsNewEvent.ts
+++ b/frontend/src/app/whatsNew/whatsNewEvent.ts
@@ -1,17 +1,47 @@
 import React from 'react';
+import type { GuidedTourEntryPoint } from './tracking/guidedTourTracking';
 
 const WHATS_NEW_EVENT = 'whats-new-tour-open';
 
-export const openWhatsNewTour = (): void => {
-  document.dispatchEvent(new CustomEvent(WHATS_NEW_EVENT));
+type WhatsNewTourEventDetail = {
+  entryPoint: GuidedTourEntryPoint;
 };
 
-export const useWhatsNewTourListener = (onOpen: () => void): void => {
+const isGuidedTourEntryPoint = (value: unknown): value is GuidedTourEntryPoint =>
+  value === 'auto-launch' || value === 'masthead' || value === 'home-task-assistant';
+
+const getEntryPointFromEvent = (event: Event): GuidedTourEntryPoint => {
+  if (!(event instanceof CustomEvent)) {
+    return 'masthead';
+  }
+  const { detail } = event;
+  if (
+    typeof detail === 'object' &&
+    detail !== null &&
+    'entryPoint' in detail &&
+    isGuidedTourEntryPoint(detail.entryPoint)
+  ) {
+    return detail.entryPoint;
+  }
+  return 'masthead';
+};
+
+export const openWhatsNewTour = (entryPoint: GuidedTourEntryPoint = 'masthead'): void => {
+  document.dispatchEvent(
+    new CustomEvent<WhatsNewTourEventDetail>(WHATS_NEW_EVENT, { detail: { entryPoint } }),
+  );
+};
+
+export const useWhatsNewTourListener = (
+  onOpen: (entryPoint: GuidedTourEntryPoint) => void,
+): void => {
   const callbackRef = React.useRef(onOpen);
   callbackRef.current = onOpen;
 
   React.useEffect(() => {
-    const handler = () => callbackRef.current();
+    const handler = (event: Event) => {
+      callbackRef.current(getEntryPointFromEvent(event));
+    };
     document.addEventListener(WHATS_NEW_EVENT, handler);
     return () => document.removeEventListener(WHATS_NEW_EVENT, handler);
   }, []);

--- a/frontend/src/pages/home/taskAssistant/TaskAssistantSection.tsx
+++ b/frontend/src/pages/home/taskAssistant/TaskAssistantSection.tsx
@@ -107,7 +107,7 @@ const TaskAssistantSection: React.FC = () => {
                     variant="link"
                     isInline
                     icon={<LightBulbIcon color="var(--pf-t--global--color--brand--default)" />}
-                    onClick={openWhatsNewTour}
+                    onClick={() => openWhatsNewTour('home-task-assistant')}
                     data-testid="whats-new-task-link"
                   >
                     Take a guided tour


### PR DESCRIPTION
## Description

Adds Segment event tracking for the What's New / guided tour feature so Amplitude can measure tour adoption, path selection, completion, documentation interest, and drop-off for the 3.5 release.

<img width="737" height="446" alt="Screenshot 2026-07-17 at 9 21 00 PM" src="https://github.com/user-attachments/assets/aca4b43c-9128-4a5b-afab-2c71e0d9a4f2" />
<img width="743" height="667" alt="Screenshot 2026-07-17 at 9 22 03 PM" src="https://github.com/user-attachments/assets/ef18a792-c58d-41e7-b4a3-2db35fdc79e6" />

Implements the six events from the [RHOAI Guided Tour Event Tracking Plan](https://docs.google.com/document/d/1Rjkp78ItQUpP0a_f6C2V4eQPcOfUr0cc5qY9ECH8t30/edit?tab=t.u9nxfxwti3h3):

| Event | Trigger |
| --- | --- |
| Guided Tour Started | Auto-launch, masthead lightbulb, or Home Task Assistant |
| Guided Tour Path Selected | Start tour / What's new in 3.5 |
| Guided Tour Completed | Close on summary |
| Guided Tour Learn More Clicked | Learn more on a step |
| Documentation Link Clicked in Summary | Docs link on summary |
| Guided Tour Dismissed | Skip, modal X, or popover/backdrop close |

Tracking lives under `frontend/src/app/whatsNew/tracking/` so the modal stays free of Segment imports. Lifecycle events use `fireFormTrackingEvent`; Learn more / summary docs use `fireMiscTrackingEvent` so Amplitude plan property names (`destinationUrl`, `stepId`, etc.) are preserved (they do not fit `LinkTrackingEventProperties`).

## How Has This Been Tested?

- Unit tests: `cd frontend && npm run test:unit -- --testPathPattern='whatsNew'`
- Lint / Prettier / type-check on changed files
- Manual verification in local dev: open DevTools console, filter for `Telemetry event triggered`, walk through auto-launch / path selection / learn more / complete / dismiss flows

## Test Impact

Added Segment tracking coverage to `WhatsNewModal.spec.tsx` for Started (auto-launch + masthead), Path Selected, Completed, Dismissed (skip from welcome), and Learn More.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guided “What’s new” tour entry-point support for masthead, homepage Task Assistant, and other entry points.
  * Introduced guided-tour analytics tracking with stable step IDs and richer event payloads, including “Learn more” and summary documentation click context.
* **Improvements**
  * Refined the guided-tour flow so skip/close/dismiss/completion actions are handled consistently and reliably report progress and dismissal details.
* **Tests**
  * Expanded automated coverage to validate tracking events across start, path selection, interactions, completion, and dismissal (including modal close behaviors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->