### PR TITLE
fix(RHOAIENG-79268): target TypeaheadSelect toggle in E2E connection type dropdown

### DIFF
--- a/packages/cypress/cypress/pages/connections.ts
+++ b/packages/cypress/cypress/pages/connections.ts
@@ -48,7 +48,9 @@ class ConnectionModal extends Modal {
   }
 
   findConnectionTypeDropdown() {
-    return this.find().findByTestId('connection-type-dropdown');
+    return this.find()
+      .findByTestId('connection-type-dropdown')
+      .findByTestId('typeahead-menu-toggle');
   }
 
   findConnectionTypeOption(name: string | RegExp) {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79268

## Description

PR #8791 added a `labelHelp` Popover to the "Connection type" `FormGroup` in `ConnectionTypeForm.tsx`. The `data-testid="connection-type-dropdown"` is on the `FormGroup` wrapper element, and the E2E page object `findConnectionTypeDropdown()` targets this wrapper and calls `.click()` on it.

With the Popover icon button now inside the `FormGroup`, the Cypress `.click()` on the container hits the Popover icon instead of the `TypeaheadSelect` toggle, so the dropdown never opens. The subsequent `findByText('S3 compatible object storage - v1')` then times out, failing the test.

This fix scopes the selector to the actual `typeahead-menu-toggle` element inside the `FormGroup`, so the click always lands on the dropdown toggle.

**5 E2E tests are affected** (all go through the same page object method):
- `testConnectionCreation.cy.ts`
- `testCreateConnectionTypes.cy.ts`
- `testDeployOCIModel.cy.ts`
- `testWorkbenchCreation.cy.ts`

## How Has This Been Tested?

- Verified the connection type dropdown and S3 option are present on the `dash-e2e-int` cluster
- Confirmed the `typeahead-menu-toggle` data-testid is rendered by the `TypeaheadSelect` component (default in `packages/ui-core/src/components/TypeaheadSelect.tsx:426`)

## Test Impact

- This PR fixes the E2E page object only — no product code changes
- No new tests needed; the existing 5 E2E tests that use `findConnectionTypeDropdown()` will pass once the selector targets the correct element

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test interactions with the connection type dropdown for more reliable selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->