### PR TITLE
fix(observability): bundle patched Perses Loki/Table/StatChart plugins [RHOAIENG-78528]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3671,6 +3671,15 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@grafana/lezer-logql": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@grafana/lezer-logql/-/lezer-logql-0.2.9.tgz",
+      "integrity": "sha512-SB9E2LQ689PiI/OPuBoTF93O5hBb1n8DbS3uSXfH2YYTsQELHqwU2HSM8BAI/ThX1ggkvIN9y0JyNTqfMKjlBA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -7335,19 +7344,75 @@
       }
     },
     "node_modules/@perses-dev/client": {
-      "version": "0.54.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@perses-dev/client/-/client-0.54.0-beta.10.tgz",
-      "integrity": "sha512-cceaVXLEmg3IW4eLGiWfe5CsDw8nE0GO/Moql4yCf/OtjSwYKgQ4XRgEjxWsP4tfKKP2o3lGd7arDewoQKKs5w==",
+      "version": "0.54.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/client/-/client-0.54.0-rc.1.tgz",
+      "integrity": "sha512-6+o+sshmbkcrgKrhYN/cY8eP1XyxbgmV1+5Oo1HAT+1rnL3TSNuLdBhqHGonbPadt95z5Sln5ohoqCdcpGVh5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@perses-dev/spec": "0.2.0-beta.6",
+        "@perses-dev/spec": "0.2.0-rc.0",
         "zod": "^3.21.4"
       }
     },
+    "node_modules/@perses-dev/client/node_modules/@perses-dev/spec": {
+      "version": "0.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/spec/-/spec-0.2.0-rc.0.tgz",
+      "integrity": "sha512-SDtY/+ziGxp0VIpFwk7rlTqRJbmMvyseHTZSpGBqwltXY9sXFuW5VSA+499yIdFdybptG4FFjURCNGt/HXrRgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-fns": "^4.1.0",
+        "mathjs": "^15.1.1",
+        "zod": "^3.21.4"
+      }
+    },
+    "node_modules/@perses-dev/client/node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/@perses-dev/client/node_modules/mathjs": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@perses-dev/client/node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@perses-dev/components": {
-      "version": "0.54.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.54.0-beta.10.tgz",
-      "integrity": "sha512-4S91IyHcyip0ozpHmhtBUVX4Xymzyrp0AnJgWv4DrMVJRnk7czWp+hUeDb92WvHmsKDOua5yoJFIay4PNhQJAw==",
+      "version": "0.54.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.54.0-rc.1.tgz",
+      "integrity": "sha512-ZfjLMgg+0f4tnaToaMahXzEZ1lfLnbZE4O6IpYO2kI2CYsKtus+OJcgrgUpjcpF/k3fnhbN18/Ww6+9OiDl35A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
@@ -7356,8 +7421,8 @@
         "@date-fns/tz": "^1.4.1",
         "@fontsource/inter": "^5.0.0",
         "@mui/x-date-pickers": "^7.23.1",
-        "@perses-dev/client": "0.54.0-beta.10",
-        "@perses-dev/spec": "0.2.0-beta.6",
+        "@perses-dev/client": "0.54.0-rc.1",
+        "@perses-dev/spec": "0.2.0-rc.0",
         "@tanstack/match-sorter-utils": "^8.19.4",
         "@tanstack/react-table": "^8.20.5",
         "@uiw/react-codemirror": "^4.19.1",
@@ -7371,7 +7436,6 @@
         "numbro": "^2.3.6",
         "react-colorful": "^5.6.1",
         "react-error-boundary": "^3.1.4",
-        "react-hook-form": "^7.51.3",
         "react-virtuoso": "^4.12.2"
       },
       "peerDependencies": {
@@ -7381,6 +7445,62 @@
         "lodash": "^4.17.21",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
+      }
+    },
+    "node_modules/@perses-dev/components/node_modules/@perses-dev/spec": {
+      "version": "0.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/spec/-/spec-0.2.0-rc.0.tgz",
+      "integrity": "sha512-SDtY/+ziGxp0VIpFwk7rlTqRJbmMvyseHTZSpGBqwltXY9sXFuW5VSA+499yIdFdybptG4FFjURCNGt/HXrRgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-fns": "^4.1.0",
+        "mathjs": "^15.1.1",
+        "zod": "^3.21.4"
+      }
+    },
+    "node_modules/@perses-dev/components/node_modules/@perses-dev/spec/node_modules/mathjs": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@perses-dev/components/node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/@perses-dev/components/node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@perses-dev/core": {
@@ -7398,15 +7518,15 @@
       }
     },
     "node_modules/@perses-dev/dashboards": {
-      "version": "0.54.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.54.0-beta.10.tgz",
-      "integrity": "sha512-9aSZf1NNISjfwhaZaRJG5Hdois5w3ROIZUlvah77WhyRECOfB8NuVj+kkZDbZuhwKb2FW8RYGmvFX30bNsnQHg==",
+      "version": "0.54.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.54.0-rc.1.tgz",
+      "integrity": "sha512-KQDjbaDyes6CS9zvbvn4dGXfJeOAr+GdtRDPM2BwdnNXcX+UipmpkGxyCAMfMeeyBdRvh04ezMZVNiyhNi6gkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@perses-dev/client": "0.54.0-beta.10",
-        "@perses-dev/components": "0.54.0-beta.10",
-        "@perses-dev/plugin-system": "0.54.0-beta.10",
-        "@perses-dev/spec": "0.2.0-beta.6",
+        "@perses-dev/client": "0.54.0-rc.1",
+        "@perses-dev/components": "0.54.0-rc.1",
+        "@perses-dev/plugin-system": "0.54.0-rc.1",
+        "@perses-dev/spec": "0.2.0-rc.0",
         "@tanstack/hotkeys": "^0.8.0",
         "@tanstack/react-hotkeys": "^0.9.1",
         "immer": "^10.1.1",
@@ -7427,17 +7547,73 @@
         "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
+    "node_modules/@perses-dev/dashboards/node_modules/@perses-dev/spec": {
+      "version": "0.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/spec/-/spec-0.2.0-rc.0.tgz",
+      "integrity": "sha512-SDtY/+ziGxp0VIpFwk7rlTqRJbmMvyseHTZSpGBqwltXY9sXFuW5VSA+499yIdFdybptG4FFjURCNGt/HXrRgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-fns": "^4.1.0",
+        "mathjs": "^15.1.1",
+        "zod": "^3.21.4"
+      }
+    },
+    "node_modules/@perses-dev/dashboards/node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/@perses-dev/dashboards/node_modules/mathjs": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@perses-dev/dashboards/node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@perses-dev/explore": {
-      "version": "0.54.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.54.0-beta.10.tgz",
-      "integrity": "sha512-NsAmOD7V9U5axOdejOiHstNbeEtdSRzVHKnurTRoZxzKruD4nobYcqtJfxNjigLH5JpJmaWgVmUfJJBTv8c9rQ==",
+      "version": "0.54.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.54.0-rc.1.tgz",
+      "integrity": "sha512-5vZ4dIEMAok+Y/4HAgluUa7T/rxhLFSyf72SSEXN59r8NSovP90a9gkvZKXhQnW+bmiFEwO9oiDbY4MJO8Ft6A==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@nexucis/fuzzy": "^0.5.1",
-        "@perses-dev/components": "0.54.0-beta.10",
-        "@perses-dev/dashboards": "0.54.0-beta.10",
-        "@perses-dev/plugin-system": "0.54.0-beta.10",
+        "@perses-dev/components": "0.54.0-rc.1",
+        "@perses-dev/dashboards": "0.54.0-rc.1",
+        "@perses-dev/plugin-system": "0.54.0-rc.1",
         "mdi-material-ui": "^7.9.2",
         "qs": "^6.14.0",
         "react-virtuoso": "^4.12.2",
