### PR TITLE
RHOAIENG-79525: Fix probe handler conflict during 3.4→3.5 upgrade

### DIFF
--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -277,6 +277,14 @@ func (r *DashboardReconciler) reconcileSidecar(
 
 	remapRayDashboardGatewayRBAC(allResources)
 
+	if err := sanitizeDeploymentProbes(ctx, r.Client, allResources); err != nil {
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("ProbeSanitizeFailed"),
+			conditions.WithError(err))
+
+		return ctrl.Result{}, fmt.Errorf("failed to sanitize deployment probes: %w", err)
+	}
+
 	deployer := deploy.NewDeployer(
 		deploy.WithFieldOwner("dashboard-operator"),
 		deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
@@ -433,6 +441,13 @@ func (r *DashboardReconciler) reconcileStandalone(
 	}
 
 	remapRayDashboardGatewayRBAC(allResources)
+
+	if err := sanitizeDeploymentProbes(ctx, r.Client, allResources); err != nil {
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("ProbeSanitizeFailed"),
+			conditions.WithError(err))
+		return ctrl.Result{}, fmt.Errorf("failed to sanitize deployment probes: %w", err)
+	}
 
 	deployer := deploy.NewDeployer(
 		deploy.WithFieldOwner("dashboard-operator"),

--- a/dashboard-operator/internal/controller/probe_sanitize.go
+++ b/dashboard-operator/internal/controller/probe_sanitize.go
@@ -1,0 +1,154 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var probeHandlerTypes = []string{"exec", "httpGet", "tcpSocket", "grpc"}
+
+func sanitizeDeploymentProbes(ctx context.Context, cli client.Client, resources []unstructured.Unstructured) error {
+	logger := log.FromContext(ctx)
+
+	for i := range resources {
+		res := &resources[i]
+		if res.GetKind() != "Deployment" || res.GroupVersionKind().Group != "apps" {
+			continue
+		}
+
+		live := &unstructured.Unstructured{}
+		live.SetGroupVersionKind(res.GroupVersionKind())
+		key := client.ObjectKeyFromObject(res)
+
+		if err := cli.Get(ctx, key, live); err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("getting live deployment %s: %w", key, err)
+		}
+
+		patch, err := buildProbeCleanupPatch(live, res)
+		if err != nil {
+			return fmt.Errorf("building probe cleanup patch for %s: %w", key, err)
+		}
+		if patch == nil {
+			continue
+		}
+
+		patchBytes, err := json.Marshal(patch)
+		if err != nil {
+			return fmt.Errorf("marshalling probe cleanup patch for %s: %w", key, err)
+		}
+
+		logger.Info("Sanitizing conflicting probe handlers before SSA", "deployment", key)
+
+		if err := cli.Patch(ctx, live, client.RawPatch(types.StrategicMergePatchType, patchBytes)); err != nil {
+			return fmt.Errorf("patching conflicting probes for %s: %w", key, err)
+		}
+	}
+
+	return nil
+}
+
+func buildProbeCleanupPatch(live, desired *unstructured.Unstructured) (map[string]interface{}, error) {
+	liveContainers, _, _ := unstructured.NestedSlice(live.Object, "spec", "template", "spec", "containers")
+	desiredContainers, _, _ := unstructured.NestedSlice(desired.Object, "spec", "template", "spec", "containers")
+
+	desiredByName := make(map[string]map[string]interface{}, len(desiredContainers))
+	for _, c := range desiredContainers {
+		cMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := cMap["name"].(string)
+		if name != "" {
+			desiredByName[name] = cMap
+		}
+	}
+
+	var patchContainers []interface{}
+
+	for _, c := range liveContainers {
+		liveC, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := liveC["name"].(string)
+		desiredC, exists := desiredByName[name]
+		if !exists {
+			continue
+		}
+
+		containerPatch := map[string]interface{}{"name": name}
+		hasConflict := false
+
+		for _, probeField := range []string{"livenessProbe", "readinessProbe", "startupProbe"} {
+			nullFields := conflictingHandlerFields(liveC, desiredC, probeField)
+			if len(nullFields) > 0 {
+				probePatch := make(map[string]interface{}, len(nullFields))
+				for _, f := range nullFields {
+					probePatch[f] = nil
+				}
+				containerPatch[probeField] = probePatch
+				hasConflict = true
+			}
+		}
+
+		if hasConflict {
+			patchContainers = append(patchContainers, containerPatch)
+		}
+	}
+
+	if len(patchContainers) == 0 {
+		return nil, nil
+	}
+
+	return map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": patchContainers,
+				},
+			},
+		},
+	}, nil
+}
+
+func conflictingHandlerFields(liveContainer, desiredContainer map[string]interface{}, probeField string) []string {
+	liveProbe, _ := liveContainer[probeField].(map[string]interface{})
+	desiredProbe, _ := desiredContainer[probeField].(map[string]interface{})
+
+	if liveProbe == nil || desiredProbe == nil {
+		return nil
+	}
+
+	desiredType := ""
+	for _, h := range probeHandlerTypes {
+		if _, ok := desiredProbe[h]; ok {
+			desiredType = h
+			break
+		}
+	}
+	if desiredType == "" {
+		return nil
+	}
+
+	var stale []string
+	for _, h := range probeHandlerTypes {
+		if h == desiredType {
+			continue
+		}
+		if _, ok := liveProbe[h]; ok {
+			stale = append(stale, h)
+		}
+	}
+
+	return stale
+}

