### PR TITLE
RHOAIENG-76227: Replace wildcard verbs with explicit verb lists in role templates

### DIFF
--- a/frontend/src/pages/projects/projectRoles/__tests__/roleTemplateCatalog.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/roleTemplateCatalog.spec.ts
@@ -47,6 +47,16 @@ describe('roleTemplateCatalog', () => {
     }
   });
 
+  it('should not use wildcard verbs in any template', () => {
+    for (const category of ROLE_TEMPLATE_CATALOG) {
+      for (const template of category.templates) {
+        for (const rule of template.rules) {
+          expect(rule.verbs).not.toContain('*');
+        }
+      }
+    }
+  });
+
   it('should not grant create or delete on notebooks in updater template', () => {
     const updater = ROLE_TEMPLATE_CATALOG.flatMap((c) => c.templates).find(
       (t) => t.id === 'workbench-updater',

--- a/frontend/src/pages/projects/projectRoles/roleTemplateCatalog.ts
+++ b/frontend/src/pages/projects/projectRoles/roleTemplateCatalog.ts
@@ -24,11 +24,15 @@ export const ROLE_TEMPLATE_CATALOG: RoleTemplateCategory[] = [
         description:
           'A set of rules that grants users to act as the admin of the workbench component.',
         rules: [
-          { apiGroups: ['kubeflow.org'], resources: ['notebooks'], verbs: ['*'] },
+          {
+            apiGroups: ['kubeflow.org'],
+            resources: ['notebooks'],
+            verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete'],
+          },
           {
             apiGroups: [''],
             resources: ['persistentvolumeclaims', 'secrets', 'configmaps'],
-            verbs: ['*'],
+            verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete'],
           },
           {
             apiGroups: [''],
@@ -99,7 +103,7 @@ export const ROLE_TEMPLATE_CATALOG: RoleTemplateCategory[] = [
           {
             apiGroups: [''],
             resources: ['persistentvolumeclaims', 'secrets', 'configmaps'],
-            verbs: ['*'],
+            verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete'],
           },
           {
             apiGroups: [''],

--- a/packages/cypress/cypress/pages/projectRoles.ts
+++ b/packages/cypress/cypress/pages/projectRoles.ts
@@ -258,6 +258,10 @@ class ProjectRolesTab {
     return cy.findByTestId('permission-rules-table');
   }
 
+  findPermissionRuleActionCells() {
+    return this.findPermissionRulesTable().find('tbody td[data-label="Actions"]');
+  }
+
   getRow(name: string) {
     return new RolesTableRow(() =>
       this.findRolesTable().findAllByTestId('role-name-link').contains(name).parents('tr'),

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
@@ -195,6 +195,38 @@ describe('Create Role submit', () => {
     });
   });
 
+  it('should submit explicit verbs from workbench-maintainer template without wildcards', () => {
+    cy.interceptK8s(
+      'POST',
+      { model: RoleModel, ns: NAMESPACE },
+      mockRoleK8sResource({ name: 'workbench-maintainer', namespace: NAMESPACE }),
+    ).as('createRole');
+
+    projectRoles.visitCreateRole(NAMESPACE);
+
+    projectRoles.findSelectRoleTemplateButton().click();
+    projectRoles.findSelectTemplateButton('workbench-maintainer').click();
+
+    projectRoles.findSubmitButton().click();
+
+    cy.wait('@createRole').then((interception) => {
+      const { rules } = interception.request.body;
+      expect(rules).to.have.length(6);
+      for (const rule of rules) {
+        expect(rule.verbs).to.not.include('*');
+      }
+      const notebookRule = rules.find((r: { resources?: string[] }) =>
+        r.resources?.includes('notebooks'),
+      );
+      expect(notebookRule)
+        .to.have.property('verbs')
+        .that.deep.equals(['get', 'list', 'watch', 'create', 'update', 'patch', 'delete']);
+    });
+
+    cy.url().should('include', `/projects/${NAMESPACE}`);
+    cy.url().should('include', 'section=roles');
+  });
+
   it('should send labels with labels.opendatahub.io/ prefix', () => {
     cy.interceptK8s(
       'POST',

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabTemplate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabTemplate.cy.ts
@@ -130,6 +130,38 @@ describe('Select role template (header button)', () => {
     cy.contains('Workbench maintainer').should('not.exist');
     cy.contains('Workbench updater').should('not.exist');
   });
+
+  it('should display explicit verbs instead of wildcards for workbench-maintainer template', () => {
+    projectRoles.visitCreateRole(NAMESPACE);
+
+    projectRoles.findSelectRoleTemplateButton().click();
+    projectRoles.findSelectTemplateButton('workbench-maintainer').click();
+
+    projectRoles.findPermissionRulesTable().should('exist');
+    projectRoles.findPermissionRuleActionCells().each(($cell) => {
+      expect($cell.text()).to.not.equal('All');
+      expect($cell.text()).to.not.contain('*');
+    });
+    projectRoles
+      .findPermissionRuleActionCells()
+      .first()
+      .should('contain.text', 'get')
+      .and('contain.text', 'create')
+      .and('contain.text', 'delete');
+  });
+
+  it('should display explicit verbs instead of wildcards for workbench-updater template', () => {
+    projectRoles.visitCreateRole(NAMESPACE);
+
+    projectRoles.findSelectRoleTemplateButton().click();
+    projectRoles.findSelectTemplateButton('workbench-updater').click();
+
+    projectRoles.findPermissionRulesTable().should('exist');
+    projectRoles.findPermissionRuleActionCells().each(($cell) => {
+      expect($cell.text()).to.not.equal('All');
+      expect($cell.text()).to.not.contain('*');
+    });
+  });
 });
 
 describe('Import rules from template (toolbar button)', () => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-76227

## Description

The workbench-maintainer and workbench-updater role templates in `roleTemplateCatalog.ts` used `verbs: ["*"]` (wildcard) for several resources. Kubernetes RBAC escalation prevention requires that the creating user already holds every permission listed in a Role being created. Since the `admin` ClusterRole grants explicit verbs but not the `*` wildcard, project admins could not create roles from these templates — only cluster-admins could.

This replaces all three `["*"]` verb entries with explicit verb lists (`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`), which are a subset of what the `admin` ClusterRole grants, enabling self-service role creation for project admins.

https://github.com/user-attachments/assets/b5a5024b-2db8-45e9-9992-bd1aa02abe80

**Changes:**
- **workbench-maintainer** — replaced `["*"]` with explicit verbs on `notebooks` and `persistentvolumeclaims/secrets/configmaps` rules
- **workbench-updater** — replaced `["*"]` with explicit verbs on `persistentvolumeclaims/secrets/configmaps` rule
- **workbench-reader** — already used explicit verbs, no changes needed
- Added unit test regression guard preventing wildcard verbs in any template
- Added Cypress mocked tests verifying templates display explicit verbs and submit correct K8s payloads

## How Has This Been Tested?

- Unit tests pass (`roleTemplateCatalog.spec.ts`)
- Cypress mocked tests pass (`rolesTabTemplate.cy.ts`, `rolesTabCreate.cy.ts`)
- Lint and type-check pass

## Test Impact

- Added unit test in `roleTemplateCatalog.spec.ts` that prevents wildcard verbs from being reintroduced in any template
- Added 2 Cypress mocked tests in `rolesTabTemplate.cy.ts` verifying that applied templates display explicit verbs (not "All"/wildcards) in the permission rules table
- Added 1 Cypress mocked test in `rolesTabCreate.cy.ts` verifying that submitting a role from the workbench-maintainer template sends explicit verbs (not wildcards) in the K8s API payload

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
Supersedes: #8581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workbench role templates to use explicit permissions instead of wildcard actions.
  * Ensured role creation and permission displays accurately show the permitted actions.

* **Tests**
  * Added coverage verifying wildcard permissions are excluded from role templates.
  * Added end-to-end checks for role creation and displayed permission actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->