### PR TITLE
chore: use transit task pattern for parallel type-check in Turbo

### DIFF
--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -22,8 +22,11 @@
       "dependsOn": ["^test-unit-coverage"],
       "outputs": ["jest-coverage/**"]
     },
+    "transit": {
+      "dependsOn": ["^transit"]
+    },
     "type-check": {
-      "dependsOn": ["^type-check"]
+      "dependsOn": ["transit"]
     },
     "test:contract": {
       "inputs": ["contract-tests/**", "upstream/bff/**"],


### PR DESCRIPTION
## Description

The `type-check` task in `turbo.jsonc` used `dependsOn: ["^type-check"]`, which forced packages to type-check sequentially through the dependency graph (~15 packages in a chain). Since all packages expose source `.ts` files via their `exports` field, `tsc --noEmit` resolves types directly from source — no dependency needs to finish type-checking first.

This switches to [Turbo's recommended transit task pattern](https://turborepo.dev/docs/crafting-your-repository/configuring-tasks): a no-op `transit` task wires up the dependency graph for correct cache invalidation, while `type-check` depends on `transit` instead of `^type-check`, allowing all packages to type-check in parallel.

**Expected CI impact**: Type-Check job should drop from ~9 min to ~3-5 min.

**Why it's safe**:
- Every package's `exports` points to source `.ts` files (e.g., `"./shared": "./src/shared/index.ts"`), so `tsc --noEmit` reads types directly from source via workspace symlinks
- The one edge case (`app-config` with `"types": "./dist/index.d.ts"`) was tested — TypeScript falls back to `./src/index.ts` when `dist/` is missing
- Cache invalidation still propagates correctly through the transit dependency graph
- This matches Turbo's official recommendation and patterns used by other large monorepos (e.g., Cal.com)

## How Has This Been Tested?

- Ran `npm run type-check` locally with the transit pattern — same results as before the change (identical pre-existing errors on `main`)
- Verified the `app-config` edge case by removing `dist/`, running `tsc --noEmit` on consumers, and confirming TypeScript falls back to resolving source `.ts` files
- Used `tsc --traceResolution` to confirm resolution paths

## Test Impact

No new tests needed — this is a build configuration change. The type-check itself validates correctness; this change only affects execution order (parallel vs sequential).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project task sequencing to improve build and type-check workflow reliability.
  * Added transit task handling across workspace packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->