### PR TITLE
fix(RHOAIENG-78206): allow null mean in AutoRAG pattern metric scores

### DIFF
--- a/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternComparisonSelectModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternComparisonSelectModal.tsx
@@ -42,7 +42,9 @@ const getColumns = (optimizedMetric: string): ColumnDef[] => [
     label: `${formatMetricName(optimizedMetric)} (Optimized)`,
     getValue: (p) => {
       const metric = getMetricByName(p, optimizedMetric);
-      return metric ? formatMetricValue(metric.scores.mean) : getOptimizedScore(p).toFixed(3);
+      return metric
+        ? formatMetricValue(metric.scores.mean ?? 'N/A')
+        : getOptimizedScore(p).toFixed(3);
     },
   },
   {

--- a/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternComparisonSelectModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternComparisonSelectModal.tsx
@@ -13,7 +13,6 @@ import {
   formatMetricName,
   formatMetricValue,
   formatPatternName,
-  getOptimizedScore,
   getMetricByName,
 } from '~/app/utilities/utils';
 
@@ -41,10 +40,8 @@ const getColumns = (optimizedMetric: string): ColumnDef[] => [
   {
     label: `${formatMetricName(optimizedMetric)} (Optimized)`,
     getValue: (p) => {
-      const metric = getMetricByName(p, optimizedMetric);
-      return metric
-        ? formatMetricValue(metric.scores.mean ?? 'N/A')
-        : getOptimizedScore(p).toFixed(3);
+      const mean = getMetricByName(p, optimizedMetric)?.scores.mean;
+      return mean != null ? formatMetricValue(mean) : 'N/A';
     },
   },
   {

--- a/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/components/ConfidenceIntervalChart.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/components/ConfidenceIntervalChart.tsx
@@ -67,14 +67,16 @@ const CIBarWithMarkers: React.FC<{
         />
       </Tooltip>
     )}
-    <Tooltip content={`Mean: ${score.mean.toFixed(3)}`}>
-      <CircleMarker
-        className="autorag-ci-marker m-mean"
-        style={{ left: `${score.mean * 100}%` }}
-        testId={`ci-marker-mean-${testIdPrefix}`}
-        ariaLabel={`Mean: ${score.mean.toFixed(3)}`}
-      />
-    </Tooltip>
+    {score.mean != null && (
+      <Tooltip content={`Mean: ${score.mean.toFixed(3)}`}>
+        <CircleMarker
+          className="autorag-ci-marker m-mean"
+          style={{ left: `${score.mean * 100}%` }}
+          testId={`ci-marker-mean-${testIdPrefix}`}
+          ariaLabel={`Mean: ${score.mean.toFixed(3)}`}
+        />
+      </Tooltip>
+    )}
     {score.ci_high != null && (
       <Tooltip content={`CI high: ${score.ci_high.toFixed(3)}`}>
         <DiamondMarker
@@ -200,7 +202,7 @@ const CILegend: React.FC = () => (
 );
 
 function hasData(score: AutoragPatternScoreMetric): boolean {
-  return score.mean > 0 || score.ci_low != null || score.ci_high != null;
+  return (score.mean != null && score.mean > 0) || score.ci_low != null || score.ci_high != null;
 }
 
 function getScoreEntries(scores: AutoragPatternScores): [string, AutoragPatternScoreMetric][] {

--- a/packages/autorag/frontend/src/app/hooks/__tests__/normalizePattern.spec.ts
+++ b/packages/autorag/frontend/src/app/hooks/__tests__/normalizePattern.spec.ts
@@ -168,6 +168,36 @@ describe('normalizePattern', () => {
       expect(result.settings).toEqual(v2.settings);
     });
 
+    it('should preserve null metric means through normalization', () => {
+      const v2WithNullMean: AutoragRawPatternV2 = {
+        ...v2,
+        evaluation: {
+          metrics: [
+            {
+              evaluator: 'judge',
+              name: 'answer_relevance',
+              scores: { mean: null, ci_low: null, ci_high: null },
+            },
+            {
+              evaluator: 'unitxt',
+              name: 'faithfulness',
+              scores: { mean: 0.8, ci_low: 0.7, ci_high: 0.9 },
+            },
+            {
+              evaluator: 'custom',
+              name: 'overall_score',
+              scores: { mean: 0.8, ci_low: null, ci_high: null },
+              optimization_metric: true,
+            },
+          ],
+        },
+      };
+      const result = normalizePattern(v2WithNullMean);
+      const relevance = result.evaluation.metrics.find((m) => m.name === 'answer_relevance');
+      expect(relevance?.scores.mean).toBeNull();
+      expect(result.evaluation.metrics).toHaveLength(3);
+    });
+
     it('should preserve name and top-level fields', () => {
       const result = normalizePattern(v2);
       expect(result.name).toBe('pattern0');

--- a/packages/autorag/frontend/src/app/hooks/__tests__/patternSchema.spec.ts
+++ b/packages/autorag/frontend/src/app/hooks/__tests__/patternSchema.spec.ts
@@ -88,6 +88,46 @@ describe('AutoragPatternSchema', () => {
     }
   });
 
+  it('should parse a V2 pattern with null metric mean', () => {
+    const patternWithNullMean = {
+      ...v2Pattern,
+      evaluation: {
+        metrics: [
+          {
+            evaluator: 'judge',
+            name: 'answer_relevance',
+            scores: { mean: null, ci_low: null, ci_high: null },
+          },
+          {
+            evaluator: 'unitxt',
+            name: 'faithfulness',
+            scores: { mean: 0.8, ci_low: 0.7, ci_high: 0.9 },
+          },
+          {
+            evaluator: 'custom',
+            name: 'overall_score',
+            scores: { mean: 0.8, ci_low: null, ci_high: null },
+            optimization_metric: true,
+          },
+        ],
+      },
+    };
+    const result = AutoragPatternSchema.safeParse(patternWithNullMean);
+    expect(result.success).toBe(true);
+  });
+
+  it('should parse a V1 pattern with null metric mean', () => {
+    const v1WithNullMean = {
+      ...v1Pattern,
+      scores: {
+        ...v1Pattern.scores,
+        answer_relevance: { mean: null, ci_low: null, ci_high: null },
+      },
+    };
+    const result = AutoragPatternSchema.safeParse(v1WithNullMean);
+    expect(result.success).toBe(true);
+  });
+
   it('should reject data missing required fields', () => {
     const result = AutoragPatternSchema.safeParse({ name: 'bad' });
     expect(result.success).toBe(false);

--- a/packages/autorag/frontend/src/app/hooks/patternSchema.ts
+++ b/packages/autorag/frontend/src/app/hooks/patternSchema.ts
@@ -15,7 +15,7 @@ import * as z from 'zod';
 
 const AutoragPatternScoreMetricSchema = z
   .object({
-    mean: z.number(),
+    mean: z.number().nullable(),
     ci_low: z.number().nullable(),
     ci_high: z.number().nullable(),
   })

--- a/packages/autorag/frontend/src/app/types/autoragPattern.ts
+++ b/packages/autorag/frontend/src/app/types/autoragPattern.ts
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 export type AutoragPatternScoreMetric = {
-  mean: number;
+  mean: number | null;
   ci_low: number | null;
   ci_high: number | null;
 };

--- a/packages/autorag/frontend/src/app/utilities/__tests__/utils.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/utils.spec.ts
@@ -11,6 +11,7 @@ import {
   isRunDeletable,
   parseErrorStatus,
   getOptimizedMetricForRAG,
+  getOptimizedScore,
   formatMetricValue,
   formatMetricName,
   formatPatternName,
@@ -316,6 +317,42 @@ describe('getOptimizedMetricForRAG', () => {
   it('should handle custom metric values', () => {
     const pipelineRun = createMockPipelineRun('custom_rag_metric');
     expect(getOptimizedMetricForRAG(pipelineRun)).toBe('custom_rag_metric');
+  });
+});
+
+describe('getOptimizedScore', () => {
+  const makePattern = (mean: number | null): AutoragPattern => ({
+    name: 'Pattern1',
+    iteration: 1,
+    max_combinations: 10,
+    duration_seconds: 5,
+    settings: {
+      chunking: { method: 'recursive', chunk_size: 256, chunk_overlap: 32 },
+      embedding: {
+        model_id: 'embed-model',
+        embedding_params: { embedding_dimension: 768 },
+      },
+      retrieval: { method: 'simple', number_of_chunks: 5 },
+      generation: { model_id: 'gen-model' },
+    },
+    evaluation: {
+      metrics: [
+        {
+          evaluator: 'custom',
+          name: 'overall_score',
+          scores: { mean, ci_low: null, ci_high: null },
+          optimization_metric: true,
+        },
+      ],
+    },
+  });
+
+  it('should return the optimization metric mean', () => {
+    expect(getOptimizedScore(makePattern(0.85))).toBe(0.85);
+  });
+
+  it('should return 0 when the optimization metric mean is null', () => {
+    expect(getOptimizedScore(makePattern(null))).toBe(0);
   });
 });
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78206

## Description

AutoRAG patterns fail to load when an evaluation metric (e.g. `answer_relevance` from an LLM judge) has a `null` mean score. The Zod validation schema defined `mean` as `z.number()`, which rejects `null`, causing the entire pattern to be dropped into `failedPatterns`.

This PR:
- Updates the Zod schema (`AutoragPatternScoreMetricSchema`) to accept `null` for `mean` via `z.number().nullable()`
- Updates the `AutoragPatternScoreMetric` TypeScript type to `mean: number | null`
- Adds null guards in `ConfidenceIntervalChart` (skips the mean marker when null) and `hasData()` check
- Falls back to `'N/A'` in `PatternComparisonSelectModal` when the optimized metric mean is null

http://localhost:4010/gen-ai-studio/autorag/results/tamdavid/d120cb61-f625-45ce-baf1-8394fcea9acc
<table><tr><td>Before</td><td>After</<td></tr>
<tr><td>
<img width="3008" height="1444" alt="image" src="https://github.com/user-attachments/assets/9c550b2e-855e-4467-82a8-c39b28e6b6b7" />
</td><td>
<img width="3008" height="1447" alt="image" src="https://github.com/user-attachments/assets/fc0162ac-2608-46bc-88db-27a1f5ec9970" />
</td></tr></table>

## How Has This Been Tested?

- Added unit tests for null-mean parsing in both V1 and V2 pattern schemas (`patternSchema.spec.ts`)
- Added unit test for null-mean preservation through V2 normalization (`normalizePattern.spec.ts`)
- Added unit tests for `getOptimizedScore` returning 0 when the optimization metric mean is null (`utils.spec.ts`)
- Verified TypeScript compilation passes with no errors

## Test Impact

Three existing test files were updated with new test cases:

- `patternSchema.spec.ts` — 2 new tests: V2 and V1 patterns with null metric mean parse successfully
- `normalizePattern.spec.ts` — 1 new test: null mean is preserved through V2 normalization
- `utils.spec.ts` — 2 new tests: `getOptimizedScore` returns the mean when present, falls back to 0 when mean is null

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing metric scores in pattern comparison results.
  * Displays “N/A” instead of errors when optimized metric means are unavailable.
  * Prevents missing mean values from rendering invalid chart markers or being treated as usable chart data.
  * Supports patterns with unknown or null metric means while preserving their values during processing.
  * Uses a safe fallback when optimized scores are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->