### PR TITLE
fix(e2e): prevent MLflow test failures on re-runs from stale name collisions

### DIFF
--- a/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
@@ -4,6 +4,7 @@ import {
   disableMlflowFeatures,
   createMlflowExperimentViaAPI,
   deleteMlflowExperimentViaAPI,
+  findAvailableExperimentSuffix,
   getMlflowExperimentIdByName,
   logMlflowRunsViaAPI,
 } from '../../../utils/oc_commands/mlflow';
@@ -18,6 +19,7 @@ import type { MlflowExperimentsTestData } from '../../../types';
 describe('Verify MLflow Experiments page', () => {
   let testData: MlflowExperimentsTestData;
   let projectName: string;
+  let testSuffix: string;
   let runsExperimentId: string | undefined;
   let uiExperimentName: string | undefined;
   let uiExperimentDeleted = false;
@@ -34,6 +36,20 @@ describe('Verify MLflow Experiments page', () => {
       .then(() => {
         cy.step('Enable all features required for MLflow Experiments');
         return enableMlflowFeatures();
+      })
+      .then(() => {
+        cy.step('Find available experiment suffix to avoid stale name collisions');
+        const allBaseNames = [
+          testData.experiments[0].name,
+          testData.experiments[0].renamedName,
+          testData.experiments[1].name,
+        ];
+        return findAvailableExperimentSuffix(projectName, allBaseNames, uuid).then((suffix) => {
+          testSuffix = suffix;
+          if (suffix !== uuid) {
+            cy.log(`UUID ${uuid} had collisions, using suffix ${suffix} instead`);
+          }
+        });
       });
   });
 
@@ -59,10 +75,10 @@ describe('Verify MLflow Experiments page', () => {
     },
     () => {
       const experiment = testData.experiments[0];
-      const experimentName = `${experiment.name}-${uuid}`;
+      const experimentName = `${experiment.name}-${testSuffix}`;
       uiExperimentName = experimentName;
-      const renamedExperimentName = `${experiment.renamedName}-${uuid}`;
-      const runsExperimentName = `${testData.experiments[1].name}-${uuid}`;
+      const renamedExperimentName = `${experiment.renamedName}-${testSuffix}`;
+      const runsExperimentName = `${testData.experiments[1].name}-${testSuffix}`;
       const [run1, run2] = testData.runs;
 
       // =======================================================================

--- a/packages/cypress/cypress/tests/e2e/promptManagement/testPromptManagement.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/promptManagement/testPromptManagement.cy.ts
@@ -2,6 +2,8 @@ import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
 import {
   enablePromptManagementFeatures,
   disablePromptManagementFeatures,
+  deleteStalePromptByName,
+  findAvailablePromptSuffix,
 } from '../../../utils/oc_commands/mlflow';
 import { deleteOpenShiftProject, createOpenShiftProject } from '../../../utils/oc_commands/project';
 import { retryableBefore } from '../../../utils/retryableHooks';
@@ -14,6 +16,7 @@ import type { PromptManagementTestData } from '../../../types';
 describe('Verify Prompt Management page', () => {
   let testData: PromptManagementTestData;
   let projectName: string;
+  let testSuffix: string;
   const uuid = generateTestUUID();
 
   retryableBefore(() => {
@@ -27,10 +30,25 @@ describe('Verify Prompt Management page', () => {
       .then(() => {
         cy.step('Enable all features required for Prompt Management');
         return enablePromptManagementFeatures();
+      })
+      .then(() => {
+        cy.step('Clean up stale prompts from prior runs');
+        return deleteStalePromptByName(projectName, `${testData.prompts[0].name}-${uuid}`);
+      })
+      .then(() => {
+        cy.step('Find available prompt suffix to avoid stale name collisions');
+        const allBaseNames = [testData.prompts[0].name];
+        return findAvailablePromptSuffix(projectName, allBaseNames, uuid).then((suffix) => {
+          testSuffix = suffix;
+          if (suffix !== uuid) {
+            cy.log(`UUID ${uuid} had collisions, using suffix ${suffix} instead`);
+          }
+        });
       });
   });
 
   after(() => {
+    deleteStalePromptByName(projectName, `${testData.prompts[0].name}-${testSuffix}`);
     disablePromptManagementFeatures();
     deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
   });
@@ -42,6 +60,7 @@ describe('Verify Prompt Management page', () => {
     },
     () => {
       const prompt = testData.prompts[0];
+      const promptName = `${prompt.name}-${testSuffix}`;
 
       cy.step('Log into the application');
       cy.visitWithLogin('/?devFeatureFlags=genAiStudio=true', HTPASSWD_CLUSTER_ADMIN_USER);
@@ -63,7 +82,7 @@ describe('Verify Prompt Management page', () => {
       promptManagement.findCreatePromptButton().click();
 
       cy.step('Fill in prompt name');
-      promptManagement.findPromptNameInput().should('be.visible').type(prompt.name);
+      promptManagement.findPromptNameInput().should('be.visible').type(promptName);
 
       cy.step('Fill in prompt template');
       promptManagement
@@ -78,7 +97,7 @@ describe('Verify Prompt Management page', () => {
       promptManagement.findCreateDialogSubmitButton().click();
 
       cy.step('Verify the prompt detail page is shown');
-      promptManagement.findPromptDetailHeading(prompt.name).should('be.visible');
+      promptManagement.findPromptDetailHeading(promptName).should('be.visible');
       promptManagement.findCreatePromptVersionButton().should('be.visible');
 
       cy.step('Verify Version 1 appears in the versions table');
@@ -118,7 +137,7 @@ describe('Verify Prompt Management page', () => {
       promptManagement.visit(projectName);
 
       cy.step('Verify the prompt persists after navigation');
-      promptManagement.findPromptInTable(prompt.name).should('be.visible');
+      promptManagement.findPromptInTable(promptName).should('be.visible');
     },
   );
 });

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -551,6 +551,7 @@ const execCurlInMlflowPod = (
   endpoint: string,
   body: object,
   workspace: string,
+  method: 'POST' | 'DELETE' = 'POST',
 ): Cypress.Chainable<string> => {
   const namespace = getApplicationsNamespace();
   const bodyJson = JSON.stringify(body);
@@ -561,11 +562,36 @@ const execCurlInMlflowPod = (
       `printf '%s' '${escapedBody}'`,
       '|',
       `oc exec -n ${namespace} -i ${podName} -c mlflow --`,
-      `curl -sk -X POST 'https://localhost:8443/mlflow${endpoint}'`,
+      `curl -sk -X ${method} 'https://localhost:8443/mlflow${endpoint}'`,
       `-H 'Content-Type: application/json'`,
       `-H "Authorization: Bearer $(oc whoami -t)"`,
       `-H 'X-MLFLOW-WORKSPACE: ${ns}'`,
       `--data-binary @-`,
+    ].join(' ');
+    return cy.exec(cmd, { timeout: 30000, log: false }).then((result) => result.stdout.trim());
+  });
+};
+
+/**
+ * Execute a GET request inside the MLflow pod against the tracking server.
+ */
+const execGetInMlflowPod = (
+  endpoint: string,
+  queryParams: Record<string, string>,
+  workspace: string,
+): Cypress.Chainable<string> => {
+  const namespace = getApplicationsNamespace();
+  const qs = Object.entries(queryParams)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+  const url = `https://localhost:8443/mlflow${endpoint}${qs ? `?${qs}` : ''}`;
+  return getMlflowPodName().then((podName) => {
+    const ns = assertNamespace(workspace);
+    const cmd = [
+      `oc exec -n ${namespace} -i ${podName} -c mlflow --`,
+      `curl -sk '${url}'`,
+      `-H "Authorization: Bearer $(oc whoami -t)"`,
+      `-H 'X-MLFLOW-WORKSPACE: ${ns}'`,
     ].join(' ');
     return cy.exec(cmd, { timeout: 30000, log: false }).then((result) => result.stdout.trim());
   });
@@ -666,6 +692,144 @@ export const getMlflowExperimentIdByName = (
   });
 
 /**
+ * Check whether an MLflow experiment name is taken, including soft-deleted
+ * experiments. MLflow's standard get-by-name only returns active experiments,
+ * but a soft-deleted experiment still reserves the name.
+ */
+export const doesMlflowExperimentNameExist = (
+  workspace: string,
+  experimentName: string,
+): Cypress.Chainable<boolean> =>
+  execCurlInMlflowPod(
+    '/api/2.0/mlflow/experiments/search',
+    // eslint-disable-next-line camelcase
+    { filter: `name = '${experimentName}'`, view_type: 'ALL', max_results: 10 },
+    workspace,
+  ).then((response) => {
+    try {
+      const experiments = JSON.parse(response)?.experiments ?? [];
+      return experiments.length > 0;
+    } catch {
+      return false;
+    }
+  });
+
+/**
+ * Find a test suffix that does not collide with any existing (active or
+ * soft-deleted) MLflow experiment. Checks every name in `baseNames` for a
+ * given suffix and increments until all names are available.
+ */
+export const findAvailableExperimentSuffix = (
+  workspace: string,
+  baseNames: string[],
+  startSuffix: string,
+  attempt = 0,
+): Cypress.Chainable<string> => {
+  if (attempt >= 20) {
+    throw new Error(
+      `Could not find available experiment suffix after ${attempt} attempts ` +
+        `(last tried: ${startSuffix})`,
+    );
+  }
+  const results: boolean[] = [];
+  return baseNames
+    .reduce<Cypress.Chainable<boolean>>(
+      (prev, name) =>
+        prev.then(() =>
+          doesMlflowExperimentNameExist(workspace, `${name}-${startSuffix}`).then(
+            (exists: boolean) => {
+              results.push(exists);
+              return exists;
+            },
+          ),
+        ),
+      cy.wrap(false),
+    )
+    .then(() => {
+      if (!results.some(Boolean)) {
+        return cy.wrap(startSuffix);
+      }
+      const taken = baseNames.filter((_, i) => results[i]);
+      cy.log(`Suffix ${startSuffix} collides on: ${taken.join(', ')}. Trying next suffix.`);
+      const next = String(Number(startSuffix) + 1).padStart(startSuffix.length, '0');
+      return findAvailableExperimentSuffix(workspace, baseNames, next, attempt + 1);
+    });
+};
+
+/**
+ * Delete an MLflow prompt (registered model) by name if it exists.
+ * Silently succeeds when the prompt is not found.
+ * Uses DELETE method — POST to this endpoint returns ENDPOINT_NOT_FOUND.
+ */
+export const deleteStalePromptByName = (
+  workspace: string,
+  promptName: string,
+): Cypress.Chainable<string> =>
+  execCurlInMlflowPod(
+    '/api/2.0/mlflow/registered-models/delete',
+    { name: promptName },
+    workspace,
+    'DELETE',
+  );
+
+/**
+ * Check whether an MLflow prompt (registered model) with the given name exists.
+ * Uses GET — the POST search endpoint returns ENDPOINT_NOT_FOUND on this server.
+ */
+export const doesMlflowPromptNameExist = (
+  workspace: string,
+  promptName: string,
+): Cypress.Chainable<boolean> =>
+  execGetInMlflowPod('/api/2.0/mlflow/registered-models/get', { name: promptName }, workspace).then(
+    (response) => {
+      try {
+        return !!JSON.parse(response)?.registered_model;
+      } catch {
+        return false;
+      }
+    },
+  );
+
+/**
+ * Find a test suffix that does not collide with any existing MLflow prompt
+ * (registered model). Same approach as findAvailableExperimentSuffix.
+ */
+export const findAvailablePromptSuffix = (
+  workspace: string,
+  baseNames: string[],
+  startSuffix: string,
+  attempt = 0,
+): Cypress.Chainable<string> => {
+  if (attempt >= 20) {
+    throw new Error(
+      `Could not find available prompt suffix after ${attempt} attempts ` +
+        `(last tried: ${startSuffix})`,
+    );
+  }
+  const results: boolean[] = [];
+  return baseNames
+    .reduce<Cypress.Chainable<boolean>>(
+      (prev, name) =>
+        prev.then(() =>
+          doesMlflowPromptNameExist(workspace, `${name}-${startSuffix}`).then((exists: boolean) => {
+            results.push(exists);
+            return exists;
+          }),
+        ),
+      cy.wrap(false),
+    )
+    .then(() => {
+      if (!results.some(Boolean)) {
+        return cy.wrap(startSuffix);
+      }
+      const taken = baseNames.filter((_, i) => results[i]);
+      cy.log(`Suffix ${startSuffix} collides on: ${taken.join(', ')}. Trying next suffix.`);
+      const next = String(Number(startSuffix) + 1).padStart(startSuffix.length, '0');
+      return findAvailablePromptSuffix(workspace, baseNames, next, attempt + 1);
+    });
+};
+
+/**
  * Log multiple runs sequentially under a single experiment.
  *
  * @param workspace - Namespace to scope the runs to.
@@ -686,7 +850,7 @@ export const logMlflowRunsViaAPI = (
       return cy.wrap(collected);
     }
     const [run, ...rest] = remaining;
-    return logMlflowRunViaAPI(workspace, experimentId, run).then((runId) =>
+    return logMlflowRunViaAPI(workspace, experimentId, run).then((runId: string) =>
       logNext(rest, [...collected, runId]),
     );
   };


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79267

  ## Description

  MLflow E2E tests (`testMlflowExperiments` and `testPromptManagement`) fail on re-runs because resource names from prior runs are still reserved.

  **Root cause:** MLflow soft-deletes experiments, so the name stays permanently reserved even after the delete API call. The `doesMlflowExperimentNameExist` helper was using the `experiments/search` API without an explicit `max_results` parameter, which defaults to `0`
  on this server and returns an `INVALID_PARAMETER_VALUE` error. The `catch` block silently treated this error as "name available," so collision detection never worked.

  **Changes:**

  - **`mlflow.ts`**: Add `max_results: 10` to the experiment search request so collision detection works correctly. Add `execGetInMlflowPod` for GET-based API calls (the registered-models endpoint requires GET, not POST). Add `doesMlflowExperimentNameExist`,
  `findAvailableExperimentSuffix`, `deleteStalePromptByName`, `doesMlflowPromptNameExist`, and `findAvailablePromptSuffix` utilities. Add `method` parameter to `execCurlInMlflowPod` (prompts require DELETE, not POST).
  - **`testMlflowExperiments.cy.ts`**: Use `findAvailableExperimentSuffix` in `retryableBefore` to detect stale name collisions and auto-increment the suffix. All three experiment names (create, rename, compare) are checked.
  - **`testPromptManagement.cy.ts`**: Use `deleteStalePromptByName` to clean up prior runs, then `findAvailablePromptSuffix` for collision detection. Prompts support permanent delete so names can be freed, but suffix detection is still used as a safety net.

  ## How Has This Been Tested?

  Ran both E2E test suites twice each on the `dash-e2e-odh.osp.rh-ods.com` cluster to verify re-run stability:

  - `testPromptManagement.cy.ts`: run 1 pass, run 2 pass
  - `testMlflowExperiments.cy.ts`: run 1 pass, run 2 pass

  Also verified via direct `curl` commands inside the MLflow pod that `max_results: 10` correctly returns soft-deleted experiments with `view_type: ALL`, and that the `permanently-delete` endpoint is not available on this server (confirming the suffix-increment approach
  is necessary).

  ## Test Impact

  This PR modifies E2E test infrastructure only, no product code changes. The changes fix existing tests to be re-runnable; no new test scenarios were added.

  ## Request review criteria:

  Self checklist (all need to be checked):
  - [x] The developer has manually tested the changes and verified that the changes work
  - [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
  - [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
  - [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

  After the PR is posted & before it merges:
  - [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated experiment and prompt management workflows by preventing naming conflicts with existing or stale entries.
  * Added cleanup support for stale prompts before test execution.

* **Tests**
  * Updated end-to-end validation to use collision-free names consistently across creation, renaming, assertions, and cleanup.
  * Added checks for existing experiments and prompts, including soft-deleted entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->