### PR TITLE
feat(gen-ai): enable proper TLS trust for OGX-to-BFF connections [RHOAIENG-79580]

### DIFF
--- a/manifests/modules/gen-ai/cluster-role.yaml
+++ b/manifests/modules/gen-ai/cluster-role.yaml
@@ -102,3 +102,13 @@ rules:
       - list
     resources:
       - storageclasses
+  # TLS trust: read the ingress CA from the router-ca secret to populate
+  # the OGX CA trust bundle when the CA injection label has not yet propagated.
+  - apiGroups:
+      - ""
+    verbs:
+      - get
+    resources:
+      - secrets
+    resourceNames:
+      - router-ca

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1389,10 +1389,10 @@ func ogxCommand(enableTracing bool) []string {
 	if enableTracing {
 		return []string{"/bin/sh", "-c", strings.Join([]string{
 			"cp /opt/app-root/lib/python*/site-packages/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py /opt/app-root/lib/python*/site-packages/ 2>/dev/null || true",
-			"opentelemetry-instrument --traces_exporter=otlp_proto_http --metrics_exporter=none --logs_exporter=none ogx run /etc/ogx/config.yaml --insecure",
+			"opentelemetry-instrument --traces_exporter=otlp_proto_http --metrics_exporter=none --logs_exporter=none ogx run /etc/ogx/config.yaml",
 		}, " && ")}
 	}
-	return []string{"/bin/sh", "-c", "ogx run /etc/ogx/config.yaml --insecure"}
+	return []string{"/bin/sh", "-c", "ogx run /etc/ogx/config.yaml"}
 }
 
 // ogxEnvVars returns the environment variables for the OGXServer pod.
@@ -1438,10 +1438,6 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 
 	// Step 1: Set up environment variables
 	envVars := []corev1.EnvVar{
-		{
-			Name:  "VLLM_TLS_VERIFY",
-			Value: "false",
-		},
 		{
 			Name:  "FAISS_STORE_DIR",
 			Value: "~/.llama/faiss",
@@ -1682,6 +1678,51 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 
 	kc.Logger.Info("ConfigMap created successfully (before OGXServer creation)", "namespace", namespace, "configMapName", configMapName)
 
+	// Step 4b: Ensure a CA trust ConfigMap exists for OGX TLS verification.
+	// First check if the DSCI-managed odh-trusted-ca-bundle already exists with CA content.
+	// If it does, use it directly. Otherwise, create ogx-trusted-ca-bundle with the
+	// OpenShift CA injection label so the ingress CA gets populated automatically.
+	caBundleConfigMapName := "odh-trusted-ca-bundle"
+	var caBundleConfigMap corev1.ConfigMap
+	err = kc.Client.Get(ctx, types.NamespacedName{Name: caBundleConfigMapName, Namespace: namespace}, &caBundleConfigMap)
+	if err != nil || caBundleConfigMap.Data["ca-bundle.crt"] == "" {
+		// DSCI bundle not available or empty — create our own with CA injection label
+		caBundleConfigMapName = "ogx-trusted-ca-bundle"
+		newCaBundleConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      caBundleConfigMapName,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"config.openshift.io/inject-trusted-cabundle": "true",
+					"ogx.io/watch": "true",
+				},
+			},
+			Data: map[string]string{},
+		}
+
+		if createErr := kc.Client.Create(ctx, newCaBundleConfigMap); createErr != nil {
+			if !apierrors.IsAlreadyExists(createErr) {
+				kc.Logger.Error("failed to create CA trust ConfigMap", "error", createErr, "namespace", namespace)
+				return nil, rollbackPgvector(fmt.Errorf("failed to create CA trust ConfigMap: %w", createErr))
+			}
+			kc.Logger.Info("CA trust ConfigMap already exists, reusing", "namespace", namespace, "configMapName", caBundleConfigMapName)
+		} else {
+			kc.Logger.Info("CA trust ConfigMap created for OGX TLS verification", "namespace", namespace, "configMapName", caBundleConfigMapName)
+		}
+	} else {
+		// DSCI bundle exists with CA content — ensure it has the ogx.io/watch label
+		if caBundleConfigMap.Labels == nil {
+			caBundleConfigMap.Labels = make(map[string]string)
+		}
+		if caBundleConfigMap.Labels["ogx.io/watch"] != "true" {
+			caBundleConfigMap.Labels["ogx.io/watch"] = "true"
+			if updateErr := kc.Client.Update(ctx, &caBundleConfigMap); updateErr != nil {
+				kc.Logger.Warn("failed to add ogx.io/watch label to DSCI CA bundle", "error", updateErr)
+			}
+		}
+		kc.Logger.Info("Using existing DSCI-managed CA trust bundle", "namespace", namespace, "configMapName", caBundleConfigMapName)
+	}
+
 	// Step 5: Create OGXServer
 	replicas := int32(1)
 	workloadResources := &corev1.ResourceRequirements{
@@ -1728,6 +1769,13 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 			Network: &ogxapi.NetworkSpec{
 				Port: 8321,
 			},
+			TLS: &ogxapi.TLSClientConfig{
+				Trust: &ogxapi.TrustConfig{
+					CACertificates: []ogxapi.ConfigMapKeyRef{
+						{Name: caBundleConfigMapName, Key: "ca-bundle.crt"},
+					},
+				},
+			},
 		},
 	}
 
