### PR TITLE
fix(RHOAIENG-78535): Model deployment dropdown only shows All for regular users

### DIFF
--- a/manifests/observability/odh/perses-dashboard-model.yaml
+++ b/manifests/observability/odh/perses-dashboard-model.yaml
@@ -34,7 +34,7 @@ spec:
                 name: cluster-prometheus-tenancy-datasource
               labelName: model_name
               matchers:
-                - kserve_vllm:num_requests_running
+                - kserve_vllm:num_requests_running{namespace=~"$namespace"}
     panels:
       # Model Deployments Table
       modelDeploymentsTable:

--- a/manifests/observability/rhoai/perses-dashboard-model.yaml
+++ b/manifests/observability/rhoai/perses-dashboard-model.yaml
@@ -34,7 +34,7 @@ spec:
                 name: cluster-prometheus-tenancy-datasource
               labelName: model_name
               matchers:
-                - kserve_vllm:num_requests_running
+                - kserve_vllm:num_requests_running{namespace=~"$namespace"}
     panels:
       # Model Deployments Table
       modelDeploymentsTable:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-78535

## Description
For regular users on the Models observability dashboard, the **Model deployment** dropdown only showed **All** and never listed individual deployments.

The `model_name` variable queries the tenancy Prometheus datasource, which requires interpolated `namespace` query params (`${namespace:queryparam}`). Perses only includes variables referenced by the variable plugin in that request context. Because the matcher did not reference `$namespace`, the first label-values call sent the template literally, the tenancy proxy returned 403, and the dropdown stayed empty aside from All.

This change adds `{namespace=~"$namespace"}` to the `model_name` matcher on the ODH and RHOAI Models dashboards (same pattern already used by the admin Models dashboard) so Perses waits on/interpolates `namespace` correctly.

Note that we use to have this value but it got removed when we duplicated the Models dashboard into one for the admin and one for regular users. This got missed as we stripped the value from all queries but it needed to stay for variables.

Available to see on my test cluster:
<img width="456" height="505" alt="image" src="https://github.com/user-attachments/assets/a85cdb40-a660-41ab-ab62-9716814db4c5" />

## How Has This Been Tested?
- Manually verified the failing label-values request (`namespace=${namespace:queryparam}` → 403) on a cluster as a regular user.
- Confirmed the admin dashboard matcher already included `$namespace` and populated model options.
- After applying the matcher change, the tenancy label-values request includes real namespace query params and model deployment options load for selected projects.

## Test Impact
No new automated tests added. This is a Perses dashboard manifest matcher change; covering it would require Perses/cluster integration around tenancy datasource interpolation rather than unit or Cypress mock coverage in this package.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model selections in observability dashboards are now limited to models running in the currently selected namespace.
  * Prevents unrelated model deployments from appearing when filtering dashboard metrics by project or namespace.
  * Applies consistently across both supported dashboard configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->