### PR TITLE
Cherrypick/tfa fixes

### DIFF
--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -117,6 +117,16 @@ export default defineConfig({
         table(message) {
           return logToConsole(LogLevel.TABLE, message);
         },
+        deleteFile(filePath: string) {
+          try {
+            if (fs.existsSync(filePath)) {
+              fs.unlinkSync(filePath);
+            }
+            return Promise.resolve(null);
+          } catch (error) {
+            return Promise.resolve(null);
+          }
+        },
       });
 
       if (config.env.CY_RECORD) {

--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataSciencePipelines/testSchedulePipeline.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataSciencePipelines/testSchedulePipeline.yaml
@@ -1,5 +1,5 @@
-pipelineName: test-scheduled-pipeline
-pipelineDescription: Pipeline scheduled via E2E
-scheduleName: test-scheduled-run
-scheduleDescription: Scheduled run created by E2E
-pipelineUrl: https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml
+pipelineName: 'test-scheduled-pipeline'
+pipelineDescription: 'Pipeline scheduled via E2E'
+scheduleName: 'test-scheduled-run'
+scheduleDescription: 'Scheduled run created by E2E'
+pipelineUrl: 'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/packages/cypress/resources/pipelines_samples/dummy_pipeline_compiled.yaml'

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/json/oci-data-connection-secret.json
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/json/oci-data-connection-secret.json
@@ -1,0 +1,7 @@
+  {
+    "auths": {
+      "quay.io": {
+        "auth": "oci_connection_auth"
+      }
+    }
+  }

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/pvc-loader-pod.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/pvc-loader-pod.yaml
@@ -12,6 +12,14 @@ spec:
     - name: s3-downloader
       image: amazon/aws-cli
       command: ["/bin/bash", "-c"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
       args:
         - |
           set -e

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
@@ -49,7 +49,7 @@ describe('An admin user can import and run a pipeline', { testIsolation: false }
       pipelineImportModal
         .findPipelineUrlInput()
         .type(
-          'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
+          'https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/packages/cypress/resources/pipelines_samples/dummy_pipeline_compiled.yaml',
         );
       pipelineImportModal.submit();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
@@ -31,7 +31,7 @@ describe('An admin user can import and run a pipeline', { testIsolation: false }
 
   it(
     'An admin User can Import and Run a Pipeline',
-    { tags: ['@Smoke', '@SmokeSet1', '@Dashboard', '@Pipelines', '@ci-dashboard-set-1'] },
+    { tags: ['@Smoke', '@SmokeSet1', '@Dashboard', '@Pipelines'] },
     () => {
       cy.step('Navigate to DSP ${projectName}');
       cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataSciencePipelines/pipelines.cy.ts
@@ -31,7 +31,7 @@ describe('An admin user can import and run a pipeline', { testIsolation: false }
 
   it(
     'An admin User can Import and Run a Pipeline',
-    { tags: ['@Smoke', '@SmokeSet1', '@Dashboard', '@Pipelines'] },
+    { tags: ['@Smoke', '@SmokeSet1', '@Dashboard', '@Pipelines', '@ci-dashboard-set-1'] },
     () => {
       cy.step('Navigate to DSP ${projectName}');
       cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testAcceleratorProfileModelServingTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testAcceleratorProfileModelServingTolerations.cy.ts
@@ -32,7 +32,7 @@ let acceleratorProfileResourceName: string;
 const awsBucket = 'BUCKET_3' as const;
 const projectUuid = generateTestUUID();
 
-describe('[Bug: RHOAIENG-33131] Verify Model Serving Creation using Accelerator Profiles and applying Tolerations', () => {
+describe('Verify Model Serving Creation using Accelerator Profiles and applying Tolerations', () => {
   retryableBefore(() => {
     return loadAcceleratorProfileModelTolerationsFixture(
       'e2e/acceleratorProfiles/testAcceleratorProfileModelServingTolerations.yaml',

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
@@ -25,8 +25,26 @@ let modelDeploymentURI: string;
 let modelDeploymentName: string;
 const uuid = generateTestUUID();
 
+const updateSecretDetailsFile = (
+  secretValue: string,
+  fixtureRelativePath: string,
+  fixtureFullPath: string,
+) => {
+  return cy.fixture(fixtureRelativePath).then((templateContent) => {
+    const updatedContent = {
+      ...templateContent,
+      auths: {
+        'quay.io': {
+          auth: secretValue,
+        },
+      },
+    };
+    return cy.writeFile(fixtureFullPath, updatedContent);
+  });
+};
+
 describe(
-  '[Product Bug: RHOAIENG-31085] A user can create an OCI connection and deploy a model with it',
+  'A user can create an OCI connection and deploy a model with it',
   { testIsolation: false },
   () => {
     let testData: DeployOCIModelData;
@@ -38,7 +56,11 @@ describe(
           testData = fixtureData;
           projectName = `${testData.projectName}-${uuid}`;
           connectionName = testData.connectionName;
-          secretDetailsFile = Cypress.env('OCI_SECRET_DETAILS_FILE');
+          // Load fixture file and update with actual secret value
+          const secretValue = Cypress.env('OCI_SECRET_VALUE');
+          const secretDetailsFixture = 'resources/json/oci-data-connection-secret.json';
+          secretDetailsFile = `cypress/fixtures/${secretDetailsFixture}`;
+          updateSecretDetailsFile(secretValue, secretDetailsFixture, secretDetailsFile);
           ociRegistryHost = testData.ociRegistryHost;
           modelDeploymentURI = Cypress.env('OCI_MODEL_URI');
           modelDeploymentName = testData.modelDeploymentName;
@@ -58,7 +80,7 @@ describe(
     it(
       'Verify User Can Create an OCI Connection in DS Connections Page And Deploy the Model',
       {
-        tags: ['@Smoke', '@SmokeSet3', '@Dashboard', '@Modelserving', '@NonConcurrent', '@Bug'],
+        tags: ['@Smoke', '@SmokeSet3', '@Dashboard', '@Modelserving', '@NonConcurrent'],
       },
       () => {
         cy.step(`Navigate to DS Project ${projectName}`);
@@ -92,12 +114,14 @@ describe(
         inferenceServiceModal.findOpenVinoOnnx().click();
         inferenceServiceModal.findOCIModelURI().type(modelDeploymentURI);
         inferenceServiceModal.findSubmitButton().focus().click();
-        checkInferenceServiceState(modelDeploymentName, projectName);
-        // Note reload is required as status tooltip was not found due to a stale element
-        cy.reload();
+        //Verify the model created and is running
+        cy.step('Verify that the Model is running');
+        // For KServe Raw deployments, we only need to check Ready condition
+        // LatestDeploymentReady is specific to Serverless deployments
+        checkInferenceServiceState(modelDeploymentName, projectName, {
+          checkReady: true,
+        });
         modelServingSection.findModelMetricsLink(modelDeploymentName);
-        modelServingSection.findStatusTooltip().click({ force: true });
-        cy.contains('Model is deployed', { timeout: 120000 }).should('be.visible');
       },
     );
   },

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelTokenAuth.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelTokenAuth.cy.ts
@@ -25,7 +25,7 @@ let modelFilePath: string;
 const awsBucket = 'BUCKET_1' as const;
 const uuid = generateTestUUID();
 
-describe('A model can be deployed with token auth', () => {
+describe('[Bug: RHOAIENG-76935] A model can be deployed with token auth', () => {
   retryableBefore(() => {
     cy.log('Loading test data');
     return loadDSPFixture('e2e/dataScienceProjects/testModelTokenAuth.yaml').then(
@@ -56,7 +56,7 @@ describe('A model can be deployed with token auth', () => {
 
   it(
     'Verify that a model can be deployed with token auth',
-    { tags: ['@Smoke', '@SmokeSet3', '@Dashboard', '@ModelServing'] },
+    { tags: ['@Smoke', '@SmokeSet3', '@Dashboard', '@ModelServing', '@Bug'] },
     () => {
       cy.log('Model Name:', modelName);
       cy.step(`Log into the application with ${HTPASSWD_CLUSTER_ADMIN_USER.USERNAME}`);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -24,7 +24,7 @@ let modelFilePath: string;
 const awsBucket = 'BUCKET_1' as const;
 const uuid = generateTestUUID();
 
-describe('Verify Admin Single Model Creation and Validation using the UI', () => {
+describe('[Bug: RHOAIENG-76935] Verify Admin Single Model Creation and Validation using the UI', () => {
   retryableBefore(() =>
     // Setup: Load test data and ensure clean state
     loadDSPFixture('e2e/dataScienceProjects/testSingleModelAdminCreation.yaml').then(
@@ -56,7 +56,15 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
   it(
     'Verify that an Admin can Serve, Query a Single Model using both the UI and External links',
     {
-      tags: ['@Smoke', '@SmokeSet3', '@ODS-2626', '@Dashboard', '@Modelserving', '@NonConcurrent'],
+      tags: [
+        '@Smoke',
+        '@SmokeSet3',
+        '@ODS-2626',
+        '@Dashboard',
+        '@Modelserving',
+        '@NonConcurrent',
+        '@Bug',
+      ],
     },
     () => {
       cy.log('Model Name:', modelName);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegistryDeployModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegistryDeployModel.cy.ts
@@ -62,11 +62,13 @@ describe('Verify models can be deployed from model registry', () => {
     cy.clearCookies();
     cy.clearLocalStorage();
 
+    cy.step(
+      'Delete the test project (before registry, so InferenceService finalizers can resolve)',
+    );
+    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+
     cy.step('Clean up model registry components');
     cleanupModelRegistryComponents([modelName], registryName);
-
-    cy.step('Delete the test project');
-    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
 
     cy.step('Delete the SQL database');
     deleteModelRegistryDatabase();

--- a/frontend/src/__tests__/cypress/cypress/types.ts
+++ b/frontend/src/__tests__/cypress/cypress/types.ts
@@ -166,7 +166,7 @@ export type TestConfig = {
   PIP_INDEX_URL: string;
   PIP_TRUSTED_HOST: string;
   NGC_API_KEY: string;
-  OCI_SECRET_DETAILS_FILE: string;
+  OCI_SECRET_VALUE: string;
   OCI_MODEL_URI: string;
 };
 

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/project.ts
@@ -42,7 +42,7 @@ export const deleteOpenShiftProject = (
   options: { timeout?: number; wait?: boolean; ignoreNotFound?: boolean } = {},
 ): Cypress.Chainable<CommandLineResult> => {
   const { timeout, wait = true, ignoreNotFound = false } = options;
-  const waitFlag = wait ? '' : '--wait=false';
+  const waitFlag = wait ? '--wait' : '--wait=false';
   const ignoreNotFoundFlag = ignoreNotFound ? '--ignore-not-found' : '';
   const ocCommand = `oc delete project ${projectName} ${waitFlag} ${ignoreNotFoundFlag}`.trim();
 

--- a/frontend/src/__tests__/cypress/cypress/utils/projectChecker.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/projectChecker.ts
@@ -20,9 +20,31 @@ export const createCleanProject = (projectName: string): void => {
   verifyOpenShiftProjectExists(projectName).then((exists) => {
     if (exists) {
       cy.log(`Project ${projectName} already exists. Deleting it.`);
-      deleteOpenShiftProject(projectName, { wait: true });
+      deleteOpenShiftProject(projectName, { wait: true }).then(() => {
+        // Verify the project is actually gone before creating a new one
+        // Projects can be in "Terminating" state even after delete --wait returns
+        cy.log(`Waiting for project ${projectName} to be fully deleted...`);
+        const checkDeleted = (): Cypress.Chainable<boolean> => {
+          return verifyOpenShiftProjectExists(projectName).then(
+            (stillExists): Cypress.Chainable<boolean> => {
+              if (stillExists) {
+                cy.log(`Project ${projectName} still exists, waiting...`);
+                // eslint-disable-next-line cypress/no-unnecessary-waiting
+                cy.wait(1000); // Wait 1 second
+                return checkDeleted(); // Recursively check again
+              }
+              return cy.wrap(true);
+            },
+          );
+        };
+        checkDeleted().then(() => {
+          cy.log(`Creating project ${projectName}`);
+          createAndVerifyProject(projectName);
+        });
+      });
+    } else {
+      cy.log(`Creating project ${projectName}`);
+      createAndVerifyProject(projectName);
     }
-    cy.log(`Creating project ${projectName}`);
-    createAndVerifyProject(projectName);
   });
 };

--- a/frontend/src/__tests__/cypress/cypress/utils/testConfig.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/testConfig.ts
@@ -80,7 +80,7 @@ const PRODUCT_NAME = testConfig?.ODH_DASHBOARD_PROJECT_NAME;
 const PIP_INDEX_URL = testConfig?.PIP_INDEX_URL;
 const PIP_TRUSTED_HOST = testConfig?.PIP_TRUSTED_HOST;
 const NGC_API_KEY = testConfig?.NGC_API_KEY;
-const OCI_SECRET_DETAILS_FILE = testConfig?.OCI_SECRET_DETAILS_FILE;
+const OCI_SECRET_VALUE = testConfig?.OCI_SECRET_VALUE;
 const OCI_MODEL_URI = testConfig?.OCI_MODEL_URI;
 
 // spread the cypressEnv variables into the cypress config
@@ -94,7 +94,7 @@ export const cypressEnv = {
   PIP_INDEX_URL,
   PIP_TRUSTED_HOST,
   NGC_API_KEY,
-  OCI_SECRET_DETAILS_FILE,
+  OCI_SECRET_VALUE,
   OCI_MODEL_URI,
 };
 

--- a/frontend/src/__tests__/cypress/test-variables.yml.example
+++ b/frontend/src/__tests__/cypress/test-variables.yml.example
@@ -37,5 +37,5 @@ S3:
 PIP_INDEX_URL: https://pypi.org/simple
 PIP_TRUSTED_HOST: pypi.org
 NGC_API_KEY: bm90IGEgdmFsaWQgYXBpIGtleQo=
-OCI_SECRET_DETAILS_FILE: /home/user/.docker/config.json 
+OCI_SECRET_VALUE: cmhvYWlfZGFzaGJvYXJkK3Job
 OCI_MODEL_URI: quay.io/my_user/my_oci_model:latest


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes E2E tests in 2.25 TFA which are failing with Test Maintain.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
job/components/job/dashboard/job/dashboard-e2e-tests/1904/
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
