### PR TITLE
feat(gen-ai): add HTTPRoute for OGX-to-BFF cross-namespace proxy connectivity

### DIFF
--- a/manifests/modules/gen-ai/httproute.yaml
+++ b/manifests/modules/gen-ai/httproute.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: odh-dashboard-gen-ai-proxy
+spec:
+  parentRefs:
+    - name: gateway-name
+      kind: Gateway
+      namespace: openshift-ingress
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/api/v1/genai-proxy"
+      backendRefs:
+        - name: odh-dashboard-gen-ai-ui
+          port: 8143

--- a/manifests/modules/gen-ai/kustomization.yaml
+++ b/manifests/modules/gen-ai/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml
+  - httproute.yaml
 configMapGenerator:
   - name: gen-ai-params
     env: params.env
@@ -43,3 +44,13 @@ replacements:
           name: gen-ai-ui
         fieldPaths:
           - spec.template.spec.containers.[name=gen-ai-ui].env.[name=GATEWAY_DOMAIN].value
+  - source:
+      kind: ConfigMap
+      name: gen-ai-params
+      fieldPath: data.gateway-name
+    targets:
+      - select:
+          kind: HTTPRoute
+          name: odh-dashboard-gen-ai-proxy
+        fieldPaths:
+          - spec.parentRefs.0.name

--- a/manifests/modules/gen-ai/params.env
+++ b/manifests/modules/gen-ai/params.env
@@ -2,3 +2,4 @@
 gen-ai-ui-image=quay.io/opendatahub/odh-mod-arch-gen-ai:main
 pgvector-image=registry.redhat.io/rhel9/postgresql-16
 gateway-domain=
+gateway-name=data-science-gateway


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-79579

## Description

Adds an HTTPRoute that exposes the gen-ai BFF's `/api/v1/genai-proxy` path via the cluster Gateway (`data-science-gateway`). This enables OGX pods running in user namespaces to reach the BFF over HTTPS for the zero-restart passthrough proxy architecture ([RHAISTRAT-1921](https://redhat.atlassian.net/browse/RHAISTRAT-1921)).

### What changed

- **New `manifests/modules/gen-ai/httproute.yaml`**: Gateway API HTTPRoute targeting `odh-dashboard-gen-ai-ui` service on port 8143, scoped to PathPrefix `/api/v1/genai-proxy`
- **Updated `kustomization.yaml`**: Added httproute.yaml as resource + kustomize replacement for `gateway-name`
- **Updated `params.env`**: Added `gateway-name=data-science-gateway` (default, operator can override)

### Design decisions

- **HTTPRoute over NetworkPolicy**: Follows the existing pattern (`manifests/base/httproute.yaml`) and gives OGX a stable external URL. The existing NetworkPolicy already allows ingress controller traffic on port 8143, so no NetworkPolicy changes are needed.
- **PathPrefix `/api/v1/genai-proxy`**: Scoped to only expose the proxy endpoints (models, chat/completions, embeddings), not the full BFF API surface.
- **No RHOAI patch needed**: The gen-ai module Service name (`odh-dashboard-gen-ai-ui`) is the same in both ODH and RHOAI modes.

### Dependencies

- The `/api/v1/genai-proxy` endpoints don't exist on main yet — they are being implemented as part of [RHOAIENG-79569](https://redhat.atlassian.net/browse/RHOAIENG-79569) (Epic 1: BFF /v1/ Proxy Endpoints). This PR provides the networking prerequisite.
- Related spike: [opendatahub-io/odh-dashboard#8934](https://github.com/opendatahub-io/odh-dashboard/pull/8934)

## How Has This Been Tested?

### 1. Kustomize build validation

```bash
kustomize build manifests/modules/gen-ai/
# Produces valid HTTPRoute with gateway-name correctly injected as data-science-gateway
```

### 2. Cluster validation — connectivity confirmed

Applied the HTTPRoute on a RHOAI 3.6 EA1 cluster and verified OGX can reach the BFF:

**Without HTTPRoute (direct pod-to-pod, blocked by NetworkPolicy):**
```bash
oc exec -n <ogx-namespace> <ogx-pod> -- curl -sk --connect-timeout 5 \
  https://odh-dashboard-gen-ai-ui.redhat-ods-applications.svc:8143/api/v1/health
# Result: exit code 28 (connection timeout) — NetworkPolicy blocks cross-namespace access
```

**With HTTPRoute (via Gateway, works):**
```bash
# Apply the HTTPRoute
cat manifests/modules/gen-ai/httproute.yaml | sed 's/gateway-name/data-science-gateway/' | \
  oc apply -n redhat-ods-applications -f -

# Verify HTTPRoute is accepted
oc get httproute odh-dashboard-gen-ai-proxy -n redhat-ods-applications \
  -o jsonpath='{.status.parents[0].conditions[0].reason}'
# Result: Accepted

# Test from OGX pod via Gateway
oc exec -n <ogx-namespace> <ogx-pod> -- curl -sk --connect-timeout 10 \
  https://data-science-gateway-data-science-gateway-class.openshift-ingress.svc.cluster.local/api/v1/genai-proxy/ns/<namespace>/v1/models
# Result: HTTP 302 (OAuth redirect) — confirms traffic reaches the BFF successfully
```

### 3. Cleanup (if needed)
```bash
oc delete httproute odh-dashboard-gen-ai-proxy -n redhat-ods-applications
```

[RHAISTRAT-1921]: https://redhat.atlassian.net/browse/RHAISTRAT-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-79569]: https://redhat.atlassian.net/browse/RHOAIENG-79569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routing for Generative AI proxy requests through the configured Gateway.
  * Requests to the GenAI proxy endpoint are now directed to the GenAI dashboard service.
  * Added configuration for selecting the Gateway used by this route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->