### PR TITLE
RHOAIENG-79881: Extract buildV2RedirectElement / v2Redirect utility to @odh-dashboard/plugin-core

### DIFF
--- a/frontend/src/pages/BYONImages/BYONImageRoutes.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageRoutes.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
+import { buildV2RedirectRoutes } from '@odh-dashboard/plugin-core/routing';
 import BYONImages from '#~/pages/BYONImages/BYONImages';
 import ManageHardwareProfile from '#~/pages/hardwareProfiles/manage/ManageHardwareProfile';
-import { buildV2RedirectRoutes } from '#~/utilities/v2Redirect';
 import { v2RedirectMap } from './v2Redirects';
 
 const BYONImageRoutes: React.FC = () => (

--- a/frontend/src/pages/distributedWorkloads/GlobalDistributedWorkloadsRoutes.tsx
+++ b/frontend/src/pages/distributedWorkloads/GlobalDistributedWorkloadsRoutes.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { Navigate, Route } from 'react-router-dom';
+import { buildV2RedirectRoutes } from '@odh-dashboard/plugin-core/routing';
 import ProjectsRoutes from '#~/concepts/projects/ProjectsRoutes';
-
 import { useDistributedWorkloadsTabs } from '#~/pages/distributedWorkloads/global/useDistributedWorkloadsTabs';
 import GlobalDistributedWorkloads from '#~/pages/distributedWorkloads/global/GlobalDistributedWorkloads';
 import NotFound from '#~/pages/NotFound';
-import { buildV2RedirectRoutes } from '#~/utilities/v2Redirect';
 import { v2RedirectMap } from './v2Redirects';
 
 const GlobalDistributedWorkloadsRoutes: React.FC = () => {

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeRoutes.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeRoutes.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Navigate, Routes, Route } from 'react-router-dom';
-import { buildV2RedirectRoutes } from '#~/utilities/v2Redirect';
+import { buildV2RedirectRoutes } from '@odh-dashboard/plugin-core/routing';
 import CustomServingRuntimeView from './CustomServingRuntimeView';
 import CustomServingRuntimeContextProvider from './CustomServingRuntimeContext';
 import CustomServingRuntimeAddTemplate from './CustomServingRuntimeAddTemplate';

--- a/frontend/src/pages/pipelines/GlobalPipelineRunsRoutes.tsx
+++ b/frontend/src/pages/pipelines/GlobalPipelineRunsRoutes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Navigate, Route } from 'react-router-dom';
 import TitleWithIcon from '@odh-dashboard/ui-core/design/TitleWithIcon';
+import { buildV2RedirectRoutes } from '@odh-dashboard/plugin-core/routing';
 import { ProjectObjectType } from '#~/concepts/design/utils';
 import ProjectsRoutes from '#~/concepts/projects/ProjectsRoutes';
 import GlobalPipelineCoreLoader from '#~/pages/pipelines/global/GlobalPipelineCoreLoader';
@@ -28,7 +29,6 @@ import {
 } from '#~/pages/pipelines/global/runs/GlobalPipelineCreateRunPage';
 import GlobalPipelineDuplicateRunPage from '#~/pages/pipelines/global/runs/GlobalPipelineDuplicateRunPage';
 import GlobalPipelineDuplicateRecurringRunPage from '#~/pages/pipelines/global/runs/GlobalPipelineDuplicateRecurringRunPage';
