### PR TITLE
Fix (RHOAIENG-78268): Disable Cluster Settings Save until the form is dirty

### DIFF
--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -24,6 +24,8 @@ import {
   MIN_CULLER_TIMEOUT,
 } from './const';
 
+const DEFAULT_DISTRIBUTED_INFERENCING = DEFAULT_CONFIG.isDistributedInferencingDefault ?? true;
+
 const ClusterSettings: React.FC = () => {
   const [loaded, setLoaded] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
@@ -33,8 +35,7 @@ const ClusterSettings: React.FC = () => {
   const [userTrackingEnabled, setUserTrackingEnabled] = React.useState(false);
   const [cullerTimeout, setCullerTimeout] = React.useState(DEFAULT_CULLER_TIMEOUT);
   const [isDistributedInferencingDefault, setisDistributedInferencingDefault] = React.useState(
-    clusterSettings.isDistributedInferencingDefault ??
-      DEFAULT_CONFIG.isDistributedInferencingDefault,
+    clusterSettings.isDistributedInferencingDefault ?? DEFAULT_DISTRIBUTED_INFERENCING,
   );
   const [defaultDeploymentStrategy, setDefaultDeploymentStrategy] = React.useState('rolling');
   // "Global project" UI maps to globalMLflowNamespaces in the CR (spec.globalMLflowNamespaces).
@@ -65,7 +66,7 @@ const ClusterSettings: React.FC = () => {
           modelServingPlatformEnabled: fetchedClusterSettings.modelServingPlatformEnabled,
           isDistributedInferencingDefault:
             fetchedClusterSettings.isDistributedInferencingDefault ??
-            DEFAULT_CONFIG.isDistributedInferencingDefault,
+            DEFAULT_DISTRIBUTED_INFERENCING,
           defaultDeploymentStrategy: deploymentStrategy,
           globalMLflowNamespaces: fetchedClusterSettings.globalMLflowNamespaces ?? [],
         };
@@ -75,8 +76,7 @@ const ClusterSettings: React.FC = () => {
         setUserTrackingEnabled(normalizedSettings.userTrackingEnabled);
         setModelServingEnabledPlatforms(normalizedSettings.modelServingPlatformEnabled);
         setisDistributedInferencingDefault(
-          normalizedSettings.isDistributedInferencingDefault ??
-            DEFAULT_CONFIG.isDistributedInferencingDefault,
+          normalizedSettings.isDistributedInferencingDefault ?? DEFAULT_DISTRIBUTED_INFERENCING,
         );
         setDefaultDeploymentStrategy(normalizedSettings.defaultDeploymentStrategy ?? 'rolling');
         setGlobalMLflowNamespace(normalizedSettings.globalMLflowNamespaces?.[0] ?? '');

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -33,7 +33,8 @@ const ClusterSettings: React.FC = () => {
   const [userTrackingEnabled, setUserTrackingEnabled] = React.useState(false);
   const [cullerTimeout, setCullerTimeout] = React.useState(DEFAULT_CULLER_TIMEOUT);
   const [isDistributedInferencingDefault, setisDistributedInferencingDefault] = React.useState(
-    clusterSettings.isDistributedInferencingDefault ?? false,
+    clusterSettings.isDistributedInferencingDefault ??
+      DEFAULT_CONFIG.isDistributedInferencingDefault,
   );
   const [defaultDeploymentStrategy, setDefaultDeploymentStrategy] = React.useState('rolling');
   // "Global project" UI maps to globalMLflowNamespaces in the CR (spec.globalMLflowNamespaces).
@@ -63,7 +64,8 @@ const ClusterSettings: React.FC = () => {
           userTrackingEnabled: fetchedClusterSettings.userTrackingEnabled,
           modelServingPlatformEnabled: fetchedClusterSettings.modelServingPlatformEnabled,
           isDistributedInferencingDefault:
-            fetchedClusterSettings.isDistributedInferencingDefault ?? false,
+            fetchedClusterSettings.isDistributedInferencingDefault ??
+            DEFAULT_CONFIG.isDistributedInferencingDefault,
           defaultDeploymentStrategy: deploymentStrategy,
           globalMLflowNamespaces: fetchedClusterSettings.globalMLflowNamespaces ?? [],
         };
@@ -73,7 +75,8 @@ const ClusterSettings: React.FC = () => {
         setUserTrackingEnabled(normalizedSettings.userTrackingEnabled);
         setModelServingEnabledPlatforms(normalizedSettings.modelServingPlatformEnabled);
         setisDistributedInferencingDefault(
-          normalizedSettings.isDistributedInferencingDefault ?? false,
+          normalizedSettings.isDistributedInferencingDefault ??
+            DEFAULT_CONFIG.isDistributedInferencingDefault,
         );
         setDefaultDeploymentStrategy(normalizedSettings.defaultDeploymentStrategy ?? 'rolling');
         setGlobalMLflowNamespace(normalizedSettings.globalMLflowNamespaces?.[0] ?? '');

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -35,7 +35,7 @@ const ClusterSettings: React.FC = () => {
   const [userTrackingEnabled, setUserTrackingEnabled] = React.useState(false);
   const [cullerTimeout, setCullerTimeout] = React.useState(DEFAULT_CULLER_TIMEOUT);
   const [isDistributedInferencingDefault, setisDistributedInferencingDefault] = React.useState(
-    clusterSettings.isDistributedInferencingDefault ?? DEFAULT_DISTRIBUTED_INFERENCING,
+    DEFAULT_DISTRIBUTED_INFERENCING,
   );
   const [defaultDeploymentStrategy, setDefaultDeploymentStrategy] = React.useState('rolling');
   // "Global project" UI maps to globalMLflowNamespaces in the CR (spec.globalMLflowNamespaces).
@@ -59,14 +59,11 @@ const ClusterSettings: React.FC = () => {
 
         // API may omit optional fields (JSON drops undefined). Fill defaults so the
         // baseline matches form state and Save stays disabled until the user edits.
+        const distributedInferencingDefault =
+          fetchedClusterSettings.isDistributedInferencingDefault ?? DEFAULT_DISTRIBUTED_INFERENCING;
         const normalizedSettings: ClusterSettingsType = {
-          pvcSize: fetchedClusterSettings.pvcSize,
-          cullerTimeout: fetchedClusterSettings.cullerTimeout,
-          userTrackingEnabled: fetchedClusterSettings.userTrackingEnabled,
-          modelServingPlatformEnabled: fetchedClusterSettings.modelServingPlatformEnabled,
-          isDistributedInferencingDefault:
-            fetchedClusterSettings.isDistributedInferencingDefault ??
-            DEFAULT_DISTRIBUTED_INFERENCING,
+          ...fetchedClusterSettings,
+          isDistributedInferencingDefault: distributedInferencingDefault,
           defaultDeploymentStrategy: deploymentStrategy,
           globalMLflowNamespaces: fetchedClusterSettings.globalMLflowNamespaces ?? [],
         };
@@ -75,10 +72,8 @@ const ClusterSettings: React.FC = () => {
         setCullerTimeout(normalizedSettings.cullerTimeout);
         setUserTrackingEnabled(normalizedSettings.userTrackingEnabled);
         setModelServingEnabledPlatforms(normalizedSettings.modelServingPlatformEnabled);
-        setisDistributedInferencingDefault(
-          normalizedSettings.isDistributedInferencingDefault ?? DEFAULT_DISTRIBUTED_INFERENCING,
-        );
-        setDefaultDeploymentStrategy(normalizedSettings.defaultDeploymentStrategy ?? 'rolling');
+        setisDistributedInferencingDefault(distributedInferencingDefault);
+        setDefaultDeploymentStrategy(deploymentStrategy);
         setGlobalMLflowNamespace(normalizedSettings.globalMLflowNamespaces?.[0] ?? '');
         setLoaded(true);
         setLoadError(undefined);

--- a/frontend/src/pages/clusterSettings/ClusterSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ClusterSettings.tsx
@@ -33,7 +33,7 @@ const ClusterSettings: React.FC = () => {
   const [userTrackingEnabled, setUserTrackingEnabled] = React.useState(false);
   const [cullerTimeout, setCullerTimeout] = React.useState(DEFAULT_CULLER_TIMEOUT);
   const [isDistributedInferencingDefault, setisDistributedInferencingDefault] = React.useState(
-    clusterSettings.isDistributedInferencingDefault,
+    clusterSettings.isDistributedInferencingDefault ?? false,
   );
   const [defaultDeploymentStrategy, setDefaultDeploymentStrategy] = React.useState('rolling');
   // "Global project" UI maps to globalMLflowNamespaces in the CR (spec.globalMLflowNamespaces).
@@ -55,17 +55,27 @@ const ClusterSettings: React.FC = () => {
         const modelServingConfig = dashboardConfig.spec.modelServing || {};
         const deploymentStrategy = modelServingConfig.deploymentStrategy ?? 'rolling';
 
+        // API may omit optional fields (JSON drops undefined). Fill defaults so the
+        // baseline matches form state and Save stays disabled until the user edits.
         const normalizedSettings: ClusterSettingsType = {
-          ...fetchedClusterSettings,
+          pvcSize: fetchedClusterSettings.pvcSize,
+          cullerTimeout: fetchedClusterSettings.cullerTimeout,
+          userTrackingEnabled: fetchedClusterSettings.userTrackingEnabled,
+          modelServingPlatformEnabled: fetchedClusterSettings.modelServingPlatformEnabled,
+          isDistributedInferencingDefault:
+            fetchedClusterSettings.isDistributedInferencingDefault ?? false,
           defaultDeploymentStrategy: deploymentStrategy,
+          globalMLflowNamespaces: fetchedClusterSettings.globalMLflowNamespaces ?? [],
         };
         setClusterSettings(normalizedSettings);
         setPvcSize(normalizedSettings.pvcSize);
         setCullerTimeout(normalizedSettings.cullerTimeout);
         setUserTrackingEnabled(normalizedSettings.userTrackingEnabled);
         setModelServingEnabledPlatforms(normalizedSettings.modelServingPlatformEnabled);
-        setisDistributedInferencingDefault(normalizedSettings.isDistributedInferencingDefault);
-        setDefaultDeploymentStrategy(deploymentStrategy);
+        setisDistributedInferencingDefault(
+          normalizedSettings.isDistributedInferencingDefault ?? false,
+        );
+        setDefaultDeploymentStrategy(normalizedSettings.defaultDeploymentStrategy ?? 'rolling');
         setGlobalMLflowNamespace(normalizedSettings.globalMLflowNamespaces?.[0] ?? '');
         setLoaded(true);
         setLoadError(undefined);
@@ -114,9 +124,7 @@ const ClusterSettings: React.FC = () => {
       globalMLflowNamespaces,
     };
 
-    const clusterSettingsUnchanged = _.isEqual(clusterSettings, newClusterSettings);
-
-    if (clusterSettingsUnchanged) {
+    if (!isSettingsChanged) {
       return;
     }
 
@@ -130,15 +138,7 @@ const ClusterSettings: React.FC = () => {
     setSaving(true);
 
     try {
-      const response = await updateClusterSettings({
-        pvcSize,
-        cullerTimeout,
-        userTrackingEnabled,
-        modelServingPlatformEnabled: modelServingEnabledPlatforms,
-        isDistributedInferencingDefault,
-        defaultDeploymentStrategy,
-        globalMLflowNamespaces,
-      });
+      const response = await updateClusterSettings(newClusterSettings);
 
       if (!response.success) {
         throw new Error(response.error);
@@ -190,7 +190,7 @@ const ClusterSettings: React.FC = () => {
                   initialValue={clusterSettings.modelServingPlatformEnabled}
                   enabledPlatforms={modelServingEnabledPlatforms}
                   setEnabledPlatforms={setModelServingEnabledPlatforms}
-                  isDistributedInferencingDefault={isDistributedInferencingDefault ?? false}
+                  isDistributedInferencingDefault={isDistributedInferencingDefault}
                   setisDistributedInferencingDefault={setisDistributedInferencingDefault}
                 />
               </StackItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78268

## Description
On Settings > Cluster Settings, "Save changes" stayed enabled even when nothing was edited. Clicking it was a no-op.


https://github.com/user-attachments/assets/77c86bae-6571-43c8-bd18-112bcc28dcc6



The page already disabled Save via `isSettingsChanged` (`_.isEqual` against the loaded baseline). That check failed because `/api/cluster-settings` omits optional fields when they are unset (`isDistributedInferencingDefault`, `defaultDeploymentStrategy`), while the form always compared a full object (with defaults). Lodash treated that shape mismatch as a change.

This fix normalizes the loaded settings to a stable shape (fill defaults for omitted optionals) so the baseline matches form state. Save stays disabled until the user edits, and enables again after a real change. 

## How Has This Been Tested?
1. Open `Settings > Cluster settings > General` (`/settings/cluster/general`).
2. Confirm **Save changes** is disabled on load (no edits).
3. Change any field  → button enables.
4. Revert the change → button disables again.
5. Make a change and save → success notification; button disables after save.

## Test Impact
- No new unit tests. Fix is a small load-path normalization; existing Cypress cluster settings coverage already expects Save disabled until edit (`clusterSettings.cy.ts`).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster settings initialization when distributed inferencing or the global MLflow namespace is missing.
  * Ensured saved settings are consistently normalized before submission.
  * Prevented unnecessary save requests when settings have not changed.
  * Updated model-serving settings to consistently reflect the normalized distributed-inferencing value.
  * Improved consistency when loading, editing, and saving cluster configuration values.
  * Reduced unexpected configuration differences between displayed and persisted settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->