### PR TITLE
refactor(gen-ai): deduplicate BeforeEach setup blocks in BFF test files

### DIFF
--- a/packages/gen-ai/bff/internal/api/aaa_models_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/aaa_models_handler_test.go
@@ -27,19 +27,7 @@ var _ = Describe("ModelsAAHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
-		require.NoError(GinkgoT(), err)
-
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			logger:                  slog.Default(),
-			kubernetesClientFactory: k8sFactory,
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewK8sLSTestApp()
 	})
 
 	It("should return 200 with AA models data when models are found", func() {

--- a/packages/gen-ai/bff/internal/api/app_helpers_test.go
+++ b/packages/gen-ai/bff/internal/api/app_helpers_test.go
@@ -3,16 +3,56 @@ package api
 import (
 	"log/slog"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/opendatahub-io/gen-ai/internal/cache"
 	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient/bffmocks"
 	k8s "github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/k8smocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack/lsmocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/mcp/mcpmocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/mlflow/mlflowmocks"
 	"github.com/opendatahub-io/gen-ai/internal/repositories"
 	"github.com/opendatahub-io/gen-ai/internal/services"
 )
+
+// NewK8sOnlyTestApp creates a minimal App with k8s factory and repositories.
+// Use for tests that only need Kubernetes access (install/delete handlers).
+func NewK8sOnlyTestApp() App {
+	k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
+	Expect(err).NotTo(HaveOccurred())
+	return App{
+		config:                  config.EnvConfig{Port: 4000},
+		logger:                  slog.Default(),
+		kubernetesClientFactory: k8sFactory,
+		repositories:            repositories.NewRepositories(),
+	}
+}
+
+// NewLSOnlyTestApp creates a minimal App with LlamaStack mock factory and repositories.
+// Use for tests that only need LlamaStack access (vectorstore/file CRUD handlers).
+func NewLSOnlyTestApp() App {
+	return App{
+		config:                  config.EnvConfig{Port: 4000},
+		llamaStackClientFactory: lsmocks.NewMockClientFactory(),
+		repositories:            repositories.NewRepositories(),
+	}
+}
+
+// NewK8sLSTestApp creates an App with both k8s factory and LlamaStack mock.
+// Use for tests that need both Kubernetes and LlamaStack access (e.g., status handler).
+func NewK8sLSTestApp() App {
+	k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
+	Expect(err).NotTo(HaveOccurred())
+	return App{
+		config:                  config.EnvConfig{Port: 4000},
+		logger:                  slog.Default(),
+		kubernetesClientFactory: k8sFactory,
+		llamaStackClientFactory: lsmocks.NewMockClientFactory(),
+		repositories:            repositories.NewRepositories(),
+	}
+}
 
 // TestAppOption configures a test App created by NewTestApp.
 type TestAppOption func(*App)

--- a/packages/gen-ai/bff/internal/api/app_helpers_test.go
+++ b/packages/gen-ai/bff/internal/api/app_helpers_test.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"log/slog"
+	"os"
+	"path/filepath"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/opendatahub-io/gen-ai/internal/cache"
@@ -15,6 +18,7 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/integrations/mlflow/mlflowmocks"
 	"github.com/opendatahub-io/gen-ai/internal/repositories"
 	"github.com/opendatahub-io/gen-ai/internal/services"
+	"github.com/opendatahub-io/gen-ai/internal/testutil"
 )
 
 // NewK8sOnlyTestApp creates a minimal App with k8s factory and repositories.
@@ -52,6 +56,44 @@ func NewK8sLSTestApp() App {
 		llamaStackClientFactory: lsmocks.NewMockClientFactory(),
 		repositories:            repositories.NewRepositories(),
 	}
+}
+
+// NewRoutesTestApp creates a full App suitable for tests that exercise HTTP routes
+// (file upload, status checks). It changes the working directory to the project root
+// (needed for OpenAPI YAML discovery), registers a DeferCleanup to restore it, and
+// returns a fully wired *App with OpenAPI handler.
+func NewRoutesTestApp() *App {
+	originalWd, err := os.Getwd()
+	Expect(err).NotTo(HaveOccurred())
+
+	projectRoot := filepath.Join(originalWd, "..", "..")
+	Expect(os.Chdir(projectRoot)).To(Succeed())
+
+	DeferCleanup(func() {
+		Expect(os.Chdir(originalWd)).To(Succeed())
+	})
+
+	cfg := config.EnvConfig{
+		Port:            4000,
+		APIPathPrefix:   "/api/v1",
+		StaticAssetsDir: "static",
+		AuthMethod:      config.AuthMethodUser,
+		AuthTokenHeader: config.DefaultAuthTokenHeader,
+		AuthTokenPrefix: config.DefaultAuthTokenPrefix,
+		MockLSClient:    true,
+		LlamaStackURL:   testutil.GetTestLlamaStackURL(),
+		MockK8sClient:   false,
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, logger)
+	Expect(err).NotTo(HaveOccurred())
+
+	openAPIHandler, err := NewOpenAPIHandler(logger)
+	Expect(err).NotTo(HaveOccurred())
+
+	return NewTestApp(cfg, logger, k8sFactory, WithOpenAPIHandler(openAPIHandler))
 }
 
 // TestAppOption configures a test App created by NewTestApp.

