### PR TITLE
test(RHOAIENG-59932): add Cypress mock tests for module federation visibility

### DIFF
--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -492,4 +492,169 @@ describe('isAreaAvailable', () => {
       expect(isAvailable.featureFlags).toEqual({ disableFeatureStore: 'on' });
     });
   });
+
+  describe('Plugin module areas', () => {
+    const PLUGIN_AUTOML = 'plugin-automl';
+    const PLUGIN_GEN_AI = 'plugin-gen-ai';
+    const PLUGIN_FEATURE_STORE = 'plugin-feature-store';
+
+    describe('AutoML', () => {
+      const stateMap = {
+        [PLUGIN_AUTOML]: {
+          featureFlags: ['automl' as const],
+          requiredComponents: [DataScienceStackComponent.DS_PIPELINES],
+        },
+      };
+
+      it('should enable when automl flag is true and DS_PIPELINES is Managed', () => {
+        const result = isAreaAvailable(
+          PLUGIN_AUTOML,
+          mockDashboardConfig({ automl: true }).spec,
+          mockDscStatus({
+            components: {
+              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
+            },
+          }),
+          null,
+          { internalStateMap: stateMap, flagState: { automl: true } },
+        );
+
+        expect(result.status).toBe(true);
+        expect(result.featureFlags).toEqual({ automl: 'on' });
+        expect(result.requiredComponents).toEqual({
+          [DataScienceStackComponent.DS_PIPELINES]: true,
+        });
+      });
+
+      it('should disable when automl flag is false', () => {
+        const result = isAreaAvailable(
+          PLUGIN_AUTOML,
+          mockDashboardConfig({ automl: false }).spec,
+          mockDscStatus({
+            components: {
+              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
+            },
+          }),
+          null,
+          { internalStateMap: stateMap, flagState: { automl: false } },
+        );
+
+        expect(result.status).toBe(false);
+        expect(result.featureFlags).toEqual({ automl: 'off' });
+      });
+
+      it('should disable when automl flag is true but DS_PIPELINES is Removed', () => {
+        const result = isAreaAvailable(
+          PLUGIN_AUTOML,
+          mockDashboardConfig({ automl: true }).spec,
+          mockDscStatus({
+            components: {
+              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Removed' },
+            },
+          }),
+          null,
+          { internalStateMap: stateMap, flagState: { automl: true } },
+        );
+
+        expect(result.status).toBe(false);
+        expect(result.featureFlags).toEqual({ automl: 'on' });
+        expect(result.requiredComponents).toEqual({
+          [DataScienceStackComponent.DS_PIPELINES]: false,
+        });
+      });
+    });
+
+    describe('Gen AI', () => {
+      const stateMap = {
+        [PLUGIN_GEN_AI]: {
+          featureFlags: ['genAiStudio' as const],
+        },
+      };
+
+      it('should enable when genAiStudio flag is true', () => {
+        const result = isAreaAvailable(
+          PLUGIN_GEN_AI,
+          mockDashboardConfig({ genAiStudio: true }).spec,
+          null,
+          null,
+          { internalStateMap: stateMap, flagState: { genAiStudio: true } },
+        );
+
+        expect(result.status).toBe(true);
+        expect(result.featureFlags).toEqual({ genAiStudio: 'on' });
+      });
+
+      it('should disable when genAiStudio flag is false', () => {
+        const result = isAreaAvailable(
+          PLUGIN_GEN_AI,
+          mockDashboardConfig({ genAiStudio: false }).spec,
+          null,
+          null,
+          { internalStateMap: stateMap, flagState: { genAiStudio: false } },
+        );
+
+        expect(result.status).toBe(false);
+        expect(result.featureFlags).toEqual({ genAiStudio: 'off' });
+      });
+    });
+
+    describe('Feature Store', () => {
+      const stateMap = {
+        ...SupportedAreasStateMap,
+        [PLUGIN_FEATURE_STORE]: {
+          featureFlags: ['disableFeatureStore' as const],
+          reliantAreas: [SupportedArea.FEATURE_STORE],
+        },
+      };
+
+      it('should enable when disableFeatureStore is false and FEATURE_STORE area is available', () => {
+        const result = isAreaAvailable(
+          PLUGIN_FEATURE_STORE,
+          mockDashboardConfig({ disableFeatureStore: false }).spec,
+          mockDscStatus({
+            components: {
+              [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+            },
+          }),
+          null,
+          { internalStateMap: stateMap, flagState: { disableFeatureStore: false } },
+        );
+
+        expect(result.status).toBe(true);
+        expect(result.featureFlags).toEqual({ disableFeatureStore: 'on' });
+        expect(result.reliantAreas).toEqual({ [SupportedArea.FEATURE_STORE]: true });
+      });
+
+      it('should disable when disableFeatureStore is true', () => {
+        const result = isAreaAvailable(
+          PLUGIN_FEATURE_STORE,
+          mockDashboardConfig({ disableFeatureStore: true }).spec,
+          null,
+          null,
+          { internalStateMap: stateMap, flagState: { disableFeatureStore: true } },
+        );
+
+        expect(result.status).toBe(false);
+        expect(result.featureFlags).toEqual({ disableFeatureStore: 'off' });
+      });
+
+      it('should disable when flag is on but FEAST_OPERATOR is Removed', () => {
+        const result = isAreaAvailable(
+          PLUGIN_FEATURE_STORE,
+          mockDashboardConfig({ disableFeatureStore: false }).spec,
+          mockDscStatus({
+            components: {
+              [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Removed' },
+            },
+          }),
+          null,
+          { internalStateMap: stateMap, flagState: { disableFeatureStore: false } },
+        );
+
+        expect(result.status).toBe(false);
+        expect(result.featureFlags).toEqual({ disableFeatureStore: 'on' });
+        expect(result.reliantAreas).toEqual({ [SupportedArea.FEATURE_STORE]: false });
+      });
+    });
+  });
 });

