### PR TITLE
fix(gen-ai): add egress rule for OGXServer port 8321 in network policy

### DIFF
--- a/manifests/modules/gen-ai/networkpolicy.yaml
+++ b/manifests/modules/gen-ai/networkpolicy.yaml
@@ -42,6 +42,11 @@ spec:
         - port: 8343
           protocol: TCP
     - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 8321
+          protocol: TCP
+    - to:
         - ipBlock:
             cidr: 0.0.0.0/0
       ports:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79633

## Description

The gen-ai-ui network policy (`gen-ai-allow-ports`) is missing an egress rule for TCP port 8321, which is the port used by OGXServer (LlamaStack) services in user namespaces. When gen-ai runs in standalone deployment mode, the network policy blocks egress to port 8321, causing `/gen-ai/api/v1/lsd/models` requests to time out with a 504 Gateway Timeout.

This was not an issue when gen-ai ran as a sidecar container in the `rhods-dashboard` pod, because the network policy's pod selector didn't match sidecar containers. When standalone deployment mode was introduced (July 15, `453d8983b`), the policy started enforcing on the new `gen-ai-ui` pods, revealing the missing rule.

**Root cause:** The egress rules allow DNS (5353), maas-ui (8243), mlflow-ui (8343), K8s API (6443), and HTTP/HTTPS (80/443) — but not OGXServer port 8321.

**Fix:** Add an egress rule allowing TCP port 8321 to any namespace (`namespaceSelector: {}`), consistent with the existing broad egress rules for ports 80/443/6443.

## How Has This Been Tested?

Tested on a live cluster (with rhoai 3.6 ea1):

1. Confirmed the gen-ai-ui pod could NOT reach the LSD service on port 8321 (curl timeout, exit code 28)
2. Manually patched the network policy to add port 8321 egress
3. Confirmed the gen-ai-ui pod could then reach the LSD service instantly (models returned successfully)
4. Verified the playground loaded models in the browser

## Test Impact

No automated tests are applicable — this is a manifest-only change to a Kubernetes NetworkPolicy. The fix was validated manually on a live cluster.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled required outbound TCP connectivity on port 8321 for supported AI functionality.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->