### PR TITLE
Add e2e test for external models

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/modelsAsService/testExternalModels.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/modelsAsService/testExternalModels.yaml
@@ -1,0 +1,4 @@
+# testExternalModels.cy.ts Test Data #
+projectResourceName: 'test-external-models'
+emptyProjectResourceName: 'test-external-models-empty'
+resourceName: 'e2e-openai'

--- a/packages/cypress/cypress/fixtures/resources/modelsAsService/ExternalModel.yaml
+++ b/packages/cypress/cypress/fixtures/resources/modelsAsService/ExternalModel.yaml
@@ -1,0 +1,12 @@
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: "{{RESOURCE_NAME}}"
+  namespace: "{{PROJECT_NAME}}"
+spec:
+  externalProviderRefs:
+    - ref:
+        name: "{{RESOURCE_NAME}}"
+      targetModel: "{{RESOURCE_NAME}}"
+      apiFormat: openai-chat
+      path: /v1/chat/completions

--- a/packages/cypress/cypress/fixtures/resources/modelsAsService/ExternalProvider.yaml
+++ b/packages/cypress/cypress/fixtures/resources/modelsAsService/ExternalProvider.yaml
@@ -1,0 +1,12 @@
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: "{{RESOURCE_NAME}}"
+  namespace: "{{PROJECT_NAME}}"
+spec:
+  provider: openai
+  endpoint: api.openai.com
+  auth:
+    type: apikey
+    secretRef:
+      name: "{{RESOURCE_NAME}}"

--- a/packages/cypress/cypress/fixtures/resources/modelsAsService/ExternalProviderSecret.yaml
+++ b/packages/cypress/cypress/fixtures/resources/modelsAsService/ExternalProviderSecret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{RESOURCE_NAME}}"
+  namespace: "{{PROJECT_NAME}}"
+  labels:
+    inference.networking.k8s.io/bbr-managed: "true"
+type: Opaque
+stringData:
+  api-key: llm-katan-openai-key

--- a/packages/cypress/cypress/fixtures/resources/modelsAsService/MaaSModelRefExternalModel.yaml
+++ b/packages/cypress/cypress/fixtures/resources/modelsAsService/MaaSModelRefExternalModel.yaml
@@ -1,0 +1,11 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: "{{RESOURCE_NAME}}"
+  namespace: "{{PROJECT_NAME}}"
+  labels:
+    opendatahub.io/dashboard: "true"
+spec:
+  modelRef:
+    kind: ExternalModel
+    name: "{{RESOURCE_NAME}}"

--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -1,6 +1,7 @@
 import { DeleteModal } from './components/DeleteModal';
 import { Modal } from './components/Modal';
 import { TableRow } from './components/table';
