### PR TITLE
feat(dashboard-operator): add ConfigMap content hash for federation rolling restart [RHOAIENG-78802]

### DIFF
--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -440,6 +440,7 @@ func (r *DashboardReconciler) reconcileStandalone(
 
 	if err := r.patchDeploymentFederationHash(ctx, fedData); err != nil {
 		logger.Error(err, "Failed to patch federation hash on deployment")
+		return ctrl.Result{}, fmt.Errorf("patching federation hash: %w", err)
 	}
 
 	// Step 8: URL extraction + degraded condition

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -429,12 +429,17 @@ func (r *DashboardReconciler) reconcileStandalone(
 	r.reconcileObservability(ctx, dashboard, cm)
 
 	// Step 7: Build and deploy federation ConfigMap (critical for standalone routing)
-	if err := r.deployFederationConfigMap(ctx, nextStatuses, dashboard); err != nil {
+	fedData, err := r.deployFederationConfigMap(ctx, nextStatuses, dashboard)
+	if err != nil {
 		cm.MarkTrue(string(common.ConditionTypeDegraded),
 			conditions.WithReason("FederationConfigMapFailed"),
 			conditions.WithError(err))
 		logger.Error(err, "Failed to deploy federation ConfigMap")
 		return ctrl.Result{}, fmt.Errorf("federation ConfigMap: %w", err)
+	}
+
+	if err := r.patchDeploymentFederationHash(ctx, fedData); err != nil {
+		logger.Error(err, "Failed to patch federation hash on deployment")
 	}
 
 	// Step 8: URL extraction + degraded condition

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -1,7 +1,27 @@
 package controller
 
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
 func SetOperatorDeploymentName(name string) (restore func()) {
 	old := operatorDeploymentName
 	operatorDeploymentName = name
 	return func() { operatorDeploymentName = old }
+}
+
+var ComputeFederationConfigHash = computeFederationConfigHash
+
+var MainDashboardDeploymentName = mainDashboardDeploymentName
+
+func BuildFederationConfigMap(r *DashboardReconciler, statuses map[string]v1alpha1.ModuleStatus, dashboard *v1alpha1.Dashboard) (*corev1.ConfigMap, error) {
+	return r.buildFederationConfigMap(statuses, dashboard)
+}
+
+func (r *DashboardReconciler) PatchDeploymentFederationHash(ctx context.Context, configData string) error {
+	return r.patchDeploymentFederationHash(ctx, configData)
 }

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -52,7 +54,6 @@ type federationEntry struct {
 	RemoteEntry  string              `json:"remoteEntry,omitempty"`
 	Authorize    bool                `json:"authorize"`
 	TLS          bool                `json:"tls"`
-	Enabled      bool                `json:"enabled"`
 	Proxy        []proxyRoute        `json:"proxy,omitempty"`
 	Service      *serviceRef         `json:"service,omitempty"`
 	ProxyService []proxyServiceEntry `json:"proxyService,omitempty"`
@@ -106,6 +107,58 @@ func standaloneServiceName(platform cluster.Platform, slug string) string {
 		prefix = "rhods-dashboard"
 	}
 	return prefix + "-" + slug + "-ui"
+}
+
+func mainDashboardDeploymentName(platform cluster.Platform) string {
+	if platform == cluster.SelfManagedRhoai || platform == cluster.ManagedRhoai {
+		return "rhods-dashboard"
+	}
+	return "odh-dashboard"
+}
+
+// --- Federation config hash for rolling restart ---
+
+const federationHashAnnotation = "dashboard.opendatahub.io/federation-config-hash"
+
+func computeFederationConfigHash(data string) string {
+	h := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(h[:])
+}
+
+func (r *DashboardReconciler) patchDeploymentFederationHash(
+	ctx context.Context,
+	configData string,
+) error {
+	hash := computeFederationConfigHash(configData)
+
+	deployName := mainDashboardDeploymentName(r.Platform)
+	var deploy appsv1.Deployment
+	key := client.ObjectKey{Name: deployName, Namespace: r.ApplicationsNamespace}
+	if err := r.Get(ctx, key, &deploy); err != nil {
+		return fmt.Errorf("getting deployment %s: %w", deployName, err)
+	}
+
+	current := ""
+	if deploy.Spec.Template.Annotations != nil {
+		current = deploy.Spec.Template.Annotations[federationHashAnnotation]
+	}
+	if current == hash {
+		return nil
+	}
+
+	patch := client.MergeFrom(deploy.DeepCopy())
+	if deploy.Spec.Template.Annotations == nil {
+		deploy.Spec.Template.Annotations = map[string]string{}
+	}
+	deploy.Spec.Template.Annotations[federationHashAnnotation] = hash
+
+	if err := r.Patch(ctx, &deploy, patch); err != nil {
+		return fmt.Errorf("patching deployment %s with federation hash: %w", deployName, err)
+	}
+
+	log.FromContext(ctx).Info("Patched federation config hash on deployment",
+		"deployment", deployName, "hash", hash[:12]+"...")
+	return nil
 }
 
 // --- Deploy individual module manifests ---
@@ -315,14 +368,12 @@ func (r *DashboardReconciler) buildFederationConfigMap(
 		}
 
 		svcName := standaloneServiceName(r.Platform, mod.ManifestSlug)
-		enabled := status.Phase == v1alpha1.ModulePhaseDeployed
 
 		entry := federationEntry{
 			Name:        name,
 			RemoteEntry: "/remoteEntry.js",
 			Authorize:   true,
 			TLS:         true,
-			Enabled:     enabled,
 			Proxy:       moduleProxyPaths[name],
 			Service: &serviceRef{
 				Name:      svcName,
@@ -360,7 +411,6 @@ func (r *DashboardReconciler) buildFederationConfigMap(
 			RemoteEntry: "/mlflow/static-files/federated/remoteEntry.js",
 			Authorize:   true,
 			TLS:         true,
-			Enabled:     s.Phase == v1alpha1.ModulePhaseDeployed,
 			Service: &serviceRef{
 				Name:      "mlflow",
 				Namespace: r.ApplicationsNamespace,
@@ -473,15 +523,15 @@ func (r *DashboardReconciler) deployFederationConfigMap(
 	ctx context.Context,
 	statuses map[string]v1alpha1.ModuleStatus,
 	dashboard *v1alpha1.Dashboard,
-) error {
+) (string, error) {
 	fedCM, err := r.buildFederationConfigMap(statuses, dashboard)
 	if err != nil {
-		return fmt.Errorf("building federation ConfigMap: %w", err)
+		return "", fmt.Errorf("building federation ConfigMap: %w", err)
 	}
 
 	fedResources, err := configMapToUnstructured(fedCM)
 	if err != nil {
-		return fmt.Errorf("converting federation ConfigMap: %w", err)
+		return "", fmt.Errorf("converting federation ConfigMap: %w", err)
 	}
 
 	fedDeployer := deploy.NewDeployer(
@@ -495,10 +545,10 @@ func (r *DashboardReconciler) deployFederationConfigMap(
 		Release:   deploy.ReleaseInfo{Type: string(r.Platform)},
 		Resources: []unstructured.Unstructured{fedResources},
 	}); err != nil {
-		return fmt.Errorf("deploying federation ConfigMap: %w", err)
+		return "", fmt.Errorf("deploying federation ConfigMap: %w", err)
 	}
 
-	return nil
+	return fedCM.Data[federationConfigKey], nil
 }
 
 // --- Helper: ConfigMap to Unstructured ---

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -157,7 +157,7 @@ func (r *DashboardReconciler) patchDeploymentFederationHash(
 	}
 
 	log.FromContext(ctx).Info("Patched federation config hash on deployment",
-		"deployment", deployName, "hash", hash[:12]+"...")
+		"deployment", deployName, "hash", hash)
 	return nil
 }
 

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -135,6 +136,10 @@ func (r *DashboardReconciler) patchDeploymentFederationHash(
 	var deploy appsv1.Deployment
 	key := client.ObjectKey{Name: deployName, Namespace: r.ApplicationsNamespace}
 	if err := r.Get(ctx, key, &deploy); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.FromContext(ctx).Info("Dashboard deployment not found, skipping federation hash patch", "deployment", deployName)
+			return nil
+		}
 		return fmt.Errorf("getting deployment %s: %w", deployName, err)
 	}
 

--- a/dashboard-operator/internal/controller/module_deploy_test.go
+++ b/dashboard-operator/internal/controller/module_deploy_test.go
@@ -264,3 +264,20 @@ func TestPatchDeploymentFederationHash_UpdatesOnChange(t *testing.T) {
 	assert.NotEqual(t, oldHash, newHash, "hash must be updated")
 	assert.Equal(t, ctrlpkg.ComputeFederationConfigHash(newConfigData), newHash)
 }
+
+func TestPatchDeploymentFederationHash_DeploymentNotFound(t *testing.T) {
+	s := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
+	}
+
+	err := r.PatchDeploymentFederationHash(context.Background(), `[{"name":"genAi"}]`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting deployment")
+}

--- a/dashboard-operator/internal/controller/module_deploy_test.go
+++ b/dashboard-operator/internal/controller/module_deploy_test.go
@@ -92,9 +92,18 @@ func TestBuildFederationConfigMap_ExcludesDisabledModules(t *testing.T) {
 	require.NoError(t, err)
 
 	data := cm.Data["module-federation-config.json"]
-	assert.NotContains(t, data, `"genAi"`, "disabled module must be excluded")
-	assert.NotContains(t, data, `"maas"`, "not-deployed module must be excluded")
-	assert.Contains(t, data, `"modelRegistry"`, "deployed module must be included")
+	var entries []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(data), &entries))
+
+	names := make(map[string]bool)
+	for _, entry := range entries {
+		if name, ok := entry["name"].(string); ok {
+			names[name] = true
+		}
+	}
+	assert.False(t, names["genAi"], "disabled module must be excluded")
+	assert.False(t, names["maas"], "not-deployed module must be excluded")
+	assert.True(t, names["modelRegistry"], "deployed module must be included")
 }
 
 func TestBuildFederationConfigMap_NoEnabledField(t *testing.T) {
@@ -278,6 +287,5 @@ func TestPatchDeploymentFederationHash_DeploymentNotFound(t *testing.T) {
 	}
 
 	err := r.PatchDeploymentFederationHash(context.Background(), `[{"name":"genAi"}]`)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "getting deployment")
+	require.NoError(t, err, "NotFound should be a no-op, not an error")
 }

--- a/dashboard-operator/internal/controller/module_deploy_test.go
+++ b/dashboard-operator/internal/controller/module_deploy_test.go
@@ -1,0 +1,266 @@
+package controller_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+)
+
+func TestComputeFederationConfigHash_Deterministic(t *testing.T) {
+	input := `[{"name":"genAi","remoteEntry":"/remoteEntry.js"}]`
+	h1 := ctrlpkg.ComputeFederationConfigHash(input)
+	h2 := ctrlpkg.ComputeFederationConfigHash(input)
+	assert.Equal(t, h1, h2, "same input must produce identical hash")
+	assert.Len(t, h1, 64, "SHA256 hex digest must be 64 characters")
+}
+
+func TestComputeFederationConfigHash_DifferentInputs(t *testing.T) {
+	h1 := ctrlpkg.ComputeFederationConfigHash(`[{"name":"genAi"}]`)
+	h2 := ctrlpkg.ComputeFederationConfigHash(`[{"name":"maas"}]`)
+	assert.NotEqual(t, h1, h2, "different inputs must produce different hashes")
+}
+
+func TestMainDashboardDeploymentName(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform cluster.Platform
+		want     string
+	}{
+		{name: "OpenDataHub", platform: cluster.OpenDataHub, want: "odh-dashboard"},
+		{name: "SelfManagedRhoai", platform: cluster.SelfManagedRhoai, want: "rhods-dashboard"},
+		{name: "ManagedRhoai", platform: cluster.ManagedRhoai, want: "rhods-dashboard"},
+		{name: "XKS falls back to ODH", platform: cluster.XKS, want: "odh-dashboard"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ctrlpkg.MainDashboardDeploymentName(tt.platform)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func allDeployedStatuses() map[string]v1alpha1.ModuleStatus {
+	statuses := make(map[string]v1alpha1.ModuleStatus)
+	for _, name := range ctrlpkg.ModuleNames() {
+		statuses[name] = v1alpha1.ModuleStatus{
+			Phase:              v1alpha1.ModulePhaseDeployed,
+			Reason:             "Deployed",
+			LastTransitionTime: metav1.Now(),
+		}
+	}
+	return statuses
+}
+
+func TestBuildFederationConfigMap_ExcludesDisabledModules(t *testing.T) {
+	s := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
+	}
+
+	statuses := allDeployedStatuses()
+	statuses["genAi"] = v1alpha1.ModuleStatus{
+		Phase:  v1alpha1.ModulePhaseDisabled,
+		Reason: "ExplicitOverride",
+	}
+	statuses["maas"] = v1alpha1.ModuleStatus{
+		Phase:  v1alpha1.ModulePhaseNotDeployed,
+		Reason: "ComponentNotAvailable",
+	}
+
+	cm, err := ctrlpkg.BuildFederationConfigMap(r, statuses, &v1alpha1.Dashboard{})
+	require.NoError(t, err)
+
+	data := cm.Data["module-federation-config.json"]
+	assert.NotContains(t, data, `"genAi"`, "disabled module must be excluded")
+	assert.NotContains(t, data, `"maas"`, "not-deployed module must be excluded")
+	assert.Contains(t, data, `"modelRegistry"`, "deployed module must be included")
+}
+
+func TestBuildFederationConfigMap_NoEnabledField(t *testing.T) {
+	s := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
+	}
+
+	statuses := allDeployedStatuses()
+	cm, err := ctrlpkg.BuildFederationConfigMap(r, statuses, &v1alpha1.Dashboard{})
+	require.NoError(t, err)
+
+	data := cm.Data["module-federation-config.json"]
+
+	var entries []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(data), &entries))
+	for _, entry := range entries {
+		_, hasEnabled := entry["enabled"]
+		assert.False(t, hasEnabled, "entry %q must not have 'enabled' field", entry["name"])
+	}
+}
+
+func TestPatchDeploymentFederationHash_CreatesAnnotation(t *testing.T) {
+	s := testScheme(t)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-dashboard",
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "dashboard"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "dashboard"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "dashboard", Image: "test:latest"}},
+				},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(deploy).Build()
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
+	}
+
+	configData := `[{"name":"genAi"}]`
+	err := r.PatchDeploymentFederationHash(context.Background(), configData)
+	require.NoError(t, err)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "odh-dashboard", Namespace: testNamespace}, &updated))
+
+	hash := updated.Spec.Template.Annotations["dashboard.opendatahub.io/federation-config-hash"]
+	assert.NotEmpty(t, hash, "annotation must be set")
+	assert.Len(t, hash, 64, "must be a SHA256 hex digest")
+}
+
+func TestPatchDeploymentFederationHash_NoOpWhenUnchanged(t *testing.T) {
+	s := testScheme(t)
+
+	configData := `[{"name":"genAi"}]`
+	expectedHash := ctrlpkg.ComputeFederationConfigHash(configData)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-dashboard",
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "dashboard"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "dashboard"},
+					Annotations: map[string]string{
+						"dashboard.opendatahub.io/federation-config-hash": expectedHash,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "dashboard", Image: "test:latest"}},
+				},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(deploy).Build()
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
+	}
+
+	err := r.PatchDeploymentFederationHash(context.Background(), configData)
+	require.NoError(t, err)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "odh-dashboard", Namespace: testNamespace}, &updated))
+	assert.Equal(t, expectedHash, updated.Spec.Template.Annotations["dashboard.opendatahub.io/federation-config-hash"])
+}
+
+func TestPatchDeploymentFederationHash_UpdatesOnChange(t *testing.T) {
+	s := testScheme(t)
+
+	oldHash := strings.Repeat("a", 64)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-dashboard",
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "dashboard"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "dashboard"},
+					Annotations: map[string]string{
+						"dashboard.opendatahub.io/federation-config-hash": oldHash,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "dashboard", Image: "test:latest"}},
+				},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(deploy).Build()
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
+	}
+
+	newConfigData := `[{"name":"genAi"},{"name":"maas"}]`
+	err := r.PatchDeploymentFederationHash(context.Background(), newConfigData)
+	require.NoError(t, err)
+
+	var updated appsv1.Deployment
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "odh-dashboard", Namespace: testNamespace}, &updated))
+
+	newHash := updated.Spec.Template.Annotations["dashboard.opendatahub.io/federation-config-hash"]
+	assert.NotEqual(t, oldHash, newHash, "hash must be updated")
+	assert.Equal(t, ctrlpkg.ComputeFederationConfigHash(newConfigData), newHash)
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78802
https://issues.redhat.com/browse/RHOAIENG-59931

