### PR TITLE
RHOAIENG-79892: Move ModelServingNoProjects to model-serving and fix self-referencing imports

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
@@ -15,8 +15,6 @@ import type {
   PersistentVolumeClaimKind,
 } from '@odh-dashboard/k8s-core';
 import { z } from 'zod';
-// eslint-disable-next-line @odh-dashboard/no-restricted-imports
-import { ConnectionOciAlert } from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciAlert';
 import {
   getPVCNameFromURI,
   isPVCUri,
@@ -31,6 +29,7 @@ import { PvcSelectField } from './modelLocationFields/PVCSelectField';
 import { CustomTypeSelectField } from './modelLocationFields/CustomTypeSelectField';
 import { useEnabledModelServingConnectionTypes } from './modelLocationFields/useEnabledConnectionTypes';
 import { ociOption, s3Option, uriOption } from './modelLocationFields/modelLocationTypes';
+import { ConnectionOciAlert } from '../../connectionTypes/ConnectionOciAlert';
 import usePvcs from '../../../concepts/usePvcs';
 import { ModelLocationData, ModelLocationType } from '../../../shared/types/form-data';
 import { resolveConnectionType } from '../utils';

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/ExistingConnectionField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/ExistingConnectionField.tsx
@@ -13,8 +13,8 @@ import TypeaheadSelect, {
   TypeaheadSelectOption,
 } from '@odh-dashboard/ui-core/components/TypeaheadSelect';
 import { ConnectionDetailsHelperText } from '@odh-dashboard/internal/concepts/connectionTypes/ConnectionDetailsHelperText';
-import ConnectionS3FolderPathField from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField';
-import ConnectionOciPathField from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField';
+import ConnectionS3FolderPathField from '../../../connectionTypes/ConnectionS3FolderPathField';
+import ConnectionOciPathField from '../../../connectionTypes/ConnectionOciPathField';
 import {
   ConnectionTypeRefs,
   ModelLocationData,

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/NewConnectionField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/NewConnectionField.tsx
@@ -11,8 +11,8 @@ import type {
   ConnectionTypeValueType,
 } from '@odh-dashboard/k8s-core';
 import ConnectionTypeFormFields from '@odh-dashboard/internal/concepts/connectionTypes/fields/ConnectionTypeFormFields';
-import ConnectionOciPathField from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField';
-import ConnectionS3FolderPathField from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField';
+import ConnectionOciPathField from '../../../connectionTypes/ConnectionOciPathField';
+import ConnectionS3FolderPathField from '../../../connectionTypes/ConnectionS3FolderPathField';
 import { ModelLocationData } from '../../../../shared/types/form-data';
 import { CreateConnectionInputFields } from '../CreateConnectionInputFields';
 import { UseModelDeploymentWizardState } from '../../useDeploymentWizard';

--- a/packages/model-serving/src/components/global/GlobalModelServingCoreLoader.tsx
+++ b/packages/model-serving/src/components/global/GlobalModelServingCoreLoader.tsx
@@ -5,8 +5,8 @@ import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext'
 import { ApplicationsPage } from '@odh-dashboard/ui-core';
 import InvalidProject from '@odh-dashboard/internal/concepts/projects/InvalidProject';
 import ModelServingContextProvider from '@odh-dashboard/internal/pages/modelServing/ModelServingContext';
-import ModelServingNoProjects from '@odh-dashboard/internal/pages/modelServing/screens/global/ModelServingNoProjects';
 import { getStoredPreferredProject } from '@odh-dashboard/internal/concepts/projects/getStoredPreferredProject';
+import ModelServingNoProjects from './ModelServingNoProjects';
 import ModelServingProjectSelection from './ModelServingProjectSelection';
 
 type ApplicationPageProps = React.ComponentProps<typeof ApplicationsPage>;

--- a/packages/model-serving/src/components/global/ModelServingNoProjects.tsx
+++ b/packages/model-serving/src/components/global/ModelServingNoProjects.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { EmptyState, EmptyStateBody, EmptyStateFooter } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
 import { useNavigate } from 'react-router-dom';
-import NewProjectButton from '#~/pages/projects/screens/projects/NewProjectButton';
+import NewProjectButton from '@odh-dashboard/internal/pages/projects/screens/projects/NewProjectButton';
 
 const ModelServingNoProjects: React.FC = () => {
   const navigate = useNavigate();


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79892

## Description

Two cleanup changes for model-serving package ownership:

1. **Move `ModelServingNoProjects`** from `frontend/src/pages/modelServing/screens/global/` to `packages/model-serving/src/components/global/`. This component is model-serving-owned and was incorrectly placed in frontend. The `#~/` alias is replaced with `@odh-dashboard/internal/` since the file is no longer in `frontend/`. `NewProjectButton` remains imported from `@odh-dashboard/internal` — it's a projects-domain component that will be bridged via host-api in [RHOAIENG-79896](https://issues.redhat.com/browse/RHOAIENG-79896).

2. **Fix self-referencing imports** in 3 model-serving files. `ConnectionS3FolderPathField`, `ConnectionOciPathField`, and `ConnectionOciAlert` already live in model-serving under `src/components/connectionTypes/` — the imports were round-tripping through `@odh-dashboard/internal` re-exports instead of using relative paths.

Files changed:
- `ModelLocationInputFields.tsx` — `ConnectionOciAlert` → relative import, removed `eslint-disable` comment
- `ExistingConnectionField.tsx` — `ConnectionS3FolderPathField`, `ConnectionOciPathField` → relative imports
- `NewConnectionField.tsx` — `ConnectionOciPathField`, `ConnectionS3FolderPathField` → relative imports
- `GlobalModelServingCoreLoader.tsx` — `ModelServingNoProjects` → relative import after move

## How Has This Been Tested?

- `npm run type-check` passes (model-serving and all dependent packages)
- `npm run lint --filter=@odh-dashboard/model-serving` passes with 0 errors (22 pre-existing warnings unchanged)

## Test Impact

No new tests added. These are purely structural changes (a file move and import path corrections) — the components themselves are unchanged. Type-checking and the build verify that all imports resolve correctly.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-79896]: https://redhat.atlassian.net/browse/RHOAIENG-79896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal component references across model serving deployment and project views.
  * Standardized module imports without changing user-facing behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->