### PR TITLE
fix(model-serving,e2e): add deployed-model-name testid and update tolerations test for status modal

### DIFF
--- a/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
@@ -17,7 +17,7 @@ import {
   validateInferenceServiceTolerations,
 } from '../../../../utils/oc_commands/modelServing';
 import { retryableBefore } from '../../../../utils/retryableHooks';
-import { attemptToClickTooltip } from '../../../../utils/models';
+import { verifyDeploymentStatusModal } from '../../../../utils/models';
 import {
   cleanupHardwareProfiles,
   createCleanHardwareProfile,
@@ -170,7 +170,7 @@ describe('ModelServing - tolerations tests', () => {
       // Note reload is required as status tooltip was not found due to a stale element
       cy.reload();
       modelServingSection.findModelMetricsLink(modelName);
-      attemptToClickTooltip();
+      verifyDeploymentStatusModal();
 
       // Validate that the toleration applied earlier displays in the newly created pod
       cy.step('Validate the Tolerations for the pod include the newly added toleration');

--- a/packages/cypress/cypress/utils/models.ts
+++ b/packages/cypress/cypress/utils/models.ts
@@ -13,22 +13,35 @@ export const NIMAccountModel = {
   plural: 'accounts',
 };
 
-const maxAttempts = 5;
-let attempts = 0;
+/**
+ * Clicks the deployment status label to open the DeploymentStatusModal,
+ * verifies the modal shows a "Ready" status, then closes it.
+ * Retries with page reloads if the status element is not yet visible.
+ */
+export function verifyDeploymentStatusModal(): void {
+  const maxAttempts = 5;
+  let attempts = 0;
 
-export function attemptToClickTooltip(): void {
-  if (attempts >= maxAttempts) {
-    throw new Error('Failed to find and click the status tooltip after 5 attempts');
+  function attempt(): void {
+    if (attempts >= maxAttempts) {
+      throw new Error('Failed to find and click the status label after 5 attempts');
+    }
+
+    modelServingSection.findStatusTooltip().then(($el) => {
+      if ($el.length > 0 && $el.is(':visible')) {
+        modelServingSection.findStatusTooltip().click({ force: true });
+        cy.findByTestId('deployment-status-modal', { timeout: 10000 }).should('be.visible');
+        cy.findByTestId('deployment-status-modal')
+          .findByTestId('model-status-text')
+          .should('include.text', 'Ready');
+        cy.findByTestId('deployment-status-modal').find('button[aria-label="Close"]').click();
+      } else {
+        attempts++;
+        cy.reload();
+        attempt();
+      }
+    });
   }
 
-  modelServingSection.findStatusTooltip().then(($tooltip) => {
-    if ($tooltip.length > 0 && $tooltip.is(':visible')) {
-      modelServingSection.findStatusTooltip().click({ force: true });
-      cy.contains('Model deployment is active', { timeout: 120000 }).should('be.visible');
-    } else {
-      attempts++;
-      cy.reload();
-      attemptToClickTooltip();
-    }
-  });
+  attempt();
 }

--- a/packages/cypress/cypress/utils/models.ts
+++ b/packages/cypress/cypress/utils/models.ts
@@ -23,10 +23,6 @@ export function verifyDeploymentStatusModal(): void {
   let attempts = 0;
 
   function attempt(): void {
-    if (attempts >= maxAttempts) {
-      throw new Error('Failed to find and click the status label after 5 attempts');
-    }
-
     modelServingSection.findStatusTooltip().then(($el) => {
       if ($el.length > 0 && $el.is(':visible')) {
         modelServingSection.findStatusTooltip().click({ force: true });
@@ -36,9 +32,11 @@ export function verifyDeploymentStatusModal(): void {
           .should('include.text', 'Ready');
         cy.findByTestId('deployment-status-modal').find('button[aria-label="Close"]').click();
       } else {
+        if (attempts + 1 >= maxAttempts) {
+          throw new Error('Failed to find and click the status label after 5 attempts');
+        }
         attempts++;
-        cy.reload();
-        attempt();
+        cy.reload().then(() => attempt());
       }
     });
   }

--- a/packages/cypress/cypress/utils/models.ts
+++ b/packages/cypress/cypress/utils/models.ts
@@ -16,7 +16,7 @@ export const NIMAccountModel = {
 /**
  * Clicks the deployment status label to open the DeploymentStatusModal,
  * verifies the modal shows a "Ready" status, then closes it.
- * Retries with page reloads if the status element is not yet visible.
+ * Retries with page reloads if the status label is not yet visible.
  */
 export function verifyDeploymentStatusModal(): void {
   const maxAttempts = 5;
@@ -25,7 +25,7 @@ export function verifyDeploymentStatusModal(): void {
   function attempt(): void {
     modelServingSection.findStatusTooltip().then(($el) => {
       if ($el.length > 0 && $el.is(':visible')) {
-        modelServingSection.findStatusTooltip().click({ force: true });
+        modelServingSection.findStatusTooltip().find('button').first().click();
         cy.findByTestId('deployment-status-modal', { timeout: 10000 }).should('be.visible');
         cy.findByTestId('deployment-status-modal')
           .findByTestId('model-status-text')

--- a/packages/model-serving/modelRegistry/__tests__/ModelDetailsDeploymentCard.spec.tsx
+++ b/packages/model-serving/modelRegistry/__tests__/ModelDetailsDeploymentCard.spec.tsx
@@ -103,6 +103,7 @@ describe('ModelDetailsDeploymentCard', () => {
       renderWithContext([deployment], <ModelDetailsDeploymentCard rmId="1" mrName="test-mr" />);
 
       expect(screen.getByTestId('metrics-link-test-deployment')).toBeInTheDocument();
+      expect(screen.getByTestId('deployed-model-name')).toBeInTheDocument();
     });
 
     it('should render metrics link when deployment state is LOADED and stopped', () => {
@@ -123,6 +124,7 @@ describe('ModelDetailsDeploymentCard', () => {
       renderWithContext([deployment], <ModelDetailsDeploymentCard rmId="1" mrName="test-mr" />);
 
       expect(screen.getByTestId('metrics-link-test-deployment')).toBeInTheDocument();
+      expect(screen.getByTestId('deployed-model-name')).toBeInTheDocument();
     });
   });
 });

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -224,6 +224,7 @@ describe('DeploymentsTableRow', () => {
       );
 
       expect(screen.getByTestId('metrics-link-test-deployment')).toBeInTheDocument();
+      expect(screen.getByTestId('deployed-model-name')).toBeInTheDocument();
     });
   });
 

--- a/packages/model-serving/src/components/metrics/DeploymentMetricsLink.tsx
+++ b/packages/model-serving/src/components/metrics/DeploymentMetricsLink.tsx
@@ -22,7 +22,9 @@ export const DeploymentMetricsLink: React.FC<{
       data-testid={`metrics-link-${getDisplayNameFromK8sResource(deployment.model)}`}
       {...props}
     >
-      {getDisplayNameFromK8sResource(deployment.model)}
+      <span data-testid="deployed-model-name">
+        {getDisplayNameFromK8sResource(deployment.model)}
+      </span>
     </Link>
   );
 };


### PR DESCRIPTION
## Description

Fixes part of https://redhat.atlassian.net/browse/RHOAIENG-79743, along with https://github.com/opendatahub-io/odh-dashboard/pull/8969

Two E2E test fixes from [Jenkins build #2007](https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/components/job/dashboard/job/dashboard-e2e-tests/2007/) failures against 3.5:

### Fix 1: `testDeployOCIModel` — missing `deployed-model-name` testid

`DeploymentMetricsLink` rendered the model name without the `deployed-model-name` `data-testid`, causing the test to fail on KServe model rows where the metrics link is shown instead of the plain text fallback.

The older `InferenceServiceTableRow` always wraps the display name in `<span data-testid="deployed-model-name">` even inside the metrics link, but the newer `DeploymentMetricsLink` component omitted it. This fix adds the same `<span>` wrapper inside `DeploymentMetricsLink` so the `deployed-model-name` testid is present regardless of whether the metrics link or plain text path renders.

### Fix 2: `testModelServingTolerations` — status popover replaced by modal

The status icon in the deployments table now opens a `DeploymentStatusModal` instead of a popover tooltip. The test's `attemptToClickTooltip` function looked for the text "Model deployment is active" in a popover, but that popover no longer exists.

Renamed the function to `verifyDeploymentStatusModal` — it now opens the modal, asserts the `Ready` status badge is present inside the `deployment-status-modal`, and closes it. Also fixed the click target: the PF `Label` component renders a `<button>` inside a `<span>`, and the previous `force: true` click on the outer span did not trigger the React onClick handler. The fix clicks the inner button element directly.

## How Has This Been Tested?
- **Fix 1:** Reproduced the missing `deployed-model-name` testid on the Zaffre ROSA cluster using Playwright — confirmed KServe rows had `metrics-link-{name}` but no `deployed-model-name`, while LLMD rows had both. Ran unit tests for `DeploymentsTableRow` and `ModelDetailsDeploymentCard` — all 13 tests pass. Added assertions to existing unit tests to verify `deployed-model-name` is present when the metrics link renders.
- **Fix 2:** Deployed a model on Zaffre, waited for Ready state, clicked the status label, and verified the `DeploymentStatusModal` opens with `model-status-text` showing "Ready" and a Close button with `aria-label="Close"`. Confirmed selectors match the test assertions. Video from CI failure confirmed the `force: true` click was landing on the Label span wrapper instead of triggering the inner button's onClick handler.

## Test Impact
- Updated `DeploymentsTableRow.spec.tsx` to assert `deployed-model-name` is present alongside `metrics-link-{name}` when the metrics link renders
- Updated `ModelDetailsDeploymentCard.spec.tsx` to assert the same for both "running" and "stopped" metrics link test cases
- Updated `testModelServingTolerations.cy.ts` to use `verifyDeploymentStatusModal` instead of the removed `attemptToClickTooltip`
- Renamed and rewrote `attemptToClickTooltip` → `verifyDeploymentStatusModal` in `cypress/utils/models.ts`

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`