### PR TITLE
fix(autorag,automl): add egress rule for MinIO port 9000

### DIFF
--- a/manifests/modules/automl/networkpolicy.yaml
+++ b/manifests/modules/automl/networkpolicy.yaml
@@ -38,6 +38,8 @@ spec:
       ports:
         - port: 8443
           protocol: TCP
+        - port: 9000
+          protocol: TCP
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0

--- a/manifests/modules/autorag/networkpolicy.yaml
+++ b/manifests/modules/autorag/networkpolicy.yaml
@@ -40,6 +40,8 @@ spec:
           protocol: TCP
         - port: 8321
           protocol: TCP
+        - port: 9000
+          protocol: TCP
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0


### PR DESCRIPTION
Cherry-pick of #9020 to v3.5.0-fixes.

## Description

Adds an egress rule for MinIO port 9000 to the `autorag-allow-ports` and `automl-allow-ports` network policies. Without this rule, the standalone BFF pods cannot reach managed MinIO instances in user namespaces, causing leaderboard/results fetches to fail with i/o timeout.

Follow-up to #8971/#8973 which added DSPA (8443) and OGX (8321) egress.

## How Has This Been Tested?

Tested on the original PR — Jenkins nightly confirmed the BFF times out fetching results from MinIO without this fix.

## Test Impact

No new tests — manifest-only NetworkPolicy change.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`