### PR TITLE
fix(ConnectedWorkbenchesLink): implement loading skeleton and update …

### DIFF
--- a/packages/feature-store/src/components/ConnectedWorkbenchesLink.tsx
+++ b/packages/feature-store/src/components/ConnectedWorkbenchesLink.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button, Skeleton, Tooltip } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons';
 import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
 import { useAccessAllowed } from '@odh-dashboard/internal/concepts/userSSAR/useAccessAllowed';
@@ -30,7 +30,7 @@ const ConnectedWorkbenchesLink: React.FC = () => {
       variant="link"
       icon={<WrenchIcon />}
       iconPosition="start"
-      isDisabled={!projectsLoaded || !!projectsError}
+      isDisabled={!!projectsError}
       isAriaDisabled={hasNoProjects}
       onClick={() => setIsModalOpen(true)}
       className="pf-v6-u-font-weight-bold"
@@ -51,7 +51,11 @@ const ConnectedWorkbenchesLink: React.FC = () => {
 
   return (
     <>
-      {content}
+      {!projectsLoaded ? (
+        <Skeleton data-testid="skeleton-loader" style={{ width: 200 }} />
+      ) : (
+        content
+      )}
       {isModalOpen && (
         <ConnectedWorkbenchesModal
           onClose={() => setIsModalOpen(false)}

--- a/packages/feature-store/src/components/ConnectedWorkbenchesLink.tsx
+++ b/packages/feature-store/src/components/ConnectedWorkbenchesLink.tsx
@@ -51,11 +51,7 @@ const ConnectedWorkbenchesLink: React.FC = () => {
 
   return (
     <>
-      {!projectsLoaded ? (
-        <Skeleton data-testid="skeleton-loader" style={{ width: 200 }} />
-      ) : (
-        content
-      )}
+      {!projectsLoaded ? <Skeleton data-testid="skeleton-loader" width="200px" /> : content}
       {isModalOpen && (
         <ConnectedWorkbenchesModal
           onClose={() => setIsModalOpen(false)}

--- a/packages/feature-store/src/components/__tests__/ConnectedWorkbenchesLink.spec.tsx
+++ b/packages/feature-store/src/components/__tests__/ConnectedWorkbenchesLink.spec.tsx
@@ -166,7 +166,7 @@ describe('ConnectedWorkbenchesLink', () => {
   });
 
   describe('loading state', () => {
-    it('should render disabled without tooltip while projects are loading', () => {
+    it('should render a loading skeleton while projects are loading', () => {
       mockUseAccessAllowed.mockReturnValue([false, false]);
       mockUseFeatureStoreAccessibleProjects.mockReturnValue({
         accessibleProjects: [],
@@ -176,8 +176,8 @@ describe('ConnectedWorkbenchesLink', () => {
 
       render(<ConnectedWorkbenchesLink />);
 
-      const button = screen.getByTestId('connected-workbenches-link');
-      expect(button).toBeDisabled();
+      expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
+      expect(screen.queryByTestId('connected-workbenches-link')).not.toBeInTheDocument();
       expect(screen.queryByText(/To connect a workbench/)).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
…button state logic

closes - https://redhat.atlassian.net/browse/RHOAIENG-78077


## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds loading indicator or animation to the View connected workbenches button on Feature Store pages


https://github.com/user-attachments/assets/dd8e3e3f-3c3c-47b7-b38e-d97e928eced9



## How Has This Been Tested?


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a visible loading placeholder while connected workbench information is loading.
  * Prevented the connected workbenches link from appearing before project data is available.
  * Preserved error-state handling when project loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->