@@ -1767,6 +1815,29 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 		// Continue without failing - the OGXServer is created successfully
 	} else {
 		kc.Logger.Info("ConfigMap updated with owner reference", "namespace", namespace, "configMapName", configMapName, "owner", lsdName)
+	}
+
+	// Step 6b: Update CA trust ConfigMap with owner reference for GC
+	// Only set owner ref if we created it (ogx-trusted-ca-bundle), not on the DSCI-managed one.
+	if caBundleConfigMapName == "ogx-trusted-ca-bundle" {
+		var caConfigMapForOwner corev1.ConfigMap
+		if err := kc.Client.Get(ctx, types.NamespacedName{Name: caBundleConfigMapName, Namespace: namespace}, &caConfigMapForOwner); err == nil {
+			caConfigMapForOwner.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion:         "ogx.io/v1beta1",
+					Kind:               "OGXServer",
+					Name:               lsdName,
+					UID:                ogxServer.UID,
+					Controller:         &[]bool{true}[0],
+					BlockOwnerDeletion: &[]bool{false}[0],
+				},
+			}
+			if err := kc.Client.Update(ctx, &caConfigMapForOwner); err != nil {
+				kc.Logger.Warn("failed to set owner reference on CA trust ConfigMap", "error", err)
+			} else {
+				kc.Logger.Info("CA trust ConfigMap updated with owner reference", "namespace", namespace, "owner", lsdName)
+			}
+		}
 	}
 
 	// Set owner references on auto-provisioned pgvector resources so

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1688,6 +1688,31 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 	if err != nil || caBundleConfigMap.Data["ca-bundle.crt"] == "" {
 		// DSCI bundle not available or empty — create our own with CA injection label
 		caBundleConfigMapName = "ogx-trusted-ca-bundle"
+
+		// Fallback: attempt to extract the ingress CA directly from the router-ca secret.
+		// This provides immediate CA content without waiting for the async injection.
+		// If we lack RBAC to read the secret, the CA injection label will still work
+		// (just with a short delay while OpenShift populates the ConfigMap).
+		var ingressCAData string
+		if kc.SAClient != nil {
+			var routerCASecret corev1.Secret
+			secretKey := types.NamespacedName{Name: "router-ca", Namespace: "openshift-ingress-operator"}
+			if getErr := kc.SAClient.Get(ctx, secretKey, &routerCASecret); getErr == nil {
+				if crt, ok := routerCASecret.Data["tls.crt"]; ok {
+					ingressCAData = string(crt)
+					kc.Logger.Info("Extracted ingress CA from router-ca secret", "namespace", "openshift-ingress-operator")
+				}
+			} else {
+				kc.Logger.Info("Could not read router-ca secret (RBAC not granted), relying on CA injection label",
+					"error", getErr)
+			}
+		}
+
+		configMapData := map[string]string{}
+		if ingressCAData != "" {
+			configMapData["ca-bundle.crt"] = ingressCAData
+		}
+
 		newCaBundleConfigMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      caBundleConfigMapName,
@@ -1697,7 +1722,7 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 					"ogx.io/watch": "true",
 				},
 			},
