### PR TITLE
RHOAIENG-79882: Move getModelPathFromUri, getPVCNameFromURI, isPVCUri to model-serving shared API

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -14,6 +14,7 @@ import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
 import { DashboardPopupIconButton } from '@odh-dashboard/ui-core';
 import { getResourceNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import type { UpdateObjectAtPropAndValue } from '@odh-dashboard/ui-core';
+import { getPVCNameFromURI, isPVCUri } from '@odh-dashboard/model-serving/shared';
 import type { LabeledConnection } from '@odh-dashboard/model-serving/shared';
 import {
   Connection,
@@ -38,12 +39,7 @@ import {
   useNewConnectionField,
   UseNewConnectionFieldData,
 } from '#~/concepts/connectionTypes/NewConnectionField';
-import {
-  getPVCFromURI,
-  getPVCNameFromURI,
-  isModelPathValid,
-  isPVCUri,
-} from '#~/pages/modelServing/screens/projects/utils';
+import { getPVCFromURI, isModelPathValid } from '#~/pages/modelServing/screens/projects/utils';
 import { AccessTypes } from '#~/pages/projects/dataConnections/const';
 import ConnectionS3FolderPathField from './ConnectionS3FolderPathField';
 import ConnectionOciPathField from './ConnectionOciPathField';

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/PVCFields.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/PVCFields.tsx
@@ -12,11 +12,11 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
-import { getModelServingPVCAnnotations } from '@odh-dashboard/model-serving/shared';
 import {
+  getModelServingPVCAnnotations,
   getModelPathFromUri,
   getPVCNameFromURI,
-} from '#~/pages/modelServing/screens/projects/utils';
+} from '@odh-dashboard/model-serving/shared';
 
 type PVCFieldsProps = {
   selectedPVC?: PersistentVolumeClaimKind;

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -1,10 +1,5 @@
 import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
-import {
-  ServingRuntimePlatform,
-  getModelPathFromUri,
-  isPVCUri,
-  getPVCNameFromURI,
-} from '@odh-dashboard/model-serving/shared';
+import { ServingRuntimePlatform } from '@odh-dashboard/model-serving/shared';
 import type { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
@@ -577,42 +572,5 @@ describe('getPVCFromURI', () => {
       mockPVCK8sResource({ name: 'pvc-2', uid: 'pvc-2-uid' }),
     ];
     expect(getPVCFromURI(uri, pvcs)).toBeUndefined();
-  });
-});
-
-describe('getModelPathFromUri', () => {
-  it('should return the model path', () => {
-    const uri = 'pvc://pvc-1/model-path';
-    expect(getModelPathFromUri(uri)).toEqual('model-path');
-  });
-  it('should return an empty string if the URI is not a valid URI', () => {
-    const uri = 'not a uri';
-    expect(getModelPathFromUri(uri)).toEqual('');
-  });
-});
-
-describe('isPVCUri', () => {
-  it('should return true if the URI is a PVC URI', () => {
-    const uri = 'pvc://pvc-1/model-path';
-    expect(isPVCUri(uri)).toEqual(true);
-  });
-  it('should return false if the URI is not a PVC URI', () => {
-    const uri = 'not a uri';
-    expect(isPVCUri(uri)).toEqual(false);
-  });
-});
-
-describe('getPVCNameFromURI', () => {
-  it('should return the PVC name from the URI', () => {
-    const uri = 'pvc://pvc-1/model-path';
-    expect(getPVCNameFromURI(uri)).toEqual('pvc-1');
-  });
-  it('should return an empty string if the URI is not a valid URI', () => {
-    const uri = 'not a uri';
-    expect(getPVCNameFromURI(uri)).toEqual('');
-  });
-  it('should return an empty string if the URI is not a PVC URI', () => {
-    const uri = 'http://pvc-1/model-path';
-    expect(getPVCNameFromURI(uri)).toEqual('');
   });
 });

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -1,5 +1,10 @@
 import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
