### PR TITLE
fix(RHOAIENG-79095): enable npm prefetch for hermetic EarlyGate builds

### DIFF
--- a/.tekton/odh-dashboard-eg-build-pull-request.yaml
+++ b/.tekton/odh-dashboard-eg-build-pull-request.yaml
@@ -42,7 +42,15 @@ spec:
   - name: build-source-image
     value: "true"
   - name: hermetic
-    value: "false"
+    value: "true"
+  - name: prefetch-input
+    value: |
+      [
+        {
+          "type": "npm",
+          "path": "."
+        }
+      ]
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79095

## Description

EarlyGate `odh-dashboard-eg-build` failed at `RUN npm ci --ignore-scripts` with `npm error Exit handler never called!`.

The failing PipelineRun ran with `--hermetic=true` but no Cachi2 npm prefetch (`prefetch-dir` empty / no prefetch SBOM). Hermetic builds have no network to npmjs, so `npm ci` cannot install dependencies.

This change aligns the EarlyGate PR PipelineRun with downstream `rhoai-3.5`:
- `hermetic: "true"`
- `prefetch-input` for npm at repo root (`.`)

cc @MohammadiIram — you own the `eg-build` EarlyGate PipelineRun; please review.

## How Has This Been Tested?

- Confirmed from Konflux build logs (`odh-dashboard-eg-build-on-pull-request-h6dwb`) that the failure was hermetic + empty cachi2 at the `npm ci` step.
- Confirmed `npm ci --ignore-scripts` succeeds on `eg-build` with normal network (lockfile is not the issue).
- Validation of this change: re-run EarlyGate build on this PR and confirm `npm ci` gets past STEP 7 with a populated cachi2 prefetch.

## Test Impact

N/A — Tekton PipelineRun config only; no product code or unit/Cypress tests.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)