### PR TITLE
Remove mlflowPipelines feature flag

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -52,7 +52,6 @@ export type MockDashboardConfigType = {
   observabilityDashboard?: boolean;
   hardwareProfileOrder?: string[];
   pvcSize?: string;
-  mlflowPipelines?: boolean;
   mcpCatalog?: boolean;
   mcpRegistry?: boolean;
   toolCalling?: boolean;
@@ -81,7 +80,6 @@ export type MockDashboardConfigType = {
 };
 
 export const mockDashboardConfig = ({
-  mlflowPipelines = true,
   projectRBAC = false,
   disableInfo = false,
   disableSupport = false,
@@ -273,7 +271,6 @@ export const mockDashboardConfig = ({
   },
   spec: {
     dashboardConfig: {
-      mlflowPipelines,
       projectRBAC,
       enablement: true,
       disableInfo,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -32,7 +32,6 @@ export const techPreviewFlags = {
 export const devTemporaryFeatureFlags = {
   disableKueue: true,
   disableProjectScoped: true,
-  mlflowPipelines: true,
   nimWizard: false,
   agentOpsDeploy: false,
   agentsCatalog: false,
@@ -254,7 +253,6 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     requiredComponents: [DataScienceStackComponent.MLFLOW],
   },
   [SupportedArea.MLFLOW_PIPELINES]: {
-    featureFlags: ['mlflowPipelines'],
     requiredComponents: [DataScienceStackComponent.DS_PIPELINES, DataScienceStackComponent.MLFLOW],
   },
   [SupportedArea.MCP_REGISTRY]: {

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/compareRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/compareRuns.cy.ts
@@ -170,7 +170,7 @@ describe('Compare runs', () => {
     });
 
     it('shows the MLflow experiment column when MLflow is enabled', () => {
-      cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+      cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
       cy.interceptOdh('GET /api/dsc/status', mockDscStatus({}));
       interceptMlflowStatus();
       compareRunsGlobal.visit(projectName, [mockRun.run_id, mockRun2.run_id]);
@@ -180,7 +180,7 @@ describe('Compare runs', () => {
     });
 
     it('hides the MLflow experiment column when DSPA has MLflow integration disabled', () => {
-      cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+      cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
       interceptMlflowStatus();
       interceptDSPAMlflowIntegration(projectName, DSPAMlflowIntegrationMode.DISABLED);
       compareRunsGlobal.visit(projectName, [mockRun.run_id, mockRun2.run_id]);
@@ -209,7 +209,7 @@ describe('Compare runs', () => {
         },
       });
 
-      cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+      cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
       cy.interceptOdh('GET /api/dsc/status', mockDscStatus({}));
       interceptMlflowStatus();
       cy.interceptOdh(

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/manageRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/manageRuns.cy.ts
@@ -105,7 +105,7 @@ describe('Manage runs', () => {
 
     it('shows the MLflow experiment column when MLflow is enabled', () => {
       initIntercepts({
-        mlflow: { enabled: true, pipelinesIntegration: true, bffConfigured: true },
+        mlflow: { enabled: true, bffConfigured: true },
       });
       interceptDSPAMlflowIntegration(projectName);
       manageRunsPage.visit(projectName, initialRunIds);
@@ -113,18 +113,9 @@ describe('Manage runs', () => {
       manageRunsTable.findColumnHeaders().should('contain', 'MLflow experiment');
     });
 
-    it('hides the MLflow experiment column when mlflowPipelines is disabled', () => {
-      initIntercepts({
-        mlflow: { enabled: true, pipelinesIntegration: false },
-      });
-      manageRunsPage.visit(projectName, initialRunIds);
-
-      manageRunsTable.findColumnHeaders().should('not.contain', 'MLflow experiment');
-    });
-
     it('hides the MLflow experiment column when BFF status is not configured', () => {
       initIntercepts({
-        mlflow: { enabled: true, pipelinesIntegration: true, bffConfigured: false },
+        mlflow: { enabled: true, bffConfigured: false },
       });
       manageRunsPage.visit(projectName, initialRunIds);
 
@@ -133,7 +124,7 @@ describe('Manage runs', () => {
 
     it('hides the MLflow experiment column when DSPA has MLflow integration disabled', () => {
       initIntercepts({
-        mlflow: { enabled: true, pipelinesIntegration: true, bffConfigured: true },
+        mlflow: { enabled: true, bffConfigured: true },
       });
       interceptDSPAMlflowIntegration(projectName, DSPAMlflowIntegrationMode.DISABLED);
       manageRunsPage.visit(projectName, initialRunIds);
@@ -145,7 +136,6 @@ describe('Manage runs', () => {
 
 type MlflowInterceptOptions = {
   enabled: boolean;
-  pipelinesIntegration?: boolean;
   bffConfigured?: boolean;
 };
 
@@ -153,16 +143,8 @@ const initIntercepts = (options: { mlflow?: MlflowInterceptOptions } = {}) => {
   const { mlflow } = options;
 
   if (mlflow?.enabled) {
-    const pipelinesIntegrationEnabled = mlflow.pipelinesIntegration !== false;
-    cy.interceptOdh(
-      'GET /api/config',
-      mockDashboardConfig({
-        mlflowPipelines: pipelinesIntegrationEnabled,
-      }),
-    );
-    if (pipelinesIntegrationEnabled) {
-      interceptMlflowStatus(mlflow.bffConfigured ?? true);
-    }
+    cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
+    interceptMlflowStatus(mlflow.bffConfigured ?? true);
   } else {
     configIntercept();
   }

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
@@ -135,7 +135,7 @@ describe('Pipeline create runs', () => {
   describe('Runs', () => {
     describe('MLflow integration', () => {
       beforeEach(() => {
-        cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+        cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
         interceptMlflowStatus();
         pipelineRunsGlobal.visit(projectName);
 
@@ -367,27 +367,8 @@ describe('Pipeline create runs', () => {
         createRunPage.findMlflowIntegrationJumpLink().should('not.exist');
       });
 
-      it('hides the MLflow integration section when mlflowPipelines is disabled', () => {
-        cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: false }));
-        pipelineRunsGlobal.visit(projectName);
-
-        createRunPage.mockGetExperiments(projectName, mockExperiments);
-        createRunPage.mockGetPipelines(projectName, [mockPipeline]);
-        createRunPage.mockGetPipelineVersions(
-          projectName,
-          [mockPipelineVersion],
-          mockPipelineVersion.pipeline_id,
-        );
-
-        pipelineRunsGlobal.findCreateRunButton().click();
-        createRunPage.find();
-
-        createRunPage.findMlflowIntegrationSection().should('not.exist');
-        createRunPage.findMlflowIntegrationJumpLink().should('not.exist');
-      });
-
       it('hides the MLflow integration section when BFF status is not configured', () => {
-        cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+        cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
         interceptMlflowStatus(false);
         pipelineRunsGlobal.visit(projectName);
 
@@ -407,7 +388,7 @@ describe('Pipeline create runs', () => {
       });
 
       it('hides the MLflow integration section when DSPA has MLflow integration disabled', () => {
-        cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+        cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
         interceptMlflowStatus();
         interceptDSPAMlflowIntegration(projectName, DSPAMlflowIntegrationMode.DISABLED);
         pipelineRunsGlobal.visit(projectName);
@@ -428,7 +409,7 @@ describe('Pipeline create runs', () => {
       });
 
       it('shows the MLflow integration section and sidebar link when MLflow is enabled', () => {
-        cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+        cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
         interceptMlflowStatus();
         pipelineRunsGlobal.visit(projectName);
 
@@ -1109,7 +1090,7 @@ describe('Pipeline create runs', () => {
     });
 
     it('creates a schedule with MLflow plugin payload', () => {
-      cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+      cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
       interceptMlflowStatus();
       pipelineRunsGlobal.visit(projectName);
       pipelineRunsGlobal.findSchedulesTab().click();
@@ -1184,7 +1165,7 @@ describe('Pipeline create runs', () => {
       });
 
       it('hides the MLflow integration section when BFF status is not configured', () => {
-        cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+        cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
         interceptMlflowStatus(false);
         pipelineRunsGlobal.visit(projectName);
         pipelineRunsGlobal.findSchedulesTab().click();
@@ -1205,7 +1186,7 @@ describe('Pipeline create runs', () => {
       });
 
       it('hides the MLflow integration section when DSPA has MLflow integration disabled', () => {
-        cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+        cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
         interceptMlflowStatus();
         interceptDSPAMlflowIntegration(projectName, DSPAMlflowIntegrationMode.DISABLED);
         pipelineRunsGlobal.visit(projectName);
@@ -1227,7 +1208,7 @@ describe('Pipeline create runs', () => {
       });
 
       it('shows the MLflow integration section when MLflow is enabled', () => {
-        cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+        cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
         interceptMlflowStatus();
         pipelineRunsGlobal.visit(projectName);
         pipelineRunsGlobal.findSchedulesTab().click();

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
@@ -480,7 +480,7 @@ describe('Pipeline runs', () => {
         });
 
         it('compare runs button navigates to MLflow when dev flag is enabled', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus();
           interceptDSPAMlflowIntegration(projectName);
           pipelineRunsGlobal.visit(projectName, 'active');
@@ -498,48 +498,8 @@ describe('Pipeline runs', () => {
           verifyRelativeURL(`/develop-train/mlflow/experiments/compare-runs?${params.toString()}`);
         });
 
-        it('compare runs button navigates to KFP when MLflow dev flag is disabled', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: false }));
-          interceptMlflowStatus(false);
-          interceptDSPAMlflowIntegration(projectName, DSPAMlflowIntegrationMode.DISABLED);
-          cy.interceptOdh(
-            'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
-            {
-              path: {
-                namespace: projectName,
-                serviceName: 'dspa',
-                runId: mockActiveRuns[0].run_id,
-              },
-            },
-            mockActiveRuns[0],
-          );
-          cy.interceptOdh(
-            'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
-            {
-              path: {
-                namespace: projectName,
-                serviceName: 'dspa',
-                runId: mockActiveRuns[1].run_id,
-              },
-            },
-            mockActiveRuns[1],
-          );
-          pipelineRunsGlobal.visit(projectName, 'active');
-          cy.wait('@mlflowStatus');
-
-          activeRunsTable.getRowByName(mockActiveRuns[0].display_name).findCheckbox().click();
-          activeRunsTable.getRowByName(mockActiveRuns[1].display_name).findCheckbox().click();
-
-          pipelineRunsGlobal.findCompareRunsButton().should('not.be.disabled');
-          pipelineRunsGlobal.findCompareRunsButton().click();
-
-          verifyRelativeURL(
-            `/develop-train/pipelines/runs/${projectName}/compare-runs?compareRuns=${mockActiveRuns[0].run_id},${mockActiveRuns[1].run_id}`,
-          );
-        });
-
         it('compare runs falls back to KFP for mixed MLflow metadata when MLflow is enabled', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus();
           interceptDSPAMlflowIntegration(projectName);
           const runWithoutMlflow = buildMockRunKF({
@@ -589,7 +549,7 @@ describe('Pipeline runs', () => {
         });
 
         it('per-row kebab Compare runs navigates to MLflow when MLflow metadata is present', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus();
           interceptDSPAMlflowIntegration(projectName);
           pipelineRunsGlobal.visit(projectName, 'active');
@@ -643,7 +603,7 @@ describe('Pipeline runs', () => {
         });
 
         it('navigate to MLflow experiment details from active run row', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus();
           const runWithMlflow = buildMockRunKF({
             display_name: 'Run with mlflow',
@@ -677,7 +637,7 @@ describe('Pipeline runs', () => {
         });
 
         it('shows the MLflow experiment column when MLflow is enabled', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus();
           activeRunsTable.mockGetActiveRuns(mockActiveRuns, projectName);
           pipelineRunsGlobal.visit(projectName, 'active');
@@ -685,16 +645,8 @@ describe('Pipeline runs', () => {
           activeRunsTable.findColumnHeaders().should('contain', 'MLflow experiment');
         });
 
-        it('hides the MLflow experiment column when mlflowPipelines is disabled', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: false }));
-          activeRunsTable.mockGetActiveRuns(mockActiveRuns, projectName);
-          pipelineRunsGlobal.visit(projectName, 'active');
-
-          activeRunsTable.findColumnHeaders().should('not.contain', 'MLflow experiment');
-        });
-
         it('hides the MLflow experiment column when BFF status is not configured', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus(false);
           activeRunsTable.mockGetActiveRuns(mockActiveRuns, projectName);
           pipelineRunsGlobal.visit(projectName, 'active');
@@ -703,7 +655,7 @@ describe('Pipeline runs', () => {
         });
 
         it('hides the MLflow experiment column when DSPA has MLflow integration disabled', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus();
           interceptDSPAMlflowIntegration(projectName, DSPAMlflowIntegrationMode.DISABLED);
           activeRunsTable.mockGetActiveRuns(mockActiveRuns, projectName);
@@ -769,7 +721,7 @@ describe('Pipeline runs', () => {
         });
 
         it('filter by MLflow experiment', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus();
           const runsWithMlflow = [
             buildMockRunKF({
@@ -1454,22 +1406,15 @@ describe('Pipeline runs', () => {
         });
 
         it('shows the MLflow experiment column in schedules when MLflow is enabled', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus();
           pipelineRunsGlobal.visit(projectName, 'scheduled');
 
           pipelineRecurringRunTable.findColumnHeaders().should('contain', 'MLflow experiment');
         });
 
-        it('hides the MLflow experiment column in schedules when mlflowPipelines is disabled', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: false }));
-          pipelineRunsGlobal.visit(projectName, 'scheduled');
-
-          pipelineRecurringRunTable.findColumnHeaders().should('not.contain', 'MLflow experiment');
-        });
-
         it('hides the MLflow experiment column in schedules when BFF status is not configured', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus(false);
           pipelineRunsGlobal.visit(projectName, 'scheduled');
 
@@ -1477,7 +1422,7 @@ describe('Pipeline runs', () => {
         });
 
         it('hides the MLflow experiment column in schedules when DSPA has MLflow integration disabled', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
           interceptMlflowStatus();
           interceptDSPAMlflowIntegration(projectName, DSPAMlflowIntegrationMode.DISABLED);
           pipelineRunsGlobal.visit(projectName, 'scheduled');

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -297,7 +297,6 @@ export type DashboardCommonConfig = {
   modelAsService?: boolean;
   externalModels?: boolean;
   aiAssetCustomEndpoints?: boolean;
-  mlflowPipelines?: boolean;
   mcpCatalog?: boolean;
   mcpRegistry?: boolean;
   toolCalling?: boolean;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-58541

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Removes the `mlflowPipelines` feature flag entirely. The `MLFLOW_PIPELINES` area is now gated only by its `requiredComponents` (`DS_PIPELINES` + `MLFLOW`), which is the
  correct behavior.

  **Why the flag was broken:** `getFlags()` returns raw CR `dashboardConfig` values without merging the defaults declared in `devTemporaryFeatureFlags`. When the cluster's  `OdhDashboardConfig` CR omits `mlflowPipelines` (which most do, the field was never in the CRD schema), `isFlagOn()` treats `undefined` as `'off'`, silently disabling the area regardless of the declared default. Rather than fix the flag plumbing, we remove the flag since `requiredComponents` already gates the area correctly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MLflow integration visibility to rely on current integration status rather than a separate dashboard feature flag.
  * Improved handling of MLflow-related navigation, columns, experiment links, and comparison actions across pipeline run views.
  * Updated test coverage to reflect the simplified configuration and ensure consistent behavior when integrations are enabled, disabled, or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->