### PR TITLE
fix(llmd-serving): fix routing and topology config edge cases in deploy wizard edit flow

### DIFF
--- a/frontend/src/__mocks__/mockLLMInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockLLMInferenceServiceK8sResource.ts
@@ -26,6 +26,7 @@ type MockLLMInferenceServiceConfigType = {
   secretName?: string;
   gatewayRefs?: { name: string; namespace: string }[];
   isLLMd?: boolean;
+  additionalAnnotations?: Record<string, string>;
 };
 
 export const mockLLMInferenceServiceK8sResource = ({
@@ -48,6 +49,7 @@ export const mockLLMInferenceServiceK8sResource = ({
   secretName,
   gatewayRefs,
   isLLMd = true,
+  additionalAnnotations,
 }: MockLLMInferenceServiceConfigType): LLMInferenceServiceKind => ({
   apiVersion: 'serving.kserve.io/v1alpha2',
   kind: 'LLMInferenceService',
@@ -60,6 +62,7 @@ export const mockLLMInferenceServiceK8sResource = ({
       ...(isStopped ? { [ModelAnnotation.STOPPED_ANNOTATION]: 'true' } : {}),
       ...(description && { 'openshift.io/description': description }),
       ...(secretName && { 'opendatahub.io/connections': secretName }),
+      ...additionalAnnotations,
     },
     creationTimestamp,
     ...(deleted ? { deletionTimestamp: new Date().toUTCString() } : {}),

--- a/packages/llmd-serving/src/wizardFields/AdvancedRoutingField.tsx
+++ b/packages/llmd-serving/src/wizardFields/AdvancedRoutingField.tsx
@@ -110,9 +110,14 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
     [routerConfigs, topologyType],
   );
 
-  // Resolve configRef from extractor (edit flow) once external data loads
+  // Resolve configRef from extractor (edit flow) once external data loads.
+  // Resolves against all routerConfigs so a previously selected incompatible config
+  // remains visible in the dropdown with a warning.
   const configRef = value?.configRef;
   const existingSelection = value?.selectedConfig;
+  const [preSelectedIncompatibleConfig, setPreSelectedIncompatibleConfig] = React.useState<
+    LLMInferenceServiceConfigKind | undefined
+  >();
   React.useEffect(() => {
     if (!configRef || existingSelection || !isLoaded) {
       return;
@@ -120,9 +125,30 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
     const resolved = (routerConfigs ?? []).find((c) => c.metadata.name === configRef);
     if (resolved) {
       onChange({ selectedConfig: resolved });
+      if (!compatibleConfigs.some((c) => c.metadata.name === resolved.metadata.name)) {
+        setPreSelectedIncompatibleConfig(resolved);
+      }
+    } else {
+      onChange({ configRef: undefined });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [configRef, isLoaded, existingSelection, routerConfigs]);
+  }, [configRef, isLoaded, existingSelection, routerConfigs, compatibleConfigs]);
+
+  // Clear stale incompatible state when the config becomes compatible
+  // (e.g. topology type changed to one the config supports).
+  React.useEffect(() => {
+    if (
+      preSelectedIncompatibleConfig &&
+      compatibleConfigs.some((c) => c.metadata.name === preSelectedIncompatibleConfig.metadata.name)
+    ) {
+      setPreSelectedIncompatibleConfig(undefined);
+    }
+  }, [compatibleConfigs, preSelectedIncompatibleConfig]);
+
+  const isIncompatibleSelected =
+    !!existingSelection &&
+    !!preSelectedIncompatibleConfig &&
+    existingSelection.metadata.name === preSelectedIncompatibleConfig.metadata.name;
 
   const options: SimpleSelectOption[] = React.useMemo(() => {
     const result: SimpleSelectOption[] = [
@@ -146,8 +172,22 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
       }),
     );
 
+    // Include the incompatible config only if it's not already in the compatible list
+    if (
+      preSelectedIncompatibleConfig &&
+      !compatibleConfigs.some(
+        (c) => c.metadata.name === preSelectedIncompatibleConfig.metadata.name,
+      )
+    ) {
+      result.push({
+        key: preSelectedIncompatibleConfig.metadata.name,
+        label: getDisplayNameFromK8sResource(preSelectedIncompatibleConfig),
+        dataTestId: `routing-config-option-${preSelectedIncompatibleConfig.metadata.name}`,
+      });
+    }
+
     return result;
-  }, [compatibleConfigs]);
+  }, [compatibleConfigs, preSelectedIncompatibleConfig]);
 
   const selectedValue = value?.selectedConfig?.metadata.name ?? DEFAULT_ROUTING_KEY;
 
@@ -175,7 +215,7 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
                 onChange({ selectedConfig: undefined });
                 return;
               }
-              const config = compatibleConfigs.find((c) => c.metadata.name === key);
+              const config = (routerConfigs ?? []).find((c) => c.metadata.name === key);
               fireRoutingSelected({
                 routingConfigurationId: key,
                 isDefaultRouting: false,
@@ -184,11 +224,15 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
             }}
             value={selectedValue}
             dataTestId="routing-config-select"
