### PR TITLE
ignore all dependabot patternfly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,16 +39,13 @@ updates:
       semver-patch-days: 14
 
     ignore:
+      - dependency-name: "@patternfly/*"
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
 
     groups:
-      patternfly:
-        applies-to: version-updates
-        patterns:
-          - "@patternfly/*"
       react:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
Updates dependabot config to ignore patternfly altogether until we manually update patternfly and fix the sharing of all patternfly packages with module federation.

Bumping patternfly can inadvertently bringing in multiple copies of the patternfly css and cause visual issues as we've recently seen in the past.

The dependabot auto merge workflow was disabled until we address patternfly. It was expected to be a short timeframe but now we are piling up on dependency updates and it's best to just ignore the problematic patternfly updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings for PatternFly packages.
  * Removed the dedicated PatternFly dependency grouping configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->