### PR TITLE
ci: add kserve backend to rhaii-tilt

### DIFF
--- a/distributions/rhaii/developing/Makefile
+++ b/distributions/rhaii/developing/Makefile
@@ -27,8 +27,12 @@ tilt-up: check-tilt setup-kind ## Start Tilt — builds, deploys, and port-forwa
 	@echo "Starting Tilt..."
 	@tilt up --port "$(TILT_PORT)"
 
+.PHONY: setup-kserve
+setup-kserve: ## Install KServe + cert-manager into the Kind cluster (idempotent)
+	@bash scripts/setup-kserve.sh
+
 .PHONY: tilt-up-model-serving
-tilt-up-model-serving: check-tilt setup-kind ## Start Tilt with model-serving enabled (experimental)
+tilt-up-model-serving: check-tilt setup-kind setup-kserve ## Start Tilt with model-serving enabled (experimental)
 	@echo "Starting Tilt with model-serving package..."
 	@ENABLE_MODEL_SERVING=true tilt up --port "$(TILT_PORT)"
 

--- a/distributions/rhaii/developing/Tiltfile
+++ b/distributions/rhaii/developing/Tiltfile
@@ -26,8 +26,10 @@ repo_root = os.path.join(tilt_root, "../../..")
 
 # ── Optional packages (set env vars to "true" to enable) ─────────────────────
 
+enable_model_serving = os.environ.get("ENABLE_MODEL_SERVING", "false") == "true"
+
 build_args = {}
-if os.environ.get("ENABLE_MODEL_SERVING", "false") == "true":
+if enable_model_serving:
     build_args["ENABLE_MODEL_SERVING"] = "true"
 
 # ── RHAII Dashboard ───────────────────────────────────────────────────────────
@@ -58,3 +60,15 @@ k8s_resource(
     port_forwards=[port_forward(4000, 4000, name="RHAII Dashboard")],
     labels=["rhaii"],
 )
+
+# ── Model Serving (optional — KServe backend) ────────────────────────────────
+# Requires: make setup-kserve (called automatically by make tilt-up-model-serving)
+
+if enable_model_serving:
+    # Stream logs from the externally-installed KServe controller for visibility
+    local_resource(
+        "kserve-controller",
+        cmd="kubectl get deployment -n kserve kserve-controller-manager -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo 'not installed'",
+        serve_cmd="kubectl logs -n kserve deployment/kserve-controller-manager -f --tail=50",
+        labels=["model-serving"],
+    )