-			Data: map[string]string{},
+			Data: configMapData,
 		}
 
 		if createErr := kc.Client.Create(ctx, newCaBundleConfigMap); createErr != nil {
@@ -1707,7 +1732,8 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 			}
 			kc.Logger.Info("CA trust ConfigMap already exists, reusing", "namespace", namespace, "configMapName", caBundleConfigMapName)
 		} else {
-			kc.Logger.Info("CA trust ConfigMap created for OGX TLS verification", "namespace", namespace, "configMapName", caBundleConfigMapName)
+			kc.Logger.Info("CA trust ConfigMap created for OGX TLS verification", "namespace", namespace,
+				"configMapName", caBundleConfigMapName, "hasIngressCA", ingressCAData != "")
 		}
 	} else {
 		// DSCI bundle exists with CA content — ensure it has the ogx.io/watch label

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -1965,6 +1965,84 @@ func TestOgxEnvVars_TracingEnabled_NamespaceInResourceAttributes(t *testing.T) {
 	assert.Equal(t, "k8s.namespace.name=other-ns", byName["OTEL_RESOURCE_ATTRIBUTES"])
 }
 
+func TestOgxTLSTrust_DSCIBundleAvailable(t *testing.T) {
+	// When odh-trusted-ca-bundle exists with CA content in the namespace,
+	// the install handler should reuse it and add the ogx.io/watch label.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	existingBundle := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-trusted-ca-bundle",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				"config.openshift.io/inject-trusted-cabundle": "true",
+			},
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\nFAKE-INGRESS-CA\n-----END CERTIFICATE-----\n",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingBundle).Build()
+
+	// Simulate the check: get the existing ConfigMap
+	var cm corev1.ConfigMap
+	err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "odh-trusted-ca-bundle", Namespace: "test-ns"}, &cm)
+	require.NoError(t, err)
+
+	// CA content exists — should use existing ConfigMap
+	assert.NotEmpty(t, cm.Data["ca-bundle.crt"])
+	assert.Contains(t, cm.Data["ca-bundle.crt"], "FAKE-INGRESS-CA")
+
+	// Should add ogx.io/watch label
+	cm.Labels["ogx.io/watch"] = "true"
+	err = fakeClient.Update(context.Background(), &cm)
+	require.NoError(t, err)
+
+	// Verify label was added
+	var updated corev1.ConfigMap
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "odh-trusted-ca-bundle", Namespace: "test-ns"}, &updated)
+	require.NoError(t, err)
+	assert.Equal(t, "true", updated.Labels["ogx.io/watch"])
+}
+
+func TestOgxTLSTrust_DSCIBundleMissing_CreatesOwnConfigMap(t *testing.T) {
+	// When odh-trusted-ca-bundle does NOT exist, the install handler should
+	// create ogx-trusted-ca-bundle with the CA injection label.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Check that odh-trusted-ca-bundle doesn't exist
+	var cm corev1.ConfigMap
+	err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "odh-trusted-ca-bundle", Namespace: "test-ns"}, &cm)
+	assert.Error(t, err) // Not found
+
+	// Create our own CA bundle ConfigMap
+	newCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ogx-trusted-ca-bundle",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				"config.openshift.io/inject-trusted-cabundle": "true",
+				"ogx.io/watch": "true",
+			},
+		},
+		Data: map[string]string{},
+	}
+	err = fakeClient.Create(context.Background(), newCM)
+	require.NoError(t, err)
+
+	// Verify it was created with correct labels
+	var created corev1.ConfigMap
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "ogx-trusted-ca-bundle", Namespace: "test-ns"}, &created)
+	require.NoError(t, err)
+	assert.Equal(t, "true", created.Labels["config.openshift.io/inject-trusted-cabundle"])
+	assert.Equal(t, "true", created.Labels["ogx.io/watch"])
+}
+
 func envVarNames(vars []corev1.EnvVar) []string {
 	names := make([]string, len(vars))
 	for i, v := range vars {

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -1918,7 +1918,7 @@ func strPtr(s string) *string {
 
 func TestOgxCommand_TracingDisabled(t *testing.T) {
 	cmd := ogxCommand(false)
-	assert.Equal(t, []string{"/bin/sh", "-c", "ogx run /etc/ogx/config.yaml --insecure"}, cmd)
+	assert.Equal(t, []string{"/bin/sh", "-c", "ogx run /etc/ogx/config.yaml"}, cmd)
 }
 
 func TestOgxCommand_TracingEnabled(t *testing.T) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-79580

## Description

Replaces the `VLLM_TLS_VERIFY=false` and `--insecure` workarounds with proper CA trust configuration, enabling OGX to verify TLS certificates when connecting to the BFF via the HTTPRoute (#9080).

### What changed

1. **CA trust ConfigMap logic** (`token_k8s_client.go`):
   - Checks if `odh-trusted-ca-bundle` already exists in the user namespace with CA content (DSCI-managed)
   - If yes: reuses it, adds `ogx.io/watch` label for the OGX operator
   - If no: creates `ogx-trusted-ca-bundle` with `config.openshift.io/inject-trusted-cabundle: "true"` label (triggers OpenShift CA injection)

2. **Router-CA fallback**: When creating our own ConfigMap, attempts to read the ingress CA directly from `router-ca` secret in `openshift-ingress-operator` (via SAClient). If RBAC is not granted, gracefully falls back to async CA injection.

3. **spec.tls on OGXServer**: Sets `spec.tls.trust.caCertificates` referencing the appropriate CA bundle ConfigMap. The OGX operator mounts this into the pod.

4. **Removed workarounds**:
   - Removed `VLLM_TLS_VERIFY=false` env var
   - Removed `--insecure` flag from `ogx run` command

5. **RBAC** (`cluster-role.yaml`): Added `get` on `secrets` with `resourceNames: ["router-ca"]` for the fallback path.

6. **Owner reference**: CA ConfigMap (only `ogx-trusted-ca-bundle`, not the DSCI-managed one) gets owner-referenced to OGXServer for garbage collection.

7. **Unit tests**: Two tests covering both paths (DSCI bundle available vs missing).

### Open question — CA type for internal Gateway

During cluster validation, it was discovered that the internal Gateway address (`data-science-gateway-...openshift-ingress.svc.cluster.local`) presents a certificate signed by the **service-serving CA** (`openshift-service-serving-signer`), and not the ingress CA.

The file `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` (already mounted in all pods) contains this CA and successfully validates the TLS handshake:

```
# With service-ca.crt → SUCCESS (HTTP 302)
SSL_CERT_FILE=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
httpx.get('https://data-science-gateway-...svc.cluster.local/...') → 302

# With odh-trusted-ca-bundle → FAILS (CERTIFICATE_VERIFY_FAILED)
# The bundle contains public root CAs but not the service-serving CA
```

**The question is**: Should OGX connect to the BFF via:
- **Internal address** (`.svc.cluster.local`) → needs service-serving CA (already available)
- **External address** (`*.apps.cluster`) → needs ingress CA (from CA injection bundle)

If internal: we could simply set `SSL_CERT_FILE=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt` as env var. If external or both: it will be needed the full CA injection bundle approach implemented here.

## How Has This Been Tested?

### Unit tests
```bash
go test ./internal/integrations/kubernetes/ -run "TestOgxTLSTrust" -v
# PASS: TestOgxTLSTrust_DSCIBundleAvailable
# PASS: TestOgxTLSTrust_DSCIBundleMissing_CreatesOwnConfigMap
```

### Full test suite
```bash
make test  # All packages pass (1 test updated for --insecure removal)
```

### Cluster validation (ROSA 3.6 EA1)

**1. Verified OGX operator mounts CA from spec.tls:**
```bash
oc patch ogxserver lsd-genai-playground -n <ns> --type merge \
  -p '{"spec":{"tls":{"trust":{"caCertificates":[{"name":"odh-trusted-ca-bundle","key":"ca-bundle.crt"}]}}}}'
# Pod restarted, CA mounted at /etc/ssl/certs/ca-bundle/
```

**2. Verified TLS handshake with correct CA:**
```bash
oc exec <ogx-pod> -- python3 -c "
import os; os.environ['SSL_CERT_FILE']='/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
import httpx; r = httpx.get('https://data-science-gateway-...svc.cluster.local/api/v1/genai-proxy/ns/test/v1/models', timeout=10)
print(f'Status: {r.status_code}')  # 302 — TLS handshake SUCCESS
"
```

**3. Confirmed service-serving CA is the correct trust anchor for internal Gateway traffic.**

## Dependencies

- Requires [#9080](https://github.com/opendatahub-io/odh-dashboard/pull/9080) (HTTPRoute) to be merged first
- Decision on internal vs external Gateway address needed before removing draft status