### PR TITLE
fix(mlflow-embedded): pass workspace prop to federated MLflow wrappers

### DIFF
--- a/packages/mlflow-embedded/experiments/MlflowExperimentsPage.tsx
+++ b/packages/mlflow-embedded/experiments/MlflowExperimentsPage.tsx
@@ -87,7 +87,7 @@ const MlflowExperimentsPage: React.FC = () => {
       <LazyCodeRefComponent
         key={workspace}
         component={loadWrapper}
-        props={{ onBreadcrumbChange: setBreadcrumbs }}
+        props={{ onBreadcrumbChange: setBreadcrumbs, workspace }}
         fallback={
           <Bullseye>
             <Spinner />

--- a/packages/mlflow-embedded/prompts/MlflowPromptManagementPage.tsx
+++ b/packages/mlflow-embedded/prompts/MlflowPromptManagementPage.tsx
@@ -85,7 +85,7 @@ const MlflowPromptManagementPage: React.FC = () => {
       <LazyCodeRefComponent
         key={workspace}
         component={loadWrapper}
-        props={{ onBreadcrumbChange: setBreadcrumbs }}
+        props={{ onBreadcrumbChange: setBreadcrumbs, workspace }}
         fallback={
           <Bullseye>
             <Spinner />


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-66298

## Description

When switching projects on "Gen AI Studio > Prompts", the list view shows the wrong latest version from the previous project's React Query cache. For example, if project A has `summarization` with 8 versions and project B has `summarization` with 3 versions, the list view for project B shows "Version 8" instead of "Version 3". The detail page shows correct data.

**Root cause:** The MLflow federated module's `QueryClient` is created at module scope and survives the `key={workspace}` React remount. Since query cache keys don't include workspace, stale data from the previous workspace is served from cache.

**Fix:** Pass `workspace` as a prop to `MlflowPromptsWrapper` and `MlflowExperimentWrapper` so the MLflow module can invalidate or re-key its cache on workspace change. This is a prerequisite for the matching MLflow-side fix (adding workspace to query cache keys / invalidating on workspace prop change).

**Note:** Full end-to-end verification requires the matching MLflow-side change (accepting and handling the `workspace` prop in the federated wrappers). This PR alone does not fix the bug. The prop is silently ignored until the MLflow side lands.

## Test Impact

No new tests. The change is a one-line prop addition in two files. The existing Cypress mock test (`promptManagement.cy.ts`) covers workspace switching behavior. The actual cache invalidation logic lives in the external MLflow module and is not testable from the dashboard side.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`