### PR TITLE
Match Token Rate Limits Max to CRD

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -365,7 +365,7 @@ describe('Subscription Create Page', () => {
     createSubscriptionPage.findModelsTable().findByTestId('add-token-limit-0').click();
     editRateLimitsModal.shouldBeOpen();
     editRateLimitsModal.findCountInput(0).clear();
-    editRateLimitsModal.findCountInput(0).type('1000000000');
+    editRateLimitsModal.findCountInput(0).type('9999999999'); // 10 digits -> exceeds max value
     editRateLimitsModal.findSaveButton().should('be.disabled');
     editRateLimitsModal
       .findHelperText(0)
@@ -373,7 +373,7 @@ describe('Subscription Create Page', () => {
     editRateLimitsModal.findCountInput(0).clear();
     editRateLimitsModal.findCountInput(0).type('5000');
     editRateLimitsModal.findTimeInput(0).clear();
-    editRateLimitsModal.findTimeInput(0).type('1000000000');
+    editRateLimitsModal.findTimeInput(0).type('999999'); // 6 digits -> exceeds max value
     editRateLimitsModal.findSaveButton().should('be.disabled');
     editRateLimitsModal
       .findHelperText(0)

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -365,7 +365,7 @@ describe('Subscription Create Page', () => {
     createSubscriptionPage.findModelsTable().findByTestId('add-token-limit-0').click();
     editRateLimitsModal.shouldBeOpen();
     editRateLimitsModal.findCountInput(0).clear();
-    editRateLimitsModal.findCountInput(0).type('9999999999'); // 10 digits -> exceeds max value
+    editRateLimitsModal.findCountInput(0).type('1000000001'); // exceeds max value
     editRateLimitsModal.findSaveButton().should('be.disabled');
     editRateLimitsModal
       .findHelperText(0)

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -365,7 +365,7 @@ describe('Subscription Create Page', () => {
     createSubscriptionPage.findModelsTable().findByTestId('add-token-limit-0').click();
     editRateLimitsModal.shouldBeOpen();
     editRateLimitsModal.findCountInput(0).clear();
-    editRateLimitsModal.findCountInput(0).type('100000');
+    editRateLimitsModal.findCountInput(0).type('1000000000');
     editRateLimitsModal.findSaveButton().should('be.disabled');
     editRateLimitsModal
       .findHelperText(0)
@@ -373,7 +373,7 @@ describe('Subscription Create Page', () => {
     editRateLimitsModal.findCountInput(0).clear();
     editRateLimitsModal.findCountInput(0).type('5000');
     editRateLimitsModal.findTimeInput(0).clear();
-    editRateLimitsModal.findTimeInput(0).type('100000');
+    editRateLimitsModal.findTimeInput(0).type('1000000000');
     editRateLimitsModal.findSaveButton().should('be.disabled');
     editRateLimitsModal
       .findHelperText(0)

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/EditRateLimitsModal.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/EditRateLimitsModal.tsx
@@ -9,9 +9,18 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { z } from 'zod';
 import { RateLimit, TokenRateLimit } from '~/app/types/subscriptions';
-import { toRateLimit, toTokenRateLimit } from '~/app/utilities/rateLimits';
+import {
+  DEFAULT_RATE_LIMIT,
+  rateLimitsSchema,
+  rateLimitExceedsMaxDigits,
+  getCountError,
+  getTimeError,
+  getCountDigitError,
+  getTimeDigitError,
+  toRateLimit,
+  toTokenRateLimit,
+} from '~/app/utilities/rateLimits';
 import { RateLimitRow } from './RateLimitRow';
 
 type EditRateLimitsModalProps = {
@@ -20,55 +29,6 @@ type EditRateLimitsModalProps = {
   onSave: (rateLimits: TokenRateLimit[]) => void;
   onClose: () => void;
 };
-
-const DEFAULT_RATE_LIMIT: RateLimit = { count: 1000, time: 1, unit: 'hour' };
-const MAX_FIVE_DIGIT_VALUE = 99_999;
-
-const exceedsFiveDigitLimit = (n: number): boolean =>
-  !Number.isNaN(n) && Math.trunc(Math.abs(n)) > MAX_FIVE_DIGIT_VALUE;
-
-const rateLimitExceedsMaxDigits = (limit: RateLimit): boolean =>
-  exceedsFiveDigitLimit(limit.count) || exceedsFiveDigitLimit(limit.time);
-
-const rateLimitSchema = z.object({
-  count: z
-    .number()
-    .int()
-    .min(1, 'Token count must be greater than 0')
-    .max(Number.MAX_SAFE_INTEGER, 'Token count exceeds maximum allowed value'),
-  time: z
-    .number()
-    .int()
-    .min(1, 'Time value must be greater than 0')
-    .max(Number.MAX_SAFE_INTEGER, 'Time value exceeds maximum allowed value'),
-  unit: z.enum(['hour', 'minute', 'second']),
-});
-
-const rateLimitsSchema = z
-  .array(rateLimitSchema)
-  .min(1, 'At least one token rate limit is required');
-
-const getCountError = (limit: RateLimit): string | undefined => {
-  if (Number.isNaN(limit.count)) {
-    return 'Token count is required';
-  }
-  const result = rateLimitSchema.shape.count.safeParse(limit.count);
-  return result.success ? undefined : result.error.issues[0].message;
-};
-
-const getTimeError = (limit: RateLimit): string | undefined => {
-  if (Number.isNaN(limit.time)) {
-    return 'Time value is required';
-  }
-  const result = rateLimitSchema.shape.time.safeParse(limit.time);
-  return result.success ? undefined : result.error.issues[0].message;
-};
-
-const getCountDigitError = (limit: RateLimit): string | undefined =>
-  exceedsFiveDigitLimit(limit.count) ? 'Token count exceeds maximum allowed value' : undefined;
-
-const getTimeDigitError = (limit: RateLimit): string | undefined =>
-  exceedsFiveDigitLimit(limit.time) ? 'Time value exceeds maximum allowed value' : undefined;
 
 const EditRateLimitsModal: React.FC<EditRateLimitsModalProps> = ({
   modelName,

--- a/packages/maas/frontend/src/app/utilities/rateLimits.ts
+++ b/packages/maas/frontend/src/app/utilities/rateLimits.ts
@@ -64,7 +64,7 @@ export const formatTokenLimits = (limits: ModelSubscriptionRef['tokenRateLimits'
 };
 
 export const DEFAULT_RATE_LIMIT: RateLimit = { count: 1000, time: 1, unit: 'hour' };
-export const MAX_VALUE = 999_999_999;
+export const MAX_VALUE = 1_000_000_000;
 export const MAX_WINDOW_VALUE = 9_999;
 
 export const exceedsTokenLimit = (n: number): boolean =>
@@ -81,12 +81,12 @@ export const rateLimitSchema = z.object({
     .number()
     .int()
     .min(1, 'Token count must be greater than 0')
-    .max(Number.MAX_SAFE_INTEGER, 'Token count exceeds maximum allowed value'),
+    .max(MAX_VALUE, 'Token count exceeds maximum allowed value'),
   time: z
     .number()
     .int()
     .min(1, 'Time value must be greater than 0')
-    .max(Number.MAX_SAFE_INTEGER, 'Time value exceeds maximum allowed value'),
+    .max(MAX_WINDOW_VALUE, 'Time value exceeds maximum allowed value'),
   unit: z.enum(['hour', 'minute', 'second']),
 });
 

--- a/packages/maas/frontend/src/app/utilities/rateLimits.ts
+++ b/packages/maas/frontend/src/app/utilities/rateLimits.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { ModelSubscriptionRef, RateLimit, TokenRateLimit } from '~/app/types/subscriptions';
 
 const WINDOW_SUFFIX_TO_UNIT: Record<string, RateLimit['unit']> = {
@@ -61,3 +62,52 @@ export const formatTokenLimits = (limits: ModelSubscriptionRef['tokenRateLimits'
     .map((l) => `${l.limit.toLocaleString('en-US')} / ${formatWindow(l.window)}`)
     .join(' | ');
 };
+
+export const DEFAULT_RATE_LIMIT: RateLimit = { count: 1000, time: 1, unit: 'hour' };
+export const MAX_VALUE = 999_999_999;
+
+export const exceedsTokenLimit = (n: number): boolean =>
+  !Number.isNaN(n) && Math.trunc(Math.abs(n)) > MAX_VALUE;
+
+export const rateLimitExceedsMaxDigits = (limit: RateLimit): boolean =>
+  exceedsTokenLimit(limit.count) || exceedsTokenLimit(limit.time);
+
+export const rateLimitSchema = z.object({
+  count: z
+    .number()
+    .int()
+    .min(1, 'Token count must be greater than 0')
+    .max(Number.MAX_SAFE_INTEGER, 'Token count exceeds maximum allowed value'),
+  time: z
+    .number()
+    .int()
+    .min(1, 'Time value must be greater than 0')
+    .max(Number.MAX_SAFE_INTEGER, 'Time value exceeds maximum allowed value'),
+  unit: z.enum(['hour', 'minute', 'second']),
+});
+
+export const rateLimitsSchema = z
+  .array(rateLimitSchema)
+  .min(1, 'At least one token rate limit is required');
+
+export const getCountError = (limit: RateLimit): string | undefined => {
+  if (Number.isNaN(limit.count)) {
+    return 'Token count is required';
+  }
+  const result = rateLimitSchema.shape.count.safeParse(limit.count);
+  return result.success ? undefined : result.error.issues[0].message;
+};
+
+export const getTimeError = (limit: RateLimit): string | undefined => {
+  if (Number.isNaN(limit.time)) {
+    return 'Time value is required';
+  }
+  const result = rateLimitSchema.shape.time.safeParse(limit.time);
+  return result.success ? undefined : result.error.issues[0].message;
+};
+
+export const getCountDigitError = (limit: RateLimit): string | undefined =>
+  exceedsTokenLimit(limit.count) ? 'Token count exceeds maximum allowed value' : undefined;
+
+export const getTimeDigitError = (limit: RateLimit): string | undefined =>
+  exceedsTokenLimit(limit.time) ? 'Time value exceeds maximum allowed value' : undefined;

--- a/packages/maas/frontend/src/app/utilities/rateLimits.ts
+++ b/packages/maas/frontend/src/app/utilities/rateLimits.ts
@@ -65,12 +65,16 @@ export const formatTokenLimits = (limits: ModelSubscriptionRef['tokenRateLimits'
 
 export const DEFAULT_RATE_LIMIT: RateLimit = { count: 1000, time: 1, unit: 'hour' };
 export const MAX_VALUE = 999_999_999;
+export const MAX_WINDOW_VALUE = 9_999;
 
 export const exceedsTokenLimit = (n: number): boolean =>
   !Number.isNaN(n) && Math.trunc(Math.abs(n)) > MAX_VALUE;
 
+export const exceedsWindowLimit = (n: number): boolean =>
+  !Number.isNaN(n) && Math.trunc(Math.abs(n)) > MAX_WINDOW_VALUE;
+
 export const rateLimitExceedsMaxDigits = (limit: RateLimit): boolean =>
-  exceedsTokenLimit(limit.count) || exceedsTokenLimit(limit.time);
+  exceedsTokenLimit(limit.count) || exceedsWindowLimit(limit.time);
 
 export const rateLimitSchema = z.object({
   count: z
@@ -110,4 +114,4 @@ export const getCountDigitError = (limit: RateLimit): string | undefined =>
   exceedsTokenLimit(limit.count) ? 'Token count exceeds maximum allowed value' : undefined;
 
 export const getTimeDigitError = (limit: RateLimit): string | undefined =>
-  exceedsTokenLimit(limit.time) ? 'Time value exceeds maximum allowed value' : undefined;
+  exceedsWindowLimit(limit.time) ? 'Time value exceeds maximum allowed value' : undefined;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-76348](https://redhat.atlassian.net/browse/RHOAIENG-76348)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
in the token rate limits modal, it sets the new maximum to `999,999,999` instead of the previous `99,999`
the time window can old hold 5 characters, including the unit (`h`, `s`, etc) so the time needs to be maxed out at 4 chars so I set the limit to `9,999`
[toke rate limit policy](https://github.com/Kuadrant/kuadrant-operator/blob/main/config/crd/bases/kuadrant.io_tokenratelimitpolicies.yaml)
```
                           properties:
                              limit:
                                description: Limit defines the max value allowed for
                                  a given period of time
                                type: integer
                              window:
                                description: Window defines the time period for which
                                  the Limit specified above applies.
                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                type: string
```

https://github.com/user-attachments/assets/ca02f653-a44c-45a9-84e8-9a51c71b945a


also moved some stuff to the `rateLimits.ts` file to keep it central


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updated mock test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-76348]: https://redhat.atlassian.net/browse/RHOAIENG-76348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rate-limit validation in the subscription rate-limits editor for token count and time window values beyond allowed limits.
  - The Save button is now reliably disabled when inputs exceed maximum size, with updated helper messages guiding users.
  - Valid entries continue to work as before, allowing subscriptions to be created normally.
- **New Features**
  - Standardized rate-limit validation and error messaging across the rate-limits modal.
- **Tests**
  - Updated and expanded coverage for out-of-range token count and time-window inputs to match the new validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->