### PR TITLE
RHOAIENG-35749: remove per-username vectorstore workaround, rely on OGX ACL

### DIFF
--- a/manifests/modules/gen-ai/deployment.yaml
+++ b/manifests/modules/gen-ai/deployment.yaml
@@ -145,6 +145,7 @@ spec:
             - '--cert-file=/etc/tls/private/tls.crt'
             - '--key-file=/etc/tls/private/tls.key'
             - '--bundle-paths=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem,/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt,/etc/pki/tls/certs/odh-ca-bundle.crt,/etc/pki/tls/certs/odh-trusted-ca-bundle.crt'
+            - '--enable-llamastack-rbac'
           env:
             - name: GATEWAY_DOMAIN
               value: gateway-domain

--- a/manifests/sidecar/deployment.yaml
+++ b/manifests/sidecar/deployment.yaml
@@ -216,6 +216,7 @@
       - '--cert-file=/etc/tls/private/tls.crt'
       - '--key-file=/etc/tls/private/tls.key'
       - '--bundle-paths=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem,/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt,/etc/pki/tls/certs/odh-ca-bundle.crt,/etc/pki/tls/certs/odh-trusted-ca-bundle.crt'
+      - '--enable-llamastack-rbac'
     env:
       - name: GATEWAY_DOMAIN
         value: ""

--- a/packages/gen-ai/bff/internal/api/lsd_audio_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_audio_handler_test.go
@@ -110,6 +110,9 @@ func (m *mockLSClientForASR) CreateVectorStore(_ context.Context, _ llamastack.C
 	return nil, nil
 }
 func (m *mockLSClientForASR) DeleteVectorStore(_ context.Context, _ string) error { return nil }
+func (m *mockLSClientForASR) RetrieveVectorStore(_ context.Context, _ string) (*openai.VectorStore, error) {
+	return nil, nil
+}
 func (m *mockLSClientForASR) UploadFile(_ context.Context, _ llamastack.UploadFileParams) (*llamastack.FileUploadResult, error) {
 	return nil, nil
 }

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
@@ -59,10 +59,17 @@ func (app *App) LlamaStackListVectorStoresHandler(w http.ResponseWriter, r *http
 			},
 		})
 		if err != nil {
-			app.handleLlamaStackClientError(w, r, err)
-			return
+			// Tolerate race: concurrent request may have created the store already.
+			// Re-fetch to pick it up; only fail if the list itself errors.
+			refreshed, listErr := app.repositories.VectorStores.ListVectorStores(ctx, llamastack.ListVectorStoresParams{})
+			if listErr != nil {
+				app.handleLlamaStackClientError(w, r, listErr)
+				return
+			}
+			vectorStores = refreshed
+		} else {
+			vectorStores = append(vectorStores, *newStore)
 		}
