### PR TITLE
fix(RHOAIENG-76231): make modal dropdowns reachable for keyboard and screen readers

### DIFF
--- a/frontend/src/components/MultiSelection.tsx
+++ b/frontend/src/components/MultiSelection.tsx
@@ -24,10 +24,7 @@ import {
 } from '@patternfly/react-core';
 
 import { TimesIcon } from '@patternfly/react-icons/dist/esm/icons/times-icon';
-import {
-  resolveSelectPopperAppendTo,
-  useModalOverflowUnlock,
-} from '#~/utilities/useModalOverflowUnlock';
+import { createOptionElementId, useMenuPopperInModal } from '#~/utilities/useModalOverflowUnlock';
 
 export type SelectionOptions = Omit<SelectOptionProps, 'id'> & {
   id: number | string;
@@ -74,15 +71,6 @@ type MultiSelectionProps = {
 const defaultCreateOptionMessage = (newValue: string) => `Create "${newValue}"`;
 const defaultFilterFunction = (filterText: string, options: SelectionOptions[]) =>
   options.filter((o) => !filterText || o.name.toLowerCase().includes(filterText.toLowerCase()));
-
-/** Encode option ids for stable, injective DOM id segments (e.g. 'a b' vs 'a-b', 'core/pods' vs 'coreu47upods'). */
-const encodeOptionIdForDom = (optionId: number | string): string =>
-  String(optionId)
-    .replace(/u/g, 'uu')
-    .replace(/[^a-zA-Z0-9_-]/g, (ch) => `u${ch.charCodeAt(0)}u`);
-
-const createOptionElementId = (instanceId: string, optionId: number | string): string =>
-  `${instanceId}-option-${encodeOptionIdForDom(optionId)}`;
 
 const normalizeOptionId = (optionId: number | string): string => String(optionId);
 
@@ -145,6 +133,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   hasCheckbox = false,
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const isOpenRef = React.useRef(false);
   const [inputValue, setInputValue] = React.useState<string>('');
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
@@ -154,21 +143,6 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   const instanceId = id ?? `multi-select-${generatedInstanceId}`;
   const listboxId = `${instanceId}-listbox`;
   const selectionErrorId = `${instanceId}-selection-error`;
-
-  useModalOverflowUnlock(isOpen, textInputRef);
-
-  const getPopperAppendTo = React.useCallback(
-    () => resolveSelectPopperAppendTo(textInputRef.current),
-    [],
-  );
-
-  const mergedPopperProps = React.useMemo(
-    () => ({
-      ...popperProps,
-      appendTo: popperProps?.appendTo ?? getPopperAppendTo,
-    }),
-    [popperProps, getPopperAppendTo],
-  );
 
   const selectGroups = React.useMemo(
     () =>
@@ -284,6 +258,10 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   };
 
   const openMenu = (focusFirstOption = false) => {
+    if (isOpenRef.current) {
+      return;
+    }
+    isOpenRef.current = true;
     setIsOpen(true);
     if (focusFirstOption) {
       const firstFocusableIndex = getNextFocusableIndex(null, 'down');
@@ -294,6 +272,10 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   };
 
   const closeMenu = () => {
+    if (!isOpenRef.current) {
+      return;
+    }
+    isOpenRef.current = false;
     if (focusTimeoutRef.current) {
       clearTimeout(focusTimeoutRef.current);
       focusTimeoutRef.current = undefined;
@@ -302,6 +284,10 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
     setInputValue('');
     resetActiveAndFocusedItem();
   };
+
+  const mergedPopperProps = useMenuPopperInModal(isOpen, textInputRef, popperProps, {
+    onEscapeClose: closeMenu,
+  });
 
   React.useEffect(
     () => () => {
@@ -313,8 +299,8 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   );
 
   const handleMenuArrowKeys = (key: string) => {
-    if (!isOpen) {
-      setIsOpen(true);
+    if (!isOpenRef.current) {
+      openMenu();
     }
 
     const optionsLength = visibleOptions.length;
@@ -346,15 +332,11 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
         }
         break;
       case 'Tab':
-        closeMenu();
-        break;
-      case 'Escape':
         if (isOpen) {
-          event.preventDefault();
-          event.stopPropagation();
-          closeMenu();
+          queueMicrotask(() => closeMenu());
         }
         break;
+      // Escape is handled by useMenuPopperInModal (document capture) via onEscapeClose.
       case 'ArrowUp':
       case 'ArrowDown':
         event.preventDefault();
@@ -383,7 +365,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, valueOfInput: string) => {
     setInputValue(valueOfInput);
     if (valueOfInput) {
-      setIsOpen(true);
+      openMenu();
     }
     resetActiveAndFocusedItem();
   };
@@ -478,7 +460,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
           }}
           role="combobox"
           isExpanded={isOpen}
-          aria-controls={listboxId}
+          {...(isOpen ? { 'aria-controls': listboxId } : {})}
         >
           <LabelGroup aria-label="Current selections">
             {visibleChips.map((selection) => (

--- a/frontend/src/components/MultiSelection.tsx
+++ b/frontend/src/components/MultiSelection.tsx
@@ -24,10 +24,7 @@ import {
 } from '@patternfly/react-core';
 
 import { TimesIcon } from '@patternfly/react-icons/dist/esm/icons/times-icon';
-import {
-  resolveSelectPopperAppendTo,
-  useModalOverflowUnlock,
-} from '#~/utilities/useModalOverflowUnlock';
+import { createOptionElementId, useMenuPopperInModal } from '#~/utilities/useModalOverflowUnlock';
 
 export type SelectionOptions = Omit<SelectOptionProps, 'id'> & {
   id: number | string;
@@ -74,15 +71,6 @@ type MultiSelectionProps = {
 const defaultCreateOptionMessage = (newValue: string) => `Create "${newValue}"`;
 const defaultFilterFunction = (filterText: string, options: SelectionOptions[]) =>
   options.filter((o) => !filterText || o.name.toLowerCase().includes(filterText.toLowerCase()));
-
-/** Encode option ids for stable, injective DOM id segments (e.g. 'a b' vs 'a-b', 'core/pods' vs 'coreu47upods'). */
-const encodeOptionIdForDom = (optionId: number | string): string =>
-  String(optionId)
-    .replace(/u/g, 'uu')
-    .replace(/[^a-zA-Z0-9_-]/g, (ch) => `u${ch.charCodeAt(0)}u`);
-
-const createOptionElementId = (instanceId: string, optionId: number | string): string =>
-  `${instanceId}-option-${encodeOptionIdForDom(optionId)}`;
 
 const normalizeOptionId = (optionId: number | string): string => String(optionId);
 
@@ -148,6 +136,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   hasCheckbox = false,
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const isOpenRef = React.useRef(false);
   const [inputValue, setInputValue] = React.useState<string>('');
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
@@ -158,21 +147,6 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   const instanceId = id ?? `multi-select-${generatedInstanceId}`;
   const listboxId = `${instanceId}-listbox`;
   const selectionErrorId = `${instanceId}-selection-error`;
-
-  useModalOverflowUnlock(isOpen, textInputRef);
-
-  const getPopperAppendTo = React.useCallback(
-    () => resolveSelectPopperAppendTo(textInputRef.current),
-    [],
-  );
-
-  const mergedPopperProps = React.useMemo(
-    () => ({
-      ...popperProps,
-      appendTo: popperProps?.appendTo ?? getPopperAppendTo,
-    }),
-    [popperProps, getPopperAppendTo],
-  );
 
   const selectGroups = React.useMemo(
     () =>
@@ -288,10 +262,14 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   };
 
   const openMenu = (focusFirstOption = false) => {
+    if (isOpenRef.current) {
+      return;
+    }
     if (exclusiveOpenCloseRef && exclusiveOpenCloseRef !== closeMenuRef) {
       exclusiveOpenCloseRef.current();
     }
     exclusiveOpenCloseRef = closeMenuRef;
+    isOpenRef.current = true;
     setIsOpen(true);
     if (focusFirstOption) {
       const firstFocusableIndex = getNextFocusableIndex(null, 'down');
@@ -302,6 +280,10 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   };
 
   const closeMenu = () => {
+    if (!isOpenRef.current) {
+      return;
+    }
+    isOpenRef.current = false;
     if (focusTimeoutRef.current) {
       clearTimeout(focusTimeoutRef.current);
       focusTimeoutRef.current = undefined;
@@ -314,6 +296,10 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
     }
   };
   closeMenuRef.current = closeMenu;
+
+  const mergedPopperProps = useMenuPopperInModal(isOpen, textInputRef, popperProps, {
+    onEscapeClose: closeMenu,
+  });
 
   React.useEffect(
     () => () => {
@@ -328,7 +314,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
   );
 
   const handleMenuArrowKeys = (key: string) => {
-    if (!isOpen) {
+    if (!isOpenRef.current) {
       openMenu();
     }
 
@@ -361,15 +347,11 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
         }
         break;
       case 'Tab':
-        closeMenu();
-        break;
-      case 'Escape':
         if (isOpen) {
-          event.preventDefault();
-          event.stopPropagation();
-          closeMenu();
+          queueMicrotask(() => closeMenu());
         }
         break;
+      // Escape is handled by useMenuPopperInModal (document capture) via onEscapeClose.
       case 'ArrowUp':
       case 'ArrowDown':
         event.preventDefault();
@@ -493,7 +475,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
           }}
           role="combobox"
           isExpanded={isOpen}
-          aria-controls={listboxId}
+          {...(isOpen ? { 'aria-controls': listboxId } : {})}
         >
           <LabelGroup aria-label="Current selections">
             {visibleChips.map((selection) => (

--- a/frontend/src/components/__tests__/MultiSelection.spec.tsx
+++ b/frontend/src/components/__tests__/MultiSelection.spec.tsx
@@ -25,21 +25,22 @@ describe('MultiSelection', () => {
     );
 
     const combobox = screen.getByRole('combobox', { name: 'Connections' });
+    expect(combobox).not.toHaveAttribute('aria-controls');
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
     expect(combobox).toHaveAttribute('aria-controls', 'test-select-listbox');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-1');
+    expect(document.getElementById('test-select-option-s-connection-1')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
 
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-1');
-    expect(document.getElementById('test-select-option-connection-1')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
-    });
-
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-2');
-    expect(document.getElementById('test-select-option-connection-2')).toBeInTheDocument();
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-2');
+    expect(document.getElementById('test-select-option-s-connection-2')).toBeInTheDocument();
   });
 
   it('should expose a listbox id linked from aria-controls', async () => {
@@ -78,7 +79,7 @@ describe('MultiSelection', () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
 
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-2');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-2');
 
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'Enter' });
@@ -158,13 +159,13 @@ describe('MultiSelection', () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
 
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-1');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-1');
 
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'ArrowUp' });
     });
 
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-3');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-3');
   });
 
   it('should close the menu on Escape and Tab', async () => {
@@ -200,6 +201,33 @@ describe('MultiSelection', () => {
 
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'Tab' });
+      await Promise.resolve();
+    });
+
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    expect(combobox).not.toHaveAttribute('aria-activedescendant');
+  });
+
+  it('should close the menu only once when Tab races with PatternFly close', async () => {
+    render(
+      <MultiSelection
+        id="test-select"
+        ariaLabel="Connections"
+        value={defaultOptions}
+        setValue={jest.fn()}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connections' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'Tab' });
+      fireEvent.keyDown(combobox, { key: 'Escape' });
+      await Promise.resolve();
     });
 
     expect(combobox).toHaveAttribute('aria-expanded', 'false');
@@ -221,22 +249,22 @@ describe('MultiSelection', () => {
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-1');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-1');
 
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-2');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-2');
 
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-3');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-3');
 
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-1');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-1');
   });
 
   it('should announce no results found when the menu opens with no options', async () => {
@@ -276,13 +304,13 @@ describe('MultiSelection', () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
 
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-1');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-1');
 
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
 
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-connection-3');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-connection-3');
   });
 
   it('should produce distinct aria-activedescendant ids for slash and encoded slash-like ids', async () => {
@@ -306,8 +334,8 @@ describe('MultiSelection', () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
 
-    const slashDescendant = 'test-select-option-coreu47upods';
-    const encodedDescendant = 'test-select-option-coreuu47uupods';
+    const slashDescendant = 'test-select-option-s-coreu47upods';
+    const encodedDescendant = 'test-select-option-s-coreuu47uupods';
 
     expect(combobox).toHaveAttribute('aria-activedescendant', slashDescendant);
     expect(document.getElementById(slashDescendant)).toBeInTheDocument();
@@ -454,8 +482,8 @@ describe('MultiSelection', () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
 
-    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-1');
-    expect(document.getElementById('test-select-option-1')).toBeInTheDocument();
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-n-1');
+    expect(document.getElementById('test-select-option-n-1')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'Enter' });

--- a/frontend/src/components/__tests__/MultiSelection.spec.tsx
+++ b/frontend/src/components/__tests__/MultiSelection.spec.tsx
@@ -456,8 +456,14 @@ describe('MultiSelection', () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
 
-    expect(within(dialog).getByRole('option', { name: 'Connection 1' })).toBeInTheDocument();
-    expect(within(dialog).getByRole('option', { name: 'Connection 2' })).toBeInTheDocument();
+    // Options must be inside the dialog but outside the combobox toggle anchor
+    // (inline render would also satisfy within(dialog)).
+    const option1 = within(dialog).getByRole('option', { name: 'Connection 1' });
+    const option2 = within(dialog).getByRole('option', { name: 'Connection 2' });
+    expect(dialog.contains(option1)).toBe(true);
+    expect(combobox.contains(option1)).toBe(false);
+    expect(dialog.contains(option2)).toBe(true);
+    expect(combobox.contains(option2)).toBe(false);
   });
 
   it('should select options when option id is numeric', async () => {

--- a/frontend/src/concepts/connectionTypes/ConnectionTypeForm.tsx
+++ b/frontend/src/concepts/connectionTypes/ConnectionTypeForm.tsx
@@ -166,6 +166,7 @@ const ConnectionTypeForm: React.FC<Props> = ({
           <FlexItem grow={{ default: 'grow' }}>
             <TypeaheadSelect
               id="connection-type"
+              ariaLabel="Connection type"
               selectOptions={selectOptions}
               onSelect={(_, selection) => {
                 if (typeof selection === 'string') {

--- a/frontend/src/concepts/connectionTypes/ExistingConnectionField.tsx
+++ b/frontend/src/concepts/connectionTypes/ExistingConnectionField.tsx
@@ -88,6 +88,7 @@ export const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = (
       <Flex direction={{ default: 'row' }} spaceItems={{ default: 'spaceItemsSm' }}>
         <FlexItem grow={{ default: 'grow' }}>
           <TypeaheadSelect
+            ariaLabel="Connection"
             selectOptions={options}
             onSelect={(_, value) => {
               const newConnection = projectConnections.find(
@@ -97,7 +98,6 @@ export const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = (
                 onSelect(newConnection.connection);
               }
             }}
-            popperProps={{ appendTo: 'inline' }}
             previewDescription={false}
           />
         </FlexItem>

--- a/frontend/src/concepts/connectionTypes/fields/DropdownFormField.scss
+++ b/frontend/src/concepts/connectionTypes/fields/DropdownFormField.scss
@@ -1,0 +1,4 @@
+// innerRef anchor without adding a layout box (keeps parent flex/grid intact).
+.odh-dropdown-form-field__toggle-anchor {
+  display: contents;
+}

--- a/frontend/src/concepts/connectionTypes/fields/DropdownFormField.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/DropdownFormField.tsx
@@ -18,8 +18,11 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import DefaultValueTextRenderer from '@odh-dashboard/ui-core/components/connectionTypes/DefaultValueTextRenderer';
+import { useMenuPopperInModal } from '#~/utilities/useModalOverflowUnlock';
 import { DropdownField } from '#~/concepts/connectionTypes/types';
 import { FieldProps } from '#~/concepts/connectionTypes/fields/types';
+
+import './DropdownFormField.scss';
 
 const DropdownFormField: React.FC<FieldProps<DropdownField>> = ({
   id,
@@ -33,6 +36,16 @@ const DropdownFormField: React.FC<FieldProps<DropdownField>> = ({
 }) => {
   const isPreview = mode === 'preview';
   const [isOpen, setIsOpen] = React.useState(false);
+  const menuToggleRef = React.useRef<HTMLDivElement | null>(null);
+  const focusMenuToggle = () => {
+    queueMicrotask(() => {
+      menuToggleRef.current?.querySelector('button')?.focus();
+    });
+  };
+  const listboxId = React.useId();
+  const popperProps = useMenuPopperInModal(isOpen, menuToggleRef, undefined, {
+    onEscapeClose: () => setIsOpen(false),
+  });
   const isMulti = field.properties.variant === 'multi';
   const selected = isPreview ? field.properties.defaultValue : value;
   const hasValidOption = field.properties.items?.find((f) => f.value || f.label);
@@ -66,6 +79,7 @@ const DropdownFormField: React.FC<FieldProps<DropdownField>> = ({
       <Select
         isOpen={isOpen}
         shouldFocusToggleOnSelect
+        popperProps={popperProps}
         onSelect={
           isPreview || !onChange
             ? undefined
@@ -84,35 +98,39 @@ const DropdownFormField: React.FC<FieldProps<DropdownField>> = ({
                 if (!isMulti) {
                   setIsOpen(false);
                 }
+                focusMenuToggle();
               }
         }
         onOpenChange={(open) => setIsOpen(open)}
         toggle={(toggleRef) => (
-          <MenuToggle
-            ref={toggleRef}
-            id={id}
-            data-testid={dataTestId}
-            isFullWidth
-            onClick={() => {
-              setIsOpen((open) => !open);
-            }}
-            isExpanded={isOpen}
-            isDisabled={!hasValidOption}
-            status={error ? 'danger' : undefined}
-          >
-            <>
-              {menuToggleText()}
-              {isMulti && (
-                <Badge className="pf-v6-u-ml-xs">
-                  {(isPreview ? field.properties.defaultValue?.length : value?.length) ?? 0}{' '}
-                  selected
-                </Badge>
-              )}
-            </>
-          </MenuToggle>
+          <div ref={menuToggleRef} className="odh-dropdown-form-field__toggle-anchor">
+            <MenuToggle
+              innerRef={toggleRef}
+              id={id}
+              data-testid={dataTestId}
+              isFullWidth
+              {...(isOpen ? { 'aria-controls': listboxId } : {})}
+              onClick={() => {
+                setIsOpen((open) => !open);
+              }}
+              isExpanded={isOpen}
+              isDisabled={!hasValidOption}
+              status={error ? 'danger' : undefined}
+            >
+              <>
+                {menuToggleText()}
+                {isMulti && (
+                  <Badge className="pf-v6-u-ml-xs">
+                    {(isPreview ? field.properties.defaultValue?.length : value?.length) ?? 0}{' '}
+                    selected
+                  </Badge>
+                )}
+              </>
+            </MenuToggle>
+          </div>
         )}
       >
-        <SelectList isAriaMultiselectable={isMulti}>
+        <SelectList id={listboxId} isAriaMultiselectable={isMulti}>
           {field.properties.items?.map(
             (item, index) =>
               (item.value || item.label) && (

--- a/frontend/src/concepts/connectionTypes/fields/__tests__/DropdownFormField.spec.tsx
+++ b/frontend/src/concepts/connectionTypes/fields/__tests__/DropdownFormField.spec.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import { act } from 'react';
 import { DropdownField } from '#~/concepts/connectionTypes/types';
 import DropdownFormField from '#~/concepts/connectionTypes/fields/DropdownFormField';
+import { MODAL_OVERFLOW_UNLOCK_COUNT_ATTR } from '#~/utilities/useModalOverflowUnlock';
 
 describe('DropdownFormField', () => {
   describe('single variant', () => {
@@ -239,5 +240,119 @@ describe('DropdownFormField', () => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
       expect(screen.queryByText('Two (Value: 2), Three (Value: 3)')).toBeInTheDocument();
     });
+  });
+
+  it('should portal options into the modal dialog for keyboard and screen reader access', async () => {
+    const dialogRef = React.createRef<HTMLDivElement>();
+    const onChange = jest.fn();
+    const field: DropdownField = {
+      type: 'dropdown',
+      name: 'Access type',
+      envVar: 'ACCESS_TYPE',
+      properties: {
+        variant: 'multi',
+        items: [
+          { value: 'Push', label: 'Push secret' },
+          { value: 'Pull', label: 'Pull secret' },
+        ],
+      },
+    };
+
+    render(
+      <div ref={dialogRef} role="dialog" style={{ overflow: 'auto' }}>
+        <DropdownFormField id="access-type" field={field} value={[]} onChange={onChange} />
+      </div>,
+    );
+
+    const dialog = dialogRef.current as HTMLDivElement;
+    const toggle = screen.getByRole('button');
+    const fieldAnchor = toggle.closest('.odh-dropdown-form-field__toggle-anchor');
+
+    act(() => {
+      toggle.click();
+    });
+
+    expect(dialog.style.overflow).toBe('visible');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBe('1');
+
+    // Multi SelectOption with checkbox: menu must portal into the dialog, not stay
+    // under the field toggle (inline render would also satisfy within(dialog)).
+    // Accessible name is "Push secret Value: Push" (label + description).
+    const pushOption = within(dialog).getByRole('checkbox', { name: /Push secret/ });
+    expect(dialog.contains(pushOption)).toBe(true);
+    expect(fieldAnchor?.contains(pushOption)).toBe(false);
+  });
+
+  it('should return focus to the toggle after selecting an option', async () => {
+    const onChange = jest.fn();
+    const field: DropdownField = {
+      type: 'dropdown',
+      name: 'Access type',
+      envVar: 'ACCESS_TYPE',
+      properties: {
+        variant: 'multi',
+        items: [
+          { value: 'Push', label: 'Push secret' },
+          { value: 'Pull', label: 'Pull secret' },
+        ],
+      },
+    };
+
+    render(<DropdownFormField id="access-type" field={field} value={[]} onChange={onChange} />);
+
+    const toggle = screen.getByRole('button', { name: /Select access type/i });
+
+    await act(async () => {
+      toggle.click();
+    });
+
+    const pushOption = screen.getByRole('checkbox', { name: /Push secret/ });
+
+    await act(async () => {
+      pushOption.click();
+      await Promise.resolve();
+    });
+
+    expect(onChange).toHaveBeenCalledWith(['Push']);
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it('should return focus to the toggle after Escape closes the menu', async () => {
+    const onChange = jest.fn();
+    const field: DropdownField = {
+      type: 'dropdown',
+      name: 'Access type',
+      envVar: 'ACCESS_TYPE',
+      properties: {
+        variant: 'multi',
+        items: [
+          { value: 'Push', label: 'Push secret' },
+          { value: 'Pull', label: 'Pull secret' },
+        ],
+      },
+    };
+
+    render(
+      <div role="dialog">
+        <DropdownFormField id="access-type" field={field} value={[]} onChange={onChange} />
+      </div>,
+    );
+
+    const toggle = screen.getByRole('button', { name: /Select access type/i });
+
+    await act(async () => {
+      toggle.click();
+    });
+
+    const pushOption = screen.getByRole('checkbox', { name: /Push secret/ });
+    pushOption.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(pushOption, { key: 'Escape' });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-expanded', 'false'));
+    expect(document.activeElement).toBe(toggle);
   });
 });

--- a/frontend/src/concepts/modelRegistry/content/ConnectionDropdown.scss
+++ b/frontend/src/concepts/modelRegistry/content/ConnectionDropdown.scss
@@ -1,0 +1,4 @@
+// innerRef anchor without adding a layout box (keeps parent flex/grid intact).
+.odh-connection-dropdown__toggle-anchor {
+  display: contents;
+}

--- a/frontend/src/concepts/modelRegistry/content/ConnectionDropdown.tsx
+++ b/frontend/src/concepts/modelRegistry/content/ConnectionDropdown.tsx
@@ -12,6 +12,9 @@ import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { Connection } from '#~/concepts/connectionTypes/types';
 import useServingConnections from '#~/pages/projects/screens/detail/connections/useServingConnections';
 import { ModelLocationType } from '#~/concepts/modelRegistry/types';
+import { useMenuPopperInModal } from '#~/utilities/useModalOverflowUnlock';
+
+import './ConnectionDropdown.scss';
 
 type ConnectionDropdownProps = {
   type: ModelLocationType;
@@ -26,6 +29,11 @@ export const ConnectionDropdown = ({
   selectedConnection,
 }: ConnectionDropdownProps): React.JSX.Element => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const menuToggleRef = React.useRef<HTMLDivElement | null>(null);
+  const menuId = React.useId();
+  const popperProps = useMenuPopperInModal(isOpen, menuToggleRef, undefined, {
+    onEscapeClose: () => setIsOpen(false),
+  });
   const [connections, connectionsLoaded, connectionsLoadError] = useServingConnections(project);
 
   const onToggle = () => {
@@ -74,34 +82,37 @@ export const ConnectionDropdown = ({
     }
   };
   return (
-    <Dropdown
-      onOpenChange={(isOpened) => setIsOpen(isOpened)}
-      toggle={(toggleRef) => (
-        <MenuToggle
-          isDisabled={!filteredConnections.length}
-          isFullWidth
-          data-testid="select-connection"
-          ref={toggleRef}
-          onClick={onToggle}
-          isExpanded={isOpen}
-        >
-          {getToggleContent()}
-        </MenuToggle>
-      )}
-      isOpen={isOpen}
-      popperProps={{ appendTo: 'inline' }}
-    >
-      <Menu onSelect={onSelectConnection} isScrollable isPlain>
-        <MenuContent>
-          <MenuList>
-            {filteredConnections.map((dataItem) => (
-              <MenuItem key={dataItem.metadata.name} itemId={dataItem.metadata.name}>
-                {getDisplayNameFromK8sResource(dataItem)}
-              </MenuItem>
-            ))}
-          </MenuList>
-        </MenuContent>
-      </Menu>
-    </Dropdown>
+    <div ref={menuToggleRef} className="odh-connection-dropdown__toggle-anchor">
+      <Dropdown
+        onOpenChange={(isOpened) => setIsOpen(isOpened)}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            isDisabled={!filteredConnections.length}
+            isFullWidth
+            data-testid="select-connection"
+            {...(isOpen ? { 'aria-controls': menuId } : {})}
+            ref={toggleRef}
+            onClick={onToggle}
+            isExpanded={isOpen}
+          >
+            {getToggleContent()}
+          </MenuToggle>
+        )}
+        isOpen={isOpen}
+        popperProps={popperProps}
+      >
+        <Menu id={menuId} onSelect={onSelectConnection} isScrollable isPlain>
+          <MenuContent>
+            <MenuList>
+              {filteredConnections.map((dataItem) => (
+                <MenuItem key={dataItem.metadata.name} itemId={dataItem.metadata.name}>
+                  {getDisplayNameFromK8sResource(dataItem)}
+                </MenuItem>
+              ))}
+            </MenuList>
+          </MenuContent>
+        </Menu>
+      </Dropdown>
+    </div>
   );
 };

--- a/frontend/src/concepts/roleBinding/RoleBindingPermissionsNameInput.tsx
+++ b/frontend/src/concepts/roleBinding/RoleBindingPermissionsNameInput.tsx
@@ -57,6 +57,7 @@ const RoleBindingPermissionsNameInput: React.FC<RoleBindingPermissionsNameInputP
   }
   return (
     <TypeaheadSelect
+      ariaLabel={placeholderText}
       dataTestId={`role-binding-name-select ${value}`}
       isScrollable
       selectOptions={selectOptions}

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
@@ -48,7 +48,6 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
                 : 'Select target project'
             }
             searchPlaceholder="Project name"
-            appendTo={() => document.body}
           >
             {visibleProjects.length === 0 && <MenuItem isDisabled>No matching results</MenuItem>}
             {visibleProjects.map((project) => (

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ConnectionSection.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ConnectionSection.spec.tsx
@@ -103,9 +103,9 @@ describe('ConnectionsFormSection', () => {
     );
 
     expect(result.getByRole('radio', { name: 'Existing connection' })).toBeChecked();
-    expect(result.getByRole('combobox', { name: 'Type to filter' })).toHaveValue('');
+    expect(result.getByRole('combobox', { name: 'Connection' })).toHaveValue('');
 
-    await act(async () => result.getByRole('button', { name: 'Typeahead menu toggle' }).click());
+    await act(async () => result.getByRole('button', { name: 'Connection' }).click());
     await act(async () => result.getByRole('option', { name: 's3-connection Type: s3' }).click());
     expect(mockSetData).toHaveBeenLastCalledWith('storage', {
       type: InferenceServiceStorageType.EXISTING_STORAGE,
@@ -152,7 +152,7 @@ describe('ConnectionsFormSection', () => {
 
     expect(result.getByRole('radio', { name: 'Existing connection' })).toBeChecked();
 
-    expect(result.getByRole('combobox', { name: 'Type to filter' })).toHaveValue('s3-connection');
+    expect(result.getByRole('combobox', { name: 'Connection' })).toHaveValue('s3-connection');
     expect(result.getByRole('textbox', { name: 'folder-path' })).toHaveValue('models/fraud');
   });
 
@@ -180,9 +180,9 @@ describe('ConnectionsFormSection', () => {
     );
 
     expect(result.getByRole('radio', { name: 'Create connection' })).toBeChecked();
-    expect(result.getByRole('combobox', { name: 'Type to filter' })).toHaveValue('');
+    expect(result.getByRole('combobox', { name: 'Connection type' })).toHaveValue('');
 
-    await act(async () => result.getByRole('button', { name: 'Typeahead menu toggle' }).click());
+    await act(async () => result.getByRole('button', { name: 'Connection type' }).click());
     await act(async () => result.getByRole('option', { name: /s3/ }).click());
 
     expect(result.getByRole('textbox', { name: 'Connection name' })).toHaveValue('');
@@ -245,9 +245,9 @@ describe('ConnectionsFormSection', () => {
     );
 
     expect(result.getByRole('radio', { name: 'Create connection' })).toBeChecked();
-    expect(result.getByRole('combobox', { name: 'Type to filter' })).toHaveValue('');
+    expect(result.getByRole('combobox', { name: 'Connection type' })).toHaveValue('');
 
-    await act(async () => result.getByRole('button', { name: 'Typeahead menu toggle' }).click());
+    await act(async () => result.getByRole('button', { name: 'Connection type' }).click());
     await act(async () => result.getByRole('option', { name: /oci/ }).click());
 
     expect(result.getByRole('textbox', { name: 'Connection name' })).toHaveValue('');
@@ -282,9 +282,9 @@ describe('ConnectionsFormSection', () => {
     );
 
     expect(result.getByRole('radio', { name: 'Create connection' })).toBeChecked();
-    expect(result.getByRole('combobox', { name: 'Type to filter' })).toHaveValue('');
+    expect(result.getByRole('combobox', { name: 'Connection type' })).toHaveValue('');
 
-    await act(async () => result.getByRole('button', { name: 'Typeahead menu toggle' }).click());
+    await act(async () => result.getByRole('button', { name: 'Connection type' }).click());
     await act(async () => result.getByRole('option', { name: /oci/ }).click());
     await act(async () =>
       fireEvent.change(result.getByRole('textbox', { name: 'Connection name' }), {

--- a/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
@@ -342,7 +342,13 @@ export const ManageConnectionModal: React.FC<Props> = ({
                 restarted, redeployed, or otherwise regenerated.
               </Alert>
             )}
-            <Form>
+            <Form
+              onSubmit={(e) => {
+                // Inputs (e.g. TypeaheadSelect) use Enter for open/select; do not
+                // allow native form submit (page refresh). Create uses the footer button.
+                e.preventDefault();
+              }}
+            >
               <ConnectionTypeForm
                 options={!isEdit ? enabledConnectionTypes : undefined}
                 connectionType={

--- a/frontend/src/pages/projects/screens/detail/connections/__tests__/ManageConnectionsModal.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/__tests__/ManageConnectionsModal.spec.tsx
@@ -94,7 +94,7 @@ describe('Create connection modal', () => {
     );
 
     await act(async () => {
-      screen.getByRole('button', { name: 'Typeahead menu toggle' }).click();
+      screen.getByRole('button', { name: 'Connection type' }).click();
     });
     expect(screen.getByRole('option', { name: /type one/ })).toBeTruthy();
     expect(screen.getByRole('option', { name: /type two/ })).toBeTruthy();
@@ -303,7 +303,7 @@ describe('Create connection modal', () => {
     );
 
     await act(async () => {
-      screen.getByRole('button', { name: 'Typeahead menu toggle' }).click();
+      screen.getByRole('button', { name: 'Connection type' }).click();
     });
     await act(async () => {
       screen.getByRole('option', { name: /type one/ }).click();
@@ -328,7 +328,7 @@ describe('Create connection modal', () => {
     expect(screen.getByRole('textbox', { name: 'Short text 1' })).toHaveValue('one field');
 
     await act(async () => {
-      screen.getByRole('button', { name: 'Typeahead menu toggle' }).click();
+      screen.getByRole('button', { name: 'Connection type' }).click();
     });
     await act(async () => {
       screen.getByRole('option', { name: /type two/ }).click();
@@ -342,7 +342,7 @@ describe('Create connection modal', () => {
     expect(screen.getByRole('textbox', { name: 'Short text 2' })).toHaveValue('');
 
     await act(async () => {
-      screen.getByRole('button', { name: 'Typeahead menu toggle' }).click();
+      screen.getByRole('button', { name: 'Connection type' }).click();
     });
     await act(async () => {
       screen.getByRole('option', { name: /type one/ }).click();
@@ -699,7 +699,7 @@ describe('ManageConnectionModal test connection', () => {
 
     // Select type one
     await act(async () => {
-      screen.getByRole('button', { name: 'Typeahead menu toggle' }).click();
+      screen.getByRole('button', { name: 'Connection type' }).click();
     });
     await act(async () => {
       screen.getByRole('option', { name: /type one/ }).click();
@@ -714,7 +714,7 @@ describe('ManageConnectionModal test connection', () => {
 
     // Change connection type
     await act(async () => {
-      screen.getByRole('button', { name: 'Typeahead menu toggle' }).click();
+      screen.getByRole('button', { name: 'Connection type' }).click();
     });
     await act(async () => {
       screen.getByRole('option', { name: /type two/ }).click();

--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTableRow.tsx
@@ -94,6 +94,7 @@ const ClusterStorageTableRow: React.FC<ClusterStorageTableRowProps> = ({
             }}
             previewDescription={false}
             dataTestId="cluster-storage-workbench-select"
+            ariaLabel="Workbench"
           />
         ) : (
           <>

--- a/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
@@ -118,9 +118,13 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
         }}
         placeholder={placeholderText}
         noOptionsFoundMessage={(filter) => `No persistent storage was found for "${filter}"`}
-        popperProps={{ direction: selectDirection, appendTo: menuAppendTo }}
+        ariaLabel="Persistent storage"
+        popperProps={{
+          direction: selectDirection,
+          ...(menuAppendTo !== undefined ? { appendTo: menuAppendTo } : {}),
+        }}
         isDisabled={!loaded}
-        data-testid="persistent-storage-typeahead"
+        dataTestId="persistent-storage-typeahead"
         isScrollable
       />
       <FormHelperText>

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -147,7 +147,8 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
         }}
         isDisabled={disableStorageClassSelect || shouldShowDefaultOnly}
         placeholder="Select storage class"
-        popperProps={{ appendTo: menuAppendTo }}
+        ariaLabel="Storage class"
+        popperProps={menuAppendTo !== undefined ? { appendTo: menuAppendTo } : undefined}
         toggleProps={{ status: validated ? validatedToToggleStatus[validated] : undefined }}
         previewDescription={false}
         isScrollable

--- a/frontend/src/utilities/useModalOverflowUnlock.ts
+++ b/frontend/src/utilities/useModalOverflowUnlock.ts
@@ -2,4 +2,8 @@ export {
   MODAL_OVERFLOW_UNLOCK_COUNT_ATTR,
   resolveSelectPopperAppendTo,
   useModalOverflowUnlock,
+  useMenuPopperInModal,
+  encodeOptionIdForDom,
+  createOptionElementId,
 } from '@odh-dashboard/ui-core/utilities';
+export type { MenuPopperAppendTo, MenuPopperProps } from '@odh-dashboard/ui-core/utilities';

--- a/notes/RHOAIENG-76231-manual-select-testing.md
+++ b/notes/RHOAIENG-76231-manual-select-testing.md
@@ -57,7 +57,8 @@ Every control below is tagged:
 ### Cluster prerequisites
 
 - Open Data Hub / RHOAI Dashboard installed
-- User with project create access (cluster-admin simplifies admin phases)
+- Dedicated non-production test user with the minimum permissions required by this runbook (project create, plus serving/registry access for Phase 2 if those operators are installed)
+- Use `cluster-admin` only on an isolated, disposable cluster when a phase requires it
 - At least one Notebook ImageStream, storage class, and (for Phase 2) model serving / model registry if those operators are installed
 
 ### Commands
@@ -369,6 +370,20 @@ Skip any row if the operator / feature flag is unavailable.
 
 ---
 
+## Phase 5 — Cleanup
+
+Record whether `manual-76231-test` existed before this run.
+
+If this run created the project, delete it after testing:
+
+```bash
+oc delete project manual-76231-test --wait=true
+```
+
+If the project pre-existed, delete only the connections, PVCs, storage, and optional serving resources created by this run, and remove their test secrets.
+
+---
+
 ## Suggested order (highest value)
 
 1. **1A** Create connection type  
@@ -419,6 +434,9 @@ REGRESSION
 
 OPTIONAL
 [ ] 4A–4D as available
+
+CLEANUP
+[ ] 5 Delete `manual-76231-test` if this run created it, otherwise remove resources created here
 ```
 
 ---
@@ -426,6 +444,6 @@ OPTIONAL
 ## Reference
 
 - Prior runbook pattern: `notes/RHOAIENG-66822-manual-select-testing.md` (may be absent in this worktree; structure mirrored here)
-- Cypress mocked: `packages/cypress/cypress/tests/mocked/projects/tabs/connections.cy.ts`, `workbench.cy.ts`
+- Cypress mocked: `packages/cypress/cypress/tests/mocked/projects/tabs/connections.cy.ts`, `packages/cypress/cypress/tests/mocked/projects/tabs/workbenchEditDelete.cy.ts`
 - Shared hook: `packages/ui-core/src/utilities/useMenuPopperInModal.ts`
 - Branch context: `.cursor/context/current/scope.md`, `notes.md`

--- a/notes/RHOAIENG-76231-manual-select-testing.md
+++ b/notes/RHOAIENG-76231-manual-select-testing.md
@@ -82,6 +82,14 @@ Re-run `make login` and restart the dev server if the session expires.
 - NIM deploy paths: enable NIM / gen-ai flags via dev banner or `?devFeatureFlags=...` if your cluster uses them
 - Model Registry: requires MR operator + registry instance
 
+### Record project ownership
+
+```bash
+oc get project manual-76231-test 2>/dev/null && echo "EXISTS" || echo "NEW"
+```
+
+Record the result. Phase 5 cleanup uses it to decide whether to delete the project or only its test resources.
+
 ---
 
 ## Phase 1 — CHANGED vs main (ticket AC — do first)
@@ -372,15 +380,13 @@ Skip any row if the operator / feature flag is unavailable.
 
 ## Phase 5 — Cleanup
 
-Record whether `manual-76231-test` existed before this run.
-
-If this run created the project, delete it after testing:
+If Phase 0 recorded `NEW`, delete the project after testing:
 
 ```bash
 oc delete project manual-76231-test --wait=true
 ```
 
-If the project pre-existed, delete only the connections, PVCs, storage, and optional serving resources created by this run, and remove their test secrets.
+If Phase 0 recorded `EXISTS`, delete only the connections, PVCs, storage, and optional serving resources created by this run, and remove their test secrets.
 
 ---
 

--- a/notes/RHOAIENG-76231-manual-select-testing.md
+++ b/notes/RHOAIENG-76231-manual-select-testing.md
@@ -1,0 +1,431 @@
+# RHOAIENG-76231 — Manual select/dropdown testing runbook
+
+Branch: `RHOAIENG-76231/modal-dropdown-a11y`  
+Ticket: [RHOAIENG-76231](https://redhat.atlassian.net/browse/RHOAIENG-76231) — remaining modal dropdown a11y (follow-up to [RHOAIENG-66822](https://redhat.atlassian.net/browse/RHOAIENG-66822)).
+
+This runbook is the executable manual test guide. Follow phases in order from a fresh workspace on a live OpenShift cluster. Prefer VoiceOver / NVDA / JAWS for acceptance criteria; keyboard-only still catches Tab/Escape regressions.
+
+---
+
+## Legend (read first)
+
+Every control below is tagged:
+
+| Tag | Meaning |
+|-----|---------|
+| **CHANGED vs main** | Control lives in a PatternFly **Modal** / dialog. On `main`, the menu is often clipped, unreachable to screen readers, or **Escape** / **Tab** dismisses the **modal**. On this branch, the menu portals into the dialog, overflow unlocks, SR can open/arrow/select, and **Tab** / **Escape** close the **menu** while the modal stays open. |
+| **REGRESSION** | Same shared wrapper, but **not** the bug surface for this ticket (page-level, spawner non-modal, or already fixed in 66822). Expect parity with current `main` / post-66822 behavior — not a new modal fix. Still smoke-test so the shared hook did not break them. |
+
+> **Callout:** Dropdowns **inside PatternFly Modals** using the wrappers below are the ones whose keyboard/SR behavior should **differ from `main`**. Page-level and non-modal spawner selects share code but should feel the same as today unless already fixed by 66822.
+
+---
+
+## What changed (test focus)
+
+| Wrapper | Path | Modal focus |
+|---------|------|-------------|
+| **TypeaheadSelect** | `packages/ui-core/src/components/TypeaheadSelect.tsx` | Primary 76231 fix (combobox ARIA + modal popper) |
+| **DropdownFormField** | `frontend/src/concepts/connectionTypes/fields/DropdownFormField.tsx` | Connection-type dropdown fields (e.g. OCI Access type) |
+| **ValueUnitField** | `packages/ui-core/src/components/ValueUnitField.tsx` | Size unit dropdown in storage modals |
+| **SearchSelector** | `packages/ui-core/src/components/searchSelector/SearchSelector.tsx` | Project pickers in modals |
+| **ConnectionDropdown** | `frontend/src/concepts/modelRegistry/content/ConnectionDropdown.tsx` | MR autofill **Connection** modal |
+| **SimpleSelect** + **StorageClassSelect** | `packages/ui-core/.../SimpleSelect.tsx` + `frontend/.../StorageClassSelect.tsx` | Shared hook refactor; StorageClassSelect no longer overrides `appendTo` when unset |
+| **MultiSelection** | `frontend/src/components/MultiSelection.tsx` | Regression only (66822) |
+| Shared hook | `packages/ui-core/src/utilities/useMenuPopperInModal.ts` | Dialog-aware `appendTo` + overflow unlock |
+
+### Per-control checklist (apply to every **CHANGED vs main** row)
+
+1. Open/close — toggle `aria-expanded` `false` → `true` → `false`
+2. Keyboard — Arrow keys move highlight; Enter/Space selects
+3. **Tab** with menu open — **one Tab** advances focus to the next field (not the modal container); menu closes; **modal stays open**
+4. **Escape** with menu open — menu closes; **modal stays open** (on `main` this often closes the modal)
+5. Clipping — full option list visible / reachable inside the dialog (not cut off by overflow)
+6. Screen reader (VO/NVDA/JAWS) — announce options; arrow and select
+7. TypeaheadSelect only — `aria-controls` points at listbox; `aria-activedescendant` tracks focused option
+8. TypeaheadSelect only — **Enter** selects the focused option **without** submitting the form or closing the modal
+
+### Per-control checklist (apply to every **REGRESSION** row)
+
+1. Open, select, close with mouse and keyboard
+2. No new clipping or broken labels vs `main`
+3. Look & feel unchanged (PF spacing, full-width toggles)
+
+---
+
+## Phase 0 — Environment setup
+
+### Cluster prerequisites
+
+- Open Data Hub / RHOAI Dashboard installed
+- User with project create access (cluster-admin simplifies admin phases)
+- At least one Notebook ImageStream, storage class, and (for Phase 2) model serving / model registry if those operators are installed
+
+### Commands
+
+```bash
+git checkout RHOAIENG-76231/modal-dropdown-a11y
+npm install
+npm run build
+make login          # or: oc login <api-url> -u <user>
+npm run dev         # backend :4000 + frontend :4010 — enough for this runbook
+```
+
+Open **http://localhost:4010** and log in with cluster credentials.
+
+Use either `npm run dev` **or** `npm run start`, not both (they compete for ports 4000/4010). Prefer `npm run dev` unless you need federated modules (Model Registry BFF). For Phase 2B/2C, use `npm run start` if MR UI is federated in your env.
+
+Re-run `make login` and restart the dev server if the session expires.
+
+### Optional feature flags
+
+- NIM deploy paths: enable NIM / gen-ai flags via dev banner or `?devFeatureFlags=...` if your cluster uses them
+- Model Registry: requires MR operator + registry instance
+
+---
+
+## Phase 1 — CHANGED vs main (ticket AC — do first)
+
+Create a project if needed:
+
+| Step | Action | Test data |
+|------|--------|-----------|
+| 1 | Sidebar → **Projects** | — |
+| 2 | **Create project** | Display / resource name: `manual-76231-test` |
+
+Land on `/projects/manual-76231-test`.
+
+### 1A. Create connection — Connection type
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | `TypeaheadSelect` via `ConnectionTypeForm` |
+| **Navigation** | Projects → `manual-76231-test` → **Connections** → **Create connection** |
+| **Control** | **Connection type** combobox (`data-testid="connection-type-dropdown"`) |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Create connection modal | [ ] |
+| 2 | Focus Connection type; open with keyboard | [ ] |
+| 3 | Arrow through types; select one (e.g. S3) | [ ] |
+| 4 | With menu open: **Tab** — **one Tab** moves focus to the next field (not modal container); menu closes; modal stays | [ ] |
+| 5 | Re-open; **Escape** — menu closes, modal stays | [ ] |
+| 6 | (SR) Open, arrow, select announced correctly | [ ] |
+
+**vs main:** On `main`, Escape often closes the whole Create connection modal; menu may be clipped or hard for SR. On this branch, Escape/Tab only dismiss the menu.
+
+Fill enough fields to create `test-s3-connection` if you will need it in Phase 2 (optional for 1A alone).
+
+### 1A2. Create connection — Access type (OCI connection-type dropdown)
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | Raw PF `Select` via `DropdownFormField` + `useMenuPopperInModal` |
+| **Navigation** | Projects → project → **Connections** → **Create connection** → select connection type **OCI** (or any type with a Dropdown field) |
+| **Control** | **Access type** (multi-select; Push secret / Pull secret) |
+| **Prerequisite** | Complete Connection type selection first (1A) |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | After selecting OCI, locate **Access type** | [ ] |
+| 2 | Open with keyboard; arrow through Push / Pull; select (Space/Enter) | [ ] |
+| 3 | With menu open: **Tab** — menu closes, modal stays | [ ] |
+| 4 | Re-open; **Escape** — menu closes, modal stays | [ ] |
+| 5 | (SR) Options reachable and announced inside the dialog | [ ] |
+
+**vs main:** Same modal clipping / focus-trap issue as other Create connection menus. This control is not SimpleSelect/MultiSelection; the shared popper hook is applied on the raw Select.
+
+### 1B. Create connection from workbench
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | Same `TypeaheadSelect` |
+| **Navigation** | Projects → project → **Workbenches** → **Create workbench** → Connections → **Create connection** |
+| **Control** | Connection type combobox in nested modal |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Create connection from spawner | [ ] |
+| 2 | Repeat open / arrow / Tab / Escape checks from 1A | [ ] |
+
+### 1C. Attach existing storage — PVC typeahead
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | `TypeaheadSelect` via `AddExistingStorageField` |
+| **Navigation** | Workbenches → Create/Edit workbench → Cluster storage → **Attach existing storage** |
+| **Control** | Persistent storage typeahead (label **Persistent storage**) |
+| **Prerequisite** | At least one PVC in the project (create via 1D/1E first if empty) |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Attach existing storage modal | [ ] |
+| 2 | Open PVC typeahead; filter/type; arrow; select | [ ] |
+| 3 | Tab / Escape close menu, not modal | [ ] |
+| 4 | (SR) Options reachable and selectable | [ ] |
+
+**vs main:** Same Escape/Tab-vs-modal and clipping issues as other modal typeaheads.
+
+### 1D. Create storage (workbench) — size unit + storage class
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrappers** | `ValueUnitField` (size unit); `SimpleSelect` / `StorageClassSelect` (storage class) |
+| **Navigation** | Workbenches → Create/Edit → Cluster storage → **Create storage** |
+| **Controls** | Persistent storage size unit dropdown; **Storage class** |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Create storage modal | [ ] |
+| 2 | Size unit dropdown — open, arrow (if supported), select Gi/Mi | [ ] |
+| 3 | Tab / Escape close unit menu, not modal | [ ] |
+| 4 | Storage class — open, select; menu not clipped | [ ] |
+| 5 | Tab / Escape close storage class menu, not modal | [ ] |
+| 6 | Name `wb-storage`, size `8`, mount path valid; create if useful for 1C | [ ] |
+
+**vs main:** Size unit (`ValueUnitField`) and StorageClassSelect append behavior are the 76231 focus here. Note: arrow-key navigation on the **unit** dropdown may still be limited by PatternFly Dropdown (pre-existing); still verify Tab/Escape and SR open/select.
+
+### 1E. Add cluster storage (project tab)
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrappers** | Same as 1D |
+| **Navigation** | Projects → project → **Cluster storage** → **Add cluster storage** |
+| **Controls** | Size unit + Storage class |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Add cluster storage modal | [ ] |
+| 2 | Repeat size unit + storage class checks from 1D | [ ] |
+| 3 | Optional: Update storage (row ⋮ → Update) — same controls | [ ] |
+
+---
+
+## Phase 2 — CHANGED vs main (model serving / Model Registry)
+
+### 2A. Deploy model — Existing connection
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | `TypeaheadSelect` via `ExistingConnectionField` |
+| **Navigation** | Projects → project → **Models** (or Model serving) → **Deploy model** → Storage → **Existing connection** |
+| **Control** | Connection typeahead |
+| **Prerequisite** | Connection from Phase 1A; serving runtime available |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Deploy model flow; choose Existing connection | [ ] |
+| 2 | Open connection typeahead; arrow/filter; select | [ ] |
+| 3 | Tab / Escape close menu, not deploy modal | [ ] |
+| 4 | (SR) smoke | [ ] |
+
+**vs main:** Modal typeahead should behave like 1A, not like page-level selects.
+
+### 2B. Model Registry — Autofill connection
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrappers** | `SearchSelector` (project) + `ConnectionDropdown` (connection name) |
+| **Navigation** | **Model Registry** → registry → **Register model** (or register version) → Model location → **Autofill connection** |
+| **Controls** | Project search dropdown; **Connection name** (`data-testid="select-connection"`) |
+| **Prerequisite** | MR instance + connection in a project; may need `npm run start` for federated MR |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Autofill from connection modal (`connection-autofill-modal`) | [ ] |
+| 2 | Project `SearchSelector` — open, search, select | [ ] |
+| 3 | Tab / Escape close project menu, not modal | [ ] |
+| 4 | Connection dropdown — open, select | [ ] |
+| 5 | Tab / Escape close connection menu, not modal | [ ] |
+| 6 | (SR) both controls | [ ] |
+
+**vs main:** Both menus are modal-hosted; expect the Escape/Tab and portal fix vs `main`.
+
+### 2C. Model Registry — Deploy (project selector)
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | `SearchSelector` via `InferenceServiceModal/ProjectSelector` |
+| **Navigation** | Model Registry → registered model → version → **Deploy** |
+| **Control** | Project selector (`data-testid="deploy-model-project-selector"`) |
+| **Also check** | If 2+ matching connections appear, connection typeahead (`ExistingConnectionField`) — **CHANGED vs main** |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Deploy from MR modal | [ ] |
+| 2 | Project selector — open, search, select; Tab/Escape | [ ] |
+| 3 | Connection typeahead if shown — same checks as 2A | [ ] |
+
+---
+
+## Phase 3 — REGRESSION (shared wrappers; no expected new modal fix)
+
+These use the same components but should **match `main` / post-66822**. Mark failures only if this branch broke them.
+
+### 3A. Workbench spawner — notebook image / version
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** |
+| **Wrapper** | `SimpleSelect` (page / non-modal spawner) |
+| **Navigation** | Workbenches → **Create workbench** |
+| **Controls** | Notebook image; Image version |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open image + version selects; choose values | [ ] |
+| 2 | Keyboard open/select works as on `main` | [ ] |
+
+**Note:** Impacted by shared `SimpleSelect` hook refactor — **expect no behavior change** vs post-66822 `main`.
+
+### 3B. Workbench env var type / data type
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** (already fixed in 66822) |
+| **Wrapper** | `SimpleSelect` |
+| **Navigation** | Create workbench → Environment variables → Add variable |
+| **Controls** | Variable type; Data type |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open type/data type; select Config Map / Key-value | [ ] |
+| 2 | Behavior still matches 66822 (usable in form; no new breakage) | [ ] |
+
+### 3C. Attach existing connections — MultiSelection
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** (66822 deliverable — must still hold) |
+| **Wrapper** | `MultiSelection` |
+| **Navigation** | Create/Edit workbench → Connections → **Attach existing connections** |
+| **Control** | Connections multiselect (`id="select-connection"`) |
+| **Prerequisite** | Connection from 1A |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open modal; filter/select connection | [ ] |
+| 2 | Tab closes menu without closing modal (66822 behavior) | [ ] |
+
+### 3D. Pipelines / area project header selector
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** |
+| **Wrapper** | `SearchSelector` (page header, not modal) |
+| **Navigation** | Sidebar → **Pipelines** (or Distributed workloads) — project switcher in page header |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open project search; pick a project | [ ] |
+| 2 | Behaves like `main` (no modal Escape semantics required) | [ ] |
+
+### 3E. Learning resources toolbar
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** |
+| **Wrapper** | `SimpleSelect` |
+| **Navigation** | Sidebar → **Learning resources** |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Sort by / Sort order dropdowns | [ ] |
+
+### 3F. Deploy model — framework / runtime (page or wizard selects)
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** |
+| **Wrapper** | `SimpleSelect` (e.g. `InferenceServiceFrameworkSection`) |
+| **Navigation** | Deploy model flow — framework / serving runtime fields |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open framework / runtime selects; choose values | [ ] |
+
+**Note:** Impacted wrapper, but **expect no new change** vs post-66822 `main`. Contrast with **2A Existing connection** in the **same** deploy flow, which **is** **CHANGED vs main**.
+
+---
+
+## Phase 4 — Optional admin / edge (smoke)
+
+| ID | Tag | Navigation | Control | Pass? |
+|----|-----|------------|---------|-------|
+| 4A | **CHANGED vs main** (if modal) | Settings → Model registry → **Create registry** (secure DB section) | `SearchSelector` | [ ] |
+| 4B | **CHANGED vs main** | Deploy model (NIM) → storage | Size unit + Storage class | [ ] |
+| 4C | **REGRESSION** (66822) | Project → Permissions → Roles → **Add rule** | MultiSelection subjects/resources | [ ] |
+| 4D | **REGRESSION** | Settings → Connection types → manage numeric advanced | Typeahead / selects on page | [ ] |
+
+Skip any row if the operator / feature flag is unavailable.
+
+---
+
+## Suggested order (highest value)
+
+1. **1A** Create connection type  
+2. **1C** Attach existing storage PVC  
+3. **1D / 1E** Size unit + storage class  
+4. **2B** MR Autofill (Project + ConnectionDropdown)  
+5. **2A / 2C** Deploy existing connection / MR Deploy project  
+6. **3C** MultiSelection attach connections (66822 hold)  
+7. One non-modal **REGRESSION** each: **3A** + **3D**
+
+---
+
+## Troubleshooting empty dropdowns
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Notebook images empty | No ImageStreams | Use a cluster with notebook images |
+| Storage class empty | No StorageClasses | Ask admin / use default SC |
+| PVC typeahead empty | No PVCs | Complete 1D/1E first |
+| Connections empty | No connections | Complete 1A |
+| Model Registry missing | Federated module / operator | `npm run start` + MR instance |
+| Serving runtime empty | KServe not ready | Check model serving operator |
+| Port already in use | Leftover `npm run start`/`dev` | `lsof -i :4000 -i :4010` then kill PIDs |
+
+---
+
+## Manual pass checklist (summary)
+
+```text
+CHANGED vs main
+[ ] 1A Create connection — Connection type (TypeaheadSelect)
+[ ] 1A2 Create connection — Access type / DropdownFormField (OCI)
+[ ] 1B Create connection from workbench (same)
+[ ] 1C Attach existing storage — PVC typeahead
+[ ] 1D Create storage — size unit + storage class
+[ ] 1E Add cluster storage — size unit + storage class
+[ ] 2A Deploy model — Existing connection
+[ ] 2B MR Autofill — Project SearchSelector + ConnectionDropdown
+[ ] 2C MR Deploy — ProjectSelector (+ connection if shown)
+
+REGRESSION
+[ ] 3A Workbench image / version SimpleSelect
+[ ] 3B Env var type / data type (66822)
+[ ] 3C Attach connections MultiSelection (66822)
+[ ] 3D Page header SearchSelector (pipelines)
+[ ] 3E Learning resources sorts
+[ ] 3F Deploy framework / runtime SimpleSelect
+
+OPTIONAL
+[ ] 4A–4D as available
+```
+
+---
+
+## Reference
+
+- Prior runbook pattern: `notes/RHOAIENG-66822-manual-select-testing.md` (may be absent in this worktree; structure mirrored here)
+- Cypress mocked: `packages/cypress/cypress/tests/mocked/projects/tabs/connections.cy.ts`, `workbench.cy.ts`
+- Shared hook: `packages/ui-core/src/utilities/useMenuPopperInModal.ts`
+- Branch context: `.cursor/context/current/scope.md`, `notes.md`

--- a/notes/RHOAIENG-76231-manual-select-testing.md
+++ b/notes/RHOAIENG-76231-manual-select-testing.md
@@ -1,0 +1,449 @@
+# RHOAIENG-76231 — Manual select/dropdown testing runbook
+
+Branch: `RHOAIENG-76231/modal-dropdown-a11y`  
+Ticket: [RHOAIENG-76231](https://redhat.atlassian.net/browse/RHOAIENG-76231) — remaining modal dropdown a11y (follow-up to [RHOAIENG-66822](https://redhat.atlassian.net/browse/RHOAIENG-66822)).
+
+This runbook is the executable manual test guide. Follow phases in order from a fresh workspace on a live OpenShift cluster. Prefer VoiceOver / NVDA / JAWS for acceptance criteria; keyboard-only still catches Tab/Escape regressions.
+
+---
+
+## Legend (read first)
+
+Every control below is tagged:
+
+| Tag | Meaning |
+|-----|---------|
+| **CHANGED vs main** | Control lives in a PatternFly **Modal** / dialog. On `main`, the menu is often clipped, unreachable to screen readers, or **Escape** / **Tab** dismisses the **modal**. On this branch, the menu portals into the dialog, overflow unlocks, SR can open/arrow/select, and **Tab** / **Escape** close the **menu** while the modal stays open. |
+| **REGRESSION** | Same shared wrapper, but **not** the bug surface for this ticket (page-level, spawner non-modal, or already fixed in 66822). Expect parity with current `main` / post-66822 behavior — not a new modal fix. Still smoke-test so the shared hook did not break them. |
+
+> **Callout:** Dropdowns **inside PatternFly Modals** using the wrappers below are the ones whose keyboard/SR behavior should **differ from `main`**. Page-level and non-modal spawner selects share code but should feel the same as today unless already fixed by 66822.
+
+---
+
+## What changed (test focus)
+
+| Wrapper | Path | Modal focus |
+|---------|------|-------------|
+| **TypeaheadSelect** | `packages/ui-core/src/components/TypeaheadSelect.tsx` | Primary 76231 fix (combobox ARIA + modal popper) |
+| **DropdownFormField** | `frontend/src/concepts/connectionTypes/fields/DropdownFormField.tsx` | Connection-type dropdown fields (e.g. OCI Access type) |
+| **ValueUnitField** | `packages/ui-core/src/components/ValueUnitField.tsx` | Size unit dropdown in storage modals |
+| **SearchSelector** | `packages/ui-core/src/components/searchSelector/SearchSelector.tsx` | Project pickers in modals |
+| **ConnectionDropdown** | `frontend/src/concepts/modelRegistry/content/ConnectionDropdown.tsx` | MR autofill **Connection** modal |
+| **SimpleSelect** + **StorageClassSelect** | `packages/ui-core/.../SimpleSelect.tsx` + `frontend/.../StorageClassSelect.tsx` | Shared hook refactor; StorageClassSelect no longer overrides `appendTo` when unset |
+| **MultiSelection** | `frontend/src/components/MultiSelection.tsx` | Regression only (66822) |
+| Shared hook | `packages/ui-core/src/utilities/useMenuPopperInModal.ts` | Dialog-aware `appendTo` + overflow unlock |
+
+### Per-control checklist (apply to every **CHANGED vs main** row)
+
+1. Open/close — toggle `aria-expanded` `false` → `true` → `false`
+2. Keyboard — Arrow keys move highlight; Enter/Space selects
+3. **Tab** with menu open — **one Tab** advances focus to the next field (not the modal container); menu closes; **modal stays open**
+4. **Escape** with menu open — menu closes; **modal stays open** (on `main` this often closes the modal)
+5. Clipping — full option list visible / reachable inside the dialog (not cut off by overflow)
+6. Screen reader (VO/NVDA/JAWS) — announce options; arrow and select
+7. TypeaheadSelect only — `aria-controls` points at listbox; `aria-activedescendant` tracks focused option
+8. TypeaheadSelect only — **Enter** selects the focused option **without** submitting the form or closing the modal
+
+### Per-control checklist (apply to every **REGRESSION** row)
+
+1. Open, select, close with mouse and keyboard
+2. No new clipping or broken labels vs `main`
+3. Look & feel unchanged (PF spacing, full-width toggles)
+
+---
+
+## Phase 0 — Environment setup
+
+### Cluster prerequisites
+
+- Open Data Hub / RHOAI Dashboard installed
+- Dedicated non-production test user with the minimum permissions required by this runbook (project create, plus serving/registry access for Phase 2 if those operators are installed)
+- Use `cluster-admin` only on an isolated, disposable cluster when a phase requires it
+- At least one Notebook ImageStream, storage class, and (for Phase 2) model serving / model registry if those operators are installed
+
+### Commands
+
+```bash
+git checkout RHOAIENG-76231/modal-dropdown-a11y
+npm install
+npm run build
+make login          # or: oc login <api-url> -u <user>
+npm run dev         # backend :4000 + frontend :4010 — enough for this runbook
+```
+
+Open **http://localhost:4010** and log in with cluster credentials.
+
+Use either `npm run dev` **or** `npm run start`, not both (they compete for ports 4000/4010). Prefer `npm run dev` unless you need federated modules (Model Registry BFF). For Phase 2B/2C, use `npm run start` if MR UI is federated in your env.
+
+Re-run `make login` and restart the dev server if the session expires.
+
+### Optional feature flags
+
+- NIM deploy paths: enable NIM / gen-ai flags via dev banner or `?devFeatureFlags=...` if your cluster uses them
+- Model Registry: requires MR operator + registry instance
+
+---
+
+## Phase 1 — CHANGED vs main (ticket AC — do first)
+
+Create a project if needed:
+
+| Step | Action | Test data |
+|------|--------|-----------|
+| 1 | Sidebar → **Projects** | — |
+| 2 | **Create project** | Display / resource name: `manual-76231-test` |
+
+Land on `/projects/manual-76231-test`.
+
+### 1A. Create connection — Connection type
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | `TypeaheadSelect` via `ConnectionTypeForm` |
+| **Navigation** | Projects → `manual-76231-test` → **Connections** → **Create connection** |
+| **Control** | **Connection type** combobox (`data-testid="connection-type-dropdown"`) |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Create connection modal | [ ] |
+| 2 | Focus Connection type; open with keyboard | [ ] |
+| 3 | Arrow through types; select one (e.g. S3) | [ ] |
+| 4 | With menu open: **Tab** — **one Tab** moves focus to the next field (not modal container); menu closes; modal stays | [ ] |
+| 5 | Re-open; **Escape** — menu closes, modal stays | [ ] |
+| 6 | (SR) Open, arrow, select announced correctly | [ ] |
+
+**vs main:** On `main`, Escape often closes the whole Create connection modal; menu may be clipped or hard for SR. On this branch, Escape/Tab only dismiss the menu.
+
+Fill enough fields to create `test-s3-connection` if you will need it in Phase 2 (optional for 1A alone).
+
+### 1A2. Create connection — Access type (OCI connection-type dropdown)
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | Raw PF `Select` via `DropdownFormField` + `useMenuPopperInModal` |
+| **Navigation** | Projects → project → **Connections** → **Create connection** → select connection type **OCI** (or any type with a Dropdown field) |
+| **Control** | **Access type** (multi-select; Push secret / Pull secret) |
+| **Prerequisite** | Complete Connection type selection first (1A) |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | After selecting OCI, locate **Access type** | [ ] |
+| 2 | Open with keyboard; arrow through Push / Pull; select (Space/Enter) | [ ] |
+| 3 | With menu open: **Tab** — menu closes, modal stays | [ ] |
+| 4 | Re-open; **Escape** — menu closes, modal stays | [ ] |
+| 5 | (SR) Options reachable and announced inside the dialog | [ ] |
+
+**vs main:** Same modal clipping / focus-trap issue as other Create connection menus. This control is not SimpleSelect/MultiSelection; the shared popper hook is applied on the raw Select.
+
+### 1B. Create connection from workbench
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | Same `TypeaheadSelect` |
+| **Navigation** | Projects → project → **Workbenches** → **Create workbench** → Connections → **Create connection** |
+| **Control** | Connection type combobox in nested modal |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Create connection from spawner | [ ] |
+| 2 | Repeat open / arrow / Tab / Escape checks from 1A | [ ] |
+
+### 1C. Attach existing storage — PVC typeahead
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | `TypeaheadSelect` via `AddExistingStorageField` |
+| **Navigation** | Workbenches → Create/Edit workbench → Cluster storage → **Attach existing storage** |
+| **Control** | Persistent storage typeahead (label **Persistent storage**) |
+| **Prerequisite** | At least one PVC in the project (create via 1D/1E first if empty) |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Attach existing storage modal | [ ] |
+| 2 | Open PVC typeahead; filter/type; arrow; select | [ ] |
+| 3 | Tab / Escape close menu, not modal | [ ] |
+| 4 | (SR) Options reachable and selectable | [ ] |
+
+**vs main:** Same Escape/Tab-vs-modal and clipping issues as other modal typeaheads.
+
+### 1D. Create storage (workbench) — size unit + storage class
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrappers** | `ValueUnitField` (size unit); `SimpleSelect` / `StorageClassSelect` (storage class) |
+| **Navigation** | Workbenches → Create/Edit → Cluster storage → **Create storage** |
+| **Controls** | Persistent storage size unit dropdown; **Storage class** |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Create storage modal | [ ] |
+| 2 | Size unit dropdown — open, arrow (if supported), select Gi/Mi | [ ] |
+| 3 | Tab / Escape close unit menu, not modal | [ ] |
+| 4 | Storage class — open, select; menu not clipped | [ ] |
+| 5 | Tab / Escape close storage class menu, not modal | [ ] |
+| 6 | Name `wb-storage`, size `8`, mount path valid; create if useful for 1C | [ ] |
+
+**vs main:** Size unit (`ValueUnitField`) and StorageClassSelect append behavior are the 76231 focus here. Note: arrow-key navigation on the **unit** dropdown may still be limited by PatternFly Dropdown (pre-existing); still verify Tab/Escape and SR open/select.
+
+### 1E. Add cluster storage (project tab)
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrappers** | Same as 1D |
+| **Navigation** | Projects → project → **Cluster storage** → **Add cluster storage** |
+| **Controls** | Size unit + Storage class |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Add cluster storage modal | [ ] |
+| 2 | Repeat size unit + storage class checks from 1D | [ ] |
+| 3 | Optional: Update storage (row ⋮ → Update) — same controls | [ ] |
+
+---
+
+## Phase 2 — CHANGED vs main (model serving / Model Registry)
+
+### 2A. Deploy model — Existing connection
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | `TypeaheadSelect` via `ExistingConnectionField` |
+| **Navigation** | Projects → project → **Models** (or Model serving) → **Deploy model** → Storage → **Existing connection** |
+| **Control** | Connection typeahead |
+| **Prerequisite** | Connection from Phase 1A; serving runtime available |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Deploy model flow; choose Existing connection | [ ] |
+| 2 | Open connection typeahead; arrow/filter; select | [ ] |
+| 3 | Tab / Escape close menu, not deploy modal | [ ] |
+| 4 | (SR) smoke | [ ] |
+
+**vs main:** Modal typeahead should behave like 1A, not like page-level selects.
+
+### 2B. Model Registry — Autofill connection
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrappers** | `SearchSelector` (project) + `ConnectionDropdown` (connection name) |
+| **Navigation** | **Model Registry** → registry → **Register model** (or register version) → Model location → **Autofill connection** |
+| **Controls** | Project search dropdown; **Connection name** (`data-testid="select-connection"`) |
+| **Prerequisite** | MR instance + connection in a project; may need `npm run start` for federated MR |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Autofill from connection modal (`connection-autofill-modal`) | [ ] |
+| 2 | Project `SearchSelector` — open, search, select | [ ] |
+| 3 | Tab / Escape close project menu, not modal | [ ] |
+| 4 | Connection dropdown — open, select | [ ] |
+| 5 | Tab / Escape close connection menu, not modal | [ ] |
+| 6 | (SR) both controls | [ ] |
+
+**vs main:** Both menus are modal-hosted; expect the Escape/Tab and portal fix vs `main`.
+
+### 2C. Model Registry — Deploy (project selector)
+
+| | |
+|--|--|
+| **Tag** | **CHANGED vs main** |
+| **Wrapper** | `SearchSelector` via `InferenceServiceModal/ProjectSelector` |
+| **Navigation** | Model Registry → registered model → version → **Deploy** |
+| **Control** | Project selector (`data-testid="deploy-model-project-selector"`) |
+| **Also check** | If 2+ matching connections appear, connection typeahead (`ExistingConnectionField`) — **CHANGED vs main** |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open Deploy from MR modal | [ ] |
+| 2 | Project selector — open, search, select; Tab/Escape | [ ] |
+| 3 | Connection typeahead if shown — same checks as 2A | [ ] |
+
+---
+
+## Phase 3 — REGRESSION (shared wrappers; no expected new modal fix)
+
+These use the same components but should **match `main` / post-66822**. Mark failures only if this branch broke them.
+
+### 3A. Workbench spawner — notebook image / version
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** |
+| **Wrapper** | `SimpleSelect` (page / non-modal spawner) |
+| **Navigation** | Workbenches → **Create workbench** |
+| **Controls** | Notebook image; Image version |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open image + version selects; choose values | [ ] |
+| 2 | Keyboard open/select works as on `main` | [ ] |
+
+**Note:** Impacted by shared `SimpleSelect` hook refactor — **expect no behavior change** vs post-66822 `main`.
+
+### 3B. Workbench env var type / data type
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** (already fixed in 66822) |
+| **Wrapper** | `SimpleSelect` |
+| **Navigation** | Create workbench → Environment variables → Add variable |
+| **Controls** | Variable type; Data type |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open type/data type; select Config Map / Key-value | [ ] |
+| 2 | Behavior still matches 66822 (usable in form; no new breakage) | [ ] |
+
+### 3C. Attach existing connections — MultiSelection
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** (66822 deliverable — must still hold) |
+| **Wrapper** | `MultiSelection` |
+| **Navigation** | Create/Edit workbench → Connections → **Attach existing connections** |
+| **Control** | Connections multiselect (`id="select-connection"`) |
+| **Prerequisite** | Connection from 1A |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open modal; filter/select connection | [ ] |
+| 2 | Tab closes menu without closing modal (66822 behavior) | [ ] |
+
+### 3D. Pipelines / area project header selector
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** |
+| **Wrapper** | `SearchSelector` (page header, not modal) |
+| **Navigation** | Sidebar → **Pipelines** (or Distributed workloads) — project switcher in page header |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open project search; pick a project | [ ] |
+| 2 | Behaves like `main` (no modal Escape semantics required) | [ ] |
+
+### 3E. Learning resources toolbar
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** |
+| **Wrapper** | `SimpleSelect` |
+| **Navigation** | Sidebar → **Learning resources** |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Sort by / Sort order dropdowns | [ ] |
+
+### 3F. Deploy model — framework / runtime (page or wizard selects)
+
+| | |
+|--|--|
+| **Tag** | **REGRESSION** |
+| **Wrapper** | `SimpleSelect` (e.g. `InferenceServiceFrameworkSection`) |
+| **Navigation** | Deploy model flow — framework / serving runtime fields |
+
+| Step | Action | Pass? |
+|------|--------|-------|
+| 1 | Open framework / runtime selects; choose values | [ ] |
+
+**Note:** Impacted wrapper, but **expect no new change** vs post-66822 `main`. Contrast with **2A Existing connection** in the **same** deploy flow, which **is** **CHANGED vs main**.
+
+---
+
+## Phase 4 — Optional admin / edge (smoke)
+
+| ID | Tag | Navigation | Control | Pass? |
+|----|-----|------------|---------|-------|
+| 4A | **CHANGED vs main** (if modal) | Settings → Model registry → **Create registry** (secure DB section) | `SearchSelector` | [ ] |
+| 4B | **CHANGED vs main** | Deploy model (NIM) → storage | Size unit + Storage class | [ ] |
+| 4C | **REGRESSION** (66822) | Project → Permissions → Roles → **Add rule** | MultiSelection subjects/resources | [ ] |
+| 4D | **REGRESSION** | Settings → Connection types → manage numeric advanced | Typeahead / selects on page | [ ] |
+
+Skip any row if the operator / feature flag is unavailable.
+
+---
+
+## Phase 5 — Cleanup
+
+Record whether `manual-76231-test` existed before this run.
+
+If this run created the project, delete it after testing:
+
+```bash
+oc delete project manual-76231-test --wait=true
+```
+
+If the project pre-existed, delete only the connections, PVCs, storage, and optional serving resources created by this run, and remove their test secrets.
+
+---
+
+## Suggested order (highest value)
+
+1. **1A** Create connection type  
+2. **1C** Attach existing storage PVC  
+3. **1D / 1E** Size unit + storage class  
+4. **2B** MR Autofill (Project + ConnectionDropdown)  
+5. **2A / 2C** Deploy existing connection / MR Deploy project  
+6. **3C** MultiSelection attach connections (66822 hold)  
+7. One non-modal **REGRESSION** each: **3A** + **3D**
+
+---
+
+## Troubleshooting empty dropdowns
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Notebook images empty | No ImageStreams | Use a cluster with notebook images |
+| Storage class empty | No StorageClasses | Ask admin / use default SC |
+| PVC typeahead empty | No PVCs | Complete 1D/1E first |
+| Connections empty | No connections | Complete 1A |
+| Model Registry missing | Federated module / operator | `npm run start` + MR instance |
+| Serving runtime empty | KServe not ready | Check model serving operator |
+| Port already in use | Leftover `npm run start`/`dev` | `lsof -i :4000 -i :4010` then kill PIDs |
+
+---
+
+## Manual pass checklist (summary)
+
+```text
+CHANGED vs main
+[ ] 1A Create connection — Connection type (TypeaheadSelect)
+[ ] 1A2 Create connection — Access type / DropdownFormField (OCI)
+[ ] 1B Create connection from workbench (same)
+[ ] 1C Attach existing storage — PVC typeahead
+[ ] 1D Create storage — size unit + storage class
+[ ] 1E Add cluster storage — size unit + storage class
+[ ] 2A Deploy model — Existing connection
+[ ] 2B MR Autofill — Project SearchSelector + ConnectionDropdown
+[ ] 2C MR Deploy — ProjectSelector (+ connection if shown)
+
+REGRESSION
+[ ] 3A Workbench image / version SimpleSelect
+[ ] 3B Env var type / data type (66822)
+[ ] 3C Attach connections MultiSelection (66822)
+[ ] 3D Page header SearchSelector (pipelines)
+[ ] 3E Learning resources sorts
+[ ] 3F Deploy framework / runtime SimpleSelect
+
+OPTIONAL
+[ ] 4A–4D as available
+
+CLEANUP
+[ ] 5 Delete `manual-76231-test` if this run created it, otherwise remove resources created here
+```
+
+---
+
+## Reference
+
+- Prior runbook pattern: `notes/RHOAIENG-66822-manual-select-testing.md` (may be absent in this worktree; structure mirrored here)
+- Cypress mocked: `packages/cypress/cypress/tests/mocked/projects/tabs/connections.cy.ts`, `packages/cypress/cypress/tests/mocked/projects/tabs/workbenchEditDelete.cy.ts`
+- Shared hook: `packages/ui-core/src/utilities/useMenuPopperInModal.ts`
+- Branch context: `.cursor/context/current/scope.md`, `notes.md`

--- a/packages/automl/frontend/src/app/components/common/__tests__/AutomlConnectionModal.spec.tsx
+++ b/packages/automl/frontend/src/app/components/common/__tests__/AutomlConnectionModal.spec.tsx
@@ -107,7 +107,7 @@ describe('AutomlConnectionModal', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Typeahead menu toggle' }));
+    await user.click(screen.getByRole('button', { name: 'Connection type' }));
     expect(screen.getByRole('option', { name: /type one/ })).toBeTruthy();
     expect(screen.getByRole('option', { name: /type two/ })).toBeTruthy();
     expect(screen.queryByRole('option', { name: /type three disabled/ })).toBeFalsy();
@@ -277,7 +277,7 @@ describe('AutomlConnectionModal', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Typeahead menu toggle' }));
+    await user.click(screen.getByRole('button', { name: 'Connection type' }));
     await user.click(screen.getByRole('option', { name: /type one/ }));
 
     await user.type(
@@ -298,7 +298,7 @@ describe('AutomlConnectionModal', () => {
     );
     expect(screen.getByRole('textbox', { name: 'Short text 1' })).toHaveValue('one field');
 
-    await user.click(screen.getByRole('button', { name: 'Typeahead menu toggle' }));
+    await user.click(screen.getByRole('button', { name: 'Connection type' }));
     await user.click(screen.getByRole('option', { name: /type two/ }));
 
     expect(screen.getByRole('textbox', { name: 'Connection name' })).toHaveValue(

--- a/packages/autorag/frontend/src/app/components/common/__tests__/AutoragConnectionModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/common/__tests__/AutoragConnectionModal.spec.tsx
@@ -105,7 +105,7 @@ describe('AutoragConnectionModal', () => {
     );
 
     await act(async () => {
-      screen.getByRole('button', { name: 'Typeahead menu toggle' }).click();
+      screen.getByRole('button', { name: 'Connection type' }).click();
     });
     expect(screen.getByRole('option', { name: /type one/ })).toBeTruthy();
     expect(screen.getByRole('option', { name: /type two/ })).toBeTruthy();
@@ -297,7 +297,7 @@ describe('AutoragConnectionModal', () => {
     );
 
     await act(async () => {
-      screen.getByRole('button', { name: 'Typeahead menu toggle' }).click();
+      screen.getByRole('button', { name: 'Connection type' }).click();
     });
     await act(async () => {
       screen.getByRole('option', { name: /type one/ }).click();
@@ -322,7 +322,7 @@ describe('AutoragConnectionModal', () => {
     expect(screen.getByRole('textbox', { name: 'Short text 1' })).toHaveValue('one field');
 
     await act(async () => {
-      screen.getByRole('button', { name: 'Typeahead menu toggle' }).click();
+      screen.getByRole('button', { name: 'Connection type' }).click();
     });
     await act(async () => {
       const optionTwo = await screen.findByRole('option', { name: /type two/ });

--- a/packages/cypress/cypress/pages/clusterStorage.ts
+++ b/packages/cypress/cypress/pages/clusterStorage.ts
@@ -119,7 +119,7 @@ class ClusterStorageModal extends Modal {
 
   findWorkbenchSelectValueField(row: number) {
     return this.findWorkbenchName(row).findByRole('combobox', {
-      name: 'Type to filter',
+      name: 'Workbench',
     });
   }
 

--- a/packages/cypress/cypress/pages/modelRegistryPermissions.ts
+++ b/packages/cypress/cypress/pages/modelRegistryPermissions.ts
@@ -71,7 +71,7 @@ class PermissionTable extends Contextual<HTMLElement> {
   }
 
   findNameSelect() {
-    return this.find().get(`[aria-label="Type to filter"]`);
+    return this.find().find('[data-testid^="role-binding-name-select"]').find('[role="combobox"]');
   }
 
   getTableRow(name: string) {

--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -225,9 +225,8 @@ class InferenceServiceModal extends ServingModal {
   }
 
   findConnectionType(name: string | RegExp) {
-    return this.findExistingConnectionSelect()
-      .findByRole('button', { name: 'Typeahead menu toggle' })
-      .findSelectOption(name);
+    // TypeaheadSelect: data-testid is on MenuToggle; options open from the combobox.
+    return this.findExistingConnectionSelectValueField().findSelectOption(name);
   }
 
   findSubmitButton() {
@@ -312,7 +311,7 @@ class InferenceServiceModal extends ServingModal {
 
   findExistingConnectionSelectValueField() {
     return this.findExistingConnectionSelect().findByRole('combobox', {
-      name: 'Type to filter',
+      name: 'Connection',
     });
   }
 

--- a/packages/cypress/cypress/pages/workbench.ts
+++ b/packages/cypress/cypress/pages/workbench.ts
@@ -4,6 +4,12 @@ import { Modal } from './components/Modal';
 import { TableRow } from './components/table';
 import type { AccessMode } from '../types';
 
+/** Match a storage option whose accessible name is `{name}` or `{name} {description}`. */
+const persistentStorageOptionName = (name: string): RegExp => {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^${escaped}(?:\\s|$)`);
+};
+
 class SelectStorageClass {
   find() {
     return cy.findByTestId('storage-classes-selector');
@@ -34,9 +40,10 @@ class StorageModal extends Modal {
 
   selectExistingPersistentStorage(name: string) {
     cy.findByTestId('persistent-storage-group')
-      .findByRole('button', { name: 'Typeahead menu toggle' })
+      .findByRole('button', { name: 'Persistent storage' })
       .click();
-    cy.findByTestId('persistent-storage-group').findByRole('option', { name }).click();
+    // Options portal into the modal; accessible name includes description (e.g. "pvc-rwx Size: 5Gi").
+    cy.findByRole('option', { name: persistentStorageOptionName(name) }).click();
   }
 
   findSubmitButton() {
@@ -417,7 +424,8 @@ class AttachExistingStorageModal extends Modal {
     cy.findByTestId('persistent-storage-group')
       .findByPlaceholderText('Select a persistent storage')
       .click();
-    cy.findByTestId('persistent-storage-typeahead').contains(name).click();
+    // Options portal into the modal; accessible name includes description (e.g. "pvc-rwx Size: 5Gi").
+    cy.findByRole('option', { name: persistentStorageOptionName(name) }).click();
   }
 
   verifyPSDropdownIsDisabled(): void {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/connections.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/connections.cy.ts
@@ -316,4 +316,44 @@ describe('Connections', () => {
       });
     });
   });
+
+  it('Create connection typeahead keeps options inside the modal dialog', () => {
+    initIntercepts({});
+    cy.interceptOdh('GET /api/connection-types', [
+      mockConnectionTypeConfigMap({
+        name: 's3',
+        displayName: 'S3 compatible object storage - v1',
+        fields: mockModelServingFields,
+      }),
+      mockConnectionTypeConfigMap({
+        name: 'uri-v1',
+        displayName: 'URI - v1',
+      }),
+    ]);
+
+    projectDetails.visitSection('test-project', 'connections');
+    connectionsPage.findAddConnectionButton().click();
+
+    // aria-controls is only set while open (listbox must exist in the DOM).
+    // Callback should keeps the element subject — chai not.have.attr yields undefined.
+    cy.findByTestId('connection-type-dropdown')
+      .findByRole('combobox', { name: 'Connection type' })
+      .should(($el) => {
+        expect($el).not.to.have.attr('aria-controls');
+      })
+      .click();
+    cy.findByTestId('connection-type-dropdown')
+      .findByRole('combobox', { name: 'Connection type' })
+      .should('have.attr', 'aria-controls', 'connection-type-listbox');
+
+    cy.findByRole('dialog').within(() => {
+      cy.get('#connection-type-listbox').should('exist');
+      cy.findByRole('option', { name: /URI/i }).should('exist');
+    });
+
+    cy.findByTestId('connection-type-dropdown')
+      .findByRole('combobox', { name: 'Connection type' })
+      .closeSelectMenu();
+    cy.findByRole('dialog').should('contain.text', 'Create connection');
+  });
 });

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbenchEditDelete.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbenchEditDelete.cy.ts
@@ -580,6 +580,29 @@ describe('Workbench page', () => {
         .findTypeaheadOptionUnderGroup('readwriteoncepod-rwop-storage', 'pvc-rwop')
         .should('exist');
 
+      attachExistingStorageModal
+        .findExistingStorageField()
+        .findByRole('combobox', { name: 'Persistent storage' })
+        .invoke('attr', 'aria-controls')
+        .should('be.a', 'string')
+        .and('not.be.empty')
+        .then((listboxId) => {
+          if (typeof listboxId !== 'string' || listboxId.length === 0) {
+            throw new Error('expected non-empty aria-controls on Persistent storage combobox');
+          }
+          cy.findByRole('dialog').within(() => {
+            cy.get(`#${listboxId}`).should('exist');
+            // Accessible name is e.g. "pvc-rwx Size: 5Gi" (content + description).
+            cy.findByRole('option', { name: /^pvc-rwx(\b|$)/ }).should('exist');
+          });
+        });
+
+      attachExistingStorageModal
+        .findExistingStorageField()
+        .findByRole('combobox', { name: 'Persistent storage' })
+        .closeSelectMenu();
+      cy.findByRole('dialog').should('contain.text', 'Attach existing storage');
+
       attachExistingStorageModal.selectExistingPersistentStorage('pvc-rwx');
       attachExistingStorageModal.verifyPSDropdownText('pvc-rwx');
     });

--- a/packages/ui-core/src/components/SimpleSelect.tsx
+++ b/packages/ui-core/src/components/SimpleSelect.tsx
@@ -15,10 +15,7 @@ import {
 } from '@patternfly/react-core';
 import { omit } from 'lodash-es';
 import TruncatedText from './TruncatedText';
-import {
-  resolveSelectPopperAppendTo,
-  useModalOverflowUnlock,
-} from '../utilities/useModalOverflowUnlock';
+import { useMenuPopperInModal } from '../utilities/useMenuPopperInModal';
 
 import './SimpleSelect.scss';
 
@@ -89,20 +86,27 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
 }) => {
   const [open, setOpen] = React.useState(false);
   const menuToggleRef = React.useRef<HTMLDivElement | null>(null);
-
-  useModalOverflowUnlock(open, menuToggleRef);
-
-  const mergedPopperProps = React.useMemo(() => {
-    if (popperProps?.appendTo !== undefined) {
-      return { maxWidth: 'trigger' as const, ...popperProps };
+  const listboxId = React.useId();
+  const groupListboxIds = React.useMemo(
+    () => (groupedOptions ?? []).map((_, index) => `${listboxId}-g${index}`),
+    [groupedOptions, listboxId],
+  );
+  const ungroupedListboxId = `${listboxId}-ungrouped`;
+  const openListboxControls = React.useMemo(() => {
+    const ids = [...groupListboxIds];
+    if (options?.length) {
+      ids.push(ungroupedListboxId);
     }
-    return {
-      maxWidth: 'trigger' as const,
-      ...popperProps,
-      // Portal into the dialog only inside modals; otherwise keep PatternFly inline default.
-      appendTo: () => resolveSelectPopperAppendTo(menuToggleRef.current),
-    };
-  }, [popperProps]);
+    return ids.join(' ');
+  }, [groupListboxIds, options?.length, ungroupedListboxId]);
+
+  const menuPopperProps = useMenuPopperInModal(open, menuToggleRef, popperProps, {
+    onEscapeClose: () => setOpen(false),
+  });
+  const mergedPopperProps = React.useMemo(
+    () => ({ maxWidth: 'trigger' as const, ...menuPopperProps }),
+    [menuPopperProps],
+  );
 
   const groupedOptionsFlat = React.useMemo(
     () =>
@@ -172,6 +176,7 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
               innerRef={toggleRef}
               data-testid={dataTestId}
               {...(toggleAriaLabel ? { 'aria-label': toggleAriaLabel } : {})}
+              {...(open && openListboxControls ? { 'aria-controls': openListboxControls } : {})}
               onClick={() => setOpen((currentOpen) => !currentOpen)}
               icon={icon}
               isExpanded={open}
@@ -196,7 +201,7 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
           <React.Fragment key={group.key}>
             {index > 0 ? <Divider /> : null}
             <SelectGroup label={group.label}>
-              <SelectList>
+              <SelectList id={groupListboxIds[index]}>
                 {group.options.map(
                   ({
                     key,
@@ -231,7 +236,7 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
         {options?.length ? (
           <>
             {groupedOptions?.length ? <Divider /> : null}
-            <SelectList>
+            <SelectList id={ungroupedListboxId}>
               {options.map(
                 ({
                   key,

--- a/packages/ui-core/src/components/TypeaheadSelect.tsx
+++ b/packages/ui-core/src/components/TypeaheadSelect.tsx
@@ -324,6 +324,28 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     setFilterValue(String(selected?.content ?? ''));
   };
 
+  const closeMenuRef = React.useRef(closeMenu);
+  React.useLayoutEffect(() => {
+    closeMenuRef.current = closeMenu;
+  });
+
+  React.useLayoutEffect(() => {
+    if (focusedItemIndex === null || activeItemId === null) {
+      return;
+    }
+    const nextIndex = navigableSelections.findIndex(
+      (option) => createOptionElementId(instanceId, option.value) === activeItemId,
+    );
+    const nextOption = nextIndex >= 0 ? navigableSelections[nextIndex] : undefined;
+    if (!nextOption || nextOption.isDisabled || nextOption.isAriaDisabled) {
+      resetActiveAndFocusedItem();
+      return;
+    }
+    if (nextIndex !== focusedItemIndex) {
+      setFocusedItemIndex(nextIndex);
+    }
+  }, [navigableSelections, instanceId, focusedItemIndex, activeItemId]);
+
   const isTabTargetForTypeahead = (event: KeyboardEvent): boolean => {
     const { target } = event;
     if (!(target instanceof Node)) {
@@ -346,7 +368,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       }
     }
     resetActiveAndFocusedItem();
-    queueMicrotask(() => closeMenu());
+    queueMicrotask(() => closeMenuRef.current());
   };
 
   React.useEffect(() => {
@@ -363,7 +385,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       }
       const { target } = event;
       if (target instanceof Node && menuToggleRef.current?.contains(target)) {
-        closeMenu();
+        closeMenuRef.current();
       }
     };
     document.addEventListener('keydown', onTabCapture, true);
@@ -617,10 +639,11 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
 
   const tSelectOption = (option: TypeaheadSelectOption, index: number) => {
     const { content, value, dropdownLabel, ...optionProps } = option;
+    const optionElementId = createOptionElementId(instanceId, value);
     return (
       <SelectOption
-        key={value}
-        id={createOptionElementId(instanceId, value)}
+        key={optionElementId}
+        id={optionElementId}
         value={value}
         isFocused={focusedItemIndex === index}
         {...optionProps}

--- a/packages/ui-core/src/components/TypeaheadSelect.tsx
+++ b/packages/ui-core/src/components/TypeaheadSelect.tsx
@@ -26,6 +26,8 @@ import {
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import TruncatedText from './TruncatedText';
+import { createOptionElementId } from '../utilities/optionElementIds';
+import { useMenuPopperInModal } from '../utilities/useMenuPopperInModal';
 
 export interface TypeaheadSelectOption extends Omit<SelectOptionProps, 'content' | 'isSelected'> {
   /** Content of the select option. */
@@ -100,6 +102,8 @@ export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSe
   previewDescription?: boolean;
   /** Optional icon rendered inside the text input */
   inputIcon?: React.ReactNode;
+  /** Accessible name for the combobox / listbox */
+  ariaLabel?: string;
 }
 
 const defaultNoOptionsFoundMessage = (filter: string) => `No results found for "${filter}"`;
@@ -130,14 +134,24 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   previewDescription = true,
   dataTestId,
   inputIcon,
+  ariaLabel,
+  popperProps,
+  id,
   ...props
 }: TypeaheadSelectProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const isOpenRef = React.useRef(false);
   const [filterValue, setFilterValue] = React.useState<string>('');
   const [isFiltering, setIsFiltering] = React.useState<boolean>(false);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
-  const textInputRef = React.useRef<HTMLInputElement>();
+  const textInputRef = React.useRef<HTMLInputElement | null>(null);
+  const menuToggleRef = React.useRef<MenuToggleElement | null>(null);
+  const accessibleName = ariaLabel ?? toggleProps?.['aria-label'] ?? 'Typeahead menu toggle';
+  const listboxAriaLabel = ariaLabel ?? toggleProps?.['aria-label'] ?? 'Options';
+  const generatedInstanceId = React.useId().replace(/:/g, '');
+  const instanceId = id ?? `typeahead-select-${generatedInstanceId}`;
+  const listboxId = `${instanceId}-listbox`;
 
   const NO_RESULTS = 'no results';
 
@@ -229,27 +243,78 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFiltering]);
 
-  const setActiveAndFocusedItem = (itemIndex: number) => {
-    setFocusedItemIndex(itemIndex);
-    const focusedItem = filteredSelections[itemIndex];
-    setActiveItemId(String(focusedItem.value));
-  };
+  const groupedSelections = React.useMemo(() => {
+    const group: Record<string, TypeaheadSelectOption[]> = {};
+    const noGroup: TypeaheadSelectOption[] = [];
+
+    filteredSelections.forEach((option) => {
+      if (option.group) {
+        if (option.group in group) {
+          group[option.group].push(option);
+        } else {
+          group[option.group] = [option];
+        }
+      } else {
+        noGroup.push(option);
+      }
+    });
+
+    return { group, noGroup };
+  }, [filteredSelections]);
+
+  /** Same order as renderOptions — keep keyboard focus / aria-activedescendant in sync with visuals. */
+  const navigableSelections = React.useMemo(() => {
+    const createOption = isCreateOptionOnTop
+      ? groupedSelections.noGroup.find((o) => o.isCreateOption)
+      : undefined;
+    const ungroupedSelections = isCreateOptionOnTop
+      ? groupedSelections.noGroup.filter((o) => !o.isCreateOption)
+      : groupedSelections.noGroup;
+    const ordered: TypeaheadSelectOption[] = [];
+    if (createOption) {
+      ordered.push(createOption);
+    }
+    Object.values(groupedSelections.group).forEach((groupOptions) => {
+      ordered.push(...groupOptions);
+    });
+    ordered.push(...ungroupedSelections);
+    return ordered;
+  }, [groupedSelections, isCreateOptionOnTop]);
+
+  const isOptionNonNavigable = (option: TypeaheadSelectOption) =>
+    !!option.isDisabled || !!option.isAriaDisabled;
 
   const resetActiveAndFocusedItem = () => {
     setFocusedItemIndex(null);
     setActiveItemId(null);
   };
 
-  const openMenu = () => {
-    if (!isOpen) {
-      if (onToggle) {
-        onToggle(true);
-      }
-      setIsOpen(true);
+  const setActiveAndFocusedItem = (itemIndex: number) => {
+    if (itemIndex < 0 || itemIndex >= navigableSelections.length) {
+      resetActiveAndFocusedItem();
+      return;
     }
+    const focusedItem = navigableSelections[itemIndex];
+    setFocusedItemIndex(itemIndex);
+    setActiveItemId(createOptionElementId(instanceId, focusedItem.value));
+  };
+
+  const openMenu = () => {
+    if (isOpenRef.current) {
+      return;
+    }
+    isOpenRef.current = true;
+    if (onToggle) {
+      onToggle(true);
+    }
+    setIsOpen(true);
   };
 
   const closeMenu = () => {
+    if (!isOpenRef.current) {
+      return;
+    }
+    isOpenRef.current = false;
     if (onToggle) {
       onToggle(false);
     }
@@ -258,6 +323,81 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     setIsFiltering(false);
     setFilterValue(String(selected?.content ?? ''));
   };
+
+  const closeMenuRef = React.useRef(closeMenu);
+  React.useLayoutEffect(() => {
+    closeMenuRef.current = closeMenu;
+  });
+
+  React.useLayoutEffect(() => {
+    if (focusedItemIndex === null || activeItemId === null) {
+      return;
+    }
+    const nextIndex = navigableSelections.findIndex(
+      (option) => createOptionElementId(instanceId, option.value) === activeItemId,
+    );
+    const nextOption = nextIndex >= 0 ? navigableSelections[nextIndex] : undefined;
+    if (!nextOption || nextOption.isDisabled || nextOption.isAriaDisabled) {
+      resetActiveAndFocusedItem();
+      return;
+    }
+    if (nextIndex !== focusedItemIndex) {
+      setFocusedItemIndex(nextIndex);
+    }
+  }, [navigableSelections, instanceId, focusedItemIndex, activeItemId]);
+
+  const isTabTargetForTypeahead = (event: KeyboardEvent): boolean => {
+    const { target } = event;
+    if (!(target instanceof Node)) {
+      return false;
+    }
+    // Toggle node and combobox only — not chrome such as the clear button.
+    if (target === menuToggleRef.current || target === textInputRef.current) {
+      return true;
+    }
+    const listbox = document.getElementById(listboxId);
+    return listbox?.contains(target) ?? false;
+  };
+
+  const handleTabWhileOpen = () => {
+    const input = textInputRef.current;
+    if (input) {
+      input.removeAttribute('aria-activedescendant');
+      if (document.activeElement !== input) {
+        input.focus({ preventScroll: true });
+      }
+    }
+    resetActiveAndFocusedItem();
+    queueMicrotask(() => closeMenuRef.current());
+  };
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const onTabCapture = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || !isOpenRef.current) {
+        return;
+      }
+      if (isTabTargetForTypeahead(event)) {
+        handleTabWhileOpen();
+        return;
+      }
+      const { target } = event;
+      if (target instanceof Node && menuToggleRef.current?.contains(target)) {
+        closeMenuRef.current();
+      }
+    };
+    document.addEventListener('keydown', onTabCapture, true);
+    return () => document.removeEventListener('keydown', onTabCapture, true);
+    // listboxId is stable (useId() / optional id prop); isTabTargetForTypeahead
+    // intentionally omitted from deps — resolve refs at event time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, listboxId]);
+
+  const mergedPopperProps = useMenuPopperInModal(isOpen, textInputRef, popperProps, {
+    onEscapeClose: closeMenu,
+  });
 
   const onInputClick = () => {
     if (!isOpen) {
@@ -279,6 +419,9 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       onSelect(_event, option.value);
     }
     closeMenu();
+    queueMicrotask(() => {
+      textInputRef.current?.focus();
+    });
   };
 
   const notAllowEmpty = !isCreatable && isRequired;
@@ -324,64 +467,80 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
 
     openMenu();
 
-    if (filteredSelections.every((option) => option.isDisabled)) {
+    if (navigableSelections.every(isOptionNonNavigable)) {
       return;
     }
 
     if (key === 'ArrowUp') {
       // When no index is set or at the first index, focus to the last, otherwise decrement focus index
       if (focusedItemIndex === null || focusedItemIndex === 0) {
-        indexToFocus = filteredSelections.length - 1;
+        indexToFocus = navigableSelections.length - 1;
       } else {
         indexToFocus = focusedItemIndex - 1;
       }
 
-      // Skip disabled options
-      while (filteredSelections[indexToFocus].isDisabled) {
+      // Skip disabled / aria-disabled options
+      while (
+        navigableSelections[indexToFocus] &&
+        isOptionNonNavigable(navigableSelections[indexToFocus])
+      ) {
         indexToFocus--;
         if (indexToFocus === -1) {
-          indexToFocus = filteredSelections.length - 1;
+          indexToFocus = navigableSelections.length - 1;
         }
       }
     }
 
     if (key === 'ArrowDown') {
       // When no index is set or at the last index, focus to the first, otherwise increment focus index
-      if (focusedItemIndex === null || focusedItemIndex === filteredSelections.length - 1) {
+      if (focusedItemIndex === null || focusedItemIndex === navigableSelections.length - 1) {
         indexToFocus = 0;
       } else {
         indexToFocus = focusedItemIndex + 1;
       }
 
-      // Skip disabled options
-      while (filteredSelections[indexToFocus].isDisabled) {
+      // Skip disabled / aria-disabled options
+      while (
+        navigableSelections[indexToFocus] &&
+        isOptionNonNavigable(navigableSelections[indexToFocus])
+      ) {
         indexToFocus++;
-        if (indexToFocus === filteredSelections.length) {
+        if (indexToFocus === navigableSelections.length) {
           indexToFocus = 0;
         }
       }
     }
 
     setActiveAndFocusedItem(indexToFocus);
+    // Keep DOM focus on the combobox for aria-activedescendant navigation. PatternFly
+    // SelectOption isFocused can move focus into the portaled listbox; Tab then unmounts
+    // that node and the modal focus trap resets to the dialog shell.
+    textInputRef.current?.focus();
   };
 
   const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    const focusedItem = focusedItemIndex !== null ? filteredSelections[focusedItemIndex] : null;
+    const focusedItem = focusedItemIndex !== null ? navigableSelections[focusedItemIndex] : null;
 
     switch (event.key) {
       case 'Enter':
+        // Prevent native <form> submit (page refresh / modal dismiss) when Enter
+        // is used to open the menu or select an option — same pattern as MultiSelection.
+        event.preventDefault();
         if (
           isOpen &&
           focusedItem &&
           focusedItem.value !== NO_RESULTS &&
-          !focusedItem.isAriaDisabled
+          !isOptionNonNavigable(focusedItem)
         ) {
           selectOption(event, focusedItem);
+        } else if (!isOpen) {
+          openMenu();
         }
 
-        openMenu();
-
         break;
+      // Tab is handled in document capture (handleTabWhileOpen) so PatternFly Select
+      // does not preventDefault and refocus the toggle instead of advancing the field.
+      // Escape is handled by useMenuPopperInModal (document capture) via onEscapeClose.
       case 'ArrowUp':
       case 'ArrowDown':
         event.preventDefault();
@@ -421,9 +580,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ref={toggleRef}
       variant="typeahead"
-      aria-label="Typeahead menu toggle"
       data-testid={dataTestId ?? 'typeahead-menu-toggle'}
       onClick={onToggleClick}
       isExpanded={isOpen}
@@ -431,6 +588,16 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       style={{ width: toggleWidth }}
       {...toggleProps}
       isDisabled={isToggleDisabled}
+      aria-label={accessibleName}
+      ref={(el) => {
+        menuToggleRef.current = el;
+        if (typeof toggleRef === 'function') {
+          toggleRef(el);
+        } else if (toggleRef) {
+          const mutableToggleRef: React.MutableRefObject<MenuToggleElement | null> = toggleRef;
+          mutableToggleRef.current = el;
+        }
+      }}
     >
       <TextInputGroup isPlain isDisabled={isToggleDisabled}>
         <Flex alignItems={{ default: 'alignItemsCenter' }} style={{ width: '100%' }}>
@@ -446,6 +613,9 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
               icon={inputIcon}
               {...(activeItemId && { 'aria-activedescendant': activeItemId })}
               role="combobox"
+              aria-label={accessibleName}
+              {...(isOpen ? { 'aria-controls': listboxId } : {})}
+              aria-haspopup="listbox"
               isExpanded={isOpen}
               className="pf-v6-u-w-100"
             />
@@ -468,30 +638,13 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     </MenuToggle>
   );
 
-  const groupedSelections = React.useMemo(() => {
-    const group: Record<string, TypeaheadSelectOption[]> = {};
-    const noGroup: TypeaheadSelectOption[] = [];
-
-    filteredSelections.forEach((option) => {
-      if (option.group) {
-        if (option.group in group) {
-          group[option.group].push(option);
-        } else {
-          group[option.group] = [option];
-        }
-      } else {
-        noGroup.push(option);
-      }
-    });
-
-    return { group, noGroup };
-  }, [filteredSelections]);
-
   const tSelectOption = (option: TypeaheadSelectOption, index: number) => {
     const { content, value, dropdownLabel, ...optionProps } = option;
+    const optionElementId = createOptionElementId(instanceId, value);
     return (
       <SelectOption
-        key={value}
+        key={optionElementId}
+        id={optionElementId}
         value={value}
         isFocused={focusedItemIndex === index}
         {...optionProps}
@@ -580,16 +733,22 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   return (
     <>
       <Select
+        {...props}
         isOpen={isOpen}
         selected={selected}
         onSelect={handleSelect}
         onOpenChange={(open) => !open && closeMenu()}
+        onOpenChangeKeys={['Escape']}
+        variant="typeahead"
         toggle={toggle}
         shouldFocusFirstItemOnOpen={false}
         ref={innerRef}
-        {...props}
+        id={id}
+        popperProps={mergedPopperProps}
       >
-        <SelectList>{renderOptions()}</SelectList>
+        <SelectList id={listboxId} aria-label={listboxAriaLabel}>
+          {renderOptions()}
+        </SelectList>
       </Select>
       {previewDescription && isSingleOption && selected?.description ? (
         <FormHelperText>

--- a/packages/ui-core/src/components/TypeaheadSelect.tsx
+++ b/packages/ui-core/src/components/TypeaheadSelect.tsx
@@ -26,6 +26,8 @@ import {
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import TruncatedText from './TruncatedText';
+import { createOptionElementId } from '../utilities/optionElementIds';
+import { useMenuPopperInModal } from '../utilities/useMenuPopperInModal';
 
 export interface TypeaheadSelectOption extends Omit<SelectOptionProps, 'content' | 'isSelected'> {
   /** Content of the select option. */
@@ -100,6 +102,8 @@ export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSe
   previewDescription?: boolean;
   /** Optional icon rendered inside the text input */
   inputIcon?: React.ReactNode;
+  /** Accessible name for the combobox / listbox */
+  ariaLabel?: string;
 }
 
 const defaultNoOptionsFoundMessage = (filter: string) => `No results found for "${filter}"`;
@@ -130,14 +134,24 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   previewDescription = true,
   dataTestId,
   inputIcon,
+  ariaLabel,
+  popperProps,
+  id,
   ...props
 }: TypeaheadSelectProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const isOpenRef = React.useRef(false);
   const [filterValue, setFilterValue] = React.useState<string>('');
   const [isFiltering, setIsFiltering] = React.useState<boolean>(false);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
-  const textInputRef = React.useRef<HTMLInputElement>();
+  const textInputRef = React.useRef<HTMLInputElement | null>(null);
+  const menuToggleRef = React.useRef<MenuToggleElement | null>(null);
+  const accessibleName = ariaLabel ?? toggleProps?.['aria-label'] ?? 'Typeahead menu toggle';
+  const listboxAriaLabel = ariaLabel ?? toggleProps?.['aria-label'] ?? 'Options';
+  const generatedInstanceId = React.useId().replace(/:/g, '');
+  const instanceId = id ?? `typeahead-select-${generatedInstanceId}`;
+  const listboxId = `${instanceId}-listbox`;
 
   const NO_RESULTS = 'no results';
 
@@ -229,27 +243,78 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFiltering]);
 
-  const setActiveAndFocusedItem = (itemIndex: number) => {
-    setFocusedItemIndex(itemIndex);
-    const focusedItem = filteredSelections[itemIndex];
-    setActiveItemId(String(focusedItem.value));
-  };
+  const groupedSelections = React.useMemo(() => {
+    const group: Record<string, TypeaheadSelectOption[]> = {};
+    const noGroup: TypeaheadSelectOption[] = [];
+
+    filteredSelections.forEach((option) => {
+      if (option.group) {
+        if (option.group in group) {
+          group[option.group].push(option);
+        } else {
+          group[option.group] = [option];
+        }
+      } else {
+        noGroup.push(option);
+      }
+    });
+
+    return { group, noGroup };
+  }, [filteredSelections]);
+
+  /** Same order as renderOptions — keep keyboard focus / aria-activedescendant in sync with visuals. */
+  const navigableSelections = React.useMemo(() => {
+    const createOption = isCreateOptionOnTop
+      ? groupedSelections.noGroup.find((o) => o.isCreateOption)
+      : undefined;
+    const ungroupedSelections = isCreateOptionOnTop
+      ? groupedSelections.noGroup.filter((o) => !o.isCreateOption)
+      : groupedSelections.noGroup;
+    const ordered: TypeaheadSelectOption[] = [];
+    if (createOption) {
+      ordered.push(createOption);
+    }
+    Object.values(groupedSelections.group).forEach((groupOptions) => {
+      ordered.push(...groupOptions);
+    });
+    ordered.push(...ungroupedSelections);
+    return ordered;
+  }, [groupedSelections, isCreateOptionOnTop]);
+
+  const isOptionNonNavigable = (option: TypeaheadSelectOption) =>
+    !!option.isDisabled || !!option.isAriaDisabled;
 
   const resetActiveAndFocusedItem = () => {
     setFocusedItemIndex(null);
     setActiveItemId(null);
   };
 
-  const openMenu = () => {
-    if (!isOpen) {
-      if (onToggle) {
-        onToggle(true);
-      }
-      setIsOpen(true);
+  const setActiveAndFocusedItem = (itemIndex: number) => {
+    if (itemIndex < 0 || itemIndex >= navigableSelections.length) {
+      resetActiveAndFocusedItem();
+      return;
     }
+    const focusedItem = navigableSelections[itemIndex];
+    setFocusedItemIndex(itemIndex);
+    setActiveItemId(createOptionElementId(instanceId, focusedItem.value));
+  };
+
+  const openMenu = () => {
+    if (isOpenRef.current) {
+      return;
+    }
+    isOpenRef.current = true;
+    if (onToggle) {
+      onToggle(true);
+    }
+    setIsOpen(true);
   };
 
   const closeMenu = () => {
+    if (!isOpenRef.current) {
+      return;
+    }
+    isOpenRef.current = false;
     if (onToggle) {
       onToggle(false);
     }
@@ -258,6 +323,59 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     setIsFiltering(false);
     setFilterValue(String(selected?.content ?? ''));
   };
+
+  const isTabTargetForTypeahead = (event: KeyboardEvent): boolean => {
+    const { target } = event;
+    if (!(target instanceof Node)) {
+      return false;
+    }
+    // Toggle node and combobox only — not chrome such as the clear button.
+    if (target === menuToggleRef.current || target === textInputRef.current) {
+      return true;
+    }
+    const listbox = document.getElementById(listboxId);
+    return listbox?.contains(target) ?? false;
+  };
+
+  const handleTabWhileOpen = () => {
+    const input = textInputRef.current;
+    if (input) {
+      input.removeAttribute('aria-activedescendant');
+      if (document.activeElement !== input) {
+        input.focus({ preventScroll: true });
+      }
+    }
+    resetActiveAndFocusedItem();
+    queueMicrotask(() => closeMenu());
+  };
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const onTabCapture = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || !isOpenRef.current) {
+        return;
+      }
+      if (isTabTargetForTypeahead(event)) {
+        handleTabWhileOpen();
+        return;
+      }
+      const { target } = event;
+      if (target instanceof Node && menuToggleRef.current?.contains(target)) {
+        closeMenu();
+      }
+    };
+    document.addEventListener('keydown', onTabCapture, true);
+    return () => document.removeEventListener('keydown', onTabCapture, true);
+    // listboxId is stable (useId() / optional id prop); isTabTargetForTypeahead
+    // intentionally omitted from deps — resolve refs at event time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, listboxId]);
+
+  const mergedPopperProps = useMenuPopperInModal(isOpen, textInputRef, popperProps, {
+    onEscapeClose: closeMenu,
+  });
 
   const onInputClick = () => {
     if (!isOpen) {
@@ -279,6 +397,9 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       onSelect(_event, option.value);
     }
     closeMenu();
+    queueMicrotask(() => {
+      textInputRef.current?.focus();
+    });
   };
 
   const notAllowEmpty = !isCreatable && isRequired;
@@ -323,64 +444,80 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
 
     openMenu();
 
-    if (filteredSelections.every((option) => option.isDisabled)) {
+    if (navigableSelections.every(isOptionNonNavigable)) {
       return;
     }
 
     if (key === 'ArrowUp') {
       // When no index is set or at the first index, focus to the last, otherwise decrement focus index
       if (focusedItemIndex === null || focusedItemIndex === 0) {
-        indexToFocus = filteredSelections.length - 1;
+        indexToFocus = navigableSelections.length - 1;
       } else {
         indexToFocus = focusedItemIndex - 1;
       }
 
-      // Skip disabled options
-      while (filteredSelections[indexToFocus].isDisabled) {
+      // Skip disabled / aria-disabled options
+      while (
+        navigableSelections[indexToFocus] &&
+        isOptionNonNavigable(navigableSelections[indexToFocus])
+      ) {
         indexToFocus--;
         if (indexToFocus === -1) {
-          indexToFocus = filteredSelections.length - 1;
+          indexToFocus = navigableSelections.length - 1;
         }
       }
     }
 
     if (key === 'ArrowDown') {
       // When no index is set or at the last index, focus to the first, otherwise increment focus index
-      if (focusedItemIndex === null || focusedItemIndex === filteredSelections.length - 1) {
+      if (focusedItemIndex === null || focusedItemIndex === navigableSelections.length - 1) {
         indexToFocus = 0;
       } else {
         indexToFocus = focusedItemIndex + 1;
       }
 
-      // Skip disabled options
-      while (filteredSelections[indexToFocus].isDisabled) {
+      // Skip disabled / aria-disabled options
+      while (
+        navigableSelections[indexToFocus] &&
+        isOptionNonNavigable(navigableSelections[indexToFocus])
+      ) {
         indexToFocus++;
-        if (indexToFocus === filteredSelections.length) {
+        if (indexToFocus === navigableSelections.length) {
           indexToFocus = 0;
         }
       }
     }
 
     setActiveAndFocusedItem(indexToFocus);
+    // Keep DOM focus on the combobox for aria-activedescendant navigation. PatternFly
+    // SelectOption isFocused can move focus into the portaled listbox; Tab then unmounts
+    // that node and the modal focus trap resets to the dialog shell.
+    textInputRef.current?.focus();
   };
 
   const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    const focusedItem = focusedItemIndex !== null ? filteredSelections[focusedItemIndex] : null;
+    const focusedItem = focusedItemIndex !== null ? navigableSelections[focusedItemIndex] : null;
 
     switch (event.key) {
       case 'Enter':
+        // Prevent native <form> submit (page refresh / modal dismiss) when Enter
+        // is used to open the menu or select an option — same pattern as MultiSelection.
+        event.preventDefault();
         if (
           isOpen &&
           focusedItem &&
           focusedItem.value !== NO_RESULTS &&
-          !focusedItem.isAriaDisabled
+          !isOptionNonNavigable(focusedItem)
         ) {
           selectOption(event, focusedItem);
+        } else if (!isOpen) {
+          openMenu();
         }
 
-        openMenu();
-
         break;
+      // Tab is handled in document capture (handleTabWhileOpen) so PatternFly Select
+      // does not preventDefault and refocus the toggle instead of advancing the field.
+      // Escape is handled by useMenuPopperInModal (document capture) via onEscapeClose.
       case 'ArrowUp':
       case 'ArrowDown':
         event.preventDefault();
@@ -420,9 +557,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ref={toggleRef}
       variant="typeahead"
-      aria-label="Typeahead menu toggle"
       data-testid={dataTestId ?? 'typeahead-menu-toggle'}
       onClick={onToggleClick}
       isExpanded={isOpen}
@@ -430,6 +565,16 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
       isFullWidth
       style={{ width: toggleWidth }}
       {...toggleProps}
+      aria-label={accessibleName}
+      ref={(el) => {
+        menuToggleRef.current = el;
+        if (typeof toggleRef === 'function') {
+          toggleRef(el);
+        } else if (toggleRef) {
+          const mutableToggleRef: React.MutableRefObject<MenuToggleElement | null> = toggleRef;
+          mutableToggleRef.current = el;
+        }
+      }}
     >
       <TextInputGroup isPlain>
         <Flex alignItems={{ default: 'alignItemsCenter' }} style={{ width: '100%' }}>
@@ -445,6 +590,9 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
               icon={inputIcon}
               {...(activeItemId && { 'aria-activedescendant': activeItemId })}
               role="combobox"
+              aria-label={accessibleName}
+              {...(isOpen ? { 'aria-controls': listboxId } : {})}
+              aria-haspopup="listbox"
               isExpanded={isOpen}
               className="pf-v6-u-w-100"
             />
@@ -467,30 +615,12 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     </MenuToggle>
   );
 
-  const groupedSelections = React.useMemo(() => {
-    const group: Record<string, TypeaheadSelectOption[]> = {};
-    const noGroup: TypeaheadSelectOption[] = [];
-
-    filteredSelections.forEach((option) => {
-      if (option.group) {
-        if (option.group in group) {
-          group[option.group].push(option);
-        } else {
-          group[option.group] = [option];
-        }
-      } else {
-        noGroup.push(option);
-      }
-    });
-
-    return { group, noGroup };
-  }, [filteredSelections]);
-
   const tSelectOption = (option: TypeaheadSelectOption, index: number) => {
     const { content, value, dropdownLabel, ...optionProps } = option;
     return (
       <SelectOption
         key={value}
+        id={createOptionElementId(instanceId, value)}
         value={value}
         isFocused={focusedItemIndex === index}
         {...optionProps}
@@ -579,16 +709,22 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   return (
     <>
       <Select
+        {...props}
         isOpen={isOpen}
         selected={selected}
         onSelect={handleSelect}
         onOpenChange={(open) => !open && closeMenu()}
+        onOpenChangeKeys={['Escape']}
+        variant="typeahead"
         toggle={toggle}
         shouldFocusFirstItemOnOpen={false}
         ref={innerRef}
-        {...props}
+        id={id}
+        popperProps={mergedPopperProps}
       >
-        <SelectList>{renderOptions()}</SelectList>
+        <SelectList id={listboxId} aria-label={listboxAriaLabel}>
+          {renderOptions()}
+        </SelectList>
       </Select>
       {previewDescription && isSingleOption && selected?.description ? (
         <FormHelperText>

--- a/packages/ui-core/src/components/ValueUnitField.scss
+++ b/packages/ui-core/src/components/ValueUnitField.scss
@@ -1,0 +1,4 @@
+// innerRef anchor without adding a layout box (keeps parent flex/grid intact).
+.odh-value-unit-field__toggle-anchor {
+  display: contents;
+}

--- a/packages/ui-core/src/components/ValueUnitField.tsx
+++ b/packages/ui-core/src/components/ValueUnitField.tsx
@@ -10,6 +10,9 @@ import {
 } from '@patternfly/react-core';
 import NumberInputWrapper from './NumberInputWrapper';
 import { splitValueUnit, UnitOption, ValueUnitString } from '../utilities/valueUnits';
+import { useMenuPopperInModal } from '../utilities/useMenuPopperInModal';
+
+import './ValueUnitField.scss';
 
 type ValueUnitFieldProps = {
   /**
@@ -32,6 +35,8 @@ type ValueUnitFieldProps = {
   menuAppendTo?: HTMLElement;
   isDisabled?: boolean;
   dataTestId?: string;
+  /** Accessible name for the unit MenuToggle. Prefer omitting when visible unit text is enough. */
+  toggleAriaLabel?: string;
 };
 
 const ValueUnitField: React.FC<ValueUnitFieldProps> = ({
@@ -45,11 +50,22 @@ const ValueUnitField: React.FC<ValueUnitFieldProps> = ({
   validated,
   isDisabled,
   dataTestId,
+  toggleAriaLabel,
 }) => {
   const [open, setOpen] = React.useState(false);
+  const menuToggleRef = React.useRef<HTMLDivElement | null>(null);
+  const menuId = React.useId();
   const [currentValue, currentUnitOption] = splitValueUnit(fullValue, options);
   const minAsNumber = typeof min === 'string' ? splitValueUnit(min, options)[0] : min;
   const maxAsNumber = typeof max === 'string' ? splitValueUnit(max, options)[0] : max;
+
+  const userPopperProps = React.useMemo(
+    () => (menuAppendTo !== undefined ? { appendTo: menuAppendTo } : undefined),
+    [menuAppendTo],
+  );
+  const popperProps = useMenuPopperInModal(open, menuToggleRef, userPopperProps, {
+    onEscapeClose: () => setOpen(false),
+  });
 
   return (
     <Split hasGutter>
@@ -84,41 +100,44 @@ const ValueUnitField: React.FC<ValueUnitFieldProps> = ({
         />
       </SplitItem>
       <SplitItem>
-        <Dropdown
-          shouldFocusToggleOnSelect
-          popperProps={{ appendTo: menuAppendTo }}
-          toggle={(toggleRef) => (
-            <MenuToggle
-              data-testid="value-unit-select"
-              aria-label="value unit field toggle"
-              id="toggle-basic"
-              ref={toggleRef}
-              onClick={() => {
-                setOpen(!open);
-              }}
-              isExpanded={open}
-              isDisabled={isDisabled}
-            >
-              {currentUnitOption.name}
-            </MenuToggle>
-          )}
-          isOpen={open}
-          onOpenChange={(isOpened) => setOpen(isOpened)}
-        >
-          <DropdownList>
-            {options.map((option) => (
-              <DropdownItem
-                key={option.unit}
+        <div ref={menuToggleRef} className="odh-value-unit-field__toggle-anchor">
+          <Dropdown
+            shouldFocusToggleOnSelect
+            popperProps={popperProps}
+            toggle={(toggleRef) => (
+              <MenuToggle
+                data-testid="value-unit-select"
+                {...(toggleAriaLabel ? { 'aria-label': toggleAriaLabel } : {})}
+                {...(open ? { 'aria-controls': menuId } : {})}
+                id={`${menuId}-toggle`}
+                ref={toggleRef}
                 onClick={() => {
-                  onChange(`${currentValue ?? ''}${option.unit}`);
-                  setOpen(false);
+                  setOpen(!open);
                 }}
+                isExpanded={open}
+                isDisabled={isDisabled}
               >
-                {option.name}
-              </DropdownItem>
-            ))}
-          </DropdownList>
-        </Dropdown>
+                {currentUnitOption.name}
+              </MenuToggle>
+            )}
+            isOpen={open}
+            onOpenChange={(isOpened) => setOpen(isOpened)}
+          >
+            <DropdownList id={menuId}>
+              {options.map((option) => (
+                <DropdownItem
+                  key={option.unit}
+                  onClick={() => {
+                    onChange(`${currentValue ?? ''}${option.unit}`);
+                    setOpen(false);
+                  }}
+                >
+                  {option.name}
+                </DropdownItem>
+              ))}
+            </DropdownList>
+          </Dropdown>
+        </div>
       </SplitItem>
     </Split>
   );

--- a/packages/ui-core/src/components/__tests__/TypeaheadSelect.spec.tsx
+++ b/packages/ui-core/src/components/__tests__/TypeaheadSelect.spec.tsx
@@ -1,0 +1,624 @@
+import React from 'react';
+import { act, createEvent, fireEvent, render, screen, within } from '@testing-library/react';
+import TypeaheadSelect from '../TypeaheadSelect';
+import { MODAL_OVERFLOW_UNLOCK_COUNT_ATTR } from '../../utilities/useModalOverflowUnlock';
+
+const defaultOptions = [
+  { content: 'S3', value: 's3' },
+  { content: 'URI', value: 'uri' },
+  { content: 'OCI', value: 'oci' },
+];
+
+describe('TypeaheadSelect', () => {
+  it('should wire combobox aria-activedescendant to stable option ids', async () => {
+    render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+    expect(combobox).not.toHaveAttribute('aria-controls');
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    expect(combobox).toHaveAttribute('aria-controls', 'test-select-listbox');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-s3');
+    expect(document.getElementById('test-select-option-s-s3')).toBeInTheDocument();
+    expect(document.getElementById('test-select-listbox')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+    expect(document.getElementById('test-select-option-s-uuri')).toBeInTheDocument();
+  });
+
+  it('should portal options into the modal dialog for screen reader access', async () => {
+    const dialogRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <div ref={dialogRef} role="dialog" style={{ overflow: 'auto' }}>
+        <TypeaheadSelect
+          ariaLabel="Connection type"
+          selectOptions={defaultOptions}
+          onSelect={jest.fn()}
+          isRequired={false}
+        />
+      </div>,
+    );
+
+    const dialog = dialogRef.current as HTMLDivElement;
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+
+    expect(dialog.style.overflow).toBe('visible');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBe('1');
+
+    const option = within(dialog).getByRole('option', { name: 'S3' });
+    expect(option).toBeInTheDocument();
+    expect(dialog.contains(option)).toBe(true);
+  });
+
+  it('should restore modal overflow when the menu closes', async () => {
+    const dialogRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <div ref={dialogRef} role="dialog" style={{ overflow: 'auto' }}>
+        <TypeaheadSelect
+          ariaLabel="Connection type"
+          selectOptions={defaultOptions}
+          onSelect={jest.fn()}
+          isRequired={false}
+        />
+      </div>,
+    );
+
+    const dialog = dialogRef.current as HTMLDivElement;
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    expect(dialog.style.overflow).toBe('visible');
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'Escape' });
+    });
+
+    expect(dialog.style.overflow).toBe('auto');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBeNull();
+  });
+
+  it('should encode special characters in option element ids', async () => {
+    render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[
+          { content: 'Core/Pods', value: 'core/pods' },
+          { content: 'A B', value: 'a b' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-coreu47upods');
+    expect(document.getElementById('test-select-option-s-coreu47upods')).toBeInTheDocument();
+  });
+
+  it('should preventDefault on Enter so parent forms do not submit', async () => {
+    const onSelect = jest.fn();
+    render(
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          throw new Error('form should not submit');
+        }}
+      >
+        <TypeaheadSelect
+          ariaLabel="Connection type"
+          selectOptions={defaultOptions}
+          onSelect={onSelect}
+          isRequired={false}
+        />
+      </form>,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    const enterClosed = createEvent.keyDown(combobox, { key: 'Enter' });
+    const preventDefaultClosed = jest.spyOn(enterClosed, 'preventDefault');
+
+    await act(async () => {
+      fireEvent(combobox, enterClosed);
+    });
+
+    expect(preventDefaultClosed).toHaveBeenCalled();
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    const enterSelect = createEvent.keyDown(combobox, { key: 'Enter' });
+    const preventDefaultSelect = jest.spyOn(enterSelect, 'preventDefault');
+
+    await act(async () => {
+      fireEvent(combobox, enterSelect);
+    });
+
+    expect(preventDefaultSelect).toHaveBeenCalled();
+    expect(onSelect).toHaveBeenCalledWith(expect.anything(), 's3');
+  });
+
+  it('should stop Escape propagation and close the menu without relying on modal dismissal', async () => {
+    render(
+      <TypeaheadSelect
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+    const escapeEvent = createEvent.keyDown(combobox, { key: 'Escape' });
+    const stopPropagation = jest.spyOn(escapeEvent, 'stopPropagation');
+
+    await act(async () => {
+      fireEvent(combobox, escapeEvent);
+    });
+
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('should keep combobox focus after arrow navigation so Tab can leave the field', async () => {
+    render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    const firstOption = screen.getByRole('option', { name: 'S3' });
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-s3');
+    expect(document.activeElement).toBe(combobox);
+
+    // Simulate focus drifting into the portaled option before Tab (DaoDao scenario B).
+    firstOption.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(firstOption, { key: 'Tab' });
+      await Promise.resolve();
+    });
+
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    expect(document.activeElement).toBe(combobox);
+  });
+
+  it('should close the menu on Tab', async () => {
+    const onToggle = jest.fn();
+    render(
+      <TypeaheadSelect
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        onToggle={onToggle}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+    onToggle.mockClear();
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'Tab' });
+      await Promise.resolve();
+    });
+
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    expect(onToggle.mock.calls.filter(([isOpenNow]) => isOpenNow === false)).toHaveLength(1);
+  });
+
+  it('should not move focus to the combobox when Tab is pressed on the clear button', async () => {
+    render(
+      <>
+        <TypeaheadSelect
+          ariaLabel="Connection type"
+          selectOptions={defaultOptions}
+          selected="s3"
+          allowClear
+          onSelect={jest.fn()}
+          isRequired={false}
+        />
+        <button type="button">Next field</button>
+      </>,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+    const clearButton = screen.getByRole('button', { name: 'Clear input value' });
+    clearButton.focus();
+    expect(document.activeElement).toBe(clearButton);
+
+    await act(async () => {
+      fireEvent.keyDown(clearButton, { key: 'Tab' });
+      await Promise.resolve();
+    });
+
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    expect(document.activeElement).toBe(clearButton);
+  });
+
+  it('should give the combobox an accessible name when ariaLabel is omitted', () => {
+    render(
+      <TypeaheadSelect selectOptions={defaultOptions} onSelect={jest.fn()} isRequired={false} />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Typeahead menu toggle' })).toBeInTheDocument();
+  });
+
+  it('should fall back to toggleProps aria-label for the combobox name', () => {
+    render(
+      <TypeaheadSelect
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        toggleProps={{ 'aria-label': 'Storage picker' }}
+        isRequired={false}
+      />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Storage picker' })).toBeInTheDocument();
+  });
+
+  it('should prefer ariaLabel over toggleProps aria-label for the combobox', () => {
+    render(
+      <TypeaheadSelect
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        ariaLabel="Connection type"
+        toggleProps={{ 'aria-label': 'Storage picker' }}
+        isRequired={false}
+      />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Connection type' })).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Storage picker' })).not.toBeInTheDocument();
+  });
+
+  it('should still apply toggleProps that the typeahead does not own', () => {
+    render(
+      <TypeaheadSelect
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        ariaLabel="Connection type"
+        toggleProps={{ id: 'notebook-search-input', style: { minWidth: '200px' } }}
+        isRequired={false}
+      />,
+    );
+
+    const toggle = screen.getByTestId('typeahead-menu-toggle');
+    expect(toggle).toHaveAttribute('id', 'notebook-search-input');
+    expect(toggle).toHaveStyle({ minWidth: '200px' });
+    expect(screen.getByRole('combobox', { name: 'Connection type' })).toBeInTheDocument();
+  });
+
+  it('should call onToggle(false) once when Tab races with PatternFly close', async () => {
+    const onToggle = jest.fn();
+    render(
+      <TypeaheadSelect
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        onToggle={onToggle}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    onToggle.mockClear();
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'Tab' });
+      fireEvent.keyDown(combobox, { key: 'Escape' });
+      await Promise.resolve();
+    });
+
+    expect(onToggle.mock.calls.filter(([isOpenNow]) => isOpenNow === false)).toHaveLength(1);
+  });
+
+  it('should call the latest onToggle(false) when Tab closes the menu', async () => {
+    const firstToggle = jest.fn();
+    const secondToggle = jest.fn();
+    const { rerender } = render(
+      <TypeaheadSelect
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        onToggle={firstToggle}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    firstToggle.mockClear();
+
+    rerender(
+      <TypeaheadSelect
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        onToggle={secondToggle}
+        isRequired={false}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'Tab' });
+      await Promise.resolve();
+    });
+
+    expect(firstToggle).not.toHaveBeenCalled();
+    expect(secondToggle.mock.calls.filter(([isOpenNow]) => isOpenNow === false)).toHaveLength(1);
+  });
+
+  it('should keep aria-activedescendant aligned with grouped render order', async () => {
+    render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Persistent storage"
+        selectOptions={[
+          { content: 'ungrouped-first', value: 'solo' },
+          { content: 'grouped-a', value: 'alpha', group: 'Group A' },
+          { content: 'grouped-b', value: 'beta', group: 'Group A' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Persistent storage' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    // Render order: groups first, then ungrouped — first arrow focuses alpha
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-alpha');
+    expect(document.getElementById('test-select-option-s-alpha')).toBeInTheDocument();
+  });
+
+  it('should render numeric and string option values as distinct options', async () => {
+    render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[
+          { content: 'Numeric one', value: 1 },
+          { content: 'String one', value: '1' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+
+    expect(document.getElementById('test-select-option-n-1')).toBeInTheDocument();
+    expect(document.getElementById('test-select-option-s-1')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Numeric one' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'String one' })).toBeInTheDocument();
+  });
+
+  it('should clear aria-activedescendant when the focused option is removed', async () => {
+    const { rerender } = render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+
+    rerender(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[{ content: 'S3', value: 's3' }]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    expect(combobox).not.toHaveAttribute('aria-activedescendant');
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-s3');
+  });
+
+  it('should reset focus when same-length options replace the focused value', async () => {
+    const { rerender } = render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+
+    rerender(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[
+          { content: 'Alpha', value: 'alpha' },
+          { content: 'Beta', value: 'beta' },
+          { content: 'Gamma', value: 'gamma' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    expect(combobox).not.toHaveAttribute('aria-activedescendant');
+  });
+
+  it('should keep aria-activedescendant on the same option when the list is reordered', async () => {
+    const { rerender } = render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+
+    rerender(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[
+          { content: 'URI', value: 'uri' },
+          { content: 'S3', value: 's3' },
+          { content: 'OCI', value: 'oci' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+    expect(document.getElementById('test-select-option-s-uuri')).toBeInTheDocument();
+  });
+
+  it('should clear aria-activedescendant when the focused option becomes disabled', async () => {
+    const { rerender } = render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+
+    rerender(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[
+          { content: 'S3', value: 's3' },
+          { content: 'URI', value: 'uri', isDisabled: true },
+          { content: 'OCI', value: 'oci' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    expect(combobox).not.toHaveAttribute('aria-activedescendant');
+  });
+});

--- a/packages/ui-core/src/components/__tests__/TypeaheadSelect.spec.tsx
+++ b/packages/ui-core/src/components/__tests__/TypeaheadSelect.spec.tsx
@@ -65,9 +65,11 @@ describe('TypeaheadSelect', () => {
     expect(dialog.style.overflow).toBe('visible');
     expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBe('1');
 
+    // Option must be inside the dialog but outside the combobox toggle anchor
+    // (inline render would also satisfy within(dialog)).
     const option = within(dialog).getByRole('option', { name: 'S3' });
-    expect(option).toBeInTheDocument();
     expect(dialog.contains(option)).toBe(true);
+    expect(combobox.contains(option)).toBe(false);
   });
 
   it('should restore modal overflow when the menu closes', async () => {

--- a/packages/ui-core/src/components/__tests__/TypeaheadSelect.spec.tsx
+++ b/packages/ui-core/src/components/__tests__/TypeaheadSelect.spec.tsx
@@ -376,6 +376,45 @@ describe('TypeaheadSelect', () => {
     expect(onToggle.mock.calls.filter(([isOpenNow]) => isOpenNow === false)).toHaveLength(1);
   });
 
+  it('should call the latest onToggle(false) when Tab closes the menu', async () => {
+    const firstToggle = jest.fn();
+    const secondToggle = jest.fn();
+    const { rerender } = render(
+      <TypeaheadSelect
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        onToggle={firstToggle}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    firstToggle.mockClear();
+
+    rerender(
+      <TypeaheadSelect
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        onToggle={secondToggle}
+        isRequired={false}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'Tab' });
+      await Promise.resolve();
+    });
+
+    expect(firstToggle).not.toHaveBeenCalled();
+    expect(secondToggle.mock.calls.filter(([isOpenNow]) => isOpenNow === false)).toHaveLength(1);
+  });
+
   it('should keep aria-activedescendant aligned with grouped render order', async () => {
     render(
       <TypeaheadSelect
@@ -402,7 +441,33 @@ describe('TypeaheadSelect', () => {
     expect(document.getElementById('test-select-option-s-alpha')).toBeInTheDocument();
   });
 
-  it('should not throw when options shrink under a stale focused index', async () => {
+  it('should render numeric and string option values as distinct options', async () => {
+    render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[
+          { content: 'Numeric one', value: 1 },
+          { content: 'String one', value: '1' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+
+    expect(document.getElementById('test-select-option-n-1')).toBeInTheDocument();
+    expect(document.getElementById('test-select-option-s-1')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Numeric one' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'String one' })).toBeInTheDocument();
+  });
+
+  it('should clear aria-activedescendant when the focused option is removed', async () => {
     const { rerender } = render(
       <TypeaheadSelect
         id="test-select"
@@ -433,9 +498,126 @@ describe('TypeaheadSelect', () => {
       />,
     );
 
+    expect(combobox).not.toHaveAttribute('aria-activedescendant');
+
     await act(async () => {
       fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     });
+
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-s3');
+  });
+
+  it('should reset focus when same-length options replace the focused value', async () => {
+    const { rerender } = render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+
+    rerender(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[
+          { content: 'Alpha', value: 'alpha' },
+          { content: 'Beta', value: 'beta' },
+          { content: 'Gamma', value: 'gamma' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    expect(combobox).not.toHaveAttribute('aria-activedescendant');
+  });
+
+  it('should keep aria-activedescendant on the same option when the list is reordered', async () => {
+    const { rerender } = render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+
+    rerender(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[
+          { content: 'URI', value: 'uri' },
+          { content: 'S3', value: 's3' },
+          { content: 'OCI', value: 'oci' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+    expect(document.getElementById('test-select-option-s-uuri')).toBeInTheDocument();
+  });
+
+  it('should clear aria-activedescendant when the focused option becomes disabled', async () => {
+    const { rerender } = render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+
+    rerender(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[
+          { content: 'S3', value: 's3' },
+          { content: 'URI', value: 'uri', isDisabled: true },
+          { content: 'OCI', value: 'oci' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
 
     expect(combobox).not.toHaveAttribute('aria-activedescendant');
   });

--- a/packages/ui-core/src/components/__tests__/TypeaheadSelect.spec.tsx
+++ b/packages/ui-core/src/components/__tests__/TypeaheadSelect.spec.tsx
@@ -1,0 +1,442 @@
+import React from 'react';
+import { act, createEvent, fireEvent, render, screen, within } from '@testing-library/react';
+import TypeaheadSelect from '../TypeaheadSelect';
+import { MODAL_OVERFLOW_UNLOCK_COUNT_ATTR } from '../../utilities/useModalOverflowUnlock';
+
+const defaultOptions = [
+  { content: 'S3', value: 's3' },
+  { content: 'URI', value: 'uri' },
+  { content: 'OCI', value: 'oci' },
+];
+
+describe('TypeaheadSelect', () => {
+  it('should wire combobox aria-activedescendant to stable option ids', async () => {
+    render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+    expect(combobox).not.toHaveAttribute('aria-controls');
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    expect(combobox).toHaveAttribute('aria-controls', 'test-select-listbox');
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-s3');
+    expect(document.getElementById('test-select-option-s-s3')).toBeInTheDocument();
+    expect(document.getElementById('test-select-listbox')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+    expect(document.getElementById('test-select-option-s-uuri')).toBeInTheDocument();
+  });
+
+  it('should portal options into the modal dialog for screen reader access', async () => {
+    const dialogRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <div ref={dialogRef} role="dialog" style={{ overflow: 'auto' }}>
+        <TypeaheadSelect
+          ariaLabel="Connection type"
+          selectOptions={defaultOptions}
+          onSelect={jest.fn()}
+          isRequired={false}
+        />
+      </div>,
+    );
+
+    const dialog = dialogRef.current as HTMLDivElement;
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+
+    expect(dialog.style.overflow).toBe('visible');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBe('1');
+
+    const option = within(dialog).getByRole('option', { name: 'S3' });
+    expect(option).toBeInTheDocument();
+    expect(dialog.contains(option)).toBe(true);
+  });
+
+  it('should restore modal overflow when the menu closes', async () => {
+    const dialogRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <div ref={dialogRef} role="dialog" style={{ overflow: 'auto' }}>
+        <TypeaheadSelect
+          ariaLabel="Connection type"
+          selectOptions={defaultOptions}
+          onSelect={jest.fn()}
+          isRequired={false}
+        />
+      </div>,
+    );
+
+    const dialog = dialogRef.current as HTMLDivElement;
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    expect(dialog.style.overflow).toBe('visible');
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'Escape' });
+    });
+
+    expect(dialog.style.overflow).toBe('auto');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBeNull();
+  });
+
+  it('should encode special characters in option element ids', async () => {
+    render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[
+          { content: 'Core/Pods', value: 'core/pods' },
+          { content: 'A B', value: 'a b' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-coreu47upods');
+    expect(document.getElementById('test-select-option-s-coreu47upods')).toBeInTheDocument();
+  });
+
+  it('should preventDefault on Enter so parent forms do not submit', async () => {
+    const onSelect = jest.fn();
+    render(
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          throw new Error('form should not submit');
+        }}
+      >
+        <TypeaheadSelect
+          ariaLabel="Connection type"
+          selectOptions={defaultOptions}
+          onSelect={onSelect}
+          isRequired={false}
+        />
+      </form>,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    const enterClosed = createEvent.keyDown(combobox, { key: 'Enter' });
+    const preventDefaultClosed = jest.spyOn(enterClosed, 'preventDefault');
+
+    await act(async () => {
+      fireEvent(combobox, enterClosed);
+    });
+
+    expect(preventDefaultClosed).toHaveBeenCalled();
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    const enterSelect = createEvent.keyDown(combobox, { key: 'Enter' });
+    const preventDefaultSelect = jest.spyOn(enterSelect, 'preventDefault');
+
+    await act(async () => {
+      fireEvent(combobox, enterSelect);
+    });
+
+    expect(preventDefaultSelect).toHaveBeenCalled();
+    expect(onSelect).toHaveBeenCalledWith(expect.anything(), 's3');
+  });
+
+  it('should stop Escape propagation and close the menu without relying on modal dismissal', async () => {
+    render(
+      <TypeaheadSelect
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+    const escapeEvent = createEvent.keyDown(combobox, { key: 'Escape' });
+    const stopPropagation = jest.spyOn(escapeEvent, 'stopPropagation');
+
+    await act(async () => {
+      fireEvent(combobox, escapeEvent);
+    });
+
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('should keep combobox focus after arrow navigation so Tab can leave the field', async () => {
+    render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    const firstOption = screen.getByRole('option', { name: 'S3' });
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-s3');
+    expect(document.activeElement).toBe(combobox);
+
+    // Simulate focus drifting into the portaled option before Tab (DaoDao scenario B).
+    firstOption.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(firstOption, { key: 'Tab' });
+      await Promise.resolve();
+    });
+
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    expect(document.activeElement).toBe(combobox);
+  });
+
+  it('should close the menu on Tab', async () => {
+    const onToggle = jest.fn();
+    render(
+      <TypeaheadSelect
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        onToggle={onToggle}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+    onToggle.mockClear();
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'Tab' });
+      await Promise.resolve();
+    });
+
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    expect(onToggle.mock.calls.filter(([isOpenNow]) => isOpenNow === false)).toHaveLength(1);
+  });
+
+  it('should not move focus to the combobox when Tab is pressed on the clear button', async () => {
+    render(
+      <>
+        <TypeaheadSelect
+          ariaLabel="Connection type"
+          selectOptions={defaultOptions}
+          selected="s3"
+          allowClear
+          onSelect={jest.fn()}
+          isRequired={false}
+        />
+        <button type="button">Next field</button>
+      </>,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+    const clearButton = screen.getByRole('button', { name: 'Clear input value' });
+    clearButton.focus();
+    expect(document.activeElement).toBe(clearButton);
+
+    await act(async () => {
+      fireEvent.keyDown(clearButton, { key: 'Tab' });
+      await Promise.resolve();
+    });
+
+    expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    expect(document.activeElement).toBe(clearButton);
+  });
+
+  it('should give the combobox an accessible name when ariaLabel is omitted', () => {
+    render(
+      <TypeaheadSelect selectOptions={defaultOptions} onSelect={jest.fn()} isRequired={false} />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Typeahead menu toggle' })).toBeInTheDocument();
+  });
+
+  it('should fall back to toggleProps aria-label for the combobox name', () => {
+    render(
+      <TypeaheadSelect
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        toggleProps={{ 'aria-label': 'Storage picker' }}
+        isRequired={false}
+      />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Storage picker' })).toBeInTheDocument();
+  });
+
+  it('should prefer ariaLabel over toggleProps aria-label for the combobox', () => {
+    render(
+      <TypeaheadSelect
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        ariaLabel="Connection type"
+        toggleProps={{ 'aria-label': 'Storage picker' }}
+        isRequired={false}
+      />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Connection type' })).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Storage picker' })).not.toBeInTheDocument();
+  });
+
+  it('should still apply toggleProps that the typeahead does not own', () => {
+    render(
+      <TypeaheadSelect
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        ariaLabel="Connection type"
+        toggleProps={{ id: 'notebook-search-input', style: { minWidth: '200px' } }}
+        isRequired={false}
+      />,
+    );
+
+    const toggle = screen.getByTestId('typeahead-menu-toggle');
+    expect(toggle).toHaveAttribute('id', 'notebook-search-input');
+    expect(toggle).toHaveStyle({ minWidth: '200px' });
+    expect(screen.getByRole('combobox', { name: 'Connection type' })).toBeInTheDocument();
+  });
+
+  it('should call onToggle(false) once when Tab races with PatternFly close', async () => {
+    const onToggle = jest.fn();
+    render(
+      <TypeaheadSelect
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        onToggle={onToggle}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.click(combobox);
+    });
+    onToggle.mockClear();
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'Tab' });
+      fireEvent.keyDown(combobox, { key: 'Escape' });
+      await Promise.resolve();
+    });
+
+    expect(onToggle.mock.calls.filter(([isOpenNow]) => isOpenNow === false)).toHaveLength(1);
+  });
+
+  it('should keep aria-activedescendant aligned with grouped render order', async () => {
+    render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Persistent storage"
+        selectOptions={[
+          { content: 'ungrouped-first', value: 'solo' },
+          { content: 'grouped-a', value: 'alpha', group: 'Group A' },
+          { content: 'grouped-b', value: 'beta', group: 'Group A' },
+        ]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Persistent storage' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    // Render order: groups first, then ungrouped — first arrow focuses alpha
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-alpha');
+    expect(document.getElementById('test-select-option-s-alpha')).toBeInTheDocument();
+  });
+
+  it('should not throw when options shrink under a stale focused index', async () => {
+    const { rerender } = render(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={defaultOptions}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Connection type' });
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+    expect(combobox).toHaveAttribute('aria-activedescendant', 'test-select-option-s-uuri');
+
+    rerender(
+      <TypeaheadSelect
+        id="test-select"
+        ariaLabel="Connection type"
+        selectOptions={[{ content: 'S3', value: 's3' }]}
+        onSelect={jest.fn()}
+        isRequired={false}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    });
+
+    expect(combobox).not.toHaveAttribute('aria-activedescendant');
+  });
+});

--- a/packages/ui-core/src/components/searchSelector/SearchSelector.tsx
+++ b/packages/ui-core/src/components/searchSelector/SearchSelector.tsx
@@ -15,8 +15,10 @@ import {
   SearchInput,
   Spinner,
   Truncate,
+  MenuToggleElement,
 } from '@patternfly/react-core';
 import './SearchSelector.scss';
+import { useMenuPopperInModal } from '../../utilities/useMenuPopperInModal';
 
 type ManualSearchSelectorOpts = {
   menuClose: () => void;
@@ -43,6 +45,11 @@ type SearchSelectorProps = {
   appendTo?: 'inline' | (() => HTMLElement) | HTMLElement;
 };
 
+/**
+ * Searchable menu toggle. Default `appendTo` is resolved by `useMenuPopperInModal`
+ * (nearest dialog when inside a modal, `document.body` otherwise). Pass `appendTo`
+ * explicitly to override.
+ */
 const SearchSelector: React.FC<SearchSelectorProps> = ({
   children,
   footer,
@@ -61,13 +68,30 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
   toggleVariant,
   toggleAriaLabel,
   toggleLabelledBy,
-  appendTo = 'inline',
+  appendTo,
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const toggleRef = React.useRef(null);
+  const toggleRef = React.useRef<MenuToggleElement | null>(null);
   const menuRef = React.useRef(null);
   const searchRef = React.useRef<HTMLInputElement | null>(null);
-  const popperProps = { minWidth, maxWidth: 'trigger', appendTo };
+  const menuId = React.useId();
+  const userPopperProps = React.useMemo(
+    () => ({
+      minWidth,
+      maxWidth: 'trigger' as const,
+      ...(appendTo !== undefined ? { appendTo } : {}),
+    }),
+    [minWidth, appendTo],
+  );
+  // Dialog-aware appendTo (modal → dialog; else body) replaces the former default
+  // appendTo: 'inline' so menus in modals stay reachable for keyboard/SR users.
+  // Callers may still pass appendTo explicitly to override.
+  const popperProps = useMenuPopperInModal(isOpen, toggleRef, userPopperProps, {
+    onEscapeClose: () => {
+      setIsOpen(false);
+      onSearchClear();
+    },
+  });
   const toggleValueId = toggleLabelledBy ? `${dataTestId}-toggle-value` : undefined;
   const toggleContents =
     typeof toggleContent !== 'string' ? toggleContent : <Truncate content={toggleContent} />;
@@ -107,6 +131,7 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
           isFullWidth={isFullWidth}
           data-testid={`${dataTestId}-toggle`}
           variant={toggleVariant}
+          {...(isOpen ? { 'aria-controls': menuId } : {})}
           {...toggleAriaProps}
         >
           {labelledToggleContents}
@@ -114,6 +139,7 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
       }
       menu={
         <Menu
+          id={menuId}
           className="odh-search-selector__menu"
           data-testid={`${dataTestId}-menu`}
           ref={menuRef}

--- a/packages/ui-core/src/components/searchSelector/__tests__/SearchSelector.spec.tsx
+++ b/packages/ui-core/src/components/searchSelector/__tests__/SearchSelector.spec.tsx
@@ -61,8 +61,11 @@ describe('SearchSelector', () => {
     expect(dialog.style.overflow).toBe('visible');
     expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBe('1');
 
+    // Menu must be inside the dialog but outside the toggle anchor
+    // (inline render would also satisfy within(dialog)).
     const menu = within(dialog).getByTestId('project-search-menu');
     expect(dialog.contains(menu)).toBe(true);
+    expect(toggle.contains(menu)).toBe(false);
     expect(screen.getByRole('menuitem', { name: 'Project A' })).toBeInTheDocument();
   });
 

--- a/packages/ui-core/src/components/searchSelector/__tests__/SearchSelector.spec.tsx
+++ b/packages/ui-core/src/components/searchSelector/__tests__/SearchSelector.spec.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { MenuItem } from '@patternfly/react-core';
+import SearchSelector from '../SearchSelector';
+import { MODAL_OVERFLOW_UNLOCK_COUNT_ATTR } from '../../../utilities/useModalOverflowUnlock';
+
+const defaultProps = {
+  dataTestId: 'project-search',
+  searchValue: '',
+  onSearchChange: jest.fn(),
+  onSearchClear: jest.fn(),
+  toggleContent: 'Select project',
+  toggleAriaLabel: 'Project',
+};
+
+describe('SearchSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should portal the menu to document.body outside a modal dialog', async () => {
+    const pageRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <div ref={pageRef} data-testid="page-shell">
+        <SearchSelector {...defaultProps}>
+          <MenuItem itemId="proj-a">Project A</MenuItem>
+        </SearchSelector>
+      </div>,
+    );
+
+    const toggle = screen.getByTestId('project-search-toggle');
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    const menu = screen.getByTestId('project-search-menu');
+    expect(document.body.contains(menu)).toBe(true);
+    expect(pageRef.current?.contains(menu)).toBe(false);
+  });
+
+  it('should portal the menu into the modal dialog and unlock overflow', async () => {
+    const dialogRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <div ref={dialogRef} role="dialog" style={{ overflow: 'auto' }} data-testid="dialog">
+        <SearchSelector {...defaultProps}>
+          <MenuItem itemId="proj-a">Project A</MenuItem>
+        </SearchSelector>
+      </div>,
+    );
+
+    const dialog = dialogRef.current as HTMLDivElement;
+    const toggle = screen.getByTestId('project-search-toggle');
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    expect(dialog.style.overflow).toBe('visible');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBe('1');
+
+    const menu = within(dialog).getByTestId('project-search-menu');
+    expect(dialog.contains(menu)).toBe(true);
+    expect(screen.getByRole('menuitem', { name: 'Project A' })).toBeInTheDocument();
+  });
+
+  it('should restore modal overflow when the menu closes', async () => {
+    const dialogRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <div ref={dialogRef} role="dialog" style={{ overflow: 'auto' }}>
+        <SearchSelector {...defaultProps}>
+          <MenuItem itemId="proj-a">Project A</MenuItem>
+        </SearchSelector>
+      </div>,
+    );
+
+    const dialog = dialogRef.current as HTMLDivElement;
+    const toggle = screen.getByTestId('project-search-toggle');
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    expect(dialog.style.overflow).toBe('visible');
+
+    await act(async () => {
+      fireEvent.keyDown(toggle, { key: 'Escape' });
+    });
+
+    expect(dialog.style.overflow).toBe('auto');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBeNull();
+  });
+
+  it('should return focus to the toggle after Escape from a portaled menu item', async () => {
+    render(
+      <div role="dialog">
+        <SearchSelector {...defaultProps}>
+          <MenuItem itemId="proj-a">Project A</MenuItem>
+        </SearchSelector>
+      </div>,
+    );
+
+    const toggle = screen.getByTestId('project-search-toggle');
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    const menuItem = screen.getByRole('menuitem', { name: 'Project A' });
+    menuItem.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(menuItem, { key: 'Escape' });
+      await Promise.resolve();
+    });
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it('should respect an explicit appendTo inline override', async () => {
+    const pageRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <div ref={pageRef} data-testid="page-shell">
+        <SearchSelector {...defaultProps} appendTo="inline">
+          <MenuItem itemId="proj-a">Project A</MenuItem>
+        </SearchSelector>
+      </div>,
+    );
+
+    const toggle = screen.getByTestId('project-search-toggle');
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    const menu = screen.getByTestId('project-search-menu');
+    expect(pageRef.current?.contains(menu)).toBe(true);
+    expect(document.body.contains(menu)).toBe(true);
+  });
+});

--- a/packages/ui-core/src/utilities/__tests__/optionElementIds.spec.ts
+++ b/packages/ui-core/src/utilities/__tests__/optionElementIds.spec.ts
@@ -1,0 +1,21 @@
+import { createOptionElementId, encodeOptionIdForDom } from '../optionElementIds';
+
+describe('optionElementIds', () => {
+  it('should distinguish numeric and string option ids', () => {
+    expect(encodeOptionIdForDom(1)).not.toBe(encodeOptionIdForDom('1'));
+    expect(createOptionElementId('test', 1)).not.toBe(createOptionElementId('test', '1'));
+  });
+
+  it('should encode special characters injectively', () => {
+    expect(encodeOptionIdForDom('a b')).not.toBe(encodeOptionIdForDom('a-b'));
+    expect(encodeOptionIdForDom('a b')).toBe('s-au32ub');
+    // The escape marker itself must be doubled, or literals collide with escapes.
+    expect(encodeOptionIdForDom('u')).toBe('s-uu');
+    expect(encodeOptionIdForDom('u32u')).not.toBe(encodeOptionIdForDom(' '));
+  });
+
+  it('should build stable option element ids', () => {
+    expect(createOptionElementId('connection-type', 's3')).toBe('connection-type-option-s-s3');
+    expect(createOptionElementId('connection-type', 42)).toBe('connection-type-option-n-42');
+  });
+});

--- a/packages/ui-core/src/utilities/__tests__/useMenuPopperInModal.spec.tsx
+++ b/packages/ui-core/src/utilities/__tests__/useMenuPopperInModal.spec.tsx
@@ -1,0 +1,366 @@
+import React from 'react';
+import { act, render, renderHook, screen } from '@testing-library/react';
+import { useMenuPopperInModal } from '../useMenuPopperInModal';
+import {
+  resolveSelectPopperAppendTo,
+  MODAL_OVERFLOW_UNLOCK_COUNT_ATTR,
+} from '../useModalOverflowUnlock';
+
+describe('useMenuPopperInModal', () => {
+  const bodyKeydownListeners = new Set<EventListener>();
+
+  const listenBodyKeydown = (listener: EventListener) => {
+    document.body.addEventListener('keydown', listener);
+    bodyKeydownListeners.add(listener);
+  };
+
+  afterEach(() => {
+    bodyKeydownListeners.forEach((listener) => {
+      document.body.removeEventListener('keydown', listener);
+    });
+    bodyKeydownListeners.clear();
+    document.body.replaceChildren();
+  });
+
+  it('should unlock dialog overflow while open', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+
+    const Harness: React.FC<{ open: boolean }> = ({ open }) => {
+      useMenuPopperInModal(open, anchorRef);
+      return (
+        <div role="dialog" style={{ overflow: 'auto' }} data-testid="dialog">
+          <input ref={anchorRef} aria-label="anchor" />
+        </div>
+      );
+    };
+
+    const { getByTestId, rerender } = render(<Harness open />);
+    const dialog = getByTestId('dialog');
+    expect(dialog.style.overflow).toBe('visible');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBe('1');
+
+    rerender(<Harness open={false} />);
+    expect(dialog.style.overflow).toBe('auto');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBeNull();
+  });
+
+  it('should auto-resolve appendTo into the nearest dialog', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+
+    const { result } = renderHook(() => useMenuPopperInModal(true, anchorRef));
+
+    render(
+      <div role="dialog" data-testid="dialog">
+        <input ref={anchorRef} aria-label="anchor" />
+      </div>,
+    );
+
+    const { appendTo } = result.current;
+    expect(typeof appendTo).toBe('function');
+    if (typeof appendTo === 'function') {
+      expect(appendTo()).toBe(screen.getByTestId('dialog'));
+    }
+  });
+
+  it('should respect an explicit appendTo override', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+    const customTarget = document.createElement('div');
+
+    const { result } = renderHook(() =>
+      useMenuPopperInModal(false, anchorRef, { appendTo: customTarget }),
+    );
+
+    expect(result.current.appendTo).toBe(customTarget);
+  });
+
+  it('should treat appendTo inline as an explicit override', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+
+    const { result } = renderHook(() =>
+      useMenuPopperInModal(false, anchorRef, { appendTo: 'inline' }),
+    );
+
+    expect(result.current.appendTo).toBe('inline');
+  });
+
+  it('should match resolveSelectPopperAppendTo outside a dialog', () => {
+    const anchor = document.createElement('input');
+    document.body.appendChild(anchor);
+    expect(resolveSelectPopperAppendTo(anchor)).toBe(document.body);
+  });
+
+  it('should preserve other popper props when merging appendTo', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+
+    const { result } = renderHook(() =>
+      useMenuPopperInModal(false, anchorRef, {
+        appendTo: undefined,
+        maxWidth: 'trigger',
+      } as { appendTo?: undefined; maxWidth: 'trigger' }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        maxWidth: 'trigger',
+        appendTo: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should update unlock when open flips via renderHook', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+
+    render(
+      <div role="dialog" style={{ overflow: 'scroll' }} data-testid="dialog">
+        <input ref={anchorRef} aria-label="anchor" />
+      </div>,
+    );
+
+    const { rerender } = renderHook(({ isOpen }) => useMenuPopperInModal(isOpen, anchorRef), {
+      initialProps: { isOpen: true },
+    });
+
+    const dialog = screen.getByTestId('dialog');
+    expect(dialog.style.overflow).toBe('visible');
+
+    act(() => {
+      rerender({ isOpen: false });
+    });
+
+    expect(dialog.style.overflow).toBe('scroll');
+  });
+
+  it('should stop Escape propagation and call onEscapeClose while open', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+    const onEscapeClose = jest.fn();
+    const modalEscapeListener = jest.fn();
+
+    const anchor = document.createElement('input');
+    document.body.appendChild(anchor);
+    // Assign after append so the ref is live for the capture listener.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    (anchorRef as React.MutableRefObject<HTMLInputElement | null>).current = anchor;
+    listenBodyKeydown(modalEscapeListener);
+
+    renderHook(() => useMenuPopperInModal(true, anchorRef, undefined, { onEscapeClose }));
+
+    act(() => {
+      anchor.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(onEscapeClose).toHaveBeenCalledTimes(1);
+    expect(modalEscapeListener).not.toHaveBeenCalled();
+  });
+
+  it('should not handle Escape when closed', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+    const onEscapeClose = jest.fn();
+
+    renderHook(() => useMenuPopperInModal(false, anchorRef, undefined, { onEscapeClose }));
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(onEscapeClose).not.toHaveBeenCalled();
+  });
+
+  it('should not intercept Escape when onEscapeClose is omitted', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+    const modalEscapeListener = jest.fn();
+
+    const menu = document.createElement('div');
+    document.body.appendChild(menu);
+    listenBodyKeydown(modalEscapeListener);
+
+    renderHook(() => useMenuPopperInModal(true, anchorRef));
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(modalEscapeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore Escape when the event target is outside this menu', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+    const onEscapeClose = jest.fn();
+
+    const anchor = document.createElement('input');
+    const other = document.createElement('button');
+    document.body.appendChild(anchor);
+    document.body.appendChild(other);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    (anchorRef as React.MutableRefObject<HTMLInputElement | null>).current = anchor;
+
+    renderHook(() => useMenuPopperInModal(true, anchorRef, undefined, { onEscapeClose }));
+
+    act(() => {
+      other.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(onEscapeClose).not.toHaveBeenCalled();
+  });
+
+  it('should handle Escape from a portaled listbox referenced by aria-controls', () => {
+    const anchorRef = React.createRef<HTMLDivElement>();
+    const onEscapeClose = jest.fn();
+
+    const anchor = document.createElement('div');
+    const toggle = document.createElement('button');
+    toggle.setAttribute('aria-controls', 'test-listbox');
+    anchor.appendChild(toggle);
+    const listbox = document.createElement('div');
+    listbox.id = 'test-listbox';
+    const option = document.createElement('div');
+    listbox.appendChild(option);
+    document.body.appendChild(anchor);
+    document.body.appendChild(listbox);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    (anchorRef as React.MutableRefObject<HTMLDivElement | null>).current = anchor;
+
+    renderHook(() => useMenuPopperInModal(true, anchorRef, undefined, { onEscapeClose }));
+
+    act(() => {
+      option.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(onEscapeClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should restore focus to the toggle after Escape from a portaled listbox', async () => {
+    const anchorRef = React.createRef<HTMLDivElement>();
+    const onEscapeClose = jest.fn();
+
+    const anchor = document.createElement('div');
+    const toggle = document.createElement('button');
+    toggle.setAttribute('aria-controls', 'focus-listbox');
+    toggle.textContent = 'Open';
+    anchor.appendChild(toggle);
+    const listbox = document.createElement('div');
+    listbox.id = 'focus-listbox';
+    const option = document.createElement('div');
+    option.setAttribute('tabindex', '-1');
+    listbox.appendChild(option);
+    document.body.appendChild(anchor);
+    document.body.appendChild(listbox);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    (anchorRef as React.MutableRefObject<HTMLDivElement | null>).current = anchor;
+    option.focus();
+
+    renderHook(() => useMenuPopperInModal(true, anchorRef, undefined, { onEscapeClose }));
+
+    await act(async () => {
+      option.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(onEscapeClose).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it('should handle Escape from a portaled menu without aria-controls in the same dialog', () => {
+    const anchorRef = React.createRef<HTMLDivElement>();
+    const onEscapeClose = jest.fn();
+    const modalEscapeListener = jest.fn();
+
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    const anchor = document.createElement('div');
+    const toggle = document.createElement('button');
+    anchor.appendChild(toggle);
+    // Menu portaled into the dialog without aria-controls (PF Dropdown pattern).
+    const menu = document.createElement('div');
+    menu.setAttribute('role', 'menu');
+    const item = document.createElement('div');
+    item.setAttribute('role', 'menuitem');
+    menu.appendChild(item);
+    dialog.appendChild(anchor);
+    dialog.appendChild(menu);
+    document.body.appendChild(dialog);
+    listenBodyKeydown(modalEscapeListener);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    (anchorRef as React.MutableRefObject<HTMLDivElement | null>).current = anchor;
+
+    renderHook(() => useMenuPopperInModal(true, anchorRef, undefined, { onEscapeClose }));
+
+    act(() => {
+      item.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(onEscapeClose).toHaveBeenCalledTimes(1);
+    expect(modalEscapeListener).not.toHaveBeenCalled();
+  });
+
+  it('should keep unlock count above zero when one of two open menus closes', () => {
+    const anchorRefA = React.createRef<HTMLInputElement>();
+    const anchorRefB = React.createRef<HTMLInputElement>();
+
+    const Harness: React.FC<{ openA: boolean; openB: boolean }> = ({ openA, openB }) => {
+      useMenuPopperInModal(openA, anchorRefA);
+      useMenuPopperInModal(openB, anchorRefB);
+      return (
+        <div role="dialog" style={{ overflow: 'auto' }} data-testid="dialog">
+          <input ref={anchorRefA} aria-label="anchor-a" />
+          <input ref={anchorRefB} aria-label="anchor-b" />
+        </div>
+      );
+    };
+
+    const { getByTestId, rerender } = render(<Harness openA openB />);
+    const dialog = getByTestId('dialog');
+    expect(dialog.style.overflow).toBe('visible');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBe('2');
+
+    rerender(<Harness openA={false} openB />);
+    expect(dialog.style.overflow).toBe('visible');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBe('1');
+
+    rerender(<Harness openA={false} openB={false} />);
+    expect(dialog.style.overflow).toBe('auto');
+    expect(dialog.getAttribute(MODAL_OVERFLOW_UNLOCK_COUNT_ATTR)).toBeNull();
+  });
+
+  it('should call the latest onEscapeClose after identity change', () => {
+    const anchorRef = React.createRef<HTMLInputElement>();
+    const firstClose = jest.fn();
+    const secondClose = jest.fn();
+
+    const anchor = document.createElement('input');
+    document.body.appendChild(anchor);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    (anchorRef as React.MutableRefObject<HTMLInputElement | null>).current = anchor;
+
+    const { rerender } = renderHook(
+      ({ onEscapeClose }) => useMenuPopperInModal(true, anchorRef, undefined, { onEscapeClose }),
+      { initialProps: { onEscapeClose: firstClose } },
+    );
+
+    act(() => {
+      rerender({ onEscapeClose: secondClose });
+    });
+
+    act(() => {
+      anchor.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(firstClose).not.toHaveBeenCalled();
+    expect(secondClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-core/src/utilities/__tests__/useMenuPopperInModal.spec.tsx
+++ b/packages/ui-core/src/utilities/__tests__/useMenuPopperInModal.spec.tsx
@@ -158,10 +158,15 @@ describe('useMenuPopperInModal', () => {
     const anchorRef = React.createRef<HTMLInputElement>();
     const onEscapeClose = jest.fn();
 
+    const anchor = document.createElement('input');
+    document.body.appendChild(anchor);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    (anchorRef as React.MutableRefObject<HTMLInputElement | null>).current = anchor;
+
     renderHook(() => useMenuPopperInModal(false, anchorRef, undefined, { onEscapeClose }));
 
     act(() => {
-      document.dispatchEvent(
+      anchor.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
       );
     });
@@ -173,14 +178,16 @@ describe('useMenuPopperInModal', () => {
     const anchorRef = React.createRef<HTMLInputElement>();
     const modalEscapeListener = jest.fn();
 
-    const menu = document.createElement('div');
-    document.body.appendChild(menu);
+    const anchor = document.createElement('input');
+    document.body.appendChild(anchor);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    (anchorRef as React.MutableRefObject<HTMLInputElement | null>).current = anchor;
     listenBodyKeydown(modalEscapeListener);
 
     renderHook(() => useMenuPopperInModal(true, anchorRef));
 
     act(() => {
-      menu.dispatchEvent(
+      anchor.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
       );
     });

--- a/packages/ui-core/src/utilities/index.ts
+++ b/packages/ui-core/src/utilities/index.ts
@@ -9,5 +9,12 @@ export {
   resolveSelectPopperAppendTo,
   useModalOverflowUnlock,
 } from './useModalOverflowUnlock';
+export { useMenuPopperInModal } from './useMenuPopperInModal';
+export type {
+  MenuPopperAppendTo,
+  MenuPopperProps,
+  UseMenuPopperInModalOptions,
+} from './useMenuPopperInModal';
+export { encodeOptionIdForDom, createOptionElementId } from './optionElementIds';
 export { BrowserStorageContext, useBrowserStorage } from '../hooks/useBrowserStorage';
 export type { BrowserStorageContextType, SetBrowserStorageHook } from '../hooks/useBrowserStorage';

--- a/packages/ui-core/src/utilities/optionElementIds.ts
+++ b/packages/ui-core/src/utilities/optionElementIds.ts
@@ -1,0 +1,11 @@
+/** Encode option ids for stable, injective DOM id segments (e.g. 'a b' vs 'a-b', 1 vs '1'). */
+export const encodeOptionIdForDom = (optionId: number | string): string => {
+  const prefix = typeof optionId === 'number' ? 'n' : 's';
+  const encoded = String(optionId)
+    .replace(/u/g, 'uu')
+    .replace(/[^a-zA-Z0-9_-]/g, (ch) => `u${ch.charCodeAt(0)}u`);
+  return `${prefix}-${encoded}`;
+};
+
+export const createOptionElementId = (instanceId: string, optionId: number | string): string =>
+  `${instanceId}-option-${encodeOptionIdForDom(optionId)}`;

--- a/packages/ui-core/src/utilities/useMenuPopperInModal.ts
+++ b/packages/ui-core/src/utilities/useMenuPopperInModal.ts
@@ -1,0 +1,151 @@
+import * as React from 'react';
+import { resolveSelectPopperAppendTo, useModalOverflowUnlock } from './useModalOverflowUnlock';
+
+/** PatternFly Select/Dropdown/MenuContainer popper append target. */
+export type MenuPopperAppendTo = HTMLElement | (() => HTMLElement) | 'inline';
+
+export type MenuPopperProps = {
+  appendTo?: MenuPopperAppendTo;
+};
+
+type MenuPopperWithAppendTo<T extends MenuPopperProps> = Omit<T, 'appendTo'> & {
+  appendTo: MenuPopperAppendTo;
+};
+
+export type UseMenuPopperInModalOptions = {
+  /**
+   * Close the open menu when Escape is pressed.
+   * Escape is handled in the capture phase so PatternFly Modal's body listener
+   * does not dismiss the dialog (including when focus is in a portaled menu).
+   * After close, focus returns to the toggle/input in `anchorRef` so the
+   * unmounted portaled item does not dump focus onto the modal trap.
+   */
+  onEscapeClose?: () => void;
+};
+
+const MENU_FOCUS_SELECTOR = 'input[role="combobox"], [role="combobox"], button, input';
+
+/** Focus the menu toggle/input after Escape closes a portaled menu. */
+const focusMenuAnchor = (anchor: Element | null): void => {
+  if (!(anchor instanceof Element)) {
+    return;
+  }
+  const target =
+    anchor instanceof HTMLElement && (anchor.matches(MENU_FOCUS_SELECTOR) || anchor.tabIndex >= 0)
+      ? anchor
+      : anchor.querySelector<HTMLElement>(MENU_FOCUS_SELECTOR);
+  target?.focus();
+};
+
+const isEscapeTargetForMenu = (event: KeyboardEvent, anchor: Element | null): boolean => {
+  if (!anchor) {
+    return false;
+  }
+  const { target } = event;
+  if (!(target instanceof Node)) {
+    return false;
+  }
+  if (anchor.contains(target)) {
+    return true;
+  }
+
+  // Portaled listbox/menu: resolve via aria-controls on the toggle/input in the anchor.
+  const controlledIds = new Set<string>();
+  const collectControls = (el: Element) => {
+    const controls = el.getAttribute('aria-controls');
+    if (controls) {
+      controls.split(/\s+/).forEach((id) => {
+        if (id) {
+          controlledIds.add(id);
+        }
+      });
+    }
+  };
+  collectControls(anchor);
+  anchor.querySelectorAll('[aria-controls]').forEach(collectControls);
+
+  for (const id of controlledIds) {
+    const controlled = document.getElementById(id);
+    if (controlled?.contains(target)) {
+      return true;
+    }
+  }
+
+  // Fallback only when this toggle has no aria-controls (PF Dropdown/MenuToggle, PF#11304):
+  // Escape from a focused item in an open menu/listbox under the same dialog.
+  if (controlledIds.size > 0) {
+    return false;
+  }
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  const dialog = anchor.closest('[role="dialog"]');
+  if (!dialog) {
+    return false;
+  }
+  return Array.from(dialog.querySelectorAll('[role="menu"], [role="listbox"]')).some((menu) =>
+    menu.contains(target),
+  );
+};
+
+/**
+ * Portal menu into the nearest modal dialog (when appendTo is unset) and unlock
+ * dialog overflow while open — PatternFly Modal + dropdown a11y pattern.
+ */
+export const useMenuPopperInModal = <T extends MenuPopperProps>(
+  isOpen: boolean,
+  anchorRef: React.RefObject<Element | null>,
+  userPopperProps?: T,
+  options?: UseMenuPopperInModalOptions,
+): MenuPopperWithAppendTo<T> => {
+  useModalOverflowUnlock(isOpen, anchorRef);
+
+  const onEscapeCloseRef = React.useRef(options?.onEscapeClose);
+  const shouldInterceptEscape = options?.onEscapeClose !== undefined;
+
+  React.useLayoutEffect(() => {
+    onEscapeCloseRef.current = options?.onEscapeClose;
+  });
+
+  React.useEffect(() => {
+    if (!isOpen || !shouldInterceptEscape) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      const close = onEscapeCloseRef.current;
+      if (!close) {
+        return;
+      }
+      if (!isEscapeTargetForMenu(event, anchorRef.current)) {
+        return;
+      }
+      // Capture on document: runs before Modal's bubble listener on body.
+      // Only this menu's toggle/input or its portaled listbox owns the event.
+      event.preventDefault();
+      event.stopPropagation();
+      close();
+      // PF's close-and-refocus path never runs after stopPropagation.
+      queueMicrotask(() => focusMenuAnchor(anchorRef.current));
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+    // anchorRef is stable; resolve .current at event time
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, shouldInterceptEscape]);
+
+  return React.useMemo((): MenuPopperWithAppendTo<T> => {
+    const appendTo: MenuPopperAppendTo =
+      userPopperProps?.appendTo !== undefined
+        ? userPopperProps.appendTo
+        : () => resolveSelectPopperAppendTo(anchorRef.current);
+
+    // Generic spread cannot prove Omit<T> without a cast (TS limitation).
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return { ...userPopperProps, appendTo } as MenuPopperWithAppendTo<T>;
+    // anchorRef is stable; resolve at appendTo call time from .current
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userPopperProps]);
+};

--- a/packages/ui-core/src/utilities/useModalOverflowUnlock.ts
+++ b/packages/ui-core/src/utilities/useModalOverflowUnlock.ts
@@ -8,20 +8,20 @@ const originalOverflowByDialog = new WeakMap<HTMLElement, string>();
 const unlockCountByDialog = new WeakMap<HTMLElement, number>();
 
 /** Resolve popper mount target: portal into the nearest modal dialog for VoiceOver + aria-modal. */
-export const resolveSelectPopperAppendTo = (
-  anchor: HTMLElement | null | undefined,
-): HTMLElement => {
+export const resolveSelectPopperAppendTo = (anchor: Element | null | undefined): HTMLElement => {
   const dialog = anchor?.closest<HTMLElement>(MODAL_DIALOG_SELECTOR);
   if (dialog) {
     return dialog;
   }
-  return anchor?.parentElement ?? document.body;
+  // Outside modals, portal to body so menus are not clipped by overflow parents
+  // (e.g. SearchSelector after dropping the old default appendTo: 'inline').
+  return document.body;
 };
 
 /** Unlock modal overflow while a portaled select menu is open; ref-counts when multiple instances share a dialog. */
 export const useModalOverflowUnlock = (
   isOpen: boolean,
-  anchorRef: React.RefObject<HTMLElement | null>,
+  anchorRef: React.RefObject<Element | null>,
 ): void => {
   React.useLayoutEffect(() => {
     if (!isOpen) {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-76231

## Description

Extends the [RHOAIENG-66822](https://redhat.atlassian.net/browse/RHOAIENG-66822) modal-menu a11y pattern to remaining dropdown wrappers so keyboard users and screen readers (VoiceOver / NVDA / JAWS) can open, navigate, and select options inside PatternFly Modals.

**Root cause (same as 66822):**
1. Menus portaled outside the modal DOM break the focus trap / `aria-modal` boundary.
2. Some wrappers had incomplete combobox ARIA (`aria-activedescendant` without matching option ids, missing `aria-controls`).

**What changed:**
- Shared `useMenuPopperInModal` — dialog-aware `appendTo`, modal overflow unlock, and Escape capture so Escape closes the menu (including when focus is in a portaled menu) without dismissing the modal
- Wired into: `TypeaheadSelect`, `ValueUnitField`, `SearchSelector`, `ConnectionDropdown`, `DropdownFormField`, plus refactor of `SimpleSelect` / `MultiSelection`
- `TypeaheadSelect` combobox ARIA fixes (stable option ids, `aria-controls`, Enter does not submit forms)
- Call-site cleanups that blocked auto `appendTo` (e.g. storage / connection forms)
- Manual runbook: `notes/RHOAIENG-76231-manual-select-testing.md`

**Affected flows (examples):** Create connection (connection type + Access type), Attach existing storage, Create cluster storage size unit, Model registry connection picker, SearchSelector-based project pickers in modals.

## How Has This Been Tested?

- Unit tests: `useMenuPopperInModal`, `TypeaheadSelect`, `MultiSelection`, `DropdownFormField`
- Cypress mocked: Create connection and workbench/storage modal coverage updates
- Manual keyboard / SR verification checklist in `notes/RHOAIENG-76231-manual-select-testing.md` (Create connection type + Access type, storage PVC picker, size unit, Escape vs modal)

## Test Impact

- Added / extended unit tests for the shared hook (appendTo, overflow unlock, Escape capture), TypeaheadSelect ARIA/keyboard behavior, and DropdownFormField modal portal
- Extended Cypress mocked tests for connection and workbench storage flows
- Updated `modelRegistryPermissions` Cypress page object for TypeaheadSelect combobox labeling (`57ef39d2d`)
- No visual UI change — keyboard/ARIA-only; screenshots N/A

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change. (N/A — no visual change; keyboard/ARIA behavior only)
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

[RHOAIENG-66822]: https://redhat.atlassian.net/browse/RHOAIENG-66822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved labels and ARIA relationships for dropdowns, typeahead fields, comboboxes, and listboxes.
  * Added stable menu and option identification for assistive technologies.
* **Usability**
  * Enhanced keyboard navigation, Escape-to-close behavior, Tab handling, and focus restoration in dialogs.
  * Prevented accidental form submission when pressing Enter in custom inputs.
* **Bug Fixes**
  * Improved dropdown positioning and portal behavior within dialogs.
* **Documentation**
  * Added a manual testing guide for modal select and dropdown accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->