### PR TITLE
fix(operator): rename config ConfigMap to odh-dashboard-config (RHOAIENG-78073)

### DIFF
--- a/dashboard-operator/charts/dashboard/values.yaml
+++ b/dashboard-operator/charts/dashboard/values.yaml
@@ -87,7 +87,7 @@ relatedImages:
   RELATED_IMAGE_ODH_AUTORAG_IMAGE: ""
 
 config:
-  name: opendatahub-dashboard-config
+  name: odh-dashboard-config
   data:
     distribution.name: Standalone
     distribution.version: "0.0.0"

--- a/dashboard-operator/internal/controller/config.go
+++ b/dashboard-operator/internal/controller/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 const operatorConfigMapName = "dashboard-operator-config"
-const distributionConfigMapName = "opendatahub-dashboard-config"
+const distributionConfigMapName = "odh-dashboard-config"
 const minReconcileInterval = 5 * time.Second
 const maxDistributionFieldLen = 256
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -786,7 +786,7 @@ func TestReconcile_PlatformVersionHandshake(t *testing.T) {
 			name: "platformVersion present — echoed to status",
 			platformConfigMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "opendatahub-dashboard-config",
+					Name:      "odh-dashboard-config",
 					Namespace: testNamespace,
 				},
 				Data: map[string]string{
@@ -799,7 +799,7 @@ func TestReconcile_PlatformVersionHandshake(t *testing.T) {
 			name: "platformVersion key absent — no platform release entry",
 			platformConfigMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "opendatahub-dashboard-config",
+					Name:      "odh-dashboard-config",
 					Namespace: testNamespace,
 				},
 				Data: map[string]string{


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78073

## Description

The platform version handshake — where the Dashboard module CR reports `releases[name="platform"]` echoing back the ODH/RHOAI operator version — silently fails on every install.

**Root cause:** The dashboard-operator reads from a ConfigMap named `opendatahub-dashboard-config` (the `distributionConfigMapName` constant in `config.go`), but the ODH operator module handler writes to `odh-dashboard-config` — following the `odh-<module>-config` naming convention from the [Module Handler Developer Guide](https://gitlab.cee.redhat.com/data-hub/odh-modularisation-docs). This name mismatch means `readPlatformVersion()` never finds the key the operator wrote, so `releases[name="platform"]` is never populated.

**Fix:** Rename the constant and chart value from `opendatahub-dashboard-config` → `odh-dashboard-config` so the dashboard-operator reads from the same ConfigMap the operator populates.

### Files changed

| File | Change |
|------|--------|
| `dashboard-operator/internal/controller/config.go` | Rename `distributionConfigMapName` constant |
| `dashboard-operator/charts/dashboard/values.yaml` | Rename `config.name` |
| `dashboard-operator/internal/controller/dashboard_reconciler_test.go` | Update hardcoded ConfigMap names in platform version handshake tests |

## How Has This Been Tested?

- `go test -race ./internal/controller/ ./api/... ./charts/...` — all tests pass
- `helm template` confirms the rendered ConfigMap is now named `odh-dashboard-config`
- Existing `TestReadPlatformVersion` and `TestReconcile_PlatformVersionHandshake` tests cover the read path

## Test Impact

Updated two hardcoded ConfigMap name references in `dashboard_reconciler_test.go` to match the renamed constant. No new tests needed — the rename is a one-line constant change and existing tests cover the behavior.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dashboard configuration handling to use the current ConfigMap name.
  * Ensured distribution and platform version information continues to be read correctly.
* **Tests**
  * Updated platform version validation scenarios to reflect the revised configuration naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->