### PR TITLE
ci: add Core BFF to npm workspaces for contract test CI coverage

### DIFF
--- a/.github/actions/module-caches/action.yml
+++ b/.github/actions/module-caches/action.yml
@@ -155,6 +155,19 @@ runs:
       shell: bash
       run: npm install --prefix packages/model-registry/upstream/frontend
 
+    - name: core-bff node_modules cache
+      id: core-bff-cache
+      if: inputs.include-modules == 'true'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: distributions/core-bff/frontend/node_modules
+        key: ${{ runner.os }}-${{ inputs.node-version }}-modules-core-bff-${{ hashFiles('distributions/core-bff/frontend/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-core-bff-
+    - name: Install core-bff dependencies
+      if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.core-bff-cache.outputs.cache-hit != 'true')
+      shell: bash
+      run: npm install --prefix distributions/core-bff/frontend
+
     - name: notebooks node_modules cache
       id: notebooks-cache
       if: inputs.include-modules == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
         if: always()
         run: |
           # Find and upload the most recent contract test results
-          LATEST_DIR=$(find packages/*/contract-tests/contract-test-results -name "ci-*" -type d 2>/dev/null | head -1)
+          LATEST_DIR=$(find packages/*/contract-tests/contract-test-results distributions/*/contract-tests/contract-test-results -name "ci-*" -type d 2>/dev/null | head -1)
           if [ -n "$LATEST_DIR" ] && [ -d "$LATEST_DIR" ]; then
             echo "Uploading from: $LATEST_DIR" && echo "results-dir=$LATEST_DIR" >> $GITHUB_OUTPUT
           else

--- a/distributions/core-bff/contract-tests/__tests__/helpers.ts
+++ b/distributions/core-bff/contract-tests/__tests__/helpers.ts
@@ -40,4 +40,4 @@ export const restrictedClient = new ContractApiClient({
   },
 });
 
-export const apiSchema = loadOpenAPISchema('../bff/openapi/src/core-bff.yaml');
+export const apiSchema = loadOpenAPISchema('bff/openapi/src/core-bff.yaml');

--- a/distributions/core-bff/package.json
+++ b/distributions/core-bff/package.json
@@ -37,8 +37,8 @@
     "prepare:e2e": "cd bff && go mod download",
     "cypress:server:e2e": "STATIC_ASSETS_DIR=../frontend/public-cypress make dev-bff-e2e-cluster E2E_BFF_PORT=9112",
     "test:contract": "npm run test:contract:openshift && npm run test:contract:xks",
-    "test:contract:openshift": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client --auth-method=user_token --platform-type=OpenShift' CONTRACT_TEST_PATH='(foundation|openshift)' odh-ct-bff-consumer --bff-dir bff",
-    "test:contract:xks": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client --auth-method=user_token --platform-type=XKS' CONTRACT_TEST_PATH='(foundation|xks)' odh-ct-bff-consumer --bff-dir bff",
+    "test:contract:openshift": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client --mock-http-client --auth-method=user_token --platform-type=OpenShift' CONTRACT_TEST_PATH='(foundation|openshift)' odh-ct-bff-consumer --bff-dir bff",
+    "test:contract:xks": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client --mock-http-client --auth-method=user_token --platform-type=XKS' CONTRACT_TEST_PATH='(foundation|xks)' odh-ct-bff-consumer --bff-dir bff",
     "lint": "cd frontend && npm run lint",
     "lint:fix": "cd frontend && npm run lint:fix"
   },

--- a/distributions/core-bff/turbo.json
+++ b/distributions/core-bff/turbo.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test:contract": {
+      "inputs": ["contract-tests/**", "bff/**"],
+      "outputs": ["contract-tests/contract-test-results/**"]
+    },
+    "cypress:server": {
+      "extends": false
+    },
+    "cypress:server:build": {
+      "extends": false
+    },
+    "cypress:server:build:coverage": {
+      "extends": false
+    },
+    "cypress:server:wait": {
+      "extends": false
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "frontend/src",
         "packages/*",
         "distributions/base",
+        "distributions/core-bff",
         "distributions/rhaii",
         "packages/model-serving/cypress"
       ],
@@ -182,6 +183,19 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "distributions/core-bff": {
+      "name": "@odh-dashboard/core-bff",
+      "version": "0.0.1",
+      "dependencies": {
+        "@odh-dashboard/internal": "*",
+        "@odh-dashboard/plugin-core": "*"
+      },
+      "devDependencies": {
+        "@odh-dashboard/contract-tests": "*",
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/tsconfig": "*"
       }
     },
     "distributions/rhaii": {
@@ -6230,6 +6244,10 @@
     },
     "node_modules/@odh-dashboard/contract-tests": {
       "resolved": "packages/contract-tests",
+      "link": true
+    },
+    "node_modules/@odh-dashboard/core-bff": {
+      "resolved": "distributions/core-bff",
       "link": true
     },
     "node_modules/@odh-dashboard/cypress": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "frontend/src",
     "packages/*",
     "distributions/base",
+    "distributions/core-bff",
     "distributions/rhaii",
     "packages/model-serving/cypress"
   ],


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
NO-ISSUE

Add `distributions/core-bff` to the npm workspaces so that Turbo discovers and runs its contract tests as part of the main `Test` workflow (`test.yml`). Previously, core-bff contract tests were not executed in CI because the distribution was not included in the workspace configuration.

#### Changes

1. **`package.json`** — Added `distributions/core-bff` to the `workspaces` array.

2. **`distributions/core-bff/turbo.json`** (new) — Package-level Turbo override so cache invalidation tracks `bff/**` instead of the root-defined `upstream/bff/**` (which doesn't exist in core-bff). Also uses `extends: false` to exclude cypress tasks (`cypress:server`, `cypress:server:build`, `cypress:server:build:coverage`, `cypress:server:wait`) since core-bff is not part of the shared `packages/cypress` test matrix.

3. **`.github/actions/module-caches/action.yml`** — Added cache and install step for `distributions/core-bff/frontend/node_modules`, matching the pattern used by other packages (gen-ai, maas, model-registry, etc.). Required for lint that now discovers core-bff as a workspace.

4. **`distributions/core-bff/contract-tests/__tests__/helpers.ts`** — Fixed OpenAPI schema path from `../bff/openapi/src/core-bff.yaml` to `bff/openapi/src/core-bff.yaml`. The relative path was incorrect when Jest's `process.cwd()` is set to the package root (as happens under Turbo).

5. **`distributions/core-bff/package.json`** — Added `--mock-http-client` to both `test:contract:openshift` and `test:contract:xks` scripts to prevent real HTTP calls during mock BFF contract test runs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran `npm run test:contract:openshift` locally — 9 suites, 119 tests passed
- Ran `npm run test:contract:xks` locally — 9 suites, 99 tests passed
- Pushed to fork and verified CI infrastructure jobs pass

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No new tests added. This PR enables existing core-bff contract tests to run in the main CI workflow.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Testing**
  * Improved dependency caching for Core BFF workflows to reduce install times.
  * Enhanced contract tests by reliably loading the OpenAPI schema from the correct location.
  * Enabled consistent HTTP client mocking for Core BFF contract test runs.
  * Made contract test result uploads more robust by also searching Core BFF result directories.

* **Configuration**
  * Added a Turbo configuration for Core BFF to better control which test inputs/outputs are used and to avoid unnecessary Cypress-related tasks.
  * Registered Core BFF as an additional workspace package for smoother tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->