### PR TITLE
feat(autorag): display `include_metadata` in pattern leaderboard and details

### DIFF
--- a/packages/autorag/frontend/src/app/components/run-results/AutoragLeaderboard.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragLeaderboard.tsx
@@ -57,6 +57,7 @@ type LeaderboardEntry = {
   chunkingMethod: string;
   chunkingChunkSize: number | string;
   chunkingChunkOverlap: number | string;
+  chunkingMetadata: boolean;
   embeddingsModelId: string;
   retrievalMethod: string;
   retrievalNumberOfChunks: number | string;
@@ -66,7 +67,10 @@ type LeaderboardEntry = {
 };
 
 // Format a settings cell value: capitalize the first letter, with special cases
-const formatSettingsValue = (value: string | number): string | number => {
+const formatSettingsValue = (value: string | number | boolean): string | number => {
+  if (typeof value === 'boolean') {
+    return value ? 'Yes' : 'No';
+  }
   if (typeof value !== 'string' || value === 'N/A' || value.length === 0) {
     return value;
   }
@@ -96,6 +100,7 @@ type SettingsField =
   | 'chunkingMethod'
   | 'chunkingChunkSize'
   | 'chunkingChunkOverlap'
+  | 'chunkingMetadata'
   | 'retrievalMethod'
   | 'retrievalNumberOfChunks'
   | 'retrievalSearchMode'
@@ -194,11 +199,19 @@ const COLUMN_META: Record<
     field: 'chunkingChunkOverlap',
     testId: 'chunking-chunk-overlap',
   },
+  chunkingMetadata: {
+    name: 'Chunk metadata',
+    description: 'Whether document metadata is included alongside chunk text during indexing.',
+    minWidth: '12rem',
+    priority: 5,
+    field: 'chunkingMetadata',
+    testId: 'chunking-metadata',
+  },
   // Retrieval group (search stage)
   retrievalMethod: {
     name: 'Retrieval method',
     description: 'The method used to retrieve relevant chunks from the vector database.',
-    priority: 5,
+    priority: 6,
     field: 'retrievalMethod',
     testId: 'retrieval-method',
     minWidth: '13rem',
@@ -208,7 +221,7 @@ const COLUMN_META: Record<
     description:
       'The search strategy. Hybrid search combines vector and keyword search and is available only with Milvus.',
     minWidth: '14rem',
-    priority: 6,
+    priority: 7,
     field: 'retrievalSearchMode',
     testId: 'retrieval-search-mode',
   },
@@ -217,7 +230,7 @@ const COLUMN_META: Record<
     description:
       'The ranking algorithm used to combine and reorder results when hybrid retrieval search mode is active. RRF (reciprocal rank fusion) merges rankings from multiple sources into a single list. Weighted ranking assigns different importance levels to each source. Only applicable when retrieval search mode is hybrid.',
     minWidth: '12rem',
-    priority: 7,
+    priority: 8,
     field: 'retrievalRankerStrategy',
     testId: 'retrieval-ranker-strategy',
   },
@@ -225,7 +238,7 @@ const COLUMN_META: Record<
     name: 'Number of chunks',
     description: 'The number of document chunks retrieved per query.',
     minWidth: '13rem',
-    priority: 8,
+    priority: 9,
     field: 'retrievalNumberOfChunks',
     testId: 'retrieval-number-of-chunks',
   },
@@ -518,6 +531,8 @@ function AutoragLeaderboard({
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/prefer-nullish-coalescing -- 0 is a valid value, must use ?? not ||
           chunkingChunkOverlap: pattern.settings?.chunking?.chunk_overlap ?? 'N/A',
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          chunkingMetadata: pattern.settings?.chunking?.include_metadata ?? false,
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           embeddingsModelId: pattern.settings?.embedding?.model_id || 'N/A',
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           retrievalMethod: pattern.settings?.retrieval?.method || 'N/A',
@@ -628,6 +643,12 @@ function AutoragLeaderboard({
           return activeSort.direction === 'asc' ? comparison : -comparison;
         }
 
+        // Handle boolean sorting (false before true)
+        if (typeof aVal === 'boolean' && typeof bVal === 'boolean') {
+          const comparison = Number(aVal) - Number(bVal);
+          return activeSort.direction === 'asc' ? comparison : -comparison;
+        }
+
         return 0;
       });
     }
