### PR TITLE
Cherry-pick Zaffre e2e test fixes into v3.5.0-fixes

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/dataScienceProjects/testDeployLLMDServing.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/dataScienceProjects/testDeployLLMDServing.yaml
@@ -18,7 +18,3 @@ yamlEditorModelName: 'facebook-opt-125m-single'
 # llm-d LLMInferenceService path
 deploymentMethod: 'llm-inference-service-llmd'
 servingRuntime: 'Distributed inference with llm-d'
-
-# topology config
-topologyConfigName: 'e2e-multi-node-topology'
-topologyConfigFixture: 'resources/modelServing/llmd-topology-config.yaml'

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployLLMDServing.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployLLMDServing.cy.ts
@@ -24,17 +24,9 @@ import {
   cleanupHardwareProfiles,
 } from '../../../../utils/oc_commands/hardwareProfiles';
 import { checkLLMInferenceServiceState } from '../../../../utils/oc_commands/modelServing';
-import {
-  createCleanLLMInferenceServiceConfig,
-  cleanupLLMInferenceServiceConfig,
-  checkLLMInferenceServiceBaseRefs,
-} from '../../../../utils/oc_commands/llmInferenceServiceConfig';
 import { stubClipboard, getClipboardContent } from '../../../../utils/clipboardUtils';
 
-let testData: DataScienceProjectData & {
-  topologyConfigName: string;
-  topologyConfigFixture: string;
-};
+let testData: DataScienceProjectData;
 let projectName: string;
 let resourceApiVersion: string;
 let resourceName: string;
