### PR TITLE
fix: keep K8s websocket watches alive [RHOAIENG-69309]

### DIFF
--- a/backend/src/__tests__/websocket-proxy.spec.ts
+++ b/backend/src/__tests__/websocket-proxy.spec.ts
@@ -3,7 +3,6 @@ import { KubeFastifyInstance, OauthFastifyRequest } from '../types';
 import wssK8sRoutes, {
   CONNECTION_TIMEOUT_MS,
   HEARTBEAT_INTERVAL_MS,
-  STALE_CONNECTION_MS,
 } from '../routes/wss/k8s/index';
 import { getDirectCallOptions, getAccessToken } from '../utils/directCallUtils';
 
@@ -111,12 +110,6 @@ describe('WebSocket K8s Proxy', () => {
 
       expect(mockFastify.get).toHaveBeenCalledWith('/*', { websocket: true }, expect.any(Function));
     });
-
-    it('should register cleanup hook for server shutdown', async () => {
-      await wssK8sRoutes(mockFastify);
-
-      expect(mockFastify.addHook).toHaveBeenCalledWith('onClose', expect.any(Function));
-    });
   });
 
   describe('Connection Timeout', () => {
@@ -180,6 +173,7 @@ describe('WebSocket K8s Proxy', () => {
       jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
 
       expect(mockTargetSocket.ping).toHaveBeenCalled();
+      expect(mockSourceSocket.ping).toHaveBeenCalled();
     });
 
     it('should send pings at regular intervals', async () => {
@@ -194,12 +188,15 @@ describe('WebSocket K8s Proxy', () => {
       // Advance through multiple heartbeat intervals
       jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
       expect(mockTargetSocket.ping).toHaveBeenCalledTimes(1);
+      expect(mockSourceSocket.ping).toHaveBeenCalledTimes(1);
 
       jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
       expect(mockTargetSocket.ping).toHaveBeenCalledTimes(2);
+      expect(mockSourceSocket.ping).toHaveBeenCalledTimes(2);
 
       jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
       expect(mockTargetSocket.ping).toHaveBeenCalledTimes(3);
+      expect(mockSourceSocket.ping).toHaveBeenCalledTimes(3);
     });
 
     it('should not ping when socket is not OPEN', async () => {
@@ -213,16 +210,19 @@ describe('WebSocket K8s Proxy', () => {
 
       // First heartbeat with socket OPEN
       jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
-      const pingsWhileOpen = mockTargetSocket.ping.mock.calls.length;
+      const targetPingsWhileOpen = mockTargetSocket.ping.mock.calls.length;
+      const sourcePingsWhileOpen = mockSourceSocket.ping.mock.calls.length;
 
       // Change socket state to CLOSING
       mockTargetSocket.readyState = WebSocket.CLOSING;
+      mockSourceSocket.readyState = WebSocket.CLOSING;
 
       // Next heartbeat with socket CLOSING
       jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
 
       // Should not have sent additional pings
-      expect(mockTargetSocket.ping.mock.calls.length).toBe(pingsWhileOpen);
+      expect(mockTargetSocket.ping.mock.calls.length).toBe(targetPingsWhileOpen);
+      expect(mockSourceSocket.ping.mock.calls.length).toBe(sourcePingsWhileOpen);
     });
 
     it('should stop heartbeat after connection closes', async () => {
@@ -236,7 +236,8 @@ describe('WebSocket K8s Proxy', () => {
 
       // First heartbeat
       jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
-      const firstPingCount = mockTargetSocket.ping.mock.calls.length;
+      const firstTargetPingCount = mockTargetSocket.ping.mock.calls.length;
+      const firstSourcePingCount = mockSourceSocket.ping.mock.calls.length;
 
       // Close connection
       const closeHandler = mockSourceSocket.on.mock.calls.find(
@@ -248,7 +249,8 @@ describe('WebSocket K8s Proxy', () => {
       jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 3);
 
       // No more pings
-      expect(mockTargetSocket.ping.mock.calls.length).toBe(firstPingCount);
+      expect(mockTargetSocket.ping.mock.calls.length).toBe(firstTargetPingCount);
+      expect(mockSourceSocket.ping.mock.calls.length).toBe(firstSourcePingCount);
     });
   });
 
@@ -618,113 +620,9 @@ describe('WebSocket K8s Proxy', () => {
     });
   });
 
-  describe('Stale Connection Cleanup', () => {
-    it('should periodically clean up stale connections', async () => {
-      await wssK8sRoutes(mockFastify);
-      routeHandler = (mockFastify.get as jest.Mock).mock.calls[0][2];
-
-      // Create a connection
-      await routeHandler(mockConnection, mockRequest);
-
-      // Advance time to trigger cleanup (runs every minute)
-      jest.advanceTimersByTime(60000);
-
-      // Connection is still active, so no cleanup warning yet
-      expect(mockLog.warn).not.toHaveBeenCalledWith(
-        expect.anything(),
-        expect.stringContaining('Closing stale websocket connection'),
-      );
-
-      // Advance time beyond stale threshold
-      jest.advanceTimersByTime(STALE_CONNECTION_MS);
-      jest.advanceTimersByTime(60000); // Trigger another cleanup cycle
-
-      // Now stale connection should be cleaned up
-      expect(mockLog.warn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          inactivityDuration: expect.any(Number),
-        }),
-        expect.stringContaining('Closing stale websocket connection'),
-      );
-    });
-
-    /**
-     * This test verifies the fix for the zombie connection bug:
-     *
-     * When a connection becomes stale, both websockets are now properly closed
-     * so that the client receives the close event and can reconnect.
-     */
-    it('should close websockets when cleaning up stale connections', async () => {
-      await wssK8sRoutes(mockFastify);
-      routeHandler = (mockFastify.get as jest.Mock).mock.calls[0][2];
-
-      // Create a connection
-      await routeHandler(mockConnection, mockRequest);
-
-      // Verify sockets haven't been closed yet
-      expect(mockSourceSocket.close).not.toHaveBeenCalled();
-      expect(mockTargetSocket.close).not.toHaveBeenCalled();
-
-      // Let connection become stale (advance past threshold + cleanup cycle)
-      jest.advanceTimersByTime(STALE_CONNECTION_MS + 60000);
-
-      // Verify stale cleanup ran
-      expect(mockLog.warn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          inactivityDuration: expect.any(Number),
-        }),
-        expect.stringContaining('Closing stale websocket connection'),
-      );
-
-      // Both websockets should be closed with code 1001 (Going Away)
-      expect(mockSourceSocket.close).toHaveBeenCalledWith(
-        1001,
-        'Connection stale due to inactivity',
-      );
-      expect(mockTargetSocket.close).toHaveBeenCalledWith(
-        1001,
-        'Connection stale due to inactivity',
-      );
-    });
-
-    /**
-     * This test verifies that heartbeat intervals are properly cleared
-     * when cleaning up stale connections.
-     */
-    it('should clear heartbeat interval when cleaning up stale connections', async () => {
-      await wssK8sRoutes(mockFastify);
-      routeHandler = (mockFastify.get as jest.Mock).mock.calls[0][2];
-
-      // Create a connection
-      await routeHandler(mockConnection, mockRequest);
-
-      // Simulate connection opening to start heartbeat
-      const openHandler = mockTargetSocket.on.mock.calls.find(
-        (call: any) => call[0] === 'open',
-      )?.[1];
-      openHandler();
-
-      // Verify heartbeat is running
-      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
-      expect(mockTargetSocket.ping).toHaveBeenCalledTimes(1);
-
-      // Advance time beyond stale threshold + cleanup cycle
-      jest.advanceTimersByTime(STALE_CONNECTION_MS + 60000);
-
-      // After cleanup, heartbeat should be stopped - no more pings
-      const pingCountAfterCleanup = mockTargetSocket.ping.mock.calls.length;
-      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 3);
-      expect(mockTargetSocket.ping.mock.calls.length).toBe(pingCountAfterCleanup);
-    });
-  });
-
   describe('Configuration Constants', () => {
     it('should have connection timeout less than heartbeat interval', () => {
       expect(CONNECTION_TIMEOUT_MS).toBeLessThan(HEARTBEAT_INTERVAL_MS);
-    });
-
-    it('should have heartbeat interval less than stale connection threshold', () => {
-      expect(HEARTBEAT_INTERVAL_MS).toBeLessThan(STALE_CONNECTION_MS);
     });
   });
 });