--- a/packages/cypress/cypress/tests/mocked/moduleFederation/moduleFederationVisibility.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/moduleFederation/moduleFederationVisibility.cy.ts
@@ -1,88 +1,50 @@
-import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__';
+import {
+  mockDashboardConfig,
+  type MockDashboardConfigType,
+} from '@odh-dashboard/internal/__mocks__';
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { pageNotfound } from '../../../pages/pageNotFound';
 import { navSidebar } from '../navSidebar/navSidebar';
 
+const initIntercepts = (
+  config: Partial<MockDashboardConfigType>,
+  components?: Record<string, { managementState: string }>,
+) => {
+  cy.interceptOdh('GET /api/config', mockDashboardConfig(config));
+  if (components) {
+    cy.interceptOdh('GET /api/dsc/status', mockDscStatus({ components }));
+  }
+};
+
 describe('Module federation visibility', () => {
   describe('Module present — nav and route accessible', () => {
-    it('should show AutoML nav item when feature flag and DSC component are enabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          automl: true,
-        }),
-      );
-      cy.interceptOdh(
-        'GET /api/dsc/status',
-        mockDscStatus({
-          components: {
-            [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
-          },
-        }),
+    it('should show AutoML nav and render route when flag and DSC are enabled', () => {
+      initIntercepts(
+        { automl: true },
+        { [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' } },
       );
       navSidebar.visit();
       navSidebar.findNavItem({ name: 'AutoML', rootSection: 'Develop & train' }).should('exist');
-    });
-
-    it('should render AutoML route when feature flag is enabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          automl: true,
-        }),
-      );
-      cy.interceptOdh(
-        'GET /api/dsc/status',
-        mockDscStatus({
-          components: {
-            [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
-          },
-        }),
-      );
       cy.visitWithLogin('/develop-train/automl');
       pageNotfound.findPage().should('not.exist');
     });
 
-    it('should show Gen AI studio section when feature flag is enabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          genAiStudio: true,
-        }),
-      );
+    it('should show Gen AI studio section and render route when flag is enabled', () => {
+      initIntercepts({ genAiStudio: true });
       navSidebar.visit();
       navSidebar.findNavSection('Gen AI studio').should('exist');
       navSidebar
         .findNavItem({ name: 'AI asset endpoints', rootSection: 'Gen AI studio' })
         .should('exist');
-    });
-
-    it('should render Gen AI route when feature flag is enabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          genAiStudio: true,
-        }),
-      );
       cy.visitWithLogin('/gen-ai-studio');
       pageNotfound.findPage().should('not.exist');
     });
 
