### PR TITLE
fix(dashboard-operator): disable webhook in Helm chart defaults

### DIFF
--- a/dashboard-operator/charts/dashboard/values.yaml
+++ b/dashboard-operator/charts/dashboard/values.yaml
@@ -56,13 +56,10 @@ rbac:
   create: true
 
 webhook:
-  enabled: true
+  enabled: false
   port: 9443
   caBundle: ""
   certManager:
-    # Disabled by default for standalone Helm installs without cert-manager.
-    # The ODH operator module handler sets this to true when cert-manager CRDs
-    # are present on the cluster.
     enabled: false
     issuerRef: {}
 


### PR DESCRIPTION
Companion change: https://github.com/opendatahub-io/opendatahub-operator/pull/3733
Part of https://redhat.atlassian.net/browse/RHOAIENG-59936 / https://issues.redhat.com/browse/RHOAIENG-61029

## Description

Disables the webhook (`webhook.enabled: false`) in the dashboard-operator Helm chart defaults. The webhook provides singleton validation for the `Dashboard` CR, but this is already enforced at the API-server level via a CEL validation rule (`self.metadata.name == 'default-dashboard'`) on the CRD itself — making the webhook pure defense-in-depth.

The operator-side PR (#3733) removes the platform handler's `GetOperatorManifests` override that toggled `webhook.certManager.enabled` based on cert-manager CRD availability. With that override gone, the chart default must be `false` so the webhook resources are not rendered without a TLS provider.

The Go webhook code in `internal/webhook/` is preserved and will be re-enabled post-3.5 when the platform framework adds module-level webhook lifecycle support with cert-manager integration.

Also removes stale comments about the ODH operator module handler setting `certManager.enabled`, since that code path is being removed in the companion PR.

## How Has This Been Tested?

- Verified chart rendering with `helm template` — webhook resources (Service, ValidatingWebhookConfiguration, cert-manager Certificate/Issuer) are correctly omitted when `webhook.enabled=false`
- Existing chart sync tests pass — they explicitly set `--set webhook.enabled=true` / `--set webhook.certManager.enabled=true` to test the enabled path, so they are independent of the default value

## Test Impact

No new tests needed. Existing `TestDashboardChartWebhookCertManagerTemplatesOffline` covers both the enabled and disabled paths via explicit `--set` overrides. The default change does not affect test coverage.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Webhooks are now disabled by default for the dashboard operator.
  * Automatic webhook certificate management is no longer enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->