### PR TITLE
External Models Event Tracking

### DIFF
--- a/frontend/src/components/table/TableRowTitleDescription.tsx
+++ b/frontend/src/components/table/TableRowTitleDescription.tsx
@@ -14,6 +14,7 @@ type TableRowTitleDescriptionProps = {
   truncateDescriptionLines?: number;
   label?: React.ReactNode;
   wrapResourceTitle?: boolean;
+  onShowPopover?: () => void;
 };
 
 const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
@@ -26,6 +27,7 @@ const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
   truncateDescriptionLines,
   label,
   wrapResourceTitle = true,
+  onShowPopover,
 }) => {
   let descriptionNode: React.ReactNode;
   if (description) {
@@ -50,7 +52,11 @@ const TableRowTitleDescription: React.FC<TableRowTitleDescriptionProps> = ({
     <div>
       <div data-testid="table-row-title">
         {resource ? (
-          <ResourceNameTooltip resource={resource} wrap={wrapResourceTitle}>
+          <ResourceNameTooltip
+            resource={resource}
+            wrap={wrapResourceTitle}
+            onShowPopover={onShowPopover}
+          >
             {title}
           </ResourceNameTooltip>
         ) : (

--- a/packages/maas/frontend/src/app/pages/external-models/AllExternalModelsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/AllExternalModelsPage.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { useNamespaceSelector } from 'mod-arch-core';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { useListExternalModels } from '~/app/hooks/useListExternalModels';
 import { ExternalModel } from '~/app/types/external-models';
+import { MaaSEvents } from '~/app/types/event-tracking';
 import EmptyExternalModelsPage from './EmptyExternalModelsPage';
 import NoProjectsPage from './NoProjectsPage';
 import {
@@ -28,8 +30,12 @@ const AllExternalModelsPage: React.FC = () => {
   );
 
   const onFilterUpdate = React.useCallback(
-    (key: string, value?: string | { label: string; value: string }) =>
-      setFilterData((prev) => ({ ...prev, [key]: value })),
+    (key: string, value?: string | { label: string; value: string }) => {
+      fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODELS_LIST_FILTERS, {
+        filterType: key,
+      });
+      setFilterData((prev) => ({ ...prev, [key]: value }));
+    },
     [],
   );
 

--- a/packages/maas/frontend/src/app/pages/external-models/AllExternalModelsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/AllExternalModelsPage.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { useNamespaceSelector } from 'mod-arch-core';
-import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { useListExternalModels } from '~/app/hooks/useListExternalModels';
 import { ExternalModel } from '~/app/types/external-models';
-import { MaaSEvents } from '~/app/types/event-tracking';
 import EmptyExternalModelsPage from './EmptyExternalModelsPage';
 import NoProjectsPage from './NoProjectsPage';
 import {
@@ -30,12 +28,8 @@ const AllExternalModelsPage: React.FC = () => {
   );
 
   const onFilterUpdate = React.useCallback(
-    (key: string, value?: string | { label: string; value: string }) => {
-      fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODELS_LIST_FILTERS, {
-        filterType: key,
-      });
-      setFilterData((prev) => ({ ...prev, [key]: value }));
-    },
+    (key: string, value?: string | { label: string; value: string }) =>
+      setFilterData((prev) => ({ ...prev, [key]: value })),
     [],
   );
 

--- a/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTableRow.tsx
@@ -3,9 +3,15 @@ import { ResourceTr } from '@odh-dashboard/ui-core';
 import TableRowTitleDescription from '@odh-dashboard/internal/components/table/TableRowTitleDescription';
 import { ActionsColumn, Tbody, Td, Tr } from '@patternfly/react-table';
 import { Button, Flex, FlexItem, Label, Stack, StackItem } from '@patternfly/react-core';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import PhaseLabel from '~/app/shared/PhaseLabel';
 import { PhaseLabelLocation, PhaseResourceType } from '~/app/utilities/phaseLabelUtils';
 import { ExternalModel, ProviderRef } from '~/app/types/external-models';
+import {
+  ExternalModelsInfoPopoverLocation,
+  ExternalModelsInfoPopoverTarget,
+  MaaSEvents,
+} from '~/app/types/event-tracking';
 import { externalModelsColumns } from './columns';
 import { GovernancePairingWarning, MissingMaaSModelRefWarning } from './const';
 import {
@@ -19,6 +25,10 @@ import ProviderURLModal from './modals/ExternalModelsProviderModal';
 import ExternalModelsExpandedTableRow from './expanded/ExternalModelsExpandedTableRow';
 
 const VISIBLE_LABEL_ROWS = 2;
+const enum ToggleLocation {
+  ARROW = 'arrow',
+  PROVIDER_LABELS = 'provider-labels',
+}
 
 type ExternalModelTableRowProps = {
   externalModel: ExternalModel;
@@ -33,11 +43,27 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
 }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [hasOverflow, setHasOverflow] = React.useState(false);
+  const [visibleLabelCount, setVisibleLabelCount] = React.useState(
+    externalModel.providerRefs.length,
+  );
   const labelsContainerRef = React.useRef<HTMLDivElement>(null);
   const [providerURLModalRef, setProviderURLModalRef] = React.useState<ProviderRef | null>(null);
   const [pathModalRef, setPathModalRef] = React.useState<ProviderRef | null>(null);
 
-  const toggleExpanded = () => {
+  const toggleExpanded = (toggleLocation: ToggleLocation) => {
+    if (!isExpanded) {
+      if (toggleLocation === ToggleLocation.ARROW) {
+        fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODEL_ROW_EXPANDED, {
+          modelStatus: externalModel.phase,
+          providerCount: externalModel.providerRefs.length,
+        });
+      } else {
+        fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODELS_PROVIDER_LABELS_EXPANDED, {
+          visibleProviderCount: visibleLabelCount,
+        });
+      }
+    }
+
     setIsExpanded((prev) => !prev);
   };
 
@@ -57,6 +83,7 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
         container.style.maxHeight = '';
         container.style.overflow = '';
         setHasOverflow(false);
+        setVisibleLabelCount(0);
         return;
       }
 
@@ -66,7 +93,12 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
       ].toSorted((a, b) => a - b);
 
       const nextHasOverflow = rowTops.length > VISIBLE_LABEL_ROWS;
+      const visibleRowTops = new Set(rowTops.slice(0, VISIBLE_LABEL_ROWS));
+      const nextVisibleCount = labels.filter((label) =>
+        visibleRowTops.has(Math.round(label.getBoundingClientRect().top)),
+      ).length;
       setHasOverflow((prev) => (prev === nextHasOverflow ? prev : nextHasOverflow));
+      setVisibleLabelCount((prev) => (prev === nextVisibleCount ? prev : nextVisibleCount));
 
       if (rowTops.length >= VISIBLE_LABEL_ROWS) {
         const lastVisibleRowTop = rowTops[VISIBLE_LABEL_ROWS - 1];
@@ -145,7 +177,7 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
             <Button
               variant="link"
               isInline
-              onClick={toggleExpanded}
+              onClick={() => toggleExpanded(ToggleLocation.PROVIDER_LABELS)}
               data-testid="external-model-providers-show-more-button"
             >
               {isExpanded ? 'Show less' : 'Show more'}
@@ -166,6 +198,12 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
             phase={externalModel.phase}
             statusMessage={getExternalModelStatusMessage(externalModel)}
             resourceType={PhaseResourceType.EXTERNAL_MODEL}
+            onClick={() => {
+              fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODELS_INFO_POPOVER_VIEWED, {
+                infoTarget: ExternalModelsInfoPopoverTarget.STATUS_LABEL,
+                location: ExternalModelsInfoPopoverLocation.TABLE_CELL,
+              });
+            }}
           />
         </FlexItem>
         {isMissingMaaSModelRef(externalModel) ? (
@@ -206,7 +244,7 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
             expand={{
               rowIndex,
               isExpanded,
-              onToggle: toggleExpanded,
+              onToggle: () => toggleExpanded(ToggleLocation.ARROW),
             }}
           />
           {nameCell}

--- a/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTableRow.tsx
@@ -144,6 +144,12 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
         description={externalModel.description ?? ''}
         truncateDescriptionLines={2}
         resource={getExternalModelResource(externalModel)}
+        onShowPopover={() => {
+          fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODELS_INFO_POPOVER_VIEWED, {
+            infoTarget: ExternalModelsInfoPopoverTarget.MODEL_REFERENCE,
+            location: ExternalModelsInfoPopoverLocation.TABLE_CELL,
+          });
+        }}
       />
     </Td>
   );

--- a/packages/maas/frontend/src/app/pages/external-models/columns.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/columns.tsx
@@ -1,5 +1,11 @@
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { SortableData } from '@odh-dashboard/ui-core';
 import * as React from 'react';
+import {
+  ExternalModelsInfoPopoverLocation,
+  MaaSEvents,
+  ExternalModelsInfoPopoverTarget,
+} from '~/app/types/event-tracking';
 import { ExternalModel } from '~/app/types/external-models';
 import { normalizePhase } from '~/app/utilities/phaseLabelUtils';
 
@@ -24,6 +30,14 @@ export const externalModelsColumns: SortableData<ExternalModel>[] = [
     info: {
       popover:
         'The provider that supplies the endpoint and credentials for this model. A model can reference multiple providers for load balancing.',
+      popoverProps: {
+        onShow: (): void => {
+          fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODELS_INFO_POPOVER_VIEWED, {
+            infoTarget: ExternalModelsInfoPopoverTarget.COLUMN_EXTERNAL_PROVIDER,
+            location: ExternalModelsInfoPopoverLocation.TABLE_HEADER,
+          });
+        },
+      },
     },
   },
   {
@@ -40,6 +54,14 @@ export const externalModelsColumns: SortableData<ExternalModel>[] = [
           hasn&apos;t been configured yet.
         </>
       ),
+      popoverProps: {
+        onShow: (): void => {
+          fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODELS_INFO_POPOVER_VIEWED, {
+            infoTarget: ExternalModelsInfoPopoverTarget.COLUMN_STATUS,
+            location: ExternalModelsInfoPopoverLocation.TABLE_HEADER,
+          });
+        },
+      },
     },
   },
 ];

