### PR TITLE
feat(ci): add opt-in E2E coverage collection with Codecov upload

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,6 +16,13 @@ coverage:
         informational: true
         target: 70%
 
+flags:
+  cypress-e2e:
+    paths:
+      - frontend/src/
+      - packages/
+    carryforward: true
+
 comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -77,6 +77,11 @@ on:
         required: false
         default: ''
         type: string
+      enable_coverage:
+        description: 'Enable E2E code coverage collection and upload to Codecov'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: e2e-${{ github.event.workflow_run.head_branch || github.ref }}
@@ -1243,7 +1248,13 @@ jobs:
 
           # Cypress reads CYPRESS_* env vars natively — avoids arg escaping through concurrently
           export CYPRESS_OC_SERVER="$OC_SERVER"
-          export CYPRESS_skipTags="@Bug @Maintain @NonConcurrent"
+          if [[ "${{ inputs.enable_coverage }}" == "true" ]]; then
+            export CY_COVERAGE=true
+            export CYPRESS_skipTags="@Bug @Maintain"
+            echo "📊 Coverage collection enabled — @NonConcurrent tests included"
+          else
+            export CYPRESS_skipTags="@Bug @Maintain @NonConcurrent"
+          fi
           export CYPRESS_grepTags="$MATRIX_TAG"
           export CYPRESS_grepFilterSpecs=true
           export CYPRESS_video=true
@@ -1267,6 +1278,15 @@ jobs:
             packages/cypress/videos/
             packages/cypress/screenshots/
           retention-days: 7
+
+      - name: Upload coverage artifact
+        if: always() && github.event.inputs.enable_coverage == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-coverage-${{ env.TAG_DIR }}
+          path: packages/cypress/coverage/coverage-final.json
+          retention-days: 7
+          if-no-files-found: warn
 
       - name: Log test completion
         if: always()
@@ -1328,6 +1348,58 @@ jobs:
             -f context="Cypress E2E Tests" \
             -f description="$DESC" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  # ---------------------------------------------------------------------------
+  # Upload E2E Coverage to Codecov (opt-in via workflow_dispatch)
+  # ---------------------------------------------------------------------------
+  upload-e2e-coverage:
+    needs: [e2e-tests]
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.enable_coverage == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: 22
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: e2e-coverage-*
+          path: e2e-coverage
+      - name: Merge coverage reports
+        run: |
+          npm install nyc --no-save
+          mkdir -p ./coverage
+
+          FOUND=0
+          for f in $(find e2e-coverage -name "coverage-final.json" 2>/dev/null); do
+            group=$(basename "$(dirname "$f")")
+            cp "$f" "./coverage/${group}.json"
+            FOUND=$((FOUND + 1))
+          done
+
+          if [ "$FOUND" -eq 0 ]; then
+            echo "⚠️ No coverage files found — tests may have failed before coverage was collected"
+            exit 0
+          fi
+
+          echo "📊 Merging $FOUND coverage file(s):"
+          ls -la ./coverage/
+          npx nyc merge ./coverage ./coverage/e2e-merged-coverage.json
+      - name: Upload to Codecov
+        if: hashFiles('./coverage/e2e-merged-coverage.json') != ''
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          name: cypress-e2e
+          flags: cypress-e2e
+          file: ./coverage/e2e-merged-coverage.json
+          disable_search: true
+          verbose: true
 
   # ---------------------------------------------------------------------------
   # Cleanup - Fix file permissions left by BFF test binaries


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78364

## Description

Adds opt-in code coverage collection to the Cypress E2E CI workflow and uploads results to Codecov under a `cypress-e2e` flag. This provides visibility into what production code paths E2E tests exercise.

The existing infrastructure already supports this — builds are instrumented with Istanbul via `@jsdevtools/coverage-istanbul-loader` (`COVERAGE=true`), and `@cypress/code-coverage` is wired into the shared Cypress config. This PR enables it for E2E runs by:

- Adding an `enable_coverage` boolean input to the `workflow_dispatch` trigger (default: off — zero impact on normal runs)
- Setting `CY_COVERAGE=true` when enabled, so `@cypress/code-coverage` collects `window.__coverage__` after each test
- Dropping `@NonConcurrent` from skip tags when coverage is enabled (so all matching tests run)
- Uploading per-matrix-job coverage artifacts
- Adding an `upload-e2e-coverage` job that merges coverage from all matrix jobs and uploads to Codecov with the `cypress-e2e` flag
- Adding the `cypress-e2e` flag definition to `.codecov.yml` with `carryforward: true`

### How to use

1. Go to **Actions** → **Cypress e2e Test** → **Run workflow**
2. Check **Enable E2E code coverage collection and upload to Codecov**
3. Enter test tags (e.g., `@Smoke` or `@Sanity`) in **Extra test tags**
4. Optionally check **Skip default tags** to run only the specified tags
5. Coverage appears in Codecov under the `cypress-e2e` flag after the run completes

## How Has This Been Tested?

This will be validated by triggering the workflow manually with `enable_coverage=true` and verifying coverage data appears in Codecov.

## Test Impact

No new tests — this is CI infrastructure. The changes are behind an opt-in toggle and do not affect normal E2E test execution.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added optional end-to-end test coverage collection for manually triggered test runs.
  * Coverage reports are now consolidated and uploaded automatically for improved visibility into test coverage.

* **Chores**
  * Improved coverage tracking configuration to retain results across runs.
  * Existing test result reporting and status checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->