### PR TITLE
Align DSC status check for MaaS to new condition name

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -1,4 +1,5 @@
 import { mockDashboardConfig, mockDscStatus } from '@odh-dashboard/internal/__mocks__';
+import { MODELS_AS_A_SERVICE_READY } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import type { APIKey, SubscriptionDetail } from '@odh-dashboard/maas/types/api-key';
 import { formatApiKeyHiddenPreview } from '@odh-dashboard/maas/utils/api-keys';
@@ -69,7 +70,7 @@ describe('API Keys Page', () => {
         components: {
           [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
         },
-        conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
+        conditions: [{ type: MODELS_AS_A_SERVICE_READY, status: 'True', reason: 'Ready' }],
       }),
     );
     cy.interceptOdh(
@@ -822,7 +823,7 @@ describe('API Keys Page (Admin)', () => {
         components: {
           [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
         },
-        conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
+        conditions: [{ type: MODELS_AS_A_SERVICE_READY, status: 'True', reason: 'Ready' }],
       }),
     );
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(mockAPIKeys())).as(
@@ -922,7 +923,7 @@ describe('API keys (mySubscriptions feature flag)', () => {
         components: {
           [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
         },
-        conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
+        conditions: [{ type: MODELS_AS_A_SERVICE_READY, status: 'True', reason: 'Ready' }],
       }),
     );
 

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -1,4 +1,5 @@
 import { mockDashboardConfig, mockDscStatus } from '@odh-dashboard/internal/__mocks__';
+import { MODELS_AS_A_SERVICE_READY } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { asProductAdminUser } from '../../../utils/mockUsers';
 import {
@@ -28,7 +29,7 @@ const setupAuthPoliciesCommon = () => {
       components: {
         [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
       },
-      conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
+      conditions: [{ type: MODELS_AS_A_SERVICE_READY, status: 'True', reason: 'Ready' }],
     }),
   );
 };

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
@@ -10,6 +10,7 @@ import {
 import { mockGlobalScopedHardwareProfiles } from '@odh-dashboard/internal/__mocks__/mockHardwareProfile';
 import { mockStandardModelServingTemplateK8sResources } from '@odh-dashboard/internal/__mocks__/mockServingRuntimeTemplateK8sResource';
 import { mockConnectionTypeConfigMap } from '@odh-dashboard/internal/__mocks__/mockConnectionType';
+import { MODELS_AS_A_SERVICE_READY } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { hardwareProfileSection } from '../../../pages/components/HardwareProfileSection';
 import { ModelLocationSelectOption, ModelTypeLabel } from '../../../utils/modelServingConstants';
@@ -39,7 +40,7 @@ describe('MaaS Deployment Wizard', () => {
           [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
           [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
         },
-        conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
+        conditions: [{ type: MODELS_AS_A_SERVICE_READY, status: 'True', reason: 'Ready' }],
       }),
     );
     cy.interceptOdh(

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasExternalModels.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasExternalModels.cy.ts
@@ -1,5 +1,6 @@
 import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig.js';
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus.js';
+import { MODELS_AS_A_SERVICE_READY } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { ProjectModel } from '@odh-dashboard/internal/api/models/index';
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
@@ -36,7 +37,7 @@ const setupCommonIntercepts = () => {
         [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
         [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
       },
-      conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
+      conditions: [{ type: MODELS_AS_A_SERVICE_READY, status: 'True', reason: 'Ready' }],
     }),
   );
 };
@@ -89,7 +90,7 @@ describe('External Models Page', () => {
           [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
           [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
         },
-        conditions: [{ type: 'ModelsAsServiceReady', status: 'False', reason: 'NotReady' }],
+        conditions: [{ type: MODELS_AS_A_SERVICE_READY, status: 'False', reason: 'NotReady' }],
       }),
     );
     externalModelsPage.visit();

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
@@ -1,4 +1,5 @@
 import { mockDashboardConfig, mockDscStatus } from '@odh-dashboard/internal/__mocks__';
