### PR TITLE
fix(operator): preserve module params.env and skip operator self-deletion

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/deployment.yaml
+++ b/dashboard-operator/charts/dashboard/templates/deployment.yaml
@@ -84,6 +84,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: OPERATOR_DEPLOYMENT_NAME
+              value: {{ include "dashboard.deploymentName" . }}
             {{- range $name, $value := .Values.relatedImages }}
             {{- if $value }}
             - name: {{ $name }}

--- a/dashboard-operator/internal/controller/actions.go
+++ b/dashboard-operator/internal/controller/actions.go
@@ -43,7 +43,7 @@ func applyKustomizeParams(dashboard *v1alpha1.Dashboard, manifests []render.Mani
 
 	for _, m := range manifests {
 		manifestPath := m.String()
-		params := readExistingParams(manifestPath + "/params.env")
+		params := readExistingParams(filepath.Join(manifestPath, "params.env"))
 		maps.Copy(params, computed)
 		if err := writeParamsEnv(manifestPath, params); err != nil {
 			return fmt.Errorf("failed to write params.env to %s: %w", manifestPath, err)
@@ -55,7 +55,7 @@ func applyKustomizeParams(dashboard *v1alpha1.Dashboard, manifests []render.Mani
 		if _, err := os.Stat(modArchPath); os.IsNotExist(err) {
 			return fmt.Errorf("modular-architecture directory not found at %s", modArchPath)
 		}
-		params := readExistingParams(modArchPath + "/params.env")
+		params := readExistingParams(filepath.Join(modArchPath, "params.env"))
 		maps.Copy(params, computed)
 		if err := writeParamsEnv(modArchPath, params); err != nil {
 			return fmt.Errorf("failed to write params.env to %s: %w", modArchPath, err)

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -33,7 +34,15 @@ import (
 
 const dashboardFinalizer = "components.platform.opendatahub.io/cleanup"
 const conditionObservabilityAvailable = "ObservabilityAvailable"
-const operatorDeploymentName = "dashboard-operator"
+
+var operatorDeploymentName = getOperatorDeploymentName()
+
+func getOperatorDeploymentName() string {
+	if name := os.Getenv("OPERATOR_DEPLOYMENT_NAME"); name != "" {
+		return name
+	}
+	return "dashboard-operator"
+}
 
 var persesdashboardGVK = schema.GroupVersionKind{
 	Group:   "perses.dev",

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -33,6 +33,7 @@ import (
 
 const dashboardFinalizer = "components.platform.opendatahub.io/cleanup"
 const conditionObservabilityAvailable = "ObservabilityAvailable"
+const operatorDeploymentName = "dashboard-operator"
 
 var persesdashboardGVK = schema.GroupVersionKind{
 	Group:   "perses.dev",
@@ -638,8 +639,18 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 
 	var deployments appsv1.DeploymentList
-	if err := deleteTyped(&deployments, "Deployment", matchLabels, inNamespace); err != nil {
-		return err
+	if err := r.List(ctx, &deployments, matchLabels, inNamespace); err != nil {
+		return fmt.Errorf("listing Deployments: %w", err)
+	}
+	for i := range deployments.Items {
+		dep := &deployments.Items[i]
+		if dep.Name == operatorDeploymentName {
+			continue
+		}
+		logger.Info("Deleting managed resource", "kind", "Deployment", "name", dep.Name)
+		if err := r.Delete(ctx, dep); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("deleting Deployment %s: %w", dep.Name, err)
+		}
 	}
 
 	var services corev1.ServiceList

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -44,6 +44,15 @@ func getOperatorDeploymentName() string {
 	return "dashboard-operator"
 }
 
+func operatorOwnedResourceNames() map[string]bool {
+	base := operatorDeploymentName
+	return map[string]bool{
+		base:                  true,
+		base + "-role":        true,
+		base + "-rolebinding": true,
+	}
+}
+
 var persesdashboardGVK = schema.GroupVersionKind{
 	Group:   "perses.dev",
 	Version: "v1alpha1",
@@ -672,9 +681,21 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 		return err
 	}
 
+	operatorResources := operatorOwnedResourceNames()
+
 	var serviceAccounts corev1.ServiceAccountList
-	if err := deleteTyped(&serviceAccounts, "ServiceAccount", matchLabels, inNamespace); err != nil {
-		return err
+	if err := r.List(ctx, &serviceAccounts, matchLabels, inNamespace); err != nil {
+		return fmt.Errorf("listing ServiceAccounts: %w", err)
+	}
+	for i := range serviceAccounts.Items {
+		sa := &serviceAccounts.Items[i]
+		if operatorResources[sa.Name] {
+			continue
+		}
+		logger.Info("Deleting managed resource", "kind", "ServiceAccount", "name", sa.Name)
+		if err := r.Delete(ctx, sa); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("deleting ServiceAccount %s: %w", sa.Name, err)
+		}
 	}
 
 	var secrets corev1.SecretList
@@ -698,13 +719,33 @@ func (r *DashboardReconciler) teardownManagedResources(ctx context.Context, dash
 	}
 
 	var clusterRoles rbacv1.ClusterRoleList
-	if err := deleteTyped(&clusterRoles, "ClusterRole", matchLabels); err != nil {
-		return err
+	if err := r.List(ctx, &clusterRoles, matchLabels); err != nil {
+		return fmt.Errorf("listing ClusterRoles: %w", err)
+	}
+	for i := range clusterRoles.Items {
+		cr := &clusterRoles.Items[i]
+		if operatorResources[cr.Name] {
+			continue
+		}
+		logger.Info("Deleting managed resource", "kind", "ClusterRole", "name", cr.Name)
+		if err := r.Delete(ctx, cr); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("deleting ClusterRole %s: %w", cr.Name, err)
+		}
 	}
 
 	var clusterRoleBindings rbacv1.ClusterRoleBindingList
-	if err := deleteTyped(&clusterRoleBindings, "ClusterRoleBinding", matchLabels); err != nil {
-		return err
+	if err := r.List(ctx, &clusterRoleBindings, matchLabels); err != nil {
+		return fmt.Errorf("listing ClusterRoleBindings: %w", err)
+	}
+	for i := range clusterRoleBindings.Items {
+		crb := &clusterRoleBindings.Items[i]
+		if operatorResources[crb.Name] {
+			continue
+		}
+		logger.Info("Deleting managed resource", "kind", "ClusterRoleBinding", "name", crb.Name)
+		if err := r.Delete(ctx, crb); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("deleting ClusterRoleBinding %s: %w", crb.Name, err)
+		}
 	}
 
 	if err := r.cleanupCrossNamespaceResources(ctx, dashboard); err != nil {

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -871,6 +871,49 @@ func TestReconcile_PlatformVersionHandshake(t *testing.T) {
 }
 
 func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
+	tests := []struct {
+		name        string
+		deployName  string
+		operatorDep string
+		operatorSA  string
+		operatorCR  string
+		operatorCRB string
+		deletedDep  string
+		deletedSA   string
+		deletedCR   string
+		deletedCRB  string
+	}{
+		{
+			name:        "default (kustomize)",
+			deployName:  "dashboard-operator",
+			operatorDep: "dashboard-operator", operatorSA: "dashboard-operator",
+			operatorCR: "dashboard-operator-role", operatorCRB: "dashboard-operator-rolebinding",
+			deletedDep: "odh-dashboard", deletedSA: "odh-dashboard-sa",
+			deletedCR: "odh-dashboard-role", deletedCRB: "odh-dashboard-rolebinding",
+		},
+		{
+			name:        "helm prefix (production)",
+			deployName:  "odh-dashboard-operator",
+			operatorDep: "odh-dashboard-operator", operatorSA: "odh-dashboard-operator",
+			operatorCR: "odh-dashboard-operator-role", operatorCRB: "odh-dashboard-operator-rolebinding",
+			deletedDep: "odh-dashboard", deletedSA: "odh-dashboard-sa",
+			deletedCR: "odh-dashboard-role", deletedCRB: "odh-dashboard-rolebinding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := ctrlpkg.SetOperatorDeploymentName(tt.deployName)
+			t.Cleanup(restore)
+
+			runPreservesOperatorResourcesTest(t, tt.operatorDep, tt.operatorSA, tt.operatorCR, tt.operatorCRB,
+				tt.deletedDep, tt.deletedSA, tt.deletedCR, tt.deletedCRB)
+		})
+	}
+}
+
+func runPreservesOperatorResourcesTest(t *testing.T, opDep, opSA, opCR, opCRB, delDep, delSA, delCR, delCRB string) {
+	t.Helper()
 	s := testScheme(t)
 
 	dashboard := &v1alpha1.Dashboard{
@@ -886,7 +929,7 @@ func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
 
 	operatorDep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dashboard-operator",
+			Name:      opDep,
 			Namespace: testNamespace,
 			Labels:    dashboardLabel,
 		},
@@ -894,7 +937,7 @@ func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
 
 	dashboardDep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "odh-dashboard",
+			Name:      delDep,
 			Namespace: testNamespace,
 			Labels:    dashboardLabel,
 		},
@@ -902,7 +945,7 @@ func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
 
 	operatorSA := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dashboard-operator",
+			Name:      opSA,
 			Namespace: testNamespace,
 			Labels:    dashboardLabel,
 		},
@@ -910,7 +953,7 @@ func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
 
 	dashboardSA := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "odh-dashboard-sa",
+			Name:      delSA,
 			Namespace: testNamespace,
 			Labels:    dashboardLabel,
 		},
@@ -918,28 +961,28 @@ func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
 
 	operatorCR := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "dashboard-operator-role",
+			Name:   opCR,
 			Labels: dashboardLabel,
 		},
 	}
 
 	dashboardCR := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "odh-dashboard-role",
+			Name:   delCR,
 			Labels: dashboardLabel,
 		},
 	}
 
 	operatorCRB := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "dashboard-operator-rolebinding",
+			Name:   opCRB,
 			Labels: dashboardLabel,
 		},
 	}
 
 	dashboardCRB := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "odh-dashboard-rolebinding",
