### PR TITLE
feat(gen-ai): grant pgvector RBAC to shared modules SA for sidecar mode

### DIFF
--- a/manifests/modular-architecture/modules-cluster-role.yaml
+++ b/manifests/modular-architecture/modules-cluster-role.yaml
@@ -81,3 +81,70 @@ rules:
       - list
     resources:
       - mcpserverregistrations
+  # pgvector auto-provisioning (RHOAIENG-68914) (gen-ai-ui)
+  # TODO: Move to modules/gen-ai/cluster-role.yaml once per-module SAs are active (3.5 pod migration)
+  # create is broad (resourceNames cannot restrict it in k8s RBAC).
+  # get/update/delete are scoped to the deterministic pgvector resource names.
+  - apiGroups:
+      - ""
+    verbs:
+      - create
+    resources:
+      - secrets
+      - services
+      - persistentvolumeclaims
+      - configmaps
+  - apiGroups:
+      - ""
+    verbs:
+      - get
+      - update
+      - delete
+    resources:
+      - secrets
+      - services
+      - persistentvolumeclaims
+      - configmaps
+    resourceNames:
+      - genai-pgvector-credentials
+      - genai-pgvector-init
+      - genai-pgvector-storage
+      - genai-pgvector
+  - apiGroups:
+      - apps
+    verbs:
+      - create
+    resources:
+      - deployments
+  - apiGroups:
+      - apps
+    verbs:
+      - get
+      - update
+      - delete
+    resources:
+      - deployments
+    resourceNames:
+      - genai-pgvector
+  - apiGroups:
+      - networking.k8s.io
+    verbs:
+      - create
+    resources:
+      - networkpolicies
+  - apiGroups:
+      - networking.k8s.io
+    verbs:
+      - get
+      - update
+      - delete
+    resources:
+      - networkpolicies
+    resourceNames:
+      - genai-pgvector
+  - apiGroups:
+      - storage.k8s.io
+    verbs:
+      - list
+    resources:
+      - storageclasses


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-77906

## Description

This is a fallback PR in case the standalone pod migration doesn't ship in time.

In sidecar mode all BFF modules run under the shared `odh-dashboard-modules` ServiceAccount. The gen-ai module needs permissions for pgvector auto-provisioning (secrets, PVCs, deployments, services, network policies, configmaps) but those only bind to the per-module SA used in standalone mode. Since the pod migration ([RHOAIENG-38191](https://issues.redhat.com/browse/RHOAIENG-38191)) hasn't flipped from sidecar to standalone yet, the gen-ai BFF hits 403s when it tries to create pgvector resources.

This adds the pgvector provisioning RBAC rules directly to the shared `modules-cluster-role.yaml`. `create` verbs are necessarily broad (k8s RBAC can't restrict `create` by `resourceNames`), but `get`/`update`/`delete` are scoped to deterministic resource names (`genai-pgvector-*`). Also adds `storageclasses` list for dynamic PVC provisioning.

Temporary. Marked with TODOs to migrate into `modules/gen-ai/cluster-role.yaml` once per-module SAs are active with the standalone pod deployment.

## How Has This Been Tested?

- Deployed to a RHOAI cluster in sidecar mode and confirmed the gen-ai BFF can provision pgvector resources (secrets, PVC, deployment, service, configmap, networkpolicy) without 403s
- Confirmed file upload + vector store indexing completes end-to-end after provisioning
- Verified standalone mode is unaffected (its own SA + binding already existed)

## Test Impact

No new tests. This is a static RBAC manifest applied by kustomize. The existing gen-ai E2E tests exercise pgvector provisioning under the sidecar deployment and will implicitly validate the binding.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-38191]: https://redhat.atlassian.net/browse/RHOAIENG-38191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permissions enabling automatic pgvector provisioning for the GenAI interface.
  * Supports creating and managing the required secrets, services, persistent storage, configuration, deployment, and network policy resources.
  * Added access to list available storage classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->