### PR TITLE
RHOAIENG-79883: Move uriToModelLocation from frontend to @odh-dashboard/k8s-core

### DIFF
--- a/frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts
@@ -1,3 +1,4 @@
+import { uriToModelLocation } from '@odh-dashboard/k8s-core';
 import { mockModelVersion } from '#~/__mocks__/mockModelVersion';
 import { mockRegisteredModel } from '#~/__mocks__/mockRegisteredModel';
 import {
@@ -10,7 +11,6 @@ import {
   isRedHatRegistryUri,
   objectStorageFieldsToUri,
   uriToConnectionTypeName,
-  uriToModelLocation,
   modelSourcePropertiesToCatalogParams,
   catalogParamsToModelSourceProperties,
   modelSourcePropertiesToPipelineRunRef,

--- a/frontend/src/concepts/modelRegistry/utils.ts
+++ b/frontend/src/concepts/modelRegistry/utils.ts
@@ -1,4 +1,5 @@
 import type { LabeledConnection } from '@odh-dashboard/model-serving/shared';
+import { ObjectStorageFields, uriToModelLocation } from '@odh-dashboard/k8s-core';
 import {
   ConnectionTypeConfigMapObj,
   ConnectionTypeValueType,
@@ -17,19 +18,6 @@ import {
   ModelSourceProperties,
   PipelineRunReference,
 } from './types';
-
-export type ObjectStorageFields = {
-  endpoint: string;
-  bucket: string;
-  region?: string;
-  path: string;
-};
-
-export type ModelLocation = {
-  s3Fields: ObjectStorageFields | null;
-  uri: string | null;
-  ociUri: string | null;
-} | null;
 
 export type PrefilledConnection = {
   initialNewConnectionType: ConnectionTypeConfigMapObj | undefined;
@@ -50,39 +38,6 @@ export const objectStorageFieldsToUri = (fields: ObjectStorageFields): string | 
     searchParams.set('defaultRegion', region);
   }
   return `s3://${bucket}/${path}?${searchParams.toString()}`;
-};
-
-export const uriToModelLocation = (uri?: string): ModelLocation => {
-  if (!uri) {
-    return null;
-  }
-  try {
-    const urlObj = new URL(uri);
-    if (urlObj.toString().startsWith('s3:')) {
-      // Some environments include the first token after the protocol (our bucket) in the pathname and some have it as the hostname
-      const [bucket, ...pathSplit] = [urlObj.hostname, ...urlObj.pathname.split('/')].filter(
-        Boolean,
-      );
-      const path = pathSplit.join('/');
-      const searchParams = new URLSearchParams(urlObj.search);
-      const endpoint = searchParams.get('endpoint');
-      const region = searchParams.get('defaultRegion');
-      if (endpoint && bucket && path) {
-        return {
-          s3Fields: { endpoint, bucket, region: region || undefined, path },
-          uri: null,
-          ociUri: null,
-        };
-      }
-      return null;
-    }
-    if (uri.startsWith('oci:')) {
-      return { s3Fields: null, uri: null, ociUri: uri };
-    }
-    return { s3Fields: null, uri, ociUri: null };
-  } catch {
-    return null;
-  }
 };
 
 export const uriToConnectionTypeName = (uri?: string): string => {

--- a/frontend/src/pages/modelServing/screens/projects/nim/useLabeledConnections.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/useLabeledConnections.ts
@@ -1,8 +1,8 @@
 import React from 'react';
 import type { LabeledConnection } from '@odh-dashboard/model-serving/shared';
+import { ModelLocation, uriToModelLocation } from '@odh-dashboard/k8s-core';
 import { Connection } from '#~/concepts/connectionTypes/types';
 import { convertObjectStorageSecretData } from '#~/concepts/connectionTypes/utils';
-import { ModelLocation, uriToModelLocation } from '#~/concepts/modelRegistry/utils';
 import { AwsKeys, AccessTypes } from '#~/pages/projects/dataConnections/const';
 
 const useLabeledConnections = (

--- a/packages/k8s-core/src/index.ts
+++ b/packages/k8s-core/src/index.ts
@@ -180,6 +180,9 @@ export {
 export type { GetByName } from './projectUtils';
 export { isK8sStatus, K8sStatusError } from './errorUtils';
 
+export { uriToModelLocation } from './modelLocationUtils';
+export type { ObjectStorageFields, ModelLocation } from './modelLocationUtils';
+
 export {
   isSecretKind,
   isConnectionTypeDataFieldType,

--- a/packages/k8s-core/src/modelLocationUtils.ts
+++ b/packages/k8s-core/src/modelLocationUtils.ts
@@ -1,0 +1,45 @@
+export type ObjectStorageFields = {
+  endpoint: string;
+  bucket: string;
+  region?: string;
+  path: string;
+};
+
+export type ModelLocation = {
+  s3Fields: ObjectStorageFields | null;
+  uri: string | null;
+  ociUri: string | null;
+} | null;
+
+export const uriToModelLocation = (uri?: string): ModelLocation => {
+  if (!uri) {
+    return null;
+  }
+  try {
+    const urlObj = new URL(uri);
+    if (urlObj.toString().startsWith('s3:')) {
+      // Some environments include the first token after the protocol (our bucket) in the pathname and some have it as the hostname
+      const [bucket, ...pathSplit] = [urlObj.hostname, ...urlObj.pathname.split('/')].filter(
+        Boolean,
+      );
+      const path = pathSplit.join('/');
+      const searchParams = new URLSearchParams(urlObj.search);
+      const endpoint = searchParams.get('endpoint');
+      const region = searchParams.get('defaultRegion');
+      if (endpoint && bucket && path) {
+        return {
+          s3Fields: { endpoint, bucket, region: region || undefined, path },
+          uri: null,
+          ociUri: null,
+        };
+      }
+      return null;
+    }
+    if (uri.startsWith('oci:')) {
+      return { s3Fields: null, uri: null, ociUri: uri };
+    }
+    return { s3Fields: null, uri, ociUri: null };
+  } catch {
+    return null;
+  }
+};

--- a/packages/model-registry/upstream/frontend/src/odh/utils.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/utils.ts
@@ -1,6 +1,6 @@
 // TODO: remove this file once we have connection types support upstream
 // and update the reference to this file to the one in the model-serving upstream package
-import { RegisteredModelLocation } from '~/app/utils';
+import { uriToModelLocation } from '@odh-dashboard/k8s-core';
 import { DEPLOY_BUTTON_TOOLTIP } from '~/odh/const';
 
 export enum ModelServingCompatibleTypes {
@@ -18,39 +18,6 @@ export const S3ConnectionTypeKeys = [
   'AWS_S3_ENDPOINT',
   'AWS_S3_BUCKET',
 ];
-
-export const uriToModelLocation = (uri?: string): RegisteredModelLocation => {
-  if (!uri) {
-    return null;
-  }
-  try {
-    const urlObj = new URL(uri);
-    if (urlObj.toString().startsWith('s3:')) {
-      // Some environments include the first token after the protocol (our bucket) in the pathname and some have it as the hostname
-      const [bucket, ...pathSplit] = [urlObj.hostname, ...urlObj.pathname.split('/')].filter(
-        Boolean,
-      );
-      const path = pathSplit.join('/');
-      const searchParams = new URLSearchParams(urlObj.search);
-      const endpoint = searchParams.get('endpoint');
-      const region = searchParams.get('defaultRegion');
-      if (endpoint && bucket && path) {
-        return {
-          s3Fields: { endpoint, bucket, region: region || undefined, path },
-          uri: null,
-          ociUri: null,
-        };
-      }
-      return null;
-    }
-    if (uri.startsWith('oci:')) {
-      return { s3Fields: null, uri: null, ociUri: uri };
-    }
-    return { s3Fields: null, uri, ociUri: null };
-  } catch {
-    return null;
-  }
-};
 
 const modelServingCompatibleTypesMetadata: Record<
   ModelServingCompatibleTypes,

--- a/packages/model-serving/modelRegistry/PreWizardDeployModal.tsx
+++ b/packages/model-serving/modelRegistry/PreWizardDeployModal.tsx
@@ -15,12 +15,11 @@ import {
 import { Link } from 'react-router';
 import { typedObjectImage, ProjectObjectType } from '@odh-dashboard/ui-core';
 import type { ProjectKind, Connection } from '@odh-dashboard/k8s-core';
-import { getConnectionTypeRef } from '@odh-dashboard/k8s-core';
+import { getConnectionTypeRef, uriToModelLocation } from '@odh-dashboard/k8s-core';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import ProjectSelector from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector';
 import useServingConnections from '@odh-dashboard/internal/pages/projects/screens/detail/connections/useServingConnections';
 import { useWatchConnectionTypes } from '@odh-dashboard/internal/utilities/useWatchConnectionTypes';
-import { uriToModelLocation } from '@odh-dashboard/internal/concepts/modelRegistry/utils';
 import type { ModelDeployPrefillInfo } from '@odh-dashboard/model-registry/shared';
 import useRegistryConnections from './useRegistryConnections';
 import { useExtractFormDataFromRegistry } from './useExtractFormDataFromRegistry';

--- a/packages/model-serving/modelRegistry/useExtractFormDataFromRegistry.ts
+++ b/packages/model-serving/modelRegistry/useExtractFormDataFromRegistry.ts
@@ -7,9 +7,9 @@ import {
   INFERENCE_SERVICE_NAME_INVALID_CHARS_MESSAGE,
   INFERENCE_SERVICE_NAME_REGEX,
   AccessTypes,
+  uriToModelLocation,
 } from '@odh-dashboard/k8s-core';
 import type { ConnectionTypeValueType } from '@odh-dashboard/k8s-core';
-import { uriToModelLocation } from '@odh-dashboard/internal/concepts/modelRegistry/utils';
 import { useWatchConnectionTypes } from '@odh-dashboard/internal/utilities/useWatchConnectionTypes';
 import type { ModelDeployPrefillInfo } from '@odh-dashboard/model-registry/shared';
 import { getModelRegistryMetadata } from './utils/deployUtils';

--- a/packages/model-serving/modelRegistry/useRegistryConnections.ts
+++ b/packages/model-serving/modelRegistry/useRegistryConnections.ts
@@ -1,7 +1,11 @@
 import React from 'react';
-import { convertObjectStorageSecretData, AccessTypes, AwsKeys } from '@odh-dashboard/k8s-core';
+import {
+  convertObjectStorageSecretData,
+  AccessTypes,
+  AwsKeys,
+  uriToModelLocation,
+} from '@odh-dashboard/k8s-core';
 import type { Connection } from '@odh-dashboard/k8s-core';
-import { uriToModelLocation } from '@odh-dashboard/internal/concepts/modelRegistry/utils';
 
 /**
  * Custom hook that filters connections to return only those that match a model artifact location.


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79883

## Description
Moves `uriToModelLocation` and its associated types (`ObjectStorageFields`, `ModelLocation`) from `frontend/src/concepts/modelRegistry/utils.ts` into `@odh-dashboard/k8s-core` as a new utility module. This function parses K8s resource URIs (S3, OCI, plain URI) into typed location objects and is consumed across multiple packages, making `k8s-core` the appropriate home.

  The function was duplicated in three locations — `frontend/src/`, `packages/model-registry/upstream/frontend/src/odh/utils.ts`, and `packages/model-registry/upstream/frontend/src/app/utils.ts`. This change consolidates the `frontend` and `model-registry/upstream/odh` copies into a single source of truth in `k8s-core`.

  **Moved items:**

  | Category | Items |
  |---|---|
  | Types | `ObjectStorageFields`, `ModelLocation` |
  | Utility | `uriToModelLocation` |

  **Updated consumers:**

  | Package | Files |
  |---|---|
  | `frontend` | `concepts/modelRegistry/utils.ts`, `concepts/modelRegistry/__tests__/utils.spec.ts`, `pages/modelServing/screens/projects/nim/useLabeledConnections.ts` |
  | `model-serving` | `modelRegistry/PreWizardDeployModal.tsx`, `modelRegistry/useRegistryConnections.ts`, `modelRegistry/useExtractFormDataFromRegistry.ts` |
  | `model-registry` | `upstream/frontend/src/odh/utils.ts` (removed duplicate, now imports from `k8s-core`) |

  **Not moved:** `objectStorageFieldsToUri` (only used within `frontend` and `model-registry` upstream), `uriToConnectionTypeName` (depends on frontend-specific connection type utilities — remains in `frontend/` and `model-registry/upstream/` but now calls the shared `uriToModelLocation` from `k8s-core`).

  ## How Has This Been Tested?

  - `npm ci` — clean install passes
  - `npm run build` — passes
  - `npm run type-check` — passes across all affected packages (`k8s-core`, `frontend`, `model-serving`, `model-registry`)
  - `npm run lint` — passes with 0 errors (no new warnings beyond pre-existing baseline)
  - `npm run test:unit` — all 358 suites / 3901 tests pass for `frontend`
  - Verified existing `uriToModelLocation` tests in `frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts` continue to pass with the updated import path

  ## Test Impact

  No new tests added. This is a pure move refactor — existing unit tests in `frontend/src/concepts/modelRegistry/__tests__/utils.spec.ts` continue to cover all moved items. Import paths were updated but behavior is unchanged.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