+			Name:   delCRB,
 			Labels: dashboardLabel,
 		},
 	}
@@ -974,8 +1017,8 @@ func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
 	for i := range deps.Items {
 		depNames = append(depNames, deps.Items[i].Name)
 	}
-	assert.Contains(t, depNames, "dashboard-operator", "operator deployment must survive teardown")
-	assert.NotContains(t, depNames, "odh-dashboard", "non-operator deployments must be deleted")
+	assert.Contains(t, depNames, opDep, "operator deployment must survive teardown")
+	assert.NotContains(t, depNames, delDep, "non-operator deployments must be deleted")
 
 	var sas corev1.ServiceAccountList
 	require.NoError(t, cli.List(ctx, &sas, client.InNamespace(testNamespace)))
@@ -983,8 +1026,8 @@ func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
 	for i := range sas.Items {
 		saNames = append(saNames, sas.Items[i].Name)
 	}
-	assert.Contains(t, saNames, "dashboard-operator", "operator SA must survive teardown")
-	assert.NotContains(t, saNames, "odh-dashboard-sa", "non-operator SAs must be deleted")
+	assert.Contains(t, saNames, opSA, "operator SA must survive teardown")
+	assert.NotContains(t, saNames, delSA, "non-operator SAs must be deleted")
 
 	var crs rbacv1.ClusterRoleList
 	require.NoError(t, cli.List(ctx, &crs))
