### PR TITLE
feat(model-registry): add Agents Catalog Segment tracking

### DIFF
--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/__tests__/tracking.spec.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/__tests__/tracking.spec.ts
@@ -1,0 +1,62 @@
+import {
+  buildAgentDetailsNavigationState,
+  countActiveAgentFilters,
+  getAgentFilterDisplayValue,
+  getToggledFilterValue,
+  isAgentCatalogDetailsNavigationState,
+} from '~/app/pages/agentsCatalog/tracking';
+
+describe('agentsCatalog tracking helpers', () => {
+  describe('countActiveAgentFilters', () => {
+    it('counts selected values across filter groups', () => {
+      expect(countActiveAgentFilters({})).toBe(0);
+      expect(countActiveAgentFilters({ framework: ['langgraph', 'crewai'] })).toBe(2);
+      expect(countActiveAgentFilters({ framework: [] })).toBe(0);
+    });
+  });
+
+  describe('getAgentFilterDisplayValue', () => {
+    it('maps known framework values to display labels', () => {
+      expect(getAgentFilterDisplayValue('framework', 'langgraph')).toBe('LangGraph');
+      expect(getAgentFilterDisplayValue('framework', 'unknown-framework')).toBe(
+        'unknown-framework',
+      );
+    });
+  });
+
+  describe('getToggledFilterValue', () => {
+    it('returns the added value when checking a filter', () => {
+      expect(getToggledFilterValue(['langgraph'], ['langgraph', 'crewai'])).toBe('crewai');
+    });
+
+    it('returns the removed value when unchecking a filter', () => {
+      expect(getToggledFilterValue(['langgraph', 'crewai'], ['langgraph'])).toBe('crewai');
+    });
+
+    it('returns undefined when nothing changed', () => {
+      expect(getToggledFilterValue(['langgraph'], ['langgraph'])).toBeUndefined();
+    });
+  });
+
+  describe('buildAgentDetailsNavigationState', () => {
+    it('builds catalog_card navigation state for details tracking', () => {
+      expect(buildAgentDetailsNavigationState(2, { framework: ['langgraph'] }, 'rag', 12)).toEqual({
+        entrySource: 'catalog_card',
+        positionIndex: 2,
+        hasActiveFilters: true,
+        countActiveFilters: 1,
+        hasSearchQuery: true,
+        resultCount: 12,
+      });
+    });
+  });
+
+  describe('isAgentCatalogDetailsNavigationState', () => {
+    it('validates known entry sources', () => {
+      expect(isAgentCatalogDetailsNavigationState({ entrySource: 'catalog_card' })).toBe(true);
+      expect(isAgentCatalogDetailsNavigationState({ entrySource: 'direct_url' })).toBe(true);
+      expect(isAgentCatalogDetailsNavigationState({ entrySource: 'other' })).toBe(false);
+      expect(isAgentCatalogDetailsNavigationState(null)).toBe(false);
+    });
+  });
+});

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/components/AgentsCatalogActiveFilters.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/components/AgentsCatalogActiveFilters.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ToolbarFilter, ToolbarLabel, ToolbarLabelGroup } from '@patternfly/react-core';
+import { useUserInteraction } from '~/concepts/userInteraction';
 import { AgentsCatalogContext } from '~/app/context/agentsCatalog/AgentsCatalogContext';
 import type { AgentFilterCategoryKey } from '~/app/pages/agentsCatalog/types/agentsCatalogFilterOptions';
 import {
@@ -7,27 +8,46 @@ import {
   AGENT_FILTER_CATEGORY_NAMES,
   AGENT_LABEL_MAPPINGS,
 } from '~/app/pages/agentsCatalog/const';
+import {
+  AGENT_CATALOG_EVENTS,
+  countActiveAgentFilters,
+  getAgentFilterDisplayValue,
+} from '~/app/pages/agentsCatalog/tracking';
 
 const AgentsCatalogActiveFilters: React.FC = () => {
+  const { trackSimpleEvent } = useUserInteraction();
   const { filters, setFilters } = React.useContext(AgentsCatalogContext);
 
   const handleRemoveFilter = React.useCallback(
     (categoryKey: AgentFilterCategoryKey, valueKey: string) => {
-      setFilters((prev) => {
-        const current = prev[categoryKey];
-        const arr = Array.isArray(current) ? current : [];
-        const newValues = arr.filter((v) => v !== valueKey);
-        return { ...prev, [categoryKey]: newValues };
+      const current = filters[categoryKey];
+      const arr = Array.isArray(current) ? current : [];
+      const nextFilters = { ...filters, [categoryKey]: arr.filter((v) => v !== valueKey) };
+      setFilters(nextFilters);
+      trackSimpleEvent(AGENT_CATALOG_EVENTS.FILTER_APPLIED, {
+        filterType: categoryKey,
+        filterValue: getAgentFilterDisplayValue(categoryKey, valueKey),
+        countActiveFilters: countActiveAgentFilters(nextFilters),
       });
     },
-    [setFilters],
+    [filters, setFilters, trackSimpleEvent],
   );
 
   const handleClearCategory = React.useCallback(
     (categoryKey: AgentFilterCategoryKey) => {
-      setFilters((prev) => ({ ...prev, [categoryKey]: [] }));
+      const current = filters[categoryKey];
+      const arr = Array.isArray(current) ? current : [];
+      const nextFilters = { ...filters, [categoryKey]: [] };
+      setFilters(nextFilters);
+      arr.forEach((valueKey) => {
+        trackSimpleEvent(AGENT_CATALOG_EVENTS.FILTER_APPLIED, {
+          filterType: categoryKey,
+          filterValue: getAgentFilterDisplayValue(categoryKey, valueKey),
+          countActiveFilters: countActiveAgentFilters(nextFilters),
+        });
+      });
     },
-    [setFilters],
+    [filters, setFilters, trackSimpleEvent],
   );
 
   return (

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/components/AgentsCatalogActiveFilters.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/components/AgentsCatalogActiveFilters.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { ToolbarFilter, ToolbarLabel, ToolbarLabelGroup } from '@patternfly/react-core';
-import { useUserInteraction } from '~/concepts/userInteraction';
 import { AgentsCatalogContext } from '~/app/context/agentsCatalog/AgentsCatalogContext';
 import type { AgentFilterCategoryKey } from '~/app/pages/agentsCatalog/types/agentsCatalogFilterOptions';
 import {
@@ -8,46 +7,27 @@ import {
   AGENT_FILTER_CATEGORY_NAMES,
   AGENT_LABEL_MAPPINGS,
 } from '~/app/pages/agentsCatalog/const';
-import {
-  AGENT_CATALOG_EVENTS,
-  countActiveAgentFilters,
-  getAgentFilterDisplayValue,
-} from '~/app/pages/agentsCatalog/tracking';
 
 const AgentsCatalogActiveFilters: React.FC = () => {
-  const { trackSimpleEvent } = useUserInteraction();
   const { filters, setFilters } = React.useContext(AgentsCatalogContext);
 
   const handleRemoveFilter = React.useCallback(
     (categoryKey: AgentFilterCategoryKey, valueKey: string) => {
-      const current = filters[categoryKey];
-      const arr = Array.isArray(current) ? current : [];
-      const nextFilters = { ...filters, [categoryKey]: arr.filter((v) => v !== valueKey) };
-      setFilters(nextFilters);
-      trackSimpleEvent(AGENT_CATALOG_EVENTS.FILTER_APPLIED, {
-        filterType: categoryKey,
-        filterValue: getAgentFilterDisplayValue(categoryKey, valueKey),
-        countActiveFilters: countActiveAgentFilters(nextFilters),
+      setFilters((prev) => {
+        const current = prev[categoryKey];
+        const arr = Array.isArray(current) ? current : [];
+        const newValues = arr.filter((v) => v !== valueKey);
+        return { ...prev, [categoryKey]: newValues };
       });
     },
-    [filters, setFilters, trackSimpleEvent],
+    [setFilters],
   );
 
   const handleClearCategory = React.useCallback(
     (categoryKey: AgentFilterCategoryKey) => {
-      const current = filters[categoryKey];
-      const arr = Array.isArray(current) ? current : [];
-      const nextFilters = { ...filters, [categoryKey]: [] };
-      setFilters(nextFilters);
-      arr.forEach((valueKey) => {
-        trackSimpleEvent(AGENT_CATALOG_EVENTS.FILTER_APPLIED, {
-          filterType: categoryKey,
-          filterValue: getAgentFilterDisplayValue(categoryKey, valueKey),
-          countActiveFilters: countActiveAgentFilters(nextFilters),
-        });
-      });
+      setFilters((prev) => ({ ...prev, [categoryKey]: [] }));
     },
-    [filters, setFilters, trackSimpleEvent],
+    [setFilters],
   );
 
   return (

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/components/AgentsCatalogCard.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/components/AgentsCatalogCard.tsx
@@ -16,9 +16,11 @@ import type { Agent } from '~/app/agentsCatalogTypes';
 import { getAgentsCatalogDetailsRoute } from '~/app/routes/agentsCatalog/agentsCatalog';
 import AgentsCatalogIcon from '~/app/pages/agentsCatalog/AgentsCatalogIcon';
 import { AGENT_FRAMEWORK_LABEL_MAPPING } from '~/app/pages/agentsCatalog/const';
+import type { AgentCatalogDetailsNavigationState } from '~/app/pages/agentsCatalog/tracking';
 
 type AgentsCatalogCardProps = {
   agent: Agent;
+  detailsNavigationState?: AgentCatalogDetailsNavigationState;
 };
 
 const AgentFallbackIcon: React.FC = () => (
@@ -30,79 +32,89 @@ const AgentFallbackIcon: React.FC = () => (
   </span>
 );
 
-const AgentsCatalogCard: React.FC<AgentsCatalogCardProps> = React.memo(({ agent }) => {
-  const agentId = agent.id;
-  const frameworkDisplay = agent.framework
-    ? (AGENT_FRAMEWORK_LABEL_MAPPING[agent.framework] ?? agent.framework)
-    : undefined;
-  const cardLabels = [frameworkDisplay, ...(agent.labels ?? [])].filter(Boolean);
-  const [logoFailed, setLogoFailed] = React.useState(false);
+const AgentsCatalogCard: React.FC<AgentsCatalogCardProps> = React.memo(
+  ({ agent, detailsNavigationState }) => {
+    const agentId = agent.id;
+    const frameworkDisplay = agent.framework
+      ? (AGENT_FRAMEWORK_LABEL_MAPPING[agent.framework] ?? agent.framework)
+      : undefined;
+    const cardLabels = [frameworkDisplay, ...(agent.labels ?? [])].filter(Boolean);
+    const [logoFailed, setLogoFailed] = React.useState(false);
 
-  return (
-    <Card isFullHeight data-testid={`agent-catalog-card-${agentId}`}>
-      <CardHeader>
-        <Flex
-          alignItems={{ default: 'alignItemsFlexStart' }}
-          gap={{ default: 'gapXs' }}
-          className="pf-v6-u-mb-md"
-        >
-          <FlexItem>
-            {agent.logo && !logoFailed ? (
-              <img
-                src={agent.logo}
-                alt=""
-                style={{ height: '32px', width: '32px' }}
-                data-testid={`agent-catalog-card-logo-${agentId}`}
-                onError={() => setLogoFailed(true)}
-              />
-            ) : (
-              <AgentFallbackIcon />
-            )}
-          </FlexItem>
-        </Flex>
-        <CardTitle>
-          <Button
-            data-testid={`agent-catalog-card-detail-link-${agentId}`}
-            variant="link"
-            isInline
-            component={(props: LinkProps) => (
-              <Link {...props} to={getAgentsCatalogDetailsRoute(agent.id)} />
-            )}
-            style={{
-              fontSize: 'var(--pf-t--global--font--size--body--default)',
-              fontWeight: 'var(--pf-t--global--font--weight--body--bold)',
-            }}
+    return (
+      <Card isFullHeight data-testid={`agent-catalog-card-${agentId}`}>
+        <CardHeader>
+          <Flex
+            alignItems={{ default: 'alignItemsFlexStart' }}
+            gap={{ default: 'gapXs' }}
+            className="pf-v6-u-mb-md"
           >
-            <Truncate
-              content={agent.displayName || agent.name}
-              position="middle"
-              tooltipPosition="top"
-              data-testid={`agent-catalog-card-name-${agentId}`}
-            />
-          </Button>
-        </CardTitle>
-      </CardHeader>
-      <CardBody>
-        <TruncatedText
-          content={agent.description ?? ''}
-          maxLines={4}
-          data-testid={`agent-catalog-card-description-${agentId}`}
-        />
-        {cardLabels.length > 0 && (
-          <Flex gap={{ default: 'gapSm' }} flexWrap={{ default: 'wrap' }} className="pf-v6-u-mt-md">
-            {cardLabels.map((label) => (
-              <FlexItem key={label}>
-                <Label isCompact data-testid={`agent-catalog-card-label-${agentId}`}>
-                  {label}
-                </Label>
-              </FlexItem>
-            ))}
+            <FlexItem>
+              {agent.logo && !logoFailed ? (
+                <img
+                  src={agent.logo}
+                  alt=""
+                  style={{ height: '32px', width: '32px' }}
+                  data-testid={`agent-catalog-card-logo-${agentId}`}
+                  onError={() => setLogoFailed(true)}
+                />
+              ) : (
+                <AgentFallbackIcon />
+              )}
+            </FlexItem>
           </Flex>
-        )}
-      </CardBody>
-    </Card>
-  );
-});
+          <CardTitle>
+            <Button
+              data-testid={`agent-catalog-card-detail-link-${agentId}`}
+              variant="link"
+              isInline
+              component={(props: LinkProps) => (
+                <Link
+                  {...props}
+                  to={getAgentsCatalogDetailsRoute(agent.id)}
+                  state={detailsNavigationState}
+                />
+              )}
+              style={{
+                fontSize: 'var(--pf-t--global--font--size--body--default)',
+                fontWeight: 'var(--pf-t--global--font--weight--body--bold)',
+              }}
+            >
+              <Truncate
+                content={agent.displayName || agent.name}
+                position="middle"
+                tooltipPosition="top"
+                data-testid={`agent-catalog-card-name-${agentId}`}
+              />
+            </Button>
+          </CardTitle>
+        </CardHeader>
+        <CardBody>
+          <TruncatedText
+            content={agent.description ?? ''}
+            maxLines={4}
+            data-testid={`agent-catalog-card-description-${agentId}`}
+          />
+          {cardLabels.length > 0 && (
+            <Flex
+              gap={{ default: 'gapSm' }}
+              flexWrap={{ default: 'wrap' }}
+              className="pf-v6-u-mt-md"
+            >
+              {cardLabels.map((label) => (
+                <FlexItem key={label}>
+                  <Label isCompact data-testid={`agent-catalog-card-label-${agentId}`}>
+                    {label}
+                  </Label>
+                </FlexItem>
+              ))}
+            </Flex>
+          )}
+        </CardBody>
+      </Card>
+    );
+  },
+);
 AgentsCatalogCard.displayName = 'AgentsCatalogCard';
 
 export default AgentsCatalogCard;

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/components/AgentsCatalogFilters.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/components/AgentsCatalogFilters.tsx
@@ -21,22 +21,29 @@ const AgentsCatalogFilters: React.FC = () => {
 
   const onFilterChange = React.useCallback(
     (key: string, values: string[]) => {
-      const matchedKey = AGENT_FILTER_KEYS.find((filterKey) => filterKey === key);
-      const previousValues = matchedKey ? filters[matchedKey] : undefined;
-      const toggledValue = getToggledFilterValue(previousValues, values);
-      const nextFilters = { ...filters, [key]: values };
+      let toggledValue: string | undefined;
+      let countActiveFilters = 0;
 
-      setFilters(nextFilters);
+      setFilters((prev) => {
+        const matchedKey = AGENT_FILTER_KEYS.find((filterKey) => filterKey === key);
+        const previousValues = matchedKey ? prev[matchedKey] : undefined;
+        const previousList = Array.isArray(previousValues) ? previousValues : undefined;
+        toggledValue = getToggledFilterValue(previousList, values);
+        const nextFilters = { ...prev, [key]: values };
+        countActiveFilters = countActiveAgentFilters(nextFilters);
+        return nextFilters;
+      });
 
+      // Sidebar checkbox toggle only — chip clear / reset are not FILTER_APPLIED.
       if (toggledValue) {
         trackSimpleEvent(AGENT_CATALOG_EVENTS.FILTER_APPLIED, {
           filterType: key,
           filterValue: getAgentFilterDisplayValue(key, toggledValue),
-          countActiveFilters: countActiveAgentFilters(nextFilters),
+          countActiveFilters,
         });
       }
     },
-    [filters, setFilters, trackSimpleEvent],
+    [setFilters, trackSimpleEvent],
   );
 
   const filterPanelItems = useCatalogFilterConfigs({

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/components/AgentsCatalogFilters.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/components/AgentsCatalogFilters.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useUserInteraction } from '~/concepts/userInteraction';
 import { AgentsCatalogContext } from '~/app/context/agentsCatalog/AgentsCatalogContext';
 import { CatalogFilterPanel, useCatalogFilterConfigs } from '~/app/shared/components/catalog';
 import {
@@ -6,16 +7,36 @@ import {
   AGENT_FILTER_CATEGORY_NAMES,
   AGENT_LABEL_MAPPINGS,
 } from '~/app/pages/agentsCatalog/const';
+import {
+  AGENT_CATALOG_EVENTS,
+  countActiveAgentFilters,
+  getAgentFilterDisplayValue,
+  getToggledFilterValue,
+} from '~/app/pages/agentsCatalog/tracking';
 
 const AgentsCatalogFilters: React.FC = () => {
+  const { trackSimpleEvent } = useUserInteraction();
   const { filters, setFilters, filterOptions, filterOptionsLoaded, filterOptionsLoadError } =
     React.useContext(AgentsCatalogContext);
 
   const onFilterChange = React.useCallback(
     (key: string, values: string[]) => {
-      setFilters((prev) => ({ ...prev, [key]: values }));
+      const matchedKey = AGENT_FILTER_KEYS.find((filterKey) => filterKey === key);
+      const previousValues = matchedKey ? filters[matchedKey] : undefined;
+      const toggledValue = getToggledFilterValue(previousValues, values);
+      const nextFilters = { ...filters, [key]: values };
+
+      setFilters(nextFilters);
+
+      if (toggledValue) {
+        trackSimpleEvent(AGENT_CATALOG_EVENTS.FILTER_APPLIED, {
+          filterType: key,
+          filterValue: getAgentFilterDisplayValue(key, toggledValue),
+          countActiveFilters: countActiveAgentFilters(nextFilters),
+        });
+      }
     },
-    [setFilters],
+    [filters, setFilters, trackSimpleEvent],
   );
 
   const filterPanelItems = useCatalogFilterConfigs({

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentDetailsPage.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentDetailsPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useParams } from 'react-router';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import {
   ActionList,
   ActionListGroup,
@@ -17,19 +17,82 @@ import {
 } from '@patternfly/react-core';
 import { GithubIcon, SearchIcon } from '@patternfly/react-icons';
 import { ApplicationsPage } from 'mod-arch-shared';
+import { useUserInteraction } from '~/concepts/userInteraction';
 import { useAgent } from '~/app/hooks/agentsCatalog/useAgent';
 import { agentsCatalogUrl } from '~/app/routes/agentsCatalog/agentsCatalog';
 import { AGENTS_CATALOG_TITLE } from '~/app/pages/agentsCatalog/const';
 import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
 import AgentsCatalogIcon from '~/app/pages/agentsCatalog/AgentsCatalogIcon';
+import {
+  AGENT_CATALOG_EVENTS,
+  isAgentCatalogDetailsNavigationState,
+} from '~/app/pages/agentsCatalog/tracking';
 import AgentDetailsView from './AgentDetailsView';
 
 const AgentDetailsPage: React.FC = () => {
   const { agentId = '' } = useParams<{ agentId: string }>();
+  const location = useLocation();
+  const { trackSimpleEvent, trackLinkEvent } = useUserInteraction();
   const [agent, agentLoaded, agentLoadError] = useAgent(agentId);
   const [logoFailed, setLogoFailed] = React.useState(false);
+  const detailsTrackedRef = React.useRef<string | null>(null);
+
+  const catalogHref = agentsCatalogUrl();
+
+  const handleOpenGitHub = React.useCallback(() => {
+    if (!agent?.repositoryUrl) {
+      return;
+    }
+    trackLinkEvent(AGENT_CATALOG_EVENTS.OPEN_GITHUB_CLICKED, {
+      href: agent.repositoryUrl,
+      type: 'external',
+      section: 'Agent Catalog Details',
+      name: agent.displayName || agent.name,
+    });
+  }, [agent, trackLinkEvent]);
+
+  const handleBackToCatalog = React.useCallback(() => {
+    trackLinkEvent(AGENT_CATALOG_EVENTS.BACK_TO_CATALOG_CLICKED, {
+      href: catalogHref,
+      type: 'internal',
+      section: 'Agent Catalog Details',
+      name: AGENTS_CATALOG_TITLE,
+    });
+  }, [catalogHref, trackLinkEvent]);
 
   const isNotFound = !agent && (agentLoaded || !!agentLoadError);
+
+  React.useEffect(() => {
+    if (!agent || !agentLoaded) {
+      return;
+    }
+
+    const trackKey = agent.id;
+    if (detailsTrackedRef.current === trackKey) {
+      return;
+    }
+    detailsTrackedRef.current = trackKey;
+
+    const navState = isAgentCatalogDetailsNavigationState(location.state)
+      ? location.state
+      : undefined;
+    const entrySource = navState?.entrySource ?? 'direct_url';
+
+    trackSimpleEvent(AGENT_CATALOG_EVENTS.DETAILS_VIEWED, {
+      templateId: agent.id,
+      templateName: agent.displayName || agent.name,
+      entrySource,
+      ...(entrySource === 'catalog_card' || entrySource === 'catalog_list'
+        ? {
+            positionIndex: navState?.positionIndex,
+            hasActiveFilters: navState?.hasActiveFilters,
+            countActiveFilters: navState?.countActiveFilters,
+            hasSearchQuery: navState?.hasSearchQuery,
+            resultCount: navState?.resultCount,
+          }
+        : {}),
+    });
+  }, [agent, agentLoaded, location.state, trackSimpleEvent]);
 
   return (
     <>
@@ -38,7 +101,9 @@ const AgentDetailsPage: React.FC = () => {
         breadcrumb={
           <Breadcrumb>
             <BreadcrumbItem>
-              <Link to={agentsCatalogUrl()}>{AGENTS_CATALOG_TITLE}</Link>
+              <Link to={catalogHref} onClick={handleBackToCatalog}>
+                {AGENTS_CATALOG_TITLE}
+              </Link>
             </BreadcrumbItem>
             <BreadcrumbItem isActive data-testid="breadcrumb-agent-name">
               {agent?.displayName || agent?.name || agentId || 'Details'}
@@ -82,6 +147,7 @@ const AgentDetailsPage: React.FC = () => {
                         target="_blank"
                         rel="noopener noreferrer"
                         data-testid="agent-github-button"
+                        onClick={handleOpenGitHub}
                       >
                         Open GitHub
                       </Button>
@@ -100,7 +166,9 @@ const AgentDetailsPage: React.FC = () => {
               <EmptyStateFooter>
                 <Button
                   variant="primary"
-                  component={(props) => <Link {...props} to={agentsCatalogUrl()} />}
+                  component={(props) => (
+                    <Link {...props} to={catalogHref} onClick={handleBackToCatalog} />
+                  )}
                 >
                   Return to {AGENTS_CATALOG_TITLE}
                 </Button>

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx
@@ -44,11 +44,7 @@ const AgentsCatalog: React.FC = () => {
 
   const handleClearSearch = React.useCallback(() => {
     setSearchQuery('');
-    trackFormEvent(AGENT_CATALOG_EVENTS.SEARCH_SUBMITTED, {
-      outcome: TrackingOutcome.submit,
-      countActiveFilters: countActiveAgentFilters(filters),
-    });
-  }, [setSearchQuery, trackFormEvent, filters]);
+  }, [setSearchQuery]);
 
   const handleResetAllFilters = React.useCallback(() => {
     trackSimpleEvent(AGENT_CATALOG_EVENTS.FILTERS_RESET);

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react';
 import { ApplicationsPage, ProjectObjectType, TitleWithIcon } from 'mod-arch-shared';
 import { SearchIcon } from '@patternfly/react-icons';
+import { useUserInteraction, TrackingOutcome } from '~/concepts/userInteraction';
 import { AgentsCatalogContext } from '~/app/context/agentsCatalog/AgentsCatalogContext';
 import { hasAgentFiltersApplied } from '~/app/pages/agentsCatalog/utils/agentsCatalogUtils';
 import AgentsCatalogFilters from '~/app/pages/agentsCatalog/components/AgentsCatalogFilters';
 import { AGENTS_CATALOG_TITLE, AGENTS_CATALOG_DESCRIPTION } from '~/app/pages/agentsCatalog/const';
 import { CatalogPageLayout, EmptyCatalogState } from '~/app/shared/components/catalog';
+import { AGENT_CATALOG_EVENTS, countActiveAgentFilters } from '~/app/pages/agentsCatalog/tracking';
 import AgentsCatalogSourceLabelSelector from './AgentsCatalogSourceLabelSelector';
 import AgentsCatalogAllAgentsView from './AgentsCatalogAllAgentsView';
 import AgentsCatalogGalleryView from './AgentsCatalogGalleryView';
 
 const AgentsCatalog: React.FC = () => {
+  const { trackSimpleEvent, trackFormEvent } = useUserInteraction();
   const {
     searchQuery,
     setSearchQuery,
@@ -31,17 +34,26 @@ const AgentsCatalog: React.FC = () => {
   const handleSearch = React.useCallback(
     (term: string) => {
       setSearchQuery(term);
+      trackFormEvent(AGENT_CATALOG_EVENTS.SEARCH_SUBMITTED, {
+        outcome: TrackingOutcome.submit,
+        countActiveFilters: countActiveAgentFilters(filters),
+      });
     },
-    [setSearchQuery],
+    [setSearchQuery, trackFormEvent, filters],
   );
 
   const handleClearSearch = React.useCallback(() => {
     setSearchQuery('');
-  }, [setSearchQuery]);
+    trackFormEvent(AGENT_CATALOG_EVENTS.SEARCH_SUBMITTED, {
+      outcome: TrackingOutcome.submit,
+      countActiveFilters: countActiveAgentFilters(filters),
+    });
+  }, [setSearchQuery, trackFormEvent, filters]);
 
   const handleResetAllFilters = React.useCallback(() => {
+    trackSimpleEvent(AGENT_CATALOG_EVENTS.FILTERS_RESET);
     clearAllFilters();
-  }, [clearAllFilters]);
+  }, [trackSimpleEvent, clearAllFilters]);
 
   return (
     <ApplicationsPage

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalogCategorySection.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalogCategorySection.tsx
@@ -12,6 +12,7 @@ import {
   OTHER_AGENTS_DISPLAY_NAME,
 } from '~/app/pages/agentsCatalog/const';
 import AgentsCatalogCard from '~/app/pages/agentsCatalog/components/AgentsCatalogCard';
+import { buildAgentDetailsNavigationState } from '~/app/pages/agentsCatalog/tracking';
 
 type AgentsCatalogCategorySectionProps = {
   label: string;
@@ -26,7 +27,7 @@ const AgentsCatalogCategorySection: React.FC<AgentsCatalogCategorySectionProps> 
   pageSize,
   onShowMore,
 }) => {
-  const { agentApiState, catalogLabels, reportCategoryEmpty } =
+  const { agentApiState, catalogLabels, reportCategoryEmpty, filters } =
     React.useContext(AgentsCatalogContext);
   const { agents, agentsLoaded, agentsLoadError } = useAgentsBySourceLabelWithAPI(agentApiState, {
     sourceLabel: label,
@@ -66,7 +67,17 @@ const AgentsCatalogCategorySection: React.FC<AgentsCatalogCategorySectionProps> 
       loadError={agentsLoadError}
       pageSize={pageSize}
       onShowMore={onShowMore}
-      renderCard={(agent) => <AgentsCatalogCard agent={agent} />}
+      renderCard={(agent, index) => (
+        <AgentsCatalogCard
+          agent={agent}
+          detailsNavigationState={buildAgentDetailsNavigationState(
+            index,
+            filters,
+            searchTerm,
+            agents.size,
+          )}
+        />
+      )}
       getItemKey={(agent) => agent.id}
       gridSpans={AGENTS_CATALOG_GRID_SPAN}
       loadingScreenReaderText={`Loading ${label} agents`}

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalogGalleryView.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalogGalleryView.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
+import { useUserInteraction } from '~/concepts/userInteraction';
 import { AgentsCatalogContext } from '~/app/context/agentsCatalog/AgentsCatalogContext';
 import { useAgentsBySourceLabelWithAPI } from '~/app/hooks/agentsCatalog/useAgentsBySourceLabel';
 import {
@@ -16,6 +17,10 @@ import {
   EmptyCatalogState,
 } from '~/app/shared/components/catalog';
 import AgentsCatalogCard from '~/app/pages/agentsCatalog/components/AgentsCatalogCard';
+import {
+  AGENT_CATALOG_EVENTS,
+  buildAgentDetailsNavigationState,
+} from '~/app/pages/agentsCatalog/tracking';
 
 type AgentsCatalogGalleryViewProps = {
   handleFilterReset: () => void;
@@ -28,6 +33,7 @@ const AgentsCatalogGalleryView: React.FC<AgentsCatalogGalleryViewProps> = ({
   isSingleCategory = false,
   singleCategoryLabel,
 }) => {
+  const { trackSimpleEvent } = useUserInteraction();
   const {
     agentApiState,
     selectedSourceLabel,
@@ -47,6 +53,7 @@ const AgentsCatalogGalleryView: React.FC<AgentsCatalogGalleryViewProps> = ({
   });
 
   const loaded = agentsLoaded && catalogLabelsLoaded;
+  const { items, size, loadMore, hasMore, isLoadingMore } = agents;
 
   const effectiveCategoryLabel = singleCategoryLabel || selectedSourceLabel || '';
   const categoryTitle = isSingleCategory
@@ -61,17 +68,37 @@ const AgentsCatalogGalleryView: React.FC<AgentsCatalogGalleryViewProps> = ({
     ? getLabelDescription(effectiveCategoryLabel, catalogLabels)
     : undefined;
 
+  const handleLoadMore = React.useCallback(() => {
+    const visibleCountBefore = items.length;
+    trackSimpleEvent(AGENT_CATALOG_EVENTS.LOAD_MORE_CLICKED, {
+      visibleCountBefore,
+      visibleCountAfter: Math.min(visibleCountBefore + AGENTS_CATALOG_GALLERY.PAGE_SIZE, size),
+      totalAvailable: size,
+    });
+    loadMore();
+  }, [items.length, size, loadMore, trackSimpleEvent]);
+
   return (
     <CatalogGalleryLayout
-      items={agents.items}
+      items={items}
       loaded={loaded}
       loadError={agentsLoadError}
-      renderCard={(agent) => <AgentsCatalogCard agent={agent} />}
+      renderCard={(agent, index) => (
+        <AgentsCatalogCard
+          agent={agent}
+          detailsNavigationState={buildAgentDetailsNavigationState(
+            index,
+            filters,
+            searchQuery,
+            size,
+          )}
+        />
+      )}
       getItemKey={(agent) => agent.id}
       gridSpans={AGENTS_CATALOG_GRID_SPAN}
-      hasMore={agents.hasMore && agents.items.length >= AGENTS_CATALOG_GALLERY.PAGE_SIZE}
-      isLoadingMore={agents.isLoadingMore}
-      onLoadMore={agents.loadMore}
+      hasMore={hasMore && items.length >= AGENTS_CATALOG_GALLERY.PAGE_SIZE}
+      isLoadingMore={isLoadingMore}
+      onLoadMore={handleLoadMore}
       loadMoreLabel="Load more agents"
       loadingMoreLabel="Loading more agents..."
       loadingLabel="Loading agents..."

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/__tests__/AgentDetailsPage.tracking.spec.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/__tests__/AgentDetailsPage.tracking.spec.tsx
@@ -1,0 +1,155 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { useUserInteraction } from '~/concepts/userInteraction';
+import { useAgent } from '~/app/hooks/agentsCatalog/useAgent';
+import type { Agent } from '~/app/agentsCatalogTypes';
+import { AGENT_CATALOG_EVENTS } from '~/app/pages/agentsCatalog/tracking';
+import { AGENTS_CATALOG_TITLE } from '~/app/pages/agentsCatalog/const';
+import { agentsCatalogUrl } from '~/app/routes/agentsCatalog/agentsCatalog';
+import AgentDetailsPage from '~/app/pages/agentsCatalog/screens/AgentDetailsPage';
+
+jest.mock('~/concepts/userInteraction', () => ({
+  useUserInteraction: jest.fn(),
+}));
+
+jest.mock('~/app/hooks/agentsCatalog/useAgent', () => ({
+  useAgent: jest.fn(),
+}));
+
+jest.mock('~/app/pages/agentsCatalog/screens/AgentDetailsView', () => ({
+  __esModule: true,
+  default: () => <div data-testid="agent-details-view" />,
+}));
+
+jest.mock('~/app/shared/components/ScrollViewOnMount', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockUseUserInteraction = jest.mocked(useUserInteraction);
+const mockUseAgent = jest.mocked(useAgent);
+
+const mockTrackSimpleEvent = jest.fn();
+const mockTrackLinkEvent = jest.fn();
+const mockTrackFormEvent = jest.fn();
+const mockTrackPageEvent = jest.fn();
+
+const mockAgent: Agent = {
+  id: 'agent-1',
+  name: 'agent-one',
+  displayName: 'Agent One',
+  repositoryUrl: 'https://github.com/example/agent-one',
+};
+
+const renderPage = (options?: {
+  agent?: Agent | null;
+  loaded?: boolean;
+  loadError?: Error;
+  locationState?: unknown;
+}) => {
+  const { agent = mockAgent, loaded = true, loadError = undefined, locationState } = options ?? {};
+
+  mockUseAgent.mockReturnValue([agent, loaded, loadError, jest.fn()]);
+
+  return render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/ai-hub/agents/catalog/agent-1/overview',
+          state: locationState,
+        },
+      ]}
+    >
+      <Routes>
+        <Route path="/ai-hub/agents/catalog/:agentId/overview" element={<AgentDetailsPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+};
+
+describe('AgentDetailsPage tracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseUserInteraction.mockReturnValue({
+      trackSimpleEvent: mockTrackSimpleEvent,
+      trackLinkEvent: mockTrackLinkEvent,
+      trackFormEvent: mockTrackFormEvent,
+      trackPageEvent: mockTrackPageEvent,
+    });
+  });
+
+  it('should fire details viewed on successful load with direct_url entry source', () => {
+    renderPage();
+
+    expect(mockTrackSimpleEvent).toHaveBeenCalledWith(AGENT_CATALOG_EVENTS.DETAILS_VIEWED, {
+      templateId: 'agent-1',
+      templateName: 'Agent One',
+      entrySource: 'direct_url',
+    });
+  });
+
+  it('should include catalog navigation props when entrySource is catalog_card', () => {
+    renderPage({
+      locationState: {
+        entrySource: 'catalog_card',
+        positionIndex: 2,
+        hasActiveFilters: true,
+        countActiveFilters: 1,
+        hasSearchQuery: false,
+        resultCount: 10,
+      },
+    });
+
+    expect(mockTrackSimpleEvent).toHaveBeenCalledWith(AGENT_CATALOG_EVENTS.DETAILS_VIEWED, {
+      templateId: 'agent-1',
+      templateName: 'Agent One',
+      entrySource: 'catalog_card',
+      positionIndex: 2,
+      hasActiveFilters: true,
+      countActiveFilters: 1,
+      hasSearchQuery: false,
+      resultCount: 10,
+    });
+  });
+
+  it('should fire open github clicked when Open GitHub is clicked', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('agent-github-button'));
+
+    expect(mockTrackLinkEvent).toHaveBeenCalledWith(AGENT_CATALOG_EVENTS.OPEN_GITHUB_CLICKED, {
+      href: 'https://github.com/example/agent-one',
+      type: 'external',
+      section: 'Agent Catalog Details',
+      name: 'Agent One',
+    });
+  });
+
+  it('should fire back to catalog clicked from the breadcrumb', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('link', { name: AGENTS_CATALOG_TITLE }));
+
+    expect(mockTrackLinkEvent).toHaveBeenCalledWith(AGENT_CATALOG_EVENTS.BACK_TO_CATALOG_CLICKED, {
+      href: agentsCatalogUrl(),
+      type: 'internal',
+      section: 'Agent Catalog Details',
+      name: AGENTS_CATALOG_TITLE,
+    });
+  });
+
+  it('should fire back to catalog clicked from the not-found empty state', () => {
+    renderPage({ agent: null, loaded: true });
+
+    fireEvent.click(screen.getByRole('link', { name: `Return to ${AGENTS_CATALOG_TITLE}` }));
+
+    expect(mockTrackLinkEvent).toHaveBeenCalledWith(AGENT_CATALOG_EVENTS.BACK_TO_CATALOG_CLICKED, {
+      href: agentsCatalogUrl(),
+      type: 'internal',
+      section: 'Agent Catalog Details',
+      name: AGENTS_CATALOG_TITLE,
+    });
+  });
+});

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/tracking.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/tracking.ts
@@ -1,0 +1,83 @@
+import type { AgentsCatalogFiltersState } from '~/app/pages/agentsCatalog/types/agentsCatalogFilterOptions';
+import { AGENT_FILTER_KEYS, AGENT_LABEL_MAPPINGS } from '~/app/pages/agentsCatalog/const';
+
+/**
+ * Agent Catalog Segment event names.
+ * @see https://docs.google.com/document/d/1m6sqycUcNViHhVFrTbaYUBjekVV-BHqectg5t4XZZQA
+ */
+export const AGENT_CATALOG_EVENTS = {
+  FILTER_APPLIED: 'Agent Catalog Filter Applied',
+  SEARCH_SUBMITTED: 'Agent Catalog Search Submitted',
+  FILTERS_RESET: 'Agent Catalog Filters Reset',
+  LOAD_MORE_CLICKED: 'Agent Catalog Load More Clicked',
+  DETAILS_VIEWED: 'Agent Catalog Details Viewed',
+  OPEN_GITHUB_CLICKED: 'Agent Catalog Details Open GitHub Clicked',
+  BACK_TO_CATALOG_CLICKED: 'Agent Catalog Details Back To Catalog Clicked',
+} as const;
+
+export type AgentCatalogEntrySource = 'catalog_card' | 'catalog_list' | 'direct_url';
+
+export type AgentCatalogDetailsNavigationState = {
+  entrySource: AgentCatalogEntrySource;
+  positionIndex?: number;
+  hasActiveFilters?: boolean;
+  countActiveFilters?: number;
+  hasSearchQuery?: boolean;
+  resultCount?: number;
+};
+
+export const countActiveAgentFilters = (filters: AgentsCatalogFiltersState): number =>
+  AGENT_FILTER_KEYS.reduce((count, key) => {
+    const values = filters[key];
+    return count + (Array.isArray(values) ? values.length : 0);
+  }, 0);
+
+/** Display label for a filter value (same pattern as catalog filter getLabel). */
+export const getAgentFilterDisplayValue = (filterType: string, filterValue: string): string => {
+  if (!(filterType in AGENT_LABEL_MAPPINGS)) {
+    return filterValue;
+  }
+  return AGENT_LABEL_MAPPINGS[filterType][filterValue] || filterValue;
+};
+
+/** Diff helper: which single value was added or removed between two filter arrays. */
+export const getToggledFilterValue = (
+  previousValues: string[] | undefined,
+  nextValues: string[],
+): string | undefined => {
+  const prev = previousValues ?? [];
+  const added = nextValues.find((value) => !prev.includes(value));
+  if (added) {
+    return added;
+  }
+  return prev.find((value) => !nextValues.includes(value));
+};
+
+export const buildAgentDetailsNavigationState = (
+  positionIndex: number,
+  filters: AgentsCatalogFiltersState,
+  searchQuery: string,
+  resultCount: number,
+): AgentCatalogDetailsNavigationState => {
+  const countActiveFilters = countActiveAgentFilters(filters);
+  return {
+    entrySource: 'catalog_card',
+    positionIndex,
+    hasActiveFilters: countActiveFilters > 0,
+    countActiveFilters,
+    hasSearchQuery: searchQuery.trim().length > 0,
+    resultCount,
+  };
+};
+
+export const isAgentCatalogDetailsNavigationState = (
+  state: unknown,
+): state is AgentCatalogDetailsNavigationState => {
+  if (!state || typeof state !== 'object' || !('entrySource' in state)) {
+    return false;
+  }
+  const { entrySource } = state;
+  return (
+    entrySource === 'catalog_card' || entrySource === 'catalog_list' || entrySource === 'direct_url'
+  );
+};

--- a/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/CatalogCategorySection.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/CatalogCategorySection.tsx
@@ -33,7 +33,7 @@ type CatalogCategorySectionProps<T> = {
   loadError: Error | undefined;
   pageSize: number;
   onShowMore: (label: string) => void;
-  renderCard: (item: T) => React.ReactNode;
+  renderCard: (item: T, index: number) => React.ReactNode;
   getItemKey: (item: T) => string;
   gridSpans?: CatalogGridSpans;
   showAllThreshold?: number;
@@ -128,9 +128,9 @@ function CatalogCategorySection<T>({
         />
       ) : (
         <Grid hasGutter>
-          {itemsToDisplay.map((item) => (
+          {itemsToDisplay.map((item, index) => (
             <GridItem key={getItemKey(item)} {...gridSpans}>
-              {renderCard(item)}
+              {renderCard(item, index)}
             </GridItem>
           ))}
         </Grid>

--- a/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/CatalogGalleryLayout.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/CatalogGalleryLayout.tsx
@@ -19,7 +19,7 @@ type CatalogGalleryLayoutProps<T> = {
   items: T[];
   loaded: boolean;
   loadError: Error | undefined;
-  renderCard: (item: T) => React.ReactNode;
+  renderCard: (item: T, index: number) => React.ReactNode;
   getItemKey: (item: T) => string;
   gridSpans?: CatalogGridSpans;
   hasMore?: boolean;
@@ -106,9 +106,9 @@ function CatalogGalleryLayout<T>({
         </div>
       )}
       <Grid hasGutter>
-        {items.map((item) => (
+        {items.map((item, index) => (
           <GridItem key={getItemKey(item)} {...gridSpansProp}>
-            {renderCard(item)}
+            {renderCard(item, index)}
           </GridItem>
         ))}
       </Grid>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-73135

## Description

Adds Segment analytics instrumentation for Agents Catalog using `useUserInteraction` / `TrackingOutcome` from the userInteraction extension wiring ([#8542](https://github.com/opendatahub-io/odh-dashboard/pull/8542)).

<img width="515" height="247" alt="Screenshot 2026-07-21 at 4 30 34 PM" src="https://github.com/user-attachments/assets/0dda6c96-528d-486c-ad45-efbcc9728aef" />
<img width="513" height="165" alt="Screenshot 2026-07-21 at 4 31 34 PM" src="https://github.com/user-attachments/assets/683778fb-81f9-48b6-9726-6b96ca31466a" />
<img width="496" height="134" alt="Screenshot 2026-07-21 at 4 33 59 PM" src="https://github.com/user-attachments/assets/9ddda62f-819c-48b8-8935-c23b839ac49a" />
<img width="449" height="59" alt="Screenshot 2026-07-21 at 4 40 23 PM" src="https://github.com/user-attachments/assets/1fef4011-bbcf-428c-b7b5-0339c0fb6a4e" />


Events covered:
- **E1** Agent Catalog Filter Applied (sidebar + filter chips)
- **E2** Agent Catalog Search Submitted (search + clear)
- **E3** Agent Catalog Filters Reset
- **E4** Agent Catalog Load More Clicked
- **E5** Agent Catalog Details Viewed (with catalog card nav state when available)
- **Open GitHub** Agent Catalog Details Open GitHub Clicked
- **E9** Agent Catalog Details Back To Catalog Clicked (breadcrumb + not-found return)

Uses `trackSimpleEvent` / `trackFormEvent` / `trackLinkEvent` only (no direct `fire*TrackingEvent` imports in catalog UI).

## How Has This Been Tested?

- Lint (`eslint --max-warnings 0`) on touched files
- Type-check (`tsc --noEmit`) in `packages/model-registry/upstream/frontend`
- Prettier check on touched files
- Unit tests:
  - `pages/agentsCatalog/__tests__/tracking.spec.ts`
  - `screens/__tests__/AgentDetailsPage.tracking.spec.tsx`
- Manual verification path: local dashboard in `DEV_MODE`, Agents Catalog UI, DevTools console filter `Telemetry event` while exercising filter/search/reset/load more/details/Open GitHub/back to catalog

## Test Impact

- Added helper unit tests for tracking utilities
- Added `AgentDetailsPage` tracking tests with mocked `useUserInteraction` covering details viewed, Open GitHub, and back-to-catalog

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)