### PR TITLE
Remove 'platform.opendatahub.io/part-of' label when creating admin llmiscfg

### DIFF
--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -210,14 +210,10 @@ const RoutingConfigurationCreateEditInner: React.FC<{
     if (existingConfig) {
       return YAML.stringify(existingConfig);
     }
-    if (state?.sourceConfig) {
+    if (isDuplicateMode) {
       const cleanMeta = cleanResourceForYAMLViewer(state.sourceConfig.metadata);
-      let cleanAnnotations = cleanMeta.annotations;
-      let cleanLabels = cleanMeta.labels;
-      if (isDuplicateMode) {
-        cleanAnnotations = stripDuplicatingAnnotations(cleanMeta.annotations);
-        cleanLabels = stripDuplicatingLabels(cleanMeta.labels);
-      }
+      const cleanAnnotations = stripDuplicatingAnnotations(cleanMeta.annotations);
+      const cleanLabels = stripDuplicatingLabels(cleanMeta.labels);
       const duplicateDisplayName = `Copy of ${getDisplayNameFromK8sResource(state.sourceConfig)}`;
       return YAML.stringify({
         apiVersion: state.sourceConfig.apiVersion,

--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -37,7 +37,12 @@ import {
   CONFIG_TYPE_LABEL,
   SUPPORTED_TOPOLOGIES_ANNOTATION,
 } from '../types';
-import { isConfigObject, cleanResourceForYAMLViewer, stripAnnotation } from '../utils';
+import {
+  isConfigObject,
+  cleanResourceForYAMLViewer,
+  stripDuplicatingAnnotations,
+  stripDuplicatingLabels,
+} from '../utils';
 import {
   createLLMInferenceServiceConfig,
   patchLLMInferenceServiceConfig,
@@ -207,10 +212,12 @@ const RoutingConfigurationCreateEditInner: React.FC<{
     }
     if (state?.sourceConfig) {
       const cleanMeta = cleanResourceForYAMLViewer(state.sourceConfig.metadata);
-      const cleanAnnotations = stripAnnotation(
-        cleanMeta.annotations,
-        'kubectl.kubernetes.io/last-applied-configuration',
-      );
+      let cleanAnnotations = cleanMeta.annotations;
+      let cleanLabels = cleanMeta.annotations;
+      if (isDuplicateMode) {
+        cleanAnnotations = stripDuplicatingAnnotations(cleanMeta.annotations);
+        cleanLabels = stripDuplicatingLabels(cleanMeta.labels);
+      }
       const duplicateDisplayName = `Copy of ${getDisplayNameFromK8sResource(state.sourceConfig)}`;
       return YAML.stringify({
         apiVersion: state.sourceConfig.apiVersion,
@@ -222,6 +229,7 @@ const RoutingConfigurationCreateEditInner: React.FC<{
             ...cleanAnnotations,
             'openshift.io/display-name': duplicateDisplayName,
           },
+          labels: cleanLabels,
         },
         spec: state.sourceConfig.spec,
       });

--- a/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigurationCreateEdit.tsx
@@ -213,7 +213,7 @@ const RoutingConfigurationCreateEditInner: React.FC<{
     if (state?.sourceConfig) {
       const cleanMeta = cleanResourceForYAMLViewer(state.sourceConfig.metadata);
       let cleanAnnotations = cleanMeta.annotations;
-      let cleanLabels = cleanMeta.annotations;
+      let cleanLabels = cleanMeta.labels;
       if (isDuplicateMode) {
         cleanAnnotations = stripDuplicatingAnnotations(cleanMeta.annotations);
         cleanLabels = stripDuplicatingLabels(cleanMeta.labels);

--- a/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
@@ -105,14 +105,10 @@ const TopologyConfigurationCreateEditInner: React.FC<{
     if (existingConfig) {
       return YAML.stringify(existingConfig);
     }
-    if (state?.sourceConfig) {
+    if (isDuplicateMode) {
       const cleanMeta = cleanResourceForYAMLViewer(state.sourceConfig.metadata);
-      let cleanAnnotations = cleanMeta.annotations;
-      let cleanLabels = cleanMeta.labels;
-      if (isDuplicateMode) {
-        cleanAnnotations = stripDuplicatingAnnotations(cleanMeta.annotations);
-        cleanLabels = stripDuplicatingLabels(cleanMeta.labels);
-      }
+      const cleanAnnotations = stripDuplicatingAnnotations(cleanMeta.annotations);
+      const cleanLabels = stripDuplicatingLabels(cleanMeta.labels);
       const duplicateDisplayName = `Copy of ${getDisplayNameFromK8sResource(state.sourceConfig)}`;
       return YAML.stringify({
         apiVersion: state.sourceConfig.apiVersion,

--- a/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
@@ -108,7 +108,7 @@ const TopologyConfigurationCreateEditInner: React.FC<{
     if (state?.sourceConfig) {
       const cleanMeta = cleanResourceForYAMLViewer(state.sourceConfig.metadata);
       let cleanAnnotations = cleanMeta.annotations;
-      let cleanLabels = cleanMeta.annotations;
+      let cleanLabels = cleanMeta.labels;
       if (isDuplicateMode) {
         cleanAnnotations = stripDuplicatingAnnotations(cleanMeta.annotations);
         cleanLabels = stripDuplicatingLabels(cleanMeta.labels);

--- a/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
+++ b/packages/llmd-serving/src/settings/TopologyConfigurationCreateEdit.tsx
@@ -35,7 +35,12 @@ import {
   TopologyTypeLabels,
   CONFIG_TYPE_LABEL,
 } from '../types';
-import { isConfigObject, cleanResourceForYAMLViewer, stripAnnotation } from '../utils';
+import {
+  isConfigObject,
+  cleanResourceForYAMLViewer,
+  stripDuplicatingAnnotations,
+  stripDuplicatingLabels,
+} from '../utils';
 import {
   createLLMInferenceServiceConfig,
   patchLLMInferenceServiceConfig,
@@ -102,10 +107,12 @@ const TopologyConfigurationCreateEditInner: React.FC<{
     }
     if (state?.sourceConfig) {
       const cleanMeta = cleanResourceForYAMLViewer(state.sourceConfig.metadata);
-      const cleanAnnotations = stripAnnotation(
-        cleanMeta.annotations,
-        'kubectl.kubernetes.io/last-applied-configuration',
-      );
+      let cleanAnnotations = cleanMeta.annotations;
+      let cleanLabels = cleanMeta.annotations;
+      if (isDuplicateMode) {
+        cleanAnnotations = stripDuplicatingAnnotations(cleanMeta.annotations);
+        cleanLabels = stripDuplicatingLabels(cleanMeta.labels);
+      }
       const duplicateDisplayName = `Copy of ${getDisplayNameFromK8sResource(state.sourceConfig)}`;
       return YAML.stringify({
         apiVersion: state.sourceConfig.apiVersion,
@@ -117,6 +124,7 @@ const TopologyConfigurationCreateEditInner: React.FC<{
             ...cleanAnnotations,
             'openshift.io/display-name': duplicateDisplayName,
           },
+          labels: cleanLabels,
         },
         spec: state.sourceConfig.spec,
       });

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/LlmAcceleratorConfigAddForm.tsx
@@ -26,7 +26,12 @@ import {
   createLLMInferenceServiceConfig,
   updateLLMInferenceServiceConfig,
 } from '../../api/LLMInferenceServiceConfigs';
-import { isConfigObject, cleanResourceForYAMLViewer } from '../../utils';
+import {
+  isConfigObject,
+  cleanResourceForYAMLViewer,
+  stripDuplicatingAnnotations,
+  stripDuplicatingLabels,
+} from '../../utils';
 import { ConfigType, CONFIG_TYPE_LABEL } from '../../types';
 import type { LLMInferenceServiceConfigKind } from '../../types';
 
@@ -84,6 +89,8 @@ const LlmAcceleratorConfigAddForm: React.FC<LlmAcceleratorConfigAddFormProps> = 
     }
     if (isDuplicate) {
       const cleanMeta = cleanResourceForYAMLViewer(sourceConfig.metadata);
+      const cleanAnnotations = stripDuplicatingAnnotations(cleanMeta.annotations);
+      const cleanLabels = stripDuplicatingLabels(cleanMeta.labels);
       const duplicateDisplayName = `Copy of ${getDisplayNameFromK8sResource(sourceConfig)}`;
       return YAML.stringify({
         ...sourceConfig,
@@ -91,9 +98,10 @@ const LlmAcceleratorConfigAddForm: React.FC<LlmAcceleratorConfigAddFormProps> = 
           ...cleanMeta,
           name: translateDisplayNameForK8s(duplicateDisplayName),
           annotations: {
-            ...cleanMeta.annotations,
+            ...cleanAnnotations,
             'openshift.io/display-name': duplicateDisplayName,
           },
+          labels: cleanLabels,
         },
       });
     }

--- a/packages/llmd-serving/src/utils.ts
+++ b/packages/llmd-serving/src/utils.ts
@@ -32,15 +32,34 @@ export const cleanResourceForYAMLViewer = (
   return result;
 };
 
-export const stripAnnotation = (
+export const stripDuplicatingAnnotations = (
   annotations: Record<string, string> | undefined,
-  key: string,
 ): Record<string, string> | undefined => {
   if (!annotations) {
     return annotations;
   }
-  const result = { ...annotations };
-  delete result[key];
+  const result = annotations;
+  delete result['kubectl.kubernetes.io/last-applied-configuration'];
+  delete result['serving.kserve.io/well-known-config'];
+  delete result['platform.opendatahub.io/instance.name'];
+  delete result['platform.opendatahub.io/instance.uid'];
+  delete result['platform.opendatahub.io/instance.generation'];
+  delete result['internal.config.kubernetes.io/previousNamespaces'];
+  delete result['internal.config.kubernetes.io/previousKinds'];
+  delete result['internal.config.kubernetes.io/previousNames'];
+  return result;
+};
+
+export const stripDuplicatingLabels = (
+  labels: Record<string, string> | undefined,
+): Record<string, string> | undefined => {
+  if (!labels) {
+    return labels;
+  }
+  const result = labels;
+  delete result['platform.opendatahub.io/part-of'];
+  delete result['app.kubernetes.io/part-of'];
+  delete result['app.opendatahub.io/kserve'];
   return result;
 };
 

--- a/packages/llmd-serving/src/utils.ts
+++ b/packages/llmd-serving/src/utils.ts
@@ -38,7 +38,7 @@ export const stripDuplicatingAnnotations = (
   if (!annotations) {
     return annotations;
   }
-  const result = annotations;
+  const result = { ...annotations };
   delete result['kubectl.kubernetes.io/last-applied-configuration'];
   delete result['serving.kserve.io/well-known-config'];
   delete result['platform.opendatahub.io/instance.name'];
@@ -56,7 +56,7 @@ export const stripDuplicatingLabels = (
   if (!labels) {
     return labels;
   }
-  const result = labels;
+  const result = { ...labels };
   delete result['platform.opendatahub.io/part-of'];
   delete result['app.kubernetes.io/part-of'];
   delete result['app.opendatahub.io/kserve'];


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://redhat.atlassian.net/browse/RHOAIENG-79310

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
All other shared components use a `platform.opendatahub.io/part-of` label for determing if it's an ootb resource. This doesn't fix it for llmiscfg's, but it makes sure when duplicating ootb ones this is removed for all versions for when we do fix it

Comparison
<img width="1473" height="521" alt="image" src="https://github.com/user-attachments/assets/ac2b28df-9832-4ae7-891e-f11cfa32c892" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Duplicate an ootb LLMisCfg accelerator profile, save it, edit it, make sure the label is gone

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
The deletes are very simple so i'd need a cypress test but there is a time issue

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource duplication across routing, topology, and accelerator configurations by removing system-generated metadata from duplicated resources.
  * Updated the generated duplicated YAML to include sanitized labels in addition to cleaned annotations, preventing metadata carryover.
  * Ensured duplicated resources no longer retain metadata that could cause conflicts or unintended associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->