### PR TITLE
fix(manifests): remove duplicate MODULE_FEDERATION_CONFIG env var from sidecar patch

### DIFF
--- a/manifests/sidecar/deployment.yaml
+++ b/manifests/sidecar/deployment.yaml
@@ -1,11 +1,3 @@
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
-    name: MODULE_FEDERATION_CONFIG
-    valueFrom:
-      configMapKeyRef:
-        key: module-federation-config.json
-        name: federation-config
 # --- SA isolation: disable auto-mount and add per-container SA tokens ---
 - op: add
   path: /spec/template/spec/automountServiceAccountToken


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79090

## Description

PR #8708 restructured the kustomize layout so that `manifests/sidecar/kustomization.yaml` now includes `../base` as a resource. The base deployment (`manifests/base/deployment.yaml`) already defines `MODULE_FEDERATION_CONFIG` as an env var on the `odh-dashboard` container (with `optional: true`).

However, the sidecar JSON6902 patch (`manifests/sidecar/deployment.yaml`) still had an `op: add` entry appending the same `MODULE_FEDERATION_CONFIG` env var to container 0. When kustomize renders the sidecar overlay, both entries exist, producing a duplicate key that Kubernetes Server-Side Apply rejects with:

```
.spec.template.spec.containers[name="odh-dashboard"].env: duplicate entries for key [name="MODULE_FEDERATION_CONFIG"]
```

This failure is observed in [opendatahub-operator PR #3829](https://github.com/opendatahub-io/opendatahub-operator/pull/3829).

**Fix**: Remove the redundant `MODULE_FEDERATION_CONFIG` patch entry from the sidecar deployment patch. The base deployment already provides this env var.

## How Has This Been Tested?

- Ran `make test` in `dashboard-operator/` — all test packages pass (`api/v1alpha1`, `charts`, `internal/controller`, `internal/webhook`)
- Verified the kustomize diff only removes the duplicate env var patch entry

## Test Impact

No new tests needed — this is a manifest fix removing a redundant JSON6902 patch entry. The existing operator unit tests cover kustomize rendering and validate the fix.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added several integrated dashboard modules, including model registry, generative AI, MLflow, evaluation, AutoML, AutoRAG, and agent operations interfaces.
  * Improved module health monitoring through HTTPS readiness and liveness checks.
  * Enhanced service-account isolation and security for dashboard components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->