+import { MODELS_AS_A_SERVICE_READY } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { asProductAdminUser } from '../../../utils/mockUsers';
 import {
@@ -26,7 +27,7 @@ const setupCommonIntercepts = () => {
       components: {
         [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
       },
-      conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
+      conditions: [{ type: MODELS_AS_A_SERVICE_READY, status: 'True', reason: 'Ready' }],
     }),
   );
   cy.interceptOdh('GET /maas/api/v1/subscription-policy-form-data', {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -1,4 +1,5 @@
 import { mockDashboardConfig, mockDscStatus } from '@odh-dashboard/internal/__mocks__';
+import { MODELS_AS_A_SERVICE_READY } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { asProductAdminUser } from '../../../utils/mockUsers';
 import {
@@ -30,7 +31,7 @@ const setupCommonIntercepts = () => {
       components: {
         [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
       },
-      conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
+      conditions: [{ type: MODELS_AS_A_SERVICE_READY, status: 'True', reason: 'Ready' }],
     }),
   );
 };

--- a/packages/gen-ai/frontend/src/odh/__tests__/extensions.spec.ts
+++ b/packages/gen-ai/frontend/src/odh/__tests__/extensions.spec.ts
@@ -23,11 +23,11 @@ describe('modelAsService area extension', () => {
     expect(area.properties.customCondition).toBeDefined();
   });
 
-  it('should return true when ModelsAsServiceReady is True', () => {
+  it('should return true when ModelsAsAServiceReady is True', () => {
     const area = findMaaSArea();
     const dscStatus = makeDscStatus([
       {
-        type: 'ModelsAsServiceReady',
+        type: 'ModelsAsAServiceReady',
         status: 'True',
         lastTransitionTime: '',
         reason: 'Ready',
@@ -44,11 +44,11 @@ describe('modelAsService area extension', () => {
     expect(result).toBe(true);
   });
 
-  it('should return false when ModelsAsServiceReady is False', () => {
+  it('should return false when ModelsAsAServiceReady is False', () => {
     const area = findMaaSArea();
     const dscStatus = makeDscStatus([
       {
-        type: 'ModelsAsServiceReady',
+        type: 'ModelsAsAServiceReady',
         status: 'False',
         lastTransitionTime: '',
         reason: 'NotReady',
@@ -65,7 +65,7 @@ describe('modelAsService area extension', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false when ModelsAsServiceReady condition is absent', () => {
+  it('should return false when ModelsAsAServiceReady condition is absent', () => {
     const area = findMaaSArea();
     const dscStatus = makeDscStatus([
       {

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -26,7 +26,7 @@ export const PROMPT_MANAGEMENT = 'promptManagement';
 export const AI_ASSET_CUSTOM_ENDPOINTS = 'aiAssetCustomEndpoints';
 export const EXTERNAL_VECTOR_STORES = 'externalVectorStores';
 export const AGENT_CONFIG_MANAGEMENT = 'agentConfigManagement';
-const MODELS_AS_SERVICE_READY = 'ModelsAsServiceReady';
+const MODELS_AS_A_SERVICE_READY = 'ModelsAsAServiceReady';
 
 const extensions: (
   | NavExtension
@@ -116,7 +116,7 @@ const extensions: (
       featureFlags: [MODEL_AS_SERVICE_CAMEL],
       customCondition: ({ dscStatus }) =>
         !!dscStatus?.conditions.some(
-          (c) => c.type === MODELS_AS_SERVICE_READY && c.status === 'True',
+          (c) => c.type === MODELS_AS_A_SERVICE_READY && c.status === 'True',
         ),
     },
   },

--- a/packages/k8s-core/src/index.ts
+++ b/packages/k8s-core/src/index.ts
@@ -33,6 +33,7 @@ export {
   MetadataAnnotation,
   HardwareProfileFeatureVisibility,
   DataScienceStackComponent,
+  MODELS_AS_A_SERVICE_READY,
 } from './k8sTypes';
 export type {
   K8sAPIOptions,

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -40,6 +40,8 @@ export type AccessReviewResourceAttributes = {
   namespace?: string;
 };
 
+export const MODELS_AS_A_SERVICE_READY = 'ModelsAsAServiceReady';
+
 export enum KnownLabels {
   DASHBOARD_RESOURCE = 'opendatahub.io/dashboard',
   PROJECT_SHARING = 'opendatahub.io/project-sharing',

--- a/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
+++ b/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
@@ -20,7 +20,7 @@ export type ODHExtensions =
   | TaskItemExtension
   | DetailTabExtension;
 const ADMIN_USER = 'ADMIN_USER';
-const MODELS_AS_SERVICE_READY = 'ModelsAsServiceReady';
+const MODELS_AS_A_SERVICE_READY = 'ModelsAsAServiceReady';
 
 const ODH_EXTENSIONS: ODHExtensions[] = [
   {
@@ -30,7 +30,7 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
       featureFlags: ['modelAsService'],
       customCondition: ({ dscStatus }) =>
         !!dscStatus?.conditions.some(
-          (c) => c.type === MODELS_AS_SERVICE_READY && c.status === 'True',
+          (c) => c.type === MODELS_AS_A_SERVICE_READY && c.status === 'True',
         ),
     },
   },


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-76577
## Description
New DSC changes from MaaS place the ready condition as `ModelsAsAServiceReady` now
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
not yet
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Updated mock tests
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model-as-a-service readiness logic to use the corrected readiness condition name, ensuring the UI gates and status messaging reflect the correct “ready” state.
* **Tests**
  * Updated mocked DSC status payloads in Cypress and unit tests to use the shared corrected readiness constant instead of the previous hard-coded string.
* **Chores**
  * Exposed the corrected readiness constant from the shared k8s core package for consistent reuse across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->