### PR TITLE
fix(RHOAIENG-72235): move process.env catch-all to shared base webpack config

### DIFF
--- a/distributions/base/config/webpack.common.js
+++ b/distributions/base/config/webpack.common.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const BASE_DIR = path.resolve(__dirname, '..');
@@ -112,6 +113,9 @@ module.exports = ({
       new HtmlWebpackPlugin({
         template: path.join(normalizedDistDir, 'index.html'),
         title,
+      }),
+      new webpack.DefinePlugin({
+        'process.env': '({})',
       }),
     ],
     resolve: {

--- a/distributions/rhaii/config/webpack.common.js
+++ b/distributions/rhaii/config/webpack.common.js
@@ -29,14 +29,9 @@ module.exports = (overrides = {}) =>
     }),
     {
       plugins: [
-        // RHAII-specific process.env overrides. Cross-distribution vars
-        // should move to the base app-shell webpack config once
-        // frontend/src/utilities/const.ts is decoupled from process.env
-        // (see docs/process-env-const-coupling.md).
         new webpack.DefinePlugin({
           'process.env.ODH_PRODUCT_NAME': JSON.stringify('RHAII'),
           'process.env.BACKEND_PORT': JSON.stringify('4000'),
-          'process.env': '({})',
         }),
         new GenerateDistributionExtensionsPlugin({
           configPath: path.resolve(__dirname, '../distribution.yaml'),


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72235

## Description

Moves the `'process.env': '({})'` DefinePlugin catch-all from the RHAII-specific webpack config to the shared base distribution config (`distributions/base/config/webpack.common.js`).

**Problem:** `const.ts` reads `process.env.*` at module scope. Distributions without `dotenv-webpack` (like RHAII) crash with `ReferenceError: process is not defined`.

**Fix:** The shared catch-all replaces any bare `process.env` with `({})` at compile time. DefinePlugin matches more-specific keys first, so dotenv-webpack's per-key replacements in RHOAI are unaffected. All current and future distributions inherit the safe fallback automatically.

### Changes
- **`distributions/base/config/webpack.common.js`** — add `'process.env': '({})'` to shared DefinePlugin
- **`distributions/rhaii/config/webpack.common.js`** — remove redundant catch-all and stale comment

## How Has This Been Tested?

- Verified RHAII distribution builds successfully with model-serving enabled
- Confirmed RHOAI build is unaffected (dotenv-webpack per-key replacements take priority)

## Test Impact

No test changes needed — this is a build config change. Existing tests continue to pass.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`