### PR TITLE
Cherry-pick #8948 into v3.5.0-fixes

### DIFF
--- a/manifests/modules/gen-ai/networkpolicy.yaml
+++ b/manifests/modules/gen-ai/networkpolicy.yaml
@@ -42,6 +42,11 @@ spec:
         - port: 8343
           protocol: TCP
     - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 8321
+          protocol: TCP
+    - to:
         - ipBlock:
             cidr: 0.0.0.0/0
       ports:


### PR DESCRIPTION
Cherry-pick of #8948 to v3.5.0-fixes.

## Description
Adds an egress rule for port 8321 (OGXServer/LlamaStack) to the gen-ai NetworkPolicy. Without this rule, the gen-ai BFF pod cannot reach LlamaStack when network policies are enforced.

## How Has This Been Tested?
Tested on the original PR — verified the BFF pod can reach LlamaStack on port 8321 with the network policy in place.

## Test Impact
No new tests — this is a manifest-only change (NetworkPolicy YAML). Network policy enforcement is validated at the cluster level, not via unit/Cypress tests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`