### PR TITLE
Filter Incompatible Models from Evaluation Benchmark dropdown

### DIFF
--- a/packages/eval-hub/bff/internal/api/inferenceservices_handler.go
+++ b/packages/eval-hub/bff/internal/api/inferenceservices_handler.go
@@ -108,6 +108,8 @@ func listInferenceServices(ctx context.Context, client dynamic.Interface, namesp
 		name := obj.GetName()
 		var url string
 		var ready bool
+		var modelFormatName string
+		var apiProtocol string
 
 		if status, ok := obj.Object["status"].(map[string]interface{}); ok {
 			// Prefer status.address.url (includes the real container port for
@@ -137,10 +139,28 @@ func listInferenceServices(ctx context.Context, client dynamic.Interface, namesp
 			}
 		}
 
+		// Extract model format and protocol from spec.predictor.model
+		if spec, ok := obj.Object["spec"].(map[string]interface{}); ok {
+			if predictor, ok := spec["predictor"].(map[string]interface{}); ok {
+				if model, ok := predictor["model"].(map[string]interface{}); ok {
+					if mf, ok := model["modelFormat"].(map[string]interface{}); ok {
+						if n, ok := mf["name"].(string); ok {
+							modelFormatName = n
+						}
+					}
+					if pv, ok := model["protocolVersion"].(string); ok {
+						apiProtocol = pv
+					}
+				}
+			}
+		}
+
 		items = append(items, models.InferenceServiceItem{
-			Name:  name,
-			URL:   url,
-			Ready: ready,
+			Name:            name,
+			URL:             url,
+			Ready:           ready,
+			ModelFormatName: modelFormatName,
+			APIProtocol:     apiProtocol,
 		})
 	}
 

--- a/packages/eval-hub/bff/internal/integrations/connectionprobe/client.go
+++ b/packages/eval-hub/bff/internal/integrations/connectionprobe/client.go
@@ -211,6 +211,18 @@ func (c *ConnectionProbeClient) Probe(ctx context.Context, req models.VerifyConn
 	}
 }
 
