### PR TITLE
RHOAIENG-79260: Apply go fmt to agent-ops BFF source files

### DIFF
--- a/packages/agent-ops/bff/internal/api/middleware.go
+++ b/packages/agent-ops/bff/internal/api/middleware.go
@@ -214,4 +214,3 @@ func (app *App) RequireAccessToService(next func(http.ResponseWriter, *http.Requ
 		next(w, r, ps)
 	}
 }
-

--- a/packages/agent-ops/bff/internal/api/middleware_test.go
+++ b/packages/agent-ops/bff/internal/api/middleware_test.go
@@ -43,7 +43,6 @@ func (c *rbacTestK8sClient) CanListServicesInNamespace(context.Context, *k8s.Req
 	return c.allowed, c.err
 }
 
-
 func (c *rbacTestK8sClient) CanAccessAgentCardEnrichment(context.Context, *k8s.RequestIdentity, string) (k8s.AgentCardEnrichmentAccess, error) {
 	if c.err != nil {
 		return k8s.AgentCardEnrichmentAccess{}, c.err
@@ -226,8 +225,8 @@ func TestRequireAuthenticatedForAgents_AuthDisabled(t *testing.T) {
 
 func TestRequireAuthenticatedForAgents_DoesNotCallGetClient(t *testing.T) {
 	app := &App{
-		config: config.EnvConfig{AuthMethod: config.AuthMethodInternal},
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		config:                  config.EnvConfig{AuthMethod: config.AuthMethodInternal},
+		logger:                  slog.New(slog.NewTextHandler(io.Discard, nil)),
 		kubernetesClientFactory: &fatalIfCalledFactory{t: t},
 	}
 

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/client_test.go
@@ -53,7 +53,6 @@ func (c *permissiveK8sClient) CanListServicesInNamespace(context.Context, *k8s.R
 	return true, nil
 }
 
-
 func (c *permissiveK8sClient) CanGetAgentInNamespace(context.Context, *k8s.RequestIdentity, string, string) (bool, error) {
 	return true, nil
 }
@@ -505,7 +504,6 @@ func (c *failingNamespacesK8sClient) GetUser(*k8s.RequestIdentity) (string, erro
 func (c *failingNamespacesK8sClient) CanListServicesInNamespace(context.Context, *k8s.RequestIdentity, string) (bool, error) {
 	return true, nil
 }
-
 
 func (c *failingNamespacesK8sClient) CanGetAgentInNamespace(context.Context, *k8s.RequestIdentity, string, string) (bool, error) {
 	return true, nil

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/deploy_test.go
@@ -42,7 +42,6 @@ func (c *deployTestK8sClient) CanListServicesInNamespace(context.Context, *k8s.R
 	return true, nil
 }
 
-
 func (c *deployTestK8sClient) CanGetAgentInNamespace(context.Context, *k8s.RequestIdentity, string, string) (bool, error) {
 	return true, nil
 }

--- a/packages/agent-ops/bff/internal/integrations/agents/kubernetes/mapper.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/kubernetes/mapper.go
@@ -44,21 +44,21 @@ func sandboxToSummary(sandbox unstructured.Unstructured, service *agents.AgentSe
 	}
 
 	return agents.AgentSummary{
-		Name:         sandbox.GetName(),
-		Namespace:    sandbox.GetNamespace(),
-		DisplayName:  mapper.AgentDisplayName(annotations, sandbox.GetName()),
-		Description:  mapper.AgentDescription(annotations),
-		Framework:    mapper.AgentFramework(annotations),
+		Name:          sandbox.GetName(),
+		Namespace:     sandbox.GetNamespace(),
+		DisplayName:   mapper.AgentDisplayName(annotations, sandbox.GetName()),
+		Description:   mapper.AgentDescription(annotations),
+		Framework:     mapper.AgentFramework(annotations),
 		Status:        sandboxPhase(sandbox),
 		StatusMessage: sandboxConditionMessage(sandbox),
 		ResourceType:  agents.ResolveAgentResourceType(labels),
-		WorkloadType: agents.WorkloadTypeSandbox,
-		ServiceFQDN:  serviceFQDN,
-		PodIP:        sandboxPodIP(sandbox),
-		Ports:        append([]agents.AgentServicePort(nil), ports...),
-		EndpointURL:  sandboxEndpointURL(sandbox, resolved),
-		CreatedAt:    formatTimestamp(sandbox.GetCreationTimestamp()),
-		LastSyncAt:   sandboxLastSyncTimestamp(sandbox),
+		WorkloadType:  agents.WorkloadTypeSandbox,
+		ServiceFQDN:   serviceFQDN,
+		PodIP:         sandboxPodIP(sandbox),
+		Ports:         append([]agents.AgentServicePort(nil), ports...),
+		EndpointURL:   sandboxEndpointURL(sandbox, resolved),
+		CreatedAt:     formatTimestamp(sandbox.GetCreationTimestamp()),
+		LastSyncAt:    sandboxLastSyncTimestamp(sandbox),
 	}
 }
 

--- a/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/mock/client.go
@@ -17,14 +17,14 @@ type Client struct {
 	Agents     map[string][]agents.AgentSummary
 	Details    map[string]agents.AgentDetail
 
-	ListNamespacesErr       error
-	ListAgentsErr           error
-	GetAgentErr             error
-	DeployAgentErr          error
-	StopAgentErr            error
-	StartAgentErr           error
-	RestartAgentErr         error
-	DeleteAgentErr          error
+	ListNamespacesErr error
+	ListAgentsErr     error
+	GetAgentErr       error
+	DeployAgentErr    error
+	StopAgentErr      error
+	StartAgentErr     error
+	RestartAgentErr   error
+	DeleteAgentErr    error
 }
 
 // NewClient returns a mock client with no data.

--- a/packages/agent-ops/bff/internal/integrations/agents/mock/demo_client.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/mock/demo_client.go
@@ -23,8 +23,8 @@ func NewDemoClient() *Client {
 				Ports: []agents.AgentServicePort{
 					{Name: "http", Port: 8080},
 				},
-				EndpointURL:  "http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080",
-				CreatedAt:    "2026-05-12T16:00:03.214610Z",
+				EndpointURL: "http://sample-support-agent.agent-ops-demo.svc.cluster.local:8080",
+				CreatedAt:   "2026-05-12T16:00:03.214610Z",
 			},
 		},
 	}

--- a/packages/agent-ops/bff/internal/integrations/agents/types.go
+++ b/packages/agent-ops/bff/internal/integrations/agents/types.go
@@ -9,21 +9,21 @@ type AgentList struct {
 
 // AgentSummary is a single agent in a list response.
 type AgentSummary struct {
-	Name         string
-	Namespace    string
-	DisplayName  string
-	Description  string
-	Framework    string
+	Name          string
+	Namespace     string
+	DisplayName   string
+	Description   string
+	Framework     string
 	Status        string
 	StatusMessage string
 	ResourceType  string
-	WorkloadType string
-	ServiceFQDN  string
-	PodIP        string
-	Ports        []AgentServicePort
-	EndpointURL  string
-	CreatedAt    string
-	LastSyncAt   string
+	WorkloadType  string
+	ServiceFQDN   string
+	PodIP         string
+	Ports         []AgentServicePort
+	EndpointURL   string
+	CreatedAt     string
+	LastSyncAt    string
 }
 
 // AgentDetail is the full workload view for one agent.

--- a/packages/agent-ops/bff/internal/mapper/agent.go
+++ b/packages/agent-ops/bff/internal/mapper/agent.go
@@ -23,20 +23,20 @@ func AgentSummaryToRuntime(item agents.AgentSummary) models.AgentRuntime {
 	}
 
 	return models.AgentRuntime{
-		Name:         item.Name,
-		Namespace:    item.Namespace,
-		DisplayName:  item.DisplayName,
-		Description:  item.Description,
-		Framework:    item.Framework,
+		Name:          item.Name,
+		Namespace:     item.Namespace,
+		DisplayName:   item.DisplayName,
+		Description:   item.Description,
+		Framework:     item.Framework,
 		Status:        strings.TrimSpace(item.Status),
 		StatusMessage: strings.TrimSpace(item.StatusMessage),
 		Type:          strings.TrimSpace(item.ResourceType),
-		ServiceFQDN:  strings.TrimSpace(item.ServiceFQDN),
-		PodIP:        strings.TrimSpace(item.PodIP),
-		Ports:        ports,
-		EndpointURL:  strings.TrimSpace(item.EndpointURL),
-		WorkloadType: strings.TrimSpace(item.WorkloadType),
-		LastSyncTime: lastSync,
+		ServiceFQDN:   strings.TrimSpace(item.ServiceFQDN),
+		PodIP:         strings.TrimSpace(item.PodIP),
+		Ports:         ports,
+		EndpointURL:   strings.TrimSpace(item.EndpointURL),
+		WorkloadType:  strings.TrimSpace(item.WorkloadType),
+		LastSyncTime:  lastSync,
 	}
 }
 

--- a/packages/agent-ops/bff/internal/mapper/agent_test.go
+++ b/packages/agent-ops/bff/internal/mapper/agent_test.go
@@ -101,8 +101,8 @@ func TestAgentSummaryToRuntime(t *testing.T) {
 		Ports: []agents.AgentServicePort{
 			{Name: "http", Port: 8080},
 		},
-		CreatedAt:    "2026-05-01T00:00:00Z",
-		LastSyncAt:   "2026-05-12T16:00:03.214610Z",
+		CreatedAt:  "2026-05-01T00:00:00Z",
+		LastSyncAt: "2026-05-12T16:00:03.214610Z",
 	}
 
 	runtime := AgentSummaryToRuntime(item)

--- a/packages/agent-ops/bff/internal/models/agent_runtime.go
+++ b/packages/agent-ops/bff/internal/models/agent_runtime.go
@@ -4,20 +4,20 @@ import "time"
 
 // AgentRuntime describes a deployed agent or tool runtime.
 type AgentRuntime struct {
-	Name         string                  `json:"name"`
-	Namespace    string                  `json:"namespace"`
-	DisplayName  string                  `json:"displayName"`
-	Description  string                  `json:"description"`
-	Framework    string                  `json:"framework,omitempty"`
-	Status        string                  `json:"status"`
-	StatusMessage string                  `json:"statusMessage,omitempty"`
-	Type          string                  `json:"type"`
-	ServiceFQDN  string                  `json:"serviceFqdn,omitempty"`
-	PodIP        string                  `json:"podIp,omitempty"`
-	Ports        []AgentServiceEndpoint  `json:"ports"`
-	EndpointURL  string                  `json:"endpointUrl,omitempty"`
-	WorkloadType string                  `json:"workloadType,omitempty"`
-	LastSyncTime time.Time               `json:"lastSyncTime"`
+	Name          string                 `json:"name"`
+	Namespace     string                 `json:"namespace"`
+	DisplayName   string                 `json:"displayName"`
+	Description   string                 `json:"description"`
+	Framework     string                 `json:"framework,omitempty"`
+	Status        string                 `json:"status"`
+	StatusMessage string                 `json:"statusMessage,omitempty"`
+	Type          string                 `json:"type"`
+	ServiceFQDN   string                 `json:"serviceFqdn,omitempty"`
+	PodIP         string                 `json:"podIp,omitempty"`
+	Ports         []AgentServiceEndpoint `json:"ports"`
+	EndpointURL   string                 `json:"endpointUrl,omitempty"`
+	WorkloadType  string                 `json:"workloadType,omitempty"`
+	LastSyncTime  time.Time              `json:"lastSyncTime"`
 }
 
 // AgentRuntimesResponse is the list payload for deployed agent runtimes.

--- a/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
+++ b/packages/agent-ops/bff/internal/repositories/agent_runtimes_test.go
@@ -44,7 +44,6 @@ func (nilAgentDetailClient) ListNamespaces(context.Context, bool) ([]string, err
 	return nil, nil
 }
 
-
 func (nilAgentDetailClient) ListAgents(context.Context, string) (*agents.AgentList, error) {
 	return nil, nil
 }
@@ -120,8 +119,8 @@ func (nilAgentDetailClient) DeployAgent(context.Context, *agents.DeployAgentPara
 }
 
 func (nilAgentDetailClient) DeleteAgent(context.Context, string, string) error  { return nil }
-func (nilAgentDetailClient) StopAgent(context.Context, string, string) error   { return nil }
-func (nilAgentDetailClient) StartAgent(context.Context, string, string) error  { return nil }
+func (nilAgentDetailClient) StopAgent(context.Context, string, string) error    { return nil }
+func (nilAgentDetailClient) StartAgent(context.Context, string, string) error   { return nil }
 func (nilAgentDetailClient) RestartAgent(context.Context, string, string) error { return nil }
 
 func TestPaginateAgentRuntimes(t *testing.T) {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79260

## Description

Several Go source files in `packages/agent-ops/bff/` were committed without running `go fmt` (introduced in #8615), causing struct field alignment and trailing whitespace inconsistencies. This results in spurious diffs whenever a developer workflow triggers `go fmt` (e.g. `make build`, `make test`, IDE auto-format).

This PR runs `go fmt ./...` on the BFF to fix 12 files. No functional changes — formatting only.

## How Has This Been Tested?

- Ran `go fmt ./...` in `packages/agent-ops/bff/` and verified only whitespace/alignment changes
- Confirmed `go vet ./...` passes

## Test Impact

No tests needed — this is a pure `go fmt` formatting fix with no behavioral changes.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized formatting and alignment across agent data structures, mappings, mock clients, and sample data.

* **Tests**
  * Reformatted test fixtures and helper methods for consistency.
  * No test logic, assertions, or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->