### PR TITLE
RHOAIENG-72402: add Segment tracking for llm-d wizard field selections

### DIFF
--- a/packages/llmd-serving/src/tracking/llmdTrackingConstants.ts
+++ b/packages/llmd-serving/src/tracking/llmdTrackingConstants.ts
@@ -1,0 +1,24 @@
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+
+export const LLMD_EVENTS = {
+  TOPOLOGY_TYPE_SELECTED: 'Model Serving LLM-D Topology Type Selected',
+  ROUTING_SELECTED: 'Model Serving LLM-D Routing Selected',
+} as const;
+
+export type TopologyTypeSelectedProperties = {
+  llmdComposablePattern: string;
+  previousPattern?: string;
+};
+
+export type RoutingSelectedProperties = {
+  routingConfigurationId: string;
+  isDefaultRouting: boolean;
+};
+
+export const fireTopologyTypeSelected = (properties: TopologyTypeSelectedProperties): void => {
+  fireMiscTrackingEvent(LLMD_EVENTS.TOPOLOGY_TYPE_SELECTED, properties);
+};
+
+export const fireRoutingSelected = (properties: RoutingSelectedProperties): void => {
+  fireMiscTrackingEvent(LLMD_EVENTS.ROUTING_SELECTED, properties);
+};

--- a/packages/llmd-serving/src/tracking/llmdTrackingConstants.ts
+++ b/packages/llmd-serving/src/tracking/llmdTrackingConstants.ts
@@ -1,9 +1,9 @@
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 
-export const LLMD_EVENTS = {
-  TOPOLOGY_TYPE_SELECTED: 'Model Serving LLM-D Topology Type Selected',
-  ROUTING_SELECTED: 'Model Serving LLM-D Routing Selected',
-} as const;
+export enum LlmdTrackingEvent {
+  TOPOLOGY_TYPE_SELECTED = 'Model Serving LLM-D Topology Type Selected',
+  ROUTING_SELECTED = 'Model Serving LLM-D Routing Selected',
+}
 
 export type TopologyTypeSelectedProperties = {
   llmdComposablePattern: string;
@@ -16,9 +16,9 @@ export type RoutingSelectedProperties = {
 };
 
 export const fireTopologyTypeSelected = (properties: TopologyTypeSelectedProperties): void => {
-  fireMiscTrackingEvent(LLMD_EVENTS.TOPOLOGY_TYPE_SELECTED, properties);
+  fireMiscTrackingEvent(LlmdTrackingEvent.TOPOLOGY_TYPE_SELECTED, properties);
 };
 
 export const fireRoutingSelected = (properties: RoutingSelectedProperties): void => {
-  fireMiscTrackingEvent(LLMD_EVENTS.ROUTING_SELECTED, properties);
+  fireMiscTrackingEvent(LlmdTrackingEvent.ROUTING_SELECTED, properties);
 };

--- a/packages/llmd-serving/src/wizardFields/AdvancedRoutingField.tsx
+++ b/packages/llmd-serving/src/wizardFields/AdvancedRoutingField.tsx
@@ -31,6 +31,7 @@ import {
 import { isConfigEnabled } from '../utils';
 import { useFetchRouterConfigs } from '../api/LLMInferenceServiceConfigs';
 import { isLLMInferenceServiceActive } from '../formUtils';
+import { fireRoutingSelected } from '../tracking/llmdTrackingConstants';
 
 // --- External data hook ---
 
@@ -165,10 +166,18 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
             options={options}
             onChange={(key, isPlaceholder) => {
               if (!key || isPlaceholder || key === DEFAULT_ROUTING_KEY) {
+                fireRoutingSelected({
+                  routingConfigurationId: DEFAULT_ROUTING_KEY,
+                  isDefaultRouting: true,
+                });
                 onChange({ selectedConfig: undefined });
                 return;
               }
               const config = compatibleConfigs.find((c) => c.metadata.name === key);
+              fireRoutingSelected({
+                routingConfigurationId: key,
+                isDefaultRouting: false,
+              });
               onChange({ selectedConfig: config ?? value?.selectedConfig });
             }}
             value={selectedValue}

--- a/packages/llmd-serving/src/wizardFields/TopologyTypeField.tsx
+++ b/packages/llmd-serving/src/wizardFields/TopologyTypeField.tsx
@@ -29,6 +29,7 @@ import {
 import { isConfigEnabled } from '../utils';
 import { useFetchTopologyConfigs } from '../api/LLMInferenceServiceConfigs';
 import { isLLMInferenceServiceActive } from '../formUtils';
+import { fireTopologyTypeSelected } from '../tracking/llmdTrackingConstants';
 
 // --- External data hook ---
 
@@ -144,6 +145,10 @@ const TopologyTypeFieldComponent: TopologyTypeFieldType['component'] = ({
             onChange={(key) => {
               const matched = Object.values(TopologyType).find((v) => v === key);
               if (matched) {
+                fireTopologyTypeSelected({
+                  llmdComposablePattern: matched,
+                  previousPattern: value?.topologyType,
+                });
                 onChange({ topologyType: matched });
               }
             }}

--- a/packages/llmd-serving/src/wizardFields/__tests__/AdvancedRoutingField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/AdvancedRoutingField.spec.tsx
@@ -1,0 +1,176 @@
+import React, { act } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { fireRoutingSelected } from '../../tracking/llmdTrackingConstants';
+import { ConfigType } from '../../types';
+import {
+  AdvancedRoutingFieldWizardField,
+  type AdvancedRoutingExternalData,
+  type AdvancedRoutingFieldData,
+} from '../AdvancedRoutingField';
+
+jest.mock('../../tracking/llmdTrackingConstants', () => ({
+  fireRoutingSelected: jest.fn(),
+}));
+
+const mockFireRoutingSelected = jest.mocked(fireRoutingSelected);
+
+const AdvancedRoutingFieldComponent = AdvancedRoutingFieldWizardField.component;
+
+describe('AdvancedRoutingField tracking', () => {
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const routerConfig1 = mockLLMInferenceServiceConfigK8sResource({
+    name: 'router-config-1',
+    displayName: 'Router Config One',
+    configType: ConfigType.ROUTER,
+  });
+
+  const routerConfig2 = mockLLMInferenceServiceConfigK8sResource({
+    name: 'router-config-2',
+    displayName: 'Router Config Two',
+    configType: ConfigType.ROUTER,
+  });
+
+  const renderComponent = ({
+    value,
+    externalData,
+    dependencies,
+  }: {
+    value?: AdvancedRoutingFieldData;
+    externalData?: { data: AdvancedRoutingExternalData; loaded: boolean; loadError?: Error };
+    dependencies?: Record<string, unknown>;
+  } = {}) =>
+    render(
+      <AdvancedRoutingFieldComponent
+        id="llmd-serving/advanced-routing"
+        value={value}
+        onChange={mockOnChange}
+        externalData={externalData}
+        dependencies={dependencies}
+      />,
+    );
+
+  const openDropdown = async () => {
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('routing-config-select'));
+    });
+  };
+
+  it('should fire fireRoutingSelected with isDefaultRouting true when default routing is selected', async () => {
+    renderComponent({
+      value: { selectedConfig: routerConfig1 },
+      externalData: {
+        data: { routerConfigs: [routerConfig1, routerConfig2] },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Default optimized routing'));
+    });
+
+    expect(mockFireRoutingSelected).toHaveBeenCalledWith({
+      routingConfigurationId: '__default-optimized-routing__',
+      isDefaultRouting: true,
+    });
+  });
+
+  it('should fire fireRoutingSelected with isDefaultRouting false when a specific config is selected', async () => {
+    renderComponent({
+      externalData: {
+        data: { routerConfigs: [routerConfig1, routerConfig2] },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Router Config One'));
+    });
+
+    expect(mockFireRoutingSelected).toHaveBeenCalledWith({
+      routingConfigurationId: 'router-config-1',
+      isDefaultRouting: false,
+    });
+  });
+
+  it('should fire fireRoutingSelected for a different config selection', async () => {
+    renderComponent({
+      value: { selectedConfig: routerConfig1 },
+      externalData: {
+        data: { routerConfigs: [routerConfig1, routerConfig2] },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Router Config Two'));
+    });
+
+    expect(mockFireRoutingSelected).toHaveBeenCalledWith({
+      routingConfigurationId: 'router-config-2',
+      isDefaultRouting: false,
+    });
+  });
+
+  it('should call onChange with selectedConfig when a specific config is selected', async () => {
+    renderComponent({
+      externalData: {
+        data: { routerConfigs: [routerConfig1] },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Router Config One'));
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith({ selectedConfig: routerConfig1 });
+  });
+
+  it('should call onChange with undefined selectedConfig when default routing is selected', async () => {
+    renderComponent({
+      value: { selectedConfig: routerConfig1 },
+      externalData: {
+        data: { routerConfigs: [routerConfig1] },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Default optimized routing'));
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith({ selectedConfig: undefined });
+  });
+
+  it('should render the default routing option and config options', async () => {
+    renderComponent({
+      externalData: {
+        data: { routerConfigs: [routerConfig1, routerConfig2] },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    expect(screen.getByTestId('routing-config-option-default')).toBeInTheDocument();
+    expect(screen.getByTestId('routing-config-option-router-config-1')).toBeInTheDocument();
+    expect(screen.getByTestId('routing-config-option-router-config-2')).toBeInTheDocument();
+  });
+});

--- a/packages/llmd-serving/src/wizardFields/__tests__/TopologyTypeField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/TopologyTypeField.spec.tsx
@@ -1,0 +1,156 @@
+import React, { act } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { fireTopologyTypeSelected } from '../../tracking/llmdTrackingConstants';
+import { TopologyType, TopologyTypeLabels } from '../../types';
+import {
+  TopologyTypeFieldWizardField,
+  type TopologyTypeExternalData,
+  type TopologyTypeFieldData,
+} from '../TopologyTypeField';
+
+jest.mock('../../tracking/llmdTrackingConstants', () => ({
+  fireTopologyTypeSelected: jest.fn(),
+}));
+
+const mockFireTopologyTypeSelected = jest.mocked(fireTopologyTypeSelected);
+
+const TopologyTypeFieldComponent = TopologyTypeFieldWizardField.component;
+
+describe('TopologyTypeField tracking', () => {
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderComponent = ({
+    value,
+    externalData,
+  }: {
+    value?: TopologyTypeFieldData;
+    externalData?: { data: TopologyTypeExternalData; loaded: boolean; loadError?: Error };
+  } = {}) =>
+    render(
+      <TopologyTypeFieldComponent
+        id="llmd-serving/topology-type"
+        value={value}
+        onChange={mockOnChange}
+        externalData={externalData}
+      />,
+    );
+
+  const openDropdown = async () => {
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('topology-type-select'));
+    });
+  };
+
+  it('should fire fireTopologyTypeSelected with undefined previousPattern on first selection', async () => {
+    renderComponent({
+      externalData: {
+        data: {
+          configsByTopology: {
+            [TopologyType.SINGLE_NODE]: [],
+            [TopologyType.MULTI_NODE]: [],
+            [TopologyType.SINGLE_NODE_DISAGGREGATED]: [],
+            [TopologyType.MULTI_NODE_DISAGGREGATED]: [],
+          },
+        },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(TopologyTypeLabels[TopologyType.SINGLE_NODE]));
+    });
+
+    expect(mockFireTopologyTypeSelected).toHaveBeenCalledWith({
+      llmdComposablePattern: TopologyType.SINGLE_NODE,
+      previousPattern: undefined,
+    });
+  });
+
+  it('should fire fireTopologyTypeSelected with previous pattern when switching', async () => {
+    renderComponent({
+      value: { topologyType: TopologyType.SINGLE_NODE },
+      externalData: {
+        data: {
+          configsByTopology: {
+            [TopologyType.SINGLE_NODE]: [],
+            [TopologyType.MULTI_NODE]: [{ metadata: { name: 'multi-config' } } as never],
+            [TopologyType.SINGLE_NODE_DISAGGREGATED]: [],
+            [TopologyType.MULTI_NODE_DISAGGREGATED]: [],
+          },
+        },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(TopologyTypeLabels[TopologyType.MULTI_NODE]));
+    });
+
+    expect(mockFireTopologyTypeSelected).toHaveBeenCalledWith({
+      llmdComposablePattern: TopologyType.MULTI_NODE,
+      previousPattern: TopologyType.SINGLE_NODE,
+    });
+  });
+
+  it('should call onChange with the selected topology type', async () => {
+    renderComponent({
+      externalData: {
+        data: {
+          configsByTopology: {
+            [TopologyType.SINGLE_NODE]: [],
+            [TopologyType.MULTI_NODE]: [],
+            [TopologyType.SINGLE_NODE_DISAGGREGATED]: [],
+            [TopologyType.MULTI_NODE_DISAGGREGATED]: [],
+          },
+        },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(TopologyTypeLabels[TopologyType.SINGLE_NODE]));
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith({
+      topologyType: TopologyType.SINGLE_NODE,
+    });
+  });
+
+  it('should render all topology type options', async () => {
+    renderComponent({
+      externalData: {
+        data: {
+          configsByTopology: {
+            [TopologyType.SINGLE_NODE]: [],
+            [TopologyType.MULTI_NODE]: [],
+            [TopologyType.SINGLE_NODE_DISAGGREGATED]: [],
+            [TopologyType.MULTI_NODE_DISAGGREGATED]: [],
+          },
+        },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    expect(screen.getByText(TopologyTypeLabels[TopologyType.SINGLE_NODE])).toBeInTheDocument();
+    expect(screen.getByText(TopologyTypeLabels[TopologyType.MULTI_NODE])).toBeInTheDocument();
+    expect(
+      screen.getByText(TopologyTypeLabels[TopologyType.SINGLE_NODE_DISAGGREGATED]),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(TopologyTypeLabels[TopologyType.MULTI_NODE_DISAGGREGATED]),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
@@ -11,6 +11,7 @@ import {
   isDeploymentMethodFieldOverride,
 } from '../types';
 import { useWizardFieldOverrides } from '../dynamicFormUtils';
+import { fireDeployMethodSelected } from '../../../tracking/modelServingTrackingConstants';
 
 // Schema
 
@@ -99,7 +100,13 @@ const DeploymentMethodSelectField: DeploymentMethodSelectFieldType['component'] 
                 opt.description ? <Content component="small">{opt.description}</Content> : undefined
               }
               isChecked={value?.method === opt.key}
-              onChange={() => onChange({ method: opt.key })}
+              onChange={() => {
+                fireDeployMethodSelected({
+                  deploymentMethod: opt.key,
+                  previousDeploymentMethod: value?.method,
+                });
+                onChange({ method: opt.key });
+              }}
               isDisabled={isEditing}
               data-testid={`deployment-method-${opt.key}`}
             />

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { fireDeployMethodSelected } from '../../../../tracking/modelServingTrackingConstants';
+import {
+  DeploymentMethodSelectFieldWizardField,
+  type DeploymentMethodExternalData,
+  type DeploymentMethodFieldData,
+} from '../DeploymentMethodSelectField';
+
+jest.mock('../../../../tracking/modelServingTrackingConstants', () => ({
+  fireDeployMethodSelected: jest.fn(),
+}));
+
+const mockFireDeployMethodSelected = jest.mocked(fireDeployMethodSelected);
+
+const DeploymentMethodSelectFieldComponent = DeploymentMethodSelectFieldWizardField.component;
+
+describe('DeploymentMethodSelectField tracking', () => {
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderComponent = ({
+    value,
+    externalData,
+    isEditing = false,
+  }: {
+    value?: DeploymentMethodFieldData;
+    externalData?: { data: DeploymentMethodExternalData; loaded: boolean; loadError?: Error };
+    isEditing?: boolean;
+  } = {}) =>
+    render(
+      <DeploymentMethodSelectFieldComponent
+        id="deploymentMethod"
+        value={value}
+        onChange={mockOnChange}
+        externalData={externalData}
+        isEditing={isEditing}
+      />,
+    );
+
+  it('should fire fireDeployMethodSelected with undefined previousDeploymentMethod on first selection', () => {
+    renderComponent({
+      externalData: {
+        data: {
+          options: [
+            { key: 'kserve', label: 'KServe', description: 'KServe deployment' },
+            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment' },
+          ],
+        },
+        loaded: true,
+      },
+    });
+
+    fireEvent.click(screen.getByTestId('deployment-method-kserve'));
+
+    expect(mockFireDeployMethodSelected).toHaveBeenCalledWith({
+      deploymentMethod: 'kserve',
+      previousDeploymentMethod: undefined,
+    });
+  });
+
+  it('should fire fireDeployMethodSelected with previous method when switching', () => {
+    renderComponent({
+      value: { method: 'kserve' },
+      externalData: {
+        data: {
+          options: [
+            { key: 'kserve', label: 'KServe', description: 'KServe deployment' },
+            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment' },
+          ],
+        },
+        loaded: true,
+      },
+    });
+
+    fireEvent.click(screen.getByTestId('deployment-method-llmd'));
+
+    expect(mockFireDeployMethodSelected).toHaveBeenCalledWith({
+      deploymentMethod: 'llmd',
+      previousDeploymentMethod: 'kserve',
+    });
+  });
+
+  it('should call onChange with the selected method', () => {
+    renderComponent({
+      externalData: {
+        data: {
+          options: [{ key: 'kserve', label: 'KServe', description: 'KServe deployment' }],
+        },
+        loaded: true,
+      },
+    });
+
+    fireEvent.click(screen.getByTestId('deployment-method-kserve'));
+
+    expect(mockOnChange).toHaveBeenCalledWith({ method: 'kserve' });
+  });
+
+  it('should disable radio buttons when in editing mode', () => {
+    renderComponent({
+      value: { method: 'kserve' },
+      externalData: {
+        data: {
+          options: [
+            { key: 'kserve', label: 'KServe', description: 'KServe deployment' },
+            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment' },
+          ],
+        },
+        loaded: true,
+      },
+      isEditing: true,
+    });
+
+    const radioInput = screen.getByRole('radio', { name: 'LLM-D' });
+    expect(radioInput).toBeDisabled();
+  });
+
+  it('should render all provided options', () => {
+    renderComponent({
+      externalData: {
+        data: {
+          options: [
+            { key: 'kserve', label: 'KServe', description: 'KServe deployment' },
+            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment' },
+          ],
+        },
+        loaded: true,
+      },
+    });
+
+    expect(screen.getByText('KServe')).toBeInTheDocument();
+    expect(screen.getByText('LLM-D')).toBeInTheDocument();
+  });
+});

--- a/packages/model-serving/src/tracking/modelServingTrackingConstants.ts
+++ b/packages/model-serving/src/tracking/modelServingTrackingConstants.ts
@@ -1,8 +1,8 @@
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 
-export const MODEL_SERVING_EVENTS = {
-  DEPLOY_METHOD_SELECTED: 'Model Serving Deploy Method Selected',
-} as const;
+export enum ModelServingTrackingEvent {
+  DEPLOY_METHOD_SELECTED = 'Model Serving Deploy Method Selected',
+}
 
 export type DeployMethodSelectedProperties = {
   deploymentMethod: string;
@@ -10,5 +10,5 @@ export type DeployMethodSelectedProperties = {
 };
 
 export const fireDeployMethodSelected = (properties: DeployMethodSelectedProperties): void => {
-  fireMiscTrackingEvent(MODEL_SERVING_EVENTS.DEPLOY_METHOD_SELECTED, properties);
+  fireMiscTrackingEvent(ModelServingTrackingEvent.DEPLOY_METHOD_SELECTED, properties);
 };

--- a/packages/model-serving/src/tracking/modelServingTrackingConstants.ts
+++ b/packages/model-serving/src/tracking/modelServingTrackingConstants.ts
@@ -1,0 +1,14 @@
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+
+export const MODEL_SERVING_EVENTS = {
+  DEPLOY_METHOD_SELECTED: 'Model Serving Deploy Method Selected',
+} as const;
+
+export type DeployMethodSelectedProperties = {
+  deploymentMethod: string;
+  previousDeploymentMethod?: string;
+};
+
+export const fireDeployMethodSelected = (properties: DeployMethodSelectedProperties): void => {
+  fireMiscTrackingEvent(MODEL_SERVING_EVENTS.DEPLOY_METHOD_SELECTED, properties);
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72402
Migrating and extending the `Model Deployed` event is out of scope and part of [RHAISTRAT-170](https://redhat.atlassian.net/browse/RHAISTRAT-170)

## Description

Adds Segment analytics tracking to the llm-d model deployment wizard. Three events are instrumented across the deployment method, topology type, and routing configuration fields, following the [tracking constants pattern](https://github.com/opendatahub-io/odh-dashboard/pull/8577).

### Events

| Event | Trigger | Properties |
|-------|---------|------------|
| `Model Serving Deploy Method Selected` | User clicks a deployment method radio button on the Model deployment step | `deploymentMethod`, `previousDeploymentMethod` |
| `Model Serving LLM-D Topology Type Selected` | User selects a topology type from the dropdown (llm-d only) | `llmdComposablePattern`, `previousPattern` |
| `Model Serving LLM-D Routing Selected` | User selects a routing configuration from the Advanced routing dropdown (llm-d only) | `routingConfigurationId`, `isDefaultRouting` |

**Spec:** [Event Tracking in RHOAI - llm-d Deploy Wizard](https://docs.google.com/document/d/1oR4ThE4BFNIbZqIPZHdRt30xU4sbkrC3b8NpFgySLLc/edit) (adjusted per designer/researcher comments and [Slack discussion](https://redhat-internal.slack.com/archives/C069KSM8T9N/p1784580424070899))

**Scope notes:**
- YAML Edit Mode event removed (out of scope per designer)
- `topologyConfigurationId` excluded from Topology Type Selected (config IDs are unique per customer, not useful to track)
- `previousDeploymentMethod` and `previousPattern` included per Andrew's funnel/journey tracking argument
- Migrating and extending the `Model Deployed` event is out of scope and part of [RHAISTRAT-170](https://redhat.atlassian.net/browse/RHAISTRAT-170)

## How Has This Been Tested?

Manually verified all three events fire with correct properties by observing `DEV_MODE` console log output:

```
Telemetry event triggered: Model Serving Deploy Method Selected - {"deploymentMethod":"llm-inference-service-llmd","previousDeploymentMethod":""} for version v3.4.0
Telemetry event triggered: Model Serving Deploy Method Selected - {"deploymentMethod":"legacy","previousDeploymentMethod":"llm-inference-service-llmd"} for version v3.4.0
Telemetry event triggered: Model Serving Deploy Method Selected - {"deploymentMethod":"llm-inference-service-llmd","previousDeploymentMethod":"legacy"} for version v3.4.0
Telemetry event triggered: Model Serving LLM-D Topology Type Selected - {"llmdComposablePattern":"workload-multi-node-data-parallel","previousPattern":"workload-single-node"} for version v3.4.0
Telemetry event triggered: Model Serving LLM-D Routing Selected - {"routingConfigurationId":"managed-scheduler-httproute","isDefaultRouting":false} for version v3.4.0
Telemetry event triggered: Model Serving LLM-D Routing Selected - {"routingConfigurationId":"__default-optimized-routing__","isDefaultRouting":true} for version v3.4.0
```

## Test Impact

Unit tests added for all three events across three test files (15 tests total):
- `DeploymentMethodSelectField.spec.tsx` — radio selection fires tracking with correct `deploymentMethod` and `previousDeploymentMethod`
- `TopologyTypeField.spec.tsx` — dropdown selection fires tracking with correct `llmdComposablePattern` and `previousPattern`
- `AdvancedRoutingField.spec.tsx` — dropdown selection fires tracking with correct `routingConfigurationId` and `isDefaultRouting` for both default and non-default options

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHAISTRAT-170]: https://redhat.atlassian.net/browse/RHAISTRAT-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for deployment method selections, including previous selections.
  * Added analytics tracking for topology type and routing configuration selections.
  * Tracking distinguishes default optimized routing from custom routing configurations.

* **Tests**
  * Added coverage verifying selection behavior, tracking data, available options, and editing-state controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->