### PR TITLE
perf: Reduce homepage API calls and lazy-load QuickStarts

### DIFF
--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -205,6 +205,13 @@ module.exports = (env) => ({
   optimization: {
     splitChunks: {
       cacheGroups: {
+        quickstartsVendor: {
+          test: /[\\/]node_modules[\\/]@patternfly[\\/]quickstarts[\\/]/,
+          name: 'quickstartsVendor',
+          chunks: 'async',
+          enforce: true,
+          priority: 20,
+        },
         pluginChunks: {
           test(module) {
             return pluginPackageDetails.some(

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -42,12 +42,13 @@ import { AppContext } from './AppContext';
 import { useApplicationSettings } from './useApplicationSettings';
 import TelemetrySetup from './TelemetrySetup';
 import { logout } from './appUtils';
-import QuickStarts from './QuickStarts';
 import SessionExpiredModal from './SessionExpiredModal';
 import DevFeatureFlagsBanner from './featureFlags/DevFeatureFlagsBanner';
 import useDevFeatureFlags from './featureFlags/useDevFeatureFlags';
 import WhatsNewModal from './whatsNew/WhatsNewModal';
 import './App.scss';
+
+const QuickStarts = React.lazy(() => import('./QuickStarts'));
 
 const App: React.FC = () => {
   const [notificationsOpen, setNotificationsOpen] = React.useState(false);
@@ -184,11 +185,19 @@ const App: React.FC = () => {
                     <ProjectsContextProvider>
                       <HardwareProfilesContextProvider>
                         <ModelRegistriesContextProvider>
-                          <QuickStarts>
-                            <NotificationWatcherContextProvider pollInterval={POLL_INTERVAL}>
-                              <AppRoutes />
-                            </NotificationWatcherContextProvider>
-                          </QuickStarts>
+                          <React.Suspense
+                            fallback={
+                              <Bullseye>
+                                <Spinner />
+                              </Bullseye>
+                            }
+                          >
+                            <QuickStarts>
+                              <NotificationWatcherContextProvider pollInterval={POLL_INTERVAL}>
+                                <AppRoutes />
+                              </NotificationWatcherContextProvider>
+                            </QuickStarts>
+                          </React.Suspense>
                         </ModelRegistriesContextProvider>
                       </HardwareProfilesContextProvider>
                     </ProjectsContextProvider>

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -185,19 +185,19 @@ const App: React.FC = () => {
                     <ProjectsContextProvider>
                       <HardwareProfilesContextProvider>
                         <ModelRegistriesContextProvider>
-                          <React.Suspense
-                            fallback={
-                              <Bullseye>
-                                <Spinner />
-                              </Bullseye>
-                            }
-                          >
-                            <QuickStarts>
-                              <NotificationWatcherContextProvider pollInterval={POLL_INTERVAL}>
+                          <NotificationWatcherContextProvider pollInterval={POLL_INTERVAL}>
+                            <React.Suspense
+                              fallback={
+                                <Bullseye>
+                                  <Spinner />
+                                </Bullseye>
+                              }
+                            >
+                              <QuickStarts>
                                 <AppRoutes />
-                              </NotificationWatcherContextProvider>
-                            </QuickStarts>
-                          </React.Suspense>
+                              </QuickStarts>
+                            </React.Suspense>
+                          </NotificationWatcherContextProvider>
                         </ModelRegistriesContextProvider>
                       </HardwareProfilesContextProvider>
                     </ProjectsContextProvider>

--- a/frontend/src/app/QuickStarts.tsx
+++ b/frontend/src/app/QuickStarts.tsx
@@ -17,7 +17,14 @@ type QuickStartsProps = {
 const QuickStarts: React.FC<QuickStartsProps> = ({ children }) => {
   const [activeQuickStartID, setActiveQuickStartID] = useLocalStorage('rhodsQuickstartId', '');
   const [allQuickStartStates, setAllQuickStartStates] = useLocalStorage('rhodsQuickstarts', {});
-  const { quickStarts } = useWatchQuickStartsQuery();
+  const { quickStarts, loadError } = useWatchQuickStartsQuery();
+
+  React.useEffect(() => {
+    if (loadError) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to load QuickStarts:', loadError);
+    }
+  }, [loadError]);
 
   const valuesForQuickStartContext = {
     quickStarts,

--- a/frontend/src/app/QuickStarts.tsx
+++ b/frontend/src/app/QuickStarts.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
-import { useLocalStorage, QuickStartContainer } from '@patternfly/quickstarts';
+import { useLocalStorage, QuickStartContainer, QuickStartContext } from '@patternfly/quickstarts';
 import '@patternfly/react-catalog-view-extension/dist/css/react-catalog-view-extension.css';
 import '@patternfly/quickstarts/dist/quickstarts.min.css';
-import { useWatchQuickStarts } from '#~/utilities/useWatchQuickStarts';
+import { QuickStartsContext } from '#~/concepts/quickStarts/QuickStartsContext';
+import { useWatchQuickStartsQuery } from '#~/utilities/useWatchQuickStartsQuery';
+
+const QuickStartsBridge: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const pfContext = React.useContext(QuickStartContext);
+  return <QuickStartsContext.Provider value={pfContext}>{children}</QuickStartsContext.Provider>;
+};
 
 type QuickStartsProps = {
   children: React.ReactNode;
@@ -11,7 +17,7 @@ type QuickStartsProps = {
 const QuickStarts: React.FC<QuickStartsProps> = ({ children }) => {
   const [activeQuickStartID, setActiveQuickStartID] = useLocalStorage('rhodsQuickstartId', '');
   const [allQuickStartStates, setAllQuickStartStates] = useLocalStorage('rhodsQuickstarts', {});
-  const { quickStarts } = useWatchQuickStarts();
+  const { quickStarts } = useWatchQuickStartsQuery();
 
   const valuesForQuickStartContext = {
     quickStarts,
@@ -20,7 +26,11 @@ const QuickStarts: React.FC<QuickStartsProps> = ({ children }) => {
     allQuickStartStates,
     setAllQuickStartStates,
   };
-  return <QuickStartContainer {...valuesForQuickStartContext}>{children}</QuickStartContainer>;
+  return (
+    <QuickStartContainer {...valuesForQuickStartContext}>
+      <QuickStartsBridge>{children}</QuickStartsBridge>
+    </QuickStartContainer>
+  );
 };
 
 export default QuickStarts;

--- a/frontend/src/bootstrap.tsx
+++ b/frontend/src/bootstrap.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { BrowserStorageContextProvider } from '@odh-dashboard/ui-core/hooks';
 import { sdkStore, store } from './redux/store/store';
 import App from './app/App';
 import { ThemeProvider } from './app/ThemeContext';
 import { AnalyticsProvider } from './concepts/analyticsTracking/AnalyticsProvider';
 import { NotificationProvider } from './utilities/NotificationProvider';
+import { queryClient } from './utilities/queryClient';
 import SDKInitialize from './SDKInitialize';
 import ErrorBoundary from './components/error/ErrorBoundary';
 import RouteErrorElement from './components/error/RouteErrorElement';
@@ -44,11 +46,13 @@ const root = createRoot(document.getElementById('root')!);
 root.render(
   <React.StrictMode>
     <ErrorBoundary>
-      <Provider store={sdkStore}>
-        <Provider store={store} context={ReduxContext}>
-          <RouterProvider router={router} />
+      <QueryClientProvider client={queryClient}>
+        <Provider store={sdkStore}>
+          <Provider store={store} context={ReduxContext}>
+            <RouterProvider router={router} />
+          </Provider>
         </Provider>
-      </Provider>
+      </QueryClientProvider>
     </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/frontend/src/components/DocCardBadges.tsx
+++ b/frontend/src/components/DocCardBadges.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { Label, LabelGroup, Tooltip } from '@patternfly/react-core';
 import { InProgressIcon, CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
-import { QuickStartContext, QuickStartContextValues } from '@patternfly/quickstarts';
 import { asEnumMember } from '@odh-dashboard/foundation';
+import {
+  QuickStartsContext,
+  type QuickStartContextValues,
+} from '#~/concepts/quickStarts/QuickStartsContext';
 import { OdhDocument, OdhDocumentType } from '#~/types';
 import { getQuickStartCompletionStatus, CompletionStatusEnum } from '#~/utilities/quickStartUtils';
 import { DOC_TYPE_TOOLTIPS } from '#~/utilities/const';
@@ -16,7 +19,7 @@ type DocCardBadgesProps = {
 };
 
 const DocCardBadges: React.FC<DocCardBadgesProps> = ({ odhDoc }) => {
-  const qsContext = React.useContext<QuickStartContextValues>(QuickStartContext);
+  const qsContext = React.useContext<QuickStartContextValues>(QuickStartsContext);
   const [completionStatus, setCompletionStatus] = React.useState<
     CompletionStatusEnum | undefined
   >();

--- a/frontend/src/components/OdhDocCard.tsx
+++ b/frontend/src/components/OdhDocCard.tsx
@@ -12,8 +12,8 @@ import {
   Content,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { QuickStartContextValues } from '@patternfly/quickstarts';
 import TruncatedText from '@odh-dashboard/ui-core/components/TruncatedText';
+import type { QuickStartContextValues } from '#~/concepts/quickStarts/QuickStartsContext';
 import { OdhDocument, OdhDocumentType } from '#~/types';
 import {
   getLaunchStatus,

--- a/frontend/src/components/__tests__/DocCardBadges.spec.tsx
+++ b/frontend/src/components/__tests__/DocCardBadges.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { QuickStartContext } from '@patternfly/quickstarts';
+import { QuickStartsContext } from '#~/concepts/quickStarts/QuickStartsContext';
 import { OdhDocument, OdhDocumentType } from '#~/types';
 import { CompletionStatusEnum } from '#~/utilities/quickStartUtils';
 import DocCardBadges from '#~/components/DocCardBadges';
@@ -44,9 +44,9 @@ const renderWithContext = (odhDoc: OdhDocument) => {
   };
 
   return render(
-    <QuickStartContext.Provider value={contextValue as never}>
+    <QuickStartsContext.Provider value={contextValue as never}>
       <DocCardBadges odhDoc={odhDoc} />
-    </QuickStartContext.Provider>,
+    </QuickStartsContext.Provider>,
   );
 };
 

--- a/frontend/src/components/__tests__/DocCardBadges.spec.tsx
+++ b/frontend/src/components/__tests__/DocCardBadges.spec.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { QuickStartsContext } from '#~/concepts/quickStarts/QuickStartsContext';
+import {
+  QuickStartsContext,
+  QuickStartContextValues,
+} from '#~/concepts/quickStarts/QuickStartsContext';
 import { OdhDocument, OdhDocumentType } from '#~/types';
 import { CompletionStatusEnum } from '#~/utilities/quickStartUtils';
 import DocCardBadges from '#~/components/DocCardBadges';
@@ -44,7 +47,7 @@ const renderWithContext = (odhDoc: OdhDocument) => {
   };
 
   return render(
-    <QuickStartsContext.Provider value={contextValue as never}>
+    <QuickStartsContext.Provider value={contextValue as unknown as QuickStartContextValues}>
       <DocCardBadges odhDoc={odhDoc} />
     </QuickStartsContext.Provider>,
   );

--- a/frontend/src/components/useQuickStartCardSelected.ts
+++ b/frontend/src/components/useQuickStartCardSelected.ts
@@ -1,12 +1,15 @@
 import React from 'react';
-import { QuickStartContext, QuickStartContextValues } from '@patternfly/quickstarts';
+import {
+  QuickStartsContext,
+  type QuickStartContextValues,
+} from '#~/concepts/quickStarts/QuickStartsContext';
 import { makeCardVisible } from '#~/utilities/utils';
 
 export const useQuickStartCardSelected = (
   quickStartName: string | null | undefined,
   cardId: string,
 ): [QuickStartContextValues, boolean] => {
-  const qsContext = React.useContext<QuickStartContextValues>(QuickStartContext);
+  const qsContext = React.useContext<QuickStartContextValues>(QuickStartsContext);
 
   const selected = React.useMemo(
     () => !!quickStartName && qsContext.activeQuickStartID === quickStartName,

--- a/frontend/src/concepts/analyticsTracking/useTrackUser.ts
+++ b/frontend/src/concepts/analyticsTracking/useTrackUser.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { AccessReviewResourceAttributes } from '@odh-dashboard/k8s-core';
-import { useAccessReview } from '@odh-dashboard/plugin-core/host-api';
+import { useAccessAllowed } from '#~/concepts/userSSAR';
 import { useUser } from '#~/redux/selectors';
 import { IdentifyEventProperties } from '#~/concepts/analyticsTracking/trackingProperties';
 
@@ -13,7 +13,7 @@ export const useTrackUser = (username?: string): [IdentifyEventProperties, boole
     resource: 'projectrequests',
     verb: 'create',
   };
-  const [allowCreate, acLoaded] = useAccessReview(createReviewResource);
+  const [allowCreate, acLoaded] = useAccessAllowed(createReviewResource);
 
   React.useEffect(() => {
     const computeAnonymousUserId = async () => {

--- a/frontend/src/concepts/docResources/docUtils.ts
+++ b/frontend/src/concepts/docResources/docUtils.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { QuickStart } from '@patternfly/quickstarts/src/utils/quick-start-types';
+import type { QuickStart } from '#~/concepts/quickStarts/types';
 import { OdhApplication, OdhDocument, OdhDocumentType } from '#~/types';
 import { combineCategoryAnnotations } from '#~/utilities/utils';
 

--- a/frontend/src/concepts/docResources/useDocResources.tsx
+++ b/frontend/src/concepts/docResources/useDocResources.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
-import { QuickStartContext, QuickStartContextValues } from '@patternfly/quickstarts';
+import {
+  QuickStartsContext,
+  type QuickStartContextValues,
+} from '#~/concepts/quickStarts/QuickStartsContext';
 import { useWatchDocs } from '#~/utilities/useWatchDocs';
-import { useWatchComponents } from '#~/utilities/useWatchComponents';
+import { useWatchComponentsQuery } from '#~/utilities/useWatchComponentsQuery';
 import { OdhDocument, OdhDocumentType } from '#~/types';
 import { getQuickStartDocs, updateDocToComponent } from './docUtils';
 
 export const useDocResources = (): { docs: OdhDocument[]; loaded: boolean; loadError?: Error } => {
   const { docs: odhDocs, loaded: docsLoaded, loadError: docsLoadError } = useWatchDocs();
-  const { components, loaded, loadError } = useWatchComponents(false);
-  const qsContext = React.useContext<QuickStartContextValues>(QuickStartContext);
+  const { components, loaded, loadError } = useWatchComponentsQuery(false);
+  const qsContext = React.useContext<QuickStartContextValues>(QuickStartsContext);
 
   return React.useMemo(() => {
     if (docsLoadError || loadError) {

--- a/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelRegistryServices.spec.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelRegistryServices.spec.ts
@@ -2,7 +2,7 @@ import { act } from 'react';
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { waitFor } from '@testing-library/react';
 import { testHook } from '@odh-dashboard/jest-config/hooks';
-import { useAccessReview } from '@odh-dashboard/plugin-core/host-api';
+import { useAccessAllowed } from '#~/concepts/userSSAR';
 import { useRulesReview, listServices } from '#~/api';
 import { ServiceKind } from '#~/k8sTypes';
 import {
@@ -21,8 +21,8 @@ jest.mock('#~/api', () => ({
   listServices: jest.fn(),
 }));
 
-jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
-  useAccessReview: jest.fn(),
+jest.mock('#~/concepts/userSSAR', () => ({
+  useAccessAllowed: jest.fn(),
 }));
 
 jest.mock('#~/concepts/modelRegistry/apiHooks/useModelRegistryServices', () => ({
@@ -47,7 +47,7 @@ const mockListServices = jest.mocked(listServices);
 describe('useModelRegistryServices', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (useAccessReview as jest.Mock).mockReturnValue([false, true]);
+    (useAccessAllowed as jest.Mock).mockReturnValue([false, true]);
     (useRulesReview as jest.Mock).mockReturnValue([{ resourceRules: [] }, true, jest.fn()]);
   });
   it('should return loading state initially', () => {
@@ -60,7 +60,7 @@ describe('useModelRegistryServices', () => {
     expect(error).toBeUndefined();
   });
   it('returns services fetched by names when allowList is false', async () => {
-    (useAccessReview as jest.Mock).mockReturnValue([false, true]);
+    (useAccessAllowed as jest.Mock).mockReturnValue([false, true]);
     (useRulesReview as jest.Mock).mockReturnValue([
       {
         resourceRules: [
@@ -114,7 +114,7 @@ describe('useModelRegistryServices', () => {
   });
 
   it('returns services when allowList is true', async () => {
-    (useAccessReview as jest.Mock).mockReturnValue([true, true]);
+    (useAccessAllowed as jest.Mock).mockReturnValue([true, true]);
     (useRulesReview as jest.Mock).mockReturnValue([{ resourceRules: [] }, true, jest.fn()]);
     mockListServices.mockResolvedValue([
       mockModelRegistryService({ name: 'service-1', namespace: 'test-namespace' }),
@@ -137,7 +137,7 @@ describe('useModelRegistryServices', () => {
   });
 
   it('returns empty array if no service names are provided', async () => {
-    (useAccessReview as jest.Mock).mockReturnValue([false, true]);
+    (useAccessAllowed as jest.Mock).mockReturnValue([false, true]);
     (useRulesReview as jest.Mock).mockReturnValue([
       {
         resourceRules: [
@@ -168,7 +168,7 @@ describe('useModelRegistryServices', () => {
     jest.useFakeTimers();
     const mockError = new Error('Test error');
     mockListServices.mockRejectedValue(mockError);
-    (useAccessReview as jest.Mock).mockReturnValue([true, true]);
+    (useAccessAllowed as jest.Mock).mockReturnValue([true, true]);
     (useRulesReview as jest.Mock).mockReturnValue([{ resourceRules: [] }, true, jest.fn()]);
 
     const { result } = testHook(() => useModelRegistryServices('namespace'))();
@@ -187,7 +187,7 @@ describe('useModelRegistryServices', () => {
   });
 
   test('returns empty array if no service names are provided', async () => {
-    (useAccessReview as jest.Mock).mockReturnValue([false, true]);
+    (useAccessAllowed as jest.Mock).mockReturnValue([false, true]);
     (useRulesReview as jest.Mock).mockReturnValue([
       {
         resourceRules: [

--- a/frontend/src/concepts/modelRegistry/apiHooks/useModelRegistryServices.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/useModelRegistryServices.ts
@@ -5,7 +5,7 @@ import useFetchState, {
   FetchStateCallbackPromise,
   NotReadyError,
 } from '@odh-dashboard/ui-core/hooks/useFetchState';
-import { useAccessReview } from '@odh-dashboard/plugin-core/host-api';
+import { useAccessAllowed } from '#~/concepts/userSSAR';
 import { ServiceKind } from '#~/k8sTypes';
 import { ServiceModel, useRulesReview, listServices } from '#~/api';
 
@@ -68,7 +68,7 @@ export type ModelRegistryServicesResult = {
 export const useModelRegistryServices = (
   namespace: string | undefined,
 ): ModelRegistryServicesResult => {
-  const [allowList, accessReviewLoaded] = useAccessReview(
+  const [allowList, accessReviewLoaded] = useAccessAllowed(
     { ...accessReviewResource, namespace: namespace || '' },
     !!namespace,
   );

--- a/frontend/src/concepts/quickStarts/QuickStartsContext.ts
+++ b/frontend/src/concepts/quickStarts/QuickStartsContext.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+import type { QuickStartContextValues } from '@patternfly/quickstarts';
+
+export type { QuickStartContextValues } from '@patternfly/quickstarts';
+
+export const QuickStartsContext = React.createContext<QuickStartContextValues>({
+  allQuickStarts: [],
+  activeQuickStartID: '',
+  allQuickStartStates: {},
+});

--- a/frontend/src/concepts/quickStarts/types.ts
+++ b/frontend/src/concepts/quickStarts/types.ts
@@ -1,0 +1,15 @@
+export type { QuickStart } from '@patternfly/quickstarts';
+
+export enum QuickStartStatus {
+  COMPLETE = 'Complete',
+  IN_PROGRESS = 'In Progress',
+  NOT_STARTED = 'Not started',
+}
+
+export enum QuickStartTaskStatus {
+  INIT = 'Initial',
+  VISITED = 'Visited',
+  REVIEW = 'Review',
+  SUCCESS = 'Success',
+  FAILED = 'Failed',
+}

--- a/frontend/src/pages/enabledApplications/EnabledApplications.tsx
+++ b/frontend/src/pages/enabledApplications/EnabledApplications.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { Gallery, PageSection } from '@patternfly/react-core';
 import TitleWithIcon from '@odh-dashboard/ui-core/design/TitleWithIcon';
 import { ApplicationsPage } from '@odh-dashboard/ui-core';
-import { useWatchComponents } from '#~/utilities/useWatchComponents';
+import { useWatchComponentsQuery } from '#~/utilities/useWatchComponentsQuery';
 import { OdhApplication } from '#~/types';
 import OdhAppCard from '#~/components/OdhAppCard';
 import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
@@ -55,7 +55,7 @@ export const EnabledApplicationsInner: React.FC<EnabledApplicationsInnerProps> =
 EnabledApplicationsInner.displayName = 'EnabledApplicationsInner';
 
 const EnabledApplications: React.FC = () => {
-  const { components, loaded, loadError } = useWatchComponents(true);
+  const { components, loaded, loadError } = useWatchComponentsQuery(true);
 
   const sortedComponents = React.useMemo(
     () =>

--- a/frontend/src/pages/exploreApplication/ExploreApplications.tsx
+++ b/frontend/src/pages/exploreApplication/ExploreApplications.tsx
@@ -11,7 +11,7 @@ import {
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import TitleWithIcon from '@odh-dashboard/ui-core/design/TitleWithIcon';
 import { ApplicationsPage } from '@odh-dashboard/ui-core';
-import { useWatchComponents } from '#~/utilities/useWatchComponents';
+import { useWatchComponentsQuery } from '#~/utilities/useWatchComponentsQuery';
 import OdhExploreCard from '#~/components/OdhExploreCard';
 import { OdhApplication } from '#~/types';
 import { removeQueryArgument, setQueryArgument } from '#~/utilities/router';
@@ -101,7 +101,7 @@ const ExploreApplicationsInner: React.FC<ExploreApplicationsInnerProps> = React.
 ExploreApplicationsInner.displayName = 'ExploreApplicationsInner';
 
 const ExploreApplications: React.FC = () => {
-  const { components, loaded, loadError } = useWatchComponents(false);
+  const { components, loaded, loadError } = useWatchComponentsQuery(false);
   const mlflowEnabled = useIsAreaAvailable(SupportedArea.MLFLOW).status;
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();

--- a/frontend/src/pages/home/projects/ProjectsSection.tsx
+++ b/frontend/src/pages/home/projects/ProjectsSection.tsx
@@ -16,7 +16,7 @@ import useDimensions from 'react-cool-dimensions';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import type { AccessReviewResourceAttributes } from '@odh-dashboard/k8s-core';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
-import { useAccessReview } from '@odh-dashboard/plugin-core/host-api';
+import { useAccessAllowed } from '#~/concepts/userSSAR';
 import ManageProjectModal from '#~/pages/projects/screens/projects/ManageProjectModal';
 import { ProjectsContext } from '#~/concepts/projects/ProjectsContext';
 import EvenlySpacedGallery from '#~/components/EvenlySpacedGallery';
@@ -41,7 +41,7 @@ const ProjectsSection: React.FC = () => {
 
   const { status: projectsAvailable } = useIsAreaAvailable(SupportedArea.DS_PROJECTS_VIEW);
   const { projects: allProjects, loaded, loadError } = React.useContext(ProjectsContext);
-  const [allowCreate, rbacLoaded] = useAccessReview(accessReviewResource);
+  const [allowCreate, rbacLoaded] = useAccessAllowed(accessReviewResource);
   const [createProjectOpen, setCreateProjectOpen] = React.useState<boolean>(false);
   const [visibleCardCount, setVisibleCardCount] = React.useState<number>(5);
 

--- a/frontend/src/services/quickStartsService.ts
+++ b/frontend/src/services/quickStartsService.ts
@@ -1,4 +1,4 @@
-import { QuickStart } from '@patternfly/quickstarts';
+import type { QuickStart } from '#~/concepts/quickStarts/types';
 import axios from '#~/utilities/axios';
 
 export const fetchQuickStarts = (): Promise<QuickStart[]> => {

--- a/frontend/src/utilities/queryClient.ts
+++ b/frontend/src/utilities/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});

--- a/frontend/src/utilities/queryClient.ts
+++ b/frontend/src/utilities/queryClient.ts
@@ -1,10 +1,3 @@
 import { QueryClient } from '@tanstack/react-query';
 
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      retry: false,
-    },
-  },
-});
+export const queryClient = new QueryClient();

--- a/frontend/src/utilities/quickStartUtils.ts
+++ b/frontend/src/utilities/quickStartUtils.ts
@@ -1,8 +1,5 @@
-import {
-  QuickStartContextValues,
-  QuickStartStatus,
-  QuickStartTaskStatus,
-} from '@patternfly/quickstarts';
+import type { QuickStartContextValues } from '#~/concepts/quickStarts/QuickStartsContext';
+import { QuickStartStatus, QuickStartTaskStatus } from '#~/concepts/quickStarts/types';
 
 export enum LaunchStatusEnum {
   Open = 'Open',

--- a/frontend/src/utilities/useQuickStart.ts
+++ b/frontend/src/utilities/useQuickStart.ts
@@ -1,5 +1,8 @@
-import { QuickStartContext, QuickStartContextValues } from '@patternfly/quickstarts';
 import * as React from 'react';
+import {
+  QuickStartsContext,
+  type QuickStartContextValues,
+} from '#~/concepts/quickStarts/QuickStartsContext';
 import { launchQuickStart as launchQuickStartUtil } from './quickStartUtils';
 
 type UseQuickStartResult = {
@@ -8,7 +11,7 @@ type UseQuickStartResult = {
 };
 
 export const useQuickStart = (): UseQuickStartResult => {
-  const qsContext = React.useContext<QuickStartContextValues>(QuickStartContext);
+  const qsContext = React.useContext<QuickStartContextValues>(QuickStartsContext);
 
   const launchQuickStart = React.useCallback(
     (quickStartId: string) => {

--- a/frontend/src/utilities/useWatchComponentsQuery.ts
+++ b/frontend/src/utilities/useWatchComponentsQuery.ts
@@ -16,6 +16,8 @@ export const useWatchComponentsQuery = (
     queryKey: ['components', installed],
     queryFn: () => fetchComponents(installed),
     refetchInterval: POLL_INTERVAL,
+    refetchOnWindowFocus: false,
+    retry: false,
   });
 
   React.useEffect(() => {

--- a/frontend/src/utilities/useWatchComponentsQuery.ts
+++ b/frontend/src/utilities/useWatchComponentsQuery.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAppSelector } from '#~/redux/hooks';
+import { fetchComponents } from '#~/services/componentsServices';
+import { OdhApplication } from '#~/types';
+import { POLL_INTERVAL } from './const';
+
+export const useWatchComponentsQuery = (
+  installed: boolean,
+): { components: OdhApplication[]; loaded: boolean; loadError: Error | undefined } => {
+  const queryClient = useQueryClient();
+  const forceUpdate = useAppSelector((state) => state.forceComponentsUpdate);
+  const initForce = React.useRef<number>(forceUpdate);
+
+  const { data, isLoading, error } = useQuery<OdhApplication[], Error>({
+    queryKey: ['components', installed],
+    queryFn: () => fetchComponents(installed),
+    refetchInterval: POLL_INTERVAL,
+  });
+
+  React.useEffect(() => {
+    if (initForce.current !== forceUpdate) {
+      initForce.current = forceUpdate;
+      queryClient.invalidateQueries({ queryKey: ['components', installed] });
+    }
+  }, [forceUpdate, installed, queryClient]);
+
+  return {
+    components: data ?? [],
+    loaded: !isLoading,
+    loadError: error ?? undefined,
+  };
+};

--- a/frontend/src/utilities/useWatchQuickStartsQuery.ts
+++ b/frontend/src/utilities/useWatchQuickStartsQuery.ts
@@ -12,6 +12,8 @@ export const useWatchQuickStartsQuery = (): {
     queryKey: ['quickStarts'],
     queryFn: fetchQuickStarts,
     refetchInterval: POLL_INTERVAL,
+    refetchOnWindowFocus: false,
+    retry: false,
   });
 
   return {

--- a/frontend/src/utilities/useWatchQuickStartsQuery.ts
+++ b/frontend/src/utilities/useWatchQuickStartsQuery.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import type { QuickStart } from '#~/concepts/quickStarts/types';
+import { fetchQuickStarts } from '#~/services/quickStartsService';
+import { POLL_INTERVAL } from './const';
+
+export const useWatchQuickStartsQuery = (): {
+  quickStarts: QuickStart[];
+  loaded: boolean;
+  loadError: Error | undefined;
+} => {
+  const { data, isLoading, error } = useQuery<QuickStart[], Error>({
+    queryKey: ['quickStarts'],
+    queryFn: fetchQuickStarts,
+    refetchInterval: POLL_INTERVAL,
+  });
+
+  return {
+    quickStarts: data ?? [],
+    loaded: !isLoading,
+    loadError: error ?? undefined,
+  };
+};


### PR DESCRIPTION
## Description

The homepage fires duplicate API calls on every load — `/api/components` 5 times, `/api/selfsubjectaccessreviews` 8 times, and `/api/quickstarts` 2 times. Additionally, `@patternfly/quickstarts` (~2.6 MB) is eagerly loaded in the initial bundle even though QuickStarts are only used when the drawer opens.

This PR addresses both issues:

**API call deduplication:**
- Added `useWatchComponentsQuery` — a react-query based hook replacing `useWatchComponents`. Three homepage consumers calling `useWatchComponentsQuery(false)` now share a single request via `queryKey: ['components', false]` instead of each firing independently. `/api/components` calls reduced from 5 to 3.
- Switched `ProjectsSection`, `useTrackUser`, and `useModelRegistryServices` from uncached `useAccessReview` (plugin-core) to cached `useAccessAllowed` (`AccessReviewContext` already mounted in `App.tsx`). SSAR calls reduced from 8 to ~4.
- Added `useWatchQuickStartsQuery` — same react-query pattern for `/api/quickstarts`. Calls reduced from 2 to 1.

`@tanstack/react-query` v4 was already in `package.json` but had zero imports — this PR adopts it with a central `QueryClient` instance wrapped via `QueryClientProvider` in `bootstrap.tsx`.

**QuickStarts lazy-load:**
- `React.lazy(() => import('./QuickStarts'))` + `Suspense` in `App.tsx` so `@patternfly/quickstarts` loads async only when needed.
- Created a custom `QuickStartsContext` that mirrors PF's `QuickStartContext` shape, and a `QuickStartsBridge` component inside `QuickStarts.tsx` that reads from PF's context and re-provides through the custom one. This breaks the import chain — consumers outside the lazy boundary import from the custom context (type-only), not from `@patternfly/quickstarts`.
- Extracted `QuickStart` type and enum shims (`QuickStartStatus`, `QuickStartTaskStatus`) into `concepts/quickStarts/types.ts` so consumers avoid runtime imports.
- All consumer files (`DocCardBadges`, `OdhDocCard`, `useQuickStartCardSelected`, `useQuickStart`, `quickStartUtils`, `docUtils`, `quickStartsService`) switched to custom context or `import type`.
- Added `quickstartsVendor` webpack cache group with `chunks: 'async'` — production build confirms a 47 KB async chunk instead of 2.6 MB in the initial bundle.

## How Has This Been Tested?

- TypeScript: `npx tsc --noEmit` passes clean
- Unit tests: 355 suites, 3846 tests all passing
- Dev server: homepage loads, Enabled/Explore pages render, QuickStarts drawer opens and progresses through steps
- Network tab: confirmed reduced API call counts for `/api/components`, `/api/selfsubjectaccessreviews`, and `/api/quickstarts`
- Production build: `quickstartsVendor` chunk correctly separated at 47 KB async

## Test Impact

- Updated `DocCardBadges.spec.tsx` — test context provider changed from PF `QuickStartContext` to custom `QuickStartsContext`
- Updated `useModelRegistryServices.spec.ts` — mock changed from `useAccessReview` (`@odh-dashboard/plugin-core/host-api`) to `useAccessAllowed` (`#~/concepts/userSSAR`)
- No new test files added — the new hooks (`useWatchComponentsQuery`, `useWatchQuickStartsQuery`) are thin wrappers over react-query's `useQuery` with the same return shape as the hooks they replace; existing consumer tests and the 3846-test suite verify behavior end-to-end

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Quick Starts lazy-loading with a Suspense spinner while the content initializes.
  - Introduced React Query at the app root for improved data fetching patterns.
  - Added new polling hooks for Quick Starts and components.
  - Standardized Quick Starts context propagation across views and cards.
- **Bug Fixes**
  - Improved permission-aware behavior for projects and model registry access.
  - Enhanced Quick Starts load error handling with warning logs.
  - Updated enabled/explore application views to use the new component polling hook.
- **Performance**
  - Separated Quick Starts resources and optimized vendor chunking for faster load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->