### PR TITLE
RHOAIENG-46527: fix URL query parameter encoding in MakeRequest

### DIFF
--- a/packages/gen-ai/bff/internal/api/api_suite_test.go
+++ b/packages/gen-ai/bff/internal/api/api_suite_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -263,20 +264,21 @@ var _ = BeforeSuite(func() {
 
 // MakeRequest is a helper to make HTTP requests in tests
 func MakeRequest(req TestRequest) *http.Response {
-	url := testCtx.BaseURL + req.Path
+	requestURL, err := url.Parse(testCtx.BaseURL + req.Path)
+	Expect(err).NotTo(HaveOccurred())
 
-	// Add query parameters
+	// Add query parameters with proper URL encoding
 	if len(req.QueryParams) > 0 {
-		url += "?"
+		q := requestURL.Query()
 		for key, value := range req.QueryParams {
-			url += fmt.Sprintf("%s=%s&", key, value)
+			q.Set(key, value)
 		}
-		url = url[:len(url)-1] // Remove trailing &
+		requestURL.RawQuery = q.Encode()
 	}
 
-	httpReq, err := http.NewRequest(req.Method, url, nil)
+	httpReq, err := http.NewRequest(req.Method, requestURL.String(), nil)
 	if req.Body != nil {
-		httpReq, err = http.NewRequestWithContext(context.Background(), req.Method, url,
+		httpReq, err = http.NewRequestWithContext(context.Background(), req.Method, requestURL.String(),
 			bytes.NewReader(req.Body))
 	}
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-46527

## Description

Replace manual string concatenation with proper URL encoding in the `MakeRequest` test helper. The previous implementation could produce malformed URLs when query parameter values contain reserved characters (`?`, `&`, `=`, spaces).

### Changes

- `api_suite_test.go`: Replace `fmt.Sprintf("%s=%s&", key, value)` with `url.Parse()` + `url.Values.Encode()`. Rename local variable from `url` to `requestURL` to avoid shadowing `net/url`.

### Why this is safe

The `MakeRequest` function is a test utility only (not production code). The `QueryParams` field it handles is not currently used by any test (all 28 callers put params directly in `Path`). This change has zero runtime impact on existing tests but ensures future tests using `QueryParams` will produce correctly encoded URLs.

### Why no new tests

`MakeRequest` requires the full Ginkgo test context (BeforeSuite with HTTP server + env vars) to exercise directly. Testing `url.Values.Encode()` in isolation would only validate Go's standard library, not the code. Existing tests pass via `make test`.

## How Has This Been Tested?

- `go build ./...` compiles clean
- `make test` passes (existing tests unaffected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request URL construction to correctly parse `BaseURL + Path` and properly encode query parameters.
  * Enhanced test request handling for special characters and complex query values, avoiding issues from manual URL string concatenation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->