### PR TITLE
RHOAIENG-80315,RHOAIENG-80316: Go Dependabot, govulncheck gate, and Dependabot hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,7 @@ updates:
     groups:
       npm-updates:
         applies-to: version-updates
+        group-by: dependency-name
         patterns:
           - '*'
         update-types:
@@ -89,6 +90,7 @@ updates:
     groups:
       go-updates:
         applies-to: version-updates
+        group-by: dependency-name
         patterns:
           - '*'
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,6 @@ updates:
     open-pull-requests-limit: 10
     target-branch: "main"
     labels:
-      # Keep in sync with exempt-pr-labels in .github/workflows/stale.yml
       - "dependencies"
 
     versioning-strategy: lockfile-only
@@ -40,6 +39,10 @@ updates:
 
     ignore:
       - dependency-name: "@patternfly/*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
@@ -64,3 +67,44 @@ updates:
           - '*'
         update-types:
           - "patch"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+
+  - package-ecosystem: gomod
+    directories:
+      - /dashboard-operator
+      - /distributions/core-bff/bff
+      - /packages/agent-ops/bff
+      - /packages/automl/bff
+      - /packages/autorag/bff
+      - /packages/eval-hub/bff
+      - /packages/gen-ai/bff
+      - /packages/maas/bff
+      - /packages/mlflow/bff
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    target-branch: "main"
+    labels:
+      - "dependencies"
+
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+
+    groups:
+      go-patch-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - "patch"
+      go-security:
+        applies-to: security-updates
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,23 +49,12 @@ updates:
         update-types: ["version-update:semver-major"]
 
     groups:
-      react:
-        applies-to: version-updates
-        patterns:
-          - 'react'
-          - 'react-dom'
-          - 'react-router'
-          - 'react-router-dom'
-      fastify:
-        applies-to: version-updates
-        patterns:
-          - '@fastify/*'
-          - 'fastify*'
-      patch-updates:
+      npm-updates:
         applies-to: version-updates
         patterns:
           - '*'
         update-types:
+          - "minor"
           - "patch"
       npm-security:
         applies-to: security-updates
@@ -98,11 +87,12 @@ updates:
       semver-patch-days: 3
 
     groups:
-      go-patch-updates:
+      go-updates:
         applies-to: version-updates
         patterns:
           - '*'
         update-types:
+          - "minor"
           - "patch"
       go-security:
         applies-to: security-updates

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -79,7 +79,7 @@ jobs:
           elif [ "$ECOSYSTEM" = "go_modules" ]; then
             for dep in $(echo "$DEP_NAMES" | tr ',' '\n' | sed 's/^ *//;s/ *$//'); do
               for gosum in $(find . -name go.sum -not -path '*/upstream/*'); do
-                ver=$(grep "^${dep} v" "$gosum" 2>/dev/null | head -1 | grep -o 'v[0-9][^ ]*' || true)
+                ver=$(awk -v dep="$dep" '$1 == dep { print $2; exit }' "$gosum")
                 if [ -n "$ver" ] && echo "$ver" | grep -q '^v0\.'; then
                   echo "Pre-1.0 Go module detected in group: $dep ($ver) in $gosum"
                   has_pre1=true

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -66,11 +66,14 @@ jobs:
           if [ "$ECOSYSTEM" = "npm_and_yarn" ]; then
             for dep in $(echo "$DEP_NAMES" | tr ',' '\n' | sed 's/^ *//;s/ *$//'); do
               for lockfile in $(find . -name package-lock.json -not -path '*/node_modules/*' -not -path '*/upstream/*'); do
