### PR TITLE
add evalhubs to requiredAccessToService

### DIFF
--- a/packages/eval-hub/bff/internal/api/middleware.go
+++ b/packages/eval-hub/bff/internal/api/middleware.go
@@ -214,8 +214,13 @@ func (app *App) AttachEvalHubClient(next func(http.ResponseWriter, *http.Request
 	}
 }
 
-// RequireAccessToService validates that the user has permission to list EvalHub CRs in the
-// namespace that was injected by the AttachNamespace middleware.
+// RequireAccessToService validates that the user has at least minimal (non-admin) permission
+// to access EvalHub in the namespace that was injected by the AttachNamespace middleware
+// (see kubernetes.EvalHubVirtualResource for which permission is checked and why). This is a
+// coarse-grained gate for endpoints that bypass the EvalHub service's own per-endpoint SAR
+// checks (e.g. InferenceServices, VerifyConnection); it intentionally does not replace the
+// EvalHub service's own authorization, which remains the source of truth for endpoints proxied
+// through AttachEvalHubClient.
 // This middleware must be placed after both InjectRequestIdentity and AttachNamespace.
 func (app *App) RequireAccessToService(next func(http.ResponseWriter, *http.Request, httprouter.Params)) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/packages/eval-hub/bff/internal/integrations/kubernetes/client.go