-		vectorStores = append(vectorStores, *newStore)
 	}
 
 	if err := app.WriteJSON(w, http.StatusOK, VectorStoresResponse{Data: vectorStores}, nil); err != nil {

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
@@ -28,6 +28,10 @@ type CreateVectorStoreRequest struct {
 // Returns all vector stores visible to the authenticated user. OGX enforces
 // per-user isolation via its AuthorizedSqlStore layer — each user only sees
 // their own stores based on the auth token forwarded in the request.
+//
+// Ensures the user has a file-upload store (metadata.created_by == "auto-provisioning")
+// creating one if needed. The frontend relies on this marker to identify the
+// store used for file attachments.
 func (app *App) LlamaStackListVectorStoresHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
 
@@ -35,6 +39,30 @@ func (app *App) LlamaStackListVectorStoresHandler(w http.ResponseWriter, r *http
 	if err != nil {
 		app.handleLlamaStackClientError(w, r, err)
 		return
+	}
+
+	// Ensure the user has a file-upload store. OGX handles ownership isolation,
+	// so we just check if any store has the auto-provisioning marker.
+	hasFileStore := false
+	for _, vs := range vectorStores {
+		if vs.Metadata != nil && vs.Metadata["created_by"] == "auto-provisioning" {
+			hasFileStore = true
+			break
+		}
+	}
+
+	if !hasFileStore {
+		newStore, err := app.repositories.VectorStores.CreateVectorStore(ctx, llamastack.CreateVectorStoreParams{
+			Name: "file-uploads",
+			Metadata: map[string]string{
+				"created_by": "auto-provisioning",
+			},
+		})
+		if err != nil {
+			app.handleLlamaStackClientError(w, r, err)
+			return
+		}
+		vectorStores = append(vectorStores, *newStore)
 	}
 
 	if err := app.WriteJSON(w, http.StatusOK, VectorStoresResponse{Data: vectorStores}, nil); err != nil {

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,8 +9,6 @@ import (
 	"strings"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/opendatahub-io/gen-ai/internal/constants"
-	"github.com/opendatahub-io/gen-ai/internal/integrations"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack"
 )
 
@@ -27,76 +23,18 @@ type CreateVectorStoreRequest struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
-// TEMPORARY: hashUsername creates a deterministic hash for username-based vectorstore isolation
-// TODO: Remove this function when proper multi-tenant vectorstore support is implemented
-func hashUsername(username string) string {
-	hash := sha256.Sum256([]byte(username))
-	// Use first 128 bits (16 bytes) results in 32 hex characters instead of 64
-	return hex.EncodeToString(hash[:16])
-}
-
 // LlamaStackListVectorStoresHandler handles GET /gen-ai/api/v1/vectorstores.
 //
-// Returns all vector stores from LlamaStack. Callers are responsible for
-// distinguishing between the auto-provisioned file-upload inline store and external
-// registered stores using the metadata fields:
-//   - Auto-provisioned (Milvus file-upload): metadata.created_by == "auto-provisioning"
-//   - External (registered from llama-stack-config): metadata.created_by is absent
-//
-// The handler ensures the current user's auto-provisioned store exists, creating
-// it if necessary, before returning all stores.
-// TEMPORARY: Auto-provisioning will be replaced with proper multi-tenant support.
+// Returns all vector stores visible to the authenticated user. OGX enforces
+// per-user isolation via its AuthorizedSqlStore layer — each user only sees
+// their own stores based on the auth token forwarded in the request.
 func (app *App) LlamaStackListVectorStoresHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
-
-	// TEMPORARY: Ensure the current user's auto-provisioned store exists.
-	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
-	if !ok || identity == nil {
-		app.unauthorizedResponse(w, r, errors.New("user identity not found in context"))
-		return
-	}
-
-	client, err := app.kubernetesClientFactory.GetClient(ctx)
-	if err != nil {
-		app.serverErrorResponse(w, r, err)
-		return
-	}
-
-	username, err := client.GetUser(ctx, identity)
-	if err != nil {
-		app.serverErrorResponse(w, r, err)
-		return
-	}
 
 	vectorStores, err := app.repositories.VectorStores.ListVectorStores(ctx, llamastack.ListVectorStoresParams{})
 	if err != nil {
 		app.handleLlamaStackClientError(w, r, err)
 		return
-	}
-
-	// TEMPORARY: Create the user's auto-provisioned store if it doesn't exist yet.
-	hashedUsername := hashUsername(username)
-	hasUserStore := false
-	for _, vs := range vectorStores {
-		if vs.Name == hashedUsername {
-			hasUserStore = true
-			break
-		}
-	}
-
-	if !hasUserStore {
-		newStore, err := app.repositories.VectorStores.CreateVectorStore(ctx, llamastack.CreateVectorStoreParams{
-			Name: hashedUsername,
-			Metadata: map[string]string{
-				"created_by": "auto-provisioning",
-				"username":   username,
-			},
-		})
-		if err != nil {
-			app.handleLlamaStackClientError(w, r, err)
-			return
-		}
-		vectorStores = append(vectorStores, *newStore)
 	}
 
 	if err := app.WriteJSON(w, http.StatusOK, VectorStoresResponse{Data: vectorStores}, nil); err != nil {

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
@@ -61,6 +61,8 @@ func (app *App) LlamaStackListVectorStoresHandler(w http.ResponseWriter, r *http
 		if err != nil {
 			// Tolerate race: concurrent request may have created the store already.
 			// Re-fetch to pick it up; only fail if the list itself errors.
+			app.logger.Warn("Auto-provisioning file-upload store failed, re-fetching (possible race)",
+				"error", err)
 			refreshed, listErr := app.repositories.VectorStores.ListVectorStores(ctx, llamastack.ListVectorStoresParams{})
 			if listErr != nil {
 				app.handleLlamaStackClientError(w, r, listErr)

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
@@ -60,12 +60,24 @@ func (app *App) LlamaStackListVectorStoresHandler(w http.ResponseWriter, r *http
 		})
 		if err != nil {
 			// Tolerate race: concurrent request may have created the store already.
-			// Re-fetch to pick it up; only fail if the list itself errors.
-			app.logger.Warn("Auto-provisioning file-upload store failed, re-fetching (possible race)",
+			// Re-fetch and confirm the auto-provisioned store exists; if not, propagate
+			// the original create error (could be permissions, quota, etc.).
+			app.logger.Warn("Auto-provisioning file-upload store failed, checking for race condition",
 				"error", err)
 			refreshed, listErr := app.repositories.VectorStores.ListVectorStores(ctx, llamastack.ListVectorStoresParams{})
 			if listErr != nil {
 				app.handleLlamaStackClientError(w, r, listErr)
+				return
+			}
+			raceConfirmed := false
+			for _, vs := range refreshed {
+				if vs.Metadata != nil && vs.Metadata["created_by"] == "auto-provisioning" {
+					raceConfirmed = true
+					break
+				}
+			}
+			if !raceConfirmed {
+				app.handleLlamaStackClientError(w, r, err)
 				return
 			}
 			vectorStores = refreshed

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
@@ -170,26 +170,9 @@ var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 		err = json.Unmarshal(body, &response)
 		assert.NoError(t, err)
 
-		// Mock returns 2 external stores; handler auto-provisions 1 user store = 3 total
+		// Mock returns 2 stores; OGX handles isolation server-side
 		vectorStores := response.Data.([]interface{})
-		assert.Len(t, vectorStores, 3)
-
-		// Find the auto-provisioned user store by contract metadata marker
-		var userStore map[string]interface{}
-		for _, vs := range vectorStores {
-			store := vs.(map[string]interface{})
-			metadata, ok := store["metadata"].(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if createdBy, ok := metadata["created_by"].(string); ok && createdBy == "auto-provisioning" {
-				userStore = store
-				break
-			}
-		}
-		require.NotNil(t, userStore, "expected auto-provisioned user store")
-		assert.NotEmpty(t, userStore["id"])
-		assert.Contains(t, []string{"completed", "in_progress"}, userStore["status"])
+		assert.Len(t, vectorStores, 2)
 	})
 
 	It("should list vector stores with limit parameter", func() {
@@ -216,9 +199,9 @@ var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 		err = json.Unmarshal(body, &response)
 		assert.NoError(t, err)
 
-		// Mock returns 2 external stores; handler auto-provisions 1 user store = 3 total
+		// Mock returns 2 stores; OGX handles isolation server-side
 		vectorStores := response.Data.([]interface{})
-		assert.Len(t, vectorStores, 3)
+		assert.Len(t, vectorStores, 2)
 	})
 
 	It("should list vector stores with order parameter", func() {
@@ -245,9 +228,9 @@ var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 		err = json.Unmarshal(body, &response)
 		assert.NoError(t, err)
 
-		// Mock returns 2 external stores; handler auto-provisions 1 user store = 3 total
+		// Mock returns 2 stores; OGX handles isolation server-side
 		vectorStores := response.Data.([]interface{})
-		assert.Len(t, vectorStores, 3)
+		assert.Len(t, vectorStores, 2)
 	})
 
 	It("should list vector stores with both limit and order parameters", func() {
@@ -274,9 +257,9 @@ var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 		err = json.Unmarshal(body, &response)
 		assert.NoError(t, err)
 
-		// Mock returns 2 external stores; handler auto-provisions 1 user store = 3 total
+		// Mock returns 2 stores; OGX handles isolation server-side
 		vectorStores := response.Data.([]interface{})
-		assert.Len(t, vectorStores, 3)
+		assert.Len(t, vectorStores, 2)
 	})
 
 	It("should ignore invalid limit parameter", func() {

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
@@ -173,6 +173,22 @@ var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 		// Mock returns 2 stores; handler auto-provisions 1 file-upload store = 3 total
 		vectorStores := response.Data.([]interface{})
 		assert.Len(t, vectorStores, 3)
+
+		// Verify the auto-provisioned store contract
+		var fileUploadStore map[string]interface{}
+		for _, vs := range vectorStores {
+			store := vs.(map[string]interface{})
+			metadata, ok := store["metadata"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if createdBy, ok := metadata["created_by"].(string); ok && createdBy == "auto-provisioning" {
+				fileUploadStore = store
+				break
+			}
+		}
+		require.NotNil(t, fileUploadStore, "expected auto-provisioned file-upload store")
+		assert.Equal(t, "file-uploads", fileUploadStore["name"])
 	})
 
 	It("should list vector stores with limit parameter", func() {

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
@@ -170,9 +170,9 @@ var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 		err = json.Unmarshal(body, &response)
 		assert.NoError(t, err)
 
-		// Mock returns 2 stores; OGX handles isolation server-side
+		// Mock returns 2 stores; handler auto-provisions 1 file-upload store = 3 total
 		vectorStores := response.Data.([]interface{})
-		assert.Len(t, vectorStores, 2)
+		assert.Len(t, vectorStores, 3)
 	})
 
 	It("should list vector stores with limit parameter", func() {
@@ -199,9 +199,9 @@ var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 		err = json.Unmarshal(body, &response)
 		assert.NoError(t, err)
 
-		// Mock returns 2 stores; OGX handles isolation server-side
+		// Mock returns 2 stores; handler auto-provisions 1 file-upload store = 3 total
 		vectorStores := response.Data.([]interface{})
-		assert.Len(t, vectorStores, 2)
+		assert.Len(t, vectorStores, 3)
 	})
 
 	It("should list vector stores with order parameter", func() {
@@ -228,9 +228,9 @@ var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 		err = json.Unmarshal(body, &response)
 		assert.NoError(t, err)
 
-		// Mock returns 2 stores; OGX handles isolation server-side
+		// Mock returns 2 stores; handler auto-provisions 1 file-upload store = 3 total
 		vectorStores := response.Data.([]interface{})
-		assert.Len(t, vectorStores, 2)
+		assert.Len(t, vectorStores, 3)
 	})
 
 	It("should list vector stores with both limit and order parameters", func() {
@@ -257,9 +257,9 @@ var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 		err = json.Unmarshal(body, &response)
 		assert.NoError(t, err)
 
-		// Mock returns 2 stores; OGX handles isolation server-side
+		// Mock returns 2 stores; handler auto-provisions 1 file-upload store = 3 total
 		vectorStores := response.Data.([]interface{})
-		assert.Len(t, vectorStores, 2)
+		assert.Len(t, vectorStores, 3)
 	})
 
 	It("should ignore invalid limit parameter", func() {

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
@@ -732,6 +732,18 @@ func (c *LlamaStackConfig) EnableRBACAuthWithCustomPolicy(apiServerURL, tlsCAFil
 		},
 		AccessPolicy: accessPolicy,
 	}
+
+	// AuthorizedSqlStore requires storage.stores.vector_stores to be configured.
+	// Without it, OGX won't enforce ownership filtering on vectorstore operations.
+	if c.Storage.Stores == nil {
+		c.Storage.Stores = make(map[string]interface{})
+	}
+	if _, exists := c.Storage.Stores["vector_stores"]; !exists {
+		c.Storage.Stores["vector_stores"] = map[string]interface{}{
+			"backend":    "sql_default",
+			"table_name": "vector_stores",
+		}
+	}
 }
 
 // DisableRBACAuth disables RBAC authentication by removing the auth configuration.

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
@@ -751,6 +751,8 @@ func (c *LlamaStackConfig) EnableRBACAuthWithCustomPolicy(apiServerURL, tlsCAFil
 	// Each vector_io provider needs config.metadata_store referencing the SQL store
 	// for AuthorizedSqlStore to activate per-provider. Without it, the provider's
 	// _list_authorized_openai_vector_stores falls back to unfiltered in-memory cache.
+	// Set unconditionally — user-supplied metadata_store values are overwritten to
+	// prevent RBAC bypass via incompatible store references (CWE-284).
 	metadataStoreRef := map[string]interface{}{
 		"backend":    "sql_default",
 		"table_name": "vector_stores",
@@ -759,9 +761,7 @@ func (c *LlamaStackConfig) EnableRBACAuthWithCustomPolicy(apiServerURL, tlsCAFil
 		if c.Providers.VectorIO[i].Config == nil {
 			c.Providers.VectorIO[i].Config = make(map[string]interface{})
 		}
-		if _, has := c.Providers.VectorIO[i].Config["metadata_store"]; !has {
-			c.Providers.VectorIO[i].Config["metadata_store"] = metadataStoreRef
-		}
+		c.Providers.VectorIO[i].Config["metadata_store"] = metadataStoreRef
 	}
 }
 

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
@@ -747,6 +747,22 @@ func (c *LlamaStackConfig) EnableRBACAuthWithCustomPolicy(apiServerURL, tlsCAFil
 			"table_name": "vector_stores",
 		}
 	}
+
+	// Each vector_io provider needs config.metadata_store referencing the SQL store
+	// for AuthorizedSqlStore to activate per-provider. Without it, the provider's
+	// _list_authorized_openai_vector_stores falls back to unfiltered in-memory cache.
+	metadataStoreRef := map[string]interface{}{
+		"backend":    "sql_default",
+		"table_name": "vector_stores",
+	}
+	for i := range c.Providers.VectorIO {
+		if c.Providers.VectorIO[i].Config == nil {
+			c.Providers.VectorIO[i].Config = make(map[string]interface{})
+		}
+		if _, has := c.Providers.VectorIO[i].Config["metadata_store"]; !has {
+			c.Providers.VectorIO[i].Config["metadata_store"] = metadataStoreRef
+		}
+	}
 }
 
 // DisableRBACAuth disables RBAC authentication by removing the auth configuration.

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
@@ -749,23 +749,29 @@ func (c *LlamaStackConfig) SetRoutePolicy(routePolicy []RouteAccessRule) {
 }
 
 // NewDefaultAccessPolicy returns the default RBAC access policy for OpenShift integration.
-// - admin group: full access (create, read, delete)
-// - system:authenticated: read-only access
+// Enforces per-user ownership isolation: users can only access their own resources.
+// Shared resources (like models) that have no owner are readable by everyone.
 func NewDefaultAccessPolicy() []AccessRule {
 	return []AccessRule{
 		{
 			Permit: &Scope{
-				Actions: []string{"create", "read", "delete"},
+				Actions: []string{"create", "read", "update", "delete"},
 			},
-			When:        "user with admin in roles",
-			Description: "admin users have full access to all resources",
+			When:        "user is owner",
+			Description: "users have full access to their own resources",
+		},
+		{
+			Permit: &Scope{
+				Actions: []string{"create"},
+			},
+			Description: "any authenticated user can create new resources",
 		},
 		{
 			Permit: &Scope{
 				Actions: []string{"read"},
 			},
-			When:        "user with system:authenticated in roles",
-			Description: "authenticated users have read-only access",
+			When:        "resource is unowned",
+			Description: "shared resources (models, tools) are readable by everyone",
 		},
 	}
 }

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
@@ -695,11 +695,14 @@ func NewVectorStore(vectorStoreID, embeddingModel string, embeddingDimension int
 
 // EnableRBACAuth enables RBAC authentication using the Kubernetes auth provider.
 // This configures the server to validate tokens against the Kubernetes API server
-// and apply access control rules based on user groups.
+// and apply ownership-based access control rules.
 //
 // Default access policy:
-//   - admin group: full access (create, read, delete)
-//   - system:authenticated: read-only access
+//   - user is owner: full CRUD on own resources
+//   - any authenticated: create new resources
+//   - resource is unowned: read shared resources (models, tools)
+//
+// Also configures storage.stores.vector_stores (required for AuthorizedSqlStore).
 //
 // Parameters:
 //   - apiServerURL: Kubernetes API server URL (use empty string for in-cluster default)

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config_test.go
@@ -592,19 +592,24 @@ func TestRBACAuth_EnableRBACAuth(t *testing.T) {
 		assert.Equal(t, "roles", config.Server.Auth.ProviderConfig.ClaimsMapping["username"])
 
 		// Verify access policy
-		require.Len(t, config.Server.Auth.AccessPolicy, 2)
+		require.Len(t, config.Server.Auth.AccessPolicy, 3)
 
-		// Admin rule
-		adminRule := config.Server.Auth.AccessPolicy[0]
-		require.NotNil(t, adminRule.Permit)
-		assert.ElementsMatch(t, []string{"create", "read", "delete"}, adminRule.Permit.Actions)
-		assert.Equal(t, "user with admin in roles", adminRule.When)
+		// Owner rule
+		ownerRule := config.Server.Auth.AccessPolicy[0]
+		require.NotNil(t, ownerRule.Permit)
+		assert.ElementsMatch(t, []string{"create", "read", "update", "delete"}, ownerRule.Permit.Actions)
+		assert.Equal(t, "user is owner", ownerRule.When)
 
-		// System:authenticated rule
-		authRule := config.Server.Auth.AccessPolicy[1]
-		require.NotNil(t, authRule.Permit)
-		assert.ElementsMatch(t, []string{"read"}, authRule.Permit.Actions)
-		assert.Equal(t, "user with system:authenticated in roles", authRule.When)
+		// Create rule
+		createRule := config.Server.Auth.AccessPolicy[1]
+		require.NotNil(t, createRule.Permit)
+		assert.ElementsMatch(t, []string{"create"}, createRule.Permit.Actions)
+
+		// Unowned read rule
+		unownedRule := config.Server.Auth.AccessPolicy[2]
+		require.NotNil(t, unownedRule.Permit)
+		assert.ElementsMatch(t, []string{"read"}, unownedRule.Permit.Actions)
+		assert.Equal(t, "resource is unowned", unownedRule.When)
 	})
 
 	t.Run("should enable RBAC auth with custom API server URL", func(t *testing.T) {
@@ -715,24 +720,28 @@ func TestRBACAuth_SetRoutePolicy(t *testing.T) {
 		require.Len(t, config.Server.Auth.RoutePolicy, 1)
 
 		// Verify access policy is still intact
-		require.Len(t, config.Server.Auth.AccessPolicy, 2)
+		require.Len(t, config.Server.Auth.AccessPolicy, 3)
 	})
 }
 
 func TestRBACAuth_NewDefaultAccessPolicy(t *testing.T) {
 	policy := NewDefaultAccessPolicy()
 
-	require.Len(t, policy, 2)
+	require.Len(t, policy, 3)
 
-	// Admin rule
+	// Owner rule
 	assert.NotNil(t, policy[0].Permit)
-	assert.ElementsMatch(t, []string{"create", "read", "delete"}, policy[0].Permit.Actions)
-	assert.Equal(t, "user with admin in roles", policy[0].When)
+	assert.ElementsMatch(t, []string{"create", "read", "update", "delete"}, policy[0].Permit.Actions)
+	assert.Equal(t, "user is owner", policy[0].When)
 
-	// System:authenticated rule
+	// Create rule
 	assert.NotNil(t, policy[1].Permit)
-	assert.ElementsMatch(t, []string{"read"}, policy[1].Permit.Actions)
-	assert.Equal(t, "user with system:authenticated in roles", policy[1].When)
+	assert.ElementsMatch(t, []string{"create"}, policy[1].Permit.Actions)
+
+	// Unowned read rule
+	assert.NotNil(t, policy[2].Permit)
+	assert.ElementsMatch(t, []string{"read"}, policy[2].Permit.Actions)
+	assert.Equal(t, "resource is unowned", policy[2].When)
 }
 
 func TestRBACAuth_NewAccessRule(t *testing.T) {
@@ -789,8 +798,8 @@ func TestRBACAuth_Serialization(t *testing.T) {
 		assert.Contains(t, yamlStr, "api_server_url:")
 		assert.Contains(t, yamlStr, "claims_mapping:")
 		assert.Contains(t, yamlStr, "access_policy:")
-		assert.Contains(t, yamlStr, "user with admin in roles")
-		assert.Contains(t, yamlStr, "user with system:authenticated in roles")
+		assert.Contains(t, yamlStr, "user is owner")
+		assert.Contains(t, yamlStr, "resource is unowned")
 	})
 
 	t.Run("should serialize and deserialize auth config", func(t *testing.T) {
@@ -811,7 +820,7 @@ func TestRBACAuth_Serialization(t *testing.T) {
 		assert.Equal(t, "kubernetes", parsedConfig.Server.Auth.ProviderConfig.Type)
 		assert.Equal(t, "https://api.cluster.example.com:6443", parsedConfig.Server.Auth.ProviderConfig.APIServerURL)
 		assert.Equal(t, "/custom/ca.crt", parsedConfig.Server.Auth.ProviderConfig.TLSCAFile)
-		assert.Len(t, parsedConfig.Server.Auth.AccessPolicy, 2)
+		assert.Len(t, parsedConfig.Server.Auth.AccessPolicy, 3)
 	})
 
 	t.Run("should serialize config without auth when not enabled", func(t *testing.T) {
@@ -886,8 +895,8 @@ func TestRBACAuth_GeneratedConfigIncludesAuth(t *testing.T) {
 		assert.Contains(t, yamlStr, "groups: roles")
 		assert.Contains(t, yamlStr, "username: roles")
 		assert.Contains(t, yamlStr, "access_policy:")
-		assert.Contains(t, yamlStr, "user with admin in roles")
-		assert.Contains(t, yamlStr, "user with system:authenticated in roles")
+		assert.Contains(t, yamlStr, "user is owner")
+		assert.Contains(t, yamlStr, "resource is unowned")
 
 		// Verify the rest of the config is still intact
 		assert.Contains(t, yamlStr, "version:")
@@ -915,19 +924,24 @@ func TestRBACAuth_GeneratedConfigIncludesAuth(t *testing.T) {
 		assert.True(t, parsedConfig.Server.Auth.ProviderConfig.VerifyTLS)
 
 		// Access policies must be preserved
-		require.Len(t, parsedConfig.Server.Auth.AccessPolicy, 2)
+		require.Len(t, parsedConfig.Server.Auth.AccessPolicy, 3)
 
-		// Admin rule: create, read, delete
-		adminRule := parsedConfig.Server.Auth.AccessPolicy[0]
-		require.NotNil(t, adminRule.Permit)
-		assert.ElementsMatch(t, []string{"create", "read", "delete"}, adminRule.Permit.Actions)
-		assert.Equal(t, "user with admin in roles", adminRule.When)
+		// Owner rule: full CRUD
+		ownerRule := parsedConfig.Server.Auth.AccessPolicy[0]
+		require.NotNil(t, ownerRule.Permit)
+		assert.ElementsMatch(t, []string{"create", "read", "update", "delete"}, ownerRule.Permit.Actions)
+		assert.Equal(t, "user is owner", ownerRule.When)
 
-		// Authenticated rule: read-only
-		authRule := parsedConfig.Server.Auth.AccessPolicy[1]
-		require.NotNil(t, authRule.Permit)
-		assert.ElementsMatch(t, []string{"read"}, authRule.Permit.Actions)
-		assert.Equal(t, "user with system:authenticated in roles", authRule.When)
+		// Create rule
+		createRule := parsedConfig.Server.Auth.AccessPolicy[1]
+		require.NotNil(t, createRule.Permit)
+		assert.ElementsMatch(t, []string{"create"}, createRule.Permit.Actions)
+
+		// Unowned read rule
+		unownedRule := parsedConfig.Server.Auth.AccessPolicy[2]
+		require.NotNil(t, unownedRule.Permit)
+		assert.ElementsMatch(t, []string{"read"}, unownedRule.Permit.Actions)
+		assert.Equal(t, "resource is unowned", unownedRule.When)
 
 		// Server port and other fields must remain intact
 		assert.Equal(t, 8321, parsedConfig.Server.Port)

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -2143,8 +2143,9 @@ func (kc *TokenKubernetesClient) generateLlamaStackConfig(ctx context.Context, n
 	// OpenShift group memberships or token forwarding configured.
 	// When enabled, this configures the LlamaStack server to validate tokens against
 	// the Kubernetes API server and enforce access policies based on OpenShift roles:
-	//   - admin group: full access (create, read, delete)
-	//   - system:authenticated: read-only access
+	//   - user is owner: full CRUD on own resources
+	//   - any authenticated: create new resources
+	//   - resource is unowned: read shared resources (models, tools)
 	if kc.EnvConfig.EnableLlamaStackRBAC {
 		config.EnableRBACAuth("", "")
 		kc.Logger.Debug("Enabled RBAC auth with Kubernetes provider for LlamaStack config")

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -2145,8 +2145,9 @@ func (kc *TokenKubernetesClient) generateLlamaStackConfig(ctx context.Context, n
 	// OpenShift group memberships or token forwarding configured.
 	// When enabled, this configures the LlamaStack server to validate tokens against
 	// the Kubernetes API server and enforce access policies based on OpenShift roles:
-	//   - admin group: full access (create, read, delete)
-	//   - system:authenticated: read-only access
+	//   - user is owner: full CRUD on own resources
+	//   - any authenticated: create new resources
+	//   - resource is unowned: read shared resources (models, tools)
 	if kc.EnvConfig.EnableLlamaStackRBAC {
 		config.EnableRBACAuth("", "")
 		kc.Logger.Debug("Enabled RBAC auth with Kubernetes provider for LlamaStack config")

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -324,11 +324,11 @@ func TestGenerateLlamaStackConfig_RBACFlag(t *testing.T) {
 		require.NotNil(t, cfg.Server.Auth, "Auth should be set when RBAC flag is enabled")
 		require.NotNil(t, cfg.Server.Auth.ProviderConfig)
 		assert.Equal(t, "kubernetes", cfg.Server.Auth.ProviderConfig.Type)
-		assert.Len(t, cfg.Server.Auth.AccessPolicy, 2)
+		assert.Len(t, cfg.Server.Auth.AccessPolicy, 3)
 
 		// Verify access policies
-		assert.Contains(t, result, "user with admin in roles")
-		assert.Contains(t, result, "user with system:authenticated in roles")
+		assert.Contains(t, result, "user is owner")
+		assert.Contains(t, result, "resource is unowned")
 	})
 
 	t.Run("default EnvConfig should have RBAC disabled", func(t *testing.T) {

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -324,11 +324,22 @@ func TestGenerateLlamaStackConfig_RBACFlag(t *testing.T) {
 		require.NotNil(t, cfg.Server.Auth, "Auth should be set when RBAC flag is enabled")
 		require.NotNil(t, cfg.Server.Auth.ProviderConfig)
 		assert.Equal(t, "kubernetes", cfg.Server.Auth.ProviderConfig.Type)
-		assert.Len(t, cfg.Server.Auth.AccessPolicy, 3)
+		require.Len(t, cfg.Server.Auth.AccessPolicy, 3, "expected 3 access policy rules")
 
-		// Verify access policies
-		assert.Contains(t, result, "user is owner")
-		assert.Contains(t, result, "resource is unowned")
+		// Rule 1: owner has full CRUD
+		assert.Equal(t, "user is owner", cfg.Server.Auth.AccessPolicy[0].When)
+		require.NotNil(t, cfg.Server.Auth.AccessPolicy[0].Permit)
+		assert.ElementsMatch(t, []string{"create", "read", "update", "delete"}, cfg.Server.Auth.AccessPolicy[0].Permit.Actions)
+
+		// Rule 2: any authenticated user can create new resources
+		assert.Empty(t, cfg.Server.Auth.AccessPolicy[1].When, "create rule should have no condition")
+		require.NotNil(t, cfg.Server.Auth.AccessPolicy[1].Permit)
+		assert.Equal(t, []string{"create"}, cfg.Server.Auth.AccessPolicy[1].Permit.Actions)
+
+		// Rule 3: unowned resources readable by everyone
+		assert.Equal(t, "resource is unowned", cfg.Server.Auth.AccessPolicy[2].When)
+		require.NotNil(t, cfg.Server.Auth.AccessPolicy[2].Permit)
+		assert.Equal(t, []string{"read"}, cfg.Server.Auth.AccessPolicy[2].Permit.Actions)
 	})
 
 	t.Run("default EnvConfig should have RBAC disabled", func(t *testing.T) {

--- a/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
@@ -625,6 +625,21 @@ func (c *LlamaStackClient) buildRequestOptions(providerData map[string]interface
 	}
 }
 
+// RetrieveVectorStore retrieves a single vector store by ID.
+// Used for ownership validation (defense-in-depth) before mutating operations.
+func (c *LlamaStackClient) RetrieveVectorStore(ctx context.Context, vectorStoreID string) (*openai.VectorStore, error) {
+	if vectorStoreID == "" {
+		return nil, NewInvalidRequestError("vectorStoreID is required")
+	}
+
+	vectorStore, err := c.client.VectorStores.Get(ctx, vectorStoreID)
+	if err != nil {
+		return nil, wrapClientError(err, "RetrieveVectorStore")
+	}
+
+	return vectorStore, nil
+}
+
 // DeleteVectorStore deletes a vector store by ID.
 func (c *LlamaStackClient) DeleteVectorStore(ctx context.Context, vectorStoreID string) error {
 	if vectorStoreID == "" {

--- a/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client_factory.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client_factory.go
@@ -14,6 +14,7 @@ type LlamaStackClientInterface interface {
 	ListModels(ctx context.Context) ([]openai.Model, error)
 	ListVectorStores(ctx context.Context, params ListVectorStoresParams) ([]openai.VectorStore, error)
 	CreateVectorStore(ctx context.Context, params CreateVectorStoreParams) (*openai.VectorStore, error)
+	RetrieveVectorStore(ctx context.Context, vectorStoreID string) (*openai.VectorStore, error)
 	DeleteVectorStore(ctx context.Context, vectorStoreID string) error
 	UploadFile(ctx context.Context, params UploadFileParams) (*FileUploadResult, error)
 	ListFiles(ctx context.Context, params ListFilesParams) ([]openai.FileObject, error)

--- a/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_client_mock.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_client_mock.go
@@ -540,6 +540,18 @@ func unmarshalEvent(data map[string]interface{}) responses.ResponseStreamEventUn
 	return event
 }
 
+// RetrieveVectorStore returns a mock vector store by ID
+func (m *MockLlamaStackClient) RetrieveVectorStore(ctx context.Context, vectorStoreID string) (*openai.VectorStore, error) {
+	if vectorStoreID == "" {
+		return nil, fmt.Errorf("vectorStoreID is required")
+	}
+	return &openai.VectorStore{
+		ID:     vectorStoreID,
+		Name:   "mock-vector-store",
+		Status: "completed",
+	}, nil
+}
+
 // DeleteVectorStore returns success for mock deletion
 func (m *MockLlamaStackClient) DeleteVectorStore(ctx context.Context, vectorStoreID string) error {
 	if vectorStoreID == "" {

--- a/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_client_mock.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_client_mock.go
@@ -542,6 +542,18 @@ func unmarshalEvent(data map[string]interface{}) responses.ResponseStreamEventUn
 	return event
 }
 
+// RetrieveVectorStore returns a mock vector store by ID
+func (m *MockLlamaStackClient) RetrieveVectorStore(ctx context.Context, vectorStoreID string) (*openai.VectorStore, error) {
+	if vectorStoreID == "" {
+		return nil, fmt.Errorf("vectorStoreID is required")
+	}
+	return &openai.VectorStore{
+		ID:     vectorStoreID,
+		Name:   "mock-vector-store",
+		Status: "completed",
+	}, nil
+}
+
 // DeleteVectorStore returns success for mock deletion
 func (m *MockLlamaStackClient) DeleteVectorStore(ctx context.Context, vectorStoreID string) error {
 	if vectorStoreID == "" {

--- a/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_test_client.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_test_client.go
@@ -93,6 +93,10 @@ func (c *TestLlamaStackClient) CreateVectorStore(ctx context.Context, params lla
 	return c.inner.CreateVectorStore(ctx, params)
 }
 
+func (c *TestLlamaStackClient) RetrieveVectorStore(ctx context.Context, vectorStoreID string) (*openai.VectorStore, error) {
+	return c.inner.RetrieveVectorStore(ctx, vectorStoreID)
+}
+
 func (c *TestLlamaStackClient) DeleteVectorStore(ctx context.Context, vectorStoreID string) error {
 	return c.inner.DeleteVectorStore(ctx, vectorStoreID)
 }

--- a/packages/gen-ai/bff/internal/repositories/lsd_vectorstores.go
+++ b/packages/gen-ai/bff/internal/repositories/lsd_vectorstores.go
@@ -46,6 +46,18 @@ func (r *VectorStoresRepository) CreateVectorStore(ctx context.Context, params l
 	return client.CreateVectorStore(ctx, params)
 }
 
+// RetrieveVectorStore retrieves a single vector store by ID.
+// Used for ownership validation before mutating operations (defense-in-depth).
+// The LlamaStack client is expected to be in the context (created by AttachOGXClient middleware).
+func (r *VectorStoresRepository) RetrieveVectorStore(ctx context.Context, vectorStoreID string) (*openai.VectorStore, error) {
+	client, err := helper.GetContextLlamaStackClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.RetrieveVectorStore(ctx, vectorStoreID)
+}
+
 // DeleteVectorStore deletes a vector store by ID.
 // The LlamaStack client is expected to be in the context (created by AttachOGXClient middleware).
 func (r *VectorStoresRepository) DeleteVectorStore(ctx context.Context, vectorStoreID string) error {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-35749

## Description

Remove the temporary per-username vectorstore isolation workaround from the BFF. OGX now supports native per-user isolation via `AuthorizedSqlStore`, vectorstores are automatically filtered by the authenticated user's ownership.

### What was removed

- `hashUsername()` that hashed the username to create deterministic store names per user
- The username-based store naming (OGX handles isolation, no need for unique names per user)

### What was simplified

The auto-provisioning logic in `LlamaStackListVectorStoresHandler` now uses a fixed name (`file-uploads`) instead of a hashed username. OGX handles per-user isolation via ownership, so the store name no longer needs to encode user identity.

### Frontend compatibility

The frontend (`useFileManagement.ts`) depends on `metadata.created_by === 'auto-provisioning'` to identify the user's file-upload vectorstore. Kept the store creation with the `created_by` metadata marker but simplified the naming. This way:
- The frontend continues finding its file-upload store without changes
- The store name is no longer a hash of the username (OGX handles user isolation)
- `KnowledgeTabContent.tsx` continues filtering out auto-provisioned stores from the external stores list

### Why it's safe

OGX enforces vectorstore isolation at the server level:
1. On CREATE: stamps `owner_principal` from the authenticated user's token
2. On LIST/GET: `AuthorizedSqlStore` filters results, each user only sees their own stores
3. The BFF already forwards the user's auth token to OGX (no BFF changes needed for that part)

### Default RBAC policy updated

Updated `NewDefaultAccessPolicy()` to enforce ownership-based isolation instead of the previous role-based approach:

**Before (role-based, no isolation):**
- admin group: full access
- system:authenticated: read-only

**After (ownership-based, per-user isolation):**
- `user is owner`: full CRUD on own resources
- any authenticated: create new resources
- `resource is unowned`: read shared resources (models, tools)

This policy is what enables OGX to filter vectorstores by ownership when `ENABLE_LLAMASTACK_RBAC=true` is set in the BFF.

### storage.stores.vector_stores configuration

Added `storage.stores.vector_stores` to the generated OGX config when RBAC is enabled. OGX requires this field for `AuthorizedSqlStore` to activate on the vectorstore metadata, without it the ownership filtering is silently skipped.

### Deployment manifests updated

Added `--enable-llamastack-rbac` to both operator deployment manifests:
- `manifests/modular-architecture/modules/gen-ai/deployment.yaml`
- `manifests/modular-architecture/deployment.yaml`

This ensures the operator deploys the BFF with RBAC active so vectorstore isolation is enforced by default.

### Additional fix

Added `RetrieveVectorStore` stub to `mockLSClientForASR` in audio handler tests. This was a pre-existing compilation error on the branch where the interface method was added but the mock wasn't updated.

## How Has This Been Tested?

- `go build ./...` compiles clean
- `make test` all specs pass (0 failures across all packages)
- Verified no regression in other vectorstore handlers (Create, Delete, ListFiles, DeleteFile)

### End-to-end cluster validation

Deployed the custom BFF image (with `--enable-llamastack-rbac` and the new ownership-based policy) on an OpenShift cluster alongside the downstream OGX image (`quay.io/rhoai/odh-ogx-core-rhel9:rhoai-3.5-linux-x86-64`). Validated the full flow as an end user:

1. Opened the Playground from the dashboard UI
2. Confirmed that OGX started with `Enabling authentication` in logs and the generated config includes `server.auth.access_policy` with ownership rules
3. Created vectorstores from the UI (file upload + external knowledge store)
4. Verified from the UI that my user sees all created stores
5. Verified from a separate user token (ServiceAccount `user-bob`) via curl that the user-created vectorstores are invisible:

6. Shared/external vectorstores (registered via config, no owner) remain visible to all users as expected

**UI evidence:**

<img width="1539" height="749" alt="image" src="https://github.com/user-attachments/assets/82d58d7c-2829-4918-b056-6d99d4b8fcac" />

<img width="1538" height="745" alt="image" src="https://github.com/user-attachments/assets/aa525a51-621b-41f6-8297-1a32220388e2" />

**Curl verification (another user cannot see your stores):**

```
$ curl -s http://localhost:8321/v1/vector_stores -H "Authorization: Bearer $BOB_TOKEN" | python3 -m json.tool

Handling connection for 8321
{
    "object": "list",
    "data": [
        {
            "id": "vs_playground_test",
            "object": "vector_store",
            "created_at": 1784630389,
            "name": "Playground Test Vector Store",
            "usage_bytes": 0,
            "file_counts": {
                "completed": 0,
                "cancelled": 0,
                "failed": 0,
                "in_progress": 0,
                "total": 0
            },
            "status": "completed",
            "expires_after": null,
            "expires_at": null,
            "last_active_at": 1784630389,
            "metadata": {
                "provider_id": "milvus-provider",
                "provider_vector_store_id": null,
                "embedding_model": "sentence-transformers/ibm-granite/granite-embedding-125m-english",
                "embedding_dimension": "768"
            }
        }
    ],
    "first_id": "vs_playground_test",
    "last_id": "vs_playground_test",
    "has_more": false
}
```

```
=== BOB sees ===
  Count: 1
  - Playground Test Vector Store    (shared/unowned - visible to all, as expected)

*** Bob CANNOT see user-created vectorstores ***
*** VECTORSTORE USER ISOLATION: CONFIRMED ***
```

### OGX server configuration (relevant extract)

```yaml
server:
  port: 8321
  auth:
    provider_config:
      type: kubernetes
      api_server_url: https://kubernetes.default.svc
      tls_cafile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
    access_policy:
    - permit:
        actions: [create, read, update, delete]
      when: user is owner
    - permit:
        actions: [create]
    - permit:
        actions: [read]
      when: resource is unowned
storage:
  stores:
    vector_stores:
      backend: sql_default
      table_name: vector_stores
```

This configuration enables the Kubernetes TokenReview auth provider, defines Cedar-style access rules that enforce per-user ownership, and configures the SQL-backed vector_stores metadata store required for `AuthorizedSqlStore` to filter results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving individual vector stores by ID.
  - Added a shared `file-uploads` vector store that is automatically created when needed.
  - Enabled LlamaStack access controls in the Gen AI deployment.

- **Improvements**
  - Vector store visibility now follows ownership and authorization rules.
  - Owners receive full access, authenticated users can create resources, and shared unowned resources can be read.
  - Improved handling of concurrent file-upload store creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->