### PR TITLE
chore: remove stale hardware-profiles-shared entry from lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36443,29 +36443,6 @@
         "react-router-dom": "^7"
       }
     },
-    "packages/hardware-profiles-shared": {
-      "name": "@odh-dashboard/hardware-profiles-shared",
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "@odh-dashboard/internal": "*",
-        "@odh-dashboard/k8s-core": "*",
-        "@odh-dashboard/plugin-core": "*",
-        "@odh-dashboard/ui-core": "*",
-        "lodash-es": "^4.17.21",
-        "zod": "^3.25.76"
-      },
-      "devDependencies": {
-        "@odh-dashboard/eslint-config": "*",
-        "@odh-dashboard/tsconfig": "*"
-      },
-      "peerDependencies": {
-        "@openshift/dynamic-plugin-sdk-utils": "^5",
-        "@patternfly/react-core": "^6",
-        "@patternfly/react-icons": "^6",
-        "react": "^18"
-      }
-    },
     "packages/jest-config": {
       "name": "@odh-dashboard/jest-config",
       "version": "0.0.0",


### PR DESCRIPTION
## Summary
- Removes a stale `packages/hardware-profiles-shared` entry (marked `"extraneous": true`) from `package-lock.json`
- This directory was renamed to `packages/hardware-profiles/shared` but the old entry was accidentally committed to the lockfile via a subsequent dependency bump PR, causing `npm install` to produce a diff on every run

## Test plan
- [x] `npm install --package-lock-only` produces no further lockfile changes
- [x] Lockfile JSON is valid

Made with [Cursor](https://cursor.com)