### PR TITLE
RHOAIENG-72274: Implement event tracking for Custom Role creation flow

### DIFF
--- a/frontend/src/pages/projects/projectRoles/CreateRoleFooter.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleFooter.tsx
@@ -14,6 +14,7 @@ type CreateRoleFooterProps = {
   isSubmitDisabled: boolean;
   isEdit?: boolean;
   onSubmit: () => Promise<void>;
+  onCancel: () => void;
   submitError?: Error;
 };
 
@@ -22,6 +23,7 @@ const CreateRoleFooter: React.FC<CreateRoleFooterProps> = ({
   isSubmitDisabled,
   isEdit = false,
   onSubmit,
+  onCancel,
   submitError,
 }) => {
   const navigate = useNavigate();
@@ -70,7 +72,10 @@ const CreateRoleFooter: React.FC<CreateRoleFooterProps> = ({
               variant="link"
               data-testid="create-role-cancel"
               isDisabled={isSubmitting}
-              onClick={() => navigate(`/projects/${namespace}?section=roles`)}
+              onClick={() => {
+                onCancel();
+                navigate(`/projects/${namespace}?section=roles`);
+              }}
             >
               Cancel
             </Button>

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -19,6 +19,11 @@ import { useAccessReview } from '#~/api/useAccessReview';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import { RoleKind } from '#~/k8sTypes';
 import { createRole, updateRole } from '#~/api';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '#~/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingProperties';
 import CreateRoleForm from './CreateRoleForm';
 import CreateRoleFooter from './CreateRoleFooter';
 import CreateRoleConfirmModal from './CreateRoleConfirmModal';
@@ -26,6 +31,7 @@ import CreateRoleYamlView from './CreateRoleYamlView';
 import ReplaceContentConfirmModal from './ReplaceContentConfirmModal';
 import SelectTemplateModal from './SelectTemplateModal';
 import type { RoleTemplate } from './roleTemplateCatalog';
+import { CUSTOM_ROLE_TRACKING_EVENTS, findTemplateCategoryId } from './trackingUtils';
 import assembleRole from './assembleRole';
 import { fromK8sLabels, toK8sLabels } from './labelUtils';
 import { USER_LABEL_PREFIX } from './const';
@@ -83,6 +89,12 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
   const [showNoRulesConfirm, setShowNoRulesConfirm] = React.useState(false);
   const [templateModal, setTemplateModal] = React.useState<TemplateModalState>({ type: 'none' });
 
+  const pageEntryTimeRef = React.useRef(Date.now());
+  const [yamlPreviewed, setYamlPreviewed] = React.useState(false);
+  const yamlExportActionsRef = React.useRef<Set<string>>(new Set());
+  const [templateUsed, setTemplateUsed] = React.useState(false);
+  const [lastTemplateId, setLastTemplateId] = React.useState<string | undefined>();
+
   const isFormDirty = React.useMemo(
     () =>
       k8sNameDescriptionData.data.name !== '' ||
@@ -99,6 +111,27 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
     ],
   );
 
+  const handleViewModeChange = React.useCallback(
+    (targetView: ViewMode) => {
+      if (targetView === viewMode) {
+        return;
+      }
+      fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.VIEW_TOGGLED, {
+        targetView,
+        sourceView: viewMode,
+      });
+      if (targetView === 'yaml') {
+        setYamlPreviewed(true);
+      }
+      setViewMode(targetView);
+    },
+    [viewMode],
+  );
+
+  const handleYamlExportAction = React.useCallback((action: 'copy' | 'download') => {
+    yamlExportActionsRef.current.add(action);
+  }, []);
+
   const handleSelectTemplateClick = React.useCallback(() => {
     setTemplateModal({ type: 'selectTemplate', mode: 'select' });
   }, []);
@@ -110,6 +143,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
   const handleConfirmReplace = React.useCallback(() => {
     if (templateModal.type === 'confirmReplace') {
       const { template } = templateModal;
+      const hadExistingRules = rules.length > 0;
       const templateRules: RuleEntry[] = template.rules.map((rule) => ({
         ...rule,
         id: getUniqueId('rule'),
@@ -119,12 +153,27 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
       setDescription(template.description);
       setRules(templateRules);
       setSubmitError(undefined);
+
+      fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.TEMPLATE_SELECTED, {
+        templateId: template.id,
+        templateName: template.name,
+        templateCategory: findTemplateCategoryId(template.id) ?? 'unknown',
+        mode: 'select',
+        rulesAdded: template.rules.length,
+        hadExistingRules,
+      });
+      setTemplateUsed(true);
+      setLastTemplateId(template.id);
+
       setTemplateModal({ type: 'none' });
     }
-  }, [templateModal, k8sNameDescriptionData]);
+  }, [templateModal, k8sNameDescriptionData, rules.length]);
 
   const handleTemplateSelected = React.useCallback(
     (template: RoleTemplate) => {
+      const mode = templateModal.type === 'selectTemplate' ? templateModal.mode : 'select';
+      const hadExistingRules = rules.length > 0;
+
       if (templateModal.type === 'selectTemplate' && templateModal.mode === 'select') {
         if (isFormDirty) {
           setTemplateModal({ type: 'confirmReplace', template });
@@ -146,9 +195,20 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
         setRules((prev) => [...prev, ...templateRules]);
       }
 
+      fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.TEMPLATE_SELECTED, {
+        templateId: template.id,
+        templateName: template.name,
+        templateCategory: findTemplateCategoryId(template.id) ?? 'unknown',
+        mode,
+        rulesAdded: template.rules.length,
+        hadExistingRules,
+      });
+      setTemplateUsed(true);
+      setLastTemplateId(template.id);
+
       setTemplateModal({ type: 'none' });
     },
-    [templateModal, k8sNameDescriptionData, isFormDirty],
+    [templateModal, k8sNameDescriptionData, isFormDirty, rules.length],
   );
 
   const handleDescriptionChange = React.useCallback((value: string) => {
@@ -170,6 +230,19 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
     k8sNameDescriptionData.data.k8sName.state.invalidCharacters ||
     k8sNameDescriptionData.data.k8sName.state.invalidLength ||
     hasInvalidLabels;
+
+  const getFormTrackingProperties = React.useCallback(
+    () => ({
+      yamlPreviewed,
+      yamlExportActions: JSON.stringify([...yamlExportActionsRef.current]),
+      totalTimeOnPageMs: Date.now() - pageEntryTimeRef.current,
+      totalRulesCount: rules.length,
+      currentView: viewMode,
+      templateUsed,
+      templateId: lastTemplateId ?? '',
+    }),
+    [yamlPreviewed, rules.length, viewMode, templateUsed, lastTemplateId],
+  );
 
   const doSubmit = React.useCallback(async () => {
     setSubmitError(undefined);
@@ -194,12 +267,23 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
       } else {
         await createRole(role);
       }
+      fireFormTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.FORM_SUBMITTED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        ...getFormTrackingProperties(),
+      });
       navigate(`/projects/${namespace}?section=roles`);
     } catch (e) {
       const error =
         e instanceof Error
           ? e
           : new Error(existingRole ? 'Failed to update role' : 'Failed to create role');
+      fireFormTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.FORM_SUBMITTED, {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: error.message,
+        ...getFormTrackingProperties(),
+      });
       setSubmitError(error);
       throw error;
     }