@@ -992,8 +1035,8 @@ func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
 	for i := range crs.Items {
 		crNames = append(crNames, crs.Items[i].Name)
 	}
-	assert.Contains(t, crNames, "dashboard-operator-role", "operator ClusterRole must survive teardown")
-	assert.NotContains(t, crNames, "odh-dashboard-role", "non-operator ClusterRoles must be deleted")
+	assert.Contains(t, crNames, opCR, "operator ClusterRole must survive teardown")
+	assert.NotContains(t, crNames, delCR, "non-operator ClusterRoles must be deleted")
 
 	var crbs rbacv1.ClusterRoleBindingList
 	require.NoError(t, cli.List(ctx, &crbs))
@@ -1001,8 +1044,8 @@ func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
 	for i := range crbs.Items {
 		crbNames = append(crbNames, crbs.Items[i].Name)
 	}
-	assert.Contains(t, crbNames, "dashboard-operator-rolebinding", "operator ClusterRoleBinding must survive teardown")
-	assert.NotContains(t, crbNames, "odh-dashboard-rolebinding", "non-operator ClusterRoleBindings must be deleted")
+	assert.Contains(t, crbNames, opCRB, "operator ClusterRoleBinding must survive teardown")
+	assert.NotContains(t, crbNames, delCRB, "non-operator ClusterRoleBindings must be deleted")
 }
 
 func boolPtr(b bool) *bool {

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -866,6 +867,67 @@ func TestReconcile_PlatformVersionHandshake(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcile_Removed_PreservesOperatorDeployment(t *testing.T) {
+	s := testScheme(t)
+
+	dashboard := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       v1alpha1.DashboardInstanceName,
+			Finalizers: []string{"components.platform.opendatahub.io/cleanup"},
+		},
+		Spec: v1alpha1.DashboardSpec{},
+	}
+	dashboard.Spec.ManagementState = "Removed"
+
+	operatorDep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dashboard-operator",
+			Namespace: testNamespace,
+			Labels:    map[string]string{labels.PlatformPartOf: "dashboard"},
+		},
+	}
+
+	dashboardDep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-dashboard",
+			Namespace: testNamespace,
+			Labels:    map[string]string{labels.PlatformPartOf: "dashboard"},
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dashboard, operatorDep, dashboardDep).
+		WithStatusSubresource(dashboard).
+		Build()
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		ManifestsBasePath:     t.TempDir(),
+		Platform:              cluster.OpenDataHub,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	var deps appsv1.DeploymentList
+	require.NoError(t, cli.List(context.Background(), &deps, client.InNamespace(testNamespace)))
+
+	var names []string
+	for _, d := range deps.Items {
+		names = append(names, d.Name)
+	}
+	assert.Contains(t, names, "dashboard-operator", "operator deployment must survive teardown")
+	assert.NotContains(t, names, "odh-dashboard", "non-operator deployments must be deleted during teardown")
 }
 
 func boolPtr(b bool) *bool {

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -869,7 +870,7 @@ func TestReconcile_PlatformVersionHandshake(t *testing.T) {
 	}
 }
 
