### PR TITLE
RHOAIENG-79644: Right-size standalone deployment resources and add PDB

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -115,6 +115,19 @@ rules:
       - update
       - patch
       - delete
+  # PodDisruptionBudgets for core dashboard availability
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   # Networking
   - apiGroups:
       - networking.k8s.io

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -99,6 +99,19 @@ rules:
       - update
       - patch
       - delete
+  # PodDisruptionBudgets for core dashboard availability
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   # Networking
   - apiGroups:
       - networking.k8s.io

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -942,5 +943,6 @@ func SetupWithManager(mgr ctrl.Manager, opts Options) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Complete(r)
 }

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - kube-rbac-proxy-config.yaml
   - service.yaml
   - service-account.yaml
+  - pdb.yaml

--- a/manifests/base/pdb.yaml
+++ b/manifests/base/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: odh-dashboard
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      deployment: odh-dashboard

--- a/manifests/modules/agent-ops/deployment.yaml
+++ b/manifests/modules/agent-ops/deployment.yaml
@@ -106,6 +106,7 @@ spec:
               memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
+              cpu: 100m
               memory: 192Mi
               ephemeral-storage: 10Mi
           ports:

--- a/manifests/modules/agent-ops/deployment.yaml
+++ b/manifests/modules/agent-ops/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: agent-ops-ui
@@ -102,11 +102,11 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8843

--- a/manifests/modules/automl/deployment.yaml
+++ b/manifests/modules/automl/deployment.yaml
@@ -106,6 +106,7 @@ spec:
               memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
+              cpu: 100m
               memory: 192Mi
               ephemeral-storage: 10Mi
           ports:

--- a/manifests/modules/automl/deployment.yaml
+++ b/manifests/modules/automl/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: automl-ui
@@ -102,11 +102,11 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8643

--- a/manifests/modules/autorag/deployment.yaml
+++ b/manifests/modules/autorag/deployment.yaml
@@ -106,6 +106,7 @@ spec:
               memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
+              cpu: 100m
               memory: 192Mi
               ephemeral-storage: 10Mi
           ports:

--- a/manifests/modules/autorag/deployment.yaml
+++ b/manifests/modules/autorag/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: autorag-ui
@@ -102,11 +102,11 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8743

--- a/manifests/modules/eval-hub/deployment.yaml
+++ b/manifests/modules/eval-hub/deployment.yaml
@@ -106,6 +106,7 @@ spec:
               memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
+              cpu: 100m
               memory: 192Mi
               ephemeral-storage: 10Mi
           ports:

--- a/manifests/modules/eval-hub/deployment.yaml
+++ b/manifests/modules/eval-hub/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: eval-hub-ui
@@ -102,11 +102,11 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8543

--- a/manifests/modules/gen-ai/deployment.yaml
+++ b/manifests/modules/gen-ai/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: gen-ai-ui
@@ -102,11 +102,11 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8143

--- a/manifests/modules/gen-ai/deployment.yaml
+++ b/manifests/modules/gen-ai/deployment.yaml
@@ -106,6 +106,7 @@ spec:
               memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
+              cpu: 100m
               memory: 192Mi
               ephemeral-storage: 10Mi
           ports:

--- a/manifests/modules/maas/deployment.yaml
+++ b/manifests/modules/maas/deployment.yaml
@@ -106,6 +106,7 @@ spec:
               memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
+              cpu: 100m
               memory: 192Mi
               ephemeral-storage: 10Mi
           ports:

--- a/manifests/modules/maas/deployment.yaml
+++ b/manifests/modules/maas/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: maas-ui
@@ -102,11 +102,11 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8243

--- a/manifests/modules/mlflow/deployment.yaml
+++ b/manifests/modules/mlflow/deployment.yaml
@@ -106,6 +106,7 @@ spec:
               memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
+              cpu: 100m
               memory: 192Mi
               ephemeral-storage: 10Mi
           ports:

--- a/manifests/modules/mlflow/deployment.yaml
+++ b/manifests/modules/mlflow/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: mlflow-ui
@@ -102,11 +102,11 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8343

--- a/manifests/modules/model-registry/deployment.yaml
+++ b/manifests/modules/model-registry/deployment.yaml
@@ -106,6 +106,7 @@ spec:
               memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
+              cpu: 100m
               memory: 192Mi
               ephemeral-storage: 10Mi
           ports:

--- a/manifests/modules/model-registry/deployment.yaml
+++ b/manifests/modules/model-registry/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: odh-dashboard
     components.platform.opendatahub.io/managed-by: opendatahub-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: model-registry-ui
@@ -102,11 +102,11 @@ spec:
             failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
               ephemeral-storage: 10Mi
             limits:
-              memory: 256Mi
+              memory: 192Mi
               ephemeral-storage: 10Mi
           ports:
             - containerPort: 8043

--- a/manifests/rhoai/base/kustomization.yaml
+++ b/manifests/rhoai/base/kustomization.yaml
@@ -73,5 +73,11 @@ patchesJson6902:
       version: v1
       kind: ClusterRoleBinding
       name: odh-dashboard-modules
+  - path: pdb.yaml
+    target:
+      group: policy
+      version: v1
+      kind: PodDisruptionBudget
+      name: odh-dashboard
 patchesStrategicMerge:
   - federation-configmap.yaml

--- a/manifests/rhoai/base/pdb.yaml
+++ b/manifests/rhoai/base/pdb.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/name
+  value: rhods-dashboard
+- op: replace
+  path: /spec/selector/matchLabels/deployment
+  value: rhods-dashboard

--- a/manifests/rhoai/standalone/kustomization.yaml
+++ b/manifests/rhoai/standalone/kustomization.yaml
@@ -82,6 +82,12 @@ patchesJson6902:
       name: odh-dashboard
   # NetworkPolicy only exists in manifests/sidecar/ — not present in ../../base.
   # No NetworkPolicy patch needed in standalone mode.
+  - path: pdb.yaml
+    target:
+      group: policy
+      version: v1
+      kind: PodDisruptionBudget
+      name: odh-dashboard
 replacements:
   - source:
       kind: ConfigMap

--- a/manifests/rhoai/standalone/pdb.yaml
+++ b/manifests/rhoai/standalone/pdb.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/name
+  value: rhods-dashboard
+- op: replace
+  path: /spec/selector/matchLabels/deployment
+  value: rhods-dashboard


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79644

## Description

Right-sizes the standalone deployment for production-scale load (100 concurrent users) and adds availability guarantees via PodDisruptionBudget.

### Module pods (all 8 modules)
| Resource | Before | After | Rationale |
|----------|--------|-------|-----------|
| Replicas | 2 | 1 | Go handles 100 connections on one goroutine-based process; only a subset of users hits any given module |
| CPU request | 50m | 10m | Actual usage ~1m idle, ~20m under 100-user load |
| Memory request | 128Mi | 64Mi | Actual usage 14-26Mi; 64Mi gives headroom |
| Memory limit | 256Mi | 192Mi | Safety margin for GC pressure spikes |

### Core dashboard (3-container pod, 2 replicas)
No resource changes — current sizing (100m/512Mi per replica) is appropriate for the Fastify proxy workload with full-body response buffering, 500-1500 WS pairs, and per-request auth.

### PodDisruptionBudget
- Core dashboard: `minAvailable: 1` — ensures at least one pod survives during node drains and cluster upgrades
- Module pods: No PDB (single replica; PDB with minAvailable: 1 blocks node drains)
- RHOAI overlay patches included to rename PDB to `rhods-dashboard`

### Operator
- Added `Owns(&policyv1.PodDisruptionBudget{})` to `SetupWithManager` so external PDB modifications/deletions trigger re-reconciliation

### Net impact (8 modules enabled)
| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Pods | 18 | 10 | 44% |
| CPU requests | 1.3 cores | 580m | 55% |
| Memory requests | ~3.5 GiB | ~2.0 GiB | 43% |

## How Has This Been Tested?

1. **Kustomize rendering** — verified PDB renders correctly across all 4 overlays (ODH sidecar, ODH standalone, RHOAI sidecar, RHOAI standalone) with correct name and selector labels
2. **Operator build & tests** — `go build ./...` and `go test ./...` pass (all 4 test packages)
3. **Live cluster deployment** — deployed changes to an ODH standalone cluster:
   - Scaled down operator, patched all 8 module deployments, created PDB
   - All 8 module pods rolled out successfully with 1 replica each
   - All module BFF healthchecks return `{"status":"available"}`
   - PDB active with `allowedDisruptions: 1`
4. **Stress test** — 200 concurrent requests to core dashboard health endpoint: **200/200 succeeded**
5. **Resource usage validation** — confirmed actual idle usage matches Jira analysis (modules: 1m CPU, 14-26Mi memory)

## Test Impact

No new unit or Cypress tests needed — changes are manifest-only (resource values and a new PDB YAML). The operator `Owns()` addition is covered by existing controller integration tests. Kustomize rendering was validated manually across all overlays.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added disruption protection for the dashboard, helping maintain at least one available pod during voluntary disruptions.
  * Dashboard disruption settings now apply consistently across deployment configurations.

* **Resource Management**
  * Reduced default replicas and CPU/memory allocations for several optional dashboard modules, lowering resource consumption while preserving ephemeral-storage settings.

* **Reliability**
  * Dashboard updates and pod disruption changes are now detected automatically, keeping managed resources in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->