--- a/packages/maas/frontend/src/app/pages/external-models/const.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/const.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { Popover, Button, Label } from '@patternfly/react-core';
 import { PendingIcon } from '@patternfly/react-icons';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  ExternalModelsInfoPopoverLocation,
+  ExternalModelsInfoPopoverTarget,
+  MaaSEvents,
+} from '~/app/types/event-tracking';
 
 export enum ExternalModelsFilterOptions {
   keyword = 'keyword',
@@ -66,6 +72,12 @@ export const GovernancePairingWarning: React.FC = () => (
       variant="plain"
       data-testid="external-model-governance-pairing-warning"
       aria-label="Awaiting governance pairing"
+      onClick={() => {
+        fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODELS_INFO_POPOVER_VIEWED, {
+          infoTarget: ExternalModelsInfoPopoverTarget.SECONDARY_STATUS,
+          location: ExternalModelsInfoPopoverLocation.TABLE_CELL,
+        });
+      }}
     >
       <Label color="purple" isCompact>
         <PendingIcon />

--- a/packages/maas/frontend/src/app/pages/external-models/expanded/ExternalModelsExpandedTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/expanded/ExternalModelsExpandedTableRow.tsx
@@ -3,11 +3,18 @@ import { ExpandableRowContent, Td, Tr } from '@patternfly/react-table';
 import { Label, Button } from '@patternfly/react-core';
 import { Table } from '@odh-dashboard/ui-core';
 import TableRowTitleDescription from '@odh-dashboard/internal/components/table/TableRowTitleDescription';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { ExternalModel, ProviderRef } from '~/app/types/external-models';
 import {
   mapAuthMechanismToHumanReadable,
   getProviderRefResource,
 } from '~/app/pages/external-models/utils';
+import {
+  ExternalModelProviderDetailType,
+  ExternalModelsInfoPopoverTarget,
+  ExternalModelsInfoPopoverLocation,
+  MaaSEvents,
+} from '~/app/types/event-tracking';
 import { ExternalModelsExpandedRowColumns } from './columns';
 
 type ExternalModelsExpandedTableRowProps = {
@@ -37,6 +44,12 @@ const ExternalModelsExpandedTableRow: React.FC<ExternalModelsExpandedTableRowPro
                   {row.provider?.displayName ?? row.providerName}
                 </Label>
               }
+              onShowPopover={() => {
+                fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODELS_INFO_POPOVER_VIEWED, {
+                  infoTarget: ExternalModelsInfoPopoverTarget.PROVIDER_REFERENCE,
+                  location: ExternalModelsInfoPopoverLocation.EXPANDED_ROW,
+                });
+              }}
               resource={getProviderRefResource(row)}
             />
           </Td>