@@ -7452,16 +7628,16 @@
       }
     },
     "node_modules/@perses-dev/plugin-system": {
-      "version": "0.54.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.54.0-beta.10.tgz",
-      "integrity": "sha512-91hxc4Sz8COscnx48xJjKVYlMQdng8Fqt9Hac1F8ww2s9DdDC1Y9PoWDjk/VrwcT7V/XqXBL9j6KfwkUkl8xZg==",
+      "version": "0.54.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.54.0-rc.1.tgz",
+      "integrity": "sha512-sWuHZpMD1eZRW5jn+FvF/ggyv4aHhc6TKWTo0IxmRHDy49gPwi9gimQorXEZDMWb+QVPRZAv0AG5W/IGyenisw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@module-federation/enhanced": "^2.6.0",
-        "@perses-dev/client": "0.54.0-beta.10",
-        "@perses-dev/components": "0.54.0-beta.10",
+        "@module-federation/enhanced": "^2.8.0",
+        "@perses-dev/client": "0.54.0-rc.1",
+        "@perses-dev/components": "0.54.0-rc.1",
         "@perses-dev/core": "0.53.0",
-        "@perses-dev/spec": "0.2.0-beta.6",
+        "@perses-dev/spec": "0.2.0-rc.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "immer": "^10.1.1",
@@ -7481,36 +7657,22 @@
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.6.0.tgz",
-      "integrity": "sha512-V+4+1PUmDgAozXPJA8evIa2G+dPJGYn1JzDoHS9wMFch2blko/DO2sMq6FGuZFnT1oyjxiWeiaWXluRElOU9rQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.8.0.tgz",
+      "integrity": "sha512-7AaaiE4YOXFb+st6xlVDK65aNKZYR9S9ykH0q2mkHAHTgquXciAjypS8JuhmKn7Lob/2rkplMOc4YsGxG3Ng9Q==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.6.0",
-        "@types/semver": "7.5.8",
-        "semver": "7.6.3"
-      }
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/bridge-react-webpack-plugin/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/cli": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.6.0.tgz",
-      "integrity": "sha512-CHBsi5f8Oe9sCN6rY4R0+P/oFApvuutnqfoYNtuORdMn6FHittFDkuLFCSYlrZN2QYw/Sqir2xgLcwmY77Z7PA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.8.0.tgz",
+      "integrity": "sha512-yTxdWkCJPPo+IGASz+NqdW13cw3DhjSBEn9r85aYn1ahckDwB1WcZe0OjDWMqCcR6yi0BMLedk0SWrUeUj0fWw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.6.0",
-        "@module-federation/sdk": "2.6.0",
+        "@module-federation/dts-plugin": "2.8.0",
+        "@module-federation/sdk": "2.8.0",
         "commander": "11.1.0",
         "jiti": "2.4.2"
       },
@@ -7522,24 +7684,22 @@
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/dts-plugin": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.6.0.tgz",
-      "integrity": "sha512-0dMjLhU+2HNPyX5Txu6JqA2CAYxVLRv3c/bpRk58aNVwhDO/jqp66IdFztdMZ1XiHqOW9jB3pkOSuIpcl/yXpQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.8.0.tgz",
+      "integrity": "sha512-defjq4jOWMEfeejezPWLP5sc8kw0O6FqTT7/E5rbZPEVyjB1A0U3ynhW6GDE5/6hk9/TzdbWS+fBNi4MqUOY6Q==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.6.0",
-        "@module-federation/managers": "2.6.0",
-        "@module-federation/sdk": "2.6.0",
-        "@module-federation/third-party-dts-extractor": "2.6.0",
+        "@module-federation/error-codes": "2.8.0",
+        "@module-federation/managers": "2.8.0",
+        "@module-federation/sdk": "2.8.0",
+        "@module-federation/third-party-dts-extractor": "2.8.0",
         "adm-zip": "0.5.10",
-        "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
-        "node-schedule": "2.1.1",
         "undici": "7.28.0",
         "ws": "8.21.0"
       },
       "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
