### PR TITLE
fix(RHOAIENG-78548): allow topology type changes in router config edit mode

### DIFF
--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -348,7 +348,6 @@ const RoutingConfigurationCreateEditInner: React.FC<{
             dataTestId="topology-type-select"
             value={selectedTopology || undefined}
             placeholder="Select topology type"
-            isDisabled={isEditMode}
             options={topologyOptions}
             onChange={(key) => {
               const matched = Object.values(TopologyType).find((v) => v === key);

--- a/packages/llmd-serving/src/settings/__tests__/RoutingConfigurationCreateEdit.spec.tsx
+++ b/packages/llmd-serving/src/settings/__tests__/RoutingConfigurationCreateEdit.spec.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useNavigate, useParams, useLocation } from 'react-router';
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { TopologyType } from '../../types';
+import { useWatchRouterConfigs } from '../../api/LLMInferenceServiceConfigs';
+import RoutingConfigurationCreateEdit from '../RoutingConfigurationCreateEdit';
+
+jest.mock('react-router', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
+  useNavigate: jest.fn(),
+  useParams: jest.fn(),
+  useLocation: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/redux/selectors/project', () => ({
+  useDashboardNamespace: jest.fn(() => ({ dashboardNamespace: 'opendatahub' })),
+}));
+
+jest.mock('@odh-dashboard/ui-core', () => ({
+  ...jest.requireActual('@odh-dashboard/ui-core'),
+  ApplicationsPage: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div data-testid="app-page" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock('@odh-dashboard/internal/utilities/useNotification', () => ({
+  __esModule: true,
+  default: () => ({ error: jest.fn(), success: jest.fn() }),
+}));
+
+jest.mock('../ConfigYAMLEditor', () =>
+  jest.fn(({ code, onCodeChange }) => (
+    <textarea
+      data-testid="yaml-editor-mock"
+      value={code}
+      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onCodeChange(e.target.value)}
+    />
+  )),
+);
+
+jest.mock('../../api/LLMInferenceServiceConfigs', () => ({
+  createLLMInferenceServiceConfig: jest.fn(),
+  patchLLMInferenceServiceConfig: jest.fn(),
+  useWatchRouterConfigs: jest.fn(),
+}));
+
+const mockUseNavigate = jest.mocked(useNavigate);
+const mockUseParams = jest.mocked(useParams);
+const mockUseLocation = jest.mocked(useLocation);
+const mockUseWatchRouterConfigs = jest.mocked(useWatchRouterConfigs);
+
+describe('RoutingConfigurationCreateEdit', () => {
+  const navigateMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNavigate.mockReturnValue(navigateMock);
+    mockUseLocation.mockReturnValue({ state: null, key: '', pathname: '', search: '', hash: '' });
+  });
+
+  describe('create mode', () => {
+    beforeEach(() => {
+      mockUseParams.mockReturnValue({});
+      mockUseWatchRouterConfigs.mockReturnValue([[], true, undefined]);
+    });
+
+    it('should not disable the topology type select', () => {
+      render(<RoutingConfigurationCreateEdit />);
+
+      const topologySelect = screen.getByTestId('topology-type-select');
+      expect(topologySelect).not.toBeDisabled();
+    });
+  });
+
+  describe('edit mode', () => {
+    const existingConfig = mockLLMInferenceServiceConfigK8sResource({
+      name: 'test-router',
+      displayName: 'Test Router',
+      configType: 'router' as never,
+      supportedTopologies: [TopologyType.SINGLE_NODE],
+    });
+
+    beforeEach(() => {
+      mockUseParams.mockReturnValue({ configName: 'test-router' });
+      mockUseWatchRouterConfigs.mockReturnValue([[existingConfig], true, undefined]);
+    });
+
+    it('should not disable the topology type select', () => {
+      render(<RoutingConfigurationCreateEdit />);
+
+      const topologySelect = screen.getByTestId('topology-type-select');
+      expect(topologySelect).not.toBeDisabled();
+    });
+  });
+});


### PR DESCRIPTION
## Description
https://issues.redhat.com/browse/RHOAIENG-78548

The "Topology type" field in the routing configuration create/edit page was always disabled in edit mode (`isDisabled={isEditMode}`). This prevented users from changing the topology type and also blocked saving when the field had no value, since the save button requires a topology selection.

Removed the `isDisabled` prop from the topology type `SimpleSelect` so the field is always editable regardless of mode.

## How Has This Been Tested?

<img width="1484" height="767" alt="Screenshot 2026-07-23 at 12 01 30 PM" src="https://github.com/user-attachments/assets/fe5dafff-f7ce-4ffa-ba17-163a195dbdda" />

- Added unit tests verifying the topology type select is not disabled in both create and edit modes
- Ran existing test suite — all tests pass
- Lint and type-check pass clean

## Test Impact
Added `RoutingConfigurationCreateEdit.spec.tsx` with tests for create and edit modes verifying the topology type field is never disabled.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The topology type selector remains available when editing an existing routing configuration.
  - Users can change the selected topology type in both new and existing routing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->