@@ -44,7 +57,13 @@ const ExternalModelsExpandedTableRow: React.FC<ExternalModelsExpandedTableRowPro
             <Button
               variant="link"
               isInline
-              onClick={() => setProviderURLModalRef(row)}
+              onClick={() => {
+                setProviderURLModalRef(row);
+                fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODEL_PROVIDER_DETAIL_VIEWED, {
+                  providerType: row.provider?.provider,
+                  detailType: ExternalModelProviderDetailType.PROVIDER_URL,
+                });
+              }}
               data-testid={`expanded-table-row-view-url-button-${row.providerName}`}
             >
               View URL
@@ -54,7 +73,13 @@ const ExternalModelsExpandedTableRow: React.FC<ExternalModelsExpandedTableRowPro
             <Button
               variant="link"
               isInline
-              onClick={() => setPathModalRef(row)}
+              onClick={() => {
+                setPathModalRef(row);
+                fireMiscTrackingEvent(MaaSEvents.EXTERNAL_MODEL_PROVIDER_DETAIL_VIEWED, {
+                  providerType: row.provider?.provider,
+                  detailType: ExternalModelProviderDetailType.PATH,
+                });
+              }}
               data-testid={`expanded-table-row-view-path-button-${row.providerName}`}
             >
               View Path

