### PR TITLE
WIP - feat(ci): add E2E coverage collection with weekly schedule and Codecov upload

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,6 +23,12 @@ coverage:
         threshold: 1%
         flags:
           - cypress-mock
+      cypress-e2e:
+        informational: true
+        target: auto
+        threshold: 1%
+        flags:
+          - cypress-e2e
     patch:
       default:
         informational: true
@@ -37,6 +43,11 @@ coverage:
         target: 50%
         flags:
           - cypress-mock
+      cypress-e2e:
+        informational: true
+        target: 50%
+        flags:
+          - cypress-e2e
 
 flags:
   unit:
@@ -47,6 +58,11 @@ flags:
       - distributions/
     carryforward: true
   cypress-mock:
+    paths:
+      - frontend/src/
+      - packages/
+    carryforward: true
+  cypress-e2e:
     paths:
       - frontend/src/
       - packages/

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -7,6 +7,7 @@ name: Cypress e2e Test
 # TRIGGERS:
 #   - Automatically after "Test" workflow completes on PRs
 #   - Manually via workflow_dispatch (Actions tab → Run workflow)
+#   - Weekly on Saturday at 06:00 UTC (coverage collection run)
 #
 # CLUSTER FAILOVER:
 #   Primary:   dash-e2e-int (checked first via DSC health)
@@ -40,7 +41,7 @@ name: Cypress e2e Test
 #        Add an entry to .github/frontend-ci-tags.json
 #
 # LIMITS:
-#   - Max 5 additional tags for labels/manual (prevents runner exhaustion)
+#   - Max 10 additional tags for labels/manual (prevents runner exhaustion)
 #   - Auto-detected tags are consolidated into 1 job (no limit needed)
 #   - 10 runners shared across 30+ devs
 #
@@ -51,6 +52,9 @@ name: Cypress e2e Test
 # =============================================================================
 
 on:
+  schedule:
+    - cron: '0 6 * * 6'  # Every Saturday at 06:00 UTC — coverage collection run
+
   workflow_run:
     workflows: ["Test"]
     types: [completed]
@@ -77,6 +81,11 @@ on:
         required: false
         default: ''
         type: string
+      enable_coverage:
+        description: 'Enable E2E code coverage collection and upload to Codecov'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: e2e-${{ github.event.workflow_run.head_branch || github.ref }}
@@ -102,8 +111,9 @@ jobs:
   # ---------------------------------------------------------------------------
   select-cluster:
     if: >-
-      github.event_name == 'workflow_dispatch' || 
-      (github.event.workflow_run.event == 'pull_request' && 
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event.workflow_run.event == 'pull_request' &&
        github.event.workflow_run.conclusion == 'success')
     runs-on: self-hosted
     outputs:
@@ -390,8 +400,9 @@ jobs:
   # ---------------------------------------------------------------------------
   set-pending-status:
     if: >-