-func TestReconcile_Removed_PreservesOperatorDeployment(t *testing.T) {
+func TestReconcile_Removed_PreservesOperatorResources(t *testing.T) {
 	s := testScheme(t)
 
 	dashboard := &v1alpha1.Dashboard{
@@ -881,11 +882,13 @@ func TestReconcile_Removed_PreservesOperatorDeployment(t *testing.T) {
 	}
 	dashboard.Spec.ManagementState = "Removed"
 
+	dashboardLabel := map[string]string{labels.PlatformPartOf: "dashboard"}
+
 	operatorDep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "dashboard-operator",
 			Namespace: testNamespace,
-			Labels:    map[string]string{labels.PlatformPartOf: "dashboard"},
+			Labels:    dashboardLabel,
 		},
 	}
 
@@ -893,13 +896,57 @@ func TestReconcile_Removed_PreservesOperatorDeployment(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "odh-dashboard",
 			Namespace: testNamespace,
-			Labels:    map[string]string{labels.PlatformPartOf: "dashboard"},
+			Labels:    dashboardLabel,
+		},
+	}
+
+	operatorSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dashboard-operator",
+			Namespace: testNamespace,
+			Labels:    dashboardLabel,
+		},
+	}
+
+	dashboardSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-dashboard-sa",
+			Namespace: testNamespace,
+			Labels:    dashboardLabel,
+		},
+	}
+
+	operatorCR := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "dashboard-operator-role",
+			Labels: dashboardLabel,
+		},
+	}
+
+	dashboardCR := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "odh-dashboard-role",
+			Labels: dashboardLabel,
+		},
+	}
+
+	operatorCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "dashboard-operator-rolebinding",
+			Labels: dashboardLabel,
+		},
+	}
+
+	dashboardCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "odh-dashboard-rolebinding",
+			Labels: dashboardLabel,
 		},
 	}
 
 	cli := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(dashboard, operatorDep, dashboardDep).
+		WithObjects(dashboard, operatorDep, dashboardDep, operatorSA, dashboardSA, operatorCR, dashboardCR, operatorCRB, dashboardCRB).
 		WithStatusSubresource(dashboard).
 		Build()
 
