### PR TITLE
fix(gen-ai): update agent content copy

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
@@ -200,7 +200,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
                   key="save-as-agent-configuration"
                   data-testid="save-as-agent-profile-button"
                 >
-                  Save as agent
+                  Save as new agent
                 </DropdownItem>
               )}
               {agentConfigManagementEnabled && profileApplied && (

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -560,7 +560,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
               }}
               data-testid="reset-agent-confirm-button"
             >
-              Reset
+              Revert
             </Button>
             <Button variant="link" onClick={() => setShowResetModal(false)}>
               Cancel

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -521,7 +521,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
             }}
             data-testid="settings-panel-save-as-button"
           >
-            Save as agent
+            Save as new agent
           </Button>
           {profileApplied && onResetToLastSaved && (
             <Button
@@ -531,7 +531,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
               onClick={() => setShowResetModal(true)}
               data-testid="settings-panel-reset-button"
             >
-              Reset to last saved
+              Revert
             </Button>
           )}
         </div>
@@ -546,7 +546,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
           data-testid="reset-agent-modal"
         >
           <ModalHeader
-            title="Reset to last saved agent?"
+            title="Revert to last saved agent?"
             labelId="reset-agent-modal-title"
             titleIconVariant="warning"
           />

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SaveAgentProfileModal.tsx
@@ -199,7 +199,7 @@ const SaveAgentProfileModal: React.FC<SaveAgentProfileModalProps> = ({
     }
   };
 
-  const title = mode === 'save' ? 'Save agent' : 'Save as agent';
+  const title = mode === 'save' ? 'Save agent' : 'Save as new agent';
   const nameError = nameTouched && !name.trim();
   const isSaveDisabled = isSaving || !name.trim();
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SaveAgentProfileModal.spec.tsx
@@ -114,7 +114,7 @@ describe('SaveAgentProfileModal', () => {
   describe('Save As mode', () => {
     it('should render with empty name field', () => {
       renderModal('save-as');
-      expect(screen.getByText('Save as agent')).toBeInTheDocument();
+      expect(screen.getByText('Save as new agent')).toBeInTheDocument();
       expect(screen.getByTestId('save-agent-profile-name-input')).toHaveValue('');
     });
 


### PR DESCRIPTION
## Description

Small copy/label fixes in the gen-ai chatbot UI:

- **"Save as agent" → "Save as new agent"** — updated in the chatbot header dropdown, settings panel button, and the save modal title for `save-as` mode. This better distinguishes the action from "Save agent" (update existing).
- **"Reset to last saved" → "Revert"** — shortened the settings panel button label for clarity.
- **"Reset to last saved agent?" → "Revert to last saved agent?"** — modal title updated to match the button rename.

Unit test updated to match the new modal title.

<img width="513" height="663" alt="image" src="https://github.com/user-attachments/assets/665bf8f7-b7d5-4a19-9bef-19827d479289" />


## How Has This Been Tested?

- Existing unit test (`SaveAgentProfileModal.spec.tsx`) updated and passes.
- Changes are string literals only — no logic affected.

## Test Impact

Updated one test assertion to match the renamed modal title. No new tests needed for pure copy changes.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`