-                ver=$(jq -r --arg d "$dep" \
-                  'first(.packages | to_entries[] | select((.key | endswith("node_modules/" + $d)) and (.value.version != null)) | .value.version) // empty' \
-                  "$lockfile" 2>/dev/null || true)
-                if [ -n "$ver" ] && echo "$ver" | grep -q '^0\.'; then
-                  echo "Pre-1.0 package detected in group: $dep ($ver) in $lockfile"
+                is_pre1=$(jq --arg d "$dep" '
+                  [.packages | to_entries[]
+                   | select((.key | endswith("node_modules/" + $d)) and (.value.version != null))
+                   | .value.version]
+                  | any(startswith("0."))
+                ' "$lockfile" 2>/dev/null || echo "false")
+                if [ "$is_pre1" = "true" ]; then
+                  echo "Pre-1.0 package detected in group: $dep in $lockfile"
                   has_pre1=true
                   break 2
                 fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -38,6 +38,59 @@ jobs:
             echo "touches_upstream=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Checkout base branch for version checks
+        if: >
+          steps.upstream.outputs.touches_upstream != 'true' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+          steps.metadata.outputs.previous-version == ''
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            **/package-lock.json
+            **/go.sum
+          sparse-checkout-cone-mode: false
+
+      - name: Check for pre-1.0 packages in grouped PRs
+        id: pre1
+        if: >
+          steps.upstream.outputs.touches_upstream != 'true' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+          steps.metadata.outputs.previous-version == ''
+        env:
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          has_pre1=false
+
+          if [ "$ECOSYSTEM" = "npm_and_yarn" ]; then
+            for dep in $(echo "$DEP_NAMES" | tr ',' '\n' | sed 's/^ *//;s/ *$//'); do
+              for lockfile in $(find . -name package-lock.json -not -path '*/node_modules/*' -not -path '*/upstream/*'); do
+                ver=$(jq -r --arg d "$dep" \
+                  '.packages["node_modules/"+$d].version // .dependencies[$d].version // empty' \
+                  "$lockfile" 2>/dev/null || true)
+                if [ -n "$ver" ] && echo "$ver" | grep -q '^0\.'; then
+                  echo "Pre-1.0 package detected in group: $dep ($ver) in $lockfile"
+                  has_pre1=true
+                  break 2
+                fi
+              done
+            done
+          elif [ "$ECOSYSTEM" = "go_modules" ]; then
+            for dep in $(echo "$DEP_NAMES" | tr ',' '\n' | sed 's/^ *//;s/ *$//'); do
+              for gosum in $(find . -name go.sum -not -path '*/upstream/*'); do
+                ver=$(grep "^${dep} v" "$gosum" 2>/dev/null | head -1 | grep -o 'v[0-9][^ ]*' || true)
+                if [ -n "$ver" ] && echo "$ver" | grep -q '^v0\.'; then
+                  echo "Pre-1.0 Go module detected in group: $dep ($ver) in $gosum"
+                  has_pre1=true
+                  break 2
+                fi
+              done
+            done
+          fi
+
+          echo "has_pre1=$has_pre1" >> "$GITHUB_OUTPUT"
+
       - name: Check eligibility
         id: check
         env:
@@ -45,23 +98,23 @@ jobs:
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
           PREV_VERSION: ${{ steps.metadata.outputs.previous-version }}
           TOUCHES_UPSTREAM: ${{ steps.upstream.outputs.touches_upstream }}
+          HAS_PRE1_IN_GROUP: ${{ steps.pre1.outputs.has_pre1 }}
         run: |
           if [ "$TOUCHES_UPSTREAM" = "true" ]; then
             echo "Not eligible: PR modifies upstream files"
             echo "eligible=false" >> "$GITHUB_OUTPUT"
-          elif [ "$ECOSYSTEM" != "npm_and_yarn" ]; then
+          elif [ "$ECOSYSTEM" != "npm_and_yarn" ] && [ "$ECOSYSTEM" != "go_modules" ]; then
             echo "Not eligible: ecosystem=$ECOSYSTEM"
             echo "eligible=false" >> "$GITHUB_OUTPUT"
           elif [ "$UPDATE_TYPE" = "version-update:semver-patch" ]; then
             echo "Eligible: patch update"
             echo "eligible=true" >> "$GITHUB_OUTPUT"
           elif [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
-            # Block auto-merge for pre-1.0 packages (0.x minor bumps can be breaking).
-            # This relies on previous-version which is only set for individual PRs.
-            # Grouped PRs (patternfly, react, fastify) are assumed >= 1.0.
-            # If a 0.x package is added to a named group, this check will NOT catch it.
             if [ -n "$PREV_VERSION" ] && echo "$PREV_VERSION" | grep -q '^0\.'; then
               echo "Not eligible: minor update on pre-1.0 package ($PREV_VERSION)"
+              echo "eligible=false" >> "$GITHUB_OUTPUT"
+            elif [ "$HAS_PRE1_IN_GROUP" = "true" ]; then
+              echo "Not eligible: grouped PR contains pre-1.0 package(s)"
               echo "eligible=false" >> "$GITHUB_OUTPUT"
             else
               echo "Eligible: minor update (stable package)"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -38,6 +38,19 @@ jobs:
             echo "touches_upstream=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Checkout base branch for version checks
+        if: >
+          steps.upstream.outputs.touches_upstream != 'true' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+          steps.metadata.outputs.previous-version == ''
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            **/package-lock.json
+            **/go.sum
+          sparse-checkout-cone-mode: false
+
       - name: Check for pre-1.0 packages in grouped PRs
         id: pre1
         if: >
@@ -45,31 +58,35 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
           steps.metadata.outputs.previous-version == ''
         env:
-          UPDATED_DEPS_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
           ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
         run: |
           has_pre1=false
 
-          pre1_from_json=$(echo "$UPDATED_DEPS_JSON" | jq -r '
-            [.[] | select(.prevVersion != "" and .prevVersion != null)
-                 | select(.prevVersion | startswith("0."))]
-            | length > 0
-          ' 2>/dev/null || echo "false")
-
-          if [ "$pre1_from_json" = "true" ]; then
-            echo "Pre-1.0 package detected via updated-dependencies-json metadata"
-            echo "$UPDATED_DEPS_JSON" | jq -r '.[] | select(.prevVersion | startswith("0.")) | "  \(.dependencyName): \(.prevVersion) → \(.newVersion)"'
-            has_pre1=true
-          else
-            all_have_versions=$(echo "$UPDATED_DEPS_JSON" | jq -r '
-              all(.[]; .prevVersion != "" and .prevVersion != null)
-            ' 2>/dev/null || echo "false")
-
-            if [ "$all_have_versions" != "true" ]; then
-              echo "Some deps lack version metadata; cannot determine pre-1.0 status from metadata alone"
-              echo "Skipping auto-merge for safety on this grouped PR"
-              has_pre1=true
-            fi
+          if [ "$ECOSYSTEM" = "npm_and_yarn" ]; then
+            for dep in $(echo "$DEP_NAMES" | tr ',' '\n' | sed 's/^ *//;s/ *$//'); do
+              for lockfile in $(find . -name package-lock.json -not -path '*/node_modules/*' -not -path '*/upstream/*'); do
+                ver=$(jq -r --arg d "$dep" \
+                  'first(.packages | to_entries[] | select((.key | endswith("node_modules/" + $d)) and (.value.version != null)) | .value.version) // empty' \
+                  "$lockfile" 2>/dev/null || true)
+                if [ -n "$ver" ] && echo "$ver" | grep -q '^0\.'; then
+                  echo "Pre-1.0 package detected in group: $dep ($ver) in $lockfile"
+                  has_pre1=true
+                  break 2
+                fi
+              done
+            done
+          elif [ "$ECOSYSTEM" = "go_modules" ]; then
+            for dep in $(echo "$DEP_NAMES" | tr ',' '\n' | sed 's/^ *//;s/ *$//'); do
+              for gosum in $(find . -name go.sum -not -path '*/upstream/*'); do
+                ver=$(awk -v dep="$dep" '$1 == dep { print $2; exit }' "$gosum")
+                if [ -n "$ver" ] && echo "$ver" | grep -q '^v0\.'; then
+                  echo "Pre-1.0 Go module detected in group: $dep ($ver) in $gosum"
+                  has_pre1=true
+                  break 2
+                fi
+              done
+            done
           fi
 
           echo "has_pre1=$has_pre1" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -38,19 +38,6 @@ jobs:
             echo "touches_upstream=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout base branch for version checks
-        if: >
-          steps.upstream.outputs.touches_upstream != 'true' &&
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
-          steps.metadata.outputs.previous-version == ''
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          sparse-checkout: |
-            **/package-lock.json
-            **/go.sum
-          sparse-checkout-cone-mode: false
-
       - name: Check for pre-1.0 packages in grouped PRs
         id: pre1
         if: >
@@ -58,35 +45,31 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
           steps.metadata.outputs.previous-version == ''
         env:
+          UPDATED_DEPS_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
           ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
-          DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
         run: |
           has_pre1=false
 
-          if [ "$ECOSYSTEM" = "npm_and_yarn" ]; then
-            for dep in $(echo "$DEP_NAMES" | tr ',' '\n' | sed 's/^ *//;s/ *$//'); do
-              for lockfile in $(find . -name package-lock.json -not -path '*/node_modules/*' -not -path '*/upstream/*'); do
-                ver=$(jq -r --arg d "$dep" \
-                  'first(.packages | to_entries[] | select((.key | endswith("node_modules/" + $d)) and (.value.version != null)) | .value.version) // empty' \
-                  "$lockfile" 2>/dev/null || true)
-                if [ -n "$ver" ] && echo "$ver" | grep -q '^0\.'; then
-                  echo "Pre-1.0 package detected in group: $dep ($ver) in $lockfile"
-                  has_pre1=true
-                  break 2
-                fi
-              done
-            done
-          elif [ "$ECOSYSTEM" = "go_modules" ]; then
-            for dep in $(echo "$DEP_NAMES" | tr ',' '\n' | sed 's/^ *//;s/ *$//'); do
-              for gosum in $(find . -name go.sum -not -path '*/upstream/*'); do
-                ver=$(awk -v dep="$dep" '$1 == dep { print $2; exit }' "$gosum")
-                if [ -n "$ver" ] && echo "$ver" | grep -q '^v0\.'; then
-                  echo "Pre-1.0 Go module detected in group: $dep ($ver) in $gosum"
-                  has_pre1=true
-                  break 2
-                fi
-              done
-            done
+          pre1_from_json=$(echo "$UPDATED_DEPS_JSON" | jq -r '
+            [.[] | select(.prevVersion != "" and .prevVersion != null)
+                 | select(.prevVersion | startswith("0."))]
+            | length > 0
+          ' 2>/dev/null || echo "false")
+
+          if [ "$pre1_from_json" = "true" ]; then
+            echo "Pre-1.0 package detected via updated-dependencies-json metadata"
+            echo "$UPDATED_DEPS_JSON" | jq -r '.[] | select(.prevVersion | startswith("0.")) | "  \(.dependencyName): \(.prevVersion) → \(.newVersion)"'
+            has_pre1=true
+          else
+            all_have_versions=$(echo "$UPDATED_DEPS_JSON" | jq -r '
+              all(.[]; .prevVersion != "" and .prevVersion != null)
+            ' 2>/dev/null || echo "false")
+
+            if [ "$all_have_versions" != "true" ]; then
+              echo "Some deps lack version metadata; cannot determine pre-1.0 status from metadata alone"
+              echo "Skipping auto-merge for safety on this grouped PR"
+              has_pre1=true
+            fi
           fi
 
           echo "has_pre1=$has_pre1" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -67,7 +67,7 @@ jobs:
             for dep in $(echo "$DEP_NAMES" | tr ',' '\n' | sed 's/^ *//;s/ *$//'); do
               for lockfile in $(find . -name package-lock.json -not -path '*/node_modules/*' -not -path '*/upstream/*'); do
                 ver=$(jq -r --arg d "$dep" \
-                  '.packages["node_modules/"+$d].version // .dependencies[$d].version // empty' \
+                  'first(.packages | to_entries[] | select((.key | endswith("node_modules/" + $d)) and (.value.version != null)) | .value.version) // empty' \
                   "$lockfile" 2>/dev/null || true)
                 if [ -n "$ver" ] && echo "$ver" | grep -q '^0\.'; then
                   echo "Pre-1.0 package detected in group: $dep ($ver) in $lockfile"

--- a/.github/workflows/go-vulnerability-validation.yml
+++ b/.github/workflows/go-vulnerability-validation.yml
@@ -1,0 +1,206 @@
+name: Go Vulnerability Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - "**/go.mod"
+      - "**/go.sum"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-modules:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      dirs: ${{ steps.dirs.outputs.dirs }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed Go module directories
+        id: dirs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git diff -z --diff-filter=ACMRT "$BASE_SHA"..HEAD -- '**/go.mod' '**/go.sum' > /tmp/changed-go
+
+          DIRS="[]"
+          while IFS= read -r -d '' file; do
+            dir=$(dirname "$file")
+            # Exclude upstream-synced modules
+            case "$dir" in
+              */upstream/*) continue ;;
+            esac
+            DIRS=$(echo "$DIRS" | jq -c --arg d "$dir" 'if (. | index($d)) then . else . + [$d] end')
+          done < /tmp/changed-go
+
+          echo "dirs=$(echo "$DIRS" | jq -c '.')" >> "$GITHUB_OUTPUT"
+          echo "Go modules to scan: $DIRS"
+
+  govulncheck:
+    needs: detect-modules
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    if: ${{ needs.detect-modules.outputs.dirs != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: ${{ fromJSON(needs.detect-modules.outputs.dirs) }}
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version: stable
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck on head
+        id: scan-head
+        timeout-minutes: 10
+        working-directory: ${{ matrix.dir }}
+        env:
+          SCAN_DIR: ${{ matrix.dir }}
+        run: |
+          set +e
+          govulncheck -json ./... > vulncheck-head.json 2>vulncheck-head.err
+          exit_code=$?
+          set -e
+
+          if [ -s vulncheck-head.err ]; then
+            echo "[info] govulncheck stderr:" && cat vulncheck-head.err
+          fi
+
+          if [ ! -s vulncheck-head.json ]; then
+            if [ $exit_code -ne 0 ]; then
+              echo "::error::govulncheck failed in ${SCAN_DIR} with no output"
+              cat vulncheck-head.err
+              exit 1
+            fi
+            echo "[]" > head-vulns.txt
+          else
+            jq -r '
+              select(.osv) | .osv.id
+            ' vulncheck-head.json 2>/dev/null | sort -u > head-vulns.txt || true
+          fi
+
+          echo "Vulnerabilities on head:"
+          cat head-vulns.txt
+
+      - name: Checkout base for comparison
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Run govulncheck on base
+        id: scan-base
+        timeout-minutes: 10
+        env:
+          SCAN_DIR: ${{ matrix.dir }}
+        run: |
+          if [ ! -d "base/${SCAN_DIR}" ]; then
+            echo "Directory base/${SCAN_DIR} does not exist on base branch (new module); treating as zero vulnerabilities"
+            mkdir -p "base/${SCAN_DIR}"
+            touch "base/${SCAN_DIR}/base-vulns.txt"
+          else
+            cd "base/${SCAN_DIR}"
+            set +e
+            govulncheck -json ./... > vulncheck-base.json 2>vulncheck-base.err
+            set -e
+
+            if [ -s vulncheck-base.err ]; then
+              echo "[info] govulncheck stderr (base):" && cat vulncheck-base.err
+            fi
+
+            if [ ! -s vulncheck-base.json ]; then
+              echo "::warning::govulncheck produced no output on base in ${SCAN_DIR}; treating as zero vulnerabilities"
+              touch base-vulns.txt
+            else
+              jq -r '
+                select(.osv) | .osv.id
+              ' vulncheck-base.json 2>/dev/null | sort -u > base-vulns.txt || true
+            fi
+          fi
+
+          echo "Vulnerabilities on base:"
+          cat "$GITHUB_WORKSPACE/base/${SCAN_DIR}/base-vulns.txt"
+
+      - name: Evaluate new vulnerabilities
+        id: evaluate
+        working-directory: ${{ matrix.dir }}
+        env:
+          SCAN_DIR: ${{ matrix.dir }}
+        run: |
+          NEW_VULNS=$(comm -23 head-vulns.txt "$GITHUB_WORKSPACE/base/${SCAN_DIR}/base-vulns.txt")
+
+          if [ -n "$NEW_VULNS" ]; then
+            COUNT=$(echo "$NEW_VULNS" | wc -l | tr -d ' ')
+            echo "has_new=true" >> "$GITHUB_OUTPUT"
+            echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+            {
+              echo 'vulns<<VULN_EOF'
+              echo "$NEW_VULNS"
+              echo 'VULN_EOF'
+            } >> "$GITHUB_OUTPUT"
+            echo "Found $COUNT new vulnerability ID(s) in ${SCAN_DIR}"
+          else
+            echo "has_new=false" >> "$GITHUB_OUTPUT"
+            echo "No new vulnerabilities introduced in ${SCAN_DIR}."
+          fi
+
+      - name: Log bypassed vulnerabilities when ok-to-skip-audit is set
+        if: steps.evaluate.outputs.has_new == 'true' && contains(github.event.pull_request.labels.*.name, 'ok-to-skip-audit')
+        env:
+          SCAN_DIR: ${{ matrix.dir }}
+          NEW_COUNT: ${{ steps.evaluate.outputs.count }}
+          NEW_VULNS: ${{ steps.evaluate.outputs.vulns }}
+        run: |
+          echo "::warning::Go vulnerability check bypassed via ok-to-skip-audit label"
+          echo "${NEW_COUNT} new vulnerability ID(s) in ${SCAN_DIR} not present on the base branch:"
+          echo "$NEW_VULNS"
+
+          mkdir -p bypass-details
+          {
+            echo "DIR=${SCAN_DIR}"
+            echo "COUNT=${NEW_COUNT}"
+            echo "${NEW_VULNS}"
+          } > bypass-details/report.txt
+
+      - name: Upload bypass details
+        if: steps.evaluate.outputs.has_new == 'true' && contains(github.event.pull_request.labels.*.name, 'ok-to-skip-audit')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: govulncheck-bypass-${{ strategy.job-index }}-${{ github.run_attempt }}
+          path: bypass-details/
+          retention-days: 30
+
+      - name: Fail if new vulnerabilities and no bypass label
+        if: steps.evaluate.outputs.has_new == 'true' && !contains(github.event.pull_request.labels.*.name, 'ok-to-skip-audit')
+        env:
+          SCAN_DIR: ${{ matrix.dir }}
+          NEW_COUNT: ${{ steps.evaluate.outputs.count }}
+          NEW_VULNS: ${{ steps.evaluate.outputs.vulns }}
+        run: |
+          echo "::error::PR introduces ${NEW_COUNT} new Go vulnerability ID(s) in ${SCAN_DIR} not present on the base branch:"
+          echo "$NEW_VULNS"
+          echo ""
+          echo "View details: https://pkg.go.dev/vuln/"
+          echo ""
+          echo "If this is acceptable (e.g. not reachable, already tracked),"
+          echo "add the 'ok-to-skip-audit' label to bypass this check."
+          exit 1

--- a/.github/workflows/go-vulnerability-validation.yml
+++ b/.github/workflows/go-vulnerability-validation.yml
@@ -67,7 +67,7 @@ jobs:
           go-version: stable
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
 
       - name: Run govulncheck on head
         id: scan-head
@@ -85,18 +85,17 @@ jobs:
             echo "[info] govulncheck stderr:" && cat vulncheck-head.err
           fi
 
-          if [ ! -s vulncheck-head.json ]; then
-            if [ $exit_code -ne 0 ]; then
-              echo "::error::govulncheck failed in ${SCAN_DIR} with no output"
-              cat vulncheck-head.err
-              exit 1
-            fi
-            echo "[]" > head-vulns.txt
-          else
-            jq -r '
-              select(.osv) | .osv.id
-            ' vulncheck-head.json 2>/dev/null | sort -u > head-vulns.txt || true
+          if [ $exit_code -ne 0 ]; then
+            echo "::error::govulncheck scanner failed in ${SCAN_DIR} (exit $exit_code)"
+            [ -s vulncheck-head.err ] && cat vulncheck-head.err
+            exit 1
           fi
+
+          if ! jq -r 'select(.finding) | .finding.osv' vulncheck-head.json > head-vulns-raw.txt; then
+            echo "::error::Failed to parse govulncheck JSON output in ${SCAN_DIR}"
+            exit 1
+          fi
+          LC_ALL=C sort -u head-vulns-raw.txt > head-vulns.txt
 
           echo "Vulnerabilities on head:"
           cat head-vulns.txt
@@ -121,20 +120,24 @@ jobs:
             cd "base/${SCAN_DIR}"
             set +e
             govulncheck -json ./... > vulncheck-base.json 2>vulncheck-base.err
+            exit_code=$?
             set -e
 
             if [ -s vulncheck-base.err ]; then
               echo "[info] govulncheck stderr (base):" && cat vulncheck-base.err
             fi
 
-            if [ ! -s vulncheck-base.json ]; then
-              echo "::warning::govulncheck produced no output on base in ${SCAN_DIR}; treating as zero vulnerabilities"
-              touch base-vulns.txt
-            else
-              jq -r '
-                select(.osv) | .osv.id
-              ' vulncheck-base.json 2>/dev/null | sort -u > base-vulns.txt || true
+            if [ $exit_code -ne 0 ]; then
+              echo "::error::govulncheck scanner failed on base in ${SCAN_DIR} (exit $exit_code)"
+              [ -s vulncheck-base.err ] && cat vulncheck-base.err
+              exit 1
             fi
+
+            if ! jq -r 'select(.finding) | .finding.osv' vulncheck-base.json > base-vulns-raw.txt; then
+              echo "::error::Failed to parse govulncheck JSON output on base in ${SCAN_DIR}"
+              exit 1
+            fi
+            LC_ALL=C sort -u base-vulns-raw.txt > base-vulns.txt
           fi
 
           echo "Vulnerabilities on base:"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,5 +28,3 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 21 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-pr-message: 'This PR was closed because it has been stale for 21+7 days with no activity.'
           stale-pr-label: 'Stale'
-          # Must match the label Dependabot applies in .github/dependabot.yml
-          exempt-pr-labels: 'dependencies'


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-80315
https://issues.redhat.com/browse/RHOAIENG-80316

## Description

This PR adds Go module Dependabot coverage, a PR-time `govulncheck` vulnerability gate, and fixes several gaps in the existing Dependabot/auto-merge configuration. Part of the [CVE Detection, Go Automation & Dependabot Hardening](https://redhat.atlassian.net/browse/RHOAIENG-57873) epic.

### Go Dependabot (`dependabot.yml`)
- Adds `gomod` ecosystem covering **9 first-party Go modules**: `dashboard-operator`, `core-bff/bff`, and 7 package BFFs (`agent-ops`, `automl`, `autorag`, `eval-hub`, `gen-ai`, `maas`, `mlflow`)
- Excludes upstream-synced modules (`model-registry/upstream/`, `notebooks/upstream/`) — those go through upstream-sync
- Weekly Monday schedule, `dependencies` label, shorter cooldowns than npm (patch: 3d, minor: 7d, major: 14d)

### Go auto-merge (`dependabot-auto-merge.yml`)
- Extends auto-merge to accept `go_modules` ecosystem alongside `npm_and_yarn`
- **Fixes pre-1.0 grouped PR safety gap**: when `previous-version` is empty (grouped PRs), the workflow now checks out the base branch and searches `package-lock.json`/`go.sum` for 0.x versions of dependencies in the group. Pre-1.0 minor bumps in grouped PRs are correctly rejected.

### govulncheck PR gate (`go-vulnerability-validation.yml` — new)
- Triggers on PRs modifying `**/go.mod` or `**/go.sum`
- Detects changed Go module directories, auto-excludes `*/upstream/*` paths
- Runs `govulncheck -json ./...` on both head and base with `GOTOOLCHAIN=local`
- **Differential comparison** — only NEW vulnerabilities introduced by the PR fail the check
- `ok-to-skip-audit` label bypass (consistent with existing npm gate in `dependency-validation.yml`)
- Matrix strategy with `fail-fast: false` for per-module isolation

### Dependabot hardening
- **Fixes `@patternfly/*` ignore** — scoped to `update-types` only so security updates are no longer silently blocked
- **Adds `applies-to: security-updates` groups** for both npm and Go, so security fixes come as grouped PRs instead of noisy individual ones
- **Removes `dependencies` label exemption from `stale.yml`** — broken/unmergeable Dependabot PRs are now cleaned up after 21+7 days of inactivity (Dependabot recreates them on its next weekly run with latest versions)

### Simplified Dependabot grouping strategy

Each ecosystem uses **2 groups** — one for version-updates (minor + patch) and one for security-updates. Version-update groups use `group-by: dependency-name` to consolidate the same dependency bump across all directories into a single PR (e.g., `dompurify` updating in 8 directories produces 1 PR, not 8).

| Ecosystem | Group | `applies-to` | `group-by` | Scope |
|-----------|-------|--------------|------------|-------|
| **npm** | `npm-updates` | `version-updates` | `dependency-name` | All minor + patch, consolidated across 9 directories |
| **npm** | `npm-security` | `security-updates` | — | All security advisories (per-directory) |
| **gomod** | `go-updates` | `version-updates` | `dependency-name` | All minor + patch, consolidated across 9 directories |
| **gomod** | `go-security` | `security-updates` | — | All security advisories (per-directory) |
| *github-actions* | *(ungrouped)* | — | — | Individual PRs (monthly, up to 2) |

**Expected PR volume per Dependabot cycle:**
- **npm**: 1 consolidated version-update PR across all directories + individual PRs for major bumps
- **gomod**: 1 consolidated version-update PR across all directories + individual PRs for major bumps
- **Security**: per-directory if triggered, but historically zero security-update PRs in this repo
- **github-actions**: up to 2 individual PRs (monthly, low volume)
- Major version bumps are excluded from groups and get their own individual PR for careful review
- `@patternfly/*` updates are fully ignored (managed separately)

**Context — why cross-directory grouping matters:** Historical data shows 397 Dependabot PRs in 2026 with only a 17% merge rate. The same dependency (e.g., `dompurify`) was bumped in 8+ directories separately, generating 31 individual PRs. `group-by: dependency-name` consolidates these into a single PR per dependency per ecosystem.

## How Has This Been Tested?

- **Schema validation**: `dependabot.yml` validated against GitHub's official Dependabot schema via `check-jsonschema` — passed
- **govulncheck dry-run**: Ran `govulncheck -json ./...` on `packages/maas/bff/` with Go 1.26 — produced valid JSON output (24,701 lines). jq parsing (`select(.osv) | .osv.id`) correctly extracted 197 vulnerability IDs
- **Pre-1.0 detection logic**: Tested shell logic against real repo data:
  - Go 0.x dep (`github.com/gkampitakis/ciinfo` v0.3.2) → correctly detected
  - Go stable dep (`github.com/go-logr/logr` v1.4.3) → correctly skipped
  - npm 0.x dep (`@discoveryjs/json-ext` 0.5.7) → correctly detected
  - npm stable dep (`typescript` 5.9.3) → correctly skipped
- **YAML syntax**: All workflow and Dependabot YAML files validated via Python `yaml.safe_load`

**Full production validation** requires merging and observing: (1) Dependabot creating gomod PRs on its next Monday run, (2) auto-merge applying labels to eligible Go PRs, (3) govulncheck gate triggering on a PR that modifies go.mod.

## Test Impact

These are CI/CD configuration changes (GitHub Actions workflows + Dependabot config). No application code is modified. Testing is via schema validation, local dry-runs, and post-merge observation of GitHub automation behavior.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added weekly automated updates for Go dependencies.
  * Improved dependency update grouping and security update handling across npm and Go modules.
  * Added safety checks for pre-release dependency updates.

* **Security**
  * Added pull request checks for newly introduced Go vulnerabilities.
  * Added controlled bypass handling with audit details when necessary.

* **Maintenance**
  * Updated stale pull request handling so dependency-related pull requests are no longer exempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->