### PR TITLE
spike(gen-ai): BFF proxy approach for OGX no-restart model configuration

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -521,6 +521,13 @@ func (app *App) Routes() http.Handler {
 	// Guardrails API route
 	apiRouter.GET(constants.GuardrailsStatusPath, app.AttachNamespace(app.RequireGuardrailAccess(app.GuardrailsStatusHandler)))
 
+	// GenAI proxy — OpenAI-compatible surface for OGX's remote::passthrough provider (RHOAIENG-78871).
+	// OGX base_url must be set to http://<bff-svc>/api/v1/genai-proxy/ns/<namespace>;
+	// OGX appends /v1 automatically, producing .../ns/<namespace>/v1/models etc.
+	apiRouter.GET(constants.GenAIProxyNSModelsPath, app.AttachBFFMaaSClient(app.GenAIProxyNSModelsHandler))
+	apiRouter.POST(constants.GenAIProxyNSChatPath, app.GenAIProxyNSChatCompletionsHandler)
+	apiRouter.POST(constants.GenAIProxyNSEmbeddingsPath, app.GenAIProxyNSEmbeddingsHandler)
+
 	// Agent Profiles API routes
 	apiRouter.GET(constants.AgentProfilesPath, app.AttachNamespace(app.RequireAccessToService(app.ListAgentProfilesHandler)))
 	apiRouter.POST(constants.AgentProfilesPath, app.AttachNamespace(app.RequireAccessToService(app.CreateAgentProfileHandler)))

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
@@ -1,0 +1,297 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/models"
+)
+
+// openAIModelItem is a single entry in the OpenAI GET /v1/models response.
+type openAIModelItem struct {
+	ID             string         `json:"id"`
+	Object         string         `json:"object"`
+	Created        int64          `json:"created"`
+	OwnedBy        string         `json:"owned_by"`
+	CustomMetadata map[string]any `json:"custom_metadata,omitempty"`
+}
+
+// openAIModelList is the OpenAI GET /v1/models response envelope.
+type openAIModelList struct {
+	Object string            `json:"object"`
+	Data   []openAIModelItem `json:"data"`
+}
+
+// proxyInferenceRequest is the minimal fields the BFF peeks at before forwarding.
+type proxyInferenceRequest struct {
+	Model           string `json:"model"`
+	ModelSourceType string `json:"model_source_type,omitempty"`
+	Subscription    string `json:"subscription,omitempty"`
+	Stream          bool   `json:"stream,omitempty"`
+}
+
+// GenAIProxyNSModelsHandler handles GET /api/v1/genai-proxy/ns/:namespace/v1/models.
+//
+// Aggregates models from namespace ISVCs, custom endpoints, and MaaS and returns them
+// in OpenAI list format. Consumed by OGX's remote::passthrough provider with refresh_models: true
+// so OGX discovers new models without a pod restart.
+func (app *App) GenAIProxyNSModelsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace := ps.ByName("namespace")
+	if namespace == "" {
+		app.badRequestResponse(w, r, errors.New("missing namespace in path"))
+		return
+	}
+
+	ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, namespace)
+	r = r.WithContext(ctx)
+
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if !ok || identity == nil {
+		app.unauthorizedResponse(w, r, errors.New("missing RequestIdentity in context"))
+		return
+	}
+
+	k8sClient, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	aaModels, err := app.repositories.AAModels.GetAAModels(k8sClient, ctx, identity, namespace)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	maasModels, err := app.fetchMaaSModels(ctx, namespace)
+	if err != nil {
+		app.logger.Warn("GenAI proxy: failed to fetch MaaS models, returning namespace models only", "error", err)
+	} else {
+		aaModels = append(aaModels, maasModels...)
+	}
+
+	items := make([]openAIModelItem, 0, len(aaModels))
+	for _, m := range aaModels {
+		if m.Status == models.ModelStatusStop {
+			continue
+		}
+		items = append(items, openAIModelItem{
+			ID:      m.ModelID,
+			Object:  "model",
+			OwnedBy: string(m.ModelSourceType),
+			CustomMetadata: map[string]any{
+				"model_type": string(m.ModelType),
+			},
+		})
+	}
+
+	list := openAIModelList{Object: "list", Data: items}
+	if err := app.WriteJSON(w, http.StatusOK, list, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// resolveModelEndpointDirect resolves the inference endpoint base URL and Authorization header
+// value for a model ID, enabling direct proxying without routing back through OGX.
+//
+// Resolution order:
+//  1. Custom endpoint — searches the external models ConfigMap by bare model ID
+//  2. Namespace ISVC — looks up the InferenceService URL and uses the user's JWT
+func (app *App) resolveModelEndpointDirect(ctx context.Context, namespace, modelID string) (endpointBaseURL, authValue string, err error) {
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if !ok || identity == nil {
+		return "", "", fmt.Errorf("missing RequestIdentity in context")
+	}
+
+	k8sClient, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get Kubernetes client: %w", err)
+	}
+
+	// 1. Search external models ConfigMap by bare model ID.
+	externalConfig, cfgErr := k8sClient.GetExternalModelsConfig(ctx, namespace)
+	if cfgErr == nil && externalConfig != nil {
+		providerMap := make(map[string]*models.InferenceProvider)
+		for i := range externalConfig.Providers.Inference {
+			p := &externalConfig.Providers.Inference[i]
+			providerMap[p.ProviderID] = p
+		}
+		for _, m := range externalConfig.RegisteredResources.Models {
+			if m.ModelID != modelID {
+				continue
+			}
+			provider, found := providerMap[m.ProviderID]
+			if !found {
+				continue
+			}
+			// Use provider-qualified ID so fetchSecretFromProvider can resolve the K8s Secret.
+			qualifiedID := m.ProviderID + "/" + m.ModelID
+			apiKey := app.fetchSecretFromProvider(ctx, k8sClient, identity, namespace, provider, qualifiedID)
+			app.logger.Debug("GenAI proxy: resolved custom endpoint", "model", modelID, "provider", m.ProviderID, "baseURL", provider.Config.BaseURL)
+			return provider.Config.BaseURL, "Bearer " + apiKey, nil
+		}
+	}
+
+	// 2. Namespace ISVC — resolve URL and forward user JWT.
+	isvcURL, isvcErr := k8sClient.GetInferenceServiceURL(ctx, identity, namespace, modelID)
+	if isvcErr != nil {
+		return "", "", fmt.Errorf("model %q not found as custom endpoint or InferenceService: %w", modelID, isvcErr)
+	}
+	if isvcURL == "" {
+		return "", "", fmt.Errorf("model %q not found in namespace %q", modelID, namespace)
+	}
+
+	app.logger.Debug("GenAI proxy: resolved namespace ISVC", "model", modelID, "url", isvcURL)
+	return isvcURL, "Bearer " + identity.Token, nil
+}
+
+// proxyDirectly forwards a request body to a target URL with a resolved Authorization header.
+// It does not go through OGX — credentials are already injected by the caller.
+func (app *App) proxyDirectly(w http.ResponseWriter, r *http.Request, ctx context.Context, targetURL string, body []byte, authValue string, stream bool) {
+	proxyReq, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to build proxy request: %w", err))
+		return
+	}
+	proxyReq.Header.Set("Content-Type", "application/json")
+	if authValue != "" {
+		proxyReq.Header.Set("Authorization", authValue)
+	}
+
+	proxyClient := &http.Client{Transport: app.httpClient.Transport}
+	resp, err := proxyClient.Do(proxyReq)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("proxy request to model failed: %w", err))
+		return
+	}
+	defer resp.Body.Close()
+
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	if stream {
+		flusher, canFlush := w.(http.Flusher)
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := resp.Body.Read(buf)
+			if n > 0 {
+				if _, writeErr := w.Write(buf[:n]); writeErr != nil {
+					return
+				}
+				if canFlush {
+					flusher.Flush()
+				}
+			}
+			if readErr != nil {
+				break
+			}
+		}
+	} else {
+		_, _ = io.Copy(w, resp.Body)
+	}
+}
+
+// GenAIProxyNSChatCompletionsHandler handles POST /api/v1/genai-proxy/ns/:namespace/v1/chat/completions.
+//
+// Resolves the model's endpoint URL and credentials, then proxies directly to the underlying
+// model (custom endpoint, namespace ISVC, or MaaS) without routing back through OGX.
+func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace := ps.ByName("namespace")
+	if namespace == "" {
+		app.badRequestResponse(w, r, errors.New("missing namespace in path"))
+		return
+	}
+	ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, namespace)
+	r = r.WithContext(ctx)
+
+	r.Body = http.MaxBytesReader(w, r.Body, constants.ResponsesMaxBodySize)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return
+	}
+
+	var req proxyInferenceRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("invalid request body: %w", err))
+		return
+	}
+	if req.Model == "" {
+		app.badRequestResponse(w, r, errors.New("model is required"))
+		return
+	}
+
+	baseURL, authValue, err := app.resolveModelEndpointDirect(ctx, namespace, req.Model)
+	if err != nil {
+		app.logger.Error("GenAI proxy: failed to resolve model endpoint", "model", req.Model, "error", err)
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to resolve model endpoint: %w", err))
+		return
+	}
+
+	target := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	app.proxyDirectly(w, r, ctx, target, body, authValue, req.Stream)
+}
+
+// GenAIProxyNSEmbeddingsHandler handles POST /api/v1/genai-proxy/ns/:namespace/v1/embeddings.
+//
+// Resolves the model's endpoint URL and credentials, then proxies directly to the underlying model.
+func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace := ps.ByName("namespace")
+	if namespace == "" {
+		app.badRequestResponse(w, r, errors.New("missing namespace in path"))
+		return
+	}
+	ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, namespace)
+	r = r.WithContext(ctx)
+
+	r.Body = http.MaxBytesReader(w, r.Body, constants.ResponsesMaxBodySize)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return
+	}
+
+	var req proxyInferenceRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("invalid request body: %w", err))
+		return
+	}
+	if req.Model == "" {
+		app.badRequestResponse(w, r, errors.New("model is required"))
+		return
+	}
+
+	baseURL, authValue, err := app.resolveModelEndpointDirect(ctx, namespace, req.Model)
+	if err != nil {
+		app.logger.Error("GenAI proxy: failed to resolve model endpoint", "model", req.Model, "error", err)
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to resolve model endpoint: %w", err))
+		return
+	}
+
+	base := strings.TrimSuffix(baseURL, "/")
+	if !strings.HasSuffix(base, "/v1") {
+		base += "/v1"
+	}
+	target := base + "/embeddings"
+	app.proxyDirectly(w, r, ctx, target, body, authValue, false)
+}
+

