### PR TITLE
RHOAIENG-79878: Export ModelServingPodSpecOptionsState from @odh-dashboard/hardware-profiles

### DIFF
--- a/frontend/src/__mocks__/mockModelServingPodSpecOptions.ts
+++ b/frontend/src/__mocks__/mockModelServingPodSpecOptions.ts
@@ -1,4 +1,4 @@
-import { ModelServingPodSpecOptions } from '#~/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
+import type { ModelServingPodSpecOptions } from '@odh-dashboard/hardware-profiles/shared';
 
 type MockResourceConfigType = Partial<ModelServingPodSpecOptions>;
 

--- a/frontend/src/concepts/hardwareProfiles/deprecated/useModelServingAcceleratorDeprecatedPodSpecOptionsState.ts
+++ b/frontend/src/concepts/hardwareProfiles/deprecated/useModelServingAcceleratorDeprecatedPodSpecOptionsState.ts
@@ -1,22 +1,16 @@
 import React from 'react';
 import { InferenceServiceKind, ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
 import { useDeepCompareMemoize } from '@odh-dashboard/ui-core/hooks';
+import type {
+  ModelServingPodSpecOptionsState,
+  ModelServingPodSpecOptions,
+} from '@odh-dashboard/hardware-profiles/shared';
 import useServingAcceleratorProfileFormState from '#~/pages/modelServing/screens/projects/useServingAcceleratorProfileFormState';
 import { useAppContext } from '#~/app/AppContext';
 import { getModelServingSizes } from '#~/concepts/modelServing/modelServingSizesUtils';
 import { getInferenceServiceSize } from '#~/pages/modelServing/utils';
 import { isGpuDisabled } from '#~/pages/modelServing/screens/projects/utils';
 import useServingHardwareProfileConfig from '#~/concepts/hardwareProfiles/useServingHardwareProfileConfig';
-import { PodSpecOptionsAcceleratorState } from '#~/concepts/hardwareProfiles/types';
-import {
-  ModelServingPodSpecOptions,
-  ModelServingSizeState,
-} from '#~/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
-
-export type ModelServingPodSpecOptionsState =
-  PodSpecOptionsAcceleratorState<ModelServingPodSpecOptions> & {
-    modelSize: ModelServingSizeState;
-  };
 
 // HERE: go through and find all the places that use this and replace with the new useServingHardwareProfileConfig
 // todo:  get NIM set up so i can test it.

--- a/frontend/src/concepts/hardwareProfiles/useModelServingPodSpecOptionsState.ts
+++ b/frontend/src/concepts/hardwareProfiles/useModelServingPodSpecOptionsState.ts
@@ -1,29 +1,15 @@
 import React from 'react';
 import { InferenceServiceKind, ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
 import { useDeepCompareMemoize } from '@odh-dashboard/ui-core/hooks';
+import type {
+  ModelServingPodSpecOptions,
+  ModelServingSizeState,
+} from '@odh-dashboard/hardware-profiles/shared';
 import { useAppContext } from '#~/app/AppContext';
 import { getModelServingSizes } from '#~/concepts/modelServing/modelServingSizesUtils';
-import { ModelServingSize } from '#~/pages/modelServing/screens/types';
 import { getInferenceServiceSize } from '#~/pages/modelServing/utils';
 import useServingHardwareProfileConfig from './useServingHardwareProfileConfig';
-import { PodSpecOptions, HardwarePodSpecOptionsState } from './types';
-
-/**
- * most of this file (everything that uses and descends from PodSpecOptions) is deprecated
- * modelmesh: RHOAIENG-34917, RHOAIENG-19185
- *
- * when modelmesh is removed; remove everything that uses and descends from PodSpecOptions
- * (do this last; it should be the last thing removed and be obvious afterwards)
- */
-export type ModelServingPodSpecOptions = PodSpecOptions & {
-  selectedModelSize?: ModelServingSize;
-};
-
-export type ModelServingSizeState = {
-  sizes: ModelServingSize[];
-  selectedSize: ModelServingSize;
-  setSelectedSize: (modelSize: ModelServingSize) => void;
-};
+import { HardwarePodSpecOptionsState } from './types';
 
 export type ModelServingHardwareProfileState =
   HardwarePodSpecOptionsState<ModelServingPodSpecOptions> & {

--- a/frontend/src/pages/modelServing/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/utils.spec.ts
@@ -1,4 +1,5 @@
 import type { ContainerResources } from '@odh-dashboard/k8s-core';
+import type { ModelServingPodSpecOptionsState } from '@odh-dashboard/hardware-profiles/shared';
 import { getModelServingPVCAnnotations } from '@odh-dashboard/model-serving/shared';
 import type {
   ServingRuntimeKind,
@@ -35,7 +36,6 @@ import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServi
 import { mockRoleK8sResource } from '#~/__mocks__/mockRoleK8sResource';
 import { ServingRuntimeVersionStatusLabel } from '#~/pages/modelServing/screens/const';
 import { ServingRuntimeEditInfo } from '#~/pages/modelServing/screens/types';
-import { ModelServingPodSpecOptionsState } from '#~/concepts/hardwareProfiles/deprecated/useModelServingAcceleratorDeprecatedPodSpecOptionsState';
 
 jest.mock('#~/api', () => ({
   ...jest.requireActual('#~/api'),

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash-es';
 import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import type { SecretKind, ContainerResources } from '@odh-dashboard/k8s-core';
 import { getDisplayNameFromK8sResource, translateDisplayNameForK8s } from '@odh-dashboard/k8s-core';
+import type { ModelServingPodSpecOptionsState } from '@odh-dashboard/hardware-profiles/shared';
 import type {
   ServingRuntimeKind,
   InferenceServiceKind,
@@ -38,7 +39,6 @@ import {
   ModelServingSize,
   ModelServingState,
 } from '#~/pages/modelServing/screens/types';
-import { ModelServingPodSpecOptionsState } from '#~/concepts/hardwareProfiles/deprecated/useModelServingAcceleratorDeprecatedPodSpecOptionsState';
 import { ServingRuntimeVersionStatusLabel } from './screens/const';
 
 type TokenNames = {

--- a/packages/hardware-profiles/shared/index.ts
+++ b/packages/hardware-profiles/shared/index.ts
@@ -9,6 +9,9 @@ export type {
   HardwareProfileBindingConfig,
   CrPathConfig,
   HardwareProfileOptions,
+  ModelServingPodSpecOptions,
+  ModelServingSizeState,
+  ModelServingPodSpecOptionsState,
 } from './types';
 
 // Constants

--- a/packages/hardware-profiles/shared/types.ts
+++ b/packages/hardware-profiles/shared/types.ts
@@ -4,10 +4,12 @@ import {
   HardwareProfileFeatureVisibility,
   type HardwareProfileKind,
   type AcceleratorProfileKind,
+  type ModelServingSize,
   ContainerResources,
   Toleration,
   NodeSelector,
 } from '@odh-dashboard/k8s-core';
+import type { PodSpecOptionsAcceleratorState } from '@odh-dashboard/internal/concepts/hardwareProfiles/types';
 import { HardwareProfileBindingState } from './const';
 import type { useHardwareProfileConfig } from './useHardwareProfileConfig';
 
@@ -72,3 +74,18 @@ export type HardwareProfileOptions = {
   visibleIn: HardwareProfileFeatureVisibility[];
   paths?: CrPathConfig;
 };
+
+export type ModelServingPodSpecOptions = PodSpecOptions & {
+  selectedModelSize?: ModelServingSize;
+};
+
+export type ModelServingSizeState = {
+  sizes: ModelServingSize[];
+  selectedSize: ModelServingSize;
+  setSelectedSize: (modelSize: ModelServingSize) => void;
+};
+
+export type ModelServingPodSpecOptionsState =
+  PodSpecOptionsAcceleratorState<ModelServingPodSpecOptions> & {
+    modelSize: ModelServingSizeState;
+  };

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -6,7 +6,7 @@ import type {
   NamespaceApplicationCase,
   ProjectKind,
 } from '@odh-dashboard/k8s-core';
-import type { ModelServingPodSpecOptionsState } from '@odh-dashboard/internal/concepts/hardwareProfiles/deprecated/useModelServingAcceleratorDeprecatedPodSpecOptionsState';
+import type { ModelServingPodSpecOptionsState } from '@odh-dashboard/hardware-profiles/shared';
 import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
 import type { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79878

## Description
Moves model-serving pod spec option types from `@odh-dashboard/internal` into `@odh-dashboard/hardware-profiles/shared` as proper package exports, reducing cross-package internal imports.

  **Moved items:**

  | Category | Items | From | To |
  |----------|-------|------|----|
  | Types | `ModelServingPodSpecOptionsState`, `ModelServingPodSpecOptions`, `ModelServingSizeState` | `frontend/src/concepts/hardwareProfiles/` | `packages/hardware-profiles/shared/types.ts` |

  **Additional changes:**

  - `packages/model-serving/extension-points/index.ts` — replaced `@odh-dashboard/internal/...` import with `@odh-dashboard/hardware-profiles/shared`
  - `frontend/src/concepts/hardwareProfiles/deprecated/useModelServingAcceleratorDeprecatedPodSpecOptionsState.ts` — imports types from the package instead of internal relative paths
  - `frontend/src/__mocks__/mockModelServingPodSpecOptions.ts` — imports from the package instead of internal relative paths
  - `frontend/src/pages/modelServing/utils.ts` and its test file — import from the barrel `@odh-dashboard/hardware-profiles/shared` instead of deep `shared/types` path
  - Eliminated 2 `@odh-dashboard/internal` imports from `packages/hardware-profiles/shared/types.ts` by defining the types locally instead of re-importing them

  ## How Has This Been Tested?

  - `npx turbo type-check --force` — all packages pass (except pre-existing `eval-hub` failure)
  - `npm run lint` — 0 errors across all packages (only pre-existing warnings)
  - `npm run test:unit` (frontend) — 356 suites, 3849 tests pass
  - Verified no remaining imports of `ModelServingPodSpecOptions` or `ModelServingSizeState` from `@odh-dashboard/internal/...` paths

  ## Test Impact

  No new tests required. This is a pure type relocation refactor — no runtime behavior changes. Existing tests (`utils.spec.ts`) were updated to import from the new location and continue to pass.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-19185]: https://redhat.atlassian.net/browse/RHOAIENG-19185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized model-serving pod spec and model size typing into the shared hardware profiles module.
  * Updated model-serving state usage across components and extension points to rely on the shared types.
  * Removed usage of deprecated type locations while keeping runtime behavior unchanged.
* **Tests**
  * Adjusted model-serving test utilities to import the updated shared state types.
* **Chores**
  * Updated related mock typing to use type-only imports from the shared module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->