### PR TITLE
fix(operator): make webhook server conditional to prevent CrashLoopBackOff

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/deployment.yaml
+++ b/dashboard-operator/charts/dashboard/templates/deployment.yaml
@@ -77,6 +77,7 @@ spec:
             - --leader-elect
             {{- end }}
             {{- if .Values.webhook.enabled }}
+            - --enable-webhook
             - --webhook-port={{ .Values.webhook.port }}
             {{- end }}
           env:

--- a/dashboard-operator/cmd/manager/main.go
+++ b/dashboard-operator/cmd/manager/main.go
@@ -42,6 +42,7 @@ func main() {
 		leaderElect       bool
 		secureMetrics     bool
 		operatorNamespace string
+		enableWebhook     bool
 		webhookPort       int
 	)
 
@@ -51,6 +52,7 @@ func main() {
 	flag.BoolVar(&leaderElect, "leader-elect", false, "Enable leader election for controller manager")
 	flag.BoolVar(&secureMetrics, "secure-metrics", true, "Serve metrics over HTTPS using cert-manager certificates")
 	flag.StringVar(&operatorNamespace, "namespace", "", "Namespace where the operator is deployed")
+	flag.BoolVar(&enableWebhook, "enable-webhook", false, "Enable the validating webhook server (requires TLS certs)")
 	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server binds to")
 
 	opts := zap.Options{Development: true}
@@ -85,14 +87,18 @@ func main() {
 		}
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOpts := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsOpts,
 		HealthProbeBindAddress: healthProbeAddr,
 		LeaderElection:         leaderElect,
 		LeaderElectionID:       "dashboard.components.platform.opendatahub.io",
-		WebhookServer:          ctrlwebhook.NewServer(ctrlwebhook.Options{Port: webhookPort}),
-	})
+	}
+	if enableWebhook {
+		mgrOpts.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{Port: webhookPort})
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to create manager")
 		os.Exit(1)
@@ -116,8 +122,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr.GetWebhookServer().Register("/validate-dashboard", webhook.NewSingletonHandler(mgr.GetAPIReader()))
-	setupLog.Info("Registered singleton validation webhook", "path", "/validate-dashboard")
+	if enableWebhook {
+		mgr.GetWebhookServer().Register("/validate-dashboard", webhook.NewSingletonHandler(mgr.GetAPIReader()))
+		setupLog.Info("Registered singleton validation webhook", "path", "/validate-dashboard")
+	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-59936

## Description

When the dashboard-operator is deployed with `webhook.enabled=false` (no TLS certs volume mounted), the operator immediately crashes with:

```
open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory
```

This happens because the Go code unconditionally creates a `WebhookServer` and registers a webhook handler, which triggers controller-runtime's TLS cert lookup at startup — even when no webhook volume is mounted.

**Root cause:** The webhook server was always initialized regardless of whether TLS certs were available.

**Fix:** Add an `--enable-webhook` flag (default `false`) to `cmd/manager/main.go`. The webhook server and handler registration are now conditional on this flag. The Helm chart template passes `--enable-webhook` only when `.Values.webhook.enabled` is `true` (which also gates the TLS certs volume mount).

This unblocks the ODH Operator module migration ([opendatahub-operator#3733](https://github.com/opendatahub-io/opendatahub-operator/pull/3733)), where the Helm chart is rendered with `webhook.enabled: false`.

## How Has This Been Tested?

- Reproduced the crash on a live cluster by running the `:main` image without webhook certs — confirmed `CrashLoopBackOff`
- Verified the Go code compiles cleanly (`go build`, `go vet`)
- All existing unit tests pass (`go test ./...`)
- Cluster validation pending with a custom-built image from this branch

## Test Impact

No new tests added. The change is a flag-gated conditional — existing webhook tests continue to cover the `enableWebhook=true` path. The `enableWebhook=false` path (default) simply skips webhook initialization, which is the standard controller-runtime behavior when no `WebhookServer` is set.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to enable or disable webhook functionality when starting the dashboard operator.
  * Kubernetes deployments now explicitly enable webhooks by default.
  * Webhook validation endpoints are available only when webhook support is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->