### PR TITLE
fix(RHOAIENG-78550): add get/list verbs for storageclasses to operator RBAC

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -285,14 +285,14 @@ rules:
       - get
       - update
       - delete
-  # Storage classes — write-only mirrors sa-rbac/cluster-role.yaml exactly.
-  # Read verbs are not granted by the operand; add here only if the operand
-  # ClusterRole is updated to include them.
+  # Storage classes — mirrors sa-rbac/cluster-role.yaml + gen-ai module ClusterRole.
   - apiGroups:
       - storage.k8s.io
     resources:
       - storageclasses
     verbs:
+      - get
+      - list
       - update
       - patch
   # Auth delegation for operand service accounts

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -269,14 +269,14 @@ rules:
       - get
       - update
       - delete
-  # Storage classes — write-only mirrors sa-rbac/cluster-role.yaml exactly.
-  # Read verbs are not granted by the operand; add here only if the operand
-  # ClusterRole is updated to include them.
+  # Storage classes — mirrors sa-rbac/cluster-role.yaml + gen-ai module ClusterRole.
   - apiGroups:
       - storage.k8s.io
     resources:
       - storageclasses
     verbs:
+      - get
+      - list
       - update
       - patch
   # Auth delegation for operand service accounts


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78550

## Description

The gen-ai module ClusterRole (`manifests/modular-architecture/modules/gen-ai/cluster-role.yaml`) requires `list` on `storage.k8s.io/storageclasses` for pgvector storage class auto-provisioning. The dashboard-operator's own ClusterRole only had `update, patch` for that resource, causing RBAC escalation failures when deploying the `odh-dashboard-gen-ai` ClusterRole.

This adds `get` and `list` verbs to the `storage.k8s.io/storageclasses` entry in both `config/rbac/role.yaml` and the Helm chart template.

This will unblock https://github.com/opendatahub-io/opendatahub-operator/pull/3733 which was hitting this RBAC escalation error during integration testing.

## How Has This Been Tested?

- `TestDashboardChartRBACInSync` passes — validates that chart RBAC rules match `config/rbac/role.yaml`.
- Verified the gen-ai module ClusterRole (`manifests/modular-architecture/modules/gen-ai/cluster-role.yaml`) requests `list` on `storageclasses`, confirming the operator needs to hold it.

## Test Impact

No new tests needed — the existing `TestDashboardChartRBACInSync` covers chart/config RBAC parity. The fix is a YAML-only change adding verbs to an existing RBAC rule.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage class access so the dashboard operator can read and list storage classes in Kubernetes environments.
  * Updated access permissions consistently across deployed configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->