### PR TITLE
fix(autorag,automl): add egress rule for MinIO port 9000

### DIFF
--- a/manifests/modules/automl/networkpolicy.yaml
+++ b/manifests/modules/automl/networkpolicy.yaml
@@ -18,7 +18,7 @@ spec:
             matchLabels:
               network.openshift.io/policy-group: ingress
   # automl is an API-only BFF — it only needs DNS, K8s API, and
-  # namespace-scoped DSPA (8443). No external HTTP(S) required.
+  # namespace-scoped DSPA (8443) + MinIO (9000). No external HTTP(S) required.
   egress:
     - to:
         - namespaceSelector:
@@ -39,4 +39,6 @@ spec:
         - namespaceSelector: {}
       ports:
         - port: 8443
+          protocol: TCP
+        - port: 9000
           protocol: TCP

--- a/manifests/modules/autorag/networkpolicy.yaml
+++ b/manifests/modules/autorag/networkpolicy.yaml
@@ -18,7 +18,7 @@ spec:
             matchLabels:
               network.openshift.io/policy-group: ingress
   # autorag is an API-only BFF — it only needs DNS, K8s API, and
-  # namespace-scoped DSPA (8443) + OGX (8321). No external HTTP(S) required.
+  # namespace-scoped DSPA (8443) + OGX (8321) + MinIO (9000). No external HTTP(S) required.
   egress:
     - to:
         - namespaceSelector:
@@ -41,4 +41,6 @@ spec:
         - port: 8443
           protocol: TCP
         - port: 8321
+          protocol: TCP
+        - port: 9000
           protocol: TCP


### PR DESCRIPTION
## Description

Adds an egress rule for MinIO port 9000 to the `autorag-allow-ports` and `automl-allow-ports` network policies. Without this rule, the standalone BFF pods cannot reach managed MinIO instances (`minio-*.svc.cluster.local:9000`) in user namespaces to upload/download S3 files.

This is a follow-up to #8971 which added egress for DSPA (8443) and OGX (8321). The MinIO port was missed in that PR — the BFF gets past the experiments page (8443 fix working) but fails when fetching pipeline results or uploading files from S3, causing leaderboard/results fetches to fail with i/o timeout.

**Root cause:** Same class of bug as #8971 and #8948 — standalone deployment mode exposes missing egress rules that were covered by the dashboard pod's broad egress policy in sidecar mode.

## How Has This Been Tested?

- Jenkins nightly run confirmed the BFF times out fetching leaderboard results from MinIO without this fix (bot classified root cause as "NetworkPolicy blocks egress to MinIO on port 9000")
- Port 8443 fix from #8971 confirmed working on the same cluster (Step 3 passes now)

## Test Impact

No automated tests — manifest-only NetworkPolicy change. Validated by AutoML/AutoRAG E2E tests passing on clusters with standalone deployment mode.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated network policy guidance to include MinIO as a required dependency.
  * Documented and enabled TCP egress access on port 9000 for AutoML and AutoRAG components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->