+        "typescript": "^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
         "vue-tsc": ">=1.0.24"
       },
       "peerDependenciesMeta": {
@@ -7549,31 +7709,30 @@
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/enhanced": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.6.0.tgz",
-      "integrity": "sha512-pQ0V93FfeHtr67Nusr6ySTQO1qeOGs1x9MMjbeZ4ObOPbXdHNX1tH19xVP8mo5k3e8iIV2teMoSayTmHT+nD0g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.8.0.tgz",
+      "integrity": "sha512-h8vkLdhK7tlcSPmyYNGfGyt0pSzfDB0tYVYdyUt2tXwQRfaJAi3bsIpujMXElw3MXtOfSHESa6M/hPKrtWTHBw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.6.0",
-        "@module-federation/cli": "2.6.0",
-        "@module-federation/dts-plugin": "2.6.0",
-        "@module-federation/error-codes": "2.6.0",
-        "@module-federation/inject-external-runtime-core-plugin": "2.6.0",
-        "@module-federation/managers": "2.6.0",
-        "@module-federation/manifest": "2.6.0",
-        "@module-federation/rspack": "2.6.0",
-        "@module-federation/runtime-tools": "2.6.0",
-        "@module-federation/sdk": "2.6.0",
-        "@module-federation/webpack-bundler-runtime": "2.6.0",
+        "@module-federation/bridge-react-webpack-plugin": "2.8.0",
+        "@module-federation/cli": "2.8.0",
+        "@module-federation/dts-plugin": "2.8.0",
+        "@module-federation/error-codes": "2.8.0",
+        "@module-federation/inject-external-runtime-core-plugin": "2.8.0",
+        "@module-federation/managers": "2.8.0",
+        "@module-federation/manifest": "2.8.0",
+        "@module-federation/rspack": "2.8.0",
+        "@module-federation/runtime-tools": "2.8.0",
+        "@module-federation/sdk": "2.8.0",
+        "@module-federation/webpack-bundler-runtime": "2.8.0",
         "schema-utils": "4.3.0",
-        "tapable": "2.3.0",
-        "upath": "2.0.1"
+        "tapable": "2.3.0"
       },
       "bin": {
         "mf": "bin/mf.js"
       },
       "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
+        "typescript": "^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
         "vue-tsc": ">=1.0.24",
         "webpack": "^5.0.0"
       },
@@ -7590,59 +7749,57 @@
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/error-codes": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.6.0.tgz",
-      "integrity": "sha512-J9opjWJJZ1JI/9EvNZF8Ps1VMHS9EsH/i0UjCkQQxFVYZxSDBX1CFunvc7awac4cY//LqJUfqBbfoQPhCfKKKw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.8.0.tgz",
+      "integrity": "sha512-Gaog9904EmxYOQV0hli3XQ7jXeFaADfh5bnBtTCtbZ37Qd/Sz9kQfd+gYQRyIj7RGmkv9DPiN/SsmrTMrTymKw==",
       "license": "MIT"
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.6.0.tgz",
-      "integrity": "sha512-x5SmH33U1nSEcBXG6YzvkwIQLoKcd/CNfrAx4IJ4qBzlQKI0NvY7U4JE83LpBnwahNTQLvp27ZVX+1f7kt4Vww==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.8.0.tgz",
+      "integrity": "sha512-fW3jD1ZVds6r/Ul8TtUA42RsB0LfT1yjo5KjqgirH9QrmEMH21x44e3e6BC6IN820XKawRDSmz2kFA5YHIQp7Q==",
       "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "2.6.0"
