### PR TITLE
RHOAIENG-75489: Move LabeledConnection type to @odh-dashboard/model-serving/shared

### DIFF
--- a/frontend/src/concepts/connectionTypes/ExistingConnectionField.tsx
+++ b/frontend/src/concepts/connectionTypes/ExistingConnectionField.tsx
@@ -8,7 +8,7 @@ import {
 import TypeaheadSelect, {
   TypeaheadSelectOption,
 } from '@odh-dashboard/ui-core/components/TypeaheadSelect';
-import { LabeledConnection } from '#~/pages/modelServing/screens/types';
+import type { LabeledConnection } from '@odh-dashboard/model-serving/shared';
 import { ConnectionDetailsHelperText } from './ConnectionDetailsHelperText';
 import { getConnectionTypeDisplayName, getConnectionTypeRef } from './utils';
 import { Connection, ConnectionTypeConfigMapObj } from './types';

--- a/frontend/src/concepts/modelRegistry/utils.ts
+++ b/frontend/src/concepts/modelRegistry/utils.ts
@@ -1,4 +1,4 @@
-import { LabeledConnection } from '#~/pages/modelServing/screens/types';
+import type { LabeledConnection } from '@odh-dashboard/model-serving/shared';
 import {
   ConnectionTypeConfigMapObj,
   ConnectionTypeValueType,

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -14,6 +14,7 @@ import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
 import { DashboardPopupIconButton } from '@odh-dashboard/ui-core';
 import { getResourceNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import type { UpdateObjectAtPropAndValue } from '@odh-dashboard/ui-core';
+import type { LabeledConnection } from '@odh-dashboard/model-serving/shared';
 import {
   Connection,
   ConnectionTypeConfigMapObj,
@@ -30,7 +31,6 @@ import { useWatchConnectionTypes } from '#~/utilities/useWatchConnectionTypes';
 import {
   CreatingInferenceServiceObject,
   InferenceServiceStorageType,
-  LabeledConnection,
 } from '#~/pages/modelServing/screens/types';
 import { ExistingConnectionField } from '#~/concepts/connectionTypes/ExistingConnectionField';
 import {

--- a/frontend/src/pages/modelServing/screens/projects/nim/useLabeledConnections.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/useLabeledConnections.ts
@@ -1,8 +1,8 @@
 import React from 'react';
+import type { LabeledConnection } from '@odh-dashboard/model-serving/shared';
 import { Connection } from '#~/concepts/connectionTypes/types';
 import { convertObjectStorageSecretData } from '#~/concepts/connectionTypes/utils';
 import { ModelLocation, uriToModelLocation } from '#~/concepts/modelRegistry/utils';
-import { LabeledConnection } from '#~/pages/modelServing/screens/types';
 import { AwsKeys, AccessTypes } from '#~/pages/projects/dataConnections/const';
 
 const useLabeledConnections = (

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -87,6 +87,3 @@ export type ServingPlatformStatuses = {
   platformEnabledCount: number;
   refreshNIMAvailability: () => Promise<boolean | undefined>;
 };
-
-// eslint-disable-next-line @odh-dashboard/no-restricted-imports -- re-exporting from model-serving for backward compatibility
-export type { LabeledConnection } from '@odh-dashboard/model-serving/components/connectionTypes/types';

--- a/packages/model-serving/package.json
+++ b/packages/model-serving/package.json
@@ -24,7 +24,6 @@
     "./components/connectionTypes/ConnectionOciAlert": "./src/components/connectionTypes/ConnectionOciAlert.tsx",
     "./components/connectionTypes/ConnectionOciPathField": "./src/components/connectionTypes/ConnectionOciPathField.tsx",
     "./components/connectionTypes/ConnectionS3FolderPathField": "./src/components/connectionTypes/ConnectionS3FolderPathField.tsx",
-    "./components/connectionTypes/types": "./src/components/connectionTypes/types.ts",
     "./concepts/auth": "./src/concepts/auth.ts",
     "./concepts/useModelServingClusterSettings": "./src/concepts/useModelServingClusterSettings.tsx",
     "./concepts/versions": "./src/concepts/versions.ts",

--- a/packages/model-serving/src/components/connectionTypes/types.ts
+++ b/packages/model-serving/src/components/connectionTypes/types.ts
@@ -1,6 +1,0 @@
-import type { Connection } from '@odh-dashboard/k8s-core';
-
-export type LabeledConnection = {
-  connection: Connection;
-  isRecommended?: boolean;
-};

--- a/packages/model-serving/src/shared/index.ts
+++ b/packages/model-serving/src/shared/index.ts
@@ -7,6 +7,7 @@ export {
   isInferenceServiceKind,
 } from './types';
 export type {
+  LabeledConnection,
   ModelStatus,
   SupportedModelFormatsInfo,
   ServingRuntimeToken,

--- a/packages/model-serving/src/shared/types.ts
+++ b/packages/model-serving/src/shared/types.ts
@@ -1,4 +1,5 @@
 import type {
+  Connection,
   K8sResourceCommon,
   ContainerResources,
   DisplayNameAnnotations,
@@ -10,6 +11,11 @@ import type {
   VolumeMount,
   ImagePullSecret,
 } from '@odh-dashboard/k8s-core';
+
+export type LabeledConnection = {
+  connection: Connection;
+  isRecommended?: boolean;
+};
 
 export enum ModelDeploymentState {
   PENDING = 'Pending',

--- a/packages/model-serving/src/shared/types/form-data.ts
+++ b/packages/model-serving/src/shared/types/form-data.ts
@@ -11,8 +11,8 @@ import type {
   SecretKind,
   SupportedModelFormats,
 } from '@odh-dashboard/k8s-core';
-import type { LabeledConnection } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import type { SimpleSelectOption } from '@odh-dashboard/ui-core/components/SimpleSelect';
+import type { LabeledConnection } from '@odh-dashboard/model-serving/shared';
 import type {
   ModelServerOption,
   ModelServerSelectField,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-75489

## Description

  Promotes `LabeledConnection` to the `@odh-dashboard/model-serving/shared` barrel export and removes the re-export from `frontend/src/pages/modelServing/screens/types.ts`.

  The type was already defined inside the `model-serving` package (at `src/components/connectionTypes/types.ts`), but consumers in `frontend/` imported it through a re-export in `frontend/src/pages/modelServing/screens/types.ts`, and `deploymentWizard/types.ts` imported it via `@odh-dashboard/internal` — creating a circular dependency back through the frontend. This was deferred from [#8350](https://github.com/opendatahub-io/odh-dashboard/pull/8350) ([RHOAIENG-72364](https://redhat.atlassian.net/browse/RHOAIENG-72364)) because the `Connection` type it depends on was not yet available outside `@odh-dashboard/internal`. Now that `Connection` is exported from `@odh-dashboard/k8s-core`, `LabeledConnection` can live in the shared barrel cleanly.

  ### What changed

  | File | Change |
  |---|---|
  | `packages/model-serving/src/shared/types.ts` | Added `LabeledConnection` type definition (imports `Connection` from `@odh-dashboard/k8s-core`) |
  | `packages/model-serving/src/shared/index.ts` | Added `LabeledConnection` to the barrel export |
  | `packages/model-serving/src/components/connectionTypes/types.ts` | Replaced inline definition with re-export from `../../shared/types` (preserves `./components/connectionTypes/types` export path) |
  | `packages/model-serving/src/components/deploymentWizard/types.ts` | Changed import from `@odh-dashboard/internal` → `@odh-dashboard/model-serving/shared` (fixes circular dependency) |
  | `frontend/src/pages/modelServing/screens/types.ts` | Removed `LabeledConnection` re-export |
  | 4 frontend consumers | Updated imports from `#~/pages/modelServing/screens/types` → `@odh-dashboard/model-serving/shared` |

  ### Invariants preserved

  - The `./shared` barrel (`shared/index.ts` → `shared/types.ts`) maintains **zero** direct imports from `@odh-dashboard/internal`
  - No new package dependencies introduced — all consuming packages already depend on `@odh-dashboard/model-serving`
  - Circular dependency between `model-serving` → `@odh-dashboard/internal` → `model-serving` is eliminated

  ## How Has This Been Tested?

  - `npm run build` passes across all packages
  - `npm run lint` passes for all changed files
  - `npm run type-check` passes for `model-serving` and `frontend` (no new type errors)
  - Frontend unit tests: **345/345** suites, **3731/3731** tests pass
  - Model-serving unit tests: **29/29** suites, **310/310** tests pass
  - Verified no circular dependencies via the import chain

  ## Test Impact

  No new tests added — this is a pure move/re-export refactor. Existing tests continue to cover all usage of `LabeledConnection`.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-72364]: https://redhat.atlassian.net/browse/RHOAIENG-72364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized labeled connection type definitions for consistent use across model-serving features.
  * Updated connection-related components to use the shared type without changing functionality.
  * Refined available package entry points for connection components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->