-import { ServingRuntimePlatform } from '@odh-dashboard/model-serving/shared';
+import {
+  ServingRuntimePlatform,
+  getModelPathFromUri,
+  isPVCUri,
+  getPVCNameFromURI,
+} from '@odh-dashboard/model-serving/shared';
 import type { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
@@ -10,12 +15,9 @@ import {
   getCreateInferenceServiceLabels,
   getProjectModelServingPlatform,
   getPVCFromURI,
-  getModelPathFromUri,
   getUrlFromKserveInferenceService,
   isCurrentServingPlatformEnabled,
   isValueFromEnvVar,
-  isPVCUri,
-  getPVCNameFromURI,
 } from '#~/pages/modelServing/screens/projects/utils';
 import { ServingPlatformStatuses } from '#~/pages/modelServing/screens/types';
 import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -11,6 +11,8 @@ import type { ModelDeployPrefillInfo } from '@odh-dashboard/model-registry/share
 import {
   ServingRuntimePlatform,
   getDisplayNameFromServingRuntimeTemplate,
+  getPVCNameFromURI,
+  isPVCUri,
 } from '@odh-dashboard/model-serving/shared';
 import useGenericObjectState from '@odh-dashboard/ui-core/utilities/useGenericObjectState';
 import { useDeepCompareMemoize } from '@odh-dashboard/ui-core/hooks';
@@ -698,35 +700,5 @@ export const getPVCFromURI = (
     return pvcs?.find((pvc) => pvc.metadata.name === pvcName);
   } catch {
     return undefined;
-  }
-};
-
-export const getPVCNameFromURI = (uri: string): string => {
-  try {
-    const url = new URL(uri);
-    if (url.protocol !== 'pvc:') {
-      return '';
-    }
-    return url.hostname;
-  } catch {
-    return '';
-  }
-};
-
-export const isPVCUri = (uri: string): boolean => {
-  try {
-    const url = new URL(uri);
-    return url.protocol === 'pvc:';
-  } catch {
-    return false;
-  }
-};
-
-export const getModelPathFromUri = (uri: string): string => {
-  try {
-    const url = new URL(uri);
-    return url.pathname.replace(/^\//, '');
-  } catch {
-    return '';
   }
 };

--- a/frontend/src/pages/projects/useInferenceServicesForConnection.ts
+++ b/frontend/src/pages/projects/useInferenceServicesForConnection.ts
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { MetadataAnnotation, type PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
-import { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import { InferenceServiceKind, getPVCNameFromURI } from '@odh-dashboard/model-serving/shared';
 import { Connection } from '#~/concepts/connectionTypes/types';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
-import { getPVCNameFromURI } from '#~/pages/modelServing/screens/projects/utils';
 
 export const useInferenceServicesForConnection = (
   connection?: Connection | PersistentVolumeClaimKind,

--- a/packages/kserve/src/modelLocationData.ts
+++ b/packages/kserve/src/modelLocationData.ts
@@ -1,7 +1,4 @@
-import {
-  getPVCNameFromURI,
-  isPVCUri,
-} from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
+import { getPVCNameFromURI, isPVCUri } from '@odh-dashboard/model-serving/shared';
 import { MetadataAnnotation, ModelServingCompatibleTypes } from '@odh-dashboard/k8s-core';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
 import {

--- a/packages/llmd-serving/src/deployments/model.ts
+++ b/packages/llmd-serving/src/deployments/model.ts
@@ -5,7 +5,11 @@ import {
   isModelServingCompatible,
   ModelServingCompatibleTypes,
 } from '@odh-dashboard/k8s-core';
-import { ServingRuntimeModelType } from '@odh-dashboard/model-serving/shared';
+import {
+  ServingRuntimeModelType,
+  getPVCNameFromURI,
+  isPVCUri,
+} from '@odh-dashboard/model-serving/shared';
 import type { ModelTypeFieldData } from '@odh-dashboard/model-serving/shared/wizard-fields';
 import {
   ModelLocationData,
@@ -14,10 +18,6 @@ import {
   EnvironmentVariablesFieldData,
   RuntimeArgsFieldData,
 } from '@odh-dashboard/model-serving/shared/types/form-data';
-import {
-  getPVCNameFromURI,
-  isPVCUri,
-} from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
 import { VLLM_ADDITIONAL_ARGS } from '../const';
 import type { LLMdContainer, LLMInferenceServiceKind, LLMdDeployment } from '../types';
 import {

--- a/packages/llmd-serving/src/deployments/validateExtraction.ts
+++ b/packages/llmd-serving/src/deployments/validateExtraction.ts
@@ -1,5 +1,5 @@
 import { MetadataAnnotation } from '@odh-dashboard/k8s-core';
-import { isPVCUri } from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
+import { isPVCUri } from '@odh-dashboard/model-serving/shared';
 import type { LLMdDeployment } from '../types';
 
 /**

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
@@ -17,10 +17,6 @@ import type {
 import { z } from 'zod';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { ConnectionOciAlert } from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciAlert';
-import {
-  getPVCNameFromURI,
-  isPVCUri,
-} from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
 import { useWatchConnectionTypes } from '@odh-dashboard/internal/utilities/useWatchConnectionTypes';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import useServingConnections from '@odh-dashboard/internal/pages/projects/screens/detail/connections/useServingConnections';
@@ -31,6 +27,7 @@ import { PvcSelectField } from './modelLocationFields/PVCSelectField';
 import { CustomTypeSelectField } from './modelLocationFields/CustomTypeSelectField';
 import { useEnabledModelServingConnectionTypes } from './modelLocationFields/useEnabledConnectionTypes';
 import { ociOption, s3Option, uriOption } from './modelLocationFields/modelLocationTypes';
+import { getPVCNameFromURI, isPVCUri } from '../../../shared/utils/pvcUtils';
 import usePvcs from '../../../concepts/usePvcs';
 import { ModelLocationData, ModelLocationType } from '../../../shared/types/form-data';
 import { resolveConnectionType } from '../utils';

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCInputField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCInputField.tsx
@@ -12,8 +12,8 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import type { PersistentVolumeClaimKind } from '@odh-dashboard/k8s-core';
-import { getModelPathFromUri } from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
 import { getModelServingPVCAnnotations } from '@odh-dashboard/model-serving/shared';
+import { getModelPathFromUri } from '../../../../shared/utils/pvcUtils';
 
 type PVCInputFieldProps = {
   selectedPVC?: PersistentVolumeClaimKind;

--- a/packages/model-serving/src/shared/index.ts
+++ b/packages/model-serving/src/shared/index.ts
@@ -21,7 +21,12 @@ export type {
   InferenceServiceKind,
 } from './types';
 
-export { getModelServingPVCAnnotations } from './utils/pvcUtils';
+export {
+  getModelServingPVCAnnotations,
+  getPVCNameFromURI,
+  isPVCUri,
+  getModelPathFromUri,
+} from './utils/pvcUtils';
 
 export {
   getTemplateEnabled,

--- a/packages/model-serving/src/shared/utils/__tests__/pvcUtils.spec.ts
+++ b/packages/model-serving/src/shared/utils/__tests__/pvcUtils.spec.ts
@@ -1,0 +1,38 @@
+import { getModelPathFromUri, isPVCUri, getPVCNameFromURI } from '../pvcUtils';
+
+describe('getModelPathFromUri', () => {
+  it('should return the model path', () => {
+    const uri = 'pvc://pvc-1/model-path';
+    expect(getModelPathFromUri(uri)).toEqual('model-path');
+  });
+  it('should return an empty string if the URI is not a valid URI', () => {
+    const uri = 'not a uri';
+    expect(getModelPathFromUri(uri)).toEqual('');
+  });
+});
+
+describe('isPVCUri', () => {
+  it('should return true if the URI is a PVC URI', () => {
+    const uri = 'pvc://pvc-1/model-path';
+    expect(isPVCUri(uri)).toEqual(true);
+  });
+  it('should return false if the URI is not a PVC URI', () => {
+    const uri = 'not a uri';
+    expect(isPVCUri(uri)).toEqual(false);
+  });
+});
+
+describe('getPVCNameFromURI', () => {
+  it('should return the PVC name from the URI', () => {
+    const uri = 'pvc://pvc-1/model-path';
+    expect(getPVCNameFromURI(uri)).toEqual('pvc-1');
+  });
+  it('should return an empty string if the URI is not a valid URI', () => {
+    const uri = 'not a uri';
+    expect(getPVCNameFromURI(uri)).toEqual('');
+  });
+  it('should return an empty string if the URI is not a PVC URI', () => {
+    const uri = 'http://pvc-1/model-path';
+    expect(getPVCNameFromURI(uri)).toEqual('');
+  });
+});

--- a/packages/model-serving/src/shared/utils/pvcUtils.ts
+++ b/packages/model-serving/src/shared/utils/pvcUtils.ts
@@ -8,3 +8,33 @@ export const getModelServingPVCAnnotations = (
 
   return { modelName, modelPath };
 };
+
+export const getPVCNameFromURI = (uri: string): string => {
+  try {
+    const url = new URL(uri);
+    if (url.protocol !== 'pvc:') {
+      return '';
+    }
+    return url.hostname;
+  } catch {
+    return '';
+  }
+};
+
+export const isPVCUri = (uri: string): boolean => {
+  try {
+    const url = new URL(uri);
+    return url.protocol === 'pvc:';
+  } catch {
+    return false;
+  }
+};
+
+export const getModelPathFromUri = (uri: string): string => {
+  try {
+    const url = new URL(uri);
+    return url.pathname.replace(/^\//, '');
+  } catch {
+    return '';
+  }
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79882

## Description
Moves three model-serving domain utilities from `frontend/src/pages/modelServing/screens/projects/utils.ts` into `@odh-dashboard/model-serving/shared` as proper package exports. These are pure URI-parsing functions with no dependencies, consumed across the serving family (`model-serving`, `kserve`, `llmd-serving`) and `frontend`.

  Since all consuming packages already depend on `@odh-dashboard/model-serving`, no new dependencies are introduced.

  **Moved items:**
  
  | Category | Items |
  |----------|-------|
  | Utilities | `getPVCNameFromURI`, `isPVCUri`, `getModelPathFromUri` |

  **Consumer updates:**
  
  | Package | Import path |
  |---------|-------------|
  | `model-serving` (internal) | Relative imports to `shared/utils/pvcUtils` |
  | `kserve` | `@odh-dashboard/model-serving/shared` |
  | `llmd-serving` | `@odh-dashboard/model-serving/shared` |
  | `frontend` | `@odh-dashboard/model-serving/shared` |
  
  ## How Has This Been Tested?

  - `npm install` (clean, no cache)
  - `npm run build` passes
  - `npm run type-check` passes for all affected packages
  - `npm run lint` passes for all affected files with 0 errors / 0 warnings
  - Unit tests pass — all 40 tests in `utils.spec.ts` continue to pass, including the tests for the three moved functions
  - Verified no circular dependencies introduced

  ## Test Impact
  
  No new tests added. This is a pure move refactor — the existing unit tests in `frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts` already cover `getModelPathFromUri`, `isPVCUri`, and `getPVCNameFromURI`. Their imports were updated to point to the new location.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared support for parsing and validating PVC-based model URIs.
  - Improved handling of PVC names and model paths across model-serving workflows.
- **Bug Fixes**
  - Invalid or non-PVC URIs now safely return empty results or indicate an invalid format.
- **Tests**
  - Added coverage for valid PVC URIs, invalid formats, non-PVC URIs, and model-path extraction.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->