### PR TITLE
fix/refactor: centralize config field overrides in overrideLlmConfigFields

### DIFF
--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -27,13 +27,11 @@ import ConfigYAMLEditor from './ConfigYAMLEditor';
 import { overrideLlmConfigFields } from './configYamlUtils';
 import {
   type LLMInferenceServiceConfigKind,
-  LLMInferenceServiceConfigModel,
   ConfigType,
   TopologyType,
   TopologyTypeLabels,
   CONFIG_TYPE_LABEL,
   SUPPORTED_TOPOLOGIES_ANNOTATION,
-  DASHBOARD_RESOURCE_LABEL,
 } from '../types';
 import { isConfigObject, cleanResourceForYAMLViewer, stripAnnotation } from '../utils';
 import {
@@ -295,32 +293,16 @@ const RoutingConfigurationCreateEditInner: React.FC<{
         throw new Error('YAML must represent a valid object with a metadata block');
       }
 
-      const withFormFields = overrideLlmConfigFields(parsed, {
+      const newConfig = overrideLlmConfigFields(parsed, {
         name: resourceName,
+        namespace: dashboardNamespace,
         displayName: k8sNameDesc.data.name,
         description: k8sNameDesc.data.description,
-      });
-      const apiGroup = LLMInferenceServiceConfigModel.apiGroup ?? '';
-      const apiVer = LLMInferenceServiceConfigModel.apiVersion;
-
-      const newConfig: LLMInferenceServiceConfigKind = {
-        ...withFormFields,
-        apiVersion: `${apiGroup}/${apiVer}`,
-        kind: 'LLMInferenceServiceConfig',
-        metadata: {
-          ...withFormFields.metadata,
-          namespace: dashboardNamespace,
-          labels: {
-            ...(withFormFields.metadata.labels ?? {}),
-            [CONFIG_TYPE_LABEL]: ConfigType.ROUTER,
-            [DASHBOARD_RESOURCE_LABEL]: 'true',
-          },
-          annotations: {
-            ...(withFormFields.metadata.annotations ?? {}),
-            [SUPPORTED_TOPOLOGIES_ANNOTATION]: JSON.stringify([selectedTopology]),
-          },
+        labels: { [CONFIG_TYPE_LABEL]: ConfigType.ROUTER },
+        annotations: {
+          [SUPPORTED_TOPOLOGIES_ANNOTATION]: JSON.stringify([selectedTopology]),
         },
-      };
+      });
 
       if (isEditMode && existingConfig) {
         await patchLLMInferenceServiceConfig(existingConfig, newConfig);

--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -290,7 +290,7 @@ const RoutingConfigurationCreateEditInner: React.FC<{
 
       const parsed: unknown = YAML.parse(yamlCode);
       if (!isConfigObject(parsed)) {
-        throw new Error('YAML must represent a valid object with a metadata block');
+        throw new Error('YAML must represent a valid kubernetes resource object');
       }
 
       const newConfig = overrideLlmConfigFields(parsed, {

--- a/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
@@ -27,11 +27,9 @@ import ConfigYAMLEditor from './ConfigYAMLEditor';
 import { overrideLlmConfigFields } from './configYamlUtils';
 import {
   type LLMInferenceServiceConfigKind,
-  LLMInferenceServiceConfigModel,
   TopologyType,
   TopologyTypeLabels,
   CONFIG_TYPE_LABEL,
-  DASHBOARD_RESOURCE_LABEL,
 } from '../types';
 import { isConfigObject, cleanResourceForYAMLViewer, stripAnnotation } from '../utils';
 import {
@@ -240,27 +238,13 @@ const TopologyConfigurationCreateEditInner: React.FC<{
         throw new Error('YAML must represent a valid object');
       }
 
-      const withFormFields = overrideLlmConfigFields(parsed, {
+      const newConfig = overrideLlmConfigFields(parsed, {
         name: resourceName,
+        namespace: dashboardNamespace,
         displayName: k8sNameDesc.data.name,
         description: k8sNameDesc.data.description,
+        labels: { [CONFIG_TYPE_LABEL]: resolvedTopologyType },
       });
-      const apiGroup = LLMInferenceServiceConfigModel.apiGroup ?? '';
-      const apiVer = LLMInferenceServiceConfigModel.apiVersion;
-      const newConfig: LLMInferenceServiceConfigKind = {
-        ...withFormFields,
-        apiVersion: `${apiGroup}/${apiVer}`,
-        kind: 'LLMInferenceServiceConfig',
-        metadata: {
-          ...withFormFields.metadata,
-          namespace: dashboardNamespace,
-          labels: {
-            ...withFormFields.metadata.labels,
-            [CONFIG_TYPE_LABEL]: resolvedTopologyType,
-            [DASHBOARD_RESOURCE_LABEL]: 'true',
-          },
-        },
-      };
 
       if (isEditMode && existingConfig) {
         await patchLLMInferenceServiceConfig(existingConfig, newConfig);

--- a/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
@@ -235,7 +235,7 @@ const TopologyConfigurationCreateEditInner: React.FC<{
 
       const parsed: unknown = YAML.parse(yamlCode);
       if (!isConfigObject(parsed)) {
-        throw new Error('YAML must represent a valid object');
+        throw new Error('YAML must represent a valid kubernetes resource object');
       }
 
       const newConfig = overrideLlmConfigFields(parsed, {

--- a/packages/llmd-serving/src/settings/__tests__/configYamlUtils.spec.ts
+++ b/packages/llmd-serving/src/settings/__tests__/configYamlUtils.spec.ts
@@ -18,66 +18,163 @@ const makeConfig = (
   spec: { model: { uri: 'hf://test/model' } },
 });
 
+const defaultOverrides = { namespace: 'opendatahub' };
+
 describe('overrideLlmConfigFields', () => {
   it('should override metadata.name', () => {
-    const result = overrideLlmConfigFields(makeConfig(), { name: 'new-name' });
+    const result = overrideLlmConfigFields(makeConfig(), {
+      ...defaultOverrides,
+      name: 'new-name',
+    });
     expect(result.metadata.name).toBe('new-name');
   });
 
   it('should not change name when name field is undefined', () => {
-    const result = overrideLlmConfigFields(makeConfig(), { displayName: 'New' });
+    const result = overrideLlmConfigFields(makeConfig(), {
+      ...defaultOverrides,
+      displayName: 'New',
+    });
     expect(result.metadata.name).toBe('original-name');
   });
 
+  it('should override namespace', () => {
+    const result = overrideLlmConfigFields(makeConfig(), { namespace: 'other-ns' });
+    expect(result.metadata.namespace).toBe('other-ns');
+  });
+
   it('should override display-name annotation', () => {
-    const result = overrideLlmConfigFields(makeConfig(), { displayName: 'New Display Name' });
+    const result = overrideLlmConfigFields(makeConfig(), {
+      ...defaultOverrides,
+      displayName: 'New Display Name',
+    });
     expect(result.metadata.annotations?.['openshift.io/display-name']).toBe('New Display Name');
   });
 
   it('should set description annotation', () => {
-    const result = overrideLlmConfigFields(makeConfig(), { description: 'A description' });
+    const result = overrideLlmConfigFields(makeConfig(), {
+      ...defaultOverrides,
+      description: 'A description',
+    });
     expect(result.metadata.annotations?.['openshift.io/description']).toBe('A description');
   });
 
   it('should set version annotation', () => {
-    const result = overrideLlmConfigFields(makeConfig(), { version: '1.0.0' });
+    const result = overrideLlmConfigFields(makeConfig(), {
+      ...defaultOverrides,
+      version: '1.0.0',
+    });
     expect(result.metadata.annotations?.['opendatahub.io/runtime-version']).toBe('1.0.0');
   });
 
   it('should remove version annotation when version is empty string', () => {
-    const result = overrideLlmConfigFields(makeConfig(), { version: '' });
+    const result = overrideLlmConfigFields(makeConfig(), { ...defaultOverrides, version: '' });
     expect(result.metadata.annotations?.['opendatahub.io/runtime-version']).toBeUndefined();
   });
 
   it('should not modify version when version is undefined', () => {
-    const result = overrideLlmConfigFields(makeConfig(), { name: 'new-name' });
+    const result = overrideLlmConfigFields(makeConfig(), {
+      ...defaultOverrides,
+      name: 'new-name',
+    });
     expect(result.metadata.annotations?.['opendatahub.io/runtime-version']).toBe('0.15.0');
+  });
+
+  it('should set apiVersion and kind from the model', () => {
+    const result = overrideLlmConfigFields(makeConfig(), defaultOverrides);
+    expect(result.apiVersion).toBe('serving.kserve.io/v1alpha2');
+    expect(result.kind).toBe('LLMInferenceServiceConfig');
+  });
+
+  it('should add dashboard label', () => {
+    const result = overrideLlmConfigFields(makeConfig(), defaultOverrides);
+    expect(result.metadata.labels?.['opendatahub.io/dashboard']).toBe('true');
+  });
+
+  it('should merge additional labels', () => {
+    const result = overrideLlmConfigFields(makeConfig(), {
+      ...defaultOverrides,
+      labels: { 'opendatahub.io/config-type': 'topology' },
+    });
+    expect(result.metadata.labels?.['opendatahub.io/config-type']).toBe('topology');
+    expect(result.metadata.labels?.['opendatahub.io/dashboard']).toBe('true');
+  });
+
+  it('should merge additional annotations', () => {
+    const result = overrideLlmConfigFields(makeConfig(), {
+      ...defaultOverrides,
+      annotations: { 'custom/key': 'value' },
+    });
+    expect(result.metadata.annotations?.['custom/key']).toBe('value');
+    expect(result.metadata.annotations?.['openshift.io/display-name']).toBe(
+      'Original Display Name',
+    );
   });
 
   it('should handle multiple overrides at once', () => {
     const result = overrideLlmConfigFields(makeConfig(), {
       name: 'new-name',
+      namespace: 'test-ns',
       displayName: 'New Name',
       description: 'New desc',
       version: '2.0.0',
     });
     expect(result.metadata.name).toBe('new-name');
+    expect(result.metadata.namespace).toBe('test-ns');
     expect(result.metadata.annotations?.['openshift.io/display-name']).toBe('New Name');
     expect(result.metadata.annotations?.['openshift.io/description']).toBe('New desc');
     expect(result.metadata.annotations?.['opendatahub.io/runtime-version']).toBe('2.0.0');
+    expect(result.metadata.labels?.['opendatahub.io/dashboard']).toBe('true');
   });
 
-  it('should preserve other metadata and spec', () => {
-    const result = overrideLlmConfigFields(makeConfig(), { name: 'new-name' });
-    expect(result.apiVersion).toBe('serving.kserve.io/v1alpha2');
-    expect(result.kind).toBe('LLMInferenceServiceConfig');
-    expect(result.metadata.namespace).toBe('opendatahub');
+  it('should preserve spec', () => {
+    const result = overrideLlmConfigFields(makeConfig(), defaultOverrides);
     expect(result.spec?.model.uri).toBe('hf://test/model');
   });
 
   it('should handle config with no existing annotations', () => {
     const config = makeConfig({ annotations: undefined });
-    const result = overrideLlmConfigFields(config, { displayName: 'Test' });
+    const result = overrideLlmConfigFields(config, {
+      ...defaultOverrides,
+      displayName: 'Test',
+    });
     expect(result.metadata.annotations?.['openshift.io/display-name']).toBe('Test');
+  });
+
+  it('should override namespace even when input config has a different namespace', () => {
+    const config = makeConfig({ namespace: 'user-provided-namespace' });
+    const result = overrideLlmConfigFields(config, { namespace: 'opendatahub' });
+    expect(result.metadata.namespace).toBe('opendatahub');
+  });
+
+  it('should override apiVersion even when input config has a different apiVersion', () => {
+    const config = {
+      ...makeConfig(),
+      apiVersion: 'v1',
+    } as unknown as LLMInferenceServiceConfigKind;
+    const result = overrideLlmConfigFields(config, defaultOverrides);
+    expect(result.apiVersion).toBe('serving.kserve.io/v1alpha2');
+  });
+
+  it('should override kind even when input config has a different kind', () => {
+    const config = {
+      ...makeConfig(),
+      kind: 'ConfigMap',
+    } as unknown as LLMInferenceServiceConfigKind;
+    const result = overrideLlmConfigFields(config, defaultOverrides);
+    expect(result.kind).toBe('LLMInferenceServiceConfig');
+  });
+
+  it('should add dashboard label even when input config has no labels', () => {
+    const config = makeConfig({ labels: undefined });
+    const result = overrideLlmConfigFields(config, defaultOverrides);
+    expect(result.metadata.labels?.['opendatahub.io/dashboard']).toBe('true');
+  });
+
+  it('should enforce dashboard label even if caller tries to override it', () => {
+    const result = overrideLlmConfigFields(makeConfig(), {
+      ...defaultOverrides,
+      labels: { 'opendatahub.io/dashboard': 'false' },
+    });
+    expect(result.metadata.labels?.['opendatahub.io/dashboard']).toBe('true');
   });
 });

--- a/packages/llmd-serving/src/settings/configYamlUtils.ts
+++ b/packages/llmd-serving/src/settings/configYamlUtils.ts
@@ -16,8 +16,7 @@ export const overrideLlmConfigFields = (
   config: LLMInferenceServiceConfigKind,
   overrides: ConfigFieldOverrides,
 ): LLMInferenceServiceConfigKind => {
-  const apiGroup = LLMInferenceServiceConfigModel.apiGroup ?? '';
-  const apiVer = LLMInferenceServiceConfigModel.apiVersion;
+  const { apiGroup, apiVersion: apiVer } = LLMInferenceServiceConfigModel;
 
   const annotations = { ...config.metadata.annotations, ...overrides.annotations };
   if (overrides.displayName !== undefined) {

--- a/packages/llmd-serving/src/settings/configYamlUtils.ts
+++ b/packages/llmd-serving/src/settings/configYamlUtils.ts
@@ -1,35 +1,52 @@
+import { DASHBOARD_RESOURCE_LABEL } from '../const';
+import { LLMInferenceServiceConfigModel } from '../types';
 import type { LLMInferenceServiceConfigKind } from '../types';
 
-export type ConfigFormFields = {
+export type ConfigFieldOverrides = {
   name?: string;
+  namespace: string;
   displayName?: string;
   description?: string;
   version?: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
 };
 
 export const overrideLlmConfigFields = (
   config: LLMInferenceServiceConfigKind,
-  fields: ConfigFormFields,
+  overrides: ConfigFieldOverrides,
 ): LLMInferenceServiceConfigKind => {
-  const annotations = { ...config.metadata.annotations };
-  if (fields.displayName !== undefined) {
-    annotations['openshift.io/display-name'] = fields.displayName;
+  const apiGroup = LLMInferenceServiceConfigModel.apiGroup ?? '';
+  const apiVer = LLMInferenceServiceConfigModel.apiVersion;
+
+  const annotations = { ...config.metadata.annotations, ...overrides.annotations };
+  if (overrides.displayName !== undefined) {
+    annotations['openshift.io/display-name'] = overrides.displayName;
   }
-  if (fields.description !== undefined) {
-    annotations['openshift.io/description'] = fields.description;
+  if (overrides.description !== undefined) {
+    annotations['openshift.io/description'] = overrides.description;
   }
-  if (fields.version !== undefined) {
-    if (fields.version) {
-      annotations['opendatahub.io/runtime-version'] = fields.version;
+  if (overrides.version !== undefined) {
+    if (overrides.version) {
+      annotations['opendatahub.io/runtime-version'] = overrides.version;
     } else {
       delete annotations['opendatahub.io/runtime-version'];
     }
   }
+
   return {
     ...config,
+    apiVersion: `${apiGroup}/${apiVer}`,
+    kind: 'LLMInferenceServiceConfig',
     metadata: {
       ...config.metadata,
-      ...(fields.name ? { name: fields.name } : {}),
+      ...(overrides.name ? { name: overrides.name } : {}),
+      namespace: overrides.namespace,
+      labels: {
+        ...config.metadata.labels,
+        ...overrides.labels,
+        [DASHBOARD_RESOURCE_LABEL]: 'true',
+      },
       annotations,
     },
   };

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
@@ -120,9 +120,7 @@ const LlmAcceleratorConfigAddForm: React.FC<LlmAcceleratorConfigAddFormProps> = 
     try {
       parsed = YAML.parse(yamlCode);
     } catch (e) {
-      if (e instanceof Error) {
-        setError(e);
-      }
+      setError(e instanceof Error ? e : new Error(String(e)));
       return;
     }
     if (!isConfigObject(parsed)) {

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
@@ -22,12 +22,12 @@ import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { LlmAcceleratorConfigContext } from './LlmAcceleratorConfigContext';
 import { overrideLlmConfigFields } from '../configYamlUtils';
 import ConfigYAMLEditor from '../ConfigYAMLEditor';
-import { DASHBOARD_RESOURCE_LABEL } from '../../const';
 import {
   createLLMInferenceServiceConfig,
   updateLLMInferenceServiceConfig,
 } from '../../api/LLMInferenceServiceConfigs';
 import { isConfigObject, cleanResourceForYAMLViewer } from '../../utils';
+import { ConfigType, CONFIG_TYPE_LABEL } from '../../types';
 import type { LLMInferenceServiceConfigKind } from '../../types';
 
 type FormMode = 'add' | 'edit' | 'duplicate';
@@ -129,24 +129,13 @@ const LlmAcceleratorConfigAddForm: React.FC<LlmAcceleratorConfigAddFormProps> = 
       setError(new Error('YAML must represent a valid object'));
       return;
     }
-    let config = overrideLlmConfigFields(parsed, {
+    const config = overrideLlmConfigFields(parsed, {
       name: isEdit ? sourceConfig?.metadata.name : nameDescData.k8sName.value,
+      namespace: dashboardNamespace,
       displayName: nameDescData.name,
       version,
+      labels: { [CONFIG_TYPE_LABEL]: ConfigType.ACCELERATOR },
     });
-    config = {
-      ...config,
-      metadata: {
-        ...config.metadata,
-        namespace: dashboardNamespace,
-        ...(!isEdit && {
-          labels: {
-            ...config.metadata.labels,
-            [DASHBOARD_RESOURCE_LABEL]: 'true',
-          },
-        }),
-      },
-    };
     setLoading(true);
     const submitFn = isEdit
       ? updateLLMInferenceServiceConfig(config)

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
@@ -126,7 +126,7 @@ const LlmAcceleratorConfigAddForm: React.FC<LlmAcceleratorConfigAddFormProps> = 
       return;
     }
     if (!isConfigObject(parsed)) {
-      setError(new Error('YAML must represent a valid object'));
+      setError(new Error('YAML must represent a valid kubernetes resource object'));
       return;
     }
     const config = overrideLlmConfigFields(parsed, {

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/__tests__/LlmAcceleratorConfigAddForm.spec.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/__tests__/LlmAcceleratorConfigAddForm.spec.tsx
@@ -109,6 +109,7 @@ describe('LlmAcceleratorConfigAddForm', () => {
       const callArg = mockCreateLLMInferenceServiceConfig.mock.calls[0][0];
       expect(callArg.metadata.annotations?.['openshift.io/display-name']).toBe('New Config');
       expect(callArg.metadata.labels?.['opendatahub.io/dashboard']).toBe('true');
+      expect(callArg.metadata.labels?.['opendatahub.io/config-type']).toBe('accelerator');
     });
 
     it('should navigate back on successful create', async () => {

--- a/packages/llmd-serving/src/types.ts
+++ b/packages/llmd-serving/src/types.ts
@@ -161,12 +161,12 @@ export const LLMInferenceServiceModel: K8sModelCommon = {
   plural: 'llminferenceservices',
 };
 
-export const LLMInferenceServiceConfigModel: K8sModelCommon = {
+export const LLMInferenceServiceConfigModel = {
   apiVersion: 'v1alpha2',
   apiGroup: 'serving.kserve.io',
   kind: 'LLMInferenceServiceConfig',
   plural: 'llminferenceserviceconfigs',
-};
+} satisfies K8sModelCommon;
 
 export enum LLMInferenceServiceReadyConditionReason {
   PROGRESS_DEADLINE_EXCEEDED = 'ProgressDeadlineExceeded',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-76001

## Description

Centralizes namespace, apiVersion, kind, labels, annotations, and the dashboard resource label into the shared `overrideLlmConfigFields` utility, so all three LLMInferenceServiceConfig settings pages (accelerator, topology, routing) delegate these concerns to a single function instead of duplicating the same metadata spread pattern at each call site.

**Changes:**
- Rename `ConfigFormFields` to `ConfigFieldOverrides` and expand it to accept `namespace` (required), `labels`, and `annotations`
- `overrideLlmConfigFields` now sets `apiVersion` and `kind` from `LLMInferenceServiceConfigModel` and applies `DASHBOARD_RESOURCE_LABEL` internally
- Caller-provided labels cannot override `DASHBOARD_RESOURCE_LABEL` — it is always applied last
- All three settings pages pass page-specific labels/annotations (e.g. `CONFIG_TYPE_LABEL`, `SUPPORTED_TOPOLOGIES_ANNOTATION`) through the util instead of manually spreading metadata
- Remove now-unused `LLMInferenceServiceConfigModel` and `DASHBOARD_RESOURCE_LABEL` imports from the call sites

This ensures it is not possible to create or update a resource with a different namespace, apiVersion, or kind than the values enforced by the util — any values in the parsed YAML for these fields are overridden.

**Bug fix included:** The accelerator config form was missing the `opendatahub.io/config-type: accelerator` label on create/edit. The list view filters by this label, so newly created configs would not appear in the list. Now fixed by passing `CONFIG_TYPE_LABEL` through the shared util.

Follow-up to PR #8485.

## How Has This Been Tested?

**Unit tests** (20 tests for `overrideLlmConfigFields`):
- Override fields: name, namespace, displayName, description, version, labels, annotations
- Enforcement: apiVersion/kind always set from model, dashboard label always `true` even if caller passes `false`
- Conflict scenarios: input config with wrong namespace, apiVersion, or kind is always overridden
- Edge cases: missing annotations, missing labels, multiple overrides at once

**Browser testing** (verified on dev cluster via Playwright):
- Pasted YAML with `metadata.namespace: some-other-namespace` — resource created in dashboard namespace, not the YAML namespace
- Pasted YAML with `apiVersion: v1` / `kind: ConfigMap` — resource created with correct `serving.kserve.io/v1alpha2` and `LLMInferenceServiceConfig`
- Accelerator configs: create, edit (display name change), duplicate (`-copy` suffix, dashboard label, config-type label)
- Topology configs: create (config-type label set), edit (metadata preserved)
- Routing configs: create and edit flows verified

**All existing llmd-serving unit tests pass** (205 total). Lint and type-check pass with 0 errors.

## Test Impact

- Updated `packages/llmd-serving/src/settings/__tests__/configYamlUtils.spec.ts` — expanded from 10 to 20 test cases:
  - Existing tests for name, displayName, description, version overrides
  - New tests for namespace override, apiVersion/kind from model, dashboard label, labels merge, annotations merge
  - New conflict tests verifying wrong namespace, apiVersion, kind, and labels in the input config are always overridden
  - Regression test for dashboard label enforcement after caller-provided labels

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved routing, topology, and accelerator configuration submission by consistently applying names, namespaces, descriptions, labels, and annotations.
  * Configuration resources now receive standardized API version and resource type metadata.

* **Bug Fixes**
  * Improved validation and error messaging for invalid YAML submissions.
  * Preserved configuration details while correctly updating metadata and dashboard visibility labels.

* **Tests**
  * Expanded coverage for metadata overrides, annotations, labels, resource identity, and specification preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->