### PR TITLE
fix(operator): add platformVersion default to chart values (RHOAIENG-78073)

### DIFF
--- a/dashboard-operator/charts/dashboard/values.yaml
+++ b/dashboard-operator/charts/dashboard/values.yaml
@@ -92,3 +92,7 @@ config:
     distribution.name: Standalone
     distribution.version: "0.0.0"
     controller.zap.level: info
+    # Injected by the ODH/RHOAI operator module handler at install time.
+    # The dashboard-operator echoes this back as releases[name="platform"]
+    # in the Dashboard CR status.
+    platformVersion: ""


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78073

## Description

The platform version handshake — where the Dashboard module CR reports `releases[name="platform"]` echoing back the ODH/RHOAI operator version — silently fails because the `platformVersion` key was never declared in the Helm chart's `values.yaml`.

The read side is fully implemented:
- `readPlatformVersion()` in `config.go` reads `platformVersion` from the `opendatahub-dashboard-config` ConfigMap
- The reconciler echoes it back as `releases[name="platform"]` in the Dashboard CR status
- Both are covered by unit tests

The chart template (`configmap.yaml`) already iterates over all keys in `.Values.config.data` via `range`, so any key present in the values is rendered. However, `platformVersion` was not declared in `values.yaml`, making the chart's interface incomplete.

This PR adds `platformVersion: ""` as an explicit default in `values.yaml`. This:
1. Documents `platformVersion` as part of the chart's data contract
2. Ensures the key is present in the rendered ConfigMap for standalone installs
3. Is overridden by the ODH/RHOAI operator module handler when it injects the actual platform version at install time

**Note:** The write side (operator injecting the actual version) is tracked separately in the opendatahub-operator repo. This PR completes the chart-side preparation.

## How Has This Been Tested?

- Verified with `helm template` that the ConfigMap renders `platformVersion: ""` by default
- Verified with `helm template --set config.data.platformVersion=2.20.0` that operator-injected values override correctly to `platformVersion: "2.20.0"`
- Ran `make test` in `dashboard-operator/` — all controller, webhook, api, and chart tests pass

## Test Impact

Existing `TestReadPlatformVersion` unit tests in `config_test.go` already cover the read path (key present, key missing, nil data, truncation). No new tests needed — this change only adds a default value to the Helm chart, which is validated by `helm template`.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`