-    it('should show Feature store section when feature flag and DSC component are enabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          disableFeatureStore: false,
-        }),
-      );
-      cy.interceptOdh(
-        'GET /api/dsc/status',
-        mockDscStatus({
-          components: {
-            [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
-          },
-        }),
+    it('should show Feature store section and render route when flag and DSC are enabled', () => {
+      initIntercepts(
+        { disableFeatureStore: false },
+        { [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' } },
       );
       navSidebar.visit();
       navSidebar
@@ -92,93 +54,32 @@ describe('Module federation visibility', () => {
           subSection: 'Feature store',
         })
         .should('exist');
-    });
-
-    it('should render Feature store route when feature flag and DSC component are enabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          disableFeatureStore: false,
-        }),
-      );
-      cy.interceptOdh(
-        'GET /api/dsc/status',
-        mockDscStatus({
-          components: {
-            [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
-          },
-        }),
-      );
       cy.visitWithLogin('/develop-train/feature-store');
       pageNotfound.findPage().should('not.exist');
     });
   });
 
   describe('Module absent — nav hidden and route shows not-found', () => {
-    it('should hide AutoML nav item when feature flag is disabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          automl: false,
-        }),
-      );
+    it('should hide AutoML nav and show 404 on route when flag is disabled', () => {
+      initIntercepts({ automl: false });
       navSidebar.visit();
       navSidebar
         .findNavItem({ name: 'AutoML', rootSection: 'Develop & train' })
         .should('not.exist');
-    });
-
-    it('should show 404 when navigating to AutoML route with flag disabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          automl: false,
-        }),
-      );
       cy.visitWithLogin('/develop-train/automl');
       pageNotfound.findPage().should('exist');
     });
 
-    it('should hide Gen AI studio section when feature flag is disabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          genAiStudio: false,
-        }),
-      );
+    it('should hide Gen AI studio section and show 404 on route when flag is disabled', () => {
+      initIntercepts({ genAiStudio: false });
       navSidebar.visit();
       navSidebar.findNavSection('Gen AI studio').should('not.exist');
-    });
-
-    it('should show 404 when navigating to Gen AI route with flag disabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          genAiStudio: false,
-        }),
-      );
       cy.visitWithLogin('/gen-ai-studio');
       pageNotfound.findPage().should('exist');
     });
 
