### PR TITLE
wip - test(cypress): add platform-aware fixture overlay system for multi-arch E2E testing

### DIFF
--- a/packages/cypress/cypress.config.ts
+++ b/packages/cypress/cypress.config.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 
+import YAML from 'yaml';
 // @ts-expect-error: Types are not available for this third-party library
 import registerCypressGrep from '@cypress/grep/src/plugin';
 import { defineConfig } from 'cypress';
@@ -143,6 +144,13 @@ export default defineConfig({
           } catch (error) {
             return Promise.resolve(null);
           }
+        },
+        loadYamlOverlay(fixturePath: string) {
+          const absPath = path.resolve(__dirname, 'cypress/fixtures', fixturePath);
+          if (fs.existsSync(absPath)) {
+            return Promise.resolve(YAML.parse(fs.readFileSync(absPath, 'utf8')));
+          }
+          return Promise.resolve(null);
         },
       });
 

--- a/packages/cypress/cypress/fixtures/e2e/dataScienceProjects/testWorkbenchStorageClasses.s390x.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/dataScienceProjects/testWorkbenchStorageClasses.s390x.yaml
@@ -1,0 +1,3 @@
+# s390x platform overlay — storage provisioner overrides
+dualAccessProvisioner: "nfs.csi.k8s.io"
+multiAccessProvisioner: "nfs.csi.k8s.io"

