### PR TITLE
WIP: Fix WebSocket disconnects by upgrading SDK utils and setting rbac-proxy upstream-timeout

### DIFF
--- a/distributions/rhaii/package.json
+++ b/distributions/rhaii/package.json
@@ -21,7 +21,7 @@
     "@odh-dashboard/model-serving": "*",
     "@odh-dashboard/plugin-core": "*",
     "@openshift/dynamic-plugin-sdk": "^5.0.1",
-    "@openshift/dynamic-plugin-sdk-utils": "^5.0.0",
+    "@openshift/dynamic-plugin-sdk-utils": "^5.0.2",
     "@patternfly/patternfly": "^6.4.0",
     "@patternfly/react-code-editor": "^6.4.0",
     "@patternfly/react-core": "^6.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,7 +71,7 @@
     "@odh-dashboard/model-serving": "*",
     "@openshift/dynamic-plugin-sdk": "^5.0.1",
     "@openshift/dynamic-plugin-sdk-extensions": "^1.4.1",
-    "@openshift/dynamic-plugin-sdk-utils": "^5.0.1",
+    "@openshift/dynamic-plugin-sdk-utils": "^5.0.2",
     "@patternfly/chatbot": "6.4.0",
     "@patternfly/patternfly": "6.4.0",
     "@patternfly/quickstarts": "6.4.0",

--- a/manifests/core-bases/base/deployment.yaml
+++ b/manifests/core-bases/base/deployment.yaml
@@ -86,6 +86,7 @@ spec:
           args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://localhost:8080
