### PR TITLE
fix(RHOAIENG-79312): clean up sidecar resources on Standalone mode switch

### DIFF
--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -351,24 +351,22 @@ func (r *DashboardReconciler) deleteSidecarResources(ctx context.Context) error 
 	ns := r.ApplicationsNamespace
 	var errs []error
 
-	namespacedResources := []client.Object{
-		&corev1.ServiceAccount{},
-		&corev1.Secret{},
-		&networkingv1.NetworkPolicy{},
-		&corev1.ConfigMap{},
+	type namedResource struct {
+		obj  client.Object
+		name string
 	}
-	namespacedNames := []string{
-		"odh-dashboard-modules",
-		"odh-dashboard-modules-token",
-		"odh-dashboard-allow-ports",
-		"sidecar-params",
+	namespacedResources := []namedResource{
+		{&corev1.ServiceAccount{}, "odh-dashboard-modules"},
+		{&corev1.Secret{}, "odh-dashboard-modules-token"},
+		{&networkingv1.NetworkPolicy{}, "odh-dashboard-allow-ports"},
+		{&corev1.ConfigMap{}, "sidecar-params"},
 	}
 
-	for i, obj := range namespacedResources {
-		obj.SetName(namespacedNames[i])
-		obj.SetNamespace(ns)
-		if err := r.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
-			errs = append(errs, fmt.Errorf("deleting %T %s: %w", obj, namespacedNames[i], err))
+	for _, nr := range namespacedResources {
+		nr.obj.SetName(nr.name)
+		nr.obj.SetNamespace(ns)
+		if err := r.Delete(ctx, nr.obj); client.IgnoreNotFound(err) != nil {
+			errs = append(errs, fmt.Errorf("deleting %T %s: %w", nr.obj, nr.name, err))
 		}
 	}
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -346,6 +346,50 @@ func (r *DashboardReconciler) reconcileSidecar(
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
+func (r *DashboardReconciler) deleteSidecarResources(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	ns := r.ApplicationsNamespace
+	var errs []error
+
+	namespacedResources := []client.Object{
+		&corev1.ServiceAccount{},
+		&corev1.Secret{},
+		&networkingv1.NetworkPolicy{},
+		&corev1.ConfigMap{},
+	}
+	namespacedNames := []string{
+		"odh-dashboard-modules",
+		"odh-dashboard-modules-token",
+		"odh-dashboard-allow-ports",
+		"sidecar-params",
+	}
+
+	for i, obj := range namespacedResources {
+		obj.SetName(namespacedNames[i])
+		obj.SetNamespace(ns)
+		if err := r.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
+			errs = append(errs, fmt.Errorf("deleting %T %s: %w", obj, namespacedNames[i], err))
+		}
+	}
+
+	clusterResources := []client.Object{
+		&rbacv1.ClusterRole{},
+		&rbacv1.ClusterRoleBinding{},
+	}
+	for _, obj := range clusterResources {
+		obj.SetName("odh-dashboard-modules")
+		if err := r.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
+			errs = append(errs, fmt.Errorf("deleting %T odh-dashboard-modules: %w", obj, err))
+		}
+	}
+
+	if len(errs) == 0 {
+		logger.Info("Cleaned up sidecar-specific resources")
+	}
+
+	return errors.Join(errs...)
+}
+
 func (r *DashboardReconciler) reconcileStandalone(
 	ctx context.Context,
 	dashboard *v1alpha1.Dashboard,
@@ -353,6 +397,12 @@ func (r *DashboardReconciler) reconcileStandalone(
 	cfg OperatorConfig,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+
+	// Step 0: Clean up sidecar-specific resources that are not part of the standalone overlay.
+	// This handles the Sidecar → Standalone upgrade path where these resources would be orphaned.
+	if err := r.deleteSidecarResources(ctx); err != nil {
+		logger.Error(err, "Failed to clean up sidecar resources")
+	}
 
 	// Step 1: Deploy core manifests (3-container pod: odh-dashboard, kube-rbac-proxy, core-bff).
 	// Uses the standalone overlay which excludes BFF module sidecar containers.

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -401,7 +401,10 @@ func (r *DashboardReconciler) reconcileStandalone(
 	// Step 0: Clean up sidecar-specific resources that are not part of the standalone overlay.
 	// This handles the Sidecar → Standalone upgrade path where these resources would be orphaned.
 	if err := r.deleteSidecarResources(ctx); err != nil {
-		logger.Error(err, "Failed to clean up sidecar resources")
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("SidecarCleanupFailed"),
+			conditions.WithError(err))
+		return ctrl.Result{}, fmt.Errorf("failed to clean up sidecar resources: %w", err)
 	}
 
 	// Step 1: Deploy core manifests (3-container pod: odh-dashboard, kube-rbac-proxy, core-bff).

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1046,6 +1047,81 @@ func runPreservesOperatorResourcesTest(t *testing.T, opDep, opSA, opCR, opCRB, d
 	}
 	assert.Contains(t, crbNames, opCRB, "operator ClusterRoleBinding must survive teardown")
 	assert.NotContains(t, crbNames, delCRB, "non-operator ClusterRoleBindings must be deleted")
+}
+
+func TestDeleteSidecarResources(t *testing.T) {
+	t.Run("deletes all sidecar-specific resources", func(t *testing.T) {
+		s := testScheme(t)
+		ctx := context.Background()
+
+		sidecarSA := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-modules", Namespace: testNamespace},
+		}
+		sidecarSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-modules-token", Namespace: testNamespace},
+		}
+		sidecarNetpol := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-allow-ports", Namespace: testNamespace},
+		}
+		sidecarCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "sidecar-params", Namespace: testNamespace},
+		}
+		sidecarCR := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-modules"},
+		}
+		sidecarCRB := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "odh-dashboard-modules"},
+		}
+
+		unrelatedCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "unrelated-config", Namespace: testNamespace},
+		}
+
+		cli := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(sidecarSA, sidecarSecret, sidecarNetpol, sidecarCM, sidecarCR, sidecarCRB, unrelatedCM).
+			Build()
+
+		r := &ctrlpkg.DashboardReconciler{
+			Client:                cli,
+			Scheme:                s,
+			ApplicationsNamespace: testNamespace,
+		}
+
+		err := r.DeleteSidecarResources(ctx)
+		require.NoError(t, err)
+
+		assert.True(t, k8sNotFound(t, cli, ctx, &corev1.ServiceAccount{}, testNamespace, "odh-dashboard-modules"))
+		assert.True(t, k8sNotFound(t, cli, ctx, &corev1.Secret{}, testNamespace, "odh-dashboard-modules-token"))
+		assert.True(t, k8sNotFound(t, cli, ctx, &networkingv1.NetworkPolicy{}, testNamespace, "odh-dashboard-allow-ports"))
+		assert.True(t, k8sNotFound(t, cli, ctx, &corev1.ConfigMap{}, testNamespace, "sidecar-params"))
+		assert.True(t, k8sNotFound(t, cli, ctx, &rbacv1.ClusterRole{}, "", "odh-dashboard-modules"))
+		assert.True(t, k8sNotFound(t, cli, ctx, &rbacv1.ClusterRoleBinding{}, "", "odh-dashboard-modules"))
+
+		assert.False(t, k8sNotFound(t, cli, ctx, &corev1.ConfigMap{}, testNamespace, "unrelated-config"),
+			"unrelated resources must not be deleted")
+	})
+
+	t.Run("succeeds when resources already absent", func(t *testing.T) {
+		s := testScheme(t)
+		cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+		r := &ctrlpkg.DashboardReconciler{
+			Client:                cli,
+			Scheme:                s,
+			ApplicationsNamespace: testNamespace,
+		}
+
+		err := r.DeleteSidecarResources(context.Background())
+		require.NoError(t, err)
+	})
+}
+
+func k8sNotFound(t *testing.T, cli client.Client, ctx context.Context, obj client.Object, ns, name string) bool {
+	t.Helper()
+	key := types.NamespacedName{Namespace: ns, Name: name}
+	err := cli.Get(ctx, key, obj)
+	return err != nil && client.IgnoreNotFound(err) == nil
 }
 
 func boolPtr(b bool) *bool {

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -1121,7 +1122,11 @@ func k8sNotFound(t *testing.T, cli client.Client, ctx context.Context, obj clien
 	t.Helper()
 	key := types.NamespacedName{Namespace: ns, Name: name}
 	err := cli.Get(ctx, key, obj)
-	return err != nil && client.IgnoreNotFound(err) == nil
+	if err == nil {
+		return false
+	}
+	require.True(t, k8serrors.IsNotFound(err), "unexpected error fetching %s/%s: %v", ns, name, err)
+	return true
 }
 
 func boolPtr(b bool) *bool {

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -25,3 +25,7 @@ func BuildFederationConfigMap(r *DashboardReconciler, statuses map[string]v1alph
 func (r *DashboardReconciler) PatchDeploymentFederationHash(ctx context.Context, configData string) error {
 	return r.patchDeploymentFederationHash(ctx, configData)
 }
+
+func (r *DashboardReconciler) DeleteSidecarResources(ctx context.Context) error {
+	return r.deleteSidecarResources(ctx)
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79312

## Description

When switching from Sidecar to Standalone deployment mode, 6 sidecar-specific resources were orphaned because `reconcileStandalone` deployed the standalone overlay but had no cleanup step for resources exclusive to the sidecar overlay.

This PR adds `deleteSidecarResources()` to the dashboard operator reconciler, which idempotently removes the following sidecar-only resources at the start of each standalone reconciliation cycle:

**Namespaced** (in `ApplicationsNamespace`):
- `ServiceAccount/odh-dashboard-modules`
- `Secret/odh-dashboard-modules-token`
- `NetworkPolicy/odh-dashboard-allow-ports`
- `ConfigMap/sidecar-params`

**Cluster-scoped:**
- `ClusterRole/odh-dashboard-modules`
- `ClusterRoleBinding/odh-dashboard-modules`

The deletion is idempotent (`client.IgnoreNotFound`) so it is safe to run on every reconcile — no-ops when the resources are already gone.

## How Has This Been Tested?

- Unit tests with `fake.NewClientBuilder()` verifying both the happy path (all 6 resources deleted, unrelated resources preserved) and the idempotent path (succeeds when resources are already absent).
- `make test` and `make lint` pass.

## Test Impact

Added `TestDeleteSidecarResources` with two sub-tests:
- `deletes all sidecar-specific resources` — seeds all 6 sidecar resources + an unrelated ConfigMap, runs cleanup, asserts sidecar resources are gone and the unrelated one is preserved.
- `succeeds when resources already absent` — runs cleanup on an empty cluster, asserts no error.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transitions from Sidecar to Standalone mode by automatically removing leftover Sidecar resources.
  * Standalone deployment continues even if cleanup encounters an error.
  * Cleanup is limited to resources associated with the previous Sidecar deployment, preserving unrelated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->