### PR TITLE
fix(eval-hub): show all MLflow experiments on run creation form

### DIFF
--- a/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
@@ -17,7 +17,6 @@ import {
   Icon,
   MenuToggle,
   PageSection,
-  Popover,
   Radio,
   Select,
   SelectList,
@@ -31,7 +30,7 @@ import {
   Flex,
   FlexItem,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Link, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import {
@@ -56,7 +55,6 @@ import type { SourceMode } from '~/app/types';
 import { getIncompatibleModelReason } from '~/app/utils/modelCompatibility';
 import {
   useStartEvaluationRunForm,
-  EXPERIMENT_FILTER,
   DEFAULT_EXPERIMENT_NAME,
   EXTERNAL_ENDPOINT_VALUE,
 } from './useStartEvaluationRunForm';
@@ -77,7 +75,6 @@ const StartEvaluationRunPage: React.FC = () => {
 
   const { data: experiments, loaded: experimentsLoaded } = useMlflowExperiments({
     workspace: namespace ?? '',
-    filter: EXPERIMENT_FILTER,
   });
 
   const {
@@ -225,29 +222,7 @@ const StartEvaluationRunPage: React.FC = () => {
               id="experiment-existing"
               data-testid="experiment-mode-existing"
               name="experiment-mode"
-              label={
-                <>
-                  Select existing experiment{' '}
-                  <Popover
-                    bodyContent={
-                      <>
-                        Only experiments that were created in MLflow and have the{' '}
-                        <b>context: evalhub</b> tag are listed here.
-                      </>
-                    }
-                  >
-                    <Button
-                      variant="plain"
-                      isInline
-                      aria-label="More info for select existing experiment"
-                      className="pf-v6-c-form__group-label-help"
-                      style={{ paddingBlock: 0 }}
-                    >
-                      <OutlinedQuestionCircleIcon />
-                    </Button>
-                  </Popover>
-                </>
-              }
+              label="Select existing experiment"
               isChecked={form.experimentMode === 'existing'}
               onChange={() => {
                 form.setExperimentMode('existing');
@@ -263,7 +238,6 @@ const StartEvaluationRunPage: React.FC = () => {
               >
                 <MlflowExperimentSelector
                   workspace={namespace}
-                  filter={EXPERIMENT_FILTER}
                   selection={form.selectedExperiment?.name}
                   onSelect={(exp) => {
                     form.setSelectedExperiment(exp);

--- a/packages/eval-hub/frontend/src/app/pages/useStartEvaluationRunForm.ts
+++ b/packages/eval-hub/frontend/src/app/pages/useStartEvaluationRunForm.ts
@@ -643,5 +643,4 @@ export function useStartEvaluationRunForm({
   };
 }
 
-export const EXPERIMENT_FILTER = "tags.context = 'eval-hub'";
 export { DEFAULT_EXPERIMENT_NAME };


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-71529

## Description

When starting a new evaluation run, the MLflow experiment selector filtered experiments by `tags.context = 'eval-hub'`. However, this tag was never being set on experiments from the frontend — `experimentTags` was hardcoded to `undefined`. This caused users to see "Error loading experiments" or an empty list even when they had valid MLflow experiments in their namespace.

This PR removes the filter so users can see and select any MLflow experiment when starting a new evaluation run. It also removes the associated popover that described the now-removed filtering behavior.

**Note:** The `context: eval-hub` tag is not consumed anywhere else in the dashboard UI — no results page, listing, or other component filters by it. The upstream EvalHub service continues to set this tag automatically on experiments it creates during job submission, so existing backend behavior is unchanged. Not adding the tag to pre-existing experiments selected by the user has no impact on UI flows.

### Why tagging existing experiments is out of scope

The original ticket also discussed automatically adding the `context: eval-hub` tag to experiments when a run is created. Investigation revealed that:

- The upstream EvalHub service already sets this tag on experiments it **creates** as part of job submission
- For **existing** experiments selected by the user, tagging them would require the eval-hub BFF to call the MLflow tracking server's `set-experiment-tag` API
- The eval-hub BFF currently has no MLflow integration — it only communicates with the upstream EvalHub service as a pass-through proxy
- Adding MLflow SDK support to the eval-hub BFF (following the pattern established by the gen-ai and mlflow BFFs which independently use `mlflow-go`) is a separate effort that should be tracked as a follow-up

## How Has This Been Tested?

- Verified all 385 existing eval-hub unit tests pass
- Confirmed the experiment selector shows all MLflow experiments on the cluster (evalhub project)
- Confirmed the evaluation run submission payload is correctly formed
- Lint-staged pre-commit hook passed with zero warnings

## Test Impact

No new tests needed — the change removes a filter constant and its usages. Existing `buildEvaluationRequest` tests and Cypress mock tests are unaffected (the Cypress intercept uses a wildcard match on the experiments endpoint).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`