### PR TITLE
fix(RHOAIENG-79525): include desired handler in probe sanitization patch

### DIFF
--- a/dashboard-operator/internal/controller/probe_sanitize.go
+++ b/dashboard-operator/internal/controller/probe_sanitize.go
@@ -89,9 +89,16 @@ func buildProbeCleanupPatch(live, desired *unstructured.Unstructured) map[string
 		for _, probeField := range []string{"livenessProbe", "readinessProbe", "startupProbe"} {
 			nullFields := conflictingHandlerFields(liveC, desiredC, probeField)
 			if len(nullFields) > 0 {
-				probePatch := make(map[string]interface{}, len(nullFields))
+				probePatch := make(map[string]interface{}, len(nullFields)+1)
 				for _, f := range nullFields {
 					probePatch[f] = nil
+				}
+				desiredProbe, _ := desiredC[probeField].(map[string]interface{})
+				for _, h := range probeHandlerTypes {
+					if val, ok := desiredProbe[h]; ok {
+						probePatch[h] = val
+						break
+					}
 				}
 				containerPatch[probeField] = probePatch
 				hasConflict = true

--- a/dashboard-operator/internal/controller/probe_sanitize_test.go
+++ b/dashboard-operator/internal/controller/probe_sanitize_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -177,16 +178,26 @@ func TestSanitizeDeploymentProbes_TcpSocketToExec(t *testing.T) {
 	if _, ok := lp["tcpSocket"]; ok {
 		t.Error("tcpSocket should have been removed from livenessProbe")
 	}
-	if _, ok := lp["exec"]; !ok {
-		t.Error("exec should have been added to livenessProbe")
+	lpExec, ok := lp["exec"].(map[string]interface{})
+	if !ok {
+		t.Fatal("exec should have been added to livenessProbe")
+	}
+	wantLivenessCmd := []interface{}{"/bin/sh", "-c", "curl -s http://localhost:8080/"}
+	if !reflect.DeepEqual(lpExec["command"], wantLivenessCmd) {
+		t.Errorf("livenessProbe exec command = %v, want %v", lpExec["command"], wantLivenessCmd)
 	}
 
 	rp, _ := c["readinessProbe"].(map[string]interface{})
 	if _, ok := rp["httpGet"]; ok {
 		t.Error("httpGet should have been removed from readinessProbe")
 	}
-	if _, ok := rp["exec"]; !ok {
-		t.Error("exec should have been added to readinessProbe")
+	rpExec, ok := rp["exec"].(map[string]interface{})
+	if !ok {
+		t.Fatal("exec should have been added to readinessProbe")
+	}
+	wantReadinessCmd := []interface{}{"/bin/sh", "-c", "curl -s http://localhost:8080/api/health"}
+	if !reflect.DeepEqual(rpExec["command"], wantReadinessCmd) {
+		t.Errorf("readinessProbe exec command = %v, want %v", rpExec["command"], wantReadinessCmd)
 	}
 }
 
@@ -265,8 +276,13 @@ func TestSanitizeDeploymentProbes_MultipleContainers(t *testing.T) {
 			if _, ok := lp["tcpSocket"]; ok {
 				t.Error("rhods-dashboard: tcpSocket should have been removed")
 			}
-			if _, ok := lp["exec"]; !ok {
-				t.Error("rhods-dashboard: exec should have been added")
+			execHandler, ok := lp["exec"].(map[string]interface{})
+			if !ok {
+				t.Fatal("rhods-dashboard: exec should have been added")
+			}
+			wantCmd := []interface{}{"/bin/sh", "-c", "curl localhost:8080/"}
+			if !reflect.DeepEqual(execHandler["command"], wantCmd) {
+				t.Errorf("rhods-dashboard: exec command = %v, want %v", execHandler["command"], wantCmd)
 			}
 		case "kube-rbac-proxy":
 			if _, ok := lp["httpGet"]; !ok {

--- a/dashboard-operator/internal/controller/probe_sanitize_test.go
+++ b/dashboard-operator/internal/controller/probe_sanitize_test.go
@@ -177,10 +177,16 @@ func TestSanitizeDeploymentProbes_TcpSocketToExec(t *testing.T) {
 	if _, ok := lp["tcpSocket"]; ok {
 		t.Error("tcpSocket should have been removed from livenessProbe")
 	}
+	if _, ok := lp["exec"]; !ok {
+		t.Error("exec should have been added to livenessProbe")
+	}
 
 	rp, _ := c["readinessProbe"].(map[string]interface{})
 	if _, ok := rp["httpGet"]; ok {
 		t.Error("httpGet should have been removed from readinessProbe")
+	}
+	if _, ok := rp["exec"]; !ok {
+		t.Error("exec should have been added to readinessProbe")
 	}
 }
 
@@ -258,6 +264,9 @@ func TestSanitizeDeploymentProbes_MultipleContainers(t *testing.T) {
 		case "rhods-dashboard":
 			if _, ok := lp["tcpSocket"]; ok {
 				t.Error("rhods-dashboard: tcpSocket should have been removed")
+			}
+			if _, ok := lp["exec"]; !ok {
+				t.Error("rhods-dashboard: exec should have been added")
 			}
 		case "kube-rbac-proxy":
 			if _, ok := lp["httpGet"]; !ok {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79525

## Description

The probe sanitization logic introduced in #9028 has a bug: the strategic merge patch only nulls out stale handler types (e.g., `tcpSocket`, `httpGet`) without setting the desired handler (`exec`). This leaves probes with no handler type, which Kubernetes rejects:

```
Deployment.apps "rhods-dashboard" is invalid:
  spec.template.spec.containers[0].livenessProbe: Required value: must specify a handler type
  spec.template.spec.containers[0].readinessProbe: Required value: must specify a handler type
```

The operator enters an error loop, retrying every ~17 minutes and never completing reconciliation.

**Root cause:** `buildProbeCleanupPatch()` builds a patch like `{"livenessProbe": {"tcpSocket": null}}` — removing the old handler but not adding the new one. The deployment transitions through an invalid intermediate state.

**Fix:** Include the desired handler value alongside the null stale handlers in the patch, so the transition is atomic:
```json
{"livenessProbe": {"tcpSocket": null, "exec": {"command": [...]}}}
```

## How Has This Been Tested?

- Unit tests updated and passing (all 5 `TestSanitize*` tests pass)
- **Verified on live cluster**: Applied the same strategic merge patch our fixed code produces to `rhods-dashboard` on a 3.4→3.5 upgrade cluster. The patch succeeded, pods rolled out 10/10, and the dashboard-operator reconciled successfully with "Standalone mode reconciled successfully" (previously stuck in error loop).

## Test Impact

Updated existing unit tests (`TestSanitizeDeploymentProbes_TcpSocketToExec` and `TestSanitizeDeploymentProbes_MultipleContainers`) to verify that the desired handler is present after sanitization, not just that the stale handler is removed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Probe cleanup now preserves the configured active health-check handler while removing conflicting handlers.
  * Corrected liveness and readiness probe handling for dashboard containers in multi-container deployments.
  * TCP socket and HTTP GET probes are now properly replaced with exec probes when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->