### PR TITLE
Feat(RHOAIENG-79913):added  workloads utility function and hook for Kueue status hook

### DIFF
--- a/frontend/src/api/k8s/__tests__/workloads.spec.ts
+++ b/frontend/src/api/k8s/__tests__/workloads.spec.ts
@@ -1,20 +1,18 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
 import type { PodKind } from '@odh-dashboard/k8s-core';
+import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import { mockWorkloadK8sResource } from '#~/__mocks__/mockWorkloadK8sResource';
 import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
 import { mockPodK8sResource } from '#~/__mocks__/mockPodK8sResource';
 import { WorkloadKind } from '#~/k8sTypes';
 import {
-  buildWorkloadMapForDeployments,
   buildWorkloadMapForNotebooks,
+  buildWorkloadMapForDeployments,
   listWorkloads,
 } from '#~/api/k8s/workloads';
 import { WorkloadModel } from '#~/api/models/kueue';
 
-const IS_NAME = 'my-model';
-const NS = 'test-project';
-const POD_UID = 'pod-uid-abc123';
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sListResourceItems: jest.fn(),
 }));
@@ -269,12 +267,21 @@ describe('buildWorkloadMapForNotebooks', () => {
   });
 });
 
-const inferenceService = (name: string) => mockInferenceServiceK8sResource({ name, namespace: NS });
+// ─── buildWorkloadMapForDeployments ──────────────────────────────────────────
 
