### PR TITLE
feat(distributed-workloads): add LeaderWorkerSet support to workload …

### DIFF
--- a/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
@@ -426,14 +426,12 @@ describe('useDWProjectCurrentMetrics', () => {
     } satisfies DWProjectCurrentMetrics);
     expect(mockAxios).toHaveBeenCalledTimes(2);
     expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/query', {
-      query: expect.stringContaining(
-        'namespace=test-project&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)',
-      ),
+      query:
+        'namespace=test-project&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) or sum by(owner_name, owner_kind) (label_replace(label_replace(kube_pod_labels{label_leaderworkerset_sigs_k8s_io_name!="", namespace="test-project"} * on (namespace, pod) group_right(label_leaderworkerset_sigs_k8s_io_name) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate, "owner_name", "$1", "label_leaderworkerset_sigs_k8s_io_name", "(.*)"), "owner_kind", "LeaderWorkerSet", "", ""))',
     });
     expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/query', {
-      query: expect.stringContaining(
-        'namespace=test-project&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)',
-      ),
+      query:
+        'namespace=test-project&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes) or sum by(owner_name, owner_kind) (label_replace(label_replace(kube_pod_labels{label_leaderworkerset_sigs_k8s_io_name!="", namespace="test-project"} * on (namespace, pod) group_right(label_leaderworkerset_sigs_k8s_io_name) node_namespace_pod_container:container_memory_working_set_bytes, "owner_name", "$1", "label_leaderworkerset_sigs_k8s_io_name", "(.*)"), "owner_kind", "LeaderWorkerSet", "", ""))',
     });
     expect(renderResult).hookToHaveUpdateCount(1);
 

--- a/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
+++ b/frontend/src/api/prometheus/__tests__/distributedWorkloads.spec.ts
@@ -19,7 +19,7 @@ import {
   useDWProjectCurrentMetrics,
 } from '#~/api/prometheus/distributedWorkloads';
 
-const expectedCpuTotalUsageWithStatefulSet = Number('0.10201116666666666');
+const expectedCpuTotalUsageWithStatefulSetAndLWS = Number('0.12201116666666666');
 
 const mockCpuUsageResults: WorkloadMetricPromQueryResponse['data']['result'] = [
   {
@@ -84,6 +84,13 @@ const mockCpuUsageResults: WorkloadMetricPromQueryResponse['data']['result'] = [
       owner_name: 'test-deployment-6c8949d6dc', // eslint-disable-line camelcase
     },
     value: [1711495542.368, '0.005'],
+  },
+  {
+    metric: {
+      owner_kind: WorkloadOwnerType.LeaderWorkerSet, // eslint-disable-line camelcase
+      owner_name: 'test-lws-inference', // eslint-disable-line camelcase
+    },
+    value: [1711495542.368, '0.02'],
   },
 ];
 
@@ -151,6 +158,13 @@ const mockMemoryUsageResults: WorkloadMetricPromQueryResponse['data']['result'] 
     },
     value: [1711495542.37, '10485760'],
   },
+  {
+    metric: {
+      owner_kind: WorkloadOwnerType.LeaderWorkerSet, // eslint-disable-line camelcase
+      owner_name: 'test-lws-inference', // eslint-disable-line camelcase
+    },
+    value: [1711495542.37, '52428800'],
+  },
 ];
 
 const mockWorkloads = [
@@ -202,6 +216,12 @@ const mockWorkloads = [
     ownerKind: WorkloadOwnerType.StatefulSet,
     ownerName: 'test-notebook-0',
   }),
+  mockWorkloadK8sResource({
+    k8sName: 'test-lws-inference-wl',
+    namespace: 'test-project',
+    ownerKind: WorkloadOwnerType.LeaderWorkerSet,
+    ownerName: 'test-lws-inference',
+  }),
 ];
 
 const mockGetWorkloadCurrentUsage = (workload: WorkloadKind): WorkloadCurrentUsage => {
@@ -251,6 +271,9 @@ describe('indexWorkloadMetricByOwner', () => {
       [WorkloadOwnerType.ReplicaSet]: {
         'test-deployment-6c8949d6dc': 0.005,
       },
+      [WorkloadOwnerType.LeaderWorkerSet]: {
+        'test-lws-inference': 0.02,
+      },
     };
     expect(indexWorkloadMetricByOwner(promResponse)).toEqual(indexedValues);
   });