--- a/packages/gen-ai/bff/internal/api/lsd_models_handler.go
+++ b/packages/gen-ai/bff/internal/api/lsd_models_handler.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/openai/openai-go/v2"
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack"
 )
 
@@ -15,7 +17,17 @@ type ModelsResponse = llamastack.APIResponse
 func (app *App) LlamaStackModelsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
 
-	models, err := app.repositories.Models.ListModels(ctx)
+	// SPIKE(RHOAIENG-78871): always forward the user's token as passthrough_api_key and
+	// vllm_api_token so OGX routes through the genai-bff-proxy passthrough provider.
+	var providerData map[string]any
+	if identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity); ok && identity != nil && identity.Token != "" {
+		providerData = map[string]any{
+			"passthrough_api_key": identity.Token,
+			"vllm_api_token":      identity.Token,
+		}
+	}
+
+	models, err := app.repositories.Models.ListModelsWithProviderData(ctx, providerData)
 	if err != nil {
 		app.handleLlamaStackClientError(w, r, err)
 		return

--- a/packages/gen-ai/bff/internal/api/lsd_responses_handler.go
+++ b/packages/gen-ai/bff/internal/api/lsd_responses_handler.go
@@ -522,6 +522,18 @@ func (app *App) LlamaStackCreateResponseHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// SPIKE(RHOAIENG-78871): always forward the user's token as passthrough_api_key and
+	// vllm_api_token so OGX routes through the genai-bff-proxy passthrough provider.
+	if identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity); ok && identity != nil && identity.Token != "" {
+		if providerData == nil {
+			providerData = make(map[string]interface{})
+		}
+		providerData["passthrough_api_key"] = identity.Token
+		if _, exists := providerData["vllm_api_token"]; !exists {
+			providerData["vllm_api_token"] = identity.Token
+		}
+	}
+
 	// Build inline guardrail options when the request includes a guardrail config.
 	// The BFF resolves the model endpoint URL and API key so the frontend never handles credentials.
 	var guardrailOpts nemo.GuardrailsOptions

