### PR TITLE
feat(RHOAIENG-78547): Add llmdTemplates Tech Preview feature flag for topology/routing fields and admin pages

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -57,6 +57,7 @@ export type MockDashboardConfigType = {
   toolCalling?: boolean;
   projectRBAC?: boolean;
   disableLLMd?: boolean;
+  llmdTemplates?: boolean;
   deploymentWizardYAMLViewer?: boolean;
   vLLMDeploymentOnMaaS?: boolean;
   llmGatewayField?: boolean;
@@ -125,6 +126,7 @@ export const mockDashboardConfig = ({
   trainingJobs = true,
   observabilityDashboard = true,
   disableLLMd = false,
+  llmdTemplates = false,
   deploymentWizardYAMLViewer = false,
   externalVectorStores = false,
   agentConfigManagement = false,
@@ -318,6 +320,7 @@ export const mockDashboardConfig = ({
       trainingJobs,
       observabilityDashboard,
       disableLLMd,
+      llmdTemplates,
       deploymentWizardYAMLViewer,
       externalVectorStores,
       agentConfigManagement,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -21,6 +21,7 @@ export const techPreviewFlags = {
   externalVectorStores: false,
   agentConfigManagement: false,
   vLLMDeploymentOnMaaS: false,
+  llmdTemplates: false,
   llmGatewayField: false,
   promptManagement: false,
   globalProjectPrompts: false,
@@ -270,6 +271,7 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     reliantAreas: [SupportedArea.LLMD_SERVING],
   },
   [SupportedArea.LLMD_TOPOLOGY_CONFIGS]: {
+    featureFlags: ['llmdTemplates'],
     reliantAreas: [SupportedArea.LLMD_SERVING],
   },
   [SupportedArea.LLMD_GATEWAY_FIELD]: {

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployLLMDServing.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployLLMDServing.cy.ts
@@ -114,7 +114,7 @@ describe('A user can deploy an LLMD model', () => {
     () => {
       cy.step('Log into the application as admin');
       cy.visitWithLogin(
-        '/?devFeatureFlags=deploymentWizardYAMLViewer=true',
+        '/?devFeatureFlags=deploymentWizardYAMLViewer=true,llmdTemplates=true',
         HTPASSWD_CLUSTER_ADMIN_USER,
       );
 

--- a/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/llmdTopologyConfigurations/testLlmdTopologyConfigurations.cy.ts
@@ -48,7 +48,7 @@ describe('LLMD Topology Configurations - Admin Settings', () => {
     { tags: ['@Smoke', '@Dashboard', '@NonConcurrent', '@LLMDServingCI'] },
     () => {
       cy.step('Log in with topology configs feature flag');
-      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+      cy.visitWithLogin('/?devFeatureFlags=llmdTemplates=true', HTPASSWD_CLUSTER_ADMIN_USER);
 
       cy.step('Navigate to topology configurations settings');
       llmdTopologySettingsPage.navigate();

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -300,6 +300,7 @@ export type DashboardCommonConfig = {
   projectRBAC?: boolean;
   observabilityDashboard?: boolean;
   disableLLMd?: boolean;
+  llmdTemplates?: boolean;
   deploymentWizardYAMLViewer?: boolean;
   externalVectorStores?: boolean;
   agentConfigManagement?: boolean;

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -43,7 +43,8 @@ import type {
 export const LLMD_SERVING_ID = 'llmd-serving';
 const ADMIN_USER = 'ADMIN_USER';
 
-const llmConfigOptionsFieldExtension: WizardFieldExtension<
+// When vLLMOnMaaS enabled + llmdTemplates disabled: show accelerator config for all llm-d (single-node fallback)
+const llmConfigOptionsFieldExtensionNoTemplates: WizardFieldExtension<
   LLMConfigOptionsFieldType,
   LLMdDeployment
 > = {
@@ -52,11 +53,30 @@ const llmConfigOptionsFieldExtension: WizardFieldExtension<
     platform: LLMD_SERVING_ID,
     field: () =>
       import('../src/wizardFields/LlmConfigOptionsField').then(
-        (m) => m.LLMConfigOptionsFieldWizardField,
+        (m) => m.LLMConfigOptionsFieldNoTemplates,
       ),
   },
   flags: {
     required: [LLMD_SERVING_ID, SupportedArea.VLLM_ON_MAAS],
+    disallowed: [SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+  },
+};
+
+// When vLLMOnMaaS enabled + llmdTemplates enabled: show accelerator config only for simple vLLM (non-llm-d)
+const llmConfigOptionsFieldExtensionWithTemplates: WizardFieldExtension<
+  LLMConfigOptionsFieldType,
+  LLMdDeployment
+> = {
+  type: 'model-serving.deployment/wizard-field',
+  properties: {
+    platform: LLMD_SERVING_ID,
+    field: () =>
+      import('../src/wizardFields/LlmConfigOptionsField').then(
+        (m) => m.LLMConfigOptionsFieldWithTemplates,
+      ),
+  },
+  flags: {
+    required: [LLMD_SERVING_ID, SupportedArea.VLLM_ON_MAAS, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
   },
 };
 
@@ -68,7 +88,7 @@ const topologyTypeFieldExtension: WizardFieldExtension<TopologyTypeFieldType, LL
       import('../src/wizardFields/TopologyTypeField').then((m) => m.TopologyTypeFieldWizardField),
   },
   flags: {
-    required: [LLMD_SERVING_ID],
+    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
   },
 };
 
@@ -85,7 +105,7 @@ const customTopologyConfigFieldExtension: WizardFieldExtension<
       ),
   },
   flags: {
-    required: [LLMD_SERVING_ID],
+    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
   },
 };
 
@@ -102,7 +122,7 @@ const advancedRoutingFieldExtension: WizardFieldExtension<
       ),
   },
   flags: {
-    required: [LLMD_SERVING_ID],
+    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
   },
 };
 
@@ -165,7 +185,7 @@ const topologyTypeApplyExtension: WizardFieldApplyExtension<TopologyTypeFieldDat
       apply: () => import('../src/deployments/topology').then((m) => m.applyTopologyType),
     },
     flags: {
-      required: [LLMD_SERVING_ID],
+      required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
     },
   };
 
@@ -180,7 +200,7 @@ const topologyTypeExtractorExtension: WizardFieldExtractorExtension<
     extract: () => import('../src/deployments/topology').then((m) => m.extractTopologyType),
   },
   flags: {
-    required: [LLMD_SERVING_ID],
+    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
   },
 };
 
@@ -195,7 +215,7 @@ const topologyConfigApplyExtension: WizardFieldApplyExtension<
     apply: () => import('../src/deployments/topology').then((m) => m.applyTopologyConfig),
   },
   flags: {
-    required: [LLMD_SERVING_ID],
+    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
   },
 };
 
@@ -210,7 +230,7 @@ const topologyConfigExtractorExtension: WizardFieldExtractorExtension<
     extract: () => import('../src/deployments/topology').then((m) => m.extractTopologyConfig),
   },
   flags: {
-    required: [LLMD_SERVING_ID],
+    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
   },
 };
 
