### PR TITLE
RHOAIENG-64932: Promote roleManagement flag to Tech Preview and add it to CRD

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -64,6 +64,7 @@ export type DashboardConfig = K8sResourceCommon & {
       aiAssetCustomEndpoints: boolean;
       disableLLMd: boolean;
       projectRBAC: boolean;
+      roleManagement: boolean;
       deploymentWizardYAMLViewer: boolean;
       externalVectorStores: boolean;
       agentConfigManagement: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -100,6 +100,7 @@ export const blankDashboardCR: DashboardConfig = {
       trainingJobs: true,
       disableLLMd: false,
       projectRBAC: true,
+      roleManagement: false,
       deploymentWizardYAMLViewer: false,
       externalVectorStores: false,
       agentConfigManagement: false,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -17,6 +17,7 @@ export const techPreviewFlags = {
   mcpCatalog: false,
   toolCalling: false,
   projectRBAC: true,
+  roleManagement: false,
   deploymentWizardYAMLViewer: false,
   externalVectorStores: false,
   agentConfigManagement: false,
@@ -35,7 +36,6 @@ export const devTemporaryFeatureFlags = {
   nimWizard: false,
   agentOpsDiscoveryMode: false,
   agentsCatalog: false,
-  roleManagement: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Group 1: Core Dashboard Features

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -215,7 +215,7 @@ const ProjectDetails: React.FC = () => {
                     title: 'Roles',
                     label: (
                       <Label isCompact color="yellow" variant="outline">
-                        Dev preview
+                        Tech preview
                       </Label>
                     ),
                     component: (

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -183,6 +183,9 @@ spec:
                     projectRBAC:
                       type: boolean
                       description: 'When true, enables project-level RBAC (Role-Based Access Control) settings.'
+                    roleManagement:
+                      type: boolean
+                      description: 'When true, enables project role management features for custom RBAC roles.'
                     trainingJobs:
                       type: boolean
                       description: 'When true, enables model training job and Ray job features.'


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-64932

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Promotes the `roleManagement` feature flag from `devTemporaryFeatureFlags` to `techPreviewFlags` status, making the Role Management UI accessible to cluster admins via the `OdhDashboardConfig` CR.

<img width="1040" height="511" alt="Screenshot 2026-07-17 at 2 41 30 PM" src="https://github.com/user-attachments/assets/fe5e2908-fc1c-4ffe-b87d-95166addf2f0" />
<img width="709" height="276" alt="Screenshot 2026-07-17 at 2 41 19 PM" src="https://github.com/user-attachments/assets/81c17f25-5030-4e70-bddb-1dd4c6991491" />
<img width="687" height="283" alt="Screenshot 2026-07-17 at 2 40 49 PM" src="https://github.com/user-attachments/assets/582407da-d375-4fbf-a7da-1d3cf9581214" />

**Changes:**
- Moved `roleManagement: false` from `devTemporaryFeatureFlags` to `techPreviewFlags` in `frontend/src/concepts/areas/const.ts`
- Added `roleManagement: boolean` to `DashboardConfig` type in `backend/src/types.ts`
- Added `roleManagement: false` to `blankDashboardCR` defaults in `backend/src/utils/constants.ts`
- Added `roleManagement` boolean property to the CRD schema in `manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml`
- Changed the Roles tab label from "Dev preview" to "Tech preview" in `ProjectDetails.tsx`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Backend and frontend type-checks pass (`tsc --noEmit`)
- All lint-staged checks pass
- Ran area availability unit tests (`utils.spec.ts`) — 23/23 pass, including the 3 `ROLE_MANAGEMENT area` tests confirming the flag still gates the feature correctly
- Ran `DevFeatureFlagsBanner.spec.tsx` — 3/3 pass, confirming the feature flag modal renders correctly with the updated flag categories
- Ran `ProjectDetails.spec.tsx` — 4/4 pass

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No test changes required. Existing tests reference `roleManagement` by flag name (not by category), so they remain valid after the promotion. The `FeatureFlagModal` UI auto-updates since it renders from `Object.keys(techPreviewFlags)` and `Object.keys(devTemporaryFeatureFlags)`.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for enabling role management features for custom project roles.
  - Added a configurable role-management feature flag to dashboard settings.

- **User Interface**
  - Updated the Roles section label from “Dev preview” to “Tech preview.”

- **Configuration**
  - Role management is disabled by default and can be enabled through dashboard configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->