### PR TITLE
fix(operator): read distribution identity from orchestrator annotations

### DIFF
--- a/dashboard-operator/internal/controller/config.go
+++ b/dashboard-operator/internal/controller/config.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/annotations"
 )
 
 const operatorConfigMapName = "dashboard-operator-config"
@@ -63,9 +64,11 @@ func readOperatorConfig(ctx context.Context, cli client.Client, namespace string
 }
 
 // readDistributionConfig reads the distribution identity from the
-// chart-deployed ConfigMap. Returns (nil, nil) when the ConfigMap is
-// absent or contains no distribution keys, and (nil, err) on transient
-// read failures so the caller can preserve last-known-good status.
+// chart-deployed ConfigMap. Orchestrator annotations (PlatformType,
+// PlatformVersion) take precedence over Helm chart data keys for backward
+// compatibility. Returns (nil, nil) when the ConfigMap is absent or
+// contains no distribution identity, and (nil, err) on transient read
+// failures so the caller can preserve last-known-good status.
 func readDistributionConfig(ctx context.Context, cli client.Client, namespace string) (*v1alpha1.Distribution, error) {
 	logger := log.FromContext(ctx)
 
@@ -80,12 +83,16 @@ func readDistributionConfig(ctx context.Context, cli client.Client, namespace st
 		return nil, fmt.Errorf("failed to read distribution config ConfigMap: %w", err)
 	}
 
-	if cm.Data == nil {
-		return nil, nil
-	}
-
 	name := cm.Data["distribution.name"]
 	version := cm.Data["distribution.version"]
+
+	// Orchestrator annotations take precedence over Helm chart data keys.
+	if annoName := cm.Annotations[annotations.PlatformType]; annoName != "" {
+		name = annoName
+	}
+	if annoVersion := cm.Annotations[annotations.PlatformVersion]; annoVersion != "" {
+		version = annoVersion
+	}
 
 	if name == "" && version == "" {
 		return nil, nil

--- a/dashboard-operator/internal/controller/config_test.go
+++ b/dashboard-operator/internal/controller/config_test.go
@@ -12,6 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/annotations"
 )
 
 func configTestScheme(t *testing.T) *runtime.Scheme {
@@ -23,6 +26,177 @@ func configTestScheme(t *testing.T) *runtime.Scheme {
 	}
 
 	return s
+}
+
+func TestReadDistributionConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		configMap *corev1.ConfigMap
+		want      *v1alpha1.Distribution
+		wantErr   bool
+	}{
+		{
+			name:      "configmap does not exist",
+			configMap: nil,
+			want:      nil,
+		},
+		{
+			name: "data keys only",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: distributionConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"distribution.name":    "Standalone",
+					"distribution.version": "0.0.0",
+				},
+			},
+			want: &v1alpha1.Distribution{Name: "Standalone", Version: "0.0.0"},
+		},
+		{
+			name: "annotations only without data keys",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      distributionConfigMapName,
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						annotations.PlatformType:    "OpenShift AI Self-Managed",
+						annotations.PlatformVersion: "3.5.0",
+					},
+				},
+			},
+			want: &v1alpha1.Distribution{Name: "OpenShift AI Self-Managed", Version: "3.5.0"},
+		},
+		{
+			name: "annotations override data keys",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      distributionConfigMapName,
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						annotations.PlatformType:    "OpenShift AI Self-Managed",
+						annotations.PlatformVersion: "3.5.0",
+					},
+				},
+				Data: map[string]string{
+					"distribution.name":    "Standalone",
+					"distribution.version": "0.0.0",
+				},
+			},
+			want: &v1alpha1.Distribution{Name: "OpenShift AI Self-Managed", Version: "3.5.0"},
+		},
+		{
+			name: "partial annotation override - name only",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      distributionConfigMapName,
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						annotations.PlatformType: "RHOAI",
+					},
+				},
+				Data: map[string]string{
+					"distribution.name":    "Standalone",
+					"distribution.version": "1.0.0",
+				},
+			},
+			want: &v1alpha1.Distribution{Name: "RHOAI", Version: "1.0.0"},
+		},
+		{
+			name: "partial annotation override - version only",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      distributionConfigMapName,
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						annotations.PlatformVersion: "3.5.0",
+					},
+				},
+				Data: map[string]string{
+					"distribution.name":    "Standalone",
+					"distribution.version": "0.0.0",
+				},
+			},
+			want: &v1alpha1.Distribution{Name: "Standalone", Version: "3.5.0"},
+		},
+		{
+			name: "empty annotations do not override",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      distributionConfigMapName,
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						annotations.PlatformType:    "",
+						annotations.PlatformVersion: "",
+					},
+				},
+				Data: map[string]string{
+					"distribution.name":    "Standalone",
+					"distribution.version": "1.0.0",
+				},
+			},
+			want: &v1alpha1.Distribution{Name: "Standalone", Version: "1.0.0"},
+		},
+		{
+			name: "nil data map with annotations",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      distributionConfigMapName,
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						annotations.PlatformType:    "ODH",
+						annotations.PlatformVersion: "2.0.0",
+					},
+				},
+			},
+			want: &v1alpha1.Distribution{Name: "ODH", Version: "2.0.0"},
+		},
+		{
+			name: "both name and version empty returns nil",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: distributionConfigMapName, Namespace: "test-ns"},
+				Data:       map[string]string{},
+			},
+			want: nil,
+		},
+		{
+			name: "oversized annotation is truncated",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      distributionConfigMapName,
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						annotations.PlatformType:    strings.Repeat("a", 300),
+						annotations.PlatformVersion: strings.Repeat("b", 300),
+					},
+				},
+			},
+			want: &v1alpha1.Distribution{
+				Name:    strings.Repeat("a", maxDistributionFieldLen),
+				Version: strings.Repeat("b", maxDistributionFieldLen),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := configTestScheme(t)
+			builder := fake.NewClientBuilder().WithScheme(s)
+
+			if tt.configMap != nil {
+				builder = builder.WithObjects(tt.configMap)
+			}
+
+			cli := builder.Build()
+			got, err := readDistributionConfig(context.Background(), cli, "test-ns")
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestReadPlatformVersion(t *testing.T) {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-80304

## Description

After migrating Dashboard lifecycle management to the new dashboard-operator (Module Controller), the `odh-dashboard-config` ConfigMap retains Helm chart defaults for `distribution.name` ("Standalone") and `distribution.version` ("0.0.0"). The ODH Operator correctly stamps the ConfigMap with annotations (`platform.opendatahub.io/type` and `platform.opendatahub.io/version`), but `readDistributionConfig()` only reads data keys, ignoring the annotations. This results in the Dashboard CR `status.distribution` reporting wrong values (`{name: "Standalone", version: "0.0.0"}` instead of `{name: "OpenShift AI Self-Managed", version: "3.5.0"}`).

**Fix:** Modify `readDistributionConfig()` to prefer orchestrator annotations over Helm chart data keys. The annotation constants (`annotations.PlatformType`, `annotations.PlatformVersion`) are already available in the `odh-platform-utilities` dependency. When present and non-empty, annotations take precedence; when absent, data keys are used for backward compatibility.

**Cluster evidence (before fix):**
```yaml
# ConfigMap data (Helm defaults — wrong)
distribution.name: Standalone
distribution.version: 0.0.0

# ConfigMap annotations (set by ODH Operator — correct)
platform.opendatahub.io/type: OpenShift AI Self-Managed
platform.opendatahub.io/version: 3.5.0

# Dashboard CR status.distribution (reads from data keys — wrong)
distribution:
  name: Standalone
  version: 0.0.0
```

Also removed the `cm.Data == nil` early return, since annotations may provide distribution identity even when data keys are absent.

## How Has This Been Tested?

- Added 10 table-driven unit tests in `TestReadDistributionConfig` covering all scenarios (annotation override, partial override, fallback to data keys, nil data with annotations, empty annotations, truncation)
- All existing tests continue to pass (`api/v1alpha1`, `charts`, `internal/controller`, `internal/webhook`)
- Lint passes with 0 issues

## Test Impact

Added `TestReadDistributionConfig` in `dashboard-operator/internal/controller/config_test.go` with 10 test cases:
- ConfigMap absent → nil
- Data keys only → backward compat
- Annotations only → annotation values used
- Annotations override data keys (the core bug scenario)
- Partial overrides (name only, version only)
- Empty annotations don't override
- Nil data map with annotations
- Both empty → nil
- Oversized annotation truncated to 256 runes

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`