### PR TITLE
fix(e2e): Feature Store flake — wait for operator reconciliation (RHOAIENG-78195)

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/featureStoreResources.ts
+++ b/packages/cypress/cypress/utils/oc_commands/featureStoreResources.ts
@@ -1,4 +1,4 @@
-import { applyOpenShiftYaml, waitForPodReady } from '../oc_commands/baseCommands';
+import { applyOpenShiftYaml, pollUntilSuccess, waitForPodReady } from '../oc_commands/baseCommands';
 import { AWS_BUCKETS } from '../s3Buckets';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
 
@@ -33,6 +33,18 @@ export const createFeatureStoreCR = (namespace: string, feastInstanceName: strin
     applyOpenShiftYaml(yamlContent);
     //wait for the feature store cr to be created
     waitForPodReady(feastInstanceName, '300s', namespace);
+
+    // Wait for Feast operator reconciliation so the dashboard can discover the Feature Store
+    pollUntilSuccess(
+      `oc get featurestores.feast.dev ${feastInstanceName} -n ${namespace} -o json | jq -e '.status.conditions[]? | select(.type=="Registry") | .status == "True"'`,
+      `FeatureStore/${feastInstanceName} Registry condition to be True`,
+      { maxAttempts: 60, pollIntervalMs: 5000 },
+    );
+    pollUntilSuccess(
+      `oc get namespace ${namespace} -o json | jq -e '.metadata.labels["opendatahub.io/feast"] == "true"'`,
+      `namespace ${namespace} to have opendatahub.io/feast=true label`,
+      { maxAttempts: 60, pollIntervalMs: 5000 },
+    );
   });
 };
 

--- a/packages/cypress/cypress/utils/oc_commands/featureStoreResources.ts
+++ b/packages/cypress/cypress/utils/oc_commands/featureStoreResources.ts
@@ -43,7 +43,7 @@ export const createFeatureStoreCR = (namespace: string, feastInstanceName: strin
     pollUntilSuccess(
       `oc get namespace ${namespace} -o json | jq -e '.metadata.labels["opendatahub.io/feast"] == "true"'`,
       `namespace ${namespace} to have opendatahub.io/feast=true label`,
-      { maxAttempts: 60, pollIntervalMs: 5000 },
+      { maxAttempts: 30, pollIntervalMs: 5000 },
     );
   });
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78195

## Description
`testFeatureStoreFeatures.cy.ts` (and other Feature Store E2E specs using `createFeatureStoreCR`) fail because setup only waits for the Feast pod. Dashboard discovery (`GET /api/featurestores`) also requires:

1. `Registry: True` on the FeatureStore CR
2. `opendatahub.io/feast=true` on the namespace

Without those, the UI shows the empty state and the project selector never appears.

This change extends `createFeatureStoreCR` to poll for both conditions via the existing `pollUntilSuccess` helper after `waitForPodReady`.

## How Has This Been Tested?
- Code change reviewed against ticket ACs and backend discovery logic in `backend/src/routes/api/featurestores/`
- Not yet run on the live e2e cluster from this PR; please verify via CI Feature Store E2E / cluster run of `testFeatureStoreFeatures.cy.ts`

## Test Impact
- Updates shared E2E setup helper used by Feature Store Cypress E2E specs
- No new unit tests (cluster/operator wait logic; covered by existing E2E once stable)
- No production code changes

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

### Testing instructions
1. Run Feature Store E2E (or wait for CI `@FeatureStore` / `@FeatureStoreCI` jobs), especially `packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts`
2. Confirm setup no longer times out looking for `feature-store-project-selector-toggle`
3. Confirm the new polls succeed (Registry condition + namespace label) before UI navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Feature Store resource setup by waiting for registry readiness and the required namespace configuration after pods become ready.
  * Helps ensure dependent operations start only when the Feature Store environment is fully prepared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->