-import { buildV2RedirectRoutes } from '#~/utilities/v2Redirect';
 import { pipelineRunsV2RedirectMap } from './v2Redirects';
 
 const GlobalPipelineRunsRoutes: React.FC = () => (

--- a/frontend/src/plugins/extensions/routes.ts
+++ b/frontend/src/plugins/extensions/routes.ts
@@ -4,7 +4,7 @@ import type { RouteExtension } from '@odh-dashboard/plugin-core/extension-points
 import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
 
 const createRedirectComponent = (args: { from: string; to: string }) => () =>
-  import('#~/utilities/v2Redirect').then((module) => ({
+  import('@odh-dashboard/plugin-core/routing').then((module) => ({
     default: () => module.buildV2RedirectElement(args),
   }));
 

--- a/packages/hardware-profiles/extensions.ts
+++ b/packages/hardware-profiles/extensions.ts
@@ -5,7 +5,7 @@ import type {
 } from '@odh-dashboard/plugin-core/extension-points';
 
 const createRedirectComponent = (args: { from: string; to: string }) => () =>
-  import('@odh-dashboard/internal/utilities/v2Redirect').then((module) => ({
+  import('@odh-dashboard/plugin-core/routing').then((module) => ({
     default: () => module.buildV2RedirectElement(args),
   }));
 

--- a/packages/model-registry/upstream/frontend/src/odh/extensions.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/extensions.ts
@@ -18,7 +18,7 @@ const PLUGIN_MODEL_REGISTRY = 'model-registry-plugin';
 const ADMIN_USER = 'ADMIN_USER';
 
 const createRedirectComponent = (args: { from: string; to: string }) => () =>
-  import('@odh-dashboard/internal/utilities/v2Redirect').then((module) => ({
+  import('@odh-dashboard/plugin-core/routing').then((module) => ({
     default: () => module.buildV2RedirectElement(args),
   }));
 

--- a/packages/model-serving/extensions/odh.ts
+++ b/packages/model-serving/extensions/odh.ts
@@ -10,7 +10,7 @@ import type { WizardFieldExtension } from '@odh-dashboard/model-serving/extensio
 import type { DeploymentMethodSelectFieldType } from '../src/components/deploymentWizard/fields/DeploymentMethodSelectField';
 
 const createRedirectComponent = (args: { from: string; to: string }) => () =>
-  import('@odh-dashboard/internal/utilities/v2Redirect').then((module) => ({
+  import('@odh-dashboard/plugin-core/routing').then((module) => ({
     default: () => module.buildV2RedirectElement(args),
   }));
 

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -17,6 +17,7 @@
     "./areas": "./src/areas/index.ts",
     "./host-api": "./src/host-api/index.ts",
     "./integrations": "./src/integrations/index.ts",
+    "./routing": "./src/routing/index.ts",
     "./testing": "./src/testing/utils.ts"
   },
   "dependencies": {

--- a/packages/plugin-core/src/routing/__tests__/v2Redirect.spec.tsx
+++ b/packages/plugin-core/src/routing/__tests__/v2Redirect.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Navigate, Location, useParams, useLocation } from 'react-router-dom';
-import { buildV2RedirectElement, buildV2RedirectRoutes } from '#~/utilities/v2Redirect';
+import { buildV2RedirectElement, buildV2RedirectRoutes } from '../v2Redirect';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/packages/plugin-core/src/routing/index.ts
+++ b/packages/plugin-core/src/routing/index.ts
@@ -1,0 +1,1 @@
+export { buildV2RedirectElement, buildV2RedirectRoutes, type RedirectConfig } from './v2Redirect';

--- a/packages/plugin-core/src/routing/v2Redirect.tsx
+++ b/packages/plugin-core/src/routing/v2Redirect.tsx
@@ -14,7 +14,7 @@ import { Navigate, Route, useParams, useLocation, Params } from 'react-router-do
  * All references to buildV2RedirectElement and buildV2RedirectRoutes should also be cleaned up at that time.
  */
 
-interface RedirectConfig {
+export interface RedirectConfig {
   from: string;
   to: string;
 }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79881

## Description
Moves `buildV2RedirectElement` and `buildV2RedirectRoutes` from `@odh-dashboard/internal` (`frontend/src/utilities/v2Redirect.tsx`) into `@odh-dashboard/plugin-core` under a new `./routing` subpath export.

  This is a generic SPA route redirect utility whose only dependencies are React and react-router-dom. Three external packages (`model-serving`, `hardware-profiles`, `model-registry`) were importing it via `@odh-dashboard/internal`, crossing internal package boundaries. `plugin-core` is the architecturally correct home because it already owns routing infrastructure (`RouteExtension` extension point, `generateExtensionTabRoutes` helper), has `react-router-dom ^7` as a peer dependency, and is already depended on by every feature package.

  | Category | Items |
  |----------|-------|
  | Functions | `buildV2RedirectElement`, `buildV2RedirectRoutes` |
  | Types | `RedirectConfig` |
  | Internal components | `WildcardRedirect`, `RelativeRedirect`, `AbsoluteRedirect` |
  | Internal helpers | `escapeForRegex`, `createParameterPattern`, `createPathPattern`, `stripWildcardSuffix`, `replacePathParameters`, `buildRedirectUrl` |

  All 8 consumers were updated to import directly from `@odh-dashboard/plugin-core/routing` — no re-export stubs left behind. The original source and test files were deleted from `frontend/src/`.

  ## How Has This Been Tested?

  - `npm ci` — clean install passes
  - `npm run type-check` — passes across all affected packages (`plugin-core`, `model-serving`, `hardware-profiles`, `model-registry`, `frontend`)
  - `npm run lint` — passes across all affected packages
  - `npm run test` — all 352 frontend test suites pass (3779 tests), plugin-core tests pass
  - `npm run build` — frontend build succeeds
  - Verified no remaining imports of the old path (`@odh-dashboard/internal/utilities/v2Redirect` or `#~/utilities/v2Redirect`)

  ## Test Impact

  No new tests added. Existing unit tests (645 lines, 29 test cases covering wildcard, relative, absolute redirects, edge cases, and state preservation) were moved from `frontend/src/utilities/__tests__/v2Redirect.spec.tsx` to `packages/plugin-core/src/routing/__tests__/v2Redirect.spec.tsx` with only the import path updated. Behavior is unchanged.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized version 2 redirect routing through the shared plugin routing package.
  - Standardized redirect handling across image, workload, model serving, pipeline, hardware profile, and extension pages.
  - Added a public routing entry point for consistent reuse across dashboard features.

- **Bug Fixes**
  - Existing redirect behavior remains unchanged while improving consistency and maintainability across supported pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->