--- a/packages/cypress/cypress/fixtures/e2e/modelRegistry/testModelRegistry.s390x.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/modelRegistry/testModelRegistry.s390x.yaml
@@ -1,0 +1,3 @@
+# s390x platform overlay — only fields that differ from base fixture
+servingRuntime: "vLLM ServingRuntime for KServe"
+modelOpenVinoPath: "kserve-vllm-test/vllm-example-model"

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts
@@ -55,6 +55,11 @@ describe('Workbench Storage Classes Tests', () => {
   let mountPathB: string;
   let mountPathC: string;
 
+  // Optional platform-specific provisioners (type derived from the helper function signatures)
+  type Provisioner = Parameters<typeof provisionDualAccessStorageClass>[1];
+  let dualAccessProvisioner: Provisioner;
+  let multiAccessProvisioner: Provisioner;
+
   const rwoLabel = AccessMode.RWO;
   const rwxLabel = AccessMode.RWX;
   const roxLabel = AccessMode.ROX;
@@ -81,11 +86,13 @@ describe('Workbench Storage Classes Tests', () => {
         mountPathB = fixtureData.mountPathB;
         mountPathC = fixtureData.mountPathC;
         notebookImage = fixtureData.notebookImage;
+        dualAccessProvisioner = fixtureData.dualAccessProvisioner as Provisioner;
+        multiAccessProvisioner = fixtureData.multiAccessProvisioner as Provisioner;
       })
       .then(() => {
         cy.step('Provisioning storage class');
-        provisionDualAccessStorageClass(storageClassRWO);
-        provisionMultiAccessStorageClass(storageClassMultiAccess);
+        provisionDualAccessStorageClass(storageClassRWO, dualAccessProvisioner);
+        provisionMultiAccessStorageClass(storageClassMultiAccess, multiAccessProvisioner);
         // Only add if not already in the array (prevent duplicates on retry)
         if (!createdStorageClasses.includes(storageClassRWO)) {
           createdStorageClasses.push(storageClassRWO);

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -210,6 +210,8 @@ export type WBStorageClassesTestData = {
   mountPathA: string;
   mountPathB: string;
   mountPathC: string;
+  dualAccessProvisioner?: string;
+  multiAccessProvisioner?: string;
 };
 
 export type ClusterStorageAccessModesTestData = {

--- a/packages/cypress/cypress/utils/dataLoader.ts
+++ b/packages/cypress/cypress/utils/dataLoader.ts
@@ -27,54 +27,82 @@ import type {
   ModelAsAServiceTestData,
 } from '../types';
 
+/**
+ * Merge a platform-specific fixture overlay onto base fixture data.
+ *
+ * When CY_PLATFORM is set (e.g., "s390x"), looks for a sibling file named
+ * `<fixture>.<platform>.yaml` and shallow-merges its fields over the base.
+ * If no overlay file exists or CY_PLATFORM is unset, returns base data unchanged.
+ */
+const mergePlatformOverlay = <T extends Record<string, unknown>>(
+  fixturePath: string,
+  baseData: T,
+): Cypress.Chainable<T> => {
+  const platform = Cypress.env('CY_PLATFORM') as string | undefined;
+  if (!platform) {
+    return cy.wrap(baseData, { log: false });
+  }
+
+  const dotIndex = fixturePath.lastIndexOf('.');
+  const overlayPath =
+    dotIndex >= 0
+      ? `${fixturePath.slice(0, dotIndex)}.${platform}${fixturePath.slice(dotIndex)}`
+      : `${fixturePath}.${platform}`;
+
+  return cy
+    .task<Partial<T> | null>('loadYamlOverlay', overlayPath, { log: false })
+    .then((overlayData) => {
+      if (overlayData) {
+        cy.log(`Loaded platform overlay: ${overlayPath}`);
+        return { ...baseData, ...overlayData } as T;
+      }
+      return baseData;
+    });
+};
+
 // Load fixture function that returns DataScienceProjectData
 export const loadDSPFixture = (fixturePath: string): Cypress.Chainable<DataScienceProjectData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as DataScienceProjectData;
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 // Load fixture function that returns ResourcesData
 export const loadResourcesFixture = (fixturePath: string): Cypress.Chainable<ResourcesData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ResourcesData;
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadPVCFixture = (fixturePath: string): Cypress.Chainable<PVCReplacements> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as PVCReplacements;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 export const loadPVCEditFixture = (fixturePath: string): Cypress.Chainable<WBEditTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WBEditTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 export const loadWBControlSuiteFixture = (
   fixturePath: string,
 ): Cypress.Chainable<WBControlSuiteTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WBControlSuiteTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 export const loadWBVariablesFixture = (
   fixturePath: string,
 ): Cypress.Chainable<WBVariablesTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WBVariablesTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadWBStatusFixture = (fixturePath: string): Cypress.Chainable<WBStatusTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WBStatusTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadWBStorageClassesFixture = (
@@ -82,8 +110,7 @@ export const loadWBStorageClassesFixture = (
 ): Cypress.Chainable<WBStorageClassesTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WBStorageClassesTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadClusterStorageAccessModesFixture = (
@@ -91,8 +118,7 @@ export const loadClusterStorageAccessModesFixture = (
 ): Cypress.Chainable<ClusterStorageAccessModesTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ClusterStorageAccessModesTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadOOTBConnectionTypesFixture = (
@@ -100,8 +126,7 @@ export const loadOOTBConnectionTypesFixture = (
 ): Cypress.Chainable<OOTBConnectionTypesData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as OOTBConnectionTypesData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadWBTolerationsFixture = (
@@ -109,8 +134,7 @@ export const loadWBTolerationsFixture = (
 ): Cypress.Chainable<WBTolerationsTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WBTolerationsTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadModifyHardwareProfileFixture = (
@@ -118,15 +142,13 @@ export const loadModifyHardwareProfileFixture = (
 ): Cypress.Chainable<ModifyHardwareProfileTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ModifyHardwareProfileTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadWBImagesFixture = (fixturePath: string): Cypress.Chainable<WBImagesTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WBImagesTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadDeployOCIModelFixture = (
@@ -134,8 +156,7 @@ export const loadDeployOCIModelFixture = (
 ): Cypress.Chainable<DeployOCIModelData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as DeployOCIModelData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadModelTolerationsFixture = (
@@ -143,8 +164,7 @@ export const loadModelTolerationsFixture = (
 ): Cypress.Chainable<ModelTolerationsTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ModelTolerationsTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadManagePermissionsFixture = (
@@ -152,8 +172,7 @@ export const loadManagePermissionsFixture = (
 ): Cypress.Chainable<ManageRegistryPermissionsTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ManageRegistryPermissionsTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadModelRegistryFixture = (
@@ -161,15 +180,13 @@ export const loadModelRegistryFixture = (
 ): Cypress.Chainable<ModelRegistryTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ModelRegistryTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadPipelineFixture = (fixturePath: string): Cypress.Chainable<PipelineTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as PipelineTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadResourcesFiltersFixture = (
@@ -177,8 +194,7 @@ export const loadResourcesFiltersFixture = (
 ): Cypress.Chainable<ResourcesFiltersTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ResourcesFiltersTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadWorkloadMetricsFixture = (
@@ -186,8 +202,7 @@ export const loadWorkloadMetricsFixture = (
 ): Cypress.Chainable<WorkloadMetricsTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as WorkloadMetricsTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadKueueWorkbenchFixture = (
@@ -195,8 +210,7 @@ export const loadKueueWorkbenchFixture = (
 ): Cypress.Chainable<KueueWorkbenchTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as KueueWorkbenchTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadKueueWorkbenchLifecycleFixture = (
@@ -204,8 +218,7 @@ export const loadKueueWorkbenchLifecycleFixture = (
 ): Cypress.Chainable<KueueWorkbenchLifecycleTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as KueueWorkbenchLifecycleTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadPromptManagementFixture = (
@@ -213,8 +226,7 @@ export const loadPromptManagementFixture = (
 ): Cypress.Chainable<PromptManagementTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as PromptManagementTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadMlflowExperimentsFixture = (
@@ -222,13 +234,11 @@ export const loadMlflowExperimentsFixture = (
 ): Cypress.Chainable<MlflowExperimentsTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as MlflowExperimentsTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });
 
 export const loadMaaSFixture = (fixturePath: string): Cypress.Chainable<ModelAsAServiceTestData> =>
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ModelAsAServiceTestData;
-
-    return data;
+    return mergePlatformOverlay(fixturePath, data);
   });

--- a/packages/cypress/cypress/utils/oc_commands/baseCommands.ts
+++ b/packages/cypress/cypress/utils/oc_commands/baseCommands.ts
@@ -404,3 +404,21 @@ export const waitForNamespace = (
     maxAttempts,
     pollIntervalMs,
   });
+
+/**
+ * Detect the cluster CPU architecture by querying node info.
+ * Returns 's390x', 'ppc64le', 'aarch64', or 'x86_64'.
+ */
+export const getClusterArchitecture = (): Cypress.Chainable<string> =>
+  cy
+    .exec("oc get nodes -o jsonpath='{.items[*].status.nodeInfo.architecture}'", {
+      failOnNonZeroExit: false,
+    })
+    .then((result) => {
+      const archOutput = result.stdout.trim().replace(/^'|'$/g, '');
+      const architectures = archOutput.split(/\s+/);
+      const arch =
+        architectures.find((a) => a === 's390x' || a === 'ppc64le' || a === 'aarch64') || 'x86_64';
+      cy.log(`Detected cluster architecture: ${arch}`);
+      return cy.wrap(arch);
+    });

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -16,6 +16,8 @@
     "run:mock": "cross-env CY_MOCK=1 CY_WS_PORT=9002 cypress run -b chrome",
     "run:mock:coverage": "rimraf coverage .nyc_output && cross-env CY_COVERAGE=true npm run run:mock",
     "run:e2e": "cypress run --env grepTags=\"${CY_TEST_TAGS}\",skipTags=\"${CY_SKIP_TAGS}\" -b chrome",
+    "run:e2e:s390x": "cross-env CY_PLATFORM=s390x cypress run --env grepTags=\"${CY_TEST_TAGS}\",skipTags=\"${CY_SKIP_TAGS}\" -b chrome",
+    "run:e2e:ppc64le": "cross-env CY_PLATFORM=ppc64le cypress run --env grepTags=\"${CY_TEST_TAGS}\",skipTags=\"${CY_SKIP_TAGS}\" -b chrome",
     "run:e2e:dashboard": "cypress run --env grepTags=@Dashboard+-@Bug -b chrome",
     "run:electron": "cypress run -b electron",
     "cypress:server:e2e": "tsx src/e2e-proxy/index.ts",


### PR DESCRIPTION
## Description

Adds a fixture overlay system so external QE teams (s390x, ppc64le, disconnected clusters, etc.) can run Cypress E2E tests on non-x86 platforms **without modifying any shared fixture data or test logic**.

### How it works

```
CY_PLATFORM=s390x  (set by Jenkins or manually)
         │
         ▼
  Fixture loader checks for:
    1. testModelRegistry.s390x.yaml   ← platform overlay (only differing fields)
    2. testModelRegistry.yaml          ← base fixture (unchanged, x86 defaults)
         │
         ▼
  Shallow-merge overlay onto base → final test data
```

- **No overlay file = base fixture used as-is.** Zero impact on existing x86 test runs.
- `CY_PLATFORM` is a free-form string — not limited to CPU architectures. Supports `s390x`, `ppc64le`, `disconnected`, `aws`, `gcp`, or any future environment.
- Overlay files are per-test — `testModelRegistry.s390x.yaml` only affects model registry tests. Other tests are completely unaffected unless they also have an overlay.
- **No existing base fixture files are modified.** Every existing `.yaml` fixture stays exactly as-is.
- **No test files need changes** to opt in — the merging happens transparently inside the shared loader functions in `dataLoader.ts`.

### Changes

- **`cypress.config.ts`** — Added `loadYamlOverlay` Cypress task (Node.js-side `fs.existsSync` check; `cy.fixture()` fails on missing files, this returns `null` gracefully)
- **`dataLoader.ts`** — Added `mergePlatformOverlay<T>` generic helper; updated all loader functions to pipe through it
- **`types.ts`** — Added optional `dualAccessProvisioner?` and `multiAccessProvisioner?` fields to `WBStorageClassesTestData`
- **`testWorkbenchStorageClasses.cy.ts`** — Passes optional provisioner from fixture data to `provisionDualAccessStorageClass`/`provisionMultiAccessStorageClass` (both already accept an optional provisioner param)
- **`baseCommands.ts`** — Added `getClusterArchitecture()` utility for runtime arch detection
- **`package.json`** — Added `run:e2e:s390x` and `run:e2e:ppc64le` npm convenience scripts

### Example overlay files (included)

**`testModelRegistry.s390x.yaml`** — overrides serving runtime and model path for s390x:
```yaml
servingRuntime: "vLLM ServingRuntime for KServe"
modelOpenVinoPath: "kserve-vllm-test/vllm-example-model"
```

**`testWorkbenchStorageClasses.s390x.yaml`** — overrides storage provisioner for s390x:
```yaml
dualAccessProvisioner: "nfs.csi.k8s.io"
multiAccessProvisioner: "nfs.csi.k8s.io"
```

### Running tests per platform

**npm scripts** (for teams not using Jenkins):
```bash
npm run run:e2e:s390x
npm run run:e2e:ppc64le
```

Or prefix any existing command:
```bash
CY_PLATFORM=s390x npx cypress run --spec 'cypress/tests/e2e/modelRegistry/*.cy.ts'
CY_PLATFORM=s390x npx cypress open
```

### Jenkins integration

The Jenkins pipeline needs one change: pass `CY_PLATFORM` as an env var for non-x86 jobs. Example Jenkinsfile snippet:

```groovy
environment {
    CY_PLATFORM = "${params.ARCHITECTURE == 'x86_64' ? '' : params.ARCHITECTURE}"
}
```

This is a pipeline-side change, not in this repo.

### Adding support for a new platform

1. Create `<testName>.<platform>.yaml` overlay files alongside the base fixtures, containing only the fields that differ
2. Set `CY_PLATFORM=<platform>` when running tests
3. No other code changes needed

## How Has This Been Tested?

- Lint: `npm run lint` passes (0 errors)
- Type check: `tsc --noEmit` passes clean
- Pre-commit hooks pass (lint-staged with `--max-warnings 0`)
- Verified that without `CY_PLATFORM` set, all loader functions return base data unchanged (backward compatible)

## Test Impact

- No new Cypress tests added — this is test infrastructure, not a test case
- All existing tests continue to work unchanged when `CY_PLATFORM` is not set
- The overlay system is exercised when `CY_PLATFORM` is set and matching overlay files exist

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`