### PR TITLE
fix(eval-hub): handle partially_failed evaluation job state

### DIFF
--- a/packages/eval-hub/bff/openapi/src/eval-hub.yaml
+++ b/packages/eval-hub/bff/openapi/src/eval-hub.yaml
@@ -635,6 +635,7 @@ components:
             - cancelled
             - stopping
             - stopped
+            - partially_failed
           example: 'completed'
           description: Current state of the evaluation job
         message:

--- a/packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx
@@ -7,6 +7,7 @@ import {
   InProgressIcon,
   OffIcon,
   PendingIcon,
+  QuestionCircleIcon,
 } from '@patternfly/react-icons';
 import { EvaluationJobState } from '~/app/types';
 
@@ -18,7 +19,7 @@ type StatusConfig = {
   isFilled?: boolean;
 };
 
-const statusMap: Record<EvaluationJobState, StatusConfig> = {
+const statusMap: Partial<Record<EvaluationJobState, StatusConfig>> = {
   pending: {
     label: 'Pending',
     color: 'purple',
@@ -55,6 +56,20 @@ const statusMap: Record<EvaluationJobState, StatusConfig> = {
     color: 'grey',
     icon: <OffIcon />,
   },
+
+  // eslint-disable-next-line camelcase -- matches the API's state value verbatim
+  partially_failed: {
+    label: 'Failed',
+    status: 'danger',
+    icon: <ExclamationCircleIcon />,
+    isFilled: true,
+  },
+};
+
+const unknownStatusConfig: StatusConfig = {
+  label: 'Unknown',
+  color: 'grey',
+  icon: <QuestionCircleIcon />,
 };
 
 type EvaluationStatusLabelProps = {
@@ -63,8 +78,8 @@ type EvaluationStatusLabelProps = {
 };
 
 const EvaluationStatusLabel: React.FC<EvaluationStatusLabelProps> = ({ state, message }) => {
-  const config = statusMap[state];
-  const hasPopover = state === 'failed' && !!message;
+  const config = statusMap[state] ?? unknownStatusConfig;
+  const hasPopover = (state === 'failed' || state === 'partially_failed') && !!message;
 
   const label = (
     <Label

--- a/packages/eval-hub/frontend/src/app/components/EvaluationsTable.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationsTable.tsx
@@ -68,6 +68,13 @@ const STATUS_OPTIONS: { value: EvaluationJobState; label: string }[] = [
   { value: 'stopping', label: 'Canceling' },
 ];
 
+const matchesStatusFilter = (jobState: EvaluationJobState, selectedStatus: EvaluationJobState) => {
+  if (selectedStatus === 'failed') {
+    return jobState === 'failed' || jobState === 'partially_failed';
+  }
+  return jobState === selectedStatus;
+};
+
 type SortConfig = {
   index: number;
   direction: 'asc' | 'desc';
@@ -141,7 +148,7 @@ const EvaluationsTable: React.FC<EvaluationsTableProps> = ({
           if (!selectedStatus) {
             return true;
           }
-          return job.status.state === selectedStatus;
+          return matchesStatusFilter(job.status.state, selectedStatus);
         }
         if (!filterValue) {
           return true;

--- a/packages/eval-hub/frontend/src/app/components/__tests__/EvaluationStatusLabel.spec.tsx
+++ b/packages/eval-hub/frontend/src/app/components/__tests__/EvaluationStatusLabel.spec.tsx
@@ -20,6 +20,8 @@ const EXPECTED_LABELS: Record<EvaluationJobState, ExpectedLabelConfigWithVariant
   cancelled: { text: 'Canceled', color: 'grey' },
   stopping: { text: 'Canceling', color: 'grey' },
   stopped: { text: 'Stopped', color: 'grey' },
+  // eslint-disable-next-line camelcase
+  partially_failed: { text: 'Failed', status: 'danger', isFilled: true },
 };
 
 describe('EvaluationStatusLabel', () => {

--- a/packages/eval-hub/frontend/src/app/components/__tests__/EvaluationsTable.spec.tsx
+++ b/packages/eval-hub/frontend/src/app/components/__tests__/EvaluationsTable.spec.tsx
@@ -287,6 +287,39 @@ describe('EvaluationsTable', () => {
 
       expect(screen.getByTestId('evaluation-row-0')).toBeInTheDocument();
     });
+
+    it('should filter by status, matching partially_failed jobs when "Failed" is selected', () => {
+      const partiallyFailedJob = mockEvaluationJob({
+        id: 'job-partially-failed',
+        name: 'Delta Evaluation',
+        state: 'partially_failed',
+        modelName: 'gpt-4',
+        createdAt: '2026-02-19T10:00:00Z',
+      });
+
+      renderTable({ evaluations: [...mockJobs, partiallyFailedJob], loaded: true });
+
+      fireEvent.click(screen.getByTestId('filter-type-toggle'));
+      fireEvent.click(screen.getByRole('option', { name: 'Status' }));
+
+      fireEvent.click(screen.getByTestId('filter-status-toggle'));
+      fireEvent.click(screen.getByRole('option', { name: 'Failed' }));
+
+      expect(screen.getByText('Gamma Evaluation')).toBeInTheDocument();
+      expect(screen.getByText('Delta Evaluation')).toBeInTheDocument();
+      expect(screen.queryByText('Alpha Evaluation')).not.toBeInTheDocument();
+      expect(screen.queryByText('Beta Evaluation')).not.toBeInTheDocument();
+    });
+
+    it('should not offer a separate "Partially failed" status filter option', () => {
+      renderTable({ evaluations: mockJobs, loaded: true });
+
+      fireEvent.click(screen.getByTestId('filter-type-toggle'));
+      fireEvent.click(screen.getByRole('option', { name: 'Status' }));
+      fireEvent.click(screen.getByTestId('filter-status-toggle'));
+
+      expect(screen.queryByRole('option', { name: 'Partially failed' })).not.toBeInTheDocument();
+    });
   });
 
   describe('pagination', () => {

--- a/packages/eval-hub/frontend/src/app/types.ts
+++ b/packages/eval-hub/frontend/src/app/types.ts
@@ -84,7 +84,8 @@ export type EvaluationJobState =
   | 'failed'
   | 'cancelled'
   | 'stopping'
-  | 'stopped';
+  | 'stopped'
+  | 'partially_failed';
 
 type JobMessage = {
   message?: string;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-78663
## Description

<img width="941" height="660" alt="partially failed" src="https://github.com/user-attachments/assets/597ed23e-1027-4bce-8d9d-deb8c75d6085" />


Fixes a crash in the eval-hub Evaluations table: `TypeError: Cannot read properties of undefined (reading 'isFilled')`, thrown from `EvaluationStatusLabel` whenever a job's status was `partially_failed`.

Root cause: the upstream [eval-hub](https://github.com/eval-hub/eval-hub) service's `OverallState` enum includes `partially_failed` (a job where some benchmarks completed and others failed), but our BFF OpenAPI spec and the frontend's `EvaluationJobState` type only knew about `pending | running | completed | failed | cancelled | stopping | stopped`. When a job with that state loaded, `statusMap[state]` was `undefined` and the very next line dereferenced `.isFilled` on it, crashing the whole page (verified live on a RHOAI 3.5.0 cluster — job `72f5b522-c365-482d-8d1b-4340d2921c8a`, tenant `zj-test-2`).

Changes:
- `packages/eval-hub/bff/openapi/src/eval-hub.yaml`: added `partially_failed` to the `JobStatus.state` enum, aligning our BFF contract with upstream's `OverallState` schema.
- `packages/eval-hub/frontend/src/app/types.ts`: added `'partially_failed'` to `EvaluationJobState`.
- `packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx`:
  - `partially_failed` now renders as a red/danger "Partially failed" label, and clicking it opens the same error popover `failed` uses (showing which benchmark(s) failed).
  - Added a generic fallback (`unknownStatusConfig`, grey "Unknown" label) for any *other* state the backend might introduce in the future that the frontend doesn't yet recognize, so a similar mismatch can't crash the page again.
- `packages/eval-hub/frontend/src/app/components/EvaluationsTable.tsx`: added "Partially failed" to the status filter dropdown.
- `packages/eval-hub/frontend/src/app/components/__tests__/EvaluationStatusLabel.spec.tsx`: added coverage for the new state.

## How Has This Been Tested?

- Reproduced the root cause against a live RHOAI 3.5.0 cluster: queried the `evalhub` service directly and confirmed a real job had `status.state: "partially_failed"`, matching the crash screenshot's stack trace (`_mf/evalHub` bundle, table row render).
- Cross-checked against the upstream `eval-hub/eval-hub` OpenAPI schemas (`OverallState.yaml`) to confirm `partially_failed` is an intentional, documented state, not a data error.
- Ran `tsc --noEmit`, `eslint --max-warnings 0` + prettier, and the full frontend unit suite for the package — all passing (399/399 tests, 34 suites).
- Did **not** manually verify the rendered fix against a live browser/cluster session (no eval-hub dev server was running against real data during this change) — leaving the manual-testing checklist item unchecked below.

## Test Impact

- Extended `EvaluationStatusLabel.spec.tsx` with a `partially_failed` entry in the existing `it.each` table-driven tests, covering: label text, test id, color/status class, filled/outline variant.
- No new test file was needed since the existing suite is parameterized over `EvaluationJobState`.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partially failed evaluation jobs.
  * Partially failed jobs now display a failed status and failure details.
  * Selecting the Failed filter includes partially failed evaluations.
  * Unknown job states display a clear fallback label and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->