### PR TITLE
Update External Models Modals Provider Field

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasExternalModels.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasExternalModels.cy.ts
@@ -134,13 +134,13 @@ describe('External Models Page', () => {
 
       gptRow.findExpandedViewUrlButton('openai-prod').click();
       externalModelProviderUrlModal.findInputValue().should('have.value', 'api.openai.com');
-      externalModelProviderUrlModal.findProviderRef().should('contain.text', 'OpenAI Production');
+      externalModelProviderUrlModal.findProviderRef().should('contain.text', 'openai');
       externalModelProviderUrlModal.findTargetModelId().should('contain.text', 'gpt-4o');
       externalModelProviderUrlModal.findCloseButton().click();
 
       gptRow.findExpandedViewPathButton('openai-prod').click();
       externalModelPathModal.findInputValue().should('have.value', '/v1/chat/completions');
-      externalModelPathModal.findProviderRef().should('contain.text', 'OpenAI Production');
+      externalModelPathModal.findProviderRef().should('contain.text', 'openai');
       externalModelPathModal.findCloseButton().click();
 
       const splitRow = externalModelsPage.getRow('Claude A/B Split');
@@ -161,7 +161,7 @@ describe('External Models Page', () => {
       externalModelProviderUrlModal
         .findInputValue()
         .should('have.value', 'bedrock.us-east-1.amazonaws.com');
-      externalModelProviderUrlModal.findProviderRef().should('contain.text', 'AWS Bedrock US East');
+      externalModelProviderUrlModal.findProviderRef().should('contain.text', 'aws-bedrock');
       externalModelProviderUrlModal
         .findTargetModelId()
         .should('contain.text', 'anthropic.claude-3-sonnet');
@@ -169,7 +169,7 @@ describe('External Models Page', () => {
 
       splitRow.findExpandedViewPathButton('anthropic-dev').click();
       externalModelPathModal.findInputValue().should('have.value', '/v1/messages');
-      externalModelPathModal.findProviderRef().should('contain.text', 'Anthropic Development');
+      externalModelPathModal.findProviderRef().should('contain.text', 'anthropic');
       externalModelPathModal.findCloseButton().click();
 
       const awaitingRow = externalModelsPage.getRow('Awaiting Pairing Model');

--- a/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/ExternalModelsTableRow.tsx
@@ -257,7 +257,7 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
         onClose={() => {
           setPathModalRef(null);
         }}
-        providerRef={pathModalRef?.provider?.displayName ?? pathModalRef?.providerName ?? ''}
+        providerRef={pathModalRef?.provider?.provider ?? ''}
       />
       <ProviderURLModal
         isOpen={!!providerURLModalRef}
@@ -265,9 +265,7 @@ const ExternalModelTableRow: React.FC<ExternalModelTableRowProps> = ({
           setProviderURLModalRef(null);
         }}
         providerURL={providerURLModalRef?.provider?.endpointUrl ?? ''}
-        providerRef={
-          providerURLModalRef?.provider?.displayName ?? providerURLModalRef?.providerName ?? ''
-        }
+        providerRef={providerURLModalRef?.provider?.provider ?? ''}
         targetModelId={providerURLModalRef?.targetModel ?? ''}
       />
     </>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-78882
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Targeting the wrong provider field for these modals, I was doing the external providers name as the provider instead of the provider field within the external provider


https://github.com/user-attachments/assets/57252d49-d9b6-4176-ac50-c0321c8702ee


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updated mock test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated external model provider URL and path dialogs to display the correct provider identifiers.
  * Improved consistency for providers such as OpenAI, AWS Bedrock, and Anthropic by showing their configured references instead of display labels.
* **Tests**
  * Updated coverage to verify the corrected provider reference values across external model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->