### PR TITLE
RHOAIENG-79879: Move PerformanceMetricType enum from frontend to model-serving shared types

### DIFF
--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -3,9 +3,9 @@ import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/ar
 import { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { RefreshIntervalTitle, TimeframeTitle } from '@odh-dashboard/ui-core/types/metrics';
 import { RefreshIntervalValue } from '@odh-dashboard/ui-core/utilities/metrics';
+import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import { PrometheusQueryRangeResponseDataResult, PrometheusQueryRangeResultValue } from '#~/types';
 import { ModelMetricType } from '#~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
-import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import useRefreshInterval from '#~/utilities/useRefreshInterval';
 import { PROMETHEUS_BIAS_PATH } from '#~/api/prometheus/const';
 import useQueryRangeResourceData from './useQueryRangeResourceData';

--- a/frontend/src/api/prometheus/serving.ts
+++ b/frontend/src/api/prometheus/serving.ts
@@ -5,7 +5,7 @@ import { RefreshIntervalTitle, TimeframeTitle } from '@odh-dashboard/ui-core/typ
 import { RefreshIntervalValue } from '@odh-dashboard/ui-core/utilities/metrics';
 import { PrometheusQueryRangeResponseDataResult, PrometheusQueryRangeResultValue } from '#~/types';
 import { ModelMetricType } from '#~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
-import { PerformanceMetricType } from '#~/pages/modelServing/screens/types';
+import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import useRefreshInterval from '#~/utilities/useRefreshInterval';
 import { PROMETHEUS_BIAS_PATH } from '#~/api/prometheus/const';
 import useQueryRangeResourceData from './useQueryRangeResourceData';

--- a/frontend/src/pages/modelServing/screens/projects/ProjectModelMetricsWrapper.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ProjectModelMetricsWrapper.tsx
@@ -5,7 +5,7 @@ import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
 import { MetricsCommonContextProvider } from '#~/concepts/metrics/MetricsCommonContext';
 import { ModelServingMetricsProvider } from '#~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
 import { getModelMetricsQueries } from '#~/pages/modelServing/screens/metrics/utils';
-import { PerformanceMetricType } from '#~/pages/modelServing/screens/types';
+import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import ProjectModelMetricsPathWrapper from './ProjectModelMetricsPathWrapper';
 
 export type ProjectModelMetricsOutletContextProps = {

--- a/frontend/src/pages/modelServing/screens/projects/ProjectModelMetricsWrapper.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ProjectModelMetricsWrapper.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { Outlet } from 'react-router-dom';
 import type { ProjectKind } from '@odh-dashboard/k8s-core';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import { MetricsCommonContextProvider } from '#~/concepts/metrics/MetricsCommonContext';
 import { ModelServingMetricsProvider } from '#~/pages/modelServing/screens/metrics/ModelServingMetricsContext';
 import { getModelMetricsQueries } from '#~/pages/modelServing/screens/metrics/utils';
-import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import ProjectModelMetricsPathWrapper from './ProjectModelMetricsPathWrapper';
 
 export type ProjectModelMetricsOutletContextProps = {

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -9,11 +9,6 @@ import type {
 } from '@odh-dashboard/model-serving/shared';
 import { EnvVariableDataEntry } from '#~/pages/projects/types';
 
-export enum PerformanceMetricType {
-  SERVER = 'server',
-  MODEL = 'model',
-}
-
 export enum MetricType {
   SERVER = 'server',
   MODEL = 'model',

--- a/packages/model-serving/src/components/metrics/GlobalModelMetricsWrapper.tsx
+++ b/packages/model-serving/src/components/metrics/GlobalModelMetricsWrapper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Outlet } from 'react-router-dom';
-import { PerformanceMetricType } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import { MetricsCommonContextProvider } from '@odh-dashboard/internal/concepts/metrics/MetricsCommonContext';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
 import ModelMetricsPathWrapper from './ModelMetricsPathWrapper';

--- a/packages/model-serving/src/components/metrics/GlobalModelMetricsWrapper.tsx
+++ b/packages/model-serving/src/components/metrics/GlobalModelMetricsWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Outlet } from 'react-router-dom';
-import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import { MetricsCommonContextProvider } from '@odh-dashboard/internal/concepts/metrics/MetricsCommonContext';
+import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
 import ModelMetricsPathWrapper from './ModelMetricsPathWrapper';
 import { ModelServingMetricsProvider } from './ModelServingMetricsContext';

--- a/packages/model-serving/src/components/metrics/ModelServingMetricsContext.tsx
+++ b/packages/model-serving/src/components/metrics/ModelServingMetricsContext.tsx
@@ -6,8 +6,8 @@ import {
   PrometheusQueryRangeResultValue,
 } from '@odh-dashboard/internal/types';
 import { DEFAULT_LIST_FETCH_STATE } from '@odh-dashboard/ui-core/utilities/fetchState';
-import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import { MetricsCommonContext } from '@odh-dashboard/internal/concepts/metrics/MetricsCommonContext';
+import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 
 export enum ModelMetricType {
   REQUEST_COUNT_SUCCESS = 'inference_request-count-successes',

--- a/packages/model-serving/src/components/metrics/ModelServingMetricsContext.tsx
+++ b/packages/model-serving/src/components/metrics/ModelServingMetricsContext.tsx
@@ -6,7 +6,7 @@ import {
   PrometheusQueryRangeResultValue,
 } from '@odh-dashboard/internal/types';
 import { DEFAULT_LIST_FETCH_STATE } from '@odh-dashboard/ui-core/utilities/fetchState';
-import { PerformanceMetricType } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { PerformanceMetricType } from '@odh-dashboard/model-serving/shared/types';
 import { MetricsCommonContext } from '@odh-dashboard/internal/concepts/metrics/MetricsCommonContext';
 
 export enum ModelMetricType {

--- a/packages/model-serving/src/shared/index.ts
+++ b/packages/model-serving/src/shared/index.ts
@@ -4,6 +4,7 @@ export {
   ServingRuntimePlatform,
   ServingRuntimeAPIProtocol,
   ServingRuntimeModelType,
+  PerformanceMetricType,
   isInferenceServiceKind,
 } from './types';
 export type {

--- a/packages/model-serving/src/shared/types.ts
+++ b/packages/model-serving/src/shared/types.ts
@@ -235,3 +235,8 @@ export enum ServingRuntimeModelType {
   PREDICTIVE = 'predictive',
   GENERATIVE = 'generative',
 }
+
+export enum PerformanceMetricType {
+  SERVER = 'server',
+  MODEL = 'model',
+}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79879

## Description
Moves the `PerformanceMetricType` enum (`SERVER`, `MODEL`) from `frontend/src/pages/modelServing/screens/types.ts` into `packages/model-serving/src/shared/types.ts` as a subpath export.

  This is a model-serving domain concept used by metrics components. Two model-serving package files were importing it via `@odh-dashboard/internal`, which is a cross-package boundary violation. Moving it to `@odh-dashboard/model-serving/shared/types` aligns ownership with the domain package.

  | Category | Items |
  |----------|-------|
  | Enum | `PerformanceMetricType` (`SERVER`, `MODEL`) |

  **Updated consumers:**

  | File | Old import | New import |
  |------|-----------|------------|
  | `packages/model-serving/.../ModelServingMetricsContext.tsx` | `@odh-dashboard/internal/pages/modelServing/screens/types` | `@odh-dashboard/model-serving/shared/types` |
  | `packages/model-serving/.../GlobalModelMetricsWrapper.tsx` | `@odh-dashboard/internal/pages/modelServing/screens/types` | `@odh-dashboard/model-serving/shared/types` |
  | `frontend/.../ProjectModelMetricsWrapper.tsx` | `#~/pages/modelServing/screens/types` | `@odh-dashboard/model-serving/shared/types` |
  | `frontend/src/api/prometheus/serving.ts` | `#~/pages/modelServing/screens/types` | `@odh-dashboard/model-serving/shared/types` |

  No new dependency edges added — `frontend` and model-serving family packages already depend on `@odh-dashboard/model-serving`.

  ## How Has This Been Tested?

  - `npm run build` — passes
  - `npm run lint` — passes
  - `npm run type-check` — passes across all affected packages
  - `npm run test` — unit tests pass

  ## Test Impact

  No new tests added. This is a pure move/re-export refactor — existing unit tests continue covering all moved items. Import paths updated but behavior unchanged.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized model-serving performance metric types in a shared module.
  * Updated model metrics components to use the shared metric definitions consistently.
  * Preserved existing metric behavior and display logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->