### PR TITLE
[cypress-e2e] feat(Agent-ops) Add E2E test for agent list page with agentOps feature flag

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/agentOps/agentRuntimes.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/agentOps/agentRuntimes.yaml
@@ -1,0 +1,6 @@
+# testAgentRuntimes.cy.ts Test Data #
+pageTitle: 'Agents'
+filterSearchTerm: 'test-agent'
+filterOptionStatus: 'status'
+statusPending: 'Pending'
+statusReady: 'Ready'

--- a/packages/cypress/cypress/fixtures/e2e/agentOps/agentRuntimes.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/agentOps/agentRuntimes.yaml
@@ -1,5 +1,6 @@
 # testAgentRuntimes.cy.ts Test Data #
 pageTitle: 'Agents'
+projectResourceName: 'agent-ops-demo'
 filterSearchTerm: 'test-agent'
 filterOptionStatus: 'status'
 statusPending: 'Pending'

--- a/packages/cypress/cypress/pages/agentRuntimes.ts
+++ b/packages/cypress/cypress/pages/agentRuntimes.ts
@@ -71,6 +71,10 @@ class AgentRuntimesPage {
     return cy.findByTestId('agent-runtimes-filter-input');
   }
 
+  clearNameFilter(): void {
+    this.findNameFilterInput().find('button[aria-label="Reset"]').click();
+  }
+
   findStatusFilterDropdown(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('agent-runtimes-filter-status');
   }
@@ -80,7 +84,8 @@ class AgentRuntimesPage {
   }
 
   findClearAllFiltersButton(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('button', { name: 'Clear all filters' });
+    // Toolbar chip clear (always when filters active) and empty-table clear
+    return cy.findAllByRole('button', { name: 'Clear all filters' }).first();
   }
 
   findNameFilterChip(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/pages/agentRuntimes.ts
+++ b/packages/cypress/cypress/pages/agentRuntimes.ts
@@ -90,6 +90,10 @@ class AgentRuntimesPage {
   findEmptyTableState(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('dashboard-empty-table-state');
   }
+
+  findNoDeploymentsEmptyState(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-deployments-empty-state');
+  }
 }
 
 export const agentRuntimesPage = new AgentRuntimesPage();

--- a/packages/cypress/cypress/pages/agentRuntimes.ts
+++ b/packages/cypress/cypress/pages/agentRuntimes.ts
@@ -83,6 +83,14 @@ class AgentRuntimesPage {
     return cy.findByRole('button', { name: 'Clear all filters' });
   }
 
+  findNameFilterChip(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('name-filter-chip');
+  }
+
+  findStatusFilterChip(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('status-filter-chip');
+  }
+
   findTableRow(namespace: string, name: string): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId(`agent-runtime-row-${namespace}-${name}`);
   }
@@ -104,9 +112,13 @@ class AgentRuntimesPage {
   }
 
   hasDeploymentsTable(): Cypress.Chainable<boolean> {
+    // Retries against the DOM until either the table or the empty state has rendered,
+    // so this can't resolve while the runtimes fetch is still in flight.
     return cy
-      .get('body')
-      .then(($body) => $body.find('[data-testid="agent-runtimes-table"]').length > 0);
+      .get('[data-testid="agent-runtimes-table"], [data-testid="agent-deployments-empty-state"]', {
+        timeout: 10000,
+      })
+      .then(($el) => $el.is('[data-testid="agent-runtimes-table"]'));
   }
 }
 

