### PR TITLE
IA Redesign Microcopy Updates

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -1455,7 +1455,7 @@ class OverviewTabPage {
 
 class SubscriptionManagementPage {
   visit(tab?: string): void {
-    const path = tab ? `/maas/subscription-management/${tab}` : '/maas/subscription-management';
+    const path = tab ? `/maas/maas-governance/${tab}` : '/maas/maas-governance';
     cy.visitWithLogin(path);
     this.wait();
   }

--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -577,7 +577,7 @@ class SubscriptionTableRow extends TableRow {
   }
 
   findName(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().find('[data-label="Name"]');
+    return this.find().find('[data-label="Subscription"]');
   }
 
   findActionsToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -1111,7 +1111,7 @@ class AuthPolicyTableRow extends TableRow {
   }
 
   findName(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().find('[data-label="Name"]');
+    return this.find().find('[data-label="Authorization policy"]');
   }
 
   findActionsToggle(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
@@ -101,15 +101,15 @@ describe('Subscription Management Page', () => {
     //subscriptionManagementPage.findOverviewTab().should('have.attr', 'aria-selected', 'true');
 
     subscriptionManagementPage.findSubscriptionsTab().click();
-    cy.url().should('include', '/subscription-management/subscriptions');
+    cy.url().should('include', '/maas-governance/subscriptions');
     subscriptionsPage.findTable().should('exist');
 
     subscriptionManagementPage.findAuthPoliciesTab().click();
-    cy.url().should('include', '/subscription-management/auth-policies');
+    cy.url().should('include', '/maas-governance/auth-policies');
     authPoliciesPage.findTable().should('exist');
 
     // subscriptionManagementPage.findOverviewTab().click();
-    // cy.url().should('include', '/subscription-management/overview');
+    // cy.url().should('include', '/maas-governance/overview');
     // overviewTabPage.findTable().should('exist');
   });
 
@@ -236,16 +236,16 @@ describe('Subscription Management Page', () => {
   //   // Test kebab menu
   //   overviewTabPage.findKebabToggleInRow(0).click();
   //   overviewTabPage.findKebabAction('Create subscription').should('be.visible').click();
-  //   cy.url().should('include', '/subscription-management/subscriptions/create');
+  //   cy.url().should('include', '/maas-governance/subscriptions/create');
   //   createSubscriptionPage.findModelsTable().should('contain.text', 'Llama 3 70B Instruct');
   //   createSubscriptionPage.findCancelButton().click();
-  //   cy.url().should('include', '/subscription-management/overview');
+  //   cy.url().should('include', '/maas-governance/overview');
   //   overviewTabPage.findKebabToggleInRow(0).click();
   //   overviewTabPage.findKebabAction('Create authorization policy').should('be.visible').click();
-  //   cy.url().should('include', '/subscription-management/auth-policies/create');
+  //   cy.url().should('include', '/maas-governance/auth-policies/create');
   //   policyPage.findModelsTable().should('contain.text', 'Granite 3 8B Instruct');
   //   policyPage.findCancelButton().click();
-  //   cy.url().should('include', '/subscription-management/overview');
+  //   cy.url().should('include', '/maas-governance/overview');
   // });
 
   it('should expand and collapse inline rows in the auth policies tab', () => {
@@ -331,13 +331,13 @@ describe('Subscription Management Page', () => {
   // it('should navigate to the correct form when creating a subscription or authorization policy via the overview toolbar', () => {
   //   subscriptionManagementPage.visit('overview');
   //   overviewTabPage.findCreateSubscriptionButton().click();
-  //   cy.url().should('include', '/subscription-management/subscriptions/create');
+  //   cy.url().should('include', '/maas-governance/subscriptions/create');
   //   createSubscriptionPage.findCancelButton().click();
-  //   cy.url().should('include', '/subscription-management/overview');
+  //   cy.url().should('include', '/maas-governance/overview');
   //   subscriptionManagementPage.findOverviewTab().click();
   //   overviewTabPage.findCreateAuthorizationPolicyButton().click();
-  //   cy.url().should('include', '/subscription-management/auth-policies/create');
+  //   cy.url().should('include', '/maas-governance/auth-policies/create');
   //   policyPage.findCancelButton().click();
-  //   cy.url().should('include', '/subscription-management/overview');
+  //   cy.url().should('include', '/maas-governance/overview');
   // });
 });

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
@@ -97,7 +97,7 @@ describe('Subscription Management Page', () => {
 
   it('should navigate between tabs and update the URL', () => {
     subscriptionManagementPage.visit();
-    subscriptionManagementPage.findTitle().should('contain.text', 'Subscription management');
+    subscriptionManagementPage.findTitle().should('contain.text', 'MaaS governance');
     //subscriptionManagementPage.findOverviewTab().should('have.attr', 'aria-selected', 'true');
 
     subscriptionManagementPage.findSubscriptionsTab().click();

--- a/packages/maas/frontend/src/app/AppRoutes.tsx
+++ b/packages/maas/frontend/src/app/AppRoutes.tsx
@@ -20,7 +20,7 @@ const AppRoutes: React.FC = () => {
   const isKeysAndSubs = pathname.startsWith(`${URL_PREFIX}/keys-and-subs`);
   const isSubscriptions = pathname.startsWith(`${URL_PREFIX}/subscriptions`);
   const isAuthPolicies = pathname.startsWith(`${URL_PREFIX}/auth-policies`);
-  const isSubscriptionManagement = pathname.startsWith(`${URL_PREFIX}/subscription-management`);
+  const isSubscriptionManagement = pathname.startsWith(`${URL_PREFIX}/maas-governance`);
 
   if (isSubscriptionManagement) {
     return (

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/columns.ts
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/columns.ts
@@ -4,7 +4,7 @@ import { normalizePhase } from '~/app/utilities/phaseLabelUtils';
 
 export const authPoliciesColumns: SortableData<MaaSAuthPolicy>[] = [
   {
-    label: 'Name',
+    label: 'Authorization policy',
     field: 'name',
     sortable: (a: MaaSAuthPolicy, b: MaaSAuthPolicy): number =>
       (a.displayName ?? a.name).localeCompare(b.displayName ?? b.name),

--- a/packages/maas/frontend/src/app/pages/external-models/__tests__/utils.spec.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/__tests__/utils.spec.tsx
@@ -124,8 +124,10 @@ describe('getExternalModelStatusMessage', () => {
     expect(container.textContent).toContain('gpt-4o-external');
   });
 
-  it('should return null for unknown phases', () => {
-    expect(getExternalModelStatusMessage(baseModel({ phase: 'SomethingElse' }))).toBeNull();
+  it('should return generic message for unknown phases', () => {
+    expect(getExternalModelStatusMessage(baseModel({ phase: 'SomethingElse' }))).toBe(
+      'The status of this external model is unknown.',
+    );
   });
 });
 

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/__tests__/ApiKeysAndSubscriptionsPage.spec.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/__tests__/ApiKeysAndSubscriptionsPage.spec.tsx
@@ -41,13 +41,17 @@ jest.mock('~/app/hooks/useApiKeysPageLoad', () => ({
   }),
 }));
 
-jest.mock('~/app/pages/api-keys/ApiKeysTab', () => {
+jest.mock('~/app/hooks/useUserSubscriptions', () => ({
+  useUserSubscriptions: () => [[], true, undefined],
+}));
+
+jest.mock('~/app/pages/keys-and-subs/apiKeys/ApiKeysTab', () => {
   const MockApiKeysTab = () => <div data-testid="mock-api-keys-tab">ApiKeysTab</div>;
   MockApiKeysTab.displayName = 'MockApiKeysTab';
   return { __esModule: true, default: MockApiKeysTab };
 });
 
-jest.mock('~/app/pages/api-keys/SubscriptionsTab', () => {
+jest.mock('~/app/pages/keys-and-subs/mySubscriptions/SubscriptionsTab', () => {
   const MockSubscriptionsTab = () => (
     <div data-testid="mock-subscriptions-tab">SubscriptionsTab</div>
   );
@@ -55,13 +59,19 @@ jest.mock('~/app/pages/api-keys/SubscriptionsTab', () => {
   return { __esModule: true, default: MockSubscriptionsTab };
 });
 
+jest.mock('@odh-dashboard/ui-core/design/TitleWithIcon', () => {
+  const MockTitleWithIcon = ({ title }: { title: string }) => <>{title}</>;
+  MockTitleWithIcon.displayName = 'MockTitleWithIcon';
+  return { __esModule: true, default: MockTitleWithIcon };
+});
+
 jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => {
   const MockApplicationsPage = (
-    props: React.PropsWithChildren<{ title: string; description: React.ReactNode }>,
+    props: React.PropsWithChildren<{ title: React.ReactNode; description?: React.ReactNode }>,
   ) => (
     <div>
       <h1 data-testid="app-page-title">{props.title}</h1>
-      <p data-testid="app-page-description">{props.description}</p>
+      {props.description ? <p data-testid="app-page-description">{props.description}</p> : null}
       {props.children}
     </div>
   );
@@ -75,13 +85,10 @@ describe('ApiKeysAndSubscriptionsPage', () => {
     mockTab = undefined;
   });
 
-  it('should show updated title and description', () => {
+  it('should show title', () => {
     render(<ApiKeysAndSubscriptionsPage />);
 
-    expect(screen.getByTestId('app-page-title')).toHaveTextContent('API keys and subscriptions');
-    expect(screen.getByTestId('app-page-description')).toHaveTextContent(
-      'Manage your API keys and view your subscription access',
-    );
+    expect(screen.getByTestId('app-page-title')).toHaveTextContent('API keys');
   });
 
   it('should render tabs for API keys and Subscriptions', () => {

--- a/packages/maas/frontend/src/app/pages/subscription-management/AuthPoliciesTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/AuthPoliciesTab.tsx
@@ -74,8 +74,7 @@ const AuthPoliciesTab: React.FC<AuthPoliciesTabProps> = ({ returnTo }) => {
         returnTo={returnTo}
         testId="empty-auth-policies-page"
         title="No authorization policies"
-        bodyText="Authorization policies control which groups have access to MaaS models. Create a policy to
-        define who can consume specific models."
+        bodyText="Authorization policies control which user groups can access MaaS models. Create a policy to define model access permissions."
         showPoliciesButton
       />
     );

--- a/packages/maas/frontend/src/app/pages/subscription-management/OverviewTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/OverviewTab.tsx
@@ -8,7 +8,7 @@ import { initialOverviewFilterData, OverviewFilterDataType } from './overview/co
 import { filterOverviewModels } from './overview/utils';
 import EmptyStatePage from './EmptyStatePage';
 
-const OVERVIEW_RETURN_TO = `${URL_PREFIX}/subscription-management/overview`;
+const OVERVIEW_RETURN_TO = `${URL_PREFIX}/maas-governance/overview`;
 
 const OverviewTab: React.FC = () => {
   const [rows, loaded, error] = useModelsOverview();

--- a/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionManagementPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionManagementPage.tsx
@@ -44,16 +44,16 @@ const SubscriptionManagementPage: React.FC = () => {
 
   return (
     <ApplicationsPage
-      title="Subscription management"
-      description="Manage subscriptions and authorization policies to control the MaaS models that each user group in your organization can access."
+      title="MaaS governance"
+      description="Manage subscriptions and authorization policies that control access to models through the Models-as-a-Service (MaaS) gateway."
       loaded={formDataLoaded}
       empty={empty}
       emptyStatePage={
         <EmptyStatePage
           returnTo={`${URL_PREFIX}/subscription-management`}
           testId="empty-overview-page"
-          title="Get started with subscription management"
-          bodyText="No subscriptions or authorization policies have been configured yet. Set up subscriptions to define rate limits and policies to control which groups can access your MaaS models."
+          title="Configure MaaS governance"
+          bodyText="No subscriptions or authorization policies exist. Create subscriptions to define token limits and authorization policies to control model access."
           showSubsButton
           showPoliciesButton
           cubeIcon

--- a/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionManagementPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionManagementPage.tsx
@@ -23,7 +23,7 @@ const SubscriptionManagementPage: React.FC = () => {
 
   const onSelectTab = React.useCallback(
     (_event: React.MouseEvent, tabKey: string | number) => {
-      navigate(`${URL_PREFIX}/subscription-management/${String(tabKey)}`);
+      navigate(`${URL_PREFIX}/maas-governance/${String(tabKey)}`);
     },
     [navigate],
   );
@@ -50,7 +50,7 @@ const SubscriptionManagementPage: React.FC = () => {
       empty={empty}
       emptyStatePage={
         <EmptyStatePage
-          returnTo={`${URL_PREFIX}/subscription-management`}
+          returnTo={`${URL_PREFIX}/maas-governance`}
           testId="empty-overview-page"
           title="Configure MaaS governance"
           bodyText="No subscriptions or authorization policies exist. Create subscriptions to define token limits and authorization policies to control model access."
@@ -80,9 +80,7 @@ const SubscriptionManagementPage: React.FC = () => {
           aria-label="Subscriptions tab"
           data-testid="subscriptions-tab"
         >
-          <SubscriptionsTab
-            returnTo={`${URL_PREFIX}/subscription-management/${SUBSCRIPTIONS_TAB}`}
-          />
+          <SubscriptionsTab returnTo={`${URL_PREFIX}/maas-governance/${SUBSCRIPTIONS_TAB}`} />
         </Tab>
         <Tab
           eventKey={AUTH_POLICIES_TAB}
@@ -90,9 +88,7 @@ const SubscriptionManagementPage: React.FC = () => {
           aria-label="Authorization policies tab"
           data-testid="auth-policies-tab"
         >
-          <AuthPoliciesTab
-            returnTo={`${URL_PREFIX}/subscription-management/${AUTH_POLICIES_TAB}`}
-          />
+          <AuthPoliciesTab returnTo={`${URL_PREFIX}/maas-governance/${AUTH_POLICIES_TAB}`} />
         </Tab>
       </Tabs>
     </ApplicationsPage>

--- a/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionsTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionsTab.tsx
@@ -72,8 +72,7 @@ const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ returnTo }) => {
         returnTo={returnTo}
         testId="empty-subscriptions-page"
         title="No subscriptions"
-        bodyText="Subscriptions define rate limits and token quotas for MaaS model access. Create a
-        subscription to control how much each group can consume."
+        bodyText="Subscriptions define token limits for model access. Create a subscription to control usage for each user group."
         showSubsButton
       />
     );

--- a/packages/maas/frontend/src/app/pages/subscription-management/__tests__/SubscriptionManagementPage.spec.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/__tests__/SubscriptionManagementPage.spec.tsx
@@ -12,6 +12,18 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ tab: mockTab }),
 }));
 
+jest.mock('~/app/hooks/useSubscriptionPolicyFormData', () => ({
+  useSubscriptionPolicyFormData: () => [
+    {
+      groups: [],
+      modelRefs: [{ name: 'model-1' }],
+      subscriptions: [{ name: 'sub-1' }],
+      policies: [{ name: 'policy-1' }],
+    },
+    true,
+  ],
+}));
+
 jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => {
   const MockApplicationsPage = (
     props: React.PropsWithChildren<{ title: string; description: React.ReactNode }>,
@@ -26,11 +38,11 @@ jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => {
   return { __esModule: true, default: MockApplicationsPage };
 });
 
-jest.mock('~/app/pages/subscription-management/OverviewTab', () => {
-  const MockOverviewTab = () => <div data-testid="mock-overview-tab">OverviewTab</div>;
-  MockOverviewTab.displayName = 'MockOverviewTab';
-  return { __esModule: true, default: MockOverviewTab };
-});
+// jest.mock('~/app/pages/subscription-management/OverviewTab', () => {
+//   const MockOverviewTab = () => <div data-testid="mock-overview-tab">OverviewTab</div>;
+//   MockOverviewTab.displayName = 'MockOverviewTab';
+//   return { __esModule: true, default: MockOverviewTab };
+// });
 
 jest.mock('~/app/pages/subscription-management/SubscriptionsTab', () => {
   const MockSubscriptionsTab = () => (
@@ -55,25 +67,25 @@ describe('SubscriptionManagementPage', () => {
   it('should show title and description', () => {
     render(<SubscriptionManagementPage />);
 
-    expect(screen.getByTestId('app-page-title')).toHaveTextContent('Subscription management');
+    expect(screen.getByTestId('app-page-title')).toHaveTextContent('MaaS governance');
     expect(screen.getByTestId('app-page-description')).toHaveTextContent(
       'Manage subscriptions and authorization policies',
     );
   });
 
-  it('should render all three tabs', () => {
+  it('should render subscriptions and authorization policies tabs', () => {
     render(<SubscriptionManagementPage />);
 
-    expect(screen.getByTestId('overview-tab')).toBeInTheDocument();
+    expect(screen.queryByTestId('overview-tab')).not.toBeInTheDocument(); //until we add it back
     expect(screen.getByTestId('subscriptions-tab')).toBeInTheDocument();
     expect(screen.getByTestId('auth-policies-tab')).toBeInTheDocument();
   });
 
-  it('should default to the overview tab when no tab param is provided', () => {
+  it('should default to the subscriptions tab when no tab param is provided', () => {
     render(<SubscriptionManagementPage />);
 
-    expect(screen.getByTestId('overview-tab')).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByTestId('mock-overview-tab')).toBeInTheDocument();
+    expect(screen.getByTestId('subscriptions-tab')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('mock-subscriptions-tab')).toBeInTheDocument();
   });
 
   it('should activate the subscriptions tab when tab param is "subscriptions"', () => {
@@ -90,11 +102,11 @@ describe('SubscriptionManagementPage', () => {
     expect(screen.getByTestId('auth-policies-tab')).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('should fall back to overview tab for an invalid tab param', () => {
+  it('should fall back to subscriptions tab for an invalid tab param', () => {
     mockTab = 'invalid-tab';
     render(<SubscriptionManagementPage />);
 
-    expect(screen.getByTestId('overview-tab')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('subscriptions-tab')).toHaveAttribute('aria-selected', 'true');
   });
 
   it('should navigate when a tab is clicked', () => {

--- a/packages/maas/frontend/src/app/pages/subscription-management/__tests__/SubscriptionManagementPage.spec.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/__tests__/SubscriptionManagementPage.spec.tsx
@@ -38,12 +38,6 @@ jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => {
   return { __esModule: true, default: MockApplicationsPage };
 });
 
-// jest.mock('~/app/pages/subscription-management/OverviewTab', () => {
-//   const MockOverviewTab = () => <div data-testid="mock-overview-tab">OverviewTab</div>;
-//   MockOverviewTab.displayName = 'MockOverviewTab';
-//   return { __esModule: true, default: MockOverviewTab };
-// });
-
 jest.mock('~/app/pages/subscription-management/SubscriptionsTab', () => {
   const MockSubscriptionsTab = () => (
     <div data-testid="mock-subscriptions-tab">SubscriptionsTab</div>
@@ -113,9 +107,9 @@ describe('SubscriptionManagementPage', () => {
     render(<SubscriptionManagementPage />);
 
     fireEvent.click(screen.getByTestId('subscriptions-tab'));
-    expect(mockNavigate).toHaveBeenCalledWith('/maas/subscription-management/subscriptions');
+    expect(mockNavigate).toHaveBeenCalledWith('/maas/maas-governance/subscriptions');
 
     fireEvent.click(screen.getByTestId('auth-policies-tab'));
-    expect(mockNavigate).toHaveBeenCalledWith('/maas/subscription-management/auth-policies');
+    expect(mockNavigate).toHaveBeenCalledWith('/maas/maas-governance/auth-policies');
   });
 });

--- a/packages/maas/frontend/src/app/pages/subscription-management/overview/ExpandedModelContent.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/overview/ExpandedModelContent.tsx
@@ -10,8 +10,8 @@ import { formatTokenLimits } from '~/app/utilities/rateLimits';
 import GroupChips from './GroupChips';
 
 const OVERVIEW_LINK_STATE = {
-  returnTo: `${URL_PREFIX}/subscription-management/overview`,
-  breadcrumbLabel: 'Subscription management',
+  returnTo: `${URL_PREFIX}/maas-governance/overview`,
+  breadcrumbLabel: 'MaaS governance',
 };
 
 const itemBorderStyle = {
@@ -178,7 +178,7 @@ const SubscriptionsSection: React.FC<SubscriptionsSectionProps> = ({
             ariaLabel={`Subscription ${sub.displayName ?? sub.name}`}
             name={sub.name}
             displayName={sub.displayName}
-            linkTo={`${URL_PREFIX}/subscription-management/subscriptions/view/${sub.name}`}
+            linkTo={`${URL_PREFIX}/maas-governance/subscriptions/view/${sub.name}`}
             linkState={OVERVIEW_LINK_STATE}
             phase={sub.phase}
             resourceType={PhaseResourceType.SUBSCRIPTION}
@@ -234,7 +234,7 @@ const PoliciesSection: React.FC<PoliciesSectionProps> = ({
             ariaLabel={`Policy ${policy.displayName ?? policy.name}`}
             name={policy.name}
             displayName={policy.displayName}
-            linkTo={`${URL_PREFIX}/subscription-management/auth-policies/view/${policy.name}`}
+            linkTo={`${URL_PREFIX}/maas-governance/auth-policies/view/${policy.name}`}
             linkState={OVERVIEW_LINK_STATE}
             phase={policy.phase}
             resourceType={PhaseResourceType.AUTHPOLICY}

--- a/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewTableRow.tsx
@@ -16,7 +16,7 @@ type OverviewTableRowProps = {
   onToggleExpand: () => void;
 };
 
-const RETURN_TO = `${URL_PREFIX}/subscription-management/overview`;
+const RETURN_TO = `${URL_PREFIX}/maas-governance/overview`;
 
 const NoSubscriptionsWarning: React.FC = () => (
   <Popover
@@ -141,10 +141,10 @@ const OverviewTableRow: React.FC<OverviewTableRowProps> = ({
               {
                 title: 'Create subscription',
                 onClick: () =>
-                  navigate(`${URL_PREFIX}/subscription-management/subscriptions/create`, {
+                  navigate(`${URL_PREFIX}/maas-governance/subscriptions/create`, {
                     state: {
                       returnTo: RETURN_TO,
-                      breadcrumbLabel: 'Subscription management',
+                      breadcrumbLabel: 'MaaS governance',
                       preSelectedModel: { name: row.id },
                     },
                   }),
@@ -152,10 +152,10 @@ const OverviewTableRow: React.FC<OverviewTableRowProps> = ({
               {
                 title: 'Create authorization policy',
                 onClick: () =>
-                  navigate(`${URL_PREFIX}/subscription-management/auth-policies/create`, {
+                  navigate(`${URL_PREFIX}/maas-governance/auth-policies/create`, {
                     state: {
                       returnTo: RETURN_TO,
-                      breadcrumbLabel: 'Subscription management',
+                      breadcrumbLabel: 'MaaS governance',
                       preSelectedModel: { name: row.id },
                     },
                   }),

--- a/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/overview/OverviewToolbar.tsx
@@ -74,10 +74,10 @@ const OverviewToolbar: React.FC<OverviewToolbarProps> = ({
           component={(props) => (
             <Link
               {...props}
-              to={`${URL_PREFIX}/subscription-management/subscriptions/create`}
+              to={`${URL_PREFIX}/maas-governance/subscriptions/create`}
               state={{
-                returnTo: returnTo ?? `${URL_PREFIX}/subscription-management/overview`,
-                breadcrumbLabel: 'Subscription management',
+                returnTo: returnTo ?? `${URL_PREFIX}/maas-governance/overview`,
+                breadcrumbLabel: 'MaaS governance',
               }}
             />
           )}
@@ -92,10 +92,10 @@ const OverviewToolbar: React.FC<OverviewToolbarProps> = ({
           component={(props) => (
             <Link
               {...props}
-              to={`${URL_PREFIX}/subscription-management/auth-policies/create`}
+              to={`${URL_PREFIX}/maas-governance/auth-policies/create`}
               state={{
-                returnTo: returnTo ?? `${URL_PREFIX}/subscription-management/overview`,
-                breadcrumbLabel: 'Subscription management',
+                returnTo: returnTo ?? `${URL_PREFIX}/maas-governance/overview`,
+                breadcrumbLabel: 'MaaS governance',
               }}
             />
           )}

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
@@ -4,7 +4,7 @@ import { normalizePhase } from '~/app/utilities/phaseLabelUtils';
 
 export const subscriptionsColumns: SortableData<MaaSSubscription>[] = [
   {
-    label: 'Name',
+    label: 'Subscription',
     field: 'name',
     sortable: (a: MaaSSubscription, b: MaaSSubscription): number =>
       (a.displayName ?? a.name).localeCompare(b.displayName ?? b.name),

--- a/packages/maas/frontend/src/app/utilities/subscriptionManagementNavigation.ts
+++ b/packages/maas/frontend/src/app/utilities/subscriptionManagementNavigation.ts
@@ -1,6 +1,6 @@
 import { URL_PREFIX } from './const';
 
-const SUBSCRIPTION_MANAGEMENT_PREFIX = `${URL_PREFIX}/subscription-management`;
+const SUBSCRIPTION_MANAGEMENT_PREFIX = `${URL_PREFIX}/maas-governance`;
 
 export const getPreSelectedModelFromState = (
   state: unknown,

--- a/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
+++ b/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
@@ -77,7 +77,7 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
     },
     properties: {
       id: 'maas-subscription-management-view',
-      title: 'Subscription management',
+      title: 'MaaS governance',
       href: '/maas/subscription-management',
       section: 'settings',
       path: '/maas/subscription-management/*',

--- a/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
+++ b/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
@@ -78,9 +78,9 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
     properties: {
       id: 'maas-subscription-management-view',
       title: 'MaaS governance',
-      href: '/maas/subscription-management',
+      href: '/maas/maas-governance',
       section: 'settings',
-      path: '/maas/subscription-management/*',
+      path: '/maas/maas-governance/*',
     },
   },
   {
@@ -148,7 +148,7 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
       required: [MODEL_AS_SERVICE_ID, ADMIN_USER, MAAS_IA_REDESIGN],
     },
     properties: {
-      path: '/maas/subscription-management/*',
+      path: '/maas/maas-governance/*',
       component: () => import('./MaaSWrapper'),
     },
   },

--- a/packages/maas/package.json
+++ b/packages/maas/package.json
@@ -37,7 +37,9 @@
     "prepare:e2e": "cd bff && go mod download",
     "cypress:server:e2e": "STATIC_ASSETS_DIR=../frontend/public-cypress make dev-bff-e2e-cluster E2E_BFF_PORT=9104",
     "lint": "cd frontend && npm run lint",
-    "lint:fix": "cd frontend && npm run lint:fix"
+    "lint:fix": "cd frontend && npm run lint:fix",
+    "test-unit": "cd frontend && npm run test:unit",
+    "type-check": "cd frontend && npm run test:type-check"
   },
   "exports": {
     "./utils/api-keys": "./frontend/src/app/pages/keys-and-subs/utils.ts",


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-71569](https://redhat.atlassian.net/browse/RHOAIENG-71569)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
[content doc](https://docs.google.com/document/d/12lH9eL9FGDnIH-UpOtTRBrLw07zw9wQtv-9f0agPVJk/edit?tab=t.fizwk2cnyo0e)


Nav item name:
<img width="276" height="106" alt="Screenshot 2026-07-21 at 9 28 44 AM" src="https://github.com/user-attachments/assets/be31efe6-3fb0-4fbd-ba31-3babd613da5e" />

Application page title and description:
<img width="923" height="110" alt="Screenshot 2026-07-21 at 9 28 47 AM" src="https://github.com/user-attachments/assets/ef841f03-9305-4bbd-9fdd-b17fcd374679" />

Policy column name:
<img width="685" height="243" alt="Screenshot 2026-07-21 at 9 28 56 AM" src="https://github.com/user-attachments/assets/9b1aae3e-d37c-44e6-bb08-d6ad4a6d9c3c" />

Subscription column name:
<img width="654" height="296" alt="Screenshot 2026-07-21 at 9 28 59 AM" src="https://github.com/user-attachments/assets/d2d72d1f-28c2-4ab5-8347-7895c250923f" />

Subscription empty state
<img width="735" height="347" alt="Screenshot 2026-07-21 at 9 32 40 AM" src="https://github.com/user-attachments/assets/9036a5a3-f305-4231-9d97-892c432368ff" />

Policy empty state:
<img width="723" height="356" alt="Screenshot 2026-07-21 at 9 33 26 AM" src="https://github.com/user-attachments/assets/e3c23188-3e0a-4da0-8e62-2f6dcc3efba3" />

No subs, policies, or model refs (more of a thing when the overview tab is relevant)
<img width="1164" height="584" alt="Screenshot 2026-07-21 at 9 35 47 AM" src="https://github.com/user-attachments/assets/897d2f64-245d-45da-b8b3-a655752068ae" />



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

tested locally

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated a mock test assertion

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-71569]: https://redhat.atlassian.net/browse/RHOAIENG-71569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updated Experience**
  - Renamed **“Subscription management”** to **“MaaS governance”** across navigation, page titles, and empty-state messaging.
  - Re-routed governance pages and updated tab behavior: the page now defaults to the **subscriptions** tab and no longer shows the overview tab.
  - Updated table headers to **“Subscription”** and **“Authorization policy”**.
- **Bug Fixes**
  - Improved messaging for external models when their status phase is unrecognized (now shows a non-null “unknown phases” message).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->