### PR TITLE
GEN AI - Replace static prompt version label with interactive version selector

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/components/PromptAssistantFormGroup.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/PromptAssistantFormGroup.tsx
@@ -28,6 +28,8 @@ import { DEFAULT_SYSTEM_INSTRUCTIONS } from '~/app/Chatbot/const';
 import { useConfirmation } from '~/app/Chatbot/hooks/useConfirmation';
 import { usePromptEdited } from '~/app/Chatbot/hooks/usePromptEdited';
 import PromptVariableInputPanel from '~/app/Chatbot/components/PromptVariableInputPanel';
+import PromptVersionSelector from '~/app/Chatbot/components/PromptVersionSelector';
+import { GenAiContext } from '~/app/context/GenAiContext';
 
 type PromptAssistantFormGroupProps = {
   configId?: string;
@@ -40,6 +42,12 @@ const CONFIRMATION_CONFIG = {
   message:
     'Your current edits haven’t been saved. Reverting will restore the last saved version of this prompt. To keep your changes, cancel and save first.',
   confirmLabel: 'Revert',
+};
+const VERSION_SWITCH_CONFIRMATION_CONFIG = {
+  title: 'Switch to a different version?',
+  message:
+    'Your current prompt has unsaved changes that will be lost. To keep your changes, cancel and save first.',
+  confirmLabel: 'Switch',
 };
 const RESET_CONFIRMATION_CONFIG = {
   title: 'Reset to default?',
@@ -54,8 +62,10 @@ export default function PromptAssistantFormGroup({
   onSystemInstructionChange,
 }: PromptAssistantFormGroupProps): React.ReactNode {
   const { openModal } = usePlaygroundStore();
+  const { namespace } = React.useContext(GenAiContext);
   const activePrompt = useChatbotConfigStore(selectActivePrompt(configId));
   const dirtyPrompt = useChatbotConfigStore(selectDirtyPrompt(configId));
+  const updateActivePrompt = useChatbotConfigStore((state) => state.updateActivePrompt);
   const updateDirtyPrompt = useChatbotConfigStore((state) => state.updateDirtyPrompt);
   const resetDirtyPrompt = useChatbotConfigStore((state) => state.resetDirtyPrompt);
   const clearPromptState = useChatbotConfigStore((state) => state.clearPromptState);
@@ -93,6 +103,32 @@ export default function PromptAssistantFormGroup({
     clearPromptState(configId, promptStub);
     onSystemInstructionChange(promptStub.template);
     setEditMode(true);
+  }
+
+  function handleVersionSwitch(version: MLflowPromptVersion) {
+    const doSwitch = () => {
+      updateActivePrompt(configId, version);
+      const instruction =
+        version.template ?? version.messages?.find((m) => m.role === 'system')?.content ?? '';
+      onSystemInstructionChange(instruction);
+      setEditMode(false);
+      fireMiscTrackingEvent('Playground Prompt Version Switched', {
+        fromVersion: activePrompt?.version,
+        toVersion: version.version,
+      });
+    };
+
+    confirm(doSwitch, {
+      ...VERSION_SWITCH_CONFIRMATION_CONFIG,
+      onConfirmTracking: () =>
+        fireMiscTrackingEvent('Playground Prompt Version Switch Interrupted', {
+          outcome: 'submit',
+        }),
+      onCancelTracking: () =>
+        fireMiscTrackingEvent('Playground Prompt Version Switch Interrupted', {
+          outcome: 'cancel',
+        }),
+    });
   }
 
   const isGlobalPrompt = activePrompt?.scope?.type === 'global';
@@ -169,14 +205,13 @@ export default function PromptAssistantFormGroup({
               </Label>
             )}
             {!!activePrompt?.version && (
-              <Label
-                data-testid="prompt-version-label"
-                isCompact
-                variant={isEdited ? 'filled' : 'outline'}
-                color={isEdited ? 'grey' : 'purple'}
-              >
-                Version {activePrompt.version.toString()}
-              </Label>
+              <PromptVersionSelector
+                promptName={activePrompt.name}
+                promptScope={activePrompt.scope}
+                currentVersion={activePrompt.version}
+                onVersionSelect={handleVersionSwitch}
+                namespace={namespace?.name}
+              />
             )}
             {isEdited && (
               <div

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/PromptVersionSelector.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/PromptVersionSelector.tsx
@@ -17,6 +17,7 @@ import {
   SearchInput,
   Spinner,
 } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { mlflowPromptManagementBaseRoute } from '@odh-dashboard/internal/routes/pipelines/mlflow';
 import { MLflowPrompt, MLflowPromptVersion } from '~/app/types';
@@ -28,6 +29,35 @@ type PromptVersionSelectorProps = {
   currentVersion: number;
   onVersionSelect: (version: MLflowPromptVersion) => void;
   namespace?: string;
+};
+
+const isValidVersion = (v: unknown): v is MLflowPromptVersion => {
+  if (typeof v !== 'object' || v == null) {
+    return false;
+  }
+  if (!('name' in v) || typeof v.name !== 'string') {
+    return false;
+  }
+  if (!('version' in v) || typeof v.version !== 'number') {
+    return false;
+  }
+  if ('template' in v && v.template != null && typeof v.template !== 'string') {
+    return false;
+  }
+  if ('messages' in v && v.messages != null) {
+    if (!Array.isArray(v.messages)) {
+      return false;
+    }
+    if (
+      !v.messages.every(
+        (m: unknown) =>
+          typeof m === 'object' && m != null && 'role' in m && typeof m.role === 'string',
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
 };
 
 const PromptVersionSelector: React.FC<PromptVersionSelectorProps> = ({
@@ -43,7 +73,9 @@ const PromptVersionSelector: React.FC<PromptVersionSelectorProps> = ({
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const menuRef = React.useRef<HTMLDivElement>(null);
 
-  const { versions, isLoading } = usePromptVersions(promptName, promptScope);
+  const { versions: rawVersions, isLoading, error } = usePromptVersions(promptName, promptScope);
+
+  const versions = React.useMemo(() => rawVersions.filter(isValidVersion), [rawVersions]);
 
   const latestVersion = versions.length > 0 ? versions[0].version : null;
   const isLatest = currentVersion === latestVersion;
@@ -72,7 +104,18 @@ const PromptVersionSelector: React.FC<PromptVersionSelectorProps> = ({
     </MenuItem>
   ));
 
-  if (searchValue.length > 0 && filteredVersions.length === 0) {
+  if (error && !isLoading) {
+    menuItems.push(
+      <MenuItem isDisabled key="error" data-testid="prompt-version-error">
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>
+            <ExclamationCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
+          </FlexItem>
+          <FlexItem>Unable to load versions</FlexItem>
+        </Flex>
+      </MenuItem>,
+    );
+  } else if (searchValue.length > 0 && filteredVersions.length === 0) {
     menuItems.push(
       <MenuItem isDisabled key="no-results">
         No results found
@@ -134,6 +177,7 @@ const PromptVersionSelector: React.FC<PromptVersionSelectorProps> = ({
           isExpanded={isOpen}
           size="sm"
           data-testid="prompt-version-toggle"
+          status={error ? 'danger' : undefined}
           icon={isLoading ? <Spinner size="sm" aria-label="Loading versions" /> : undefined}
         >
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/PromptVersionSelector.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/PromptVersionSelector.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import {
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  FlexItem,
+  Menu,
+  MenuContainer,
+  MenuContent,
+  MenuFooter,
+  MenuItem,
+  MenuList,
+  MenuSearch,
+  MenuSearchInput,
+  MenuToggle,
+  SearchInput,
+  Spinner,
+} from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { mlflowPromptManagementBaseRoute } from '@odh-dashboard/internal/routes/pipelines/mlflow';
+import { MLflowPrompt, MLflowPromptVersion } from '~/app/types';
+import { usePromptVersions } from '~/app/Chatbot/components/promptManagementModal/usePromptQueries';
+
+type PromptVersionSelectorProps = {
+  promptName: string;
+  promptScope?: MLflowPrompt['scope'];
+  currentVersion: number;
+  onVersionSelect: (version: MLflowPromptVersion) => void;
+  namespace?: string;
+};
+
+const PromptVersionSelector: React.FC<PromptVersionSelectorProps> = ({
+  promptName,
+  promptScope,
+  currentVersion,
+  onVersionSelect,
+  namespace,
+}) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [searchValue, setSearchValue] = React.useState('');
+
+  const toggleRef = React.useRef<HTMLButtonElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+
+  const { versions, isLoading } = usePromptVersions(promptName, promptScope);
+
+  const latestVersion = versions.length > 0 ? versions[0].version : null;
+  const isLatest = currentVersion === latestVersion;
+
+  const filteredVersions = versions.filter(
+    (v) =>
+      searchValue === '' ||
+      `Version ${v.version}`.toLowerCase().includes(searchValue.toLowerCase()),
+  );
+
+  const menuItems = filteredVersions.map((v) => (
+    <MenuItem
+      key={v.version}
+      itemId={v.version}
+      isSelected={v.version === currentVersion}
+      data-testid={`prompt-version-item-${v.version}`}
+    >
+      <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+        <FlexItem>{`Version ${v.version}`}</FlexItem>
+        {v.version === latestVersion && (
+          <FlexItem>
+            <Badge color="blue">Latest</Badge>
+          </FlexItem>
+        )}
+      </Flex>
+    </MenuItem>
+  ));
+
+  if (searchValue.length > 0 && filteredVersions.length === 0) {
+    menuItems.push(
+      <MenuItem isDisabled key="no-results">
+        No results found
+      </MenuItem>,
+    );
+  }
+
+  const menu = (
+    <Menu
+      onSelect={(_e, itemId) => {
+        if (typeof itemId === 'number') {
+          const selected = versions.find((v) => v.version === itemId);
+          if (selected && selected.version !== currentVersion) {
+            onVersionSelect(selected);
+          }
+          setIsOpen(false);
+        }
+      }}
+      ref={menuRef}
+      isScrollable
+      activeItemId={currentVersion}
+      data-testid="prompt-version-selector-menu"
+    >
+      <MenuSearch>
+        <MenuSearchInput>
+          <SearchInput
+            data-testid="prompt-version-search"
+            value={searchValue}
+            aria-label="Find by version name"
+            placeholder="Find by version name"
+            onChange={(_event, value) => setSearchValue(value)}
+          />
+        </MenuSearchInput>
+      </MenuSearch>
+      <Divider />
+      <MenuContent>
+        <MenuList data-testid="prompt-version-selector-list">{menuItems}</MenuList>
+      </MenuContent>
+      <MenuFooter>
+        <Link to={mlflowPromptManagementBaseRoute(namespace)} style={{ textDecoration: 'none' }}>
+          <Button
+            isInline
+            variant="link"
+            data-testid="prompt-view-all-versions"
+          >{`View all ${versions.length} versions`}</Button>
+        </Link>
+      </MenuFooter>
+    </Menu>
+  );
+
+  return (
+    <MenuContainer
+      isOpen={isOpen}
+      toggleRef={toggleRef}
+      toggle={
+        <MenuToggle
+          ref={toggleRef}
+          onClick={() => setIsOpen((prev) => !prev)}
+          isExpanded={isOpen}
+          size="sm"
+          data-testid="prompt-version-toggle"
+          icon={isLoading ? <Spinner size="sm" aria-label="Loading versions" /> : undefined}
+        >
+          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+            <FlexItem>{`Version ${currentVersion}`}</FlexItem>
+            {isOpen && isLatest && (
+              <FlexItem>
+                <Badge color="blue">Latest</Badge>
+              </FlexItem>
+            )}
+          </Flex>
+        </MenuToggle>
+      }
+      menu={menu}
+      menuRef={menuRef}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) {
+          setSearchValue('');
+        }
+      }}
+    />
+  );
+};
+
+export default PromptVersionSelector;

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/PromptAssistantFormGroup.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/PromptAssistantFormGroup.spec.tsx
@@ -48,6 +48,18 @@ jest.mock('~/app/components/SafeNavigationBlocker', () => ({
   default: () => null,
 }));
 
+jest.mock('~/app/Chatbot/components/PromptVersionSelector', () => ({
+  __esModule: true,
+  default: ({ currentVersion }: { currentVersion: number }) => (
+    <div data-testid="prompt-version-toggle">{`Version ${currentVersion}`}</div>
+  ),
+}));
+
+const MockGenAiContext = React.createContext({ namespace: { name: 'test-ns' } });
+jest.mock('~/app/context/GenAiContext', () => ({
+  GenAiContext: MockGenAiContext,
+}));
+
 const mockProjectPrompt: MLflowPromptVersion = {
   name: 'project-prompt',
   version: 1,
@@ -233,7 +245,7 @@ describe('PromptAssistantFormGroup', () => {
     });
 
     describe('Label positioning', () => {
-      it('should appear between prompt name and version label', () => {
+      it('should appear between prompt name and version selector', () => {
         const selectActivePrompt = jest.mocked(chatbotStore.selectActivePrompt);
         const selectDirtyPrompt = jest.mocked(chatbotStore.selectDirtyPrompt);
         selectActivePrompt.mockReturnValue(() => mockProjectPrompt);
@@ -243,14 +255,14 @@ describe('PromptAssistantFormGroup', () => {
 
         const promptName = screen.getByTestId('prompt-name-title');
         const scopeLabel = screen.getByTestId('prompt-scope-label');
-        const versionLabel = screen.getByTestId('prompt-version-label');
+        const versionToggle = screen.getByTestId('prompt-version-toggle');
 
         const flexContainer = promptName.parentElement;
         const children = Array.from(flexContainer?.children || []);
 
         const nameIndex = children.indexOf(promptName);
         const scopeIndex = children.indexOf(scopeLabel);
-        const versionIndex = children.indexOf(versionLabel);
+        const versionIndex = children.indexOf(versionToggle);
 
         expect(scopeIndex).toBeGreaterThan(nameIndex);
         expect(scopeIndex).toBeLessThan(versionIndex);

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/PromptAssistantFormGroup.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/PromptAssistantFormGroup.spec.tsx
@@ -55,10 +55,12 @@ jest.mock('~/app/Chatbot/components/PromptVersionSelector', () => ({
   ),
 }));
 
-const MockGenAiContext = React.createContext({ namespace: { name: 'test-ns' } });
-jest.mock('~/app/context/GenAiContext', () => ({
-  GenAiContext: MockGenAiContext,
-}));
+jest.mock('~/app/context/GenAiContext', () => {
+  const actualReact = jest.requireActual<typeof import('react')>('react');
+  return {
+    GenAiContext: actualReact.createContext({ namespace: { name: 'test-ns' } }),
+  };
+});
 
 const mockProjectPrompt: MLflowPromptVersion = {
   name: 'project-prompt',

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/PromptVersionSelector.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/PromptVersionSelector.spec.tsx
@@ -1,0 +1,204 @@
+/* eslint-disable camelcase */
+import * as React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PromptVersionSelector from '~/app/Chatbot/components/PromptVersionSelector';
+import { MLflowPromptVersion } from '~/app/types';
+
+jest.mock('~/app/utilities/const', () => ({
+  URL_PREFIX: '/gen-ai',
+  DEPLOYMENT_MODE: 'federated',
+  MCP_SERVERS_SESSION_STORAGE_KEY: 'gen-ai-playground-servers',
+}));
+
+const mockVersions: MLflowPromptVersion[] = [
+  {
+    name: 'test-prompt',
+    version: 3,
+    template: 'Version 3 template',
+    commit_message: 'v3',
+    tags: {},
+    created_at: '2024-03-01T10:00:00Z',
+    updated_at: '2024-03-01T10:00:00Z',
+  },
+  {
+    name: 'test-prompt',
+    version: 2,
+    template: 'Version 2 template',
+    commit_message: 'v2',
+    tags: {},
+    created_at: '2024-02-01T10:00:00Z',
+    updated_at: '2024-02-01T10:00:00Z',
+  },
+  {
+    name: 'test-prompt',
+    version: 1,
+    template: 'Version 1 template',
+    commit_message: 'v1',
+    tags: {},
+    created_at: '2024-01-01T10:00:00Z',
+    updated_at: '2024-01-01T10:00:00Z',
+  },
+];
+
+const mockUsePromptVersions = jest.fn();
+
+jest.mock('~/app/Chatbot/components/promptManagementModal/usePromptQueries', () => ({
+  usePromptVersions: (...args: unknown[]) => mockUsePromptVersions(...args),
+}));
+
+jest.mock('@odh-dashboard/internal/routes/pipelines/mlflow', () => ({
+  mlflowPromptManagementBaseRoute: (ns?: string) =>
+    ns ? `/gen-ai-studio/prompts?workspace=${ns}` : '/gen-ai-studio/prompts',
+}));
+
+function renderSelector(props: Partial<React.ComponentProps<typeof PromptVersionSelector>> = {}) {
+  const defaultProps: React.ComponentProps<typeof PromptVersionSelector> = {
+    promptName: 'test-prompt',
+    currentVersion: 3,
+    onVersionSelect: jest.fn(),
+    namespace: 'test-ns',
+  };
+  return render(
+    <MemoryRouter>
+      <PromptVersionSelector {...defaultProps} {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe('PromptVersionSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePromptVersions.mockReturnValue({
+      versions: mockVersions,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('renders toggle with current version', () => {
+    renderSelector();
+    expect(screen.getByTestId('prompt-version-toggle')).toHaveTextContent('Version 3');
+  });
+
+  it('opens dropdown and shows all versions', () => {
+    renderSelector();
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+
+    expect(screen.getByTestId('prompt-version-item-3')).toBeInTheDocument();
+    expect(screen.getByTestId('prompt-version-item-2')).toBeInTheDocument();
+    expect(screen.getByTestId('prompt-version-item-1')).toBeInTheDocument();
+  });
+
+  it('shows Latest badge on the most recent version in the menu', () => {
+    renderSelector();
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+
+    const item3 = screen.getByTestId('prompt-version-item-3');
+    expect(item3).toHaveTextContent('Latest');
+
+    const item2 = screen.getByTestId('prompt-version-item-2');
+    expect(item2).not.toHaveTextContent('Latest');
+  });
+
+  it('shows Latest badge in toggle when expanded and current version is latest', () => {
+    renderSelector({ currentVersion: 3 });
+
+    const toggle = screen.getByTestId('prompt-version-toggle');
+    expect(toggle).not.toHaveTextContent('Latest');
+
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('prompt-version-toggle')).toHaveTextContent('Latest');
+  });
+
+  it('does not show Latest badge in toggle when current version is not latest', () => {
+    renderSelector({ currentVersion: 2 });
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+    expect(screen.getByTestId('prompt-version-toggle')).not.toHaveTextContent('Latest');
+  });
+
+  it('calls onVersionSelect when a different version is selected', () => {
+    const onVersionSelect = jest.fn();
+    renderSelector({ currentVersion: 3, onVersionSelect });
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+
+    const item2 = screen.getByTestId('prompt-version-item-2');
+    const button = within(item2).getByRole('menuitem');
+    fireEvent.click(button);
+
+    expect(onVersionSelect).toHaveBeenCalledWith(mockVersions[1]);
+  });
+
+  it('does not call onVersionSelect when the same version is selected', () => {
+    const onVersionSelect = jest.fn();
+    renderSelector({ currentVersion: 3, onVersionSelect });
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+
+    const item3 = screen.getByTestId('prompt-version-item-3');
+    const button = within(item3).getByRole('menuitem');
+    fireEvent.click(button);
+
+    expect(onVersionSelect).not.toHaveBeenCalled();
+  });
+
+  it('renders "View all N versions" link with correct count', () => {
+    renderSelector();
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+
+    const viewAllLink = screen.getByTestId('prompt-view-all-versions');
+    expect(viewAllLink).toHaveTextContent('View all 3 versions');
+  });
+
+  it('renders "View all" link with workspace in href', () => {
+    renderSelector({ namespace: 'my-project' });
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+
+    const link = screen.getByTestId('prompt-view-all-versions').closest('a');
+    expect(link).toHaveAttribute('href', '/gen-ai-studio/prompts?workspace=my-project');
+  });
+
+  it('shows loading spinner when versions are loading', () => {
+    mockUsePromptVersions.mockReturnValue({
+      versions: [],
+      isLoading: true,
+      error: null,
+    });
+    renderSelector();
+
+    expect(screen.getByLabelText('Loading versions')).toBeInTheDocument();
+  });
+
+  it('does not show loading spinner when versions are loaded', () => {
+    renderSelector();
+    expect(screen.queryByLabelText('Loading versions')).not.toBeInTheDocument();
+  });
+
+  it('renders search placeholder text', () => {
+    renderSelector();
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+
+    expect(screen.getByPlaceholderText('Find by version name')).toBeInTheDocument();
+  });
+
+  it('passes scope to usePromptVersions', () => {
+    const scope = { type: 'global' as const, namespace: 'rhoai-templates' };
+    renderSelector({ promptScope: scope });
+
+    expect(mockUsePromptVersions).toHaveBeenCalledWith('test-prompt', scope);
+  });
+
+  it('renders with size sm toggle', () => {
+    renderSelector();
+
+    const toggle = screen.getByTestId('prompt-version-toggle');
+    expect(toggle).toHaveClass('pf-m-small');
+  });
+});

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/PromptVersionSelector.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/PromptVersionSelector.spec.tsx
@@ -201,4 +201,72 @@ describe('PromptVersionSelector', () => {
     const toggle = screen.getByTestId('prompt-version-toggle');
     expect(toggle).toHaveClass('pf-m-small');
   });
+
+  it('renders error state when usePromptVersions returns an error', () => {
+    mockUsePromptVersions.mockReturnValue({
+      versions: [],
+      isLoading: false,
+      error: new Error('Network failure'),
+    });
+    renderSelector();
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+
+    expect(screen.getByTestId('prompt-version-error')).toHaveTextContent('Unable to load versions');
+  });
+
+  it('applies danger status to the toggle when there is an error', () => {
+    mockUsePromptVersions.mockReturnValue({
+      versions: [],
+      isLoading: false,
+      error: new Error('API failure'),
+    });
+    renderSelector();
+
+    expect(screen.getByTestId('prompt-version-toggle')).toHaveClass('pf-m-danger');
+  });
+
+  it('filters out malformed versions with missing name or version', () => {
+    mockUsePromptVersions.mockReturnValue({
+      versions: [
+        ...mockVersions,
+        { version: 4, template: 'no name field' } as unknown as MLflowPromptVersion,
+        { name: 'test', template: 'no version field' } as unknown as MLflowPromptVersion,
+      ],
+      isLoading: false,
+      error: null,
+    });
+    renderSelector({ currentVersion: 3 });
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+
+    expect(screen.getByTestId('prompt-version-item-3')).toBeInTheDocument();
+    expect(screen.getByTestId('prompt-version-item-2')).toBeInTheDocument();
+    expect(screen.getByTestId('prompt-version-item-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('prompt-version-item-4')).not.toBeInTheDocument();
+  });
+
+  it('filters out versions with null entries in messages array', () => {
+    mockUsePromptVersions.mockReturnValue({
+      versions: [
+        {
+          name: 'test-prompt',
+          version: 5,
+          messages: [null, { role: 'system', content: 'hello' }],
+          tags: {},
+          created_at: '2024-04-01T10:00:00Z',
+          updated_at: '2024-04-01T10:00:00Z',
+        } as unknown as MLflowPromptVersion,
+        ...mockVersions,
+      ],
+      isLoading: false,
+      error: null,
+    });
+    renderSelector({ currentVersion: 3 });
+
+    fireEvent.click(screen.getByTestId('prompt-version-toggle'));
+
+    expect(screen.queryByTestId('prompt-version-item-5')).not.toBeInTheDocument();
+    expect(screen.getByTestId('prompt-version-item-3')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Replace static prompt version label with interactive version selector
- Add a searchable dropdown for switching between prompt versions in the Playground's Prompt tab.
- The selector shows a "Latest" badge on the most recent version, a checkmark on the currently selected one, and a "View all N versions" link to the Prompts list page. Switching versions triggers an unsaved-changes confirmation dialog.

<img width="463" height="639" alt="Screenshot 2026-07-31 at 13 15 26" src="https://github.com/user-attachments/assets/07725f99-892b-4ba5-92f7-fcacc09f6c53" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- added unit tests

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a searchable prompt version selector for active prompts.
  * Displays the latest and currently selected versions, loading and no-results states, and a link to view all versions.
  * Prompts for confirmation before switching versions when unsaved edits are present.
  * Automatically updates prompt instructions and exits edit mode after selection.

* **Tests**
  * Added coverage for version searching, selection, navigation, loading states, and unsaved-change handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->