### PR TITLE
feat(RHOAIENG-65097): migrate package imports from internal to core packages (Phase 2)

### DIFF
--- a/frontend/src/__mocks__/mockResourceFlavorK8sResource.ts
+++ b/frontend/src/__mocks__/mockResourceFlavorK8sResource.ts
@@ -1,4 +1,4 @@
-import { ResourceFlavorKind } from '@odh-dashboard/internal/k8sTypes';
+import type { ResourceFlavorKind } from '@odh-dashboard/k8s-core';
 import { genUID } from '#~/__mocks__/mockUtils';
 
 type MockResourceFlavorConfigType = {

--- a/frontend/src/concepts/projects/utils.ts
+++ b/frontend/src/concepts/projects/utils.ts
@@ -1,34 +1,9 @@
-import type { ProjectKind } from '@odh-dashboard/k8s-core';
-import { KnownLabels } from '@odh-dashboard/k8s-core';
-
-export const isAiProject = (project: ProjectKind): boolean => {
-  return project.metadata.labels?.[KnownLabels.DASHBOARD_RESOURCE] === 'true';
-};
-
-export const isAvailableProject = (projectName: string, dashboardNamespace: string): boolean =>
-  !(
-    projectName.startsWith('openshift-') ||
-    projectName.startsWith('kube-') ||
-    projectName === 'default' ||
-    projectName === 'system' ||
-    projectName === 'openshift' ||
-    projectName === dashboardNamespace
-  );
-
-export const getProjectOwner = (project: ProjectKind): string =>
-  project.metadata.annotations?.['openshift.io/requester'] || '';
-export const getProjectCreationTime = (project: ProjectKind): number =>
-  project.metadata.creationTimestamp ? new Date(project.metadata.creationTimestamp).getTime() : 0;
-
-// eslint-disable-next-line @odh-dashboard/no-restricted-imports -- re-exporting shared utility
-export { namespaceToProjectDisplayName } from '@odh-dashboard/k8s-core';
-
-export const projectDisplayNameToNamespace = (
-  displayName: string,
-  projects: ProjectKind[],
-): string => {
-  const project = projects.find(
-    (p) => p.metadata.annotations?.['openshift.io/display-name'] === displayName,
-  );
-  return project?.metadata.name || displayName;
-};
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports -- re-exporting shared utilities from k8s-core for backward compatibility
+export {
+  isAiProject,
+  isAvailableProject,
+  getProjectOwner,
+  getProjectCreationTime,
+  namespaceToProjectDisplayName,
+  projectDisplayNameToNamespace,
+} from '@odh-dashboard/k8s-core';

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -25,7 +25,6 @@ import type {
   AccessReviewResourceAttributes,
   ManagementState,
   DataScienceClusterKindStatus,
-  ImagePullSecret,
   AcceleratorProfileKind,
   ConfigMapKind,
   EventKind,

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1,10 +1,12 @@
-import { K8sResourceCommon, MatchExpression } from '@openshift/dynamic-plugin-sdk-utils';
+import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import type { EitherNotBoth } from '@odh-dashboard/foundation';
 import {
   KnownLabels,
   MetadataAnnotation,
   ContainerResourceAttributes,
   DataScienceStackComponent,
+  DSPAMlflowIntegrationMode,
+  WorkloadOwnerType,
 } from '@odh-dashboard/k8s-core';
 import type {
   DisplayNameAnnotations,
@@ -25,13 +27,41 @@ import type {
   DataScienceClusterKindStatus,
   ImagePullSecret,
   AcceleratorProfileKind,
+  ConfigMapKind,
+  EventKind,
+  StorageClassKind,
+  NotebookAnnotations,
+  NotebookKind,
+  RoleBindingSubject,
+  RoleBindingRoleRef,
+  ResourceRule,
+  RoleKind,
+  RoleBindingKind,
+  TrustyAIKind,
+  ClusterQueueKind,
+  LocalQueueKind,
+  WorkloadPodSet,
+  WorkloadKind,
+  WorkloadConditionType,
+  WorkloadCondition,
+  CohortKind,
+  ResourceFlavorKind,
+  ServiceKind,
+  NIMAccountKind,
+  ConfigSecretItem,
 } from '@odh-dashboard/k8s-core';
 import { AwsKeys } from '#~/pages/projects/dataConnections/const';
 import { AccessMode } from '#~/pages/storageClasses/storageEnums';
 import { ImageStreamStatusTagCondition, ImageStreamStatusTagItem } from './types';
 
 // Re-export types from k8s-core that are used throughout the application
-export { KnownLabels, MetadataAnnotation, ContainerResourceAttributes };
+export {
+  KnownLabels,
+  MetadataAnnotation,
+  ContainerResourceAttributes,
+  DSPAMlflowIntegrationMode,
+  WorkloadOwnerType,
+};
 export type {
   DisplayNameAnnotations,
   K8sCondition,
@@ -47,6 +77,28 @@ export type {
   VolumeMount,
   HardwareProfileBindingAnnotations,
   AccessReviewResourceAttributes,
+  ConfigMapKind,
+  EventKind,
+  StorageClassKind,
+  NotebookAnnotations,
+  NotebookKind,
+  RoleBindingSubject,
+  RoleBindingRoleRef,
+  ResourceRule,
+  RoleKind,
+  RoleBindingKind,
+  TrustyAIKind,
+  ClusterQueueKind,
+  LocalQueueKind,
+  WorkloadPodSet,
+  WorkloadKind,
+  WorkloadConditionType,
+  WorkloadCondition,
+  CohortKind,
+  ResourceFlavorKind,
+  ServiceKind,
+  NIMAccountKind,
+  ConfigSecretItem,
 };
 
 export type ModelRegistry = {
@@ -67,15 +119,6 @@ export type StorageClassConfig = {
   accessModeSettings?: AccessModeSettings;
 };
 
-type StorageClassAnnotations = Partial<{
-  // if true, enables any persistent volume claim (PVC) that does not specify a specific storage class to automatically be provisioned.
-  // Only one, if any, StorageClass per cluster can be set as default.
-  [MetadataAnnotation.StorageClassIsDefault]: 'true' | 'false';
-  // the description provided by the cluster admin or Container Storage Interface (CSI) provider
-  [MetadataAnnotation.K8sDescription]: string;
-  [MetadataAnnotation.OdhStorageClassConfig]: string;
-}>;
-
 type ImageStreamAnnotations = Partial<{
   'opendatahub.io/notebook-image-desc': string;
   'opendatahub.io/notebook-image-name': string;
@@ -92,19 +135,6 @@ type ImageStreamSpecTagAnnotations = Partial<{
   'opendatahub.io/notebook-build-commit': string;
   'openshift.io/imported-from': string;
 }>;
-
-export type NotebookAnnotations = Partial<{
-  'kubeflow-resource-stopped': string | null; // datestamp of stop (if omitted, it is running),  `odh-notebook-controller-lock` is set when first creating the notebook to avoid race conditions, it's a fake stop
-  'notebooks.kubeflow.org/last-activity': string; // datestamp of last use
-  'opendatahub.io/user': string; // translated username -- see translateUsername
-  'opendatahub.io/username': string; // the untranslated username behind the notebook
-  'notebooks.opendatahub.io/last-image-selection': string; // the last image they selected
-  'opendatahub.io/image-display-name': string; // the display name of the image
-  'notebooks.opendatahub.io/last-image-version-git-commit-selection': string; // the build commit of the last image they selected
-  'opendatahub.io/workbench-image-namespace': string | null; // namespace of the
-  'opendatahub.io/connections': string | undefined; // the connections attached to the notebook
-}> &
-  Partial<HardwareProfileBindingAnnotations>;
 
 // from: https://github.com/opendatahub-io/data-science-pipelines-operator/blob/9b518e02ee794d0afbe2b9ad35c85be10051ce6e/controllers/config/defaults.go#L127-L138
 export enum K8sDspaConditionReason {
@@ -171,13 +201,6 @@ export enum BuildPhase {
   CANCELLED = 'Cancelled',
 }
 
-export type ConfigMapKind = K8sResourceCommon & {
-  metadata: {
-    name: string;
-  };
-  data?: Record<string, string>;
-};
-
 export type ConsoleLinkKind = {
   spec: {
     text: string;
@@ -189,22 +212,6 @@ export type ConsoleLinkKind = {
     };
   };
 } & K8sResourceCommon;
-
-export type EventKind = K8sResourceCommon & {
-  metadata: {
-    uid?: string;
-  };
-  involvedObject: {
-    name: string;
-    uid?: string;
-    kind?: string;
-  };
-  lastTimestamp?: string;
-  eventTime: string;
-  type: 'Normal' | 'Warning';
-  reason: string;
-  message: string;
-};
 
 export type ImageStreamKind = K8sResourceCommon & {
   metadata: {
@@ -273,37 +280,6 @@ export type OdhQuickStart = K8sResourceCommon & {
   };
 };
 
-export type StorageClassKind = K8sResourceCommon & {
-  metadata: {
-    annotations?: StorageClassAnnotations;
-    name: string;
-  };
-  provisioner: string;
-  parameters?: string;
-  reclaimPolicy: string;
-  volumeBindingMode: string;
-  allowVolumeExpansion?: boolean;
-};
-
-export type NotebookKind = K8sResourceCommon & {
-  metadata: {
-    annotations?: DisplayNameAnnotations & NotebookAnnotations;
-    name: string;
-    namespace: string;
-  };
-  spec: {
-    template: {
-      spec: PodSpec;
-    };
-  };
-  status?: {
-    containerState?: {
-      terminated?: { [key: string]: string };
-    };
-    readyReplicas?: number;
-  };
-};
-
 export type ServiceAccountKind = K8sResourceCommon & {
   metadata: {
     annotations?: DisplayNameAnnotations;
@@ -315,40 +291,11 @@ export type ServiceAccountKind = K8sResourceCommon & {
   }[];
 };
 
-export type RoleBindingSubject = {
-  kind: string;
-  apiGroup?: string;
-  name: string;
-};
-
-export type RoleBindingRoleRef = {
-  kind: 'Role' | 'ClusterRole';
-  apiGroup?: string;
-  name: string;
-};
-
-export type RoleKind = K8sResourceCommon & {
-  metadata: {
-    name: string;
-    namespace: string;
-  };
-  rules?: ResourceRule[];
-};
-
 export type ClusterRoleKind = K8sResourceCommon & {
   metadata: {
     name: string;
   };
   rules?: ResourceRule[];
-};
-
-export type RoleBindingKind = K8sResourceCommon & {
-  metadata: {
-    name: string;
-    namespace: string;
-  };
-  subjects?: RoleBindingSubject[];
-  roleRef: RoleBindingRoleRef;
 };
 
 export type RouteKind = K8sResourceCommon & {
@@ -376,39 +323,6 @@ export type AWSSecretKind = SecretKind & {
   data: Record<AwsKeys, string>;
 };
 
-export type TrustyAIKind = K8sResourceCommon & {
-  metadata: {
-    name: string;
-    namespace: string;
-  };
-  spec: {
-    storage:
-      | {
-          format: 'DATABASE';
-          databaseConfigurations: string;
-        }
-      | {
-          format: 'PVC';
-          folder: string;
-          size: string;
-        };
-    data?: {
-      filename: string;
-      format: string;
-    };
-    metrics: {
-      schedule: string;
-      batchSize?: number;
-    };
-  };
-  status?: {
-    conditions?: K8sCondition[];
-    phase?: string;
-    ready?: string;
-    replicas?: number;
-  };
-};
-
 export type DSPipelineExternalStorageKind = {
   bucket: string;
   host: string;
@@ -425,11 +339,6 @@ export type DSPipelineExternalStorageKind = {
 export enum DSPipelineAPIServerStore {
   KUBERNETES = 'kubernetes',
   DATABASE = 'database',
-}
-
-export enum DSPAMlflowIntegrationMode {
-  DISABLED = 'DISABLED',
-  AUTODETECT = 'AUTODETECT',
 }
 
 export type DSPipelineMlflowKind = {
@@ -536,351 +445,6 @@ export type DSPipelineKind = K8sResourceCommon & {
   };
 };
 
-type ClusterQueueFlavorUsage = {
-  name: string;
-  resources: {
-    name: ContainerResourceAttributes;
-    borrowed?: string | number;
-    total?: string | number;
-  }[];
-};
-
-// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ClusterQueue
-export type ClusterQueueKind = K8sResourceCommon & {
-  apiVersion: 'kueue.x-k8s.io/v1beta2';
-  kind: 'ClusterQueue';
-  spec: {
-    admissionChecksStrategy?: {
-      admissionChecks: {
-        name: string;
-        onFlavors?: string[];
-      }[];
-    };
-    cohortName?: string;
-    flavorFungibility?: {
-      whenCanBorrow: 'Borrow' | 'TryNextFlavor';
-      whenCanPreempt: 'Preempt' | 'TryNextFlavor';
-    };
-    namespaceSelector?: {
-      matchExpressions?: MatchExpression[];
-      matchLabels?: Record<string, string>;
-    };
-    preemption?: {
-      borrowWithinCohort?: {
-        maxPriorityThreshold?: number;
-        policy?: 'Never' | 'LowerPriority';
-      };
-      reclaimWithinCohort?: 'Never' | 'LowerPriority' | 'Any';
-      withinClusterQueue?: 'Never' | 'LowerPriority' | 'LowerOrNewerEqualPriority';
-    };
-    queueingStrategy?: 'StrictFIFO' | 'BestEffortFIFO';
-    resourceGroups?: {
-      coveredResources: ContainerResourceAttributes[];
-      flavors: {
-        name: string;
-        resources: {
-          name: ContainerResourceAttributes;
-          nominalQuota: string | number; // e.g. 9 for cpu/pods, "36Gi" for memory
-        }[];
-      }[];
-    }[];
-    stopPolicy?: 'None' | 'Hold' | 'HoldAndDrain';
-  };
-  status?: {
-    flavorsReservation?: ClusterQueueFlavorUsage[];
-    flavorsUsage?: ClusterQueueFlavorUsage[];
-    pendingWorkloads?: number;
-    reservingWorkloads?: number;
-    admittedWorkloads?: number;
-    conditions?: {
-      lastTransitionTime: string;
-      message: string;
-      observedGeneration?: number;
-      reason: string;
-      status: 'True' | 'False' | 'Unknown';
-      type: string;
-    }[];
-    pendingWorkloadsStatus?: {
-      clusterQueuePendingWorkload?: {
-        name: string;
-        namespace: string;
-      }[];
-      lastChangeTime: string;
-    };
-  };
-};
-
-type LocalQueueFlavorUsage = {
-  name: string;
-  resources: {
-    name: ContainerResourceAttributes;
-    total?: string | number;
-  }[];
-};
-
-// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-LocalQueue
-export type LocalQueueKind = K8sResourceCommon & {
-  apiVersion: 'kueue.x-k8s.io/v1beta2';
-  kind: 'LocalQueue';
-  spec: {
-    clusterQueue: string;
-  };
-  status?: {
-    flavorsReservation?: LocalQueueFlavorUsage[];
-    flavorsUsage?: LocalQueueFlavorUsage[];
-    pendingWorkloads?: number;
-    reservingWorkloads?: number;
-    admittedWorkloads?: number;
-    conditions?: {
-      lastTransitionTime: string;
-      message: string;
-      observedGeneration?: number;
-      reason: string;
-      status: 'True' | 'False' | 'Unknown';
-      type: string;
-    }[];
-  };
-};
-
-type WorkloadPodAffinityTerm = {
-  labelSelector?: {
-    matchExpressions?: MatchExpression[];
-    matchLabels?: Record<string, string>;
-  };
-  matchLabelKeys?: string[];
-  mismatchLabelKeys?: string[];
-  namespaceSelector?: {
-    matchExpressions?: MatchExpression[];
-    matchLabels?: Record<string, string>;
-  };
-  namespaces?: string[];
-  topologyKey: string;
-};
-
-export type WorkloadPodSet = {
-  count: number;
-  minCount?: number;
-  name: string;
-  template: {
-    metadata?: K8sResourceCommon['metadata'];
-    spec: {
-      activeDeadlineSeconds?: number;
-      affinity?: {
-        nodeAffinity?: {
-          preferredDuringSchedulingIgnoredDuringExecution: {
-            preference: {
-              matchExpressions?: MatchExpression[];
-              matchFields?: MatchExpression[];
-            };
-            weight: number;
-          }[];
-          requiredDuringSchedulingIgnoredDuringExecution: {
-            nodeSelectorTerms: {
-              matchExpressions?: MatchExpression[];
-              matchFields?: MatchExpression[];
-            }[];
-          };
-        };
-        podAffinity?: {
-          preferredDuringSchedulingIgnoredDuringExecution?: {
-            podAffinityTerm: WorkloadPodAffinityTerm;
-            weight: number;
-          }[];
-          requiredDuringSchedulingIgnoredDuringExecution?: WorkloadPodAffinityTerm[];
-          weight: number;
-        }[];
-        podAntiAffinity?: {
-          preferredDuringSchedulingIgnoredDuringExecution?: {
-            podAffinityTerm: WorkloadPodAffinityTerm;
-            weight: number;
-          }[];
-          requiredDuringSchedulingIgnoredDuringExecution?: WorkloadPodAffinityTerm[];
-          weight: number;
-        };
-      };
-      automountServiceAccountToken?: boolean;
-      containers: PodContainer[];
-      dnsConfig?: {
-        nameservers?: string[];
-        options?: {
-          name: string;
-          value?: string;
-        }[];
-        searches?: string[];
-      };
-      dnsPolicy?: string;
-      enableServiceLinks?: boolean;
-      ephemeralContainers?: PodContainer[];
-      hostAliases?: {
-        hostnames?: string[];
-        ip: string;
-      }[];
-      hostIPC?: boolean;
-      hostNetwork?: boolean;
-      hostPID?: boolean;
-      hostUsers?: boolean;
-      hostname?: string;
-      imagePullSecrets?: ImagePullSecret[];
-      initContainers?: PodContainer[];
-      nodeName?: string;
-      nodeSelector?: Record<string, string>;
-      os?: { name: string };
-      overhead?: Record<string, string | number>;
-      preemptionPolicy?: string;
-      priority?: number;
-      priorityClassName?: string;
-      readinessGates?: {
-        conditionType: string;
-      }[];
-      resourceClaims?: {
-        name: string;
-        source?: {
-          resourceClaimName?: string;
-          resourceClaimTemplateName: string;
-        };
-      }[];
-      restartPolicy?: string;
-      runtimeClassName?: string;
-      schedulerName?: string;
-      schedulingGates?: {
-        name: string;
-      }[];
-      securityContext?: {
-        fsGroup?: number;
-        fsGroupChangePolicy?: string;
-        runAsGroup?: number;
-        runAsNonRoot?: boolean;
-        runAsUser?: number;
-        seLinuxOptions?: {
-          level?: string;
-          role?: string;
-          type?: string;
-          user?: string;
-        };
-        seccompProfile?: {
-          localhostProfile?: string;
-          type: string;
-        };
-        supplementalGroups?: number[];
-        sysctls?: {
-          name: string;
-          value: string;
-        }[];
-        windowsOptions?: {
-          gmsaCredentialSpec?: string;
-          gmsaCredentialSpecName?: string;
-          hostProcess?: string;
-          runAsUserName?: string;
-        };
-      };
-      serviceAccount?: string;
-      serviceAccountName?: string;
-      setHostnameAsFQDN?: boolean;
-      shareProcessNamespace?: boolean;
-      subdomain?: string;
-      terminationGracePeriodSeconds?: number;
-      tolerations?: {
-        effect?: string;
-        key?: string;
-        operator?: string;
-        tolerationSeconds?: number;
-        value?: string;
-      }[];
-      topologySpreadConstraints?: {
-        labelSelector?: {
-          matchExpressions?: MatchExpression[];
-          matchLabels?: Record<string, string>;
-        };
-        matchLabelKeys?: [];
-        maxSkew: number;
-        minDomains?: number;
-        nodeAffinityPolicy?: string;
-        nodeTaintsPolicy?: string;
-        topologyKey: string;
-        whenUnsatisfiable: string;
-      }[];
-      volumes?: {
-        name: string;
-        [key: string]: unknown; // Lots of storage types with various properties in here, add later from CRD if needed
-      }[];
-    };
-  };
-};
-
-export enum WorkloadOwnerType {
-  RayCluster = 'RayCluster',
-  Job = 'Job',
-  StatefulSet = 'StatefulSet',
-  ReplicaSet = 'ReplicaSet',
-}
-
-// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Workload
-export type WorkloadKind = K8sResourceCommon & {
-  apiVersion: 'kueue.x-k8s.io/v1beta2';
-  kind: 'Workload';
-  spec: {
-    active?: boolean;
-    podSets: WorkloadPodSet[];
-    priority?: number;
-    priorityClassRef?: {
-      group: string;
-      kind: string;
-      name: string;
-    };
-    queueName?: string;
-  };
-  status?: {
-    admission?: {
-      clusterQueue: string;
-      podSetAssignments: {
-        name: string;
-        count?: number;
-        flavors?: Record<string, string>;
-        resourceUsage?: Record<string, string | number>;
-      }[];
-    };
-    admissionChecks?: {
-      name: string;
-      message: string;
-      state: 'Pending' | 'Ready' | 'Retry' | 'Rejected';
-      lastTransitionTime: string;
-      podSetUpdates?: {
-        annotations?: Record<string, string>;
-        labels?: Record<string, string>;
-        name: string;
-        nodeSelector?: Record<string, string>;
-        tolerations?: Toleration[];
-      }[];
-    }[];
-    conditions?: WorkloadCondition[];
-    reclaimablePods?: {
-      count: number;
-      name: string;
-    }[];
-    requeueState?: {
-      count?: number;
-      requeueAt?: string;
-    };
-  };
-};
-
-export type WorkloadConditionType =
-  | 'QuotaReserved'
-  | 'Admitted'
-  | 'PodsReady'
-  | 'Finished'
-  | 'Evicted'
-  | 'Preempted';
-
-export type WorkloadCondition = {
-  lastTransitionTime: string;
-  message: string;
-  observedGeneration?: number;
-  reason: string;
-  status: 'True' | 'False' | 'Unknown';
-  type: WorkloadConditionType | (string & NonNullable<unknown>);
-};
-
 export type WorkloadPriorityClassKind = K8sResourceCommon & {
   metadata: {
     name: string;
@@ -908,51 +472,6 @@ export type PendingWorkloadsSummary = {
   items: PendingWorkload[];
 };
 
-// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Cohort
-export type CohortKind = K8sResourceCommon & {
-  apiVersion: 'kueue.x-k8s.io/v1beta2';
-  kind: 'Cohort';
-  spec: {
-    parentName?: string;
-    resourceGroups?: {
-      coveredResources: ContainerResourceAttributes[];
-      flavors: {
-        name: string;
-        resources: {
-          name: ContainerResourceAttributes;
-          nominalQuota: string | number;
-          borrowingLimit?: string | number;
-          lendingLimit?: string | number;
-        }[];
-      }[];
-    }[];
-    fairSharing?: {
-      weight?: string | number;
-    };
-  };
-  status?: {
-    fairSharing?: {
-      weightedShare: number;
-    };
-  };
-};
-
-// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ResourceFlavor
-export type ResourceFlavorKind = K8sResourceCommon & {
-  apiVersion: 'kueue.x-k8s.io/v1beta2';
-  kind: 'ResourceFlavor';
-  spec: {
-    nodeLabels?: Record<string, string>;
-    nodeTaints?: {
-      key: string;
-      value?: string;
-      effect: 'NoSchedule' | 'NoExecute' | 'PreferNoSchedule';
-    }[];
-    tolerations?: Toleration[];
-    topologyName?: string;
-  };
-};
-
 export type SelfSubjectAccessReviewKind = K8sResourceCommon & {
   spec: {
     resourceAttributes?: AccessReviewResourceAttributes;
@@ -963,13 +482,6 @@ export type SelfSubjectAccessReviewKind = K8sResourceCommon & {
     reason?: string;
     evaluationError?: string;
   };
-};
-
-export type ResourceRule = {
-  verbs: string[];
-  apiGroups?: string[];
-  resourceNames?: string[];
-  resources?: string[];
 };
 
 export type SelfSubjectRulesReviewKind = K8sResourceCommon & {
@@ -984,34 +496,6 @@ export type SelfSubjectRulesReviewKind = K8sResourceCommon & {
     }[];
     resourceRules: ResourceRule[];
     evaluationError?: string;
-  };
-};
-
-export type ServiceKind = K8sResourceCommon & {
-  metadata: {
-    annotations?: DisplayNameAnnotations &
-      Partial<{
-        'routing.opendatahub.io/external-address-rest': string;
-        'routing.opendatahub.io/external-address-grpc': string;
-      }>;
-    name: string;
-    namespace: string;
-    labels?: Partial<{
-      component: string;
-    }>;
-  };
-  spec: {
-    selector: {
-      app: string;
-      component: string;
-    };
-    ports: {
-      name?: string;
-      protocol?: string;
-      appProtocol?: string;
-      port?: number;
-      targetPort?: number | string;
-    }[];
   };
 };
 
@@ -1195,35 +679,6 @@ export type ModelRegistryKind = K8sResourceCommon & {
   status?: {
     conditions?: K8sCondition[];
   };
-};
-
-export type NIMAccountKind = K8sResourceCommon & {
-  metadata: {
-    name: string;
-    namespace: string;
-  };
-  spec: {
-    apiKeySecret: {
-      name: string;
-    };
-  };
-  status?: {
-    nimConfig?: {
-      name: string;
-    };
-    runtimeTemplate?: {
-      name: string;
-    };
-    nimPullSecret?: {
-      name: string;
-    };
-    conditions?: K8sCondition[];
-  };
-};
-
-export type ConfigSecretItem = {
-  name: string;
-  keys: string[];
 };
 
 export type ListConfigSecretsResponse = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36880,6 +36880,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@odh-dashboard/internal": "*",
+        "@odh-dashboard/k8s-core": "*",
         "@odh-dashboard/plugin-core": "*",
         "@odh-dashboard/ui-core": "*"
       },

--- a/packages/agent-ops/frontend/src/app/hooks/useAgentOpsProjectNamespaces.ts
+++ b/packages/agent-ops/frontend/src/app/hooks/useAgentOpsProjectNamespaces.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isAvailableProject } from '@odh-dashboard/internal/concepts/projects/utils';
+import { isAvailableProject } from '@odh-dashboard/k8s-core';
 import type { Namespace } from '@odh-dashboard/internal/types';
 import { useNamespaceSelector } from 'mod-arch-core';
 import { useProjectsBridge } from '~/odh/context/ProjectsBridgeContext';

--- a/packages/agent-ops/package.json
+++ b/packages/agent-ops/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
+    "@odh-dashboard/k8s-core": "*",
     "@odh-dashboard/plugin-core": "*",
     "@odh-dashboard/ui-core": "*"
   },

--- a/packages/agent-ops/src/ProjectsBridgeProvider.tsx
+++ b/packages/agent-ops/src/ProjectsBridgeProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import type { ProjectsBridgeData } from '../frontend/src/odh/extension-points';
 
 const getProjectDisplayName = (project: {

--- a/packages/cypress/cypress/pages/storageClasses.ts
+++ b/packages/cypress/cypress/pages/storageClasses.ts
@@ -1,5 +1,5 @@
 import { mockStorageClassList } from '@odh-dashboard/internal/__mocks__';
-import type { StorageClassKind } from '@odh-dashboard/internal/k8sTypes';
+import type { StorageClassKind } from '@odh-dashboard/k8s-core';
 import { TableRow } from './components/table';
 import { appChrome } from './appChrome';
 import { TableToolbar } from './components/TableToolbar';

--- a/packages/cypress/cypress/support/commands/odh.ts
+++ b/packages/cypress/cypress/support/commands/odh.ts
@@ -40,23 +40,23 @@ import type {
   RegisteredModelList,
 } from '@odh-dashboard/internal/concepts/modelRegistry/types';
 import type {
+  ConfigMapKind,
   ConnectionTypeConfigMap,
   DashboardConfigKind,
   DataScienceClusterInitializationKindStatus,
   DataScienceClusterKindStatus,
+  NotebookKind,
+  RoleBindingKind,
   SecretKind,
   TemplateKind,
 } from '@odh-dashboard/k8s-core';
 import type { FeatureStoreKind } from '@odh-dashboard/feature-store/k8sTypes';
 import type {
-  ConfigMapKind,
   ConsoleLinkKind,
   ListConfigSecretsResponse,
   ModelRegistry,
   ModelRegistryKind,
-  NotebookKind,
   OdhQuickStart,
-  RoleBindingKind,
 } from '@odh-dashboard/internal/k8sTypes';
 import type { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports

--- a/packages/cypress/cypress/tests/mocked/applications/administration.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/applications/administration.cy.ts
@@ -1,7 +1,7 @@
 import { mockHardwareProfile } from '@odh-dashboard/internal/__mocks__/mockHardwareProfile';
 import { mockRoleBindingK8sResource } from '@odh-dashboard/internal/__mocks__/mockRoleBindingK8sResource';
 import { mockK8sResourceList, mockNotebookK8sResource } from '@odh-dashboard/internal/__mocks__';
-import type { RoleBindingSubject } from '@odh-dashboard/internal/k8sTypes';
+import type { RoleBindingSubject } from '@odh-dashboard/k8s-core';
 import { mockAllowedUsers } from '@odh-dashboard/internal/__mocks__/mockAllowedUsers';
 import type { AllowedUser } from '@odh-dashboard/internal/pages/notebookController/screens/admin/types';
 import { mockStartNotebookData } from '@odh-dashboard/internal/__mocks__/mockStartNotebookData';

--- a/packages/cypress/cypress/tests/mocked/applications/enabled.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/applications/enabled.cy.ts
@@ -1,4 +1,4 @@
-import type { RoleBindingSubject } from '@odh-dashboard/internal/k8sTypes';
+import type { RoleBindingSubject } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { mockComponents } from '@odh-dashboard/internal/__mocks__/mockComponents';
 import { mockDashboardConfig, mockK8sResourceList } from '@odh-dashboard/internal/__mocks__';

--- a/packages/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -6,14 +6,13 @@ import {
   mockNotebookK8sResource,
   mockStorageClassList,
 } from '@odh-dashboard/internal/__mocks__';
-import type { RoleBindingSubject } from '@odh-dashboard/internal/k8sTypes';
+import type { EnvironmentVariable, RoleBindingSubject } from '@odh-dashboard/k8s-core';
 import { mockAllowedUsers } from '@odh-dashboard/internal/__mocks__/mockAllowedUsers';
 import { mockStartNotebookData } from '@odh-dashboard/internal/__mocks__/mockStartNotebookData';
 import {
   mockGlobalScopedHardwareProfiles,
   mockProjectScopedHardwareProfiles,
 } from '@odh-dashboard/internal/__mocks__/mockHardwareProfile';
-import type { EnvironmentVariable } from '@odh-dashboard/k8s-core';
 import type { NotebookData } from '@odh-dashboard/internal/types';
 import { mockConfigMap } from '@odh-dashboard/internal/__mocks__/mockConfigMap';
 import { mockImageStreamK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockImageStreamK8sResource';

--- a/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -8,11 +8,11 @@ import { mockWorkloadK8sResource } from '@odh-dashboard/internal/__mocks__/mockW
 import type {
   ClusterQueueKind,
   LocalQueueKind,
+  PodContainer,
   WorkloadKind,
   WorkloadPodSet,
-} from '@odh-dashboard/internal/k8sTypes';
-import { WorkloadOwnerType } from '@odh-dashboard/internal/k8sTypes';
-import type { PodContainer } from '@odh-dashboard/k8s-core';
+} from '@odh-dashboard/k8s-core';
+import { WorkloadOwnerType } from '@odh-dashboard/k8s-core';
 import { WorkloadStatusType } from '@odh-dashboard/internal/concepts/distributedWorkloads/utils';
 import { mockClusterQueueK8sResource } from '@odh-dashboard/internal/__mocks__/mockClusterQueueK8sResource';
 import { mockLocalQueueK8sResource } from '@odh-dashboard/internal/__mocks__/mockLocalQueueK8sResource';

--- a/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistryPermissions.cy.ts
@@ -5,7 +5,7 @@ import {
 } from '@odh-dashboard/internal/__mocks__';
 import { mock200Status } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
 import { mockRoleBindingK8sResource } from '@odh-dashboard/internal/__mocks__/mockRoleBindingK8sResource';
-import type { RoleBindingSubject } from '@odh-dashboard/internal/k8sTypes';
+import type { RoleBindingSubject } from '@odh-dashboard/k8s-core';
 import { mockModelRegistry } from '@odh-dashboard/internal/__mocks__/mockModelRegistry';
 import { mockGroup } from '@odh-dashboard/internal/__mocks__/mockGroup';
 import { be } from '../../../utils/should';

--- a/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -7,7 +7,7 @@ import {
 import { mockDsciStatus } from '@odh-dashboard/internal/__mocks__/mockDsciStatus';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { mockModelRegistry } from '@odh-dashboard/internal/__mocks__/mockModelRegistry';
-import type { ConfigSecretItem, RoleBindingSubject } from '@odh-dashboard/internal/k8sTypes';
+import type { ConfigSecretItem, RoleBindingSubject } from '@odh-dashboard/k8s-core';
 import { mockRoleBindingK8sResource } from '@odh-dashboard/internal/__mocks__/mockRoleBindingK8sResource';
 import {
   DatabaseType,

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/compareRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/compareRuns.cy.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { PluginStateKF } from '@odh-dashboard/internal/concepts/pipelines/kfTypes';
-import { DSPAMlflowIntegrationMode } from '@odh-dashboard/internal/k8sTypes';
+import { DSPAMlflowIntegrationMode } from '@odh-dashboard/k8s-core';
 import {
   buildMockExperimentKF,
   mockDashboardConfig,

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/manageRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/manageRuns.cy.ts
@@ -9,7 +9,7 @@ import {
   mockDashboardConfig,
 } from '@odh-dashboard/internal/__mocks__';
 import type { PipelineRunKF } from '@odh-dashboard/internal/concepts/pipelines/kfTypes';
-import { DSPAMlflowIntegrationMode } from '@odh-dashboard/internal/k8sTypes';
+import { DSPAMlflowIntegrationMode } from '@odh-dashboard/k8s-core';
 import { manageRunsPage, manageRunsTable } from '../../../../pages/pipelines/manageRuns';
 import { configIntercept, dspaIntercepts, projectsIntercept } from '../intercepts';
 import {

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
@@ -7,7 +7,7 @@ import {
   InputDefinitionParameterType,
   StorageStateKF,
 } from '@odh-dashboard/internal/concepts/pipelines/kfTypes';
-import { DSPAMlflowIntegrationMode } from '@odh-dashboard/internal/k8sTypes';
+import { DSPAMlflowIntegrationMode } from '@odh-dashboard/k8s-core';
 import {
   buildMockRunKF,
   buildMockPipeline,

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
@@ -6,7 +6,7 @@ import {
   runtimeStateLabels,
   StorageStateKF,
 } from '@odh-dashboard/internal/concepts/pipelines/kfTypes';
-import { DSPAMlflowIntegrationMode } from '@odh-dashboard/internal/k8sTypes';
+import { DSPAMlflowIntegrationMode } from '@odh-dashboard/k8s-core';
 import {
   mockK8sResourceList,
   mockProjectK8sResource,

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/permissions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/permissions.cy.ts
@@ -8,7 +8,7 @@ import {
   mockRoleBindingK8sResource,
 } from '@odh-dashboard/internal/__mocks__';
 import { mock200Status } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
-import type { RoleBindingSubject } from '@odh-dashboard/internal/k8sTypes';
+import type { RoleBindingSubject } from '@odh-dashboard/k8s-core';
 import { permissions, roleBindingPermissionsChangeModal } from '../../../../pages/permissions';
 import { be } from '../../../../utils/should';
 import { ProjectModel, RoleBindingModel } from '../../../../utils/models';

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -22,9 +22,8 @@ import { mockPVCK8sResource } from '@odh-dashboard/internal/__mocks__/mockPVCK8s
 import { mockPodK8sResource } from '@odh-dashboard/internal/__mocks__/mockPodK8sResource';
 import { mock200Status, mock404Error } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
 import { mockConnectionTypeConfigMap } from '@odh-dashboard/internal/__mocks__/mockConnectionType';
-import type { HardwareProfileKind, PodKind } from '@odh-dashboard/k8s-core';
+import type { HardwareProfileKind, NotebookKind, PodKind } from '@odh-dashboard/k8s-core';
 import { IdentifierResourceType, SchedulingType } from '@odh-dashboard/k8s-core';
-import type { NotebookKind } from '@odh-dashboard/internal/k8sTypes';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { SpawnerPageSectionID } from '@odh-dashboard/internal/pages/projects/screens/spawner/types';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';

--- a/packages/cypress/cypress/utils/featureStoreSpawnerMocks.ts
+++ b/packages/cypress/cypress/utils/featureStoreSpawnerMocks.ts
@@ -3,7 +3,7 @@ import {
   mockDscStatus,
   mockNotebookK8sResource,
 } from '@odh-dashboard/internal/__mocks__';
-import type { NotebookKind } from '@odh-dashboard/internal/k8sTypes';
+import type { NotebookKind } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 
 export const FEATURE_STORE_CREDIT_NAMESPACE = 'credit-namespace';

--- a/packages/cypress/cypress/utils/mlflowUtils.ts
+++ b/packages/cypress/cypress/utils/mlflowUtils.ts
@@ -1,4 +1,4 @@
-import type { DSPAMlflowIntegrationMode } from '@odh-dashboard/internal/k8sTypes';
+import type { DSPAMlflowIntegrationMode } from '@odh-dashboard/k8s-core';
 import {
   mockDataSciencePipelineApplicationK8sResource,
   mockK8sResourceList,

--- a/packages/feature-store/src/__mocks__/mockFeatureStoreService.ts
+++ b/packages/feature-store/src/__mocks__/mockFeatureStoreService.ts
@@ -1,4 +1,4 @@
-import { ServiceKind } from '@odh-dashboard/internal/k8sTypes';
+import { ServiceKind } from '@odh-dashboard/k8s-core';
 
 type MockFeatureStoreServiceType = {
   name?: string;

--- a/packages/feature-store/src/api/custom.ts
+++ b/packages/feature-store/src/api/custom.ts
@@ -1,5 +1,5 @@
 import { proxyGET } from '@odh-dashboard/internal/api/proxyUtils';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { handleFeatureStoreFailures } from './errorUtils';
 import { fetchAllPages, mergeRelationships } from './paginationUtils';
 import { FeatureStoreLineage, FeatureViewLineage } from '../types/lineage';

--- a/packages/feature-store/src/api/featureStores.ts
+++ b/packages/feature-store/src/api/featureStores.ts
@@ -5,11 +5,10 @@ import {
   k8sListResource,
   K8sStatus,
 } from '@openshift/dynamic-plugin-sdk-utils';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
 import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
 import { PodModel } from '@odh-dashboard/internal/api/models/k8s';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
-import { isValidK8sName, PodKind } from '@odh-dashboard/k8s-core';
+import { isValidK8sName, K8sAPIOptions, PodKind } from '@odh-dashboard/k8s-core';
 import { FeatureStoreKind } from '../k8sTypes';
 import {
   assembleFeatureStore,

--- a/packages/feature-store/src/api/paginationUtils.ts
+++ b/packages/feature-store/src/api/paginationUtils.ts
@@ -1,5 +1,5 @@
 import { proxyGET } from '@odh-dashboard/internal/api/proxyUtils';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { handleFeatureStoreFailures } from './errorUtils';
 import { FEATURE_STORE_PAGE_SIZE } from '../const';
 import { FeatureStorePagination } from '../types/global';

--- a/packages/feature-store/src/hooks/__tests__/useAccessibleNamespaces.spec.tsx
+++ b/packages/feature-store/src/hooks/__tests__/useAccessibleNamespaces.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { checkAccess } from '@odh-dashboard/internal/api/useAccessReview';
 import { ProjectKind } from '@odh-dashboard/k8s-core';
 import useAccessibleNamespaces from '../useAccessibleNamespaces';

--- a/packages/feature-store/src/hooks/__tests__/useExistingFeatureStores.spec.tsx
+++ b/packages/feature-store/src/hooks/__tests__/useExistingFeatureStores.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { renderHook, waitFor, act } from '@testing-library/react';
-import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { ProjectKind } from '@odh-dashboard/k8s-core';
 import { FeatureStoreKind } from '../../k8sTypes';
 import { listFeatureStores } from '../../api/featureStores';

--- a/packages/feature-store/src/hooks/useAccessibleNamespaces.ts
+++ b/packages/feature-store/src/hooks/useAccessibleNamespaces.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ProjectKind } from '@odh-dashboard/k8s-core';
-import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { checkAccess } from '@odh-dashboard/internal/api/useAccessReview';
 import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
 import useFetch, {

--- a/packages/feature-store/src/hooks/useExistingFeatureStores.ts
+++ b/packages/feature-store/src/hooks/useExistingFeatureStores.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ProjectKind } from '@odh-dashboard/k8s-core';
-import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { FeatureStoreKind } from '../k8sTypes';
 import { listFeatureStores } from '../api/featureStores';
 import {

--- a/packages/feature-store/src/hooks/useNamespaceConfigMaps.ts
+++ b/packages/feature-store/src/hooks/useNamespaceConfigMaps.ts
@@ -4,7 +4,7 @@ import useFetch, {
   FetchStateCallbackPromise,
   NotReadyError,
 } from '@odh-dashboard/ui-core/hooks/useFetch';
-import { ConfigMapKind } from '@odh-dashboard/internal/k8sTypes';
+import { ConfigMapKind } from '@odh-dashboard/k8s-core';
 import { ConfigMapModel } from '@odh-dashboard/internal/api/models';
 
 const useNamespaceConfigMaps = (

--- a/packages/feature-store/src/types/dataSets.ts
+++ b/packages/feature-store/src/types/dataSets.ts
@@ -1,4 +1,4 @@
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { FeatureStorePagination, FeatureStoreRelationship } from './global';
 
 export type DataSetFileStorage = {

--- a/packages/feature-store/src/types/dataSources.ts
+++ b/packages/feature-store/src/types/dataSources.ts
@@ -1,4 +1,4 @@
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { FeatureStorePagination, FeatureStoreRelationship } from './global';
 
 export type FileFormat = {

--- a/packages/feature-store/src/types/entities.ts
+++ b/packages/feature-store/src/types/entities.ts
@@ -1,4 +1,4 @@
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { DataSource } from './dataSources';
 import { FeatureStoreMeta, FeatureStorePagination, FeatureStoreRelationship } from './global';
 

--- a/packages/feature-store/src/types/featureServices.ts
+++ b/packages/feature-store/src/types/featureServices.ts
@@ -1,4 +1,4 @@
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { BatchSource, FeatureStoreMeta, FeatureStoreRelationship } from './global';
 import { FeatureColumns } from './features';
 

--- a/packages/feature-store/src/types/featureStoreProjects.ts
+++ b/packages/feature-store/src/types/featureStoreProjects.ts
@@ -1,4 +1,4 @@
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { FeatureStoreMeta, FeatureStorePagination } from './global';
 
 export type FeatureStoreProject = {

--- a/packages/feature-store/src/types/featureView.ts
+++ b/packages/feature-store/src/types/featureView.ts
@@ -1,4 +1,4 @@
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { FeatureStoreMeta, BatchSource, FileOptions, NameValueTypePair } from './global';
 import { FeatureColumns } from './features';
 import { Relationship } from '../screens/featureViews/utils';

--- a/packages/feature-store/src/types/features.ts
+++ b/packages/feature-store/src/types/features.ts
@@ -1,4 +1,4 @@
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { FeatureStorePagination, NameValueTypePair } from './global';
 
 export type FeatureColumns = NameValueTypePair & {

--- a/packages/feature-store/src/types/lineage.ts
+++ b/packages/feature-store/src/types/lineage.ts
@@ -1,7 +1,7 @@
 // Feature Store Lineage Data Types
 // Reusing existing types from the feature store package
 
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { Entity } from './entities';
 import { DataSource } from './dataSources';
 import {

--- a/packages/feature-store/src/types/metrics.ts
+++ b/packages/feature-store/src/types/metrics.ts
@@ -1,4 +1,4 @@
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 
 export type ResourceCounts = {
   entities: number;

--- a/packages/feature-store/src/types/search.ts
+++ b/packages/feature-store/src/types/search.ts
@@ -1,4 +1,4 @@
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 
 export type GlobalSearchResult = {
   type: string;

--- a/packages/gpuaas/src/components/ClusterQueueCard.tsx
+++ b/packages/gpuaas/src/components/ClusterQueueCard.tsx
@@ -14,7 +14,7 @@ import {
   chart_color_blue_300 as chartColorBlue,
   chart_color_orange_100 as chartColorOrange,
 } from '@patternfly/react-tokens';
-import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import AcceleratorDonutChart from './AcceleratorDonutChart';
 import {
   BorrowBadge,

--- a/packages/gpuaas/src/hooks/__tests__/useBorrowingLendingMetrics.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useBorrowingLendingMetrics.spec.ts
@@ -1,4 +1,4 @@
-import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import {
   buildSeries,
   getGpuNominalQuota,

--- a/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
+++ b/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import usePrometheusQueryRange from '@odh-dashboard/internal/api/prometheus/usePrometheusQueryRange';
-import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import type {
   PrometheusQueryRangeResponseData,
   PrometheusQueryRangeResponseDataResult,

--- a/packages/gpuaas/src/hooks/useCohorts.ts
+++ b/packages/gpuaas/src/hooks/useCohorts.ts
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { ClusterQueueKind, CohortKind } from '@odh-dashboard/internal/k8sTypes';
 import useFetch, { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { listClusterQueues } from '@odh-dashboard/internal/api/k8s/clusterQueues';
 import { listCohorts } from '@odh-dashboard/internal/api/k8s/cohorts';
-import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+import { ClusterQueueKind, CohortKind, ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
 import { FlavorQuota, UnifiedCohort } from '../types';
 import { INFRASTRUCTURE_REFRESH_INTERVAL } from '../const';
 import parseK8sQuantity from '../utils/parseK8sQuantity';

--- a/packages/gpuaas/src/hooks/useResourceFlavors.ts
+++ b/packages/gpuaas/src/hooks/useResourceFlavors.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ResourceFlavorKind } from '@odh-dashboard/internal/k8sTypes';
+import { ResourceFlavorKind } from '@odh-dashboard/k8s-core';
 import useFetch, { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { listResourceFlavors } from '@odh-dashboard/internal/api/k8s/resourceFlavors';
 import { INFRASTRUCTURE_REFRESH_INTERVAL } from '../const';

--- a/packages/gpuaas/src/types.ts
+++ b/packages/gpuaas/src/types.ts
@@ -1,5 +1,4 @@
-import { ClusterQueueKind, CohortKind } from '@odh-dashboard/internal/k8sTypes';
-import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+import { ClusterQueueKind, CohortKind, ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
 
 export type CohortState = 'explicit' | 'implicit' | 'standalone';
 

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
@@ -1,4 +1,4 @@
-import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import { CQDcgmResult, UnifiedCohort } from '../../types';
 import {
   AcceleratorDonutType,

--- a/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/hardwareModels.spec.ts
@@ -1,4 +1,4 @@
-import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/internal/k8sTypes';
+import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/k8s-core';
 import { resolveHardwareModels, resolvePerModelGpuCounts } from '../hardwareModels';
 
 const makeGpuCQ = (

--- a/packages/gpuaas/src/utils/borrowingLending.ts
+++ b/packages/gpuaas/src/utils/borrowingLending.ts
@@ -1,5 +1,4 @@
-import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
-import { ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
+import { ClusterQueueKind, ContainerResourceAttributes } from '@odh-dashboard/k8s-core';
 import parseK8sQuantity from './parseK8sQuantity';
 
 type FlavorResourceUsage = {

--- a/packages/gpuaas/src/utils/clusterQueueUtils.ts
+++ b/packages/gpuaas/src/utils/clusterQueueUtils.ts
@@ -1,4 +1,4 @@
-import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import parseK8sQuantity from './parseK8sQuantity';
 import { ModelGpuCount } from './hardwareModels';
 import { ACCELERATOR_RESOURCE_REGEX } from '../const';

--- a/packages/gpuaas/src/utils/hardwareModels.ts
+++ b/packages/gpuaas/src/utils/hardwareModels.ts
@@ -1,4 +1,4 @@
-import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/internal/k8sTypes';
+import { ClusterQueueKind, ResourceFlavorKind } from '@odh-dashboard/k8s-core';
 import parseK8sQuantity from './parseK8sQuantity';
 import { ACCELERATOR_RESOURCE_REGEX } from '../const';
 

--- a/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
+++ b/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
@@ -18,7 +18,7 @@ import {
 import * as React from 'react';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { t_global_icon_color_disabled as disabledIconColor } from '@patternfly/react-tokens';
-import type { HardwareProfileKind } from '@odh-dashboard/k8s-core';
+import { type HardwareProfileKind, byName } from '@odh-dashboard/k8s-core';
 import SimpleSelect, { SimpleSelectOption } from '@odh-dashboard/ui-core/components/SimpleSelect';
 import TruncatedText from '@odh-dashboard/ui-core/components/TruncatedText';
 import ProjectScopedIcon from '@odh-dashboard/ui-core/components/searchSelector/ProjectScopedIcon';
@@ -35,7 +35,7 @@ import {
   orderHardwareProfiles,
 } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
-import { ProjectsContext, byName } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { useApplicationSettings } from '@odh-dashboard/internal/app/useApplicationSettings';
 import {
   computeLocalQueueNamesResult,

--- a/packages/hardware-profiles/shared/HardwareProfileTableColumn.tsx
+++ b/packages/hardware-profiles/shared/HardwareProfileTableColumn.tsx
@@ -3,7 +3,7 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { DashboardPopupIconButton, ScopedLabel } from '@odh-dashboard/ui-core';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
-import type { NotebookKind } from '@odh-dashboard/internal/k8sTypes';
+import type { NotebookKind } from '@odh-dashboard/k8s-core';
 import { getHardwareProfileDisplayName } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
 import { KUEUE_QUEUE_LABEL } from '@odh-dashboard/internal/concepts/kueue/index';
 import type { HardwareProfileResource } from './types';

--- a/packages/hardware-profiles/shared/useHardwareProfileBindingState.ts
+++ b/packages/hardware-profiles/shared/useHardwareProfileBindingState.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { HardwareProfileFeatureVisibility } from '@odh-dashboard/k8s-core';
-import type { NotebookKind } from '@odh-dashboard/internal/k8sTypes';
+import type { NotebookKind } from '@odh-dashboard/k8s-core';
 import { isHardwareProfileEnabled } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors';
 import { useHardwareProfilesByFeatureVisibility } from '@odh-dashboard/internal/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility';

--- a/packages/hardware-profiles/src/pages/utils.ts
+++ b/packages/hardware-profiles/src/pages/utils.ts
@@ -3,8 +3,8 @@ import {
   type HardwareProfileKind,
   type Identifier,
   IdentifierResourceType,
+  LocalQueueKind,
 } from '@odh-dashboard/k8s-core';
-import { LocalQueueKind } from '@odh-dashboard/internal/k8sTypes';
 import { DisplayNameAnnotation } from '@odh-dashboard/internal/types';
 import {
   HardwareProfileWarningType,

--- a/packages/k8s-core/src/index.ts
+++ b/packages/k8s-core/src/index.ts
@@ -34,6 +34,8 @@ export {
   HardwareProfileFeatureVisibility,
   DataScienceStackComponent,
   MODELS_AS_A_SERVICE_READY,
+  DSPAMlflowIntegrationMode,
+  WorkloadOwnerType,
 } from './k8sTypes';
 export type {
   K8sAPIOptions,
@@ -62,6 +64,28 @@ export type {
   DataScienceClusterComponentStatus,
   DataScienceClusterKindStatus,
   DataScienceClusterInitializationKindStatus,
+  ConfigMapKind,
+  EventKind,
+  StorageClassKind,
+  NotebookAnnotations,
+  NotebookKind,
+  RoleBindingSubject,
+  RoleBindingRoleRef,
+  ResourceRule,
+  RoleKind,
+  RoleBindingKind,
+  TrustyAIKind,
+  ClusterQueueKind,
+  LocalQueueKind,
+  WorkloadPodSet,
+  WorkloadKind,
+  WorkloadConditionType,
+  WorkloadCondition,
+  CohortKind,
+  ResourceFlavorKind,
+  ServiceKind,
+  NIMAccountKind,
+  ConfigSecretItem,
 } from './k8sTypes';
 
 export {
@@ -140,7 +164,17 @@ export type {
   FieldMode,
 } from './connectionTypes';
 
-export { NamespaceApplicationCase, byName, namespaceToProjectDisplayName } from './projectUtils';
+export {
+  NamespaceApplicationCase,
+  byName,
+  namespaceToProjectDisplayName,
+  isAvailableProject,
+  isAiProject,
+  getProjectOwner,
+  getProjectCreationTime,
+  projectDisplayNameToNamespace,
+} from './projectUtils';
+export type { GetByName } from './projectUtils';
 export { isK8sStatus, K8sStatusError } from './errorUtils';
 
 export {

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -1,8 +1,11 @@
-import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import type { K8sResourceCommon, MatchExpression } from '@openshift/dynamic-plugin-sdk-utils';
 import type {
+  ContainerResourceAttributes,
   HardwareProfileAnnotations,
+  HardwareProfileBindingAnnotations,
   HardwareProfileScheduling,
   Identifier,
+  ImagePullSecret,
   ModelServingSize,
   NodeSelector,
   NotebookSize,
@@ -405,4 +408,593 @@ export type DataScienceClusterInitializationKindStatus = {
   };
   components?: Record<string, never>;
   phase?: string;
+};
+
+export type ConfigMapKind = K8sResourceCommon & {
+  metadata: {
+    name: string;
+  };
+  data?: Record<string, string>;
+};
+
+export type EventKind = K8sResourceCommon & {
+  metadata: {
+    uid?: string;
+  };
+  involvedObject: {
+    name: string;
+    uid?: string;
+    kind?: string;
+  };
+  lastTimestamp?: string;
+  eventTime: string;
+  type: 'Normal' | 'Warning';
+  reason: string;
+  message: string;
+};
+
+type StorageClassAnnotations = Partial<{
+  [MetadataAnnotation.StorageClassIsDefault]: 'true' | 'false';
+  [MetadataAnnotation.K8sDescription]: string;
+  [MetadataAnnotation.OdhStorageClassConfig]: string;
+}>;
+
+export type StorageClassKind = K8sResourceCommon & {
+  metadata: {
+    annotations?: StorageClassAnnotations;
+    name: string;
+  };
+  provisioner: string;
+  parameters?: string;
+  reclaimPolicy: string;
+  volumeBindingMode: string;
+  allowVolumeExpansion?: boolean;
+};
+
+export type NotebookAnnotations = Partial<{
+  'kubeflow-resource-stopped': string | null;
+  'notebooks.kubeflow.org/last-activity': string;
+  'opendatahub.io/user': string;
+  'opendatahub.io/username': string;
+  'notebooks.opendatahub.io/last-image-selection': string;
+  'opendatahub.io/image-display-name': string;
+  'notebooks.opendatahub.io/last-image-version-git-commit-selection': string;
+  'opendatahub.io/workbench-image-namespace': string | null;
+  'opendatahub.io/connections': string | undefined;
+}> &
+  Partial<HardwareProfileBindingAnnotations>;
+
+export type NotebookKind = K8sResourceCommon & {
+  metadata: {
+    annotations?: DisplayNameAnnotations & NotebookAnnotations;
+    name: string;
+    namespace: string;
+  };
+  spec: {
+    template: {
+      spec: PodSpec;
+    };
+  };
+  status?: {
+    containerState?: {
+      terminated?: { [key: string]: string };
+    };
+    readyReplicas?: number;
+  };
+};
+
+export type RoleBindingSubject = {
+  kind: string;
+  apiGroup?: string;
+  name: string;
+};
+
+export type RoleBindingRoleRef = {
+  kind: 'Role' | 'ClusterRole';
+  apiGroup?: string;
+  name: string;
+};
+
+export type ResourceRule = {
+  verbs: string[];
+  apiGroups?: string[];
+  resourceNames?: string[];
+  resources?: string[];
+};
+
+export type RoleKind = K8sResourceCommon & {
+  metadata: {
+    name: string;
+    namespace: string;
+  };
+  rules?: ResourceRule[];
+};
+
+export type RoleBindingKind = K8sResourceCommon & {
+  metadata: {
+    name: string;
+    namespace: string;
+  };
+  subjects?: RoleBindingSubject[];
+  roleRef: RoleBindingRoleRef;
+};
+
+export type TrustyAIKind = K8sResourceCommon & {
+  metadata: {
+    name: string;
+    namespace: string;
+  };
+  spec: {
+    storage:
+      | {
+          format: 'DATABASE';
+          databaseConfigurations: string;
+        }
+      | {
+          format: 'PVC';
+          folder: string;
+          size: string;
+        };
+    data?: {
+      filename: string;
+      format: string;
+    };
+    metrics: {
+      schedule: string;
+      batchSize?: number;
+    };
+  };
+  status?: {
+    conditions?: K8sCondition[];
+    phase?: string;
+    ready?: string;
+    replicas?: number;
+  };
+};
+
+export enum DSPAMlflowIntegrationMode {
+  DISABLED = 'DISABLED',
+  AUTODETECT = 'AUTODETECT',
+}
+
+type ClusterQueueFlavorUsage = {
+  name: string;
+  resources: {
+    name: ContainerResourceAttributes;
+    borrowed?: string | number;
+    total?: string | number;
+  }[];
+};
+
+export type ClusterQueueKind = K8sResourceCommon & {
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
+  kind: 'ClusterQueue';
+  spec: {
+    admissionChecksStrategy?: {
+      admissionChecks: {
+        name: string;
+        onFlavors?: string[];
+      }[];
+    };
+    cohortName?: string;
+    flavorFungibility?: {
+      whenCanBorrow: 'Borrow' | 'TryNextFlavor';
+      whenCanPreempt: 'Preempt' | 'TryNextFlavor';
+    };
+    namespaceSelector?: {
+      matchExpressions?: MatchExpression[];
+      matchLabels?: Record<string, string>;
+    };
+    preemption?: {
+      borrowWithinCohort?: {
+        maxPriorityThreshold?: number;
+        policy?: 'Never' | 'LowerPriority';
+      };
+      reclaimWithinCohort?: 'Never' | 'LowerPriority' | 'Any';
+      withinClusterQueue?: 'Never' | 'LowerPriority' | 'LowerOrNewerEqualPriority';
+    };
+    queueingStrategy?: 'StrictFIFO' | 'BestEffortFIFO';
+    resourceGroups?: {
+      coveredResources: ContainerResourceAttributes[];
+      flavors: {
+        name: string;
+        resources: {
+          name: ContainerResourceAttributes;
+          nominalQuota: string | number;
+        }[];
+      }[];
+    }[];
+    stopPolicy?: 'None' | 'Hold' | 'HoldAndDrain';
+  };
+  status?: {
+    flavorsReservation?: ClusterQueueFlavorUsage[];
+    flavorsUsage?: ClusterQueueFlavorUsage[];
+    pendingWorkloads?: number;
+    reservingWorkloads?: number;
+    admittedWorkloads?: number;
+    conditions?: {
+      lastTransitionTime: string;
+      message: string;
+      observedGeneration?: number;
+      reason: string;
+      status: 'True' | 'False' | 'Unknown';
+      type: string;
+    }[];
+    pendingWorkloadsStatus?: {
+      clusterQueuePendingWorkload?: {
+        name: string;
+        namespace: string;
+      }[];
+      lastChangeTime: string;
+    };
+  };
+};
+
+type LocalQueueFlavorUsage = {
+  name: string;
+  resources: {
+    name: ContainerResourceAttributes;
+    total?: string | number;
+  }[];
+};
+
+export type LocalQueueKind = K8sResourceCommon & {
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
+  kind: 'LocalQueue';
+  spec: {
+    clusterQueue: string;
+  };
+  status?: {
+    flavorsReservation?: LocalQueueFlavorUsage[];
+    flavorsUsage?: LocalQueueFlavorUsage[];
+    pendingWorkloads?: number;
+    reservingWorkloads?: number;
+    admittedWorkloads?: number;
+    conditions?: {
+      lastTransitionTime: string;
+      message: string;
+      observedGeneration?: number;
+      reason: string;
+      status: 'True' | 'False' | 'Unknown';
+      type: string;
+    }[];
+  };
+};
+
+type WorkloadPodAffinityTerm = {
+  labelSelector?: {
+    matchExpressions?: MatchExpression[];
+    matchLabels?: Record<string, string>;
+  };
+  matchLabelKeys?: string[];
+  mismatchLabelKeys?: string[];
+  namespaceSelector?: {
+    matchExpressions?: MatchExpression[];
+    matchLabels?: Record<string, string>;
+  };
+  namespaces?: string[];
+  topologyKey: string;
+};
+
+export type WorkloadPodSet = {
+  count: number;
+  minCount?: number;
+  name: string;
+  template: {
+    metadata?: K8sResourceCommon['metadata'];
+    spec: {
+      activeDeadlineSeconds?: number;
+      affinity?: {
+        nodeAffinity?: {
+          preferredDuringSchedulingIgnoredDuringExecution: {
+            preference: {
+              matchExpressions?: MatchExpression[];
+              matchFields?: MatchExpression[];
+            };
+            weight: number;
+          }[];
+          requiredDuringSchedulingIgnoredDuringExecution: {
+            nodeSelectorTerms: {
+              matchExpressions?: MatchExpression[];
+              matchFields?: MatchExpression[];
+            }[];
+          };
+        };
+        podAffinity?: {
+          preferredDuringSchedulingIgnoredDuringExecution?: {
+            podAffinityTerm: WorkloadPodAffinityTerm;
+            weight: number;
+          }[];
+          requiredDuringSchedulingIgnoredDuringExecution?: WorkloadPodAffinityTerm[];
+          weight: number;
+        }[];
+        podAntiAffinity?: {
+          preferredDuringSchedulingIgnoredDuringExecution?: {
+            podAffinityTerm: WorkloadPodAffinityTerm;
+            weight: number;
+          }[];
+          requiredDuringSchedulingIgnoredDuringExecution?: WorkloadPodAffinityTerm[];
+          weight: number;
+        };
+      };
+      automountServiceAccountToken?: boolean;
+      containers: PodContainer[];
+      dnsConfig?: {
+        nameservers?: string[];
+        options?: {
+          name: string;
+          value?: string;
+        }[];
+        searches?: string[];
+      };
+      dnsPolicy?: string;
+      enableServiceLinks?: boolean;
+      ephemeralContainers?: PodContainer[];
+      hostAliases?: {
+        hostnames?: string[];
+        ip: string;
+      }[];
+      hostIPC?: boolean;
+      hostNetwork?: boolean;
+      hostPID?: boolean;
+      hostUsers?: boolean;
+      hostname?: string;
+      imagePullSecrets?: ImagePullSecret[];
+      initContainers?: PodContainer[];
+      nodeName?: string;
+      nodeSelector?: Record<string, string>;
+      os?: { name: string };
+      overhead?: Record<string, string | number>;
+      preemptionPolicy?: string;
+      priority?: number;
+      priorityClassName?: string;
+      readinessGates?: {
+        conditionType: string;
+      }[];
+      resourceClaims?: {
+        name: string;
+        source?: {
+          resourceClaimName?: string;
+          resourceClaimTemplateName: string;
+        };
+      }[];
+      restartPolicy?: string;
+      runtimeClassName?: string;
+      schedulerName?: string;
+      schedulingGates?: {
+        name: string;
+      }[];
+      securityContext?: {
+        fsGroup?: number;
+        fsGroupChangePolicy?: string;
+        runAsGroup?: number;
+        runAsNonRoot?: boolean;
+        runAsUser?: number;
+        seLinuxOptions?: {
+          level?: string;
+          role?: string;
+          type?: string;
+          user?: string;
+        };
+        seccompProfile?: {
+          localhostProfile?: string;
+          type: string;
+        };
+        supplementalGroups?: number[];
+        sysctls?: {
+          name: string;
+          value: string;
+        }[];
+        windowsOptions?: {
+          gmsaCredentialSpec?: string;
+          gmsaCredentialSpecName?: string;
+          hostProcess?: string;
+          runAsUserName?: string;
+        };
+      };
+      serviceAccount?: string;
+      serviceAccountName?: string;
+      setHostnameAsFQDN?: boolean;
+      shareProcessNamespace?: boolean;
+      subdomain?: string;
+      terminationGracePeriodSeconds?: number;
+      tolerations?: {
+        effect?: string;
+        key?: string;
+        operator?: string;
+        tolerationSeconds?: number;
+        value?: string;
+      }[];
+      topologySpreadConstraints?: {
+        labelSelector?: {
+          matchExpressions?: MatchExpression[];
+          matchLabels?: Record<string, string>;
+        };
+        matchLabelKeys?: [];
+        maxSkew: number;
+        minDomains?: number;
+        nodeAffinityPolicy?: string;
+        nodeTaintsPolicy?: string;
+        topologyKey: string;
+        whenUnsatisfiable: string;
+      }[];
+      volumes?: {
+        name: string;
+        [key: string]: unknown;
+      }[];
+    };
+  };
+};
+
+export enum WorkloadOwnerType {
+  RayCluster = 'RayCluster',
+  Job = 'Job',
+  StatefulSet = 'StatefulSet',
+  ReplicaSet = 'ReplicaSet',
+}
+
+export type WorkloadKind = K8sResourceCommon & {
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
+  kind: 'Workload';
+  spec: {
+    active?: boolean;
+    podSets: WorkloadPodSet[];
+    priority?: number;
+    priorityClassRef?: {
+      group: string;
+      kind: string;
+      name: string;
+    };
+    queueName?: string;
+  };
+  status?: {
+    admission?: {
+      clusterQueue: string;
+      podSetAssignments: {
+        name: string;
+        count?: number;
+        flavors?: Record<string, string>;
+        resourceUsage?: Record<string, string | number>;
+      }[];
+    };
+    admissionChecks?: {
+      name: string;
+      message: string;
+      state: 'Pending' | 'Ready' | 'Retry' | 'Rejected';
+      lastTransitionTime: string;
+      podSetUpdates?: {
+        annotations?: Record<string, string>;
+        labels?: Record<string, string>;
+        name: string;
+        nodeSelector?: Record<string, string>;
+        tolerations?: Toleration[];
+      }[];
+    }[];
+    conditions?: WorkloadCondition[];
+    reclaimablePods?: {
+      count: number;
+      name: string;
+    }[];
+    requeueState?: {
+      count?: number;
+      requeueAt?: string;
+    };
+  };
+};
+
+export type WorkloadConditionType =
+  | 'QuotaReserved'
+  | 'Admitted'
+  | 'PodsReady'
+  | 'Finished'
+  | 'Evicted'
+  | 'Preempted';
+
+export type WorkloadCondition = {
+  lastTransitionTime: string;
+  message: string;
+  observedGeneration?: number;
+  reason: string;
+  status: 'True' | 'False' | 'Unknown';
+  type: WorkloadConditionType | (string & NonNullable<unknown>);
+};
+
+export type CohortKind = K8sResourceCommon & {
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
+  kind: 'Cohort';
+  spec: {
+    parentName?: string;
+    resourceGroups?: {
+      coveredResources: ContainerResourceAttributes[];
+      flavors: {
+        name: string;
+        resources: {
+          name: ContainerResourceAttributes;
+          nominalQuota: string | number;
+          borrowingLimit?: string | number;
+          lendingLimit?: string | number;
+        }[];
+      }[];
+    }[];
+    fairSharing?: {
+      weight?: string | number;
+    };
+  };
+  status?: {
+    fairSharing?: {
+      weightedShare: number;
+    };
+  };
+};
+
+export type ResourceFlavorKind = K8sResourceCommon & {
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
+  kind: 'ResourceFlavor';
+  spec: {
+    nodeLabels?: Record<string, string>;
+    nodeTaints?: {
+      key: string;
+      value?: string;
+      effect: 'NoSchedule' | 'NoExecute' | 'PreferNoSchedule';
+    }[];
+    tolerations?: Toleration[];
+    topologyName?: string;
+  };
+};
+
+export type ServiceKind = K8sResourceCommon & {
+  metadata: {
+    annotations?: DisplayNameAnnotations &
+      Partial<{
+        'routing.opendatahub.io/external-address-rest': string;
+        'routing.opendatahub.io/external-address-grpc': string;
+      }>;
+    name: string;
+    namespace: string;
+    labels?: Partial<{
+      component: string;
+    }>;
+  };
+  spec: {
+    selector: {
+      app: string;
+      component: string;
+    };
+    ports: {
+      name?: string;
+      protocol?: string;
+      appProtocol?: string;
+      port?: number;
+      targetPort?: number | string;
+    }[];
+  };
+};
+
+export type NIMAccountKind = K8sResourceCommon & {
+  metadata: {
+    name: string;
+    namespace: string;
+  };
+  spec: {
+    apiKeySecret: {
+      name: string;
+    };
+  };
+  status?: {
+    nimConfig?: {
+      name: string;
+    };
+    runtimeTemplate?: {
+      name: string;
+    };
+    nimPullSecret?: {
+      name: string;
+    };
+    conditions?: K8sCondition[];
+  };
+};
+
+export type ConfigSecretItem = {
+  name: string;
+  keys: string[];
 };

--- a/packages/k8s-core/src/projectUtils.ts
+++ b/packages/k8s-core/src/projectUtils.ts
@@ -1,4 +1,5 @@
 import type { ProjectKind } from './k8sTypes';
+import { KnownLabels } from './k8sTypes';
 import { getDisplayNameFromK8sResource } from './k8sResourceUtils';
 
 export enum NamespaceApplicationCase {
@@ -21,8 +22,27 @@ export enum NamespaceApplicationCase {
 }
 
 /** Returns a predicate that matches a project by `metadata.name`. */
-type GetByName = (name?: string) => Parameters<Array<ProjectKind>['find']>[0];
+export type GetByName = (name?: string) => Parameters<Array<ProjectKind>['find']>[0];
 export const byName: GetByName = (name) => (project) => project.metadata.name === name;
+
+export const isAvailableProject = (projectName: string, dashboardNamespace: string): boolean =>
+  !(
+    projectName.startsWith('openshift-') ||
+    projectName.startsWith('kube-') ||
+    projectName === 'default' ||
+    projectName === 'system' ||
+    projectName === 'openshift' ||
+    projectName === dashboardNamespace
+  );
+
+export const isAiProject = (project: ProjectKind): boolean =>
+  project.metadata.labels?.[KnownLabels.DASHBOARD_RESOURCE] === 'true';
+
+export const getProjectOwner = (project: ProjectKind): string =>
+  project.metadata.annotations?.['openshift.io/requester'] || '';
+
+export const getProjectCreationTime = (project: ProjectKind): number =>
+  project.metadata.creationTimestamp ? new Date(project.metadata.creationTimestamp).getTime() : 0;
 
 export const namespaceToProjectDisplayName = (
   namespace: string,
@@ -30,4 +50,14 @@ export const namespaceToProjectDisplayName = (
 ): string => {
   const project = projects.find((p) => p.metadata.name === namespace);
   return project ? getDisplayNameFromK8sResource(project) : namespace;
+};
+
+export const projectDisplayNameToNamespace = (
+  displayName: string,
+  projects: ProjectKind[],
+): string => {
+  const project = projects.find(
+    (p) => p.metadata.annotations?.['openshift.io/display-name'] === displayName,
+  );
+  return project?.metadata.name || displayName;
 };

--- a/packages/kserve/src/api/inferenceService.ts
+++ b/packages/kserve/src/api/inferenceService.ts
@@ -1,5 +1,5 @@
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import type { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import {
   k8sCreateResource,
   k8sPatchResource,

--- a/packages/kserve/src/api/watch.ts
+++ b/packages/kserve/src/api/watch.ts
@@ -1,7 +1,6 @@
 import { PodModel } from '@odh-dashboard/internal/api/models/index';
-import type { PodKind, ProjectKind } from '@odh-dashboard/k8s-core';
+import type { K8sAPIOptions, PodKind, ProjectKind } from '@odh-dashboard/k8s-core';
 import type { InferenceServiceKind, ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
 import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
 import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
 import {

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -29,13 +29,11 @@ import {
   SupportedModelFormats,
   isModelServingCompatible,
   ModelServingCompatibleTypes,
-} from '@odh-dashboard/k8s-core';
-import {
   K8sAPIOptions,
   RoleBindingKind,
-  ServiceAccountKind,
   RoleKind,
-} from '@odh-dashboard/internal/k8sTypes';
+} from '@odh-dashboard/k8s-core';
+import { ServiceAccountKind } from '@odh-dashboard/internal/k8sTypes';
 import {
   type InferenceServiceKind,
   ServingRuntimeModelType,

--- a/packages/kserve/src/deployments.ts
+++ b/packages/kserve/src/deployments.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ProjectKind } from '@odh-dashboard/k8s-core';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import {
   type InferenceServiceKind,
   type ServingRuntimeKind,

--- a/packages/llmd-serving/src/api/LLMInferenceService.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceService.ts
@@ -1,4 +1,4 @@
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import type { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import {
   k8sCreateResource,
   k8sPatchResource,

--- a/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
@@ -10,7 +10,7 @@ import {
 } from '@openshift/dynamic-plugin-sdk-utils';
 import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
 import { createPatchesFromDiff, groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
 import { CONFIG_TYPE_LABEL } from '../const';

--- a/packages/llmd-serving/src/api/services/gatewayDiscovery.ts
+++ b/packages/llmd-serving/src/api/services/gatewayDiscovery.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { proxyGET } from '@odh-dashboard/internal/api/proxyUtils';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import useFetch, {
   NotReadyError,
   type FetchStateObject,

--- a/packages/llmd-serving/src/deployments/deployUtils.ts
+++ b/packages/llmd-serving/src/deployments/deployUtils.ts
@@ -9,7 +9,7 @@ import { assembleServiceAccount } from '@odh-dashboard/internal/api/k8s/serviceA
 import { generateRoleBindingServiceAccount } from '@odh-dashboard/internal/api/k8s/roleBindings';
 import { addOwnerReference } from '@odh-dashboard/internal/api/k8sUtils';
 import { KnownLabels, SecretKind } from '@odh-dashboard/k8s-core';
-import type { K8sAPIOptions, RoleKind } from '@odh-dashboard/internal/k8sTypes';
+import type { K8sAPIOptions, RoleKind } from '@odh-dashboard/k8s-core';
 import { getTokenNames } from '@odh-dashboard/model-serving/concepts/auth';
 import {
   createServiceAccountIfMissing,

--- a/packages/llmd-serving/src/deployments/status.ts
+++ b/packages/llmd-serving/src/deployments/status.ts
@@ -9,8 +9,7 @@ import {
   type ModelStatus,
 } from '@odh-dashboard/model-serving/shared';
 import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import type { PodKind } from '@odh-dashboard/k8s-core';
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import type { K8sAPIOptions, PodKind } from '@odh-dashboard/k8s-core';
 import { PodModel } from '@odh-dashboard/internal/api/models/k8s';
 import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
 import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';

--- a/packages/llmd-serving/src/deployments/useWatchDeployments.ts
+++ b/packages/llmd-serving/src/deployments/useWatchDeployments.ts
@@ -1,6 +1,5 @@
 import React from 'react';
-import type { ProjectKind } from '@odh-dashboard/k8s-core';
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import type { K8sAPIOptions, ProjectKind } from '@odh-dashboard/k8s-core';
 import { getLLMdDeploymentEndpoints } from './endpoints';
 import { getLLMdDeploymentStatus, useLLMInferenceServicePods } from './status';
 import { type LLMdDeployment, type LLMInferenceServiceKind } from '../types';

--- a/packages/maas/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
+++ b/packages/maas/frontend/src/__tests__/cypress/cypress/support/commands/api.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-relative-import-paths/no-relative-import-paths */
-import type { RoleBindingKind } from '@odh-dashboard/internal/k8sTypes';
+import type { RoleBindingKind } from '@odh-dashboard/k8s-core';
 import type { GenericStaticResponse, RouteHandlerController } from 'cypress/types/net-stubbing';
 import type { Namespace, UserSettings } from 'mod-arch-core';
 import { mockModArchResponse } from 'mod-arch-core';

--- a/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx
+++ b/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx
@@ -12,7 +12,7 @@ import {
 import { Navigate, useSearchParams } from 'react-router-dom';
 import { loadRemote } from '@module-federation/runtime';
 import { LazyCodeRefComponent } from '@odh-dashboard/plugin-core';
-import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { getStoredPreferredProject } from '@odh-dashboard/internal/concepts/projects/getStoredPreferredProject';
 import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/ProjectIconWithSize';
 import { IconSize } from '@odh-dashboard/internal/types';

--- a/packages/mlflow-embedded/shared/MlflowBreadcrumbs.tsx
+++ b/packages/mlflow-embedded/shared/MlflowBreadcrumbs.tsx
@@ -10,9 +10,9 @@ import {
   FlexItem,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
-import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import { byName, getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { WORKSPACE_QUERY_PARAM } from '@odh-dashboard/internal/routes/pipelines/mlflow';
-import { byName, ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/ProjectIconWithSize';
 import { IconSize } from '@odh-dashboard/internal/types';
 import './MlflowBreadcrumbs.scss';

--- a/packages/mlflow-embedded/shared/WorkspaceRouteLoader.tsx
+++ b/packages/mlflow-embedded/shared/WorkspaceRouteLoader.tsx
@@ -3,7 +3,8 @@ import { Navigate, useSearchParams, useNavigate } from 'react-router-dom';
 import { EmptyState, EmptyStateBody, EmptyStateFooter } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
 import { ApplicationsPage } from '@odh-dashboard/ui-core';
-import { byName, ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
+import { byName } from '@odh-dashboard/k8s-core';
 import InvalidProject from '@odh-dashboard/internal/concepts/projects/InvalidProject';
 import { getStoredPreferredProject } from '@odh-dashboard/internal/concepts/projects/getStoredPreferredProject';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports

--- a/packages/model-registry/src/projectSelector/ProjectSelectorField.tsx
+++ b/packages/model-registry/src/projectSelector/ProjectSelectorField.tsx
@@ -10,7 +10,7 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import ProjectSelector from '@odh-dashboard/ui-core/components/projectSelector/ProjectSelector';
-import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import FieldGroupHelpLabelIcon from '@odh-dashboard/ui-core/components/FieldGroupHelpLabelIcon';
 import type { NamespaceSelectorFieldProps } from '@mf/modelRegistry/extension-points';
 

--- a/packages/model-registry/src/projectSelector/ProjectsBridgeProvider.tsx
+++ b/packages/model-registry/src/projectSelector/ProjectsBridgeProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import type { ProjectsBridgeData } from '@mf/modelRegistry/extension-points';
 
 type ProjectsBridgeProviderProps = {

--- a/packages/model-registry/src/projectSelector/__tests__/ProjectSelectorField.spec.tsx
+++ b/packages/model-registry/src/projectSelector/__tests__/ProjectSelectorField.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { mockProjectK8sResource } from '@odh-dashboard/internal/__mocks__/mockProjectK8sResource';
 import ProjectSelectorField from '../ProjectSelectorField';
 

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelMetrics.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelMetrics.cy.ts
@@ -7,8 +7,7 @@ import {
   mockCustomSecretK8sResource,
   mockSecretK8sResource,
 } from '@odh-dashboard/internal/__mocks__/mockSecretK8sResource';
-import type { SecretKind } from '@odh-dashboard/k8s-core';
-import type { TrustyAIKind } from '@odh-dashboard/internal/k8sTypes';
+import type { SecretKind, TrustyAIKind } from '@odh-dashboard/k8s-core';
 import {
   type InferenceServiceKind,
   type ServingRuntimeKind,

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -2,10 +2,10 @@ import type { Extension, CodeRef, ResolvedExtension } from '@openshift/dynamic-p
 import type { SortableData, ToggleState, ProjectObjectType } from '@odh-dashboard/ui-core';
 import type {
   DisplayNameAnnotations,
+  K8sAPIOptions,
   NamespaceApplicationCase,
   ProjectKind,
 } from '@odh-dashboard/k8s-core';
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
 import type { ModelServingPodSpecOptionsState } from '@odh-dashboard/internal/concepts/hardwareProfiles/deprecated/useModelServingAcceleratorDeprecatedPodSpecOptionsState';
 import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';

--- a/packages/model-training/src/__mocks__/mockEventK8sResource.ts
+++ b/packages/model-training/src/__mocks__/mockEventK8sResource.ts
@@ -1,5 +1,5 @@
 import { genUID } from '@odh-dashboard/internal/__mocks__/mockUtils';
-import { EventKind } from '@odh-dashboard/internal/k8sTypes';
+import { EventKind } from '@odh-dashboard/k8s-core';
 
 type MockEventResourceConfigType = {
   name?: string;

--- a/packages/model-training/src/api/__tests__/events.spec.ts
+++ b/packages/model-training/src/api/__tests__/events.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { EventKind } from '@odh-dashboard/internal/k8sTypes';
+import { EventKind } from '@odh-dashboard/k8s-core';
 import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
 import { EventModel } from '@odh-dashboard/internal/api/models/k8s';
 import { useWatchTrainJobEvents } from '../events';

--- a/packages/model-training/src/api/__tests__/queue.spec.ts
+++ b/packages/model-training/src/api/__tests__/queue.spec.ts
@@ -1,6 +1,6 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { LocalQueueModel, ClusterQueueModel } from '@odh-dashboard/internal/api/models/kueue';
-import { LocalQueueKind, ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { LocalQueueKind, ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import { getLocalQueue, getClusterQueue } from '../queue';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils');

--- a/packages/model-training/src/api/events.ts
+++ b/packages/model-training/src/api/events.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EventKind } from '@odh-dashboard/internal/k8sTypes';
+import { EventKind } from '@odh-dashboard/k8s-core';
 import { EventModel } from '@odh-dashboard/internal/api/models/k8s';
 import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
 import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';

--- a/packages/model-training/src/api/lifecycle.ts
+++ b/packages/model-training/src/api/lifecycle.ts
@@ -1,6 +1,6 @@
 import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
-import { K8sAPIOptions, WorkloadKind } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions, WorkloadKind } from '@odh-dashboard/k8s-core';
 import { TrainJobModel } from '@odh-dashboard/internal/api/models/kubeflow';
 import { getWorkloadForJob, patchWorkloadActiveState } from './workloads';
 import { TrainJobKind } from '../k8sTypes';

--- a/packages/model-training/src/api/queue.ts
+++ b/packages/model-training/src/api/queue.ts
@@ -1,6 +1,6 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { LocalQueueModel, ClusterQueueModel } from '@odh-dashboard/internal/api/models/kueue';
-import { LocalQueueKind, ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { LocalQueueKind, ClusterQueueKind } from '@odh-dashboard/k8s-core';
 
 export const getLocalQueue = async (name: string, namespace: string): Promise<LocalQueueKind> =>
   k8sGetResource<LocalQueueKind>({

--- a/packages/model-training/src/api/rayJobLifecycle.ts
+++ b/packages/model-training/src/api/rayJobLifecycle.ts
@@ -1,6 +1,6 @@
 import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { RayJobModel } from '@odh-dashboard/internal/api/models/kubeflow';
 import { getWorkloadForJob, patchWorkloadActiveState } from './workloads';
 import { RayJobKind } from '../k8sTypes';

--- a/packages/model-training/src/api/rayJobs.ts
+++ b/packages/model-training/src/api/rayJobs.ts
@@ -5,7 +5,7 @@ import {
   Patch,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
 import { RayJobModel } from '@odh-dashboard/internal/api/models/kubeflow';
 import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';

--- a/packages/model-training/src/api/runtimes.ts
+++ b/packages/model-training/src/api/runtimes.ts
@@ -1,6 +1,6 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { ClusterTrainingRuntimeModel } from '@odh-dashboard/internal/api/models/kubeflow';
 import { ClusterTrainingRuntimeKind } from '../k8sTypes';
 

--- a/packages/model-training/src/api/scaling.ts
+++ b/packages/model-training/src/api/scaling.ts
@@ -1,6 +1,6 @@
 import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { TrainJobModel } from '@odh-dashboard/internal/api/models/kubeflow';
 import { TrainJobKind } from '../k8sTypes';
 

--- a/packages/model-training/src/api/trainJobs.ts
+++ b/packages/model-training/src/api/trainJobs.ts
@@ -1,6 +1,6 @@
 import { k8sDeleteResource, K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
-import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
 import { TrainJobModel } from '@odh-dashboard/internal/api/models/kubeflow';
 import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';

--- a/packages/model-training/src/api/workloads.ts
+++ b/packages/model-training/src/api/workloads.ts
@@ -1,6 +1,6 @@
 import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
-import { K8sAPIOptions, WorkloadKind } from '@odh-dashboard/internal/k8sTypes';
+import { K8sAPIOptions, WorkloadKind } from '@odh-dashboard/k8s-core';
 import { listWorkloads } from '@odh-dashboard/internal/api/k8s/workloads';
 import { WorkloadModel } from '@odh-dashboard/internal/api/models/kueue';
 import { UnifiedJobKind } from '../types';

--- a/packages/model-training/src/global/ModelTrainingContext.tsx
+++ b/packages/model-training/src/global/ModelTrainingContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import type { ProjectKind } from '@odh-dashboard/k8s-core';
+import { type ProjectKind, byName } from '@odh-dashboard/k8s-core';
 import { DEFAULT_LIST_WATCH_RESULT } from '@odh-dashboard/internal/utilities/const';
-import { ProjectsContext, byName } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import type { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import { useTrainJobs, useRayJobs } from '../api';

--- a/packages/model-training/src/global/ModelTrainingCoreLoader.tsx
+++ b/packages/model-training/src/global/ModelTrainingCoreLoader.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Navigate, Outlet, useParams } from 'react-router-dom';
 import { ApplicationsPage } from '@odh-dashboard/ui-core';
-import { byName, ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
+import { byName } from '@odh-dashboard/k8s-core';
 import InvalidProject from '@odh-dashboard/internal/concepts/projects/InvalidProject';
 import { getStoredPreferredProject } from '@odh-dashboard/internal/concepts/projects/getStoredPreferredProject';
 import { ModelTrainingContextProvider } from './ModelTrainingContext';

--- a/packages/model-training/src/global/trainingJobDetailsDrawer/__tests__/utils.spec.ts
+++ b/packages/model-training/src/global/trainingJobDetailsDrawer/__tests__/utils.spec.ts
@@ -1,5 +1,5 @@
 import { ContainerResourceAttributes, PodKind } from '@odh-dashboard/k8s-core';
-import type { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import type { ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import { mockClusterQueueK8sResource } from '@odh-dashboard/internal/__mocks__/mockClusterQueueK8sResource';
 import { mockPodK8sResource } from '@odh-dashboard/internal/__mocks__/mockPodK8sResource';
 import {

--- a/packages/model-training/src/global/trainingJobDetailsDrawer/utils.ts
+++ b/packages/model-training/src/global/trainingJobDetailsDrawer/utils.ts
@@ -1,5 +1,4 @@
-import type { PodKind } from '@odh-dashboard/k8s-core';
-import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes.js';
+import type { PodKind, ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import type { UnitOption } from '@odh-dashboard/ui-core/utilities/valueUnits';
 import {
   CPU_UNITS,

--- a/packages/model-training/src/global/trainingJobList/JobProject.tsx
+++ b/packages/model-training/src/global/trainingJobList/JobProject.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { HelperText, HelperTextItem, Skeleton } from '@patternfly/react-core';
-import { ProjectsContext, byName } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
-import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
+import { byName, getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { UnifiedJobKind } from '../../types';
 
 type JobProjectProps = {

--- a/packages/model-training/src/global/trainingJobList/__tests__/rayJobUtils.spec.ts
+++ b/packages/model-training/src/global/trainingJobList/__tests__/rayJobUtils.spec.ts
@@ -1,4 +1,4 @@
-import { WorkloadCondition, WorkloadKind } from '@odh-dashboard/internal/k8sTypes';
+import { WorkloadCondition, WorkloadKind } from '@odh-dashboard/k8s-core';
 import { mockRayJobK8sResource } from '../../../__mocks__/mockRayJobK8sResource';
 import { mockTrainJobK8sResource } from '../../../__mocks__/mockTrainJobK8sResource';
 import {

--- a/packages/model-training/src/global/trainingJobList/__tests__/utils.spec.ts
+++ b/packages/model-training/src/global/trainingJobList/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { WorkloadCondition, WorkloadKind } from '@odh-dashboard/internal/k8sTypes';
+import { WorkloadCondition, WorkloadKind } from '@odh-dashboard/k8s-core';
 import { genUID } from '@odh-dashboard/internal/__mocks__/mockUtils';
 import { mockTrainJobK8sResource } from '../../../__mocks__/mockTrainJobK8sResource';
 import { mockRayJobK8sResource } from '../../../__mocks__/mockRayJobK8sResource';

--- a/packages/model-training/src/global/trainingJobList/hooks/useWorkloadForTrainJob.ts
+++ b/packages/model-training/src/global/trainingJobList/hooks/useWorkloadForTrainJob.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { WorkloadKind } from '@odh-dashboard/internal/k8sTypes';
+import { WorkloadKind } from '@odh-dashboard/k8s-core';
 import { WorkloadModel } from '@odh-dashboard/internal/api/models/kueue';
 import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
 import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';

--- a/packages/model-training/src/global/trainingJobList/utils.ts
+++ b/packages/model-training/src/global/trainingJobList/utils.ts
@@ -12,8 +12,7 @@ import {
   PlayIcon,
 } from '@patternfly/react-icons';
 import { AlertVariant, LabelProps } from '@patternfly/react-core';
-import { WorkloadCondition } from '@odh-dashboard/internal/k8sTypes';
-import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import { getDisplayNameFromK8sResource, WorkloadCondition } from '@odh-dashboard/k8s-core';
 import type { JobsFilterDataType } from './const';
 import { TrainJobKind, RayJobKind, RayClusterKind, RayClusterSpec } from '../../k8sTypes';
 import {

--- a/packages/model-training/src/hooks/useClusterQueue.ts
+++ b/packages/model-training/src/hooks/useClusterQueue.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import useFetch, { NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { getClusterQueue } from '../api/queue';
 

--- a/packages/model-training/src/hooks/useClusterQueueFromLocalQueue.ts
+++ b/packages/model-training/src/hooks/useClusterQueueFromLocalQueue.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { LocalQueueKind } from '@odh-dashboard/internal/k8sTypes';
+import { LocalQueueKind } from '@odh-dashboard/k8s-core';
 import useFetch, { NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { getLocalQueue } from '../api/queue';
 

--- a/packages/nim-serving/src/api/accounts/api.ts
+++ b/packages/nim-serving/src/api/accounts/api.ts
@@ -1,5 +1,4 @@
-import type { SecretKind } from '@odh-dashboard/k8s-core';
-import type { NIMAccountKind } from '@odh-dashboard/internal/k8sTypes';
+import type { NIMAccountKind, SecretKind } from '@odh-dashboard/k8s-core';
 import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
 import {
   assembleNIMSecret,

--- a/packages/nim-serving/src/api/accounts/hooks.ts
+++ b/packages/nim-serving/src/api/accounts/hooks.ts
@@ -4,7 +4,7 @@ import useFetch, {
   NotReadyError,
 } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { POLL_INTERVAL, FAST_POLL_INTERVAL } from '@odh-dashboard/internal/utilities/const';
-import { NIMAccountKind } from '@odh-dashboard/internal/k8sTypes';
+import { NIMAccountKind } from '@odh-dashboard/k8s-core';
 import { listNIMAccounts } from './k8s';
 import { NIMAccountStatus, deriveAccountStatus, getAccountStatusTransitionTime } from './utils';
 import { NIM_ACCOUNT_NAME, REVALIDATION_TIMEOUT_MS } from './constants';

--- a/packages/nim-serving/src/api/accounts/k8s.ts
+++ b/packages/nim-serving/src/api/accounts/k8s.ts
@@ -4,8 +4,7 @@ import {
   k8sDeleteResource,
   k8sListResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
-import type { SecretKind } from '@odh-dashboard/k8s-core';
-import type { NIMAccountKind } from '@odh-dashboard/internal/k8sTypes';
+import type { NIMAccountKind, SecretKind } from '@odh-dashboard/k8s-core';
 import { SecretModel } from '@odh-dashboard/internal/api/models';
 import { createSecret, getSecret, replaceSecret } from '@odh-dashboard/internal/api/k8s/secrets';
 import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';

--- a/packages/nim-serving/src/api/accounts/utils.ts
+++ b/packages/nim-serving/src/api/accounts/utils.ts
@@ -1,5 +1,4 @@
-import type { K8sCondition } from '@odh-dashboard/k8s-core';
-import type { NIMAccountKind } from '@odh-dashboard/internal/k8sTypes';
+import type { K8sCondition, NIMAccountKind } from '@odh-dashboard/k8s-core';
 
 import { VALIDATION_TIMEOUT_MS } from './constants';
 

--- a/packages/nim-serving/src/api/deployments/useWatchDeployments.ts
+++ b/packages/nim-serving/src/api/deployments/useWatchDeployments.ts
@@ -1,6 +1,5 @@
 import React from 'react';
-import type { ProjectKind } from '@odh-dashboard/k8s-core';
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import type { K8sAPIOptions, ProjectKind } from '@odh-dashboard/k8s-core';
 import { getKServeDeploymentEndpoints } from '@odh-dashboard/kserve/deploymentEndpoints';
 import { useWatchInferenceServices, useWatchNIMDeploymentPods } from './watch';
 import { getNIMDeploymentStatus } from './status';

--- a/packages/nim-serving/src/api/deployments/watch.ts
+++ b/packages/nim-serving/src/api/deployments/watch.ts
@@ -1,7 +1,6 @@
 import { PodModel } from '@odh-dashboard/internal/api/models/index';
-import type { PodKind, ProjectKind } from '@odh-dashboard/k8s-core';
+import type { K8sAPIOptions, PodKind, ProjectKind } from '@odh-dashboard/k8s-core';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
 import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
 import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
 import { InferenceServiceModel } from '@odh-dashboard/internal/api/models/kserve';

--- a/packages/nim-serving/src/api/images/api.ts
+++ b/packages/nim-serving/src/api/images/api.ts
@@ -1,5 +1,5 @@
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { ConfigMapKind, NIMAccountKind } from '@odh-dashboard/internal/k8sTypes';
+import { ConfigMapKind, NIMAccountKind } from '@odh-dashboard/k8s-core';
 import { ConfigMapModel } from '@odh-dashboard/internal/api/models';
 import type { NIMImage } from './types';
 

--- a/packages/nim-serving/src/api/images/hooks.ts
+++ b/packages/nim-serving/src/api/images/hooks.ts
@@ -3,7 +3,7 @@ import useFetch, {
   NotReadyError,
   type FetchStateCallbackPromise,
 } from '@odh-dashboard/ui-core/hooks/useFetch';
-import { NIMAccountKind } from '@odh-dashboard/internal/k8sTypes';
+import { NIMAccountKind } from '@odh-dashboard/k8s-core';
 import type { NIMImage } from './types';
 import { fetchNIMImages } from './api';
 

--- a/packages/nim-serving/src/api/nimservices/k8s.ts
+++ b/packages/nim-serving/src/api/nimservices/k8s.ts
@@ -1,5 +1,5 @@
 import { KnownLabels } from '@odh-dashboard/k8s-core';
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import type { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import {
   k8sCreateResource,
   k8sPatchResource,

--- a/packages/nim-serving/src/api/nimservices/watch.ts
+++ b/packages/nim-serving/src/api/nimservices/watch.ts
@@ -1,5 +1,4 @@
-import type { ProjectKind } from '@odh-dashboard/k8s-core';
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import type { K8sAPIOptions, ProjectKind } from '@odh-dashboard/k8s-core';
 import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
 import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
 import type { CustomWatchK8sResult } from '@odh-dashboard/internal/types';

--- a/packages/observability/src/api/usePersesDashboards.ts
+++ b/packages/observability/src/api/usePersesDashboards.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DashboardResource } from '@perses-dev/core';
 import { useAccessReview } from '@odh-dashboard/internal/api/useAccessReview';
-import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import type { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import useFetch, { type FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { fetchPersesDashboardsMetadata } from '../perses/perses-client';
 import { filterDashboards, THANOS_QUERIER_NON_TENANCY_ACCESS } from '../utils/dashboardUtils';


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-65097

## Description

Phase 2 follow-up to #8603. Migrates 105 `@odh-dashboard/internal` imports across packages to their canonical core locations, following the package topology decision flow.

| What moved | Destination | Files |
|---|---|---|
| `ProjectsContext` | `@odh-dashboard/ui-core/context/ProjectsContext` | 17 |
| 5 project utilities (`isAvailableProject`, `isAiProject`, etc.) | `@odh-dashboard/k8s-core` | 5 |
| 19 K8s resource types (`ConfigMapKind`, `EventKind`, `NotebookKind`, etc.) | `@odh-dashboard/k8s-core` | 89 |

Frontend backward compatibility preserved via re-export shims in `k8sTypes.ts` and `concepts/projects/utils.ts` (−550 lines of duplicated definitions).

Internal import count: 1453 → 1348.

### Scope boundary

This PR covers Phase 2 — import path migration only. Extension points for `ProjectDetailsContext` and `ProjectSelector` are tracked for Phase 3.

## How Has This Been Tested?

- `npx turbo type-check --force` passes across all packages
- Pure mechanical refactor — import path swaps and re-export shim conversions only
- Existing unit and Cypress tests pass without modification

## Test Impact

No new tests — zero runtime behavior change.

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our Best Practices

After the PR is posted & before it merges:

- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated shared Kubernetes resource types and project utilities into common packages.
  - Standardized project context access across dashboard features.
  - Updated feature-store, model-serving, training, GPU, and testing components to use consistent shared definitions.
  - Preserved existing APIs, workflows, hooks, mocks, and test behavior while improving cross-package consistency.
  - Added broader shared type coverage for workloads, queues, notebooks, RBAC, services, events, storage, and model integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->