-    it('should show 404 when navigating to Feature store route with flag disabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          disableFeatureStore: true,
-        }),
-      );
-      cy.visitWithLogin('/develop-train/feature-store');
-      pageNotfound.findPage().should('exist');
-    });
-
-    it('should hide Feature store section when feature flag is disabled', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          disableFeatureStore: true,
-        }),
-      );
+    it('should hide Feature store section and show 404 on route when flag is disabled', () => {
+      initIntercepts({ disableFeatureStore: true });
       navSidebar.visit();
       navSidebar
         .findNavItem({
@@ -187,19 +88,18 @@ describe('Module federation visibility', () => {
           subSection: 'Feature store',
         })
         .should('not.exist');
+      cy.visitWithLogin('/develop-train/feature-store');
+      pageNotfound.findPage().should('exist');
     });
   });
 
   describe('Mixed state — some modules present, others absent', () => {
     it('should show enabled modules and hide disabled ones simultaneously', () => {
-      cy.interceptOdh(
-        'GET /api/config',
-        mockDashboardConfig({
-          genAiStudio: true,
-          automl: false,
-          disableFeatureStore: true,
-        }),
-      );
+      initIntercepts({
+        genAiStudio: true,
+        automl: false,
+        disableFeatureStore: true,
+      });
       navSidebar.visit();
       navSidebar.findNavSection('Gen AI studio').should('exist');
       navSidebar

--- a/packages/cypress/cypress/tests/mocked/moduleFederation/moduleFederationVisibility.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/moduleFederation/moduleFederationVisibility.cy.ts
@@ -25,6 +25,25 @@ describe('Module federation visibility', () => {
       navSidebar.findNavItem({ name: 'AutoML', rootSection: 'Develop & train' }).should('exist');
     });
 
+    it('should render AutoML route when feature flag is enabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          automl: true,
+        }),
+      );
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
+          },
+        }),
+      );
+      cy.visitWithLogin('/develop-train/automl');
+      pageNotfound.findPage().should('not.exist');
+    });
+
     it('should show Gen AI studio section when feature flag is enabled', () => {
       cy.interceptOdh(
         'GET /api/config',
@@ -37,6 +56,17 @@ describe('Module federation visibility', () => {
       navSidebar
         .findNavItem({ name: 'AI asset endpoints', rootSection: 'Gen AI studio' })
         .should('exist');
+    });
+
+    it('should render Gen AI route when feature flag is enabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          genAiStudio: true,
+        }),
+      );
+      cy.visitWithLogin('/gen-ai-studio');
+      pageNotfound.findPage().should('not.exist');
     });
 
     it('should show Feature store section when feature flag and DSC component are enabled', () => {
@@ -62,6 +92,25 @@ describe('Module federation visibility', () => {
           subSection: 'Feature store',
         })
         .should('exist');
+    });
+
+    it('should render Feature store route when feature flag and DSC component are enabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          disableFeatureStore: false,
+        }),
+      );
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+          },
+        }),
+      );
+      cy.visitWithLogin('/develop-train/feature-store');
+      pageNotfound.findPage().should('not.exist');
     });
   });
 
@@ -109,6 +158,17 @@ describe('Module federation visibility', () => {
         }),
       );
       cy.visitWithLogin('/gen-ai-studio');
+      pageNotfound.findPage().should('exist');
+    });
+
+    it('should show 404 when navigating to Feature store route with flag disabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          disableFeatureStore: true,
+        }),
+      );
+      cy.visitWithLogin('/develop-train/feature-store');
       pageNotfound.findPage().should('exist');
     });
 

