### PR TITLE
chore(RHOAIENG-78547): Add llmdTemplates feature flag to OdhDashboardConfig CRD

### DIFF
--- a/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -206,7 +206,6 @@ spec:
                       description: 'When true, disables the LLMd (Large Language Model daemon) serving features on KServe.'
                     llmdTemplates:
                       type: boolean
-                      default: false
                       description: 'When true, enables llm-d topology and routing configuration fields in the deployment wizard and admin settings pages. Tech Preview.'
                     deploymentWizardYAMLViewer:
                       type: boolean

--- a/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -204,6 +204,10 @@ spec:
                     disableLLMd:
                       type: boolean
                       description: 'When true, disables the LLMd (Large Language Model daemon) serving features on KServe.'
+                    llmdTemplates:
+                      type: boolean
+                      default: false
+                      description: 'When true, enables llm-d topology and routing configuration fields in the deployment wizard and admin settings pages. Tech Preview.'
                     deploymentWizardYAMLViewer:
                       type: boolean
                       description: 'When true, enables the YAML viewer in the model deployment wizard.'


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
https://issues.redhat.com/browse/RHOAIENG-78547

## Description

Follow-up to PR #8781 — adds the `llmdTemplates` feature flag to the OdhDashboardConfig CRD definition.

PR #8781 added `llmdTemplates` to the TypeScript `DashboardCommonConfig` type and gated the topology/routing wizard fields and admin pages behind it, but did not add it to the CRD. Per team guidance, CRD changes happen when the feature is ready for customers to opt in — this is now the case as signoffs are complete.

### Change

Added to `manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml`:
The flag defaults to false (disabled). Customers must explicitly set llmdTemplates: true in their OdhDashboardConfig to enable the llm-d topology/routing features. This follows the TP (Tech Preview) pattern — opt-in only.

### How Has This Been Tested?
CRD YAML validated for correct indentation and schema structure
Verified the field is placed alongside other llm-d flags (disableLLMd, llmGatewayField)
No runtime changes — this is a schema-only addition

### Test Impact
No test changes needed — the CRD schema addition has no runtime impact until a customer sets the flag to true, which is already covered by existing tests from PR #8781
### Request review criteria:
The developer has manually tested the changes and verified that the changes work
 Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
 The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
 The code follows our [Best Practices](vscode-file://vscode-app/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:

 The developer has tested their solution on a cluster by using the image produced by the PR to main]The developer has manually tested the changes and verified that the changes work
 Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
 The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
 The code follows our [Best Practices](vscode-file://vscode-app/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:

 The developer has tested their solution on a cluster by using the image produced by the PR to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Tech Preview feature flag to enable LLMd topology and routing configuration options in the deployment wizard and administrator settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->