### PR TITLE
fix(RHOAIENG-79525): add missing selector label to kustomization commonLabels [v3.5.0]

### DIFF
--- a/manifests/odh/kustomization.yaml
+++ b/manifests/odh/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 commonLabels:
   app: odh-dashboard
   app.kubernetes.io/part-of: odh-dashboard
+  # Legacy label from the old opendatahub-operator's CreateAddLabelsPlugin.
+  # Required for upgrade compatibility: spec.selector.matchLabels is immutable,
+  # so the selector must match what the old operator wrote to existing Deployments.
+  app.opendatahub.io/odh-dashboard: "true"
 resources:
   - ../sidecar
   - ../base/consolelink

--- a/manifests/odh/standalone/kustomization.yaml
+++ b/manifests/odh/standalone/kustomization.yaml
@@ -5,6 +5,10 @@ kind: Kustomization
 commonLabels:
   app: odh-dashboard
   app.kubernetes.io/part-of: odh-dashboard
+  # Legacy label from the old opendatahub-operator's CreateAddLabelsPlugin.
+  # Required for upgrade compatibility: spec.selector.matchLabels is immutable,
+  # so the selector must match what the old operator wrote to existing Deployments.
+  app.opendatahub.io/odh-dashboard: "true"
 resources:
   - ../../base
   - ../../base/consolelink

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 commonLabels:
   app: rhods-dashboard
   app.kubernetes.io/part-of: rhods-dashboard
+  # Legacy label from the old opendatahub-operator's CreateAddLabelsPlugin.
+  # Required for upgrade compatibility: spec.selector.matchLabels is immutable,
+  # so the selector must match what the old operator wrote to existing Deployments.
   app.opendatahub.io/rhods-dashboard: "true"
 resources:
   - ./apps

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 commonLabels:
   app: rhods-dashboard
   app.kubernetes.io/part-of: rhods-dashboard
+  app.opendatahub.io/rhods-dashboard: "true"
 resources:
   - ./apps
   - ./base

--- a/manifests/rhoai/standalone/kustomization.yaml
+++ b/manifests/rhoai/standalone/kustomization.yaml
@@ -6,6 +6,7 @@ kind: Kustomization
 commonLabels:
   app: rhods-dashboard
   app.kubernetes.io/part-of: rhods-dashboard
+  app.opendatahub.io/rhods-dashboard: "true"
 resources:
   - ../../base
   - ../consolelink

--- a/manifests/rhoai/standalone/kustomization.yaml
+++ b/manifests/rhoai/standalone/kustomization.yaml
@@ -6,6 +6,9 @@ kind: Kustomization
 commonLabels:
   app: rhods-dashboard
   app.kubernetes.io/part-of: rhods-dashboard
+  # Legacy label from the old opendatahub-operator's CreateAddLabelsPlugin.
+  # Required for upgrade compatibility: spec.selector.matchLabels is immutable,
+  # so the selector must match what the old operator wrote to existing Deployments.
   app.opendatahub.io/rhods-dashboard: "true"
 resources:
   - ../../base


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79525

Cherry-pick of #8950 to `v3.5.0-fixes`.

## Description

When upgrading RHOAI from 3.4 to 3.5, the dashboard-operator fails to reconcile the `rhods-dashboard` Deployment because `spec.selector.matchLabels` is immutable and the old opendatahub-operator injected `app.opendatahub.io/<component>: "true"` into the selector at deploy time — but the new manifests never included it.

This adds the legacy `app.opendatahub.io/<component>: "true"` label to `commonLabels` in all four kustomization files (RHOAI + ODH, sidecar + standalone). Kustomize `commonLabels` propagates to `spec.selector.matchLabels`, making the new manifests compatible with existing Deployments.

See #8950 for the full root cause analysis.

## How Has This Been Tested?

Same as #8950 — declarative manifest change, kustomize `commonLabels` behavior is well-defined.

## Test Impact

No new tests needed — 4 lines of YAML across 4 files, no new code paths.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`