## Description

When modules are enabled or disabled, the operator updates the `federation-config` ConfigMap but pods only pick up the new values on restart (the ConfigMap is consumed via `configMapKeyRef` env var, not a mounted volume). This PR adds a content-hash annotation on the Deployment's pod template so Kubernetes triggers a rolling restart whenever the ConfigMap content changes.

Changes:
- **Drop `Enabled` field** from `federationEntry` struct — the frontend `ModuleFederationConfig` TypeScript type never had an `enabled` property; this was dead code.
- **Add `mainDashboardDeploymentName()`** — platform-aware helper returning `odh-dashboard` (ODH) or `rhods-dashboard` (RHOAI).
- **Add `computeFederationConfigHash()`** — pure SHA256 hex digest of the serialized ConfigMap data.
- **Add `patchDeploymentFederationHash()`** — reads the live Deployment, compares the current annotation, and patches only when the hash differs (no-op otherwise).
- **Wire into `reconcileStandalone()`** — after deploying the federation ConfigMap, patch the Deployment annotation. Failure is non-fatal (logged, retried next reconcile cycle).
- **Return config data from `deployFederationConfigMap()`** — signature changed from `error` to `(string, error)` to pass the serialized JSON to the hash function.

## How Has This Been Tested?

- `make test` in `dashboard-operator/` — all tests pass (8 new test cases + existing suite)
- `make lint` — 0 issues
- `make build` — compiles cleanly