--- a/packages/cypress/cypress/tests/mocked/moduleFederation/moduleFederationVisibility.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/moduleFederation/moduleFederationVisibility.cy.ts
@@ -1,0 +1,157 @@
+import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { pageNotfound } from '../../../pages/pageNotFound';
+import { navSidebar } from '../navSidebar/navSidebar';
+
+describe('Module federation visibility', () => {
+  describe('Module present — nav and route accessible', () => {
+    it('should show AutoML nav item when feature flag and DSC component are enabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          automl: true,
+        }),
+      );
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
+          },
+        }),
+      );
+      navSidebar.visit();
+      navSidebar.findNavItem({ name: 'AutoML', rootSection: 'Develop & train' }).should('exist');
+    });
+
+    it('should show Gen AI studio section when feature flag is enabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          genAiStudio: true,
+        }),
+      );
+      navSidebar.visit();
+      navSidebar.findNavSection('Gen AI studio').should('exist');
+      navSidebar
+        .findNavItem({ name: 'AI asset endpoints', rootSection: 'Gen AI studio' })
+        .should('exist');
+    });
+
+    it('should show Feature store section when feature flag and DSC component are enabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          disableFeatureStore: false,
+        }),
+      );
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+          },
+        }),
+      );
+      navSidebar.visit();
+      navSidebar
+        .findNavItem({
+          name: 'Feature views',
+          rootSection: 'Develop & train',
+          subSection: 'Feature store',
+        })
+        .should('exist');
+    });
+  });
+
+  describe('Module absent — nav hidden and route shows not-found', () => {
+    it('should hide AutoML nav item when feature flag is disabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          automl: false,
+        }),
+      );
+      navSidebar.visit();
+      navSidebar
+        .findNavItem({ name: 'AutoML', rootSection: 'Develop & train' })
+        .should('not.exist');
+    });
+
+    it('should show 404 when navigating to AutoML route with flag disabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          automl: false,
+        }),
+      );
+      cy.visitWithLogin('/develop-train/automl');
+      pageNotfound.findPage().should('exist');
+    });
+
+    it('should hide Gen AI studio section when feature flag is disabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          genAiStudio: false,
+        }),
+      );
+      navSidebar.visit();
+      navSidebar.findNavSection('Gen AI studio').should('not.exist');
+    });
+
+    it('should show 404 when navigating to Gen AI route with flag disabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          genAiStudio: false,
+        }),
+      );
+      cy.visitWithLogin('/gen-ai-studio');
+      pageNotfound.findPage().should('exist');
+    });
+
+    it('should hide Feature store section when feature flag is disabled', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          disableFeatureStore: true,
+        }),
+      );
+      navSidebar.visit();
+      navSidebar
+        .findNavItem({
+          name: 'Feature views',
+          rootSection: 'Develop & train',
+          subSection: 'Feature store',
+        })
+        .should('not.exist');
+    });
+  });
+
+  describe('Mixed state — some modules present, others absent', () => {
+    it('should show enabled modules and hide disabled ones simultaneously', () => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          genAiStudio: true,
+          automl: false,
+          disableFeatureStore: true,
+        }),
+      );
+      navSidebar.visit();
+      navSidebar.findNavSection('Gen AI studio').should('exist');
+      navSidebar
+        .findNavItem({ name: 'AutoML', rootSection: 'Develop & train' })
+        .should('not.exist');
+      navSidebar
+        .findNavItem({
+          name: 'Feature views',
+          rootSection: 'Develop & train',
+          subSection: 'Feature store',
+        })
+        .should('not.exist');
+    });
+  });
+});


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-59932

## Description

Add Cypress mock tests validating that modules correctly appear or disappear from the UI based on their presence/absence in the federation ConfigMap.

The operator adds/removes module entries from the `federation-config` ConfigMap and triggers a pod restart. These tests verify the **end result**: modules present in the ConfigMap are visible (nav items shown, routes accessible), and modules absent are not (nav items hidden, routes return 404).

Tests exercise three representative modules that cover different extension patterns:

- **AutoML** — simple module: `app.area` + `app.navigation/href` + `app.route`, gated by `automl` feature flag + `DS_PIPELINES` DSC component
- **Gen AI** — section-based module: registers `app.navigation/section` ("Gen AI studio") with child nav items, gated by `genAiStudio` flag
- **Feature Store** — section-based module under "Develop & train", gated by `disableFeatureStore` flag + `FEAST_OPERATOR` DSC component

**Test scenarios:**

1. **Module present** — nav item visible when feature flag enabled (with DSC component mock where needed)
2. **Module absent** — nav item hidden when feature flag disabled, direct route navigation shows 404
3. **Mixed state** — Gen AI enabled while AutoML and Feature Store disabled simultaneously

## How Has This Been Tested?

- Lint passes: `npm run lint --workspace=packages/cypress` — 0 errors
- Pre-commit hook (lint-staged + eslint) passes on commit

## Test Impact

- Added `moduleFederationVisibility.cy.ts` in `packages/cypress/cypress/tests/mocked/moduleFederation/` — 8 tests covering module present, absent, and mixed-state scenarios via feature flag mocking with `mockDashboardConfig()` and `mockDscStatus()`
- No new page objects needed — reuses existing `navSidebar` and `pageNotfound` page objects
- No new mock functions needed — reuses `mockDashboardConfig`, `mockDscStatus` from `@odh-dashboard/internal/__mocks__`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage verifying that navigation items appear when corresponding modules are enabled.
  * Added coverage confirming disabled modules are hidden and their routes display a not-found page.
  * Added mixed-configuration checks to ensure enabled and disabled modules are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->