### PR TITLE
test(operator): add Perses federation ConfigMap test for observability projection (RHOAIENG-87523)

### DIFF
--- a/dashboard-operator/internal/controller/module_deploy_test.go
+++ b/dashboard-operator/internal/controller/module_deploy_test.go
@@ -362,3 +362,56 @@ func TestPatchDeploymentFederationHash_DeploymentNotFound(t *testing.T) {
 	err := r.PatchDeploymentFederationHash(context.Background(), `[{"name":"genAi"}]`)
 	require.NoError(t, err, "NotFound should be a no-op, not an error")
 }
+
+func TestBuildFederationConfigMap_IncludesPersesWhenObsEnabled(t *testing.T) {
+	s := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		Platform:              cluster.SelfManagedRhoai,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
+	}
+
+	statuses := allDeployedStatuses()
+	dashboard := &v1alpha1.Dashboard{
+		Spec: v1alpha1.DashboardSpec{
+			Observability: &v1alpha1.ObservabilitySpec{
+				Enabled: true,
+				PersesService: &v1alpha1.ServiceTarget{
+					Name:      "data-science-perses",
+					Namespace: "redhat-ods-monitoring",
+					Port:      8080,
+				},
+			},
+		},
+	}
+
+	cm, err := ctrlpkg.BuildFederationConfigMap(r, statuses, dashboard)
+	require.NoError(t, err)
+
+	data := cm.Data["module-federation-config.json"]
+	var entries []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(data), &entries))
+
+	var persesEntry map[string]interface{}
+	for _, entry := range entries {
+		if name, ok := entry["name"].(string); ok && name == "perses" {
+			persesEntry = entry
+		}
+	}
+
+	require.NotNil(t, persesEntry, "perses entry must be present when observability is enabled")
+
+	proxyServices, ok := persesEntry["proxyService"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, proxyServices, 1)
+
+	ps := proxyServices[0].(map[string]interface{})
+	assert.Equal(t, "/perses/api", ps["path"])
+	svc := ps["service"].(map[string]interface{})
+	assert.Equal(t, "data-science-perses", svc["name"])
+	assert.Equal(t, "redhat-ods-monitoring", svc["namespace"])
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-87523
Follow-up to [RHOAIENG-80354](https://redhat.atlassian.net/browse/RHOAIENG-80354)

## Description

On RHOAI deployments, the Perses observability proxy is never configured because nothing sets `spec.observability` on the Dashboard CR. The dashboard-operator relies on this field to include the Perses proxy entry in the federation ConfigMap, but the ODH Operator's Dashboard handler does not project it.

This PR adds a test verifying that `buildFederationConfigMap` correctly includes the Perses proxy entry when `spec.observability` is configured on the Dashboard CR. The observability configuration is projected by the ODH Operator handler via `BuildModuleCR`, following the modularization best practice: module operators read only from their own CR spec, not from DSCI directly.

**Companion PR:** opendatahub-io/opendatahub-operator#3923 — adds the observability projection logic to the ODH Operator's Dashboard handler.

## How Has This Been Tested?

- `make test` in `dashboard-operator/` passes
- New test `TestBuildFederationConfigMap_IncludesPersesWhenObsEnabled` verifies the Perses federation entry is present when observability is configured

## Test Impact

Added `TestBuildFederationConfigMap_IncludesPersesWhenObsEnabled` in `module_deploy_test.go` — validates that the federation ConfigMap includes the Perses proxy entry when `Dashboard.Spec.Observability` is enabled with a `PersesService` target.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-80354]: https://redhat.atlassian.net/browse/RHOAIENG-80354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