### PR TITLE
fix(eval-hub): send X-Tenant on EvalHub health check

### DIFF
--- a/packages/eval-hub/bff/internal/api/evalhub_health_handler.go
+++ b/packages/eval-hub/bff/internal/api/evalhub_health_handler.go
@@ -81,8 +81,13 @@ func (app *App) EvalHubServiceHealthHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	tenantNS := app.dashboardNamespace
+	if ns, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string); ok && ns != "" {
+		tenantNS = ns
+	}
+
 	ehClient := app.evalHubClientFactory.CreateClient(serviceURL, authToken, app.config.InsecureSkipVerify, app.rootCAs, "/api/v1")
-	if _, err := ehClient.HealthCheck(ctx); err != nil {
+	if _, err := ehClient.HealthCheck(ctx, tenantNS); err != nil {
 		writeHealth(EvalHubHealthStatusServiceUnreachable, false)
 		return
 	}

--- a/packages/eval-hub/bff/internal/api/test_utils.go
+++ b/packages/eval-hub/bff/internal/api/test_utils.go
@@ -181,7 +181,7 @@ func (c *testK8sClient) GetEvalHubCRStatus(_ context.Context, _ *kubernetes.Requ
 // Used in health handler tests to simulate "service-unreachable".
 type erroringEHClient struct{}
 
-func (e *erroringEHClient) HealthCheck(_ context.Context) (*evalhub.HealthResponse, error) {
+func (e *erroringEHClient) HealthCheck(_ context.Context, _ string) (*evalhub.HealthResponse, error) {
 	return nil, fmt.Errorf("connection refused")
 }
 func (e *erroringEHClient) ListEvaluationJobs(_ context.Context, _ evalhub.ListEvaluationJobsParams) ([]evalhub.EvaluationJob, error) {

--- a/packages/eval-hub/bff/internal/integrations/evalhub/ehmocks/evalhub_client_mock.go
+++ b/packages/eval-hub/bff/internal/integrations/evalhub/ehmocks/evalhub_client_mock.go
@@ -14,7 +14,7 @@ func NewMockEvalHubClient() *MockEvalHubClient {
 	return &MockEvalHubClient{}
 }
 
-func (m *MockEvalHubClient) HealthCheck(_ context.Context) (*evalhub.HealthResponse, error) {
+func (m *MockEvalHubClient) HealthCheck(_ context.Context, _ string) (*evalhub.HealthResponse, error) {
 	return &evalhub.HealthResponse{Status: "healthy"}, nil
 }
 

--- a/packages/eval-hub/bff/internal/integrations/evalhub/evalhub_client.go
+++ b/packages/eval-hub/bff/internal/integrations/evalhub/evalhub_client.go
@@ -36,7 +36,7 @@ type ListCollectionsParams struct {
 
 // EvalHubClientInterface defines the operations available against the EvalHub API.
 type EvalHubClientInterface interface {
-	HealthCheck(ctx context.Context) (*HealthResponse, error)
+	HealthCheck(ctx context.Context, namespace string) (*HealthResponse, error)
 	ListEvaluationJobs(ctx context.Context, params ListEvaluationJobsParams) ([]EvaluationJob, error)
 	GetEvaluationJob(ctx context.Context, id string, namespace string) (*EvaluationJob, error)
 	CreateEvaluationJob(ctx context.Context, namespace string, req CreateEvaluationJobRequest) (*EvaluationJob, error)
@@ -395,8 +395,14 @@ func NewEvalHubClient(baseURL string, authToken string, insecureSkipVerify bool,
 }
 
 // HealthCheck retrieves the health status from EvalHub.
-func (c *EvalHubClient) HealthCheck(ctx context.Context) (*HealthResponse, error) {
-	resp, err := get[HealthResponse](c, ctx, "/health", nil)
+// The namespace is sent as the X-Tenant header; /api/v1/health requires it in cluster mode.
+func (c *EvalHubClient) HealthCheck(ctx context.Context, namespace string) (*HealthResponse, error) {
+	headers, err := tenantHeaders(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := get[HealthResponse](c, ctx, "/health", headers)
 	if err != nil {
 		return nil, wrapClientError(err, "HealthCheck")
 	}

--- a/packages/eval-hub/bff/internal/integrations/evalhub/evalhub_client_test.go
+++ b/packages/eval-hub/bff/internal/integrations/evalhub/evalhub_client_test.go
@@ -14,27 +14,39 @@ import (
 func TestEvalHubClient_HealthCheck(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/api/v1/health", r.URL.Path)
+		assert.Equal(t, "my-ns", r.Header.Get("X-Tenant"))
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(HealthResponse{Status: "healthy"})
 	}))
 	defer server.Close()
 
 	client := NewEvalHubClient(server.URL, "", false, nil, "/api/v1")
-	resp, err := client.HealthCheck(context.Background())
+	resp, err := client.HealthCheck(context.Background(), "my-ns")
 
 	require.NoError(t, err)
 	assert.Equal(t, "healthy", resp.Status)
 }
 
+func TestEvalHubClient_HealthCheck_RequiresNamespace(t *testing.T) {
+	client := NewEvalHubClient("http://example.invalid", "", false, nil, "/api/v1")
+	_, err := client.HealthCheck(context.Background(), "")
+
+	require.Error(t, err)
+	var ehErr *EvalHubError
+	require.ErrorAs(t, err, &ehErr)
+	assert.Equal(t, ErrCodeInvalidRequest, ehErr.Code)
+}
+
 func TestEvalHubClient_HealthCheck_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "my-ns", r.Header.Get("X-Tenant"))
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("internal error"))
 	}))
 	defer server.Close()
 
 	client := NewEvalHubClient(server.URL, "", false, nil, "/api/v1")
-	_, err := client.HealthCheck(context.Background())
+	_, err := client.HealthCheck(context.Background(), "my-ns")
 
 	require.Error(t, err)
 	var ehErr *EvalHubError
@@ -232,7 +244,7 @@ func TestEvalHubClient_ListCollections_ServerError(t *testing.T) {
 
 func TestEvalHubClient_ConnectionError(t *testing.T) {
 	client := NewEvalHubClient("http://localhost:1", "", false, nil, "/api/v1")
-	_, err := client.HealthCheck(context.Background())
+	_, err := client.HealthCheck(context.Background(), "my-ns")
 
 	require.Error(t, err)
 	var ehErr *EvalHubError


### PR DESCRIPTION
## Description
EvalHub's `/api/v1/health` endpoint requires the `X-Tenant` header in cluster mode. The BFF health client call was the only upstream request that omitted it, so service health probes could fail even when EvalHub was reachable.

This change:
- Updates `HealthCheck` to accept a namespace and send `X-Tenant` via the existing `tenantHeaders` helper (same pattern as jobs/providers/collections).
- Resolves the tenant from `?namespace=` when present, otherwise falls back to `dashboardNamespace`.
- Extends unit tests to assert the header is sent and that an empty namespace is rejected.

## How Has This Been Tested?
- Ran `go test ./internal/integrations/evalhub/ ./internal/api/` in `packages/eval-hub/bff` (pass).
- Verified against cluster behavior that `/api/v1/health` requires identity/`X-Tenant` in cluster mode; other BFF EvalHub calls already sent `X-Tenant`.

## Test Impact
- Updated `evalhub_client_test.go` to assert `X-Tenant` on health requests.
- Added `TestEvalHubClient_HealthCheck_RequiresNamespace`.
- Updated mock/`erroringEHClient` signatures for the new `HealthCheck` interface.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now use the correct tenant namespace, improving service status accuracy in multi-tenant environments.
  * Health check requests without a valid namespace are rejected with a clear invalid-request error.
  * Service health responses continue to distinguish healthy, unreachable, and unavailable states.

* **Tests**
  * Expanded coverage for tenant-scoped health checks, missing namespaces, server errors, and connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->