@@ -919,15 +966,43 @@ func TestReconcile_Removed_PreservesOperatorDeployment(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
 
-	var deps appsv1.DeploymentList
-	require.NoError(t, cli.List(context.Background(), &deps, client.InNamespace(testNamespace)))
+	ctx := context.Background()
 
-	var names []string
-	for _, d := range deps.Items {
-		names = append(names, d.Name)
+	var deps appsv1.DeploymentList
+	require.NoError(t, cli.List(ctx, &deps, client.InNamespace(testNamespace)))
+	var depNames []string
+	for i := range deps.Items {
+		depNames = append(depNames, deps.Items[i].Name)
 	}
-	assert.Contains(t, names, "dashboard-operator", "operator deployment must survive teardown")
-	assert.NotContains(t, names, "odh-dashboard", "non-operator deployments must be deleted during teardown")
+	assert.Contains(t, depNames, "dashboard-operator", "operator deployment must survive teardown")
+	assert.NotContains(t, depNames, "odh-dashboard", "non-operator deployments must be deleted")
+
+	var sas corev1.ServiceAccountList
+	require.NoError(t, cli.List(ctx, &sas, client.InNamespace(testNamespace)))
+	var saNames []string
+	for i := range sas.Items {
+		saNames = append(saNames, sas.Items[i].Name)
+	}
+	assert.Contains(t, saNames, "dashboard-operator", "operator SA must survive teardown")
+	assert.NotContains(t, saNames, "odh-dashboard-sa", "non-operator SAs must be deleted")
+
+	var crs rbacv1.ClusterRoleList
+	require.NoError(t, cli.List(ctx, &crs))
+	var crNames []string
+	for i := range crs.Items {
+		crNames = append(crNames, crs.Items[i].Name)
+	}
+	assert.Contains(t, crNames, "dashboard-operator-role", "operator ClusterRole must survive teardown")
+	assert.NotContains(t, crNames, "odh-dashboard-role", "non-operator ClusterRoles must be deleted")
+
+	var crbs rbacv1.ClusterRoleBindingList
+	require.NoError(t, cli.List(ctx, &crbs))
+	var crbNames []string
+	for i := range crbs.Items {
+		crbNames = append(crbNames, crbs.Items[i].Name)
+	}
+	assert.Contains(t, crbNames, "dashboard-operator-rolebinding", "operator ClusterRoleBinding must survive teardown")
+	assert.NotContains(t, crbNames, "odh-dashboard-rolebinding", "non-operator ClusterRoleBindings must be deleted")
 }
 
 func boolPtr(b bool) *bool {

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -1,0 +1,7 @@
+package controller
+
+func SetOperatorDeploymentName(name string) (restore func()) {
+	old := operatorDeploymentName
+	operatorDeploymentName = name
+	return func() { operatorDeploymentName = old }
+}

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -133,7 +133,7 @@ func (r *DashboardReconciler) deployModuleManifests(
 			continue
 		}
 
-		params := make(map[string]string, len(computed))
+		params := readExistingParams(modulePath + "/params.env")
 		maps.Copy(params, computed)
 		addInterBFFParams(params, name, statuses, r.Platform)
 		if err := writeParamsEnv(modulePath, params); err != nil {

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -133,7 +133,7 @@ func (r *DashboardReconciler) deployModuleManifests(
 			continue
 		}
 
-		params := readExistingParams(modulePath + "/params.env")
+		params := readExistingParams(filepath.Join(modulePath, "params.env"))
 		maps.Copy(params, computed)
 		addInterBFFParams(params, name, statuses, r.Platform)
 		if err := writeParamsEnv(modulePath, params); err != nil {

--- a/dashboard-operator/internal/controller/support.go
+++ b/dashboard-operator/internal/controller/support.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -124,5 +125,5 @@ func writeParamsEnv(manifestPath string, params map[string]string) error {
 		sb.WriteString(params[k])
 		sb.WriteString("\n")
 	}
-	return os.WriteFile(manifestPath+"/params.env", []byte(sb.String()), 0600)
+	return os.WriteFile(filepath.Join(manifestPath, "params.env"), []byte(sb.String()), 0600)
 }

--- a/dashboard-operator/internal/controller/support_test.go
+++ b/dashboard-operator/internal/controller/support_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -168,4 +169,24 @@ func TestWriteParamsEnv(t *testing.T) {
 
 	expected := "alpha=a\nmid=m\nzebra=z\n"
 	assert.Equal(t, expected, string(data), "params must be sorted alphabetically")
+}
+
+func TestParamsPreservation(t *testing.T) {
+	dir := t.TempDir()
+
+	existing := "module-specific-key=module-value\nshared-key=original\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "params.env"), []byte(existing), 0644))
+
+	params := readExistingParams(filepath.Join(dir, "params.env"))
+	computed := map[string]string{
+		"computed-key": "computed-value",
+		"shared-key":   "overwritten-by-computed",
+	}
+	maps.Copy(params, computed)
+	require.NoError(t, writeParamsEnv(dir, params))
+
+	result := readExistingParams(filepath.Join(dir, "params.env"))
+	assert.Equal(t, "module-value", result["module-specific-key"], "existing module-specific params must be preserved")
+	assert.Equal(t, "computed-value", result["computed-key"], "computed params must be added")
+	assert.Equal(t, "overwritten-by-computed", result["shared-key"], "computed params must take precedence over existing")
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78293
https://issues.redhat.com/browse/RHOAIENG-78294

## Description

Fixes two bugs in the dashboard-operator controller:

**[RHOAIENG-78293](https://redhat.atlassian.net/browse/RHOAIENG-78293) — Module params.env wiped on every reconciliation**

`deployModuleManifests` was creating a fresh empty map (`make(map[string]string, len(computed))`) instead of reading the existing module `params.env` before merging computed values. This caused module-specific kustomize variables (set by the module's own manifests) to be wiped on every reconcile loop. The fix calls `readExistingParams()` first, then merges computed values on top — matching the pattern already used in `actions.go` for the main dashboard manifests.

**[RHOAIENG-78294](https://redhat.atlassian.net/browse/RHOAIENG-78294) — Operator deletes itself during managementState: Removed teardown**

`teardownManagedResources` used the generic `deleteTyped` helper for Deployments, which deletes ALL label-matched Deployments including the operator's own (since it carries the same `platform.opendatahub.io/part-of=dashboard` label). When an admin sets `managementState: Removed`, the operator deleted itself, preventing any future recovery. The fix manually iterates Deployments and skips the `dashboard-operator` Deployment by name.

## How Has This Been Tested?

**Unit tests:**
- Added `TestParamsPreservation` — verifies `readExistingParams` + `maps.Copy` preserves existing module params while computed values take precedence.
- Added `TestReconcile_Removed_PreservesOperatorDeployment` — creates a Dashboard CR with `managementState: Removed`, two Deployments (operator + dashboard), runs Reconcile, and verifies the operator Deployment survives while non-operator Deployments are deleted.
- `make test` and `make lint` pass.

**Cluster validation (ROSA - ui-monarch-rosa):**

1. Deployed the operator image `quay.io/lferrnan/odh-dashboard-operator:rhoaieng-78293` to an ODH cluster.
2. **[RHOAIENG-78293](https://redhat.atlassian.net/browse/RHOAIENG-78293) validation**: After reconciliation, verified `gen-ai` module's `params.env` contains `pgvector-image=registry.redhat.io/rhel9/postgresql-16` (the module-specific value that was being wiped). All module-specific defaults, inter-BFF params, and computed dashboard variables are correctly merged. All modules deployed without kustomize var resolution errors.
3. **[RHOAIENG-78294](https://redhat.atlassian.net/browse/RHOAIENG-78294) validation**: Set `managementState: Removed`. Before teardown: 9 Deployments with the dashboard label. After teardown: only `dashboard-operator` remains (1/9). The operator pod stayed `Running` (1/1) and successfully wrote `Ready=False, reason=Removed` to the Dashboard CR status. Restored to `Managed` — operator recovered and re-deployed all resources.

## Test Impact

- Added `TestParamsPreservation` in `support_test.go` — covers the params merge behavior for [RHOAIENG-78293](https://redhat.atlassian.net/browse/RHOAIENG-78293).
- Added `TestReconcile_Removed_PreservesOperatorDeployment` in `dashboard_reconciler_test.go` — covers the operator self-preservation during teardown for [RHOAIENG-78294](https://redhat.atlassian.net/browse/RHOAIENG-78294).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-78293]: https://redhat.atlassian.net/browse/RHOAIENG-78293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-78294]: https://redhat.atlassian.net/browse/RHOAIENG-78294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-78293]: https://redhat.atlassian.net/browse/RHOAIENG-78293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented operator-owned Deployments, ServiceAccounts, ClusterRoles, and ClusterRoleBindings from being removed during dashboard cleanup by using an explicit operator Deployment name.
  * Preserved existing module-specific `params.env` keys while updating computed configuration values.
  * Improved `params.env` path handling for more reliable file writing across environments.
* **Tests**
  * Added coverage to ensure operator resources remain when a dashboard is marked as removed, and that `params.env` key preservation works correctly.
* **Documentation**
  * Deployment templates now expose `OPERATOR_DEPLOYMENT_NAME` via an environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->