+            - --upstream-timeout=0
             - --config-file=/etc/kube-rbac-proxy/config-file.yaml
             - --tls-cert-file=/etc/tls/private/tls.crt
             - --tls-private-key-file=/etc/tls/private/tls.key

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       ],
       "dependencies": {
         "@kubernetes/client-node": "^0.12.3",
-        "@openshift/dynamic-plugin-sdk-utils": "^5.0.1",
+        "@openshift/dynamic-plugin-sdk-utils": "^5.0.2",
         "@types/tar": "^6.1.13",
         "jsonpath-plus": "^10.4.0",
         "tough-cookie": "^4.1.4",
@@ -193,7 +193,7 @@
         "@odh-dashboard/model-serving": "*",
         "@odh-dashboard/plugin-core": "*",
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@openshift/dynamic-plugin-sdk-utils": "^5.0.0",
+        "@openshift/dynamic-plugin-sdk-utils": "^5.0.2",
         "@patternfly/patternfly": "^6.4.0",
         "@patternfly/react-code-editor": "^6.4.0",
         "@patternfly/react-core": "^6.4.1",
@@ -246,7 +246,7 @@
         "@odh-dashboard/model-serving": "*",
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
         "@openshift/dynamic-plugin-sdk-extensions": "^1.4.1",
-        "@openshift/dynamic-plugin-sdk-utils": "^5.0.1",
+        "@openshift/dynamic-plugin-sdk-utils": "^5.0.2",
         "@patternfly/chatbot": "6.4.0",
         "@patternfly/patternfly": "6.4.0",
         "@patternfly/quickstarts": "6.4.0",
@@ -6441,21 +6441,20 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk-utils": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-utils/-/dynamic-plugin-sdk-utils-5.0.1.tgz",
-      "integrity": "sha512-R6gDQy8pyBGbhWNlvmJLgI7gC+UMaWy6stizT9H7D4eXhrxdfSs4on295dEcjKNK1wXb1mpX3TXa0duSjoKBmw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-utils/-/dynamic-plugin-sdk-utils-5.0.2.tgz",
+      "integrity": "sha512-AucGfWpWz1cq7ZUtu4cNhXDQr5koHBaQGgFcHaMfWizsVsv2Ynsq1RYjkavPUapk0cI7Cn5nOWFrQcTK8Y7R6g==",
       "license": "Apache-2.0",
       "dependencies": {
         "immutable": "^3.8.2",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "pluralize": "^8.0.0",
         "typesafe-actions": "^4.4.2",
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "@openshift/dynamic-plugin-sdk": "^4 || ^5",
-        "@openshift/dynamic-plugin-sdk-extensions": "^1.4.0",
-        "react": "^17 || ^18",
+        "@openshift/dynamic-plugin-sdk": "^4 || ^5 || ^6 || ^7 || ^8",
+        "react": "^18 || ^19",
         "react-redux": "^7 || ^8",
         "redux": "^4.1.2",
         "redux-thunk": "^2.4.1"
@@ -36739,7 +36738,7 @@
         "@odh-dashboard/model-registry": "*",
         "@odh-dashboard/model-training": "*",
         "@odh-dashboard/plugin-core": "*",
-        "@openshift/dynamic-plugin-sdk-utils": "^5.0.1",
+        "@openshift/dynamic-plugin-sdk-utils": "^5.0.2",
         "@testing-library/cypress": "^10.0.1",
         "@testing-library/dom": "^9.3.4",
         "@types/chai-subset": "^1.3.5",
@@ -37075,7 +37074,7 @@
       "dependencies": {
         "@odh-dashboard/foundation": "*",
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@openshift/dynamic-plugin-sdk-utils": "^5.0.0",
+        "@openshift/dynamic-plugin-sdk-utils": "^5.0.2",
         "lodash-es": "^4.18.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.12.3",
-    "@openshift/dynamic-plugin-sdk-utils": "^5.0.1",
+    "@openshift/dynamic-plugin-sdk-utils": "^5.0.2",
     "@types/tar": "^6.1.13",
     "jsonpath-plus": "^10.4.0",
     "tough-cookie": "^4.1.4",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -33,7 +33,7 @@
     "@odh-dashboard/model-registry": "*",
     "@odh-dashboard/model-training": "*",
     "@odh-dashboard/plugin-core": "*",
-    "@openshift/dynamic-plugin-sdk-utils": "^5.0.1",
+    "@openshift/dynamic-plugin-sdk-utils": "^5.0.2",
     "@testing-library/cypress": "^10.0.1",
     "@testing-library/dom": "^9.3.4",
     "@types/chai-subset": "^1.3.5",

--- a/packages/k8s-core/package.json
+++ b/packages/k8s-core/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@odh-dashboard/foundation": "*",
     "@openshift/dynamic-plugin-sdk": "^5.0.1",
-    "@openshift/dynamic-plugin-sdk-utils": "^5.0.0",
+    "@openshift/dynamic-plugin-sdk-utils": "^5.0.2",
     "lodash-es": "^4.18.1"
   },
   "devDependencies": {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-69309

## Description

WebSocket K8s watch connections were closing every ~30s (`1006`) during quiet periods, so the UI went stale (e.g. project creation spinning) until a full refresh.

**Root cause:** Traffic to the dashboard goes through the `kube-rbac-proxy` sidecar (`Service:8443` → proxy → `localhost:8080`). That binary defaults `--upstream-timeout` to **30s**. Idle watches with no upstream response activity were aborted on that timer. This was misattributed earlier to HAProxy/Istio; on the affected cluster those already had long/disabled timeouts for this path.

A second issue prevented recovery after the backend’s intentional stale cleanup (5 minutes, close `1001`): `@openshift/dynamic-plugin-sdk-utils` **v5.0.1** leaves `WebSocketFactory.connectionAttempt` at `-1` (truthy), so `reconnect()` never runs. Fixed in **v5.0.2**.

**Changes:**

- Set `--upstream-timeout=0` on the dashboard `kube-rbac-proxy` container so long-lived watches are not cut at the 30s default (connection lifetime stays owned by the backend stale cleanup + client reconnect)
- Bump `@openshift/dynamic-plugin-sdk-utils` from `^5.0.1` to `^5.0.2` so the client reconnects after backend-initiated stale closes

## How Has This Been Tested?

- Confirmed on a ROSA cluster that closes correlated with `kube-rbac-proxy`’s default 30s `--upstream-timeout` (not HAProxy/Envoy route timeouts)
- After setting `--upstream-timeout=0`, watches should remain open past 30s of idle traffic; after 5 minutes of inactivity the backend still closes with `1001` and the SDK reconnects

## Test Impact

- No new automated tests for the manifest flag change (deployment arg only)
- SDK bump covered by upstream release; reconnect behavior is best validated manually against a cluster with quiet watches

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`