### PR TITLE
Fix(eval-hub): Update Security Insights table label size and value casing [v3.5.0]

### DIFF
--- a/packages/eval-hub/frontend/src/app/components/__tests__/benchmarkUtils.spec.ts
+++ b/packages/eval-hub/frontend/src/app/components/__tests__/benchmarkUtils.spec.ts
@@ -1,0 +1,73 @@
+import { toTitleCase, capitalizeFirst, getCategoryColor } from '~/app/components/benchmarkUtils';
+
+describe('toTitleCase', () => {
+  it('should return empty string unchanged', () => {
+    expect(toTitleCase('')).toBe('');
+  });
+
+  it('should capitalize the first letter of each word', () => {
+    expect(toTitleCase('hello world')).toBe('Hello World');
+    expect(toTitleCase('prompt injection')).toBe('Prompt Injection');
+  });
+
+  it('should preserve all-caps words (acronyms)', () => {
+    expect(toTitleCase('NLP safety')).toBe('NLP Safety');
+    expect(toTitleCase('DAN attack')).toBe('DAN Attack');
+    expect(toTitleCase('BBQ benchmark')).toBe('BBQ Benchmark');
+  });
+
+  it('should handle single-word input', () => {
+    expect(toTitleCase('hello')).toBe('Hello');
+    expect(toTitleCase('NLP')).toBe('NLP');
+  });
+
+  it('should handle mixed case input', () => {
+    expect(toTitleCase('mcdonald analysis')).toBe('Mcdonald Analysis');
+    expect(toTitleCase('HELLO WORLD')).toBe('HELLO WORLD');
+  });
+
+  it('should handle single character words', () => {
+    expect(toTitleCase('a b c')).toBe('A B C');
+  });
+
+  it('should handle already title-cased input', () => {
+    expect(toTitleCase('Already Title Case')).toBe('Already Title Case');
+  });
+
+  it('should return falsy values unchanged', () => {
+    // @ts-expect-error testing runtime guard with non-string input
+    expect(toTitleCase(undefined)).toBeUndefined();
+    // @ts-expect-error testing runtime guard with non-string input
+    expect(toTitleCase(null)).toBeNull();
+  });
+});
+
+describe('capitalizeFirst', () => {
+  it('should capitalize the first character only', () => {
+    expect(capitalizeFirst('hello')).toBe('Hello');
+    expect(capitalizeFirst('hello world')).toBe('Hello world');
+  });
+
+  it('should not change already capitalized strings', () => {
+    expect(capitalizeFirst('Hello')).toBe('Hello');
+  });
+});
+
+describe('getCategoryColor', () => {
+  it('should return blue for undefined category', () => {
+    expect(getCategoryColor(undefined)).toBe('blue');
+  });
+
+  it('should return blue for empty string', () => {
+    expect(getCategoryColor('')).toBe('blue');
+  });
+
+  it('should return a consistent color for the same category', () => {
+    const color = getCategoryColor('safety');
+    expect(getCategoryColor('safety')).toBe(color);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(getCategoryColor('Safety')).toBe(getCategoryColor('safety'));
+  });
+});