+// chatCompletionResponse is the minimal OpenAI-compatible response shape
+// needed to verify the endpoint speaks the expected protocol.
+type chatCompletionResponse struct {
+	ID      string `json:"id"`
+	Choices []struct {
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
 func (c *ConnectionProbeClient) probeModelEndpoint(ctx context.Context, req models.VerifyConnectionRequest, startTime time.Time) (*models.VerifyConnectionResponse, error) {
 	chatReq := chatCompletionRequest{
 		Model: "test",
@@ -242,7 +254,25 @@ func (c *ConnectionProbeClient) probeModelEndpoint(ctx context.Context, req mode
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	return c.executeAndMap(ctx, httpReq, fullURL, startTime)
+	return c.executeAndMap(ctx, httpReq, fullURL, startTime, true)
+}
+
+// isOpenAICompatibleResponse checks whether the body matches the minimal
+// OpenAI chat completion shape (has "id" and non-empty "choices").
+func isOpenAICompatibleResponse(body []byte, logger *slog.Logger) bool {
+	if len(body) == 0 {
+		return false
+	}
+	var parsed chatCompletionResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		logger.Debug("OpenAI compat check: failed to parse response", "error", err)
+		return false
+	}
+	if parsed.ID == "" || len(parsed.Choices) == 0 {
+		logger.Debug("OpenAI compat check: missing id or choices", "id", parsed.ID, "choicesLen", len(parsed.Choices))
+		return false
+	}
+	return true
 }
 
 func (c *ConnectionProbeClient) probePrerecordedEndpoint(ctx context.Context, _ models.VerifyConnectionRequest, startTime time.Time) (*models.VerifyConnectionResponse, error) {
@@ -256,10 +286,10 @@ func (c *ConnectionProbeClient) probePrerecordedEndpoint(ctx context.Context, _ 
 		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.secretValue))
 	}
 
-	return c.executeAndMap(ctx, httpReq, fullURL, startTime)
+	return c.executeAndMap(ctx, httpReq, fullURL, startTime, false)
 }
 
-func (c *ConnectionProbeClient) executeAndMap(ctx context.Context, httpReq *http.Request, fullURL string, startTime time.Time) (*models.VerifyConnectionResponse, error) {
+func (c *ConnectionProbeClient) executeAndMap(ctx context.Context, httpReq *http.Request, fullURL string, startTime time.Time, checkOpenAI bool) (*models.VerifyConnectionResponse, error) {
 	if !c.skipSSRFValidation {
 		parsedURL, err := url.Parse(fullURL)
 		if err != nil {
@@ -279,7 +309,6 @@ func (c *ConnectionProbeClient) executeAndMap(ctx context.Context, httpReq *http
 	}
 	defer resp.Body.Close()
 
-	// Drain body with size limit
 	limitedReader := io.LimitReader(resp.Body, maxResponseBodySize)
 	responseBody, err := io.ReadAll(limitedReader)
 	if err != nil {
@@ -289,11 +318,16 @@ func (c *ConnectionProbeClient) executeAndMap(ctx context.Context, httpReq *http
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
 		elapsed := int(time.Since(startTime).Milliseconds())
-		return &models.VerifyConnectionResponse{
+		result := &models.VerifyConnectionResponse{
 			Success:      true,
 			Message:      "Connection verified successfully",
 			ResponseTime: elapsed,
-		}, nil
+		}
+		if checkOpenAI {
+			compat := isOpenAICompatibleResponse(responseBody, c.logger)
+			result.OpenAICompat = &compat
+		}
+		return result, nil
 	case http.StatusUnauthorized:
 		return nil, NewUnauthorizedError(c.baseURL)
 	case http.StatusForbidden:

--- a/packages/eval-hub/bff/internal/integrations/connectionprobe/client_test.go
+++ b/packages/eval-hub/bff/internal/integrations/connectionprobe/client_test.go
@@ -195,3 +195,66 @@ func TestNewConnectionProbeClient_NilOptions(t *testing.T) {
 	require.NotNil(t, client)
 	assert.False(t, client.skipSSRFValidation)
 }
+
+func TestIsOpenAICompatibleResponse(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tests := []struct {
+		name     string
+		body     string
+		expected bool
+	}{
+		{
+			"valid OpenAI response",
+			`{"id":"chatcmpl-123","choices":[{"message":{"role":"assistant","content":"hello"}}]}`,
+			true,
+		},
+		{
+			"missing id",
+			`{"choices":[{"message":{"role":"assistant","content":"hello"}}]}`,
+			false,
+		},
+		{
+			"empty choices",
+			`{"id":"chatcmpl-123","choices":[]}`,
+			false,
+		},
+		{
+			"missing choices",
+			`{"id":"chatcmpl-123"}`,
+			false,
+		},
+		{
+			"prediction array (AutoGluon/sklearn)",
+			`{"predictions":[0.85,0.12]}`,
+			false,
+		},
+		{
+			"TensorFlow Serving response",
+			`{"predictions":[[0.1,0.9]]}`,
+			false,
+		},
+		{
+			"empty body",
+			``,
+			false,
+		},
+		{
+			"invalid JSON",
+			`not json`,
+			false,
+		},
+		{
+			"httpbin echo response",
+			`{"args":{},"data":"{\"model\":\"test\"}","headers":{},"url":"https://httpbin.org/anything/chat/completions"}`,
+			false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isOpenAICompatibleResponse([]byte(tc.body), logger)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/packages/eval-hub/bff/internal/models/inferenceservice.go
+++ b/packages/eval-hub/bff/internal/models/inferenceservice.go
@@ -1,9 +1,11 @@
 package models
 
 type InferenceServiceItem struct {
-	Name  string `json:"name"`
-	URL   string `json:"url,omitempty"`
-	Ready bool   `json:"ready"`
+	Name            string `json:"name"`
+	URL             string `json:"url,omitempty"`
+	Ready           bool   `json:"ready"`
+	ModelFormatName string `json:"model_format_name,omitempty"`
+	APIProtocol     string `json:"api_protocol,omitempty"`
 }
 
 type InferenceServicesResponse struct {

--- a/packages/eval-hub/bff/internal/models/verify_connection.go
+++ b/packages/eval-hub/bff/internal/models/verify_connection.go
@@ -12,4 +12,5 @@ type VerifyConnectionResponse struct {
 	Success      bool   `json:"success"`
 	Message      string `json:"message"`
 	ResponseTime int    `json:"response_time_ms,omitempty"`
+	OpenAICompat *bool  `json:"openai_compatible,omitempty"`
 }

--- a/packages/eval-hub/bff/openapi/src/eval-hub.yaml
+++ b/packages/eval-hub/bff/openapi/src/eval-hub.yaml
@@ -423,6 +423,8 @@ paths:
                   - name: 'llama-32-1b-instruct'
                     url: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
                     ready: true
+                    model_format_name: 'vLLM'
+                    api_protocol: 'REST'
                   - name: 'mistral-7b'
                     url: 'http://mistral-7b-predictor.default.svc.cluster.local:8080/v1'
                     ready: true
@@ -481,6 +483,7 @@ paths:
                   success: true
                   message: 'Connection successful'
                   response_time_ms: 120
+                  openai_compatible: true
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1001,6 +1004,22 @@ components:
           type: boolean
           description: Whether the InferenceService is in a Ready state
           example: true
+        model_format_name:
+          type: string
+          description: >-
+            Model format name from the InferenceService spec
+            (spec.predictor.model.modelFormat.name). Empty when not set.
+          example: 'vLLM'
+        api_protocol:
+          type: string
+          enum:
+            - REST
+            - gRPC
+          description: >-
+            API protocol version from the InferenceService spec
+            (spec.predictor.model.protocolVersion or the ServingRuntime's
+            supportedModelFormats protocolVersion). Absent when not set.
+          example: 'REST'
 
     InferenceServicesResponse:
       type: object
@@ -1022,9 +1041,13 @@ components:
           - name: 'llama-32-1b-instruct'
             url: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
             ready: true
+            model_format_name: 'vLLM'
+            api_protocol: 'REST'
           - name: 'mistral-7b'
             url: 'http://mistral-7b-predictor.default.svc.cluster.local:8080/v1'
             ready: true
+            model_format_name: 'vLLM'
+            api_protocol: 'REST'
 
     # -------------------------------------------------------------------------
     # Connection verification schemas
@@ -1084,6 +1107,14 @@ components:
           type: integer
           description: Round-trip time in milliseconds (present on success)
           example: 142
+        openai_compatible:
+          type: boolean
+          description: >-
+            Whether the endpoint responded with a valid OpenAI-compatible
+            chat completions response shape. Only present for model/agent
+            source types when the probe succeeds. False when the endpoint
+            returns a non-OpenAI response body.
+          example: true
 
     # -------------------------------------------------------------------------
     # Evaluation job schemas

--- a/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/startEvaluationRun.cy.ts
+++ b/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/startEvaluationRun.cy.ts
@@ -21,7 +21,15 @@ const mockMlflowExperiments = (experiments: { id: string; name: string }[] = [])
   });
 };
 
-const mockInferenceServices = (items: { name: string; url?: string; ready: boolean }[] = []) => {
+const mockInferenceServices = (
+  items: {
+    name: string;
+    url?: string;
+    ready: boolean;
+    model_format_name?: string;
+    api_protocol?: string;
+  }[] = [],
+) => {
   cy.interceptApi('GET /api/:apiVersion/inferenceservices', { path: API_VERSION }, { items });
 };
 
@@ -29,7 +37,12 @@ const mockVerifyConnectionSuccess = () => {
   cy.interceptApi(
     'POST /api/:apiVersion/evaluations/verify-connection',
     { path: API_VERSION },
-    { success: true, message: 'Connection established successfully.', response_time_ms: 120 },
+    {
+      success: true,
+      message: 'Connection established successfully.',
+      response_time_ms: 120,
+      openai_compatible: true,
+    },
   ).as('verifyConnection');
 };
 
@@ -188,6 +201,7 @@ describe('Start Evaluation Run - Benchmark Mode', () => {
     startEvaluationRunPage.findEndpointUrlInput().should('exist');
     startEvaluationRunPage.findApiKeyInput().should('exist');
     startEvaluationRunPage.findValidateConnectionButton().should('exist');
+    cy.findByTestId('external-endpoint-compatibility-alert').should('exist');
   });
 
   it('should submit evaluation job and show success toast', () => {
@@ -602,6 +616,51 @@ describe('Start Evaluation Run - Cluster Model Selection', () => {
     cy.wait('@createClusterJob').then((interception) => {
       expect(interception.request.body.model).to.have.property('name', 'llama-3.2-1b-instruct');
     });
+  });
+
+  it('should disable incompatible models in the dropdown', () => {
+    mockInferenceServices([
+      {
+        name: 'vllm-model',
+        url: 'http://vllm.svc.cluster.local:8080/v1',
+        ready: true,
+        model_format_name: 'vLLM',
+      },
+      {
+        name: 'autogluon-model',
+        url: 'http://autogluon.svc.cluster.local:8080/v1',
+        ready: true,
+        model_format_name: 'AutoGluon',
+      },
+    ]);
+
+    navigateToBenchmarkStart();
+
+    startEvaluationRunPage.findModelPickerToggle().click();
+    cy.findByTestId('model-option-vllm-model').click();
+    startEvaluationRunPage.findModelPickerToggle().should('contain.text', 'vllm-model');
+
+    startEvaluationRunPage.findModelPickerToggle().click();
+    cy.findByTestId('model-option-autogluon-model')
+      .should('contain.text', 'autogluon-model')
+      .and('contain.text', 'not compatible with evaluation benchmarks');
+  });
+
+  it('should allow selecting models without a model_format_name', () => {
+    mockInferenceServices([
+      {
+        name: 'legacy-model',
+        url: 'http://legacy.svc.cluster.local:8080/v1',
+        ready: true,
+      },
+    ]);
+
+    navigateToBenchmarkStart();
+
+    startEvaluationRunPage.findModelPickerToggle().click();
+    cy.findByTestId('model-option-legacy-model').click();
+
+    startEvaluationRunPage.findSubmitButton().should('be.enabled');
   });
 });
 

--- a/packages/eval-hub/frontend/src/app/components/SourceModelFields.tsx
+++ b/packages/eval-hub/frontend/src/app/components/SourceModelFields.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Alert,
   FormGroup,
   FormHelperText,
   HelperText,
@@ -11,7 +12,9 @@ import {
 } from '@patternfly/react-core';
 import LabelHelpPopover from '~/app/components/LabelHelpPopover';
 import ConnectionValidationButton from '~/app/components/ConnectionValidationButton';
-import type { ConnectionValidationState } from '~/app/types';
+import { verifyConnection } from '~/app/api/k8s';
+import { isValidUrl } from '~/app/utils/validationUtils';
+import type { ConnectionValidationState, VerifyConnectionRequest } from '~/app/types';
 
 type SourceModelFieldsProps = {
   modelName: string;
@@ -26,6 +29,7 @@ type SourceModelFieldsProps = {
   connectionValidation: ConnectionValidationState;
   canVerifyConnection: boolean;
   onVerifyConnection: () => void;
+  namespace?: string;
 };
 
 const SourceModelFields: React.FC<SourceModelFieldsProps> = ({
@@ -41,12 +45,74 @@ const SourceModelFields: React.FC<SourceModelFieldsProps> = ({
   connectionValidation,
   canVerifyConnection,
   onVerifyConnection,
+  namespace,
 }) => {
   const endpointUrlValidated =
     touched.endpointUrl && endpointUrlError ? ValidatedOptions.error : ValidatedOptions.default;
 
+  const [compatWarning, setCompatWarning] = React.useState<string | undefined>(undefined);
+  const compatAbortRef = React.useRef<AbortController | null>(null);
+
+  React.useEffect(() => {
+    setCompatWarning(undefined);
+  }, [endpointUrl]);
+
+  const handleEndpointBlur = React.useCallback(() => {
+    markTouched('endpointUrl');
+
+    const url = endpointUrl.trim();
+    if (!namespace || !url || !isValidUrl(url)) {
+      return;
+    }
+
+    compatAbortRef.current?.abort();
+    const controller = new AbortController();
+    compatAbortRef.current = controller;
+
+    /* eslint-disable camelcase */
+    const request: VerifyConnectionRequest = {
+      source_type: 'model',
+      base_url: url,
+      ...(modelName.trim() ? { model_id: modelName.trim() } : {}),
+      ...(apiKeySecretRef.trim() ? { secret_name: apiKeySecretRef.trim() } : {}),
+    };
+    /* eslint-enable camelcase */
+
+    verifyConnection(
+      '',
+      namespace,
+      request,
+    )({ signal: controller.signal })
+      .then((result) => {
+        if (!controller.signal.aborted && result.openai_compatible === false) {
+          setCompatWarning(
+            'This endpoint does not appear to be OpenAI-compatible. Evaluation benchmarks may fail.',
+          );
+        }
+      })
+      .catch(() => {
+        // Connection errors are handled by the existing validate button flow
+      });
+  }, [endpointUrl, namespace, modelName, apiKeySecretRef, markTouched]);
+
+  React.useEffect(
+    () => () => {
+      compatAbortRef.current?.abort();
+    },
+    [],
+  );
+
   return (
     <Stack hasGutter>
+      <StackItem>
+        <Alert
+          variant="info"
+          isInline
+          isPlain
+          title="This model must expose an OpenAI-compatible chat/completions endpoint."
+          data-testid="external-endpoint-compatibility-alert"
+        />
+      </StackItem>
       <StackItem>
         <FormGroup
           label="Model name"
@@ -81,7 +147,7 @@ const SourceModelFields: React.FC<SourceModelFieldsProps> = ({
             data-testid="endpoint-url-input"
             value={endpointUrl}
             onChange={(_e, val) => onEndpointUrlChange(val)}
-            onBlur={() => markTouched('endpointUrl')}
+            onBlur={handleEndpointBlur}
             placeholder="https://api.example.com/v1/model"
             isRequired
             validated={endpointUrlValidated}
@@ -90,6 +156,15 @@ const SourceModelFields: React.FC<SourceModelFieldsProps> = ({
             <FormHelperText>
               <HelperText>
                 <HelperTextItem variant="error">{endpointUrlError}</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          ) : null}
+          {compatWarning && !endpointUrlError ? (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="warning" data-testid="openai-compat-warning">
+                  {compatWarning}
+                </HelperTextItem>
               </HelperText>
             </FormHelperText>
           ) : null}

--- a/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
@@ -24,7 +24,6 @@ import {
   SelectOption,
   Spinner,
   TextInput,
-  Tooltip,
   EmptyState,
   EmptyStateBody,
   EmptyStateActions,
@@ -385,7 +384,7 @@ const StartEvaluationRunPage: React.FC = () => {
                         const incompatibleReason = getIncompatibleModelReason(is);
                         const isDisabled = !!incompatibleReason;
 
-                        const option = (
+                        return (
                           <SelectOption
                             key={is.name}
                             value={is.name}
@@ -395,6 +394,7 @@ const StartEvaluationRunPage: React.FC = () => {
                               form.modelSelection === 'cluster' &&
                               form.selectedInferenceService?.name === is.name
                             }
+                            description={incompatibleReason}
                           >
                             {is.name}
                             {isDisabled && (
@@ -407,14 +407,6 @@ const StartEvaluationRunPage: React.FC = () => {
                               </Icon>
                             )}
                           </SelectOption>
-                        );
-
-                        return incompatibleReason ? (
-                          <Tooltip key={is.name} content={incompatibleReason}>
-                            <span>{option}</span>
-                          </Tooltip>
-                        ) : (
-                          option
                         );
                       })}
                       <Divider />

--- a/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
@@ -54,6 +54,7 @@ import SourceModelFields from '~/app/components/SourceModelFields';
 import SourceAgentFields from '~/app/components/SourceAgentFields';
 import SourcePrerecordedFields from '~/app/components/SourcePrerecordedFields';
 import type { SourceMode } from '~/app/types';
+import { getIncompatibleModelReason } from '~/app/utils/modelCompatibility';
 import {
   useStartEvaluationRunForm,
   EXPERIMENT_FILTER,
@@ -380,20 +381,23 @@ const StartEvaluationRunPage: React.FC = () => {
                 <SelectList>
                   {isLoaded && inferenceServices.length > 0 ? (
                     <>
-                      {inferenceServices.map((is) => (
-                        <SelectOption
-                          key={is.name}
-                          value={is.name}
-                          data-testid={`model-option-${is.name}`}
-                          isDisabled={!is.ready}
-                          isSelected={
-                            form.modelSelection === 'cluster' &&
-                            form.selectedInferenceService?.name === is.name
-                          }
-                        >
-                          {is.name}
-                          {!is.ready && (
-                            <Tooltip content="This model is unavailable. Check the model's deployment status.">
+                      {inferenceServices.map((is) => {
+                        const incompatibleReason = getIncompatibleModelReason(is);
+                        const isDisabled = !!incompatibleReason;
+
+                        const option = (
+                          <SelectOption
+                            key={is.name}
+                            value={is.name}
+                            data-testid={`model-option-${is.name}`}
+                            isDisabled={isDisabled}
+                            isSelected={
+                              form.modelSelection === 'cluster' &&
+                              form.selectedInferenceService?.name === is.name
+                            }
+                          >
+                            {is.name}
+                            {isDisabled && (
                               <Icon
                                 status="danger"
                                 iconSize="sm"
@@ -401,10 +405,18 @@ const StartEvaluationRunPage: React.FC = () => {
                               >
                                 <ExclamationCircleIcon />
                               </Icon>
-                            </Tooltip>
-                          )}
-                        </SelectOption>
-                      ))}
+                            )}
+                          </SelectOption>
+                        );
+
+                        return incompatibleReason ? (
+                          <Tooltip key={is.name} content={incompatibleReason}>
+                            <span>{option}</span>
+                          </Tooltip>
+                        ) : (
+                          option
+                        );
+                      })}
                       <Divider />
                     </>
                   ) : null}
@@ -452,6 +464,7 @@ const StartEvaluationRunPage: React.FC = () => {
               connectionValidation={form.connectionValidation}
               canVerifyConnection={form.canVerifyConnection}
               onVerifyConnection={form.handleVerifyConnection}
+              namespace={namespace}
             />
           )}
 

--- a/packages/eval-hub/frontend/src/app/types.ts
+++ b/packages/eval-hub/frontend/src/app/types.ts
@@ -439,6 +439,8 @@ export type InferenceServiceItem = {
   name: string;
   url?: string;
   ready: boolean;
+  model_format_name?: string;
+  api_protocol?: 'REST' | 'gRPC';
 };
 
 export type InferenceServicesResponse = {
@@ -462,6 +464,7 @@ export type VerifyConnectionResponse = {
   success: boolean;
   message: string;
   response_time_ms?: number;
+  openai_compatible?: boolean;
 };
 
 export type ConnectionValidationStatus = 'idle' | 'validating' | 'success' | 'error';

--- a/packages/eval-hub/frontend/src/app/utils/__tests__/modelCompatibility.spec.ts
+++ b/packages/eval-hub/frontend/src/app/utils/__tests__/modelCompatibility.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import type { InferenceServiceItem } from '~/app/types';
-import { isEvalCompatibleModel, getIncompatibleModelReason } from '../modelCompatibility';
+import { isEvalCompatibleModel, getIncompatibleModelReason } from '~/app/utils/modelCompatibility';
 
 const makeModel = (overrides: Partial<InferenceServiceItem> = {}): InferenceServiceItem => ({
   name: 'test-model',

--- a/packages/eval-hub/frontend/src/app/utils/__tests__/modelCompatibility.spec.ts
+++ b/packages/eval-hub/frontend/src/app/utils/__tests__/modelCompatibility.spec.ts
@@ -1,0 +1,100 @@
+/* eslint-disable camelcase */
+import type { InferenceServiceItem } from '~/app/types';
+import { isEvalCompatibleModel, getIncompatibleModelReason } from '../modelCompatibility';
+
+const makeModel = (overrides: Partial<InferenceServiceItem> = {}): InferenceServiceItem => ({
+  name: 'test-model',
+  ready: true,
+  ...overrides,
+});
+
+describe('isEvalCompatibleModel', () => {
+  it.each(['vLLM', 'tgis', 'HuggingFace', 'caikit', 'OpenVINO'])(
+    'returns true for compatible format %s',
+    (format) => {
+      expect(isEvalCompatibleModel(makeModel({ model_format_name: format }))).toBe(true);
+    },
+  );
+
+  it('is case-insensitive for format names', () => {
+    expect(isEvalCompatibleModel(makeModel({ model_format_name: 'VLLM' }))).toBe(true);
+    expect(isEvalCompatibleModel(makeModel({ model_format_name: 'Tgis' }))).toBe(true);
+  });
+
+  it('returns true when model_format_name is absent (legacy models)', () => {
+    expect(isEvalCompatibleModel(makeModel())).toBe(true);
+  });
+
+  it('returns true when model_format_name is empty string', () => {
+    expect(isEvalCompatibleModel(makeModel({ model_format_name: '' }))).toBe(true);
+  });
+
+  it.each(['AutoGluon', 'sklearn', 'tensorflow', 'pytorch', 'xgboost'])(
+    'returns false for incompatible format %s',
+    (format) => {
+      expect(isEvalCompatibleModel(makeModel({ model_format_name: format }))).toBe(false);
+    },
+  );
+
+  it('returns false for gRPC protocol regardless of format', () => {
+    expect(
+      isEvalCompatibleModel(makeModel({ model_format_name: 'vLLM', api_protocol: 'gRPC' })),
+    ).toBe(false);
+  });
+
+  it('returns true for REST protocol with compatible format', () => {
+    expect(
+      isEvalCompatibleModel(makeModel({ model_format_name: 'vLLM', api_protocol: 'REST' })),
+    ).toBe(true);
+  });
+
+  it('returns true when api_protocol is absent', () => {
+    expect(isEvalCompatibleModel(makeModel({ model_format_name: 'vLLM' }))).toBe(true);
+  });
+});
+
+describe('getIncompatibleModelReason', () => {
+  it('returns undefined for a compatible, ready model', () => {
+    expect(getIncompatibleModelReason(makeModel({ model_format_name: 'vLLM' }))).toBeUndefined();
+  });
+
+  it('returns undefined for a legacy model without format', () => {
+    expect(getIncompatibleModelReason(makeModel())).toBeUndefined();
+  });
+
+  it('returns not-ready reason when model is not ready', () => {
+    const reason = getIncompatibleModelReason(makeModel({ ready: false }));
+    expect(reason).toContain('unavailable');
+  });
+
+  it('returns not-ready reason even if format is also incompatible', () => {
+    const reason = getIncompatibleModelReason(
+      makeModel({ ready: false, model_format_name: 'AutoGluon' }),
+    );
+    expect(reason).toContain('unavailable');
+    expect(reason).not.toContain('AutoGluon');
+  });
+
+  it('returns format reason for incompatible model', () => {
+    const reason = getIncompatibleModelReason(makeModel({ model_format_name: 'AutoGluon' }));
+    expect(reason).toContain('AutoGluon');
+    expect(reason).toContain('not compatible');
+  });
+
+  it('returns gRPC reason for gRPC-only model', () => {
+    const reason = getIncompatibleModelReason(
+      makeModel({ model_format_name: 'vLLM', api_protocol: 'gRPC' }),
+    );
+    expect(reason).toContain('gRPC');
+    expect(reason).toContain('REST');
+  });
+
+  it('returns gRPC reason before checking format', () => {
+    const reason = getIncompatibleModelReason(
+      makeModel({ model_format_name: 'AutoGluon', api_protocol: 'gRPC' }),
+    );
+    expect(reason).toContain('gRPC');
+    expect(reason).not.toContain('AutoGluon');
+  });
+});
+/* eslint-enable camelcase */

--- a/packages/eval-hub/frontend/src/app/utils/modelCompatibility.ts
+++ b/packages/eval-hub/frontend/src/app/utils/modelCompatibility.ts
@@ -1,0 +1,31 @@
+import type { InferenceServiceItem } from '~/app/types';
+
+/**
+ * Model formats known to serve OpenAI-compatible chat/completions endpoints.
+ * Expand this set as new LLM serving runtimes are added.
+ */
+const EVAL_COMPATIBLE_FORMATS = new Set(['vllm', 'tgis', 'huggingface', 'caikit', 'openvino']);
+
+/**
+ * Returns true when we can determine that a model is compatible with
+ * evaluation benchmarks (i.e. it serves an OpenAI-compatible endpoint).
+ *
+ * When `model_format_name` is absent we treat the model as compatible
+ * to avoid blocking legacy deployments that pre-date the field.
+ */
+export const isEvalCompatibleModel = (is: InferenceServiceItem): boolean => {
+  if (!is.model_format_name) {
+    return true;
+  }
+  return EVAL_COMPATIBLE_FORMATS.has(is.model_format_name.toLowerCase());
+};
+
+export const getIncompatibleModelReason = (is: InferenceServiceItem): string | undefined => {
+  if (!is.ready) {
+    return 'This model is unavailable. Check the model\u2019s deployment status.';
+  }
+  if (!isEvalCompatibleModel(is)) {
+    return `Model format "${is.model_format_name}" is not compatible with evaluation benchmarks. Evaluations require an OpenAI-compatible chat/completions endpoint (e.g. vLLM, TGIS).`;
+  }
+  return undefined;
+};

--- a/packages/eval-hub/frontend/src/app/utils/modelCompatibility.ts
+++ b/packages/eval-hub/frontend/src/app/utils/modelCompatibility.ts
@@ -8,12 +8,18 @@ const EVAL_COMPATIBLE_FORMATS = new Set(['vllm', 'tgis', 'huggingface', 'caikit'
 
 /**
  * Returns true when we can determine that a model is compatible with
- * evaluation benchmarks (i.e. it serves an OpenAI-compatible endpoint).
+ * evaluation benchmarks (i.e. it serves an OpenAI-compatible REST endpoint).
  *
  * When `model_format_name` is absent we treat the model as compatible
  * to avoid blocking legacy deployments that pre-date the field.
+ *
+ * gRPC-only models are always incompatible because evaluation benchmarks
+ * require an OpenAI-compatible REST chat/completions endpoint.
  */
 export const isEvalCompatibleModel = (is: InferenceServiceItem): boolean => {
+  if (is.api_protocol === 'gRPC') {
+    return false;
+  }
   if (!is.model_format_name) {
     return true;
   }
@@ -23,6 +29,9 @@ export const isEvalCompatibleModel = (is: InferenceServiceItem): boolean => {
 export const getIncompatibleModelReason = (is: InferenceServiceItem): string | undefined => {
   if (!is.ready) {
     return 'This model is unavailable. Check the model\u2019s deployment status.';
+  }
+  if (is.api_protocol === 'gRPC') {
+    return 'This model uses gRPC and does not expose a REST chat/completions endpoint. Evaluations require an OpenAI-compatible REST endpoint.';
   }
   if (!isEvalCompatibleModel(is)) {
     return `Model format "${is.model_format_name}" is not compatible with evaluation benchmarks. Evaluations require an OpenAI-compatible chat/completions endpoint (e.g. vLLM, TGIS).`;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://redhat.atlassian.net/browse/RHOAIENG-76215

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
**Filter incompatible models from evaluation benchmark dropdown** 
Incompatible models (e.g. AutoGluon, sklearn) were selectable in the evaluation benchmark model picker, causing evaluation runs to fail with a HuggingFace model lookup error.

**BFF changes:**
- Extract model_format_name and api_protocol from KServe InferenceService spec (spec.predictor.model.modelFormat.name and protocolVersion)
- Return openai_compatible boolean in verify-connection response by validating the response body matches the OpenAI chat completions shape
- Unify executeAndMap/executeAndMapModel into a single method with a checkOpenAI flag

**Frontend changes:**
- Disable non-LLM models in the cluster model dropdown with a tooltip explaining the incompatibility (allowlist: vLLM, TGIS, HuggingFace, Caikit, OpenVINO)
- Add info alert on external endpoint form about OpenAI compatibility
- Auto-validate endpoint URL on blur to warn when the endpoint does notreturn an OpenAI-compatible response

<img width="769" height="622" alt="Screenshot 2026-07-21 at 10 13 04" src="https://github.com/user-attachments/assets/ec598482-ec1c-40f3-ba79-e08c31fecec7" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
on cluster and locally

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
unit and cypress test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Inference service listings now include model format name and API protocol.
  - Model selection disables incompatible options and shows an explanatory reason.
  - Endpoint URL validation now warns when an endpoint isn’t OpenAI-compatible.
  - Connection verification now returns an `openai_compatible` flag when applicable.
  - OpenAPI schema updated to reflect the new fields.

- **Bug Fixes**
  - Backward compatibility preserved for inference services missing model format metadata.

- **Tests**
  - Added unit tests for OpenAI-compatibility detection and model-compatibility rules.
  - Extended Cypress coverage for selection and warning behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->