@@ -212,6 +296,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
     navigate,
     existingRole,
     initialRole?.metadata.labels,
+    getFormTrackingProperties,
   ]);
 
   const handleSubmit = React.useCallback(async () => {
@@ -221,6 +306,13 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
     }
     await doSubmit();
   }, [rules.length, doSubmit]);
+
+  const handleCancel = React.useCallback(() => {
+    fireFormTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.FORM_SUBMITTED, {
+      outcome: TrackingOutcome.cancel,
+      ...getFormTrackingProperties(),
+    });
+  }, [getFormTrackingProperties]);
 
   if (!loaded) {
     return (
@@ -269,14 +361,14 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
                 buttonId="form-view-toggle"
                 data-testid="form-view-toggle"
                 isSelected={viewMode === 'form'}
-                onChange={() => setViewMode('form')}
+                onChange={() => handleViewModeChange('form')}
               />
               <ToggleGroupItem
                 text="YAML (read-only)"
                 buttonId="yaml-view-toggle"
                 data-testid="yaml-view-toggle"
                 isSelected={viewMode === 'yaml'}
-                onChange={() => setViewMode('yaml')}
+                onChange={() => handleViewModeChange('yaml')}
               />
             </ToggleGroup>
           </Flex>
@@ -308,6 +400,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
               description={description}
               rules={rules}
               labels={labels}
+              onExportAction={handleYamlExportAction}
             />
           )}
         </PageSection>
