### PR TITLE
Cherry-pick: Fix(RHOAIENG-78948): lent case removal (#8803)

### DIFF
--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -56,28 +56,28 @@ class InfrastructurePage {
     return cy.findByTestId('hardware-usage-empty');
   }
 
-  findBorrowingLendingSection() {
-    return cy.findByTestId('infrastructure-borrowing-lending-section');
+  findBorrowingSection() {
+    return cy.findByTestId('infrastructure-borrowing-section');
   }
 
-  findBorrowingLendingChart() {
-    return cy.findByTestId('borrowing-lending-chart-has-data');
+  findBorrowingChart() {
+    return cy.findByTestId('borrowing-chart-has-data');
   }
 
-  findBorrowingLendingEmptyState() {
-    return cy.findByTestId('borrowing-lending-empty-state');
+  findBorrowingEmptyState() {
+    return cy.findByTestId('borrowing-empty-state');
   }
 
   findCohortSelect() {
-    return cy.findByTestId('borrowing-lending-cohort-select');
+    return cy.findByTestId('borrowing-cohort-select');
   }
 
   findCqNameFilter() {
-    return cy.findByTestId('borrowing-lending-cq-filter');
+    return cy.findByTestId('borrowing-cq-filter');
   }
 
   findCountLabel() {
-    return cy.findByTestId('borrowing-lending-count-label');
+    return cy.findByTestId('borrowing-count-label');
   }
 
   findCQUtilizationSection() {
@@ -105,8 +105,8 @@ class InfrastructurePage {
     return cy.findByTestId(`cohort-accordion-${cohortName}`);
   }
 
-  findCohortBorrowLendBadge() {
-    return cy.findByTestId('cohort-borrow-lend-badge');
+  findCohortBorrowBadge() {
+    return cy.findByTestId('cohort-borrow-badge');
   }
 
   findCohortUnallocatedBorrowable() {
@@ -119,10 +119,6 @@ class InfrastructurePage {
 
   findCQBorrowBadge() {
     return cy.findByTestId('cq-borrowed-badge');
-  }
-
-  findCQLendBadge() {
-    return cy.findByTestId('cq-lent-badge');
   }
 
   findCQWorkloadCounts() {
@@ -147,10 +143,6 @@ class InfrastructurePage {
 
   findDcgmMemoryDonutInCard(cqName: string) {
     return this.findCQCard(cqName).findByTestId('dcgm-memory-donut');
-  }
-
-  findCQLendBadgeInCard(cqName: string) {
-    return this.findCQCard(cqName).find('[data-testid="cq-lent-badge"]');
   }
 
   findCQBorrowBadgeInCard(cqName: string) {

--- a/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
@@ -32,8 +32,8 @@ describe('GPUaaS Infrastructure Page', () => {
       cy.step('Verify Hardware usage section is present');
       infrastructurePage.findHardwareUsageSection().should('exist');
 
-      cy.step('Verify Borrowing & lending section is present');
-      infrastructurePage.findBorrowingLendingSection().should('exist');
+      cy.step('Verify Borrowing section is present');
+      infrastructurePage.findBorrowingSection().should('exist');
 
       cy.step('Verify Cluster queue utilization section is present');
       infrastructurePage.findClusterQueueUtilizationSection().should('exist');

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -342,7 +342,7 @@ describe('GPUaaS Infrastructure Page', () => {
     });
   });
 
-  describe('Borrowing & lending chart', () => {
+  describe('Borrowing chart', () => {
     const cq1Opts = { name: 'cq-inference', cohortName: 'cohort-inference' };
     const cq2Opts = { name: 'cq-training', cohortName: 'cohort-inference' };
     const cohortName = 'cohort-inference';
@@ -356,7 +356,7 @@ describe('GPUaaS Infrastructure Page', () => {
       });
       infrastructurePage.visit();
 
-      infrastructurePage.findBorrowingLendingChart().should('exist');
+      infrastructurePage.findBorrowingChart().should('exist');
 
       infrastructurePage
         .findCohortSelect()
@@ -380,7 +380,7 @@ describe('GPUaaS Infrastructure Page', () => {
       asClusterAdminUser();
       initIntercepts({ hasChartData: false, clusterQueues: [cq1Opts], cohortNames: [cohortName] });
       infrastructurePage.visit();
-      infrastructurePage.findBorrowingLendingEmptyState().should('exist');
+      infrastructurePage.findBorrowingEmptyState().should('exist');
     });
   });
 
@@ -484,8 +484,8 @@ describe('GPUaaS Infrastructure Page', () => {
       infrastructurePage.findAcceleratorDonutChartInCard('experiment-queues').should('exist');
     });
 
-    describe('borrow-lend donut state', () => {
-      // a100-train-queues: 6 nominal, 4 used → lends 2; burst-training: 8 nominal, 10 used, 2 borrowed
+    describe('borrow donut state', () => {
+      // a100-train-queues: 6 nominal, 4 used → 2 unallocated (available to borrow); burst-training: 8 nominal, 10 used, 2 borrowed
       const COHORT = 'ml-training-cohort';
       const FLAVOR = 'a100-flavor';
 
@@ -520,18 +520,15 @@ describe('GPUaaS Infrastructure Page', () => {
         infrastructurePage.scrollToCQUtilizationSection();
       });
 
-      it('shows lend/borrow badges, workload counts, all chart columns, and per-model badge popovers', () => {
+      it('shows borrow badge, no lent badge, workload counts, all chart columns, and per-model badge popovers', () => {
         // Cohort-level badges
         infrastructurePage.findCohortAccordion(COHORT).should('exist');
-        infrastructurePage.findCohortBorrowLendBadge().should('exist');
+        infrastructurePage.findCohortBorrowBadge().should('exist');
         infrastructurePage
           .findCohortUnallocatedBorrowable()
           .should('contain.text', '2 available to borrow');
 
-        // Lender card
-        infrastructurePage
-          .findCQLendBadgeInCard('a100-train-queues')
-          .should('contain.text', 'Lent: 2');
+        // Unallocated-capacity CQ — no borrow badge, normal donut
         infrastructurePage
           .findWorkloadCountsInCard('a100-train-queues')
           .should('contain.text', 'Workloads: 1 active, 2 pending');
@@ -540,15 +537,6 @@ describe('GPUaaS Infrastructure Page', () => {
           .findCQCard('a100-train-queues')
           .should('contain.text', 'Compute consumption')
           .should('contain.text', 'Memory consumption');
-
-        // Lent badge popover: shows counterpart CQ and per-model lent count
-        infrastructurePage.findCQLendBadgeInCard('a100-train-queues').click();
-        infrastructurePage
-          .findOpenPopover()
-          .should('contain.text', 'Lent capacity')
-          .should('contain.text', 'burst-training')
-          .should('contain.text', '2 × NVIDIA A100');
-        cy.get('body').type('{esc}');
 
         // Borrower card
         infrastructurePage
@@ -563,18 +551,18 @@ describe('GPUaaS Infrastructure Page', () => {
           .should('contain.text', 'Compute consumption')
           .should('contain.text', 'Memory consumption');
 
-        // Borrowed badge popover: shows counterpart CQ and per-model borrowed count
+        // Borrowed badge popover: shows per-model borrowed count
         infrastructurePage.findCQBorrowBadgeInCard('burst-training').click();
         infrastructurePage
           .findOpenPopover()
           .should('contain.text', 'Borrowed capacity')
-          .should('contain.text', 'a100-train-queues')
           .should('contain.text', '2 × NVIDIA A100');
         cy.get('body').type('{esc}');
       });
 
       it('shows per-model breakdown in donut segment hover tooltip', () => {
-        // Total accelerators — Own segment
+        // a100-train-queues has unallocated capacity but is shown as a normal donut (no Lent segment).
+        // Hovering the used segment shows the own-capacity tooltip.
         infrastructurePage
           .findAcceleratorDonutChartInCard('a100-train-queues')
           .find('svg path')
@@ -583,27 +571,6 @@ describe('GPUaaS Infrastructure Page', () => {
         infrastructurePage
           .findCQCard('a100-train-queues')
           .should('contain.text', 'NVIDIA A100: 4/6 in use');
-
-        // Total accelerators — Lent segment
-        infrastructurePage
-          .findAcceleratorDonutChartInCard('a100-train-queues')
-          .find('svg path')
-          .eq(1)
-          .trigger('mouseover', { force: true });
-        infrastructurePage
-          .findCQCard('a100-train-queues')
-          .should('contain.text', '2 GPUs lent')
-          .should('contain.text', 'NVIDIA A100: 2 lent');
-
-        // DCGM compute — Lent segment
-        infrastructurePage
-          .findDcgmComputeDonutInCard('a100-train-queues')
-          .find('svg path')
-          .eq(1)
-          .trigger('mouseover', { force: true });
-        infrastructurePage
-          .findCQCard('a100-train-queues')
-          .should('contain.text', 'NVIDIA A100: 30% utilization');
       });
 
       describe('pure borrower CQ (nominal=0, used>0)', () => {

--- a/packages/gpuaas/src/components/AcceleratorDonutChart.tsx
+++ b/packages/gpuaas/src/components/AcceleratorDonutChart.tsx
@@ -1,14 +1,8 @@
 import * as React from 'react';
 import { Bullseye } from '@patternfly/react-core';
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
 import {
-  ChartDonut,
-  ChartDonutThreshold,
-  ChartDonutUtilization,
-} from '@patternfly/react-charts/victory';
-import {
-  chart_color_black_300 as chartColorGray,
   chart_color_blue_300 as chartColorBlue,
-  chart_color_purple_100 as chartColorPurple,
   chart_color_orange_100 as chartColorOrange,
 } from '@patternfly/react-tokens';
 import { SUBTITLE_LABEL, TITLE_LABEL } from './ClusterQueueChartComponents';
@@ -17,7 +11,6 @@ import {
   AcceleratorDonutType,
   AcceleratorSegment,
   buildAcceleratorBorrowedLines,
-  buildAcceleratorLentLines,
   buildAcceleratorOwnLines,
 } from '../utils/clusterQueueUtils';
 import { CQ_DONUT_INNER_RADIUS, CQ_DONUT_SIZE } from '../const';
@@ -38,85 +31,25 @@ const AcceleratorDonutChart: React.FC<AcceleratorDonutChartProps> = ({
     return null;
   }
 
-  if (config.type === AcceleratorDonutType.BorrowLend) {
-    if (config.isBorrowing) {
-      const nonZeroSegments = config.segments.filter((s) => s.y > 0);
-      const totalSlots = nonZeroSegments.reduce((sum, s) => sum + s.y, 0);
-      const borrowedSlots =
-        nonZeroSegments.find((s) => s.x === AcceleratorSegment.Borrowed)?.y ?? 0;
-      const borrowedPct = totalSlots > 0 ? (borrowedSlots / totalSlots) * 100 : 0;
+  if (config.type === AcceleratorDonutType.Borrow) {
+    const nonZeroSegments = config.segments.filter((s) => s.y > 0);
+    const totalSlots = nonZeroSegments.reduce((sum, s) => sum + s.y, 0);
+    const borrowedSlots = nonZeroSegments.find((s) => s.x === AcceleratorSegment.Borrowed)?.y ?? 0;
+    const borrowedPct = totalSlots > 0 ? (borrowedSlots / totalSlots) * 100 : 0;
 
-      const borrowedTooltip = [
-        `Total borrowed in use: ${Math.round(borrowedPct)}%`,
-        buildAcceleratorBorrowedLines(perModelGpus),
-      ]
-        .filter(Boolean)
-        .join('\n');
-
-      const ownUsed = config.used - borrowedSlots;
-      // Pure borrowers have no owned capacity, skip per-model breakdown to avoid "6/0 in use" output
-      const ownBorrowedTooltip = [
-        `Total owned in use: ${ownUsed}`,
-        ownUsed > 0 ? buildAcceleratorOwnLines(perModelGpus) : null,
-      ]
-        .filter(Boolean)
-        .join('\n');
-
-      return (
-        <Bullseye
-          data-testid="accelerator-donut-chart"
-          style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }}
-        >
-          <ChartDonutThreshold
-            ariaTitle={`Accelerator consumption: ${config.title} (borrowed)`}
-            constrainToVisibleArea
-            data={[{ x: AcceleratorSegment.Own, y: ownUsed > 0 ? 100 : 0 }]}
-            colorScale={[chartColorBlue.value]}
-            height={CQ_DONUT_SIZE}
-            width={CQ_DONUT_SIZE}
-            name={`accelerators-${cqName}`}
-            labels={() => ownBorrowedTooltip}
-          >
-            <ChartDonutUtilization
-              data={{ x: AcceleratorSegment.Borrowed, y: borrowedPct }}
-              thresholds={[{ value: 0, color: chartColorOrange.value }]}
-              labels={({ datum }) =>
-                datum.x === AcceleratorSegment.Borrowed ? borrowedTooltip : ''
-              }
-              title={config.title}
-              subTitle="in use"
-              titleComponent={TITLE_LABEL}
-              subTitleComponent={SUBTITLE_LABEL}
-            />
-          </ChartDonutThreshold>
-        </Bullseye>
-      );
-    }
-
-    // Lent: proportional ring — Own (blue) + Lent (purple).
-    const colorMap: Record<string, string> = {
-      [AcceleratorSegment.Own]: chartColorBlue.value,
-      [AcceleratorSegment.Lent]: chartColorPurple.value,
-    };
-    const visibleSegments = config.segments.filter((seg) => seg.y > 0);
-    const chartData =
-      visibleSegments.length > 0
-        ? visibleSegments
-        : [{ x: AcceleratorSegment.NoData, y: config.nominal }];
-    const chartColorScale =
-      visibleSegments.length > 0
-        ? visibleSegments.map((seg) => colorMap[seg.x] ?? chartColorGray.value)
-        : [chartColorGray.value];
-
-    const ownTooltip = [
-      `Total owned in use: ${config.used}`,
-      buildAcceleratorOwnLines(perModelGpus),
+    const borrowedTooltip = [
+      `Total borrowed in use: ${Math.round(borrowedPct)}%`,
+      buildAcceleratorBorrowedLines(perModelGpus),
     ]
       .filter(Boolean)
       .join('\n');
 
-    const lentCount = config.segments.find((s) => s.x === AcceleratorSegment.Lent)?.y ?? 0;
-    const lentTooltip = [`${lentCount} GPUs lent`, buildAcceleratorLentLines(perModelGpus)]
+    const ownUsed = config.used - borrowedSlots;
+    // Pure borrowers have no owned capacity, skip per-model breakdown to avoid "6/0 in use" output
+    const ownBorrowedTooltip = [
+      `Total owned in use: ${ownUsed}`,
+      ownUsed > 0 ? buildAcceleratorOwnLines(perModelGpus) : null,
+    ]
       .filter(Boolean)
       .join('\n');
 
@@ -125,21 +58,26 @@ const AcceleratorDonutChart: React.FC<AcceleratorDonutChartProps> = ({
         data-testid="accelerator-donut-chart"
         style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }}
       >
-        <ChartDonut
-          ariaTitle={`Accelerator consumption: ${config.title} (lent)`}
+        <ChartDonutThreshold
+          ariaTitle={`Accelerator consumption: ${config.title} (borrowed)`}
           constrainToVisibleArea
-          data={chartData}
-          colorScale={chartColorScale}
-          labels={({ datum }) => (datum.x === AcceleratorSegment.Own ? ownTooltip : lentTooltip)}
+          data={[{ x: AcceleratorSegment.Own, y: ownUsed > 0 ? 100 : 0 }]}
+          colorScale={[chartColorBlue.value]}
           height={CQ_DONUT_SIZE}
           width={CQ_DONUT_SIZE}
-          innerRadius={CQ_DONUT_INNER_RADIUS}
-          title={config.title}
-          subTitle="in use"
-          titleComponent={TITLE_LABEL}
-          subTitleComponent={SUBTITLE_LABEL}
           name={`accelerators-${cqName}`}
-        />
+          labels={() => ownBorrowedTooltip}
+        >
+          <ChartDonutUtilization
+            data={{ x: AcceleratorSegment.Borrowed, y: borrowedPct }}
+            thresholds={[{ value: 0, color: chartColorOrange.value }]}
+            labels={({ datum }) => (datum.x === AcceleratorSegment.Borrowed ? borrowedTooltip : '')}
+            title={config.title}
+            subTitle="in use"
+            titleComponent={TITLE_LABEL}
+            subTitleComponent={SUBTITLE_LABEL}
+          />
+        </ChartDonutThreshold>
       </Bullseye>
     );
   }

--- a/packages/gpuaas/src/components/BorrowingLendingChart.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingChart.tsx
@@ -114,9 +114,9 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
       {loaded && !error && !hasSomeData && (
         <EmptyState
           icon={ChartLineIcon}
-          titleText="No borrowing/lending activity detected"
+          titleText="No borrowing activity detected"
           headingLevel="h4"
-          data-testid="borrowing-lending-empty-state"
+          data-testid="borrowing-empty-state"
         >
           <EmptyStateBody>
             No accelerator usage data is available for the selected cluster queues over the past 7
@@ -127,7 +127,7 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
       {showChart && (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
-          data-testid="borrowing-lending-chart-has-data"
+          data-testid="borrowing-chart-has-data"
           onClick={(e) => {
             if (e.target instanceof SVGTextElement) {
               return;
@@ -138,7 +138,7 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
           }}
         >
           <Chart
-            ariaTitle="Borrowing and lending trends"
+            ariaTitle="Borrowing trends"
             containerComponent={
               <CursorVoronoiContainer
                 cursorDimension="x"
@@ -183,13 +183,6 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
               text="Borrowed"
               x={4}
               y={CHART_PADDING.top - 12}
-              style={AXIS_DIRECTION_LABEL_STYLE}
-              textAnchor="start"
-            />
-            <ChartLabel
-              text="Lent"
-              x={4}
-              y={CHART_HEIGHT - CHART_PADDING.bottom - 12}
               style={AXIS_DIRECTION_LABEL_STYLE}
               textAnchor="start"
             />

--- a/packages/gpuaas/src/components/BorrowingLendingSection.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingSection.tsx
@@ -110,7 +110,7 @@ const BorrowingLendingSection: React.FC = () => {
           <ToolbarGroup style={{ width: '100%' }}>
             <ToolbarItem className="gpuaas-cohort-select-toolbar-item">
               <FormGroup
-                fieldId="borrowing-lending-cohort-select-toggle"
+                fieldId="borrowing-cohort-select-toggle"
                 label="Cohort"
                 style={{ width: '100%' }}
               >
@@ -120,8 +120,8 @@ const BorrowingLendingSection: React.FC = () => {
                   onChange={(val) => setSelectedCohort(val)}
                   groupedOptions={cohortGroupedOptions}
                   isDisabled={!cohortsLoaded}
-                  toggleProps={{ id: 'borrowing-lending-cohort-select-toggle' }}
-                  dataTestId="borrowing-lending-cohort-select"
+                  toggleProps={{ id: 'borrowing-cohort-select-toggle' }}
+                  dataTestId="borrowing-cohort-select"
                   popperProps={{ maxWidth: undefined }}
                 />
               </FormGroup>
@@ -134,13 +134,13 @@ const BorrowingLendingSection: React.FC = () => {
                 value={cqNameFilter}
                 onChange={(_ev, val) => setCqNameFilter(val)}
                 onClear={() => setCqNameFilter('')}
-                inputProps={{ 'data-testid': 'borrowing-lending-cq-filter' }}
+                inputProps={{ 'data-testid': 'borrowing-cq-filter' }}
               />
             </ToolbarItem>
           </ToolbarGroup>
         </ToolbarContent>
       </Toolbar>
-      <Content component="small" data-testid="borrowing-lending-count-label">
+      <Content component="small" data-testid="borrowing-count-label">
         {`Showing ${visibleCQCount} of ${totalCQCount} cluster queues`}
       </Content>
       <div ref={chartContainerRef}>

--- a/packages/gpuaas/src/components/BorrowingLendingTooltip.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingTooltip.tsx
@@ -110,9 +110,8 @@ const buildTooltipSnapshot = (
 const TooltipSeriesEntry: React.FC<TooltipSeriesEntryProps> = ({ point, info, color }) => {
   const net = Math.round(point.y);
   const quota = Math.round(point.nominalQuota ?? 0);
-  const usage = Math.round(point.y + (point.nominalQuota ?? 0));
+  const usage = Math.round(point.gpuUsage ?? point.y + (point.nominalQuota ?? 0));
   const borrowing = Math.max(0, net);
-  const lending = Math.max(0, -net);
   const entryLabel = getEntryLabel(info, point.childName ?? '');
 
   return (
@@ -138,7 +137,7 @@ const TooltipSeriesEntry: React.FC<TooltipSeriesEntryProps> = ({ point, info, co
       </StackItem>
       <StackItem>
         <Content component="small" className="gpuaas-tooltip-subtle">
-          {`Borrowing ${borrowing} · Lending ${lending}`}
+          {`Borrowing ${borrowing}`}
         </Content>
       </StackItem>
     </Stack>

--- a/packages/gpuaas/src/components/ClusterQueueCard.tsx
+++ b/packages/gpuaas/src/components/ClusterQueueCard.tsx
@@ -12,13 +12,12 @@ import {
 } from '@patternfly/react-core';
 import {
   chart_color_blue_300 as chartColorBlue,
-  chart_color_purple_100 as chartColorPurple,
   chart_color_orange_100 as chartColorOrange,
 } from '@patternfly/react-tokens';
 import { ClusterQueueKind } from '@odh-dashboard/internal/k8sTypes';
 import AcceleratorDonutChart from './AcceleratorDonutChart';
 import {
-  BorrowLendBadge,
+  BorrowBadge,
   ChartColumn,
   DcgmDonut,
   PerModelDcgmData,
@@ -29,8 +28,8 @@ import {
   AcceleratorSegment,
   formatWorkloadCounts,
   getAcceleratorDonutConfig,
-  getBorrowLendBadgeState,
-  getBorrowLendInfo,
+  getBorrowBadgeState,
+  getBorrowInfo,
   isInCohort,
 } from '../utils/clusterQueueUtils';
 
@@ -38,7 +37,6 @@ type ClusterQueueCardProps = {
   cq: ClusterQueueKind;
   hardwareModels: string[];
   perModelGpus?: ModelGpuCount[];
-  counterpartCQNames?: string[];
   /** True when the DCGM service is present; controls whether the two chart columns render at all. */
   dcgmAvailable?: boolean;
   computeUtilization?: number | null;
@@ -50,14 +48,12 @@ type ClusterQueueCardProps = {
 const LEGEND_COLORS: Record<string, string> = {
   [AcceleratorSegment.Own]: chartColorBlue.value,
   [AcceleratorSegment.Borrowed]: chartColorOrange.value,
-  [AcceleratorSegment.Lent]: chartColorPurple.value,
 };
 
 const ClusterQueueCard: React.FC<ClusterQueueCardProps> = ({
   cq,
   hardwareModels,
   perModelGpus = [],
-  counterpartCQNames = [],
   dcgmAvailable = false,
   computeUtilization,
   memoryUtilization,
@@ -70,14 +66,12 @@ const ClusterQueueCard: React.FC<ClusterQueueCardProps> = ({
   const cqIsInCohort = isInCohort(cq);
 
   const donutConfig = getAcceleratorDonutConfig(cq, cqIsInCohort);
-  const { borrowing, lending, lentCount, borrowedCount } = getBorrowLendBadgeState(donutConfig);
+  const { borrowing, borrowedCount } = getBorrowBadgeState(donutConfig);
 
-  const borrowLendInfo = getBorrowLendInfo(donutConfig);
+  const borrowInfo = getBorrowInfo(donutConfig);
   const legendSeriesNames =
-    donutConfig.type === AcceleratorDonutType.BorrowLend
-      ? donutConfig.isBorrowing
-        ? [AcceleratorSegment.Own, AcceleratorSegment.Borrowed]
-        : [AcceleratorSegment.Own, AcceleratorSegment.Lent]
+    donutConfig.type === AcceleratorDonutType.Borrow
+      ? [AcceleratorSegment.Own, AcceleratorSegment.Borrowed]
       : [];
   const legendItems = legendSeriesNames.map((seriesName) => ({
     name: seriesName,
@@ -85,7 +79,7 @@ const ClusterQueueCard: React.FC<ClusterQueueCardProps> = ({
   }));
 
   return (
-    <Card isCompact data-testid={`cq-card-${name}`}>
+    <Card isCompact isFullHeight data-testid={`cq-card-${name}`}>
       <CardTitle>
         <Flex
           alignItems={{ default: 'alignItemsCenter' }}
@@ -110,25 +104,12 @@ const ClusterQueueCard: React.FC<ClusterQueueCardProps> = ({
               </LabelGroup>
             </FlexItem>
           )}
-          {lending && cqIsInCohort && (
-            <FlexItem>
-              <BorrowLendBadge
-                type="lent"
-                count={lentCount}
-                models={hardwareModels}
-                perModelGpus={perModelGpus}
-                counterpartCQNames={counterpartCQNames}
-              />
-            </FlexItem>
-          )}
           {borrowing && (
             <FlexItem>
-              <BorrowLendBadge
-                type="borrowed"
+              <BorrowBadge
                 count={borrowedCount}
                 models={hardwareModels}
                 perModelGpus={perModelGpus}
-                counterpartCQNames={counterpartCQNames}
               />
             </FlexItem>
           )}
@@ -160,7 +141,7 @@ const ClusterQueueCard: React.FC<ClusterQueueCardProps> = ({
                   <DcgmDonut
                     percentage={computeUtilization}
                     ariaLabel="Accelerator compute consumption"
-                    borrowLendInfo={borrowLendInfo}
+                    borrowInfo={borrowInfo}
                     perModelData={perModelComputeDcgm}
                     testId="dcgm-compute-donut"
                   />
@@ -171,7 +152,7 @@ const ClusterQueueCard: React.FC<ClusterQueueCardProps> = ({
                   <DcgmDonut
                     percentage={memoryUtilization}
                     ariaLabel="Accelerator memory consumption"
-                    borrowLendInfo={borrowLendInfo}
+                    borrowInfo={borrowInfo}
                     perModelData={perModelMemoryDcgm}
                     testId="dcgm-memory-donut"
                   />

--- a/packages/gpuaas/src/components/ClusterQueueChartComponents.tsx
+++ b/packages/gpuaas/src/components/ClusterQueueChartComponents.tsx
@@ -12,37 +12,30 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import {
-  ChartDonut,
   ChartDonutThreshold,
   ChartDonutUtilization,
   ChartLabel,
 } from '@patternfly/react-charts/victory';
 import {
-  chart_color_black_300 as chartColorGray,
   chart_color_blue_300 as chartColorBlue,
-  chart_color_purple_100 as chartColorPurple,
   chart_color_orange_100 as chartColorOrange,
 } from '@patternfly/react-tokens';
 import {
   AcceleratorSegment,
-  BorrowLendInfo,
+  BorrowInfo,
   PerModelDcgmData,
   buildDcgmBorrowedTooltip,
-  buildDcgmLentTooltip,
   buildDcgmOwnTooltip,
-  computeDcgmSplitData,
 } from '../utils/clusterQueueUtils';
 import { ModelGpuCount } from '../utils/hardwareModels';
 import { CQ_DONUT_INNER_RADIUS, CQ_DONUT_SIZE } from '../const';
 
-export type { BorrowLendInfo, PerModelDcgmData };
+export type { BorrowInfo, PerModelDcgmData };
 
-type BorrowLendBadgeProps = {
-  type: 'borrowed' | 'lent';
+type BorrowBadgeProps = {
   count: number;
   models: string[];
   perModelGpus?: ModelGpuCount[];
-  counterpartCQNames?: string[];
 };
 
 type DcgmDonutProps = {
@@ -53,17 +46,10 @@ type DcgmDonutProps = {
    */
   percentage: number | null | undefined;
   ariaLabel: string;
-  borrowLendInfo?: BorrowLendInfo;
-  /** Per-GPU-model utilization for richer hover tooltips in lent/borrowed state. */
+  borrowInfo?: BorrowInfo;
+  /** Per-GPU-model utilization for richer hover tooltips in borrowed state. */
   perModelData?: PerModelDcgmData[];
   testId?: string;
-};
-
-const SEGMENT_COLORS: Record<string, string> = {
-  [AcceleratorSegment.Own]: chartColorBlue.value,
-  [AcceleratorSegment.Lent]: chartColorPurple.value,
-  [AcceleratorSegment.Available]: chartColorGray.value,
-  [AcceleratorSegment.NoData]: chartColorGray.value,
 };
 
 export const TITLE_LABEL = <ChartLabel style={{ fontSize: 18, fill: 'currentColor' }} />;
@@ -91,31 +77,14 @@ export const ChartColumn: React.FC<{ label: string; children: React.ReactNode }>
   </FlexItem>
 );
 
-export const BorrowLendBadge: React.FC<BorrowLendBadgeProps> = ({
-  type,
-  count,
-  models,
-  perModelGpus = [],
-  counterpartCQNames = [],
-}) => {
-  const isBorrowed = type === 'borrowed';
-  const directionLabel = isBorrowed ? 'From' : 'To';
-
-  const perModelRows = isBorrowed
-    ? perModelGpus
-        .filter((m) => (m.borrowed ?? 0) > 0)
-        .map((m) => (
-          <Content key={m.model} component={ContentVariants.small}>
-            {m.borrowed ?? 0} × {m.model}
-          </Content>
-        ))
-    : perModelGpus
-        .filter((m) => m.nominal - m.used > 0)
-        .map((m) => (
-          <Content key={m.model} component={ContentVariants.small}>
-            {m.nominal - m.used} × {m.model}
-          </Content>
-        ));
+export const BorrowBadge: React.FC<BorrowBadgeProps> = ({ count, models, perModelGpus = [] }) => {
+  const perModelRows = perModelGpus
+    .filter((m) => (m.borrowed ?? 0) > 0)
+    .map((m) => (
+      <Content key={m.model} component={ContentVariants.small}>
+        {m.borrowed ?? 0} × {m.model}
+      </Content>
+    ));
 
   const fallbackRow = (
     <Content component={ContentVariants.small}>
@@ -125,29 +94,15 @@ export const BorrowLendBadge: React.FC<BorrowLendBadgeProps> = ({
 
   return (
     <Popover
-      headerContent={isBorrowed ? 'Borrowed capacity' : 'Lent capacity'}
+      headerContent="Borrowed capacity"
       bodyContent={
         <Stack hasGutter>
-          {counterpartCQNames.length > 0 && (
-            <StackItem>
-              {counterpartCQNames.map((cqName) => (
-                <Content key={cqName} component={ContentVariants.small}>
-                  {directionLabel}: <strong>{cqName}</strong>
-                </Content>
-              ))}
-            </StackItem>
-          )}
           <StackItem>{perModelRows.length > 0 ? perModelRows : fallbackRow}</StackItem>
         </Stack>
       }
     >
-      <Label
-        color={isBorrowed ? 'orange' : 'purple'}
-        isCompact
-        onClick={() => undefined}
-        data-testid={`cq-${type}-badge`}
-      >
-        {isBorrowed ? `Borrowed: ${count}` : `Lent: ${count}`}
+      <Label color="orange" isCompact onClick={() => undefined} data-testid="cq-borrowed-badge">
+        Borrowed: {count}
       </Label>
     </Popover>
   );
@@ -156,7 +111,7 @@ export const BorrowLendBadge: React.FC<BorrowLendBadgeProps> = ({
 export const DcgmDonut: React.FC<DcgmDonutProps> = ({
   percentage,
   ariaLabel,
-  borrowLendInfo,
+  borrowInfo,
   perModelData = [],
   testId,
 }) => {
@@ -189,69 +144,34 @@ export const DcgmDonut: React.FC<DcgmDonutProps> = ({
     );
   }
 
-  if (borrowLendInfo) {
-    if (borrowLendInfo.isBorrowing) {
-      const fillPct = Math.min(percentage, 99.9); // avoid full-circle SVG edge case at 100
-      return (
-        <Bullseye style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }} data-testid={testId}>
-          <ChartDonutThreshold
-            ariaTitle={`${ariaLabel} (borrowed)`}
-            constrainToVisibleArea
-            data={[{ x: AcceleratorSegment.Own, y: 100 }]}
-            colorScale={[chartColorBlue.value]}
-            height={CQ_DONUT_SIZE}
-            width={CQ_DONUT_SIZE}
-            name={`dcgm-${ariaLabel}`}
-            labels={() => buildDcgmOwnTooltip(percentage, perModelData)}
-          >
-            <ChartDonutUtilization
-              data={{ x: AcceleratorSegment.Borrowed, y: fillPct }}
-              thresholds={[{ value: 0, color: chartColorOrange.value }]}
-              labels={({ datum }) =>
-                datum.x === AcceleratorSegment.Borrowed
-                  ? buildDcgmBorrowedTooltip(datum.y, perModelData)
-                  : `Own: ${Math.round(datum.y)}%`
-              }
-              title={`${Math.round(percentage)}%`}
-              subTitle="consumption"
-              titleComponent={TITLE_LABEL}
-              subTitleComponent={SUBTITLE_LABEL}
-            />
-          </ChartDonutThreshold>
-        </Bullseye>
-      );
-    }
-
-    // Lent: proportional ring — Own / Lent / Available segments.
-    const { chartData } = computeDcgmSplitData(percentage, borrowLendInfo);
-    // Map colors by segment name so filtering zero-value segments doesn't shift colors.
-    const chartColorScale = chartData.map((d) => SEGMENT_COLORS[d.x] ?? chartColorGray.value);
-
+  if (borrowInfo) {
+    const fillPct = Math.min(percentage, 99.9); // avoid full-circle SVG edge case at 100
     return (
       <Bullseye style={{ height: CQ_DONUT_SIZE, width: CQ_DONUT_SIZE }} data-testid={testId}>
-        <ChartDonut
-          ariaTitle={`${ariaLabel} (lent)`}
+        <ChartDonutThreshold
+          ariaTitle={`${ariaLabel} (borrowed)`}
           constrainToVisibleArea
-          data={chartData}
-          colorScale={chartColorScale}
-          labels={({ datum }) => {
-            if (datum.x === AcceleratorSegment.Available || datum.x === AcceleratorSegment.NoData) {
-              return `Available: ${Math.round(datum.y)}%`;
-            }
-            if (datum.x === AcceleratorSegment.Lent) {
-              return buildDcgmLentTooltip(datum.y, perModelData);
-            }
-            return `Own: ${Math.round(datum.y)}%`;
-          }}
+          data={[{ x: AcceleratorSegment.Own, y: 100 }]}
+          colorScale={[chartColorBlue.value]}
           height={CQ_DONUT_SIZE}
           width={CQ_DONUT_SIZE}
-          innerRadius={CQ_DONUT_INNER_RADIUS}
-          title={`${Math.round(percentage)}%`}
-          subTitle="consumption"
-          titleComponent={TITLE_LABEL}
-          subTitleComponent={SUBTITLE_LABEL}
           name={`dcgm-${ariaLabel}`}
-        />
+          labels={() => buildDcgmOwnTooltip(percentage, perModelData)}
+        >
+          <ChartDonutUtilization
+            data={{ x: AcceleratorSegment.Borrowed, y: fillPct }}
+            thresholds={[{ value: 0, color: chartColorOrange.value }]}
+            labels={({ datum }) =>
+              datum.x === AcceleratorSegment.Borrowed
+                ? buildDcgmBorrowedTooltip(datum.y, perModelData)
+                : `Own: ${Math.round(datum.y)}%`
+            }
+            title={`${Math.round(percentage)}%`}
+            subTitle="consumption"
+            titleComponent={TITLE_LABEL}
+            subTitleComponent={SUBTITLE_LABEL}
+          />
+        </ChartDonutThreshold>
       </Bullseye>
     );
   }

--- a/packages/gpuaas/src/components/CohortAccordionGroup.tsx
+++ b/packages/gpuaas/src/components/CohortAccordionGroup.tsx
@@ -22,8 +22,7 @@ import {
   filterAcceleratorCQs,
   getCohortTotalAccelerators,
   getCohortUnallocatedBorrowable,
-  getCounterpartCQNames,
-  isCohortBorrowLendActive,
+  isCohortBorrowActive,
   resolveCQDcgmUtilization,
   resolvePerModelDcgmData,
 } from '../utils/clusterQueueUtils';
@@ -64,7 +63,7 @@ const CohortAccordionGroup: React.FC<CohortAccordionGroupProps> = ({
         const acceleratorCQs = filterAcceleratorCQs(cohort.memberClusterQueues);
         const total = getCohortTotalAccelerators(cohort);
         const unallocatedBorrowable = getCohortUnallocatedBorrowable(cohort);
-        const borrowLendActive = isCohortBorrowLendActive(cohort);
+        const borrowActive = isCohortBorrowActive(cohort);
         const isExpanded = expanded.has(cohort.name);
         const cohortLabel = cohort.name || 'Not in a cohort';
 
@@ -116,9 +115,14 @@ const CohortAccordionGroup: React.FC<CohortAccordionGroupProps> = ({
                           </Content>
                         </FlexItem>
                       )}
-                      {borrowLendActive && (
+                      {borrowActive && (
                         <FlexItem>
-                          <Label color="purple" isCompact data-testid="cohort-borrow-lend-badge">
+                          <Label
+                            color="orange"
+                            variant="outline"
+                            isCompact
+                            data-testid="cohort-borrow-badge"
+                          >
                             Borrowing enabled
                           </Label>
                         </FlexItem>
@@ -156,20 +160,12 @@ const CohortAccordionGroup: React.FC<CohortAccordionGroupProps> = ({
                         // 1 card → full width; 2+ → half each so they always fill the row
                         const span = acceleratorCQs.length === 1 ? 12 : 6;
 
-                        // Use all member CQs (not just accelerator-filtered ones) so borrowing CQs
-                        // with nominal=0 GPU quota are still found as counterparts.
-                        const counterpartCQNames = getCounterpartCQNames(
-                          cq,
-                          cohort.memberClusterQueues,
-                        );
-
                         return (
                           <GridItem key={cqName} span={span}>
                             <ClusterQueueCard
                               cq={cq}
                               hardwareModels={models}
                               perModelGpus={perModelGpus}
-                              counterpartCQNames={counterpartCQNames}
                               dcgmAvailable={dcgmAvailable}
                               computeUtilization={computeUtilization}
                               memoryUtilization={memoryUtilization}

--- a/packages/gpuaas/src/components/__tests__/BorrowingLendingChart.spec.tsx
+++ b/packages/gpuaas/src/components/__tests__/BorrowingLendingChart.spec.tsx
@@ -13,7 +13,8 @@ const makeSeries = (cqName: string, cohortName: string, points = 3): CQMetricSer
   nominalQuota: 8,
   data: Array.from({ length: points }, (_, i) => ({
     x: NOW - (points - i) * ONE_HOUR_MS,
-    y: i % 2 === 0 ? 2 : -1,
+    y: i % 2 === 0 ? 2 : 0,
+    gpuUsage: i % 2 === 0 ? 10 : 7,
   })),
 });
 
@@ -25,8 +26,8 @@ describe('BorrowingLendingChart', () => {
 
   it('shows empty state when loaded with no data', () => {
     render(<BorrowingLendingChart series={[]} loaded error={undefined} />);
-    expect(screen.getByTestId('borrowing-lending-empty-state')).toBeInTheDocument();
-    expect(screen.getByText(/No borrowing\/lending activity detected/i)).toBeInTheDocument();
+    expect(screen.getByTestId('borrowing-empty-state')).toBeInTheDocument();
+    expect(screen.getByText(/No borrowing activity detected/i)).toBeInTheDocument();
   });
 
   it('shows error message when an error is provided', () => {
@@ -40,6 +41,6 @@ describe('BorrowingLendingChart', () => {
     const series = [makeSeries('cq-a', 'cohort-1')];
     render(<BorrowingLendingChart series={series} loaded error={undefined} />);
     expect(document.querySelector('svg')).toBeInTheDocument();
-    expect(screen.queryByTestId('borrowing-lending-empty-state')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('borrowing-empty-state')).not.toBeInTheDocument();
   });
 });

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -16,10 +16,10 @@ export const INFRASTRUCTURE_SECTIONS = [
     isPlain: false,
   },
   {
-    id: 'borrowing-lending',
-    title: 'Borrowing and lending',
+    id: 'borrowing',
+    title: 'Borrowing trends',
     description:
-      '7-day borrowing and lending trends by cluster queue. When a cluster queue uses its full quota, it can borrow accelerators from other queues. ',
+      '7-day borrowing trends by cluster queue. When a cluster queue uses its full quota, it can borrow accelerators from other queues.',
     isPlain: false,
   },
   {

--- a/packages/gpuaas/src/hooks/__tests__/useBorrowingLendingMetrics.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useBorrowingLendingMetrics.spec.ts
@@ -112,13 +112,30 @@ describe('buildSeries', () => {
   });
 
   it.each([
-    ['borrowing (usage > quota)', '6', 4, 2],
-    ['lending (usage < quota)', '1', 4, -3],
-  ])('computes y correctly for %s', (_label, usage, quota, expectedY) => {
+    ['borrowing (usage > quota)', '6', 4, 2, 6],
+    ['unallocated capacity (usage < quota) — clipped to 0', '1', 4, 0, 1],
+  ])(
+    'computes y and gpuUsage correctly for %s',
+    (_label, usage, quota, expectedY, expectedGpuUsage) => {
+      const series = buildSeries(
+        [makeResult('cq-a', [[1700000000, usage]])],
+        makeCQInfoMap([['cq-a', { nominalQuota: quota, cohortName: 'cohort-1' }]]),
+      );
+      expect(series[0].data[0].y).toBeCloseTo(expectedY);
+      expect(series[0].data[0].gpuUsage).toBeCloseTo(expectedGpuUsage);
+    },
+  );
+
+  it.each([
+    ['NaN string', 'NaN'],
+    ['empty string', ''],
+    ['whitespace', '   '],
+    ['Infinity', 'Infinity'],
+  ])('drops non-finite sample: %s', (_label, valueStr) => {
     const series = buildSeries(
-      [makeResult('cq-a', [[1700000000, usage]])],
-      makeCQInfoMap([['cq-a', { nominalQuota: quota, cohortName: 'cohort-1' }]]),
+      [makeResult('cq-a', [[1700000000, valueStr]])],
+      makeCQInfoMap([['cq-a', { nominalQuota: 4, cohortName: 'cohort-1' }]]),
     );
-    expect(series[0].data[0].y).toBeCloseTo(expectedY);
+    expect(series[0].data).toHaveLength(0);
   });
 });

--- a/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
+++ b/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
@@ -45,7 +45,7 @@ export type CQMetricSeries = {
   cohortName: string;
   /** Nominal GPU quota declared for this cluster queue (in GPU units). */
   nominalQuota: number;
-  data: { x: number; y: number }[];
+  data: { x: number; y: number; gpuUsage: number }[];
 };
 
 type CQInfo = {
@@ -139,8 +139,8 @@ const buildSeries = (
         return null;
       }
       const info = cqInfoMap.get(cqName);
-      // Only include CQs that are members of a cohort — borrowing and lending
-      // are cohort-level concepts. Standalone CQs cannot borrow or lend.
+      // Only include CQs that are members of a cohort — borrowing is a
+      // cohort-level concept. Standalone CQs cannot borrow.
       if (!info) {
         return null;
       }
@@ -148,10 +148,19 @@ const buildSeries = (
         cqName,
         cohortName: info.cohortName,
         nominalQuota: info.nominalQuota,
-        data: result.values.map(([timestamp, valueStr]) => ({
-          x: timestamp * 1000,
-          y: parseFloat(valueStr) - info.nominalQuota,
-        })),
+        data: result.values.flatMap(([timestamp, valueStr]) => {
+          const gpuUsage = Number(valueStr);
+          if (valueStr.trim() === '' || !Number.isFinite(gpuUsage)) {
+            return [];
+          }
+          return [
+            {
+              x: timestamp * 1000,
+              y: Math.max(0, gpuUsage - info.nominalQuota),
+              gpuUsage,
+            },
+          ];
+        }),
       };
     })
     .filter((s): s is CQMetricSeries => s !== null);

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -72,7 +72,7 @@ const InfrastructurePage: React.FC = () => {
   const SECTION_COMPONENTS: Record<SectionId, React.ReactElement | null> = {
     cluster: <ClusterSummaryCards metrics={metrics} />,
     'hardware-usage': <HardwareUsageSection metrics={metrics} />,
-    'borrowing-lending': <BorrowingLendingSection />,
+    borrowing: <BorrowingLendingSection />,
     'cluster-queue-utilization': <ClusterQueueUtilizationSection />,
   };
 

--- a/packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx
+++ b/packages/gpuaas/src/pages/__tests__/InfrastructurePage.tracking.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('@odh-dashboard/plugin-core/areas', () => ({
   useIsAreaAvailable: jest.fn(),
 }));
 
-jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => {
+jest.mock('@odh-dashboard/ui-core', () => {
   const ApplicationsPage: React.FC<{
     children: React.ReactNode;
     headerAction?: React.ReactNode;
@@ -27,7 +27,7 @@ jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => {
       {children}
     </div>
   );
-  return { __esModule: true, default: ApplicationsPage };
+  return { ApplicationsPage };
 });
 
 jest.mock('@odh-dashboard/internal/utilities/time', () => ({
@@ -66,7 +66,7 @@ jest.mock('../../components/HardwareUsageSection', () => ({
 
 jest.mock('../../components/BorrowingLendingSection', () => ({
   __esModule: true,
-  default: () => <div data-testid="borrowing-lending" />,
+  default: () => <div data-testid="borrowing" />,
 }));
 
 jest.mock('../../components/ClusterQueueUtilizationSection', () => ({
@@ -138,7 +138,7 @@ describe('InfrastructurePage - Tracking Events', () => {
       const user = userEvent.setup();
       render(<InfrastructurePage />);
 
-      const refreshButton = screen.getByRole('button', { name: 'Refresh page data' });
+      const refreshButton = screen.getByRole('button', { name: 'Refresh' });
       await user.click(refreshButton);
 
       expect(mockFireMisc).toHaveBeenCalledWith(GPUAAS_EVENTS.DATA_REFRESHED, expect.any(Object));
@@ -154,7 +154,7 @@ describe('InfrastructurePage - Tracking Events', () => {
       };
       render(<InfrastructurePage />);
 
-      const refreshButton = screen.getByRole('button', { name: 'Refresh page data' });
+      const refreshButton = screen.getByRole('button', { name: 'Refresh' });
       await user.click(refreshButton);
 
       expect(mockFireMisc).toHaveBeenCalledWith(

--- a/packages/gpuaas/src/tracking/gpuaasTrackingConstants.ts
+++ b/packages/gpuaas/src/tracking/gpuaasTrackingConstants.ts
@@ -2,10 +2,9 @@ export const GPUAAS_EVENTS = {
   PAGE_VIEWED: 'Infrastructure Page Viewed',
   PAGE_INTERACTED: 'Infrastructure Page Interacted',
   COHORT_SECTION_TOGGLED: 'Infrastructure Cohort Section Toggled',
-  BORROW_LEND_DETAIL_VIEWED: 'Infrastructure Borrow Lend Detail Viewed',
   DATA_REFRESHED: 'Infrastructure Data Refreshed',
-  BORROW_LEND_COHORT_FILTER_SELECTED: 'Infrastructure Borrow Lend Cohort Filter Selected',
-  BORROW_LEND_QUEUE_FILTER_APPLIED: 'Infrastructure Borrow Lend Queue Filter Applied',
+  BORROW_COHORT_FILTER_SELECTED: 'Infrastructure Borrow Cohort Filter Selected',
+  BORROW_QUEUE_FILTER_APPLIED: 'Infrastructure Borrow Queue Filter Applied',
 } as const;
 
 export type PageViewedProperties = {
@@ -25,7 +24,7 @@ export type PageInteractedProperties = {
     | 'cohortFilter'
     | 'queueFilter'
     | 'cohortToggle'
-    | 'borrowLendDetail'
+    | 'borrowDetail'
     | 'trendLegendToggle';
   secondsSincePageLoad: number;
 };
@@ -37,18 +36,7 @@ export type CohortSectionToggledProperties = {
   isUncohortedBucket: boolean;
   isExpanded: boolean;
   clusterQueueCount: number;
-  hasBorrowLendActive: boolean;
-};
-
-// TODO: Wire when BorrowLendDetailPopover is instrumented
-export type BorrowLendDetailViewedProperties = {
-  clusterQueueName: string;
-  clusterQueueId: string;
-  kueueCohortName: string;
-  direction: 'borrowed' | 'lent';
-  acceleratorCount: number;
-  acceleratorLabel: string;
-  counterpartyQueueName: string;
+  hasBorrowActive: boolean;
 };
 
 export type DataRefreshedProperties = {
@@ -59,14 +47,14 @@ export type DataRefreshedProperties = {
 };
 
 // TODO: Wire when cohort filter dropdown is instrumented
-export type BorrowLendCohortFilterSelectedProperties = {
+export type BorrowCohortFilterSelectedProperties = {
   selectedCohort: string;
   selectedCohortId: string;
   visibleQueueCount: number;
 };
 
 // TODO: Wire when queue search field is instrumented
-export type BorrowLendQueueFilterAppliedProperties = {
+export type BorrowQueueFilterAppliedProperties = {
   searchQuery: string;
   matchCount: number;
   isEmptyResult: boolean;

--- a/packages/gpuaas/src/utils/__tests__/borrowingLendingChart.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/borrowingLendingChart.spec.ts
@@ -35,7 +35,7 @@ const makeSeries = (
   cqName,
   cohortName,
   nominalQuota: 4,
-  data: yValues.map((y, i) => ({ x: i * 1000, y })),
+  data: yValues.map((y, i) => ({ x: i * 1000, y, gpuUsage: y + 4 })),
 });
 
 /** Returns a ref-like object whose getBoundingClientRect reports the given origin. */
@@ -65,9 +65,7 @@ describe('formatYTick', () => {
   it.each([
     [0, '0'],
     [3, '+3'],
-    [-3, '-3'],
     [1000, '+1.0k'],
-    [-2500, '-2.5k'],
   ])('formats %d as "%s"', (y, expected) => {
     expect(formatYTick(y)).toBe(expected);
   });
@@ -124,14 +122,14 @@ describe('getLegendLabel', () => {
 });
 
 describe('buildYDomain', () => {
-  it('returns ±1 buffer around zero for empty series', () => {
-    expect(buildYDomain([])).toEqual({ minY: -1, maxY: 1 });
+  it('returns 0..1 buffer for empty series (minY pinned to 0)', () => {
+    expect(buildYDomain([])).toEqual({ minY: 0, maxY: 1 });
   });
 
   it.each([
-    ['only positive values', [3, 5], { minY: -1, maxY: 6 }],
-    ['mixed values', [-3, 4], { minY: -4, maxY: 5 }],
-  ])('applies ±1 buffer and always includes zero for %s', (_desc, yValues, expected) => {
+    ['only positive values', [3, 5], { minY: 0, maxY: 6 }],
+    ['values already clipped to zero', [0, 4], { minY: 0, maxY: 5 }],
+  ])('pins minY to 0 and applies +1 buffer on max for %s', (_desc, yValues, expected) => {
     expect(buildYDomain([makeSeries('cq', SHORT_COHORT, yValues)])).toEqual(expected);
   });
 });

--- a/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
+++ b/packages/gpuaas/src/utils/__tests__/clusterQueueUtils.spec.ts
@@ -7,18 +7,16 @@ import {
   getCQNominalAccelerators,
   getCQUsedAccelerators,
   getAcceleratorBorrowedCount,
-  getAcceleratorLentCount,
+  getAcceleratorUnallocatedCount,
   isAcceleratorBorrowing,
-  isAcceleratorLending,
   isInCohort,
   filterAcceleratorCQs,
   getCohortTotalAccelerators,
   getCohortUnallocatedBorrowable,
-  isCohortBorrowLendActive,
+  isCohortBorrowActive,
   getAcceleratorDonutConfig,
-  getBorrowLendBadgeState,
-  getBorrowLendInfo,
-  getCounterpartCQNames,
+  getBorrowBadgeState,
+  getBorrowInfo,
   formatWorkloadCounts,
   normalizeModelName,
   resolveCQDcgmUtilization,
@@ -167,13 +165,15 @@ describe('getAcceleratorBorrowedCount', () => {
   });
 });
 
-describe('getAcceleratorLentCount', () => {
+describe('getAcceleratorUnallocatedCount', () => {
   it.each([
     [8, 0, 0, 'fully used'],
     [3, 0, 5, 'unused capacity'],
     [10, 2, 0, 'over quota floored at 0'],
   ])('used=%d borrowed=%d → %d (%s)', (used, borrowed, expected) => {
-    expect(getAcceleratorLentCount(makeGpuCQ('cq', { nominal: 8, used, borrowed }))).toBe(expected);
+    expect(getAcceleratorUnallocatedCount(makeGpuCQ('cq', { nominal: 8, used, borrowed }))).toBe(
+      expected,
+    );
   });
 });
 
@@ -186,22 +186,12 @@ describe('isInCohort', () => {
   });
 });
 
-describe('isAcceleratorBorrowing / isAcceleratorLending', () => {
+describe('isAcceleratorBorrowing', () => {
   it('detects borrowing', () => {
     expect(isAcceleratorBorrowing(makeGpuCQ('cq', { nominal: 8, used: 10, borrowed: 2 }))).toBe(
       true,
     );
     expect(isAcceleratorBorrowing(makeGpuCQ('cq', { nominal: 8, used: 4 }))).toBe(false);
-  });
-
-  it('detects lending (unused capacity)', () => {
-    expect(
-      isAcceleratorLending(makeGpuCQWithCohort('cq', 'cohort-a', { nominal: 8, used: 3 })),
-    ).toBe(true);
-    expect(
-      isAcceleratorLending(makeGpuCQWithCohort('cq', 'cohort-a', { nominal: 8, used: 8 })),
-    ).toBe(false);
-    expect(isAcceleratorLending(makeGpuCQ('cq', { nominal: 8, used: 3 }))).toBe(false); // standalone CQs cannot lend
   });
 });
 
@@ -245,8 +235,8 @@ describe('getCohortTotalAccelerators', () => {
 describe('getCohortUnallocatedBorrowable', () => {
   it('sums unused capacity across member CQs', () => {
     const cohort = makeCohort([
-      makeGpuCQ('a', { nominal: 8, used: 5 }), // lent: 3
-      makeGpuCQ('b', { nominal: 8, used: 8 }), // lent: 0
+      makeGpuCQ('a', { nominal: 8, used: 5 }), // unallocated: 3
+      makeGpuCQ('b', { nominal: 8, used: 8 }), // unallocated: 0
     ]);
     expect(getCohortUnallocatedBorrowable(cohort)).toBe(3);
   });
@@ -257,18 +247,18 @@ describe('getCohortUnallocatedBorrowable', () => {
   });
 });
 
-describe('isCohortBorrowLendActive', () => {
+describe('isCohortBorrowActive', () => {
   it.each([
     ['borrowing CQ', makeCohort([makeGpuCQ('a', { nominal: 8, used: 10, borrowed: 2 })]), true],
-    [
-      'lending CQ (unused capacity)',
-      makeCohort([makeGpuCQWithCohort('a', 'test-cohort', { nominal: 8, used: 3 })]),
-      true,
-    ],
     ['fully used, no borrowing', makeCohort([makeGpuCQ('a', { nominal: 8, used: 8 })]), false],
+    [
+      'CQ with unused capacity, no borrowing',
+      makeCohort([makeGpuCQWithCohort('a', 'test-cohort', { nominal: 8, used: 3 })]),
+      false,
+    ],
     ['empty cohort', makeCohort([]), false],
   ] as const)('%s → %s', (_label, cohort, expected) => {
-    expect(isCohortBorrowLendActive(cohort)).toBe(expected);
+    expect(isCohortBorrowActive(cohort)).toBe(expected);
   });
 
   it('returns false for a standalone group even if CQs have spare capacity or borrow', () => {
@@ -279,34 +269,7 @@ describe('isCohortBorrowLendActive', () => {
       ],
       'standalone',
     );
-    expect(isCohortBorrowLendActive(cohort)).toBe(false);
-  });
-});
-
-describe('getCounterpartCQNames', () => {
-  it('lender sees names of borrowing siblings', () => {
-    const lender = makeGpuCQ('lender', { nominal: 8, used: 3 });
-    const borrower = makeGpuCQ('borrower', { nominal: 8, used: 10, borrowed: 2 });
-    const other = makeGpuCQ('other', { nominal: 8, used: 8 });
-    expect(getCounterpartCQNames(lender, [lender, borrower, other])).toEqual(['borrower']);
-  });
-
-  it('borrower sees names of lending siblings', () => {
-    const borrower = makeGpuCQ('borrower', { nominal: 8, used: 10, borrowed: 2 });
-    const lender = makeGpuCQWithCohort('lender', 'test-cohort', { nominal: 8, used: 3 });
-    const other = makeGpuCQ('other', { nominal: 8, used: 8 });
-    expect(getCounterpartCQNames(borrower, [borrower, lender, other])).toEqual(['lender']);
-  });
-
-  it.each([
-    [
-      'siblings present but no borrow-lend activity',
-      [makeGpuCQ('sibling', { nominal: 8, used: 8 })],
-    ],
-    ['no siblings at all', []],
-  ] as const)('returns empty array — %s', (_label, siblings) => {
-    const cq = makeGpuCQ('cq', { nominal: 8, used: 8 });
-    expect(getCounterpartCQNames(cq, [cq, ...siblings])).toEqual([]);
+    expect(isCohortBorrowActive(cohort)).toBe(false);
   });
 });
 
@@ -350,8 +313,8 @@ describe('getAcceleratorDonutConfig', () => {
       [6, '6'],
     ])('used=%d → title="%s" single Borrowed segment', (used, title) => {
       const config = getAcceleratorDonutConfig(makeGpuCQ('burst-cq', { nominal: 0, used }));
-      expect(config.type).toBe(AcceleratorDonutType.BorrowLend);
-      if (config.type === AcceleratorDonutType.BorrowLend) {
+      expect(config.type).toBe(AcceleratorDonutType.Borrow);
+      if (config.type === AcceleratorDonutType.Borrow) {
         expect(config.isBorrowing).toBe(true);
         expect(config.title).toBe(title);
         expect(config.stateLabel).toBe(AcceleratorSegment.Borrowed);
@@ -376,32 +339,31 @@ describe('getAcceleratorDonutConfig', () => {
     });
   });
 
-  describe('lending state — used < nominal', () => {
+  describe('unallocated capacity state — used < nominal, treated as normal', () => {
     it.each([
-      // [nominal, used, expectedOwnUsed, expectedLent]
-      [8, 3, 3, 5],
-      [8, 0, 0, 8],
-    ])('nominal=%d used=%d → segments Own=%d Lent=%d', (nominal, used, ownUsed, lent) => {
+      // [nominal, used, expectedPercentage]
+      // Math.round(3/8 * 100) = 38
+      [8, 3, 38],
+      // Math.round(0/8 * 100) = 0
+      [8, 0, 0],
+    ])('nominal=%d used=%d → type=normal percentage=%d', (nominal, used, expectedPercentage) => {
       const config = getAcceleratorDonutConfig(
         makeGpuCQWithCohort('cq', 'test-cohort', { nominal, used }),
       );
-      expect(config.type).toBe(AcceleratorDonutType.BorrowLend);
-      if (config.type === AcceleratorDonutType.BorrowLend) {
-        expect(config.isBorrowing).toBe(false);
-        expect(config.stateLabel).toBe(AcceleratorSegment.Lent);
-        expect(config.segments).toEqual([
-          { x: AcceleratorSegment.Own, y: ownUsed },
-          { x: AcceleratorSegment.Lent, y: lent },
-        ]);
+      expect(config.type).toBe(AcceleratorDonutType.Normal);
+      if (config.type === AcceleratorDonutType.Normal) {
+        expect(config.percentage).toBe(expectedPercentage);
+        expect(config.used).toBe(used);
+        expect(config.nominal).toBe(nominal);
       }
     });
   });
 
-  describe('standalone CQ (inCohort=false) — borrow-lend suppressed to normal', () => {
+  describe('standalone CQ (inCohort=false) — borrow suppressed to normal', () => {
     it.each([
       // [description, cqOpts, expectedPercentage]
       // Math.round(3/8 * 100) = 38
-      ['lending CQ', { nominal: 8, used: 3 }, 38],
+      ['unallocated capacity CQ', { nominal: 8, used: 3 }, 38],
       // used=8 equals nominal=8; borrowed=2 suppressed → 100%
       ['borrowing CQ', { nominal: 8, used: 8, borrowed: 2 }, 100],
     ] as const)('%s → type=normal percentage=%d', (_label, cqOpts, expectedPercentage) => {
@@ -422,8 +384,8 @@ describe('getAcceleratorDonutConfig', () => {
       'nominal=%d used=%d borrowed=%d → segments Own=%d Available=%d',
       (nominal, used, borrowed, ownUsed, available) => {
         const config = getAcceleratorDonutConfig(makeGpuCQ('cq', { nominal, used, borrowed }));
-        expect(config.type).toBe(AcceleratorDonutType.BorrowLend);
-        if (config.type === AcceleratorDonutType.BorrowLend) {
+        expect(config.type).toBe(AcceleratorDonutType.Borrow);
+        if (config.type === AcceleratorDonutType.Borrow) {
           expect(config.isBorrowing).toBe(true);
           expect(config.stateLabel).toBe(AcceleratorSegment.Borrowed);
           expect(config.segments).toEqual([
@@ -437,68 +399,69 @@ describe('getAcceleratorDonutConfig', () => {
   });
 });
 
-describe('getBorrowLendBadgeState', () => {
+describe('getBorrowBadgeState', () => {
   it.each([
     [
       'fully utilised (type=normal)',
       { nominal: 8, used: 8 },
       true,
-      { borrowing: false, lending: false, lentCount: 0, borrowedCount: 0 },
+      { borrowing: false, borrowedCount: 0 },
     ],
     [
-      'lending CQ',
+      'unallocated capacity CQ — treated as normal, no badge',
       { nominal: 8, used: 3 },
       true,
-      { borrowing: false, lending: true, lentCount: 5, borrowedCount: 0 },
+      { borrowing: false, borrowedCount: 0 },
     ],
     [
       'borrowing CQ',
       { nominal: 8, used: 10, borrowed: 2 },
       true,
-      { borrowing: true, lending: false, lentCount: 0, borrowedCount: 2 },
+      { borrowing: true, borrowedCount: 2 },
     ],
     [
-      'lending suppressed by inCohort=false',
+      'inCohort=false (standalone)',
       { nominal: 8, used: 3 },
       false,
-      { borrowing: false, lending: false, lentCount: 0, borrowedCount: 0 },
+      { borrowing: false, borrowedCount: 0 },
     ],
   ] as const)('%s', (_label, cqOpts, inCohort, expected) => {
     const cq = inCohort
       ? makeGpuCQWithCohort('cq', 'test-cohort', cqOpts)
       : makeGpuCQ('cq', cqOpts);
     const config = getAcceleratorDonutConfig(cq, inCohort);
-    expect(getBorrowLendBadgeState(config)).toEqual(expected);
+    expect(getBorrowBadgeState(config)).toEqual(expected);
   });
 });
 
-describe('getBorrowLendInfo', () => {
+describe('getBorrowInfo', () => {
   it('returns undefined for a Normal donut', () => {
     const config = getAcceleratorDonutConfig(makeGpuCQ('cq', { nominal: 8, used: 4 }));
-    expect(getBorrowLendInfo(config)).toBeUndefined();
+    expect(getBorrowInfo(config)).toBeUndefined();
   });
 
   it.each([
     // Pure borrower: nominal=0 set to used as rendering trick — Own segment absent → ownRatio must be 0
-    ['pure borrower', makeGpuCQ('burst-cq', { nominal: 0, used: 6 }), true, 0],
+    ['pure borrower', makeGpuCQ('burst-cq', { nominal: 0, used: 6 }), 0],
     // Regular borrower: nominal=8, used=10, borrowed=2 → ownUsed=8, ownRatio=8/10=0.8
     [
       'regular borrower',
       makeGpuCQWithCohort('cq', 'cohort', { nominal: 8, used: 10, borrowed: 2 }),
-      true,
       0.8,
     ],
-    // Lender: nominal=8, used=4 → ownRatio=4/8=0.5
-    ['lender', makeGpuCQWithCohort('cq', 'cohort', { nominal: 8, used: 4 }), false, 0.5],
-  ] as const)(
-    '%s — isBorrowing=%s, ownRatio≈%s',
-    (_label, cq, expectedIsBorrowing, expectedRatio) => {
-      const config = getAcceleratorDonutConfig(cq, true);
-      const info = getBorrowLendInfo(config);
-      expect(info?.isBorrowing).toBe(expectedIsBorrowing);
-      expect(info?.ownRatio).toBeCloseTo(expectedRatio);
-    },
-  );
+  ] as const)('%s — isBorrowing=true, ownRatio≈%s', (_label, cq, expectedRatio) => {
+    const config = getAcceleratorDonutConfig(cq, true);
+    const info = getBorrowInfo(config);
+    expect(info?.isBorrowing).toBe(true);
+    expect(info?.ownRatio).toBeCloseTo(expectedRatio);
+  });
+
+  it('returns undefined for a CQ with unallocated capacity', () => {
+    const unallocatedCQ = makeGpuCQWithCohort('cq', 'cohort', { nominal: 8, used: 4 });
+    const config = getAcceleratorDonutConfig(unallocatedCQ, true);
+    expect(config.type).toBe(AcceleratorDonutType.Normal);
+    expect(getBorrowInfo(config)).toBeUndefined();
+  });
 });
 
 describe('resolveCQDcgmUtilization', () => {

--- a/packages/gpuaas/src/utils/borrowingLending.ts
+++ b/packages/gpuaas/src/utils/borrowingLending.ts
@@ -22,46 +22,8 @@ const getTotalBorrowed = (flavorsUsage?: FlavorResourceUsage[]): number => {
   );
 };
 
-const getNominalQuota = (cq: ClusterQueueKind): number => {
-  if (!cq.spec.resourceGroups) {
-    return 0;
-  }
-  return cq.spec.resourceGroups.reduce(
-    (total, rg) =>
-      total +
-      rg.flavors.reduce(
-        (sum, f) => sum + f.resources.reduce((s, r) => s + parseK8sQuantity(r.nominalQuota), 0),
-        0,
-      ),
-    0,
-  );
-};
-
-const getTotalUsage = (flavorsUsage?: FlavorResourceUsage[]): number => {
-  if (!flavorsUsage) {
-    return 0;
-  }
-  return flavorsUsage.reduce(
-    (total, flavor) =>
-      total + flavor.resources.reduce((sum, r) => sum + parseK8sQuantity(r.total), 0),
-    0,
-  );
-};
-
 export const isBorrowing = (cq: ClusterQueueKind): boolean =>
   getTotalBorrowed(cq.status?.flavorsUsage) > 0;
 
-export const isLending = (cq: ClusterQueueKind): boolean => {
-  const nominal = getNominalQuota(cq);
-  const usage = getTotalUsage(cq.status?.flavorsUsage);
-  return nominal > 0 && usage < nominal;
-};
-
 export const getBorrowedCount = (cq: ClusterQueueKind): number =>
   getTotalBorrowed(cq.status?.flavorsUsage);
-
-export const getLentCount = (cq: ClusterQueueKind): number => {
-  const nominal = getNominalQuota(cq);
-  const usage = getTotalUsage(cq.status?.flavorsUsage);
-  return Math.max(0, nominal - usage);
-};

--- a/packages/gpuaas/src/utils/borrowingLendingChart.ts
+++ b/packages/gpuaas/src/utils/borrowingLendingChart.ts
@@ -13,6 +13,7 @@ export type TooltipPoint = {
   x: number;
   y: number;
   nominalQuota?: number;
+  gpuUsage?: number;
 };
 
 /**
@@ -48,14 +49,13 @@ export const formatTooltipDate = (x: number): string => {
   return `${weekday} ${day} ${month}, ${time}`;
 };
 
-/** Signed values: "+2", "0", "-3" so positive = borrowing, negative = lending */
+/** Positive values: "+2" for borrowing above quota, "0" at quota. */
 export const formatYTick = (y: number): string => {
   if (y === 0) {
     return '0';
   }
-  const abs = Math.abs(y);
-  const val = abs >= 1000 ? `${(abs / 1000).toFixed(1)}k` : String(Math.round(abs));
-  return y > 0 ? `+${val}` : `-${val}`;
+  const val = y >= 1000 ? `${(y / 1000).toFixed(1)}k` : String(Math.round(y));
+  return `+${val}`;
 };
 
 /**
@@ -84,9 +84,8 @@ export const getLegendLabel = (s: CQMetricSeries): string =>
  */
 export const buildYDomain = (series: CQMetricSeries[]): { minY: number; maxY: number } => {
   const allY = series.flatMap((s) => s.data.map((d) => d.y));
-  const rawMin = allY.reduce((min, y) => Math.min(min, y), 0);
   const rawMax = allY.reduce((max, y) => Math.max(max, y), 0);
-  return { minY: rawMin - 1, maxY: rawMax + 1 };
+  return { minY: 0, maxY: rawMax + 1 };
 };
 
 /**

--- a/packages/gpuaas/src/utils/clusterQueueUtils.ts
+++ b/packages/gpuaas/src/utils/clusterQueueUtils.ts
@@ -6,7 +6,6 @@ import { CQDcgmResult, UnifiedCohort } from '../types';
 
 export enum AcceleratorSegment {
   Own = 'Own',
-  Lent = 'Lent',
   Borrowed = 'Borrowed',
   Available = 'Available',
   NoData = 'No data',
@@ -15,7 +14,7 @@ export enum AcceleratorSegment {
 export enum AcceleratorDonutType {
   None = 'none',
   Normal = 'normal',
-  BorrowLend = 'borrow-lend',
+  Borrow = 'borrow',
 }
 
 export type AcceleratorDonutConfig =
@@ -28,12 +27,12 @@ export type AcceleratorDonutConfig =
       percentage: number;
     }
   | {
-      type: AcceleratorDonutType.BorrowLend;
+      type: AcceleratorDonutType.Borrow;
       used: number;
       nominal: number;
       title: string;
-      isBorrowing: boolean;
-      stateLabel: AcceleratorSegment.Borrowed | AcceleratorSegment.Lent;
+      isBorrowing: true;
+      stateLabel: AcceleratorSegment.Borrowed;
       segments: Array<{ x: string; y: number }>;
     };
 
@@ -41,8 +40,8 @@ export type AcceleratorDonutConfig =
  * Fraction of total in-use GPUs attributed to "own" allocation.
  * Used by DcgmDonut to split the utilisation ring proportionally.
  */
-export type BorrowLendInfo = {
-  isBorrowing: boolean;
+export type BorrowInfo = {
+  isBorrowing: true;
   ownRatio: number;
 };
 
@@ -97,16 +96,13 @@ export const getAcceleratorBorrowedCount = (cq: ClusterQueueKind): number =>
   );
 
 /** Returns GPU units unused and available for other CQs to borrow. Floored at 0. */
-export const getAcceleratorLentCount = (cq: ClusterQueueKind): number =>
+export const getAcceleratorUnallocatedCount = (cq: ClusterQueueKind): number =>
   Math.max(0, getCQNominalAccelerators(cq) - getCQUsedAccelerators(cq));
 
 export const isAcceleratorBorrowing = (cq: ClusterQueueKind): boolean =>
   getAcceleratorBorrowedCount(cq) > 0;
 
-export const isAcceleratorLending = (cq: ClusterQueueKind): boolean =>
-  isInCohort(cq) && getAcceleratorLentCount(cq) > 0;
-
-/** True when the CQ belongs to a Kueue cohort and can participate in borrow/lend. */
+/** True when the CQ belongs to a Kueue cohort and can participate in borrowing. */
 export const isInCohort = (cq: ClusterQueueKind): boolean => !!cq.spec.cohortName;
 
 /** Filters to CQs with non-zero accelerator quota or active usage (includes pure borrowers). */
@@ -129,42 +125,24 @@ export const getCohortTotalAccelerators = (cohort: UnifiedCohort): number => {
     : cohort.memberClusterQueues.reduce((sum, cq) => sum + getCQUsedAccelerators(cq), 0);
 };
 
-/** Sum of unused GPU capacity across member CQs — how much the cohort can lend out.
- *  Returns 0 for standalone (non-cohort) groups since they cannot participate in lending. */
+/** Unallocated GPU capacity across member CQs — how much the cohort has available to borrow.
+ *  Returns 0 for standalone (non-cohort) groups since they cannot participate in borrowing. */
 export const getCohortUnallocatedBorrowable = (cohort: UnifiedCohort): number =>
   cohort.state === 'standalone'
     ? 0
-    : cohort.memberClusterQueues.reduce((sum, cq) => sum + getAcceleratorLentCount(cq), 0);
+    : cohort.memberClusterQueues.reduce((sum, cq) => sum + getAcceleratorUnallocatedCount(cq), 0);
 
-/** True if any member CQ in the cohort is currently borrowing or lending GPU resources.
+/** True if any member CQ in the cohort is currently borrowing GPU resources.
  *  Always false for standalone groups since they cannot exchange quota. */
-export const isCohortBorrowLendActive = (cohort: UnifiedCohort): boolean =>
+export const isCohortBorrowActive = (cohort: UnifiedCohort): boolean =>
   cohort.state !== 'standalone' &&
-  cohort.memberClusterQueues.some((cq) => isAcceleratorBorrowing(cq) || isAcceleratorLending(cq));
-
-/**
- * Returns the names of sibling CQs that are on the other side of a borrow/lend relationship.
- * For a lending CQ → names of CQs currently borrowing.
- * For a borrowing CQ → names of CQs currently lending (from whom capacity flows).
- */
-export const getCounterpartCQNames = (
-  cq: ClusterQueueKind,
-  siblingsInCohort: ClusterQueueKind[],
-): string[] => {
-  const cqName = cq.metadata?.name ?? '';
-  const siblings = siblingsInCohort.filter((s) => s.metadata?.name !== cqName);
-  const check = isAcceleratorBorrowing(cq) ? isAcceleratorLending : isAcceleratorBorrowing;
-  return siblings
-    .filter(check)
-    .map((s) => s.metadata?.name ?? '')
-    .filter(Boolean);
-};
+  cohort.memberClusterQueues.some((cq) => isAcceleratorBorrowing(cq));
 
 /**
  * Derives the donut chart config for a ClusterQueue's accelerator utilization.
  * Returns 'none' when the CQ has no accelerator quota.
- * Returns 'borrow-lend' when the CQ is borrowing or lending GPU resources AND belongs to a cohort.
- * Returns 'normal' otherwise (including standalone CQs which cannot exchange quota).
+ * Returns 'borrow' when the CQ is borrowing GPU resources AND belongs to a cohort.
+ * Returns 'normal' otherwise (including CQs with unallocated capacity and standalone CQs).
  */
 export const getAcceleratorDonutConfig = (
   cq: ClusterQueueKind,
@@ -181,7 +159,7 @@ export const getAcceleratorDonutConfig = (
     // Standalone CQs (inCohort=false) cannot borrow, so they fall through to None above.
     // nominal is set to used so the donut renders as fully filled with the borrowed segment.
     return {
-      type: AcceleratorDonutType.BorrowLend,
+      type: AcceleratorDonutType.Borrow,
       used,
       nominal: used,
       title: `${used}`,
@@ -192,30 +170,23 @@ export const getAcceleratorDonutConfig = (
   }
   const borrowed = getAcceleratorBorrowedCount(cq);
   const borrowing = isAcceleratorBorrowing(cq);
-  const lending = isAcceleratorLending(cq);
 
-  if (inCohort && (borrowing || lending)) {
+  if (inCohort && borrowing) {
     const ownUsed = Math.max(0, used - borrowed);
-    const lent = Math.max(0, nominal - ownUsed);
-    const available = Math.max(0, nominal - ownUsed - (borrowing ? 0 : lent));
+    const available = Math.max(0, nominal - ownUsed);
 
     return {
-      type: AcceleratorDonutType.BorrowLend,
+      type: AcceleratorDonutType.Borrow,
       used,
       nominal,
       title: `${used}/${nominal}`,
-      isBorrowing: borrowing,
-      stateLabel: borrowing ? AcceleratorSegment.Borrowed : AcceleratorSegment.Lent,
-      segments: borrowing
-        ? [
-            { x: AcceleratorSegment.Own, y: ownUsed },
-            { x: AcceleratorSegment.Borrowed, y: borrowed },
-            { x: AcceleratorSegment.Available, y: available },
-          ]
-        : [
-            { x: AcceleratorSegment.Own, y: ownUsed },
-            { x: AcceleratorSegment.Lent, y: lent },
-          ],
+      isBorrowing: true,
+      stateLabel: AcceleratorSegment.Borrowed,
+      segments: [
+        { x: AcceleratorSegment.Own, y: ownUsed },
+        { x: AcceleratorSegment.Borrowed, y: borrowed },
+        { x: AcceleratorSegment.Available, y: available },
+      ],
     };
   }
 
@@ -228,74 +199,35 @@ export const getAcceleratorDonutConfig = (
   };
 };
 
-export type BorrowLendBadgeState = {
+export type BorrowBadgeState = {
   borrowing: boolean;
-  lending: boolean;
-  lentCount: number;
   borrowedCount: number;
 };
 
-/** Derives the badge visibility and counts for the borrow/lend badges on a CQ card. */
-export const getBorrowLendBadgeState = (config: AcceleratorDonutConfig): BorrowLendBadgeState => ({
-  borrowing: config.type === AcceleratorDonutType.BorrowLend && config.isBorrowing,
-  lending: config.type === AcceleratorDonutType.BorrowLend && !config.isBorrowing,
-  lentCount:
-    config.type === AcceleratorDonutType.BorrowLend && !config.isBorrowing
-      ? config.segments.find((s) => s.x === AcceleratorSegment.Lent)?.y ?? 0
-      : 0,
+/** Derives the badge visibility and count for the borrowed badge on a CQ card. */
+export const getBorrowBadgeState = (config: AcceleratorDonutConfig): BorrowBadgeState => ({
+  borrowing: config.type === AcceleratorDonutType.Borrow,
   borrowedCount:
-    config.type === AcceleratorDonutType.BorrowLend && config.isBorrowing
+    config.type === AcceleratorDonutType.Borrow
       ? config.segments.find((s) => s.x === AcceleratorSegment.Borrowed)?.y ?? 0
       : 0,
 });
 
 /**
- * Derives the borrow-lend split ratio from the donut config.
- * Returns undefined when the CQ is neither borrowing nor lending.
- *
- * - Borrowing: own = Own segment slots out of total used (0 for pure borrowers).
- * - Lending:   own = used GPUs out of nominal total quota.
+ * Derives the borrow split ratio from the donut config for borrowing CQs.
+ * Returns undefined for non-Borrow configs (Normal / None).
  *
  * ownRatio is derived from segments rather than nominal/used to handle pure borrowers
  * correctly — they set nominal=used as a rendering trick, which would give ownRatio=1
  * (100% owned) if we used nominal/used directly.
  */
-export const getBorrowLendInfo = (config: AcceleratorDonutConfig): BorrowLendInfo | undefined => {
-  if (config.type !== AcceleratorDonutType.BorrowLend) {
+export const getBorrowInfo = (config: AcceleratorDonutConfig): BorrowInfo | undefined => {
+  if (config.type !== AcceleratorDonutType.Borrow) {
     return undefined;
   }
-  const ownRatio = config.isBorrowing
-    ? (config.segments.find((s) => s.x === AcceleratorSegment.Own)?.y ?? 0) / (config.used || 1)
-    : config.used / (config.nominal || 1);
-  return { isBorrowing: config.isBorrowing, ownRatio };
-};
-
-/**
- * Computes the Victory chart data array for a DCGM donut in borrow-lend mode.
- * Clamps the remainder so the ring stays on a 0–100% scale.
- */
-export const computeDcgmSplitData = (
-  percentage: number,
-  { isBorrowing, ownRatio }: BorrowLendInfo,
-): {
-  chartData: Array<{ x: string; y: number }>;
-  splitLabel: AcceleratorSegment.Borrowed | AcceleratorSegment.Lent;
-} => {
-  const splitLabel = isBorrowing ? AcceleratorSegment.Borrowed : AcceleratorSegment.Lent;
-  const ownPct = percentage * ownRatio;
-  const splitPct = percentage * (1 - ownRatio);
-  // Remainder keeps the ring at 100% scale; clamped so >100% utilisation fills the ring completely.
-  const remainingPct = Math.max(0, 100 - ownPct - splitPct);
-
-  // Victory renders y:0 slices as a degenerate path (tiny visible line), so filter them out.
-  const rawData = [
-    { x: AcceleratorSegment.Own, y: ownPct },
-    { x: splitLabel, y: splitPct },
-    { x: AcceleratorSegment.Available, y: remainingPct },
-  ].filter((d) => d.y > 0);
-
-  const chartData = rawData.length === 0 ? [{ x: AcceleratorSegment.NoData, y: 100 }] : rawData;
-  return { chartData, splitLabel };
+  const ownRatio =
+    (config.segments.find((s) => s.x === AcceleratorSegment.Own)?.y ?? 0) / (config.used || 1);
+  return { isBorrowing: true, ownRatio };
 };
 
 /** Formats the active/pending workload count line shown on a CQ card. */
@@ -352,7 +284,7 @@ export type PerModelDcgmData = { model: string; pct: number };
 
 /**
  * Returns per-model DCGM utilization arrays for a CQ's hardware models, used to
- * build per-model tooltip lines in the DCGM lent/borrowed donut charts.
+ * build per-model tooltip lines in the DCGM borrowed donut charts.
  * Accepts an optional map so callers can pass `dcgmByModel` directly regardless of
  * whether DCGM is available, and always get a safe `{ compute, memory }` result.
  */
@@ -383,14 +315,6 @@ export const resolvePerModelDcgmData = (
   return { compute, memory };
 };
 
-export const buildDcgmLentTooltip = (lentPct: number, data: PerModelDcgmData[]): string =>
-  [
-    `Total lent in use: ${Math.round(lentPct)}%`,
-    ...data.map((d) => `${d.model}: ${d.pct}% utilization`),
-  ]
-    .filter(Boolean)
-    .join('\n');
-
 export const buildDcgmBorrowedTooltip = (borrowedPct: number, data: PerModelDcgmData[]): string =>
   [
     `Total borrowed in use: ${Math.round(borrowedPct)}%`,
@@ -409,12 +333,6 @@ export const buildDcgmOwnTooltip = (ownPct: number, data: PerModelDcgmData[]): s
 
 export const buildAcceleratorOwnLines = (gpus: ModelGpuCount[]): string =>
   gpus.map((m) => `${m.model}: ${m.used}/${m.nominal} in use`).join('\n');
-
-export const buildAcceleratorLentLines = (gpus: ModelGpuCount[]): string =>
-  gpus
-    .filter((m) => m.nominal - m.used > 0)
-    .map((m) => `${m.model}: ${m.nominal - m.used} lent`)
-    .join('\n');
 
 export const buildAcceleratorBorrowedLines = (gpus: ModelGpuCount[]): string =>
   gpus


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78948

## Description

Cherry-pick of #8803 from `main` into `v3.5.0-fixes` for the 3.5 GA release.

This fix removes incorrect "Lending" terminology from the GPU Utilization screens. Kueue does not support lending as a concept — only borrowing — so the UI was misrepresenting data. The fix:

- Removes all "lent" naming occurrences from components, utilities, and constants
- Updates the AcceleratorDonutChart to no longer show a lending segment
- Fixes NaN/empty value handling from Prometheus queries
- Updates related Cypress and Jest tests

Original PR: #8803
Original author: @claudialphonse78

## How Has This Been Tested?

This is a clean cherry-pick (no conflicts) of a PR that was already reviewed, approved, and merged to `main`. The original PR was tested on cluster with GPU topology data.

## Test Impact

The cherry-picked commit includes updated Jest unit tests and Cypress E2E tests for the affected components.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`