### PR TITLE
gpuaas tab restructuring

### DIFF
--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -12,6 +12,19 @@ class InfrastructurePage {
     return appChrome.findNavItem({ name: 'Infrastructure', rootSection: 'Observe & monitor' });
   }
 
+  findUtilizationTab() {
+    return cy.findByTestId('infrastructure-tab-utilization');
+  }
+
+  findClusterQueueUtilizationTab() {
+    return cy.findByTestId('infrastructure-tab-cluster-queue-utilization');
+  }
+
+  switchToClusterQueueUtilizationTab() {
+    this.findClusterQueueUtilizationTab().click();
+    return this;
+  }
+
   shouldNotFoundPage() {
     return cy.findByTestId('not-found-page').should('exist');
   }

--- a/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
@@ -10,7 +10,7 @@ describe('GPUaaS Infrastructure Page', () => {
 
   it(
     'Verify Infrastructure page is accessible for admin users and displays expected sections',
-    { tags: ['@Dashboard', '@GPUaaS'] },
+    { tags: ['@Dashboard', '@GPUaaS', '@GpuaasCI'] },
     () => {
       cy.step('Log in as admin user');
       cy.visitWithLogin('/', LDAP_ADMIN_USER);
@@ -43,7 +43,7 @@ describe('GPUaaS Infrastructure Page', () => {
 
   it(
     'Verify Infrastructure page is not accessible for non-admin users',
-    { tags: ['@Dashboard', '@GPUaaS'] },
+    { tags: ['@Dashboard', '@GPUaaS', '@GpuaasCI'] },
     () => {
       cy.step('Log in as non-admin user');
       cy.visitWithLogin('/', LDAP_CONTRIBUTOR_USER);

--- a/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
@@ -35,8 +35,9 @@ describe('GPUaaS Infrastructure Page', () => {
       cy.step('Verify Borrowing section is present');
       infrastructurePage.findBorrowingSection().should('exist');
 
-      cy.step('Verify Cluster queue utilization section is present');
-      infrastructurePage.findClusterQueueUtilizationSection().should('exist');
+      cy.step('Click Compute profile utilization tab and verify section is present');
+      infrastructurePage.switchToClusterQueueUtilizationTab();
+      infrastructurePage.findClusterQueueUtilizationSection().should('be.visible');
     },
   );
 

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -393,6 +393,7 @@ describe('GPUaaS Infrastructure Page', () => {
       // Stage 1: no cluster queues at all
       initIntercepts({ clusterQueues: [], cohortNames: [], resourceFlavors: [] });
       infrastructurePage.visit();
+      infrastructurePage.switchToClusterQueueUtilizationTab();
       infrastructurePage
         .findCQUtilizationEmptyState()
         .should('exist')
@@ -412,6 +413,7 @@ describe('GPUaaS Infrastructure Page', () => {
         resourceFlavors: [],
       });
       infrastructurePage.visit();
+      infrastructurePage.switchToClusterQueueUtilizationTab();
       infrastructurePage.findCQUtilizationEmptyState().should('exist');
     });
 
@@ -432,9 +434,10 @@ describe('GPUaaS Infrastructure Page', () => {
         resourceFlavors: [{ name: 'a100-flavor', gpuProduct: 'NVIDIA A100' }],
       });
       infrastructurePage.visit();
+      infrastructurePage.switchToClusterQueueUtilizationTab();
       infrastructurePage
         .findCQUtilizationSubtitle()
-        .should('contain.text', 'Cluster queue accelerator consumption grouped by cohort.');
+        .should('contain.text', 'Compute profile accelerator utilization grouped by Kueue cohort.');
       infrastructurePage.findCohortAccordion('cohort-1').should('exist');
       infrastructurePage.findCQCard('cq-gpu').should('exist');
       infrastructurePage.findHardwareModelBadge('NVIDIA A100').should('exist');
@@ -471,6 +474,7 @@ describe('GPUaaS Infrastructure Page', () => {
         dcgmModelName: 'AMD MI300X',
       });
       infrastructurePage.visit();
+      infrastructurePage.switchToClusterQueueUtilizationTab();
       infrastructurePage.scrollToCQUtilizationSection();
       infrastructurePage.findCohortAccordion('research-sandbox').should('exist');
       infrastructurePage.findCQCard('notebook-queues').should('exist');
@@ -517,6 +521,7 @@ describe('GPUaaS Infrastructure Page', () => {
           dcgmModelName: 'NVIDIA A100',
         });
         infrastructurePage.visit();
+        infrastructurePage.switchToClusterQueueUtilizationTab();
         infrastructurePage.scrollToCQUtilizationSection();
       });
 
@@ -595,6 +600,7 @@ describe('GPUaaS Infrastructure Page', () => {
             dcgmModelName: 'NVIDIA H100',
           });
           infrastructurePage.visit();
+          infrastructurePage.switchToClusterQueueUtilizationTab();
         });
 
         it('renders the CQ card with all 3 chart columns and a fully-filled borrowed donut', () => {

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -2,21 +2,29 @@ export const INFRASTRUCTURE_REFRESH_INTERVAL = 30_000;
 
 export const TREND_REFRESH_INTERVAL = 5 * 60 * 1000;
 
+export const INFRASTRUCTURE_TABS = [
+  { id: 'utilization', title: 'Utilization' },
+  { id: 'cluster-queue-utilization', title: 'Compute profile utilization' },
+] as const;
+
 export const INFRASTRUCTURE_SECTIONS = [
   {
     id: 'cluster',
+    tab: 'utilization',
     title: 'Summary',
     description: 'Cluster-wide accelerator allocation and average compute and memory consumption.',
     isPlain: true,
   },
   {
     id: 'hardware-usage',
+    tab: 'utilization',
     title: 'Hardware usage',
     description: 'Accelerator counts by hardware type.',
     isPlain: false,
   },
   {
     id: 'borrowing',
+    tab: 'utilization',
     title: 'Borrowing trends',
     description:
       '7-day borrowing trends by cluster queue. When a cluster queue uses its full quota, it can borrow accelerators from other queues.',
@@ -24,8 +32,9 @@ export const INFRASTRUCTURE_SECTIONS = [
   },
   {
     id: 'cluster-queue-utilization',
-    title: 'Cluster queue consumption',
-    description: 'Cluster queue accelerator consumption grouped by cohort.',
+    tab: 'cluster-queue-utilization',
+    title: 'Compute profile utilization',
+    description: 'Compute profile accelerator utilization grouped by Kueue cohort.',
     isPlain: true,
   },
 ] as const;

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -88,8 +88,9 @@ const InfrastructurePage: React.FC = () => {
     'cluster-queue-utilization': <ClusterQueueUtilizationSection />,
   };
 
-  const headerAction = metrics.lastRefreshed ? (
+  const lastUpdatedBadge = metrics.lastRefreshed ? (
     <Flex
+      justifyContent={{ default: 'justifyContentFlexEnd' }}
       alignItems={{ default: 'alignItemsCenter' }}
       spaceItems={{ default: 'spaceItemsSm' }}
       data-testid="infrastructure-refresh-badge"
@@ -116,7 +117,6 @@ const InfrastructurePage: React.FC = () => {
       loaded
       empty={false}
       provideChildrenPadding
-      headerAction={headerAction}
     >
       <Tabs
         activeKey={activeTabKey}
@@ -140,8 +140,15 @@ const InfrastructurePage: React.FC = () => {
               }
               data-testid={`infrastructure-tab-${tabInfo.id}`}
             >
-              <PageSection hasBodyWrapper={false} isFilled>
+              <PageSection
+                hasBodyWrapper={false}
+                isFilled
+                className={tabInfo.id === 'utilization' ? 'pf-v6-u-pt-0' : undefined}
+              >
                 <Stack hasGutter>
+                  {tabInfo.id === 'utilization' && lastUpdatedBadge && (
+                    <StackItem>{lastUpdatedBadge}</StackItem>
+                  )}
                   {INFRASTRUCTURE_SECTIONS.filter((section) => section.tab === tabInfo.id).map(
                     ({ id, title, description, isPlain }) => (
                       <StackItem key={id}>

--- a/packages/gpuaas/src/pages/InfrastructurePage.tsx
+++ b/packages/gpuaas/src/pages/InfrastructurePage.tsx
@@ -10,14 +10,19 @@ import {
   Content,
   Flex,
   FlexItem,
+  PageSection,
   Stack,
   StackItem,
+  Tab,
+  Tabs,
+  TabTitleIcon,
+  TabTitleText,
   Tooltip,
   Title,
 } from '@patternfly/react-core';
-import { SyncAltIcon } from '@patternfly/react-icons';
+import { ClusterIcon, MicrochipIcon, SyncAltIcon } from '@patternfly/react-icons';
 import { relativeTime } from '@odh-dashboard/internal/utilities/time';
-import { INFRASTRUCTURE_SECTIONS } from '../const';
+import { INFRASTRUCTURE_SECTIONS, INFRASTRUCTURE_TABS } from '../const';
 import { GPUAAS_EVENTS, type PageViewedProperties } from '../tracking/gpuaasTrackingConstants';
 import ClusterSummaryCards from '../components/ClusterSummaryCards';
 import HardwareUsageSection from '../components/HardwareUsageSection';
@@ -26,11 +31,18 @@ import ClusterQueueUtilizationSection from '../components/ClusterQueueUtilizatio
 import useInfrastructureMetrics from '../hooks/useInfrastructureMetrics';
 
 type SectionId = (typeof INFRASTRUCTURE_SECTIONS)[number]['id'];
+type TabId = (typeof INFRASTRUCTURE_TABS)[number]['id'];
+
+const TAB_ICONS: Record<TabId, React.ComponentType> = {
+  utilization: MicrochipIcon,
+  'cluster-queue-utilization': ClusterIcon,
+};
 
 const InfrastructurePage: React.FC = () => {
   const metrics = useInfrastructureMetrics();
   const isKueueAvailable = useIsAreaAvailable(SupportedArea.KUEUE).status;
   const hasTrackedPageView = React.useRef(false);
+  const [activeTabKey, setActiveTabKey] = React.useState<string>(INFRASTRUCTURE_TABS[0].id);
 
   React.useEffect(() => {
     if (metrics.loaded && !hasTrackedPageView.current) {
@@ -106,27 +118,61 @@ const InfrastructurePage: React.FC = () => {
       provideChildrenPadding
       headerAction={headerAction}
     >
-      <Stack hasGutter>
-        {INFRASTRUCTURE_SECTIONS.map(({ id, title, description, isPlain }) => (
-          <StackItem key={id}>
-            <Stack hasGutter>
-              <StackItem>
-                <Title headingLevel="h2" data-testid={`infrastructure-${id}-title`}>
-                  {title}
-                </Title>
-                <Content component="p" data-testid={`infrastructure-${id}-description`}>
-                  {description}
-                </Content>
-              </StackItem>
-              <StackItem>
-                <Card isPlain={isPlain} data-testid={`infrastructure-${id}-section`}>
-                  {isPlain ? SECTION_COMPONENTS[id] : <CardBody>{SECTION_COMPONENTS[id]}</CardBody>}
-                </Card>
-              </StackItem>
-            </Stack>
-          </StackItem>
-        ))}
-      </Stack>
+      <Tabs
+        activeKey={activeTabKey}
+        onSelect={(_event, eventKey) => setActiveTabKey(String(eventKey))}
+        aria-label="Infrastructure page tabs"
+        data-testid="infrastructure-tabs"
+      >
+        {INFRASTRUCTURE_TABS.map((tabInfo) => {
+          const TabIcon = TAB_ICONS[tabInfo.id];
+          return (
+            <Tab
+              key={tabInfo.id}
+              eventKey={tabInfo.id}
+              title={
+                <>
+                  <TabTitleIcon>
+                    <TabIcon />
+                  </TabTitleIcon>
+                  <TabTitleText>{tabInfo.title}</TabTitleText>
+                </>
+              }
+              data-testid={`infrastructure-tab-${tabInfo.id}`}
+            >
+              <PageSection hasBodyWrapper={false} isFilled>
+                <Stack hasGutter>
+                  {INFRASTRUCTURE_SECTIONS.filter((section) => section.tab === tabInfo.id).map(
+                    ({ id, title, description, isPlain }) => (
+                      <StackItem key={id}>
+                        <Stack hasGutter>
+                          <StackItem>
+                            <Title headingLevel="h2" data-testid={`infrastructure-${id}-title`}>
+                              {title}
+                            </Title>
+                            <Content component="p" data-testid={`infrastructure-${id}-description`}>
+                              {description}
+                            </Content>
+                          </StackItem>
+                          <StackItem>
+                            <Card isPlain={isPlain} data-testid={`infrastructure-${id}-section`}>
+                              {isPlain ? (
+                                SECTION_COMPONENTS[id]
+                              ) : (
+                                <CardBody>{SECTION_COMPONENTS[id]}</CardBody>
+                              )}
+                            </Card>
+                          </StackItem>
+                        </Stack>
+                      </StackItem>
+                    ),
+                  )}
+                </Stack>
+              </PageSection>
+            </Tab>
+          );
+        })}
+      </Tabs>
     </ApplicationsPage>
   );
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79838

## Description

Restructures the GPUaaS Infrastructure page into a tabbed layout
Previously all four sections (Summary, Hardware usage, Borrowing trends, Cluster queue consumption) were stacked vertically on a single page. They're now split across two tabs:

Utilization  — Summary, Hardware usage, Borrowing trends
Compute profile utilization — the former "Cluster queue consumption" section, renamed to "Compute profile utilization" with an updated description ("Compute profile accelerator utilization grouped by Kueue cohort.")

<img width="1598" height="892" alt="infrastrucure-tab" src="https://github.com/user-attachments/assets/7b831070-8f9c-4c15-bf13-a74d502dbe6a" />

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Tested locally

1. Go to infrastructure page and notice two tab (Utilization and Compute profile utilization)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact

- Updated packages/cypress/cypress/pages/infrastructure.ts with findUtilizationTab(), findClusterQueueUtilizationTab(), and switchToClusterQueueUtilizationTab() page-object helpers.
- Updated packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts to switch to the "Compute profile utilization" tab before asserting on its contents, and updated the subtitle text assertion to match the new copy.
- Updated packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts to click into the new tab and assert be.visible (rather than just exist) for the cluster queue section.
- No new unit tests were added since this is primarily a layout/composition change with no new logic; existing Cypress coverage was adapted to the new tab structure instead.

<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tabs to organize infrastructure utilization views.
  * Added a dedicated **Compute profile utilization** tab for accelerator usage grouped by Kueue cohort.
  * Improved navigation between utilization sections with clearer titles and descriptions.
  * Kept refresh controls available within the active utilization view for easier updates.
  * Displayed only the sections relevant to the selected infrastructure tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->