### PR TITLE
docs: update distribution rules to reflect workspace membership

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -89,7 +89,7 @@ The controller is **not** part of the npm workspace or Turbo pipeline. It has it
 
 ## Distributions (`distributions/`)
 
-Independently-deployable dashboard variants. These are NOT part of the npm workspace or Turbo pipeline — monorepo-wide `npm run` commands do not apply. Each sub-distribution is self-contained.
+Independently-deployable dashboard variants. All three are **npm workspace members** and participate in the **Turbo pipeline** — Turbo-based root commands (`lint`, `type-check`, `test:contract`) run on distributions that define matching scripts. Some root convenience scripts (`build`, `test`, `dev`) are hardcoded to `frontend/` and `backend/` and do not cover distributions.
 
 | Directory | Description | Has BFF? | Build System |
 |-----------|-------------|----------|--------------|
@@ -100,7 +100,7 @@ Independently-deployable dashboard variants. These are NOT part of the npm works
 - `base/` is a shared library/framework (not independently deployed) — it provides the app shell (masthead, sidebar, error boundary, theme context) that `core-bff/` and `rhaii/` extend
 - `rhaii/` is frontend-only — React + Webpack + Module Federation host configuration
 - `core-bff/` has both a Go BFF (`bff/`) and React frontend (`frontend/`) with its own contract tests (`contract-tests/`)
-- Each distribution has its own `package.json`, `tsconfig.json`, and webpack config
+- Each distribution has its own `package.json`, `tsconfig.json`, and webpack config; dependencies on internal packages resolve through the workspace
 - `core-bff/` follows contract-first development (OpenAPI → BFF stub → Frontend → Production BFF)
 
 See `distributions/core-bff/AGENTS.md` for the most detailed reference. See `.claude/rules/distributions.md` for distribution-specific conventions and `.claude/rules/bff-go.md` for Go BFF conventions (applies to core-bff BFF code).

--- a/.claude/rules/distributions.md
+++ b/.claude/rules/distributions.md
@@ -8,7 +8,7 @@ paths:
 
 # Distribution Conventions
 
-Distributions are independently-deployable dashboard variants in `distributions/`. They are NOT part of the npm workspace or Turbo pipeline — monorepo-wide `npm run` commands do not apply.
+Distributions are independently-deployable dashboard variants in `distributions/`. All three are **npm workspace members** and participate in the **Turbo pipeline** — Turbo-based root commands (`npm run lint`, `npm run type-check`, `npm run test:contract`, etc.) include distributions that define matching scripts.
 
 ## Sub-distributions
 
@@ -20,19 +20,29 @@ Distributions are independently-deployable dashboard variants in `distributions/
 
 > **`base/` is a library, not a deployable distribution.** It provides the shared app shell framework (masthead, sidebar, error boundary, theme context, extensibility hooks) that concrete distributions like `core-bff/` and `rhaii/` extend. Do not treat it as a standalone application.
 
-## Isolation from npm workspaces
+## Workspace integration
 
-Distributions are self-contained. Always `cd` into the distribution directory before running commands:
+Distributions are workspace members listed in the root `package.json`. Dependencies on internal packages (`@odh-dashboard/eslint-config`, `@odh-dashboard/tsconfig`, `@odh-dashboard/plugin-core`, etc.) resolve through the workspace — no special workarounds are needed.
+
+Turbo-based commands run on any distribution that defines the matching script:
 
 ```bash
-# WRONG — distributions are invisible to the root workspace
-npm run lint          # won't touch distributions/
-npm run type-check    # won't touch distributions/
-
-# RIGHT — run from within the distribution
-cd distributions/base && npx eslint src/
-cd distributions/core-bff && make lint
+# These Turbo commands DO cover distributions
+npm run lint          # runs lint on base, core-bff, rhaii (all define "lint")
+npm run type-check    # runs type-check on base, rhaii (both define "type-check")
+npm run test:contract # runs test:contract on core-bff (defines "test:contract")
 ```
+
+Some root convenience scripts are hardcoded to `frontend/` and `backend/` and do **not** cover distributions:
+
+```bash
+# These do NOT cover distributions — they target frontend/ and backend/ directly
+npm run build         # only builds frontend + backend
+npm run test          # only tests frontend + backend
+npm run dev           # only starts frontend + backend dev servers
+```
+
+For distribution-specific builds and BFF operations, work from within the distribution directory or use `make` targets (see commands below).
 
 ## Build and dev commands
 
@@ -108,7 +118,6 @@ When modifying Module Federation config in distributions, verify that remote nam
 
 ## Common mistakes
 
-- **Running `npm install` from a distribution directory without the workspace workaround** — dependencies on internal packages (`@odh-dashboard/eslint-config`, `@odh-dashboard/tsconfig`) won't resolve. See `distributions/base/README.md` for the workaround.
 - **Confusing `core-bff/bff/` with `dashboard-operator/`** — They are separate Go modules with different `go.mod` files and different patterns. `core-bff/bff/` is an HTTP BFF (uses httprouter); `dashboard-operator/` is a Kubernetes controller (uses controller-runtime).
-- **Assuming monorepo-wide lint/test commands cover distributions** — They don't. Always run validation from within the distribution directory.
+- **Assuming root `build`/`test`/`dev` commands cover distributions** — They don't; those scripts are hardcoded to `frontend/` and `backend/`. Turbo-based commands (`lint`, `type-check`, `test:contract`) *do* cover distributions.
 - **Forgetting to update the OpenAPI spec** when adding new endpoints to `core-bff/bff/` — Reviewers must see a diff in the OpenAPI file alongside code changes.


### PR DESCRIPTION
## Description

NO-ISSUE

Both `.claude/rules/distributions.md` and `.claude/rules/architecture.md` stated that distributions "are NOT part of the npm workspace or Turbo pipeline" — this is outdated since all three distributions (`base`, `core-bff`, `rhaii`) are now workspace members listed in the root `package.json` and participate in Turbo tasks.

**Changes:**
- Replaced the false "NOT part of workspace" claims with accurate descriptions of workspace integration
- Renamed the "Isolation from npm workspaces" section to "Workspace integration" with concrete examples of which root commands do vs. don't cover distributions
- Removed the outdated common-mistake about needing a "workspace workaround" for `npm install`
- Clarified the nuance: Turbo-based commands (`lint`, `type-check`, `test:contract`) DO cover distributions, while hardcoded root scripts (`build`, `test`, `dev`) do not
- Noted that internal package dependencies resolve through the workspace normally

## How Has This Been Tested?

This is a documentation-only change (agent rule files). Verified accuracy by inspecting:
- Root `package.json` `workspaces` array (lists all three distributions)
- Root `turbo.jsonc` task definitions
- Each distribution's `package.json` scripts (to confirm which Turbo tasks they participate in)

## Test Impact

No tests required — documentation-only change to `.claude/rules/` files that do not affect runtime behavior.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that distribution dashboards are npm workspace members included in Turbo-based linting, type checks, and contract tests.
  * Documented which root commands include distributions and which convenience scripts apply only to the frontend and backend.
  * Updated workspace dependency guidance and corrected installation and testing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->