--- a/distributions/rhaii/developing/scripts/setup-kserve.sh
+++ b/distributions/rhaii/developing/scripts/setup-kserve.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pinned versions — update these together when upgrading KServe
+CERT_MANAGER_VERSION="v1.17.0"
+KSERVE_VERSION="v0.19.0"
+
+# Pinned manifest URLs
+CERT_MANAGER_URL="https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+KSERVE_URL="https://github.com/kserve/kserve/releases/download/${KSERVE_VERSION}/kserve.yaml"
+
+EXPECTED_CONTEXT="kind-rhaii-tilt"
+WAIT_TIMEOUT="120s"
+
+info()  { echo "==> $*"; }
+error() { echo "ERROR: $*" >&2; exit 1; }
+
+# --- Prerequisites -----------------------------------------------------------
+
+command -v kubectl >/dev/null 2>&1 || error "kubectl not found in PATH"
+
+CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || true)
+if [[ "$CURRENT_CONTEXT" != "$EXPECTED_CONTEXT" ]]; then
+  error "kubectl context is '${CURRENT_CONTEXT}', expected '${EXPECTED_CONTEXT}'. Run 'make setup-kind' first."
+fi
+
+kubectl cluster-info >/dev/null 2>&1 || error "Cluster not reachable. Is the Kind cluster running?"
+
+# --- cert-manager -------------------------------------------------------------
+
+if kubectl get namespace cert-manager >/dev/null 2>&1; then
+  info "cert-manager namespace already exists — skipping install"
+else
+  info "Installing cert-manager ${CERT_MANAGER_VERSION}..."
+  kubectl apply -f "$CERT_MANAGER_URL"
+fi
+
+info "Waiting for cert-manager-webhook to be ready..."
+kubectl wait deployment cert-manager-webhook \
+  -n cert-manager \
+  --for=condition=Available \
+  --timeout="$WAIT_TIMEOUT"
+
+# --- KServe core (CRDs + controller + webhooks) ------------------------------
+# The kserve.yaml manifest bundles namespace, CRDs, controller, webhooks, and
+# custom resources (ClusterStorageContainer) in a single file. A plain
+# `kubectl apply` fails for three reasons:
+#   1. CRD annotations exceed the 262144-byte last-applied-configuration limit
+#   2. Namespaced resources fail if the namespace object hasn't been created yet
+#   3. ClusterStorageContainer CR is applied before its CRD is established
+#
+# Fix: create the namespace up front, then use server-side apply in two passes.
+# Server-side apply avoids the annotation size limit, and the second pass picks
+# up any resources that failed due to CRD ordering.
+
+if kubectl get deployment kserve-controller-manager -n kserve >/dev/null 2>&1; then
+  info "KServe controller already installed — skipping core install"
+else
+  info "Ensuring kserve namespace exists..."
+  kubectl create namespace kserve --dry-run=client -o yaml | kubectl apply -f -
+
+  info "Installing KServe ${KSERVE_VERSION} (pass 1: CRDs + core resources)..."
+  kubectl apply --server-side --force-conflicts -f "$KSERVE_URL" 2>&1 || true
+
+  info "Waiting for KServe CRDs to be established..."
+  kubectl wait crd inferenceservices.serving.kserve.io --for=condition=Established --timeout=60s
+  kubectl wait crd servingruntimes.serving.kserve.io --for=condition=Established --timeout=60s
+
+  info "Installing KServe ${KSERVE_VERSION} (pass 2: remaining resources)..."
+  kubectl apply --server-side --force-conflicts -f "$KSERVE_URL"
+fi
+
+info "Waiting for kserve-controller-manager to be ready..."
+kubectl wait deployment kserve-controller-manager \
+  -n kserve \
+  --for=condition=Available \
+  --timeout="$WAIT_TIMEOUT"
+
+# --- Configure RawDeployment mode ---------------------------------------------
+# KServe defaults to serverless (Knative) mode. We run without Knative/Istio,
+# so switch to RawDeployment mode and disable ingress creation.
+
+info "Configuring KServe for RawDeployment mode..."
+kubectl patch configmap inferenceservice-config \
+  -n kserve \
+  --type merge \
+  -p '{
+    "data": {
+      "deploy": "{\"defaultDeploymentMode\": \"RawDeployment\"}",
+      "ingress": "{\"disableIngressCreation\": true}"
+    }
+  }'
+
+# --- Summary ------------------------------------------------------------------
+
+info "KServe dev environment ready!"
+echo "  cert-manager: ${CERT_MANAGER_VERSION}"
+echo "  KServe:       ${KSERVE_VERSION}"
+echo "  LLMIsvc CRDs: included"
+echo "  Deploy mode:  RawDeployment"
+echo ""
+echo "CRDs installed:"
+kubectl get crd -o name | grep kserve | sed 's|^|  |'


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-79244

## Description

The RHAII Tilt dev environment previously only deployed the dashboard itself. Running `make tilt-up-model-serving` enabled the model-serving frontend package via a Docker build arg, but there was no actual KServe backend in the Kind cluster — API proxy calls to KServe resources would 404 because the CRDs did not exist.

This commit installs a real KServe backend into the Kind cluster so the dashboard's model-serving features get real (empty) K8s API responses instead of errors. No Knative or Istio is required — KServe is configured for RawDeployment mode.

New files:

- scripts/setup-kserve.sh: Idempotent script that installs cert-manager v1.17.0 and KServe v0.19.0 from pinned upstream release manifests.   Uses server-side apply in two passes to handle CRD annotation size limits and resource ordering. Configures RawDeployment mode and disables Istio ingress creation. Includes LLMIsvc CRDs bundled in the v0.19.0 release (InferenceService, ServingRuntime, LLMInferenceService, LLMInferenceServiceConfig).

Modified files:

- Makefile: Added `setup-kserve` target and wired it as a prerequisite of `tilt-up-model-serving`, running after Kind cluster creation and before Tilt starts.

- Tiltfile: Added conditional model-serving section gated on ENABLE_MODEL_SERVING. When enabled, streams KServe controller logs as a local_resource for Tilt UI visibility.

## How Has This Been Tested?
- `make tilt-up-model-serving`
- kserve API calls proxied through `core-bff`

## Test Impact
- n/a - purely local dev env related

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated setup for KServe and cert-manager in the local Kind development environment.
  * Added readiness checks for required Kubernetes services and KServe resources.
  * Added optional model-serving enablement through an environment setting.
  * Added visibility into KServe controller logs during model-serving development.

* **Bug Fixes**
  * Configured KServe for RawDeployment mode without creating ingress resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->