-            isDisabled={!isLoaded || hasLoadError || compatibleConfigs.length === 0}
+            isDisabled={
+              !isLoaded ||
+              hasLoadError ||
+              (compatibleConfigs.length === 0 && !preSelectedIncompatibleConfig)
+            }
             autoSelectOnlyOption={false}
-            toggleProps={hasLoadError ? { status: 'warning' } : undefined}
+            toggleProps={hasLoadError || isIncompatibleSelected ? { status: 'warning' } : undefined}
           />
-          {hasLoadError && (
+          {hasLoadError ? (
             <FormHelperText>
               <HelperText>
                 <HelperTextItem variant="warning">
@@ -196,7 +240,16 @@ const AdvancedRoutingFieldComponent: AdvancedRoutingFieldType['component'] = ({
                 </HelperTextItem>
               </HelperText>
             </FormHelperText>
-          )}
+          ) : isIncompatibleSelected ? (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="warning">
+                  The selected routing configuration is not compatible with the current topology
+                  type. Select a different routing configuration or contact your administrator.
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          ) : null}
         </StackItem>
       </Stack>
     </FormGroup>
@@ -246,7 +299,9 @@ export const AdvancedRoutingFieldWizardField: AdvancedRoutingFieldType = {
     },
     setFieldData: (value: AdvancedRoutingFieldData) => value,
     getInitialFieldData: (existingFieldData?: AdvancedRoutingFieldData): AdvancedRoutingFieldData =>
-      existingFieldData?.selectedConfig ? existingFieldData : { selectedConfig: undefined },
+      existingFieldData?.selectedConfig || existingFieldData?.configRef
+        ? existingFieldData
+        : { selectedConfig: undefined },
     validationSchema: z.object({
       selectedConfig: z
         .custom<LLMInferenceServiceConfigKind>(

--- a/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
+++ b/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
@@ -86,15 +86,18 @@ const CustomTopologyConfigFieldComponent: CustomTopologyConfigFieldType['compone
 
   const configRef = value?.configRef;
 
-  // Auto-select first config for non-single-node when configs load (new deploy only)
+  // Auto-select first config for non-single-node when configs load (new deploy only,
+  // or after a deleted configRef is cleared by the resolution effect below).
   React.useEffect(() => {
     if (isLoaded && !isSingleNode && !hasRealConfig && !configRef && filteredConfigs.length > 0) {
       onChange({ selectedConfig: filteredConfigs[0] });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoaded, filteredConfigs.length, topologyType]);
+  }, [isLoaded, filteredConfigs.length, topologyType, configRef]);
 
-  // Resolve configRef from extractor (edit flow) once external data loads
+  // Resolve configRef from extractor (edit flow) once external data loads.
+  // If the config was deleted, clear configRef and set the default for single-node,
+  // or clear configRef so the auto-select effect can pick one for other topologies.
   React.useEffect(() => {
     if (!configRef || hasRealConfig || !isLoaded) {
       return;
@@ -103,6 +106,10 @@ const CustomTopologyConfigFieldComponent: CustomTopologyConfigFieldType['compone
     const resolved = allConfigs.find((c) => c.metadata.name === configRef);
     if (resolved) {
       onChange({ selectedConfig: resolved });
+    } else if (isSingleNode) {
+      onChange({ selectedConfig: TOPOLOGY_CONFIG_DEFAULT });
+    } else {
+      onChange({ configRef: undefined });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [configRef, isLoaded, existingSelection, configsByTopology]);
@@ -248,7 +255,7 @@ export const CustomTopologyConfigFieldWizardField: CustomTopologyConfigFieldType
       externalData?: TopologyTypeExternalData,
       dependencies?: CustomTopologyConfigDependencies,
     ): CustomTopologyConfigFieldData => {
-      if (existingFieldData?.selectedConfig) {
+      if (existingFieldData?.selectedConfig || existingFieldData?.configRef) {
         return existingFieldData;
       }
       const topologyType = dependencies?.topologyType?.topologyType;

--- a/packages/llmd-serving/src/wizardFields/__tests__/AdvancedRoutingField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/AdvancedRoutingField.spec.tsx
@@ -1,9 +1,10 @@
 import React, { act } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
 import { fireRoutingSelected } from '../../tracking/llmdTrackingConstants';
-import { ConfigType } from '../../types';
+import { ConfigType, TopologyType } from '../../types';
 import {
   AdvancedRoutingFieldWizardField,
   type AdvancedRoutingExternalData,
@@ -16,15 +17,136 @@ jest.mock('../../tracking/llmdTrackingConstants', () => ({
 
 const mockFireRoutingSelected = jest.mocked(fireRoutingSelected);
 
+const { getInitialFieldData, validationSchema } = AdvancedRoutingFieldWizardField.reducerFunctions;
 const AdvancedRoutingFieldComponent = AdvancedRoutingFieldWizardField.component;
 
-describe('AdvancedRoutingField tracking', () => {
-  const mockOnChange = jest.fn();
+const mockConfig = mockLLMInferenceServiceConfigK8sResource({
+  name: 'router-config-1',
+  displayName: 'Router Config 1',
+});
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+const mockCompatibleConfig = mockLLMInferenceServiceConfigK8sResource({
+  name: 'compatible-config',
+  displayName: 'Compatible Config',
+  supportedTopologies: [TopologyType.SINGLE_NODE],
+});
+
+const mockIncompatibleConfig = mockLLMInferenceServiceConfigK8sResource({
+  name: 'incompatible-config',
+  displayName: 'Incompatible Config',
+  supportedTopologies: [TopologyType.MULTI_NODE],
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// --- getInitialFieldData ---
+
+describe('AdvancedRoutingField getInitialFieldData', () => {
+  it('should return existing field data when provided (edit flow)', () => {
+    const existing: AdvancedRoutingFieldData = { selectedConfig: mockConfig };
+
+    const result = getInitialFieldData(existing);
+
+    expect(result).toBe(existing);
   });
 
+  it('should return default state when no existing data', () => {
+    const result = getInitialFieldData(undefined);
+
+    expect(result).toEqual({ selectedConfig: undefined });
+  });
+
+  it('should preserve configRef from edit extractor for resolution by the component', () => {
+    const existing: AdvancedRoutingFieldData = { configRef: 'some-config' };
+
+    const result = getInitialFieldData(existing);
+
+    expect(result).toBe(existing);
+  });
+
+  it('should fall through to defaults when neither selectedConfig nor configRef is set', () => {
+    const existing: AdvancedRoutingFieldData = {};
+
+    const result = getInitialFieldData(existing);
+
+    expect(result).toEqual({ selectedConfig: undefined });
+  });
+});
+
+// --- validationSchema ---
+
+describe('AdvancedRoutingField validationSchema', () => {
+  if (!validationSchema) {
+    throw new Error('validationSchema is required');
+  }
+  const schema = validationSchema;
+
+  it('should accept undefined selectedConfig (default routing)', () => {
+    const result = schema.safeParse({ selectedConfig: undefined });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept a valid config object', () => {
+    const result = schema.safeParse({ selectedConfig: mockConfig });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept configRef string', () => {
+    const result = schema.safeParse({ configRef: 'my-config' });
+    expect(result.success).toBe(true);
+  });
+});
+
+// --- shouldResetOnDependencyChange ---
+
+describe('AdvancedRoutingField shouldResetOnDependencyChange', () => {
+  const { shouldResetOnDependencyChange } = AdvancedRoutingFieldWizardField;
+  if (!shouldResetOnDependencyChange) {
+    throw new Error('shouldResetOnDependencyChange is required');
+  }
+  const resetCheck = shouldResetOnDependencyChange;
+
+  it('should reset when topology type changes', () => {
+    const prev = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
+    const next = { topologyType: { topologyType: TopologyType.SINGLE_NODE_DISAGGREGATED } };
+
+    expect(resetCheck(prev, next)).toBe(true);
+  });
+
+  it('should not reset when topology type stays the same', () => {
+    const prev = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
+    const next = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
+
+    expect(resetCheck(prev, next)).toBe(false);
+  });
+
+  it('should reset when topology type goes from defined to undefined', () => {
+    const prev = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
+    const next = { topologyType: undefined };
+
+    expect(resetCheck(prev, next)).toBe(true);
+  });
+
+  it('should reset when topology type goes from undefined to defined', () => {
+    const prev = { topologyType: undefined };
+    const next = { topologyType: { topologyType: TopologyType.SINGLE_NODE } };
+
+    expect(resetCheck(prev, next)).toBe(true);
+  });
+
+  it('should not reset when both are undefined', () => {
+    const prev = { topologyType: undefined };
+    const next = { topologyType: undefined };
+
+    expect(resetCheck(prev, next)).toBe(false);
+  });
+});
+
+// --- Tracking ---
+
+describe('AdvancedRoutingField tracking', () => {
   const routerConfig1 = mockLLMInferenceServiceConfigK8sResource({
     name: 'router-config-1',
     displayName: 'Router Config One',
@@ -50,7 +172,7 @@ describe('AdvancedRoutingField tracking', () => {
       <AdvancedRoutingFieldComponent
         id="llmd-serving/advanced-routing"
         value={value}
-        onChange={mockOnChange}
+        onChange={jest.fn()}
         externalData={externalData}
         dependencies={dependencies}
       />,
@@ -72,7 +194,6 @@ describe('AdvancedRoutingField tracking', () => {
     });
 
     await openDropdown();
-
     await act(async () => {
       fireEvent.click(screen.getByText('Default optimized routing'));
     });
@@ -92,7 +213,6 @@ describe('AdvancedRoutingField tracking', () => {
     });
 
     await openDropdown();
-
     await act(async () => {
       fireEvent.click(screen.getByText('Router Config One'));
     });
@@ -101,62 +221,6 @@ describe('AdvancedRoutingField tracking', () => {
       routingConfigurationId: 'router-config-1',
       isDefaultRouting: false,
     });
-  });
-
-  it('should fire fireRoutingSelected for a different config selection', async () => {
-    renderComponent({
-      value: { selectedConfig: routerConfig1 },
-      externalData: {
-        data: { routerConfigs: [routerConfig1, routerConfig2] },
-        loaded: true,
-      },
-    });
-
-    await openDropdown();
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Router Config Two'));
-    });
-
-    expect(mockFireRoutingSelected).toHaveBeenCalledWith({
-      routingConfigurationId: 'router-config-2',
-      isDefaultRouting: false,
-    });
-  });
-
-  it('should call onChange with selectedConfig when a specific config is selected', async () => {
-    renderComponent({
-      externalData: {
-        data: { routerConfigs: [routerConfig1] },
-        loaded: true,
-      },
-    });
-
-    await openDropdown();
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Router Config One'));
-    });
-
-    expect(mockOnChange).toHaveBeenCalledWith({ selectedConfig: routerConfig1 });
-  });
-
-  it('should call onChange with undefined selectedConfig when default routing is selected', async () => {
-    renderComponent({
-      value: { selectedConfig: routerConfig1 },
-      externalData: {
-        data: { routerConfigs: [routerConfig1] },
-        loaded: true,
-      },
-    });
-
-    await openDropdown();
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Default optimized routing'));
-    });
-
-    expect(mockOnChange).toHaveBeenCalledWith({ selectedConfig: undefined });
   });
 
   it('should render the default routing option and config options', async () => {
@@ -172,5 +236,155 @@ describe('AdvancedRoutingField tracking', () => {
     expect(screen.getByTestId('routing-config-option-default')).toBeInTheDocument();
     expect(screen.getByTestId('routing-config-option-router-config-1')).toBeInTheDocument();
     expect(screen.getByTestId('routing-config-option-router-config-2')).toBeInTheDocument();
+  });
+});
+
+// --- Incompatible config handling ---
+
+describe('AdvancedRoutingField component — incompatible config handling', () => {
+  const buildExternalData = (
+    configs: ReturnType<typeof mockLLMInferenceServiceConfigK8sResource>[],
+  ): { data: AdvancedRoutingExternalData; loaded: boolean } => ({
+    data: { routerConfigs: configs },
+    loaded: true,
+  });
+
+  const fieldId = 'llmd-serving/advanced-routing';
+
+  const renderAndResolveIncompatible = async (onChange: jest.Mock) => {
+    const allConfigs = [mockCompatibleConfig, mockIncompatibleConfig];
+    const result = render(
+      <AdvancedRoutingFieldComponent
+        id={fieldId}
+        value={{ configRef: 'incompatible-config' }}
+        onChange={onChange}
+        externalData={buildExternalData(allConfigs)}
+        dependencies={{ topologyType: { topologyType: TopologyType.SINGLE_NODE } }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ selectedConfig: mockIncompatibleConfig });
+    });
+
+    result.rerender(
+      <AdvancedRoutingFieldComponent
+        id={fieldId}
+        value={{ selectedConfig: mockIncompatibleConfig, configRef: 'incompatible-config' }}
+        onChange={onChange}
+        externalData={buildExternalData(allConfigs)}
+        dependencies={{ topologyType: { topologyType: TopologyType.SINGLE_NODE } }}
+      />,
+    );
+
+    return result;
+  };
+
+  it('should resolve an incompatible configRef and show a warning', async () => {
+    const onChange = jest.fn();
+    await renderAndResolveIncompatible(onChange);
+
+    expect(
+      screen.getByText(/is not compatible with the current topology type/),
+    ).toBeInTheDocument();
+  });
+
+  it('should include the incompatible config as a selectable option in the dropdown', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    await renderAndResolveIncompatible(onChange);
+
+    await user.click(screen.getByTestId('routing-config-select'));
+
+    expect(screen.getByTestId('routing-config-option-incompatible-config')).toBeInTheDocument();
+  });
+
+  it('should hide the warning when a compatible config is selected', async () => {
+    const allConfigs = [mockCompatibleConfig, mockIncompatibleConfig];
+    const onChange = jest.fn();
+
+    const { rerender } = await renderAndResolveIncompatible(onChange);
+
+    rerender(
+      <AdvancedRoutingFieldComponent
+        id={fieldId}
+        value={{ selectedConfig: mockCompatibleConfig, configRef: 'incompatible-config' }}
+        onChange={onChange}
+        externalData={buildExternalData(allConfigs)}
+        dependencies={{ topologyType: { topologyType: TopologyType.SINGLE_NODE } }}
+      />,
+    );
+
+    expect(
+      screen.queryByText(/is not compatible with the current topology type/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should keep the incompatible option in the dropdown after selecting a different option', async () => {
+    const user = userEvent.setup();
+    const allConfigs = [mockCompatibleConfig, mockIncompatibleConfig];
+    const onChange = jest.fn();
+
+    const { rerender } = await renderAndResolveIncompatible(onChange);
+
+    await user.click(screen.getByTestId('routing-config-select'));
+    await user.click(screen.getByTestId('routing-config-option-default'));
+
+    rerender(
+      <AdvancedRoutingFieldComponent
+        id={fieldId}
+        value={{ selectedConfig: undefined, configRef: 'incompatible-config' }}
+        onChange={onChange}
+        externalData={buildExternalData(allConfigs)}
+        dependencies={{ topologyType: { topologyType: TopologyType.SINGLE_NODE } }}
+      />,
+    );
+
+    await user.click(screen.getByTestId('routing-config-select'));
+    expect(screen.getByTestId('routing-config-option-incompatible-config')).toBeInTheDocument();
+  });
+
+  it('should resolve a compatible configRef and show it selected without warning', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <AdvancedRoutingFieldComponent
+        id={fieldId}
+        value={{ configRef: 'compatible-config' }}
+        onChange={onChange}
+        externalData={buildExternalData([mockCompatibleConfig, mockIncompatibleConfig])}
+        dependencies={{ topologyType: { topologyType: TopologyType.SINGLE_NODE } }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ selectedConfig: mockCompatibleConfig });
+    });
+
+    expect(
+      screen.queryByText(/is not compatible with the current topology type/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should clear configRef when it references a deleted config', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <AdvancedRoutingFieldComponent
+        id={fieldId}
+        value={{ configRef: 'deleted-config' }}
+        onChange={onChange}
+        externalData={buildExternalData([mockCompatibleConfig])}
+        dependencies={{ topologyType: { topologyType: TopologyType.SINGLE_NODE } }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ configRef: undefined });
+    });
+
+    expect(
+      screen.queryByText(/is not compatible with the current topology type/),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/llmd-serving/src/wizardFields/__tests__/CustomTopologyConfigField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/CustomTopologyConfigField.spec.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
 import { TopologyType } from '../../types';
 import {
@@ -8,6 +10,7 @@ import type { TopologyTypeExternalData } from '../TopologyTypeField';
 import type { CustomTopologyConfigFieldData } from '../CustomTopologyConfigField';
 
 const { getInitialFieldData } = CustomTopologyConfigFieldWizardField.reducerFunctions;
+const CustomTopologyConfigFieldComponent = CustomTopologyConfigFieldWizardField.component;
 
 const mockMultiNodeConfig = mockLLMInferenceServiceConfigK8sResource({
   name: 'multi-node-config-1',
@@ -56,8 +59,15 @@ describe('CustomTopologyConfigField getInitialFieldData', () => {
     expect(result).toBe(existing);
   });
 
-  it('should fall through to defaults when only configRef is set (unresolved edit extractor)', () => {
+  it('should preserve configRef from edit extractor for resolution by the component', () => {
     const existing: CustomTopologyConfigFieldData = { configRef: 'some-config' };
+    const result = getInitialFieldData(existing);
+
+    expect(result).toBe(existing);
+  });
+
+  it('should fall through to defaults when neither selectedConfig nor configRef is set', () => {
+    const existing: CustomTopologyConfigFieldData = {};
     const result = getInitialFieldData(existing);
 
     expect(result).toEqual({ selectedConfig: TOPOLOGY_CONFIG_DEFAULT });
@@ -123,5 +133,101 @@ describe('CustomTopologyConfigField getInitialFieldData', () => {
     const result = getInitialFieldData(undefined, undefined, deps);
 
     expect(result).toEqual({ selectedConfig: undefined });
+  });
+});
+
+describe('CustomTopologyConfigField component — edit flow configRef resolution', () => {
+  const fieldId = 'llmd-serving/custom-topology-config';
+
+  it('should resolve a compatible configRef and show it selected', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <CustomTopologyConfigFieldComponent
+        id={fieldId}
+        value={{ configRef: 'multi-node-config-1' }}
+        onChange={onChange}
+        externalData={{
+          data: {
+            configsByTopology: {
+              ...emptyConfigsByTopology,
+              [TopologyType.MULTI_NODE]: [mockMultiNodeConfig, mockMultiNodeConfig2],
+            },
+          },
+          loaded: true,
+        }}
+        dependencies={{ topologyType: { topologyType: TopologyType.MULTI_NODE } }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ selectedConfig: mockMultiNodeConfig });
+    });
+  });
+
+  it('should clear configRef and auto-select when it references a deleted config', async () => {
+    const onChange = jest.fn();
+    const externalData = {
+      data: {
+        configsByTopology: {
+          ...emptyConfigsByTopology,
+          [TopologyType.MULTI_NODE]: [mockMultiNodeConfig],
+        },
+      },
+      loaded: true,
+    };
+    const deps = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
+
+    const { rerender } = render(
+      <CustomTopologyConfigFieldComponent
+        id={fieldId}
+        value={{ configRef: 'deleted-config' }}
+        onChange={onChange}
+        externalData={externalData}
+        dependencies={deps}
+      />,
+    );
+
+    // The resolution effect clears configRef when the config isn't found
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ configRef: undefined });
+    });
+
+    // Simulate the wizard framework applying the cleared configRef
+    rerender(
+      <CustomTopologyConfigFieldComponent
+        id={fieldId}
+        value={{}}
+        onChange={onChange}
+        externalData={externalData}
+        dependencies={deps}
+      />,
+    );
+
+    // The auto-select effect should now pick the first available config
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ selectedConfig: mockMultiNodeConfig });
+    });
+  });
+
+  it('should set default when deleted configRef is resolved on single-node topology', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <CustomTopologyConfigFieldComponent
+        id={fieldId}
+        value={{ configRef: 'deleted-config' }}
+        onChange={onChange}
+        externalData={{
+          data: { configsByTopology: emptyConfigsByTopology },
+          loaded: true,
+        }}
+        dependencies={{ topologyType: { topologyType: TopologyType.SINGLE_NODE } }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ selectedConfig: TOPOLOGY_CONFIG_DEFAULT });
+    });
   });
 });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -1,6 +1,13 @@
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { mockLLMInferenceServiceK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceK8sResource';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { ConfigType, TopologyType } from '@odh-dashboard/llmd-serving/types';
+import {
+  ConfigType,
+  TopologyType,
+  TOPOLOGY_TYPE_ANNOTATION,
+  TOPOLOGY_CONFIG_REF_ANNOTATION,
+  ROUTING_CONFIG_REF_ANNOTATION,
+} from '@odh-dashboard/llmd-serving/types';
 import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
@@ -25,6 +32,7 @@ import {
 import {
   modelServingGlobal,
   modelServingWizard,
+  modelServingWizardEdit,
 } from '@odh-dashboard/cypress/cypress/pages/modelServing';
 
 const buildTopologyConfig = (
@@ -391,6 +399,163 @@ describe('Model Serving LLMD Topology & Routing', () => {
       cy.findByTestId('routing-config-select').click();
       cy.findByTestId('routing-config-option-default').click();
       cy.findByTestId('routing-config-select').should('contain.text', 'Default optimized routing');
+    });
+  });
+
+  describe('edit flow — config resolution', () => {
+    const initEditIntercepts = ({
+      topologyConfigs = mockTopologyConfigs,
+      routerConfigs = mockRouterConfigs,
+      existingDeployment,
+    }: {
+      topologyConfigs?: ReturnType<typeof mockLLMInferenceServiceConfigK8sResource>[];
+      routerConfigs?: ReturnType<typeof mockLLMInferenceServiceConfigK8sResource>[];
+      existingDeployment: ReturnType<typeof mockLLMInferenceServiceK8sResource>;
+    }) => {
+      initIntercepts({ topologyConfigs, routerConfigs });
+      cy.interceptK8sList(
+        { model: LLMInferenceServiceModel, ns: 'test-project' },
+        mockK8sResourceList([existingDeployment]),
+      );
+      cy.intercept('PUT', '**/llminferenceservices/**', (req) => {
+        req.reply({ statusCode: 200, body: req.body });
+      }).as('updateLLMInferenceService');
+    };
+
+    const openEditWizardModelDeploymentStep = (displayName: string) => {
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.getModelRow(displayName).findKebabAction('Edit').click();
+      modelServingWizardEdit.findNextButton().should('be.enabled').click();
+    };
+
+    it('should pre-select topology config and routing config from existing deployment', () => {
+      initEditIntercepts({
+        existingDeployment: mockLLMInferenceServiceK8sResource({
+          additionalAnnotations: {
+            [TOPOLOGY_TYPE_ANNOTATION]: TopologyType.MULTI_NODE,
+            [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'multi-node-config',
+            [ROUTING_CONFIG_REF_ANNOTATION]: 'managed-scheduler',
+          },
+          baseRefs: [{ name: 'multi-node-config' }, { name: 'managed-scheduler' }],
+        }),
+      });
+
+      openEditWizardModelDeploymentStep('Test LLM Inference Service');
+
+      cy.findByTestId('topology-type-select').should('contain.text', 'Multi-node data parallel');
+      cy.findByTestId('custom-topology-config-select').should(
+        'contain.text',
+        'Multi-node Data Parallel',
+      );
+      cy.findByTestId('routing-config-select').should('contain.text', 'Managed scheduler');
+      modelServingWizardEdit.findNextButton().should('be.enabled');
+    });
+
+    it('should fall back to default routing when routing config has been deleted', () => {
+      initEditIntercepts({
+        existingDeployment: mockLLMInferenceServiceK8sResource({
+          additionalAnnotations: {
+            [TOPOLOGY_TYPE_ANNOTATION]: TopologyType.SINGLE_NODE,
+            [ROUTING_CONFIG_REF_ANNOTATION]: 'deleted-router',
+          },
+          baseRefs: [{ name: 'deleted-router' }],
+        }),
+      });
+
+      openEditWizardModelDeploymentStep('Test LLM Inference Service');
+
+      cy.findByTestId('routing-config-select').should('contain.text', 'Default optimized routing');
+      modelServingWizardEdit.findNextButton().should('be.enabled');
+    });
+
+    it('should show warning when routing config is incompatible with topology type', () => {
+      const incompatibleRouterConfig = mockLLMInferenceServiceConfigK8sResource({
+        name: 'multi-only-router',
+        displayName: 'Multi-only Router',
+        configType: ConfigType.ROUTER,
+        supportedTopologies: [TopologyType.MULTI_NODE],
+      });
+
+      initEditIntercepts({
+        routerConfigs: [...mockRouterConfigs, incompatibleRouterConfig],
+        existingDeployment: mockLLMInferenceServiceK8sResource({
+          additionalAnnotations: {
+            [TOPOLOGY_TYPE_ANNOTATION]: TopologyType.SINGLE_NODE,
+            [ROUTING_CONFIG_REF_ANNOTATION]: 'multi-only-router',
+          },
+          baseRefs: [{ name: 'multi-only-router' }],
+        }),
+      });
+
+      openEditWizardModelDeploymentStep('Test LLM Inference Service');
+
+      cy.findByTestId('routing-config-select').should('contain.text', 'Multi-only Router');
+      cy.findByText(/is not compatible with the current topology type/).should('exist');
+      modelServingWizardEdit.findNextButton().should('be.enabled');
+    });
+
+    it('should retain selection of topology config on edit if it is incompatible with topology type', () => {
+      initEditIntercepts({
+        existingDeployment: mockLLMInferenceServiceK8sResource({
+          additionalAnnotations: {
+            [TOPOLOGY_TYPE_ANNOTATION]: TopologyType.SINGLE_NODE,
+            [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'multi-node-config',
+          },
+          baseRefs: [{ name: 'multi-node-config' }],
+        }),
+      });
+
+      openEditWizardModelDeploymentStep('Test LLM Inference Service');
+
+      cy.findByTestId('custom-topology-config-select').should(
+        'contain.text',
+        'Multi-node Data Parallel',
+      );
+      modelServingWizardEdit.findNextButton().should('be.enabled');
+    });
+
+    it('should auto-select another config when topology config has been deleted', () => {
+      initEditIntercepts({
+        existingDeployment: mockLLMInferenceServiceK8sResource({
+          additionalAnnotations: {
+            [TOPOLOGY_TYPE_ANNOTATION]: TopologyType.MULTI_NODE,
+            [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'deleted-topo-config',
+          },
+          baseRefs: [{ name: 'deleted-topo-config' }],
+        }),
+      });
+
+      openEditWizardModelDeploymentStep('Test LLM Inference Service');
+
+      cy.findByTestId('topology-type-select').should('contain.text', 'Multi-node data parallel');
+      cy.findByTestId('custom-topology-config-select').should(
+        'contain.text',
+        'Multi-node Data Parallel',
+      );
+      modelServingWizardEdit.findNextButton().should('be.enabled');
+    });
+
+    it('should allow switching to single-node after deleted topology config is resolved', () => {
+      initEditIntercepts({
+        existingDeployment: mockLLMInferenceServiceK8sResource({
+          additionalAnnotations: {
+            [TOPOLOGY_TYPE_ANNOTATION]: TopologyType.MULTI_NODE,
+            [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'deleted-topo-config',
+          },
+          baseRefs: [{ name: 'deleted-topo-config' }],
+        }),
+      });
+
+      openEditWizardModelDeploymentStep('Test LLM Inference Service');
+
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId('topology-type-option-workload-single-node').click();
+      cy.findByTestId('topology-type-select').should('contain.text', 'Single node');
+      cy.findByTestId('custom-topology-config-select').should(
+        'contain.text',
+        'Single node (default)',
+      );
+      modelServingWizardEdit.findNextButton().should('be.enabled');
     });
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-76494

## Description

Fixes multiple edge cases in `AdvancedRoutingField` and `CustomTopologyConfigField` where config selections could become stale, orphaned, or lost during the deploy wizard edit flow.

cc @vconzola

**Gap 1 — No reset on topology type change:** The routing field now resets when the topology type dependency changes via `shouldResetOnDependencyChange`, matching the existing pattern in `CustomTopologyConfigField`. Previously, if a user selected a routing config restricted to a specific topology type and then changed the topology, the stale selection persisted in field state but disappeared from the dropdown. The user could continue to submit with the invalid routing config.

**Here's the previous buggy behavior for gap 1:**

https://github.com/user-attachments/assets/8436bd08-a118-4f3f-b02f-af90c5d48b6a

**Here's the fixed behavior for gap 1:**

https://github.com/user-attachments/assets/c4abc0bc-8299-488e-a882-3e94647cc41f


**Gap 2 — Orphaned config in edit flow:** When editing a deployment whose routing config has become incompatible with the current topology type (e.g. the config's `supportedTopologies` annotation was changed after deploy), the config is now resolved against all router configs and remains visible and selectable in the dropdown. A warning is shown while the incompatible config is selected: *"The selected routing configuration is not compatible with the current topology type. Select a different routing configuration or contact your administrator."* The warning clears when the user selects a different option. The incompatible option remains in the dropdown even after switching to a different selection. If the user proceeds with the incompatible option selected despite the warning, we still allow them to submit.

**Here's the previous buggy behavior for gap 2:**

https://github.com/user-attachments/assets/c282c18d-2b60-4a78-87af-aaf29a19d855

**Here's the fixed behavior for gap 2:**

https://github.com/user-attachments/assets/25bd6198-1833-4bbe-8f19-27d3a971edd3

Here's that warning:
<img width="1005" height="194" alt="Screenshot 2026-07-22 at 5 39 50 PM" src="https://github.com/user-attachments/assets/2527e908-0ccd-49f1-9da6-c9554e7bf16b" />

### Additional corner cases covered and regressions from #8718

While testing the original two gaps, we discovered that #8718 ([RHOAIENG-77671](https://redhat.atlassian.net/browse/RHOAIENG-77671)) introduced a regression: its `getInitialFieldData` fix for the deleted-config case checked `existingFieldData?.selectedConfig` and dropped the `configRef` when `selectedConfig` was absent. This broke all edit-flow config resolution for both routing and topology config fields — the saved config was never pre-selected when editing a deployment.

This PR fixes that regression and covers the following additional corner cases:

- **configRef preserved in `getInitialFieldData`:** Both fields now preserve `existingFieldData` when either `selectedConfig` or `configRef` is present, so the resolution effect can look up the config.
- **Deleted config handling:** When the resolution effect can't find a config (deleted from cluster), it clears `configRef` so downstream behavior works correctly — auto-select kicks in for topology configs, and the routing field falls back to default. For single-node topology, the resolution effect sets `TOPOLOGY_CONFIG_DEFAULT` directly since the auto-select effect only handles non-single-node topologies.
- **Auto-select dep fix:** `CustomTopologyConfigField`'s auto-select effect now includes `configRef` in its dependency array so it re-fires after a deleted configRef is cleared.
- **Stale incompatible state:** `preSelectedIncompatibleConfig` is cleared when the config becomes compatible (e.g. after a topology type change), preventing phantom options and false warnings.
- **Disabled select edge case:** When the incompatible config is the only router config, the dropdown stays enabled so the user can still select "Default optimized routing."
- **Duplicate option guard:** The incompatible config option is only appended when it's not already in `compatibleConfigs`.

cc @YuliaKrimerman — the `getInitialFieldData` change in this PR supersedes the one from #8718 for both fields.

### Possible follow-up

`CustomTopologyConfigField` has the same orphaned-config display pattern (lines 132-142) but does not show a warning when the selected config is incompatible. A follow-up ticket could apply the same warning UX there. cc @YuliaKrimerman I can open this, but I think it can go on the backlog, the broken behavior was fixed in https://github.com/opendatahub-io/odh-dashboard/pull/8549 and it just doesn't show a warning. This is a super unlikely corner case.

## How Has This Been Tested?

- **Type-check**: passes
- **Lint**: 0 errors
- **Unit tests**: 30 tests pass across both field test files:
  - `AdvancedRoutingField.spec.tsx` (18 tests): `getInitialFieldData`, `validationSchema`, `shouldResetOnDependencyChange`, component rendering for incompatible config warning, compatible configRef resolution, deleted configRef clearing
  - `CustomTopologyConfigField.spec.tsx` (12 tests): `getInitialFieldData` with configRef preservation and empty-data fallthrough, compatible configRef resolution, deleted configRef clearing with auto-select, deleted configRef on single-node sets default
- **Cypress mock tests**: 7 new integration tests in `modelServingLlmdTopology.cy.ts`, all asserting Next button is enabled:
  - Edit flow pre-selects topology config and routing config from existing deployment annotations
  - Deleted routing config falls back to default
  - Incompatible routing config shown with warning
  - Incompatible topology config retained on edit
  - Deleted topology config auto-selects next available
  - Switching to single-node after deleted topology config is resolved ([RHOAIENG-77671](https://redhat.atlassian.net/browse/RHOAIENG-77671) case 6 regression check)
- **Manual testing on zaffre cluster**: 20 test scenarios covering Gap 1 (topology change resets), Gap 2 (incompatible config warning), deleted config regression checks for both topology and routing, and normal create/edit flow regressions. Full checklist: `pr-8764-test-checklist.md`

## Test Impact

- **Added**: `AdvancedRoutingField.spec.tsx` — 18 unit/component tests (new file)
- **Modified**: `CustomTopologyConfigField.spec.tsx` — 12 tests (renamed from `.spec.ts`, added component render tests for configRef resolution and deleted config handling)
- **Added**: 7 Cypress mock tests in `modelServingLlmdTopology.cy.ts` for edit flow config resolution
- **Modified**: `mockLLMInferenceServiceK8sResource.ts` — added `additionalAnnotations` param for setting topology/routing config refs on mock deployments

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-77671]: https://redhat.atlassian.net/browse/RHOAIENG-77671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