--- a/packages/cypress/cypress/pages/agentRuntimes.ts
+++ b/packages/cypress/cypress/pages/agentRuntimes.ts
@@ -1,0 +1,95 @@
+import { appChrome } from './appChrome';
+
+class AgentRuntimesPage {
+  navigate(): void {
+    appChrome.findNavItem({ name: 'Agents', rootSection: 'AI hub' }).click();
+    this.wait();
+  }
+
+  visit(namespace?: string): void {
+    const basePath = namespace
+      ? `/ai-hub/agents/deployments/${namespace}`
+      : '/ai-hub/agents/deployments';
+    cy.visitWithLogin(`${basePath}?devFeatureFlags=agentOps=true`);
+    this.wait();
+  }
+
+  private wait(): void {
+    this.findPageTitle().should('exist');
+    cy.testA11y();
+  }
+
+  findNavItem(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return appChrome.findNavItem({ name: 'Agents', rootSection: 'AI hub' });
+  }
+
+  findPageTitle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('app-tab-page-title');
+  }
+
+  findDeploymentsTab(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('tab', { name: 'Deployments' });
+  }
+
+  findProjectSelector(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-ops-project-selector');
+  }
+
+  findSelectProjectEmptyState(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-deployments-select-project');
+  }
+
+  findAccessDeniedState(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-deployments-access-denied');
+  }
+
+  findTable(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-runtimes-table');
+  }
+
+  findFilterToolbar(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-runtimes-table-toolbar');
+  }
+
+  findFilterDropdownToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('filter-toolbar-dropdown');
+  }
+
+  findFilterOption(option: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`filter-toolbar-option-${option}`);
+  }
+
+  findNameFilterInput(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-runtimes-filter-input');
+  }
+
+  findStatusFilterDropdown(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-runtimes-filter-status');
+  }
+
+  findStatusOption(status: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(status);
+  }
+
+  findClearAllFiltersButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('button', { name: 'Clear all filters' });
+  }
+
+  findTableRow(namespace: string, name: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`agent-runtime-row-${namespace}-${name}`);
+  }
+
+  findKebabActions(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('agent-runtime-actions');
+  }
+
+  findModalSubmitButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('modal-submit-button');
+  }
+
+  findEmptyTableState(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('dashboard-empty-table-state');
+  }
+}
+
+export const agentRuntimesPage = new AgentRuntimesPage();

--- a/packages/cypress/cypress/pages/agentRuntimes.ts
+++ b/packages/cypress/cypress/pages/agentRuntimes.ts
@@ -35,6 +35,14 @@ class AgentRuntimesPage {
     return cy.findByTestId('agent-ops-project-selector');
   }
 
+  findProjectSelectorToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('project-selector-toggle');
+  }
+
+  findProjectSelectorMenu(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('project-selector-menu');
+  }
+
   findSelectProjectEmptyState(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('agent-deployments-select-project');
   }
@@ -93,6 +101,12 @@ class AgentRuntimesPage {
 
   findNoDeploymentsEmptyState(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('agent-deployments-empty-state');
+  }
+
+  hasDeploymentsTable(): Cypress.Chainable<boolean> {
+    return cy
+      .get('body')
+      .then(($body) => $body.find('[data-testid="agent-runtimes-table"]').length > 0);
   }
 }
 

--- a/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
@@ -1,6 +1,7 @@
 import * as yaml from 'js-yaml';
 import { LDAP_ADMIN_USER } from '../../../utils/e2eUsers';
 import { agentRuntimesPage } from '../../../pages/agentRuntimes';