## Test Impact

New test file: `dashboard-operator/internal/controller/module_deploy_test.go` with 8 test cases:
- `TestComputeFederationConfigHash_Deterministic` — same input → same hash
- `TestComputeFederationConfigHash_DifferentInputs` — different inputs → different hashes
- `TestMainDashboardDeploymentName` — platform-aware naming (ODH, SelfManagedRhoai, ManagedRhoai, XKS)
- `TestBuildFederationConfigMap_ExcludesDisabledModules` — disabled/not-deployed modules excluded from output
- `TestBuildFederationConfigMap_NoEnabledField` — JSON output contains no `"enabled"` key
- `TestPatchDeploymentFederationHash_CreatesAnnotation` — first call adds annotation
- `TestPatchDeploymentFederationHash_NoOpWhenUnchanged` — same hash → no patch
- `TestPatchDeploymentFederationHash_UpdatesOnChange` — different hash → annotation updated

Updated `export_test.go` with test-only exports for `ComputeFederationConfigHash`, `MainDashboardDeploymentName`, `BuildFederationConfigMap`, and `PatchDeploymentFederationHash`.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard deployments now compute and apply a federation hash to the main Deployment’s pod template annotations, updating configurations and triggering a rollout when the hash changes.
  * Federation configuration generation excludes disabled or not-deployed modules.
  * Federation config output no longer includes an “enabled” field; deployment naming now adapts to the platform.
* **Bug Fixes**
  * Federation hash patch failures are no longer silently ignored; they correctly fail the reconcile cycle.
* **Tests**
  * Added coverage for federation hash determinism, platform-specific naming, configuration filtering, and annotation patch behavior (including no-op cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->