@@ -55,7 +47,7 @@ describe('A user can deploy an LLMD model', () => {
     cy.log('Loading test data');
     return loadDSPFixture('e2e/dataScienceProjects/testDeployLLMDServing.yaml')
       .then((fixtureData: DataScienceProjectData) => {
-        testData = fixtureData as typeof testData;
+        testData = fixtureData;
         projectName = `${testData.projectResourceName}-${uuid}`;
         resourceApiVersion = testData.resourceApiVersion;
         modelName = testData.singleModelName;
@@ -77,13 +69,6 @@ describe('A user can deploy an LLMD model', () => {
         cy.log(`Load Hardware Profile Name: ${hardwareProfileResourceName}`);
         // Cleanup Hardware Profile if it already exists
         createCleanHardwareProfile(hardwareProfileYamlPath);
-      })
-      .then(() => {
-        cy.log('Provisioning topology config for topology selection tests');
-        createCleanLLMInferenceServiceConfig(
-          testData.topologyConfigName,
-          testData.topologyConfigFixture,
-        );
       });
   });
 
@@ -92,7 +77,6 @@ describe('A user can deploy an LLMD model', () => {
     cy.log(`Cleaning up Hardware Profile: ${testData.hardwareProfileName}`);
     // Call cleanupHardwareProfiles with the actual name from the YAML file
     cleanupHardwareProfiles(hardwareProfileResourceName);
-    cleanupLLMInferenceServiceConfig(testData.topologyConfigName);
     // Delete provisioned Project - wait for completion due to RHOAIENG-19969 to support test retries, 5 minute timeout
     // TODO: Review this timeout once RHOAIENG-19969 is resolved
     deleteOpenShiftProject(projectName, { wait: true, ignoreNotFound: true, timeout: 300000 });
@@ -114,7 +98,7 @@ describe('A user can deploy an LLMD model', () => {
     () => {
       cy.step('Log into the application as admin');
       cy.visitWithLogin(
-        '/?devFeatureFlags=deploymentWizardYAMLViewer=true,llmdTemplates=true',
+        '/?devFeatureFlags=deploymentWizardYAMLViewer=true',
         HTPASSWD_CLUSTER_ADMIN_USER,
       );
 
@@ -161,13 +145,6 @@ describe('A user can deploy an LLMD model', () => {
       modelServingWizard.findYAMLEditorEmptyState().should('be.visible');
       modelServingWizard.findYAMLViewerToggle(YAMLViewerToggleOption.FORM).should('exist').click();
       modelServingWizard.selectDeploymentMethodByKey(deploymentMethod);
-
-      cy.step('Select topology type and configuration');
-      modelServingWizard.selectTopologyType('topology-type-workload-multi-node-data-parallel');
-      modelServingWizard.selectTopologyConfig(
-        `topology-config-option-${testData.topologyConfigName}`,
-      );
-      modelServingWizard.findRoutingConfigSelect().should('exist');
       modelServingWizard.findYAMLViewerToggle(YAMLViewerToggleOption.YAML).should('exist').click();
       modelServingWizard.findYAMLCodeEditor().waitForReady();
 
@@ -206,11 +183,6 @@ describe('A user can deploy an LLMD model', () => {
       // Image was patched in YAML editor before submit, so no post-deployment patching needed
       cy.then(() => {
         checkLLMInferenceServiceState(resourceName, projectName, { checkReady: true });
-      });
-
-      cy.step('Verify topology baseRef on LLMInferenceService CR');
-      cy.then(() => {
-        checkLLMInferenceServiceBaseRefs(resourceName, projectName, [testData.topologyConfigName]);
       });
 
       cy.step('Verify the model Row');

--- a/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
@@ -17,7 +17,7 @@ import {
   validateInferenceServiceTolerations,
 } from '../../../../utils/oc_commands/modelServing';
 import { retryableBefore } from '../../../../utils/retryableHooks';
-import { attemptToClickTooltip } from '../../../../utils/models';
+import { verifyDeploymentStatusModal } from '../../../../utils/models';
 import {
   cleanupHardwareProfiles,
   createCleanHardwareProfile,
@@ -170,7 +170,7 @@ describe('ModelServing - tolerations tests', () => {
       // Note reload is required as status tooltip was not found due to a stale element
       cy.reload();
       modelServingSection.findModelMetricsLink(modelName);
-      attemptToClickTooltip();
+      verifyDeploymentStatusModal();
 
       // Validate that the toleration applied earlier displays in the newly created pod
       cy.step('Validate the Tolerations for the pod include the newly added toleration');

--- a/packages/cypress/cypress/utils/models.ts
+++ b/packages/cypress/cypress/utils/models.ts
@@ -13,22 +13,33 @@ export const NIMAccountModel = {
   plural: 'accounts',
 };
 
-const maxAttempts = 5;
-let attempts = 0;
+/**
+ * Clicks the deployment status label to open the DeploymentStatusModal,
+ * verifies the modal shows a "Ready" status, then closes it.
+ * Retries with page reloads if the status label is not yet visible.
+ */
+export function verifyDeploymentStatusModal(): void {
+  const maxAttempts = 5;
+  let attempts = 0;
 
-export function attemptToClickTooltip(): void {
-  if (attempts >= maxAttempts) {
-    throw new Error('Failed to find and click the status tooltip after 5 attempts');
+  function attempt(): void {
+    modelServingSection.findStatusTooltip().then(($el) => {
+      if ($el.length > 0 && $el.is(':visible')) {
+        modelServingSection.findStatusTooltip().find('button').first().click();
+        cy.findByTestId('deployment-status-modal', { timeout: 10000 }).should('be.visible');
+        cy.findByTestId('deployment-status-modal')
+          .findByTestId('model-status-text')
+          .should('include.text', 'Ready');
+        cy.findByTestId('deployment-status-modal').find('button[aria-label="Close"]').click();
+      } else {
+        if (attempts + 1 >= maxAttempts) {
+          throw new Error('Failed to find and click the status label after 5 attempts');
+        }
+        attempts++;
+        cy.reload().then(() => attempt());
+      }
+    });
   }
 
-  modelServingSection.findStatusTooltip().then(($tooltip) => {
-    if ($tooltip.length > 0 && $tooltip.is(':visible')) {
-      modelServingSection.findStatusTooltip().click({ force: true });
-      cy.contains('Model deployment is active', { timeout: 120000 }).should('be.visible');
-    } else {
-      attempts++;
-      cy.reload();
-      attemptToClickTooltip();
-    }
-  });
+  attempt();
 }

--- a/packages/model-serving/modelRegistry/__tests__/ModelDetailsDeploymentCard.spec.tsx
+++ b/packages/model-serving/modelRegistry/__tests__/ModelDetailsDeploymentCard.spec.tsx
@@ -103,6 +103,7 @@ describe('ModelDetailsDeploymentCard', () => {
       renderWithContext([deployment], <ModelDetailsDeploymentCard rmId="1" mrName="test-mr" />);
 
       expect(screen.getByTestId('metrics-link-test-deployment')).toBeInTheDocument();
+      expect(screen.getByTestId('deployed-model-name')).toBeInTheDocument();
     });
 
     it('should render metrics link when deployment state is LOADED and stopped', () => {
@@ -123,6 +124,7 @@ describe('ModelDetailsDeploymentCard', () => {
       renderWithContext([deployment], <ModelDetailsDeploymentCard rmId="1" mrName="test-mr" />);
 
       expect(screen.getByTestId('metrics-link-test-deployment')).toBeInTheDocument();
+      expect(screen.getByTestId('deployed-model-name')).toBeInTheDocument();
     });
   });
 });

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -224,6 +224,7 @@ describe('DeploymentsTableRow', () => {
       );
 
       expect(screen.getByTestId('metrics-link-test-deployment')).toBeInTheDocument();
+      expect(screen.getByTestId('deployed-model-name')).toBeInTheDocument();
     });
   });
 

--- a/packages/model-serving/src/components/metrics/DeploymentMetricsLink.tsx
+++ b/packages/model-serving/src/components/metrics/DeploymentMetricsLink.tsx
@@ -22,7 +22,9 @@ export const DeploymentMetricsLink: React.FC<{
       data-testid={`metrics-link-${getDisplayNameFromK8sResource(deployment.model)}`}
       {...props}
     >
-      {getDisplayNameFromK8sResource(deployment.model)}
+      <span data-testid="deployed-model-name">
+        {getDisplayNameFromK8sResource(deployment.model)}
+      </span>
     </Link>
   );
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-79743

## Description
Cherry-picks model serving E2E test fixes from `main` into `v3.5.0-fixes` for the 3.5 GA release.

**Cherry-picked PRs:**
- #8969 — fix model serving e2e (`testDeployLLMDServing.cy.ts`): removes topology-selection and topology-reference checks that don't apply in 3.5, simplifies OCI model deployment validation
- #8964 — fix(model-serving,e2e): add `deployed-model-name` testid and update tolerations test for status modal: adds missing `data-testid` to `DeploymentMetricsLink`, updates `testModelServingTolerations` to use the new `DeploymentStatusModal` instead of the removed popover tooltip

## How Has This Been Tested?
Both PRs were tested on `main` and merged. This is a cherry-pick backport to `v3.5.0-fixes`. The upstream PRs were validated against Jenkins E2E runs on 3.5 clusters.

## Test Impact
- **Production code:** Added `deployed-model-name` `data-testid` span wrapper to `DeploymentMetricsLink.tsx` so the testid is present regardless of whether the metrics link or plain text path renders (#8964)
- **Unit tests:** Updated `DeploymentsTableRow.spec.tsx` and `ModelDetailsDeploymentCard.spec.tsx` to assert `deployed-model-name` is present alongside `metrics-link-{name}` when the metrics link renders (#8964)
- **E2E tests:** Updated `testModelServingTolerations.cy.ts` to use `verifyDeploymentStatusModal` instead of the removed `attemptToClickTooltip`; renamed and rewrote the helper in `cypress/utils/models.ts` (#8964)
- **E2E tests:** Removed topology-selection and topology-reference checks from `testDeployLLMDServing.cy.ts`; simplified OCI model deployment validation (#8969)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`