### PR TITLE
refactor(RHOAIENG-78633): extract CurrentProjectContext to ui-core 

### DIFF
--- a/distributions/rhaii/src/context/ProjectsContextProvider.tsx
+++ b/distributions/rhaii/src/context/ProjectsContextProvider.tsx
@@ -122,28 +122,31 @@ const ProjectsContextProvider: React.FC<ProjectsContextProviderProps> = ({ child
 
   const waitControllerRef = React.useRef<AbortController | null>(null);
   const waitTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const waitRejectRef = React.useRef<((reason: Error) => void) | null>(null);
 
-  React.useEffect(
-    () => () => {
-      waitControllerRef.current?.abort();
-      if (waitTimerRef.current != null) {
-        clearTimeout(waitTimerRef.current);
-      }
-    },
-    [],
-  );
+  const cancelActiveWait = React.useCallback(() => {
+    waitRejectRef.current?.(new DOMException('The operation was aborted.', 'AbortError'));
+    waitRejectRef.current = null;
+    waitControllerRef.current?.abort();
+    waitControllerRef.current = null;
+    if (waitTimerRef.current != null) {
+      clearTimeout(waitTimerRef.current);
+      waitTimerRef.current = null;
+    }
+  }, []);
+
+  React.useEffect(() => () => cancelActiveWait(), [cancelActiveWait]);
 
   const waitForProject = React.useCallback<ProjectsContextType['waitForProject']>(
     (projectName) =>
       new Promise((resolve, reject) => {
-        waitControllerRef.current?.abort();
-        if (waitTimerRef.current != null) {
-          clearTimeout(waitTimerRef.current);
-        }
+        cancelActiveWait();
         const controller = new AbortController();
         waitControllerRef.current = controller;
+        waitRejectRef.current = reject;
 
         const timer = setTimeout(() => {
+          waitRejectRef.current = null;
           controller.abort();
           reject(new Error(`Timed out waiting for project "${projectName}"`));
         }, WAIT_FOR_PROJECT_TIMEOUT_MS);
@@ -161,6 +164,7 @@ const ProjectsContextProvider: React.FC<ProjectsContextProviderProps> = ({ child
             }
             if (fresh.find(byName(projectName))) {
               clearTimeout(timer);
+              waitRejectRef.current = null;
               setProjectData(fresh);
               resolve();
               return;
@@ -175,7 +179,7 @@ const ProjectsContextProvider: React.FC<ProjectsContextProviderProps> = ({ child
         };
         void poll();
       }),
-    [],
+    [cancelActiveWait],
   );
 
   const contextValue = React.useMemo<ProjectsContextType>(

--- a/distributions/rhaii/src/context/ProjectsContextProvider.tsx
+++ b/distributions/rhaii/src/context/ProjectsContextProvider.tsx
@@ -37,6 +37,9 @@ const ProjectsContextProvider: React.FC<ProjectsContextProviderProps> = ({ child
     React.useState<ProjectsContextType['preferredProject']>(null);
   const initializedFromStorage = React.useRef(false);
 
+  // Fetch once on mount. The BFF exposes a REST endpoint (not a watch),
+  // so there is no streaming refresh. waitForProject handles the case
+  // where a newly-created namespace needs to appear.
   React.useEffect(() => {
     let unmounted = false;
     const controller = new AbortController();
@@ -117,31 +120,43 @@ const ProjectsContextProvider: React.FC<ProjectsContextProviderProps> = ({ child
     }
   }, [loaded, projects, storedPreferredName]);
 
-  const isMounted = React.useRef(true);
-  React.useEffect(() => {
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
+  const waitControllerRef = React.useRef<AbortController | null>(null);
+  const waitTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(
+    () => () => {
+      waitControllerRef.current?.abort();
+      if (waitTimerRef.current != null) {
+        clearTimeout(waitTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const waitForProject = React.useCallback<ProjectsContextType['waitForProject']>(
     (projectName) =>
       new Promise((resolve, reject) => {
+        waitControllerRef.current?.abort();
+        if (waitTimerRef.current != null) {
+          clearTimeout(waitTimerRef.current);
+        }
         const controller = new AbortController();
+        waitControllerRef.current = controller;
+
         const timer = setTimeout(() => {
           controller.abort();
           reject(new Error(`Timed out waiting for project "${projectName}"`));
         }, WAIT_FOR_PROJECT_TIMEOUT_MS);
+        waitTimerRef.current = timer;
 
         const poll = async (): Promise<void> => {
-          if (!isMounted.current || controller.signal.aborted) {
+          if (controller.signal.aborted) {
             return;
           }
           try {
             const fresh = await fetchNamespaces(controller.signal);
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- ref may change during await
-            if (!isMounted.current || controller.signal.aborted) {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- signal may change during await
+            if (controller.signal.aborted) {
               return;
             }
             if (fresh.find(byName(projectName))) {

--- a/distributions/rhaii/src/context/__tests__/ProjectsContextProvider.spec.tsx
+++ b/distributions/rhaii/src/context/__tests__/ProjectsContextProvider.spec.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { render, act } from '@testing-library/react';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
+import type { ProjectKind } from '@odh-dashboard/k8s-core';
+
+const mockFetchNamespaces = jest.fn<Promise<ProjectKind[]>, [AbortSignal?]>();
+jest.mock('../fetchNamespaces', () => ({
+  __esModule: true,
+  default: (...args: [AbortSignal?]) => mockFetchNamespaces(...args),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const ProjectsContextProvider = require('../ProjectsContextProvider').default as React.FC<{
+  children: React.ReactNode;
+}>;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockFetchNamespaces.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe('ProjectsContextProvider — waitForProject settlement', () => {
+  it('rejects the first wait when a second waitForProject supersedes it', async () => {
+    let waitForProject: (name: string) => Promise<void> = () => Promise.resolve();
+
+    const Consumer: React.FC = () => {
+      const ctx = React.useContext(ProjectsContext);
+      waitForProject = ctx.waitForProject;
+      return null;
+    };
+
+    await act(async () => {
+      render(
+        <ProjectsContextProvider>
+          <Consumer />
+        </ProjectsContextProvider>,
+      );
+    });
+
+    const first = waitForProject('project-a');
+    const second = waitForProject('project-b');
+
+    await expect(first).rejects.toThrow('The operation was aborted.');
+
+    mockFetchNamespaces.mockResolvedValue([
+      {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'project-b' },
+        status: { phase: 'Active' },
+      } as ProjectKind,
+    ]);
+
+    await act(async () => {
+      jest.advanceTimersByTime(2_000);
+    });
+
+    await expect(second).resolves.toBeUndefined();
+  });
+});

--- a/frontend/docs/projects.md
+++ b/frontend/docs/projects.md
@@ -25,7 +25,8 @@
 - Index route is project detail: **horizontal tab host** (`GenericHorizontalBar`); visible tabs from `SupportedArea` and SSAR results.
 - Tab changes only update the query string; provider and polls keep running—avoids refetch storms when switching tabs.
 - `ProjectsContext` at app root: full project list, preferred project, helpers (e.g. waiting after create).
-- **Project detail** is centralized on `/:namespace`: `ProjectDetailsContext` aggregates notebooks, PVCs, connections, serving resources, secrets, role bindings, hardware/Kueue data, etc.
+- `CurrentProjectContext` in `@odh-dashboard/ui-core`: the resolved `ProjectKind` for the current namespace. Feature packages that only need the project (e.g. model-serving) consume this instead of the full `ProjectDetailsContext`.
+- **Project detail** is centralized on `/:namespace`: `ProjectDetailsContext` aggregates notebooks, PVCs, connections, serving resources, secrets, role bindings, hardware/Kueue data, etc. It wraps children in both `CurrentProjectContext.Provider` and `ProjectDetailsContext.Provider`.
 - Tab components read that context instead of duplicate fetches for resources the provider already loads.
 - Spawner and permissions flows live under `pages/projects/` alongside detail screens and follow the same routing boundaries.
 
@@ -48,6 +49,7 @@
 | Dependency | Type | Details |
 |-----------|------|---------|
 | `ProjectsContext` | Frontend | Project list and preferred project; namespace resolution for detail |
+| `CurrentProjectContext` | Frontend (ui-core) | Resolved `ProjectKind` for current namespace; consumed by feature packages via `React.useContext` |
 | `concepts/pipelines/context` | Frontend | `PipelineContextProvider` on detail route when `DS_PIPELINES` enabled; Pipelines tab consumes it |
 | Workbenches / notebook controller | Frontend | Spawner and notebook hooks in `projects/`; image/hardware data from model-serving and notebook-controller concepts |
 | `pages/modelServing` / kserve | Frontend | Serving runtimes, inference services, secrets; deployments tab via project detail hooks |

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -4,25 +4,15 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { IdentifierResourceType, SchedulingType } from '@odh-dashboard/k8s-core';
 import { DEFAULT_LIST_FETCH_STATE } from '@odh-dashboard/ui-core/utilities/fetchState';
+import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 import { mockHardwareProfile } from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
-import {
-  ProjectDetailsContext,
-  ProjectDetailsContextType,
-} from '#~/pages/projects/ProjectDetailsContext';
 import HardwareProfileDetailsPopover from '#~/concepts/hardwareProfiles/HardwareProfileDetailsPopover';
 
 const renderWithContext = (ui: React.ReactElement) =>
   render(
-    <ProjectDetailsContext.Provider
-      value={
-        {
-          currentProject: { metadata: { name: 'test-project' } },
-          localQueues: DEFAULT_LIST_FETCH_STATE,
-        } as unknown as ProjectDetailsContextType
-      }
-    >
+    <LocalQueuesContext.Provider value={{ localQueues: DEFAULT_LIST_FETCH_STATE }}>
       {ui}
-    </ProjectDetailsContext.Provider>,
+    </LocalQueuesContext.Provider>,
   );
 
 describe('HardwareProfileDetailsPopover', () => {

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -15,11 +15,11 @@ import {
 } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
 import { DEFAULT_LIST_FETCH_STATE } from '@odh-dashboard/ui-core/utilities/fetchState';
 import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
+import type { LocalQueuesContextType } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 import { mockHardwareProfile } from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
-import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
-import type { LocalQueuesContextType } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 import { ProjectsContext } from '#~/concepts/projects/ProjectsContext';
 import HardwareProfileSelect from '#~/concepts/hardwareProfiles/HardwareProfileSelect';
 

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -14,6 +14,7 @@ import {
   KueueFilteringState,
 } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
 import { DEFAULT_LIST_FETCH_STATE } from '@odh-dashboard/ui-core/utilities/fetchState';
+import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { mockHardwareProfile } from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
@@ -135,39 +136,41 @@ const renderComponent = (
   };
 
   return render(
-    <ProjectsContext.Provider
-      value={{
-        ...defaultProjectsContextValue,
-        projects,
-        loaded: true,
-        loadError: undefined,
-      }}
-    >
-      <ProjectDetailsContext.Provider
-        value={
-          {
-            currentProject,
-            refresh: jest.fn(),
-            localQueues: localQueuesOverride ?? DEFAULT_LIST_FETCH_STATE,
-          } as unknown as ProjectDetailsContextType
-        }
+    <CurrentProjectContext.Provider value={{ currentProject }}>
+      <ProjectsContext.Provider
+        value={{
+          ...defaultProjectsContextValue,
+          projects,
+          loaded: true,
+          loadError: undefined,
+        }}
       >
-        <HardwareProfileSelect
-          initialHardwareProfile={initialHardwareProfile}
-          previewDescription={false}
-          hardwareProfiles={hardwareProfiles}
-          isProjectScoped={false}
-          hardwareProfilesLoaded
-          hardwareProfilesError={undefined}
-          projectScopedHardwareProfiles={[[], true, undefined]}
-          allowExistingSettings={allowExistingSettings}
-          hardwareProfileConfig={hardwareProfileConfig}
-          isHardwareProfileSupported={() => true}
-          onChange={() => null}
-          project={projectProp}
-        />
-      </ProjectDetailsContext.Provider>
-    </ProjectsContext.Provider>,
+        <ProjectDetailsContext.Provider
+          value={
+            {
+              currentProject,
+              refresh: jest.fn(),
+              localQueues: localQueuesOverride ?? DEFAULT_LIST_FETCH_STATE,
+            } as unknown as ProjectDetailsContextType
+          }
+        >
+          <HardwareProfileSelect
+            initialHardwareProfile={initialHardwareProfile}
+            previewDescription={false}
+            hardwareProfiles={hardwareProfiles}
+            isProjectScoped={false}
+            hardwareProfilesLoaded
+            hardwareProfilesError={undefined}
+            projectScopedHardwareProfiles={[[], true, undefined]}
+            allowExistingSettings={allowExistingSettings}
+            hardwareProfileConfig={hardwareProfileConfig}
+            isHardwareProfileSupported={() => true}
+            onChange={() => null}
+            project={projectProp}
+          />
+        </ProjectDetailsContext.Provider>
+      </ProjectsContext.Provider>
+    </CurrentProjectContext.Provider>,
   );
 };
 
@@ -532,43 +535,45 @@ describe('HardwareProfileSelect - LocalQueue availability filtering', () => {
     useHardwareProfileConfigMock.mockReturnValue(hardwareProfileConfig);
 
     render(
-      <ProjectsContext.Provider
-        value={{
-          projects: [project],
-          modelServingProjects: [],
-          nonActiveProjects: [],
-          preferredProject: null,
-          updatePreferredProject: () => undefined,
-          loaded: true,
-          loadError: undefined,
-          waitForProject: () => Promise.resolve(),
-        }}
-      >
-        <ProjectDetailsContext.Provider
-          value={
-            {
-              currentProject: project,
-              refresh: jest.fn(),
-              localQueues,
-            } as unknown as ProjectDetailsContextType
-          }
+      <CurrentProjectContext.Provider value={{ currentProject: project }}>
+        <ProjectsContext.Provider
+          value={{
+            projects: [project],
+            modelServingProjects: [],
+            nonActiveProjects: [],
+            preferredProject: null,
+            updatePreferredProject: () => undefined,
+            loaded: true,
+            loadError: undefined,
+            waitForProject: () => Promise.resolve(),
+          }}
         >
-          <HardwareProfileSelect
-            isProjectScoped
-            initialHardwareProfile={projectKueueProfile}
-            previewDescription={false}
-            hardwareProfiles={[globalKueueProfile]}
-            hardwareProfilesLoaded
-            hardwareProfilesError={undefined}
-            projectScopedHardwareProfiles={[[projectKueueProfile], true, undefined]}
-            allowExistingSettings={false}
-            hardwareProfileConfig={hardwareProfileConfig}
-            isHardwareProfileSupported={() => true}
-            onChange={() => null}
-            project="test-project"
-          />
-        </ProjectDetailsContext.Provider>
-      </ProjectsContext.Provider>,
+          <ProjectDetailsContext.Provider
+            value={
+              {
+                currentProject: project,
+                refresh: jest.fn(),
+                localQueues,
+              } as unknown as ProjectDetailsContextType
+            }
+          >
+            <HardwareProfileSelect
+              isProjectScoped
+              initialHardwareProfile={projectKueueProfile}
+              previewDescription={false}
+              hardwareProfiles={[globalKueueProfile]}
+              hardwareProfilesLoaded
+              hardwareProfilesError={undefined}
+              projectScopedHardwareProfiles={[[projectKueueProfile], true, undefined]}
+              allowExistingSettings={false}
+              hardwareProfileConfig={hardwareProfileConfig}
+              isHardwareProfileSupported={() => true}
+              onChange={() => null}
+              project="test-project"
+            />
+          </ProjectDetailsContext.Provider>
+        </ProjectsContext.Provider>
+      </CurrentProjectContext.Provider>,
     );
 
     await userEvent.click(screen.getByTestId('hardware-profile-selection-toggle'));

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -18,10 +18,8 @@ import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentPro
 import { mockHardwareProfile } from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
-import {
-  ProjectDetailsContext,
-  ProjectDetailsContextType,
-} from '#~/pages/projects/ProjectDetailsContext';
+import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
+import type { LocalQueuesContextType } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 import { ProjectsContext } from '#~/concepts/projects/ProjectsContext';
 import HardwareProfileSelect from '#~/concepts/hardwareProfiles/HardwareProfileSelect';
 
@@ -97,7 +95,7 @@ const renderComponent = (
   projects: ProjectKind[] = [],
   projectProp?: string,
   allowExistingSettings = false,
-  localQueuesOverride?: ProjectDetailsContextType['localQueues'],
+  localQueuesOverride?: LocalQueuesContextType['localQueues'],
   initialHardwareProfile?: HardwareProfileKind,
 ) => {
   // Mock useKueueConfiguration to return the specified filtering state
@@ -145,14 +143,8 @@ const renderComponent = (
           loadError: undefined,
         }}
       >
-        <ProjectDetailsContext.Provider
-          value={
-            {
-              currentProject,
-              refresh: jest.fn(),
-              localQueues: localQueuesOverride ?? DEFAULT_LIST_FETCH_STATE,
-            } as unknown as ProjectDetailsContextType
-          }
+        <LocalQueuesContext.Provider
+          value={{ localQueues: localQueuesOverride ?? DEFAULT_LIST_FETCH_STATE }}
         >
           <HardwareProfileSelect
             initialHardwareProfile={initialHardwareProfile}
@@ -168,7 +160,7 @@ const renderComponent = (
             onChange={() => null}
             project={projectProp}
           />
-        </ProjectDetailsContext.Provider>
+        </LocalQueuesContext.Provider>
       </ProjectsContext.Provider>
     </CurrentProjectContext.Provider>,
   );
@@ -548,15 +540,7 @@ describe('HardwareProfileSelect - LocalQueue availability filtering', () => {
             waitForProject: () => Promise.resolve(),
           }}
         >
-          <ProjectDetailsContext.Provider
-            value={
-              {
-                currentProject: project,
-                refresh: jest.fn(),
-                localQueues,
-              } as unknown as ProjectDetailsContextType
-            }
-          >
+          <LocalQueuesContext.Provider value={{ localQueues }}>
             <HardwareProfileSelect
               isProjectScoped
               initialHardwareProfile={projectKueueProfile}
@@ -571,7 +555,7 @@ describe('HardwareProfileSelect - LocalQueue availability filtering', () => {
               onChange={() => null}
               project="test-project"
             />
-          </ProjectDetailsContext.Provider>
+          </LocalQueuesContext.Provider>
         </ProjectsContext.Provider>
       </CurrentProjectContext.Provider>,
     );

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
@@ -3,7 +3,7 @@ import { act } from '@testing-library/react';
 import { renderHook, testHook } from '@odh-dashboard/jest-config/hooks';
 import * as areasUtils from '@odh-dashboard/plugin-core/areas';
 import { SchedulingType } from '@odh-dashboard/k8s-core';
-import * as currentProjectModule from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { mockHardwareProfile } from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
@@ -34,9 +34,6 @@ const mockUseDashboardNamespace = jest.mocked(reduxSelectors.useDashboardNamespa
 
 describe('useHardwareProfileConfig', () => {
   beforeEach(() => {
-    jest
-      .spyOn(currentProjectModule, 'useCurrentProject')
-      .mockReturnValue(mockProjectK8sResource({}));
     mockUseHardwareProfiles.mockReturnValue({
       projectProfiles: [[], true, undefined],
       globalProfiles: [[], true, undefined],
@@ -731,17 +728,20 @@ describe('useHardwareProfileConfig', () => {
 
 const makeKueueProjectWrapper = (localQueues: ProjectDetailsContextType['localQueues']) => {
   const kueueProject = mockProjectK8sResource({ enableKueue: true });
-  jest.spyOn(currentProjectModule, 'useCurrentProject').mockReturnValue(kueueProject);
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
     React.createElement(
-      ProjectDetailsContext.Provider,
-      {
-        value: {
-          currentProject: kueueProject,
-          localQueues,
-        } as unknown as ProjectDetailsContextType,
-      },
-      children,
+      CurrentProjectContext.Provider,
+      { value: { currentProject: kueueProject } },
+      React.createElement(
+        ProjectDetailsContext.Provider,
+        {
+          value: {
+            currentProject: kueueProject,
+            localQueues,
+          } as unknown as ProjectDetailsContextType,
+        },
+        children,
+      ),
     );
   Wrapper.displayName = 'KueueProjectWrapper';
   return Wrapper;

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
@@ -4,16 +4,14 @@ import { renderHook, testHook } from '@odh-dashboard/jest-config/hooks';
 import * as areasUtils from '@odh-dashboard/plugin-core/areas';
 import { SchedulingType } from '@odh-dashboard/k8s-core';
 import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 import { mockHardwareProfile } from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
 import { useHardwareProfileConfig } from '#~/concepts/hardwareProfiles/useHardwareProfileConfig';
 import * as reduxSelectors from '#~/redux/selectors';
 import * as useHardwareProfilesModule from '#~/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility';
-import {
-  ProjectDetailsContext,
-  type ProjectDetailsContextType,
-} from '#~/pages/projects/ProjectDetailsContext';
+import type { LocalQueuesContextType } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({
   ...jest.requireActual('@odh-dashboard/plugin-core/areas'),
@@ -726,20 +724,15 @@ describe('useHardwareProfileConfig', () => {
 // in the current project's namespace.
 // ---------------------------------------------------------------------------
 
-const makeKueueProjectWrapper = (localQueues: ProjectDetailsContextType['localQueues']) => {
+const makeKueueProjectWrapper = (localQueues: LocalQueuesContextType['localQueues']) => {
   const kueueProject = mockProjectK8sResource({ enableKueue: true });
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
     React.createElement(
       CurrentProjectContext.Provider,
       { value: { currentProject: kueueProject } },
       React.createElement(
-        ProjectDetailsContext.Provider,
-        {
-          value: {
-            currentProject: kueueProject,
-            localQueues,
-          } as unknown as ProjectDetailsContextType,
-        },
+        LocalQueuesContext.Provider,
+        { value: { localQueues } },
         children,
       ),
     );

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
@@ -5,13 +5,13 @@ import * as areasUtils from '@odh-dashboard/plugin-core/areas';
 import { SchedulingType } from '@odh-dashboard/k8s-core';
 import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
+import type { LocalQueuesContextType } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 import { mockHardwareProfile } from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
 import { useHardwareProfileConfig } from '#~/concepts/hardwareProfiles/useHardwareProfileConfig';
 import * as reduxSelectors from '#~/redux/selectors';
 import * as useHardwareProfilesModule from '#~/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility';
-import type { LocalQueuesContextType } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({
   ...jest.requireActual('@odh-dashboard/plugin-core/areas'),
@@ -730,11 +730,7 @@ const makeKueueProjectWrapper = (localQueues: LocalQueuesContextType['localQueue
     React.createElement(
       CurrentProjectContext.Provider,
       { value: { currentProject: kueueProject } },
-      React.createElement(
-        LocalQueuesContext.Provider,
-        { value: { localQueues } },
-        children,
-      ),
+      React.createElement(LocalQueuesContext.Provider, { value: { localQueues } }, children),
     );
   Wrapper.displayName = 'KueueProjectWrapper';
   return Wrapper;

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
@@ -3,6 +3,7 @@ import { act } from '@testing-library/react';
 import { renderHook, testHook } from '@odh-dashboard/jest-config/hooks';
 import * as areasUtils from '@odh-dashboard/plugin-core/areas';
 import { SchedulingType } from '@odh-dashboard/k8s-core';
+import * as currentProjectModule from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { mockHardwareProfile } from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
@@ -33,6 +34,9 @@ const mockUseDashboardNamespace = jest.mocked(reduxSelectors.useDashboardNamespa
 
 describe('useHardwareProfileConfig', () => {
   beforeEach(() => {
+    jest
+      .spyOn(currentProjectModule, 'useCurrentProject')
+      .mockReturnValue(mockProjectK8sResource({}));
     mockUseHardwareProfiles.mockReturnValue({
       projectProfiles: [[], true, undefined],
       globalProfiles: [[], true, undefined],
@@ -727,6 +731,7 @@ describe('useHardwareProfileConfig', () => {
 
 const makeKueueProjectWrapper = (localQueues: ProjectDetailsContextType['localQueues']) => {
   const kueueProject = mockProjectK8sResource({ enableKueue: true });
+  jest.spyOn(currentProjectModule, 'useCurrentProject').mockReturnValue(kueueProject);
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
     React.createElement(
       ProjectDetailsContext.Provider,

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -10,6 +10,8 @@ import type {
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import type { InferenceServiceKind, ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
 import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
+import { ProjectHardwareProfilesContext } from '@odh-dashboard/ui-core/context/ProjectHardwareProfilesContext';
 import { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { DEFAULT_LIST_FETCH_STATE } from '@odh-dashboard/ui-core/utilities/fetchState';
 import { GroupKind, LocalQueueKind, RoleBindingKind } from '#~/k8sTypes';
@@ -200,7 +202,14 @@ const ProjectDetailsContextProvider: React.FC = () => {
     [project],
   );
 
-  if (!project || !contextValue || !currentProjectValue) {
+  const localQueuesValue = React.useMemo(() => ({ localQueues }), [localQueues]);
+
+  const projectHardwareProfilesValue = React.useMemo(
+    () => ({ projectHardwareProfiles }),
+    [projectHardwareProfiles],
+  );
+
+  if (!project || !contextValue || !currentProjectValue || !localQueuesValue || !projectHardwareProfilesValue) {
     if (projectsEnabled && projects.length === 0) {
       // No projects, but we do have the projects view -- navigate them so they can go through normal flows
       return <Navigate to="/projects" replace />;
@@ -215,21 +224,23 @@ const ProjectDetailsContextProvider: React.FC = () => {
     );
   }
 
-  // CurrentProjectContext (ui-core) exposes only currentProject so feature packages
-  // can consume it without depending on the full ProjectDetailsContext from internal.
-  // During migration, both providers coexist; this wrapper will shrink as more fields
-  // are extracted into standalone shared contexts.
+  // Shared contexts (ui-core) expose individual fields so feature packages can consume
+  // them without depending on the full ProjectDetailsContext from internal.
   return (
     <CurrentProjectContext.Provider value={currentProjectValue}>
-      <ProjectDetailsContext.Provider value={contextValue}>
-        {pipelinesEnabled ? (
-          <PipelineContextProvider namespace={project.metadata.name}>
-            <Outlet />
-          </PipelineContextProvider>
-        ) : (
-          <Outlet />
-        )}
-      </ProjectDetailsContext.Provider>
+      <LocalQueuesContext.Provider value={localQueuesValue}>
+        <ProjectHardwareProfilesContext.Provider value={projectHardwareProfilesValue}>
+          <ProjectDetailsContext.Provider value={contextValue}>
+            {pipelinesEnabled ? (
+              <PipelineContextProvider namespace={project.metadata.name}>
+                <Outlet />
+              </PipelineContextProvider>
+            ) : (
+              <Outlet />
+            )}
+          </ProjectDetailsContext.Provider>
+        </ProjectHardwareProfilesContext.Provider>
+      </LocalQueuesContext.Provider>
     </CurrentProjectContext.Provider>
   );
 };

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -195,9 +195,13 @@ const ProjectDetailsContextProvider: React.FC = () => {
     ],
   );
 
-  if (!project || !contextValue) {
+  const currentProjectValue = React.useMemo(
+    () => (project ? { currentProject: project } : undefined),
+    [project],
+  );
+
+  if (!project || !contextValue || !currentProjectValue) {
     if (projectsEnabled && projects.length === 0) {
-      // No projects, but we do have the projects view -- navigate them so they can go through normal flows
       return <Navigate to="/projects" replace />;
     }
 
@@ -209,11 +213,6 @@ const ProjectDetailsContextProvider: React.FC = () => {
       />
     );
   }
-
-  const currentProjectValue = React.useMemo(
-    () => ({ currentProject: project }),
-    [project],
-  );
 
   return (
     <CurrentProjectContext.Provider value={currentProjectValue}>

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -209,7 +209,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
     [projectHardwareProfiles],
   );
 
-  if (!project || !contextValue || !currentProjectValue || !localQueuesValue || !projectHardwareProfilesValue) {
+  if (!project || !contextValue || !currentProjectValue) {
     if (projectsEnabled && projects.length === 0) {
       // No projects, but we do have the projects view -- navigate them so they can go through normal flows
       return <Navigate to="/projects" replace />;

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -202,6 +202,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
 
   if (!project || !contextValue || !currentProjectValue) {
     if (projectsEnabled && projects.length === 0) {
+      // No projects, but we do have the projects view -- navigate them so they can go through normal flows
       return <Navigate to="/projects" replace />;
     }
 

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -215,6 +215,10 @@ const ProjectDetailsContextProvider: React.FC = () => {
     );
   }
 
+  // CurrentProjectContext (ui-core) exposes only currentProject so feature packages
+  // can consume it without depending on the full ProjectDetailsContext from internal.
+  // During migration, both providers coexist; this wrapper will shrink as more fields
+  // are extracted into standalone shared contexts.
   return (
     <CurrentProjectContext.Provider value={currentProjectValue}>
       <ProjectDetailsContext.Provider value={contextValue}>

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -9,6 +9,7 @@ import type {
 } from '@odh-dashboard/k8s-core';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import type { InferenceServiceKind, ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
+import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { DEFAULT_LIST_FETCH_STATE } from '@odh-dashboard/ui-core/utilities/fetchState';
 import { GroupKind, LocalQueueKind, RoleBindingKind } from '#~/k8sTypes';
@@ -209,16 +210,23 @@ const ProjectDetailsContextProvider: React.FC = () => {
     );
   }
 
+  const currentProjectValue = React.useMemo(
+    () => ({ currentProject: project }),
+    [project],
+  );
+
   return (
-    <ProjectDetailsContext.Provider value={contextValue}>
-      {pipelinesEnabled ? (
-        <PipelineContextProvider namespace={project.metadata.name}>
+    <CurrentProjectContext.Provider value={currentProjectValue}>
+      <ProjectDetailsContext.Provider value={contextValue}>
+        {pipelinesEnabled ? (
+          <PipelineContextProvider namespace={project.metadata.name}>
+            <Outlet />
+          </PipelineContextProvider>
+        ) : (
           <Outlet />
-        </PipelineContextProvider>
-      ) : (
-        <Outlet />
-      )}
-    </ProjectDetailsContext.Provider>
+        )}
+      </ProjectDetailsContext.Provider>
+    </CurrentProjectContext.Provider>
   );
 };
 

--- a/packages/hardware-profiles/shared/HardwareProfileDetailsPopover.tsx
+++ b/packages/hardware-profiles/shared/HardwareProfileDetailsPopover.tsx
@@ -18,8 +18,7 @@ import {
   getHardwareProfileDescription,
   getHardwareProfileDisplayName,
 } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
-// eslint-disable-next-line @odh-dashboard/no-restricted-imports
-import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
+import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 import {
   formatToleration,
   formatNodeSelector,
@@ -47,7 +46,7 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
   tableView = false,
   onExpandRow,
 }) => {
-  const { localQueues } = React.useContext(ProjectDetailsContext);
+  const { localQueues } = React.useContext(LocalQueuesContext);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const [isPopoverVisible, setIsPopoverVisible] = React.useState(false);
   const clusterQueueName = React.useMemo(

--- a/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
+++ b/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
@@ -35,7 +35,7 @@ import {
   orderHardwareProfiles,
 } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
 import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
-import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
+import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { useApplicationSettings } from '@odh-dashboard/internal/app/useApplicationSettings';
 import {
@@ -94,7 +94,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
   ] = projectScopedHardwareProfiles;
 
   const { currentProject } = React.useContext(CurrentProjectContext);
-  const { localQueues } = React.useContext(ProjectDetailsContext);
+  const { localQueues } = React.useContext(LocalQueuesContext);
   const { projects } = React.useContext(ProjectsContext);
   const { dashboardConfig } = useApplicationSettings();
   const hardwareProfileOrder = React.useMemo(

--- a/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
+++ b/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
@@ -34,6 +34,7 @@ import {
   isHardwareProfileEnabled,
   orderHardwareProfiles,
 } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
+import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { useApplicationSettings } from '@odh-dashboard/internal/app/useApplicationSettings';
@@ -92,7 +93,8 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     currentProjectHardwareProfilesError,
   ] = projectScopedHardwareProfiles;
 
-  const { currentProject, localQueues } = React.useContext(ProjectDetailsContext);
+  const currentProject = useCurrentProject();
+  const { localQueues } = React.useContext(ProjectDetailsContext);
   const { projects } = React.useContext(ProjectsContext);
   const { dashboardConfig } = useApplicationSettings();
   const hardwareProfileOrder = React.useMemo(

--- a/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
+++ b/packages/hardware-profiles/shared/HardwareProfileSelect.tsx
@@ -34,7 +34,7 @@ import {
   isHardwareProfileEnabled,
   orderHardwareProfiles,
 } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
-import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { useApplicationSettings } from '@odh-dashboard/internal/app/useApplicationSettings';
@@ -93,7 +93,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     currentProjectHardwareProfilesError,
   ] = projectScopedHardwareProfiles;
 
-  const currentProject = useCurrentProject();
+  const { currentProject } = React.useContext(CurrentProjectContext);
   const { localQueues } = React.useContext(ProjectDetailsContext);
   const { projects } = React.useContext(ProjectsContext);
   const { dashboardConfig } = useApplicationSettings();

--- a/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
+++ b/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
@@ -12,7 +12,7 @@ import { isCpuLimitLarger, isMemoryLimitLarger } from '@odh-dashboard/ui-core/ut
 import { isHardwareProfileEnabled } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors';
 import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
-import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
+import { LocalQueuesContext } from '@odh-dashboard/ui-core/context/LocalQueuesContext';
 import { useHardwareProfilesByFeatureVisibility } from '@odh-dashboard/internal/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility';
 import {
   computeLocalQueueNamesResult,
@@ -123,7 +123,7 @@ export const useHardwareProfileConfig = (
 ): UseHardwareProfileConfigResult => {
   const { dashboardNamespace } = useDashboardNamespace();
   const { currentProject } = React.useContext(CurrentProjectContext);
-  const { localQueues } = React.useContext(ProjectDetailsContext);
+  const { localQueues } = React.useContext(LocalQueuesContext);
 
   const {
     globalProfiles: [dashboardProfiles, dashboardProfilesLoaded, dashboardProfilesLoadError],

--- a/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
+++ b/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
@@ -11,6 +11,7 @@ import useGenericObjectState from '@odh-dashboard/ui-core/utilities/useGenericOb
 import { isCpuLimitLarger, isMemoryLimitLarger } from '@odh-dashboard/ui-core/utilities/valueUnits';
 import { isHardwareProfileEnabled } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors';
+import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { useHardwareProfilesByFeatureVisibility } from '@odh-dashboard/internal/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility';
 import {
@@ -121,7 +122,8 @@ export const useHardwareProfileConfig = (
   hardwareProfileNamespace?: string | null,
 ): UseHardwareProfileConfigResult => {
   const { dashboardNamespace } = useDashboardNamespace();
-  const { currentProject, localQueues } = React.useContext(ProjectDetailsContext);
+  const currentProject = useCurrentProject();
+  const { localQueues } = React.useContext(ProjectDetailsContext);
 
   const {
     globalProfiles: [dashboardProfiles, dashboardProfilesLoaded, dashboardProfilesLoadError],

--- a/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
+++ b/packages/hardware-profiles/shared/useHardwareProfileConfig.ts
@@ -11,7 +11,7 @@ import useGenericObjectState from '@odh-dashboard/ui-core/utilities/useGenericOb
 import { isCpuLimitLarger, isMemoryLimitLarger } from '@odh-dashboard/ui-core/utilities/valueUnits';
 import { isHardwareProfileEnabled } from '@odh-dashboard/internal/pages/hardwareProfiles/utils';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors';
-import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { useHardwareProfilesByFeatureVisibility } from '@odh-dashboard/internal/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility';
 import {
@@ -122,7 +122,7 @@ export const useHardwareProfileConfig = (
   hardwareProfileNamespace?: string | null,
 ): UseHardwareProfileConfigResult => {
   const { dashboardNamespace } = useDashboardNamespace();
-  const currentProject = useCurrentProject();
+  const { currentProject } = React.useContext(CurrentProjectContext);
   const { localQueues } = React.useContext(ProjectDetailsContext);
 
   const {

--- a/packages/hardware-profiles/src/pages/__tests__/useHardwareProfilesByUseCase.spec.ts
+++ b/packages/hardware-profiles/src/pages/__tests__/useHardwareProfilesByUseCase.spec.ts
@@ -5,7 +5,7 @@ import {
   type HardwareProfileKind,
 } from '@odh-dashboard/k8s-core';
 import { HardwareProfilesContext } from '@odh-dashboard/internal/concepts/hardwareProfiles/HardwareProfilesContext';
-import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
+import { ProjectHardwareProfilesContext } from '@odh-dashboard/ui-core/context/ProjectHardwareProfilesContext';
 import { mockHardwareProfile } from '../../__mocks__/mockHardwareProfile';
 import { useHardwareProfilesByFeatureVisibility } from '../useHardwareProfilesByFeatureVisibility';
 
@@ -15,8 +15,8 @@ jest.mock('@odh-dashboard/internal/concepts/hardwareProfiles/HardwareProfilesCon
   },
 }));
 
-jest.mock('@odh-dashboard/internal/pages/projects/ProjectDetailsContext', () => ({
-  ProjectDetailsContext: {
+jest.mock('@odh-dashboard/ui-core/context/ProjectHardwareProfilesContext', () => ({
+  ProjectHardwareProfilesContext: {
     _currentValue: null,
   },
 }));
@@ -33,7 +33,7 @@ const mockContexts = (
   globalProfiles: HardwareProfileKind[],
   globalLoaded = true,
   globalError: Error | undefined = undefined,
-  projectOverrides?: Partial<React.ContextType<typeof ProjectDetailsContext>>,
+  projectOverrides?: Partial<React.ContextType<typeof ProjectHardwareProfilesContext>>,
 ) => {
   jest.spyOn(React, 'useContext').mockImplementation((context: React.Context<unknown>) => {
     if (context === HardwareProfilesContext) {
@@ -41,9 +41,8 @@ const mockContexts = (
         globalHardwareProfiles: [globalProfiles, globalLoaded, globalError],
       };
     }
-    if (context === ProjectDetailsContext) {
+    if (context === ProjectHardwareProfilesContext) {
       return {
-        currentProject: { metadata: { name: 'test-project' } },
         projectHardwareProfiles: [[], true, undefined],
         ...projectOverrides,
       };

--- a/packages/hardware-profiles/src/pages/useHardwareProfilesByFeatureVisibility.ts
+++ b/packages/hardware-profiles/src/pages/useHardwareProfilesByFeatureVisibility.ts
@@ -4,6 +4,7 @@ import {
   HardwareProfileFeatureVisibility,
 } from '@odh-dashboard/k8s-core';
 import { HardwareProfilesContext } from '@odh-dashboard/internal/concepts/hardwareProfiles/HardwareProfilesContext';
+import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { useWatchHardwareProfiles } from '@odh-dashboard/internal/utilities/useWatchHardwareProfiles';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors';
@@ -39,8 +40,8 @@ export const useHardwareProfilesByFeatureVisibility = (
     globalHardwareProfiles: [globalProfiles, globalProfilesLoaded, globalProfilesError],
   } = React.useContext(HardwareProfilesContext);
 
-  // Try to get project profiles from ProjectDetailsContext
-  const { currentProject, projectHardwareProfiles: contextProjectProfiles } =
+  const currentProject = useCurrentProject();
+  const { projectHardwareProfiles: contextProjectProfiles } =
     React.useContext(ProjectDetailsContext);
 
   // Determine if we should use context project profiles or fetch them

--- a/packages/hardware-profiles/src/pages/useHardwareProfilesByFeatureVisibility.ts
+++ b/packages/hardware-profiles/src/pages/useHardwareProfilesByFeatureVisibility.ts
@@ -41,8 +41,9 @@ export const useHardwareProfilesByFeatureVisibility = (
   } = React.useContext(HardwareProfilesContext);
 
   const { currentProject } = React.useContext(CurrentProjectContext);
-  const { projectHardwareProfiles: contextProjectProfiles } =
-    React.useContext(ProjectHardwareProfilesContext);
+  const { projectHardwareProfiles: contextProjectProfiles } = React.useContext(
+    ProjectHardwareProfilesContext,
+  );
 
   // Determine if we should use context project profiles or fetch them
   const shouldUseContextProfiles =

--- a/packages/hardware-profiles/src/pages/useHardwareProfilesByFeatureVisibility.ts
+++ b/packages/hardware-profiles/src/pages/useHardwareProfilesByFeatureVisibility.ts
@@ -5,7 +5,7 @@ import {
 } from '@odh-dashboard/k8s-core';
 import { HardwareProfilesContext } from '@odh-dashboard/internal/concepts/hardwareProfiles/HardwareProfilesContext';
 import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
-import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
+import { ProjectHardwareProfilesContext } from '@odh-dashboard/ui-core/context/ProjectHardwareProfilesContext';
 import { useWatchHardwareProfiles } from '@odh-dashboard/internal/utilities/useWatchHardwareProfiles';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors';
 import { filterRecognizedVisibility, isHardwareProfileValid } from './utils';
@@ -16,7 +16,7 @@ import { filterRecognizedVisibility, isHardwareProfileValid } from './utils';
  * Simple logic:
  * 1. Global profiles - always from HardwareProfilesContext (dashboard namespace)
  * 2. Project profiles:
- *    - If in ProjectDetailsContext and namespace matches (or no namespace) → use context
+ *    - If in ProjectHardwareProfilesContext and namespace matches (or no namespace) → use context
  *    - Otherwise, fetch for the specific namespace
  *
  * Note: This may create duplicate watches in some cases (e.g., global deployments table),
@@ -42,7 +42,7 @@ export const useHardwareProfilesByFeatureVisibility = (
 
   const { currentProject } = React.useContext(CurrentProjectContext);
   const { projectHardwareProfiles: contextProjectProfiles } =
-    React.useContext(ProjectDetailsContext);
+    React.useContext(ProjectHardwareProfilesContext);
 
   // Determine if we should use context project profiles or fetch them
   const shouldUseContextProfiles =

--- a/packages/hardware-profiles/src/pages/useHardwareProfilesByFeatureVisibility.ts
+++ b/packages/hardware-profiles/src/pages/useHardwareProfilesByFeatureVisibility.ts
@@ -4,7 +4,7 @@ import {
   HardwareProfileFeatureVisibility,
 } from '@odh-dashboard/k8s-core';
 import { HardwareProfilesContext } from '@odh-dashboard/internal/concepts/hardwareProfiles/HardwareProfilesContext';
-import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { useWatchHardwareProfiles } from '@odh-dashboard/internal/utilities/useWatchHardwareProfiles';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors';
@@ -40,7 +40,7 @@ export const useHardwareProfilesByFeatureVisibility = (
     globalHardwareProfiles: [globalProfiles, globalProfilesLoaded, globalProfilesError],
   } = React.useContext(HardwareProfilesContext);
 
-  const currentProject = useCurrentProject();
+  const { currentProject } = React.useContext(CurrentProjectContext);
   const { projectHardwareProfiles: contextProjectProfiles } =
     React.useContext(ProjectDetailsContext);
 

--- a/packages/model-serving/src/ModelsProjectDetailsTab.tsx
+++ b/packages/model-serving/src/ModelsProjectDetailsTab.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line @odh-dashboard/no-restricted-imports
-import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
+import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core';
 import DetailsSection from '@odh-dashboard/ui-core/components/detail/DetailsSection';
 import { useProjectServingPlatform } from './concepts/useProjectServingPlatform';
@@ -24,7 +23,7 @@ const LoadingSection: React.FC<{ error?: Error }> = ({ error }) => (
 );
 
 const ModelsProjectDetailsTab: React.FC = () => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const currentProject = useCurrentProject();
 
   const { clusterPlatforms, clusterPlatformsLoaded, clusterPlatformsError } =
     useAvailableClusterPlatforms();

--- a/packages/model-serving/src/ModelsProjectDetailsTab.tsx
+++ b/packages/model-serving/src/ModelsProjectDetailsTab.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core';
 import DetailsSection from '@odh-dashboard/ui-core/components/detail/DetailsSection';
 import { useProjectServingPlatform } from './concepts/useProjectServingPlatform';
@@ -23,7 +23,7 @@ const LoadingSection: React.FC<{ error?: Error }> = ({ error }) => (
 );
 
 const ModelsProjectDetailsTab: React.FC = () => {
-  const currentProject = useCurrentProject();
+  const { currentProject } = React.useContext(CurrentProjectContext);
 
   const { clusterPlatforms, clusterPlatformsLoaded, clusterPlatformsError } =
     useAvailableClusterPlatforms();

--- a/packages/model-serving/src/ServeModelsSection.tsx
+++ b/packages/model-serving/src/ServeModelsSection.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line @odh-dashboard/no-restricted-imports
-import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
+import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import ErrorOverviewCard from '@odh-dashboard/ui-core/components/detail/ErrorOverviewCard';
 import { CollapsibleSection, ProjectObjectType, SectionType } from '@odh-dashboard/ui-core';
 import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core';
@@ -67,7 +66,7 @@ const ServeModelsSectionContent: React.FC<{ platforms: ModelServingPlatform[] }>
 };
 
 const ServeModelsSection: React.FC = () => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const currentProject = useCurrentProject();
 
   const { clusterPlatforms, clusterPlatformsLoaded } = useAvailableClusterPlatforms();
   const { activePlatform } = useProjectServingPlatform(currentProject, clusterPlatforms);

--- a/packages/model-serving/src/ServeModelsSection.tsx
+++ b/packages/model-serving/src/ServeModelsSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import ErrorOverviewCard from '@odh-dashboard/ui-core/components/detail/ErrorOverviewCard';
 import { CollapsibleSection, ProjectObjectType, SectionType } from '@odh-dashboard/ui-core';
 import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core';
@@ -66,7 +66,7 @@ const ServeModelsSectionContent: React.FC<{ platforms: ModelServingPlatform[] }>
 };
 
 const ServeModelsSection: React.FC = () => {
-  const currentProject = useCurrentProject();
+  const { currentProject } = React.useContext(CurrentProjectContext);
 
   const { clusterPlatforms, clusterPlatformsLoaded } = useAvailableClusterPlatforms();
   const { activePlatform } = useProjectServingPlatform(currentProject, clusterPlatforms);

--- a/packages/model-serving/src/components/overview/DeployedModelsSection.tsx
+++ b/packages/model-serving/src/components/overview/DeployedModelsSection.tsx
@@ -26,7 +26,7 @@ import {
   TypeBorderedCard,
 } from '@odh-dashboard/ui-core';
 import HeaderIcon from '@odh-dashboard/ui-core/design/HeaderIcon';
-import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
 import { ModelStatusIcon } from '@odh-dashboard/model-serving/shared/components';
@@ -150,7 +150,7 @@ const DeployedModelsGallery: React.FC<DeployedModelsGalleryProps> = ({
   onClearFilters,
 }) => {
   const navigate = useNavigate();
-  const currentProject = useCurrentProject();
+  const { currentProject } = React.useContext(CurrentProjectContext);
   const { deployments } = React.useContext(ModelDeploymentsContext);
 
   const { extensionDataMap, onLoad } = usePlatformExtensionDataMap(
@@ -234,7 +234,7 @@ const DeployedModelsGallery: React.FC<DeployedModelsGalleryProps> = ({
 };
 
 const DeployedModelsSection: React.FC<{ platforms: ModelServingPlatform[] }> = ({ platforms }) => {
-  const currentProject = useCurrentProject();
+  const { currentProject } = React.useContext(CurrentProjectContext);
   const { activePlatform } = useProjectServingPlatform(currentProject, platforms);
   const [filteredState, setFilteredState] = React.useState<FilterStates | undefined>();
 

--- a/packages/model-serving/src/components/overview/DeployedModelsSection.tsx
+++ b/packages/model-serving/src/components/overview/DeployedModelsSection.tsx
@@ -26,7 +26,7 @@ import {
   TypeBorderedCard,
 } from '@odh-dashboard/ui-core';
 import HeaderIcon from '@odh-dashboard/ui-core/design/HeaderIcon';
-import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
+import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
 import { ModelStatusIcon } from '@odh-dashboard/model-serving/shared/components';
@@ -150,7 +150,7 @@ const DeployedModelsGallery: React.FC<DeployedModelsGalleryProps> = ({
   onClearFilters,
 }) => {
   const navigate = useNavigate();
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const currentProject = useCurrentProject();
   const { deployments } = React.useContext(ModelDeploymentsContext);
 
   const { extensionDataMap, onLoad } = usePlatformExtensionDataMap(
@@ -234,7 +234,7 @@ const DeployedModelsGallery: React.FC<DeployedModelsGalleryProps> = ({
 };
 
 const DeployedModelsSection: React.FC<{ platforms: ModelServingPlatform[] }> = ({ platforms }) => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const currentProject = useCurrentProject();
   const { activePlatform } = useProjectServingPlatform(currentProject, platforms);
   const [filteredState, setFilteredState] = React.useState<FilterStates | undefined>();
 

--- a/packages/model-serving/src/components/overview/ModelPlatformSection.tsx
+++ b/packages/model-serving/src/components/overview/ModelPlatformSection.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { CollapsibleSection, ProjectObjectType, SectionType } from '@odh-dashboard/ui-core';
 import OverviewCard from '@odh-dashboard/ui-core/components/detail/OverviewCard';
-import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
+import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { ModelServingPlatformSelectErrorAlert } from '@odh-dashboard/model-serving/shared/components';
 import EmptyModelServingPlatformSection from './NoProjectServingEnabledSection';
 import {
@@ -28,7 +28,7 @@ const galleryWidth = {
 };
 
 const ModelPlatformSection: React.FC<{ platforms: ModelServingPlatform[] }> = ({ platforms }) => {
-  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const currentProject = useCurrentProject();
 
   const {
     activePlatform,

--- a/packages/model-serving/src/components/overview/ModelPlatformSection.tsx
+++ b/packages/model-serving/src/components/overview/ModelPlatformSection.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { CollapsibleSection, ProjectObjectType, SectionType } from '@odh-dashboard/ui-core';
 import OverviewCard from '@odh-dashboard/ui-core/components/detail/OverviewCard';
-import { useCurrentProject } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
+import { CurrentProjectContext } from '@odh-dashboard/ui-core/context/CurrentProjectContext';
 import { ModelServingPlatformSelectErrorAlert } from '@odh-dashboard/model-serving/shared/components';
 import EmptyModelServingPlatformSection from './NoProjectServingEnabledSection';
 import {
@@ -28,7 +28,7 @@ const galleryWidth = {
 };
 
 const ModelPlatformSection: React.FC<{ platforms: ModelServingPlatform[] }> = ({ platforms }) => {
-  const currentProject = useCurrentProject();
+  const { currentProject } = React.useContext(CurrentProjectContext);
 
   const {
     activePlatform,

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -58,6 +58,8 @@
     "./utilities/useGenericObjectState": "./src/utilities/useGenericObjectState.ts",
     "./utilities/useValidation": "./src/utilities/useValidation.ts",
     "./context/CurrentProjectContext": "./src/context/CurrentProjectContext.tsx",
+    "./context/LocalQueuesContext": "./src/context/LocalQueuesContext.tsx",
+    "./context/ProjectHardwareProfilesContext": "./src/context/ProjectHardwareProfilesContext.tsx",
     "./context/ProjectsContext": "./src/context/ProjectsContext.tsx",
     "./contexts/ThemeContext": "./src/contexts/ThemeContext.tsx",
     "./contexts/AnalyticsContext": "./src/contexts/AnalyticsContext.tsx",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -57,6 +57,7 @@
     "./hooks/useZodFormValidation": "./src/hooks/useZodFormValidation.ts",
     "./utilities/useGenericObjectState": "./src/utilities/useGenericObjectState.ts",
     "./utilities/useValidation": "./src/utilities/useValidation.ts",
+    "./context/CurrentProjectContext": "./src/context/CurrentProjectContext.tsx",
     "./context/ProjectsContext": "./src/context/ProjectsContext.tsx",
     "./contexts/ThemeContext": "./src/contexts/ThemeContext.tsx",
     "./contexts/AnalyticsContext": "./src/contexts/AnalyticsContext.tsx",

--- a/packages/ui-core/src/context/CurrentProjectContext.tsx
+++ b/packages/ui-core/src/context/CurrentProjectContext.tsx
@@ -5,16 +5,6 @@ export type CurrentProjectContextType = {
   currentProject: ProjectKind;
 };
 
-const DEFAULT_VALUE: CurrentProjectContextType = {
+export const CurrentProjectContext = React.createContext<CurrentProjectContextType>({
   currentProject: { apiVersion: '', kind: '', metadata: { name: '' } },
-};
-
-export const CurrentProjectContext = React.createContext<CurrentProjectContextType>(DEFAULT_VALUE);
-
-export const useCurrentProject = (): ProjectKind => {
-  const { currentProject } = React.useContext(CurrentProjectContext);
-  if (!currentProject.metadata.name) {
-    throw new Error('useCurrentProject must be used within a CurrentProjectContext provider');
-  }
-  return currentProject;
-};
+});

--- a/packages/ui-core/src/context/CurrentProjectContext.tsx
+++ b/packages/ui-core/src/context/CurrentProjectContext.tsx
@@ -13,5 +13,8 @@ export const CurrentProjectContext = React.createContext<CurrentProjectContextTy
 
 export const useCurrentProject = (): ProjectKind => {
   const { currentProject } = React.useContext(CurrentProjectContext);
+  if (!currentProject.metadata.name) {
+    throw new Error('useCurrentProject must be used within a CurrentProjectContext provider');
+  }
   return currentProject;
 };

--- a/packages/ui-core/src/context/CurrentProjectContext.tsx
+++ b/packages/ui-core/src/context/CurrentProjectContext.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import type { ProjectKind } from '@odh-dashboard/k8s-core';
+
+export type CurrentProjectContextType = {
+  currentProject: ProjectKind;
+};
+
+const DEFAULT_VALUE: CurrentProjectContextType = {
+  currentProject: { apiVersion: '', kind: '', metadata: { name: '' } },
+};
+
+export const CurrentProjectContext = React.createContext<CurrentProjectContextType>(DEFAULT_VALUE);
+
+export const useCurrentProject = (): ProjectKind => {
+  const { currentProject } = React.useContext(CurrentProjectContext);
+  return currentProject;
+};

--- a/packages/ui-core/src/context/LocalQueuesContext.tsx
+++ b/packages/ui-core/src/context/LocalQueuesContext.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import type { LocalQueueKind } from '@odh-dashboard/k8s-core';
 import type { FetchStateObject } from '../hooks/useFetch';
-import { DEFAULT_LIST_FETCH_STATE } from '../utilities/fetchState';
 
 export type LocalQueuesContextType = {
   localQueues: FetchStateObject<LocalQueueKind[]>;
 };
 
 export const LocalQueuesContext = React.createContext<LocalQueuesContextType>({
-  localQueues: DEFAULT_LIST_FETCH_STATE as FetchStateObject<LocalQueueKind[]>,
+  localQueues: {
+    data: [],
+    loaded: false,
+    refresh: () => Promise.resolve(undefined),
+  },
 });

--- a/packages/ui-core/src/context/LocalQueuesContext.tsx
+++ b/packages/ui-core/src/context/LocalQueuesContext.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import type { LocalQueueKind } from '@odh-dashboard/k8s-core';
+import type { FetchStateObject } from '../hooks/useFetch';
+import { DEFAULT_LIST_FETCH_STATE } from '../utilities/fetchState';
+
+export type LocalQueuesContextType = {
+  localQueues: FetchStateObject<LocalQueueKind[]>;
+};
+
+export const LocalQueuesContext = React.createContext<LocalQueuesContextType>({
+  localQueues: DEFAULT_LIST_FETCH_STATE as FetchStateObject<LocalQueueKind[]>,
+});

--- a/packages/ui-core/src/context/ProjectHardwareProfilesContext.tsx
+++ b/packages/ui-core/src/context/ProjectHardwareProfilesContext.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import type { HardwareProfileKind } from '@odh-dashboard/k8s-core';
+
+export type ProjectHardwareProfilesContextType = {
+  projectHardwareProfiles: [HardwareProfileKind[], boolean, Error | undefined];
+};
+
+export const ProjectHardwareProfilesContext =
+  React.createContext<ProjectHardwareProfilesContextType>({
+    projectHardwareProfiles: [[], false, undefined],
+  });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78633

## Description

First step in decomposing `ProjectDetailsContext` — extracts `currentProject` into a standalone `CurrentProjectContext` in `@odh-dashboard/ui-core`, following the `ProjectsContext` convention.

- **New:** `CurrentProjectContext` in `ui-core` — consumed via `React.useContext(CurrentProjectContext)`
- **model-serving:** Fully decoupled from `@odh-dashboard/internal` (4 files)
- **hardware-profiles:** `currentProject` decoupled; `localQueues` remains on `ProjectDetailsContext` (transitional, follow-up)
- **frontend:** `ProjectDetailsContextProvider` now wraps children in both providers
- **bugfix:** Fixed unsettled Promises in RHAII `waitForProject` (overlapping calls / unmount could hang); regression test added

Based on `RHOAIENG-78652/rhaii-projects-context-provider` — diff against `main` includes commits from that branch.

## How Has This Been Tested?

- `npx turbo type-check` — all changed packages pass
- Context extraction: pure import-path refactor, existing tests pass
- `waitForProject` fix: new regression test (`ProjectsContextProvider.spec.tsx`)
- Hardware profile tests updated to provide `CurrentProjectContext`

### No visual regressions introduced

Tested on Zaffre cluster:
<img width="500" alt="Screenshot 2026-07-31 at 2 09 32 PM" src="https://github.com/user-attachments/assets/e6ae4aa8-6723-495b-8474-a59cd80736be" />
<img width="500" alt="Screenshot 2026-07-31 at 2 10 55 PM" src="https://github.com/user-attachments/assets/d335d57f-240f-41e3-836b-05807a3ab3f4" />
<img width="500" alt="Screenshot 2026-07-31 at 2 11 00 PM" src="https://github.com/user-attachments/assets/5a6a916b-3ecc-4b49-ba76-f61d46e06565" />
<img width="500" alt="Screenshot 2026-07-31 at 2 11 08 PM" src="https://github.com/user-attachments/assets/c4e28c27-a273-4146-ba47-764aadd41fe1" />



## Request review criteria:

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our [Best Practices](/docs/best-practices.md)
- [x] The developer has tested their solution on a cluster

Made with [Cursor](https://cursor.com)