### PR TITLE
feat(RHAI-339): add modelCapabilities feature flag and well-known values

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -77,6 +77,7 @@ export type DashboardConfig = K8sResourceCommon & {
       globalProjectPrompts: boolean;
       gpuaas: boolean;
       connectionTest: boolean;
+      modelCapabilities: boolean;
       observabilityDashboard: boolean;
     };
     // Intentionally disjointed from the CRD, we should move away from this code-wise now; CRD later

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -113,6 +113,7 @@ export const blankDashboardCR: DashboardConfig = {
       globalProjectPrompts: false,
       gpuaas: true,
       connectionTest: false,
+      modelCapabilities: false,
       observabilityDashboard: true,
     },
     notebookController: {

--- a/distributions/core-bff/bff/internal/models/dashboard_config.go
+++ b/distributions/core-bff/bff/internal/models/dashboard_config.go
@@ -95,6 +95,7 @@ type DashboardFeatureFlags struct {
 	PromptManagement             bool `json:"promptManagement"`
 	MySubscriptions              bool `json:"mySubscriptions"`
 	ConnectionTest               bool `json:"connectionTest"`
+	ModelCapabilities            bool `json:"modelCapabilities"`
 }
 
 type NotebookController struct {
@@ -189,6 +190,7 @@ var BlankDashboardCR = DashboardConfig{
 			PromptManagement:             false,
 			MySubscriptions:              false,
 			ConnectionTest:               false,
+			ModelCapabilities:            false,
 		},
 		NotebookController: &NotebookController{
 			Enabled: true,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -70,6 +70,7 @@ export type MockDashboardConfigType = {
   roleManagement?: boolean;
   gpuaas?: boolean;
   connectionTest?: boolean;
+  modelCapabilities?: boolean;
   globalMLflowNamespaces?: string[];
   genAiStudioConfig?: {
     aiAssetCustomEndpoints?: {
@@ -141,6 +142,7 @@ export const mockDashboardConfig = ({
   roleManagement = true,
   gpuaas = true,
   connectionTest = false,
+  modelCapabilities = false,
   hardwareProfileOrder = ['test-hardware-profile'],
   globalMLflowNamespaces = [],
   genAiStudioConfig = {
@@ -335,6 +337,7 @@ export const mockDashboardConfig = ({
       roleManagement,
       gpuaas,
       connectionTest,
+      modelCapabilities,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -17,6 +17,7 @@ export const techPreviewFlags = {
   mcpCatalog: false,
   mcpRegistry: false,
   toolCalling: false,
+  modelCapabilities: false,
   deploymentWizardYAMLViewer: false,
   externalVectorStores: false,
   agentConfigManagement: false,
@@ -35,7 +36,6 @@ export const devTemporaryFeatureFlags = {
   nimWizard: false,
   agentOpsDeploy: false,
   agentsCatalog: false,
-  modelCapabilities: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Group 1: Core Dashboard Features

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -35,6 +35,7 @@ export const devTemporaryFeatureFlags = {
   nimWizard: false,
   agentOpsDeploy: false,
   agentsCatalog: false,
+  modelCapabilities: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Group 1: Core Dashboard Features
@@ -293,6 +294,10 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.CONNECTION_TEST]: {
     featureFlags: ['connectionTest'],
+  },
+  [SupportedArea.MODEL_CAPABILITIES]: {
+    featureFlags: ['modelCapabilities'],
+    reliantAreas: [SupportedArea.MODEL_SERVING],
   },
 };
 

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -319,6 +319,7 @@ export type DashboardCommonConfig = {
   roleManagement?: boolean;
   gpuaas?: boolean;
   connectionTest?: boolean;
+  modelCapabilities?: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {

--- a/packages/model-serving/package.json
+++ b/packages/model-serving/package.json
@@ -21,6 +21,7 @@
     "./shared/components": "./src/shared/components/index.ts",
     "./shared/wizard-fields": "./src/shared/wizard-fields.ts",
     "./shared/types/form-data": "./src/shared/types/form-data.ts",
+    "./shared/modelCapabilities": "./src/shared/modelCapabilities.ts",
     "./components/connectionTypes/ConnectionOciAlert": "./src/components/connectionTypes/ConnectionOciAlert.tsx",
     "./components/connectionTypes/ConnectionOciPathField": "./src/components/connectionTypes/ConnectionOciPathField.tsx",
     "./components/connectionTypes/ConnectionS3FolderPathField": "./src/components/connectionTypes/ConnectionS3FolderPathField.tsx",

--- a/packages/model-serving/src/shared/index.ts
+++ b/packages/model-serving/src/shared/index.ts
@@ -64,3 +64,6 @@ export {
   initialModelServingFilterData,
 } from './const';
 export type { ModelServingFilterDataType } from './const';
+
+export { MODEL_CAPABILITIES_ANNOTATION, WELL_KNOWN_MODEL_CAPABILITIES } from './modelCapabilities';
+export type { WellKnownModelCapability, ModelCapability } from './modelCapabilities';

--- a/packages/model-serving/src/shared/modelCapabilities.ts
+++ b/packages/model-serving/src/shared/modelCapabilities.ts
@@ -1,0 +1,16 @@
+/**
+ * Annotation key for Model Capabilities on InferenceService / LLMInferenceService.
+ * Value is a JSON-encoded string array, e.g. `["Vision","Transcription"]`.
+ */
+export const MODEL_CAPABILITIES_ANNOTATION = 'opendatahub.io/model-capabilities';
+
+/**
+ * Hardcoded well-known Model Capability values offered by the dashboard UI.
+ * New values can be added here without BFF/CRD changes.
+ */
+export const WELL_KNOWN_MODEL_CAPABILITIES = ['Vision', 'Transcription'] as const;
+
+export type WellKnownModelCapability = (typeof WELL_KNOWN_MODEL_CAPABILITIES)[number];
+
+/** Any capability string, including well-known and custom values. */
+export type ModelCapability = string;

--- a/packages/plugin-core/src/areas/types.ts
+++ b/packages/plugin-core/src/areas/types.ts
@@ -123,6 +123,9 @@ export enum SupportedArea {
 
   /* Connection Test */
   CONNECTION_TEST = 'connection-test',
+
+  /* Model Capabilities */
+  MODEL_CAPABILITIES = 'model-capabilities',
 }
 
 export type SupportedAreaType = SupportedArea | string;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAI-339

## Description

Foundational work for Model Capabilities in the deployment wizard and deployments table:

- Add `modelCapabilities` as a **dev temporary** feature flag (default `false`), wired through frontend areas, `DashboardCommonConfig` types, mocks, backend defaults, and core-bff dashboard config
- Add `SupportedArea.MODEL_CAPABILITIES` (reliant on `MODEL_SERVING`) so consumers can gate UI with `useIsAreaAvailable`
- Export shared well-known values and annotation key from `@odh-dashboard/model-serving/shared` / `@odh-dashboard/model-serving/shared/modelCapabilities`:
  - `MODEL_CAPABILITIES_ANNOTATION` (`opendatahub.io/model-capabilities`)
  - `WELL_KNOWN_MODEL_CAPABILITIES`: `Vision`, `Transcription`

Intentionally **not** added to the `OdhDashboardConfig` CRD yet. Enable locally via `?devFeatureFlags=modelCapabilities=true`.

Wizard field UI, annotation apply/extract, and deployments table column remain out of scope (follow-up: [RHAI-340](https://redhat.atlassian.net/browse/RHAI-340) / [RHAI-341](https://redhat.atlassian.net/browse/RHAI-341)).

## How Has This Been Tested?

- Ran type-check on `frontend`, `packages/model-serving`, `packages/plugin-core`, and `packages/k8s-core`
- Ran eslint on changed TypeScript files
- Pre-commit lint-staged passed

## Test Impact

No new unit/Cypress tests. This PR only introduces a feature flag and shared constants with no user-facing UI yet; later stories that consume the flag will add coverage.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

[RHAI-340]: https://redhat.atlassian.net/browse/RHAI-340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dashboard feature flag for Model Capabilities, disabled by default.
  * Added Model Capabilities as a supported area, available when model serving is enabled.
  * Added support for recognizing Vision and Transcription model capabilities, along with additional capability values.
  * Added configuration support for enabling Model Capabilities across dashboard and deployment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->