--- a/packages/eval-hub/frontend/src/app/components/benchmarkUtils.ts
+++ b/packages/eval-hub/frontend/src/app/components/benchmarkUtils.ts
@@ -24,6 +24,21 @@ export const getCategoryColor = (category?: string): CategoryColor => {
 export const capitalizeFirst = (value: string): string =>
   value.charAt(0).toUpperCase() + value.slice(1);
 
+export const toTitleCase = (value: string): string => {
+  if (!value) {
+    return value;
+  }
+  return value
+    .split(' ')
+    .map((word) => {
+      if (word === word.toUpperCase() && word.length > 1) {
+        return word;
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+    })
+    .join(' ');
+};
+
 export const VISIBLE_METRICS_COUNT = 3;
 
 export const toSafeExternalUrl = (raw?: string): string | undefined => {

--- a/packages/eval-hub/frontend/src/app/pages/modelCatalog/SecurityInsightsView.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/modelCatalog/SecurityInsightsView.tsx
@@ -32,7 +32,7 @@ import {
   DEFAULT_TABLE_PER_PAGE,
   TABLE_PER_PAGE_OPTIONS,
 } from '~/app/utilities/tablePaginationConstants';
-import { getCategoryColor, capitalizeFirst } from '~/app/components/benchmarkUtils';
+import { getCategoryColor, capitalizeFirst, toTitleCase } from '~/app/components/benchmarkUtils';
 import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 import SecurityInsightsEmptyState from './SecurityInsightsEmptyState';
 import { type SecurityInsightsViewProps } from './securityInsightsTypes';
@@ -226,7 +226,7 @@ const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
                         value="evaluation"
                         data-testid="security-filter-option-evaluation"
                       >
-                        Evaluation name
+                        Evaluation Name
                       </SelectOption>
                       <SelectOption value="category" data-testid="security-filter-option-category">
                         Category
@@ -285,7 +285,7 @@ const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
           <Thead>
             <Tr>
               <Th sort={getSortParams(0)} modifier="nowrap">
-                Evaluation name
+                Evaluation Name
               </Th>
               <Th sort={getSortParams(1)} modifier="nowrap">
                 Category
@@ -299,7 +299,7 @@ const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
                     'The normalized, weighted value of the benchmarks’ primary metric, such as accuracy, speed, or resource efficiency.',
                 }}
               >
-                Evaluation score
+                Evaluation Score
               </Th>
             </Tr>
           </Thead>
@@ -309,22 +309,22 @@ const SecurityInsightsView: React.FC<SecurityInsightsViewProps> = ({
                 key={`${insight.benchmarkName}-${insight.evaluation}`}
                 data-testid="security-insight-row"
               >
-                <Td dataLabel="Evaluation name">{insight.evaluation}</Td>
+                <Td dataLabel="Evaluation Name">{toTitleCase(insight.evaluation)}</Td>
                 <Td dataLabel="Category">
                   {insight.category && (
-                    <Label color={getCategoryColor(insight.category)} isCompact>
+                    <Label color={getCategoryColor(insight.category)}>
                       {capitalizeFirst(insight.category)}
                     </Label>
                   )}
                 </Td>
                 <Td dataLabel="Benchmark">
                   <TableRowTitleDescription
-                    title={insight.benchmarkName}
+                    title={toTitleCase(insight.benchmarkName)}
                     description={insight.benchmarkDescription}
                     truncateDescriptionLines={2}
                   />
                 </Td>
-                <Td dataLabel="Evaluation score">{insight.result}</Td>
+                <Td dataLabel="Evaluation Score">{insight.result}</Td>
               </Tr>
             ))}
           </Tbody>

--- a/packages/eval-hub/frontend/src/app/pages/modelCatalog/__tests__/SecurityInsightsView.tracking.spec.ts
+++ b/packages/eval-hub/frontend/src/app/pages/modelCatalog/__tests__/SecurityInsightsView.tracking.spec.ts
@@ -155,7 +155,7 @@ describe('SecurityInsightsView - Tracking Events', () => {
       await renderView();
       mockFireMisc.mockClear();
 
-      await selectFilterOption('Evaluation name');
+      await selectFilterOption('Evaluation Name');
 
       const filterChangeCalls = mockFireMisc.mock.calls.filter(
         ([event]) => event === EVAL_HUB_EVENTS.SECURITY_INSIGHTS_FILTER_TYPE_CHANGED,

--- a/packages/eval-hub/frontend/src/app/pages/modelCatalog/const.ts
+++ b/packages/eval-hub/frontend/src/app/pages/modelCatalog/const.ts
@@ -3,15 +3,15 @@ import { type SecurityInsight } from './securityInsightsTypes';
 export type FilterOption = 'evaluation' | 'category' | 'benchmark';
 
 export const FILTER_LABELS: Record<FilterOption, string> = {
-  evaluation: 'Evaluation name',
+  evaluation: 'Evaluation Name',
   category: 'Category',
   benchmark: 'Benchmark',
 };
 
 export const FILTER_PLACEHOLDERS: Record<FilterOption, string> = {
-  evaluation: 'Filter by evaluation name',
-  category: 'Filter by category',
-  benchmark: 'Filter by benchmark',
+  evaluation: 'Filter by Evaluation Name',
+  category: 'Filter by Category',
+  benchmark: 'Filter by Benchmark',
 };
 
 export type SortConfig = {


### PR DESCRIPTION
Cherry-pick of #8949 to `v3.5.0-fixes`.

## Description

Fix(eval-hub): Update Security Insights table label size and value casing

Use default label size for category labels and apply title casing to Evaluation Name and Benchmark Name column values. Title-case column headers for consistency.

See #8949 for the full details.

## How Has This Been Tested?

Same as #8949 — UI casing change, verified visually.

## Test Impact

Unit tests for toTitleCase utility included in the cherry-pick. No additional tests needed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)