+        "@module-federation/runtime-tools": "2.8.0"
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/managers": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.6.0.tgz",
-      "integrity": "sha512-7Y4Ri6Lh10dCHoEJvNGFmK2Gg1JKy7oJ1TEZhuU3n3mgIpZ519fDNRvU4+tiO9C49p1xyK+mQ8ewxth83waKUA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.8.0.tgz",
+      "integrity": "sha512-SnVBCwmi962WGg6hLFElxZUCnrRJdR6glE2ZKPBY/iK07AHUN2ZxuaBCBsVzyws+xLZGHZxBHmVstijTh8dSUA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.6.0",
-        "find-pkg": "2.0.0"
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/manifest": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.6.0.tgz",
-      "integrity": "sha512-wIjI4wgFKBoq4l/iBOT2lva+i5sPv1+Ci1gOLOfjMAkygyGo97csUG5TaCWgLJpZzbYrpbFObCB2wZhqaLrQIw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.8.0.tgz",
+      "integrity": "sha512-wfVeBXc4/C2F70nRFSPqJhkcwbDgo+wQyEn3jbjJTDoUqxxhYBfHFs1ACBYOk3Qm97L7hHclHGtUG0/nvDEfAA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.6.0",
-        "@module-federation/managers": "2.6.0",
-        "@module-federation/sdk": "2.6.0",
-        "find-pkg": "2.0.0"
+        "@module-federation/dts-plugin": "2.8.0",
+        "@module-federation/managers": "2.8.0",
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/rspack": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.6.0.tgz",
-      "integrity": "sha512-Ayh7WLxhLRMyfBfajDwEytR5StFfnqf8p4tPHq5ds+HzJMlGz/M+NIYEzdOpfOFdE5IqN9bY/mj2AFI5lCureQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.8.0.tgz",
+      "integrity": "sha512-TPcrkHpaZgL25Vx3c8oSNwyv7/KktC7uo6HTQdVWlFzbq5RSoMMGkWoir5pY5124isae2/p6v5xAuqICi4r0Zg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.6.0",
-        "@module-federation/dts-plugin": "2.6.0",
-        "@module-federation/inject-external-runtime-core-plugin": "2.6.0",
-        "@module-federation/managers": "2.6.0",
-        "@module-federation/manifest": "2.6.0",
-        "@module-federation/runtime-tools": "2.6.0",
-        "@module-federation/sdk": "2.6.0"
+        "@module-federation/bridge-react-webpack-plugin": "2.8.0",
+        "@module-federation/dts-plugin": "2.8.0",
+        "@module-federation/inject-external-runtime-core-plugin": "2.8.0",
+        "@module-federation/managers": "2.8.0",
+        "@module-federation/manifest": "2.8.0",
+        "@module-federation/runtime-tools": "2.8.0",
+        "@module-federation/sdk": "2.8.0"
       },
       "peerDependencies": {
         "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
-        "typescript": "^4.9.0 || ^5.0.0",
+        "typescript": "^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
         "vue-tsc": ">=1.0.24"
       },
       "peerDependenciesMeta": {
@@ -7655,69 +7812,57 @@
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/runtime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.6.0.tgz",
-      "integrity": "sha512-Y8KgL70RDxD8cCtGWGlGkt+TSDleIjdGmS27gnllibQAIgG/vHhPD11r8kd92x44k4dqtMIntzreOphGICl92g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.8.0.tgz",
+      "integrity": "sha512-cGtUBQ1/TVy7KrXy6xPgy3FEmOGyIYkBA2T4iGH3ZH5PNPPTmqN9jF2AfneTSOj0RtBr7Pxq3CUt81E/UCvK1A==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.6.0",
-        "@module-federation/runtime-core": "2.6.0",
-        "@module-federation/sdk": "2.6.0"
+        "@module-federation/error-codes": "2.8.0",
+        "@module-federation/runtime-core": "2.8.0",
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/runtime-core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.6.0.tgz",
-      "integrity": "sha512-9sL7Yj3H3COZI9JpK/J4hmJUBkIJdmowkj6phHuFiy5Hm5bHiE5U+9WBbR9KqTdyNhAVSL9FeprBW5/Io6i59A==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.8.0.tgz",
+      "integrity": "sha512-Tf98+epGGiPSHqmQHuXa2uXZMMvjGf1IqJDR1/FpXfmobv5ECN0mGZCjUHGNSyxvoDyXKIkKwJu7IwEoh0ouQA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.6.0",
-        "@module-federation/sdk": "2.6.0"
+        "@module-federation/error-codes": "2.8.0",
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/runtime-tools": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.6.0.tgz",
-      "integrity": "sha512-LfvihAhAWWNWlAL9zM+UDVDSSuLE2ZU0ATJ6dcbJuLstYbHYfUqq2e6IyU8TKLPXIib0VAWqPrT44TPam1VJ7g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.8.0.tgz",
+      "integrity": "sha512-3yOqjdSHXxX4HA3GhlXg3hghGAXW2RJUsnwXCcik2/lTxOHizKI8f3RM+GGCKPxDVqtw43IShe3tA12jNL5A/A==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "2.6.0",
-        "@module-federation/webpack-bundler-runtime": "2.6.0"
+        "@module-federation/runtime": "2.8.0",
+        "@module-federation/webpack-bundler-runtime": "2.8.0"
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/sdk": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.6.0.tgz",
-      "integrity": "sha512-Z3HT1uDciMrvz2at3sw6TJbAK9Fl7RmoC/8iqO35HDtQMQJ1qSsMIAjnsiCpAC0D4nAm6PIqgSqPWRO/WYgo0Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^2.7.0 || ^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
-      }
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.8.0.tgz",
+      "integrity": "sha512-yBP+9+0Z8nlvKEXAZS3AsQVy7bFbZf8eMivGk4q4ZdwG3TsLMlsPjb1dQb2i7gcAG6ux9y2LWLkj/0LVk74cnQ==",
+      "license": "MIT"
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.6.0.tgz",
-      "integrity": "sha512-rEC1YRC3gTafoOcFm1Htz6cAwHRoWEMQNCm1LXR1HiuayJzUkViVpK/1Pp37UZfytOyQ0qIaP6Ag81PdGvDbmw==",
-      "license": "MIT",
-      "dependencies": {
-        "find-pkg": "2.0.0",
-        "resolve": "1.22.8"
-      }
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.8.0.tgz",
+      "integrity": "sha512-nAMlr74OKIylkfRwlunOhytQbmsgb3gCqdXWnPQhG+ZtqWXGELLfMT4a1Q1ht3cS+sRpWj2SZRqK2M7GadI6tA==",
+      "license": "MIT"
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.6.0.tgz",
-      "integrity": "sha512-JjuWOU3ktwDjBWhM4WCoeiErcUxcB5YwUnVjyTMfNJHC3+DMhG4m6ziCl5EJrCv+KaEQdcvXmxLliNZidBZGQg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.8.0.tgz",
+      "integrity": "sha512-82fDy9v+7qV5fiN8TKVhOdrxhmAZnUIX/IKivYX5ulCt8aoOzVFTiwm/P1GQUDD8z6dqR48xgJdZdf0548Mc9w==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.6.0",
-        "@module-federation/runtime": "2.6.0",
-        "@module-federation/sdk": "2.6.0"
+        "@module-federation/error-codes": "2.8.0",
+        "@module-federation/runtime": "2.8.0",
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/@perses-dev/core": {
@@ -7731,6 +7876,40 @@
         "mathjs": "^10.6.4",
         "numbro": "^2.3.6",
         "zod": "^3.21.4"
+      }
+    },
+    "node_modules/@perses-dev/plugin-system/node_modules/@perses-dev/spec": {
+      "version": "0.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/spec/-/spec-0.2.0-rc.0.tgz",
+      "integrity": "sha512-SDtY/+ziGxp0VIpFwk7rlTqRJbmMvyseHTZSpGBqwltXY9sXFuW5VSA+499yIdFdybptG4FFjURCNGt/HXrRgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-fns": "^4.1.0",
+        "mathjs": "^15.1.1",
+        "zod": "^3.21.4"
+      }
+    },
+    "node_modules/@perses-dev/plugin-system/node_modules/@perses-dev/spec/node_modules/mathjs": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/adm-zip": {
@@ -7780,9 +7959,9 @@
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -7794,6 +7973,19 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@perses-dev/plugin-system/node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/isomorphic-ws": {
       "version": "5.0.0",
@@ -7852,6 +8044,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@perses-dev/plugin-system/node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@perses-dev/plugin-system/node_modules/undici": {
@@ -10101,6 +10302,7 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -11386,6 +11588,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13063,6 +13266,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/chroma-js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz",
+      "integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -13977,6 +14186,7 @@
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
       "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "luxon": "^3.2.1"
@@ -17277,6 +17487,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "homedir-polyfill": "^1.0.1"
@@ -17879,6 +18090,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-2.0.1.tgz",
       "integrity": "sha512-qVdaUhYO39zmh28/JLQM5CoYN9byEOKEH4qfa8K1eNV17W0UUMJ9WgbR/hHFH+t5rcl+6RTb5UC7ck/I+uRkpQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-dir": "^1.0.1"
