### PR TITLE
fix: add missing order property to DeploymentMethodSelectField test mocks

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
@@ -47,8 +47,8 @@ describe('DeploymentMethodSelectField tracking', () => {
       externalData: {
         data: {
           options: [
-            { key: 'kserve', label: 'KServe', description: 'KServe deployment' },
-            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment' },
+            { key: 'kserve', label: 'KServe', description: 'KServe deployment', order: 0 },
+            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment', order: 1 },
           ],
         },
         loaded: true,
@@ -69,8 +69,8 @@ describe('DeploymentMethodSelectField tracking', () => {
       externalData: {
         data: {
           options: [
-            { key: 'kserve', label: 'KServe', description: 'KServe deployment' },
-            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment' },
+            { key: 'kserve', label: 'KServe', description: 'KServe deployment', order: 0 },
+            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment', order: 1 },
           ],
         },
         loaded: true,
@@ -89,7 +89,7 @@ describe('DeploymentMethodSelectField tracking', () => {
     renderComponent({
       externalData: {
         data: {
-          options: [{ key: 'kserve', label: 'KServe', description: 'KServe deployment' }],
+          options: [{ key: 'kserve', label: 'KServe', description: 'KServe deployment', order: 0 }],
         },
         loaded: true,
       },
@@ -106,8 +106,8 @@ describe('DeploymentMethodSelectField tracking', () => {
       externalData: {
         data: {
           options: [
-            { key: 'kserve', label: 'KServe', description: 'KServe deployment' },
-            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment' },
+            { key: 'kserve', label: 'KServe', description: 'KServe deployment', order: 0 },
+            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment', order: 1 },
           ],
         },
         loaded: true,
@@ -124,8 +124,8 @@ describe('DeploymentMethodSelectField tracking', () => {
       externalData: {
         data: {
           options: [
-            { key: 'kserve', label: 'KServe', description: 'KServe deployment' },
-            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment' },
+            { key: 'kserve', label: 'KServe', description: 'KServe deployment', order: 0 },
+            { key: 'llmd', label: 'LLM-D', description: 'LLM-D deployment', order: 1 },
           ],
         },
         loaded: true,


### PR DESCRIPTION
Amendment to https://redhat.atlassian.net/browse/RHOAIENG-72402
## Description
The `DeploymentMethodOption` type requires an `order` property (made required in #8701), but the test mocks added in #8736 omitted it, causing `type-check` failures in the `model-serving` package.

This adds the missing `order` property to all 9 mock `DeploymentMethodOption` objects in the test file.

## How Has This Been Tested?
- `npm run type-check` passes with no errors in `model-serving`

## Test Impact
No new tests needed — this fixes existing test code to satisfy the type checker.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`