### PR TITLE
External Models Microcopy Updates

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -1597,6 +1597,14 @@ class ExternalModelTableRow extends TableRow {
     return cy.findByTestId('external-model-governance-pairing-warning-popover');
   }
 
+  findMissingMaaSModelRefWarning(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('external-model-missing-maas-model-ref');
+  }
+
+  findMissingMaaSModelRefWarningPopover(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('external-model-missing-maas-model-ref-popover');
+  }
+
   findExpandedProviderRow(providerName: string): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.scope().findByTestId(`expanded-provider-row-${providerName}`);
   }

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasExternalModels.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasExternalModels.cy.ts
@@ -109,7 +109,7 @@ describe('External Models Page', () => {
     });
 
     it('should display table content with status popover and expanded provider details', () => {
-      externalModelsPage.findRows().should('have.length', 3);
+      externalModelsPage.findRows().should('have.length', 4);
 
       const gptRow = externalModelsPage.getRow('GPT-4o External');
       gptRow.findName().should('contain.text', 'GPT-4o External');
@@ -179,28 +179,36 @@ describe('External Models Page', () => {
         .findGovernanceWarningPopover()
         .should('exist')
         .should('contain.text', 'Pending MaaS governance');
+
+      const missingRefRow = externalModelsPage.getRow('Missing Ref Model');
+      missingRefRow.findPhaseLabel().should('contain.text', 'Ready');
+      missingRefRow.findMissingMaaSModelRefWarning().should('exist').click();
+      missingRefRow
+        .findMissingMaaSModelRefWarningPopover()
+        .should('exist')
+        .should('contain.text', 'MaaS model reference required');
     });
 
     it('should filter external models by keyword across name, display name, and description', () => {
-      externalModelsPage.findRows().should('have.length', 3);
+      externalModelsPage.findRows().should('have.length', 4);
 
       externalModelsPage.findFilterInput().type('gpt-4o-external');
       externalModelsPage.findRows().should('have.length', 1);
       externalModelsPage.getRow('GPT-4o External').findName().should('exist');
       externalModelsPage.findFilterResetButton().click();
-      externalModelsPage.findRows().should('have.length', 3);
+      externalModelsPage.findRows().should('have.length', 4);
 
       externalModelsPage.findFilterInput().type('Claude A/B');
       externalModelsPage.findRows().should('have.length', 1);
       externalModelsPage.getRow('Claude A/B Split').findName().should('exist');
       externalModelsPage.findFilterResetButton().click();
-      externalModelsPage.findRows().should('have.length', 3);
+      externalModelsPage.findRows().should('have.length', 4);
 
       externalModelsPage.findFilterInput().type('subscription and auth pairing');
       externalModelsPage.findRows().should('have.length', 1);
       externalModelsPage.getRow('Awaiting Pairing Model').findName().should('exist');
       externalModelsPage.findFilterResetButton().click();
-      externalModelsPage.findRows().should('have.length', 3);
+      externalModelsPage.findRows().should('have.length', 4);
     });
 
     it('should delete an external model', () => {
@@ -226,7 +234,7 @@ describe('External Models Page', () => {
       deleteExternalModelModal.findSubmitButton().click();
       cy.wait('@deleteExternalModel');
       cy.wait('@listExternalModels');
-      externalModelsPage.findRows().should('have.length', 2);
+      externalModelsPage.findRows().should('have.length', 3);
       externalModelsPage.findTable().should('not.contain', 'GPT-4o External');
     });
   });

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasExternalModels.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasExternalModels.cy.ts
@@ -186,7 +186,7 @@ describe('External Models Page', () => {
       missingRefRow
         .findMissingMaaSModelRefWarningPopover()
         .should('exist')
-        .should('contain.text', 'MaaS model reference required');
+        .should('contain.text', 'Missing MaaS model setup');
     });
 
     it('should filter external models by keyword across name, display name, and description', () => {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasExternalModels.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasExternalModels.cy.ts
@@ -178,7 +178,7 @@ describe('External Models Page', () => {
       awaitingRow
         .findGovernanceWarningPopover()
         .should('exist')
-        .should('contain.text', 'Not ready for consumption');
+        .should('contain.text', 'Pending MaaS governance');
     });
 
     it('should filter external models by keyword across name, display name, and description', () => {

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -909,4 +909,13 @@ export const mockExternalModels = (): ExternalModel[] => [
       statusMessage: 'Awaiting governance pairing',
     },
   }),
+  mockExternalModel({
+    name: 'missing-ref-model',
+    displayName: 'Missing Ref Model',
+    description: 'External model without a MaaS model reference.',
+    modelName: 'missing-ref',
+    phase: 'Ready',
+    statusMessage: 'External model is ready',
+    maaSModelRef: undefined,
+  }),
 ];

--- a/packages/maas/frontend/src/app/pages/external-models/DeleteExternalModelModal.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/DeleteExternalModelModal.tsx
@@ -39,10 +39,9 @@ const DeleteExternalModelModal: React.FC<DeleteExternalModelModalProps> = ({
     >
       <Stack hasGutter>
         <StackItem data-testid="delete-modal-confirmation-message">
-          The <strong>{externalModel.displayName || externalModel.name}</strong> external model and
-          its corresponding Model Ref will be permanently deleted. Any subscriptions or
-          authorization policies referencing this model will lose access. This action cannot be
-          undone.
+          The <strong>{externalModel.displayName || externalModel.name}</strong> external model will
+          be deleted. Any subscriptions or authorization policies referencing this model will lose
+          access.
         </StackItem>
       </Stack>
     </DeleteModal>

--- a/packages/maas/frontend/src/app/pages/external-models/EmptyExternalModelsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/EmptyExternalModelsPage.tsx
@@ -11,9 +11,18 @@ const EmptyExternalModelsPage: React.FC = () => (
     icon={PlusCircleIcon}
   >
     <EmptyStateBody>
-      Add external model endpoints to make off-cluster models available through the inference
-      gateway. Configure external providers to connect to OpenAI, Anthropic, AWS Bedrock, and other
-      hosted model APIs.
+      <>
+        External models enable you to route inference requests to off-cluster model providers
+        through the MaaS gateway.
+        <br />
+        <br />
+        To get started, add an external model with at least one provider reference via the CLI.
+        <br />
+        <br />
+        Once ready, it can be made accessible to consumers by setting up a subscription and
+        authorization policy on the <strong>MaaS governance</strong> page. Consumers will also need
+        an API key to send requests.
+      </>
     </EmptyStateBody>
   </EmptyState>
 );

--- a/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTableRow.tsx
@@ -7,11 +7,12 @@ import PhaseLabel from '~/app/shared/PhaseLabel';
 import { PhaseResourceType } from '~/app/utilities/phaseLabelUtils';
 import { ExternalModel, ProviderRef } from '~/app/types/external-models';
 import { externalModelsColumns } from './columns';
-import { GovernancePairingWarning } from './const';
+import { GovernancePairingWarning, MissingMaaSModelRefWarning } from './const';
 import {
   getExternalModelResource,
   getExternalModelStatusMessage,
   isAwaitingGovernancePairing,
+  isMissingMaaSModelRef,
 } from './utils';
 import PathModal from './modals/ExternalModelsPathModal';
 import ProviderURLModal from './modals/ExternalModelsProviderModal';
@@ -166,10 +167,16 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
             resourceType={PhaseResourceType.EXTERNAL_MODEL}
           />
         </FlexItem>
-        {isAwaitingGovernancePairing(externalModel) && (
+        {isMissingMaaSModelRef(externalModel) ? (
           <FlexItem>
-            <GovernancePairingWarning />
+            <MissingMaaSModelRefWarning />
           </FlexItem>
+        ) : (
+          isAwaitingGovernancePairing(externalModel) && (
+            <FlexItem>
+              <GovernancePairingWarning />
+            </FlexItem>
+          )
         )}
       </Flex>
     </Td>

--- a/packages/maas/frontend/src/app/pages/external-models/__tests__/utils.spec.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/__tests__/utils.spec.tsx
@@ -97,7 +97,7 @@ describe('getExternalModelStatusMessage', () => {
     const { container } = render(
       <>{getExternalModelStatusMessage(baseModel({ phase: PhaseStatus.PENDING }))}</>,
     );
-    expect(container.textContent).toContain('is being reconciled');
+    expect(container.textContent).toContain('is being set up');
     expect(container.textContent).toContain('GPT-4o External');
   });
 
@@ -105,12 +105,14 @@ describe('getExternalModelStatusMessage', () => {
     const { container } = render(
       <>{getExternalModelStatusMessage(baseModel({ phase: PhaseStatus.FAILED }))}</>,
     );
-    expect(container.textContent).toContain('could not be reconciled');
+    expect(container.textContent).toContain('failed to set up');
   });
 
   it('should return ready reconciliation copy', () => {
     const { container } = render(<>{getExternalModelStatusMessage(baseModel())}</>);
-    expect(container.textContent).toContain('have been created successfully');
+    expect(container.textContent).toContain(
+      'Requests are being routed to the configured provider(s).',
+    );
   });
 
   it('should fall back to resource name when display name is missing', () => {

--- a/packages/maas/frontend/src/app/pages/external-models/__tests__/utils.spec.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/__tests__/utils.spec.tsx
@@ -9,6 +9,7 @@ import {
   getExternalModelStatusMessage,
   getProviderRefResource,
   isAwaitingGovernancePairing,
+  isMissingMaaSModelRef,
   mapAuthMechanismToHumanReadable,
 } from '~/app/pages/external-models/utils';
 
@@ -20,6 +21,20 @@ const baseModel = (overrides: Partial<ExternalModel> = {}): ExternalModel => ({
   providerRefs: [],
   phase: PhaseStatus.READY,
   ...overrides,
+});
+
+describe('isMissingMaaSModelRef', () => {
+  it('should return true when maaSModelRef is undefined', () => {
+    expect(isMissingMaaSModelRef(baseModel())).toBe(true);
+  });
+
+  it('should return false when maaSModelRef is present', () => {
+    expect(isMissingMaaSModelRef(baseModel({ maaSModelRef: { phase: 'Ready' } }))).toBe(false);
+  });
+
+  it('should return false when maaSModelRef is present with empty object', () => {
+    expect(isMissingMaaSModelRef(baseModel({ maaSModelRef: {} }))).toBe(false);
+  });
 });
 
 describe('isAwaitingGovernancePairing', () => {

--- a/packages/maas/frontend/src/app/pages/external-models/columns.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/columns.tsx
@@ -17,13 +17,13 @@ export const externalModelsColumns: SortableData<ExternalModel>[] = [
       (a.displayName ?? a.name).localeCompare(b.displayName ?? b.name),
   },
   {
-    label: 'External provider',
+    label: 'Provider',
     field: 'externalProvider',
     width: 30,
     sortable: false,
     info: {
       popover:
-        'The ExternalProvider resource that supplies the endpoint and credentials for this model. One model can reference multiple providers for weighted traffic routing.',
+        'The provider that supplies the endpoint and credentials for this model. A model can reference multiple providers for load balancing.',
     },
   },
   {
@@ -35,14 +35,9 @@ export const externalModelsColumns: SortableData<ExternalModel>[] = [
     info: {
       popover: (
         <>
-          The reconciliation phase of the ExternalModel resource. &quot;Ready&quot; means all
-          networking resources were created successfully. &quot;Pending&quot; means reconciliation
-          is in progress. &quot;Failed&quot; means an error occurred — such as a missing provider,
-          missing Secret, a missing config key referenced in the path, or network policy issue.
-          <br />
-          <br />A warning icon next to the status indicates that the model is not yet consumable —
-          typically because a subscription, authorization policy, or both have not been configured.
-          Consumers also need an API key to send requests.
+          The model&apos;s status. A second status appears when the model is waiting for MaaS
+          governance setup - for example, when a MaaS subscription or authorization policy
+          hasn&apos;t been configured yet.
         </>
       ),
     },

--- a/packages/maas/frontend/src/app/pages/external-models/const.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/const.tsx
@@ -22,20 +22,16 @@ export const deploymentsExternalPath = (namespace: string): string =>
 const GOVERNANCE_PAIRING_WARNING_BODY = (
   <div>
     <p>
-      This model is awaiting governance pairing. An active subscription and authorization policy are
-      required before consumers can access the gateway endpoint.
+      Consumers can&apos;t access this model until they are given access in a MaaS subscription and
+      authorization policy from the <strong>MaaS governance</strong> page.
     </p>
   </div>
 );
 
-const GOVERNANCE_PAIRING_WARNING_FOOTER =
-  'Consumers will also need an API key to authenticate requests. API keys can be generated from the API keys page in GenAI Studio.';
-
 export const GovernancePairingWarning: React.FC = () => (
   <Popover
-    headerContent="Not ready for consumption"
+    headerContent="Pending MaaS governance"
     bodyContent={GOVERNANCE_PAIRING_WARNING_BODY}
-    footerContent={GOVERNANCE_PAIRING_WARNING_FOOTER}
     data-testid="external-model-governance-pairing-warning-popover"
   >
     <Button

--- a/packages/maas/frontend/src/app/pages/external-models/const.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/const.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Popover, Button, Label } from '@patternfly/react-core';
-import { InfoCircleIcon, PendingIcon } from '@patternfly/react-icons';
+import { PendingIcon } from '@patternfly/react-icons';
 
 export enum ExternalModelsFilterOptions {
   keyword = 'keyword',
@@ -43,8 +43,8 @@ export const MissingMaaSModelRefWarning: React.FC = () => (
       data-testid="external-model-missing-maas-model-ref"
       aria-label="Missing MaaS model reference"
     >
-      <Label color="orange" isCompact>
-        <InfoCircleIcon />
+      <Label color="purple" isCompact>
+        <PendingIcon />
       </Label>
     </Button>
   </Popover>

--- a/packages/maas/frontend/src/app/pages/external-models/const.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/const.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Popover, Button, Label } from '@patternfly/react-core';
-import { PendingIcon } from '@patternfly/react-icons';
+import { InfoCircleIcon, PendingIcon } from '@patternfly/react-icons';
 
 export enum ExternalModelsFilterOptions {
   keyword = 'keyword',
@@ -18,6 +18,37 @@ export const initialExternalModelsFilterData: ExternalModelsFilterDataType = {
 
 export const deploymentsExternalPath = (namespace: string): string =>
   `/ai-hub/models/deployments/external/${namespace}`;
+
+const MISSING_MAAS_MODEL_REF_BODY = (
+  <div>
+    <p>
+      This external model does not have a MaaS model reference. A MaaS model reference is required
+      for subscriptions, authorization policies, and API key generation.
+    </p>
+  </div>
+);
+
+const MISSING_MAAS_MODEL_REF_FOOTER =
+  'Create a MaaS model reference to enable governance features and allow consumers to access this model through the gateway.';
+
+export const MissingMaaSModelRefWarning: React.FC = () => (
+  <Popover
+    headerContent="MaaS model reference required"
+    bodyContent={MISSING_MAAS_MODEL_REF_BODY}
+    footerContent={MISSING_MAAS_MODEL_REF_FOOTER}
+    data-testid="external-model-missing-maas-model-ref-popover"
+  >
+    <Button
+      variant="plain"
+      data-testid="external-model-missing-maas-model-ref"
+      aria-label="Missing MaaS model reference"
+    >
+      <Label color="orange" isCompact>
+        <InfoCircleIcon />
+      </Label>
+    </Button>
+  </Popover>
+);
 
 const GOVERNANCE_PAIRING_WARNING_BODY = (
   <div>

--- a/packages/maas/frontend/src/app/pages/external-models/const.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/const.tsx
@@ -22,20 +22,17 @@ export const deploymentsExternalPath = (namespace: string): string =>
 const MISSING_MAAS_MODEL_REF_BODY = (
   <div>
     <p>
-      This external model does not have a MaaS model reference. A MaaS model reference is required
-      for subscriptions, authorization policies, and API key generation.
+      MaaS governance features (subscriptions, authorization policies, API keys) require a
+      MaaSModelRef resource that references this external model. This resource must be deployed in
+      the same namespace as the external model.
     </p>
   </div>
 );
 
-const MISSING_MAAS_MODEL_REF_FOOTER =
-  'Create a MaaS model reference to enable governance features and allow consumers to access this model through the gateway.';
-
 export const MissingMaaSModelRefWarning: React.FC = () => (
   <Popover
-    headerContent="MaaS model reference required"
+    headerContent="Missing MaaS model setup"
     bodyContent={MISSING_MAAS_MODEL_REF_BODY}
-    footerContent={MISSING_MAAS_MODEL_REF_FOOTER}
     data-testid="external-model-missing-maas-model-ref-popover"
   >
     <Button

--- a/packages/maas/frontend/src/app/pages/external-models/modals/ExternalModelsPathModal.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/modals/ExternalModelsPathModal.tsx
@@ -27,9 +27,8 @@ const PathModal: React.FC<PathModalProps> = ({ path, isOpen, onClose, providerRe
     <ModalBody>
       <Stack hasGutter>
         <StackItem>
-          The resolved request path for this provider reference, with configuration values
-          substituted into the template. This is the path appended to the provider URL when routing
-          inference requests.
+          The request path appended to the provider URL. If path variables were configured,
+          they&apos;re shown with resolved values.
         </StackItem>
         <StackItem>
           <InputGroup>

--- a/packages/maas/frontend/src/app/pages/external-models/modals/ExternalModelsProviderModal.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/modals/ExternalModelsProviderModal.tsx
@@ -39,8 +39,8 @@ const ProviderURLModal: React.FC<ProviderURLModalProps> = ({
     <ModalBody>
       <Stack hasGutter>
         <StackItem>
-          This is the backend URL that the MaaS gateway routes traffic to for this provider.
-          Consumers do not use this URL directly — they use the gateway endpoint shown in the table.
+          The URL where requests are routed for this provider. Consumers use the gateway endpoint,
+          not this URL directly.
         </StackItem>
         <StackItem>
           <InputGroup>

--- a/packages/maas/frontend/src/app/pages/external-models/utils.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/utils.tsx
@@ -6,6 +6,9 @@ import { PhaseStatus } from '~/app/utilities/phaseLabelUtils';
 /** Ready-condition message on the companion MaaSModelRef when sub+auth pairing is missing. */
 export const AWAITING_GOVERNANCE_PAIRING_MESSAGE = 'Awaiting governance pairing';
 
+export const isMissingMaaSModelRef = (externalModel: ExternalModel): boolean =>
+  externalModel.maaSModelRef === undefined;
+
 export const isAwaitingGovernancePairing = (externalModel: ExternalModel): boolean =>
   externalModel.maaSModelRef?.statusMessage === AWAITING_GOVERNANCE_PAIRING_MESSAGE ||
   externalModel.maaSModelRef?.governanceAttached === false;

--- a/packages/maas/frontend/src/app/pages/external-models/utils.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/utils.tsx
@@ -30,31 +30,19 @@ export const getExternalModelStatusMessage = (externalModel: ExternalModel): Rea
   const modelName = <strong>{externalModel.displayName ?? externalModel.name}</strong>;
 
   if (externalModel.phase === PhaseStatus.PENDING) {
-    return (
-      <>
-        {modelName} is being reconciled. The controller is creating networking resources
-        (HTTPRoutes, service entries) and validating provider connections. This typically completes
-        within a few seconds.
-      </>
-    );
+    return <>{modelName} is being set up. This typically completes within a few seconds.</>;
   }
   if (externalModel.phase === PhaseStatus.FAILED) {
     return (
       <>
-        {modelName} could not be reconciled. Common causes include a missing ExternalProvider
-        reference, a Secret that doesn&apos;t exist in the namespace, a missing config key
-        referenced as a {'{key}'} placeholder in the path, or a network policy blocking Istio
-        resource creation. Check the model&apos;s conditions for details.
+        {modelName} failed to set up. Common causes include a missing provider reference or secret,
+        invalid path configuration, or a network policy issue. For details, check the model&apos;s
+        conditions.
       </>
     );
   }
   if (externalModel.phase === PhaseStatus.READY) {
-    return (
-      <>
-        All networking resources for {modelName} have been created successfully. The HTTPRoute is
-        active and inference requests are being routed to the configured provider(s).
-      </>
-    );
+    return <>{modelName} is ready. Requests are being routed to the configured provider(s).</>;
   }
   return 'The status of this external model is unknown.';
 };

--- a/packages/model-serving/src/components/global/GlobalDeploymentsView.tsx
+++ b/packages/model-serving/src/components/global/GlobalDeploymentsView.tsx
@@ -51,7 +51,7 @@ const GlobalDeploymentsView: React.FC<GlobalDeploymentsViewProps> = ({
   const hasDeploymentErrors = Boolean(deploymentsErrors && deploymentsErrors.length > 0);
   const pageDescription = hidePageDescription
     ? undefined
-    : 'Manage and view the health and performance of your deployed models.';
+    : 'View and manage the health and performance of deployed models. ';
 
   const deploymentErrorsAlert =
     hasDeploymentErrors && deploymentsErrors ? (

--- a/packages/model-serving/src/components/global/GlobalModelsPage.tsx
+++ b/packages/model-serving/src/components/global/GlobalModelsPage.tsx
@@ -29,7 +29,7 @@ export const GLOBAL_DEPLOYMENTS_DETAIL_TAB_GROUP = 'model-serving.global-deploym
 const INTERNAL_MODELS_TAB_ID = 'internal-models';
 const EXTERNAL_MODELS_TAB_ID = 'external-models';
 const DEPLOYMENTS_PAGE_DESCRIPTION =
-  'Manage and view the health and performance of your deployed models.';
+  'View and manage the health and performance of deployed models. ';
 
 type GlobalModelsPageContentProps = {
   hidePageDescription?: boolean;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-78222](https://redhat.atlassian.net/browse/RHOAIENG-78222) and [RHOAIENG-78500](https://redhat.atlassian.net/browse/RHOAIENG-78500)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
[content doc](https://docs.google.com/document/d/1aG1KkR4XSxPE1fcCCgemhOzw0S6NAWN4zL_H6Y5n6g4/edit?tab=t.0)

Empty state:
<img width="1208" height="697" alt="Screenshot 2026-07-21 at 11 33 46 AM" src="https://github.com/user-attachments/assets/b6ed0d84-daf7-4967-ab87-4b126fdcfe2f" />

Provider and status column popovers:
<img width="381" height="150" alt="Screenshot 2026-07-21 at 11 33 52 AM" src="https://github.com/user-attachments/assets/5ed5dba4-4ed7-4345-92f3-129e6323d7e2" />

<img width="389" height="195" alt="Screenshot 2026-07-21 at 11 33 58 AM" src="https://github.com/user-attachments/assets/772c3a0a-4016-4581-8507-d212d35dbda1" />

Provider URL modal:
<img width="862" height="393" alt="Screenshot 2026-07-21 at 11 34 08 AM" src="https://github.com/user-attachments/assets/a35df171-3844-44ad-aad3-dcf35528f875" />


Path modal:
<img width="860" height="321" alt="Screenshot 2026-07-21 at 11 34 12 AM" src="https://github.com/user-attachments/assets/6cb04f51-ca63-4bcd-894b-607b7fd5265f" />

Status popovers:
<img width="370" height="168" alt="Screenshot 2026-07-21 at 11 34 20 AM" src="https://github.com/user-attachments/assets/b3b3da9a-1f2a-4a4c-b659-fcaa5b4155fc" />

<img width="340" height="206" alt="Screenshot 2026-07-21 at 11 34 24 AM" src="https://github.com/user-attachments/assets/d4725dd8-382f-4d52-bde7-c7012fe50256" />

<img width="360" height="170" alt="Screenshot 2026-07-21 at 11 34 30 AM" src="https://github.com/user-attachments/assets/fb988b01-4c07-4069-a8d5-e397bf53a5f1" />

<img width="362" height="191" alt="Screenshot 2026-07-21 at 11 34 33 AM" src="https://github.com/user-attachments/assets/1bae1c09-4886-4ef5-9de6-f93d50d6c01a" />

Delete modal:
<img width="607" height="337" alt="Screenshot 2026-07-21 at 11 34 37 AM" src="https://github.com/user-attachments/assets/f72d9369-f731-44eb-b727-f47b65b0ef53" />

Column Names:
<img width="971" height="94" alt="Screenshot 2026-07-21 at 11 35 17 AM" src="https://github.com/user-attachments/assets/6876fb79-6608-4616-a970-12233ca3d1fe" />


New popover:
<img width="780" height="506" alt="Screenshot 2026-07-21 at 3 47 36 PM" src="https://github.com/user-attachments/assets/4e9beb8d-47f8-4cc7-8e47-c0ac36b84472" />



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updated tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-78222]: https://redhat.atlassian.net/browse/RHOAIENG-78222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a warning for external models missing the MaaS model reference, including updated popover guidance.
* **Documentation**
  * Refreshed empty-state instructions and updated help text across external models tables, modals, and status messaging, including new “Pending MaaS governance” copy.
* **Bug Fixes**
  * Updated external model deletion confirmation wording and improved phase-specific guidance for setup, failure, and routing.
* **Tests**
  * Updated Cypress fixtures and UI assertions (including table row counts and governance/missing-ref popover expectations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-78500]: https://redhat.atlassian.net/browse/RHOAIENG-78500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