@@ -317,6 +410,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
             isSubmitDisabled={isSubmitDisabled}
             isEdit={isEdit}
             onSubmit={handleSubmit}
+            onCancel={handleCancel}
             submitError={submitError}
           />
         </PageSection>

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -267,23 +267,31 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole, duplicate
       } else {
         await createRole(role);
       }
-      fireFormTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.FORM_SUBMITTED, {
-        outcome: TrackingOutcome.submit,
-        success: true,
-        ...getFormTrackingProperties(),
-      });
+      try {
+        fireFormTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.FORM_SUBMITTED, {
+          outcome: TrackingOutcome.submit,
+          success: true,
+          ...getFormTrackingProperties(),
+        });
+      } catch {
+        // best-effort — analytics must not block a successful save
+      }
       navigate(`/projects/${namespace}?section=roles`);
     } catch (e) {
       const error =
         e instanceof Error
           ? e
           : new Error(existingRole ? 'Failed to update role' : 'Failed to create role');
-      fireFormTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.FORM_SUBMITTED, {
-        outcome: TrackingOutcome.submit,
-        success: false,
-        error: error.message,
-        ...getFormTrackingProperties(),
-      });
+      try {
+        fireFormTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.FORM_SUBMITTED, {
+          outcome: TrackingOutcome.submit,
+          success: false,
+          errorCode: existingRole ? 'role_update_failed' : 'role_create_failed',
+          ...getFormTrackingProperties(),
+        });
+      } catch {
+        // best-effort — preserve the original API error
+      }
       setSubmitError(error);
       throw error;
     }

--- a/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
@@ -10,11 +10,20 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { Language } from '@patternfly/react-code-editor';
-import { CompressArrowsAltIcon, ExpandArrowsAltIcon } from '@patternfly/react-icons';
+import {
+  CompressArrowsAltIcon,
+  CopyIcon,
+  DownloadIcon,
+  ExpandArrowsAltIcon,
+} from '@patternfly/react-icons';
 import YAML from 'yaml';
 import DashboardCodeEditor from '#~/concepts/dashboard/codeEditor/DashboardCodeEditor';
+import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
+import { CUSTOM_ROLE_TRACKING_EVENTS } from './trackingUtils';
 import assembleRole from './assembleRole';
 import type { LabelEntry, RuleEntry } from './types';
+
+type YamlExportAction = 'copy' | 'download';
 
 type CreateRoleYamlViewProps = {
   namespace: string;
@@ -23,6 +32,7 @@ type CreateRoleYamlViewProps = {
   description: string;
   rules: RuleEntry[];
   labels: LabelEntry[];
+  onExportAction?: (action: YamlExportAction) => void;
 };
 
 const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
@@ -32,6 +42,7 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
   description,
   rules,
   labels,
+  onExportAction,
 }) => {
   const [isFullScreen, setIsFullScreen] = React.useState(false);
   const editorContainerRef = React.useRef<HTMLDivElement>(null);
@@ -75,8 +86,60 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
     }
   };
 