--- a/dashboard-operator/internal/controller/probe_sanitize.go
+++ b/dashboard-operator/internal/controller/probe_sanitize.go
@@ -34,10 +34,7 @@ func sanitizeDeploymentProbes(ctx context.Context, cli client.Client, resources 
 			return fmt.Errorf("getting live deployment %s: %w", key, err)
 		}
 
-		patch, err := buildProbeCleanupPatch(live, res)
-		if err != nil {
-			return fmt.Errorf("building probe cleanup patch for %s: %w", key, err)
-		}
+		patch := buildProbeCleanupPatch(live, res)
 		if patch == nil {
 			continue
 		}
@@ -57,7 +54,7 @@ func sanitizeDeploymentProbes(ctx context.Context, cli client.Client, resources 
 	return nil
 }
 
-func buildProbeCleanupPatch(live, desired *unstructured.Unstructured) (map[string]interface{}, error) {
+func buildProbeCleanupPatch(live, desired *unstructured.Unstructured) map[string]interface{} {
 	liveContainers, _, _ := unstructured.NestedSlice(live.Object, "spec", "template", "spec", "containers")
 	desiredContainers, _, _ := unstructured.NestedSlice(desired.Object, "spec", "template", "spec", "containers")
 
@@ -107,7 +104,7 @@ func buildProbeCleanupPatch(live, desired *unstructured.Unstructured) (map[strin
 	}
 
 	if len(patchContainers) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	return map[string]interface{}{
@@ -118,7 +115,7 @@ func buildProbeCleanupPatch(live, desired *unstructured.Unstructured) (map[strin
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 func conflictingHandlerFields(liveContainer, desiredContainer map[string]interface{}, probeField string) []string {

--- a/dashboard-operator/internal/controller/probe_sanitize_test.go
+++ b/dashboard-operator/internal/controller/probe_sanitize_test.go
@@ -1,0 +1,300 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func deploymentWithProbes(name, namespace string, containers []interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{"app": name},
+				},
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{"app": name},
+					},
+					"spec": map[string]interface{}{
+						"containers": containers,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestSanitizeDeploymentProbes_NoLiveDeployment(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	desired := deploymentWithProbes("test-deploy", "test-ns", []interface{}{
+		map[string]interface{}{
+			"name":  "main",
+			"image": "img:v1",
+			"livenessProbe": map[string]interface{}{
+				"exec": map[string]interface{}{
+					"command": []interface{}{"/bin/sh", "-c", "curl -s http://localhost:8080/"},
+				},
+			},
+		},
+	})
+
+	err := sanitizeDeploymentProbes(context.Background(), cli, []unstructured.Unstructured{*desired})
+	if err != nil {
+		t.Fatalf("expected no error for missing deployment, got: %v", err)
+	}
+}
+
+func TestSanitizeDeploymentProbes_NoConflict(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+
+	live := deploymentWithProbes("test-deploy", "test-ns", []interface{}{
+		map[string]interface{}{
+			"name":  "main",
+			"image": "img:v1",
+			"livenessProbe": map[string]interface{}{
+				"exec": map[string]interface{}{
+					"command": []interface{}{"/bin/sh", "-c", "curl -s http://localhost:8080/"},
+				},
+			},
+		},
+	})
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(live).Build()
+
+	desired := deploymentWithProbes("test-deploy", "test-ns", []interface{}{
+		map[string]interface{}{
+			"name":  "main",
+			"image": "img:v2",
+			"livenessProbe": map[string]interface{}{
+				"exec": map[string]interface{}{
+					"command": []interface{}{"/bin/sh", "-c", "curl -s http://localhost:8080/"},
+				},
+			},
+		},
+	})
+
+	err := sanitizeDeploymentProbes(context.Background(), cli, []unstructured.Unstructured{*desired})
+	if err != nil {
+		t.Fatalf("expected no error when probe types match, got: %v", err)
+	}
+
+	// Verify the live deployment was NOT patched (probes unchanged)
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(live.GroupVersionKind())
+	if err := cli.Get(context.Background(), keyFromUnstructured(live), got); err != nil {
+		t.Fatal(err)
+	}
+
+	containers, _, _ := unstructured.NestedSlice(got.Object, "spec", "template", "spec", "containers")
+	c := containers[0].(map[string]interface{})
+	lp := c["livenessProbe"].(map[string]interface{})
+	if _, ok := lp["exec"]; !ok {
+		t.Error("exec should still be present on live deployment")
+	}
+}
+
+func TestSanitizeDeploymentProbes_TcpSocketToExec(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+
+	live := deploymentWithProbes("rhods-dashboard", "redhat-ods-applications", []interface{}{
+		map[string]interface{}{
+			"name":  "rhods-dashboard",
+			"image": "dashboard:v1",
+			"livenessProbe": map[string]interface{}{
+				"tcpSocket": map[string]interface{}{
+					"port": int64(8080),
+				},
+			},
+			"readinessProbe": map[string]interface{}{
+				"httpGet": map[string]interface{}{
+					"path":   "/api/health",
+					"port":   int64(8080),
+					"scheme": "HTTP",
+				},
+			},
+		},
+	})
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(live).Build()
+
+	desired := deploymentWithProbes("rhods-dashboard", "redhat-ods-applications", []interface{}{
+		map[string]interface{}{
+			"name":  "rhods-dashboard",
+			"image": "dashboard:v2",
+			"livenessProbe": map[string]interface{}{
+				"exec": map[string]interface{}{
+					"command": []interface{}{"/bin/sh", "-c", "curl -s http://localhost:8080/"},
+				},
+			},
+			"readinessProbe": map[string]interface{}{
+				"exec": map[string]interface{}{
+					"command": []interface{}{"/bin/sh", "-c", "curl -s http://localhost:8080/api/health"},
+				},
+			},
+		},
+	})
+
+	err := sanitizeDeploymentProbes(context.Background(), cli, []unstructured.Unstructured{*desired})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(live.GroupVersionKind())
+	if err := cli.Get(context.Background(), keyFromUnstructured(live), got); err != nil {
+		t.Fatal(err)
+	}
+
+	containers, _, _ := unstructured.NestedSlice(got.Object, "spec", "template", "spec", "containers")
+	c := containers[0].(map[string]interface{})
+
+	lp, _ := c["livenessProbe"].(map[string]interface{})
+	if _, ok := lp["tcpSocket"]; ok {
+		t.Error("tcpSocket should have been removed from livenessProbe")
+	}
+
+	rp, _ := c["readinessProbe"].(map[string]interface{})
+	if _, ok := rp["httpGet"]; ok {
+		t.Error("httpGet should have been removed from readinessProbe")
+	}
+}
+
+func TestSanitizeDeploymentProbes_MultipleContainers(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+
+	live := deploymentWithProbes("rhods-dashboard", "test-ns", []interface{}{
+		map[string]interface{}{
+			"name":  "rhods-dashboard",
+			"image": "dashboard:v1",
+			"livenessProbe": map[string]interface{}{
+				"tcpSocket": map[string]interface{}{"port": int64(8080)},
+			},
+		},
+		map[string]interface{}{
+			"name":  "kube-rbac-proxy",
+			"image": "rbac-proxy:v1",
+			"livenessProbe": map[string]interface{}{
+				"httpGet": map[string]interface{}{
+					"path":   "/healthz",
+					"port":   int64(8444),
+					"scheme": "HTTPS",
+				},
+			},
+		},
+	})
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(live).Build()
+
+	desired := deploymentWithProbes("rhods-dashboard", "test-ns", []interface{}{
+		map[string]interface{}{
+			"name":  "rhods-dashboard",
+			"image": "dashboard:v2",
+			"livenessProbe": map[string]interface{}{
+				"exec": map[string]interface{}{
+					"command": []interface{}{"/bin/sh", "-c", "curl localhost:8080/"},
+				},
+			},
+		},
+		map[string]interface{}{
+			"name":  "kube-rbac-proxy",
+			"image": "rbac-proxy:v2",
+			"livenessProbe": map[string]interface{}{
+				"httpGet": map[string]interface{}{
+					"path":   "/healthz",
+					"port":   int64(8444),
+					"scheme": "HTTPS",
+				},
+			},
+		},
+	})
+
+	err := sanitizeDeploymentProbes(context.Background(), cli, []unstructured.Unstructured{*desired})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(live.GroupVersionKind())
+	if err := cli.Get(context.Background(), keyFromUnstructured(live), got); err != nil {
+		t.Fatal(err)
+	}
+
+	containers, _, _ := unstructured.NestedSlice(got.Object, "spec", "template", "spec", "containers")
+
+	for _, c := range containers {
+		cMap := c.(map[string]interface{})
+		name := cMap["name"].(string)
+		lp, _ := cMap["livenessProbe"].(map[string]interface{})
+
+		switch name {
+		case "rhods-dashboard":
+			if _, ok := lp["tcpSocket"]; ok {
+				t.Error("rhods-dashboard: tcpSocket should have been removed")
+			}
+		case "kube-rbac-proxy":
+			if _, ok := lp["httpGet"]; !ok {
+				t.Error("kube-rbac-proxy: httpGet should be preserved (no conflict)")
+			}
+		}
+	}
+}
+
+func TestSanitizeDeploymentProbes_SkipsNonDeployments(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	svc := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "test-svc",
+				"namespace": "test-ns",
+			},
+		},
+	}
+
+	err := sanitizeDeploymentProbes(context.Background(), cli, []unstructured.Unstructured{svc})
+	if err != nil {
+		t.Fatalf("expected no error for non-deployment resources, got: %v", err)
+	}
+}
+
+func keyFromUnstructured(u *unstructured.Unstructured) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      u.GetName(),
+		Namespace: u.GetNamespace(),
+	}
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79525

## Description

When upgrading from RHOAI 3.4 to 3.5, the dashboard-operator fails to apply the `rhods-dashboard` Deployment because of a probe handler type conflict. The old 3.4 deployment uses `tcpSocket` for liveness and `httpGet` for readiness probes, while the new 3.5 manifests use `exec` (curl) for both.

Server-Side Apply (SSA) adds the new `exec` handler but cannot remove the old handler types because they are owned by a different field manager. Kubernetes rejects the update with:

```
may not specify more than 1 handler type
```

This causes the operator to enter a continuous reconciliation failure loop, with `DashboardReady: False` on the DSC.

### Fix

Adds `sanitizeDeploymentProbes()` which runs before `deployer.Deploy()` in both `reconcileSidecar()` and `reconcileStandalone()` paths. For each Deployment in the desired resources:

1. Fetches the live Deployment from the cluster
2. Compares probe handler types per container (matched by name) for liveness, readiness, and startup probes
3. If the live probe has a different handler type than the desired probe, builds a strategic merge patch that nulls out the stale handler type
4. Applies the patch before SSA proceeds, preventing the conflict

The `MergeDeployments` strategy from `odh-platform-utilities` only preserves `spec.replicas` and container `resources` — it does not handle probes, so this fix must live in the dashboard-operator.

## How Has This Been Tested?

- Unit tests covering all scenarios (see Test Impact)
- `go test -race ./internal/controller/` passes
- Verified on a live cluster that the operator is currently stuck in the exact failure mode this fixes (continuous `ProvisioningSucceeded=False` with the probe conflict error since the 3.5 upgrade)

## Test Impact

Added `probe_sanitize_test.go` with 5 test cases:
- `NoLiveDeployment` — deployment doesn't exist in cluster, skip silently (first deploy)
- `NoConflict` — live and desired both use `exec`, no patch needed
- `TcpSocketToExec` — the exact 3.4→3.5 upgrade scenario: live has `tcpSocket` liveness + `httpGet` readiness, desired has `exec` for both
- `MultipleContainers` — only the container with a conflict gets patched, others untouched
- `SkipsNonDeployments` — Service and other resources are ignored

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by removing conflicting health-check probe settings before updates.
  * Supports liveness, readiness, and startup probes using exec, HTTP, TCP, and gRPC handlers.
  * Prevents deployment when probe cleanup fails and reports a provisioning error.

* **Tests**
  * Added coverage for probe conflicts, multiple containers, missing deployments, compatible probes, and non-deployment resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->