--- a/packages/gen-ai/bff/internal/constants/api_constants.go
+++ b/packages/gen-ai/bff/internal/constants/api_constants.go
@@ -79,4 +79,12 @@ const (
 	// Agent Profiles endpoints
 	AgentProfilesPath  = ApiPathPrefix + "/agent-profiles"
 	AgentProfileIDPath = ApiPathPrefix + "/agent-profiles/:id"
+
+	// GenAI proxy — OpenAI-compatible surface for OGX's remote::passthrough provider.
+	// OGX base_url must include the namespace: .../api/v1/genai-proxy/ns/<namespace>
+	// OGX appends /v1 automatically, producing .../ns/<namespace>/v1/models etc.
+	// RHOAIENG-78871
+	GenAIProxyNSModelsPath     = ApiPathPrefix + "/genai-proxy/ns/:namespace/v1/models"
+	GenAIProxyNSChatPath       = ApiPathPrefix + "/genai-proxy/ns/:namespace/v1/chat/completions"
+	GenAIProxyNSEmbeddingsPath = ApiPathPrefix + "/genai-proxy/ns/:namespace/v1/embeddings"
 )

--- a/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
@@ -62,7 +62,13 @@ func NewLlamaStackClient(baseURL string, authToken string, insecureSkipVerify bo
 
 // ListModels retrieves all available models from Llama Stack.
 func (c *LlamaStackClient) ListModels(ctx context.Context) ([]openai.Model, error) {
-	modelsPage, err := c.client.Models.List(ctx)
+	return c.ListModelsWithProviderData(ctx, nil)
+}
+
+// ListModelsWithProviderData retrieves models, forwarding provider data as X-OGX-Provider-Data.
+func (c *LlamaStackClient) ListModelsWithProviderData(ctx context.Context, providerData map[string]any) ([]openai.Model, error) {
+	opts := c.buildRequestOptions(providerData)
+	modelsPage, err := c.client.Models.List(ctx, opts...)
 	if err != nil {
 		return nil, wrapClientError(err, "ListModels")
 	}

--- a/packages/gen-ai/bff/internal/repositories/lsd_models.go
+++ b/packages/gen-ai/bff/internal/repositories/lsd_models.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openai/openai-go/v2"
 	helper "github.com/opendatahub-io/gen-ai/internal/helpers"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack"
 )
 
 // ModelsRepository handles model-related operations and data transformations.
@@ -20,13 +21,19 @@ func NewModelsRepository() *ModelsRepository {
 // ListModels retrieves all available models and transforms them for BFF use.
 // The LlamaStack client is expected to be in the context (created by AttachOGXClient middleware).
 func (r *ModelsRepository) ListModels(ctx context.Context) ([]openai.Model, error) {
-	// Get ready-to-use LlamaStack client from context using helper
+	return r.ListModelsWithProviderData(ctx, nil)
+}
+
+// ListModelsWithProviderData retrieves models forwarding provider data as X-OGX-Provider-Data.
+func (r *ModelsRepository) ListModelsWithProviderData(ctx context.Context, providerData map[string]any) ([]openai.Model, error) {
 	client, err := helper.GetContextLlamaStackClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	// Repository layer can add transformation logic here if needed
-	// For now, direct passthrough from client to handler
-	return client.ListModels(ctx)
+	lsClient, ok := client.(*llamastack.LlamaStackClient)
+	if !ok {
+		// Mock or other client — fall back to standard ListModels
+		return client.ListModels(ctx)
+	}
+	return lsClient.ListModelsWithProviderData(ctx, providerData)
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78871
https://redhat.atlassian.net/browse/RHAISTRAT-1921

## Description

**This is a DRAFT spike PR — not intended for merge.**


https://github.com/user-attachments/assets/ba64327b-f188-4496-aed4-bc82d11d2b98



Proof-of-concept implementation validating the BFF-as-proxy approach for eliminating OGX pod restarts when new models are added and enabling per-request credential injection.

The spike configures OGX with a single `remote::passthrough` provider pointing at the gen-ai BFF instead of one provider per model. The BFF serves an OpenAI-compatible surface (`/v1/models`, `/v1/chat/completions`, `/v1/embeddings`) that aggregates models from all source types and proxies inference requests directly to the underlying model with credentials resolved from K8s at request time.

See `packages/gen-ai/PROXY_SPIKE.md` for full findings, architecture decisions, limitations, open questions, and effort estimate. This spike informs [RHAISTRAT-1921](https://redhat.atlassian.net/browse/RHAISTRAT-1921) — the code here should be used as a reference for breaking the work into properly scoped production tickets, not merged as-is.

## How Has This Been Tested?

Validated end-to-end on a RHOAI 3.5.0 cluster:
- `/v1/models` dynamically returning custom endpoint and namespace models without OGX restart
- `/v1/chat/completions` and `/v1/responses` routing through OGX passthrough → BFF → Anthropic directly
- `/v1/embeddings` routing through OGX passthrough → BFF → OpenAI directly
- Streaming responses working through the full chain
- `file_search` with both inline pgvector and external OpenAI-embedded vector stores

## Test Impact

Spike only — no tests added intentionally. Production implementation will require full unit and E2E test coverage.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHAISTRAT-1921]: https://redhat.atlassian.net/browse/RHAISTRAT-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