### PR TITLE
Fix MaaS download flake in mock tests

### DIFF
--- a/packages/cypress/cypress/utils/downloadUtils.ts
+++ b/packages/cypress/cypress/utils/downloadUtils.ts
@@ -21,11 +21,15 @@ export const stubDownload = (aliasName: string): void => {
 
     let pendingContent = '';
     const OriginalBlob = win.Blob;
+    const originalAnchorClick = win.HTMLAnchorElement.prototype.click;
+
+    // Capture string content from PatternFly download Blobs (`type: 'text'`).
+    // Monaco worker Blobs use `application/javascript` — leave those alone.
     cy.stub(win, 'Blob').callsFake(function BlobStub(
       blobParts?: BlobPart[],
       options?: BlobPropertyBag,
     ) {
-      if (Array.isArray(blobParts)) {
+      if (options?.type === 'text' && Array.isArray(blobParts)) {
         const [firstPart] = blobParts;
         if (typeof firstPart === 'string') {
           pendingContent = firstPart;
@@ -34,14 +38,15 @@ export const stubDownload = (aliasName: string): void => {
       return new OriginalBlob(blobParts, options);
     });
 
-    cy.stub(win.URL, 'createObjectURL').callsFake(() => 'blob:cypress-mock-download');
-
     cy.stub(win.HTMLAnchorElement.prototype, 'click').callsFake(function anchorClickStub(
       this: HTMLAnchorElement,
     ) {
       if (this.download) {
         downloads.push({ fileName: this.download, content: pendingContent });
+        pendingContent = '';
+        return;
       }
+      return originalAnchorClick.call(this);
     });
   });
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-80066
## Description
Cypress mocks are flaking for our YAML download test. Updated the util to be more stable so there's no race conditions with monaco text editor and cypress.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Ran the maasSubscriptions test locally and everything is working
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Test fix so just mocks
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download handling in automated browser tests.
  * Preserved Monaco worker resources while capturing text file downloads.
  * Ensured regular links continue to behave normally.
  * Reset captured download content after each download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->