@@ -17905,6 +18117,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-2.0.0.tgz",
       "integrity": "sha512-WgZ+nKbELDa6N3i/9nrHeNznm+lY3z4YfhDDWgW+5P0pdmMj26bxaxU11ookgY3NyP9GC7HvZ9etp0jRFqGEeQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-file-up": "^2.0.1"
@@ -18542,6 +18755,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "global-prefix": "^1.0.1",
@@ -18556,6 +18770,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "expand-tilde": "^2.0.2",
@@ -18572,12 +18787,14 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/global-prefix/node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -19212,6 +19429,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parse-passwd": "^1.0.0"
@@ -20668,6 +20886,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23003,6 +23222,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
       "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -23069,6 +23289,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
       "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -26126,6 +26347,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
       "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cron-parser": "^4.2.0",
@@ -27311,6 +27533,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29920,6 +30143,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "expand-tilde": "^2.0.0",
@@ -31413,6 +31637,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
       "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/source-map": {
@@ -34282,6 +34507,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
       "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4",
@@ -37336,8 +37562,11 @@
         "@perses-dev/components": "^0.54.0-beta.10",
         "@perses-dev/core": "^0.54.0-beta.2",
         "@perses-dev/dashboards": "^0.54.0-beta.10",
+        "@perses-dev/loki-plugin": "v0.6.0-rc.2",
         "@perses-dev/plugin-system": "^0.54.0-beta.10",
-        "@perses-dev/prometheus-plugin": "v0.58.0-beta.3"
+        "@perses-dev/prometheus-plugin": "v0.58.0-beta.3",
+        "@perses-dev/stat-chart-plugin": "v0.13.0-rc.1",
+        "@perses-dev/table-plugin": "v0.13.0-rc.1"
       },
       "devDependencies": {
         "@odh-dashboard/cypress": "*",
@@ -37354,6 +37583,143 @@
         "react-dom": "^18",
         "react-router-dom": "^7",
         "use-query-params": "^2.2.2"
+      }
+    },
+    "packages/observability/node_modules/@perses-dev/loki-plugin": {
+      "version": "0.6.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@perses-dev/loki-plugin/-/loki-plugin-0.6.0-rc.2.tgz",
+      "integrity": "sha512-37zmr0AOa4bZ+xLsR1qWqXOOIUPVvMD5W/v7ZXOfna431IzJIAOAB3/1XzNMfSBm5ykfUyNQvaSN7b7+az5U6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grafana/lezer-logql": "^0.2.8"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
+        "@hookform/resolvers": "^3.2.0",
+        "@perses-dev/components": "^0.54.0-rc.1",
+        "@perses-dev/dashboards": "^0.54.0-rc.1",
+        "@perses-dev/explore": "^0.54.0-rc.1",
+        "@perses-dev/plugin-system": "^0.54.0-rc.1",
+        "@perses-dev/spec": "^0.2.0-rc.0",
+        "@tanstack/react-query": "^4.39.1",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
+        "echarts": "5.5.0",
+        "immer": "^10.1.1",
+        "lodash": "^4.17.21",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0",
+        "react-hook-form": "^7.52.2",
+        "use-resize-observer": "^9.0.0"
+      }
+    },
+    "packages/observability/node_modules/@perses-dev/spec": {
+      "version": "0.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/spec/-/spec-0.2.0-rc.0.tgz",
+      "integrity": "sha512-SDtY/+ziGxp0VIpFwk7rlTqRJbmMvyseHTZSpGBqwltXY9sXFuW5VSA+499yIdFdybptG4FFjURCNGt/HXrRgg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "date-fns": "^4.1.0",
+        "mathjs": "^15.1.1",
+        "zod": "^3.21.4"
+      }
+    },
+    "packages/observability/node_modules/@perses-dev/stat-chart-plugin": {
+      "version": "0.13.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/stat-chart-plugin/-/stat-chart-plugin-0.13.0-rc.1.tgz",
+      "integrity": "sha512-aqcpg//i0qpIPoWN+inbjMw7f9WdoU/RftGA8ZQAW7+K4WhrWlaPxYFyYGiBQmNzHXshptJpKXSKzhyvVUjrLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chroma-js": "^3.1.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
+        "@hookform/resolvers": "^3.2.0",
+        "@perses-dev/components": "^0.54.0-rc.1",
+        "@perses-dev/plugin-system": "^0.54.0-rc.1",
+        "@perses-dev/spec": "^0.2.0-rc.0",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
+        "echarts": "5.5.0",
+        "immer": "^10.1.1",
+        "lodash": "^4.17.21",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0",
+        "use-resize-observer": "^9.0.0"
+      }
+    },
+    "packages/observability/node_modules/@perses-dev/table-plugin": {
+      "version": "0.13.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/table-plugin/-/table-plugin-0.13.0-rc.1.tgz",
+      "integrity": "sha512-BdiI83ZXH9BDXxybdEIdOJaE50Uk/nIqSi7M5iSNeyU3ViRKnolDoPS3kRzrXsA+tKehsAweoiNpVYtG3OvGYw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
+        "@hookform/resolvers": "^3.2.0",
+        "@perses-dev/components": "^0.54.0-rc.1",
+        "@perses-dev/dashboards": "^0.54.0-rc.1",
+        "@perses-dev/plugin-system": "^0.54.0-rc.1",
+        "@perses-dev/spec": "^0.2.0-rc.0",
+        "@tanstack/react-table": "^8.20.5",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
+        "echarts": "5.5.0",
+        "lodash": "^4.17.21",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0",
+        "use-resize-observer": "^9.0.0"
+      }
+    },
+    "packages/observability/node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "packages/observability/node_modules/mathjs": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/observability/node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 18"
       }
     },
     "packages/plugin-core": {

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -48,8 +48,11 @@
     "@perses-dev/components": "^0.54.0-beta.10",
     "@perses-dev/core": "^0.54.0-beta.2",
     "@perses-dev/dashboards": "^0.54.0-beta.10",
+    "@perses-dev/loki-plugin": "v0.6.0-rc.2",
     "@perses-dev/plugin-system": "^0.54.0-beta.10",
-    "@perses-dev/prometheus-plugin": "v0.58.0-beta.3"
+    "@perses-dev/prometheus-plugin": "v0.58.0-beta.3",
+    "@perses-dev/stat-chart-plugin": "v0.13.0-rc.1",
+    "@perses-dev/table-plugin": "v0.13.0-rc.1"
   },
   "devDependencies": {
     "@odh-dashboard/cypress": "*",

--- a/packages/observability/src/perses/__tests__/persesPluginsLoader.spec.ts
+++ b/packages/observability/src/perses/__tests__/persesPluginsLoader.spec.ts
@@ -1,0 +1,252 @@
+import type { PluginModuleResource } from '@perses-dev/plugin-system';
+import { getPluginModuleCompoundKey, remotePluginLoader } from '@perses-dev/plugin-system';
+import {
+  loadBundledOverride,
+  pluginLoader,
+  resetBundledOverridesForTests,
+  type BundledPluginModule,
+} from '../persesPluginsLoader';
+
+jest.mock('../perses-client', () => ({
+  PERSES_PROXY_BASE_PATH: '/perses/api',
+}));
+
+jest.mock('@perses-dev/plugin-system', () => ({
+  getPluginModuleCompoundKey: ({
+    kind,
+    name,
+    registry,
+    version,
+  }: {
+    kind: string;
+    name: string;
+    registry?: string;
+    version?: string;
+  }) => `${kind}:${name}:${registry ?? ''}:${version ?? ''}`,
+  remotePluginLoader: jest.fn(() => ({
+    getInstalledPlugins: jest.fn(),
+    importPluginModule: jest.fn(),
+  })),
+}));
+
+const remoteLoader = jest.mocked(remotePluginLoader).mock.results[0]?.value as {
+  getInstalledPlugins: jest.Mock;
+  importPluginModule: jest.Mock;
+};
+
+const createMockModule = (packageName: string, exportName = 'Table'): BundledPluginModule => {
+  const pluginExport = { kind: 'Panel' };
+  return {
+    [exportName]: pluginExport,
+    getPluginModule: () => ({
+      kind: 'PluginModule',
+      metadata: {
+        name: packageName,
+        version: '1.0.0',
+        registry: 'perses.dev',
+      },
+      spec: {
+        plugins: [
+          {
+            kind: 'Panel',
+            spec: {
+              name: exportName,
+              display: { name: exportName },
+            },
+          },
+        ],
+      },
+    }),
+  };
+};
+
+const createRemoteResource = (
+  name: string,
+  options?: { version?: string; registry?: string; pluginName?: string },
+): PluginModuleResource => ({
+  kind: 'PluginModule',
+  metadata: {
+    name,
+    version: options?.version ?? '0.1.0',
+    registry: options?.registry ?? 'perses.dev',
+  },
+  spec: {
+    plugins: [
+      {
+        kind: 'Panel',
+        spec: {
+          name: options?.pluginName ?? 'Table',
+          display: { name: options?.pluginName ?? 'Table' },
+        },
+      },
+    ],
+  },
+});
+
+describe('loadBundledOverride', () => {
+  beforeEach(() => {
+    resetBundledOverridesForTests(new Map());
+  });
+
+  it('should resolve a plugin by remote manifest name', async () => {
+    const mockModule = createMockModule('@perses-dev/table-plugin');
+    const loader = jest.fn().mockResolvedValue(mockModule);
+    resetBundledOverridesForTests(new Map([['Table', loader]]));
+
+    const result = await loadBundledOverride('Table');
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(result).toBe(mockModule);
+  });
+
+  it('should resolve a previously loaded plugin by npm package name alias', async () => {
+    const mockModule = createMockModule('@perses-dev/table-plugin');
+    const loader = jest.fn().mockResolvedValue(mockModule);
+    resetBundledOverridesForTests(new Map([['Table', loader]]));
+
+    await loadBundledOverride('Table');
+    const aliased = await loadBundledOverride('@perses-dev/table-plugin');
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(aliased).toBe(mockModule);
+  });
+
+  it('should return undefined for unknown plugins', () => {
+    resetBundledOverridesForTests(new Map([['Table', jest.fn()]]));
+
+    expect(loadBundledOverride('Unknown')).toBeUndefined();
+  });
+
+  it('should retry after a rejected dynamic import by clearing the cache entry', async () => {
+    const mockModule = createMockModule('@perses-dev/table-plugin');
+    const loader = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('chunk load failed'))
+      .mockResolvedValueOnce(mockModule);
+    resetBundledOverridesForTests(new Map([['Table', loader]]));
+
+    await expect(loadBundledOverride('Table')).rejects.toThrow('chunk load failed');
+    await expect(loadBundledOverride('Table')).resolves.toBe(mockModule);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not leave a rejected npm package alias cached after failure', async () => {
+    const failingModule = {
+      getPluginModule: () => {
+        throw new Error('invalid module metadata');
+      },
+    };
+    const loader = jest
+      .fn()
+      .mockResolvedValueOnce(failingModule)
+      .mockResolvedValueOnce(createMockModule('@perses-dev/table-plugin'));
+    resetBundledOverridesForTests(new Map([['Table', loader]]));
+
+    await expect(loadBundledOverride('Table')).rejects.toThrow('invalid module metadata');
+    await expect(loadBundledOverride('Table')).resolves.toBeDefined();
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('pluginLoader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetBundledOverridesForTests(new Map());
+  });
+
+  describe('getInstalledPlugins', () => {
+    it('should replace matching remote plugins with bundled module metadata', async () => {
+      const mockModule = createMockModule('@perses-dev/table-plugin');
+      resetBundledOverridesForTests(new Map([['Table', jest.fn().mockResolvedValue(mockModule)]]));
+      const remoteTable = createRemoteResource('Table');
+      const remoteOther = createRemoteResource('TimeSeriesChart');
+      remoteLoader.getInstalledPlugins.mockResolvedValue([remoteTable, remoteOther]);
+
+      const installed = await pluginLoader.getInstalledPlugins();
+
+      expect(installed).toEqual([mockModule.getPluginModule(), remoteOther]);
+    });
+
+    it('should leave unknown remote plugins unchanged', async () => {
+      const remoteOther = createRemoteResource('TimeSeriesChart');
+      remoteLoader.getInstalledPlugins.mockResolvedValue([remoteOther]);
+
+      const installed = await pluginLoader.getInstalledPlugins();
+
+      expect(installed).toEqual([remoteOther]);
+      expect(remoteLoader.importPluginModule).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('importPluginModule', () => {
+    it('should return compound-keyed exports for a bundled override', async () => {
+      const mockModule = createMockModule('@perses-dev/table-plugin', 'Table');
+      resetBundledOverridesForTests(new Map([['Table', jest.fn().mockResolvedValue(mockModule)]]));
+      const resource = createRemoteResource('Table', {
+        version: '1.0.0',
+        registry: 'perses.dev',
+        pluginName: 'Table',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const imported = (await pluginLoader.importPluginModule(resource)) as Record<string, unknown>;
+
+      const compoundKey = getPluginModuleCompoundKey({
+        kind: 'Panel',
+        name: 'Table',
+        registry: resource.metadata.registry,
+        version: resource.metadata.version,
+      });
+      expect(imported.Table).toBe(mockModule.Table);
+      expect(imported[compoundKey]).toBe(mockModule.Table);
+      expect(remoteLoader.importPluginModule).not.toHaveBeenCalled();
+    });
+
+    it('should resolve an override via cached npm package name after manifest load', async () => {
+      const mockModule = createMockModule('@perses-dev/table-plugin', 'Table');
+      const loader = jest.fn().mockResolvedValue(mockModule);
+      resetBundledOverridesForTests(new Map([['Table', loader]]));
+
+      await loadBundledOverride('Table');
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const imported = (await pluginLoader.importPluginModule(
+        mockModule.getPluginModule(),
+      )) as Record<string, unknown>;
+
+      expect(loader).toHaveBeenCalledTimes(1);
+      expect(imported.Table).toBe(mockModule.Table);
+    });
+
+    it('should delegate unknown plugins to the remote loader with stripped version metadata', async () => {
+      const resource = createRemoteResource('TimeSeriesChart', {
+        version: '9.9.9',
+        registry: 'perses.dev',
+        pluginName: 'TimeSeriesChart',
+      });
+      const strippedKey = getPluginModuleCompoundKey({
+        kind: 'Panel',
+        name: 'TimeSeriesChart',
+      });
+      const versionedKey = getPluginModuleCompoundKey({
+        kind: 'Panel',
+        name: 'TimeSeriesChart',
+        registry: 'perses.dev',
+        version: '9.9.9',
+      });
+      const remotePlugin = { render: jest.fn() };
+      remoteLoader.importPluginModule.mockResolvedValue({
+        [strippedKey]: remotePlugin,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const imported = (await pluginLoader.importPluginModule(resource)) as Record<string, unknown>;
+
+      expect(remoteLoader.importPluginModule).toHaveBeenCalledWith({
+        ...resource,
+        metadata: { ...resource.metadata, version: '', registry: '' },
+      });
+      expect(imported[versionedKey]).toBe(remotePlugin);
+    });
+  });
+});

--- a/packages/observability/src/perses/persesPluginsLoader.tsx
+++ b/packages/observability/src/perses/persesPluginsLoader.tsx
@@ -1,8 +1,6 @@
 import type { PluginLoader, PluginModuleResource } from '@perses-dev/plugin-system';
 import { getPluginModuleCompoundKey, remotePluginLoader } from '@perses-dev/plugin-system';
 
-import * as prometheusPlugin from '@perses-dev/prometheus-plugin';
-
 import { PERSES_PROXY_BASE_PATH } from './perses-client';
 
 declare global {
@@ -22,9 +20,43 @@ if (typeof window !== 'undefined') {
   window.PERSES_APP_CONFIG = { api_prefix: PERSES_PROXY_BASE_PATH };
 }
 
-const BUNDLED_OVERRIDES = new Map<string, { getPluginModule: () => PluginModuleResource }>([
-  ['@perses-dev/prometheus-plugin', prometheusPlugin],
+type BundledPluginModule = {
+  getPluginModule: () => PluginModuleResource;
+} & Record<string, unknown>;
+
+/**
+ * Locally bundled plugins that replace the matching remote module.
+ * Keyed by Perses server module name (mf-manifest `name`). After load, the
+ * npm package name from getPluginModule() is also cached for importPluginModule.
+ */
+const BUNDLED_OVERRIDE_LOADERS = new Map<string, () => Promise<BundledPluginModule>>([
+  ['Prometheus', () => import('@perses-dev/prometheus-plugin')],
+  ['Loki', () => import('@perses-dev/loki-plugin')],
+  ['Table', () => import('@perses-dev/table-plugin')],
+  ['StatChart', () => import('@perses-dev/stat-chart-plugin')],
 ]);
+
+const loadedOverrides = new Map<string, Promise<BundledPluginModule>>();
+
+const loadBundledOverride = (name: string): Promise<BundledPluginModule> | undefined => {
+  const cached = loadedOverrides.get(name);
+  if (cached) {
+    return cached;
+  }
+
+  const loader = BUNDLED_OVERRIDE_LOADERS.get(name);
+  if (!loader) {
+    return undefined;
+  }
+
+  const pending = loader().then((mod) => {
+    // Also resolve under the npm package name used after getPluginModule() replacement.
+    loadedOverrides.set(mod.getPluginModule().metadata.name, pending);
+    return mod;
+  });
+  loadedOverrides.set(name, pending);
+  return pending;
+};
 
 const remoteLoader = remotePluginLoader({
   apiPrefix: PERSES_PROXY_BASE_PATH,
@@ -43,14 +75,16 @@ const remoteLoader = remotePluginLoader({
 export const pluginLoader: PluginLoader = {
   getInstalledPlugins: async () => {
     const remotePlugins = await remoteLoader.getInstalledPlugins();
-    return remotePlugins.map((resource) => {
-      const override = BUNDLED_OVERRIDES.get(resource.metadata.name);
-      return override ? override.getPluginModule() : resource;
-    });
+    return Promise.all(
+      remotePlugins.map(async (resource) => {
+        const override = await loadBundledOverride(resource.metadata.name);
+        return override ? override.getPluginModule() : resource;
+      }),
+    );
   },
 
   importPluginModule: async (resource: PluginModuleResource) => {
-    const override = BUNDLED_OVERRIDES.get(resource.metadata.name);
+    const override = await loadBundledOverride(resource.metadata.name);
     if (override) {
       const {
         metadata: { version, registry },

--- a/packages/observability/src/perses/persesPluginsLoader.tsx
+++ b/packages/observability/src/perses/persesPluginsLoader.tsx
@@ -20,42 +20,67 @@ if (typeof window !== 'undefined') {
   window.PERSES_APP_CONFIG = { api_prefix: PERSES_PROXY_BASE_PATH };
 }
 
-type BundledPluginModule = {
+export type BundledPluginModule = {
   getPluginModule: () => PluginModuleResource;
 } & Record<string, unknown>;
+
+const createDefaultBundledOverrideLoaders = (): Map<string, () => Promise<BundledPluginModule>> =>
+  new Map<string, () => Promise<BundledPluginModule>>([
+    ['Prometheus', () => import('@perses-dev/prometheus-plugin')],
+    ['Loki', () => import('@perses-dev/loki-plugin')],
+    ['Table', () => import('@perses-dev/table-plugin')],
+    ['StatChart', () => import('@perses-dev/stat-chart-plugin')],
+  ]);
 
 /**
  * Locally bundled plugins that replace the matching remote module.
  * Keyed by Perses server module name (mf-manifest `name`). After load, the
  * npm package name from getPluginModule() is also cached for importPluginModule.
  */
-const BUNDLED_OVERRIDE_LOADERS = new Map<string, () => Promise<BundledPluginModule>>([
-  ['Prometheus', () => import('@perses-dev/prometheus-plugin')],
-  ['Loki', () => import('@perses-dev/loki-plugin')],
-  ['Table', () => import('@perses-dev/table-plugin')],
-  ['StatChart', () => import('@perses-dev/stat-chart-plugin')],
-]);
+let bundledOverrideLoaders = createDefaultBundledOverrideLoaders();
 
 const loadedOverrides = new Map<string, Promise<BundledPluginModule>>();
 
-const loadBundledOverride = (name: string): Promise<BundledPluginModule> | undefined => {
+const evictLoadedOverride = (pending: Promise<BundledPluginModule>): void => {
+  for (const [key, value] of loadedOverrides.entries()) {
+    if (value === pending) {
+      loadedOverrides.delete(key);
+    }
+  }
+};
+
+/** Resolves a bundled override by remote module name or cached npm package name. */
+export const loadBundledOverride = (name: string): Promise<BundledPluginModule> | undefined => {
   const cached = loadedOverrides.get(name);
   if (cached) {
     return cached;
   }
 
-  const loader = BUNDLED_OVERRIDE_LOADERS.get(name);
+  const loader = bundledOverrideLoaders.get(name);
   if (!loader) {
     return undefined;
   }
 
-  const pending = loader().then((mod) => {
-    // Also resolve under the npm package name used after getPluginModule() replacement.
-    loadedOverrides.set(mod.getPluginModule().metadata.name, pending);
-    return mod;
-  });
+  const pending = loader()
+    .then((mod) => {
+      // Also resolve under the npm package name used after getPluginModule() replacement.
+      loadedOverrides.set(mod.getPluginModule().metadata.name, pending);
+      return mod;
+    })
+    .catch((error: unknown) => {
+      evictLoadedOverride(pending);
+      throw error;
+    });
   loadedOverrides.set(name, pending);
   return pending;
+};
+
+/** Clears override cache and optionally replaces loaders. Restores defaults when omitted. */
+export const resetBundledOverridesForTests = (
+  loaders?: Map<string, () => Promise<BundledPluginModule>>,
+): void => {
+  loadedOverrides.clear();
+  bundledOverrideLoaders = loaders ?? createDefaultBundledOverrideLoaders();
 };
 
 const remoteLoader = remotePluginLoader({


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-78528

## Description

Bundles newer Perses plugin builds as local overrides so Loki-backed Table and StatChart panels use instant queries instead of always hitting `query_range`.

The COO-shipped Perses Loki plugin incorrectly sends range queries for panels that need instant queries, producing silently wrong values. Upstream fixes landed in:

- [perses/plugins#736](https://github.com/perses/plugins/pull/736)
- [perses/plugins#737](https://github.com/perses/plugins/pull/737)
- [perses/plugins#738](https://github.com/perses/plugins/pull/738)

This PR overrides:

| Plugin | Version |
| --- | --- |
| `@perses-dev/loki-plugin` | `v0.6.0-rc.2` |
| `@perses-dev/table-plugin` | `v0.13.0-rc.1` |
| `@perses-dev/stat-chart-plugin` | `v0.13.0-rc.1` |

Also registers the existing Prometheus override under the remote module name (`Prometheus`) so bundled overrides match both the Perses API name and the npm package name.

Compare the usage breakdown table:
Before:
<img width="1882" height="999" alt="image" src="https://github.com/user-attachments/assets/a256cd84-4610-4234-b2c7-649d73aee1a8" />
After:
<img width="1895" height="870" alt="image" src="https://github.com/user-attachments/assets/35fca94e-80d4-43ff-a17a-86a2186fe142" />

## How Has This Been Tested?

Manually tested on a shared cluster: compared Loki-backed StatChart / Table panel values against direct Loki instant queries and confirmed results align with the patched plugin behavior.

Confirmed Model dashboard continues to load for a regular user.

## Test Impact

No new automated tests. Coverage is a third-party Perses plugin version override; validation is against live Loki query behavior on a cluster.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Loki data visualizations in observability dashboards.
  * Added statistical chart and table visualizations.
* **Improvements**
  * Enhanced bundled plugin compatibility by dynamically resolving and caching bundled overrides for Prometheus, Loki, StatChart, and Table.
  * Improved behavior when bundled modules fail to load, including retry after transient errors.
* **Tests**
  * Added Jest coverage for bundled override resolution and plugin loader integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->