### PR TITLE
fixSelect default deployment method for generative models in wizard

### DIFF
--- a/packages/kserve/src/wizardFields/__tests__/deploymentMethodField.spec.ts
+++ b/packages/kserve/src/wizardFields/__tests__/deploymentMethodField.spec.ts
@@ -1,0 +1,53 @@
+import {
+  legacyDeploymentMethodOverride,
+  LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY,
+} from '../deploymentMethodField';
+
+describe('legacyDeploymentMethodOverride', () => {
+  it('should have id "deploymentMethod"', () => {
+    expect(legacyDeploymentMethodOverride.id).toBe('deploymentMethod');
+  });
+
+  it('should always be active', () => {
+    expect(legacyDeploymentMethodOverride.isActive({})).toBe(true);
+  });
+
+  it('should expose the legacy option with order 3', () => {
+    expect(legacyDeploymentMethodOverride.options).toHaveLength(1);
+    expect(legacyDeploymentMethodOverride.options[0].key).toBe(
+      LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY,
+    );
+    expect(legacyDeploymentMethodOverride.options[0].order).toBe(3);
+  });
+
+  describe('suggestion', () => {
+    it('should suggest legacy when isLLMdDefault is false', () => {
+      const result = legacyDeploymentMethodOverride.suggestion?.({ isLLMdDefault: false });
+      expect(result).toBeDefined();
+      expect(result?.key).toBe(LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY);
+    });
+
+    it('should suggest legacy when isLLMdDefault is undefined', () => {
+      const result = legacyDeploymentMethodOverride.suggestion?.({});
+      expect(result).toBeDefined();
+      expect(result?.key).toBe(LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY);
+    });
+
+    it('should suggest legacy when clusterSettings is null', () => {
+      const result = legacyDeploymentMethodOverride.suggestion?.(null);
+      expect(result).toBeDefined();
+      expect(result?.key).toBe(LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY);
+    });
+
+    it('should suggest legacy when clusterSettings is undefined', () => {
+      const result = legacyDeploymentMethodOverride.suggestion?.(undefined);
+      expect(result).toBeDefined();
+      expect(result?.key).toBe(LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY);
+    });
+
+    it('should not suggest legacy when isLLMdDefault is true', () => {
+      const result = legacyDeploymentMethodOverride.suggestion?.({ isLLMdDefault: true });
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/kserve/src/wizardFields/deploymentMethodField.ts
+++ b/packages/kserve/src/wizardFields/deploymentMethodField.ts
@@ -2,17 +2,18 @@ import type { DeploymentMethodFieldOverride } from '@odh-dashboard/model-serving
 
 export const LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY = 'legacy';
 
+const LEGACY_OPTION = {
+  key: LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY,
+  label: 'Legacy deployment',
+  description:
+    'Deploy using a serving runtime template. Use this option for non-LLM models or for compatibility with previous deployments. This method does not support Models as a Service.',
+  order: 3,
+};
+
 export const legacyDeploymentMethodOverride: DeploymentMethodFieldOverride = {
   id: 'deploymentMethod',
   type: 'modifier',
   isActive: () => true,
-  options: [
-    {
-      key: LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY,
-      label: 'Legacy deployment',
-      description:
-        'Deploy using a serving runtime template. Use this option for non-LLM models or for compatibility with previous deployments. This method does not support Models as a Service.',
-      order: 3,
-    },
-  ],
+  options: [LEGACY_OPTION],
+  suggestion: (clusterSettings) => (!clusterSettings?.isLLMdDefault ? LEGACY_OPTION : undefined),
 };

--- a/packages/llmd-serving/src/wizardFields/__tests__/deploymentMethodField.spec.ts
+++ b/packages/llmd-serving/src/wizardFields/__tests__/deploymentMethodField.spec.ts
@@ -1,0 +1,94 @@
+import type { RecursivePartial } from '@odh-dashboard/foundation';
+import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
+import {
+  vllmDeploymentMethodOverride,
+  llmdDeploymentMethodOverride,
+  SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY,
+  LLMD_DEPLOYMENT_METHOD_KEY,
+} from '../deploymentMethodField';
+
+const mockWizardState: RecursivePartial<WizardFormData['state']> = {};
+
+describe('vllmDeploymentMethodOverride', () => {
+  it('should have id "deploymentMethod"', () => {
+    expect(vllmDeploymentMethodOverride.id).toBe('deploymentMethod');
+  });
+
+  it('should always be active', () => {
+    expect(vllmDeploymentMethodOverride.isActive(mockWizardState)).toBe(true);
+  });
+
+  it('should expose the simple vLLM option', () => {
+    expect(vllmDeploymentMethodOverride.options).toHaveLength(1);
+    expect(vllmDeploymentMethodOverride.options[0].key).toBe(SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY);
+  });
+
+  describe('suggestion', () => {
+    it('should suggest simple vLLM when isLLMdDefault is false', () => {
+      const result = vllmDeploymentMethodOverride.suggestion?.({ isLLMdDefault: false });
+      expect(result).toBeDefined();
+      expect(result?.key).toBe(SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY);
+    });
+
+    it('should suggest simple vLLM when isLLMdDefault is undefined', () => {
+      const result = vllmDeploymentMethodOverride.suggestion?.({});
+      expect(result).toBeDefined();
+      expect(result?.key).toBe(SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY);
+    });
+
+    it('should suggest simple vLLM when clusterSettings is null', () => {
+      const result = vllmDeploymentMethodOverride.suggestion?.(null);
+      expect(result).toBeDefined();
+      expect(result?.key).toBe(SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY);
+    });
+
+    it('should suggest simple vLLM when clusterSettings is undefined', () => {
+      const result = vllmDeploymentMethodOverride.suggestion?.(undefined);
+      expect(result).toBeDefined();
+      expect(result?.key).toBe(SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY);
+    });
+
+    it('should not suggest simple vLLM when isLLMdDefault is true', () => {
+      const result = vllmDeploymentMethodOverride.suggestion?.({ isLLMdDefault: true });
+      expect(result).toBeUndefined();
+    });
+  });
+});
+
+describe('llmdDeploymentMethodOverride', () => {
+  it('should have id "deploymentMethod"', () => {
+    expect(llmdDeploymentMethodOverride.id).toBe('deploymentMethod');
+  });
+
+  it('should always be active', () => {
+    expect(llmdDeploymentMethodOverride.isActive(mockWizardState)).toBe(true);
+  });
+
+  it('should expose the llm-d option', () => {
+    expect(llmdDeploymentMethodOverride.options).toHaveLength(1);
+    expect(llmdDeploymentMethodOverride.options[0].key).toBe(LLMD_DEPLOYMENT_METHOD_KEY);
+  });
+
+  describe('suggestion', () => {
+    it('should suggest llm-d when isLLMdDefault is true', () => {
+      const result = llmdDeploymentMethodOverride.suggestion?.({ isLLMdDefault: true });
+      expect(result).toBeDefined();
+      expect(result?.key).toBe(LLMD_DEPLOYMENT_METHOD_KEY);
+    });
+
+    it('should not suggest llm-d when isLLMdDefault is false', () => {
+      const result = llmdDeploymentMethodOverride.suggestion?.({ isLLMdDefault: false });
+      expect(result).toBeUndefined();
+    });
+
+    it('should not suggest llm-d when clusterSettings is null', () => {
+      const result = llmdDeploymentMethodOverride.suggestion?.(null);
+      expect(result).toBeUndefined();
+    });
+
+    it('should not suggest llm-d when clusterSettings is undefined', () => {
+      const result = llmdDeploymentMethodOverride.suggestion?.(undefined);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/llmd-serving/src/wizardFields/deploymentMethodField.ts
+++ b/packages/llmd-serving/src/wizardFields/deploymentMethodField.ts
@@ -19,6 +19,8 @@ export const vllmDeploymentMethodOverride: DeploymentMethodFieldOverride = {
   type: 'modifier',
   isActive: () => true,
   options: [SIMPLE_VLLM_OPTION],
+  suggestion: (clusterSettings) =>
+    !clusterSettings?.isLLMdDefault ? SIMPLE_VLLM_OPTION : undefined,
 };
 
 // LLM-d

--- a/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
@@ -11,8 +11,12 @@ import {
 import { z } from 'zod';
 import type { RecursivePartial } from '@odh-dashboard/foundation';
 import { ServingRuntimeModelType } from '@odh-dashboard/model-serving/shared';
-import { useModelServingClusterSettings } from '../../../concepts/useModelServingClusterSettings';
 import {
+  useModelServingClusterSettings,
+  type ModelServingClusterSettings,
+} from '../../../concepts/useModelServingClusterSettings';
+import {
+  type DeploymentMethodFieldOverride,
   type DeploymentMethodOption,
   type WizardField,
   type WizardFormData,
@@ -36,6 +40,21 @@ export type DeploymentMethodExternalData = {
   suggestion?: DeploymentMethodOption;
 };
 
+export const resolveDeploymentMethodSuggestion = (
+  overrides: DeploymentMethodFieldOverride[],
+  clusterSettings: ModelServingClusterSettings | null | undefined,
+): DeploymentMethodOption | undefined =>
+  overrides.reduce<DeploymentMethodOption | undefined>((acc, override) => {
+    const s = override.suggestion?.(clusterSettings);
+    if (!s) {
+      return acc;
+    }
+    if (!acc) {
+      return s;
+    }
+    return s.order < acc.order ? s : acc;
+  }, undefined);
+
 export const useDeploymentMethodExternalData = (): {
   data: DeploymentMethodExternalData;
   loaded: boolean;
@@ -53,10 +72,7 @@ export const useDeploymentMethodExternalData = (): {
     const options = overrides
       .flatMap((override) => override.options)
       .toSorted((a, b) => a.order - b.order);
-    const suggestion = overrides.reduce<DeploymentMethodOption | undefined>(
-      (acc, override) => acc ?? override.suggestion?.(modelServingClusterSettings),
-      undefined,
-    );
+    const suggestion = resolveDeploymentMethodSuggestion(overrides, modelServingClusterSettings);
 
     return {
       data: { options, suggestion },

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
@@ -4,9 +4,11 @@ import '@testing-library/jest-dom';
 import { fireDeployMethodSelected } from '../../../../shared/tracking/modelServingTrackingConstants';
 import {
   DeploymentMethodSelectFieldWizardField,
+  resolveDeploymentMethodSuggestion,
   type DeploymentMethodExternalData,
   type DeploymentMethodFieldData,
 } from '../DeploymentMethodSelectField';
+import type { DeploymentMethodFieldOverride } from '../../../../shared/types/form-data';
 
 jest.mock('../../../../shared/tracking/modelServingTrackingConstants', () => ({
   fireDeployMethodSelected: jest.fn(),
@@ -15,6 +17,89 @@ jest.mock('../../../../shared/tracking/modelServingTrackingConstants', () => ({
 const mockFireDeployMethodSelected = jest.mocked(fireDeployMethodSelected);
 
 const DeploymentMethodSelectFieldComponent = DeploymentMethodSelectFieldWizardField.component;
+
+const vllmOption = { key: 'vllm', label: 'LLM inference service', description: '', order: 1 };
+const llmdOption = { key: 'llmd', label: 'llm-d', description: '', order: 2 };
+const legacyOption = { key: 'legacy', label: 'Legacy', description: '', order: 3 };
+
+const makeOverride = (
+  option: { key: string; label: string; description: string; order: number },
+  suggestion?: DeploymentMethodFieldOverride['suggestion'],
+): DeploymentMethodFieldOverride => ({
+  id: 'deploymentMethod',
+  type: 'modifier',
+  isActive: () => true,
+  options: [option],
+  suggestion,
+});
+
+describe('resolveDeploymentMethodSuggestion', () => {
+  it('should pick the suggestion with the lowest order when multiple suggest', () => {
+    const overrides = [
+      makeOverride(legacyOption, () => legacyOption),
+      makeOverride(vllmOption, () => vllmOption),
+    ];
+    expect(resolveDeploymentMethodSuggestion(overrides, null)?.key).toBe('vllm');
+  });
+
+  it('should return the only suggestion when just one override suggests', () => {
+    const overrides = [
+      makeOverride(vllmOption, () => undefined),
+      makeOverride(legacyOption, () => legacyOption),
+    ];
+    expect(resolveDeploymentMethodSuggestion(overrides, null)?.key).toBe('legacy');
+  });
+
+  it('should return undefined when no overrides suggest', () => {
+    const overrides = [
+      makeOverride(vllmOption, () => undefined),
+      makeOverride(legacyOption, () => undefined),
+    ];
+    expect(resolveDeploymentMethodSuggestion(overrides, null)).toBeUndefined();
+  });
+
+  it('should return undefined for empty overrides', () => {
+    expect(resolveDeploymentMethodSuggestion([], null)).toBeUndefined();
+  });
+
+  it('3 options, isLLMdDefault OFF: vLLM wins over legacy', () => {
+    const overrides = [
+      makeOverride(vllmOption, (cs) => (!cs?.isLLMdDefault ? vllmOption : undefined)),
+      makeOverride(llmdOption, (cs) => (cs?.isLLMdDefault ? llmdOption : undefined)),
+      makeOverride(legacyOption, (cs) => (!cs?.isLLMdDefault ? legacyOption : undefined)),
+    ];
+    expect(resolveDeploymentMethodSuggestion(overrides, { isLLMdDefault: false })?.key).toBe(
+      'vllm',
+    );
+  });
+
+  it('3 options, isLLMdDefault ON: llm-d wins', () => {
+    const overrides = [
+      makeOverride(vllmOption, (cs) => (!cs?.isLLMdDefault ? vllmOption : undefined)),
+      makeOverride(llmdOption, (cs) => (cs?.isLLMdDefault ? llmdOption : undefined)),
+      makeOverride(legacyOption, (cs) => (!cs?.isLLMdDefault ? legacyOption : undefined)),
+    ];
+    expect(resolveDeploymentMethodSuggestion(overrides, { isLLMdDefault: true })?.key).toBe('llmd');
+  });
+
+  it('2 options (no vLLM), isLLMdDefault OFF: legacy wins', () => {
+    const overrides = [
+      makeOverride(llmdOption, (cs) => (cs?.isLLMdDefault ? llmdOption : undefined)),
+      makeOverride(legacyOption, (cs) => (!cs?.isLLMdDefault ? legacyOption : undefined)),
+    ];
+    expect(resolveDeploymentMethodSuggestion(overrides, { isLLMdDefault: false })?.key).toBe(
+      'legacy',
+    );
+  });
+
+  it('2 options (no vLLM), isLLMdDefault ON: llm-d wins', () => {
+    const overrides = [
+      makeOverride(llmdOption, (cs) => (cs?.isLLMdDefault ? llmdOption : undefined)),
+      makeOverride(legacyOption, (cs) => (!cs?.isLLMdDefault ? legacyOption : undefined)),
+    ];
+    expect(resolveDeploymentMethodSuggestion(overrides, { isLLMdDefault: true })?.key).toBe('llmd');
+  });
+});
 
 describe('DeploymentMethodSelectField tracking', () => {
   const mockOnChange = jest.fn();


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79257

## Description

When deploying a generative model via the wizard, no deployment method was pre-selected. The user had to manually choose between "LLM inference service" and "llm-d".

The root cause was that `vllmDeploymentMethodOverride` in `packages/llmd-serving/src/wizardFields/deploymentMethodField.ts` had no `suggestion` function. When `isLLMdDefault` was false, no suggestion was produced and `getInitialFieldData` defaulted to an empty method string.

Added a `suggestion` function to `vllmDeploymentMethodOverride` that returns `SIMPLE_VLLM_OPTION` when `isLLMdDefault` is not true. This mirrors the existing pattern in `llmdDeploymentMethodOverride` and ensures:
- "LLM inference service" is selected by default when llm-d default is OFF
- "llm-d" is selected by default when the admin toggles llm-d default ON
- There is always a default selection for generative models

## How Has This Been Tested? 
Default legacy option 

https://github.com/user-attachments/assets/00ae41ca-0411-4468-bfa3-890d459b03f4

Inference without llmd deployment 

https://github.com/user-attachments/assets/4e2884b3-9120-4c02-b215-3760d2f435c9

Llmd default 

https://github.com/user-attachments/assets/c6ae00ba-11ad-415a-9a3f-ef93a6d50436



Ran lint, type-check, and full unit test suite for the llmd-serving package. All 25 test suites (258 tests) pass.


## Test Impact

Added `deploymentMethodField.spec.ts` with 15 tests covering both `vllmDeploymentMethodOverride` and `llmdDeploymentMethodOverride` suggestion logic across all cluster settings scenarios (isLLMdDefault true/false/undefined, null/undefined clusterSettings).

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our Best Practices (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved deployment-method wizard suggestions with configuration-aware behavior across vLLM, llm-d, and legacy options.
  * When multiple suggestions are available, the wizard now consistently selects the one with the highest priority (lowest order).
* **Tests**
  * Added/expanded Jest coverage for both vLLM and llm-d/legacy wizard overrides, including activation, option metadata, and suggestion rules.
  * Updated deployment wizard tests to validate cross-override suggestion selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->