+++ b/packages/eval-hub/bff/internal/integrations/kubernetes/client.go
@@ -25,8 +25,9 @@ type KubernetesClientInterface interface {
 
 	// EvalHub CR auto-discovery (fallback)
 
-	// CanListEvalHubInstances performs a SubjectAccessReview to verify the user has permission
-	// to list EvalHub custom resources in the given namespace.
+	// CanListEvalHubInstances performs SubjectAccessReviews to verify the user has at least
+	// minimal (non-admin) permission to access EvalHub in the given namespace. Allowed if `get`
+	// is permitted on EITHER of two resources — see EvalHubVirtualResource for details.
 	CanListEvalHubInstances(ctx context.Context, identity *RequestIdentity, namespace string) (bool, error)
 	// GetEvalHubServiceURL lists EvalHub CRs in the namespace (filtered by the ODH dashboard label)
 	// and returns the service URL from the first CR's status.url field.

--- a/packages/eval-hub/bff/internal/integrations/kubernetes/evalhub_cr.go
+++ b/packages/eval-hub/bff/internal/integrations/kubernetes/evalhub_cr.go
@@ -12,15 +12,16 @@ const (
 	// EvalHubCRDVersion is the API version for EvalHub custom resources.
 	EvalHubCRDVersion = "v1alpha1"
 
-	// EvalHubCRDResource is the plural resource name for the EvalHub operator CRD.
-	// Used by the BFF's service account to discover the EvalHub service URL from CR status.
-	// Only accessible to cluster-admins and the BFF's own service account — never used for user SAR checks.
+	// EvalHubCRDResource is the plural resource name for the EvalHub operator CRD. Used for CR
+	// discovery, and as one half of the OR check in CanListEvalHubInstances: evalhub-user grants
+	// get/list on this resource, though that grant isn't in the documented RBAC reference.
 	EvalHubCRDResource = "evalhubs"
 
-	// EvalHubVirtualResource is the virtual resource name used for SubjectAccessReview checks.
-	// The TrustyAI operator provisions per-tenant Roles granting access to this virtual resource
-	// in each namespace labelled with evalhub.trustyai.opendatahub.io/tenant.
-	// Using this (not EvalHubCRDResource) ensures the SAR reflects actual tenant-level permissions.
+	// EvalHubVirtualResource, together with EvalHubCRDResource, is used by the BFF's blanket
+	// EvalHub access gate (see CanListEvalHubInstances): allowed if `get` passes on EITHER
+	// resource. Neither alone covers every tenant Role pattern the operator provisions —
+	// evalhub-user lacks "evaluations", and hand-authored multi-tenancy Roles lack "evalhubs" —
+	// so both are checked.
 	EvalHubVirtualResource = "evaluations"
 
 	// EvalHubDiscoveryConfigMap is the name of the ConfigMap injected by the EvalHub operator

--- a/packages/eval-hub/bff/internal/integrations/kubernetes/internal_k8s_client.go
+++ b/packages/eval-hub/bff/internal/integrations/kubernetes/internal_k8s_client.go
@@ -216,12 +216,33 @@ func (kc *InternalKubernetesClient) GetUser(identity *RequestIdentity) (string, 
 	return identity.UserID, nil
 }
 
-// CanListEvalHubInstances performs a SubjectAccessReview on behalf of the identified user
-// to check whether they have permission to access EvalHub evaluations in the given namespace.
-// Checks the virtual "evaluations" resource provisioned by the TrustyAI operator per-tenant
-// (via a RoleBinding in each namespace labelled evalhub.trustyai.opendatahub.io/tenant),
-// not the "evalhubs" CRD which is only accessible to cluster-admins.
+// CanListEvalHubInstances checks whether the identified user has permission to access EvalHub
+// in the given namespace: allowed if `get` passes on either EvalHubVirtualResource or
+// EvalHubCRDResource (see EvalHubVirtualResource for why both are checked).
 func (kc *InternalKubernetesClient) CanListEvalHubInstances(ctx context.Context, identity *RequestIdentity, namespace string) (bool, error) {
+	var lastErr error
+	for _, resource := range [...]string{EvalHubVirtualResource, EvalHubCRDResource} {
+		allowed, err := kc.sarGet(ctx, identity, namespace, resource)
+		if err != nil {
+			kc.Logger.Error("failed to perform EvalHub access SAR", "namespace", namespace, "resource", resource, "error", err)
+			lastErr = err
+			continue
+		}
+		if allowed {
+			return true, nil
+		}
+	}
+
+	if lastErr != nil {
+		return false, fmt.Errorf("failed to verify EvalHub access permissions: %w", lastErr)
+	}
+	return false, nil
+}
+
+// sarGet performs a single SubjectAccessReview for the `get` verb on the given EvalHub
+// CRD-group resource in namespace, on behalf of identity. Shared helper for
+// CanListEvalHubInstances' OR check.
+func (kc *InternalKubernetesClient) sarGet(ctx context.Context, identity *RequestIdentity, namespace, resource string) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -232,7 +253,7 @@ func (kc *InternalKubernetesClient) CanListEvalHubInstances(ctx context.Context,
 			ResourceAttributes: &authv1.ResourceAttributes{
 				Verb:      "get",
 				Group:     EvalHubCRDGroup,
-				Resource:  EvalHubVirtualResource,
+				Resource:  resource,
 				Namespace: namespace,
 			},
 		},
@@ -240,8 +261,7 @@ func (kc *InternalKubernetesClient) CanListEvalHubInstances(ctx context.Context,
 
 	resp, err := kc.Client.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 	if err != nil {
-		kc.Logger.Error("failed to perform EvalHub list SAR", "namespace", namespace, "error", err)
-		return false, fmt.Errorf("failed to verify EvalHub list permissions: %w", err)
+		return false, err
 	}
 
 	return resp.Status.Allowed, nil

--- a/packages/eval-hub/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/eval-hub/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -260,13 +260,33 @@ func (kc *TokenKubernetesClient) GetUser(_ *RequestIdentity) (string, error) {
 	return username, nil
 }
 
-// CanListEvalHubInstances performs a SelfSubjectAccessReview to check whether the user's
-// token has permission to access EvalHub evaluations in the given namespace.
-// Checks the virtual "evaluations" resource provisioned by the TrustyAI operator per-tenant
-// (via a RoleBinding in each namespace labelled evalhub.trustyai.opendatahub.io/tenant),
-// not the "evalhubs" CRD which is only accessible to cluster-admins.
+// CanListEvalHubInstances checks whether the user's token has permission to access EvalHub in
+// the given namespace: allowed if `get` passes on either EvalHubVirtualResource or
+// EvalHubCRDResource (see EvalHubVirtualResource for why both are checked).
 // The RequestIdentity parameter is unused because the token already represents the user.
 func (kc *TokenKubernetesClient) CanListEvalHubInstances(ctx context.Context, _ *RequestIdentity, namespace string) (bool, error) {
+	var lastErr error
+	for _, resource := range [...]string{EvalHubVirtualResource, EvalHubCRDResource} {
+		allowed, err := kc.selfSARGet(ctx, namespace, resource)
+		if err != nil {
+			kc.Logger.Error("failed to perform EvalHub access SAR", "namespace", namespace, "resource", resource, "error", err)
+			lastErr = err
+			continue
+		}
+		if allowed {
+			return true, nil
+		}
+	}
+
+	if lastErr != nil {
+		return false, fmt.Errorf("failed to verify EvalHub access permissions: %w", lastErr)
+	}
+	return false, nil
+}
+
+// selfSARGet performs a single SelfSubjectAccessReview for the `get` verb on the given
+// EvalHub CRD-group resource in namespace. Shared helper for CanListEvalHubInstances' OR check.
+func (kc *TokenKubernetesClient) selfSARGet(ctx context.Context, namespace, resource string) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -275,7 +295,7 @@ func (kc *TokenKubernetesClient) CanListEvalHubInstances(ctx context.Context, _ 
 			ResourceAttributes: &authv1.ResourceAttributes{
 				Verb:      "get",
 				Group:     EvalHubCRDGroup,
-				Resource:  EvalHubVirtualResource,
+				Resource:  resource,
 				Namespace: namespace,
 			},
 		},
@@ -283,8 +303,7 @@ func (kc *TokenKubernetesClient) CanListEvalHubInstances(ctx context.Context, _ 
 
 	resp, err := kc.Client.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 	if err != nil {
-		kc.Logger.Error("failed to perform EvalHub list SAR", "namespace", namespace, "error", err)
-		return false, fmt.Errorf("failed to verify EvalHub list permissions: %w", err)
+		return false, err
 	}
 
 	return resp.Status.Allowed, nil


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-74966

## Description

Fixes a `403 Access forbidden` error when accessing EvalHub in single-tenancy mode. The BFF's `RequireAccessToService` middleware gated all EvalHub access on a `SelfSubjectAccessReview`/`SubjectAccessReview` for `get` on the `evaluations` resource only. The TrustyAI operator's `evalhub-user` Role (used for standard, non-admin tenant access in single-tenancy mode) does not grant `evaluations`, so legitimate non-admin users were rejected before ever reaching the EvalHub service.

`CanListEvalHubInstances` now performs the SAR check against `evaluations` **OR** `evalhubs` (the EvalHub CRD resource), and is allowed through if either passes. This covers every tenant Role pattern the operator provisions:
- `evalhub-tenant-admin` (single-tenancy, full CRUD): has `evaluations`
- `evalhub-user` (single-tenancy, standard access): lacks `evaluations`, but has `get`/`list` on `evalhubs`
- hand-authored multi-tenancy Roles (e.g. `evalhub-evaluator`): have `evaluations`, but not `evalhubs`

This gate remains coarse-grained and intentionally does not replace the EvalHub service's own per-endpoint authorization, which stays the source of truth for proxied endpoints.

## How Has This Been Tested?

- Verified `go build`, `go vet`, and `go test` pass for `packages/eval-hub/bff`.
- Manually reproduced the `403` in the `eval-hub-e2e-manual-test` namespace with a non-admin (`evalhub-user`-bound) identity, confirmed the fix resolves it, and confirmed existing tenant-admin and multi-tenancy access patterns still pass.

## Test Impact

- No new automated tests added; covered by manual verification against a live cluster across all three tenant Role patterns described above. Existing unit tests for the `kubernetes` package continue to pass.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EvalHub access checks to recognize the required permission across supported resource types.
  * Users with valid access through either supported resource type can now access EvalHub instances as expected.
  * Improved handling of permission-check failures for more consistent access results.

* **Documentation**
  * Clarified access requirements and middleware usage for EvalHub endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->