@@ -225,7 +245,7 @@ const routingConfigApplyExtension: WizardFieldApplyExtension<
     apply: () => import('../src/deployments/topology').then((m) => m.applyRoutingConfig),
   },
   flags: {
-    required: [LLMD_SERVING_ID],
+    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
   },
 };
 
@@ -240,7 +260,7 @@ const routingConfigExtractorExtension: WizardFieldExtractorExtension<
     extract: () => import('../src/deployments/topology').then((m) => m.extractRoutingConfig),
   },
   flags: {
-    required: [LLMD_SERVING_ID],
+    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
   },
 };
 
@@ -487,7 +507,8 @@ const extensions: (
       required: [LLMD_SERVING_ID],
     },
   },
-  llmConfigOptionsFieldExtension,
+  llmConfigOptionsFieldExtensionNoTemplates,
+  llmConfigOptionsFieldExtensionWithTemplates,
   topologyTypeFieldExtension,
   customTopologyConfigFieldExtension,
   advancedRoutingFieldExtension,
@@ -537,7 +558,7 @@ const extensions: (
   {
     type: 'app.navigation/href',
     flags: {
-      required: [LLMD_SERVING_ID, ADMIN_USER],
+      required: [SupportedArea.LLMD_TOPOLOGY_CONFIGS, ADMIN_USER],
     },
     properties: {
       id: 'settings-llmd-topology-configurations',
@@ -551,7 +572,7 @@ const extensions: (
   {
     type: 'app.route',
     flags: {
-      required: [LLMD_SERVING_ID, ADMIN_USER],
+      required: [SupportedArea.LLMD_TOPOLOGY_CONFIGS, ADMIN_USER],
     },
     properties: {
       path: '/settings/model-resources-operations/llmd-topology-configurations/*',
@@ -561,7 +582,7 @@ const extensions: (
   {
     type: 'app.navigation/href',
     flags: {
-      required: [LLMD_SERVING_ID, ADMIN_USER],
+      required: [SupportedArea.LLMD_TOPOLOGY_CONFIGS, ADMIN_USER],
     },
     properties: {
       id: 'settings-llmd-routing-configurations',
@@ -575,7 +596,7 @@ const extensions: (
   {
     type: 'app.route',
     flags: {
-      required: [LLMD_SERVING_ID, ADMIN_USER],
+      required: [SupportedArea.LLMD_TOPOLOGY_CONFIGS, ADMIN_USER],
     },
     properties: {
       path: '/settings/model-resources-operations/llmd-routing-configurations/*',

--- a/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
+++ b/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
@@ -16,7 +16,7 @@ import {
 } from '@odh-dashboard/model-serving/concepts/versions';
 import { useFetchLLMInferenceServiceConfigs } from '../api/LLMInferenceServiceConfigs';
 import { LLMInferenceServiceConfigKind } from '../types';
-import { isSimpleLLMInferenceService } from '../formUtils';
+import { isLLMInferenceServiceActive, isSimpleLLMInferenceService } from '../formUtils';
 
 // External data hook
 
@@ -138,12 +138,13 @@ const LLMConfigOptionsField: LLMConfigOptionsFieldType['component'] = ({
   );
 };
 
-export const LLMConfigOptionsFieldWizardField: LLMConfigOptionsFieldType = {
+// When llmdTemplates disabled: show for ALL llm-d methods (single-node fallback)
+export const LLMConfigOptionsFieldNoTemplates: LLMConfigOptionsFieldType = {
   id: 'llmd-serving/modelServer',
   step: 'modelDeployment',
   type: 'replacement',
   stateKey: 'modelServer',
-  isActive: isSimpleLLMInferenceService,
+  isActive: isLLMInferenceServiceActive,
   reducerFunctions: {
     resolveDependencies: (formData) => ({
       hardwareProfile: formData.hardwareProfileConfig.formData.selectedProfile,
@@ -179,4 +180,10 @@ export const LLMConfigOptionsFieldWizardField: LLMConfigOptionsFieldType = {
   },
   component: LLMConfigOptionsField,
   externalDataHook: useLLMConfigOptions,
+};
+
+// When llmdTemplates enabled: show only for simple vLLM (non-llm-d), topology fields handle the rest
+export const LLMConfigOptionsFieldWithTemplates: LLMConfigOptionsFieldType = {
+  ...LLMConfigOptionsFieldNoTemplates,
+  isActive: isSimpleLLMInferenceService,
 };

--- a/packages/llmd-serving/src/wizardFields/__tests__/LlmConfigOptionsField.spec.ts
+++ b/packages/llmd-serving/src/wizardFields/__tests__/LlmConfigOptionsField.spec.ts
@@ -4,7 +4,7 @@ import { mockHardwareProfile } from '@odh-dashboard/internal/__mocks__/mockHardw
 import { IdentifierResourceType } from '@odh-dashboard/k8s-core';
 import * as projectSelectors from '@odh-dashboard/internal/redux/selectors/project';
 import * as llmConfigsApi from '../../api/LLMInferenceServiceConfigs';
-import { useLLMConfigOptions, LLMConfigOptionsFieldWizardField } from '../LlmConfigOptionsField';
+import { useLLMConfigOptions, LLMConfigOptionsFieldNoTemplates } from '../LlmConfigOptionsField';
 
 jest.mock('@odh-dashboard/internal/redux/selectors/project');
 jest.mock('../../api/LLMInferenceServiceConfigs');
@@ -145,7 +145,7 @@ describe('useLLMConfigOptions', () => {
 });
 
 describe('getInitialFieldData', () => {
-  const { getInitialFieldData } = LLMConfigOptionsFieldWizardField.reducerFunctions;
+  const { getInitialFieldData } = LLMConfigOptionsFieldNoTemplates.reducerFunctions;
 
   it('should return existing field data when provided', () => {
     const existingData = {

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdRoutingAdmin.cy.ts
@@ -70,6 +70,7 @@ const initIntercepts = ({
   const config = mockDashboardConfig({
     disableKServe: false,
     disableLLMd: false,
+    llmdTemplates: true,
   });
   cy.interceptOdh('GET /api/config', config);
   cy.interceptOdh('GET /api/components', null, []);

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -84,6 +84,7 @@ const initIntercepts = ({
     genAiStudio: true,
     modelAsService: true,
     disableLLMd: false,
+    llmdTemplates: true,
     vLLMDeploymentOnMaaS: true,
   });
   cy.interceptOdh('GET /api/config', config);

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopologyAdmin.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopologyAdmin.cy.ts
@@ -50,6 +50,7 @@ const initIntercepts = ({
   const config = mockDashboardConfig({
     disableKServe: false,
     disableLLMd: false,
+    llmdTemplates: true,
   });
   cy.interceptOdh('GET /api/config', config);
   cy.interceptOdh('GET /api/components', null, []);


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
https://issues.redhat.com/browse/RHOAIENG-78547

## Description

Adds a new Tech Preview feature flag `llmdTemplates` (default: `false`) that gates the llm-d topology and routing wizard fields and admin configuration pages. This allows customers to opt-in to the composable topology/routing experience while keeping the simpler accelerator-config-only flow as the default.

### Behavior matrix

| Feature | `llmdTemplates=false` (default) | `llmdTemplates=true` |
|---------|-------------------------------|---------------------|
| Wizard: Topology type field | Hidden | Shown |
| Wizard: Topology configuration field | Hidden | Shown |
| Wizard: Routing field | Hidden | Shown |
| Wizard: Accelerator config (llm-d) | Shown (all llm-d = single-node) | Hidden (topology fields replace it) |
| Wizard: Accelerator config (simple vLLM) | Shown | Shown |
| Admin: Topology configurations page | Hidden | Shown |
| Admin: Routing configurations page | Hidden | Shown |
| Admin: LLM accelerator configurations page | Shown (gated by `vLLMOnMaaS`) | Shown (gated by `vLLMOnMaaS`) |

### Test updates

| File | Change |
|------|--------|
| `LlmConfigOptionsField.spec.ts` | Updated import for renamed export |
| `modelServingLlmdTopology.cy.ts` | Added `llmdTemplates: true` to mock config |
| `modelServingLlmdTopologyAdmin.cy.ts` | Added `llmdTemplates: true` to mock config |
| `modelServingLlmdRoutingAdmin.cy.ts` | Added `llmdTemplates: true` to mock config |
| `testDeployLLMDServing.cy.ts` | Added `llmdTemplates=true` to devFeatureFlags URL |
| `testLlmdTopologyConfigurations.cy.ts` | Added `llmdTemplates=true` to devFeatureFlags URL |

## How Has This Been Tested?

- **Unit tests**: 17 suites, 206 tests pass (including updated `LlmConfigOptionsField.spec.ts`)
- **Lint**: All 10 changed files pass ESLint (0 errors)
- **Manual verification**: Verified on local dev server:
  - `llmdTemplates=false`: topology/routing fields hidden, accelerator config shows for llm-d, admin pages hidden
  - `llmdTemplates=true`: topology/routing fields visible, accelerator config hidden for llm-d, admin pages visible

### Testing instructions

To test locally:
- **Flag off** (default): Open deploy wizard, select llm-d — should see accelerator config, NOT topology/routing fields. Admin settings should NOT show topology/routing pages.
- **Flag on**: Visit `/?devFeatureFlags=llmdTemplates=true` — should see topology/routing fields in wizard, admin pages visible under Settings > Model resources and operations.

## Test Impact

- **Modified**: 6 test files updated to set `llmdTemplates: true` in mock configs and devFeatureFlags URLs
- No new tests needed — existing tests cover the gated functionality when the flag is enabled

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`