### PR TITLE
RHOAIENG-79707: Improve Connected feature stores UX in workbench creation form

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTable.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTable.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- shared table component from ui-core
 import { Table } from '@odh-dashboard/ui-core';
+import { Button, Stack, StackItem } from '@patternfly/react-core';
 import type { SelectedFeatureStoreConfig } from './useWorkbenchFeatureStores';
 import { FeatureStoreConnectedTableRow } from './FeatureStoreConnectedTableRow';
 import { featureStoreConnectedTableColumns } from './featureStoreConnectedTableConst';
@@ -16,21 +17,58 @@ export const FeatureStoreConnectedTable: React.FC<FeatureStoreConnectedTableProp
   featureStores,
   availabilityLoaded,
   onRemove,
-}) => (
-  <Table
-    data={featureStores}
-    data-testid="feature-store-connected-table"
-    columns={featureStoreConnectedTableColumns}
-    rowRenderer={(featureStore) => (
-      <FeatureStoreConnectedTableRow
-        key={getFeatureStoreProjectId(featureStore)}
-        featureStore={featureStore}
-        availabilityLoaded={availabilityLoaded}
-        onRemove={onRemove}
-      />
-    )}
-    isStriped
-  />
-);
+}) => {
+  const [showUnavailable, setShowUnavailable] = React.useState(false);
+
+  const unavailableCount = React.useMemo(
+    () => featureStores.filter((featureStore) => featureStore.isUnavailable).length,
+    [featureStores],
+  );
+
+  const visibleFeatureStores = React.useMemo(() => {
+    if (showUnavailable || unavailableCount === 0) {
+      return featureStores;
+    }
+    return featureStores.filter((featureStore) => !featureStore.isUnavailable);
+  }, [featureStores, showUnavailable, unavailableCount]);
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Table
+          data={visibleFeatureStores}
+          data-testid="feature-store-connected-table"
+          columns={featureStoreConnectedTableColumns}
+          rowRenderer={(featureStore) => (
+            <FeatureStoreConnectedTableRow
+              key={getFeatureStoreProjectId(featureStore)}
+              featureStore={featureStore}
+              availabilityLoaded={availabilityLoaded}
+              onRemove={onRemove}
+            />
+          )}
+          isStriped
+        />
+      </StackItem>
+      {unavailableCount > 0 && (
+        <StackItem>
+          <Button
+            isInline
+            variant="link"
+            onClick={() => setShowUnavailable((prev) => !prev)}
+            aria-label={
+              showUnavailable
+                ? 'Show less unavailable feature stores'
+                : 'Show unavailable feature stores'
+            }
+            data-testid="feature-store-show-unavailable"
+          >
+            {showUnavailable ? 'Show less' : 'Show unavailable'}
+          </Button>
+        </StackItem>
+      )}
+    </Stack>
+  );
+};
 
 export default FeatureStoreConnectedTable;

--- a/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTableRow.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTableRow.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { ActionList, ActionListItem, Button, Content, Truncate } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
-import text from '@patternfly/react-styles/css/utilities/Text/text';
 import { Td, Tr } from '@patternfly/react-table';
 import type { SelectedFeatureStoreConfig } from './useWorkbenchFeatureStores';
 import { FeatureStorePermissionLabels } from './FeatureStorePermissionLabels';
