### PR TITLE
feat(dashboard-operator): preserve user-configured replicas and resources per ADR-0005 [RHOAIENG-78745]

### DIFF
--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -59,6 +59,12 @@ var persesdashboardGVK = schema.GroupVersionKind{
 	Kind:    "PersesDashboardList",
 }
 
+var deploymentGVK = schema.GroupVersionKind{
+	Group:   "apps",
+	Version: "v1",
+	Kind:    "Deployment",
+}
+
 // Version is set at build time via -ldflags.
 var Version = "unknown"
 
@@ -272,6 +278,7 @@ func (r *DashboardReconciler) reconcileSidecar(
 		deploy.WithFieldOwner("dashboard-operator"),
 		deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
 		deploy.WithApplyOrder(),
+		deploy.WithMergeStrategy(deploymentGVK, deploy.MergeDeployments),
 	)
 
 	if err := deployer.Deploy(ctx, deploy.DeployInput{
@@ -375,6 +382,7 @@ func (r *DashboardReconciler) reconcileStandalone(
 		deploy.WithFieldOwner("dashboard-operator"),
 		deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
 		deploy.WithApplyOrder(),
+		deploy.WithMergeStrategy(deploymentGVK, deploy.MergeDeployments),
 	)
 
 	if err := deployer.Deploy(ctx, deploy.DeployInput{

--- a/dashboard-operator/internal/controller/merge_deployments_test.go
+++ b/dashboard-operator/internal/controller/merge_deployments_test.go
@@ -1,0 +1,373 @@
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
+)
+
+func TestDeploymentGVK(t *testing.T) {
+	expected := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	if deploymentGVK != expected {
+		t.Errorf("deploymentGVK = %v, want %v", deploymentGVK, expected)
+	}
+}
+
+func TestMergeDeployments_PreservesReplicas(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "test-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(3),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "main",
+								"image": "old-image:v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "test-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "main",
+								"image": "new-image:v2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := deploy.MergeDeployments(existing, desired); err != nil {
+		t.Fatalf("MergeDeployments returned error: %v", err)
+	}
+
+	replicas, found, err := unstructured.NestedInt64(desired.Object, "spec", "replicas")
+	if err != nil {
+		t.Fatalf("failed to get replicas: %v", err)
+	}
+	if !found {
+		t.Fatal("replicas field not found after merge")
+	}
+	if replicas != 3 {
+		t.Errorf("replicas = %d, want 3 (user-configured value should be preserved)", replicas)
+	}
+}
+
+func TestMergeDeployments_PreservesContainerResources(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "test-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "odh-dashboard",
+								"image": "dashboard:v1",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{
+										"memory": "512Mi",
+										"cpu":    "500m",
+									},
+									"limits": map[string]interface{}{
+										"memory": "2Gi",
+									},
+								},
+							},
+							map[string]interface{}{
+								"name":  "kube-rbac-proxy",
+								"image": "rbac-proxy:v1",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{
+										"memory": "64Mi",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "test-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "odh-dashboard",
+								"image": "dashboard:v2",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{
+										"memory": "256Mi",
+										"cpu":    "200m",
+									},
+								},
+							},
+							map[string]interface{}{
+								"name":  "kube-rbac-proxy",
+								"image": "rbac-proxy:v2",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{
+										"memory": "32Mi",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := deploy.MergeDeployments(existing, desired); err != nil {
+		t.Fatalf("MergeDeployments returned error: %v", err)
+	}
+
+	containers, found, err := unstructured.NestedSlice(desired.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found {
+		t.Fatalf("failed to get containers: found=%v, err=%v", found, err)
+	}
+
+	for _, c := range containers {
+		cMap := c.(map[string]interface{})
+		name := cMap["name"].(string)
+		resources, ok := cMap["resources"].(map[string]interface{})
+
+		switch name {
+		case "odh-dashboard":
+			if !ok {
+				t.Fatal("odh-dashboard container should have resources after merge")
+			}
+			requests := resources["requests"].(map[string]interface{})
+			if requests["memory"] != "512Mi" {
+				t.Errorf("odh-dashboard memory request = %v, want 512Mi (user value)", requests["memory"])
+			}
+			if requests["cpu"] != "500m" {
+				t.Errorf("odh-dashboard cpu request = %v, want 500m (user value)", requests["cpu"])
+			}
+			limits, ok := resources["limits"].(map[string]interface{})
+			if !ok {
+				t.Fatal("odh-dashboard should have limits preserved from existing")
+			}
+			if limits["memory"] != "2Gi" {
+				t.Errorf("odh-dashboard memory limit = %v, want 2Gi (user value)", limits["memory"])
+			}
+
+		case "kube-rbac-proxy":
+			if !ok {
+				t.Fatal("kube-rbac-proxy container should have resources after merge")
+			}
+			requests := resources["requests"].(map[string]interface{})
+			if requests["memory"] != "64Mi" {
+				t.Errorf("kube-rbac-proxy memory request = %v, want 64Mi (user value)", requests["memory"])
+			}
+		}
+	}
+}
+
+func TestMergeDeployments_MatchesByContainerName(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "sidecar-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(2),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "odh-dashboard",
+								"image": "dashboard:v1",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{"memory": "1Gi"},
+								},
+							},
+							map[string]interface{}{
+								"name":  "model-registry-bff",
+								"image": "mr-bff:v1",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{"memory": "256Mi"},
+								},
+							},
+							map[string]interface{}{
+								"name":  "gen-ai-bff",
+								"image": "genai-bff:v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "sidecar-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "odh-dashboard",
+								"image": "dashboard:v2",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{"memory": "512Mi"},
+								},
+							},
+							map[string]interface{}{
+								"name":  "model-registry-bff",
+								"image": "mr-bff:v2",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{"memory": "128Mi"},
+								},
+							},
+							map[string]interface{}{
+								"name":  "gen-ai-bff",
+								"image": "genai-bff:v2",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{"memory": "64Mi"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := deploy.MergeDeployments(existing, desired); err != nil {
+		t.Fatalf("MergeDeployments returned error: %v", err)
+	}
+
+	replicas, _, _ := unstructured.NestedInt64(desired.Object, "spec", "replicas")
+	if replicas != 2 {
+		t.Errorf("replicas = %d, want 2", replicas)
+	}
+
+	containers, _, _ := unstructured.NestedSlice(desired.Object, "spec", "template", "spec", "containers")
+
+	for _, c := range containers {
+		cMap := c.(map[string]interface{})
+		name := cMap["name"].(string)
+
+		switch name {
+		case "odh-dashboard":
+			res := cMap["resources"].(map[string]interface{})
+			req := res["requests"].(map[string]interface{})
+			if req["memory"] != "1Gi" {
+				t.Errorf("odh-dashboard memory = %v, want 1Gi", req["memory"])
+			}
+
+		case "model-registry-bff":
+			res := cMap["resources"].(map[string]interface{})
+			req := res["requests"].(map[string]interface{})
+			if req["memory"] != "256Mi" {
+				t.Errorf("model-registry-bff memory = %v, want 256Mi", req["memory"])
+			}
+
+		case "gen-ai-bff":
+			if _, ok := cMap["resources"]; ok {
+				t.Error("gen-ai-bff should have no resources (existing had none)")
+			}
+		}
+	}
+}
+
+func TestMergeDeployments_DefaultsAppliedOnFirstDeploy(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "new-deploy"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "main",
+								"image": "image:v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "new-deploy"},
+			"spec": map[string]interface{}{
+				"replicas": int64(2),
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "main",
+								"image": "image:v1",
+								"resources": map[string]interface{}{
+									"requests": map[string]interface{}{
+										"memory": "256Mi",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := deploy.MergeDeployments(existing, desired); err != nil {
+		t.Fatalf("MergeDeployments returned error: %v", err)
+	}
+
+	_, found, _ := unstructured.NestedInt64(desired.Object, "spec", "replicas")
+	if found {
+		t.Error("replicas should be removed when existing has no replicas set (K8s default)")
+	}
+
+	containers, _, _ := unstructured.NestedSlice(desired.Object, "spec", "template", "spec", "containers")
+	cMap := containers[0].(map[string]interface{})
+	if _, ok := cMap["resources"]; ok {
+		t.Error("resources should be removed when existing container had no resources (first deploy scenario)")
+	}
+}

--- a/dashboard-operator/internal/controller/module_deploy.go
+++ b/dashboard-operator/internal/controller/module_deploy.go
@@ -221,6 +221,7 @@ func (r *DashboardReconciler) deployModuleManifests(
 			deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
 			deploy.WithLabel(moduleComponentLabel, mod.ManifestSlug),
 			deploy.WithApplyOrder(),
+			deploy.WithMergeStrategy(deploymentGVK, deploy.MergeDeployments),
 		)
 
 		if err := deployer.Deploy(ctx, deploy.DeployInput{


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78745

## Description

Wires `deploy.WithMergeStrategy(deploymentGVK, deploy.MergeDeployments)` into all three `deploy.NewDeployer` calls in the dashboard-operator so that user modifications to `spec.replicas` and `spec.template.spec.containers[].resources` are preserved across reconcile cycles instead of being reverted by SSA.

**What changed:**
- Added `deploymentGVK` package-level var in `dashboard_reconciler.go`
- Added `deploy.WithMergeStrategy(deploymentGVK, deploy.MergeDeployments)` to:
  - Sidecar deployer (`reconcileSidecar`)
  - Standalone core deployer (`reconcileStandalone`)
  - Per-module standalone deployer (`deployModuleManifests` in `module_deploy.go`)

**How it works:**
`MergeDeployments` (from `odh-platform-utilities`) reads the live resource before SSA apply and merges `spec.replicas` and per-container `resources` (matched by container name) from the existing object into the desired manifest. This means:
- If a user scales replicas via `oc scale` or `kubectl`, the operator preserves that value
- If a user sets container resource requests/limits via `oc set resources` or `kubectl edit`, those are preserved
- On first deploy (no existing resource), K8s defaults apply normally

## How Has This Been Tested?

**Unit tests:** All 5 new tests pass, `make test` passes for all operator packages (57.3% coverage for `internal/controller`).

**Build verification:** `go build ./...` compiles cleanly, `make lint` passes with 0 issues.

**Cluster verification (ui-monarch-rosa):**

1. Built the operator image with the merge strategy changes (`podman build --platform linux/amd64`)
2. Pushed to the OpenShift internal registry (`image-registry.openshift-image-registry.svc:5000/opendatahub/dashboard-operator:rhoaieng-78745`)
3. Installed Dashboard CRD, deployed the operator with RBAC
4. Created a `Dashboard` CR — operator reconciled and deployed the sidecar dashboard (11 containers)
5. **Test: Modified replicas from 2 → 5** via `oc scale` — after multiple reconcile cycles, replicas stayed at **5** ✅
6. **Test: Modified odh-dashboard container resources** (memory request 512Mi→1Gi, CPU 100m→500m, memory limit 1Gi→2Gi) — after reconcile, all user values were preserved ✅
7. **Test: Other containers' resources unchanged** — kube-rbac-proxy, core-bff, and all module sidecar containers retained their manifest defaults ✅

## Test Impact

Added `merge_deployments_test.go` with 5 unit tests:
- `TestDeploymentGVK` — verifies the GVK constant
- `TestMergeDeployments_PreservesReplicas` — user replicas=3 preserved over manifest default=1
- `TestMergeDeployments_PreservesContainerResources` — user memory/cpu requests/limits preserved per container
- `TestMergeDeployments_MatchesByContainerName` — multi-container sidecar pod: each container's resources merged independently by name
- `TestMergeDeployments_DefaultsAppliedOnFirstDeploy` — when existing has no replicas/resources, desired values are cleared to let K8s defaults apply

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`