### PR TITLE
fix(automl,autorag): fix chart color mismatch on curve toggle and CI marker clipping

### DIFF
--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/components/EvaluationCurveChart.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/components/EvaluationCurveChart.tsx
@@ -78,9 +78,10 @@ const CursorVoronoiContainer = createContainer('cursor', 'voronoi');
 // These singletons bridge that gap.
 const chartState: {
   curveLines: CurveLine[];
+  isMulticlass: boolean;
   xMetricLabel: string;
   yMetricLabel: string;
-} = { curveLines: [], xMetricLabel: '', yMetricLabel: '' };
+} = { curveLines: [], isMulticlass: false, xMetricLabel: '', yMetricLabel: '' };
 
 const TOOLTIP_ROW_H = 16;
 const TOOLTIP_PAD = 10;
@@ -126,13 +127,13 @@ const CurveChartTooltip = ({
   const formattedX = datum.x.toFixed(4);
   const dotX = AXIS_LEFT + datum.x * PLOT_WIDTH;
   const lines = chartState.curveLines;
-  const isBinary = lines.length === 1;
+  const isBinary = !chartState.isMulticlass;
 
   const seriesPoints: SeriesPoint[] = isBinary
     ? [{ label: datum.name, index: 0, y: datum.y }]
-    : lines.map((line, idx) => ({
+    : lines.map((line) => ({
         label: line.label,
-        index: idx,
+        index: line.points[0]?.index ?? 0,
         y: findYAtX(line.points, datum.x),
       }));
 
@@ -268,6 +269,7 @@ const EvaluationCurveChart: React.FC<EvaluationCurveChartProps> = ({
   );
 
   chartState.curveLines = visibleLines;
+  chartState.isMulticlass = curveLines.length > 1;
   chartState.xMetricLabel = xMetricLabel;
   chartState.yMetricLabel = yMetricLabel;
 

--- a/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternDetailsModal.scss
+++ b/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternDetailsModal.scss
@@ -189,7 +189,7 @@
   --autorag-ci--label-width: 160px;
 
   margin-top: var(--pf-t--global--spacer--xl);
-  padding-left: var(--pf-t--global--spacer--lg);
+  padding-inline: var(--pf-t--global--spacer--lg);
 }
 
 .autorag-ci-scores__header {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-78026

## Description

Fixes two visual bugs in AutoML and AutoRAG run results charts:

**AutoML — Evaluation curve chart color mismatch (ROC / Precision-Recall):**
When toggling curves off via the legend eye-toggle in multiclass mode, the tooltip dot colors would mismatch the rendered curve colors. Two issues:
1. `isBinary` was derived from `visibleLines.length === 1` (filtered lines), so hiding all but one curve in a multiclass chart incorrectly switched the tooltip to binary mode.
2. The tooltip used the positional index of the visible/filtered array to look up colors, but ChartLine stroke colors use the original index in the full `curveLines` array.


https://github.com/user-attachments/assets/92774e5e-3888-46a9-9af2-d9113d3dce4d

**AutoRAG — CI marker clipping:**
The `.autorag-ci-scores` container only had `padding-left`, so confidence interval markers near the right edge were clipped. Changed to `padding-inline` to pad both sides.

<img width="830" height="633" alt="Screenshot 2026-07-20 at 2 17 30 PM" src="https://github.com/user-attachments/assets/7e3da70c-bbfc-4b4e-914e-df9ef05d20d3" />


## How Has This Been Tested?

Manually tested with multiclass classification results — toggled curves on/off and verified tooltip dot colors match rendered curve colors in all toggle combinations. Verified CI markers render without clipping on both edges.

## Test Impact

No new tests added. The tooltip rendering logic depends on Victory's internal component model which is difficult to unit test in isolation. The existing `EvaluationCurveChart.spec.tsx` covers the `findYAtX` interpolation utility. A follow-up could extract the `seriesPoints` derivation into a testable pure function.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`