### PR TITLE
test(RHOAIENG-72402): mock analytics sink instead of helper wrappers in segment tracking tests for llm-d and fast-vllm components

### DIFF
--- a/frontend/src/pages/modelServing/customServingRuntimes/__tests__/CustomServingRuntimeEnabledToggle.spec.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/__tests__/CustomServingRuntimeEnabledToggle.spec.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { TemplateKind } from '@odh-dashboard/k8s-core';
-import {
-  fireRiskAccepted,
-  fireRiskDismissed,
-} from '@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking';
+import { LimitedSupportEvent } from '@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking';
+import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { mockServingRuntimeTemplateK8sResource } from '@odh-dashboard/internal/__mocks__/mockServingRuntimeTemplateK8sResource';
 import type { CustomWatchK8sResult } from '#~/types';
@@ -29,17 +27,19 @@ jest.mock('#~/services/templateService', () => ({
   patchTemplateAcceptedAnnotationBackend: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('#~/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
 jest.mock('@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking', () => ({
-  fireRiskAccepted: jest.fn(),
-  fireRiskDismissed: jest.fn(),
+  ...jest.requireActual('@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking'),
   getResourceVersions: jest.fn(() => ({
     version: '1.0.0',
     fastVersion: '2',
   })),
 }));
 
-const mockFireRiskAccepted = jest.mocked(fireRiskAccepted);
-const mockFireRiskDismissed = jest.mocked(fireRiskDismissed);
+const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
 
 const mockContextValue = {
   refreshData: jest.fn(),
@@ -88,7 +88,7 @@ describe('CustomServingRuntimeEnabledToggle', () => {
     fireEvent.click(screen.getByTestId('unsupported-status-accept-button'));
 
     await waitFor(() => {
-      expect(mockFireRiskAccepted).toHaveBeenCalledWith({
+      expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(LimitedSupportEvent.RISK_ACCEPTED, {
         runtimeResourceType: 'serving-runtime-template',
         resourceId: 'fast-vllm-template',
         resourceName: 'Fast vLLM Runtime',
@@ -117,7 +117,7 @@ describe('CustomServingRuntimeEnabledToggle', () => {
     fireEvent.click(screen.getByTestId('unsupported-status-cancel-button'));
 
     expect(screen.queryByTestId('unsupported-status-acceptance-modal')).not.toBeInTheDocument();
-    expect(mockFireRiskDismissed).toHaveBeenCalledWith({
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(LimitedSupportEvent.RISK_DISMISSED, {
       runtimeResourceType: 'serving-runtime-template',
       resourceId: 'fast-vllm-template',
       resourceName: 'Fast vLLM Runtime',
@@ -145,7 +145,7 @@ describe('CustomServingRuntimeEnabledToggle', () => {
     fireEvent.click(screen.getByLabelText('Close'));
 
     expect(screen.queryByTestId('unsupported-status-acceptance-modal')).not.toBeInTheDocument();
-    expect(mockFireRiskDismissed).toHaveBeenCalledWith({
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(LimitedSupportEvent.RISK_DISMISSED, {
       runtimeResourceType: 'serving-runtime-template',
       resourceId: 'fast-vllm-template',
       resourceName: 'Fast vLLM Runtime',

--- a/packages/llmd-serving/src/settings/llmAcceleratorConfigs/__tests__/LlmAcceleratorConfigEnabledToggle.spec.tsx
+++ b/packages/llmd-serving/src/settings/llmAcceleratorConfigs/__tests__/LlmAcceleratorConfigEnabledToggle.spec.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
-import {
-  fireRiskAccepted,
-  fireRiskDismissed,
-} from '@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { LimitedSupportEvent } from '@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking';
 import LlmAcceleratorConfigEnabledToggle from '../LlmAcceleratorConfigEnabledToggle';
 import { patchLLMInferenceServiceConfig } from '../../../api/LLMInferenceServiceConfigs';
 import type { LLMInferenceServiceConfigKind } from '../../../types';
@@ -19,17 +17,19 @@ jest.mock('../../../api/LLMInferenceServiceConfigs', () => ({
   patchLLMInferenceServiceConfig: jest.fn(),
 }));
 
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
 jest.mock('@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking', () => ({
-  fireRiskAccepted: jest.fn(),
-  fireRiskDismissed: jest.fn(),
+  ...jest.requireActual('@odh-dashboard/model-serving/shared/tracking/limitedSupportTracking'),
   getResourceVersions: jest.fn(() => ({
     version: undefined,
     fastVersion: undefined,
   })),
 }));
 
-const mockFireRiskAccepted = jest.mocked(fireRiskAccepted);
-const mockFireRiskDismissed = jest.mocked(fireRiskDismissed);
+const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
 const mockPatchConfig = jest.mocked(patchLLMInferenceServiceConfig);
 
 const mockNotification =
@@ -167,7 +167,7 @@ describe('LlmAcceleratorConfigEnabledToggle', () => {
     });
 
     await waitFor(() => {
-      expect(mockFireRiskAccepted).toHaveBeenCalledWith({
+      expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(LimitedSupportEvent.RISK_ACCEPTED, {
         runtimeResourceType: 'llm-accelerator-config',
         resourceId: config.metadata.name,
         resourceName: 'Test vLLM Config',
@@ -194,7 +194,7 @@ describe('LlmAcceleratorConfigEnabledToggle', () => {
       expect(mockNotification.error).toHaveBeenCalled();
     });
 
-    expect(mockFireRiskAccepted).not.toHaveBeenCalled();
+    expect(mockFireMiscTrackingEvent).not.toHaveBeenCalled();
   });
 
   it('should close modal without patching when cancel is clicked and fire tracking event', () => {
@@ -209,7 +209,7 @@ describe('LlmAcceleratorConfigEnabledToggle', () => {
 
     expect(screen.queryByTestId('unsupported-status-acceptance-modal')).not.toBeInTheDocument();
     expect(mockPatchConfig).not.toHaveBeenCalled();
-    expect(mockFireRiskDismissed).toHaveBeenCalledWith({
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(LimitedSupportEvent.RISK_DISMISSED, {
       runtimeResourceType: 'llm-accelerator-config',
       resourceId: config.metadata.name,
       resourceName: 'Test vLLM Config',
@@ -232,7 +232,7 @@ describe('LlmAcceleratorConfigEnabledToggle', () => {
 
     expect(screen.queryByTestId('unsupported-status-acceptance-modal')).not.toBeInTheDocument();
     expect(mockPatchConfig).not.toHaveBeenCalled();
-    expect(mockFireRiskDismissed).toHaveBeenCalledWith({
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(LimitedSupportEvent.RISK_DISMISSED, {
       runtimeResourceType: 'llm-accelerator-config',
       resourceId: config.metadata.name,
       resourceName: 'Test vLLM Config',

--- a/packages/llmd-serving/src/wizardFields/__tests__/AdvancedRoutingField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/AdvancedRoutingField.spec.tsx
@@ -3,7 +3,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
-import { fireRoutingSelected } from '../../tracking/llmdTrackingConstants';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { LlmdTrackingEvent } from '../../tracking/llmdTrackingConstants';
 import { ConfigType, TopologyType } from '../../types';
 import {
   AdvancedRoutingFieldWizardField,
@@ -11,11 +12,11 @@ import {
   type AdvancedRoutingFieldData,
 } from '../AdvancedRoutingField';
 
-jest.mock('../../tracking/llmdTrackingConstants', () => ({
-  fireRoutingSelected: jest.fn(),
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireMiscTrackingEvent: jest.fn(),
 }));
 
-const mockFireRoutingSelected = jest.mocked(fireRoutingSelected);
+const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
 
 const { getInitialFieldData, validationSchema } = AdvancedRoutingFieldWizardField.reducerFunctions;
 const AdvancedRoutingFieldComponent = AdvancedRoutingFieldWizardField.component;
@@ -198,7 +199,7 @@ describe('AdvancedRoutingField tracking', () => {
       fireEvent.click(screen.getByText('Default optimized routing'));
     });
 
-    expect(mockFireRoutingSelected).toHaveBeenCalledWith({
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(LlmdTrackingEvent.ROUTING_SELECTED, {
       routingConfigurationId: '__default-optimized-routing__',
       isDefaultRouting: true,
     });
@@ -217,10 +218,66 @@ describe('AdvancedRoutingField tracking', () => {
       fireEvent.click(screen.getByText('Router Config One'));
     });
 
-    expect(mockFireRoutingSelected).toHaveBeenCalledWith({
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(LlmdTrackingEvent.ROUTING_SELECTED, {
       routingConfigurationId: 'router-config-1',
       isDefaultRouting: false,
     });
+  });
+
+  it('should fire fireRoutingSelected for a different config selection', async () => {
+    renderComponent({
+      value: { selectedConfig: routerConfig1 },
+      externalData: {
+        data: { routerConfigs: [routerConfig1, routerConfig2] },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Router Config Two'));
+    });
+
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(LlmdTrackingEvent.ROUTING_SELECTED, {
+      routingConfigurationId: 'router-config-2',
+      isDefaultRouting: false,
+    });
+  });
+
+  it('should call onChange with selectedConfig when a specific config is selected', async () => {
+    renderComponent({
+      externalData: {
+        data: { routerConfigs: [routerConfig1] },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Router Config One'));
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith({ selectedConfig: routerConfig1 });
+  });
+
+  it('should call onChange with undefined selectedConfig when default routing is selected', async () => {
+    renderComponent({
+      value: { selectedConfig: routerConfig1 },
+      externalData: {
+        data: { routerConfigs: [routerConfig1] },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Default optimized routing'));
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith({ selectedConfig: undefined });
   });
 
   it('should render the default routing option and config options', async () => {

--- a/packages/llmd-serving/src/wizardFields/__tests__/AdvancedRoutingField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/AdvancedRoutingField.spec.tsx
@@ -245,41 +245,6 @@ describe('AdvancedRoutingField tracking', () => {
     });
   });
 
-  it('should call onChange with selectedConfig when a specific config is selected', async () => {
-    renderComponent({
-      externalData: {
-        data: { routerConfigs: [routerConfig1] },
-        loaded: true,
-      },
-    });
-
-    await openDropdown();
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Router Config One'));
-    });
-
-    expect(mockOnChange).toHaveBeenCalledWith({ selectedConfig: routerConfig1 });
-  });
-
-  it('should call onChange with undefined selectedConfig when default routing is selected', async () => {
-    renderComponent({
-      value: { selectedConfig: routerConfig1 },
-      externalData: {
-        data: { routerConfigs: [routerConfig1] },
-        loaded: true,
-      },
-    });
-
-    await openDropdown();
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Default optimized routing'));
-    });
-
-    expect(mockOnChange).toHaveBeenCalledWith({ selectedConfig: undefined });
-  });
-
   it('should render the default routing option and config options', async () => {
     renderComponent({
       externalData: {

--- a/packages/llmd-serving/src/wizardFields/__tests__/AdvancedRoutingField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/AdvancedRoutingField.spec.tsx
@@ -185,7 +185,7 @@ describe('AdvancedRoutingField tracking', () => {
     });
   };
 
-  it('should fire fireRoutingSelected with isDefaultRouting true when default routing is selected', async () => {
+  it('should fire routing selected tracking with isDefaultRouting true when default routing is selected', async () => {
     renderComponent({
       value: { selectedConfig: routerConfig1 },
       externalData: {
@@ -205,7 +205,7 @@ describe('AdvancedRoutingField tracking', () => {
     });
   });
 
-  it('should fire fireRoutingSelected with isDefaultRouting false when a specific config is selected', async () => {
+  it('should fire routing selected tracking with isDefaultRouting false when a specific config is selected', async () => {
     renderComponent({
       externalData: {
         data: { routerConfigs: [routerConfig1, routerConfig2] },
@@ -224,7 +224,7 @@ describe('AdvancedRoutingField tracking', () => {
     });
   });
 
-  it('should fire fireRoutingSelected for a different config selection', async () => {
+  it('should fire routing selected tracking for a different config selection', async () => {
     renderComponent({
       value: { selectedConfig: routerConfig1 },
       externalData: {

--- a/packages/llmd-serving/src/wizardFields/__tests__/TopologyTypeField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/TopologyTypeField.spec.tsx
@@ -47,7 +47,7 @@ describe('TopologyTypeField tracking', () => {
     });
   };
 
-  it('should fire fireTopologyTypeSelected with undefined previousPattern on first selection', async () => {
+  it('should fire topology type selected tracking with undefined previousPattern on first selection', async () => {
     renderComponent({
       externalData: {
         data: {
@@ -77,7 +77,7 @@ describe('TopologyTypeField tracking', () => {
     );
   });
 
-  it('should fire fireTopologyTypeSelected with previous pattern when switching', async () => {
+  it('should fire topology type selected tracking with previous pattern when switching', async () => {
     renderComponent({
       value: { topologyType: TopologyType.SINGLE_NODE },
       externalData: {

--- a/packages/llmd-serving/src/wizardFields/__tests__/TopologyTypeField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/TopologyTypeField.spec.tsx
@@ -1,7 +1,8 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { fireTopologyTypeSelected } from '../../tracking/llmdTrackingConstants';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { LlmdTrackingEvent } from '../../tracking/llmdTrackingConstants';
 import { TopologyType, TopologyTypeLabels } from '../../types';
 import {
   TopologyTypeFieldWizardField,
@@ -9,11 +10,11 @@ import {
   type TopologyTypeFieldData,
 } from '../TopologyTypeField';
 
-jest.mock('../../tracking/llmdTrackingConstants', () => ({
-  fireTopologyTypeSelected: jest.fn(),
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireMiscTrackingEvent: jest.fn(),
 }));
 
-const mockFireTopologyTypeSelected = jest.mocked(fireTopologyTypeSelected);
+const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
 
 const TopologyTypeFieldComponent = TopologyTypeFieldWizardField.component;
 
@@ -67,10 +68,13 @@ describe('TopologyTypeField tracking', () => {
       fireEvent.click(screen.getByText(TopologyTypeLabels[TopologyType.SINGLE_NODE]));
     });
 
-    expect(mockFireTopologyTypeSelected).toHaveBeenCalledWith({
-      llmdComposablePattern: TopologyType.SINGLE_NODE,
-      previousPattern: undefined,
-    });
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(
+      LlmdTrackingEvent.TOPOLOGY_TYPE_SELECTED,
+      {
+        llmdComposablePattern: TopologyType.SINGLE_NODE,
+        previousPattern: undefined,
+      },
+    );
   });
 
   it('should fire fireTopologyTypeSelected with previous pattern when switching', async () => {
@@ -95,10 +99,13 @@ describe('TopologyTypeField tracking', () => {
       fireEvent.click(screen.getByText(TopologyTypeLabels[TopologyType.MULTI_NODE]));
     });
 
-    expect(mockFireTopologyTypeSelected).toHaveBeenCalledWith({
-      llmdComposablePattern: TopologyType.MULTI_NODE,
-      previousPattern: TopologyType.SINGLE_NODE,
-    });
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(
+      LlmdTrackingEvent.TOPOLOGY_TYPE_SELECTED,
+      {
+        llmdComposablePattern: TopologyType.MULTI_NODE,
+        previousPattern: TopologyType.SINGLE_NODE,
+      },
+    );
   });
 
   it('should call onChange with the selected topology type', async () => {

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { fireDeployMethodSelected } from '../../../../shared/tracking/modelServingTrackingConstants';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { ModelServingTrackingEvent } from '../../../../shared/tracking/modelServingTrackingConstants';
 import {
   DeploymentMethodSelectFieldWizardField,
   resolveDeploymentMethodSuggestion,
@@ -10,11 +11,11 @@ import {
 } from '../DeploymentMethodSelectField';
 import type { DeploymentMethodFieldOverride } from '../../../../shared/types/form-data';
 
-jest.mock('../../../../shared/tracking/modelServingTrackingConstants', () => ({
-  fireDeployMethodSelected: jest.fn(),
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireMiscTrackingEvent: jest.fn(),
 }));
 
-const mockFireDeployMethodSelected = jest.mocked(fireDeployMethodSelected);
+const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
 
 const DeploymentMethodSelectFieldComponent = DeploymentMethodSelectFieldWizardField.component;
 
@@ -142,10 +143,13 @@ describe('DeploymentMethodSelectField tracking', () => {
 
     fireEvent.click(screen.getByTestId('deployment-method-kserve'));
 
-    expect(mockFireDeployMethodSelected).toHaveBeenCalledWith({
-      deploymentMethod: 'kserve',
-      previousDeploymentMethod: undefined,
-    });
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(
+      ModelServingTrackingEvent.DEPLOY_METHOD_SELECTED,
+      {
+        deploymentMethod: 'kserve',
+        previousDeploymentMethod: undefined,
+      },
+    );
   });
 
   it('should fire fireDeployMethodSelected with previous method when switching', () => {
@@ -164,10 +168,13 @@ describe('DeploymentMethodSelectField tracking', () => {
 
     fireEvent.click(screen.getByTestId('deployment-method-llmd'));
 
-    expect(mockFireDeployMethodSelected).toHaveBeenCalledWith({
-      deploymentMethod: 'llmd',
-      previousDeploymentMethod: 'kserve',
-    });
+    expect(mockFireMiscTrackingEvent).toHaveBeenCalledWith(
+      ModelServingTrackingEvent.DEPLOY_METHOD_SELECTED,
+      {
+        deploymentMethod: 'llmd',
+        previousDeploymentMethod: 'kserve',
+      },
+    );
   });
 
   it('should call onChange with the selected method', () => {

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
@@ -128,7 +128,7 @@ describe('DeploymentMethodSelectField tracking', () => {
       />,
     );
 
-  it('should fire fireDeployMethodSelected with undefined previousDeploymentMethod on first selection', () => {
+  it('should fire deploy method selected tracking with undefined previousDeploymentMethod on first selection', () => {
     renderComponent({
       externalData: {
         data: {
@@ -152,7 +152,7 @@ describe('DeploymentMethodSelectField tracking', () => {
     );
   });
 
-  it('should fire fireDeployMethodSelected with previous method when switching', () => {
+  it('should fire deploy method selected tracking with previous method when switching', () => {
     renderComponent({
       value: { method: 'kserve' },
       externalData: {


### PR DESCRIPTION
Followup to https://issues.redhat.com/browse/RHOAIENG-72402 and https://redhat.atlassian.net/browse/RHOAIENG-73369

## Description

Improves tracking test coverage by mocking `fireMiscTrackingEvent` at the analytics sink level instead of mocking the helper wrapper functions (`fireDeployMethodSelected`, `fireTopologyTypeSelected`, etc.). This ensures tests verify that the correct event name enum value is forwarded through the helper, catching broken event name constants or forwarding logic that the previous mock pattern would miss.

Applies the same fix across all tracking test files:
- `DeploymentMethodSelectField.spec.tsx` (model-serving)
- `TopologyTypeField.spec.tsx` (llmd-serving)
- `AdvancedRoutingField.spec.tsx` (llmd-serving)
- `LlmAcceleratorConfigEnabledToggle.spec.tsx` (llmd-serving)
- `CustomServingRuntimeEnabledToggle.spec.tsx` (frontend)

Motivated by [CodeRabbit review feedback](https://github.com/opendatahub-io/odh-dashboard/pull/8736#discussion_r2970539098) on PR #8736.

## How Has This Been Tested?

All affected tests pass locally:
- `npx jest DeploymentMethodSelectField.spec.tsx` — 13 passed
- `npx jest TopologyTypeField.spec.tsx` — 4 passed
- `npx jest AdvancedRoutingField.spec.tsx` — 22 passed
- `npx jest LlmAcceleratorConfigEnabledToggle.spec.tsx` — 12 passed
- `npx jest CustomServingRuntimeEnabledToggle.spec.tsx` — 3 passed

## Test Impact

Test-only change. No production code modified. Existing tests updated to mock at a deeper level — same assertions, better coverage of the forwarding path.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated analytics test coverage for custom serving runtime and accelerator risk acceptance or dismissal.
  * Updated tracking tests for routing, topology type, and deployment method selections.
  * Added validation of event payloads, including selected and previous values.
  * Confirmed tracking events are not sent when related updates fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->