+import type { UserAuthConfig } from '../types';
 
 // MaaS Wizard Field helpers for the model deployment wizard
 class MaaSWizardField {
@@ -1512,6 +1513,18 @@ class ExternalModelsPage {
     cy.testA11y();
   }
 
+  visitAsUser(
+    user: UserAuthConfig,
+    options?: { enableExternalModelsFlag?: boolean; projectName?: string },
+  ): void {
+    const projectSegment = options?.projectName ? `/${options.projectName}` : '';
+    const flagQuery = options?.enableExternalModelsFlag
+      ? '?devFeatureFlags=externalModels=true'
+      : '';
+    cy.visitWithLogin(`/ai-hub/models/deployments/external${projectSegment}${flagQuery}`, user);
+    cy.testA11y();
+  }
+
   findTabPageTitle(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('app-tab-page-title');
   }
@@ -1526,6 +1539,19 @@ class ExternalModelsPage {
 
   findProjectSelector(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('external-models-project-selector');
+  }
+
+  findProjectSelectorToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findProjectSelector().findByTestId('project-selector-toggle');
+  }
+
+  findProjectSelectorOption(name: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('project-selector-menuList').findByRole('menuitem', { name });
+  }
+
+  selectProject(name: string): void {
+    this.findProjectSelectorToggle().click();
+    this.findProjectSelectorOption(name).click();
   }
 
   findEmptyState(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/tests/e2e/modelsAsAService/testExternalModels.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelsAsAService/testExternalModels.cy.ts
@@ -1,0 +1,115 @@
+import yaml from 'js-yaml';
+import {
+  cleanupExternalModelsResources,
+  createExternalModel,
+  createExternalProvider,
+  createExternalProviderSecret,
+  createMaaSModelRefForExternalModel,
+  waitForExternalModelGovernancePending,
+} from '../../../utils/oc_commands/maas';
+import { addUserToProject, deleteOpenShiftProject } from '../../../utils/oc_commands/project';
+import { LDAP_CONTRIBUTOR_USER } from '../../../utils/e2eUsers';
+import { ensureAdminOcSession } from '../../../utils/oc_commands/baseCommands';
+import { retryableBefore } from '../../../utils/retryableHooks';
+import { createCleanProject } from '../../../utils/projectChecker';
+import { externalModelsPage } from '../../../pages/modelsAsAService';
+import { generateTestUUID } from '../../../utils/uuidGenerator';
+
+const uuid = generateTestUUID();
+
+let projectWithModels: string;
+let emptyProject: string;
+let resourceName: string;
+
+describe('External models read-only list', () => {
+  retryableBefore(() => {
+    cy.log('Loading external models test data');
+    return cy
+      .fixture('e2e/modelsAsService/testExternalModels.yaml', 'utf8')
+      .then((yamlContent: string) => {
+        const fixtureData = yaml.load(yamlContent) as {
+          projectResourceName: string;
+          emptyProjectResourceName: string;
+          resourceName: string;
+        };
+        projectWithModels = `${fixtureData.projectResourceName}-${uuid}`;
+        emptyProject = `${fixtureData.emptyProjectResourceName}-${uuid}`;
+        resourceName = `${fixtureData.resourceName}-${uuid}`;
+
+        ensureAdminOcSession();
+        cleanupExternalModelsResources(projectWithModels, resourceName);
+        createCleanProject(projectWithModels);
+        createCleanProject(emptyProject);
+      })
+      .then(() => {
+        ensureAdminOcSession();
+        cy.log(
+          `Grant ${LDAP_CONTRIBUTOR_USER.USERNAME} edit access to both projects for namespace selector`,
+        );
+        return addUserToProject(projectWithModels, LDAP_CONTRIBUTOR_USER.USERNAME, 'edit').then(
+          () => addUserToProject(emptyProject, LDAP_CONTRIBUTOR_USER.USERNAME, 'edit'),
+        );
+      })
+      .then(() => {
+        ensureAdminOcSession();
+        cy.log(`Create Secret, ExternalProvider, ExternalModel, and MaaSModelRef: ${resourceName}`);
+        createExternalProviderSecret(projectWithModels, resourceName);
+        createExternalProvider(projectWithModels, resourceName);
+        createExternalModel(projectWithModels, resourceName);
+        createMaaSModelRefForExternalModel(projectWithModels, resourceName);
+        waitForExternalModelGovernancePending(projectWithModels, resourceName);
+      });
+  });
+
+  after(() => {
+    ensureAdminOcSession();
+    cy.log(`Cleaning up external model resources: ${resourceName}`);
+    cleanupExternalModelsResources(projectWithModels, resourceName);
+    deleteOpenShiftProject(projectWithModels, {
+      wait: true,
+      ignoreNotFound: true,
+      timeout: 300000,
+    });
+    deleteOpenShiftProject(emptyProject, { wait: true, ignoreNotFound: true, timeout: 300000 });
+  });
+
+  it(
+    'lists external model, shows governance warning, and empty state in another project',
+    {
+      tags: ['@Dashboard', '@MaaS', '@NonConcurrent'],
+    },
+    () => {
+      cy.step('Log into Deployments > External models as a normal user with the flag enabled');
+      externalModelsPage.visitAsUser(LDAP_CONTRIBUTOR_USER, {
+        enableExternalModelsFlag: true,
+        projectName: projectWithModels,
+      });
+
+      cy.step('Verify the External models tab and table list the applied model and provider');
+      externalModelsPage.findExternalModelsTab().should('exist');
+      externalModelsPage.findPage().should('exist');
+      externalModelsPage.findTable().should('exist');
+
+      const row = externalModelsPage.getRow(resourceName);
+      row.findName().should('contain.text', resourceName);
+      row.findProviderLabel(resourceName).should('exist');
+      row.findExpandButton().click();
+      row.findExpandedProviderName(resourceName).should('exist');
+
+      cy.step(
+        'Verify the pending governance warning next to status (subscription and policy needed)',
+      );
+      row.findGovernanceWarning().should('exist').click();
+      row
+        .findGovernanceWarningPopover()
+        .should('exist')
+        .and('contain.text', 'Pending MaaS governance')
+        .and('contain.text', 'subscription')
+        .and('contain.text', 'authorization policy');
+
+      cy.step('Switch to a project without external models and verify empty state');
+      externalModelsPage.selectProject(emptyProject);
+      externalModelsPage.findEmptyState().should('exist');
+    },
+  );
+});

--- a/packages/cypress/cypress/utils/oc_commands/maas.ts
+++ b/packages/cypress/cypress/utils/oc_commands/maas.ts
@@ -336,6 +336,148 @@ EOF`;
   });
 };
 
+const applyExternalModelsFixture = (
+  resourceLabel: string,
+  projectName: string,
+  resourceName: string,
+  fixturePath: string,
+  failOnNonZeroExit = true,
+): Cypress.Chainable<CommandLineResult> => {
+  cy.log(`Creating ${resourceLabel} "${resourceName}" in namespace "${projectName}"`);
+  return cy.fixture(fixturePath).then((yamlContent: string) => {
+    const processedYaml = replacePlaceholdersInYaml(yamlContent, {
+      PROJECT_NAME: projectName,
+      RESOURCE_NAME: resourceName,
+    });
+    const ocCommand = `cat <<'EOF' | oc apply -f -
+${processedYaml}
+EOF`;
+    cy.log(`Applying ${resourceLabel} YAML for "${resourceName}" in "${projectName}"`);
+    return cy.exec(ocCommand, { failOnNonZeroExit });
+  });
+};
+
+export const createExternalProviderSecret = (
+  projectName: string,
+  resourceName: string,
+  fixturePath = 'resources/modelsAsService/ExternalProviderSecret.yaml',
+): Cypress.Chainable<CommandLineResult> =>
+  applyExternalModelsFixture('Secret', projectName, resourceName, fixturePath);
+
+export const createExternalProvider = (
+  projectName: string,
+  resourceName: string,
+  fixturePath = 'resources/modelsAsService/ExternalProvider.yaml',
+): Cypress.Chainable<CommandLineResult> =>
+  applyExternalModelsFixture('ExternalProvider', projectName, resourceName, fixturePath);
+
+export const createExternalModel = (
+  projectName: string,
+  resourceName: string,
+  fixturePath = 'resources/modelsAsService/ExternalModel.yaml',
+): Cypress.Chainable<CommandLineResult> =>
+  applyExternalModelsFixture('ExternalModel', projectName, resourceName, fixturePath);
+
+export const createMaaSModelRefForExternalModel = (
+  projectName: string,
+  resourceName: string,
+  fixturePath = 'resources/modelsAsService/MaaSModelRefExternalModel.yaml',
+): Cypress.Chainable<CommandLineResult> =>
+  applyExternalModelsFixture('MaaSModelRef', projectName, resourceName, fixturePath, false);
+
+/**
+ * Deletes ExternalModel-related resources created by Cypress e2e setup.
+ * Order: MaaSModelRef → ExternalModel → ExternalProvider → Secret.
+ */
+export const cleanupExternalModelsResources = (
+  projectName: string,
+  resourceName: string,
+): Cypress.Chainable<CommandLineResult> => {
+  cy.log(`Cleaning up external model resources "${resourceName}" in namespace "${projectName}"`);
+  return cy
+    .exec(`oc delete MaaSModelRef ${resourceName} -n ${projectName} --ignore-not-found`, {
+      failOnNonZeroExit: false,
+    })
+    .then(() =>
+      cy.exec(`oc delete ExternalModel ${resourceName} -n ${projectName} --ignore-not-found`, {
+        failOnNonZeroExit: false,
+      }),
+    )
+    .then(() =>
+      cy.exec(`oc delete ExternalProvider ${resourceName} -n ${projectName} --ignore-not-found`, {
+        failOnNonZeroExit: false,
+      }),
+    )
+    .then(() =>
+      cy.exec(`oc delete Secret ${resourceName} -n ${projectName} --ignore-not-found`, {
+        failOnNonZeroExit: false,
+      }),
+    );
+};
+
+type MaaSModelRefCondition = {
+  type?: string;
+  status?: string;
+};
+
+type MaaSModelRefDoc = {
+  status?: {
+    conditions?: MaaSModelRefCondition[];
+  };
+};
+
+/**
+ * Poll until the companion MaaSModelRef exists and GovernanceAttached is not True
+ * (no subscription/policy yet → UI shows the pending governance warning).
+ */
+export const waitForExternalModelGovernancePending = (
+  projectName: string,
+  resourceName: string,
+  options: { maxAttempts?: number; retryIntervalMs?: number } = {},
+): Cypress.Chainable<CommandLineResult> => {
+  const maxAttempts = options.maxAttempts ?? MAAS_STATE_DEFAULT_MAX_ATTEMPTS;
+  const retryIntervalMs = options.retryIntervalMs ?? MAAS_STATE_DEFAULT_RETRY_INTERVAL_MS;
+  const ocCommand = `oc get MaaSModelRef ${resourceName} -n ${projectName} -o json`;
+  let attempts = 0;
+
+  const checkState = (): Cypress.Chainable<CommandLineResult> =>
+    cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {
+      attempts++;
+      if (result.exitCode === 0) {
+        let doc: MaaSModelRefDoc;
+        try {
+          doc = JSON.parse(result.stdout) as MaaSModelRefDoc;
+        } catch {
+          throw new Error(`Failed to parse MaaSModelRef JSON for ${resourceName}`);
+        }
+        const governanceCondition = doc.status?.conditions?.find(
+          (condition) => condition.type === 'GovernanceAttached',
+        );
+        const governanceAttached = governanceCondition?.status === 'True';
+        if (!governanceAttached) {
+          cy.log(
+            `✅ MaaSModelRef ${resourceName} exists with GovernanceAttached not True (attempt ${attempts})`,
+          );
+          return cy.wrap(result);
+        }
+      }
+
+      if (attempts < maxAttempts) {
+        cy.log(
+          `⏳ Waiting for MaaSModelRef ${resourceName} governance pending (attempt ${attempts}/${maxAttempts})`,
+        );
+        // eslint-disable-next-line cypress/no-unnecessary-waiting -- poll for controller reconcile
+        return cy.wait(retryIntervalMs).then(() => checkState());
+      }
+
+      throw new Error(
+        `MaaSModelRef ${resourceName} did not reach governance-pending state in namespace ${projectName}`,
+      );
+    });
+
+  return checkState();
+};
+
 const parseMaaSSubscriptionDoc = (
   subscriptionName: string,
   stdout: string,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
