### PR TITLE
fix: add isDanger styling to Delete actions on Accelerator Configs and Serving Runtimes pages

### DIFF
--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -94,6 +94,7 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
                   {
                     title: 'Delete',
                     onClick: () => onDeleteTemplate(template),
+                    isDanger: true,
                   },
                 ]
           }

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigTableRow.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigTableRow.tsx
@@ -47,6 +47,7 @@ const LlmAcceleratorConfigTableRow: React.FC<LlmAcceleratorConfigTableRowProps> 
         {
           title: 'Delete',
           onClick: () => onDeleteConfig(config),
+          isDanger: true,
         },
       ];
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78028

<img width="170" height="210" alt="image" src="https://github.com/user-attachments/assets/f7154cb5-dd5e-45f4-bf44-bce127a261a1" />


## Description
The "Delete" action in the kebab dropdown menu on the **LLM accelerator configurations** and **Serving Runtimes** admin settings pages was not styled as a danger action (red text). Added `isDanger: true` to both, matching the existing pattern on the llm-d topology and routing config pages.

## How Has This Been Tested?
- Type-check passes
- Existing unit tests pass (LlmAcceleratorConfigTableRow — 10/10 tests)

## Test Impact
No new tests needed — this is a cosmetic one-property addition. Existing tests cover the kebab menu rendering.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated delete actions for custom serving runtimes and LLM accelerator configurations to use a visually distinct dangerous-action style.
  * Improved clarity around the destructive nature of these actions in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->