### PR TITLE
fix(autox): desynchronized pipeline status and visualization

### DIFF
--- a/packages/automl/frontend/src/app/components/run-results/AutomlPipelineVisualization.scss
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlPipelineVisualization.scss
@@ -10,14 +10,6 @@
   border-bottom: 1px solid var(--pf-t--global--border--color--default);
 }
 
-.automl-pipeline-visualization__toolbar {
-  margin-left: auto;
-
-  .pf-v6-l-flex {
-    justify-content: flex-end;
-  }
-}
-
 .automl-pipeline-visualization__body {
   height: 45vh;
   min-height: 45vh;
@@ -54,16 +46,4 @@
   height: 100%;
   min-height: 0;
   overflow: hidden;
-}
-
-@media (max-width: 992px) {
-  .automl-pipeline-visualization__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .automl-pipeline-visualization__toolbar {
-    margin-left: 0;
-    width: 100%;
-  }
 }

--- a/packages/automl/frontend/src/app/components/run-results/AutomlPipelineVisualization.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlPipelineVisualization.tsx
@@ -102,14 +102,9 @@ const AutomlPipelineVisualization: React.FC<AutomlPipelineVisualizationProps> = 
         className="automl-pipeline-visualization__header"
         alignItems={{ default: 'alignItemsCenter' }}
         justifyContent={{ default: 'justifyContentSpaceBetween' }}
-        flexWrap={{ default: 'wrap' }}
-        spaceItems={{ default: 'spaceItemsMd' }}
       >
         <FlexItem>
-          <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            spaceItems={{ default: 'spaceItemsMd' }}
-          >
+          <Flex>
             <FlexItem>
               <Title headingLevel="h3" size="lg">
                 {runTitle}
@@ -127,13 +122,8 @@ const AutomlPipelineVisualization: React.FC<AutomlPipelineVisualizationProps> = 
           </Flex>
         </FlexItem>
 
-        <FlexItem className="automl-pipeline-visualization__toolbar">
-          <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            justifyContent={{ default: 'justifyContentFlexEnd' }}
-            spaceItems={{ default: 'spaceItemsMd' }}
-            flexWrap={{ default: 'wrap' }}
-          >
+        <FlexItem>
+          <Flex>
             <FlexItem>
               <Button
                 variant="tertiary"