@@ -271,26 +294,26 @@ describe('getTopResourceConsumingWorkloads', () => {
   it('sorts the top 5 workloads and sums remaining as "other" when there are more than 6', () => {
     expect(getTopResourceConsumingWorkloads(mockWorkloads, mockGetWorkloadCurrentUsage)).toEqual({
       cpuCoresUsed: {
-        totalUsage: expectedCpuTotalUsageWithStatefulSet,
+        totalUsage: expectedCpuTotalUsageWithStatefulSetAndLWS,
         topWorkloads: [
           { workload: mockWorkloads[3], usage: 0.04300163333333333 },
+          { workload: mockWorkloads[8], usage: 0.02 },
           { workload: mockWorkloads[6], usage: 0.01500163333333333 },
           { workload: mockWorkloads[5], usage: 0.01300163333333333 },
           { workload: mockWorkloads[2], usage: 0.0120015 },
-          { workload: mockWorkloads[4], usage: 0.01100163333333333 },
         ],
-        otherUsage: 0.00800313333333333,
+        otherUsage: 0.019004766666666662,
       },
       memoryBytesUsed: {
-        totalUsage: 174396710,
+        totalUsage: 226825510,
         topWorkloads: [
           { workload: mockWorkloads[3], usage: 82493440 },
+          { workload: mockWorkloads[8], usage: 52428800 },
           { workload: mockWorkloads[4], usage: 42493440 },
           { workload: mockWorkloads[6], usage: 10337050 },
           { workload: mockWorkloads[2], usage: 9349344 },
-          { workload: mockWorkloads[1], usage: 8249344 },
         ],
-        otherUsage: 21474092,
+        otherUsage: 29723436,
       },
     } satisfies TopWorkloadsByUsage);
   });
@@ -403,12 +426,14 @@ describe('useDWProjectCurrentMetrics', () => {
     } satisfies DWProjectCurrentMetrics);
     expect(mockAxios).toHaveBeenCalledTimes(2);
     expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/query', {
-      query:
-        'namespace=test-project&query=sum by(owner_name, owner_kind)  (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)',
+      query: expect.stringContaining(
+        'namespace=test-project&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)',
+      ),
     });
     expect(mockAxios).toHaveBeenCalledWith('/api/prometheus/query', {
-      query:
+      query: expect.stringContaining(
         'namespace=test-project&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="test-project"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)',
+      ),
     });
     expect(renderResult).hookToHaveUpdateCount(1);
 
@@ -435,6 +460,9 @@ describe('useDWProjectCurrentMetrics', () => {
             [WorkloadOwnerType.ReplicaSet]: {
               'test-deployment-6c8949d6dc': 0.005,
             },
+            [WorkloadOwnerType.LeaderWorkerSet]: {
+              'test-lws-inference': 0.02,
+            },
           },
           error: undefined,
           loaded: true,
@@ -459,6 +487,9 @@ describe('useDWProjectCurrentMetrics', () => {
             [WorkloadOwnerType.ReplicaSet]: {
               'test-deployment-6c8949d6dc': 10485760,
             },
+            [WorkloadOwnerType.LeaderWorkerSet]: {
+              'test-lws-inference': 52428800,
+            },
           },
           error: undefined,
           loaded: true,
@@ -473,24 +504,24 @@ describe('useDWProjectCurrentMetrics', () => {
         cpuCoresUsed: {
           topWorkloads: [
             { workload: mockWorkloads[3], usage: 0.04300163333333333 },
+            { workload: mockWorkloads[8], usage: 0.02 },
             { workload: mockWorkloads[6], usage: 0.01500163333333333 },
             { workload: mockWorkloads[5], usage: 0.01300163333333333 },
             { workload: mockWorkloads[2], usage: 0.0120015 },
-            { workload: mockWorkloads[4], usage: 0.01100163333333333 },
           ],
-          otherUsage: 0.00800313333333333,
-          totalUsage: expectedCpuTotalUsageWithStatefulSet,
+          otherUsage: 0.019004766666666662,
+          totalUsage: expectedCpuTotalUsageWithStatefulSetAndLWS,
         },
         memoryBytesUsed: {
           topWorkloads: [
             { workload: mockWorkloads[3], usage: 82493440 },
+            { workload: mockWorkloads[8], usage: 52428800 },
             { workload: mockWorkloads[4], usage: 42493440 },
             { workload: mockWorkloads[6], usage: 10337050 },
             { workload: mockWorkloads[2], usage: 9349344 },
-            { workload: mockWorkloads[1], usage: 8249344 },
           ],
-          otherUsage: 21474092,
-          totalUsage: 174396710,
+          otherUsage: 29723436,
+          totalUsage: 226825510,
         },
       },
     };
@@ -599,6 +630,10 @@ describe('useDWProjectCurrentMetrics', () => {
     expect(getWorkloadCurrentUsage(mockWorkloads[7])).toEqual({
       cpuCoresUsed: 0.008,
       memoryBytesUsed: 5000000,
+    } satisfies WorkloadCurrentUsage);
+    expect(getWorkloadCurrentUsage(mockWorkloads[8])).toEqual({
+      cpuCoresUsed: 0.02,
+      memoryBytesUsed: 52428800,
     } satisfies WorkloadCurrentUsage);
   });
 });