@@ -666,7 +687,12 @@ function AutoragLeaderboard({
   const columnPresets: ColumnPreset[] = React.useMemo(() => {
     const leadingKeys = ['rank', 'pattern', 'modelNames', 'optimized-metric'];
     const metricColumnKeys = nonOptimizedMetricKeys.map((key) => `metric:${key}`);
-    const chunkingKeys = ['chunkingMethod', 'chunkingChunkSize', 'chunkingChunkOverlap'];
+    const chunkingKeys = [
+      'chunkingMethod',
+      'chunkingChunkSize',
+      'chunkingChunkOverlap',
+      'chunkingMetadata',
+    ];
     const allSettingKeys = SETTINGS_COLUMNS.map((col) => col.id);
 
     return [

--- a/packages/autorag/frontend/src/app/hooks/patternSchema.ts
+++ b/packages/autorag/frontend/src/app/hooks/patternSchema.ts
@@ -39,6 +39,8 @@ const ChunkingSchema = z
     method: z.string(),
     chunk_size: z.number(),
     chunk_overlap: z.number(),
+    // TODO: make required once backend fix is confirmed
+    include_metadata: z.boolean().optional(),
   })
   .passthrough();
 

--- a/packages/autorag/frontend/src/app/mocks/mockAutoRAGPatterns.ts
+++ b/packages/autorag/frontend/src/app/mocks/mockAutoRAGPatterns.ts
@@ -14,7 +14,7 @@ const basePatternV1 = {
       provider_type: 'remote::milvus',
       vector_store_id: 'vs_collection0',
     },
-    chunking: { method: 'recursive', chunk_size: 256, chunk_overlap: 128 },
+    chunking: { method: 'recursive', chunk_size: 256, chunk_overlap: 128, include_metadata: true },
     embedding: {
       model_id: 'mock-embed-a',
       distance_metric: 'cosine',
@@ -91,7 +91,7 @@ const basePattern = {
       provider_type: 'milvus',
       vector_store_id: 'collection0',
     },
-    chunking: { method: 'recursive', chunk_size: 256, chunk_overlap: 128 },
+    chunking: { method: 'hybrid', chunk_size: 256, chunk_overlap: 128, include_metadata: true },
     embedding: {
       model_id: 'mock-embed-a',
       embedding_params: {

--- a/packages/autorag/frontend/src/app/types/autoragPattern.ts
+++ b/packages/autorag/frontend/src/app/types/autoragPattern.ts
@@ -31,6 +31,7 @@ export type AutoragPatternSettingsV1 = {
     method: string;
     chunk_size: number;
     chunk_overlap: number;
+    include_metadata?: boolean;
   };
   embedding: {
     model_id: string;
@@ -108,6 +109,7 @@ export type AutoragPatternSettings = {
     method: string;
     chunk_size: number;
     chunk_overlap: number;
+    include_metadata?: boolean;
   };
   embedding: {
     model_id: string;

--- a/packages/autorag/frontend/src/app/utilities/utils.ts
+++ b/packages/autorag/frontend/src/app/utilities/utils.ts
@@ -245,6 +245,8 @@ export function formatMetricName(metricKey: string): string {
 const HUMANIZE_OVERRIDES: Record<string, string> = {
   // eslint-disable-next-line camelcase
   duration_seconds: 'Duration (seconds)',
+  // eslint-disable-next-line camelcase
+  include_metadata: 'Chunk metadata',
 };
 
 export const humanize = (key: string): string =>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-61563

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
