### PR TITLE
Add mock test for security insights tab

### DIFF
--- a/packages/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
+++ b/packages/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
@@ -87,9 +87,39 @@ class ModelDetailsPage {
     return cy.findByTestId('overview-tab');
   }
 
+  findSecurityInsightsTab() {
+    return cy.findByTestId('security-insights-tab');
+  }
+
+  findSecurityInsightsTabContent() {
+    return cy.findByTestId('security-insights-tab-content');
+  }
+
+  findSecurityInsightsView() {
+    return cy.findByTestId('security-insights-view');
+  }
+
+  findSecurityInsightsTable() {
+    return cy.findByTestId('security-insights-table');
+  }
+
+  findSecurityInsightsEmptyState() {
+    return cy.findByTestId('security-insights-empty-state');
+  }
+
+  clickSecurityInsightsTab() {
+    this.findSecurityInsightsTab().click();
+    return this;
+  }
+
   clickPerformanceInsightsTab() {
     this.findPerformanceInsightsTab().click();
     return this;
+  }
+
+  visitSecurityInsights(sourceId = 'sample-source', modelName = 'repo1%2Fmodel1') {
+    cy.visitWithLogin(`/ai-hub/models/catalog/${sourceId}/${modelName}/security-insights`);
+    this.wait();
   }
 
   findHardwareConfigurationTable() {

--- a/packages/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
+++ b/packages/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
@@ -107,11 +107,6 @@ class ModelDetailsPage {
     return cy.findByTestId('security-insights-empty-state');
   }
 
-  clickSecurityInsightsTab() {
-    this.findSecurityInsightsTab().click();
-    return this;
-  }
-
   clickPerformanceInsightsTab() {
     this.findPerformanceInsightsTab().click();
     return this;

--- a/packages/cypress/cypress/tests/mocked/modelCatalog/securityInsightsTab.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelCatalog/securityInsightsTab.cy.ts
@@ -139,7 +139,8 @@ describe('Model Catalog Security Insights tab (eval-hub extension)', () => {
     cy.wait('@getSecurityArtifacts');
   });
 
-  it('should not show the security insights tab when LM eval is disabled', () => {
+  it('should still show the security insights tab when LM eval is disabled', () => {
+    // Security Insights is gated by MODEL_CATALOG only (decoupled from LM_EVAL / Eval Hub Tech Preview).
     cy.interceptOdh(
       'GET /api/config',
       mockDashboardConfig({
@@ -148,13 +149,11 @@ describe('Model Catalog Security Insights tab (eval-hub extension)', () => {
         disableLMEval: true,
       }),
     );
+    interceptSecurityArtifacts([]);
 
     cy.visitWithLogin(`/ai-hub/models/catalog/${SOURCE_ID}/${ENCODED_MODEL_NAME}/overview`);
-    // With only the Overview tab present, ExtensibleDetailTabs renders content without a tab bar.
     modelDetailsPage.findPageTitle().should('exist');
-    modelDetailsPage.findLongDescription().should('exist');
-    modelDetailsPage.findSecurityInsightsTab().should('not.exist');
-    modelDetailsPage.findSecurityInsightsView().should('not.exist');
+    modelDetailsPage.findSecurityInsightsTab().should('exist');
   });
 
   it('should render security insights table content from the eval-hub API', () => {

--- a/packages/cypress/cypress/tests/mocked/modelCatalog/securityInsightsTab.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelCatalog/securityInsightsTab.cy.ts
@@ -1,0 +1,173 @@
+/* eslint-disable camelcase */
+import { mockDashboardConfig, mockDscStatus } from '@odh-dashboard/internal/__mocks__';
+import { mockDsciStatus } from '@odh-dashboard/internal/__mocks__/mockDsciStatus';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { asProductAdminUser } from '../../../utils/mockUsers';
+import { modelDetailsPage } from '../../../pages/modelCatalog/modelDetailsPage';
+import {
+  mockSecurityArtifacts,
+  mockSecurityArtifactsResponse,
+} from '../../../utils/securityInsightsUtils';
+
+const API_VERSION = 'v1';
+const SOURCE_ID = 'sample-source';
+const MODEL_NAME = 'repo1/model1';
+const ENCODED_MODEL_NAME = 'repo1%2Fmodel1';
+const REGISTRIES_NAMESPACE = 'odh-model-registries';
+
+const catalogModel = {
+  source_id: SOURCE_ID,
+  name: MODEL_NAME,
+  description: 'Sample catalog model for security insights mock tests.',
+  provider: 'provider1',
+  license: 'apache-2.0',
+  tasks: ['text-generation'],
+  customProperties: {},
+};
+
+const setupCommonIntercepts = () => {
+  asProductAdminUser();
+
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableModelCatalog: false,
+      disableModelRegistry: false,
+      disableLMEval: false,
+    }),
+  );
+
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.MODEL_REGISTRY]: {
+          managementState: 'Managed',
+          registriesNamespace: REGISTRIES_NAMESPACE,
+        },
+        [DataScienceStackComponent.TRUSTY_AI]: { managementState: 'Managed' },
+      },
+    }),
+  );
+
+  cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({}));
+
+  cy.interceptOdh(
+    'GET /model-registry/api/:apiVersion/user',
+    { path: { apiVersion: API_VERSION } },
+    { data: { userId: 'user@example.com', clusterAdmin: true } },
+  );
+
+  cy.interceptOdh(
+    'GET /model-registry/api/:apiVersion/namespaces',
+    { path: { apiVersion: API_VERSION } },
+    { data: [{ metadata: { name: REGISTRIES_NAMESPACE } }] },
+  );
+
+  cy.interceptOdh(
+    'GET /model-registry/api/:apiVersion/model_registry',
+    { path: { apiVersion: API_VERSION } },
+    { data: [] },
+  );
+
+  cy.interceptOdh(
+    'GET /model-registry/api/:apiVersion/model_catalog/sources',
+    { path: { apiVersion: API_VERSION } },
+    {
+      data: {
+        items: [
+          {
+            id: SOURCE_ID,
+            name: 'Sample source',
+            enabled: true,
+            labels: ['Community'],
+            status: 'available',
+          },
+        ],
+        size: 1,
+        pageSize: 10,
+        nextPageToken: '',
+      },
+    },
+  );
+
+  cy.intercept(
+    'GET',
+    `**/model-registry/api/${API_VERSION}/model_catalog/sources/${SOURCE_ID}/models/**`,
+    { body: { data: catalogModel } },
+  ).as('getCatalogModel');
+
+  cy.intercept(
+    'GET',
+    `**/model-registry/api/${API_VERSION}/model_catalog/sources/${SOURCE_ID}/artifacts/**`,
+    {
+      body: {
+        data: {
+          items: [],
+          size: 0,
+          pageSize: 10,
+          nextPageToken: '',
+        },
+      },
+    },
+  ).as('getCatalogArtifacts');
+};
+
+const interceptSecurityArtifacts = (
+  items = mockSecurityArtifacts(),
+  alias = 'getSecurityArtifacts',
+) => {
+  cy.intercept(
+    'GET',
+    `**/eval-hub/api/${API_VERSION}/catalog/sources/${SOURCE_ID}/security_artifacts/**`,
+    { body: mockSecurityArtifactsResponse(items) },
+  ).as(alias);
+};
+
+describe('Model Catalog Security Insights tab (eval-hub extension)', () => {
+  beforeEach(() => {
+    setupCommonIntercepts();
+  });
+
+  it('should show the security insights tab when LM eval and model catalog are enabled', () => {
+    interceptSecurityArtifacts([]);
+    modelDetailsPage.visitSecurityInsights(SOURCE_ID, ENCODED_MODEL_NAME);
+
+    modelDetailsPage.findSecurityInsightsTab().should('exist');
+    modelDetailsPage.findSecurityInsightsTabContent().should('exist');
+    modelDetailsPage.findSecurityInsightsEmptyState().should('exist');
+    cy.wait('@getSecurityArtifacts');
+  });
+
+  it('should not show the security insights tab when LM eval is disabled', () => {
+    cy.interceptOdh(
+      'GET /api/config',
+      mockDashboardConfig({
+        disableModelCatalog: false,
+        disableModelRegistry: false,
+        disableLMEval: true,
+      }),
+    );
+
+    cy.visitWithLogin(`/ai-hub/models/catalog/${SOURCE_ID}/${ENCODED_MODEL_NAME}/overview`);
+    // With only the Overview tab present, ExtensibleDetailTabs renders content without a tab bar.
+    modelDetailsPage.findPageTitle().should('exist');
+    modelDetailsPage.findLongDescription().should('exist');
+    modelDetailsPage.findSecurityInsightsTab().should('not.exist');
+    modelDetailsPage.findSecurityInsightsView().should('not.exist');
+  });
+
+  it('should render security insights table content from the eval-hub API', () => {
+    interceptSecurityArtifacts();
+    modelDetailsPage.visitSecurityInsights(SOURCE_ID, ENCODED_MODEL_NAME);
+
+    modelDetailsPage.findSecurityInsightsTab().should('exist');
+    modelDetailsPage.findSecurityInsightsView().should('exist');
+    modelDetailsPage.findSecurityInsightsTable().should('exist');
+    modelDetailsPage.findSecurityInsightsTable().should('contain.text', 'Toxicity');
+    modelDetailsPage.findSecurityInsightsTable().should('contain.text', 'PII Leakage');
+    modelDetailsPage.findSecurityInsightsTable().should('contain.text', '92.0%');
+    modelDetailsPage.findSecurityInsightsEmptyState().should('not.exist');
+    cy.wait('@getSecurityArtifacts');
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/modelCatalog/securityInsightsTab.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelCatalog/securityInsightsTab.cy.ts
@@ -25,7 +25,7 @@ const catalogModel = {
   customProperties: {},
 };
 
-const setupCommonIntercepts = () => {
+const setupCommonIntercepts = ({ disableLMEval = false }: { disableLMEval?: boolean } = {}) => {
   asProductAdminUser();
 
   cy.interceptOdh(
@@ -33,7 +33,7 @@ const setupCommonIntercepts = () => {
     mockDashboardConfig({
       disableModelCatalog: false,
       disableModelRegistry: false,
-      disableLMEval: false,
+      disableLMEval,
     }),
   );
 
@@ -95,7 +95,7 @@ const setupCommonIntercepts = () => {
     'GET',
     `**/model-registry/api/${API_VERSION}/model_catalog/sources/${SOURCE_ID}/models/**`,
     { body: { data: catalogModel } },
-  ).as('getCatalogModel');
+  );
 
   cy.intercept(
     'GET',
@@ -110,18 +110,15 @@ const setupCommonIntercepts = () => {
         },
       },
     },
-  ).as('getCatalogArtifacts');
+  );
 };
 
-const interceptSecurityArtifacts = (
-  items = mockSecurityArtifacts(),
-  alias = 'getSecurityArtifacts',
-) => {
+const interceptSecurityArtifacts = (items = mockSecurityArtifacts()) => {
   cy.intercept(
     'GET',
     `**/eval-hub/api/${API_VERSION}/catalog/sources/${SOURCE_ID}/security_artifacts/**`,
     { body: mockSecurityArtifactsResponse(items) },
-  ).as(alias);
+  ).as('getSecurityArtifacts');
 };
 
 describe('Model Catalog Security Insights tab (eval-hub extension)', () => {
@@ -134,21 +131,12 @@ describe('Model Catalog Security Insights tab (eval-hub extension)', () => {
     modelDetailsPage.visitSecurityInsights(SOURCE_ID, ENCODED_MODEL_NAME);
 
     modelDetailsPage.findSecurityInsightsTab().should('exist');
-    modelDetailsPage.findSecurityInsightsTabContent().should('exist');
     modelDetailsPage.findSecurityInsightsEmptyState().should('exist');
     cy.wait('@getSecurityArtifacts');
   });
 
   it('should still show the security insights tab when LM eval is disabled', () => {
-    // Security Insights is gated by MODEL_CATALOG only (decoupled from LM_EVAL / Eval Hub Tech Preview).
-    cy.interceptOdh(
-      'GET /api/config',
-      mockDashboardConfig({
-        disableModelCatalog: false,
-        disableModelRegistry: false,
-        disableLMEval: true,
-      }),
-    );
+    setupCommonIntercepts({ disableLMEval: true });
     interceptSecurityArtifacts([]);
 
     cy.visitWithLogin(`/ai-hub/models/catalog/${SOURCE_ID}/${ENCODED_MODEL_NAME}/overview`);
@@ -161,8 +149,6 @@ describe('Model Catalog Security Insights tab (eval-hub extension)', () => {
     modelDetailsPage.visitSecurityInsights(SOURCE_ID, ENCODED_MODEL_NAME);
 
     modelDetailsPage.findSecurityInsightsTab().should('exist');
-    modelDetailsPage.findSecurityInsightsView().should('exist');
-    modelDetailsPage.findSecurityInsightsTable().should('exist');
     modelDetailsPage.findSecurityInsightsTable().should('contain.text', 'Toxicity');
     modelDetailsPage.findSecurityInsightsTable().should('contain.text', 'PII Leakage');
     modelDetailsPage.findSecurityInsightsTable().should('contain.text', '92.0%');

--- a/packages/cypress/cypress/utils/securityInsightsUtils.ts
+++ b/packages/cypress/cypress/utils/securityInsightsUtils.ts
@@ -1,0 +1,64 @@
+/* eslint-disable camelcase */
+
+export type MockSecurityArtifact = {
+  artifactType: string;
+  id: string;
+  customProperties: {
+    evaluation: { metadataType: 'MetadataStringValue'; string_value: string };
+    category: { metadataType: 'MetadataStringValue'; string_value: string };
+    benchmark: { metadataType: 'MetadataStringValue'; string_value: string };
+    description: { metadataType: 'MetadataStringValue'; string_value: string };
+    result: { metadataType: 'MetadataDoubleValue'; double_value: number };
+  };
+};
+
+export type MockSecurityArtifactsResponse = {
+  data: {
+    items: MockSecurityArtifact[];
+    size: number;
+    pageSize: number;
+    nextPageToken: string;
+  };
+};
+
+export const mockSecurityArtifacts = (): MockSecurityArtifact[] => [
+  {
+    artifactType: 'SecurityArtifact',
+    id: 'security-art-1',
+    customProperties: {
+      evaluation: { metadataType: 'MetadataStringValue', string_value: 'Pipeline' },
+      category: { metadataType: 'MetadataStringValue', string_value: 'security' },
+      benchmark: { metadataType: 'MetadataStringValue', string_value: 'Toxicity' },
+      description: {
+        metadataType: 'MetadataStringValue',
+        string_value: 'Measures toxic output',
+      },
+      result: { metadataType: 'MetadataDoubleValue', double_value: 0.92 },
+    },
+  },
+  {
+    artifactType: 'SecurityArtifact',
+    id: 'security-art-2',
+    customProperties: {
+      evaluation: { metadataType: 'MetadataStringValue', string_value: 'Collection' },
+      category: { metadataType: 'MetadataStringValue', string_value: 'privacy' },
+      benchmark: { metadataType: 'MetadataStringValue', string_value: 'PII Leakage' },
+      description: {
+        metadataType: 'MetadataStringValue',
+        string_value: 'Detects personally identifiable information leakage',
+      },
+      result: { metadataType: 'MetadataDoubleValue', double_value: 0.15 },
+    },
+  },
+];
+
+export const mockSecurityArtifactsResponse = (
+  items: MockSecurityArtifact[] = mockSecurityArtifacts(),
+): MockSecurityArtifactsResponse => ({
+  data: {
+    items,
+    size: items.length,
+    pageSize: 100,
+    nextPageToken: '',
+  },
+});


### PR DESCRIPTION
Closes: https://redhat.atlassian.net/browse/RHOAIENG-79850

## Description
Adds cypress mock test for the security insights tab 

## How Has This Been Tested?
make sure the cypress tests are passing 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the Model Catalog’s Security Insights tab.
  * Verified tab visibility based on feature availability, loading behavior, empty states, and security metric tables.
  * Added realistic mocked security artifact data to validate displayed metrics and values.
* **Test Utilities**
  * Added reusable helpers for generating paginated security insights responses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->