--- a/frontend/src/api/prometheus/distributedWorkloads.ts
+++ b/frontend/src/api/prometheus/distributedWorkloads.ts
@@ -16,6 +16,7 @@ export const EMPTY_WORKLOAD_METRIC_INDEXED_BY_OWNER: WorkloadMetricIndexedByOwne
   [WorkloadOwnerType.Job]: {},
   [WorkloadOwnerType.StatefulSet]: {},
   [WorkloadOwnerType.ReplicaSet]: {},
+  [WorkloadOwnerType.LeaderWorkerSet]: {},
 };
 
 export type WorkloadMetricPromQueryResponse = PrometheusQueryResponse<{
@@ -133,12 +134,26 @@ export const DEFAULT_DW_PROJECT_CURRENT_METRICS: DWProjectCurrentMetrics = {
   refresh: () => Promise.resolve(undefined),
 };
 
+const getLWSMetricSubquery = (metricName: string, namespace: string): string =>
+  `sum by(owner_name, owner_kind) (label_replace(label_replace(kube_pod_labels{label_leaderworkerset_sigs_k8s_io_name!="", namespace="${namespace}"} * on (namespace, pod) group_right(label_leaderworkerset_sigs_k8s_io_name) ${metricName}, "owner_name", "$1", "label_leaderworkerset_sigs_k8s_io_name", "(.*)"), "owner_kind", "LeaderWorkerSet", "", ""))`;
+
 const getDWProjectCurrentMetricsQueries = (
   namespace: string,
-): Record<DWProjectCurrentMetricType, string> => ({
-  cpuCoresUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind)  (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate)`,
-  memoryBytesUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) node_namespace_pod_container:container_memory_working_set_bytes)`,
-});
+): Record<DWProjectCurrentMetricType, string> => {
+  const cpuMetric = 'node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate';
+  const memoryMetric = 'node_namespace_pod_container:container_memory_working_set_bytes';
+
+  return {
+    cpuCoresUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) ${cpuMetric}) or ${getLWSMetricSubquery(
+      cpuMetric,
+      namespace,
+    )}`,
+    memoryBytesUsedByWorkloadOwner: `namespace=${namespace}&query=sum by(owner_name, owner_kind) (kube_pod_owner{owner_kind=~"RayCluster|Job|StatefulSet|ReplicaSet", namespace="${namespace}"} * on (namespace, pod) group_right(owner_name, owner_kind) ${memoryMetric}) or ${getLWSMetricSubquery(
+      memoryMetric,
+      namespace,
+    )}`,
+  };
+};
 
 export const useDWProjectCurrentMetrics = (
   workloads: WorkloadKind[],

--- a/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
@@ -159,6 +159,19 @@ describe('getWorkloadOwner', () => {
     });
   });
 
+  it('returns the name of a leaderworkerset found in ownerReferences of a workload if present', () => {
+    const mockWorkload = mockWorkloadK8sResource({
+      k8sName: 'test-workload',
+      namespace: 'test-project',
+      ownerKind: WorkloadOwnerType.LeaderWorkerSet,
+      ownerName: 'test-lws-inference',
+    });
+    expect(getWorkloadOwner(mockWorkload)).toStrictEqual({
+      kind: 'LeaderWorkerSet',
+      name: 'test-lws-inference',
+    });
+  });
+
   it('returns undefined if there is no job in ownerReferences', () => {
     const mockWorkload = mockWorkloadK8sResource({
       k8sName: 'test-workload',

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/WorkloadResourceMetricsTableRow.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/WorkloadResourceMetricsTableRow.tsx
@@ -30,7 +30,11 @@ const WorkloadResourceMetricsTableRow: React.FC<WorkloadResourceMetricsTableRowP
   return (
     <Tr key={workload.metadata?.uid}>
       <Td dataLabel="Name">{getWorkloadName(workload)}</Td>
-      <Td dataLabel="CPU usage (cores)" style={{ paddingRight: 'var(--pf-t--global--spacer--xl)' }}>
+      <Td
+        dataLabel="CPU usage (cores)"
+        data-testid="workload-cpu-usage-cell"
+        style={{ paddingRight: 'var(--pf-t--global--spacer--xl)' }}
+      >
         {' '}
         <WorkloadResourceUsageBar
           showData={inActiveState || (usage.cpuCoresUsed || 0) > 0}
@@ -43,6 +47,7 @@ const WorkloadResourceMetricsTableRow: React.FC<WorkloadResourceMetricsTableRowP
       </Td>
       <Td
         dataLabel="Memory usage (GiB)"
+        data-testid="workload-memory-usage-cell"
         style={{ paddingRight: 'var(--pf-t--global--spacer--xl)' }}
       >
         {' '}

--- a/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -117,6 +117,13 @@ const initIntercepts = ({
       mockStatus: WorkloadStatusType.Running,
       podSets: [mockPodset],
     }),
+    mockWorkloadK8sResource({
+      k8sName: 'test-workload-lws',
+      ownerKind: WorkloadOwnerType.LeaderWorkerSet,
+      ownerName: 'test-lws-inference',
+      mockStatus: WorkloadStatusType.Running,
+      podSets: [mockPodset],
+    }),
   ],
 }: HandlersProps) => {
   cy.interceptOdh(
@@ -181,6 +188,9 @@ const initIntercepts = ({
           [WorkloadOwnerType.ReplicaSet]: {
             'test-deployment-6c8949d6dc': 0.5,
           },
+          [WorkloadOwnerType.LeaderWorkerSet]: {
+            'test-lws-inference': 3.4,
+          },
         }),
       });
     } else if (req.body.query.includes('container_memory_working_set_bytes')) {
@@ -200,6 +210,9 @@ const initIntercepts = ({
           },
           [WorkloadOwnerType.ReplicaSet]: {
             'test-deployment-6c8949d6dc': 268435456, // 256 MiB
+          },
+          [WorkloadOwnerType.LeaderWorkerSet]: {
+            'test-lws-inference': 2684354560, // 2.5 GiB
           },
         }),
       });
@@ -407,6 +420,20 @@ describe('Project Metrics tab', () => {
         .within(() => {
           cy.get('td[data-label="CPU usage (cores)"]').should('contain.text', '0.5');
           cy.get('td[data-label="Memory usage (GiB)"]').should('contain.text', '0.3');
+        });
+    });
+
+    it('Should render usage bars on a LeaderWorkerSet workload', () => {
+      initIntercepts({});
+      globalDistributedWorkloads.visit();
+      cy.findByLabelText('Project metrics tab').click();
+      globalDistributedWorkloads
+        .findWorkloadResourceMetricsTable()
+        .findByText('test-workload-lws')
+        .closest('tr')
+        .within(() => {
+          cy.get('td[data-label="CPU usage (cores)"]').should('contain.text', '3.4');
+          cy.get('td[data-label="Memory usage (GiB)"]').should('contain.text', '2.5');
         });
     });
 

--- a/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -376,8 +376,8 @@ describe('Project Metrics tab', () => {
         .findByText('test-workload-finished')
         .closest('tr')
         .within(() => {
-          cy.get('td[data-label="CPU usage (cores)"]').should('contain.text', '-');
-          cy.get('td[data-label="Memory usage (GiB)"]').should('contain.text', '-');
+          cy.findByTestId('workload-cpu-usage-cell').should('contain.text', '-');
+          cy.findByTestId('workload-memory-usage-cell').should('contain.text', '-');
         });
     });
 
@@ -390,8 +390,8 @@ describe('Project Metrics tab', () => {
         .findByText('test-workload-running')
         .closest('tr')
         .within(() => {
-          cy.get('td[data-label="CPU usage (cores)"]').should('not.contain.text', '-');
-          cy.get('td[data-label="Memory usage (GiB)"]').should('not.contain.text', '-');
+          cy.findByTestId('workload-cpu-usage-cell').should('not.contain.text', '-');
+          cy.findByTestId('workload-memory-usage-cell').should('not.contain.text', '-');
         });
     });
 
@@ -404,8 +404,8 @@ describe('Project Metrics tab', () => {
         .findByText('test-workload-notebook')
         .closest('tr')
         .within(() => {
-          cy.get('td[data-label="CPU usage (cores)"]').should('not.contain.text', '-');
-          cy.get('td[data-label="Memory usage (GiB)"]').should('not.contain.text', '-');
+          cy.findByTestId('workload-cpu-usage-cell').should('not.contain.text', '-');
+          cy.findByTestId('workload-memory-usage-cell').should('not.contain.text', '-');
         });
     });
 
@@ -418,8 +418,8 @@ describe('Project Metrics tab', () => {
         .findByText('test-workload-replicaset')
         .closest('tr')
         .within(() => {
-          cy.get('td[data-label="CPU usage (cores)"]').should('contain.text', '0.5');
-          cy.get('td[data-label="Memory usage (GiB)"]').should('contain.text', '0.3');
+          cy.findByTestId('workload-cpu-usage-cell').should('contain.text', '0.5');
+          cy.findByTestId('workload-memory-usage-cell').should('contain.text', '0.3');
         });
     });
 
@@ -432,8 +432,8 @@ describe('Project Metrics tab', () => {
         .findByText('test-workload-lws')
         .closest('tr')
         .within(() => {
-          cy.get('td[data-label="CPU usage (cores)"]').should('contain.text', '3.4');
-          cy.get('td[data-label="Memory usage (GiB)"]').should('contain.text', '2.5');
+          cy.findByTestId('workload-cpu-usage-cell').should('contain.text', '3.4');
+          cy.findByTestId('workload-memory-usage-cell').should('contain.text', '2.5');
         });
     });
 
@@ -446,8 +446,8 @@ describe('Project Metrics tab', () => {
         .findByText('test-workload-spinning-down-both')
         .closest('tr')
         .within(() => {
-          cy.get('td[data-label="CPU usage (cores)"]').should('not.contain.text', '-');
-          cy.get('td[data-label="Memory usage (GiB)"]').should('not.contain.text', '-');
+          cy.findByTestId('workload-cpu-usage-cell').should('not.contain.text', '-');
+          cy.findByTestId('workload-memory-usage-cell').should('not.contain.text', '-');
         });
     });
 
@@ -460,8 +460,8 @@ describe('Project Metrics tab', () => {
         .findByText('test-workload-spinning-down-cpu-only')
         .closest('tr')
         .within(() => {
-          cy.get('td[data-label="CPU usage (cores)"]').should('not.contain.text', '-');
-          cy.get('td[data-label="Memory usage (GiB)"]').should('contain.text', '-');
+          cy.findByTestId('workload-cpu-usage-cell').should('not.contain.text', '-');
+          cy.findByTestId('workload-memory-usage-cell').should('contain.text', '-');
         });
     });
   });

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -836,6 +836,7 @@ export enum WorkloadOwnerType {
   Job = 'Job',
   StatefulSet = 'StatefulSet',
   ReplicaSet = 'ReplicaSet',
+  LeaderWorkerSet = 'LeaderWorkerSet',
 }
 
 export type WorkloadKind = K8sResourceCommon & {


### PR DESCRIPTION
…metrics
https://redhat.atlassian.net/browse/RHOAIENG-76115

## Description
Fixes issue where on the Distributed Workloads Project Metrics tab, workloads owned by a LeaderWorkerSet (LWS) show - for CPU and memory usage even when pods are running and consuming resources.

Root cause
- Kueue sets the Workload CR ownerReferences.kind to LeaderWorkerSet.

- LWS manages pods via StatefulSets, so Prometheus kube_pod_owner reports owner_kind=StatefulSet (and StatefulSet names), not LeaderWorkerSet.

- The dashboard lookup cpuData[owner.kind][owner.name] / memoryData[owner.kind][owner.name] therefore finds nothing → UI shows -.

## Screenshots 

# BEFORE

<img width="1440" height="900" alt="lws-metrics-before-page" src="https://github.com/user-attachments/assets/5d393d75-5ec9-464f-8890-086d64310e54" />

<img width="1078" height="59" alt="lws-metrics-before-row" src="https://github.com/user-attachments/assets/8b8beea2-5b16-4b17-8ee1-abcb1496de4c" />
<img width="1078" height="177" alt="lws-metrics-before-table" src="https://github.com/user-attachments/assets/9c0be424-60eb-4256-b577-6c6a5c04110f" />

**On Cluster (dash-e2e-int)**
<img width="2541" height="1283" alt="SCR-20260810-lmyl" src="https://github.com/user-attachments/assets/82a65f46-d2b6-49c4-a6ab-339955ed01f5" />



# AFTER 
<img width="1078" height="59" alt="lws-metrics-after-row" src="https://github.com/user-attachments/assets/89298665-dd86-42e7-9fdc-e5fd46759d25" />
<img width="1078" height="177" alt="lws-metrics-after-table" src="https://github.com/user-attachments/assets/41c9114c-c30a-4aaf-a86d-01002283a86c" />

<img width="1440" height="900" alt="lws-metrics-after-page" src="https://github.com/user-attachments/assets/e0f71294-922a-4d64-ab02-bf083f7e481e" />

**On Cluster (dash-e2e-int)**
(memory is 0 because pod is not consuming memory)
<img width="2542" height="1279" alt="SCR-20260810-lprg" src="https://github.com/user-attachments/assets/1b07c8ac-4c15-48b9-8e15-d1161a6c34a1" />




## How Has This Been Tested?

**Automated**
- Unit: `cd frontend && npx jest --testPathPattern="distributedWorkloads" --no-coverage` (31 tests)
- Cypress mock: `globalDistributedWorkloads.cy.ts` — LWS row renders CPU/memory usage bars
- Before/after screenshots captured against Cypress mock server (`cypress:server:dev`)
**Cluster (dash-e2e-int)**
- Enabled Kueue `LeaderWorkerSet` integration temporarily
- Created ns `pdhote-lws-verify` with LocalQueue + smoke LWS `pdhote-lws-smoke`
- Verified Kueue Workload owned by `LeaderWorkerSet`, admitted, pod Running
- Prometheus: pod has both `label_leaderworkerset_sigs_k8s_io_name=pdhote-lws-smoke` and `kube_pod_owner{owner_kind="StatefulSet"}`
- PromQL LWS branch returns `owner_kind=LeaderWorkerSet`, `owner_name=pdhote-lws-smoke`
- UI via local dev (`npm run start:dev:ext`):
  - **With this PR:** Project metrics shows LWS workload in Top 5 + table with usage/requested columns populated
  - **On `main`:** same workload row exists but Top 5 shows "No workload metrics" (no LWS Prom series)
- Usage values were `0` because smoke pod runs `sleep infinity` (idle); requested `0.05` CPU / `0.06` GiB matched workload spec


## Test Impact
- Updated `distributedWorkloads.spec.ts` — PromQL assertions for LWS sub-query
- Updated `utils.spec.ts` — `getWorkloadOwner` for `LeaderWorkerSet`
- Added Cypress mock test: `Should render usage bars on a LeaderWorkerSet workload`
- Mock Prometheus response includes LWS CPU/memory series keyed by `LeaderWorkerSet` owner

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for monitoring LeaderWorkerSet workloads in distributed workload views.
- CPU and memory metrics now include LeaderWorkerSet workloads.
- LeaderWorkerSet workloads appear in ownership data, resource rankings, and usage totals.
- Resource tables display CPU and memory consumption alongside other supported workload types.
- “Other workloads” calculations now accurately include LeaderWorkerSet resource usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->