### PR TITLE
fix: include model-serving cypress tests in CI matrix

### DIFF
--- a/scripts/generate-cypress-test-matrix.js
+++ b/scripts/generate-cypress-test-matrix.js
@@ -213,8 +213,15 @@ function generatePackageTestGroups() {
         continue;
       }
 
-      const pkgName = pkg.name.split('/').pop();
-      const testPath = path.join('packages', pkgName);
+      // Use the workspace location field (relative to repo root) instead of
+      // deriving from the package name, which breaks for nested paths like
+      // packages/model-serving/cypress
+      const pkgRelPath = pkg.location?.replace(/^packages\//, '');
+      if (!pkgRelPath) {
+        continue;
+      }
+
+      const testPath = path.join('packages', pkgRelPath);
 
       // Verify tests actually exist
       if (!fs.existsSync(testPath)) {
@@ -226,8 +233,8 @@ function generatePackageTestGroups() {
 
       if (hasTests.length > 0) {
         groups.push({
-          name: `pkg-${pkgName}`,
-          spec: `${pkgName}/${pkg.cypress.mocked}`,
+          name: `pkg-${pkgRelPath.replace(/\//g, '-')}`,
+          spec: `${pkgRelPath}/${pkg.cypress.mocked}`,
           strategy: 'package',
         });
       }


### PR DESCRIPTION
## Description

Fixes CI matrix generation for co-located Cypress packages with nested workspace paths.

The matrix script was resolving package directories from the npm name:

```
@odh-dashboard/model-serving-cypress  →  packages/model-serving-cypress
```

The actual workspace location is `packages/model-serving/cypress`. This mismatch caused the specs to be skipped during matrix generation.

**Fix:** Use the `location` field from `npm query` — the same approach `discoverTestPatterns.ts` already uses — to correctly resolve any workspace path regardless of nesting.

## How Has This Been Tested?

Ran the matrix script locally and confirmed it now produces the correct `pkg-model-serving-cypress` shard with a spec glob that resolves all 10 model-serving `.cy.ts` files from the CI working directory.

| | Before | After |
|---|---|---|
| Package groups | 1 (observability) | 2 (observability + model-serving) |
| Total shards | 68 | 69 |

## Test Impact

No new tests — this is a CI infrastructure fix that restores coverage for 10 existing model-serving mock specs.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cypress test discovery for workspaces located in nested paths.
  * Updated generated test group names and package specifications to accurately reflect each workspace’s full relative path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->