--- a/backend/src/routes/wss/k8s/index.ts
+++ b/backend/src/routes/wss/k8s/index.ts
@@ -49,8 +49,6 @@ const waitConnection = (socket: WebSocket, write: () => void) => {
 // Connection metrics for monitoring
 type ConnectionMetrics = {
   created: number;
-  lastMessageReceived: number;
-  lastMessageSent: number;
   messagesReceived: number;
   messagesSent: number;
   lastResourceVersion?: string;
@@ -70,63 +68,9 @@ const activeConnections = new Map<string, TrackedConnection>();
 
 // Constants for connection management (exported for testing)
 export const CONNECTION_TIMEOUT_MS = 10000; // 10 seconds to establish connection
-export const HEARTBEAT_INTERVAL_MS = 15000; // 15 seconds between heartbeats
-export const STALE_CONNECTION_MS = 300000; // 5 minutes of inactivity
-
-// Periodic cleanup of stale connections
-const cleanupStaleConnections = (fastify: KubeFastifyInstance) => {
-  const now = Date.now();
-  let cleanedCount = 0;
-
-  for (const [connectionId, tracked] of activeConnections.entries()) {
-    const { metrics, source, target, kubeUri, heartbeatInterval } = tracked;
-    const inactivityDuration = now - Math.max(metrics.lastMessageReceived, metrics.lastMessageSent);
-
-    if (inactivityDuration > STALE_CONNECTION_MS) {
-      fastify.log.warn(
-        {
-          connectionId,
-          inactivityDuration,
-          messagesReceived: metrics.messagesReceived,
-          messagesSent: metrics.messagesSent,
-          duration: now - metrics.created,
-        },
-        `Closing stale websocket connection: ${kubeUri}`,
-      );
-
-      // Clear heartbeat interval if it exists
-      if (heartbeatInterval) {
-        clearInterval(heartbeatInterval);
-      }
-
-      // Close both websockets so the client receives the close event and can reconnect
-      // Use code 1001 (going away) to indicate the server is closing due to inactivity
-      closeWebSocket(source, 1001, 'Connection stale due to inactivity');
-      closeWebSocket(target, 1001, 'Connection stale due to inactivity');
-
-      activeConnections.delete(connectionId);
-      cleanedCount++;
-    }
-  }
-
-  if (cleanedCount > 0) {
-    fastify.log.info(
-      `Cleaned up ${cleanedCount} stale connection(s). Active: ${activeConnections.size}`,
-    );
-  }
-};
+export const HEARTBEAT_INTERVAL_MS = 30000; // 30 seconds between heartbeats (matches OpenShift Console)
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
-  // Start periodic cleanup of stale connections
-  const cleanupInterval = setInterval(() => {
-    cleanupStaleConnections(fastify);
-  }, 60000); // Run every minute
-
-  // Clean up on server shutdown
-  fastify.addHook('onClose', async () => {
-    clearInterval(cleanupInterval);
-  });
-
   fastify.get(
     '/*',
     { websocket: true },
@@ -148,11 +92,8 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         }/${kubeUri}?${new URLSearchParams(req.query)}`;
 
         // Initialize connection metrics
-        const now = Date.now();
         const metrics: ConnectionMetrics = {
-          created: now,
-          lastMessageReceived: now,
-          lastMessageSent: now,
+          created: Date.now(),
           messagesReceived: 0,
           messagesSent: 0,
         };
@@ -265,16 +206,26 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
             `WebSocket connection established to K8s API: ${kubeUri}`,
           );
 
-          // Start heartbeat monitoring
+          // Ping both sides to keep the connection alive through proxies/load balancers
+          // (OpenShift Console pings the client every 30s for the same reason).
           tracked.heartbeatInterval = setInterval(() => {
-            // Send ping to keep connection alive
             if (target.readyState === WebSocket.OPEN) {
               try {
                 target.ping();
               } catch (error) {
                 fastify.log.error(
                   { connectionId, error: error.message },
-                  `Failed to send ping: ${error.message}`,
+                  `Failed to send ping to K8s API: ${error.message}`,
+                );
+              }
+            }
+            if (source.readyState === WebSocket.OPEN) {
+              try {
+                source.ping();
+              } catch (error) {
+                fastify.log.error(
+                  { connectionId, error: error.message },
+                  `Failed to send ping to client: ${error.message}`,
                 );
               }
             }
@@ -283,7 +234,6 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
 
         // Handle messages from K8s API to client
         target.on('message', (data, binary) => {
-          metrics.lastMessageReceived = Date.now();
           metrics.messagesReceived++;
 
           // Try to extract resourceVersion from watch events for diagnostics
@@ -314,7 +264,6 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
             try {
               source.send(data, { binary });
               metrics.messagesSent++;
-              metrics.lastMessageSent = Date.now();
             } catch (error) {
               fastify.log.error(
                 {

--- a/manifests/core-bases/base/deployment.yaml
+++ b/manifests/core-bases/base/deployment.yaml
@@ -86,6 +86,7 @@ spec:
           args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://localhost:8080
+            - --upstream-timeout=0
             - --config-file=/etc/kube-rbac-proxy/config-file.yaml
             - --tls-cert-file=/etc/tls/private/tls.crt
             - --tls-private-key-file=/etc/tls/private/tls.key


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-69309

## Description
Create Project modal can spin forever after a successful create because the project watch websocket drops and never reconnects (SDK reconnect is broken upstream).

Root cause of the disconnects: kube-rbac-proxy's default 30s upstream timeout closes idle watches. After that, our backend stale-connection handler (5 min) also tears down quiet watches — which would not be needed if SDK reconnect worked.

This PR:
- Sets `--upstream-timeout=0` on kube-rbac-proxy so idle watches are not closed
- Removes the backend stale websocket cleanup path
- Pings both client and K8s sides on the heartbeat interval to keep proxies happy

Upstream SDK reconnect fix still needed separately: https://github.com/openshift/dynamic-plugin-sdk/pull/330

Once we can successfully reconnect with an update to dynamic-plugin-sdk-utils, we could re-establish a timeout at the nodejs backend or on the kube-rbac-proxy.

## How Has This Been Tested?
- Unit tests updated/passed for websocket proxy (`backend/src/__tests__/websocket-proxy.spec.ts`)
- Manual cluster verification pending post-CI image

## Test Impact
- Removed stale-connection unit tests (behavior removed)
- Extended heartbeat tests to assert pings to both source and target sockets

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection reliability by sending heartbeat signals to both client and Kubernetes connections.
  * Prevented unnecessary heartbeat activity when connections are closing or already closed.
  * Kept heartbeat processing active for longer-lived connections.
  * Updated proxy timeout handling to avoid premature upstream request termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->