### PR TITLE
RHOAIENG-72366: Move template hooks to @odh-dashboard/model-serving/shared

### DIFF
--- a/frontend/src/pages/modelServing/customServingRuntimes/useTemplateDisablement.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/useTemplateDisablement.ts
@@ -1,11 +1,6 @@
-import * as React from 'react';
-import useFetch, {
-  FetchOptions,
-  FetchStateObject,
-  NotReadyError,
-} from '@odh-dashboard/ui-core/hooks/useFetch';
+import { FetchOptions, FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
+import { useTemplateDisablement as useTemplateDisablementBase } from '@odh-dashboard/model-serving/shared';
 import { getDashboardConfigTemplateDisablement } from '#~/api';
-import useCustomServingRuntimesEnabled from '#~/pages/modelServing/customServingRuntimes/useCustomServingRuntimesEnabled';
 import { getDashboardConfigTemplateDisablementBackend } from '#~/services/dashboardService';
 
 const useTemplateDisablement = (
@@ -13,36 +8,12 @@ const useTemplateDisablement = (
   adminPanel?: boolean,
   fetchOptions?: Partial<FetchOptions>,
 ): FetchStateObject<string[]> => {
-  const customServingRuntimesEnabled = useCustomServingRuntimesEnabled();
+  // TODO: Remove backend workaround when we migrate admin panel to Passthrough API
+  const fetcher = adminPanel
+    ? getDashboardConfigTemplateDisablementBackend
+    : getDashboardConfigTemplateDisablement;
 
-  const getTemplateEnablement = React.useCallback(() => {
-    if (!namespace) {
-      return Promise.reject(new Error('No namespace provided'));
-    }
-
-    if (!customServingRuntimesEnabled) {
-      return Promise.reject(new NotReadyError('Custom serving runtime is not enabled'));
-    }
-
-    // TODO: Remove this when we migrate admin panel to Passthrough API
-    if (adminPanel) {
-      return getDashboardConfigTemplateDisablementBackend(namespace).catch((e) => {
-        if (e.statusObject?.code === 404) {
-          throw new Error('Dashboard config template enablement is not configured.');
-        }
-        throw e;
-      });
-    }
-
-    return getDashboardConfigTemplateDisablement(namespace).catch((e) => {
-      if (e.statusObject?.code === 404) {
-        throw new Error('Dashboard config template enablement is not configured.');
-      }
-      throw e;
-    });
-  }, [namespace, customServingRuntimesEnabled, adminPanel]);
-
-  return useFetch<string[]>(getTemplateEnablement, [], fetchOptions);
+  return useTemplateDisablementBase(namespace, fetcher, fetchOptions);
 };
 
 export default useTemplateDisablement;

--- a/frontend/src/pages/modelServing/customServingRuntimes/useTemplateOrder.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/useTemplateOrder.ts
@@ -1,11 +1,6 @@
-import * as React from 'react';
-import useFetch, {
-  FetchOptions,
-  FetchStateObject,
-  NotReadyError,
-} from '@odh-dashboard/ui-core/hooks/useFetch';
+import { FetchOptions, FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
+import { useTemplateOrder as useTemplateOrderBase } from '@odh-dashboard/model-serving/shared';
 import { getDashboardConfigTemplateOrder } from '#~/api';
-import useCustomServingRuntimesEnabled from '#~/pages/modelServing/customServingRuntimes/useCustomServingRuntimesEnabled';
 import { getDashboardConfigTemplateOrderBackend } from '#~/services/dashboardService';
 
 const useTemplateOrder = (
@@ -13,36 +8,12 @@ const useTemplateOrder = (
   adminPanel?: boolean,
   fetchOptions?: Partial<FetchOptions>,
 ): FetchStateObject<string[]> => {
-  const customServingRuntimesEnabled = useCustomServingRuntimesEnabled();
+  // TODO: Remove backend workaround when we migrate admin panel to Passthrough API
+  const fetcher = adminPanel
+    ? getDashboardConfigTemplateOrderBackend
+    : getDashboardConfigTemplateOrder;
 
-  const getTemplateOrder = React.useCallback(() => {
-    if (!namespace) {
-      return Promise.reject(new Error('No namespace provided'));
-    }
-
-    if (!customServingRuntimesEnabled) {
-      return Promise.reject(new NotReadyError('Custom serving runtime is not enabled'));
-    }
-
-    // TODO: Remove this when we migrate admin panel to Passthrough API
-    if (adminPanel) {
-      return getDashboardConfigTemplateOrderBackend(namespace).catch((e) => {
-        if (e.statusObject?.code === 404) {
-          throw new Error('Dashboard config template order is not configured.');
-        }
-        throw e;
-      });
-    }
-
-    return getDashboardConfigTemplateOrder(namespace).catch((e) => {
-      if (e.statusObject?.code === 404) {
-        throw new Error('Dashboard config template order is not configured.');
-      }
-      throw e;
-    });
-  }, [namespace, customServingRuntimesEnabled, adminPanel]);
-
-  return useFetch<string[]>(getTemplateOrder, [], fetchOptions);
+  return useTemplateOrderBase(namespace, fetcher, fetchOptions);
 };
 
 export default useTemplateOrder;

--- a/packages/model-serving/src/concepts/servingRuntimeTemplates/useServingRuntimeTemplates.ts
+++ b/packages/model-serving/src/concepts/servingRuntimeTemplates/useServingRuntimeTemplates.ts
@@ -1,14 +1,18 @@
 import React from 'react';
+import {
+  useTemplates,
+  getDashboardConfigTemplateOrder,
+  getDashboardConfigTemplateDisablement,
+} from '@odh-dashboard/internal/api/index';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
-import { useTemplates } from '@odh-dashboard/internal/api/index';
-import useTemplateOrder from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/useTemplateOrder';
-import useTemplateDisablement from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/useTemplateDisablement';
 import type { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 import type { TemplateKind } from '@odh-dashboard/k8s-core';
 import {
   ServingRuntimePlatform,
   getSortedTemplates,
   getTemplateEnabled,
+  useTemplateOrder,
+  useTemplateDisablement,
 } from '@odh-dashboard/model-serving/shared';
 
 /**
@@ -54,12 +58,12 @@ export const useServingRuntimeTemplates = (
     data: order,
     loaded: orderLoaded,
     error: orderError,
-  } = useTemplateOrder(dashboardNamespace);
+  } = useTemplateOrder(dashboardNamespace, getDashboardConfigTemplateOrder);
   const {
     data: disablement,
     loaded: disablementLoaded,
     error: disablementError,
-  } = useTemplateDisablement(dashboardNamespace);
+  } = useTemplateDisablement(dashboardNamespace, getDashboardConfigTemplateDisablement);
 
   const result = React.useMemo(() => {
     if (templates.length === 0 || !orderLoaded || !disablementLoaded) {

--- a/packages/model-serving/src/shared/hooks/__tests__/useServingRuntimeConfigList.spec.ts
+++ b/packages/model-serving/src/shared/hooks/__tests__/useServingRuntimeConfigList.spec.ts
@@ -1,0 +1,140 @@
+import { testHook, standardUseFetchStateObject } from '@odh-dashboard/jest-config/hooks';
+import { useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+import type { IsAreaAvailableStatus } from '@odh-dashboard/plugin-core/areas';
+import useServingRuntimeConfigList from '../useServingRuntimeConfigList';
+
+jest.mock('@odh-dashboard/plugin-core/areas', () => ({
+  ...jest.requireActual('@odh-dashboard/plugin-core/areas'),
+  useIsAreaAvailable: jest.fn(),
+}));
+
+const mockUseIsAreaAvailable = jest.mocked(useIsAreaAvailable);
+
+const mockAreaStatus = (status: boolean): IsAreaAvailableStatus => ({
+  status,
+  devFlags: null,
+  featureFlags: null,
+  reliantAreas: null,
+  requiredCapabilities: null,
+  requiredComponents: null,
+  customCondition: () => false,
+});
+
+describe('useServingRuntimeConfigList', () => {
+  const mockFetcher = jest.fn<Promise<string[]>, [string]>();
+  const errorMessage = 'Config is not configured.';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseIsAreaAvailable.mockReturnValue(mockAreaStatus(true));
+  });
+
+  it('should return default state initially', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    mockFetcher.mockReturnValue(new Promise(() => {}));
+
+    const renderResult = testHook(useServingRuntimeConfigList)(
+      'test-ns',
+      mockFetcher,
+      errorMessage,
+    );
+
+    expect(renderResult).hookToStrictEqual(standardUseFetchStateObject({ data: [] }));
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+
+  it('should fetch and return data on success', async () => {
+    mockFetcher.mockResolvedValue(['template-a', 'template-b']);
+
+    const renderResult = testHook(useServingRuntimeConfigList)(
+      'test-ns',
+      mockFetcher,
+      errorMessage,
+    );
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchStateObject({
+        data: ['template-a', 'template-b'],
+        loaded: true,
+      }),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(mockFetcher).toHaveBeenCalledWith('test-ns');
+  });
+
+  it('should error when namespace is undefined', async () => {
+    const renderResult = testHook(useServingRuntimeConfigList)(
+      undefined,
+      mockFetcher,
+      errorMessage,
+    );
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchStateObject({
+        data: [],
+        error: new Error('No namespace provided'),
+      }),
+    );
+    expect(mockFetcher).not.toHaveBeenCalled();
+  });
+
+  it('should stay suspended when custom serving runtimes are disabled', () => {
+    mockUseIsAreaAvailable.mockReturnValue(mockAreaStatus(false));
+
+    const renderResult = testHook(useServingRuntimeConfigList)(
+      'test-ns',
+      mockFetcher,
+      errorMessage,
+    );
+
+    expect(renderResult).hookToStrictEqual(standardUseFetchStateObject({ data: [] }));
+    expect(renderResult).hookToHaveUpdateCount(1);
+    expect(mockFetcher).not.toHaveBeenCalled();
+  });
+
+  it('should translate 404 errors to the provided error message', async () => {
+    const notFoundError = Object.assign(new Error('not found'), {
+      statusObject: { code: 404 },
+    });
+    mockFetcher.mockRejectedValue(notFoundError);
+
+    const renderResult = testHook(useServingRuntimeConfigList)(
+      'test-ns',
+      mockFetcher,
+      errorMessage,
+    );
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchStateObject({
+        data: [],
+        error: new Error(errorMessage),
+      }),
+    );
+  });
+
+  it('should propagate non-404 errors as-is', async () => {
+    const serverError = new Error('Internal server error');
+    mockFetcher.mockRejectedValue(serverError);
+
+    const renderResult = testHook(useServingRuntimeConfigList)(
+      'test-ns',
+      mockFetcher,
+      errorMessage,
+    );
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchStateObject({
+        data: [],
+        error: serverError,
+      }),
+    );
+  });
+});

--- a/packages/model-serving/src/shared/hooks/__tests__/useTemplateDisablement.spec.ts
+++ b/packages/model-serving/src/shared/hooks/__tests__/useTemplateDisablement.spec.ts
@@ -1,0 +1,60 @@
+import { testHook, standardUseFetchStateObject } from '@odh-dashboard/jest-config/hooks';
+import { useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+import type { IsAreaAvailableStatus } from '@odh-dashboard/plugin-core/areas';
+import useTemplateDisablement from '../useTemplateDisablement';
+
+jest.mock('@odh-dashboard/plugin-core/areas', () => ({
+  ...jest.requireActual('@odh-dashboard/plugin-core/areas'),
+  useIsAreaAvailable: jest.fn(),
+}));
+
+const mockUseIsAreaAvailable = jest.mocked(useIsAreaAvailable);
+
+const mockAreaStatus = (status: boolean): IsAreaAvailableStatus => ({
+  status,
+  devFlags: null,
+  featureFlags: null,
+  reliantAreas: null,
+  requiredCapabilities: null,
+  requiredComponents: null,
+  customCondition: () => false,
+});
+
+describe('useTemplateDisablement', () => {
+  const mockFetcher = jest.fn<Promise<string[]>, [string]>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseIsAreaAvailable.mockReturnValue(mockAreaStatus(true));
+  });
+
+  it('should return fetched template disablement list', async () => {
+    mockFetcher.mockResolvedValue(['disabled-runtime-1']);
+
+    const renderResult = testHook(useTemplateDisablement)('test-ns', mockFetcher);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchStateObject({
+        data: ['disabled-runtime-1'],
+        loaded: true,
+      }),
+    );
+    expect(mockFetcher).toHaveBeenCalledWith('test-ns');
+  });
+
+  it('should error when namespace is undefined', async () => {
+    const renderResult = testHook(useTemplateDisablement)(undefined, mockFetcher);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchStateObject({
+        data: [],
+        error: new Error('No namespace provided'),
+      }),
+    );
+    expect(mockFetcher).not.toHaveBeenCalled();
+  });
+});

--- a/packages/model-serving/src/shared/hooks/__tests__/useTemplateOrder.spec.ts
+++ b/packages/model-serving/src/shared/hooks/__tests__/useTemplateOrder.spec.ts
@@ -1,0 +1,60 @@
+import { testHook, standardUseFetchStateObject } from '@odh-dashboard/jest-config/hooks';
+import { useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+import type { IsAreaAvailableStatus } from '@odh-dashboard/plugin-core/areas';
+import useTemplateOrder from '../useTemplateOrder';
+
+jest.mock('@odh-dashboard/plugin-core/areas', () => ({
+  ...jest.requireActual('@odh-dashboard/plugin-core/areas'),
+  useIsAreaAvailable: jest.fn(),
+}));
+
+const mockUseIsAreaAvailable = jest.mocked(useIsAreaAvailable);
+
+const mockAreaStatus = (status: boolean): IsAreaAvailableStatus => ({
+  status,
+  devFlags: null,
+  featureFlags: null,
+  reliantAreas: null,
+  requiredCapabilities: null,
+  requiredComponents: null,
+  customCondition: () => false,
+});
+
+describe('useTemplateOrder', () => {
+  const mockFetcher = jest.fn<Promise<string[]>, [string]>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseIsAreaAvailable.mockReturnValue(mockAreaStatus(true));
+  });
+
+  it('should return fetched template order', async () => {
+    mockFetcher.mockResolvedValue(['runtime-b', 'runtime-a']);
+
+    const renderResult = testHook(useTemplateOrder)('test-ns', mockFetcher);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchStateObject({
+        data: ['runtime-b', 'runtime-a'],
+        loaded: true,
+      }),
+    );
+    expect(mockFetcher).toHaveBeenCalledWith('test-ns');
+  });
+
+  it('should error when namespace is undefined', async () => {
+    const renderResult = testHook(useTemplateOrder)(undefined, mockFetcher);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual(
+      standardUseFetchStateObject({
+        data: [],
+        error: new Error('No namespace provided'),
+      }),
+    );
+    expect(mockFetcher).not.toHaveBeenCalled();
+  });
+});

--- a/packages/model-serving/src/shared/hooks/useServingRuntimeConfigList.ts
+++ b/packages/model-serving/src/shared/hooks/useServingRuntimeConfigList.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import useFetch, {
+  FetchOptions,
+  FetchStateObject,
+  NotReadyError,
+} from '@odh-dashboard/ui-core/hooks/useFetch';
+import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+
+const useServingRuntimeConfigList = (
+  namespace: string | undefined,
+  fetcher: (namespace: string) => Promise<string[]>,
+  errorMessage: string,
+  fetchOptions?: Partial<FetchOptions>,
+): FetchStateObject<string[]> => {
+  const customServingRuntimesEnabled = useIsAreaAvailable(SupportedArea.CUSTOM_RUNTIMES).status;
+
+  const fetchCallback = React.useCallback(() => {
+    if (!namespace) {
+      return Promise.reject(new Error('No namespace provided'));
+    }
+
+    if (!customServingRuntimesEnabled) {
+      return Promise.reject(new NotReadyError('Custom serving runtime is not enabled'));
+    }
+
+    return fetcher(namespace).catch((e) => {
+      if (e.statusObject?.code === 404) {
+        throw new Error(errorMessage);
+      }
+      throw e;
+    });
+  }, [namespace, customServingRuntimesEnabled, fetcher, errorMessage]);
+
+  return useFetch<string[]>(fetchCallback, [], fetchOptions);
+};
+
+export default useServingRuntimeConfigList;

--- a/packages/model-serving/src/shared/hooks/useTemplateDisablement.ts
+++ b/packages/model-serving/src/shared/hooks/useTemplateDisablement.ts
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import useFetch, {
+  FetchOptions,
+  FetchStateObject,
+  NotReadyError,
+} from '@odh-dashboard/ui-core/hooks/useFetch';
+import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+
+const useTemplateDisablement = (
+  namespace: string | undefined,
+  fetcher: (namespace: string) => Promise<string[]>,
+  fetchOptions?: Partial<FetchOptions>,
+): FetchStateObject<string[]> => {
+  const customServingRuntimesEnabled = useIsAreaAvailable(SupportedArea.CUSTOM_RUNTIMES).status;
+
+  const getTemplateEnablement = React.useCallback(() => {
+    if (!namespace) {
+      return Promise.reject(new Error('No namespace provided'));
+    }
+
+    if (!customServingRuntimesEnabled) {
+      return Promise.reject(new NotReadyError('Custom serving runtime is not enabled'));
+    }
+
+    return fetcher(namespace).catch((e) => {
+      if (e.statusObject?.code === 404) {
+        throw new Error('Dashboard config template enablement is not configured.');
+      }
+      throw e;
+    });
+  }, [namespace, customServingRuntimesEnabled, fetcher]);
+
+  return useFetch<string[]>(getTemplateEnablement, [], fetchOptions);
+};
+
+export default useTemplateDisablement;

--- a/packages/model-serving/src/shared/hooks/useTemplateDisablement.ts
+++ b/packages/model-serving/src/shared/hooks/useTemplateDisablement.ts
@@ -1,36 +1,16 @@
-import * as React from 'react';
-import useFetch, {
-  FetchOptions,
-  FetchStateObject,
-  NotReadyError,
-} from '@odh-dashboard/ui-core/hooks/useFetch';
-import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+import { FetchOptions, FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
+import useServingRuntimeConfigList from './useServingRuntimeConfigList';
 
 const useTemplateDisablement = (
   namespace: string | undefined,
   fetcher: (namespace: string) => Promise<string[]>,
   fetchOptions?: Partial<FetchOptions>,
-): FetchStateObject<string[]> => {
-  const customServingRuntimesEnabled = useIsAreaAvailable(SupportedArea.CUSTOM_RUNTIMES).status;
-
-  const getTemplateEnablement = React.useCallback(() => {
-    if (!namespace) {
-      return Promise.reject(new Error('No namespace provided'));
-    }
-
-    if (!customServingRuntimesEnabled) {
-      return Promise.reject(new NotReadyError('Custom serving runtime is not enabled'));
-    }
-
-    return fetcher(namespace).catch((e) => {
-      if (e.statusObject?.code === 404) {
-        throw new Error('Dashboard config template enablement is not configured.');
-      }
-      throw e;
-    });
-  }, [namespace, customServingRuntimesEnabled, fetcher]);
-
-  return useFetch<string[]>(getTemplateEnablement, [], fetchOptions);
-};
+): FetchStateObject<string[]> =>
+  useServingRuntimeConfigList(
+    namespace,
+    fetcher,
+    'Dashboard config template enablement is not configured.',
+    fetchOptions,
+  );
 
 export default useTemplateDisablement;

--- a/packages/model-serving/src/shared/hooks/useTemplateOrder.ts
+++ b/packages/model-serving/src/shared/hooks/useTemplateOrder.ts
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import useFetch, {
+  FetchOptions,
+  FetchStateObject,
+  NotReadyError,
+} from '@odh-dashboard/ui-core/hooks/useFetch';
+import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+
+const useTemplateOrder = (
+  namespace: string | undefined,
+  fetcher: (namespace: string) => Promise<string[]>,
+  fetchOptions?: Partial<FetchOptions>,
+): FetchStateObject<string[]> => {
+  const customServingRuntimesEnabled = useIsAreaAvailable(SupportedArea.CUSTOM_RUNTIMES).status;
+
+  const getTemplateOrder = React.useCallback(() => {
+    if (!namespace) {
+      return Promise.reject(new Error('No namespace provided'));
+    }
+
+    if (!customServingRuntimesEnabled) {
+      return Promise.reject(new NotReadyError('Custom serving runtime is not enabled'));
+    }
+
+    return fetcher(namespace).catch((e) => {
+      if (e.statusObject?.code === 404) {
+        throw new Error('Dashboard config template order is not configured.');
+      }
+      throw e;
+    });
+  }, [namespace, customServingRuntimesEnabled, fetcher]);
+
+  return useFetch<string[]>(getTemplateOrder, [], fetchOptions);
+};
+
+export default useTemplateOrder;

--- a/packages/model-serving/src/shared/hooks/useTemplateOrder.ts
+++ b/packages/model-serving/src/shared/hooks/useTemplateOrder.ts
@@ -1,36 +1,16 @@
-import * as React from 'react';
-import useFetch, {
-  FetchOptions,
-  FetchStateObject,
-  NotReadyError,
-} from '@odh-dashboard/ui-core/hooks/useFetch';
-import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+import { FetchOptions, FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
+import useServingRuntimeConfigList from './useServingRuntimeConfigList';
 
 const useTemplateOrder = (
   namespace: string | undefined,
   fetcher: (namespace: string) => Promise<string[]>,
   fetchOptions?: Partial<FetchOptions>,
-): FetchStateObject<string[]> => {
-  const customServingRuntimesEnabled = useIsAreaAvailable(SupportedArea.CUSTOM_RUNTIMES).status;
-
-  const getTemplateOrder = React.useCallback(() => {
-    if (!namespace) {
-      return Promise.reject(new Error('No namespace provided'));
-    }
-
-    if (!customServingRuntimesEnabled) {
-      return Promise.reject(new NotReadyError('Custom serving runtime is not enabled'));
-    }
-
-    return fetcher(namespace).catch((e) => {
-      if (e.statusObject?.code === 404) {
-        throw new Error('Dashboard config template order is not configured.');
-      }
-      throw e;
-    });
-  }, [namespace, customServingRuntimesEnabled, fetcher]);
-
-  return useFetch<string[]>(getTemplateOrder, [], fetchOptions);
-};
+): FetchStateObject<string[]> =>
+  useServingRuntimeConfigList(
+    namespace,
+    fetcher,
+    'Dashboard config template order is not configured.',
+    fetchOptions,
+  );
 
 export default useTemplateOrder;

--- a/packages/model-serving/src/shared/index.ts
+++ b/packages/model-serving/src/shared/index.ts
@@ -53,5 +53,7 @@ export {
 } from './utils/kserveStatusUtils';
 
 export { default as useModelMetricsEnabled } from './hooks/useModelMetricsEnabled';
+export { default as useTemplateOrder } from './hooks/useTemplateOrder';
+export { default as useTemplateDisablement } from './hooks/useTemplateDisablement';
 
 export { getServingRuntimeVersion } from '../concepts/versions';


### PR DESCRIPTION

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-72366

## Description

  Moves `useTemplateOrder` and `useTemplateDisablement` from `@odh-dashboard/internal` (`frontend/src/pages/modelServing/customServingRuntimes/`) into `@odh-dashboard/model-serving/shared` as subpath exports.

  Both hooks fetch serving runtime template configuration (ordering and disablement) from the RHOAI backend. They previously lived in the frontend and were imported by the `model-serving` package via `@odh-dashboard/internal`, creating an undesirable cross-boundary dependency.

  **Approach — fetcher injection with preserved consumer API:**

  The hooks depend on dashboard config service functions (`getDashboardConfigTemplateOrder`, `getDashboardConfigTemplateDisablement`) that make HTTP requests to RHOAI backend API endpoints. To avoid pulling backend-specific fetch logic into the shared package, the hooks were refactored to accept the fetch function as a parameter (dependency inversion).

  Thin wrapper hooks remain in the original frontend location, injecting the real fetch functions and preserving the existing `(namespace, adminPanel, fetchOptions)` API. All three frontend consumers are unchanged.

  | Layer | Location | API |
  |-------|----------|-----|
  | **Frontend wrappers** | `frontend/src/pages/modelServing/customServingRuntimes/` | `(namespace, adminPanel, fetchOptions)` — selects backend vs passthrough fetcher, delegates to shared hook |

  **Additional change:** `useCustomServingRuntimesEnabled` (a one-liner wrapping `useIsAreaAvailable`) was inlined as a direct `useIsAreaAvailable(SupportedArea.CUSTOM_RUNTIMES)` call in the shared hooks, since `@odh-dashboard/plugin-core/areas` is already a dependency of `model-serving`.

  **Moved items:**
  
  | Category | Items |
  |----------|-------|
  | Hooks | `useTemplateOrder`, `useTemplateDisablement` |
  
  **Updated consumers:**

  | File | Change |
  |------|--------|
  | `frontend/.../CustomServingRuntimeContext.tsx` | No change (uses frontend wrapper) |
  | `frontend/.../ModelServingContext.tsx` | No change (uses frontend wrapper) |
  | `frontend/.../ProjectDetailsContext.tsx` | No change (uses frontend wrapper) |
  | `packages/model-serving/.../useServingRuntimeTemplates.ts` | Imports shared hooks + passes fetcher from `@odh-dashboard/internal/api/index` |

  ## How Has This Been Tested?

  - `npm run type-check` — passes across all affected packages (`frontend`, `model-serving`)
  - `npm run lint` — passes for all changed files
  - `npm run test` — unit tests pass for `model-serving` (308 tests), frontend model serving area (246 tests)
  - Verified `model-serving/shared` does not import from `@odh-dashboard/internal`

  ## Test Impact
  
  No new tests were added. This is a pure refactor — existing unit tests continue covering all moved items. The shared hooks have the same logic as the originals; the frontend wrappers are trivial delegations. Import paths were updated but behavior remains unchanged.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized how custom serving runtime templates are ordered and enabled across different views.
  - Centralized shared template configuration loading to keep sorting, enabled-state evaluation, and combined loading/error behavior consistent.
  - Improved messaging when a required namespace is missing or when custom runtime settings aren’t available.
  - Updated “not configured” handling for template order/enablement failures.

- **Bug Fixes**
  - Improved consistency between standard and administrator flows when fetching template configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->