+import { retryableBefore } from '../../../utils/retryableHooks';
 import type { AgentRuntimesTestData } from '../../../types';
 
 describe('Agent Runtimes list page', () => {
@@ -8,7 +9,7 @@ describe('Agent Runtimes list page', () => {
   const namespace = Cypress.env('AGENT_OPS_NAMESPACE') as string;
   const filterTest = namespace ? it : it.skip;
 
-  before(() => {
+  retryableBefore(() => {
     cy.fixture('e2e/agentOps/agentRuntimes.yaml', 'utf8').then((yamlContent: string) => {
       testData = yaml.load(yamlContent) as AgentRuntimesTestData;
     });

--- a/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
@@ -2,16 +2,25 @@ import * as yaml from 'js-yaml';
 import { LDAP_ADMIN_USER } from '../../../utils/e2eUsers';
 import { agentRuntimesPage } from '../../../pages/agentRuntimes';
 import { retryableBefore } from '../../../utils/retryableHooks';
+import { verifyOpenShiftProjectExists } from '../../../utils/oc_commands/project';
 import type { AgentRuntimesTestData } from '../../../types';
 
 describe('Agent Runtimes list page', () => {
   let testData: AgentRuntimesTestData;
-  const namespace = Cypress.env('AGENT_OPS_NAMESPACE') as string;
-  const filterTest = namespace ? it : it.skip;
+  let skipFilterTest = false;
 
   retryableBefore(() => {
     cy.fixture('e2e/agentOps/agentRuntimes.yaml', 'utf8').then((yamlContent: string) => {
       testData = yaml.load(yamlContent) as AgentRuntimesTestData;
+
+      verifyOpenShiftProjectExists(testData.projectResourceName).then((exists) => {
+        if (!exists) {
+          cy.log(
+            `Project '${testData.projectResourceName}' not found; skipping namespace-scoped filter test.`,
+          );
+          skipFilterTest = true;
+        }
+      });
     });
   });
 
@@ -42,12 +51,16 @@ describe('Agent Runtimes list page', () => {
     },
   );
 
-  filterTest(
+  it(
     'should display table toolbar and support filter interactions when a project is selected',
     { tags: ['@Dashboard', '@AgentOps', '@Featureflagged'] },
-    () => {
+    function filterInteractionsWhenProjectSelected() {
+      if (skipFilterTest) {
+        this.skip();
+      }
+
       cy.step('Visit the agents deployments page for the configured namespace');
-      agentRuntimesPage.visit(namespace);
+      agentRuntimesPage.visit(testData.projectResourceName);
 
       cy.step('Verify the project selector shows the current namespace');
       agentRuntimesPage.findProjectSelector().should('exist');
@@ -67,7 +80,7 @@ describe('Agent Runtimes list page', () => {
         agentRuntimesPage.findNameFilterChip().should('contain.text', testData.filterSearchTerm);
 
         cy.step('Clear the name filter and verify its filter chip is removed');
-        agentRuntimesPage.findNameFilterInput().clear();
+        agentRuntimesPage.clearNameFilter();
         agentRuntimesPage.findNameFilterChip().should('not.exist');
 
         cy.step('Switch the filter dropdown to Status');

--- a/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
@@ -24,54 +24,59 @@ describe('Agent Runtimes list page', () => {
     },
   );
 
-  it(
+  const namespace = Cypress.env('AGENT_OPS_NAMESPACE') as string;
+  const filterTest = namespace ? it : it.skip;
+
+  filterTest(
     'should display table toolbar and support filter interactions when a project is selected',
     { tags: ['@Dashboard', '@AgentOps', '@Featureflagged'] },
     () => {
-      const namespace = Cypress.env('AGENT_OPS_NAMESPACE') as string;
+      cy.fixture('e2e/agentOps/agentRuntimes.yaml').then((testData) => {
+        cy.step('Visit the agents deployments page for the configured namespace');
+        agentRuntimesPage.visit(namespace);
 
-      if (!namespace) {
-        cy.log('Skipping: AGENT_OPS_NAMESPACE not set in test-variables.yml');
-        return;
-      }
+        cy.step('Verify the project selector shows the current namespace');
+        agentRuntimesPage.findProjectSelector().should('exist');
 
-      cy.step('Visit the agents deployments page for the configured namespace');
-      agentRuntimesPage.visit(namespace);
+        cy.step('Verify the table or no-deployments empty state renders');
+        cy.get('body').then(($body) => {
+          const hasTable = $body.find('[data-testid="agent-runtimes-table"]').length > 0;
 
-      cy.step('Verify the project selector shows the current namespace');
-      agentRuntimesPage.findProjectSelector().should('exist');
+          if (!hasTable) {
+            agentRuntimesPage.findNoDeploymentsEmptyState().should('exist');
+            return;
+          }
 
-      cy.step('Verify the table or empty state renders');
-      agentRuntimesPage.findTable().should('exist');
+          cy.step('Verify the filter toolbar is present');
+          agentRuntimesPage.findFilterToolbar().should('exist');
 
-      cy.step('Verify the filter toolbar is present');
-      agentRuntimesPage.findFilterToolbar().should('exist');
+          cy.step('Type a search term in the name filter');
+          agentRuntimesPage.findNameFilterInput().type(testData.filterSearchTerm);
 
-      cy.step('Type a search term in the name filter');
-      agentRuntimesPage.findNameFilterInput().type('test-agent');
+          cy.step('Clear the name filter');
+          agentRuntimesPage.findNameFilterInput().clear();
 
-      cy.step('Clear the name filter');
-      agentRuntimesPage.findNameFilterInput().clear();
+          cy.step('Switch the filter dropdown to Status');
+          agentRuntimesPage.findFilterDropdownToggle().click();
+          agentRuntimesPage.findFilterOption(testData.filterOptionStatus).click();
 
-      cy.step('Switch the filter dropdown to Status');
-      agentRuntimesPage.findFilterDropdownToggle().click();
-      agentRuntimesPage.findFilterOption('status').click();
+          cy.step('Select Pending from the status filter');
+          agentRuntimesPage.findStatusFilterDropdown().click();
+          agentRuntimesPage.findStatusOption(testData.statusPending).click();
 
-      cy.step('Select Pending from the status filter');
-      agentRuntimesPage.findStatusFilterDropdown().click();
-      agentRuntimesPage.findStatusOption('Pending').click();
+          cy.step('Clear all filters');
+          agentRuntimesPage.findClearAllFiltersButton().click();
 
-      cy.step('Clear all filters');
-      agentRuntimesPage.findClearAllFiltersButton().click();
+          cy.step('Switch the filter dropdown back to Status and select Ready');
+          agentRuntimesPage.findFilterDropdownToggle().click();
+          agentRuntimesPage.findFilterOption(testData.filterOptionStatus).click();
+          agentRuntimesPage.findStatusFilterDropdown().click();
+          agentRuntimesPage.findStatusOption(testData.statusReady).click();
 
-      cy.step('Switch the filter dropdown back to Status and select Ready');
-      agentRuntimesPage.findFilterDropdownToggle().click();
-      agentRuntimesPage.findFilterOption('status').click();
-      agentRuntimesPage.findStatusFilterDropdown().click();
-      agentRuntimesPage.findStatusOption('Ready').click();
-
-      cy.step('Clear all filters again');
-      agentRuntimesPage.findClearAllFiltersButton().click();
+          cy.step('Clear all filters again');
+          agentRuntimesPage.findClearAllFiltersButton().click();
+        });
+      });
     },
   );
 });

--- a/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
@@ -61,31 +61,37 @@ describe('Agent Runtimes list page', () => {
         cy.step('Verify the filter toolbar is present');
         agentRuntimesPage.findFilterToolbar().should('exist');
 
-        cy.step('Type a search term in the name filter');
+        cy.step('Type a search term in the name filter and verify the filter chip renders it');
         agentRuntimesPage.findNameFilterInput().type(testData.filterSearchTerm);
+        agentRuntimesPage.findNameFilterChip().should('contain.text', testData.filterSearchTerm);
 
-        cy.step('Clear the name filter');
+        cy.step('Clear the name filter and verify its filter chip is removed');
         agentRuntimesPage.findNameFilterInput().clear();
+        agentRuntimesPage.findNameFilterChip().should('not.exist');
 
         cy.step('Switch the filter dropdown to Status');
         agentRuntimesPage.findFilterDropdownToggle().click();
         agentRuntimesPage.findFilterOption(testData.filterOptionStatus).click();
 
-        cy.step('Select Pending from the status filter');
+        cy.step('Select Pending from the status filter and verify the filter chip renders it');
         agentRuntimesPage.findStatusFilterDropdown().click();
         agentRuntimesPage.findStatusOption(testData.statusPending).click();
+        agentRuntimesPage.findStatusFilterChip().should('contain.text', testData.statusPending);
 
-        cy.step('Clear all filters');
+        cy.step('Clear all filters and verify the status filter chip is removed');
         agentRuntimesPage.findClearAllFiltersButton().click();
+        agentRuntimesPage.findStatusFilterChip().should('not.exist');
 
         cy.step('Switch the filter dropdown back to Status and select Ready');
         agentRuntimesPage.findFilterDropdownToggle().click();
         agentRuntimesPage.findFilterOption(testData.filterOptionStatus).click();
         agentRuntimesPage.findStatusFilterDropdown().click();
         agentRuntimesPage.findStatusOption(testData.statusReady).click();
+        agentRuntimesPage.findStatusFilterChip().should('contain.text', testData.statusReady);
 
-        cy.step('Clear all filters again');
+        cy.step('Clear all filters again and verify the status filter chip is removed');
         agentRuntimesPage.findClearAllFiltersButton().click();
+        agentRuntimesPage.findStatusFilterChip().should('not.exist');
       });
     },
   );

--- a/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
@@ -1,81 +1,91 @@
-import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
+import * as yaml from 'js-yaml';
+import { LDAP_ADMIN_USER } from '../../../utils/e2eUsers';
 import { agentRuntimesPage } from '../../../pages/agentRuntimes';
+import type { AgentRuntimesTestData } from '../../../types';
 
 describe('Agent Runtimes list page', () => {
+  let testData: AgentRuntimesTestData;
+  const namespace = Cypress.env('AGENT_OPS_NAMESPACE') as string;
+  const filterTest = namespace ? it : it.skip;
+
+  before(() => {
+    cy.fixture('e2e/agentOps/agentRuntimes.yaml', 'utf8').then((yamlContent: string) => {
+      testData = yaml.load(yamlContent) as AgentRuntimesTestData;
+    });
+  });
+
   it(
     'should display the Agents nav item and load the deployments page when agentOps flag is enabled',
     { tags: ['@Dashboard', '@AgentOps', '@Featureflagged'] },
     () => {
       cy.step('Log into the application with agentOps feature flag enabled');
-      cy.visitWithLogin('/?devFeatureFlags=agentOps=true', HTPASSWD_CLUSTER_ADMIN_USER);
+      cy.visitWithLogin('/?devFeatureFlags=agentOps=true', LDAP_ADMIN_USER);
 
       cy.step('Verify Agents nav item is visible under AI hub');
       agentRuntimesPage.findNavItem().should('be.visible');
 
       cy.step('Navigate to the Agents page');
       agentRuntimesPage.findNavItem().click();
-      cy.url().should('include', '/ai-hub/agents');
 
       cy.step('Verify the Agents page title is displayed');
-      agentRuntimesPage.findPageTitle().should('be.visible').and('contain.text', 'Agents');
+      agentRuntimesPage
+        .findPageTitle()
+        .should('be.visible')
+        .and('contain.text', testData.pageTitle);
 
-      cy.step('Verify the project selector is displayed');
+      cy.step('Verify the project selector is displayed and opens a project list');
       agentRuntimesPage.findProjectSelector().should('exist');
+      agentRuntimesPage.findProjectSelectorToggle().click();
+      agentRuntimesPage.findProjectSelectorMenu().should('be.visible');
+      agentRuntimesPage.findProjectSelectorToggle().click();
     },
   );
-
-  const namespace = Cypress.env('AGENT_OPS_NAMESPACE') as string;
-  const filterTest = namespace ? it : it.skip;
 
   filterTest(
     'should display table toolbar and support filter interactions when a project is selected',
     { tags: ['@Dashboard', '@AgentOps', '@Featureflagged'] },
     () => {
-      cy.fixture('e2e/agentOps/agentRuntimes.yaml').then((testData) => {
-        cy.step('Visit the agents deployments page for the configured namespace');
-        agentRuntimesPage.visit(namespace);
+      cy.step('Visit the agents deployments page for the configured namespace');
+      agentRuntimesPage.visit(namespace);
 
-        cy.step('Verify the project selector shows the current namespace');
-        agentRuntimesPage.findProjectSelector().should('exist');
+      cy.step('Verify the project selector shows the current namespace');
+      agentRuntimesPage.findProjectSelector().should('exist');
 
-        cy.step('Verify the table or no-deployments empty state renders');
-        cy.get('body').then(($body) => {
-          const hasTable = $body.find('[data-testid="agent-runtimes-table"]').length > 0;
+      cy.step('Verify the table or no-deployments empty state renders');
+      agentRuntimesPage.hasDeploymentsTable().then((hasTable) => {
+        if (!hasTable) {
+          agentRuntimesPage.findNoDeploymentsEmptyState().should('exist');
+          return;
+        }
 
-          if (!hasTable) {
-            agentRuntimesPage.findNoDeploymentsEmptyState().should('exist');
-            return;
-          }
+        cy.step('Verify the filter toolbar is present');
+        agentRuntimesPage.findFilterToolbar().should('exist');
 
-          cy.step('Verify the filter toolbar is present');
-          agentRuntimesPage.findFilterToolbar().should('exist');
+        cy.step('Type a search term in the name filter');
+        agentRuntimesPage.findNameFilterInput().type(testData.filterSearchTerm);
 
-          cy.step('Type a search term in the name filter');
-          agentRuntimesPage.findNameFilterInput().type(testData.filterSearchTerm);
+        cy.step('Clear the name filter');
+        agentRuntimesPage.findNameFilterInput().clear();
 
-          cy.step('Clear the name filter');
-          agentRuntimesPage.findNameFilterInput().clear();
+        cy.step('Switch the filter dropdown to Status');
+        agentRuntimesPage.findFilterDropdownToggle().click();
+        agentRuntimesPage.findFilterOption(testData.filterOptionStatus).click();
 
-          cy.step('Switch the filter dropdown to Status');
-          agentRuntimesPage.findFilterDropdownToggle().click();
-          agentRuntimesPage.findFilterOption(testData.filterOptionStatus).click();
+        cy.step('Select Pending from the status filter');
+        agentRuntimesPage.findStatusFilterDropdown().click();
+        agentRuntimesPage.findStatusOption(testData.statusPending).click();
 
-          cy.step('Select Pending from the status filter');
-          agentRuntimesPage.findStatusFilterDropdown().click();
-          agentRuntimesPage.findStatusOption(testData.statusPending).click();
+        cy.step('Clear all filters');
+        agentRuntimesPage.findClearAllFiltersButton().click();
 
-          cy.step('Clear all filters');
-          agentRuntimesPage.findClearAllFiltersButton().click();
+        cy.step('Switch the filter dropdown back to Status and select Ready');
+        agentRuntimesPage.findFilterDropdownToggle().click();
+        agentRuntimesPage.findFilterOption(testData.filterOptionStatus).click();
+        agentRuntimesPage.findStatusFilterDropdown().click();
+        agentRuntimesPage.findStatusOption(testData.statusReady).click();
 
-          cy.step('Switch the filter dropdown back to Status and select Ready');
-          agentRuntimesPage.findFilterDropdownToggle().click();
-          agentRuntimesPage.findFilterOption(testData.filterOptionStatus).click();
-          agentRuntimesPage.findStatusFilterDropdown().click();
-          agentRuntimesPage.findStatusOption(testData.statusReady).click();
-
-          cy.step('Clear all filters again');
-          agentRuntimesPage.findClearAllFiltersButton().click();
-        });
+        cy.step('Clear all filters again');
+        agentRuntimesPage.findClearAllFiltersButton().click();
       });
     },
   );

--- a/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/agentOps/testAgentRuntimes.cy.ts
@@ -1,0 +1,77 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
+import { agentRuntimesPage } from '../../../pages/agentRuntimes';
+
+describe('Agent Runtimes list page', () => {
+  it(
+    'should display the Agents nav item and load the deployments page when agentOps flag is enabled',
+    { tags: ['@Dashboard', '@AgentOps', '@Featureflagged'] },
+    () => {
+      cy.step('Log into the application with agentOps feature flag enabled');
+      cy.visitWithLogin('/?devFeatureFlags=agentOps=true', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      cy.step('Verify Agents nav item is visible under AI hub');
+      agentRuntimesPage.findNavItem().should('be.visible');
+
+      cy.step('Navigate to the Agents page');
+      agentRuntimesPage.findNavItem().click();
+      cy.url().should('include', '/ai-hub/agents');
+
+      cy.step('Verify the Agents page title is displayed');
+      agentRuntimesPage.findPageTitle().should('be.visible').and('contain.text', 'Agents');
+
+      cy.step('Verify the project selector is displayed');
+      agentRuntimesPage.findProjectSelector().should('exist');
+    },
+  );
+
+  it(
+    'should display table toolbar and support filter interactions when a project is selected',
+    { tags: ['@Dashboard', '@AgentOps', '@Featureflagged'] },
+    () => {
+      const namespace = Cypress.env('AGENT_OPS_NAMESPACE') as string;
+
+      if (!namespace) {
+        cy.log('Skipping: AGENT_OPS_NAMESPACE not set in test-variables.yml');
+        return;
+      }
+
+      cy.step('Visit the agents deployments page for the configured namespace');
+      agentRuntimesPage.visit(namespace);
+
+      cy.step('Verify the project selector shows the current namespace');
+      agentRuntimesPage.findProjectSelector().should('exist');
+
+      cy.step('Verify the table or empty state renders');
+      agentRuntimesPage.findTable().should('exist');
+
+      cy.step('Verify the filter toolbar is present');
+      agentRuntimesPage.findFilterToolbar().should('exist');
+
+      cy.step('Type a search term in the name filter');
+      agentRuntimesPage.findNameFilterInput().type('test-agent');
+
+      cy.step('Clear the name filter');
+      agentRuntimesPage.findNameFilterInput().clear();
+
+      cy.step('Switch the filter dropdown to Status');
+      agentRuntimesPage.findFilterDropdownToggle().click();
+      agentRuntimesPage.findFilterOption('status').click();
+
+      cy.step('Select Pending from the status filter');
+      agentRuntimesPage.findStatusFilterDropdown().click();
+      agentRuntimesPage.findStatusOption('Pending').click();
+
+      cy.step('Clear all filters');
+      agentRuntimesPage.findClearAllFiltersButton().click();
+
+      cy.step('Switch the filter dropdown back to Status and select Ready');
+      agentRuntimesPage.findFilterDropdownToggle().click();
+      agentRuntimesPage.findFilterOption('status').click();
+      agentRuntimesPage.findStatusFilterDropdown().click();
+      agentRuntimesPage.findStatusOption('Ready').click();
+
+      cy.step('Clear all filters again');
+      agentRuntimesPage.findClearAllFiltersButton().click();
+    },
+  );
+});

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -860,6 +860,7 @@ export type AutoragTestData = {
 
 export type AgentRuntimesTestData = {
   pageTitle: string;
+  projectResourceName: string;
   filterSearchTerm: string;
   filterOptionStatus: string;
   statusPending: string;

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -857,3 +857,11 @@ export type AutoragTestData = {
   maxRagPatterns: number;
   optimizationMetric?: string;
 };
+
+export type AgentRuntimesTestData = {
+  pageTitle: string;
+  filterSearchTerm: string;
+  filterOptionStatus: string;
+  statusPending: string;
+  statusReady: string;
+};


### PR DESCRIPTION
## Description

For https://redhat.atlassian.net/browse/RHOAIENG-73642 

Adds E2E test coverage for the agent-ops "Agents" list page when the `agentOps`
The feature flag is enabled. Verifies nav item visibility, page load, and project selector.

Also adds an `agentRuntimesPage` page object with finder methods for table, filters,
Kebab actions and modals for future test expansion.

## How Has This Been Tested?

- Ran locally via Cypress open mode against the E2E Roy cluster (

## Test Impact

New E2E test only — no product code changes.

Self-checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the Agent Runtimes list page with the required feature-flag enabled.
  * Verifies navigation to the Agents section, page title, and the project selector menu.
  * Confirms deployments table rendering vs. “no deployments” empty state, including project-scoped behavior.
  * Exercises name search, Status filtering (Pending/Ready), and clearing filters.
  * Adds accessibility checks and new shared fixture-driven test data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->