### PR TITLE
Sync from kubeflow/model-registry 38902a0

### DIFF
--- a/packages/cypress/cypress/pages/mcpCatalogSettings.ts
+++ b/packages/cypress/cypress/pages/mcpCatalogSettings.ts
@@ -24,7 +24,7 @@ class McpCatalogSettings {
 
   private findHeading() {
     cy.findByTestId('app-page-title').should('exist');
-    cy.findByTestId('app-page-title').contains('MCP catalog settings');
+    cy.findByTestId('app-page-title').contains('MCP catalog sources');
   }
 
   findNavItem() {

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "dd9292b656d9e2e3afa1eb34bfc0590ead7d9258"
+    "commit": "38902a0a51f08c79f9298b5584b39e6bffa530b6"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "cac86723c5130dcd764f14c19148db141932b34b"
+    "commit": "dd9292b656d9e2e3afa1eb34bfc0590ead7d9258"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "670c1dfe7f3caaabff4c94cf9f368448762d78ed"
+    "commit": "97e9c42a4bf7645e458938fd17c9ea3b814fc67a"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -27,7 +27,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "97e9c42a4bf7645e458938fd17c9ea3b814fc67a"
+    "commit": "cac86723c5130dcd764f14c19148db141932b34b"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/upstream/frontend/package-lock.json
+++ b/packages/model-registry/upstream/frontend/package-lock.json
@@ -25327,9 +25327,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/model-registry/upstream/frontend/package-lock.json
+++ b/packages/model-registry/upstream/frontend/package-lock.json
@@ -14730,9 +14730,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/agentsCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/agentsCatalog.ts
@@ -107,8 +107,8 @@ class AgentDetailsPage {
     return cy.findByTestId('agent-framework');
   }
 
-  findGitHubButton() {
-    return cy.findByTestId('agent-github-button');
+  findRepositoryButton() {
+    return cy.findByTestId('agent-repository-button');
   }
 
   findAgentNotFound() {

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/mcpCatalogSettings.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/mcpCatalogSettings.ts
@@ -24,11 +24,11 @@ class McpCatalogSettings {
 
   findHeading() {
     cy.findByTestId('app-page-title').should('exist');
-    cy.findByTestId('app-page-title').contains('MCP catalog settings');
+    cy.findByTestId('app-page-title').contains('MCP catalog sources');
   }
 
   findNavItem() {
-    return appChrome.findNavItem('MCP catalog settings', 'Settings');
+    return appChrome.findNavItem('MCP catalog sources', 'Settings');
   }
 
   findDescription() {
@@ -109,7 +109,7 @@ class McpManageSourcePage {
   }
 
   findAddSourceTitle() {
-    return cy.findByTestId('app-page-title').contains('Add a source');
+    return cy.findByTestId('app-page-title').contains('Add source');
   }
 
   findManageSourceTitle() {
@@ -121,9 +121,7 @@ class McpManageSourcePage {
   }
 
   findManageSourceDescription() {
-    return cy.contains(
-      'Configure which MCP servers from this pre-loaded catalog source are visible in the MCP catalog.',
-    );
+    return cy.contains('Configure which servers from this source appear in the MCP catalog.');
   }
 
   // Form field methods
@@ -148,7 +146,7 @@ class McpManageSourcePage {
   }
 
   findServerVisibilitySection() {
-    return cy.findByTestId('mcp-server-visibility-section');
+    return cy.findByTestId('mcp-server-filters-section');
   }
 
   toggleServerVisibility() {

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/agentsCatalog/agentsCatalog.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/agentsCatalog/agentsCatalog.cy.ts
@@ -116,15 +116,15 @@ describe('Agent Details Page', () => {
   });
 
   describe('Action buttons', () => {
-    it('should show Open GitHub button when repositoryUrl is present', () => {
+    it('should show Open repository button when repositoryUrl is present', () => {
       initAgentsCatalogIntercepts();
       const agent = mockAgent({ name: 'gh-agent', repositoryUrl: 'https://github.com/test' });
       interceptSingleAgent(agent);
 
       agentDetailsPage.visit('gh-agent');
-      agentDetailsPage.findGitHubButton().should('be.visible');
+      agentDetailsPage.findRepositoryButton().should('be.visible');
       agentDetailsPage
-        .findGitHubButton()
+        .findRepositoryButton()
         .should('have.attr', 'href', 'https://github.com/test')
         .and('have.attr', 'target', '_blank');
     });
@@ -135,7 +135,7 @@ describe('Agent Details Page', () => {
       interceptSingleAgent(agent);
 
       agentDetailsPage.visit('no-gh');
-      agentDetailsPage.findGitHubButton().should('not.exist');
+      agentDetailsPage.findRepositoryButton().should('not.exist');
     });
   });
 

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalogSettings/mcpCatalogSettings.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalogSettings/mcpCatalogSettings.cy.ts
@@ -54,7 +54,7 @@ describe('MCP Catalog Settings', () => {
   it('should display the "Add a source" button in empty state', () => {
     mcpCatalogSettings.visit();
     mcpCatalogSettings.findAddSourceButton().should('be.visible');
-    mcpCatalogSettings.findAddSourceButton().should('contain', 'Add a source');
+    mcpCatalogSettings.findAddSourceButton().should('contain', 'Add source');
   });
 
   it('should navigate to add-source page when button is clicked', () => {
@@ -63,7 +63,7 @@ describe('MCP Catalog Settings', () => {
     mcpManageSourcePage.findAddSourceTitle();
     mcpManageSourcePage.findAddSourceDescription();
     mcpManageSourcePage.findBreadcrumb().should('exist');
-    mcpManageSourcePage.findBreadcrumbAction().should('contain', 'Add a source');
+    mcpManageSourcePage.findBreadcrumbAction().should('contain', 'Add source');
   });
 });
 
@@ -77,7 +77,7 @@ describe('MCP Manage Source Page - Add Source Mode', () => {
       mcpManageSourcePage.visitAddSource();
       mcpManageSourcePage.findAddSourceTitle();
       mcpManageSourcePage.findBreadcrumb().should('exist');
-      mcpManageSourcePage.findBreadcrumbAction().should('contain', 'Add a source');
+      mcpManageSourcePage.findBreadcrumbAction().should('contain', 'Add source');
     });
 
     it('should show correct page description', () => {
@@ -227,22 +227,6 @@ describe('MCP Manage Source Page - Add Source Mode', () => {
 
       mcpManageSourcePage.findIncludedServersInput().should('have.value', 'Kubernetes, GitHub');
       mcpManageSourcePage.findExcludedServersInput().should('have.value', '*preview*');
-    });
-
-    it('should show correct placeholder text for included servers', () => {
-      mcpManageSourcePage.visitAddSource();
-      mcpManageSourcePage.toggleServerVisibility();
-      mcpManageSourcePage
-        .findIncludedServersInput()
-        .should('have.attr', 'placeholder', 'Example: Kubernetes, GitHub, PostgreSQL');
-    });
-
-    it('should show correct placeholder text for excluded servers', () => {
-      mcpManageSourcePage.visitAddSource();
-      mcpManageSourcePage.toggleServerVisibility();
-      mcpManageSourcePage
-        .findExcludedServersInput()
-        .should('have.attr', 'placeholder', 'Example: *preview*');
     });
   });
 
@@ -790,7 +774,7 @@ describe('MCP Catalog Source Configs Table', () => {
       mcpCatalogSettings
         .findTable()
         .find('thead th')
-        .contains('Source name')
+        .contains('Name')
         .parents('th')
         .should('have.attr', 'aria-sort');
     });

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/AgentsCatalogCoreLoader.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/AgentsCatalogCoreLoader.tsx
@@ -34,7 +34,7 @@ const AgentsCatalogCoreLoader: React.FC = () => {
         empty
         emptyStatePage={
           <Bullseye>
-            <Alert title="Agents catalog source load error" variant="danger" isInline>
+            <Alert title="Unable to load agent catalog" variant="danger" isInline>
               {catalogSourcesLoadError.message}
             </Alert>
           </Bullseye>
@@ -82,7 +82,7 @@ const AgentsCatalogCoreLoader: React.FC = () => {
             description={
               isMUITheme
                 ? 'To discover agents, follow the instructions in the docs below.'
-                : 'There are no agent sources to display. Request that your administrator configure agent sources for the catalog.'
+                : 'Request that your administrator configure agent template sources for this catalog.'
             }
             headerIcon={() => (
               <img src={typedEmptyImage(ProjectObjectType.modelRegistrySettings)} alt="" />

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/const.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/const.ts
@@ -2,7 +2,7 @@ import type { AgentFilterCategoryKey } from '~/app/pages/agentsCatalog/types/age
 
 export const AGENTS_CATALOG_TITLE = 'Agents Catalog';
 export const AGENTS_CATALOG_DESCRIPTION =
-  'Discover agents that are available for your organization.';
+  'Discover agent templates that are available for your organization.';
 
 export const AGENT_FILTER_KEYS: AgentFilterCategoryKey[] = ['framework'];
 

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentDetailsPage.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentDetailsPage.tsx
@@ -146,10 +146,10 @@ const AgentDetailsPage: React.FC = () => {
                         href={agent.repositoryUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        data-testid="agent-github-button"
+                        data-testid="agent-repository-button"
                         onClick={handleOpenGitHub}
                       >
-                        Open GitHub
+                        Open repository
                       </Button>
                     </ActionListItem>
                   )}

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
-import { ApplicationsPage, ProjectObjectType, TitleWithIcon } from 'mod-arch-shared';
-import { SearchIcon } from '@patternfly/react-icons';
+import {
+  ApplicationsPage,
+  KubeflowDocs,
+  ProjectObjectType,
+  TitleWithIcon,
+  WhosMyAdministrator,
+} from 'mod-arch-shared';
+import { useThemeContext } from 'mod-arch-kubeflow';
 import { useUserInteraction, TrackingOutcome } from '~/concepts/userInteraction';
 import { AgentsCatalogContext } from '~/app/context/agentsCatalog/AgentsCatalogContext';
 import { hasAgentFiltersApplied } from '~/app/pages/agentsCatalog/utils/agentsCatalogUtils';
@@ -27,6 +33,7 @@ const AgentsCatalog: React.FC = () => {
     emptyCategoryLabels,
     setCategoryCount,
   } = React.useContext(AgentsCatalogContext);
+  const { isMUITheme } = useThemeContext();
 
   const filtersApplied = hasAgentFiltersApplied(filters, searchQuery);
   const isAllAgentsView = selectedSourceLabel === undefined && !filtersApplied;
@@ -74,9 +81,14 @@ const AgentsCatalog: React.FC = () => {
         renderEmptyCategoriesState={() => (
           <EmptyCatalogState
             testid="empty-agents-catalog-no-categories"
-            title="No agents available"
-            headerIcon={SearchIcon}
-            description="There are no agent categories available. Configure sources in settings to get started."
+            title="Configure agent template sources"
+            headerIcon={null}
+            description={
+              isMUITheme
+                ? 'There are no agent templates to display. Follow the instructions in the docs below to add agent templates.'
+                : 'There are no agent templates to display. Use the OpenShift console to add agent templates to the catalog.'
+            }
+            primaryAction={isMUITheme ? <KubeflowDocs /> : <WhosMyAdministrator />}
           />
         )}
         renderFilterSidebar={() => <AgentsCatalogFilters />}

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalogGalleryView.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalogGalleryView.tsx
@@ -110,7 +110,7 @@ const AgentsCatalogGalleryView: React.FC<AgentsCatalogGalleryViewProps> = ({
           testid="empty-agents-catalog-state"
           title="No results found"
           headerIcon={SearchIcon}
-          description="Adjust your filters and try again."
+          description="No agent templates match your filters. Adjust your filters and try again."
           primaryAction={
             <Button variant="link" onClick={handleFilterReset}>
               Reset filters

--- a/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/__tests__/AgentDetailsPage.tracking.spec.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/__tests__/AgentDetailsPage.tracking.spec.tsx
@@ -114,10 +114,10 @@ describe('AgentDetailsPage tracking', () => {
     });
   });
 
-  it('should fire open github clicked when Open GitHub is clicked', () => {
+  it('should fire open github clicked when Open repository is clicked', () => {
     renderPage();
 
-    fireEvent.click(screen.getByTestId('agent-github-button'));
+    fireEvent.click(screen.getByTestId('agent-repository-button'));
 
     expect(mockTrackLinkEvent).toHaveBeenCalledWith(AGENT_CATALOG_EVENTS.OPEN_GITHUB_CLICKED, {
       href: 'https://github.com/example/agent-one',

--- a/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/components/McpCatalogSourceStatus.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/components/McpCatalogSourceStatus.tsx
@@ -3,7 +3,7 @@ import { Button, Label, Spinner, Stack, StackItem, Truncate } from '@patternfly/
 import { InProgressIcon } from '@patternfly/react-icons';
 import { McpCatalogSourceConfig } from '~/app/mcpServerCatalogTypes';
 import { McpCatalogSettingsContext } from '~/app/context/mcpCatalogSettings/McpCatalogSettingsContext';
-import { CatalogSourceStatus as CatalogSourceStatusEnum } from '~/concepts/modelCatalogSettings/const';
+import { CatalogSourceStatus } from '~/app/shared/types/catalogTypes';
 import CatalogSourceStatusErrorModal from '~/app/pages/modelCatalogSettings/components/CatalogSourceStatusErrorModal';
 
 type McpCatalogSourceStatusProps = {
@@ -47,7 +47,7 @@ const McpCatalogSourceStatus: React.FC<McpCatalogSourceStatusProps> = ({
   }
 
   switch (matchingSource.status) {
-    case CatalogSourceStatusEnum.AVAILABLE:
+    case CatalogSourceStatus.AVAILABLE:
       return (
         <Label
           status="success"
@@ -58,7 +58,7 @@ const McpCatalogSourceStatus: React.FC<McpCatalogSourceStatusProps> = ({
         </Label>
       );
 
-    case CatalogSourceStatusEnum.ERROR: {
+    case CatalogSourceStatus.ERROR: {
       const errorMessage = matchingSource.error || 'Unknown error occurred';
 
       return (
@@ -94,7 +94,7 @@ const McpCatalogSourceStatus: React.FC<McpCatalogSourceStatusProps> = ({
       );
     }
 
-    case CatalogSourceStatusEnum.DISABLED:
+    case CatalogSourceStatus.DISABLED:
       return startingOrUnknownLabel;
     default:
       return startingOrUnknownLabel;

--- a/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/components/McpManageSourceForm.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/components/McpManageSourceForm.tsx
@@ -38,7 +38,7 @@ import {
 } from '~/app/pages/mcpCatalogSettings/tracking/mcpCatalogSourcesTracking';
 import McpSourceDetailsSection from './McpSourceDetailsSection';
 import McpYamlSection from './McpYamlSection';
-import McpServerVisibilitySection from './McpServerVisibilitySection';
+import McpServerFiltersSection from './McpServerFiltersSection';
 import McpPreviewPanel from './McpPreviewPanel';
 import McpManageSourceFormFooter from './McpManageSourceFormFooter';
 
@@ -195,7 +195,7 @@ const McpManageSourceForm: React.FC<McpManageSourceFormProps> = ({
               )}
 
               <StackItem>
-                <McpServerVisibilitySection
+                <McpServerFiltersSection
                   formData={formData}
                   setData={setData}
                   isDefaultExpanded={

--- a/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/components/McpServerFiltersSection.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/components/McpServerFiltersSection.tsx
@@ -10,19 +10,15 @@ import {
 import { UpdateObjectAtPropAndValue, ThemeAwareFormGroupWrapper } from 'mod-arch-shared';
 import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
 import { ManageMcpSourceFormData } from '~/app/pages/mcpCatalogSettings/useManageMcpSourceData';
-import {
-  MCP_FORM_LABELS,
-  MCP_PLACEHOLDERS,
-  MCP_DESCRIPTION_TEXT,
-} from '~/app/pages/mcpCatalogSettings/constants';
+import { MCP_FORM_LABELS, MCP_DESCRIPTION_TEXT } from '~/app/pages/mcpCatalogSettings/constants';
 
-type McpServerVisibilitySectionProps = {
+type McpServerFiltersSectionProps = {
   formData: ManageMcpSourceFormData;
   setData: UpdateObjectAtPropAndValue<ManageMcpSourceFormData>;
   isDefaultExpanded?: boolean;
 };
 
-const McpServerVisibilitySection: React.FC<McpServerVisibilitySectionProps> = ({
+const McpServerFiltersSection: React.FC<McpServerFiltersSectionProps> = ({
   formData,
   setData,
   isDefaultExpanded = false,
@@ -36,7 +32,6 @@ const McpServerVisibilitySection: React.FC<McpServerVisibilitySectionProps> = ({
       onChange={(_event, value) => setData('includedServers', value)}
       rows={3}
       resizeOrientation="vertical"
-      placeholder={MCP_PLACEHOLDERS.INCLUDED_SERVERS}
     />
   );
 
@@ -57,7 +52,6 @@ const McpServerVisibilitySection: React.FC<McpServerVisibilitySectionProps> = ({
       onChange={(_event, value) => setData('excludedServers', value)}
       rows={3}
       resizeOrientation="vertical"
-      placeholder={MCP_PLACEHOLDERS.EXCLUDED_SERVERS}
     />
   );
 
@@ -72,18 +66,18 @@ const McpServerVisibilitySection: React.FC<McpServerVisibilitySectionProps> = ({
   return (
     <FormSection>
       <FormFieldGroupExpandable
-        toggleAriaLabel="Server visibility"
+        toggleAriaLabel="Server filters"
         header={
           <FormFieldGroupHeader
             titleText={{
-              text: MCP_FORM_LABELS.SERVER_VISIBILITY,
-              id: 'mcp-server-visibility-title',
+              text: MCP_FORM_LABELS.SERVER_FILTERS,
+              id: 'mcp-server-filters-title',
             }}
             titleDescription={MCP_DESCRIPTION_TEXT.FILTER_INFO}
           />
         }
         isExpanded={isDefaultExpanded}
-        data-testid="mcp-server-visibility-section"
+        data-testid="mcp-server-filters-section"
       >
         <ThemeAwareFormGroupWrapper
           label={MCP_FORM_LABELS.INCLUDED_SERVERS}
@@ -105,4 +99,4 @@ const McpServerVisibilitySection: React.FC<McpServerVisibilitySectionProps> = ({
   );
 };
 
-export default McpServerVisibilitySection;
+export default McpServerFiltersSection;

--- a/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/const.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/const.ts
@@ -1,3 +1,8 @@
 export const MCP_SOURCE_TYPE_LABELS: Record<string, string> = {
   yaml: 'YAML file',
 };
+
+export enum McpServerVisibilityBadgeColor {
+  FILTERED = 'purple',
+  UNFILTERED = 'grey',
+}

--- a/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/constants.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/constants.ts
@@ -3,7 +3,7 @@ export const MCP_FORM_LABELS = {
   YAML_CONTENT: 'Upload a YAML file',
   CATALOG_YAML_FILE: 'Catalog YAML file',
   MCP_SERVERS: 'MCP servers',
-  SERVER_VISIBILITY: 'Server visibility',
+  SERVER_FILTERS: 'Server filters',
   INCLUDED_SERVERS: 'Included MCP servers',
   EXCLUDED_SERVERS: 'Excluded MCP servers',
   ENABLE_SOURCE: 'Enable source',
@@ -29,18 +29,13 @@ export const MCP_DESCRIPTION_TEXT = {
   FILTER_INFO:
     'Optionally filter which MCP servers from your source appear in the MCP catalog. If no filters are set, all servers from the source will be visible.',
   INCLUDED_SERVERS:
-    'Enter MCP server names to include from this source. Separate names with commas. Use an asterisk suffix for prefix matching (Example: Kubernetes*).',
+    'Enter the names of servers to include, separated by commas. To match partial names, add an asterisk (*) suffix. For example, “Kube*” includes servers that contain "Kube" (Kubernetes, KubeFlow).',
   EXCLUDED_SERVERS:
-    'Enter MCP server names to exclude from this source. Separate names with commas. Use wildcards for pattern matching (Example: *experimental*).',
+    'Enter the names of servers to exclude, separated by commas. To match partial names, add an asterisk (*) suffix. For example, "Kube*" excludes servers that contain "Kube" (Kubernetes, KubeFlow).',
 } as const;
 
 export const MCP_HELPER_TEXT = {
   YAML: 'Upload or paste a YAML string.',
-} as const;
-
-export const MCP_PLACEHOLDERS = {
-  INCLUDED_SERVERS: 'Example: Kubernetes, GitHub, PostgreSQL',
-  EXCLUDED_SERVERS: 'Example: *preview*',
 } as const;
 
 export const MCP_EXPECTED_YAML_FORMAT_LABEL = 'View expected file format';
@@ -66,4 +61,19 @@ export const MCP_EMPTY_STATE_TEXT = {
     'No MCP servers from this source are visible in the MCP catalog. To include servers, edit the server visibility settings of this source.',
   NO_SERVERS_EXCLUDED: 'No MCP servers excluded',
   NO_SERVERS_EXCLUDED_BODY: 'No MCP servers from this source are excluded by this filter.',
+} as const;
+
+export const MCP_TABLE_COLUMN_LABELS = {
+  NAME: 'Name',
+  SERVER_VISIBILITY: 'Server visibility',
+  SOURCE_TYPE: 'Source type',
+  ENABLE: 'Enable',
+  VALIDATION_STATUS: 'Validation status',
+} as const;
+
+export const MCP_TABLE_COLUMN_POPOVERS = {
+  SERVER_VISIBILITY:
+    'Indicates whether all servers from this source appear in the catalog, or if filters limit which servers are visible.',
+  ENABLE:
+    'Enable a source to make its MCP servers available to users in your organization from the MCP catalog.',
 } as const;

--- a/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/screens/McpCatalogSourceConfigsTableColumns.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/screens/McpCatalogSourceConfigsTableColumns.tsx
@@ -1,42 +1,44 @@
 import { kebabTableColumn, SortableData } from 'mod-arch-shared';
 import { McpCatalogSourceConfig } from '~/app/mcpServerCatalogTypes';
+import {
+  MCP_TABLE_COLUMN_LABELS,
+  MCP_TABLE_COLUMN_POPOVERS,
+} from '~/app/pages/mcpCatalogSettings/constants';
 
 export const mcpCatalogSourceConfigsColumns: SortableData<McpCatalogSourceConfig>[] = [
   {
     field: 'name',
-    label: 'Source name',
+    label: MCP_TABLE_COLUMN_LABELS.NAME,
     sortable: (a, b) => a.name.localeCompare(b.name),
     width: 20,
   },
   {
     field: 'filters',
-    label: 'Server visibility',
+    label: MCP_TABLE_COLUMN_LABELS.SERVER_VISIBILITY,
     sortable: false,
     info: {
-      popover:
-        'Shows whether all MCP servers from a source appear in the MCP catalog or if visibility is filtered.',
+      popover: MCP_TABLE_COLUMN_POPOVERS.SERVER_VISIBILITY,
     },
     width: 15,
   },
   {
     field: 'type',
-    label: 'Source type',
+    label: MCP_TABLE_COLUMN_LABELS.SOURCE_TYPE,
     sortable: false,
     width: 15,
   },
   {
     field: 'enabled',
-    label: 'Enable',
+    label: MCP_TABLE_COLUMN_LABELS.ENABLE,
     sortable: false,
     info: {
-      popover:
-        'Enable a source to make its MCP servers available to users in your organization from the MCP catalog.',
+      popover: MCP_TABLE_COLUMN_POPOVERS.ENABLE,
     },
     width: 10,
   },
   {
     field: 'status',
-    label: 'Validation status',
+    label: MCP_TABLE_COLUMN_LABELS.VALIDATION_STATUS,
     sortable: false,
     width: 15,
   },

--- a/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/screens/McpCatalogSourceConfigsTableRow.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/screens/McpCatalogSourceConfigsTableRow.tsx
@@ -4,11 +4,13 @@ import { Button, Label, Switch } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import { McpCatalogSourceConfig } from '~/app/mcpServerCatalogTypes';
 import { mcpManageSourceUrl } from '~/app/routes/mcpCatalogSettings/mcpCatalogSettings';
-import { ModelVisibilityBadgeColor } from '~/concepts/modelCatalogSettings/const';
+import {
+  McpServerVisibilityBadgeColor,
+  MCP_SOURCE_TYPE_LABELS,
+} from '~/app/pages/mcpCatalogSettings/const';
 import DeleteModal from '~/app/shared/components/DeleteModal';
 import { useNotification } from '~/app/hooks/useNotification';
 import McpCatalogSourceStatus from '~/app/pages/mcpCatalogSettings/components/McpCatalogSourceStatus';
-import { MCP_SOURCE_TYPE_LABELS } from '~/app/pages/mcpCatalogSettings/const';
 import { useUserInteraction, TrackingOutcome } from '~/concepts/userInteraction';
 import {
   MCP_CATALOG_SOURCES_EVENTS,
@@ -125,14 +127,14 @@ const McpCatalogSourceConfigsTableRow: React.FC<McpCatalogSourceConfigsTableRowP
         <Td dataLabel="Server visibility" style={{ verticalAlign: 'middle' }}>
           {hasFilters ? (
             <Label
-              color={ModelVisibilityBadgeColor.FILTERED}
+              color={McpServerVisibilityBadgeColor.FILTERED}
               data-testid={`mcp-server-visibility-filtered-${mcpCatalogSourceConfig.id}`}
             >
               Filtered
             </Label>
           ) : (
             <Label
-              color={ModelVisibilityBadgeColor.UNFILTERED}
+              color={McpServerVisibilityBadgeColor.UNFILTERED}
               data-testid={`mcp-server-visibility-unfiltered-${mcpCatalogSourceConfig.id}`}
               variant="outline"
             >

--- a/packages/model-registry/upstream/frontend/src/app/routes/mcpCatalogSettings/mcpCatalogSettings.ts
+++ b/packages/model-registry/upstream/frontend/src/app/routes/mcpCatalogSettings/mcpCatalogSettings.ts
@@ -1,13 +1,13 @@
-export const MCP_CATALOG_SETTINGS_PAGE_TITLE = 'MCP catalog settings';
+export const MCP_CATALOG_SETTINGS_PAGE_TITLE = 'MCP catalog sources';
 export const MCP_CATALOG_SETTINGS_DESCRIPTION =
-  'Add and manage MCP catalog sources. Each source is a YAML catalog file that can contain multiple MCP servers for users in your organization.';
+  'Add and manage sources that populate the MCP catalog for users in your organization. Each source is a YAML file that can contain multiple servers.';
 
-export const MCP_ADD_SOURCE_TITLE = 'Add a source';
+export const MCP_ADD_SOURCE_TITLE = 'Add source';
 export const MCP_ADD_SOURCE_DESCRIPTION = 'Add a new MCP catalog source to your organization.';
 
 export const MCP_MANAGE_SOURCE_TITLE = 'Manage source';
 export const MCP_MANAGE_SOURCE_DESCRIPTION =
-  'Configure which MCP servers from this pre-loaded catalog source are visible in the MCP catalog.';
+  'Configure which servers from this source appear in the MCP catalog.';
 
 export const mcpCatalogSettingsUrl = (): string => '/settings/mcp-resources/mcp-catalog';
 

--- a/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/EmptyCatalogState.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/EmptyCatalogState.tsx
@@ -13,7 +13,7 @@ type EmptyCatalogStateProps = {
   className?: string;
   title: string;
   description: React.ReactNode;
-  headerIcon?: React.ComponentType;
+  headerIcon?: React.ComponentType | null;
   children?: React.ReactNode;
   primaryAction?: React.ReactNode;
   secondaryAction?: React.ReactNode;
@@ -33,7 +33,7 @@ const EmptyCatalogState: React.FC<EmptyCatalogStateProps> = ({
 }) => (
   <EmptyState
     className={className}
-    icon={headerIcon ?? PlusCircleIcon}
+    icon={headerIcon === null ? undefined : (headerIcon ?? PlusCircleIcon)}
     titleText={title}
     variant={variant}
     data-testid={testid}

--- a/packages/model-registry/upstream/frontend/src/app/shared/types/catalogTypes.ts
+++ b/packages/model-registry/upstream/frontend/src/app/shared/types/catalogTypes.ts
@@ -1,3 +1,11 @@
+// Catalog source status values from the API
+export enum CatalogSourceStatus {
+  AVAILABLE = 'available',
+  PARTIALLY_AVAILABLE = 'partially-available',
+  ERROR = 'error',
+  DISABLED = 'disabled',
+}
+
 export type {
   CatalogSource,
   CatalogSourceList,

--- a/packages/model-registry/upstream/frontend/src/concepts/modelCatalogSettings/const.ts
+++ b/packages/model-registry/upstream/frontend/src/concepts/modelCatalogSettings/const.ts
@@ -3,6 +3,9 @@ import {
   HuggingFaceCatalogSourceConfig,
   CatalogSourceType,
 } from '~/app/modelCatalogTypes';
+import { CatalogSourceStatus } from '~/app/shared/types/catalogTypes';
+
+export { CatalogSourceStatus };
 
 export const CATALOG_SOURCE_TYPE_LABELS: Record<CatalogSourceType, string> = {
   [CatalogSourceType.YAML]: 'YAML file',
@@ -12,14 +15,6 @@ export const CATALOG_SOURCE_TYPE_LABELS: Record<CatalogSourceType, string> = {
 export enum ModelVisibilityBadgeColor {
   FILTERED = 'purple',
   UNFILTERED = 'grey',
-}
-
-// Catalog source status values from the API
-export enum CatalogSourceStatus {
-  AVAILABLE = 'available',
-  PARTIALLY_AVAILABLE = 'partially-available',
-  ERROR = 'error',
-  DISABLED = 'disabled',
 }
 
 /**


### PR DESCRIPTION
## Description

Sync to pull in changes from:
* https://github.com/kubeflow/model-registry/pull/3001
* https://github.com/kubeflow/model-registry/pull/3002
* https://github.com/kubeflow/model-registry/pull/3003
* https://github.com/kubeflow/model-registry/pull/3004

### Conflicts Resolved

The following conflicts were resolved during this sync:

**[#3001 - (fix):the agents catalog label texts](https://github.com/kubeflow/model-registry/pull/3001)**
- `packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentDetailsPage.tsx`
- `packages/model-registry/upstream/frontend/src/app/pages/agentsCatalog/screens/AgentsCatalog.tsx`

*Nature of conflict:* Upstream renamed GitHub button/labels and updated empty-state copy; ODH had tracking hooks (`onClick` / `useUserInteraction`) and different imports on the same lines.

*Resolution:* Took upstream label/testid/empty-state changes; kept ODH tracking (`onClick={handleOpenGitHub}`, `useUserInteraction` / `TrackingOutcome`) and merged imports.

**[#3002 - fix the mcp settings labels](https://github.com/kubeflow/model-registry/pull/3002)**
- `packages/model-registry/upstream/frontend/src/app/pages/mcpCatalogSettings/screens/McpCatalogSourceConfigsTableRow.tsx`
- `packages/model-registry/upstream/frontend/src/app/shared/types/catalogTypes.ts`
- `packages/model-registry/upstream/frontend/src/concepts/modelCatalogSettings/const.ts`
- `packages/model-registry/upstream/frontend/src/app/routes/mcpCatalogSettings/mcpCatalogSettings.ts`

*Nature of conflict:* Upstream renamed MCP settings labels and moved `CatalogSourceStatus` into `catalogTypes.ts`; ODH had tracking imports, re-exports from `modelCatalogTypes`, `isSourceStatusWithModels`, and different route paths.

*Resolution:* Took upstream label text and `CatalogSourceStatus` move; kept ODH tracking, `isSourceStatusWithModels`, catalog type re-exports, and ODH route paths (`/settings/mcp-resources/mcp-catalog`).

## How Has This Been Tested?

Tested by running backend, frontend and the federated MR package separately as described below, verifying existing behavior in the files this diff touches, and verifying the incoming changes.

Also ran unit tests: `npm run test:unit`
and ran type check: `npm run test:type-check`
(both in `packages/model-registry/upstream/frontend`)

Also ran lint: `npm run test:lint` in `packages/model-registry/upstream/frontend`

Process to run everything locally this way:
* Create `.env.development.local` and copy the contents of `.env.development` to it. Change the backend port to 4020 to avoid conflicts with the upstream running.
* `oc login` to a cluster with ODH installed
* Run both `frontend` and `backend` folders with `npm run start:dev` after running `npm install` on odh-dashboard root repository
* Before continuing, install [kubectl](https://kubernetes.io/docs/tasks/tools/) and [golang](https://go.dev/doc/install)
* With these two terminal tabs open, open a third terminal tab, go to `packages/model-registry/upstream` and run `make dev-install-dependencies` followed by `PORT=9100 make dev-start-federated INSECURE_SKIP_VERIFY=true`

## Test Impact

Upstream changes include their own tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the model registry package reference to a newer revision.
* **Tests**
  * Adjusted Cypress assertions to match the updated MCP catalog page heading (“MCP catalog sources”).
* **User Impact**
  * No user-facing features or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->