### PR TITLE
feat(feature store): separate available and unavailable stores in not…

### DIFF
--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -142,7 +142,12 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
             )}
             {availableNames.length > DEFAULT_VISIBLE_LENGTH && unavailableNames.length > 0 && (
               <StackItem>
-                <Divider data-testid="notebook-feature-store-section-divider" />
+                <Flex>
+                  <FlexItem flex={{ default: 'flex_4' }}>
+                    <Divider data-testid="notebook-feature-store-section-divider" />
+                  </FlexItem>
+                  <FlexItem flex={{ default: 'flex_1' }} />
+                </Flex>
               </StackItem>
             )}
             {unavailableNames.length > 0 && (

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -8,15 +8,17 @@ import {
   Icon,
   List,
   ListItem,
+  Popover,
+  Skeleton,
   Stack,
   StackItem,
-  Tooltip,
 } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 
 import { NotebookKind } from '#~/k8sTypes';
 import { FEAST_CONFIG_ANNOTATION } from '#~/pages/projects/screens/spawner/featureStore/const';
+import { FEATURE_STORE_UNAVAILABLE_TOOLTIP } from '#~/pages/projects/screens/spawner/featureStore/utils';
 import ShowAllButton from './ShowAllButton';
 
 type NotebookFeatureStoreListProps = {
@@ -43,7 +45,8 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
   availableStoreMap,
   availabilityLoaded,
 }) => {
-  const [showAll, setShowAll] = React.useState(false);
+  const [showAllAvailable, setShowAllAvailable] = React.useState(false);
+  const [showUnavailable, setShowUnavailable] = React.useState(false);
 
   const feastAnnotation = notebook.metadata.annotations?.[FEAST_CONFIG_ANNOTATION];
   const featureStoreNames = React.useMemo(
@@ -51,9 +54,29 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
     [feastAnnotation],
   );
 
-  const visibleNames = showAll
-    ? featureStoreNames
-    : featureStoreNames.slice(0, DEFAULT_VISIBLE_LENGTH);
+  const { availableNames, unavailableNames } = React.useMemo((): {
+    availableNames: string[];
+    unavailableNames: string[];
+  } => {
+    if (!availabilityLoaded) {
+      return { availableNames: [], unavailableNames: [] };
+    }
+
+    const available: string[] = [];
+    const unavailable: string[] = [];
+    featureStoreNames.forEach((name) => {
+      if (availableStoreMap.has(name)) {
+        available.push(name);
+      } else {
+        unavailable.push(name);
+      }
+    });
+    return { availableNames: available, unavailableNames: unavailable };
+  }, [availabilityLoaded, availableStoreMap, featureStoreNames]);
+
+  const visibleAvailableNames = showAllAvailable
+    ? availableNames
+    : availableNames.slice(0, DEFAULT_VISIBLE_LENGTH);
 
   return (
     <Stack hasGutter>
@@ -65,67 +88,94 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
           <Content data-testid="notebook-feature-store-none" component="small">
             None
           </Content>
+        ) : !availabilityLoaded ? (
+          <Stack hasGutter data-testid="notebook-feature-store-loading">
+            <StackItem>
+              <Skeleton
+                screenreaderText="Loading connected feature stores"
+                height="1.25rem"
+                width="60%"
+              />
+            </StackItem>
+            <StackItem>
+              <Skeleton aria-hidden height="1.25rem" width="40%" />
+            </StackItem>
+          </Stack>
         ) : (
-          <List data-testid="notebook-feature-store-list">
-            {visibleNames.map((name) => {
-              const isUnavailable = availabilityLoaded && !availableStoreMap.has(name);
-
-              if (isUnavailable) {
-                return (
-                  <ListItem key={name}>
-                    <Flex
-                      spaceItems={{ default: 'spaceItemsSm' }}
-                      alignItems={{ default: 'alignItemsCenter' }}
+          <List isPlain data-testid="notebook-feature-store-list">
+            {visibleAvailableNames.map((name) => (
+              <ListItem key={name}>
+                <Link
+                  to={`/develop-train/feature-store/overview/${name}`}
+                  state={{ registryNamespace: availableStoreMap.get(name) }}
+                  data-testid={`feature-store-link-${name}`}
+                >
+                  {name}
+                </Link>
+              </ListItem>
+            ))}
+            {unavailableNames.length > 0 &&
+              (showUnavailable ? (
+                <>
+                  {unavailableNames.map((name) => (
+                    <ListItem key={name} data-testid={`feature-store-unavailable-${name}`}>
+                      <Content className={text.textColorDisabled}>{name}</Content>
+                    </ListItem>
+                  ))}
+                  <ListItem>
+                    <Button
+                      isInline
+                      variant="link"
+                      onClick={() => setShowUnavailable(false)}
+                      data-testid="feature-store-show-unavailable"
                     >
-                      <FlexItem>
-                        <Content className={text.textColorDisabled}>{name}</Content>
-                      </FlexItem>
-                      <FlexItem>
-                        <Tooltip content="This feature store is no longer available. It may have been deleted or access has been revoked.">
-                          <Button
-                            hasNoPadding
-                            variant="plain"
-                            isInline
-                            aria-label="This feature store is no longer available"
-                            data-testid="feature-store-unavailable-icon"
-                          >
-                            <Icon isInline status="info">
-                              <InfoCircleIcon />
-                            </Icon>
-                          </Button>
-                        </Tooltip>
-                      </FlexItem>
-                    </Flex>
+                      Show less
+                    </Button>
                   </ListItem>
-                );
-              }
-
-              if (!availabilityLoaded) {
-                return <ListItem key={name}>{name}</ListItem>;
-              }
-
-              return (
-                <ListItem key={name}>
-                  <Link
-                    to={`/develop-train/feature-store/overview/${name}`}
-                    state={{ registryNamespace: availableStoreMap.get(name) }}
-                    data-testid={`feature-store-link-${name}`}
+                </>
+              ) : (
+                <ListItem data-testid="feature-store-show-unavailable">
+                  <Flex
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                    alignItems={{ default: 'alignItemsCenter' }}
                   >
-                    {name}
-                  </Link>
+                    <FlexItem>
+                      <Button isInline variant="link" onClick={() => setShowUnavailable(true)}>
+                        Show unavailable
+                      </Button>
+                    </FlexItem>
+                    <FlexItem>
+                      <Popover
+                        aria-label="Why feature stores may be unavailable"
+                        bodyContent={FEATURE_STORE_UNAVAILABLE_TOOLTIP}
+                        position="right"
+                      >
+                        <Button
+                          hasNoPadding
+                          variant="plain"
+                          isInline
+                          aria-label="Why feature stores may be unavailable"
+                          data-testid="feature-store-unavailable-help"
+                        >
+                          <Icon isInline aria-hidden>
+                            <OutlinedQuestionCircleIcon />
+                          </Icon>
+                        </Button>
+                      </Popover>
+                    </FlexItem>
+                  </Flex>
                 </ListItem>
-              );
-            })}
+              ))}
           </List>
         )}
       </StackItem>
-      {featureStoreNames.length > DEFAULT_VISIBLE_LENGTH && (
+      {availabilityLoaded && availableNames.length > DEFAULT_VISIBLE_LENGTH && (
         <StackItem>
           <ShowAllButton
-            isExpanded={showAll}
+            isExpanded={showAllAvailable}
             visibleLength={DEFAULT_VISIBLE_LENGTH}
-            onToggle={() => setShowAll(!showAll)}
-            totalSize={featureStoreNames.length}
+            onToggle={() => setShowAllAvailable(!showAllAvailable)}
+            totalSize={availableNames.length}
             data-testid="feature-store-show-all"
           />
         </StackItem>

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -102,84 +102,102 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
             </StackItem>
           </Stack>
         ) : (
-          <List isPlain data-testid="notebook-feature-store-list">
-            {visibleAvailableNames.map((name) => (
-              <ListItem key={name}>
-                <Link
-                  to={`/develop-train/feature-store/overview/${name}`}
-                  state={{ registryNamespace: availableStoreMap.get(name) }}
-                  data-testid={`feature-store-link-${name}`}
-                >
-                  {name}
-                </Link>
-              </ListItem>
-            ))}
-            {unavailableNames.length > 0 &&
-              (showUnavailable ? (
-                <>
-                  {unavailableNames.map((name) => (
-                    <ListItem key={name} data-testid={`feature-store-unavailable-${name}`}>
-                      <Content className={text.textColorDisabled}>{name}</Content>
-                    </ListItem>
-                  ))}
-                  <ListItem>
-                    <Button
-                      isInline
-                      variant="link"
-                      onClick={() => setShowUnavailable(false)}
-                      data-testid="feature-store-show-unavailable"
-                    >
-                      Show less
-                    </Button>
-                  </ListItem>
-                </>
-              ) : (
-                <ListItem data-testid="feature-store-show-unavailable">
-                  <Flex
-                    spaceItems={{ default: 'spaceItemsSm' }}
-                    alignItems={{ default: 'alignItemsCenter' }}
-                  >
-                    <FlexItem>
-                      <Button isInline variant="link" onClick={() => setShowUnavailable(true)}>
-                        Show unavailable
-                      </Button>
-                    </FlexItem>
-                    <FlexItem>
-                      <Popover
-                        aria-label="Why feature stores may be unavailable"
-                        bodyContent={FEATURE_STORE_UNAVAILABLE_TOOLTIP}
-                        position="right"
+          <Stack hasGutter>
+            {availableNames.length > 0 && (
+              <StackItem data-testid="notebook-feature-store-available-section">
+                <Stack hasGutter>
+                  <StackItem>
+                    <List isPlain data-testid="notebook-feature-store-list">
+                      {visibleAvailableNames.map((name) => (
+                        <ListItem key={name}>
+                          <Link
+                            to={`/develop-train/feature-store/overview/${name}`}
+                            state={{ registryNamespace: availableStoreMap.get(name) }}
+                            data-testid={`feature-store-link-${name}`}
+                          >
+                            {name}
+                          </Link>
+                        </ListItem>
+                      ))}
+                    </List>
+                  </StackItem>
+                  {availableNames.length > DEFAULT_VISIBLE_LENGTH && (
+                    <StackItem>
+                      <ShowAllButton
+                        isExpanded={showAllAvailable}
+                        visibleLength={DEFAULT_VISIBLE_LENGTH}
+                        onToggle={() => setShowAllAvailable(!showAllAvailable)}
+                        totalSize={availableNames.length}
+                        data-testid="feature-store-show-all"
+                      />
+                    </StackItem>
+                  )}
+                </Stack>
+              </StackItem>
+            )}
+            {unavailableNames.length > 0 && (
+              <StackItem data-testid="notebook-feature-store-unavailable-section">
+                <Stack hasGutter>
+                  {showUnavailable && (
+                    <StackItem>
+                      <List isPlain data-testid="notebook-feature-store-unavailable-list">
+                        {unavailableNames.map((name) => (
+                          <ListItem key={name} data-testid={`feature-store-unavailable-${name}`}>
+                            <Content className={text.textColorDisabled}>{name}</Content>
+                          </ListItem>
+                        ))}
+                      </List>
+                    </StackItem>
+                  )}
+                  <StackItem>
+                    {showUnavailable ? (
+                      <Button
+                        isInline
+                        variant="link"
+                        onClick={() => setShowUnavailable(false)}
+                        data-testid="feature-store-show-unavailable"
                       >
-                        <Button
-                          hasNoPadding
-                          variant="plain"
-                          isInline
-                          aria-label="Why feature stores may be unavailable"
-                          data-testid="feature-store-unavailable-help"
-                        >
-                          <Icon isInline aria-hidden>
-                            <OutlinedQuestionCircleIcon />
-                          </Icon>
-                        </Button>
-                      </Popover>
-                    </FlexItem>
-                  </Flex>
-                </ListItem>
-              ))}
-          </List>
+                        Show less
+                      </Button>
+                    ) : (
+                      <Flex
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                        alignItems={{ default: 'alignItemsCenter' }}
+                        data-testid="feature-store-show-unavailable"
+                      >
+                        <FlexItem>
+                          <Button isInline variant="link" onClick={() => setShowUnavailable(true)}>
+                            Show unavailable
+                          </Button>
+                        </FlexItem>
+                        <FlexItem>
+                          <Popover
+                            aria-label="Why feature stores may be unavailable"
+                            bodyContent={FEATURE_STORE_UNAVAILABLE_TOOLTIP}
+                            position="right"
+                          >
+                            <Button
+                              hasNoPadding
+                              variant="plain"
+                              isInline
+                              aria-label="Why feature stores may be unavailable"
+                              data-testid="feature-store-unavailable-help"
+                            >
+                              <Icon isInline aria-hidden>
+                                <OutlinedQuestionCircleIcon />
+                              </Icon>
+                            </Button>
+                          </Popover>
+                        </FlexItem>
+                      </Flex>
+                    )}
+                  </StackItem>
+                </Stack>
+              </StackItem>
+            )}
+          </Stack>
         )}
       </StackItem>
-      {availabilityLoaded && availableNames.length > DEFAULT_VISIBLE_LENGTH && (
-        <StackItem>
-          <ShowAllButton
-            isExpanded={showAllAvailable}
-            visibleLength={DEFAULT_VISIBLE_LENGTH}
-            onToggle={() => setShowAllAvailable(!showAllAvailable)}
-            totalSize={availableNames.length}
-            data-testid="feature-store-show-all"
-          />
-        </StackItem>
-      )}
     </Stack>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -18,7 +18,7 @@ import text from '@patternfly/react-styles/css/utilities/Text/text';
 
 import { NotebookKind } from '#~/k8sTypes';
 import { FEAST_CONFIG_ANNOTATION } from '#~/pages/projects/screens/spawner/featureStore/const';
-import { FEATURE_STORE_UNAVAILABLE_TOOLTIP } from '#~/pages/projects/screens/spawner/featureStore/utils';
+import { FEATURE_STORE_UNAVAILABLE_LIST_TOOLTIP } from '#~/pages/projects/screens/spawner/featureStore/utils';
 import ShowAllButton from './ShowAllButton';
 
 type NotebookFeatureStoreListProps = {
@@ -128,6 +128,10 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
                         visibleLength={DEFAULT_VISIBLE_LENGTH}
                         onToggle={() => setShowAllAvailable(!showAllAvailable)}
                         totalSize={availableNames.length}
+                        toggleAriaLabel={{
+                          expanded: 'Show less connected feature stores',
+                          collapsed: 'Show all connected feature stores',
+                        }}
                         data-testid="feature-store-show-all"
                       />
                     </StackItem>
@@ -155,6 +159,7 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
                         isInline
                         variant="link"
                         onClick={() => setShowUnavailable(false)}
+                        aria-label="Show less unavailable feature stores"
                         data-testid="feature-store-show-unavailable"
                       >
                         Show less
@@ -166,14 +171,19 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
                         data-testid="feature-store-show-unavailable"
                       >
                         <FlexItem>
-                          <Button isInline variant="link" onClick={() => setShowUnavailable(true)}>
+                          <Button
+                            isInline
+                            variant="link"
+                            onClick={() => setShowUnavailable(true)}
+                            aria-label="Show unavailable feature stores"
+                          >
                             Show unavailable
                           </Button>
                         </FlexItem>
                         <FlexItem>
                           <Popover
                             aria-label="Why feature stores may be unavailable"
-                            bodyContent={FEATURE_STORE_UNAVAILABLE_TOOLTIP}
+                            bodyContent={FEATURE_STORE_UNAVAILABLE_LIST_TOOLTIP}
                             position="right"
                           >
                             <Button

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import {
   Button,
   Content,
+  Divider,
   Flex,
   FlexItem,
   Icon,
@@ -137,6 +138,11 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
                     </StackItem>
                   )}
                 </Stack>
+              </StackItem>
+            )}
+            {availableNames.length > DEFAULT_VISIBLE_LENGTH && unavailableNames.length > 0 && (
+              <StackItem>
+                <Divider data-testid="notebook-feature-store-section-divider" />
               </StackItem>
             )}
             {unavailableNames.length > 0 && (

--- a/frontend/src/pages/projects/screens/detail/notebooks/ShowAllButton.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/ShowAllButton.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Flex, FlexItem } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import React from 'react';
 
 type ShowAllButtonProps = {
@@ -26,27 +26,21 @@ const ShowAllButton: React.FC<ShowAllButtonProps> = ({
   }
 
   return (
-    <Flex spaceItems={{ default: 'spaceItemsSm' }} data-testid={testId}>
-      <FlexItem>
-        <Button
-          isInline
-          variant="link"
-          onClick={onToggle}
-          aria-label={
-            toggleAriaLabel
-              ? isExpanded
-                ? toggleAriaLabel.expanded
-                : toggleAriaLabel.collapsed
-              : undefined
-          }
-        >
-          {isExpanded ? 'Show less' : 'Show all'}
-        </Button>
-      </FlexItem>
-      <FlexItem>
-        {!isExpanded && <Badge isRead>{`${totalSize - visibleLength} more`}</Badge>}
-      </FlexItem>
-    </Flex>
+    <Button
+      isInline
+      variant="link"
+      onClick={onToggle}
+      data-testid={testId}
+      aria-label={
+        toggleAriaLabel
+          ? isExpanded
+            ? toggleAriaLabel.expanded
+            : toggleAriaLabel.collapsed
+          : undefined
+      }
+    >
+      {isExpanded ? 'Show less' : 'Show all'}
+    </Button>
   );
 };
 

--- a/frontend/src/pages/projects/screens/detail/notebooks/ShowAllButton.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/ShowAllButton.tsx
@@ -6,6 +6,10 @@ type ShowAllButtonProps = {
   isExpanded: boolean;
   totalSize: number;
   onToggle: () => void;
+  toggleAriaLabel?: {
+    expanded: string;
+    collapsed: string;
+  };
   'data-testid'?: string;
 };
 
@@ -14,6 +18,7 @@ const ShowAllButton: React.FC<ShowAllButtonProps> = ({
   totalSize,
   onToggle,
   isExpanded,
+  toggleAriaLabel,
   'data-testid': testId,
 }) => {
   if (visibleLength >= totalSize) {
@@ -23,7 +28,18 @@ const ShowAllButton: React.FC<ShowAllButtonProps> = ({
   return (
     <Flex spaceItems={{ default: 'spaceItemsSm' }} data-testid={testId}>
       <FlexItem>
-        <Button isInline variant="link" onClick={onToggle}>
+        <Button
+          isInline
+          variant="link"
+          onClick={onToggle}
+          aria-label={
+            toggleAriaLabel
+              ? isExpanded
+                ? toggleAriaLabel.expanded
+                : toggleAriaLabel.collapsed
+              : undefined
+          }
+        >
           {isExpanded ? 'Show less' : 'Show all'}
         </Button>
       </FlexItem>

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
@@ -91,11 +91,23 @@ describe('NotebookFeatureStoreList', () => {
     expect(items[1]).toHaveTextContent('project-b');
     expect(items[2]).toHaveTextContent('project-c');
     expect(screen.queryByTestId('feature-store-show-all')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('feature-store-show-unavailable')).not.toBeInTheDocument();
   });
 
-  it('should expand and collapse for more than 5 items', async () => {
+  it('should expand and collapse for more than 5 available items', async () => {
     const user = userEvent.setup();
-    renderFeatureStoreList(SEVEN_STORES);
+    renderFeatureStoreList(
+      SEVEN_STORES,
+      new Map([
+        ['store-1', 'ns-1'],
+        ['store-2', 'ns-2'],
+        ['store-3', 'ns-3'],
+        ['store-4', 'ns-4'],
+        ['store-5', 'ns-5'],
+        ['store-6', 'ns-6'],
+        ['store-7', 'ns-7'],
+      ]),
+    );
 
     const list = screen.getByTestId('notebook-feature-store-list');
     expect(within(list).getAllByRole('listitem')).toHaveLength(5);
@@ -113,8 +125,49 @@ describe('NotebookFeatureStoreList', () => {
     expect(showAllContainer).toHaveTextContent('Show all');
   });
 
-  it('should show info icon only for unavailable stores and hide icons while loading', () => {
-    const { unmount } = render(
+  it('should hide unavailable stores by default and show help popover trigger', () => {
+    renderFeatureStoreList('project-a,project-b,project-c', new Map([['project-b', 'ns-b']]));
+
+    const list = screen.getByTestId('notebook-feature-store-list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent('project-b');
+    expect(screen.queryByTestId('feature-store-unavailable-project-a')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('feature-store-unavailable-icon')).not.toBeInTheDocument();
+
+    const showUnavailable = screen.getByTestId('feature-store-show-unavailable');
+    expect(showUnavailable).toHaveTextContent('Show unavailable');
+    expect(screen.getByTestId('feature-store-unavailable-help')).toBeInTheDocument();
+  });
+
+  it('should expand and collapse unavailable stores with disabled text', async () => {
+    const user = userEvent.setup();
+    renderFeatureStoreList('project-a,project-b,project-c', new Map([['project-b', 'ns-b']]));
+
+    await user.click(
+      within(screen.getByTestId('feature-store-show-unavailable')).getByRole('button', {
+        name: 'Show unavailable',
+      }),
+    );
+
+    expect(screen.getByTestId('feature-store-unavailable-project-a')).toHaveTextContent(
+      'project-a',
+    );
+    expect(screen.getByTestId('feature-store-unavailable-project-c')).toHaveTextContent(
+      'project-c',
+    );
+    expect(screen.getByTestId('feature-store-show-unavailable')).toHaveTextContent('Show less');
+    expect(screen.queryByTestId('feature-store-unavailable-help')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show less' }));
+    expect(screen.queryByTestId('feature-store-unavailable-project-a')).not.toBeInTheDocument();
+    expect(screen.getByTestId('feature-store-show-unavailable')).toHaveTextContent(
+      'Show unavailable',
+    );
+  });
+
+  it('should show skeleton rows while loading and hide unavailable controls', () => {
+    render(
       <MemoryRouter>
         <NotebookFeatureStoreList
           notebook={mockNotebookK8sResource({
@@ -129,20 +182,12 @@ describe('NotebookFeatureStoreList', () => {
         />
       </MemoryRouter>,
     );
-    expect(screen.queryAllByTestId('feature-store-unavailable-icon')).toHaveLength(0);
-    expect(
-      within(screen.getByTestId('notebook-feature-store-list')).getAllByRole('listitem'),
-    ).toHaveLength(3);
-    unmount();
-
-    renderFeatureStoreList('project-a,project-b,project-c', new Map([['project-b', 'ns-b']]));
-    const list = screen.getByTestId('notebook-feature-store-list');
-    const items = within(list).getAllByRole('listitem');
-    expect(within(items[0]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
-    expect(
-      within(items[1]).queryByTestId('feature-store-unavailable-icon'),
-    ).not.toBeInTheDocument();
-    expect(within(items[2]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
+    const loading = screen.getByTestId('notebook-feature-store-loading');
+    expect(loading).toBeInTheDocument();
+    expect(loading.querySelectorAll('.pf-v6-c-skeleton')).toHaveLength(2);
+    expect(screen.queryByTestId('notebook-feature-store-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('feature-store-unavailable-help')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('feature-store-show-unavailable')).not.toBeInTheDocument();
   });
 
   it('should render links only when availability is loaded', () => {
@@ -166,8 +211,8 @@ describe('NotebookFeatureStoreList', () => {
         />
       </MemoryRouter>,
     );
-    const list = screen.getByTestId('notebook-feature-store-list');
-    expect(within(list).queryAllByRole('link')).toHaveLength(0);
+    expect(screen.getByTestId('notebook-feature-store-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('notebook-feature-store-list')).not.toBeInTheDocument();
     unmount();
 
     render(
@@ -203,7 +248,7 @@ describe('NotebookFeatureStoreList', () => {
     });
   });
 
-  it('should show info icons with expand/collapse for mixed stores', async () => {
+  it('should show only available stores with show unavailable for mixed stores', async () => {
     const user = userEvent.setup();
     renderFeatureStoreList(
       SEVEN_STORES,
@@ -215,22 +260,41 @@ describe('NotebookFeatureStoreList', () => {
     );
 
     const list = screen.getByTestId('notebook-feature-store-list');
-    const initialItems = within(list).getAllByRole('listitem');
-    expect(initialItems).toHaveLength(5);
+    expect(within(list).getAllByRole('listitem')).toHaveLength(4);
+    expect(within(list).getByText('store-1')).toBeInTheDocument();
+    expect(within(list).getByText('store-3')).toBeInTheDocument();
+    expect(within(list).getByText('store-5')).toBeInTheDocument();
+    expect(screen.queryByTestId('feature-store-show-all')).not.toBeInTheDocument();
 
-    expect(
-      within(initialItems[0]).queryByTestId('feature-store-unavailable-icon'),
-    ).not.toBeInTheDocument();
-    expect(
-      within(initialItems[1]).getByTestId('feature-store-unavailable-icon'),
-    ).toBeInTheDocument();
+    await user.click(
+      within(screen.getByTestId('feature-store-show-unavailable')).getByRole('button', {
+        name: 'Show unavailable',
+      }),
+    );
 
-    const showAllContainer = screen.getByTestId('feature-store-show-all');
-    await user.click(within(showAllContainer).getByRole('button'));
+    expect(screen.getByTestId('feature-store-unavailable-store-2')).toHaveTextContent('store-2');
+    expect(screen.getByTestId('feature-store-unavailable-store-7')).toHaveTextContent('store-7');
+  });
 
-    const allItems = within(list).getAllByRole('listitem');
-    expect(allItems).toHaveLength(7);
-    expect(within(allItems[5]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
-    expect(within(allItems[6]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
+  it('should omit show unavailable when all stores are available', () => {
+    renderFeatureStoreList(
+      'project-a,project-b',
+      new Map([
+        ['project-a', 'ns-a'],
+        ['project-b', 'ns-b'],
+      ]),
+    );
+
+    expect(screen.queryByTestId('feature-store-show-unavailable')).not.toBeInTheDocument();
+  });
+
+  it('should show unavailable toggle when all stores are unavailable', () => {
+    renderFeatureStoreList('project-a,project-b', new Map());
+
+    const list = screen.getByTestId('notebook-feature-store-list');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByTestId('feature-store-show-unavailable')).toHaveTextContent(
+      'Show unavailable',
+    );
   });
 });

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
@@ -114,13 +114,12 @@ describe('NotebookFeatureStoreList', () => {
 
     const showAllContainer = screen.getByTestId('feature-store-show-all');
     expect(showAllContainer).toHaveTextContent('Show all');
-    expect(showAllContainer).toHaveTextContent('2 more');
 
-    await user.click(within(showAllContainer).getByRole('button'));
+    await user.click(showAllContainer);
     expect(within(list).getAllByRole('listitem')).toHaveLength(7);
     expect(showAllContainer).toHaveTextContent('Show less');
 
-    await user.click(within(showAllContainer).getByRole('button'));
+    await user.click(showAllContainer);
     expect(within(list).getAllByRole('listitem')).toHaveLength(5);
     expect(showAllContainer).toHaveTextContent('Show all');
   });
@@ -335,7 +334,7 @@ describe('NotebookFeatureStoreList', () => {
       ]),
     );
 
-    await user.click(within(screen.getByTestId('feature-store-show-all')).getByRole('button'));
+    await user.click(screen.getByTestId('feature-store-show-all'));
     await user.click(
       within(screen.getByTestId('feature-store-show-unavailable')).getByRole('button', {
         name: 'Show unavailable feature stores',
@@ -348,9 +347,7 @@ describe('NotebookFeatureStoreList', () => {
 
     expect(showAll).toHaveTextContent('Show less');
     expect(showUnavailable).toHaveTextContent('Show less');
-    expect(
-      within(showAll).getByRole('button', { name: 'Show less connected feature stores' }),
-    ).toBeInTheDocument();
+    expect(showAll).toHaveAttribute('aria-label', 'Show less connected feature stores');
     expect(showUnavailable).toHaveAttribute('aria-label', 'Show less unavailable feature stores');
     expect(showAll.compareDocumentPosition(unavailableList)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(unavailableList.compareDocumentPosition(showUnavailable)).toBe(

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
@@ -137,6 +137,9 @@ describe('NotebookFeatureStoreList', () => {
 
     const showUnavailable = screen.getByTestId('feature-store-show-unavailable');
     expect(showUnavailable).toHaveTextContent('Show unavailable');
+    expect(
+      within(showUnavailable).getByRole('button', { name: 'Show unavailable feature stores' }),
+    ).toBeInTheDocument();
     expect(screen.getByTestId('feature-store-unavailable-help')).toBeInTheDocument();
   });
 
@@ -146,7 +149,7 @@ describe('NotebookFeatureStoreList', () => {
 
     await user.click(
       within(screen.getByTestId('feature-store-show-unavailable')).getByRole('button', {
-        name: 'Show unavailable',
+        name: 'Show unavailable feature stores',
       }),
     );
 
@@ -268,7 +271,7 @@ describe('NotebookFeatureStoreList', () => {
 
     await user.click(
       within(screen.getByTestId('feature-store-show-unavailable')).getByRole('button', {
-        name: 'Show unavailable',
+        name: 'Show unavailable feature stores',
       }),
     );
 
@@ -335,7 +338,7 @@ describe('NotebookFeatureStoreList', () => {
     await user.click(within(screen.getByTestId('feature-store-show-all')).getByRole('button'));
     await user.click(
       within(screen.getByTestId('feature-store-show-unavailable')).getByRole('button', {
-        name: 'Show unavailable',
+        name: 'Show unavailable feature stores',
       }),
     );
 
@@ -345,6 +348,10 @@ describe('NotebookFeatureStoreList', () => {
 
     expect(showAll).toHaveTextContent('Show less');
     expect(showUnavailable).toHaveTextContent('Show less');
+    expect(
+      within(showAll).getByRole('button', { name: 'Show less connected feature stores' }),
+    ).toBeInTheDocument();
+    expect(showUnavailable).toHaveAttribute('aria-label', 'Show less unavailable feature stores');
     expect(showAll.compareDocumentPosition(unavailableList)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(unavailableList.compareDocumentPosition(showUnavailable)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
@@ -130,7 +130,7 @@ describe('NotebookFeatureStoreList', () => {
 
     const list = screen.getByTestId('notebook-feature-store-list');
     const items = within(list).getAllByRole('listitem');
-    expect(items).toHaveLength(2);
+    expect(items).toHaveLength(1);
     expect(items[0]).toHaveTextContent('project-b');
     expect(screen.queryByTestId('feature-store-unavailable-project-a')).not.toBeInTheDocument();
     expect(screen.queryByTestId('feature-store-unavailable-icon')).not.toBeInTheDocument();
@@ -159,7 +159,7 @@ describe('NotebookFeatureStoreList', () => {
     expect(screen.getByTestId('feature-store-show-unavailable')).toHaveTextContent('Show less');
     expect(screen.queryByTestId('feature-store-unavailable-help')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Show less' }));
+    await user.click(screen.getByTestId('feature-store-show-unavailable'));
     expect(screen.queryByTestId('feature-store-unavailable-project-a')).not.toBeInTheDocument();
     expect(screen.getByTestId('feature-store-show-unavailable')).toHaveTextContent(
       'Show unavailable',
@@ -260,7 +260,7 @@ describe('NotebookFeatureStoreList', () => {
     );
 
     const list = screen.getByTestId('notebook-feature-store-list');
-    expect(within(list).getAllByRole('listitem')).toHaveLength(4);
+    expect(within(list).getAllByRole('listitem')).toHaveLength(3);
     expect(within(list).getByText('store-1')).toBeInTheDocument();
     expect(within(list).getByText('store-3')).toBeInTheDocument();
     expect(within(list).getByText('store-5')).toBeInTheDocument();
@@ -291,10 +291,63 @@ describe('NotebookFeatureStoreList', () => {
   it('should show unavailable toggle when all stores are unavailable', () => {
     renderFeatureStoreList('project-a,project-b', new Map());
 
-    const list = screen.getByTestId('notebook-feature-store-list');
-    expect(within(list).getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.queryByTestId('notebook-feature-store-list')).not.toBeInTheDocument();
     expect(screen.getByTestId('feature-store-show-unavailable')).toHaveTextContent(
       'Show unavailable',
+    );
+  });
+
+  it('should render show all before show unavailable when both apply', () => {
+    renderFeatureStoreList(
+      `${SEVEN_STORES},removed-a,removed-b`,
+      new Map([
+        ['store-1', 'ns-1'],
+        ['store-2', 'ns-2'],
+        ['store-3', 'ns-3'],
+        ['store-4', 'ns-4'],
+        ['store-5', 'ns-5'],
+        ['store-6', 'ns-6'],
+        ['store-7', 'ns-7'],
+      ]),
+    );
+
+    const showAll = screen.getByTestId('feature-store-show-all');
+    const showUnavailable = screen.getByTestId('feature-store-show-unavailable');
+
+    expect(showAll.compareDocumentPosition(showUnavailable)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('should keep each show less toggle anchored to its own section when both are expanded', async () => {
+    const user = userEvent.setup();
+    renderFeatureStoreList(
+      `${SEVEN_STORES},removed-a,removed-b`,
+      new Map([
+        ['store-1', 'ns-1'],
+        ['store-2', 'ns-2'],
+        ['store-3', 'ns-3'],
+        ['store-4', 'ns-4'],
+        ['store-5', 'ns-5'],
+        ['store-6', 'ns-6'],
+        ['store-7', 'ns-7'],
+      ]),
+    );
+
+    await user.click(within(screen.getByTestId('feature-store-show-all')).getByRole('button'));
+    await user.click(
+      within(screen.getByTestId('feature-store-show-unavailable')).getByRole('button', {
+        name: 'Show unavailable',
+      }),
+    );
+
+    const showAll = screen.getByTestId('feature-store-show-all');
+    const unavailableList = screen.getByTestId('notebook-feature-store-unavailable-list');
+    const showUnavailable = screen.getByTestId('feature-store-show-unavailable');
+
+    expect(showAll).toHaveTextContent('Show less');
+    expect(showUnavailable).toHaveTextContent('Show less');
+    expect(showAll.compareDocumentPosition(unavailableList)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(unavailableList.compareDocumentPosition(showUnavailable)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
     );
   });
 });

--- a/frontend/src/pages/projects/screens/spawner/featureStore/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/utils.ts
@@ -26,6 +26,9 @@ export const FEATURE_STORE_EMPTY_STATE_BODY =
 export const FEATURE_STORE_UNAVAILABLE_TOOLTIP =
   'This feature store is no longer available. It may have been deleted or access has been revoked.';
 
+export const FEATURE_STORE_UNAVAILABLE_LIST_TOOLTIP =
+  'These feature stores are no longer available. They may have been deleted or access has been revoked.';
+
 export const removeFeatureStoreProjectById = (
   configs: SelectedFeatureStoreConfig[],
   projectId: string,

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbenchFeatureStore.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbenchFeatureStore.cy.ts
@@ -12,6 +12,7 @@ import {
   initFeatureStoreSpawnerIntercepts,
   mockEmptyWorkbenchIntegrationResponse,
   mockNotebookWithFeastConfig,
+  mockWorkbenchIntegrationForProjects,
   mockWorkbenchIntegrationResponse,
 } from '../../../../utils/featureStoreSpawnerMocks';
 
@@ -70,6 +71,10 @@ describe('Workbench page — Feature Store', () => {
         ],
       });
       enableFeatureStoreArea();
+      cy.interceptOdh(
+        'GET /api/featurestores/workbench-integration',
+        mockWorkbenchIntegrationForProjects(['project-a', 'project-b', 'project-c']),
+      );
       workbenchPage.visit('test-project');
       const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
       notebookRow.findExpansionButton().click();
@@ -98,6 +103,18 @@ describe('Workbench page — Feature Store', () => {
         ],
       });
       enableFeatureStoreArea();
+      cy.interceptOdh(
+        'GET /api/featurestores/workbench-integration',
+        mockWorkbenchIntegrationForProjects([
+          'store-1',
+          'store-2',
+          'store-3',
+          'store-4',
+          'store-5',
+          'store-6',
+          'store-7',
+        ]),
+      );
       workbenchPage.visit('test-project');
       const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
       notebookRow.findExpansionButton().click();

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbenchFeatureStore.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbenchFeatureStore.cy.ts
@@ -129,13 +129,12 @@ describe('Workbench page — Feature Store', () => {
       notebookRow.findFeatureStoreList().find('li').should('have.length', 5);
       notebookRow.findFeatureStoreShowAll().should('exist');
       notebookRow.findFeatureStoreShowAll().should('contain.text', 'Show all');
-      notebookRow.findFeatureStoreShowAll().should('contain.text', '2 more');
 
-      notebookRow.findFeatureStoreShowAll().find('button').click();
+      notebookRow.findFeatureStoreShowAll().click();
       notebookRow.findFeatureStoreList().find('li').should('have.length', 7);
       notebookRow.findFeatureStoreShowAll().should('contain.text', 'Show less');
 
-      notebookRow.findFeatureStoreShowAll().find('button').click();
+      notebookRow.findFeatureStoreShowAll().click();
       notebookRow.findFeatureStoreList().find('li').should('have.length', 5);
       notebookRow.findFeatureStoreShowAll().should('contain.text', 'Show all');
     });

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbenchFeatureStore.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbenchFeatureStore.cy.ts
@@ -26,7 +26,11 @@ describe('Workbench page — Feature Store', () => {
   });
 
   describe('Expanded row feature stores (area enabled)', () => {
-    const enableFeatureStoreArea = () => {
+    const enableFeatureStoreArea = (
+      workbenchIntegration:
+        | typeof mockWorkbenchIntegrationResponse
+        | typeof mockEmptyWorkbenchIntegrationResponse = mockEmptyWorkbenchIntegrationResponse,
+    ) => {
       cy.interceptOdh(
         'GET /api/dsc/status',
         mockDscStatus({
@@ -40,12 +44,18 @@ describe('Workbench page — Feature Store', () => {
         'GET /api/config',
         mockDashboardConfig({ disableFeatureStore: false, disableProjectScoped: true }),
       );
+      cy.interceptOdh('GET /api/featurestores/workbench-integration', workbenchIntegration);
+    };
+
+    const visitWorkbenches = () => {
+      workbenchPage.visit('test-project');
+      workbenchPage.findNotebookTable(30000).should('exist');
     };
 
     it('shows "None" when feast-config annotation is absent', () => {
       initIntercepts({});
       enableFeatureStoreArea();
-      workbenchPage.visit('test-project');
+      visitWorkbenches();
       const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
       notebookRow.findExpansionButton().click();
       notebookRow.shouldHaveFeatureStoreTitle();
@@ -70,12 +80,10 @@ describe('Workbench page — Feature Store', () => {
           }),
         ],
       });
-      enableFeatureStoreArea();
-      cy.interceptOdh(
-        'GET /api/featurestores/workbench-integration',
+      enableFeatureStoreArea(
         mockWorkbenchIntegrationForProjects(['project-a', 'project-b', 'project-c']),
       );
-      workbenchPage.visit('test-project');
+      visitWorkbenches();
       const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
       notebookRow.findExpansionButton().click();
       notebookRow.shouldHaveFeatureStoreTitle();
@@ -102,9 +110,7 @@ describe('Workbench page — Feature Store', () => {
           }),
         ],
       });
-      enableFeatureStoreArea();
-      cy.interceptOdh(
-        'GET /api/featurestores/workbench-integration',
+      enableFeatureStoreArea(
         mockWorkbenchIntegrationForProjects([
           'store-1',
           'store-2',
@@ -115,7 +121,7 @@ describe('Workbench page — Feature Store', () => {
           'store-7',
         ]),
       );
-      workbenchPage.visit('test-project');
+      visitWorkbenches();
       const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
       notebookRow.findExpansionButton().click();
       notebookRow.shouldHaveFeatureStoreTitle();
@@ -152,12 +158,8 @@ describe('Workbench page — Feature Store', () => {
           }),
         ],
       });
-      enableFeatureStoreArea();
-      cy.interceptOdh(
-        'GET /api/featurestores/workbench-integration',
-        mockWorkbenchIntegrationResponse,
-      );
-      workbenchPage.visit('test-project');
+      enableFeatureStoreArea(mockWorkbenchIntegrationResponse);
+      visitWorkbenches();
       const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
       notebookRow.findExpansionButton().click();
       notebookRow.shouldHaveFeatureStoreLinks([

--- a/packages/cypress/cypress/utils/featureStoreSpawnerMocks.ts
+++ b/packages/cypress/cypress/utils/featureStoreSpawnerMocks.ts
@@ -70,6 +70,23 @@ export const mockEmptyWorkbenchIntegrationResponse = {
   namespaces: [],
 };
 
+export const mockWorkbenchIntegrationForProjects = (
+  projectNames: string[],
+  namespace = 'test-feast-namespace',
+): typeof mockWorkbenchIntegrationResponse => ({
+  namespaces: [
+    {
+      namespace,
+      clientConfigs: projectNames.map((projectName) => ({
+        configName: projectName,
+        projectName,
+        hasAccessToFeatureStore: true,
+        permissionLevel: ['Read'],
+      })),
+    },
+  ],
+});
+
 type InitFeatureStoreSpawnerInterceptsOptions = {
   workbenchIntegration?:
     | typeof mockWorkbenchIntegrationResponse


### PR DESCRIPTION
…ebook feature store list

https://redhat.atlassian.net/browse/RHOAIENG-79615

## Description

UpdateD the "Connected feature stores" section in the Workbench table expanded row so unavailable stores are not mixed into the main list with per-item info icons.


## BEFORE

Available and unavailable stores shown in one list
Unavailable items use a purple info icon + per-item tooltip
"Show all / Show less" truncates by count only




https://github.com/user-attachments/assets/9b941075-b77b-469c-9e1e-a71b447cdd16



## AFTER

Default: show only available (connected) feature stores as links
Below: "Show unavailable" link with a ? popover explaining why (same copy as today's tooltip, once)
Expanded: grayed-out unavailable names + "Show less"


https://github.com/user-attachments/assets/9909348b-8be8-4181-97e5-487b63c0cfe7


### when there are multiple Feature Stores [UPDATED]


https://github.com/user-attachments/assets/582fd573-a6f1-48fd-ad07-a2ff24d66f57







## How Has This Been Tested?
Tested manually and with Cypress automated tests

## Test Impact
Updated Cypress tests and unit tests


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature stores are now organized into available and unavailable sections after availability loads.
  * Unavailable stores are hidden by default, can be expanded with help text, and show pluralized explanatory messaging.
  * Loading now shows skeleton placeholders; available stores keep independent expansion.
  * “Show all” controls use state-appropriate, optional ARIA labels for improved accessibility.
* **Bug Fixes**
  * Improved ordering and expansion behavior to align with availability states.
* **Tests**
  * Updated UI and end-to-end coverage for loading, grouping, expansion controls, and project-specific feature-store access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->