### PR TITLE
feat(RHOAIENG-78400): promote mcpRegistry from dev flag to CRD feature flag

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -59,6 +59,7 @@ export type DashboardConfig = K8sResourceCommon & {
       externalModels: boolean;
       mlflow: boolean;
       mcpCatalog: boolean;
+      mcpRegistry: boolean;
       agentOps: boolean;
       agentsCatalog: boolean;
       toolCalling: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -95,6 +95,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableLMEval: true,
       mlflow: true,
       mcpCatalog: false,
+      mcpRegistry: false,
       agentOps: false,
       agentsCatalog: false,
       toolCalling: false,

--- a/distributions/core-bff/bff/internal/models/dashboard_config.go
+++ b/distributions/core-bff/bff/internal/models/dashboard_config.go
@@ -80,6 +80,7 @@ type DashboardFeatureFlags struct {
 	MaasAuthPolicies             bool `json:"maasAuthPolicies"`
 	Mlflow                       bool `json:"mlflow"`
 	McpCatalog                   bool `json:"mcpCatalog"`
+	McpRegistry                  bool `json:"mcpRegistry"`
 	AgentsCatalog                bool `json:"agentsCatalog"`
 	ToolCalling                  bool `json:"toolCalling"`
 	TrainingJobs                 bool `json:"trainingJobs"`
@@ -173,6 +174,7 @@ var BlankDashboardCR = DashboardConfig{
 			MaasAuthPolicies:             true,
 			Mlflow:                       true,
 			McpCatalog:                   false,
+			McpRegistry:                  false,
 			AgentsCatalog:                false,
 			ToolCalling:                  false,
 			TrainingJobs:                 true,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -53,6 +53,7 @@ export type MockDashboardConfigType = {
   pvcSize?: string;
   mlflowPipelines?: boolean;
   mcpCatalog?: boolean;
+  mcpRegistry?: boolean;
   toolCalling?: boolean;
   projectRBAC?: boolean;
   disableLLMd?: boolean;
@@ -111,6 +112,7 @@ export const mockDashboardConfig = ({
   disableDistributedWorkloads = false,
   disableModelCatalog = false,
   mcpCatalog = false,
+  mcpRegistry = false,
   toolCalling = false,
   disableModelRegistry = false,
   disableModelRegistrySecureDB = false,
@@ -303,6 +305,7 @@ export const mockDashboardConfig = ({
       disableDistributedWorkloads,
       disableModelCatalog,
       mcpCatalog,
+      mcpRegistry,
       toolCalling,
       disableModelRegistry,
       disableModelRegistrySecureDB,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -15,6 +15,7 @@ export const techPreviewFlags = {
   externalModels: false,
   aiAssetCustomEndpoints: false,
   mcpCatalog: false,
+  mcpRegistry: false,
   toolCalling: false,
   projectRBAC: true,
   roleManagement: false,
@@ -37,7 +38,6 @@ export const devTemporaryFeatureFlags = {
   nimWizard: false,
   agentOpsDeploy: false,
   agentsCatalog: false,
-  mcpRegistry: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Group 1: Core Dashboard Features

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -174,6 +174,9 @@ spec:
                     mcpCatalog:
                       type: boolean
                       description: 'When true, enables the MCP (Model Context Protocol) Catalog page.'
+                    mcpRegistry:
+                      type: boolean
+                      description: 'When true, enables the MCP (Model Context Protocol) Registry tab within the MCP Servers page.'
                     agentOps:
                       type: boolean
                       description: 'When true, enables the Agent Ops features in the Gen AI Studio.'


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78400

## Description

Promotes the `mcpRegistry` feature flag from `devTemporaryFeatureFlags` to a proper CRD-backed feature flag in `techPreviewFlags`, defaulting to `false`. This allows cluster admins to toggle the MCP Registry tab (within the MCP Servers page) via the `OdhDashboardConfig` CR.

**Changes across layers:**
- **CRD schema** — Added `mcpRegistry` boolean field with description
- **Backend types** — Added `mcpRegistry` to `DashboardConfig`
- **Backend defaults** — Set `mcpRegistry: false` in `blankDashboardCR`
- **Core BFF (Go)** — Added `McpRegistry` to `DashboardFeatureFlags` struct and `BlankDashboardCR`
- **Frontend** — Moved flag from `devTemporaryFeatureFlags` to `techPreviewFlags`, updated mock config

Follows the same pattern as `mcpCatalog` which was previously promoted.

## How Has This Been Tested?

- Verified the flag is correctly consumed by the existing `SupportedArea.MCP_REGISTRY` area config
- Confirmed `mcpRegistry` is removed from `devTemporaryFeatureFlags` and present in `techPreviewFlags`
- Verified type-checking passes across frontend, backend, and core-bff

## Test Impact

No new tests required — this is a configuration-only change moving an existing flag between flag groups. The existing `SupportedArea.MCP_REGISTRY` area config and `mlflow-embedded` extension gating remain unchanged. The mock config is updated to support the new flag in tests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable feature flag for the MCP Registry tab on the MCP Servers page.
  * Added support for enabling the MCP Registry through dashboard configuration.
* **Configuration**
  * MCP Registry is disabled by default and can be enabled as a technology preview feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->