### PR TITLE
fix(gen-ai): update SENTENCE_TRANSFORMERS_HOME path for latest OGX image [RHOAIENG-78649]

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1562,7 +1562,7 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 		},
 		{
 			Name:  "SENTENCE_TRANSFORMERS_HOME",
-			Value: "/opt/app-root/src/.cache/huggingface/hub",
+			Value: "/opt/app-root/.cache/huggingface/hub",
 		},
 		{
 			Name:  "HF_HUB_OFFLINE",


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-78649

## Description

The OGX distribution changed its HuggingFace cache base path from `$HOME` (`/opt/app-root/src`) to `$APP_ROOT` (`/opt/app-root`) in [this commit](https://github.com/opendatahub-io/ogx-distribution/commit/29cadd36d38970368c04d46bca2acc6aff0ab470). Gen AI Studio was still setting the old path when creating OGXServer CRs:

```
SENTENCE_TRANSFORMERS_HOME=/opt/app-root/src/.cache/huggingface/hub
```

Because RHOAI defaults to `HF_HUB_OFFLINE=1`, OGX could not fall back to downloading the embedding model, causing every vector store file upload to fail with:

```
vector store file operation failed: We couldn't connect to 'https://huggingface.co' to load the files, and couldn't find them in the cached files.
```

This drops the extra `src/` segment to match the new image layout. Confirmed with the OGX team (Eoin Fennessy) that the path change was intentional.

## How Has This Been Tested?

Manually applied the updated `SENTENCE_TRANSFORMERS_HOME` value to the OGXServer CR on a dev cluster running `quay.io/opendatahub/odh-ogx-core:latest` (v1.2.1+rhaiv.0, built 2026-07-21) and verified that document upload to a vector store succeeds.

## Test Impact

No test changes needed. This is a one-line correction to a hardcoded path string; the correctness is determined by the OGX image layout and was verified manually on cluster.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the OGXServer configuration to use the correct cache location for sentence-transformer models, improving installation and model availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->