@@ -25,7 +24,10 @@ export const FeatureStoreConnectedTableRow: React.FC<FeatureStoreConnectedTableR
     <Tr data-testid={`feature-store-connected-row-${projectId}`}>
       <Td dataLabel="Name">
         {featureStore.isUnavailable ? (
-          <Content className={text.textColorDisabled} data-testid="feature-store-unavailable-name">
+          <Content
+            className="pf-v6-u-disabled-color-100"
+            data-testid="feature-store-unavailable-name"
+          >
             <Truncate content={featureStore.projectName} />
           </Content>
         ) : availabilityLoaded ? (

--- a/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTableRow.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTableRow.tsx
@@ -25,7 +25,7 @@ export const FeatureStoreConnectedTableRow: React.FC<FeatureStoreConnectedTableR
       <Td dataLabel="Name">
         {featureStore.isUnavailable ? (
           <Content
-            className="pf-v6-u-disabled-color-100"
+            className="pf-v6-u-text-color-disabled"
             data-testid="feature-store-unavailable-name"
           >
             <Truncate content={featureStore.projectName} />

--- a/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTableRow.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreConnectedTableRow.tsx
@@ -1,21 +1,12 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import {
-  ActionList,
-  ActionListItem,
-  Button,
-  Flex,
-  FlexItem,
-  Icon,
-  Tooltip,
-  Truncate,
-} from '@patternfly/react-core';
-import { InfoCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
+import { ActionList, ActionListItem, Button, Content, Truncate } from '@patternfly/react-core';
+import { MinusCircleIcon } from '@patternfly/react-icons';
+import text from '@patternfly/react-styles/css/utilities/Text/text';
 import { Td, Tr } from '@patternfly/react-table';
 import type { SelectedFeatureStoreConfig } from './useWorkbenchFeatureStores';
 import { FeatureStorePermissionLabels } from './FeatureStorePermissionLabels';
 import { getFeatureStoreProjectId } from './selectFeatureStoresModalConst';
-import { FEATURE_STORE_UNAVAILABLE_TOOLTIP } from './utils';
 
 export type FeatureStoreConnectedTableRowProps = {
   featureStore: SelectedFeatureStoreConfig;
@@ -34,21 +25,9 @@ export const FeatureStoreConnectedTableRow: React.FC<FeatureStoreConnectedTableR
     <Tr data-testid={`feature-store-connected-row-${projectId}`}>
       <Td dataLabel="Name">
         {featureStore.isUnavailable ? (
-          <Flex
-            spaceItems={{ default: 'spaceItemsSm' }}
-            alignItems={{ default: 'alignItemsCenter' }}
-          >
-            <FlexItem>
-              <Truncate content={featureStore.projectName} />
-            </FlexItem>
-            <FlexItem>
-              <Tooltip content={FEATURE_STORE_UNAVAILABLE_TOOLTIP}>
-                <Icon isInline status="info" data-testid="feature-store-unavailable-icon">
-                  <InfoCircleIcon />
-                </Icon>
-              </Tooltip>
-            </FlexItem>
-          </Flex>
+          <Content className={text.textColorDisabled} data-testid="feature-store-unavailable-name">
+            <Truncate content={featureStore.projectName} />
+          </Content>
         ) : availabilityLoaded ? (
           <Link
             to={`/develop-train/feature-store/overview/${featureStore.projectName}`}

--- a/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreFormSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/FeatureStoreFormSection.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Alert,
   Bullseye,
   EmptyState,
   EmptyStateBody,
@@ -29,6 +30,7 @@ import {
   FEATURE_STORE_CODE_DESCRIPTION,
   FEATURE_STORE_EMPTY_STATE_BODY,
   FEATURE_STORE_EMPTY_STATE_TITLE,
+  FEATURE_STORE_UNAVAILABLE_TOOLTIP,
   generateFeatureStoreCode,
   removeFeatureStoreProjectById,
 } from './utils';
@@ -63,6 +65,7 @@ export const FeatureStoreFormSection: React.FC<FeatureStoreFormSectionProps> = (
 
   const codeContent = React.useMemo(() => generateFeatureStoreCode(), []);
   const hasSelectedFeatureStores = selectedFeatureStores.length > 0;
+  const hasUnavailableFeatureStores = selectedFeatureStores.some((fs) => fs.isUnavailable);
 
   if (!isFeastOperatorAvailable) {
     return null;
@@ -102,6 +105,16 @@ export const FeatureStoreFormSection: React.FC<FeatureStoreFormSectionProps> = (
       aria-label={SpawnerPageSectionTitles[SpawnerPageSectionID.FEATURE_STORE]}
     >
       <Stack hasGutter>
+        {hasSelectedFeatureStores && hasUnavailableFeatureStores && (
+          <StackItem>
+            <Alert
+              data-testid="feature-store-unavailable-alert"
+              variant="info"
+              isInline
+              title={FEATURE_STORE_UNAVAILABLE_TOOLTIP}
+            />
+          </StackItem>
+        )}
         {hasSelectedFeatureStores ? (
           <StackItem>
             <FeatureStoreConnectedTable

--- a/frontend/src/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 /* eslint-disable @odh-dashboard/no-restricted-imports */
 import {
+  Alert,
   Button,
   Modal,
   ModalBody,
@@ -25,6 +26,7 @@ import {
   SELECT_FEATURE_STORES_MODAL_TITLE,
   selectFeatureStoresColumns,
 } from './selectFeatureStoresModalConst';
+import { FEATURE_STORE_UNAVAILABLE_TOOLTIP } from './utils';
 
 export type SelectFeatureStoresModalProps = {
   featureStores: WorkbenchFeatureStoreConfig[];
@@ -111,6 +113,8 @@ export const SelectFeatureStoresModal: React.FC<SelectFeatureStoresModalProps> =
     setFilterText('');
   }, []);
 
+  const hasUnavailableFeatureStores = allFeatureStores.some((fs) => fs.isUnavailable);
+
   return (
     <Modal
       isOpen
@@ -125,6 +129,15 @@ export const SelectFeatureStoresModal: React.FC<SelectFeatureStoresModalProps> =
         description={SELECT_FEATURE_STORES_MODAL_DESCRIPTION}
       />
       <ModalBody>
+        {hasUnavailableFeatureStores && (
+          <Alert
+            className="pf-v6-u-mb-md"
+            data-testid="feature-store-unavailable-alert"
+            variant="info"
+            isInline
+            title={FEATURE_STORE_UNAVAILABLE_TOOLTIP}
+          />
+        )}
         <TableBase
           {...tableProps}
           data-testid="select-feature-stores-table"

--- a/frontend/src/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModal.tsx
@@ -8,9 +8,12 @@ import {
   ModalFooter,
   ModalHeader,
   SearchInput,
+  ToggleGroup,
+  ToggleGroupItem,
+  ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DashboardEmptyTableView, TableBase, useTableColumnSort } from '@odh-dashboard/ui-core';
+import { DashboardEmptyTableView, Table } from '@odh-dashboard/ui-core';
 /* eslint-enable @odh-dashboard/no-restricted-imports */
 import { useCheckboxTableBase } from '#~/components/table';
 import type {
@@ -35,6 +38,8 @@ export type SelectFeatureStoresModalProps = {
   onSave: (featureStores: SelectedFeatureStoreConfig[]) => void;
   onClose: () => void;
 };
+
+type AvailabilityFilter = 'all' | 'available' | 'unavailable';
 
 const getInitialSelections = (
   featureStores: SelectedFeatureStoreConfig[],
@@ -62,6 +67,7 @@ export const SelectFeatureStoresModal: React.FC<SelectFeatureStoresModalProps> =
   onClose,
 }) => {
   const [filterText, setFilterText] = React.useState('');
+  const [availabilityFilter, setAvailabilityFilter] = React.useState<AvailabilityFilter>('all');
 
   const allFeatureStores = React.useMemo((): SelectedFeatureStoreConfig[] => {
     const availableIds = new Set(featureStores.map(getFeatureStoreProjectId));
@@ -71,6 +77,23 @@ export const SelectFeatureStoresModal: React.FC<SelectFeatureStoresModalProps> =
     return [...featureStores, ...unavailable];
   }, [featureStores, unavailableFeatureStores]);
 
+  const availabilityCounts = React.useMemo(() => {
+    let available = 0;
+    let unavailable = 0;
+    allFeatureStores.forEach((featureStore) => {
+      if (featureStore.isUnavailable) {
+        unavailable += 1;
+      } else {
+        available += 1;
+      }
+    });
+    return {
+      all: allFeatureStores.length,
+      available,
+      unavailable,
+    };
+  }, [allFeatureStores]);
+
   const initialSelectionIdsRef = React.useRef(
     getInitialSelections(allFeatureStores, initialSelections).map(getFeatureStoreProjectId),
   );
@@ -79,25 +102,26 @@ export const SelectFeatureStoresModal: React.FC<SelectFeatureStoresModalProps> =
   >(() => getInitialSelections(allFeatureStores, initialSelections));
 
   const filteredFeatureStores = React.useMemo(() => {
-    const normalized = filterText.trim().toLowerCase();
-    if (!normalized) {
-      return allFeatureStores;
+    let stores = allFeatureStores;
+    if (availabilityFilter === 'available') {
+      stores = stores.filter((featureStore) => !featureStore.isUnavailable);
+    } else if (availabilityFilter === 'unavailable') {
+      stores = stores.filter((featureStore) => featureStore.isUnavailable);
     }
 
-    return allFeatureStores.filter((featureStore) =>
+    const normalized = filterText.trim().toLowerCase();
+    if (!normalized) {
+      return stores;
+    }
+
+    return stores.filter((featureStore) =>
       featureStore.projectName.toLowerCase().includes(normalized),
     );
-  }, [allFeatureStores, filterText]);
-
-  const sort = useTableColumnSort<SelectedFeatureStoreConfig>(selectFeatureStoresColumns, [], 1);
-  const sortedFeatureStores = React.useMemo(
-    () => sort.transformData(filteredFeatureStores),
-    [filteredFeatureStores, sort],
-  );
+  }, [allFeatureStores, availabilityFilter, filterText]);
 
   const { selections, toggleSelection, isSelected, tableProps } =
     useCheckboxTableBase<SelectedFeatureStoreConfig>(
-      sortedFeatureStores,
+      filteredFeatureStores,
       selectedFeatureStores,
       setSelectedFeatureStores,
       getFeatureStoreProjectId,
@@ -111,9 +135,10 @@ export const SelectFeatureStoresModal: React.FC<SelectFeatureStoresModalProps> =
 
   const onClearFilters = React.useCallback(() => {
     setFilterText('');
+    setAvailabilityFilter('all');
   }, []);
 
-  const hasUnavailableFeatureStores = allFeatureStores.some((fs) => fs.isUnavailable);
+  const hasUnavailableFeatureStores = availabilityCounts.unavailable > 0;
 
   return (
     <Modal
@@ -138,25 +163,67 @@ export const SelectFeatureStoresModal: React.FC<SelectFeatureStoresModalProps> =
             title={FEATURE_STORE_UNAVAILABLE_TOOLTIP}
           />
         )}
-        <TableBase
+        <Table
           {...tableProps}
           data-testid="select-feature-stores-table"
           aria-label="Select feature stores table"
           variant="compact"
-          data={sortedFeatureStores}
+          enablePagination="compact"
+          defaultSortColumn={1}
+          data={filteredFeatureStores}
           columns={selectFeatureStoresColumns}
-          getColumnSort={sort.getColumnSort}
           toolbarContent={
-            <ToolbarItem className="pf-v6-u-w-100">
-              <SearchInput
-                aria-label="Find by name"
-                placeholder="Find by name"
-                value={filterText}
-                onChange={(_event, value) => setFilterText(value)}
-                onClear={onClearFilters}
-                data-testid="select-feature-stores-name-filter"
-              />
-            </ToolbarItem>
+            <ToolbarGroup>
+              {hasUnavailableFeatureStores && (
+                <ToolbarItem>
+                  <ToggleGroup
+                    aria-label="Filter by availability"
+                    data-testid="select-feature-stores-availability-filter"
+                  >
+                    <ToggleGroupItem
+                      text={`All (${availabilityCounts.all})`}
+                      buttonId="select-feature-stores-filter-all"
+                      isSelected={availabilityFilter === 'all'}
+                      onChange={(_event, selected) => {
+                        if (selected) {
+                          setAvailabilityFilter('all');
+                        }
+                      }}
+                    />
+                    <ToggleGroupItem
+                      text={`Available (${availabilityCounts.available})`}
+                      buttonId="select-feature-stores-filter-available"
+                      isSelected={availabilityFilter === 'available'}
+                      onChange={(_event, selected) => {
+                        if (selected) {
+                          setAvailabilityFilter('available');
+                        }
+                      }}
+                    />
+                    <ToggleGroupItem
+                      text={`Unavailable (${availabilityCounts.unavailable})`}
+                      buttonId="select-feature-stores-filter-unavailable"
+                      isSelected={availabilityFilter === 'unavailable'}
+                      onChange={(_event, selected) => {
+                        if (selected) {
+                          setAvailabilityFilter('unavailable');
+                        }
+                      }}
+                    />
+                  </ToggleGroup>
+                </ToolbarItem>
+              )}
+              <ToolbarItem>
+                <SearchInput
+                  aria-label="Find by name"
+                  placeholder="Find by name"
+                  value={filterText}
+                  onChange={(_event, value) => setFilterText(value)}
+                  onClear={() => setFilterText('')}
+                  data-testid="select-feature-stores-name-filter"
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
           }
           emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
           onClearFilters={onClearFilters}

--- a/frontend/src/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModalRow.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModalRow.tsx
@@ -33,7 +33,7 @@ export const SelectFeatureStoresModalRow: React.FC<SelectFeatureStoresModalRowPr
       <Td dataLabel="Name">
         {featureStore.isUnavailable ? (
           <Content
-            className="pf-v6-u-disabled-color-100"
+            className="pf-v6-u-text-color-disabled"
             data-testid="feature-store-unavailable-name"
           >
             <Truncate content={featureStore.projectName} />

--- a/frontend/src/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModalRow.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModalRow.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { Flex, FlexItem, Icon, Tooltip, Truncate } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { Content, Truncate } from '@patternfly/react-core';
+import text from '@patternfly/react-styles/css/utilities/Text/text';
 import { Td, Tr } from '@patternfly/react-table';
 import type { SelectedFeatureStoreConfig } from './useWorkbenchFeatureStores';
 import { FeatureStorePermissionLabels } from './FeatureStorePermissionLabels';
 import { getFeatureStoreProjectId } from './selectFeatureStoresModalConst';
-import { FEATURE_STORE_UNAVAILABLE_TOOLTIP } from './utils';
 
 export type SelectFeatureStoresModalRowProps = {
   rowIndex: number;
@@ -34,21 +33,9 @@ export const SelectFeatureStoresModalRow: React.FC<SelectFeatureStoresModalRowPr
       />
       <Td dataLabel="Name">
         {featureStore.isUnavailable ? (
-          <Flex
-            spaceItems={{ default: 'spaceItemsSm' }}
-            alignItems={{ default: 'alignItemsCenter' }}
-          >
-            <FlexItem>
-              <Truncate content={featureStore.projectName} />
-            </FlexItem>
-            <FlexItem>
-              <Tooltip content={FEATURE_STORE_UNAVAILABLE_TOOLTIP}>
-                <Icon isInline status="info" data-testid="feature-store-unavailable-icon">
-                  <InfoCircleIcon />
-                </Icon>
-              </Tooltip>
-            </FlexItem>
-          </Flex>
+          <Content className={text.textColorDisabled} data-testid="feature-store-unavailable-name">
+            <Truncate content={featureStore.projectName} />
+          </Content>
         ) : (
           <Truncate content={featureStore.projectName} />
         )}

--- a/frontend/src/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModalRow.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModalRow.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Content, Truncate } from '@patternfly/react-core';
-import text from '@patternfly/react-styles/css/utilities/Text/text';
 import { Td, Tr } from '@patternfly/react-table';
 import type { SelectedFeatureStoreConfig } from './useWorkbenchFeatureStores';
 import { FeatureStorePermissionLabels } from './FeatureStorePermissionLabels';
@@ -33,7 +32,10 @@ export const SelectFeatureStoresModalRow: React.FC<SelectFeatureStoresModalRowPr
       />
       <Td dataLabel="Name">
         {featureStore.isUnavailable ? (
-          <Content className={text.textColorDisabled} data-testid="feature-store-unavailable-name">
+          <Content
+            className="pf-v6-u-disabled-color-100"
+            data-testid="feature-store-unavailable-name"
+          >
             <Truncate content={featureStore.projectName} />
           </Content>
         ) : (

--- a/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/FeatureStoreFormSection.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/FeatureStoreFormSection.spec.tsx
@@ -8,6 +8,7 @@ import type {
   WorkbenchFeatureStoreConfig,
   SelectedFeatureStoreConfig,
 } from '#~/pages/projects/screens/spawner/featureStore/useWorkbenchFeatureStores';
+import { FEATURE_STORE_UNAVAILABLE_TOOLTIP } from '#~/pages/projects/screens/spawner/featureStore/utils';
 
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({
   SupportedArea: { FEATURE_STORE: 'feature-store' },
@@ -191,7 +192,9 @@ describe('FeatureStoreFormSection', () => {
       </MemoryRouter>,
     );
 
-    expect(result.getByTestId('feature-store-unavailable-alert')).toBeInTheDocument();
+    expect(result.getByTestId('feature-store-unavailable-alert')).toHaveTextContent(
+      FEATURE_STORE_UNAVAILABLE_TOOLTIP,
+    );
     expect(result.getByTestId('feature-store-unavailable-name')).toHaveTextContent(
       'deleted_project',
     );

--- a/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/FeatureStoreFormSection.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/FeatureStoreFormSection.spec.tsx
@@ -191,6 +191,12 @@ describe('FeatureStoreFormSection', () => {
       </MemoryRouter>,
     );
 
+    expect(result.getByTestId('feature-store-unavailable-alert')).toBeInTheDocument();
+    expect(result.getByTestId('feature-store-unavailable-name')).toHaveTextContent(
+      'deleted_project',
+    );
+    expect(result.queryByTestId('feature-store-unavailable-icon')).not.toBeInTheDocument();
+
     await act(async () => {
       result.getByRole('button', { name: 'Select feature stores' }).click();
     });

--- a/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/FeatureStoreFormSection.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/FeatureStoreFormSection.spec.tsx
@@ -195,10 +195,16 @@ describe('FeatureStoreFormSection', () => {
     expect(result.getByTestId('feature-store-unavailable-alert')).toHaveTextContent(
       FEATURE_STORE_UNAVAILABLE_TOOLTIP,
     );
+    expect(result.queryByTestId('feature-store-unavailable-name')).not.toBeInTheDocument();
+    expect(result.queryByTestId('feature-store-unavailable-icon')).not.toBeInTheDocument();
+
+    await act(async () => {
+      result.getByTestId('feature-store-show-unavailable').click();
+    });
+
     expect(result.getByTestId('feature-store-unavailable-name')).toHaveTextContent(
       'deleted_project',
     );
-    expect(result.queryByTestId('feature-store-unavailable-icon')).not.toBeInTheDocument();
 
     await act(async () => {
       result.getByRole('button', { name: 'Select feature stores' }).click();

--- a/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/SelectFeatureStoresModal.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/SelectFeatureStoresModal.spec.tsx
@@ -1,0 +1,77 @@
+import React, { act } from 'react';
+import '@testing-library/jest-dom';
+import { render, within } from '@testing-library/react';
+import { SelectFeatureStoresModal } from '#~/pages/projects/screens/spawner/featureStore/SelectFeatureStoresModal';
+import type { SelectedFeatureStoreConfig } from '#~/pages/projects/screens/spawner/featureStore/useWorkbenchFeatureStores';
+import { FEATURE_STORE_UNAVAILABLE_TOOLTIP } from '#~/pages/projects/screens/spawner/featureStore/utils';
+
+const mockFeatureStore = (
+  overrides: Partial<SelectedFeatureStoreConfig> = {},
+): SelectedFeatureStoreConfig => ({
+  namespace: 'credit-namespace',
+  configName: 'credit-scoring-local',
+  projectName: 'credit_scoring_local',
+  configMap: null,
+  hasAccessToFeatureStore: true,
+  permissions: ['Read'],
+  ...overrides,
+});
+
+describe('SelectFeatureStoresModal', () => {
+  it('should filter by availability and show the unavailable alert', async () => {
+    const availableStore = mockFeatureStore();
+    const unavailableStore = mockFeatureStore({
+      namespace: '',
+      configName: '',
+      projectName: 'deleted_project',
+      hasAccessToFeatureStore: false,
+      permissions: [],
+      isUnavailable: true,
+    });
+
+    const result = render(
+      <SelectFeatureStoresModal
+        featureStores={[availableStore]}
+        unavailableFeatureStores={[unavailableStore]}
+        onSave={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const modal = result.getByTestId('select-feature-stores-modal');
+    expect(within(modal).getByTestId('feature-store-unavailable-alert')).toHaveTextContent(
+      FEATURE_STORE_UNAVAILABLE_TOOLTIP,
+    );
+    expect(within(modal).getByRole('button', { name: 'All (2)' })).toBeInTheDocument();
+    expect(
+      within(modal).getByTestId('select-feature-stores-row-credit-namespace/credit_scoring_local'),
+    ).toBeInTheDocument();
+    expect(
+      within(modal).getByTestId('select-feature-stores-row-/deleted_project'),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      within(modal).getByRole('button', { name: 'Available (1)' }).click();
+    });
+
+    expect(
+      within(modal).getByTestId('select-feature-stores-row-credit-namespace/credit_scoring_local'),
+    ).toBeInTheDocument();
+    expect(
+      within(modal).queryByTestId('select-feature-stores-row-/deleted_project'),
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      within(modal).getByRole('button', { name: 'Unavailable (1)' }).click();
+    });
+
+    expect(
+      within(modal).queryByTestId(
+        'select-feature-stores-row-credit-namespace/credit_scoring_local',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      within(modal).getByTestId('select-feature-stores-row-/deleted_project'),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/projects/screens/spawner/featureStore/featureStoreConnectedTableConst.ts
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/featureStoreConnectedTableConst.ts
@@ -1,17 +1,21 @@
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- shared table types from ui-core
 import type { SortableData } from '@odh-dashboard/ui-core';
 import type { SelectedFeatureStoreConfig } from './useWorkbenchFeatureStores';
+import {
+  compareFeatureStoresConnectedFirst,
+  compareFeatureStoresWithProjectFirst,
+} from './selectFeatureStoresModalConst';
 
 export const featureStoreConnectedTableColumns: SortableData<SelectedFeatureStoreConfig>[] = [
   {
     label: 'Name',
     field: 'projectName',
-    sortable: (a, b) => a.projectName.localeCompare(b.projectName),
+    sortable: compareFeatureStoresConnectedFirst,
   },
   {
     label: 'Project',
     field: 'namespace',
-    sortable: (a, b) => a.namespace.localeCompare(b.namespace),
+    sortable: compareFeatureStoresWithProjectFirst,
   },
   {
     label: 'Permissions',

--- a/frontend/src/pages/projects/screens/spawner/featureStore/selectFeatureStoresModalConst.ts
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/selectFeatureStoresModalConst.ts
@@ -20,19 +20,45 @@ export const getFeatureStoreProjectId = (
   item: Pick<WorkbenchFeatureStoreConfig, 'namespace' | 'projectName'>,
 ): string => `${item.namespace}/${item.projectName}`;
 
+/** Available / with-project first, then alphabetical by name. */
+export const compareFeatureStoresConnectedFirst = (
+  a: SelectedFeatureStoreConfig,
+  b: SelectedFeatureStoreConfig,
+): number => {
+  const aUnavailable = !!a.isUnavailable;
+  const bUnavailable = !!b.isUnavailable;
+  if (aUnavailable !== bUnavailable) {
+    return aUnavailable ? 1 : -1;
+  }
+  return a.projectName.localeCompare(b.projectName);
+};
+
+/** Rows with a project first, then alphabetical by project. */
+export const compareFeatureStoresWithProjectFirst = (
+  a: SelectedFeatureStoreConfig,
+  b: SelectedFeatureStoreConfig,
+): number => {
+  const aHasProject = !a.isUnavailable && !!a.namespace;
+  const bHasProject = !b.isUnavailable && !!b.namespace;
+  if (aHasProject !== bHasProject) {
+    return aHasProject ? -1 : 1;
+  }
+  return a.namespace.localeCompare(b.namespace);
+};
+
 export const selectFeatureStoresColumns: SortableData<SelectedFeatureStoreConfig>[] = [
   { label: '', field: 'checkbox', width: 10, sortable: false },
   {
     label: 'Name',
     field: 'projectName',
     width: 30,
-    sortable: (a, b) => a.projectName.localeCompare(b.projectName),
+    sortable: compareFeatureStoresConnectedFirst,
   },
   {
     label: 'Project',
     field: 'namespace',
     width: 30,
-    sortable: (a, b) => a.namespace.localeCompare(b.namespace),
+    sortable: compareFeatureStoresWithProjectFirst,
   },
   {
     label: 'Permissions',

--- a/frontend/src/pages/projects/screens/spawner/featureStore/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/utils.ts
@@ -24,7 +24,7 @@ export const FEATURE_STORE_EMPTY_STATE_BODY =
   'Select feature stores to connect to this workbench. Features in connected feature stores have read and write access to this workbench.';
 
 export const FEATURE_STORE_UNAVAILABLE_TOOLTIP =
-  'This feature store is no longer available. It may have been deleted or access has been revoked.';
+  'Some feature stores are no longer available. They may have been deleted, or access may have been revoked.';
 
 export const removeFeatureStoreProjectById = (
   configs: SelectedFeatureStoreConfig[],


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-79707

## Description
Improves Connected feature stores UX in the workbench creation/edit form:
**Connected feature stores (form)**
- Removes repetitive unavailable per-row info icons
- Shows unavailable message once via inline info alert
- Grays unavailable store names
- Hides unavailable stores by default; adds **Show unavailable** / **Show less** (no popover — alert already explains why)
- Sorts available / with-project stores first

**Connect feature stores modal**
- Adds **All / Available / Unavailable** filters with counts (when unavailable stores exist)
- Adds compact pagination
- Keeps available-first grouping on **All**
- Uses the same single unavailable info alert (no per-row icons)

Alert copy was [updated per UX review](https://github.com/opendatahub-io/odh-dashboard/pull/9058#issuecomment-5214803312) to:
“Some feature stores are no longer available. They may have been deleted, or access may have been revoked.”
Further UX guidance from [Rachel’s review](https://github.com/opendatahub-io/odh-dashboard/pull/9058#issuecomment-5238610139): Show unavailable on the form, modal availability filters + pagination (Infrastructure modal pattern).

## Screenshots
**Before**



<img width="500" alt="before-edit" src="https://github.com/user-attachments/assets/602db314-c3f3-468b-bbc4-ac1721af2d56" />
<img width="500" alt="before-nonedit" src="https://github.com/user-attachments/assets/46b643f9-03be-4abf-968d-99cf9cb88c00" />

**After**

<img width="500" alt="after-edit" src="https://github.com/user-attachments/assets/d4c0eca1-d412-49ed-b480-f070440db970" />
<img width="500" alt="after-nonedit" src="https://github.com/user-attachments/assets/daeea597-ffb8-49b3-8c4f-51217ee44a1b" />



https://github.com/user-attachments/assets/3a553f1c-a9c1-4664-9d80-2fab295030c7


## How Has This Been Tested?
-  Unit: `FeatureStoreFormSection.spec.tsx`, `SelectFeatureStoresModal.spec.tsx`
- Manual on `feast/test`: Form: single alert, no per-row icons, gray names, Show unavailable / Show less
  - Modal: All / Available / Unavailable filters, pagination, available-first on All


## Test Impact
- Updated `FeatureStoreFormSection` tests for alert text, removed icons, and Show unavailable toggle
- Added `SelectFeatureStoresModal` tests for availability filters

## Request review criteria:
- [x] Manually tested
- [x] Testing instructions in PR body
- [x] Tests updated
- [x] Follows Best Practices
- [x] Screenshots included
- [ ] UX tagged
- [ ] Cluster-tested with PR image