--- a/packages/automl/frontend/src/app/components/run-results/StepDetailsPanel.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/StepDetailsPanel.tsx
@@ -12,9 +12,11 @@ import {
   DrawerPanelBody,
   Label,
   Spinner,
+  type SpinnerProps,
   Stack,
   StackItem,
   Title,
+  type TitleProps,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
@@ -35,6 +37,7 @@ import {
   getPipelineStatusFilterLabel,
   getPipelineStatusLabelProps,
   getPipelineTreeLoadingContent,
+  getStepDetailsLoadingContent,
   getStepStateLabel,
   type PipelineStatusLabel,
   type PipelineTreeLoadingMode,
@@ -119,16 +122,20 @@ const StepDetailsPanelHeader: React.FC<StepDetailsPanelHeaderProps> = ({
 type StepDetailsLoadingBodyProps = {
   primaryText: string;
   secondaryText: string;
+  spinnerSize?: SpinnerProps['size'];
+  titleSize?: TitleProps['size'];
 };
 
 const StepDetailsLoadingBody: React.FC<StepDetailsLoadingBodyProps> = ({
   primaryText,
   secondaryText,
+  spinnerSize = 'xl',
+  titleSize = 'xl',
 }) => (
   <div className="automl-step-details__empty-state">
     <div className="automl-step-details__empty-state-content">
-      <Spinner size="xl" className="automl-step-details__empty-state-spinner" />
-      <Title headingLevel="h3" size="xl" className="automl-step-details__empty-state-title">
+      <Spinner size={spinnerSize} className="automl-step-details__empty-state-spinner" />
+      <Title headingLevel="h3" size={titleSize} className="automl-step-details__empty-state-title">
         {primaryText}
       </Title>
       <Content component={ContentVariants.p} className="automl-step-details__empty-state-subtitle">
@@ -231,7 +238,7 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
     nodeData.stepState === 'completed';
   const panelTitle = isBestModel ? 'Best model' : (nodeData.label ?? 'Step details');
   const statusLabel = getStepStateLabel(nodeData.stepState);
-  const inProgressLoadingContent = getPipelineDetailsEmptyContent('in-progress');
+  const inProgressLoadingContent = getStepDetailsLoadingContent();
   const isStepLoading = nodeData.stepState === 'active';
 
   return (
@@ -264,6 +271,8 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
               <StepDetailsLoadingBody
                 primaryText={inProgressLoadingContent.primaryText ?? inProgressLoadingContent.title}
                 secondaryText={inProgressLoadingContent.secondaryText ?? ''}
+                spinnerSize="lg"
+                titleSize="lg"
               />
             </StackItem>
           ) : (

--- a/packages/automl/frontend/src/app/components/run-results/pipelineStatusLabels.ts
+++ b/packages/automl/frontend/src/app/components/run-results/pipelineStatusLabels.ts
@@ -152,6 +152,13 @@ export type PipelineDetailsEmptyContent = {
   secondaryText?: string;
 };
 
+export const getStepDetailsLoadingContent = (): PipelineDetailsEmptyContent => ({
+  title: 'Running task',
+  variant: 'loading',
+  primaryText: 'Running task',
+  secondaryText: 'Details will appear once this step is complete.',
+});
+
 export const getPipelineDetailsEmptyContent = (
   statusFilter: PipelineStatusFilter,
 ): PipelineDetailsEmptyContent => {
@@ -168,7 +175,7 @@ export const getPipelineDetailsEmptyContent = (
         title: 'Running pipeline',
         variant: 'loading',
         primaryText: 'Running pipeline',
-        secondaryText: 'Details will appear once the step is complete.',
+        secondaryText: 'Details will appear once the run is complete.',
       };
     case 'completed':
     case 'canceled':

--- a/packages/automl/frontend/src/app/topology/__tests__/parseUtils.spec.ts
+++ b/packages/automl/frontend/src/app/topology/__tests__/parseUtils.spec.ts
@@ -95,14 +95,14 @@ describe('parseRuntimeInfoFromRunDetails', () => {
     expect(result?.state).toBe(RuntimeStateKF.FAILED);
   });
 
-  it('should pick worst status when main and driver tasks both exist', () => {
+  it('should prefer the executor status over the driver when both exist', () => {
     const details = makeRunDetails(
       { task_id: 'task-1', display_name: 'task-1', state: RuntimeStateKF.SUCCEEDED },
       { task_id: 'task-1-driver', display_name: 'task-1-driver', state: RuntimeStateKF.FAILED },
     );
     const result = parseRuntimeInfoFromRunDetails('task-1', details);
 
-    expect(result?.state).toBe(RuntimeStateKF.FAILED);
+    expect(result?.state).toBe(RuntimeStateKF.SUCCEEDED);
   });
 
   it('should keep succeeded when paired with canceled driver status', () => {
@@ -115,14 +115,14 @@ describe('parseRuntimeInfoFromRunDetails', () => {
     expect(result?.state).toBe(RuntimeStateKF.SUCCEEDED);
   });
 
-  it('should pick failed over canceled', () => {
+  it('should prefer the executor status over the driver even when the driver failed', () => {
     const details = makeRunDetails(
       { task_id: 'task-1', display_name: 'task-1', state: RuntimeStateKF.CANCELED },
       { task_id: 'task-1-driver', display_name: 'task-1-driver', state: RuntimeStateKF.FAILED },
     );
     const result = parseRuntimeInfoFromRunDetails('task-1', details);
 
-    expect(result?.state).toBe(RuntimeStateKF.FAILED);
+    expect(result?.state).toBe(RuntimeStateKF.CANCELED);
   });
 });
 

--- a/packages/automl/frontend/src/app/topology/parseUtils.ts
+++ b/packages/automl/frontend/src/app/topology/parseUtils.ts
@@ -40,7 +40,11 @@ const worstStatus = (details: TaskDetailKF[]): TaskDetailKF['state'] =>
 
 /**
  * Get the run status of a task from the RunDetailsKF (task_details array).
- * Considers both the main task and its driver task, picking the most-progressed status.
+ * The `-driver` task only resolves inputs/caching and can finish independently of the
+ * actual executor container — e.g. it may report SUCCEEDED before the executor even starts,
+ * or CANCELED as cleanup after the executor has already finished. Its state must never
+ * override the executor's real state, so the executor entry (if present) is authoritative;
+ * the driver entry is only used as a fallback before the executor appears in task_details.
  */
 export const parseRuntimeInfoFromRunDetails = (
   taskId: string,
@@ -50,7 +54,11 @@ export const parseRuntimeInfoFromRunDetails = (
     return undefined;
   }
 
-  const nameVariants = [taskId, `${taskId}-driver`];
+  const driverName = `${taskId}-driver`;
+  const isDriverEntry = (td: TaskDetailKF): boolean =>
+    td.display_name === driverName || td.task_id === driverName;
+
+  const nameVariants = [taskId, driverName];
   const matchingDetails = runDetails.task_details.filter(
     (td) =>
       (td.display_name != null && nameVariants.includes(td.display_name)) ||
@@ -61,11 +69,14 @@ export const parseRuntimeInfoFromRunDetails = (
     return undefined;
   }
 
+  const executorDetails = matchingDetails.filter((td) => !isDriverEntry(td));
+  const relevantDetails = executorDetails.length > 0 ? executorDetails : matchingDetails;
+
   return {
-    startTime: matchingDetails[0].start_time,
-    completeTime: matchingDetails[0].end_time,
-    state: worstStatus(matchingDetails),
-    taskId: matchingDetails[0].task_id,
+    startTime: relevantDetails[0].start_time,
+    completeTime: relevantDetails[0].end_time,
+    state: worstStatus(relevantDetails),
+    taskId: relevantDetails[0].task_id,
   };
 };
 

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragPipelineVisualization.scss
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragPipelineVisualization.scss
@@ -10,14 +10,6 @@
   border-bottom: 1px solid var(--pf-t--global--border--color--default);
 }
 
-.autorag-pipeline-visualization__toolbar {
-  margin-left: auto;
-
-  .pf-v6-l-flex {
-    justify-content: flex-end;
-  }
-}
-
 .autorag-pipeline-visualization__body {
   height: 45vh;
   min-height: 45vh;
@@ -54,16 +46,4 @@
   height: 100%;
   min-height: 0;
   overflow: hidden;
-}
-
-@media (max-width: 992px) {
-  .autorag-pipeline-visualization__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .autorag-pipeline-visualization__toolbar {
-    margin-left: 0;
-    width: 100%;
-  }
 }

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragPipelineVisualization.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragPipelineVisualization.tsx
@@ -102,14 +102,9 @@ const AutoragPipelineVisualization: React.FC<AutoragPipelineVisualizationProps> 
         className="autorag-pipeline-visualization__header"
         alignItems={{ default: 'alignItemsCenter' }}
         justifyContent={{ default: 'justifyContentSpaceBetween' }}
-        flexWrap={{ default: 'wrap' }}
-        spaceItems={{ default: 'spaceItemsMd' }}
       >
         <FlexItem>
-          <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            spaceItems={{ default: 'spaceItemsMd' }}
-          >
+          <Flex>
             <FlexItem>
               <Title headingLevel="h3" size="lg">
                 {runTitle}
@@ -123,13 +118,8 @@ const AutoragPipelineVisualization: React.FC<AutoragPipelineVisualizationProps> 
           </Flex>
         </FlexItem>
 
-        <FlexItem className="autorag-pipeline-visualization__toolbar">
-          <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            justifyContent={{ default: 'justifyContentFlexEnd' }}
-            spaceItems={{ default: 'spaceItemsMd' }}
-            flexWrap={{ default: 'wrap' }}
-          >
+        <FlexItem>
+          <Flex>
             <FlexItem>
               <Button
                 variant="tertiary"

--- a/packages/autorag/frontend/src/app/components/run-results/StepDetailsPanel.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/StepDetailsPanel.tsx
@@ -12,9 +12,11 @@ import {
   DrawerPanelBody,
   Label,
   Spinner,
+  type SpinnerProps,
   Stack,
   StackItem,
   Title,
+  type TitleProps,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
@@ -35,6 +37,7 @@ import {
   getPipelineStatusFilterLabel,
   getPipelineStatusLabelProps,
   getPipelineTreeLoadingContent,
+  getStepDetailsLoadingContent,
   getStepStateLabel,
   type PipelineStatusLabel,
   type PipelineTreeLoadingMode,
@@ -120,16 +123,20 @@ const StepDetailsPanelHeader: React.FC<StepDetailsPanelHeaderProps> = ({
 type StepDetailsLoadingBodyProps = {
   primaryText: string;
   secondaryText: string;
+  spinnerSize?: SpinnerProps['size'];
+  titleSize?: TitleProps['size'];
 };
 
 const StepDetailsLoadingBody: React.FC<StepDetailsLoadingBodyProps> = ({
   primaryText,
   secondaryText,
+  spinnerSize = 'xl',
+  titleSize = 'xl',
 }) => (
   <div className="autorag-step-details__empty-state">
     <div className="autorag-step-details__empty-state-content">
-      <Spinner size="xl" className="autorag-step-details__empty-state-spinner" />
-      <Title headingLevel="h3" size="xl" className="autorag-step-details__empty-state-title">
+      <Spinner size={spinnerSize} className="autorag-step-details__empty-state-spinner" />
+      <Title headingLevel="h3" size={titleSize} className="autorag-step-details__empty-state-title">
         {primaryText}
       </Title>
       <Content component={ContentVariants.p} className="autorag-step-details__empty-state-subtitle">
@@ -235,7 +242,7 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
     nodeData.stepState === 'completed';
   const panelTitle = isBestPattern ? 'Best pattern' : (nodeData.label ?? 'Step details');
   const statusLabel = getStepStateLabel(nodeData.stepState);
-  const inProgressLoadingContent = getPipelineDetailsEmptyContent('in-progress');
+  const inProgressLoadingContent = getStepDetailsLoadingContent();
   const isStepLoading = nodeData.stepState === 'active';
 
   return (
@@ -268,6 +275,8 @@ const StepDetailsPanel: React.FC<StepDetailsPanelProps> = ({
               <StepDetailsLoadingBody
                 primaryText={inProgressLoadingContent.primaryText ?? inProgressLoadingContent.title}
                 secondaryText={inProgressLoadingContent.secondaryText ?? ''}
+                spinnerSize="lg"
+                titleSize="lg"
               />
             </StackItem>
           ) : (

--- a/packages/autorag/frontend/src/app/components/run-results/pipelineStatusLabels.ts
+++ b/packages/autorag/frontend/src/app/components/run-results/pipelineStatusLabels.ts
@@ -152,6 +152,13 @@ export type PipelineDetailsEmptyContent = {
   secondaryText?: string;
 };
 
+export const getStepDetailsLoadingContent = (): PipelineDetailsEmptyContent => ({
+  title: 'Running task',
+  variant: 'loading',
+  primaryText: 'Running task',
+  secondaryText: 'Details will appear once this step is complete.',
+});
+
 export const getPipelineDetailsEmptyContent = (
   statusFilter: PipelineStatusFilter,
 ): PipelineDetailsEmptyContent => {
@@ -168,7 +175,7 @@ export const getPipelineDetailsEmptyContent = (
         title: 'Running pipeline',
         variant: 'loading',
         primaryText: 'Running pipeline',
-        secondaryText: 'Details will appear once the step is complete.',
+        secondaryText: 'Details will appear once the run is complete.',
       };
     case 'completed':
     case 'canceled':

--- a/packages/autorag/frontend/src/app/topology/__tests__/parseUtils.spec.ts
+++ b/packages/autorag/frontend/src/app/topology/__tests__/parseUtils.spec.ts
@@ -95,14 +95,14 @@ describe('parseRuntimeInfoFromRunDetails', () => {
     expect(result?.state).toBe(RuntimeStateKF.FAILED);
   });
 
-  it('should pick worst status when main and driver tasks both exist', () => {
+  it('should prefer the executor status over the driver when both exist', () => {
     const details = makeRunDetails(
       { task_id: 'task-1', display_name: 'task-1', state: RuntimeStateKF.SUCCEEDED },
       { task_id: 'task-1-driver', display_name: 'task-1-driver', state: RuntimeStateKF.FAILED },
     );
     const result = parseRuntimeInfoFromRunDetails('task-1', details);
 
-    expect(result?.state).toBe(RuntimeStateKF.FAILED);
+    expect(result?.state).toBe(RuntimeStateKF.SUCCEEDED);
   });
 
   it('should keep succeeded when paired with canceled driver status', () => {
@@ -115,14 +115,14 @@ describe('parseRuntimeInfoFromRunDetails', () => {
     expect(result?.state).toBe(RuntimeStateKF.SUCCEEDED);
   });
 
-  it('should pick failed over canceled', () => {
+  it('should prefer the executor status over the driver even when the driver failed', () => {
     const details = makeRunDetails(
       { task_id: 'task-1', display_name: 'task-1', state: RuntimeStateKF.CANCELED },
       { task_id: 'task-1-driver', display_name: 'task-1-driver', state: RuntimeStateKF.FAILED },
     );
     const result = parseRuntimeInfoFromRunDetails('task-1', details);
 
-    expect(result?.state).toBe(RuntimeStateKF.FAILED);
+    expect(result?.state).toBe(RuntimeStateKF.CANCELED);
   });
 });
 

--- a/packages/autorag/frontend/src/app/topology/__tests__/stageMapStatus.spec.ts
+++ b/packages/autorag/frontend/src/app/topology/__tests__/stageMapStatus.spec.ts
@@ -173,7 +173,7 @@ describe('getComponentRunStatus', () => {
     expect(getComponentRunStatus(component, undefined)).toBe(RunStatus.Succeeded);
   });
 
-  it('should include driver task variants and prefer the worst matching status', () => {
+  it('should include driver task variants and prefer the executor status', () => {
     const component = makeComponent();
     const runDetails = {
       task_details: [
@@ -198,7 +198,7 @@ describe('getComponentRunStatus', () => {
       ],
     } as RunDetailsKF;
 
-    expect(getComponentRunStatus(component, runDetails)).toBe(RunStatus.Failed);
+    expect(getComponentRunStatus(component, runDetails)).toBe(RunStatus.Succeeded);
   });
 });
 

--- a/packages/autorag/frontend/src/app/topology/parseUtils.ts
+++ b/packages/autorag/frontend/src/app/topology/parseUtils.ts
@@ -40,7 +40,11 @@ const worstStatus = (details: TaskDetailKF[]): TaskDetailKF['state'] =>
 
 /**
  * Get the run status of a task from the RunDetailsKF (task_details array).
- * Considers both the main task and its driver task, picking the most-progressed status.
+ * The `-driver` task only resolves inputs/caching and can finish independently of the
+ * actual executor container — e.g. it may report SUCCEEDED before the executor even starts,
+ * or CANCELED as cleanup after the executor has already finished. Its state must never
+ * override the executor's real state, so the executor entry (if present) is authoritative;
+ * the driver entry is only used as a fallback before the executor appears in task_details.
  */
 export const parseRuntimeInfoFromRunDetails = (
   taskId: string,
@@ -50,7 +54,11 @@ export const parseRuntimeInfoFromRunDetails = (
     return undefined;
   }
 
-  const nameVariants = [taskId, `${taskId}-driver`];
+  const driverName = `${taskId}-driver`;
+  const isDriverEntry = (td: TaskDetailKF): boolean =>
+    td.display_name === driverName || td.task_id === driverName;
+
+  const nameVariants = [taskId, driverName];
   const matchingDetails = runDetails.task_details.filter(
     (td) =>
       (td.display_name != null && nameVariants.includes(td.display_name)) ||
@@ -61,11 +69,14 @@ export const parseRuntimeInfoFromRunDetails = (
     return undefined;
   }
 
+  const executorDetails = matchingDetails.filter((td) => !isDriverEntry(td));
+  const relevantDetails = executorDetails.length > 0 ? executorDetails : matchingDetails;
+
   return {
-    startTime: matchingDetails[0].start_time,
-    completeTime: matchingDetails[0].end_time,
-    state: worstStatus(matchingDetails),
-    taskId: matchingDetails[0].task_id,
+    startTime: relevantDetails[0].start_time,
+    completeTime: relevantDetails[0].end_time,
+    state: worstStatus(relevantDetails),
+    taskId: relevantDetails[0].task_id,
   };
 };
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-78207
https://redhat.atlassian.net/browse/RHOAIENG-79313

## Description

Fixes three related bugs in the AutoRAG/AutoML pipeline run visualization (both packages share the same components):

1. **Pipeline status and visualization desync** — `parseRuntimeInfoFromRunDetails` (and the AutoML equivalent) could report a task's status from its `-driver` entry even after the actual executor entry existed in `task_details`. The `-driver` task resolves inputs/caching and can finish (e.g. report `SUCCEEDED`) independently of and before the actual executor container, so a step could show as succeeded in the tree/topology view while the real task was still running. The executor entry is now authoritative when present, with the driver entry used only as a fallback before the executor appears in `task_details`.
2. **Pipeline visualization title shifting on smaller viewports** — the "AutoRAG pipeline run" / "AutoML pipeline run" header in the pipeline visualization panel wrapped/re-centered at intermediate viewport widths even though there was still room for the title and toolbar on one line. Simplified the header `Flex` layout (removed the custom wrap/margin-auto/media-query overrides) so it stays left-aligned.
3. **Misleading running-state text** — the step details drawer showed "Running pipeline" / "Details will appear once the step is complete" both when no node was selected (the whole pipeline is running) and when a specific step was selected and running. This is now split into two distinct messages:
   - No node selected: "Running pipeline" / "Details will appear once the run is complete."
   - A running step selected: "Running task" / "Details will appear once the step is complete."
   The step-selected loading spinner and title are now also rendered one size smaller (`lg` instead of `xl`) to better fit the narrower step details panel, via new configurable `spinnerSize`/`titleSize` props on the shared loading body.

## How Has This Been Tested?

- Ran the full Jest unit test suites for `packages/autorag/frontend` and `packages/automl/frontend` (all passing).
- Ran `tsc --noEmit` for both packages' frontend `tsconfig.json`.
- Manually exercised the pipeline visualization drawer locally with no node selected and with a running node selected to confirm the new copy and spinner/title sizing.

Before | After
--- | ---
. | <video src="https://github.com/user-attachments/assets/34abad2a-569a-41b7-afe4-0f37bfbe0556" />
<img width="1440" height="786" alt="image" src="https://github.com/user-attachments/assets/d23dcf07-1d59-4776-9932-0fe3fea96cc8" /> | <video src="https://github.com/user-attachments/assets/836eb25e-9269-4130-87b7-5043af81c7dc" />

## Test Impact

- Updated `parseUtils.spec.ts` (autorag + automl) and `stageMapStatus.spec.ts` (autorag) to reflect the corrected executor-vs-driver precedence.
- No new component tests were added for the `StepDetailsPanel` copy/size changes — there is no existing component test suite for that file to extend; behavior was verified manually in-browser.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

