### PR TITLE
feat: Model deployment settings tabbed page shell and feature flag

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -71,6 +71,7 @@ export type MockDashboardConfigType = {
   gpuaas?: boolean;
   connectionTest?: boolean;
   modelCapabilities?: boolean;
+  modelDeploymentSettings?: boolean;
   globalMLflowNamespaces?: string[];
   genAiStudioConfig?: {
     aiAssetCustomEndpoints?: {
@@ -143,6 +144,7 @@ export const mockDashboardConfig = ({
   gpuaas = true,
   connectionTest = false,
   modelCapabilities = false,
+  modelDeploymentSettings = false,
   hardwareProfileOrder = ['test-hardware-profile'],
   globalMLflowNamespaces = [],
   genAiStudioConfig = {
@@ -338,6 +340,7 @@ export const mockDashboardConfig = ({
       gpuaas,
       connectionTest,
       modelCapabilities,
+      modelDeploymentSettings,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -380,6 +380,153 @@ describe('isAreaAvailable', () => {
     });
   });
 
+  describe('MODEL_DEPLOYMENT_SETTINGS area', () => {
+    it('should be available when modelDeploymentSettings flag is true and MODEL_SERVING is available', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        mockDashboardConfig({ modelDeploymentSettings: true, disableModelServing: false }).spec,
+        null,
+        null,
+      );
+
+      expect(isAvailable.status).toBe(true);
+      expect(isAvailable.featureFlags).toEqual({ modelDeploymentSettings: 'on' });
+      expect(isAvailable.reliantAreas).toEqual({ [SupportedArea.MODEL_SERVING]: true });
+    });
+
+    it('should not be available when modelDeploymentSettings flag is false', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        mockDashboardConfig({ modelDeploymentSettings: false }).spec,
+        null,
+        null,
+      );
+
+      expect(isAvailable.status).toBe(false);
+      expect(isAvailable.featureFlags).toEqual({ modelDeploymentSettings: 'off' });
+    });
+
+    it('should not be available when MODEL_SERVING is disabled', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        mockDashboardConfig({ modelDeploymentSettings: true, disableModelServing: true }).spec,
+        null,
+        null,
+      );
+
+      expect(isAvailable.status).toBe(false);
+      expect(isAvailable.reliantAreas).toEqual({ [SupportedArea.MODEL_SERVING]: false });
+    });
+  });
+
+  describe('LLM admin page areas with MODEL_DEPLOYMENT_SETTINGS enabled', () => {
+    it('should make LLMD_TOPOLOGY_CONFIGS available when llmdTemplates is true', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.LLMD_TOPOLOGY_CONFIGS,
+        mockDashboardConfig({
+          modelDeploymentSettings: true,
+          llmdTemplates: true,
+          disableLLMd: false,
+          disableModelServing: false,
+          disableKServe: false,
+        }).spec,
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+          },
+        }),
+        mockDsciStatus({}),
+      );
+
+      expect(isAvailable.status).toBe(true);
+      expect(isAvailable.featureFlags).toEqual({ llmdTemplates: 'on' });
+      expect(isAvailable.reliantAreas).toEqual({ [SupportedArea.LLMD_SERVING]: true });
+    });
+
+    it('should hide LLMD_TOPOLOGY_CONFIGS when llmdTemplates is false', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.LLMD_TOPOLOGY_CONFIGS,
+        mockDashboardConfig({
+          modelDeploymentSettings: true,
+          llmdTemplates: false,
+          disableLLMd: false,
+          disableModelServing: false,
+          disableKServe: false,
+        }).spec,
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+          },
+        }),
+        mockDsciStatus({}),
+      );
+
+      expect(isAvailable.status).toBe(false);
+      expect(isAvailable.featureFlags).toEqual({ llmdTemplates: 'off' });
+    });
+
+    it('should make VLLM_ON_MAAS available when vLLMDeploymentOnMaaS is true and LLMD_SERVING is available', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.VLLM_ON_MAAS,
+        mockDashboardConfig({
+          modelDeploymentSettings: true,
+          vLLMDeploymentOnMaaS: true,
+          disableLLMd: false,
+          disableModelServing: false,
+          disableKServe: false,
+        }).spec,
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+          },
+        }),
+        mockDsciStatus({}),
+      );
+
+      expect(isAvailable.status).toBe(true);
+      expect(isAvailable.featureFlags).toEqual({ vLLMDeploymentOnMaaS: 'on' });
+      expect(isAvailable.reliantAreas).toEqual({ [SupportedArea.LLMD_SERVING]: true });
+    });
+
+    it('should hide VLLM_ON_MAAS when vLLMDeploymentOnMaaS is false', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.VLLM_ON_MAAS,
+        mockDashboardConfig({
+          modelDeploymentSettings: true,
+          vLLMDeploymentOnMaaS: false,
+          disableLLMd: false,
+          disableModelServing: false,
+          disableKServe: false,
+        }).spec,
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+          },
+        }),
+        mockDsciStatus({}),
+      );
+
+      expect(isAvailable.status).toBe(false);
+      expect(isAvailable.featureFlags).toEqual({ vLLMDeploymentOnMaaS: 'off' });
+    });
+
+    it('should hide LLMD_TOPOLOGY_CONFIGS when LLMD_SERVING is disabled', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.LLMD_TOPOLOGY_CONFIGS,
+        mockDashboardConfig({
+          modelDeploymentSettings: true,
+          llmdTemplates: true,
+          disableLLMd: true,
+        }).spec,
+        null,
+        null,
+      );
+
+      expect(isAvailable.status).toBe(false);
+      expect(isAvailable.reliantAreas).toEqual({ [SupportedArea.LLMD_SERVING]: false });
+    });
+  });
+
   describe('ROLE_MANAGEMENT area', () => {
     it('should be available when roleManagement flag is true', () => {
       const isAvailable = isAreaAvailable(

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -31,6 +31,7 @@ export const techPreviewFlags = {
 } satisfies Partial<DashboardCommonConfig>;
 
 export const devTemporaryFeatureFlags = {
+  modelDeploymentSettings: false,
   disableKueue: true,
   disableProjectScoped: true,
   nimWizard: false,
@@ -155,6 +156,10 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.MODEL_SERVING]: {
     featureFlags: ['disableModelServing'],
+  },
+  [SupportedArea.MODEL_DEPLOYMENT_SETTINGS]: {
+    featureFlags: ['modelDeploymentSettings'],
+    reliantAreas: [SupportedArea.MODEL_SERVING],
   },
   [SupportedArea.USER_MANAGEMENT]: {
     featureFlags: ['disableUserManagement'],

--- a/frontend/src/plugins/extensions/navigation.ts
+++ b/frontend/src/plugins/extensions/navigation.ts
@@ -331,6 +331,7 @@ const extensions: (NavExtension | TabRoutePageExtension)[] = [
     type: 'app.navigation/href',
     flags: {
       required: [SupportedArea.CUSTOM_RUNTIMES, ADMIN_USER],
+      disallowed: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS],
     },
     properties: {
       id: 'settings-custom-serving-runtimes',

--- a/frontend/src/plugins/extensions/routes.ts
+++ b/frontend/src/plugins/extensions/routes.ts
@@ -315,6 +315,7 @@ const extensions: RouteExtension[] = [
     type: 'app.route',
     flags: {
       required: [ADMIN_USER],
+      disallowed: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS],
     },
     properties: {
       path: '/settings/model-resources-operations/serving-runtimes/*',
@@ -326,6 +327,7 @@ const extensions: RouteExtension[] = [
     type: 'app.route',
     flags: {
       required: [ADMIN_USER],
+      disallowed: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS],
     },
     properties: {
       path: '/servingRuntimes/*',

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -320,6 +320,7 @@ export type DashboardCommonConfig = {
   gpuaas?: boolean;
   connectionTest?: boolean;
   modelCapabilities?: boolean;
+  modelDeploymentSettings?: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -21,7 +21,10 @@ import type {
   DeploymentWizardFieldOverrideExtension,
 } from '@odh-dashboard/model-serving/extension-points/deployment-wizard';
 import type { WizardField } from '@odh-dashboard/model-serving/shared/types/form-data';
-import type { AreaExtension } from '@odh-dashboard/plugin-core/extension-points';
+import type {
+  AreaExtension,
+  TabRouteTabExtension,
+} from '@odh-dashboard/plugin-core/extension-points';
 import { DataScienceStackComponent, SupportedArea } from '@odh-dashboard/plugin-core/areas';
 import type { DeploymentMethodFieldData } from '@odh-dashboard/model-serving/shared/wizard-fields';
 import type { TimeoutFieldValue } from './src/wizardFields/timeout/TimeoutField';
@@ -29,6 +32,7 @@ import type { KServeServingRuntimeFieldType } from './src/wizardFields/servingRu
 import type { KServeDeployment } from './src/deployments';
 
 export const KSERVE_ID = 'kserve';
+const ADMIN_USER = 'ADMIN_USER';
 
 const kserveServingRuntimeFieldExtension: WizardFieldExtension<
   KServeServingRuntimeFieldType,
@@ -113,6 +117,7 @@ const extensions: (
   | WizardFieldExtractorExtension<TimeoutFieldValue, KServeDeployment>
   | WizardFieldExtractorExtension<DeploymentMethodFieldData, KServeDeployment>
   | DeploymentWizardFieldOverrideExtension<KServeDeployment>
+  | TabRouteTabExtension
 )[] = [
   {
     type: 'app.area',
@@ -304,6 +309,23 @@ const extensions: (
     },
     flags: {
       required: [SupportedArea.K_SERVE],
+    },
+  },
+  {
+    type: 'app.tab-route/tab',
+    flags: {
+      required: [
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        SupportedArea.CUSTOM_RUNTIMES,
+        ADMIN_USER,
+      ],
+    },
+    properties: {
+      pageId: 'model-deployment-settings',
+      id: 'serving-runtime-templates',
+      title: 'Serving runtime templates',
+      component: () => import('./src/settings/ServingRuntimeTemplatesTab'),
+      group: '2_serving-runtimes',
     },
   },
 ];

--- a/packages/kserve/src/settings/ServingRuntimeTemplatesTab.tsx
+++ b/packages/kserve/src/settings/ServingRuntimeTemplatesTab.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { EmptyState, EmptyStateBody, PageSection } from '@patternfly/react-core';
+
+const ServingRuntimeTemplatesTab: React.FC = () => (
+  <PageSection hasBodyWrapper={false}>
+    <EmptyState headingLevel="h2" titleText="Serving runtime templates">
+      <EmptyStateBody>
+        Serving runtime templates will be available here. This tab is under construction.
+      </EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default ServingRuntimeTemplatesTab;

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -620,7 +620,12 @@ const extensions: (
   {
     type: 'app.route',
     flags: {
-      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+      required: [
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        LLMD_SERVING_ID,
+        ADMIN_USER,
+        SupportedArea.VLLM_ON_MAAS,
+      ],
     },
     properties: {
       path: '/settings/model-resources-operations/llm-accelerator-configs/*',
@@ -633,7 +638,11 @@ const extensions: (
   {
     type: 'app.route',
     flags: {
-      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+      required: [
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        SupportedArea.LLMD_TOPOLOGY_CONFIGS,
+        ADMIN_USER,
+      ],
     },
     properties: {
       path: '/settings/model-resources-operations/llmd-topology-configurations/*',
@@ -646,7 +655,11 @@ const extensions: (
   {
     type: 'app.route',
     flags: {
-      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+      required: [
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        SupportedArea.LLMD_TOPOLOGY_CONFIGS,
+        ADMIN_USER,
+      ],
     },
     properties: {
       path: '/settings/model-resources-operations/llmd-routing-configurations/*',

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -669,7 +669,6 @@ const extensions: (
       }),
     },
   },
-  // Placeholder tabs on the model deployment settings page (replaced by migration stories)
   {
     type: 'app.tab-route/tab',
     flags: {

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -19,6 +19,7 @@ import type {
   AreaExtension,
   HrefNavItemExtension,
   RouteExtension,
+  TabRouteTabExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
 import type { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import type { LLMdDeployment, LLMInferenceServiceConfigKind } from '../src/types';
@@ -42,6 +43,11 @@ import type {
 
 export const LLMD_SERVING_ID = 'llmd-serving';
 const ADMIN_USER = 'ADMIN_USER';
+
+const createRedirectComponent = (args: { from: string; to: string }) => () =>
+  import('@odh-dashboard/internal/utilities/v2Redirect').then((module) => ({
+    default: () => module.buildV2RedirectElement(args),
+  }));
 
 // When vLLMOnMaaS enabled + llmdTemplates disabled: show accelerator config for all llm-d (single-node fallback)
 const llmConfigOptionsFieldExtensionNoTemplates: WizardFieldExtension<
@@ -323,6 +329,7 @@ const extensions: (
   | WizardFieldExtractorExtension<{ method: string }, LLMdDeployment>
   | HrefNavItemExtension
   | RouteExtension
+  | TabRouteTabExtension
 )[] = [
   {
     type: 'app.area',
@@ -535,6 +542,7 @@ const extensions: (
     type: 'app.navigation/href',
     flags: {
       required: [LLMD_SERVING_ID, ADMIN_USER, SupportedArea.VLLM_ON_MAAS],
+      disallowed: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS],
     },
     properties: {
       id: 'settings-llm-accelerator-configs',
@@ -549,6 +557,7 @@ const extensions: (
     type: 'app.route',
     flags: {
       required: [LLMD_SERVING_ID, ADMIN_USER, SupportedArea.VLLM_ON_MAAS],
+      disallowed: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS],
     },
     properties: {
       path: '/settings/model-resources-operations/llm-accelerator-configs/*',
@@ -559,6 +568,7 @@ const extensions: (
     type: 'app.navigation/href',
     flags: {
       required: [SupportedArea.LLMD_TOPOLOGY_CONFIGS, ADMIN_USER],
+      disallowed: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS],
     },
     properties: {
       id: 'settings-llmd-topology-configurations',
@@ -573,6 +583,7 @@ const extensions: (
     type: 'app.route',
     flags: {
       required: [SupportedArea.LLMD_TOPOLOGY_CONFIGS, ADMIN_USER],
+      disallowed: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS],
     },
     properties: {
       path: '/settings/model-resources-operations/llmd-topology-configurations/*',
@@ -583,6 +594,7 @@ const extensions: (
     type: 'app.navigation/href',
     flags: {
       required: [SupportedArea.LLMD_TOPOLOGY_CONFIGS, ADMIN_USER],
+      disallowed: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS],
     },
     properties: {
       id: 'settings-llmd-routing-configurations',
@@ -597,10 +609,104 @@ const extensions: (
     type: 'app.route',
     flags: {
       required: [SupportedArea.LLMD_TOPOLOGY_CONFIGS, ADMIN_USER],
+      disallowed: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS],
     },
     properties: {
       path: '/settings/model-resources-operations/llmd-routing-configurations/*',
       component: () => import('../src/settings/RoutingConfigurationsRoutes'),
+    },
+  },
+  // Redirects from old standalone URLs to tabs on the model deployment settings page
+  {
+    type: 'app.route',
+    flags: {
+      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+    },
+    properties: {
+      path: '/settings/model-resources-operations/llm-accelerator-configs/*',
+      component: createRedirectComponent({
+        from: '/settings/model-resources-operations/llm-accelerator-configs/*',
+        to: '/settings/model-resources-operations/model-deployment-settings/llm-accelerator-configurations/*',
+      }),
+    },
+  },
+  {
+    type: 'app.route',
+    flags: {
+      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+    },
+    properties: {
+      path: '/settings/model-resources-operations/llmd-topology-configurations/*',
+      component: createRedirectComponent({
+        from: '/settings/model-resources-operations/llmd-topology-configurations/*',
+        to: '/settings/model-resources-operations/model-deployment-settings/topology-configurations/*',
+      }),
+    },
+  },
+  {
+    type: 'app.route',
+    flags: {
+      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+    },
+    properties: {
+      path: '/settings/model-resources-operations/llmd-routing-configurations/*',
+      component: createRedirectComponent({
+        from: '/settings/model-resources-operations/llmd-routing-configurations/*',
+        to: '/settings/model-resources-operations/model-deployment-settings/routing-configurations/*',
+      }),
+    },
+  },
+  // Placeholder tabs on the model deployment settings page (replaced by migration stories)
+  {
+    type: 'app.tab-route/tab',
+    flags: {
+      required: [
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        LLMD_SERVING_ID,
+        ADMIN_USER,
+        SupportedArea.VLLM_ON_MAAS,
+      ],
+    },
+    properties: {
+      pageId: 'model-deployment-settings',
+      id: 'llm-accelerator-configurations',
+      title: 'LLM accelerator configurations',
+      component: () => import('../src/settings/LlmAcceleratorConfigsTab'),
+      group: '3_accelerator',
+    },
+  },
+  {
+    type: 'app.tab-route/tab',
+    flags: {
+      required: [
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        SupportedArea.LLMD_TOPOLOGY_CONFIGS,
+        ADMIN_USER,
+      ],
+    },
+    properties: {
+      pageId: 'model-deployment-settings',
+      id: 'topology-configurations',
+      title: 'llm-d topology configurations',
+      component: () => import('../src/settings/TopologyConfigsTab'),
+      group: '4_topology',
+    },
+  },
+  {
+    type: 'app.tab-route/tab',
+    flags: {
+      required: [
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        SupportedArea.LLMD_TOPOLOGY_CONFIGS,
+        ADMIN_USER,
+      ],
+    },
+    properties: {
+      pageId: 'model-deployment-settings',
+      id: 'routing-configurations',
+      title: 'llm-d routing configurations',
+      component: () => import('../src/settings/RoutingConfigsTab'),
+      group: '5_routing',
     },
   },
 ];

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -45,7 +45,7 @@ export const LLMD_SERVING_ID = 'llmd-serving';
 const ADMIN_USER = 'ADMIN_USER';
 
 const createRedirectComponent = (args: { from: string; to: string }) => () =>
-  import('@odh-dashboard/internal/utilities/v2Redirect').then((module) => ({
+  import('@odh-dashboard/plugin-core/routing').then((module) => ({
     default: () => module.buildV2RedirectElement(args),
   }));
 

--- a/packages/llmd-serving/src/settings/LlmAcceleratorConfigsTab.tsx
+++ b/packages/llmd-serving/src/settings/LlmAcceleratorConfigsTab.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { EmptyState, EmptyStateBody, PageSection } from '@patternfly/react-core';
+
+const LlmAcceleratorConfigsTab: React.FC = () => (
+  <PageSection hasBodyWrapper={false}>
+    <EmptyState headingLevel="h2" titleText="LLM accelerator configurations">
+      <EmptyStateBody>
+        LLM accelerator configurations will be available here. This tab is under construction.
+      </EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default LlmAcceleratorConfigsTab;

--- a/packages/llmd-serving/src/settings/RoutingConfigsTab.tsx
+++ b/packages/llmd-serving/src/settings/RoutingConfigsTab.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { EmptyState, EmptyStateBody, PageSection } from '@patternfly/react-core';
+
+const RoutingConfigsTab: React.FC = () => (
+  <PageSection hasBodyWrapper={false}>
+    <EmptyState headingLevel="h2" titleText="llm-d routing configurations">
+      <EmptyStateBody>
+        llm-d routing configurations will be available here. This tab is under construction.
+      </EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default RoutingConfigsTab;

--- a/packages/llmd-serving/src/settings/TopologyConfigsTab.tsx
+++ b/packages/llmd-serving/src/settings/TopologyConfigsTab.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { EmptyState, EmptyStateBody, PageSection } from '@patternfly/react-core';
+
+const TopologyConfigsTab: React.FC = () => (
+  <PageSection hasBodyWrapper={false}>
+    <EmptyState headingLevel="h2" titleText="llm-d topology configurations">
+      <EmptyStateBody>
+        llm-d topology configurations will be available here. This tab is under construction.
+      </EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default TopologyConfigsTab;

--- a/packages/model-serving/extensions/odh.ts
+++ b/packages/model-serving/extensions/odh.ts
@@ -162,7 +162,11 @@ const extensions: (
       }),
     },
     flags: {
-      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+      required: [
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        SupportedArea.CUSTOM_RUNTIMES,
+        ADMIN_USER,
+      ],
     },
   },
   {
@@ -175,7 +179,11 @@ const extensions: (
       }),
     },
     flags: {
-      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+      required: [
+        SupportedArea.MODEL_DEPLOYMENT_SETTINGS,
+        SupportedArea.CUSTOM_RUNTIMES,
+        ADMIN_USER,
+      ],
     },
   },
 ];

--- a/packages/model-serving/extensions/odh.ts
+++ b/packages/model-serving/extensions/odh.ts
@@ -3,11 +3,14 @@ import type {
   OverviewSectionExtension,
   ProjectDetailsTab,
   RouteExtension,
+  TabRoutePageExtension,
   TabRouteTabExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
 import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
 import type { WizardFieldExtension } from '@odh-dashboard/model-serving/extension-points/deployment-wizard';
 import type { DeploymentMethodSelectFieldType } from '../src/components/deploymentWizard/fields/DeploymentMethodSelectField';
+
+const ADMIN_USER = 'ADMIN_USER';
 
 const createRedirectComponent = (args: { from: string; to: string }) => () =>
   import('@odh-dashboard/plugin-core/routing').then((module) => ({
@@ -32,6 +35,7 @@ const extensions: (
   | ProjectDetailsTab
   | RouteExtension
   | OverviewSectionExtension
+  | TabRoutePageExtension
   | TabRouteTabExtension
   | WizardFieldExtension<DeploymentMethodSelectFieldType>
 )[] = [
@@ -118,6 +122,62 @@ const extensions: (
     },
   },
   deploymentMethodFieldExtension,
+  // Model deployment settings tabbed page
+  {
+    type: 'app.tab-route/page',
+    flags: {
+      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+    },
+    properties: {
+      id: 'model-deployment-settings',
+      title: 'Model deployment settings',
+      href: '/settings/model-resources-operations/model-deployment-settings',
+      path: '/settings/model-resources-operations/model-deployment-settings/*',
+      section: 'settings-model-resources-and-operations',
+      group: '1_model-resources',
+    },
+  },
+  // General settings tab in the Model deployment settings page
+  {
+    type: 'app.tab-route/tab',
+    flags: {
+      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+    },
+    properties: {
+      pageId: 'model-deployment-settings',
+      id: 'general-settings',
+      title: 'General settings',
+      component: () => import('../src/components/settings/GeneralSettingsTab'),
+      group: '1_general',
+    },
+  },
+  // Redirect old serving runtimes URL to the new model deployment settings page
+  {
+    type: 'app.route',
+    properties: {
+      path: '/settings/model-resources-operations/serving-runtimes/*',
+      component: createRedirectComponent({
+        from: '/settings/model-resources-operations/serving-runtimes/*',
+        to: '/settings/model-resources-operations/model-deployment-settings/serving-runtime-templates/*',
+      }),
+    },
+    flags: {
+      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+    },
+  },
+  {
+    type: 'app.route',
+    properties: {
+      path: '/servingRuntimes/*',
+      component: createRedirectComponent({
+        from: '/servingRuntimes/*',
+        to: '/settings/model-resources-operations/model-deployment-settings/serving-runtime-templates/*',
+      }),
+    },
+    flags: {
+      required: [SupportedArea.MODEL_DEPLOYMENT_SETTINGS, ADMIN_USER],
+    },
+  },
 ];
 
 export default extensions;

--- a/packages/model-serving/src/components/settings/GeneralSettingsTab.tsx
+++ b/packages/model-serving/src/components/settings/GeneralSettingsTab.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { EmptyState, EmptyStateBody, PageSection } from '@patternfly/react-core';
+
+const GeneralSettingsTab: React.FC = () => (
+  <PageSection hasBodyWrapper={false}>
+    <EmptyState headingLevel="h2" titleText="General settings">
+      <EmptyStateBody>
+        Model serving general settings will be available here. This tab is under construction.
+      </EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default GeneralSettingsTab;

--- a/packages/plugin-core/src/areas/types.ts
+++ b/packages/plugin-core/src/areas/types.ts
@@ -50,6 +50,7 @@ export enum SupportedArea {
 
   /* Model Serving areas */
   MODEL_SERVING = 'model-serving-shell',
+  MODEL_DEPLOYMENT_SETTINGS = 'model-deployment-settings',
   CUSTOM_RUNTIMES = 'custom-serving-runtimes',
   K_SERVE = 'kserve',
   K_SERVE_AUTH = 'kserve-auth',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-68983

## Description

Replaces [PR #8116](https://github.com/opendatahub-io/odh-dashboard/pull/8116) by @YuliaKrimerman — incorporates its changes rebased as the first commit, then extends with additional work.

Adds the foundation for the new "Model deployment settings" tabbed admin page that consolidates all model serving settings into a single page with tabs. This PR implements the page shell story ([RHOAIENG-68983](https://redhat.atlassian.net/browse/RHOAIENG-68983)) from the [RHOAIENG-68972](https://redhat.atlassian.net/browse/RHOAIENG-68972) epic.

**What this PR does:**
- Adds `modelDeploymentSettings` dev feature flag (off by default) and `MODEL_DEPLOYMENT_SETTINGS` supported area
- Registers a `TabRoutePageExtension` in the model-serving package for the tabbed page
- Adds a placeholder "General settings" tab (model-serving package)
- Adds placeholder tabs for serving-runtime-templates (kserve package), LLM accelerator configurations, llm-d topology configurations, and llm-d routing configurations (llmd-serving package)
- Hides all existing standalone pages when the flag is on via `disallowed` flags:
  - "Serving runtimes" nav item and routes (in frontend extensions)
  - "LLM accelerator configurations" nav item and route (in llmd-serving extensions)
  - "llm-d topology configurations" nav item and route (in llmd-serving extensions)
  - "llm-d routing configurations" nav item and route (in llmd-serving extensions)
- Adds redirect routes from all old standalone URLs to corresponding tabs
- Each placeholder tab preserves the same feature flag gating as its standalone page (e.g. accelerator configs tab requires `VLLM_ON_MAAS`, topology/routing tabs require `LLMD_TOPOLOGY_CONFIGS`)

## How Has This Been Tested?

- Manually verified with `?devFeatureFlags=modelDeploymentSettings=true`:
  - Flag OFF (default): all standalone pages and nav items work as before, no regressions
  - Flag ON: "Model deployment settings" appears in sidebar, tabbed page renders with all 5 placeholder tabs, old standalone nav items hidden
  - Verified tab visibility respects underlying flags (disabling `llmdTemplates` hides topology/routing tabs, disabling `vLLMDeploymentOnMaaS` hides accelerator tab)
  - Verified redirects from old standalone URLs land on correct tabs
- Type checks pass
- Lint passes

## Test Impact

Added unit tests for `MODEL_DEPLOYMENT_SETTINGS` area availability:
- Flag on/off behavior
- Interaction with `MODEL_SERVING` reliant area
- `LLMD_TOPOLOGY_CONFIGS` visibility with `llmdTemplates` flag (on/off and with LLMD_SERVING disabled)
- `VLLM_ON_MAAS` visibility with `vLLMDeploymentOnMaaS` flag (on/off)
- Added `modelDeploymentSettings` to `mockDashboardConfig`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-68983]: https://redhat.atlassian.net/browse/RHOAIENG-68983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-68972]: https://redhat.atlassian.net/browse/RHOAIENG-68972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a model deployment settings area with tabbed navigation for general, accelerator, topology, routing, and serving runtime settings.
  * Added access controls for administrators and supported model-serving configurations.
  * Added redirects from legacy settings pages to the new model deployment settings area.
  * Added placeholder screens indicating settings currently under construction.

* **Tests**
  * Added coverage for feature availability, dependencies, and configuration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->