+  const [copyTooltip, setCopyTooltip] = React.useState('Copy to clipboard');
+
+  const handleCopy = React.useCallback(() => {
+    navigator.clipboard.writeText(yamlContent).then(() => {
+      setCopyTooltip('Copied!');
+      setTimeout(() => setCopyTooltip('Copy to clipboard'), 2000);
+    });
+    fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.YAML_EXPORT_SELECTED, {
+      actionType: 'copy',
+    });
+    onExportAction?.('copy');
+  }, [yamlContent, onExportAction]);
+
+  const handleDownload = React.useCallback(
+    (value: string, fileName: string) => {
+      const blob = new Blob([value], { type: 'text/yaml;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = fileName;
+      a.click();
+      URL.revokeObjectURL(url);
+      fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.YAML_EXPORT_SELECTED, {
+        actionType: 'download',
+      });
+      onExportAction?.('download');
+    },
+    [onExportAction],
+  );
+
   const customControls = (
     <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+      <FlexItem>
+        <Tooltip content={copyTooltip} aria="none">
+          <Button
+            variant="plain"
+            aria-label="Copy to clipboard"
+            data-testid="yaml-copy-button"
+            onClick={handleCopy}
+            icon={<CopyIcon />}
+          />
+        </Tooltip>
+      </FlexItem>
+      <FlexItem>
+        <Tooltip content="Download" aria="none">
+          <Button
+            variant="plain"
+            aria-label="Download"
+            data-testid="yaml-download-button"
+            onClick={() => handleDownload(yamlContent, `${k8sName || 'untitled-role'}.yaml`)}
+            icon={<DownloadIcon />}
+          />
+        </Tooltip>
+      </FlexItem>
       <FlexItem>
         <Tooltip content={isFullScreen ? 'Exit full screen' : 'Full screen'} aria="none">
           <Button
@@ -118,9 +181,6 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
             code={yamlContent}
             isReadOnly
             isLanguageLabelVisible
-            isCopyEnabled
-            isDownloadEnabled
-            downloadFileName={`${k8sName || 'untitled-role'}.yaml`}
             language={Language.yaml}
             height={isFullScreen ? '100%' : undefined}
             codeEditorHeight={isFullScreen ? 'calc(100vh - 66px)' : '500px'}

--- a/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
@@ -88,21 +88,20 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
 
   const [copyTooltip, setCopyTooltip] = React.useState('Copy to clipboard');
 
-  const handleCopy = React.useCallback(() => {
-    navigator.clipboard
-      .writeText(yamlContent)
-      .then(() => {
-        setCopyTooltip('Copied!');
-        setTimeout(() => setCopyTooltip('Copy to clipboard'), 2000);
-        fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.YAML_EXPORT_SELECTED, {
-          actionType: 'copy',
-        });
-        onExportAction?.('copy');
-      })
-      .catch(() => {
-        setCopyTooltip('Unable to copy');
-        setTimeout(() => setCopyTooltip('Copy to clipboard'), 2000);
-      });
+  const handleCopy = React.useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(yamlContent);
+    } catch {
+      setCopyTooltip('Unable to copy');
+      setTimeout(() => setCopyTooltip('Copy to clipboard'), 2000);
+      return;
+    }
+    setCopyTooltip('Copied!');
+    setTimeout(() => setCopyTooltip('Copy to clipboard'), 2000);
+    fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.YAML_EXPORT_SELECTED, {
+      actionType: 'copy',
+    });
+    onExportAction?.('copy');
   }, [yamlContent, onExportAction]);
 
   const handleDownload = React.useCallback(

--- a/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleYamlView.tsx
@@ -89,14 +89,20 @@ const CreateRoleYamlView: React.FC<CreateRoleYamlViewProps> = ({
   const [copyTooltip, setCopyTooltip] = React.useState('Copy to clipboard');
 
   const handleCopy = React.useCallback(() => {
-    navigator.clipboard.writeText(yamlContent).then(() => {
-      setCopyTooltip('Copied!');
-      setTimeout(() => setCopyTooltip('Copy to clipboard'), 2000);
-    });
-    fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.YAML_EXPORT_SELECTED, {
-      actionType: 'copy',
-    });
-    onExportAction?.('copy');
+    navigator.clipboard
+      .writeText(yamlContent)
+      .then(() => {
+        setCopyTooltip('Copied!');
+        setTimeout(() => setCopyTooltip('Copy to clipboard'), 2000);
+        fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.YAML_EXPORT_SELECTED, {
+          actionType: 'copy',
+        });
+        onExportAction?.('copy');
+      })
+      .catch(() => {
+        setCopyTooltip('Unable to copy');
+        setTimeout(() => setCopyTooltip('Copy to clipboard'), 2000);
+      });
   }, [yamlContent, onExportAction]);
 
   const handleDownload = React.useCallback(

--- a/frontend/src/pages/projects/projectRoles/PermissionRulesSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/PermissionRulesSection.tsx
@@ -12,9 +12,11 @@ import { ImportIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { TableBase, useTableColumnSort } from '@odh-dashboard/ui-core';
 import SimpleSelect from '@odh-dashboard/ui-core/components/SimpleSelect';
 
+import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 import AddRuleModal from './AddRuleModal';
 import PermissionRulesTableRow from './PermissionRulesTableRow';
 import { permissionRulesColumns, formatRuleValues } from './permissionRulesColumns';
+import { CUSTOM_ROLE_TRACKING_EVENTS } from './trackingUtils';
 import type { RuleEntry } from './types';
 
 const FILTER_RESOURCES = 'resources';
@@ -45,14 +47,23 @@ const PermissionRulesSection: React.FC<PermissionRulesSectionProps> = ({
 
   const handleAddRule = React.useCallback(
     (rule: RuleEntry) => {
-      const existingIndex = rules.findIndex((r) => r.id === rule.id);
-      if (existingIndex >= 0) {
+      const isRuleEdit = rules.some((r) => r.id === rule.id);
+      if (isRuleEdit) {
         const updated = [...rules];
-        updated[existingIndex] = rule;
+        updated[rules.findIndex((r) => r.id === rule.id)] = rule;
         onRulesChange(updated);
       } else {
         onRulesChange([...rules, rule]);
       }
+
+      fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.RULE_ADDED, {
+        apiGroups: JSON.stringify(rule.apiGroups),
+        resourceTypes: JSON.stringify(rule.resources),
+        verbs: JSON.stringify(rule.verbs),
+        totalRulesCount: isRuleEdit ? rules.length : rules.length + 1,
+        isEdit: isRuleEdit,
+      });
+
       setIsAddModalOpen(false);
       setEditingRule(undefined);
     },

--- a/frontend/src/pages/projects/projectRoles/RolesTable.tsx
+++ b/frontend/src/pages/projects/projectRoles/RolesTable.tsx
@@ -12,7 +12,9 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { Link, useNavigate } from 'react-router-dom';
 import { Table, DashboardEmptyTableView } from '@odh-dashboard/ui-core';
 import type { RoleRef } from '#~/concepts/permissions/types';
+import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 import RoleDetailsModal from '#~/pages/projects/projectPermissions/roleDetails/RoleDetailsModal';
+import { CUSTOM_ROLE_TRACKING_EVENTS } from './trackingUtils';
 import { SEARCH_PLACEHOLDER } from './const';
 import type { RoleListRow } from './types';
 import { columns } from './columns';
@@ -65,6 +67,11 @@ const RolesTable: React.FC<RolesTableProps> = ({
           variant="primary"
           component={(props) => <Link {...props} to={`/projects/${namespace}/roles/create`} />}
           data-testid="create-role-button"
+          onClick={() =>
+            fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.CREATION_INITIATED, {
+              source: 'roles-list-page',
+            })
+          }
         >
           Create custom role
         </Button>
@@ -89,6 +96,11 @@ const RolesTable: React.FC<RolesTableProps> = ({
               variant="primary"
               component={(props) => <Link {...props} to={`/projects/${namespace}/roles/create`} />}
               data-testid="create-role-button"
+              onClick={() =>
+                fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.CREATION_INITIATED, {
+                  source: 'empty-state',
+                })
+              }
             >
               Create custom role
             </Button>

--- a/frontend/src/pages/projects/projectRoles/RolesTable.tsx
+++ b/frontend/src/pages/projects/projectRoles/RolesTable.tsx
@@ -12,7 +12,7 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { Link, useNavigate } from 'react-router-dom';
 import { Table, DashboardEmptyTableView } from '@odh-dashboard/ui-core';
 import type { RoleRef } from '#~/concepts/permissions/types';
-import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
+import { fireLinkTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 import RoleDetailsModal from '#~/pages/projects/projectPermissions/roleDetails/RoleDetailsModal';
 import { CUSTOM_ROLE_TRACKING_EVENTS } from './trackingUtils';
 import { SEARCH_PLACEHOLDER } from './const';
@@ -68,8 +68,9 @@ const RolesTable: React.FC<RolesTableProps> = ({
           component={(props) => <Link {...props} to={`/projects/${namespace}/roles/create`} />}
           data-testid="create-role-button"
           onClick={() =>
-            fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.CREATION_INITIATED, {
-              source: 'roles-list-page',
+            fireLinkTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.CREATION_INITIATED, {
+              to: `/projects/${namespace}/roles/create`,
+              type: 'roles-list-page',
             })
           }
         >
@@ -97,8 +98,9 @@ const RolesTable: React.FC<RolesTableProps> = ({
               component={(props) => <Link {...props} to={`/projects/${namespace}/roles/create`} />}
               data-testid="create-role-button"
               onClick={() =>
-                fireMiscTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.CREATION_INITIATED, {
-                  source: 'empty-state',
+                fireLinkTrackingEvent(CUSTOM_ROLE_TRACKING_EVENTS.CREATION_INITIATED, {
+                  to: `/projects/${namespace}/roles/create`,
+                  type: 'empty-state',
                 })
               }
             >

--- a/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleFooter.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleFooter.spec.tsx
@@ -10,6 +10,7 @@ const renderFooter = (props: Partial<React.ComponentProps<typeof CreateRoleFoote
         namespace="test-ns"
         isSubmitDisabled={false}
         onSubmit={jest.fn().mockResolvedValue(undefined)}
+        onCancel={jest.fn()}
         {...props}
       />
     </MemoryRouter>,

--- a/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleFooter.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleFooter.spec.tsx
@@ -118,4 +118,13 @@ describe('CreateRoleFooter', () => {
       expect(screen.getByTestId('create-role-submit')).not.toBeDisabled();
     });
   });
+
+  it('should call onCancel when Cancel is clicked', () => {
+    const onCancel = jest.fn();
+    renderFooter({ onCancel });
+
+    fireEvent.click(screen.getByTestId('create-role-cancel'));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/pages/projects/projectRoles/trackingUtils.ts
+++ b/frontend/src/pages/projects/projectRoles/trackingUtils.ts
@@ -1,0 +1,13 @@
+import { ROLE_TEMPLATE_CATALOG } from './roleTemplateCatalog';
+
+export const CUSTOM_ROLE_TRACKING_EVENTS = {
+  CREATION_INITIATED: 'Custom Role Creation Initiated',
+  VIEW_TOGGLED: 'Custom Role View Toggled',
+  RULE_ADDED: 'Custom Role Rule Added',
+  YAML_EXPORT_SELECTED: 'Custom Role YAML Export Selected',
+  FORM_SUBMITTED: 'Custom Role Form Submitted',
+  TEMPLATE_SELECTED: 'Custom Role Template Selected',
+} as const;
+
+export const findTemplateCategoryId = (templateId: string): string | undefined =>
+  ROLE_TEMPLATE_CATALOG.find((cat) => cat.templates.some((t) => t.id === templateId))?.id;

--- a/frontend/src/pages/projects/projectRoles/trackingUtils.ts
+++ b/frontend/src/pages/projects/projectRoles/trackingUtils.ts
@@ -9,5 +9,53 @@ export const CUSTOM_ROLE_TRACKING_EVENTS = {
   TEMPLATE_SELECTED: 'Custom Role Template Selected',
 } as const;
 
+export type CreationInitiatedProperties = {
+  to: string;
+  type: 'roles-list-page' | 'empty-state';
+};
+
+export type ViewToggledProperties = {
+  targetView: 'form' | 'yaml';
+  sourceView: 'form' | 'yaml';
+};
+
+export type RuleAddedProperties = {
+  /** JSON-stringified array of API group names. */
+  apiGroups: string;
+  /** JSON-stringified array of resource type names. */
+  resourceTypes: string;
+  /** JSON-stringified array of verb names. */
+  verbs: string;
+  totalRulesCount: number;
+  isEdit: boolean;
+};
+
+export type YamlExportSelectedProperties = {
+  actionType: 'copy' | 'download';
+};
+
+export type TemplateSelectedProperties = {
+  templateId: string;
+  templateName: string;
+  templateCategory: string;
+  mode: 'select' | 'addRules';
+  rulesAdded: number;
+  hadExistingRules: boolean;
+};
+
+export type FormSubmittedProperties = {
+  outcome: string;
+  success?: boolean;
+  errorCode?: string;
+  yamlPreviewed: boolean;
+  /** JSON-stringified array of export action types taken (e.g. ["copy","download"]). */
+  yamlExportActions: string;
+  totalTimeOnPageMs: number;
+  totalRulesCount: number;
+  currentView: 'form' | 'yaml';
+  templateUsed: boolean;
+  templateId: string;
+};
+
 export const findTemplateCategoryId = (templateId: string): string | undefined =>
   ROLE_TEMPLATE_CATALOG.find((cat) => cat.templates.some((t) => t.id === templateId))?.id;

--- a/packages/tsconfig/typings.d.ts
+++ b/packages/tsconfig/typings.d.ts
@@ -4,6 +4,7 @@ declare module '*.jpeg';
 declare module '*.gif';
 declare module '*.svg';
 declare module '*.css';
+declare module '*.scss';
 declare module '*.wav';
 declare module '*.mp3';
 declare module '*.m4a';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-72274

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Implements 6 Segment telemetry events for the Custom Role creation flow to provide visibility into user behavior, YAML toggle usage, template adoption, permission configuration patterns, and form completion health.

**Events implemented:**
| # | Event Name | Trigger | Key Properties |
|---|-----------|---------|----------------|
| 1 | Custom Role Creation Initiated | "Create custom role" button click | `source` (roles-list-page \| empty-state) |
| 2 | Custom Role View Toggled | Form/YAML toggle switch | `targetView`, `sourceView` |
| 3 | Custom Role Rule Added | Rule saved in Add Rule modal | `apiGroups`, `resourceTypes`, `verbs`, `totalRulesCount`, `isEdit` |
| 4 | Custom Role YAML Export Selected | Copy/Download button in YAML view | `actionType` (copy \| download) |
| 5 | Custom Role Template Selected | Template picked from catalog | `templateId`, `templateName`, `templateCategory`, `mode`, `rulesAdded`, `hadExistingRules` |
| 6 | Custom Role Form Submitted | Submit or Cancel | `outcome`, `success`, `error`, `yamlPreviewed`, `yamlExportActions`, `totalTimeOnPageMs`, `totalRulesCount`, `currentView`, `templateUsed`, `templateId` |

**Implementation details:**
- Uses existing `fireFormTrackingEvent` (for submit/cancel with outcome) and `fireMiscTrackingEvent` (for interaction events) — no new tracking infrastructure
- Replaced PF CodeEditor's built-in copy/download buttons with custom controls to enable copy/download tracking (PF's `isCopyEnabled` has no callback)
- Tracking state (`yamlPreviewed`, `yamlExportActions`, `templateUsed`, `totalTimeOnPageMs`) is accumulated in `CreateRolePage` and correlated into the form-submitted event
- Also adds `*.scss` to shared tsconfig typings to fix a pre-existing missing module declaration

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- All 201 existing unit tests in `projectRoles/__tests__/` pass (including `CreateRoleFooter`, `CreateRoleYamlView`, `SelectTemplateModal`)
- TypeScript type-check (`tsc --noEmit`) passes cleanly
- ESLint + Prettier pass via pre-commit hook
- Verified events log to console in DEV_MODE by reviewing the `fireTrackingEvent` code path (events use `console.log` in dev instead of calling `window.analytics.track`)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No new unit tests added in this PR. The 6 tracking events are fire-and-forget calls to existing Segment utilities and do not affect component rendering or user-facing behavior. All 201 existing tests continue to pass, confirming no regressions. Unit tests for tracking event assertions can be added as a follow-up if desired.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expanded analytics tracking across custom role create/edit flows, including view toggles, template selection, rule saves, YAML preview/export actions, form submission outcomes, and cancellations.
  * Enhanced the YAML editor with explicit **Copy to clipboard** and **Download** controls (with action tracking).
  * Added link tracking when initiating role creation from both the roles list and empty state.
* **Behavior Changes**
  * The role creation footer **Cancel** action now triggers its callback before navigating back to the roles section.
* **Tests**
  * Updated and added coverage for the footer cancel callback behavior.
* **Chores**
  * Enabled importing `*.scss` styles in TypeScript.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->