--- a/packages/gen-ai/bff/internal/api/app_helpers_test.go
+++ b/packages/gen-ai/bff/internal/api/app_helpers_test.go
@@ -39,6 +39,7 @@ func NewK8sOnlyTestApp() App {
 func NewLSOnlyTestApp() App {
 	return App{
 		config:                  config.EnvConfig{Port: 4000},
+		logger:                  slog.Default(),
 		llamaStackClientFactory: lsmocks.NewMockClientFactory(),
 		repositories:            repositories.NewRepositories(),
 	}

--- a/packages/gen-ai/bff/internal/api/external_models_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/external_models_handler_test.go
@@ -8,16 +8,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"log/slog"
-
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
-	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/k8smocks"
-	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack/lsmocks"
 	"github.com/opendatahub-io/gen-ai/internal/models"
-	"github.com/opendatahub-io/gen-ai/internal/repositories"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,19 +20,7 @@ var _ = Describe("CreateExternalModelHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
-		require.NoError(GinkgoT(), err)
-
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			logger:                  slog.Default(),
-			kubernetesClientFactory: k8sFactory,
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewK8sLSTestApp()
 	})
 
 	It("should successfully create an external model with all required fields", func() {
@@ -501,19 +483,7 @@ var _ = Describe("DeleteExternalModelHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
-		require.NoError(GinkgoT(), err)
-
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			logger:                  slog.Default(),
-			kubernetesClientFactory: k8sFactory,
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewK8sLSTestApp()
 	})
 
 	It("should successfully delete an existing external model", func() {
@@ -720,19 +690,7 @@ var _ = Describe("VerifyExternalModelHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
-		require.NoError(GinkgoT(), err)
-
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			logger:                  slog.Default(),
-			kubernetesClientFactory: k8sFactory,
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewK8sLSTestApp()
 	})
 
 	It("should return 400 when namespace query parameter is missing", func() {

--- a/packages/gen-ai/bff/internal/api/lsd_files_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_files_handler_test.go
@@ -12,15 +12,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/textproto"
-	"os"
-	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/openai/openai-go/v2"
 	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
-	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/k8smocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack/lsmocks"
 	"github.com/opendatahub-io/gen-ai/internal/testutil"
@@ -33,40 +30,7 @@ var _ = Describe("LlamaStackUploadFileHandler", func() {
 	var createMultipartFormData func(filename, content, vectorStoreID, purpose, chunkingType string) ([]byte, string, error)
 
 	BeforeEach(func() {
-		originalWd, err := os.Getwd()
-		require.NoError(GinkgoT(), err)
-
-		// Change to project root so OpenAPI handler can find the YAML file
-		projectRoot := filepath.Join(originalWd, "..", "..")
-		err = os.Chdir(projectRoot)
-		require.NoError(GinkgoT(), err)
-
-		DeferCleanup(func() {
-			err := os.Chdir(originalWd)
-			require.NoError(GinkgoT(), err)
-		})
-
-		cfg := config.EnvConfig{
-			Port:            4000,
-			APIPathPrefix:   "/api/v1",
-			StaticAssetsDir: "static",
-			AuthMethod:      config.AuthMethodUser,
-			AuthTokenHeader: config.DefaultAuthTokenHeader,
-			AuthTokenPrefix: config.DefaultAuthTokenPrefix,
-			MockLSClient:    true,
-			LlamaStackURL:   testutil.GetTestLlamaStackURL(),
-			MockK8sClient:   false, // Use shared envtest from BeforeSuite
-		}
-
-		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, logger)
-		require.NoError(GinkgoT(), err)
-
-		openAPIHandler, err := NewOpenAPIHandler(logger)
-		require.NoError(GinkgoT(), err)
-
-		app = NewTestApp(cfg, logger, k8sFactory, WithOpenAPIHandler(openAPIHandler))
+		app = NewRoutesTestApp()
 
 		createMultipartFormData = func(filename, content, vectorStoreID, purpose, chunkingType string) ([]byte, string, error) {
 			var err error
@@ -443,40 +407,7 @@ var _ = Describe("LlamaStackFileUploadStatusHandler", func() {
 	var app *App
 
 	BeforeEach(func() {
-		originalWd, err := os.Getwd()
-		require.NoError(GinkgoT(), err)
-
-		// Change to project root so OpenAPI handler can find the YAML file
-		projectRoot := filepath.Join(originalWd, "..", "..")
-		err = os.Chdir(projectRoot)
-		require.NoError(GinkgoT(), err)
-
-		DeferCleanup(func() {
-			err := os.Chdir(originalWd)
-			require.NoError(GinkgoT(), err)
-		})
-
-		cfg := config.EnvConfig{
-			Port:            4000,
-			APIPathPrefix:   "/api/v1",
-			StaticAssetsDir: "static",
-			AuthMethod:      config.AuthMethodUser,
-			AuthTokenHeader: config.DefaultAuthTokenHeader,
-			AuthTokenPrefix: config.DefaultAuthTokenPrefix,
-			MockLSClient:    true,
-			LlamaStackURL:   testutil.GetTestLlamaStackURL(),
-			MockK8sClient:   false, // Use shared envtest from BeforeSuite
-		}
-
-		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, logger)
-		require.NoError(GinkgoT(), err)
-
-		openAPIHandler, err := NewOpenAPIHandler(logger)
-		require.NoError(GinkgoT(), err)
-
-		app = NewTestApp(cfg, logger, k8sFactory, WithOpenAPIHandler(openAPIHandler))
+		app = NewRoutesTestApp()
 	})
 
 	It("should return pending status for newly created job", func() {
@@ -767,39 +698,7 @@ var _ = Describe("LlamaStackMediaFileUploadHandler", func() {
 	var createMediaMultipart func(filename string, content []byte, contentType, mediaType string) ([]byte, string, error)
 
 	BeforeEach(func() {
-		originalWd, err := os.Getwd()
-		require.NoError(GinkgoT(), err)
-
-		projectRoot := filepath.Join(originalWd, "..", "..")
-		err = os.Chdir(projectRoot)
-		require.NoError(GinkgoT(), err)
-
-		DeferCleanup(func() {
-			err := os.Chdir(originalWd)
-			require.NoError(GinkgoT(), err)
-		})
-
-		cfg := config.EnvConfig{
-			Port:            4000,
-			APIPathPrefix:   "/api/v1",
-			StaticAssetsDir: "static",
-			AuthMethod:      config.AuthMethodUser,
-			AuthTokenHeader: config.DefaultAuthTokenHeader,
-			AuthTokenPrefix: config.DefaultAuthTokenPrefix,
-			MockLSClient:    true,
-			LlamaStackURL:   testutil.GetTestLlamaStackURL(),
-			MockK8sClient:   false,
-		}
-
-		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, logger)
-		require.NoError(GinkgoT(), err)
-
-		openAPIHandler, err := NewOpenAPIHandler(logger)
-		require.NoError(GinkgoT(), err)
-
-		app = NewTestApp(cfg, logger, k8sFactory, WithOpenAPIHandler(openAPIHandler))
+		app = NewRoutesTestApp()
 
 		createMediaMultipart = func(filename string, content []byte, contentType, mediaType string) ([]byte, string, error) {
 			var body bytes.Buffer

--- a/packages/gen-ai/bff/internal/api/lsd_files_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_files_handler_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/k8smocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack/lsmocks"
-	"github.com/opendatahub-io/gen-ai/internal/repositories"
 	"github.com/opendatahub-io/gen-ai/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -362,14 +361,7 @@ var _ = Describe("LlamaStackListFilesHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewLSOnlyTestApp()
 	})
 
 	It("successful list files", func() {
@@ -705,14 +697,7 @@ var _ = Describe("LlamaStackDeleteFileHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewLSOnlyTestApp()
 	})
 
 	It("successful delete file", func() {

--- a/packages/gen-ai/bff/internal/api/lsd_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_handler_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -17,14 +16,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient/bffmocks"
-	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/k8smocks"
-	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack/lsmocks"
-	"github.com/opendatahub-io/gen-ai/internal/repositories"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,19 +46,7 @@ var _ = Describe("LlamaStackDistributionStatusHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
-		require.NoError(GinkgoT(), err)
-
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			logger:                  slog.Default(),
-			kubernetesClientFactory: k8sFactory,
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewK8sLSTestApp()
 	})
 
 	It("should return 200 with data when LSD is found", func() {
@@ -163,17 +146,7 @@ var _ = Describe("LlamaStackDistributionInstallHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
-		require.NoError(GinkgoT(), err)
-
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			logger:                  slog.Default(),
-			kubernetesClientFactory: k8sFactory,
-			repositories:            repositories.NewRepositories(), // No LlamaStack client needed for this test
-		}
+		app = NewK8sOnlyTestApp()
 	})
 
 	It("should install LSD successfully with models", func() {
@@ -349,17 +322,7 @@ var _ = Describe("LlamaStackDistributionInstallHandlerWithMaaSModels", func() {
 	var app App
 
 	BeforeEach(func() {
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
-		require.NoError(GinkgoT(), err)
-
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			logger:                  slog.Default(),
-			kubernetesClientFactory: k8sFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewK8sOnlyTestApp()
 	})
 
 	It("should handle MaaS models correctly", func() {
@@ -676,17 +639,7 @@ var _ = Describe("LlamaStackDistributionInstallHandlerWithVectorStores", func() 
 	var app App
 
 	BeforeEach(func() {
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
-		require.NoError(GinkgoT(), err)
-
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			logger:                  slog.Default(),
-			kubernetesClientFactory: k8sFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewK8sOnlyTestApp()
 	})
 
 	It("should install LSD successfully with empty vector_stores", func() {
@@ -837,17 +790,7 @@ var _ = Describe("LlamaStackDistributionDeleteHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
-		require.NoError(GinkgoT(), err)
-
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			logger:                  slog.Default(),
-			kubernetesClientFactory: k8sFactory,
-			repositories:            repositories.NewRepositories(), // No LlamaStack client needed for this test
-		}
+		app = NewK8sOnlyTestApp()
 	})
 
 	It("should delete LSD successfully with valid k8s name", func() {

--- a/packages/gen-ai/bff/internal/api/lsd_models_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_models_handler_test.go
@@ -25,14 +25,7 @@ var _ = Describe("LlamaStackModelsHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewLSOnlyTestApp()
 	})
 
 	It("should return all models successfully", func() {

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -14,13 +13,10 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
-	"github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/k8smocks"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack/lsmocks"
-	"github.com/opendatahub-io/gen-ai/internal/repositories"
 	"github.com/opendatahub-io/gen-ai/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,19 +120,7 @@ var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
-		require.NoError(GinkgoT(), err)
-
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			llamaStackClientFactory: llamaStackClientFactory,
-			kubernetesClientFactory: k8sFactory,
-			repositories:            repositories.NewRepositories(),
-			logger:                  slog.Default(),
-		}
+		app = NewK8sLSTestApp()
 
 		if realClient := lsmocks.TryCreateTestClient(); realClient != nil {
 			ctx := context.Background()
@@ -355,14 +339,7 @@ var _ = Describe("LlamaStackCreateVectorStoreHandler", func() {
 	var createJSONRequest func(payload interface{}) (*http.Request, error)
 
 	BeforeEach(func() {
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewLSOnlyTestApp()
 
 		createJSONRequest = func(payload interface{}) (*http.Request, error) {
 			jsonData, err := json.Marshal(payload)
@@ -653,14 +630,7 @@ var _ = Describe("LlamaStackDeleteVectorStoreHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewLSOnlyTestApp()
 	})
 
 	It("successful delete vector store", func() {
@@ -733,14 +703,7 @@ var _ = Describe("LlamaStackListVectorStoreFilesHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewLSOnlyTestApp()
 	})
 
 	It("successful list vector store files", func() {
@@ -844,14 +807,7 @@ var _ = Describe("LlamaStackDeleteVectorStoreFileHandler", func() {
 	var app App
 
 	BeforeEach(func() {
-		llamaStackClientFactory := lsmocks.NewMockClientFactory()
-		app = App{
-			config: config.EnvConfig{
-				Port: 4000,
-			},
-			llamaStackClientFactory: llamaStackClientFactory,
-			repositories:            repositories.NewRepositories(),
-		}
+		app = NewLSOnlyTestApp()
 	})
 
 	It("delete vector store file for non-member file", func() {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-50699

## Description

Extracts shared test helpers to eliminate duplicated `BeforeEach` setup blocks across BFF test files. The same 5-10 line App initialization pattern was copy-pasted 19 times across 5 test files, making any setup change require editing all of them and risking drift.

### Key changes

- **New helpers in `app_helpers_test.go`**:
  - `NewK8sOnlyTestApp()` — minimal App with K8s factory + repositories (used by install/delete handlers)
  - `NewLSOnlyTestApp()` — minimal App with LlamaStack mock + repositories (used by vectorstore/file CRUD)
  - `NewK8sLSTestApp()` — App with both K8s and LlamaStack (used by status/models handlers)
  - `NewRoutesTestApp()` — full-stack App with OpenAPI handler, working directory setup, and DeferCleanup (used by file upload/status tests that exercise HTTP routes)

- **Migrated files**:
  - `lsd_handler_test.go` — 5 blocks deduplicated
  - `lsd_vectorstores_handler_test.go` — 5 blocks deduplicated
  - `lsd_files_handler_test.go` — 5 blocks deduplicated
  - `external_models_handler_test.go` — 3 blocks deduplicated
  - `aaa_models_handler_test.go` — 1 block deduplicated

Net reduction: **-290 lines / +98 lines** across 6 files.

### Notes

- The helpers use `Expect(err).NotTo(HaveOccurred())` (Gomega) instead of the original `require.NoError(GinkgoT(), err)` (testify). Both are functionally equivalent in Ginkgo context — they fail the test immediately — but the helpers align with Gomega idiom since the file already imports Gomega for the existing `NewTestApp()` assertions.

- `NewLSOnlyTestApp()` now includes `logger: slog.Default()` which the original inline code omitted. This is a defensive improvement to prevent nil panics if future handlers log during tests.

- Remaining files (`mcp_helpers_test.go`, `guardrails_handler_test.go`, etc.) either use custom loggers or already delegate to `NewTestApp()` — they are intentionally left as-is.

## How Has This Been Tested?

- `go vet ./internal/api/...` clean after each commit
- `make test` full suite passes locally (all packages OK, exit code 0)
- Mechanical extraction only — no logic changes, test behavior preserved