### PR TITLE
Cherry-pick #8971 into v3.5.0-fixes

### DIFF
--- a/manifests/modules/automl/networkpolicy.yaml
+++ b/manifests/modules/automl/networkpolicy.yaml
@@ -34,6 +34,11 @@ spec:
         - port: 6443
           protocol: TCP
     - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 8443
+          protocol: TCP
+    - to:
         - ipBlock:
             cidr: 0.0.0.0/0
       ports:

--- a/manifests/modules/autorag/networkpolicy.yaml
+++ b/manifests/modules/autorag/networkpolicy.yaml
@@ -34,6 +34,13 @@ spec:
         - port: 6443
           protocol: TCP
     - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 8443
+          protocol: TCP
+        - port: 8321
+          protocol: TCP
+    - to:
         - ipBlock:
             cidr: 0.0.0.0/0
       ports:


### PR DESCRIPTION
Cherry-pick of #8971 to v3.5.0-fixes.

## Description

Adds egress rules for DSPA (port 8443) and OGX (port 8321) to the AutoRAG and AutoML standalone BFF network policies. Without these rules, the BFF pods cannot reach the pipeline server or OGX in user namespaces when network policies are enforced in standalone deployment mode.

## How Has This Been Tested?

Tested on the original PR — confirmed the BFF pod times out reaching DSPA on port 8443 without the fix, and succeeds with it.

## Test Impact

No new tests — this is a manifest-only change (NetworkPolicy YAML). Network policy enforcement is validated at the cluster level, not via unit/Cypress tests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`