-/**
- * Build a Pod whose UID matches POD_UID and whose labels include the IS label.
- * The `uid` from genUID in mockPodK8sResource is random; override it here for determinism.
- */
+const NS = 'test-ns';
+const IS_NAME = 'my-model';
+const LLMIS_NAME = 'my-llm-model';
+const POD_UID = 'pod-uid-abc123';
+
+const inferenceService = (name: string): InferenceServiceKind =>
+  mockInferenceServiceK8sResource({ name, namespace: NS });
+
+const llmInferenceService = (name: string): { metadata: { name: string } } => ({
+  metadata: { name },
+});
+
+/** IS pod: carries serving.kserve.io/inferenceservice label. */
 function isPod(podName: string, isName: string, uid = POD_UID): PodKind {
   const pod = mockPodK8sResource({
     name: podName,
@@ -284,10 +291,20 @@ function isPod(podName: string, isName: string, uid = POD_UID): PodKind {
   return { ...pod, metadata: { ...pod.metadata, uid } };
 }
 
-/**
- * Build a Workload whose ownerRef points to a Pod by UID.
- * This mirrors what Kueue's Plain Pod integration actually creates on a live cluster.
- */
+/** LLMIS pod: carries app.kubernetes.io/component + app.kubernetes.io/name labels. */
+function llmisPod(podName: string, llmisName: string, uid = POD_UID): PodKind {
+  const pod = mockPodK8sResource({
+    name: podName,
+    namespace: NS,
+    labels: {
+      'app.kubernetes.io/component': 'llminferenceservice-workload',
+      'app.kubernetes.io/name': llmisName,
+    },
+  });
+  return { ...pod, metadata: { ...pod.metadata, uid } };
+}
+
+/** Workload whose ownerRef points to a Pod by UID (Plain Pod integration). */
 function workloadWithPodOwnerRef(workloadName: string, podUid: string): WorkloadKind {
   const wl = mockWorkloadK8sResource({ k8sName: workloadName, namespace: NS });
   return {
@@ -295,12 +312,7 @@ function workloadWithPodOwnerRef(workloadName: string, podUid: string): Workload
     metadata: {
       ...wl.metadata,
       ownerReferences: [
-        {
-          apiVersion: 'v1',
-          kind: 'Pod',
-          name: `model-predictor-${podUid.slice(0, 8)}`,
-          uid: podUid,
-        },
+        { apiVersion: 'v1', kind: 'Pod', name: `predictor-${podUid.slice(0, 8)}`, uid: podUid },
       ],
     },
   };
@@ -313,11 +325,35 @@ describe('buildWorkloadMapForDeployments', () => {
     expect(result[IS_NAME]).not.toBeNull();
   });
 
-  it('correlates Workload to IS via Pod UID ownerRef + serving.kserve.io/inferenceservice label', () => {
+  it('seeds LLMIS entries alongside IS entries', () => {
+    const result = buildWorkloadMapForDeployments(
+      [],
+      [],
+      [inferenceService(IS_NAME)],
+      [llmInferenceService(LLMIS_NAME)],
+    );
+    expect(result[IS_NAME]).toEqual([]);
+    expect(result[LLMIS_NAME]).toEqual([]);
+  });
+
+  it('correlates Workload to IS via Pod UID + serving.kserve.io/inferenceservice label', () => {
     const pod = isPod('model-predictor-abc', IS_NAME);
     const wl = workloadWithPodOwnerRef('wl-1', POD_UID);
     const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
     expect(result[IS_NAME]).toEqual([wl]);
+  });
+
+  it('correlates Workload to LLMIS via Pod UID + app.kubernetes.io/name label', () => {
+    const uid = 'llmis-pod-uid-xyz';
+    const pod = llmisPod('llm-predictor-abc', LLMIS_NAME, uid);
+    const wl = workloadWithPodOwnerRef('wl-llmis-1', uid);
+    const result = buildWorkloadMapForDeployments(
+      [wl],
+      [pod],
+      [],
+      [llmInferenceService(LLMIS_NAME)],
+    );
+    expect(result[LLMIS_NAME]).toEqual([wl]);
   });
 
   it('returns empty array when Workload ownerRef Pod UID not in pods list (orphaned)', () => {
@@ -326,7 +362,7 @@ describe('buildWorkloadMapForDeployments', () => {
     expect(result[IS_NAME]).toEqual([]);
   });
 
-  it('returns empty array when Pod found but has no serving.kserve.io/inferenceservice label', () => {
+  it('returns empty array when Pod found but has no model-serving label', () => {
     const rawPod = mockPodK8sResource({ name: 'unrelated-pod', namespace: NS });
     const pod = { ...rawPod, metadata: { ...rawPod.metadata, uid: POD_UID } };
     const wl = workloadWithPodOwnerRef('wl-1', POD_UID);
@@ -334,19 +370,18 @@ describe('buildWorkloadMapForDeployments', () => {
     expect(result[IS_NAME]).toEqual([]);
   });
 
-  it('skips Workloads that have no Pod ownerRef (non-IS workloads)', () => {
-    // A Workload with no ownerRef or a non-Pod ownerRef should not appear for any IS.
+  it('skips Workloads with no Pod ownerRef', () => {
     const rawWl = mockWorkloadK8sResource({ k8sName: 'wl-no-pod-ref', namespace: NS });
     const wl = { ...rawWl, metadata: { ...rawWl.metadata, ownerReferences: [] } };
     const result = buildWorkloadMapForDeployments([wl], [], [inferenceService(IS_NAME)]);
     expect(result[IS_NAME]).toEqual([]);
   });
 
-  it('multi-replica IS: all per-Pod Workloads are included', () => {
+  it('multi-replica IS: all per-Pod Workloads are collected', () => {
     const uid0 = 'uid-pod-0';
     const uid1 = 'uid-pod-1';
-    const pod0 = isPod('model-predictor-0', IS_NAME, uid0);
-    const pod1 = isPod('model-predictor-1', IS_NAME, uid1);
+    const pod0 = isPod('predictor-0', IS_NAME, uid0);
+    const pod1 = isPod('predictor-1', IS_NAME, uid1);
     const wl0 = workloadWithPodOwnerRef('wl-replica-0', uid0);
     const wl1 = workloadWithPodOwnerRef('wl-replica-1', uid1);
     const result = buildWorkloadMapForDeployments(
@@ -375,33 +410,43 @@ describe('buildWorkloadMapForDeployments', () => {
     expect(result['model-b']).toEqual([wlB]);
   });
 
-  it('IS with undefined metadata.name is skipped — no key added to result', () => {
-    const is = inferenceService(IS_NAME);
-    // @ts-expect-error intentionally clearing name for test
-    is.metadata.name = undefined;
-    const result = buildWorkloadMapForDeployments([], [], [is]);
-    expect(Object.keys(result)).toHaveLength(0);
+  it('IS and LLMIS Workloads are isolated in the result map', () => {
+    const isUid = 'uid-is-pod';
+    const llmisUid = 'uid-llmis-pod';
+    const pod = isPod('predictor-is', IS_NAME, isUid);
+    const llmPod = llmisPod('predictor-llmis', LLMIS_NAME, llmisUid);
+    const wl = workloadWithPodOwnerRef('wl-is', isUid);
+    const llmWl = workloadWithPodOwnerRef('wl-llmis', llmisUid);
+    const result = buildWorkloadMapForDeployments(
+      [wl, llmWl],
+      [pod, llmPod],
+      [inferenceService(IS_NAME)],
+      [llmInferenceService(LLMIS_NAME)],
+    );
+    expect(result[IS_NAME]).toEqual([wl]);
+    expect(result[LLMIS_NAME]).toEqual([llmWl]);
   });
 
-  it('Pod whose IS label value is not a known IS is skipped', () => {
-    // Pod labels an IS name that's not in the inferenceServices list.
-    const pod = isPod('predictor-other', 'unknown-model', POD_UID);
-    const wl = workloadWithPodOwnerRef('wl-unknown', POD_UID);
-    const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
-    // The known IS has no workload; the unknown model is not added.
-    expect(result[IS_NAME]).toEqual([]);
-    expect(result['unknown-model']).toBeUndefined();
-  });
-
-  it('ownerRef kind matching is case-insensitive for Pod', () => {
-    const pod = isPod('model-predictor-abc', IS_NAME, POD_UID);
-    const wl = mockWorkloadK8sResource({ k8sName: 'wl-case', namespace: NS });
-    if (wl.metadata) {
-      wl.metadata.ownerReferences = [
-        { apiVersion: 'v1', kind: 'pod', name: 'model-predictor-abc', uid: POD_UID },
-      ];
-    }
+  it('matches ownerRef kind case-insensitively', () => {
+    const rawWl = mockWorkloadK8sResource({ k8sName: 'wl-lower', namespace: NS });
+    const wl = {
+      ...rawWl,
+      metadata: {
+        ...rawWl.metadata,
+        ownerReferences: [{ apiVersion: 'v1', kind: 'pod', name: 'predictor-abc', uid: POD_UID }],
+      },
+    };
+    const pod = isPod('predictor-abc', IS_NAME);
     const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
     expect(result[IS_NAME]).toEqual([wl]);
+  });
+
+  it('Workload for unknown model name does not add an extra key to result', () => {
+    const uid = 'uid-unknown';
+    const pod = isPod('predictor-unknown', 'unknown-model', uid);
+    const wl = workloadWithPodOwnerRef('wl-unknown', uid);
+    const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
+    expect(result[IS_NAME]).toEqual([]);
+    expect(Object.keys(result)).toEqual([IS_NAME]);
   });
 });

--- a/frontend/src/api/k8s/__tests__/workloads.spec.ts
+++ b/frontend/src/api/k8s/__tests__/workloads.spec.ts
@@ -1,10 +1,20 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import type { PodKind } from '@odh-dashboard/k8s-core';
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import { mockWorkloadK8sResource } from '#~/__mocks__/mockWorkloadK8sResource';
+import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
+import { mockPodK8sResource } from '#~/__mocks__/mockPodK8sResource';
 import { WorkloadKind } from '#~/k8sTypes';
-import { buildWorkloadMapForNotebooks, listWorkloads } from '#~/api/k8s/workloads';
+import {
+  buildWorkloadMapForDeployments,
+  buildWorkloadMapForNotebooks,
+  listWorkloads,
+} from '#~/api/k8s/workloads';
 import { WorkloadModel } from '#~/api/models/kueue';
 
+const IS_NAME = 'my-model';
+const NS = 'test-project';
+const POD_UID = 'pod-uid-abc123';
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sListResourceItems: jest.fn(),
 }));
@@ -256,5 +266,142 @@ describe('buildWorkloadMapForNotebooks', () => {
     nb.metadata.name = '';
     const result = buildWorkloadMapForNotebooks([], [nb]);
     expect(result['']).toBeNull();
+  });
+});
+
+const inferenceService = (name: string) => mockInferenceServiceK8sResource({ name, namespace: NS });
+
+/**
+ * Build a Pod whose UID matches POD_UID and whose labels include the IS label.
+ * The `uid` from genUID in mockPodK8sResource is random; override it here for determinism.
+ */
+function isPod(podName: string, isName: string, uid = POD_UID): PodKind {
+  const pod = mockPodK8sResource({
+    name: podName,
+    namespace: NS,
+    labels: { 'serving.kserve.io/inferenceservice': isName },
+  });
+  return { ...pod, metadata: { ...pod.metadata, uid } };
+}
+
+/**
+ * Build a Workload whose ownerRef points to a Pod by UID.
+ * This mirrors what Kueue's Plain Pod integration actually creates on a live cluster.
+ */
+function workloadWithPodOwnerRef(workloadName: string, podUid: string): WorkloadKind {
+  const wl = mockWorkloadK8sResource({ k8sName: workloadName, namespace: NS });
+  return {
+    ...wl,
+    metadata: {
+      ...wl.metadata,
+      ownerReferences: [
+        {
+          apiVersion: 'v1',
+          kind: 'Pod',
+          name: `model-predictor-${podUid.slice(0, 8)}`,
+          uid: podUid,
+        },
+      ],
+    },
+  };
+}
+
+describe('buildWorkloadMapForDeployments', () => {
+  it('seeds every IS with an empty array even when no workloads exist', () => {
+    const result = buildWorkloadMapForDeployments([], [], [inferenceService(IS_NAME)]);
+    expect(result[IS_NAME]).toEqual([]);
+    expect(result[IS_NAME]).not.toBeNull();
+  });
+
+  it('correlates Workload to IS via Pod UID ownerRef + serving.kserve.io/inferenceservice label', () => {
+    const pod = isPod('model-predictor-abc', IS_NAME);
+    const wl = workloadWithPodOwnerRef('wl-1', POD_UID);
+    const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
+    expect(result[IS_NAME]).toEqual([wl]);
+  });
+
+  it('returns empty array when Workload ownerRef Pod UID not in pods list (orphaned)', () => {
+    const wl = workloadWithPodOwnerRef('wl-orphan', 'nonexistent-uid');
+    const result = buildWorkloadMapForDeployments([wl], [], [inferenceService(IS_NAME)]);
+    expect(result[IS_NAME]).toEqual([]);
+  });
+
+  it('returns empty array when Pod found but has no serving.kserve.io/inferenceservice label', () => {
+    const rawPod = mockPodK8sResource({ name: 'unrelated-pod', namespace: NS });
+    const pod = { ...rawPod, metadata: { ...rawPod.metadata, uid: POD_UID } };
+    const wl = workloadWithPodOwnerRef('wl-1', POD_UID);
+    const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
+    expect(result[IS_NAME]).toEqual([]);
+  });
+
+  it('skips Workloads that have no Pod ownerRef (non-IS workloads)', () => {
+    // A Workload with no ownerRef or a non-Pod ownerRef should not appear for any IS.
+    const rawWl = mockWorkloadK8sResource({ k8sName: 'wl-no-pod-ref', namespace: NS });
+    const wl = { ...rawWl, metadata: { ...rawWl.metadata, ownerReferences: [] } };
+    const result = buildWorkloadMapForDeployments([wl], [], [inferenceService(IS_NAME)]);
+    expect(result[IS_NAME]).toEqual([]);
+  });
+
+  it('multi-replica IS: all per-Pod Workloads are included', () => {
+    const uid0 = 'uid-pod-0';
+    const uid1 = 'uid-pod-1';
+    const pod0 = isPod('model-predictor-0', IS_NAME, uid0);
+    const pod1 = isPod('model-predictor-1', IS_NAME, uid1);
+    const wl0 = workloadWithPodOwnerRef('wl-replica-0', uid0);
+    const wl1 = workloadWithPodOwnerRef('wl-replica-1', uid1);
+    const result = buildWorkloadMapForDeployments(
+      [wl0, wl1],
+      [pod0, pod1],
+      [inferenceService(IS_NAME)],
+    );
+    expect(result[IS_NAME]).toHaveLength(2);
+    expect(result[IS_NAME]).toContain(wl0);
+    expect(result[IS_NAME]).toContain(wl1);
+  });
+
+  it('Workload for one IS does not bleed into another IS entry', () => {
+    const uidA = 'uid-pod-model-a';
+    const uidB = 'uid-pod-model-b';
+    const podA = isPod('predictor-a', 'model-a', uidA);
+    const podB = isPod('predictor-b', 'model-b', uidB);
+    const wlA = workloadWithPodOwnerRef('wl-a', uidA);
+    const wlB = workloadWithPodOwnerRef('wl-b', uidB);
+    const result = buildWorkloadMapForDeployments(
+      [wlA, wlB],
+      [podA, podB],
+      [inferenceService('model-a'), inferenceService('model-b')],
+    );
+    expect(result['model-a']).toEqual([wlA]);
+    expect(result['model-b']).toEqual([wlB]);
+  });
+
+  it('IS with undefined metadata.name is skipped — no key added to result', () => {
+    const is = inferenceService(IS_NAME);
+    // @ts-expect-error intentionally clearing name for test
+    is.metadata.name = undefined;
+    const result = buildWorkloadMapForDeployments([], [], [is]);
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('Pod whose IS label value is not a known IS is skipped', () => {
+    // Pod labels an IS name that's not in the inferenceServices list.
+    const pod = isPod('predictor-other', 'unknown-model', POD_UID);
+    const wl = workloadWithPodOwnerRef('wl-unknown', POD_UID);
+    const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
+    // The known IS has no workload; the unknown model is not added.
+    expect(result[IS_NAME]).toEqual([]);
+    expect(result['unknown-model']).toBeUndefined();
+  });
+
+  it('ownerRef kind matching is case-insensitive for Pod', () => {
+    const pod = isPod('model-predictor-abc', IS_NAME, POD_UID);
+    const wl = mockWorkloadK8sResource({ k8sName: 'wl-case', namespace: NS });
+    if (wl.metadata) {
+      wl.metadata.ownerReferences = [
+        { apiVersion: 'v1', kind: 'pod', name: 'model-predictor-abc', uid: POD_UID },
+      ];
+    }
+    const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
+    expect(result[IS_NAME]).toEqual([wl]);
   });
 });

--- a/frontend/src/api/k8s/workloads.ts
+++ b/frontend/src/api/k8s/workloads.ts
@@ -1,6 +1,9 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+import type { PodKind } from '@odh-dashboard/k8s-core';
+import { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
 import { NotebookKind, WorkloadKind } from '#~/k8sTypes';
 import { WorkloadModel } from '#~/api/models/kueue';
+import { PodModel } from '#~/api/models/k8s';
 import { groupVersionKind } from '#~/api/k8sUtils';
 import { CustomWatchK8sResult } from '#~/types';
 import useK8sWatchResourceList from '#~/utilities/useK8sWatchResourceList';
@@ -60,6 +63,80 @@ export const buildWorkloadMapForNotebooks = (
   }
   return result;
 };
+
+/**
+ * Two-hop Workload-to-IS correlation
+ * Workload CR ownerRef (kind: Pod) → Pod lookup by UID → Pod label
+ * `serving.kserve.io/inferenceservice` → IS name.
+ *
+ * Returns IS name → WorkloadKind[] (1:many when replicas > 1).
+ * Workloads whose Pod UID is not in pods (orphaned) are silently skipped.
+ * LLMIS deferred: pod labels differ, ownerRef path unconfirmed on validation cluster.
+ */
+export const buildWorkloadMapForDeployments = (
+  workloads: WorkloadKind[],
+  pods: PodKind[],
+  inferenceServices: InferenceServiceKind[],
+): Record<string, WorkloadKind[]> => {
+  // Prime a UID → Pod lookup for O(1) resolution of ownerRef UIDs.
+  const podByUID = new Map<string, PodKind>(
+    pods.flatMap((p) => (p.metadata.uid != null ? [[p.metadata.uid, p]] : [])),
+  );
+
+  // Seed every known IS with an empty array so callers can distinguish
+  // "IS exists but no workload yet" from "IS not in result at all".
+  const result: Record<string, WorkloadKind[]> = {};
+  for (const is of inferenceServices) {
+    if (is.metadata.name) {
+      result[is.metadata.name] = [];
+    }
+  }
+
+  for (const wl of workloads) {
+    // Find the ownerRef that points to a Pod (Plain Pod integration).
+    const podRef = (wl.metadata?.ownerReferences ?? []).find(
+      (ref) => ref.kind.toLowerCase() === 'pod',
+    );
+    if (!podRef) continue;
+
+    const pod = podByUID.get(podRef.uid);
+    if (!pod) continue; // Pod gone (scale-down, rolling update) — skip orphaned Workload.
+
+    const isISPod = pod.metadata.labels?.['serving.kserve.io/inferenceservice'];
+    if (!isISPod) continue; // Not an IS Pod.
+
+    if (Object.prototype.hasOwnProperty.call(result, isISPod)) {
+      result[isISPod].push(wl);
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Watch IS-labeled Pods in a namespace.
+ * Used as the Pod lookup source for two-hop Workload-to-IS correlation.
+ * Pass undefined namespace to disable the watch.
+ */
+export const useWatchISPods = (namespace: string | undefined): CustomWatchK8sResult<PodKind[]> =>
+  useK8sWatchResourceList(
+    namespace
+      ? {
+          isList: true,
+          groupVersionKind: groupVersionKind(PodModel),
+          namespace,
+          selector: {
+            matchExpressions: [
+              {
+                key: 'serving.kserve.io/inferenceservice',
+                operator: 'Exists',
+              },
+            ],
+          },
+        }
+      : null,
+    PodModel,
+  );
 
 /**
  * Watch Kueue Workloads in a namespace. Updates from the API watch stream (no polling).

--- a/frontend/src/api/k8s/workloads.ts
+++ b/frontend/src/api/k8s/workloads.ts
@@ -1,9 +1,9 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
 import type { PodKind } from '@odh-dashboard/k8s-core';
-import { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
 import { NotebookKind, WorkloadKind } from '#~/k8sTypes';
 import { WorkloadModel } from '#~/api/models/kueue';
-import { PodModel } from '#~/api/models/k8s';
+import { PodModel } from '#~/api/models';
 import { groupVersionKind } from '#~/api/k8sUtils';
 import { CustomWatchK8sResult } from '#~/types';
 import useK8sWatchResourceList from '#~/utilities/useK8sWatchResourceList';
@@ -64,32 +64,42 @@ export const buildWorkloadMapForNotebooks = (
   return result;
 };
 
+// Minimal structural type for a named model deployment.
+// Avoids importing @odh-dashboard/llmd-serving/types which is not a frontend dep.
+type NamedModelResource = { metadata: { name: string } };
+
 /**
- * Two-hop Workload-to-IS correlation
- * Workload CR ownerRef (kind: Pod) → Pod lookup by UID → Pod label
- * `serving.kserve.io/inferenceservice` → IS name.
+ * Two-hop Workload-to-IS/LLMIS correlation (confirmed on live RHOAI + RHBoK cluster):
+ * Workload CR ownerRef (kind: Pod) → Pod lookup by UID → Pod label → model name.
  *
- * Returns IS name → WorkloadKind[] (1:many when replicas > 1).
+ * InferenceService pods carry: `serving.kserve.io/inferenceservice` = IS name
+ * LLMInferenceService pods carry: `app.kubernetes.io/component = llminferenceservice-workload`
+ *   (discriminator) and `app.kubernetes.io/name` = LLMIS name.
+ *
+ * Returns model name → WorkloadKind[] (1:many when replicas > 1).
  * Workloads whose Pod UID is not in pods (orphaned) are silently skipped.
- * LLMIS deferred: pod labels differ, ownerRef path unconfirmed on validation cluster.
  */
 export const buildWorkloadMapForDeployments = (
   workloads: WorkloadKind[],
   pods: PodKind[],
   inferenceServices: InferenceServiceKind[],
+  llmInferenceServices: NamedModelResource[] = [],
 ): Record<string, WorkloadKind[]> => {
   // Prime a UID → Pod lookup for O(1) resolution of ownerRef UIDs.
   const podByUID = new Map<string, PodKind>(
     pods.flatMap((p) => (p.metadata.uid != null ? [[p.metadata.uid, p]] : [])),
   );
 
-  // Seed every known IS with an empty array so callers can distinguish
-  // "IS exists but no workload yet" from "IS not in result at all".
+  // Seed every known IS and LLMIS with an empty array so callers can distinguish
+  // "model exists but no workload yet" from "model not in result at all".
   const result: Record<string, WorkloadKind[]> = {};
   for (const is of inferenceServices) {
     if (is.metadata.name) {
       result[is.metadata.name] = [];
     }
+  }
+  for (const llmis of llmInferenceServices) {
+    result[llmis.metadata.name] = [];
   }
 
   for (const wl of workloads) {
@@ -102,11 +112,19 @@ export const buildWorkloadMapForDeployments = (
     const pod = podByUID.get(podRef.uid);
     if (!pod) continue; // Pod gone (scale-down, rolling update) — skip orphaned Workload.
 
-    const isISPod = pod.metadata.labels?.['serving.kserve.io/inferenceservice'];
-    if (!isISPod) continue; // Not an IS Pod.
+    const labels = pod.metadata.labels ?? {};
 
-    if (Object.prototype.hasOwnProperty.call(result, isISPod)) {
-      result[isISPod].push(wl);
+    // IS: serving.kserve.io/inferenceservice. LLMIS: component=llminferenceservice-workload + name.
+    const modelName =
+      labels['serving.kserve.io/inferenceservice'] ??
+      (labels['app.kubernetes.io/component'] === 'llminferenceservice-workload'
+        ? labels['app.kubernetes.io/name']
+        : undefined);
+
+    if (!modelName) continue; // Not a model serving Pod.
+
+    if (Object.prototype.hasOwnProperty.call(result, modelName)) {
+      result[modelName].push(wl);
     }
   }
 
@@ -114,8 +132,8 @@ export const buildWorkloadMapForDeployments = (
 };
 
 /**
- * Watch IS-labeled Pods in a namespace.
- * Used as the Pod lookup source for two-hop Workload-to-IS correlation.
+ * Watch IS-labeled Pods in a namespace (serving.kserve.io/inferenceservice: Exists).
+ * Used as the InferenceService Pod source for two-hop Workload-to-IS correlation.
  * Pass undefined namespace to disable the watch.
  */
 export const useWatchISPods = (namespace: string | undefined): CustomWatchK8sResult<PodKind[]> =>
@@ -126,10 +144,32 @@ export const useWatchISPods = (namespace: string | undefined): CustomWatchK8sRes
           groupVersionKind: groupVersionKind(PodModel),
           namespace,
           selector: {
+            matchExpressions: [{ key: 'serving.kserve.io/inferenceservice', operator: 'Exists' }],
+          },
+        }
+      : null,
+    PodModel,
+  );
+
+/**
+ * Watch LLMIS-labeled Pods in a namespace
+ * (app.kubernetes.io/component = llminferenceservice-workload).
+ * Used as the LLMInferenceService Pod source for two-hop Workload-to-LLMIS correlation.
+ * Pass undefined namespace to disable the watch.
+ */
+export const useWatchLLMISPods = (namespace: string | undefined): CustomWatchK8sResult<PodKind[]> =>
+  useK8sWatchResourceList(
+    namespace
+      ? {
+          isList: true,
+          groupVersionKind: groupVersionKind(PodModel),
+          namespace,
+          selector: {
             matchExpressions: [
               {
-                key: 'serving.kserve.io/inferenceservice',
-                operator: 'Exists',
+                key: 'app.kubernetes.io/component',
+                operator: 'In',
+                values: ['llminferenceservice-workload'],
               },
             ],
           },

--- a/frontend/src/concepts/kueue/index.ts
+++ b/frontend/src/concepts/kueue/index.ts
@@ -292,3 +292,40 @@ export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo
       return { label: status, color: 'grey', IconComponent: OutlinedClockIcon };
   }
 };
+
+/**
+ * Priority order for most-restrictive-state aggregation across multiple Workload CRs.
+ * Earlier in the array = more restrictive = wins over later entries.
+ * Used by aggregateKueueStatusForModel().
+ */
+const AGGREGATE_PRIORITY_ORDER: KueueWorkloadStatus[] = [
+  KueueWorkloadStatus.Failed,
+  KueueWorkloadStatus.Evicted,
+  KueueWorkloadStatus.Inadmissible,
+  KueueWorkloadStatus.BlockedOnPreemptionGates,
+  KueueWorkloadStatus.Preempted,
+  KueueWorkloadStatus.Requeued,
+  KueueWorkloadStatus.Queued,
+  KueueWorkloadStatus.AdmissionCheck,
+  KueueWorkloadStatus.Admitted,
+  KueueWorkloadStatus.Running,
+  KueueWorkloadStatus.Complete,
+];
+
+/**
+ * Aggregate Kueue status across multiple Workload CRs for one InferenceService.
+ * Most-restrictive state wins — e.g. if 2 of 3 pods are Admitted and 1 is Queued,
+ * the IS-level status is Queued.
+ * Returns null when workloads array is empty (IS has no correlated Workload CRs).
+ */
+export const aggregateKueueStatusForModel = (
+  workloads: WorkloadKind[],
+): KueueWorkloadStatusWithMessage | null => {
+  if (workloads.length === 0) return null;
+  const statuses = workloads.map((wl) => getKueueWorkloadStatusWithMessage(wl));
+  for (const target of AGGREGATE_PRIORITY_ORDER) {
+    const match = statuses.find((s) => s.status === target);
+    if (match) return match;
+  }
+  return statuses[0];
+};

--- a/frontend/src/concepts/kueue/index.ts
+++ b/frontend/src/concepts/kueue/index.ts
@@ -296,7 +296,6 @@ export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo
 /**
  * Priority order for most-restrictive-state aggregation across multiple Workload CRs.
  * Earlier in the array = more restrictive = wins over later entries.
- * Used by aggregateKueueStatusForModel().
  */
 const AGGREGATE_PRIORITY_ORDER: KueueWorkloadStatus[] = [
   KueueWorkloadStatus.Failed,
@@ -313,16 +312,23 @@ const AGGREGATE_PRIORITY_ORDER: KueueWorkloadStatus[] = [
 ];
 
 /**
- * Aggregate Kueue status across multiple Workload CRs for one InferenceService.
- * Most-restrictive state wins — e.g. if 2 of 3 pods are Admitted and 1 is Queued,
- * the IS-level status is Queued.
- * Returns null when workloads array is empty (IS has no correlated Workload CRs).
+ * Aggregate Kueue status across multiple Workload CRs for one model deployment.
+ * Most-restrictive state wins — e.g. if 2 of 3 pods are Running and 1 is Queued,
+ * the model-level status is Queued.
+ *
+ * The returned workloadName belongs to the Workload that supplied the winning status,
+ * not necessarily the first Workload in the list.
+ *
+ * Returns null when workloads array is empty (model has no correlated Workload CRs).
  */
 export const aggregateKueueStatusForModel = (
   workloads: WorkloadKind[],
 ): KueueWorkloadStatusWithMessage | null => {
   if (workloads.length === 0) return null;
-  const statuses = workloads.map((wl) => getKueueWorkloadStatusWithMessage(wl));
+  const statuses = workloads.map((wl) => ({
+    ...getKueueWorkloadStatusWithMessage(wl),
+    workloadName: wl.metadata?.name,
+  }));
   for (const target of AGGREGATE_PRIORITY_ORDER) {
     const match = statuses.find((s) => s.status === target);
     if (match) return match;

--- a/frontend/src/concepts/kueue/types.ts
+++ b/frontend/src/concepts/kueue/types.ts
@@ -53,3 +53,19 @@ export const KUEUE_STATUSES_OVERRIDE_WORKBENCH: KueueWorkloadStatus[] = [
   KueueWorkloadStatus.Requeued,
   KueueWorkloadStatus.Complete,
 ];
+
+/**
+ * Kueue statuses that override the normal KServe deployment status in the Status column.
+ * For Admitted/Running we show the normal KServe lifecycle state instead.
+ * Mirrors KUEUE_STATUSES_OVERRIDE_WORKBENCH for model deployment rows.
+ */
+export const KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT: KueueWorkloadStatus[] = [
+  KueueWorkloadStatus.Queued,
+  KueueWorkloadStatus.Inadmissible,
+  KueueWorkloadStatus.Failed,
+  KueueWorkloadStatus.Preempted,
+  KueueWorkloadStatus.Evicted,
+  KueueWorkloadStatus.Requeued,
+  KueueWorkloadStatus.AdmissionCheck,
+  KueueWorkloadStatus.BlockedOnPreemptionGates,
+];

--- a/frontend/src/concepts/kueue/types.ts
+++ b/frontend/src/concepts/kueue/types.ts
@@ -56,8 +56,9 @@ export const KUEUE_STATUSES_OVERRIDE_WORKBENCH: KueueWorkloadStatus[] = [
 
 /**
  * Kueue statuses that override the normal KServe deployment status in the Status column.
- * For Admitted/Running we show the normal KServe lifecycle state instead.
- * Mirrors KUEUE_STATUSES_OVERRIDE_WORKBENCH for model deployment rows.
+ * For Admitted/Running we show the standard KServe lifecycle state instead.
+ * Differs from KUEUE_STATUSES_OVERRIDE_WORKBENCH: includes AdmissionCheck and
+ * BlockedOnPreemptionGates (relevant for model deployments), excludes Complete.
  */
 export const KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT: KueueWorkloadStatus[] = [
   KueueWorkloadStatus.Queued,

--- a/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
@@ -1,0 +1,263 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import type { PodKind } from '@odh-dashboard/k8s-core';
+import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
+import { mockWorkloadK8sResource } from '#~/__mocks__/mockWorkloadK8sResource';
+import { mockPodK8sResource } from '#~/__mocks__/mockPodK8sResource';
+import { WorkloadStatusType } from '#~/concepts/distributedWorkloads/utils';
+import {
+  KueueFilteringState,
+  useKueueConfiguration,
+} from '#~/concepts/hardwareProfiles/kueueUtils';
+import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
+import {
+  buildWorkloadMapForDeployments,
+  useWatchWorkloads,
+  useWatchISPods,
+} from '#~/api/k8s/workloads';
+import { useKueueStatusForDeployments } from '#~/pages/modelServing/useKueueStatusForDeployments';
+import type { WorkloadKind } from '#~/k8sTypes';
+
+jest.mock('#~/concepts/hardwareProfiles/kueueUtils', () => ({
+  ...jest.requireActual('#~/concepts/hardwareProfiles/kueueUtils'),
+  useKueueConfiguration: jest.fn(),
+}));
+
+jest.mock('#~/api/k8s/workloads', () => ({
+  ...jest.requireActual('#~/api/k8s/workloads'),
+  useWatchWorkloads: jest.fn(),
+  useWatchISPods: jest.fn(),
+  buildWorkloadMapForDeployments: jest.fn(),
+}));
+
+const useKueueConfigurationMock = jest.mocked(useKueueConfiguration);
+const useWatchWorkloadsMock = jest.mocked(useWatchWorkloads);
+const useWatchISPodsMock = jest.mocked(useWatchISPods);
+const buildWorkloadMapMock = jest.mocked(buildWorkloadMapForDeployments);
+
+const IS_NAME = 'my-model';
+const NS = 'test-project';
+const POD_UID = 'pod-uid-abc123';
+
+const project = mockProjectK8sResource({ k8sName: NS, enableKueue: true });
+
+const mockKueueEnabled = {
+  isKueueDisabled: false,
+  isKueueFeatureEnabled: true,
+  isProjectKueueEnabled: true,
+  kueueFilteringState: KueueFilteringState.ONLY_KUEUE_PROFILES,
+};
+
+const inferenceService = (name: string): InferenceServiceKind =>
+  mockInferenceServiceK8sResource({ name, namespace: NS });
+
+/** Pod whose UID matches POD_UID and carries the IS label. */
+function isPod(isName: string, uid = POD_UID): PodKind {
+  const pod = mockPodK8sResource({
+    name: `model-predictor-${uid.slice(0, 8)}`,
+    namespace: NS,
+    labels: { 'serving.kserve.io/inferenceservice': isName },
+  });
+  return { ...pod, metadata: { ...pod.metadata, uid } };
+}
+
+/** Workload whose ownerRef points to a Pod by UID. */
+function workloadWithPodOwnerRef(
+  workloadName: string,
+  podUid: string,
+  status = WorkloadStatusType.Running,
+): WorkloadKind {
+  const wl = mockWorkloadK8sResource({ k8sName: workloadName, namespace: NS, mockStatus: status });
+  return {
+    ...wl,
+    metadata: {
+      ...wl.metadata,
+      ownerReferences: [
+        {
+          apiVersion: 'v1',
+          kind: 'Pod',
+          name: `model-predictor-${podUid.slice(0, 8)}`,
+          uid: podUid,
+        },
+      ],
+    },
+  };
+}
+
+describe('useKueueStatusForDeployments', () => {
+  beforeEach(() => {
+    useKueueConfigurationMock.mockReturnValue(mockKueueEnabled);
+    useWatchWorkloadsMock.mockReturnValue([[], true, undefined]);
+    useWatchISPodsMock.mockReturnValue([[], true, undefined]);
+    buildWorkloadMapMock.mockReturnValue({});
+  });
+
+  // --- Kueue disabled paths ---
+  describe('when Kueue is not active', () => {
+    it.each([
+      ['feature disabled', { isKueueFeatureEnabled: false, isProjectKueueEnabled: true }],
+      ['project not Kueue-enabled', { isKueueFeatureEnabled: true, isProjectKueueEnabled: false }],
+      ['both disabled', { isKueueFeatureEnabled: false, isProjectKueueEnabled: false }],
+    ])('%s — returns empty map and passes undefined to both watches', (_, flags) => {
+      useKueueConfigurationMock.mockReturnValue({ ...mockKueueEnabled, ...flags });
+      const { result } = testHook(useKueueStatusForDeployments)(
+        [inferenceService(IS_NAME)],
+        project,
+      );
+      expect(useWatchWorkloadsMock).toHaveBeenCalledWith(undefined);
+      expect(useWatchISPodsMock).toHaveBeenCalledWith(undefined);
+      expect(result.current.kueueStatusByISName).toEqual({});
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('undefined project — passes undefined to both watches', () => {
+      useKueueConfigurationMock.mockReturnValue({
+        ...mockKueueEnabled,
+        isKueueFeatureEnabled: false,
+        isProjectKueueEnabled: false,
+      });
+      testHook(useKueueStatusForDeployments)([], undefined);
+      expect(useKueueConfigurationMock).toHaveBeenCalledWith(undefined);
+      expect(useWatchWorkloadsMock).toHaveBeenCalledWith(undefined);
+      expect(useWatchISPodsMock).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  // --- Watch setup ---
+  it('passes project namespace to both watches when Kueue is active', () => {
+    testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
+    expect(useWatchWorkloadsMock).toHaveBeenCalledWith(NS);
+    expect(useWatchISPodsMock).toHaveBeenCalledWith(NS);
+  });
+
+  // --- Loading ---
+  it('isLoading true when workloads watch not yet loaded', () => {
+    useWatchWorkloadsMock.mockReturnValue([[], false, undefined]);
+    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('isLoading true when pods watch not yet loaded', () => {
+    useWatchISPodsMock.mockReturnValue([[], false, undefined]);
+    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('isLoading false when both watches loaded', () => {
+    useWatchWorkloadsMock.mockReturnValue([[], true, undefined]);
+    useWatchISPodsMock.mockReturnValue([[], true, undefined]);
+    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  // --- Error ---
+  it('surfaces workload watch error message', () => {
+    useWatchWorkloadsMock.mockReturnValue([[], true, new Error('network failure')]);
+    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
+    expect(result.current.error).toBe('network failure');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  // --- Status map population ---
+  it('returns null for IS when buildWorkloadMapForDeployments returns empty array', () => {
+    buildWorkloadMapMock.mockReturnValue({ [IS_NAME]: [] });
+    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
+    expect(result.current.kueueStatusByISName[IS_NAME]).toBeNull();
+  });
+
+  it('returns aggregated Kueue status for IS when workload matches', () => {
+    const wl = workloadWithPodOwnerRef('wl-1', POD_UID, WorkloadStatusType.Pending);
+    buildWorkloadMapMock.mockReturnValue({ [IS_NAME]: [wl] });
+    useWatchWorkloadsMock.mockReturnValue([[wl], true, undefined]);
+    useWatchISPodsMock.mockReturnValue([[isPod(IS_NAME)], true, undefined]);
+
+    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
+    expect(result.current.kueueStatusByISName[IS_NAME]).toEqual(
+      expect.objectContaining({
+        status: KueueWorkloadStatus.Queued,
+        workloadName: 'wl-1',
+      }),
+    );
+  });
+
+  it('includes queueName from IS kueue.x-k8s.io/queue-name label', () => {
+    const is = inferenceService(IS_NAME);
+    is.metadata.labels = { ...is.metadata.labels, 'kueue.x-k8s.io/queue-name': 'my-queue' };
+    const wl = workloadWithPodOwnerRef('wl-q', POD_UID, WorkloadStatusType.Running);
+    buildWorkloadMapMock.mockReturnValue({ [IS_NAME]: [wl] });
+    useWatchWorkloadsMock.mockReturnValue([[wl], true, undefined]);
+    useWatchISPodsMock.mockReturnValue([[isPod(IS_NAME)], true, undefined]);
+
+    const { result } = testHook(useKueueStatusForDeployments)([is], project);
+    expect(result.current.kueueStatusByISName[IS_NAME]).toEqual(
+      expect.objectContaining({ queueName: 'my-queue' }),
+    );
+  });
+
+  // --- Multi-replica aggregation (most-restrictive-state wins) ---
+  it('multi-replica IS: shows most restrictive state (Queued beats Running)', () => {
+    const uidQueued = 'uid-pod-queued';
+    const uidRunning = 'uid-pod-running';
+    const wlQueued = workloadWithPodOwnerRef('wl-queued', uidQueued, WorkloadStatusType.Pending);
+    const wlRunning = workloadWithPodOwnerRef('wl-running', uidRunning, WorkloadStatusType.Running);
+    // buildWorkloadMap is mocked — return both workloads for the IS.
+    buildWorkloadMapMock.mockReturnValue({ [IS_NAME]: [wlQueued, wlRunning] });
+    useWatchWorkloadsMock.mockReturnValue([[wlQueued, wlRunning], true, undefined]);
+    useWatchISPodsMock.mockReturnValue([
+      [isPod(IS_NAME, uidQueued), isPod(IS_NAME, uidRunning)],
+      true,
+      undefined,
+    ]);
+
+    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
+    // Queued (Pending) is more restrictive than Running — must win.
+    expect(result.current.kueueStatusByISName[IS_NAME]).toEqual(
+      expect.objectContaining({ status: KueueWorkloadStatus.Queued }),
+    );
+  });
+
+  it('multi-replica IS: all Running → status is Running', () => {
+    const uid0 = 'uid-r0';
+    const uid1 = 'uid-r1';
+    const wl0 = workloadWithPodOwnerRef('wl-r0', uid0, WorkloadStatusType.Running);
+    const wl1 = workloadWithPodOwnerRef('wl-r1', uid1, WorkloadStatusType.Running);
+    buildWorkloadMapMock.mockReturnValue({ [IS_NAME]: [wl0, wl1] });
+    useWatchWorkloadsMock.mockReturnValue([[wl0, wl1], true, undefined]);
+    useWatchISPodsMock.mockReturnValue([
+      [isPod(IS_NAME, uid0), isPod(IS_NAME, uid1)],
+      true,
+      undefined,
+    ]);
+
+    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
+    expect(result.current.kueueStatusByISName[IS_NAME]).toEqual(
+      expect.objectContaining({ status: KueueWorkloadStatus.Running }),
+    );
+  });
+
+  it('two IS in namespace get independent statuses', () => {
+    const IS_A = 'model-a';
+    const IS_B = 'model-b';
+    const uidA = 'uid-a';
+    const uidB = 'uid-b';
+    const wlA = workloadWithPodOwnerRef('wl-a', uidA, WorkloadStatusType.Running);
+    const wlB = workloadWithPodOwnerRef('wl-b', uidB, WorkloadStatusType.Pending);
+    buildWorkloadMapMock.mockReturnValue({ [IS_A]: [wlA], [IS_B]: [wlB] });
+    useWatchWorkloadsMock.mockReturnValue([[wlA, wlB], true, undefined]);
+    useWatchISPodsMock.mockReturnValue([[isPod(IS_A, uidA), isPod(IS_B, uidB)], true, undefined]);
+
+    const { result } = testHook(useKueueStatusForDeployments)(
+      [inferenceService(IS_A), inferenceService(IS_B)],
+      project,
+    );
+    expect(result.current.kueueStatusByISName[IS_A]).toEqual(
+      expect.objectContaining({ status: KueueWorkloadStatus.Running }),
+    );
+    expect(result.current.kueueStatusByISName[IS_B]).toEqual(
+      expect.objectContaining({ status: KueueWorkloadStatus.Queued }),
+    );
+  });
+});

--- a/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
@@ -1,45 +1,40 @@
-import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { renderHook } from '@testing-library/react';
+import type { PodKind } from '@odh-dashboard/k8s-core';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
-import type { PodKind } from '@odh-dashboard/k8s-core';
 import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
 import { mockWorkloadK8sResource } from '#~/__mocks__/mockWorkloadK8sResource';
 import { mockPodK8sResource } from '#~/__mocks__/mockPodK8sResource';
+import type { WorkloadKind } from '#~/k8sTypes';
 import { WorkloadStatusType } from '#~/concepts/distributedWorkloads/utils';
 import {
-  KueueFilteringState,
   useKueueConfiguration,
+  KueueFilteringState,
 } from '#~/concepts/hardwareProfiles/kueueUtils';
-import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
 import {
   buildWorkloadMapForDeployments,
   useWatchWorkloads,
   useWatchISPods,
+  useWatchLLMISPods,
 } from '#~/api/k8s/workloads';
 import { useKueueStatusForDeployments } from '#~/pages/modelServing/useKueueStatusForDeployments';
-import type { WorkloadKind } from '#~/k8sTypes';
+import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
 
-jest.mock('#~/concepts/hardwareProfiles/kueueUtils', () => ({
-  ...jest.requireActual('#~/concepts/hardwareProfiles/kueueUtils'),
-  useKueueConfiguration: jest.fn(),
-}));
-
-jest.mock('#~/api/k8s/workloads', () => ({
-  ...jest.requireActual('#~/api/k8s/workloads'),
-  useWatchWorkloads: jest.fn(),
-  useWatchISPods: jest.fn(),
-  buildWorkloadMapForDeployments: jest.fn(),
+jest.mock('#~/concepts/hardwareProfiles/kueueUtils');
+jest.mock('#~/api/k8s/workloads');
+jest.mock('#~/concepts/kueue/index', () => ({
+  ...jest.requireActual('#~/concepts/kueue/index'),
+  KUEUE_QUEUE_LABEL: 'kueue.x-k8s.io/queue-name',
 }));
 
 const useKueueConfigurationMock = jest.mocked(useKueueConfiguration);
 const useWatchWorkloadsMock = jest.mocked(useWatchWorkloads);
 const useWatchISPodsMock = jest.mocked(useWatchISPods);
-const buildWorkloadMapMock = jest.mocked(buildWorkloadMapForDeployments);
+const useWatchLLMISPodsMock = jest.mocked(useWatchLLMISPods);
+const buildWorkloadMapForDeploymentsMock = jest.mocked(buildWorkloadMapForDeployments);
 
-const IS_NAME = 'my-model';
-const NS = 'test-project';
+const NS = 'test-ns';
 const POD_UID = 'pod-uid-abc123';
-
 const project = mockProjectK8sResource({ k8sName: NS, enableKueue: true });
 
 const mockKueueEnabled = {
@@ -52,7 +47,6 @@ const mockKueueEnabled = {
 const inferenceService = (name: string): InferenceServiceKind =>
   mockInferenceServiceK8sResource({ name, namespace: NS });
 
-/** Pod whose UID matches POD_UID and carries the IS label. */
 function isPod(isName: string, uid = POD_UID): PodKind {
   const pod = mockPodK8sResource({
     name: `model-predictor-${uid.slice(0, 8)}`,
@@ -62,7 +56,18 @@ function isPod(isName: string, uid = POD_UID): PodKind {
   return { ...pod, metadata: { ...pod.metadata, uid } };
 }
 
-/** Workload whose ownerRef points to a Pod by UID. */
+function llmisPod(llmisName: string, uid: string): PodKind {
+  const pod = mockPodK8sResource({
+    name: `llm-predictor-${uid.slice(0, 8)}`,
+    namespace: NS,
+    labels: {
+      'app.kubernetes.io/component': 'llminferenceservice-workload',
+      'app.kubernetes.io/name': llmisName,
+    },
+  });
+  return { ...pod, metadata: { ...pod.metadata, uid } };
+}
+
 function workloadWithPodOwnerRef(
   workloadName: string,
   podUid: string,
@@ -87,177 +92,225 @@ function workloadWithPodOwnerRef(
 
 describe('useKueueStatusForDeployments', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     useKueueConfigurationMock.mockReturnValue(mockKueueEnabled);
     useWatchWorkloadsMock.mockReturnValue([[], true, undefined]);
     useWatchISPodsMock.mockReturnValue([[], true, undefined]);
-    buildWorkloadMapMock.mockReturnValue({});
+    useWatchLLMISPodsMock.mockReturnValue([[], true, undefined]);
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({});
   });
 
-  // --- Kueue disabled paths ---
-  describe('when Kueue is not active', () => {
-    it.each([
-      ['feature disabled', { isKueueFeatureEnabled: false, isProjectKueueEnabled: true }],
-      ['project not Kueue-enabled', { isKueueFeatureEnabled: true, isProjectKueueEnabled: false }],
-      ['both disabled', { isKueueFeatureEnabled: false, isProjectKueueEnabled: false }],
-    ])('%s — returns empty map and passes undefined to both watches', (_, flags) => {
-      useKueueConfigurationMock.mockReturnValue({ ...mockKueueEnabled, ...flags });
-      const { result } = testHook(useKueueStatusForDeployments)(
-        [inferenceService(IS_NAME)],
-        project,
-      );
-      expect(useWatchWorkloadsMock).toHaveBeenCalledWith(undefined);
-      expect(useWatchISPodsMock).toHaveBeenCalledWith(undefined);
-      expect(result.current.kueueStatusByISName).toEqual({});
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBeNull();
+  it('returns empty status and no loading when Kueue is disabled', () => {
+    useKueueConfigurationMock.mockReturnValue({
+      isKueueDisabled: true,
+      isKueueFeatureEnabled: false,
+      isProjectKueueEnabled: false,
+      kueueFilteringState: KueueFilteringState.ONLY_KUEUE_PROFILES,
     });
-
-    it('undefined project — passes undefined to both watches', () => {
-      useKueueConfigurationMock.mockReturnValue({
-        ...mockKueueEnabled,
-        isKueueFeatureEnabled: false,
-        isProjectKueueEnabled: false,
-      });
-      testHook(useKueueStatusForDeployments)([], undefined);
-      expect(useKueueConfigurationMock).toHaveBeenCalledWith(undefined);
-      expect(useWatchWorkloadsMock).toHaveBeenCalledWith(undefined);
-      expect(useWatchISPodsMock).toHaveBeenCalledWith(undefined);
-    });
-  });
-
-  // --- Watch setup ---
-  it('passes project namespace to both watches when Kueue is active', () => {
-    testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
-    expect(useWatchWorkloadsMock).toHaveBeenCalledWith(NS);
-    expect(useWatchISPodsMock).toHaveBeenCalledWith(NS);
-  });
-
-  // --- Loading ---
-  it('isLoading true when workloads watch not yet loaded', () => {
-    useWatchWorkloadsMock.mockReturnValue([[], false, undefined]);
-    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
-    expect(result.current.isLoading).toBe(true);
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.kueueStatusByISName).toEqual({});
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
   });
 
-  it('isLoading true when pods watch not yet loaded', () => {
-    useWatchISPodsMock.mockReturnValue([[], false, undefined]);
-    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
+  it('passes project namespace to all three watches when Kueue is active', () => {
+    renderHook(() => useKueueStatusForDeployments([inferenceService('my-model')], project));
+    expect(useWatchWorkloadsMock).toHaveBeenCalledWith(NS);
+    expect(useWatchISPodsMock).toHaveBeenCalledWith(NS);
+    expect(useWatchLLMISPodsMock).toHaveBeenCalledWith(NS);
+  });
+
+  it('passes undefined namespace to all three watches when project is undefined', () => {
+    renderHook(() => useKueueStatusForDeployments([inferenceService('my-model')], undefined));
+    expect(useWatchWorkloadsMock).toHaveBeenCalledWith(undefined);
+    expect(useWatchISPodsMock).toHaveBeenCalledWith(undefined);
+    expect(useWatchLLMISPodsMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it('passes combined IS+LLMIS pods and llmInferenceServices to buildWorkloadMapForDeployments', () => {
+    const is = inferenceService('my-model');
+    const llmis = { metadata: { name: 'my-llm' } };
+    const isPodResource = isPod('my-model', 'uid-is');
+    const llmisPodResource = llmisPod('my-llm', 'uid-llmis');
+    const workloads = [workloadWithPodOwnerRef('wl-1', 'uid-is')];
+
+    useWatchWorkloadsMock.mockReturnValue([workloads, true, undefined]);
+    useWatchISPodsMock.mockReturnValue([[isPodResource], true, undefined]);
+    useWatchLLMISPodsMock.mockReturnValue([[llmisPodResource], true, undefined]);
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-model': [], 'my-llm': [] });
+
+    renderHook(() => useKueueStatusForDeployments([is], project, [llmis]));
+
+    expect(buildWorkloadMapForDeploymentsMock).toHaveBeenCalledWith(
+      workloads,
+      [isPodResource, llmisPodResource],
+      [is],
+      [llmis],
+    );
+  });
+
+  it('is loading while workloads watch is pending', () => {
+    useWatchWorkloadsMock.mockReturnValue([[], false, undefined]);
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
     expect(result.current.isLoading).toBe(true);
   });
 
-  it('isLoading false when both watches loaded', () => {
-    useWatchWorkloadsMock.mockReturnValue([[], true, undefined]);
-    useWatchISPodsMock.mockReturnValue([[], true, undefined]);
-    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
-    expect(result.current.isLoading).toBe(false);
+  it('is loading while IS pods watch is pending', () => {
+    useWatchISPodsMock.mockReturnValue([[], false, undefined]);
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.isLoading).toBe(true);
   });
 
-  // --- Error ---
-  it('surfaces workload watch error message', () => {
-    useWatchWorkloadsMock.mockReturnValue([[], true, new Error('network failure')]);
-    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
-    expect(result.current.error).toBe('network failure');
-    expect(result.current.isLoading).toBe(false);
+  it('is loading while LLMIS pods watch is pending', () => {
+    useWatchLLMISPodsMock.mockReturnValue([[], false, undefined]);
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.isLoading).toBe(true);
   });
 
-  // --- Status map population ---
-  it('returns null for IS when buildWorkloadMapForDeployments returns empty array', () => {
-    buildWorkloadMapMock.mockReturnValue({ [IS_NAME]: [] });
-    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
-    expect(result.current.kueueStatusByISName[IS_NAME]).toBeNull();
+  it('returns workload watch error when present', () => {
+    const err = new Error('workload watch failed');
+    useWatchWorkloadsMock.mockReturnValue([[], true, err]);
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.error).toBe('workload watch failed');
   });
 
-  it('returns aggregated Kueue status for IS when workload matches', () => {
-    const wl = workloadWithPodOwnerRef('wl-1', POD_UID, WorkloadStatusType.Pending);
-    buildWorkloadMapMock.mockReturnValue({ [IS_NAME]: [wl] });
-    useWatchWorkloadsMock.mockReturnValue([[wl], true, undefined]);
-    useWatchISPodsMock.mockReturnValue([[isPod(IS_NAME)], true, undefined]);
+  it('returns IS pods watch error when workload watch is healthy', () => {
+    const err = new Error('IS pod watch failed');
+    useWatchISPodsMock.mockReturnValue([[], true, err]);
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.error).toBe('IS pod watch failed');
+  });
 
-    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
-    expect(result.current.kueueStatusByISName[IS_NAME]).toEqual(
-      expect.objectContaining({
-        status: KueueWorkloadStatus.Queued,
-        workloadName: 'wl-1',
-      }),
+  it('returns LLMIS pods watch error when both other watches are healthy', () => {
+    const err = new Error('LLMIS pod watch failed');
+    useWatchLLMISPodsMock.mockReturnValue([[], true, err]);
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.error).toBe('LLMIS pod watch failed');
+  });
+
+  it('returns null status when workload map has no entry for an IS', () => {
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-model': [] });
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.kueueStatusByISName['my-model']).toBeNull();
+  });
+
+  it('returns aggregated status when workload map has entries', () => {
+    const uid = POD_UID;
+    const pod = isPod('my-model', uid);
+    const wl = workloadWithPodOwnerRef('wl-1', uid, WorkloadStatusType.Inadmissible);
+    useWatchISPodsMock.mockReturnValue([[pod], true, undefined]);
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-model': [wl] });
+
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.kueueStatusByISName['my-model']?.status).toBe(
+      KueueWorkloadStatus.Inadmissible,
     );
   });
 
-  it('includes queueName from IS kueue.x-k8s.io/queue-name label', () => {
-    const is = inferenceService(IS_NAME);
-    is.metadata.labels = { ...is.metadata.labels, 'kueue.x-k8s.io/queue-name': 'my-queue' };
-    const wl = workloadWithPodOwnerRef('wl-q', POD_UID, WorkloadStatusType.Running);
-    buildWorkloadMapMock.mockReturnValue({ [IS_NAME]: [wl] });
-    useWatchWorkloadsMock.mockReturnValue([[wl], true, undefined]);
-    useWatchISPodsMock.mockReturnValue([[isPod(IS_NAME)], true, undefined]);
+  it('includes queueName from IS label in the status', () => {
+    const is = {
+      ...inferenceService('my-model'),
+      metadata: {
+        ...inferenceService('my-model').metadata,
+        labels: { 'kueue.x-k8s.io/queue-name': 'team-queue' },
+      },
+    };
+    const wl = workloadWithPodOwnerRef('wl-1', POD_UID);
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-model': [wl] });
 
-    const { result } = testHook(useKueueStatusForDeployments)([is], project);
-    expect(result.current.kueueStatusByISName[IS_NAME]).toEqual(
-      expect.objectContaining({ queueName: 'my-queue' }),
+    const { result } = renderHook(() => useKueueStatusForDeployments([is], project));
+    expect(result.current.kueueStatusByISName['my-model']?.queueName).toBe('team-queue');
+  });
+
+  it('multi-replica: most-restrictive status wins (Inadmissible beats Running)', () => {
+    const uid0 = 'uid-0';
+    const uid1 = 'uid-1';
+    const wlRunning = workloadWithPodOwnerRef('wl-running', uid0, WorkloadStatusType.Running);
+    const wlInadmissible = workloadWithPodOwnerRef(
+      'wl-inadmissible',
+      uid1,
+      WorkloadStatusType.Inadmissible,
+    );
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({
+      'my-model': [wlRunning, wlInadmissible],
+    });
+
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.kueueStatusByISName['my-model']?.status).toBe(
+      KueueWorkloadStatus.Inadmissible,
     );
   });
 
-  // --- Multi-replica aggregation (most-restrictive-state wins) ---
-  it('multi-replica IS: shows most restrictive state (Queued beats Running)', () => {
-    const uidQueued = 'uid-pod-queued';
-    const uidRunning = 'uid-pod-running';
-    const wlQueued = workloadWithPodOwnerRef('wl-queued', uidQueued, WorkloadStatusType.Pending);
-    const wlRunning = workloadWithPodOwnerRef('wl-running', uidRunning, WorkloadStatusType.Running);
-    // buildWorkloadMap is mocked — return both workloads for the IS.
-    buildWorkloadMapMock.mockReturnValue({ [IS_NAME]: [wlQueued, wlRunning] });
-    useWatchWorkloadsMock.mockReturnValue([[wlQueued, wlRunning], true, undefined]);
-    useWatchISPodsMock.mockReturnValue([
-      [isPod(IS_NAME, uidQueued), isPod(IS_NAME, uidRunning)],
-      true,
-      undefined,
-    ]);
+  it('workloadName comes from the winning Workload, not the first one', () => {
+    const uid0 = 'uid-first';
+    const uid1 = 'uid-second';
+    // First workload is Running, second is Inadmissible — Inadmissible wins.
+    const wlRunning = workloadWithPodOwnerRef('wl-running', uid0, WorkloadStatusType.Running);
+    const wlInadmissible = workloadWithPodOwnerRef(
+      'wl-inadmissible',
+      uid1,
+      WorkloadStatusType.Inadmissible,
+    );
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({
+      'my-model': [wlRunning, wlInadmissible],
+    });
 
-    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
-    // Queued (Pending) is more restrictive than Running — must win.
-    expect(result.current.kueueStatusByISName[IS_NAME]).toEqual(
-      expect.objectContaining({ status: KueueWorkloadStatus.Queued }),
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.kueueStatusByISName['my-model']?.workloadName).toBe('wl-inadmissible');
+  });
+
+  it('all-running: aggregation returns Running', () => {
+    const wl0 = workloadWithPodOwnerRef('wl-0', 'uid-0', WorkloadStatusType.Running);
+    const wl1 = workloadWithPodOwnerRef('wl-1', 'uid-1', WorkloadStatusType.Running);
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-model': [wl0, wl1] });
+
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService('my-model')], project),
+    );
+    expect(result.current.kueueStatusByISName['my-model']?.status).toBe(
+      KueueWorkloadStatus.Running,
     );
   });
 
-  it('multi-replica IS: all Running → status is Running', () => {
-    const uid0 = 'uid-r0';
-    const uid1 = 'uid-r1';
-    const wl0 = workloadWithPodOwnerRef('wl-r0', uid0, WorkloadStatusType.Running);
-    const wl1 = workloadWithPodOwnerRef('wl-r1', uid1, WorkloadStatusType.Running);
-    buildWorkloadMapMock.mockReturnValue({ [IS_NAME]: [wl0, wl1] });
-    useWatchWorkloadsMock.mockReturnValue([[wl0, wl1], true, undefined]);
-    useWatchISPodsMock.mockReturnValue([
-      [isPod(IS_NAME, uid0), isPod(IS_NAME, uid1)],
-      true,
-      undefined,
-    ]);
+  it('two IS resources get independent status entries', () => {
+    const wlA = workloadWithPodOwnerRef('wl-a', 'uid-a', WorkloadStatusType.Inadmissible);
+    const wlB = workloadWithPodOwnerRef('wl-b', 'uid-b', WorkloadStatusType.Running);
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({
+      'model-a': [wlA],
+      'model-b': [wlB],
+    });
 
-    const { result } = testHook(useKueueStatusForDeployments)([inferenceService(IS_NAME)], project);
-    expect(result.current.kueueStatusByISName[IS_NAME]).toEqual(
-      expect.objectContaining({ status: KueueWorkloadStatus.Running }),
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments(
+        [inferenceService('model-a'), inferenceService('model-b')],
+        project,
+      ),
     );
-  });
-
-  it('two IS in namespace get independent statuses', () => {
-    const IS_A = 'model-a';
-    const IS_B = 'model-b';
-    const uidA = 'uid-a';
-    const uidB = 'uid-b';
-    const wlA = workloadWithPodOwnerRef('wl-a', uidA, WorkloadStatusType.Running);
-    const wlB = workloadWithPodOwnerRef('wl-b', uidB, WorkloadStatusType.Pending);
-    buildWorkloadMapMock.mockReturnValue({ [IS_A]: [wlA], [IS_B]: [wlB] });
-    useWatchWorkloadsMock.mockReturnValue([[wlA, wlB], true, undefined]);
-    useWatchISPodsMock.mockReturnValue([[isPod(IS_A, uidA), isPod(IS_B, uidB)], true, undefined]);
-
-    const { result } = testHook(useKueueStatusForDeployments)(
-      [inferenceService(IS_A), inferenceService(IS_B)],
-      project,
+    expect(result.current.kueueStatusByISName['model-a']?.status).toBe(
+      KueueWorkloadStatus.Inadmissible,
     );
-    expect(result.current.kueueStatusByISName[IS_A]).toEqual(
-      expect.objectContaining({ status: KueueWorkloadStatus.Running }),
-    );
-    expect(result.current.kueueStatusByISName[IS_B]).toEqual(
-      expect.objectContaining({ status: KueueWorkloadStatus.Queued }),
-    );
+    expect(result.current.kueueStatusByISName['model-b']?.status).toBe(KueueWorkloadStatus.Running);
   });
 });

--- a/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
+++ b/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import type { ProjectKind } from '@odh-dashboard/k8s-core';
+import { useKueueConfiguration } from '#~/concepts/hardwareProfiles/kueueUtils';
+import type { KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
+import {
+  buildWorkloadMapForDeployments,
+  useWatchWorkloads,
+  useWatchISPods,
+} from '#~/api/k8s/workloads';
+import { aggregateKueueStatusForModel, KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
+
+export type KueueStatusForDeploymentsResult = {
+  kueueStatusByISName: Record<string, KueueWorkloadStatusWithMessage | null>;
+  isLoading: boolean;
+  error: string | null;
+};
+
+/**
+ * Watches Kueue Workload status for InferenceServices in the project.
+ *
+ * Correlation uses the confirmed two-hop path from a live RHOAI cluster with RHBoK:
+ *   Workload CR ownerRef → Pod (by UID) → Pod label serving.kserve.io/inferenceservice → IS name
+ *
+ * For multi-replica IS the most-restrictive Kueue state across all per-Pod Workload CRs is shown.
+ * Only runs when Kueue is enabled for the project. Mirrors useKueueStatusForNotebooks.
+ */
+export const useKueueStatusForDeployments = (
+  inferenceServices: InferenceServiceKind[],
+  project: ProjectKind | undefined,
+): KueueStatusForDeploymentsResult => {
+  const { isKueueFeatureEnabled, isProjectKueueEnabled } = useKueueConfiguration(project);
+  const useKueue = Boolean(isKueueFeatureEnabled && isProjectKueueEnabled);
+  const namespace = project == null ? undefined : project.metadata.name;
+
+  const [workloads, workloadsLoaded, watchError] = useWatchWorkloads(
+    useKueue ? namespace : undefined,
+  );
+  const [pods, podsLoaded] = useWatchISPods(useKueue ? namespace : undefined);
+
+  const kueueStatusByISName = React.useMemo(() => {
+    if (!useKueue) {
+      return {};
+    }
+    const workloadMap = buildWorkloadMapForDeployments(workloads, pods, inferenceServices);
+    const isByName = new Map(
+      inferenceServices
+        .filter((is): is is typeof is & { metadata: { name: string } } => Boolean(is.metadata.name))
+        .map((is) => [is.metadata.name, is]),
+    );
+    const statusMap: Record<string, KueueWorkloadStatusWithMessage | null> = {};
+    for (const [name, isWorkloads] of Object.entries(workloadMap)) {
+      const aggregated = aggregateKueueStatusForModel(isWorkloads);
+      if (!aggregated) {
+        statusMap[name] = null;
+        continue;
+      }
+      const is = isByName.get(name);
+      statusMap[name] = {
+        ...aggregated,
+        queueName: is?.metadata.labels?.[KUEUE_QUEUE_LABEL],
+        workloadName: isWorkloads[0]?.metadata?.name,
+      };
+    }
+    return statusMap;
+  }, [useKueue, workloads, pods, inferenceServices]);
+
+  return {
+    kueueStatusByISName,
+    isLoading: useKueue && (!workloadsLoaded || !podsLoaded),
+    error: useKueue && watchError ? watchError.message : null,
+  };
+};

--- a/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
+++ b/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
@@ -7,8 +7,12 @@ import {
   buildWorkloadMapForDeployments,
   useWatchWorkloads,
   useWatchISPods,
+  useWatchLLMISPods,
 } from '#~/api/k8s/workloads';
 import { aggregateKueueStatusForModel, KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
+
+// Avoids importing @odh-dashboard/llmd-serving/types (not a frontend dep).
+type NamedModelResource = { metadata: { name: string } };
 
 export type KueueStatusForDeploymentsResult = {
   kueueStatusByISName: Record<string, KueueWorkloadStatusWithMessage | null>;
@@ -17,17 +21,21 @@ export type KueueStatusForDeploymentsResult = {
 };
 
 /**
- * Watches Kueue Workload status for InferenceServices in the project.
+ * Watches Kueue Workload status for InferenceServices (and optionally LLMInferenceServices)
+ * in the project.
  *
  * Correlation uses the confirmed two-hop path from a live RHOAI cluster with RHBoK:
- *   Workload CR ownerRef → Pod (by UID) → Pod label serving.kserve.io/inferenceservice → IS name
+ *   IS:    Workload ownerRef → Pod (by UID) → Pod label `serving.kserve.io/inferenceservice`
+ *   LLMIS: Workload ownerRef → Pod (by UID) → Pod label `app.kubernetes.io/name`
+ *          (filtered by `app.kubernetes.io/component = llminferenceservice-workload`)
  *
- * For multi-replica IS the most-restrictive Kueue state across all per-Pod Workload CRs is shown.
- * Only runs when Kueue is enabled for the project. Mirrors useKueueStatusForNotebooks.
+ * For multi-replica models the most-restrictive Kueue state across all per-Pod Workload CRs
+ * is shown. Only runs when Kueue is enabled for the project.
  */
 export const useKueueStatusForDeployments = (
   inferenceServices: InferenceServiceKind[],
   project: ProjectKind | undefined,
+  llmInferenceServices: NamedModelResource[] = [],
 ): KueueStatusForDeploymentsResult => {
   const { isKueueFeatureEnabled, isProjectKueueEnabled } = useKueueConfiguration(project);
   const useKueue = Boolean(isKueueFeatureEnabled && isProjectKueueEnabled);
@@ -36,13 +44,22 @@ export const useKueueStatusForDeployments = (
   const [workloads, workloadsLoaded, watchError] = useWatchWorkloads(
     useKueue ? namespace : undefined,
   );
-  const [pods, podsLoaded] = useWatchISPods(useKueue ? namespace : undefined);
+  const [isPods, isPodsLoaded, isPodsWatchError] = useWatchISPods(useKueue ? namespace : undefined);
+  const [llmisPods, llmisPodsLoaded, llmisPodsWatchError] = useWatchLLMISPods(
+    useKueue ? namespace : undefined,
+  );
 
   const kueueStatusByISName = React.useMemo(() => {
     if (!useKueue) {
       return {};
     }
-    const workloadMap = buildWorkloadMapForDeployments(workloads, pods, inferenceServices);
+    const allPods = [...isPods, ...llmisPods];
+    const workloadMap = buildWorkloadMapForDeployments(
+      workloads,
+      allPods,
+      inferenceServices,
+      llmInferenceServices,
+    );
     const isByName = new Map(
       inferenceServices
         .filter((is): is is typeof is & { metadata: { name: string } } => Boolean(is.metadata.name))
@@ -57,17 +74,18 @@ export const useKueueStatusForDeployments = (
       }
       const is = isByName.get(name);
       statusMap[name] = {
-        ...aggregated,
+        ...aggregated, // includes workloadName from the winning Workload
         queueName: is?.metadata.labels?.[KUEUE_QUEUE_LABEL],
-        workloadName: isWorkloads[0]?.metadata?.name,
       };
     }
     return statusMap;
-  }, [useKueue, workloads, pods, inferenceServices]);
+  }, [useKueue, workloads, isPods, llmisPods, inferenceServices, llmInferenceServices]);
 
   return {
     kueueStatusByISName,
-    isLoading: useKueue && (!workloadsLoaded || !podsLoaded),
-    error: useKueue && watchError ? watchError.message : null,
+    isLoading: useKueue && (!workloadsLoaded || !isPodsLoaded || !llmisPodsLoaded),
+    error: useKueue
+      ? (watchError ?? isPodsWatchError ?? llmisPodsWatchError)?.message ?? null
+      : null,
   };
 };


### PR DESCRIPTION

Closes [RHOAIENG-79913](https://issues.redhat.com/browse/RHOAIENG-79913)

## Description

Adds Kueue queue status visibility for KServe model deployments (InferenceService in RawDeployment mode), mirroring the existing notebook Kueue status integration.

**Why this is non-trivial:** Kueue does not attach its workloads to KServe Deployments directly. On a live RHOAI + RHBoK cluster, Kueue uses its Plain Pod integration , each predictor pod gets its own `Workload` CR, and the only stable link between that Workload CR and the InferenceService is a label on the pod itself (`serving.kserve.io/inferenceservice`). A naive approach using `kueue.x-k8s.io/job-name` does not work for IS pods.

**Workload → IS correlation (`buildWorkloadMapForDeployments`):**
- Builds a `uid → Pod` map from a scoped pod watch
- For each Workload CR, follows the `ownerRef` (kind: Pod) to the pod by UID
- Reads `serving.kserve.io/inferenceservice` from that pod's labels to identify the IS
- Orphaned Workloads (pod gone after scale-down or rolling update) are silently skipped

**Multi-replica aggregation (`aggregateKueueStatusForModel`):**
- A multi-replica IS produces one Workload CR per pod
- Uses a priority-ordered list to pick the most restrictive state across all CRs (e.g. if two pods are Admitted but one is Queued, the IS shows Queued)

**Scoped pod watch (`useWatchISPods`):**
- Watches only pods carrying the `serving.kserve.io/inferenceservice` label via `matchExpressions: Exists`
- Avoids streaming the full pod list for the namespace
- Disabled (null watch) when Kueue is not enabled for the project

**Hook (`useKueueStatusForDeployments`):**
- Takes a list of InferenceServices and a project, returns `kueueStatusByISName: Record<string, KueueWorkloadStatusWithMessage | null>`
- Null entry = IS exists but no Workload CR found (not yet queued or Kueue not active)
- Exposes `isLoading` and `error` consistent with the notebook equivalent

**Types (`KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT`):**
- Defines which Kueue states should override the normal KServe deployment status in the UI
- Admitted and Running are excluded — when a workload is admitted and running, the standard KServe lifecycle state is shown instead

## How Has This Been Tested?

**Unit tests (50 total, all passing):**
- `workloads.spec.ts` — covers `buildWorkloadMapForDeployments`:
  - Happy path: Workload correctly correlated to IS via Pod UID and label
  - Orphaned Workload (pod UID absent from watch list)
  - Pod present but missing IS label
  - Workload with no Pod ownerRef
  - Multi-replica IS (multiple Workload CRs collected)
  - Isolation between two different ISes
  - Case-insensitive `ownerRef.kind` matching
  - Unknown IS name does not bleed into result
- `useKueueStatusForDeployments.spec.ts` — covers the hook:
  - Short-circuits when Kueue is disabled
  - Loading state while either watch is pending
  - Error propagation from the Workload watch
  - Status populated from correlated Workloads
  - `queueName` extracted from IS label
  - Multi-replica aggregation: Queued wins over Running
  - All-running aggregation returns Running
  - Two independent ISes get independent status entries


## Test Impact

Modified:
- `frontend/src/api/k8s/__tests__/workloads.spec.ts` — new `buildWorkloadMapForDeployments` test block
- `frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts` — new hook test suite

## Request review criteria

Self checklist:
- [x] Manually tested changes
- [x] Testing instructions added in PR body
- [x] Unit tests added for all new functions and the hook
- [x] Code follows project Best Practices

After the PR is posted & before it merges:
- [ ] Developer has tested on a cluster using the PR image

[RHOAIENG-79913]: https://redhat.atlassian.net/browse/RHOAIENG-79913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Kueue status visibility for model deployments, including loading and error states.
  * Added support for InferenceServices and LLM InferenceServices.
  * Added accurate workload and pod correlation for per-service status reporting.
  * Added queue and workload details to deployment status information.
  * Added status aggregation across replicas using the most restrictive applicable status.

* **Tests**
  * Added comprehensive coverage for workload mapping, status aggregation, replicas, isolation, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->