--- a/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
+++ b/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
@@ -17,6 +17,7 @@ type PhaseLabelProps = {
   statusMessage?: React.ReactNode;
   forcePopover?: boolean;
   location: PhaseLabelLocation;
+  onClick?: () => void;
 };
 
 const PhaseLabel: React.FC<PhaseLabelProps> = ({
@@ -25,6 +26,7 @@ const PhaseLabel: React.FC<PhaseLabelProps> = ({
   statusMessage,
   forcePopover = false,
   location,
+  onClick,
 }) => {
   const normalized = normalizePhase(phase);
   const phaseProps = getPhaseProps(normalized);
@@ -38,6 +40,7 @@ const PhaseLabel: React.FC<PhaseLabelProps> = ({
       isClickable={hasPopover}
       data-testid="phase-label"
       {...phaseProps}
+      onClick={onClick}
     >
       {normalized}
     </Label>

--- a/packages/maas/frontend/src/app/types/event-tracking.ts
+++ b/packages/maas/frontend/src/app/types/event-tracking.ts
@@ -1,5 +1,6 @@
 import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
 import { PhaseLabelLocation, PhaseStatus } from '~/app/utilities/phaseLabelUtils';
+import { ExternalModelsFilterOptions } from '~/app/pages/external-models/const';
 
 export const MaaSEvents = {
   MAAS_RESOURCE_DELETED: 'MaaS Settings Resource Deleted',
@@ -12,6 +13,11 @@ export const MaaSEvents = {
   SUBSCRIPTION_MANAGEMENT_STATUS_POPOVER_VIEWED: 'Subscription Management Status Popover Viewed',
   SUBSCRIPTION_MANAGEMENT_YAML_VIEWED: 'Subscription Management YAML Viewed',
   SUBSCRIPTION_MANAGEMENT_YAML_EXPORTED: 'Subscription Management YAML Exported',
+  EXTERNAL_MODELS_LIST_FILTERS: 'External Models List Filtered',
+  EXTERNAL_MODEL_ROW_EXPANDED: 'External Model Row Expanded',
+  EXTERNAL_MODELS_PROVIDER_LABELS_EXPANDED: 'External Models Provider Labels Expanded',
+  EXTERNAL_MODELS_INFO_POPOVER_VIEWED: 'External Models Info Popover Viewed',
+  EXTERNAL_MODEL_PROVIDER_DETAIL_VIEWED: 'External Model Provider Detail Viewed',
 };
 
 export type MaaSResourceDeletedProperties = {
@@ -116,4 +122,56 @@ export enum EventTrackingFilterAttribute {
   POLICY = 'policy',
   STATUS = 'status',
   KEYWORD = 'keyword',
+}
+
+export type ExternalModelsListFiltersProperties = {
+  filterType: ExternalModelsFilterOptions;
+  statusFilters?: string[]; // not supported yet, right now we only have keyword filtering
+};
+
+export type ExternalModelRowExpandedProperties = {
+  modelStatus: PhaseStatus;
+  providerCount: number;
+};
+
+export type ExternalModelsProviderLabelsExpandedProperties = {
+  visibleProviderCount: number;
+};
+
+export type ExternalModelsInfoPopoverViewedProperties = {
+  infoTarget: ExternalModelsInfoPopoverTarget;
+  location: ExternalModelsInfoPopoverLocation;
+};
+
+export type ExternalModelProviderDetailViewedProperties = {
+  detailType: ExternalModelProviderDetailType;
+  providerType: ExternalModelProviderType;
+};
+
+export const enum ExternalModelsInfoPopoverTarget {
+  COLUMN_EXTERNAL_PROVIDER = 'column-external-provider',
+  COLUMN_STATUS = 'column-status',
+  PROVIDER_REFERENCE = 'provider-reference',
+  STATUS_LABEL = 'status-label',
+  SECONDARY_STATUS = 'secondary-status',
+}
+
+export const enum ExternalModelsInfoPopoverLocation {
+  TABLE_HEADER = 'table-header',
+  EXPANDED_ROW = 'expanded-row',
+  TABLE_CELL = 'table-cell',
+}
+
+export const enum ExternalModelProviderDetailType {
+  PROVIDER_URL = 'provider-url',
+  PATH = 'path',
+}
+
+const enum ExternalModelProviderType {
+  OPENAI = 'openai',
+  ANTHROPIC = 'anthropic',
+  AZURE = 'azure',
+  BEDROCK = 'bedrock',
+  VERTEX = 'vertex',
+  OTHER = 'other',
 }

--- a/packages/maas/frontend/src/app/types/event-tracking.ts
+++ b/packages/maas/frontend/src/app/types/event-tracking.ts
@@ -152,6 +152,7 @@ export const enum ExternalModelsInfoPopoverTarget {
   COLUMN_EXTERNAL_PROVIDER = 'column-external-provider',
   COLUMN_STATUS = 'column-status',
   PROVIDER_REFERENCE = 'provider-reference',
+  MODEL_REFERENCE = 'model-reference',
   STATUS_LABEL = 'status-label',
   SECONDARY_STATUS = 'secondary-status',
 }

--- a/packages/ui-core/src/components/ResourceNameTooltip.tsx
+++ b/packages/ui-core/src/components/ResourceNameTooltip.tsx
@@ -19,12 +19,14 @@ type ResourceNameTooltipProps = {
   resource: K8sResourceCommon;
   children: React.ReactNode;
   wrap?: boolean;
+  onShowPopover?: () => void;
 };
 
 const ResourceNameTooltip: React.FC<ResourceNameTooltipProps> = ({
   children,
   resource,
   wrap = true,
+  onShowPopover,
 }) => (
   <div style={{ display: wrap ? 'block' : 'inline-flex' }}>
     <Flex
@@ -36,6 +38,11 @@ const ResourceNameTooltip: React.FC<ResourceNameTooltipProps> = ({
       {resource.metadata?.name && (
         <Popover
           position="right"
+          onShow={(): void => {
+            if (onShowPopover) {
+              onShowPopover();
+            }
+          }}
           bodyContent={
             <Stack hasGutter>
               <StackItem>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-77909](https://redhat.atlassian.net/browse/RHOAIENG-77909)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- [ ] External Models List Filtered
- [ ] External Model Row Expanded
- [ ] External Models Labels Expanded
- [ ] External Models Info Popover Viewed
  - [ ] external provider column popover 
  - [ ] status column popover 
  - [ ] status label
  - [ ] secondary status label
  - [ ] provider resource popover
- [ ] External Models Provider Detail Viewed

Event tracking [doc](https://docs.google.com/document/d/1G-29qIJAq6f7JBTewaJ_-LgXgiAfIVWFLCgFIkfcNiw/edit?tab=t.ceaawjqcdf81#heading=h.x5u745kkxxi9)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally

to test:
- open your console
- try filtering
- expand a row using the arrow
- expand a row using the 'show more' button (you need a model with enough providers to see that button)
- click the `?` buttons in the columns
- click the status labels
- open the 'view url' and 'view path' modals
- click the `?` button next to the provider name

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-77909]: https://redhat.atlassian.net/browse/RHOAIENG-77909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interaction tracking for the External Models table, including filter use, row expansion, provider label expansion, info popover views, and provider detail views.
  * Added event reporting when users open info popovers from table headers, rows, status labels, and governance warnings.
  * Enabled popover/tooltip open callbacks so related UI actions can record analytics when overlays appear.

* **User Experience**
  * Expanded rows now distinguish between expanding via the arrow vs. provider labels, including visible provider counts.
  * “View URL” and “View Path” actions still open their respective details while recording usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->