### PR TITLE
chore: add paulovmr and caponetto to general-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -19,6 +19,8 @@ aliases:
     - andyatmiami
     - chrjones-rh
     - nickmazzi
+    - paulovmr
+    - caponetto
 
   # Backup alias for managers to help with unblocking during PTO
   managers-backup-approvers:


### PR DESCRIPTION
`paulovmr` and `caponetto` are both PSEs who have spent the past 2 months actively refactoring all areas of `odh-dashboard` as part of their work on the Pewter squad.  The nature of this team naturally has them working across any/every area of the codebase - and adding them to `general-approvers` gives them the freedom to execute on their goals.  It is a responsibility I know they will maximize and take seriously.

LETS GO!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added two additional approvers to the general approval list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->