### PR TITLE
fix(RHOAIENG-78549): gate LLM accelerator configs page behind vLLMDeploymentOnMaaS flag

### DIFF
--- a/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigs.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigs.cy.ts
@@ -1,3 +1,4 @@
+import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__';
 import {
   llmAcceleratorConfigsIntercept,
   interceptLlmAcceleratorConfigPatch,
@@ -11,6 +12,15 @@ import { pageNotfound } from '../../../pages/pageNotFound';
 
 it('LLM accelerator configurations should not be available for non product admins', () => {
   asProjectAdminUser();
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ vLLMDeploymentOnMaaS: true }));
+  llmAcceleratorConfigs.visit(false);
+  pageNotfound.findPage().should('exist');
+  llmAcceleratorConfigs.findNavItem().should('not.exist');
+});
+
+it('LLM accelerator configurations should not be available when vLLMDeploymentOnMaaS is disabled', () => {
+  asProductAdminUser();
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ vLLMDeploymentOnMaaS: false }));
   llmAcceleratorConfigs.visit(false);
   pageNotfound.findPage().should('exist');
   llmAcceleratorConfigs.findNavItem().should('not.exist');

--- a/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigsUtils.ts
+++ b/packages/cypress/cypress/tests/mocked/llmAcceleratorConfigs/llmAcceleratorConfigsUtils.ts
@@ -1,3 +1,4 @@
+import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__';
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
 import {
   mockLLMInferenceServiceConfigK8sResource,
@@ -51,6 +52,7 @@ export const llmAcceleratorConfigsInitialMock = [
 ];
 
 export const llmAcceleratorConfigsIntercept = (): void => {
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ vLLMDeploymentOnMaaS: true }));
   cy.interceptK8sList(
     {
       model: llmAcceleratorConfigModel,

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -513,7 +513,7 @@ const extensions: (
   {
     type: 'app.navigation/href',
     flags: {
-      required: [LLMD_SERVING_ID, ADMIN_USER],
+      required: [LLMD_SERVING_ID, ADMIN_USER, SupportedArea.VLLM_ON_MAAS],
     },
     properties: {
       id: 'settings-llm-accelerator-configs',
@@ -527,7 +527,7 @@ const extensions: (
   {
     type: 'app.route',
     flags: {
-      required: [LLMD_SERVING_ID, ADMIN_USER],
+      required: [LLMD_SERVING_ID, ADMIN_USER, SupportedArea.VLLM_ON_MAAS],
     },
     properties: {
       path: '/settings/model-resources-operations/llm-accelerator-configs/*',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78549

## Description

The LLM accelerator configurations admin settings page was gated only on `LLMD_SERVING_ID` + `ADMIN_USER`, but it should also require `SupportedArea.VLLM_ON_MAAS` (the `vLLMDeploymentOnMaaS` feature flag). Without this, the page was visible even when the feature flag was disabled.

The wizard field extension (`llmConfigOptionsFieldExtension`) already correctly requires `VLLM_ON_MAAS`, but the admin page's navigation and route extensions did not.

### Changes
- Added `SupportedArea.VLLM_ON_MAAS` to the `flags.required` array on both the `app.navigation/href` and `app.route` extensions for the LLM accelerator configurations page
- Updated Cypress mock test utils to enable the `vLLMDeploymentOnMaaS` flag so existing tests continue to pass
- Added a new test verifying the page is hidden when the flag is disabled

## How Has This Been Tested?

- Manually verified in a browser that the page is hidden when `vLLMDeploymentOnMaaS` is `false` and visible when `true` (with admin access)
- Type-check and lint pass on all modified packages

## Test Impact

- Updated `llmAcceleratorConfigsUtils.ts` to enable `vLLMDeploymentOnMaaS: true` in `llmAcceleratorConfigsIntercept()` so existing mock tests work with the new flag requirement
- Added a new Cypress mock test: "LLM accelerator configurations should not be available when vLLMDeploymentOnMaaS is disabled"
- Updated existing non-admin test to explicitly set the flag to `true` so it tests admin access independently of the feature flag

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Restricted access to LLM accelerator configuration pages and navigation for non-product administrators.
  - Added feature-flag control so the LLM accelerator configuration experience is available only when vLLM deployment on managed infrastructure is enabled.

- **Tests**
  - Added coverage verifying the page and navigation item are hidden when authorization or feature-flag requirements are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->