-      github.event_name == 'workflow_dispatch' || 
-      (github.event.workflow_run.event == 'pull_request' && 
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event.workflow_run.event == 'pull_request' &&
        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
@@ -580,9 +591,18 @@ jobs:
           STEP_AUTO_TAGS: ${{ steps.detect.outputs.auto_tags }}
           STEP_LABELS: ${{ steps.labels.outputs.labels }}
         run: |
+          # Scheduled coverage runs use a fixed tag set — skip all tag resolution
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            SCHEDULE_TAGS='["@SmokeSet1","@SmokeSet2","@SmokeSet3","@SmokeSet4","@SmokeSet5","@SanitySet1","@SanitySet2","@SanitySet3","@SanitySet4"]'
+            echo "matrix=$SCHEDULE_TAGS" >> $GITHUB_OUTPUT
+            echo "source=schedule" >> $GITHUB_OUTPUT
+            echo "🕐 Scheduled coverage run — fixed tags: $SCHEDULE_TAGS"
+            exit 0
+          fi
+
           # Configuration
-          MAX_EXTRA_TAGS=5  # Limit additional tags to prevent runner exhaustion (for labels/manual only)
-          
+          MAX_EXTRA_TAGS=10  # Limit additional tags to prevent runner exhaustion (for labels/manual only)
+
           # Defaults
           TAGS=""
           SOURCE="default"
@@ -1243,7 +1263,13 @@ jobs:
 
           # Cypress reads CYPRESS_* env vars natively — avoids arg escaping through concurrently
           export CYPRESS_OC_SERVER="$OC_SERVER"
-          export CYPRESS_skipTags="@Bug @Maintain @NonConcurrent"
+          if [[ "${{ inputs.enable_coverage }}" == "true" || "${{ github.event_name }}" == "schedule" ]]; then
+            export CY_COVERAGE=true
+            export CYPRESS_skipTags="@Bug @Maintain"
+            echo "📊 Coverage collection enabled — @NonConcurrent tests included"
+          else
+            export CYPRESS_skipTags="@Bug @Maintain @NonConcurrent"
+          fi
           export CYPRESS_grepTags="$MATRIX_TAG"
           export CYPRESS_grepFilterSpecs=true
           export CYPRESS_video=true
@@ -1268,6 +1294,15 @@ jobs:
             packages/cypress/screenshots/
           retention-days: 7
 
+      - name: Upload coverage artifact
+        if: always() && (github.event.inputs.enable_coverage == 'true' || github.event_name == 'schedule')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-coverage-${{ env.TAG_DIR }}
+          path: packages/cypress/coverage/coverage-final.json
+          retention-days: 7
+          if-no-files-found: warn
+
       - name: Log test completion
         if: always()
         run: |
@@ -1283,9 +1318,10 @@ jobs:
   set-final-status:
     needs: [select-cluster, e2e-tests]
     if: >-
-      always() && 
-      (github.event_name == 'workflow_dispatch' || 
-       (github.event.workflow_run.event == 'pull_request' && 
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event_name == 'schedule' ||
+       (github.event.workflow_run.event == 'pull_request' &&
         github.event.workflow_run.conclusion == 'success'))
     runs-on: ubuntu-latest
     steps:
@@ -1330,12 +1366,65 @@ jobs:
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   # ---------------------------------------------------------------------------
+  # Upload E2E Coverage to Codecov (opt-in via workflow_dispatch or weekly schedule)
+  # ---------------------------------------------------------------------------
+  upload-e2e-coverage:
+    needs: [e2e-tests]
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' &&
+        inputs.enable_coverage == true))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: 22
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: e2e-coverage-*
+          path: e2e-coverage
+      - name: Merge coverage reports
+        run: |
+          npm install nyc --no-save
+          mkdir -p ./coverage
+
+          FOUND=0
+          for f in $(find e2e-coverage -name "coverage-final.json" 2>/dev/null); do
+            group=$(basename "$(dirname "$f")")
+            cp "$f" "./coverage/${group}.json"
+            FOUND=$((FOUND + 1))
+          done
+
+          if [ "$FOUND" -eq 0 ]; then
+            echo "⚠️ No coverage files found — tests may have failed before coverage was collected"
+            exit 0
+          fi
+
+          echo "📊 Merging $FOUND coverage file(s):"
+          ls -la ./coverage/
+          npx nyc merge ./coverage ./coverage/e2e-merged-coverage.json
+      - name: Upload to Codecov
+        if: hashFiles('./coverage/e2e-merged-coverage.json') != ''
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          name: cypress-e2e
+          flags: cypress-e2e
+          file: ./coverage/e2e-merged-coverage.json
+          disable_search: true
+          verbose: true
+
+  # ---------------------------------------------------------------------------
   # Cleanup - Fix file permissions left by BFF test binaries
   # ---------------------------------------------------------------------------
   cleanup:
     needs: [e2e-tests]
     runs-on: self-hosted
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success')) }}
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success')) }}
     steps:
       - name: Fix envtest binary permissions
         run: |


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78364

## Description

Adds opt-in code coverage collection to the Cypress E2E CI workflow and uploads results to Codecov under a `cypress-e2e` flag. This provides visibility into what production code paths E2E tests exercise.

Replaces the closed upstream PR: https://github.com/opendatahub-io/odh-dashboard/pull/8712

### Changes

**`.codecov.yml`** — adds `cypress-e2e` flag definition with `carryforward: true`, and `cypress-e2e` status checks (informational, `target: auto` for project, `target: 50%` for patch).

**`.github/workflows/cypress-e2e-test.yml`**:

- **Weekly schedule**: `cron: '0 6 * * 6'` (Saturday 06:00 UTC) runs the full Smoke/Sanity suite with coverage enabled
- **Schedule tag set**: `@SmokeSet1`–`@SmokeSet5`, `@SanitySet1`–`@SanitySet4` (9 matrix jobs) — bypasses `MAX_EXTRA_TAGS` limit
- **`enable_coverage` input**: opt-in toggle for manual `workflow_dispatch` runs (default: off — zero impact on normal PR runs)
- **Coverage collection**: sets `CY_COVERAGE=true` and drops `@NonConcurrent` from skip tags when coverage is enabled (schedule or manual)
- **Per-job artifact upload**: each matrix job uploads its `coverage-final.json`
- **`upload-e2e-coverage` job**: merges all per-tag coverage files with `nyc merge` and uploads to Codecov with the `cypress-e2e` flag
- **`MAX_EXTRA_TAGS` bump**: 5 → 10 (unrelated, bundled)

### How to use (manual)

1. Go to **Actions** → **Cypress e2e Test** → **Run workflow**
2. Check **Enable E2E code coverage collection and upload to Codecov**
3. Enter test tags (e.g., `@SmokeSet1`) in **Extra test tags**
4. Coverage appears in Codecov under the `cypress-e2e` flag after the run completes

## How Has This Been Tested?

Will be validated by triggering the workflow manually with `enable_coverage=true` and verifying coverage data appears in Codecov. The weekly schedule will provide ongoing validation.

## Test Impact

No new tests — this is CI infrastructure. The changes are behind an opt-in toggle and weekly schedule, and do not affect normal E2E test execution on PRs.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled weekly end-to-end test coverage runs.
  * Added an option to enable coverage for manually triggered runs.
  * Added consolidated end-to-end coverage reporting.

* **Improvements**
  * Expanded test tagging support for scheduled and manual runs.
  * Improved coverage status reporting and artifact collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->