### PR TITLE
Add analytics tracking for global project selections

### DIFF
--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -3,8 +3,9 @@ import * as _ from 'lodash-es';
 import { AlertVariant, Button, Stack, StackItem } from '@patternfly/react-core';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import TitleWithIcon from '@odh-dashboard/ui-core/design/TitleWithIcon';
-import { ApplicationsPage } from '@odh-dashboard/ui-core';
+import { ApplicationsPage, TrackingOutcome } from '@odh-dashboard/ui-core';
 import { useAppContext } from '#~/app/AppContext';
+import { fireFormTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 import { fetchClusterSettings, updateClusterSettings } from '#~/services/clusterSettingsService';
 import { ClusterSettingsType, ModelServingPlatformEnabled } from '#~/types';
 import { addNotification } from '#~/redux/actions/actions';
@@ -133,6 +134,11 @@ const ClusterSettings: React.FC = () => {
       return;
     }
 
+    const globalProjectName = !_.isEqual(
+      clusterSettings.globalMLflowNamespaces,
+      newClusterSettings.globalMLflowNamespaces,
+    );
+
     setSaving(true);
 
     try {
@@ -144,6 +150,12 @@ const ClusterSettings: React.FC = () => {
 
       setClusterSettings(newClusterSettings);
 
+      fireFormTrackingEvent('Cluster Settings Global Project Selected', {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        globalProjectName,
+      });
+
       dispatch(
         addNotification({
           status: AlertVariant.success,
@@ -153,6 +165,13 @@ const ClusterSettings: React.FC = () => {
         }),
       );
     } catch (error) {
+      fireFormTrackingEvent('Cluster Settings Global Project Selected', {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        globalProjectName,
+        error: error instanceof Error ? error.message : 'unknown error',
+      });
+
       dispatch(
         addNotification({
           status: AlertVariant.danger,

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -151,6 +151,7 @@ const ClusterSettings: React.FC = () => {
     else globalProjectName = GlobalProjectState.changed;
 
     try {
+      setSaving(true);
       const response = await updateClusterSettings(newClusterSettings);
 
       if (!response.success) {
@@ -175,12 +176,14 @@ const ClusterSettings: React.FC = () => {
         }),
       );
     } catch (error) {
-      fireFormTrackingEvent('Cluster Settings Global Project Selected', {
-        outcome: TrackingOutcome.submit,
-        success: false,
-        globalProjectName,
-        error: error instanceof Error ? error.message : 'unknown error',
-      });
+      if (globalProjectName !== GlobalProjectState.unchanged) {
+        fireFormTrackingEvent('Cluster Settings Global Project Selected', {
+          outcome: TrackingOutcome.submit,
+          success: false,
+          globalProjectName,
+          error: error instanceof Error ? error.message : 'unknown error',
+        });
+      }
 
       dispatch(
         addNotification({

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -27,6 +27,13 @@ import {
 
 const DEFAULT_DISTRIBUTED_INFERENCING = DEFAULT_CONFIG.isDistributedInferencingDefault ?? true;
 
+enum GlobalProjectState {
+  added = 'Added',
+  changed = 'Changed',
+  unchanged = 'Unchanged',
+  removed = 'Removed',
+}
+
 const ClusterSettings: React.FC = () => {
   const [loaded, setLoaded] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
@@ -134,12 +141,14 @@ const ClusterSettings: React.FC = () => {
       return;
     }
 
-    const globalProjectName = !_.isEqual(
-      clusterSettings.globalMLflowNamespaces,
-      newClusterSettings.globalMLflowNamespaces,
-    );
-
-    setSaving(true);
+    const currentGlobalNamespace = clusterSettings.globalMLflowNamespaces?.[0];
+    const newGlobalNamespace = newClusterSettings.globalMLflowNamespaces?.[0];
+    let globalProjectName: GlobalProjectState;
+    if (currentGlobalNamespace === newGlobalNamespace)
+      globalProjectName = GlobalProjectState.unchanged;
+    else if (!currentGlobalNamespace) globalProjectName = GlobalProjectState.added;
+    else if (!newGlobalNamespace) globalProjectName = GlobalProjectState.removed;
+    else globalProjectName = GlobalProjectState.changed;
 
     try {
       const response = await updateClusterSettings(newClusterSettings);
@@ -150,11 +159,12 @@ const ClusterSettings: React.FC = () => {
 
       setClusterSettings(newClusterSettings);
 
-      fireFormTrackingEvent('Cluster Settings Global Project Selected', {
-        outcome: TrackingOutcome.submit,
-        success: true,
-        globalProjectName,
-      });
+      if (globalProjectName !== GlobalProjectState.unchanged)
+        fireFormTrackingEvent('Cluster Settings Global Project Selected', {
+          outcome: TrackingOutcome.submit,
+          success: true,
+          globalProjectName,
+        });
 
       dispatch(
         addNotification({

--- a/frontend/src/pages/clusterSettings/__tests__/ClusterSettings.spec.tsx
+++ b/frontend/src/pages/clusterSettings/__tests__/ClusterSettings.spec.tsx
@@ -32,14 +32,19 @@ jest.mock('#~/concepts/analyticsTracking/segmentIOUtils', () => ({
   fireFormTrackingEvent: jest.fn(),
 }));
 
-// Simplify GlobalProjectSettings to a single button that selects a new namespace,
-// avoiding the need to stand up ProjectsContext/ProjectSelector for these tests.
+// Simplify GlobalProjectSettings to two buttons that either select a new namespace
+// or clear the current one, avoiding the need to stand up ProjectsContext/ProjectSelector.
 jest.mock('#~/pages/clusterSettings/GlobalProjectSettings', () => ({
   __esModule: true,
   default: ({ setSelectedNamespace }: { setSelectedNamespace: (ns: string) => void }) => (
-    <button type="button" onClick={() => setSelectedNamespace('new-project')}>
-      Select global project
-    </button>
+    <>
+      <button type="button" onClick={() => setSelectedNamespace('new-project')}>
+        Select global project
+      </button>
+      <button type="button" onClick={() => setSelectedNamespace('')}>
+        Clear global project
+      </button>
+    </>
   ),
 }));
 
@@ -84,22 +89,24 @@ describe('ClusterSettings', () => {
     mockFetchClusterSettings.mockResolvedValue(DEFAULT_CONFIG);
   });
 
-  const renderAndSelectGlobalProject = async () => {
+  const renderAndWaitForLoad = async () => {
     render(<ClusterSettings />);
-
     await screen.findByTestId('submit-cluster-settings');
+  };
 
-    fireEvent.click(screen.getByText('Select global project'));
+  const clickAndWaitForEnabled = async (buttonText: string) => {
+    fireEvent.click(screen.getByText(buttonText));
 
     await waitFor(() => {
       expect(screen.getByTestId('submit-cluster-settings')).toBeEnabled();
     });
   };
 
-  it('should fire a success tracking event with globalProjectName true on successful save', async () => {
+  it('should fire an Added tracking event when a global project is selected from empty on successful save', async () => {
     mockUpdateClusterSettings.mockResolvedValue({ success: true, error: '' });
 
-    await renderAndSelectGlobalProject();
+    await renderAndWaitForLoad();
+    await clickAndWaitForEnabled('Select global project');
 
     fireEvent.click(screen.getByTestId('submit-cluster-settings'));
 
@@ -109,17 +116,91 @@ describe('ClusterSettings', () => {
         {
           outcome: 'submit',
           success: true,
-          globalProjectName: true,
+          globalProjectName: 'Added',
         },
       );
     });
+  });
+
+  it('should fire a Changed tracking event when an existing global project is replaced on successful save', async () => {
+    mockFetchClusterSettings.mockResolvedValue({
+      ...DEFAULT_CONFIG,
+      globalMLflowNamespaces: ['existing-ns'],
+    });
+    mockUpdateClusterSettings.mockResolvedValue({ success: true, error: '' });
+
+    await renderAndWaitForLoad();
+    await clickAndWaitForEnabled('Select global project');
+
+    fireEvent.click(screen.getByTestId('submit-cluster-settings'));
+
+    await waitFor(() => {
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+        'Cluster Settings Global Project Selected',
+        {
+          outcome: 'submit',
+          success: true,
+          globalProjectName: 'Changed',
+        },
+      );
+    });
+  });
+
+  it('should fire a Removed tracking event when an existing global project is cleared on successful save', async () => {
+    mockFetchClusterSettings.mockResolvedValue({
+      ...DEFAULT_CONFIG,
+      globalMLflowNamespaces: ['existing-ns'],
+    });
+    mockUpdateClusterSettings.mockResolvedValue({ success: true, error: '' });
+
+    await renderAndWaitForLoad();
+    await clickAndWaitForEnabled('Clear global project');
+
+    fireEvent.click(screen.getByTestId('submit-cluster-settings'));
+
+    await waitFor(() => {
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+        'Cluster Settings Global Project Selected',
+        {
+          outcome: 'submit',
+          success: true,
+          globalProjectName: 'Removed',
+        },
+      );
+    });
+  });
+
+  it('should not fire a global project tracking event when the global project is unchanged, even if other settings changed', async () => {
+    mockFetchClusterSettings.mockResolvedValue({
+      ...DEFAULT_CONFIG,
+      globalMLflowNamespaces: ['existing-ns'],
+    });
+    mockUpdateClusterSettings.mockResolvedValue({ success: true, error: '' });
+
+    await renderAndWaitForLoad();
+
+    // Change an unrelated setting so the form is dirty, but leave the global project untouched.
+    fireEvent.change(screen.getByTestId('pvc-size-input'), { target: { value: '25' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('submit-cluster-settings')).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByTestId('submit-cluster-settings'));
+
+    await waitFor(() => {
+      expect(mockUpdateClusterSettings).toHaveBeenCalled();
+    });
+
+    expect(mockFireFormTrackingEvent).not.toHaveBeenCalled();
   });
 
   it('should fire a failure tracking event with the error message when the update API rejects', async () => {
     const error = new Error('Update failed');
     mockUpdateClusterSettings.mockRejectedValue(error);
 
-    await renderAndSelectGlobalProject();
+    await renderAndWaitForLoad();
+    await clickAndWaitForEnabled('Select global project');
 
     fireEvent.click(screen.getByTestId('submit-cluster-settings'));
 
@@ -129,7 +210,7 @@ describe('ClusterSettings', () => {
         {
           outcome: 'submit',
           success: false,
-          globalProjectName: true,
+          globalProjectName: 'Added',
           error: error.message,
         },
       );
@@ -139,7 +220,8 @@ describe('ClusterSettings', () => {
   it('should fire a failure tracking event when the update API resolves unsuccessfully', async () => {
     mockUpdateClusterSettings.mockResolvedValue({ success: false, error: 'Rejected by server' });
 
-    await renderAndSelectGlobalProject();
+    await renderAndWaitForLoad();
+    await clickAndWaitForEnabled('Select global project');
 
     fireEvent.click(screen.getByTestId('submit-cluster-settings'));
 
@@ -149,7 +231,7 @@ describe('ClusterSettings', () => {
         {
           outcome: 'submit',
           success: false,
-          globalProjectName: true,
+          globalProjectName: 'Added',
           error: 'Rejected by server',
         },
       );

--- a/frontend/src/pages/clusterSettings/__tests__/ClusterSettings.spec.tsx
+++ b/frontend/src/pages/clusterSettings/__tests__/ClusterSettings.spec.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+import ClusterSettings from '#~/pages/clusterSettings/ClusterSettings';
+import { useAppContext } from '#~/app/AppContext';
+import { useAppDispatch } from '#~/redux/hooks';
+import { fetchClusterSettings, updateClusterSettings } from '#~/services/clusterSettingsService';
+import { fireFormTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
+import { mockDashboardConfig } from '#~/__mocks__/mockDashboardConfig';
+import { DEFAULT_CONFIG } from '#~/pages/clusterSettings/const';
+
+jest.mock('#~/app/AppContext', () => ({
+  useAppContext: jest.fn(),
+}));
+
+jest.mock('#~/redux/hooks', () => ({
+  useAppDispatch: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/plugin-core/areas', () => ({
+  ...jest.requireActual('@odh-dashboard/plugin-core/areas'),
+  useIsAreaAvailable: jest.fn(),
+}));
+
+jest.mock('#~/services/clusterSettingsService', () => ({
+  fetchClusterSettings: jest.fn(),
+  updateClusterSettings: jest.fn(),
+}));
+
+jest.mock('#~/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+}));
+
+// Simplify GlobalProjectSettings to a single button that selects a new namespace,
+// avoiding the need to stand up ProjectsContext/ProjectSelector for these tests.
+jest.mock('#~/pages/clusterSettings/GlobalProjectSettings', () => ({
+  __esModule: true,
+  default: ({ setSelectedNamespace }: { setSelectedNamespace: (ns: string) => void }) => (
+    <button type="button" onClick={() => setSelectedNamespace('new-project')}>
+      Select global project
+    </button>
+  ),
+}));
+
+const mockUseAppContext = useAppContext as jest.MockedFunction<typeof useAppContext>;
+const mockUseAppDispatch = useAppDispatch as jest.MockedFunction<typeof useAppDispatch>;
+const mockUseIsAreaAvailable = useIsAreaAvailable as jest.MockedFunction<typeof useIsAreaAvailable>;
+const mockFetchClusterSettings = fetchClusterSettings as jest.MockedFunction<
+  typeof fetchClusterSettings
+>;
+const mockUpdateClusterSettings = updateClusterSettings as jest.MockedFunction<
+  typeof updateClusterSettings
+>;
+const mockFireFormTrackingEvent = fireFormTrackingEvent as jest.MockedFunction<
+  typeof fireFormTrackingEvent
+>;
+
+describe('ClusterSettings', () => {
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseAppDispatch.mockReturnValue(mockDispatch as ReturnType<typeof useAppDispatch>);
+
+    mockUseAppContext.mockReturnValue({
+      buildStatuses: [],
+      dashboardConfig: mockDashboardConfig({ globalProjectPrompts: true }),
+      storageClasses: [],
+      isRHOAI: false,
+    });
+
+    mockUseIsAreaAvailable.mockReturnValue({
+      status: false,
+      featureFlags: {},
+      devFlags: {},
+      reliantAreas: {},
+      requiredComponents: {},
+      requiredCapabilities: {},
+      customCondition: jest.fn(),
+    } as ReturnType<typeof useIsAreaAvailable>);
+
+    mockFetchClusterSettings.mockResolvedValue(DEFAULT_CONFIG);
+  });
+
+  const renderAndSelectGlobalProject = async () => {
+    render(<ClusterSettings />);
+
+    await screen.findByTestId('submit-cluster-settings');
+
+    fireEvent.click(screen.getByText('Select global project'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('submit-cluster-settings')).toBeEnabled();
+    });
+  };
+
+  it('should fire a success tracking event with globalProjectName true on successful save', async () => {
+    mockUpdateClusterSettings.mockResolvedValue({ success: true, error: '' });
+
+    await renderAndSelectGlobalProject();
+
+    fireEvent.click(screen.getByTestId('submit-cluster-settings'));
+
+    await waitFor(() => {
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+        'Cluster Settings Global Project Selected',
+        {
+          outcome: 'submit',
+          success: true,
+          globalProjectName: true,
+        },
+      );
+    });
+  });
+
+  it('should fire a failure tracking event with the error message when the update API rejects', async () => {
+    const error = new Error('Update failed');
+    mockUpdateClusterSettings.mockRejectedValue(error);
+
+    await renderAndSelectGlobalProject();
+
+    fireEvent.click(screen.getByTestId('submit-cluster-settings'));
+
+    await waitFor(() => {
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+        'Cluster Settings Global Project Selected',
+        {
+          outcome: 'submit',
+          success: false,
+          globalProjectName: true,
+          error: error.message,
+        },
+      );
+    });
+  });
+
+  it('should fire a failure tracking event when the update API resolves unsuccessfully', async () => {
+    mockUpdateClusterSettings.mockResolvedValue({ success: false, error: 'Rejected by server' });
+
+    await renderAndSelectGlobalProject();
+
+    fireEvent.click(screen.getByTestId('submit-cluster-settings'));
+
+    await waitFor(() => {
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+        'Cluster Settings Global Project Selected',
+        {
+          outcome: 'submit',
+          success: false,
+          globalProjectName: true,
+          error: 'Rejected by server',
+        },
+      );
+    });
+  });
+});

--- a/packages/mlflow-embedded/prompts/MlflowPromptManagementPage.tsx
+++ b/packages/mlflow-embedded/prompts/MlflowPromptManagementPage.tsx
@@ -25,12 +25,13 @@ import { getDashboardMainContainer } from '@odh-dashboard/internal/utilities/uti
 import { useUser } from '@odh-dashboard/internal/redux/selectors/user';
 import ProjectSelectorNavigator from '@odh-dashboard/ui-core/components/projectSelector/ProjectSelectorNavigator';
 import TitleWithIcon from '@odh-dashboard/ui-core/design/TitleWithIcon';
-import { ApplicationsPage, ProjectObjectType } from '@odh-dashboard/ui-core';
+import { ApplicationsPage, ProjectObjectType, TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   promptManagementPath,
   mlflowPromptManagementBaseRoute,
   WORKSPACE_QUERY_PARAM,
 } from '@odh-dashboard/internal/routes/pipelines/mlflow';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import MLflowUnavailable from '../shared/MLflowUnavailable';
 import MLflowNotConfigured from '../shared/MLflowNotConfigured';
 import MlflowBreadcrumbs, { type BreadcrumbEntry } from '../shared/MlflowBreadcrumbs';
@@ -62,6 +63,18 @@ const MlflowPromptManagementPage: React.FC = () => {
     [],
   );
 
+  const handleProjectSelectChange = React.useCallback(
+    (projectName: string) => {
+      fireFormTrackingEvent('Prompts global project changed', {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        isGlobalProject: projectName === globalNamespace,
+        selectedProject: projectName,
+      });
+    },
+    [globalNamespace],
+  );
+
   const isTopLevel = breadcrumbs.length === 0;
 
   return (
@@ -91,6 +104,7 @@ const MlflowPromptManagementPage: React.FC = () => {
                 </FlexItem>
                 <FlexItem>
                   <ProjectSelectorNavigator
+                    onProjectChange={handleProjectSelectChange}
                     getRedirectPath={mlflowPromptManagementBaseRoute}
                     queryParamNamespace={WORKSPACE_QUERY_PARAM}
                     appendTo={getDashboardMainContainer}

--- a/packages/mlflow-embedded/prompts/MlflowPromptManagementPage.tsx
+++ b/packages/mlflow-embedded/prompts/MlflowPromptManagementPage.tsx
@@ -25,13 +25,13 @@ import { getDashboardMainContainer } from '@odh-dashboard/internal/utilities/uti
 import { useUser } from '@odh-dashboard/internal/redux/selectors/user';
 import ProjectSelectorNavigator from '@odh-dashboard/ui-core/components/projectSelector/ProjectSelectorNavigator';
 import TitleWithIcon from '@odh-dashboard/ui-core/design/TitleWithIcon';
-import { ApplicationsPage, ProjectObjectType, TrackingOutcome } from '@odh-dashboard/ui-core';
+import { ApplicationsPage, ProjectObjectType } from '@odh-dashboard/ui-core';
 import {
   promptManagementPath,
   mlflowPromptManagementBaseRoute,
   WORKSPACE_QUERY_PARAM,
 } from '@odh-dashboard/internal/routes/pipelines/mlflow';
-import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import MLflowUnavailable from '../shared/MLflowUnavailable';
 import MLflowNotConfigured from '../shared/MLflowNotConfigured';
 import MlflowBreadcrumbs, { type BreadcrumbEntry } from '../shared/MlflowBreadcrumbs';
@@ -65,9 +65,7 @@ const MlflowPromptManagementPage: React.FC = () => {
 
   const handleProjectSelectChange = React.useCallback(
     (projectName: string) => {
-      fireFormTrackingEvent('Prompts global project changed', {
-        outcome: TrackingOutcome.submit,
-        success: true,
+      fireMiscTrackingEvent('Prompts global project changed', {
         isGlobalProject: projectName === globalNamespace,
         selectedProject: projectName,
       });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-76575

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added analytics for two user interactions. 
1. Within the cluster settings -> general settings -> global project dropdown
2. Gen AI -> Prompts page -> project dropdown on top

These follow the spec described [here](https://docs.google.com/document/d/1etpV2F9BZWpVYN_YhCHhBqYvaBBbSaf1aoqdUpYVqNI/edit?tab=t.0#heading=h.skdbkkr95lbp)

For 1, when the user presses save to save the settings, the `globalProjectName` will be set to `Changed`, `Added`, or `Removed` based on if the current global project differs from the newly selected global project. This will only fire when the user clicks the save settings button. 

For 2, whenever the user selects a project from the dropdown, the `selectedProject` = user selected project and `isGlobalProject` = `true/false` will be sent. `isGlobalProject` will be `true` if the selected project is a global project. This fires everytime the user changes a project from the Prompts page.



https://github.com/user-attachments/assets/71baaa7d-0430-4770-a322-4db1571eabab


https://github.com/user-attachments/assets/de932f64-5c51-4838-8ed4-a28e2228074d





## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
### Event 1
1. Ensure you are on the latest cluster version and have MLFlow enabled and configured.
2. Enable the dev feature flag: `genAiStudio` and `globalProjectPrompts`
4. Go to settings -> cluster settings -> general settings -> global project and select a project. 
5. Save your changes. If you are in dev mode, you should see a log in your web browser console.

### Event 2
1. Same as above
2. Same as above
3. Go to Gen AI -> Prompts -> project select dropdown
4. Change the project to a non global and a global project.
6. You should see a console log everytime you switch a project.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a test for cluster settings project dropdown that asserts the `fireFormTrackingEvent` function is called with the proper values based off the spec linked at the top of this description. Tests were **not** added for the Prompts page since the change lives in a separate package with no testing infra yet (I could be wrong). 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for global project selection changes in cluster settings, including successful, failed, added, changed, removed, and unchanged outcomes.
  * Added analytics tracking for project selection and submission outcomes in prompt management, including whether the selected project matches the global project.

* **Tests**
  * Added coverage for successful saves, rejected updates, API failures, success states, selected-project state, error messages, and corresponding analytics details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->