### PR TITLE
fix(autorag,automl): add egress rules for DSPA and OGX ports in network policies

### DIFF
--- a/manifests/modules/automl/networkpolicy.yaml
+++ b/manifests/modules/automl/networkpolicy.yaml
@@ -34,6 +34,11 @@ spec:
         - port: 6443
           protocol: TCP
     - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 8443
+          protocol: TCP
+    - to:
         - ipBlock:
             cidr: 0.0.0.0/0
       ports:

--- a/manifests/modules/autorag/networkpolicy.yaml
+++ b/manifests/modules/autorag/networkpolicy.yaml
@@ -34,6 +34,13 @@ spec:
         - port: 6443
           protocol: TCP
     - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 8443
+          protocol: TCP
+        - port: 8321
+          protocol: TCP
+    - to:
         - ipBlock:
             cidr: 0.0.0.0/0
       ports:


### PR DESCRIPTION
## Description

The `autorag-allow-ports` and `automl-allow-ports` network policies are missing egress rules for ports that the standalone BFF pods need to reach in user namespaces:

- **Port 8443** (DSPA pipeline server) — both AutoRAG and AutoML BFFs call this to list pipelines, create pipeline runs, and monitor run status
- **Port 8321** (OGX/LlamaStack) — the AutoRAG BFF calls this to fetch models (`/v1/models`) and vector store providers (`/v1/providers`)

This was not an issue when the BFFs ran as sidecar containers in the `rhods-dashboard` pod, because the `rhods-dashboard-allow-ports` network policy has a broad egress rule (`namespaceSelector: {}`) that covered all outbound traffic. When standalone deployment mode was introduced in #8708, each module's own network policy took effect, and the missing egress rules caused the BFF's requests to DSPA and OGX to hang until timeout.

**Symptoms:** AutoRAG experiments page stuck on loading spinner — the BFF logs show `context deadline exceeded (Client.Timeout exceeded while awaiting headers)` on every request to `ds-pipeline-dspa.<namespace>.svc.cluster.local:8443`. The "Create run" button never appears.

**Fix:** Add egress rules allowing TCP ports 8443 and 8321 to any namespace (`namespaceSelector: {}`), consistent with the existing broad egress pattern used in `rhods-dashboard-allow-ports`.

## How Has This Been Tested?

- Confirmed the BFF pod cannot reach DSPA from `redhat-ods-applications` namespace (curl timeout, exit code 28) when running in standalone mode
- Confirmed the BFF pod CAN reach DSPA when running as sidecar (covered by dashboard's network policy)
- BFF logs on the RHOAI nightly cluster (`dash-e2e-rhoai`) show repeated `context deadline exceeded` errors for every pipeline discovery request
- Pending: Jenkins E2E validation with the fix applied

## Test Impact

No automated tests are applicable — this is a manifest-only change to Kubernetes NetworkPolicies. The fix is validated by the AutoRAG and AutoML E2E tests passing on clusters where standalone deployment mode is active.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`