### PR TITLE
Add tool calling card on preconfigure deployment step

### DIFF
--- a/frontend/src/__mocks__/mockValidatedConfigurations.ts
+++ b/frontend/src/__mocks__/mockValidatedConfigurations.ts
@@ -1,0 +1,22 @@
+import type { ValidatedConfiguration } from '@odh-dashboard/model-serving/shared';
+
+export const TOOL_CALLING_VALIDATED_ARGS_VALUE = [
+  '--enable-auto-tool-choice',
+  '--tool-call-parser hermes',
+  '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+].join(' \\\n');
+
+export const mockToolCallingValidatedConfiguration = (): ValidatedConfiguration => ({
+  forField: 'args',
+  title: 'Validated arguments',
+  description:
+    'This model has runtime configurations that have been tested and validated by Red Hat. Selected configurations will be applied as runtime arguments in your deployment.',
+  options: [
+    {
+      title: 'Tool calling',
+      description:
+        'Allows the model to call external tools and APIs, enabling it to take actions like querying databases or running code.',
+      value: TOOL_CALLING_VALIDATED_ARGS_VALUE,
+    },
+  ],
+});

--- a/packages/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
+++ b/packages/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
@@ -1,8 +1,6 @@
 class ModelDetailsPage {
-  visit() {
-    const sourceName = 'source-2';
-    const modelName = 'sample%20category%201-model-1';
-    cy.visitWithLogin(`/ai-hub/models/catalog/${sourceName}/${modelName}/overview`);
+  visit(sourceId = 'source-2', modelName = 'sample%20category%201-model-1') {
+    cy.visitWithLogin(`/ai-hub/models/catalog/${sourceId}/${modelName}/overview`);
     this.wait();
   }
 

--- a/packages/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
+++ b/packages/cypress/cypress/pages/modelCatalog/modelDetailsPage.ts
@@ -146,7 +146,7 @@ class ModelDetailsPage {
   }
 
   findToolCallingToggle() {
-    return cy.get('#tool-calling-toggle');
+    return this.findToolCallingCard().findByRole('button', { name: 'Tool Calling' });
   }
 
   findValidatedDeploymentResourceLabels() {

--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -968,9 +968,10 @@ class ModelServingWizard extends Wizard {
   }
 
   visitWithValidatedConfigurations(initialData: Record<string, unknown>) {
-    cy.visit('/ai-hub/models/deployments/deploy', {
+    const url = '/ai-hub/models/deployments/deploy';
+    cy.visit(url, {
       onBeforeLoad(win) {
-        win.history.pushState({ initialData }, '', '/ai-hub/models/deployments/deploy');
+        win.history.pushState({ usr: { initialData } }, '', url);
       },
     });
     cy.findByTestId('app-page-title').contains('Deploy a model');

--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -967,16 +967,6 @@ class ModelServingWizard extends Wizard {
     return cy.findByTestId(`validated-configuration-arguments-popover-content-${optionSlug}`);
   }
 
-  visitWithValidatedConfigurations(initialData: Record<string, unknown>) {
-    const url = '/ai-hub/models/deployments/deploy';
-    cy.visit(url, {
-      onBeforeLoad(win) {
-        win.history.pushState({ usr: { initialData } }, '', url);
-      },
-    });
-    cy.findByTestId('app-page-title').contains('Deploy a model');
-  }
-
   findModelSourceStep() {
     return this.findStep('source-model-step');
   }

--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -947,6 +947,35 @@ class ModelServingWizard extends Wizard {
     return cy.findByTestId('project-selector-menuList').findByRole('menuitem', { name });
   }
 
+  findValidatedConfigurationSection(forField: string) {
+    return cy.findByTestId(`validated-configuration-section-${forField}`);
+  }
+
+  findValidatedConfigurationOption(optionSlug: string) {
+    return cy.findByTestId(`validated-configuration-option-${optionSlug}`);
+  }
+
+  findValidatedConfigurationOptionCheckbox(optionSlug: string) {
+    return cy.findByTestId(`validated-configuration-option-checkbox-${optionSlug}`);
+  }
+
+  findValidatedConfigurationViewArguments(optionSlug: string) {
+    return cy.findByTestId(`validated-configuration-view-arguments-${optionSlug}`);
+  }
+
+  findValidatedConfigurationArgumentsPopoverContent(optionSlug: string) {
+    return cy.findByTestId(`validated-configuration-arguments-popover-content-${optionSlug}`);
+  }
+
+  visitWithValidatedConfigurations(initialData: Record<string, unknown>) {
+    cy.visit('/ai-hub/models/deployments/deploy', {
+      onBeforeLoad(win) {
+        win.history.pushState({ initialData }, '', '/ai-hub/models/deployments/deploy');
+      },
+    });
+    cy.findByTestId('app-page-title').contains('Deploy a model');
+  }
+
   findModelSourceStep() {
     return this.findStep('source-model-step');
   }

--- a/packages/model-registry/shared/index.ts
+++ b/packages/model-registry/shared/index.ts
@@ -12,6 +12,7 @@ export type DeployPrefillData = {
     description: string;
     options: { title: string; description: string; value: string }[];
   }[];
+  selectedValidatedConfigurations?: Record<string, string[]>;
 };
 
 export type ModelDeployPrefillInfo = {

--- a/packages/model-registry/upstream/frontend/src/app/hooks/useModelRegistryDashboardConfig.ts
+++ b/packages/model-registry/upstream/frontend/src/app/hooks/useModelRegistryDashboardConfig.ts
@@ -8,7 +8,7 @@ type ModelRegistryDashboardConfig = {
 const useModelRegistryDashboardConfig = (): ModelRegistryDashboardConfig => {
   const config = React.useContext(DashboardConfigContext);
   return {
-    toolCalling: config === null ? true : (config.dashboardConfig.toolCalling ?? false),
+    toolCalling: config === null ? false : (config.dashboardConfig.toolCalling ?? false),
   };
 };
 

--- a/packages/model-registry/upstream/frontend/src/app/hooks/useModelRegistryDashboardConfig.ts
+++ b/packages/model-registry/upstream/frontend/src/app/hooks/useModelRegistryDashboardConfig.ts
@@ -8,7 +8,7 @@ type ModelRegistryDashboardConfig = {
 const useModelRegistryDashboardConfig = (): ModelRegistryDashboardConfig => {
   const config = React.useContext(DashboardConfigContext);
   return {
-    toolCalling: config === null ? false : (config.dashboardConfig.toolCalling ?? false),
+    toolCalling: config === null ? true : (config.dashboardConfig.toolCalling ?? false),
   };
 };
 

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -1917,6 +1917,23 @@ describe('getToolCallingArgs', () => {
     });
     expect(result).toBe('--tool-call-parser mistral');
   });
+
+  it('should quote values containing whitespace', () => {
+    const result = getToolCallingArgs({
+      toolCallParser: 'parser with spaces',
+      chatTemplate: '/path with spaces/template.jinja',
+    });
+    expect(result).toContain('--tool-call-parser "parser with spaces"');
+    expect(result).toContain('--chat-template "/path with spaces/template.jinja"');
+  });
+
+  it('should trim and omit empty requiredArgs entries', () => {
+    const result = getToolCallingArgs({
+      toolCallParser: 'granite',
+      requiredArgs: ['  --config_format granite  ', '   '],
+    });
+    expect(result).toBe('--tool-call-parser granite \\\n--config_format granite');
+  });
 });
 
 describe('getValidatedConfigurationsForModel', () => {

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -44,9 +44,9 @@ import {
   getActiveSourceLabels,
   hasValidatedToolCalling,
   getToolCallingArgs,
+  getValidatedConfigurationsForModel,
   getSortParams,
   getEffectiveSortBy,
-  servingConfigToValidatedConfigurations,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { mockCatalogModelArtifact } from '~/__mocks__/mockCatalogModelArtifactList';
 import { ModelRegistryMetadataType } from '~/app/types';
@@ -1920,6 +1920,40 @@ describe('getToolCallingArgs', () => {
   });
 });
 
+describe('getValidatedConfigurationsForModel', () => {
+  const validatedToolCallingModel = {
+    name: 'test-model',
+    validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+    servingConfig: { toolCalling: { toolCallParser: 'granite' } },
+  };
+
+  it('should return empty object when the toolCalling flag is disabled', () => {
+    expect(getValidatedConfigurationsForModel(validatedToolCallingModel, false)).toEqual({});
+  });
+
+  it('should return empty object when the model has no validated tool calling', () => {
+    expect(getValidatedConfigurationsForModel({ name: 'test-model' }, true)).toEqual({});
+  });
+
+  it('should return validatedConfigurations and selectedValidatedConfigurations when enabled and validated', () => {
+    const result = getValidatedConfigurationsForModel(validatedToolCallingModel, true);
+
+    expect(result.validatedConfigurations).toHaveLength(1);
+    expect(result.validatedConfigurations?.[0]).toMatchObject({
+      forField: 'args',
+      title: 'Validated arguments',
+    });
+    expect(result.validatedConfigurations?.[0].options).toHaveLength(1);
+    expect(result.validatedConfigurations?.[0].options[0]).toMatchObject({
+      title: 'Tool calling',
+      value: '--tool-call-parser granite',
+    });
+    expect(result.selectedValidatedConfigurations).toEqual({
+      args: ['--tool-call-parser granite'],
+    });
+  });
+});
+
 describe('getEffectiveSortBy', () => {
   it('returns the provided sortBy when not null', () => {
     expect(getEffectiveSortBy(ModelCatalogSortOption.LOWEST_LATENCY, false)).toBe(
@@ -1991,53 +2025,3 @@ describe('getSortParams', () => {
   });
 });
 
-describe('servingConfigToValidatedConfigurations', () => {
-  it('returns undefined when model has no servingConfig', () => {
-    const model: CatalogModel = {
-      name: 'test-model',
-    };
-    expect(servingConfigToValidatedConfigurations(model)).toBeUndefined();
-  });
-
-  it('returns undefined when toolCalling has no validatedTasks', () => {
-    const model: CatalogModel = {
-      name: 'test-model',
-      servingConfig: {
-        toolCalling: {
-          toolCallParser: 'hermes',
-        },
-      },
-      validatedTasks: [],
-    };
-    expect(servingConfigToValidatedConfigurations(model)).toBeUndefined();
-  });
-
-  it('returns a ValidatedConfiguration array when model has valid tool calling config', () => {
-    const model: CatalogModel = {
-      name: 'test-model',
-      servingConfig: {
-        toolCalling: {
-          toolCallParser: 'hermes',
-        },
-      },
-      validatedTasks: [ModelCatalogTask.TOOL_CALLING],
-    };
-
-    const result = servingConfigToValidatedConfigurations(model);
-
-    expect(result).toBeDefined();
-    expect(result).toHaveLength(1);
-    expect(result![0]).toEqual({
-      forField: 'runtimeArgs',
-      title: 'Tool calling',
-      description: 'Validated tool calling configuration for this model',
-      options: [
-        {
-          title: 'hermes',
-          description: 'Enable tool calling with validated configuration',
-          value: '--tool-call-parser hermes',
-        },
-      ],
-    });
-  });
-});

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -10,7 +10,6 @@ import {
   CatalogArtifactType,
   CatalogArtifacts,
   MetricsType,
-  CatalogModel,
 } from '~/app/modelCatalogTypes';
 import {
   AllLanguageCode,
@@ -2024,4 +2023,3 @@ describe('getSortParams', () => {
     });
   });
 });
-

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -215,6 +215,51 @@ export const getToolCallingArgs = (config?: ToolCallingConfig): string => {
   return parts.join(' \\\n');
 };
 
+/**
+ * Builds the `validatedConfigurations` entries to prefill into the deployment wizard for a
+ * catalog model. Each supported validated configuration (currently just tool calling) is
+ * responsible for its own gating here — the wizard itself renders whatever it receives, with
+ * no knowledge of individual feature flags or model fields.
+ *
+ * Returns both the available configurations and a pre-selection record so that validated
+ * options are checked by default when the wizard opens.
+ */
+export const getValidatedConfigurationsForModel = (
+  model: CatalogModel,
+  isToolCallingEnabled: boolean,
+): Pick<DeployPrefillData, 'validatedConfigurations' | 'selectedValidatedConfigurations'> => {
+  const options: NonNullable<DeployPrefillData['validatedConfigurations']>[number]['options'] = [];
+
+  if (isToolCallingEnabled && hasValidatedToolCalling(model)) {
+    options.push({
+      title: 'Tool calling',
+      description:
+        'Allows the model to call external tools and APIs, enabling it to take actions like querying databases or running code.',
+      value: getToolCallingArgs(model.servingConfig?.toolCalling),
+    });
+  }
+
+  if (options.length === 0) {
+    return {};
+  }
+
+  const validatedConfigurations: DeployPrefillData['validatedConfigurations'] = [
+    {
+      forField: 'args',
+      title: 'Validated arguments',
+      description:
+        'This model has runtime configurations that have been tested and validated by Red Hat. Selected configurations will be applied as runtime arguments in your deployment.',
+      options,
+    },
+  ];
+
+  const selectedValidatedConfigurations: Record<string, string[]> = {
+    args: options.map((option) => option.value),
+  };
+
+  return { validatedConfigurations, selectedValidatedConfigurations };
+};
+
 const isArrayOfSelections = (
   filterOption: CatalogFilterOptions[keyof CatalogFilterOptions],
   data: unknown,
@@ -831,34 +876,4 @@ export const getMinimumVramFromCustomProperties = (
     return `${doubleVal.toFixed(2)} GB`;
   }
   return getCustomPropString(customProperties, CatalogModelCustomPropertyKey.MINIMUM_VRAM);
-};
-
-/**
- * Converts a CatalogModel's serving config into generic ValidatedConfiguration entries
- * for the deployment wizard's preconfigure step.
- */
-export const servingConfigToValidatedConfigurations = (
-  model: CatalogModel,
-): DeployPrefillData['validatedConfigurations'] => {
-  if (!hasValidatedToolCalling(model)) {
-    return undefined;
-  }
-
-  const toolCalling = model.servingConfig!.toolCalling!;
-  const argsValue = getToolCallingArgs(toolCalling);
-
-  return [
-    {
-      forField: 'runtimeArgs',
-      title: 'Tool calling',
-      description: 'Validated tool calling configuration for this model',
-      options: [
-        {
-          title: toolCalling.toolCallParser!,
-          description: 'Enable tool calling with validated configuration',
-          value: argsValue,
-        },
-      ],
-    },
-  ];
 };

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -198,19 +198,27 @@ export const hasValidatedToolCalling = (model: CatalogModel): boolean =>
   model.validatedTasks?.includes(ModelCatalogTask.TOOL_CALLING) === true &&
   !!model.servingConfig?.toolCalling?.toolCallParser;
 
+const quoteCliArgValue = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed || !/\s/.test(trimmed)) {
+    return trimmed;
+  }
+  return `"${trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+};
+
 export const getToolCallingArgs = (config?: ToolCallingConfig): string => {
   const parts: string[] = [];
   if (config?.enableAutoToolChoice) {
     parts.push('--enable-auto-tool-choice');
   }
   if (config?.toolCallParser) {
-    parts.push(`--tool-call-parser ${config.toolCallParser}`);
+    parts.push(`--tool-call-parser ${quoteCliArgValue(config.toolCallParser)}`);
   }
   if (config?.chatTemplate) {
-    parts.push(`--chat-template ${config.chatTemplate}`);
+    parts.push(`--chat-template ${quoteCliArgValue(config.chatTemplate)}`);
   }
   if (config?.requiredArgs) {
-    parts.push(...config.requiredArgs);
+    parts.push(...config.requiredArgs.map((arg) => arg.trim()).filter(Boolean));
   }
   return parts.join(' \\\n');
 };

--- a/packages/model-registry/upstream/frontend/src/odh/components/CatalogDeployAction.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/CatalogDeployAction.tsx
@@ -10,7 +10,7 @@ import { getCatalogModelDetailsRoute } from '~/app/routes/modelCatalog/catalogMo
 import {
   decodeParams,
   getModelArtifactUri,
-  servingConfigToValidatedConfigurations,
+  getValidatedConfigurationsForModel,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { getDeployButtonState } from '~/odh/utils';
 import useModelRegistryDashboardConfig from '~/app/hooks/useModelRegistryDashboardConfig';
@@ -53,11 +53,9 @@ const CatalogDeployAction: React.FC<CatalogDeployActionProps> = ({ model }) => {
       cancelReturnRouteValue: cancelReturnRoute,
       wizardStartIndex: 1,
       prefillAlertText: `The ${model.name} model details have been imported from the model catalog.`,
-      validatedConfigurations: isToolCallingEnabled
-        ? servingConfigToValidatedConfigurations(model)
-        : undefined,
+      ...getValidatedConfigurationsForModel(model, isToolCallingEnabled),
     }),
-    [uri, cancelReturnRoute, isToolCallingEnabled, model],
+    [model, uri, cancelReturnRoute, isToolCallingEnabled],
   );
 
   const [navigateExtensions, navigateExtensionsLoaded] = useResolvedExtensions(

--- a/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
@@ -1,0 +1,101 @@
+import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
+import { mockToolCallingValidatedConfiguration } from '@odh-dashboard/internal/__mocks__/mockValidatedConfigurations';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { ProjectModel } from '@odh-dashboard/cypress/cypress/utils/models';
+import { modelServingWizard } from '@odh-dashboard/cypress/cypress/pages/modelServing';
+
+const mockValidatedConfigurationsInitialData = {
+  validatedConfigurations: [mockToolCallingValidatedConfiguration()],
+};
+
+const initIntercepts = () => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+      },
+    }),
+  );
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableNIMModelServing: true,
+      disableKServe: false,
+    }),
+  );
+  cy.interceptOdh('GET /api/components', null, []);
+  cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProjectK8sResource({})]));
+};
+
+describe('Preconfigure deployment validated arguments', () => {
+  it('should render validated argument cards when validatedConfigurations is provided', () => {
+    initIntercepts();
+    modelServingWizard.visitWithValidatedConfigurations(mockValidatedConfigurationsInitialData);
+
+    modelServingWizard.findPreconfigureStep().should('be.enabled');
+    modelServingWizard.findValidatedConfigurationSection('args').should('be.visible');
+    modelServingWizard.findValidatedConfigurationOption('tool-calling').should('be.visible');
+    modelServingWizard
+      .findValidatedConfigurationOption('tool-calling')
+      .should('contain.text', 'Tool calling');
+  });
+
+  it('should toggle validated argument card selection', () => {
+    initIntercepts();
+    modelServingWizard.visitWithValidatedConfigurations(mockValidatedConfigurationsInitialData);
+
+    modelServingWizard.findValidatedConfigurationOptionCheckbox('tool-calling').click();
+    modelServingWizard
+      .findValidatedConfigurationOption('tool-calling')
+      .should('have.attr', 'aria-selected', 'true');
+    modelServingWizard.findValidatedConfigurationOptionCheckbox('tool-calling').click();
+    modelServingWizard
+      .findValidatedConfigurationOption('tool-calling')
+      .should('have.attr', 'aria-selected', 'false');
+  });
+
+  it('should display formatted CLI args in the view arguments popover', () => {
+    initIntercepts();
+    modelServingWizard.visitWithValidatedConfigurations(mockValidatedConfigurationsInitialData);
+
+    modelServingWizard.findValidatedConfigurationViewArguments('tool-calling').click();
+    modelServingWizard
+      .findValidatedConfigurationArgumentsPopoverContent('tool-calling')
+      .should('contain.text', '--enable-auto-tool-choice');
+    modelServingWizard
+      .findValidatedConfigurationArgumentsPopoverContent('tool-calling')
+      .should('contain.text', '--tool-call-parser hermes');
+  });
+
+  it('should not render validated arguments when validatedConfigurations is absent', () => {
+    initIntercepts();
+    modelServingWizard.visit();
+
+    modelServingWizard.findPreconfigureStep().should('be.enabled');
+    cy.findByTestId('validated-configuration-section-args').should('not.exist');
+  });
+
+  it('should not render option cards when a configuration has no options', () => {
+    initIntercepts();
+    modelServingWizard.visitWithValidatedConfigurations({
+      validatedConfigurations: [
+        {
+          forField: 'args',
+          title: 'Validated arguments',
+          description: 'No options available for this model.',
+          options: [],
+        },
+      ],
+    });
+
+    modelServingWizard.findPreconfigureStep().should('be.enabled');
+    modelServingWizard.findValidatedConfigurationSection('args').should('be.visible');
+    cy.findByTestId('validated-configuration-options-args')
+      .find('[data-testid^="validated-configuration-option-"]')
+      .should('not.exist');
+  });
+});

--- a/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
@@ -50,12 +50,13 @@ describe('Preconfigure deployment validated arguments', () => {
 
     modelServingWizard.findValidatedConfigurationOptionCheckbox('tool-calling').click();
     modelServingWizard
-      .findValidatedConfigurationOption('tool-calling')
-      .should('have.attr', 'aria-selected', 'true');
+      .findValidatedConfigurationOptionCheckbox('tool-calling')
+      .should('be.checked');
+
     modelServingWizard.findValidatedConfigurationOptionCheckbox('tool-calling').click();
     modelServingWizard
-      .findValidatedConfigurationOption('tool-calling')
-      .should('have.attr', 'aria-selected', 'false');
+      .findValidatedConfigurationOptionCheckbox('tool-calling')
+      .should('not.be.checked');
   });
 
   it('should display formatted CLI args in the view arguments popover', () => {

--- a/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
@@ -1,22 +1,63 @@
 import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockDsciStatus } from '@odh-dashboard/internal/__mocks__/mockDsciStatus';
+import { mockConnectionTypeConfigMap } from '@odh-dashboard/internal/__mocks__/mockConnectionType';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
-import { mockToolCallingValidatedConfiguration } from '@odh-dashboard/internal/__mocks__/mockValidatedConfigurations';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { asProductAdminUser } from '@odh-dashboard/cypress/cypress/utils/mockUsers';
 import { ProjectModel } from '@odh-dashboard/cypress/cypress/utils/models';
+import { modelDetailsPage } from '@odh-dashboard/cypress/cypress/pages/modelCatalog/modelDetailsPage';
+import { modelCatalog } from '@odh-dashboard/cypress/cypress/pages/modelCatalog/modelCatalog';
 import { modelServingWizard } from '@odh-dashboard/cypress/cypress/pages/modelServing';
 
-const mockValidatedConfigurationsInitialData = {
-  validatedConfigurations: [mockToolCallingValidatedConfiguration()],
+const API_VERSION = 'v1';
+const SOURCE_ID = 'sample-source';
+const MODEL_NAME = 'validated-model';
+const REGISTRIES_NAMESPACE = 'odh-model-registries';
+const MODEL_URI = 'oci://quay.io/test-org/validated-model:latest';
+
+/* eslint-disable camelcase -- catalog API payloads use snake_case field names */
+const catalogModel = {
+  source_id: SOURCE_ID,
+  name: MODEL_NAME,
+  description: 'Validated catalog model with tool calling for deploy handoff tests.',
+  provider: 'provider1',
+  license: 'apache-2.0',
+  tasks: ['text-generation', 'tool-calling'],
+  validatedTasks: ['tool-calling'],
+  customProperties: {
+    validated: {
+      metadataType: 'MetadataStringValue',
+      string_value: '',
+    },
+    validated_on: {
+      metadataType: 'MetadataStringValue',
+      string_value: '["RHOAI 2.20","RHAIIS 3.0","vLLM v0.8.5 - CUDA"]',
+    },
+  },
+  servingConfig: {
+    toolCalling: {
+      toolCallParser: 'granite',
+      chatTemplate: 'opt/app-root/template/tool_chat_template_granite.jinja',
+      enableAutoToolChoice: true,
+    },
+  },
 };
+/* eslint-enable camelcase */
 
 const initIntercepts = () => {
+  asProductAdminUser();
+
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
       components: {
         [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+        [DataScienceStackComponent.MODEL_REGISTRY]: {
+          managementState: 'Managed',
+          registriesNamespace: REGISTRIES_NAMESPACE,
+        },
       },
     }),
   );
@@ -25,78 +66,110 @@ const initIntercepts = () => {
     mockDashboardConfig({
       disableNIMModelServing: true,
       disableKServe: false,
+      disableModelCatalog: false,
+      disableModelRegistry: false,
+      toolCalling: true,
     }),
   );
+  cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({}));
   cy.interceptOdh('GET /api/components', null, []);
+  cy.interceptOdh('GET /api/connection-types', [
+    mockConnectionTypeConfigMap({
+      displayName: 'URI - v1',
+      name: 'uri-v1',
+      category: ['existing-category'],
+      fields: [
+        {
+          type: 'uri',
+          name: 'URI',
+          envVar: 'URI',
+          required: true,
+          properties: {},
+        },
+      ],
+    }),
+  ]);
   cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProjectK8sResource({})]));
+
+  cy.interceptOdh(
+    'GET /model-registry/api/:apiVersion/user',
+    { path: { apiVersion: API_VERSION } },
+    { data: { userId: 'user@example.com', clusterAdmin: true } },
+  );
+  cy.interceptOdh(
+    'GET /model-registry/api/:apiVersion/namespaces',
+    { path: { apiVersion: API_VERSION } },
+    { data: [{ metadata: { name: REGISTRIES_NAMESPACE } }] },
+  );
+  cy.interceptOdh(
+    'GET /model-registry/api/:apiVersion/model_registry',
+    { path: { apiVersion: API_VERSION } },
+    { data: [] },
+  );
+  cy.interceptOdh(
+    'GET /model-registry/api/:apiVersion/model_catalog/sources',
+    { path: { apiVersion: API_VERSION } },
+    {
+      data: {
+        items: [
+          {
+            id: SOURCE_ID,
+            name: 'Sample source',
+            enabled: true,
+            labels: ['Community'],
+            status: 'available',
+          },
+        ],
+        size: 1,
+        pageSize: 10,
+        nextPageToken: '',
+      },
+    },
+  );
+  cy.intercept(
+    'GET',
+    `**/model-registry/api/${API_VERSION}/model_catalog/sources/${SOURCE_ID}/models/**`,
+    { body: { data: catalogModel } },
+  );
+  cy.intercept(
+    'GET',
+    `**/model-registry/api/${API_VERSION}/model_catalog/sources/${SOURCE_ID}/artifacts/**`,
+    {
+      body: {
+        data: {
+          items: [
+            {
+              artifactType: 'model-artifact',
+              createTimeSinceEpoch: '1739210683000',
+              lastUpdateTimeSinceEpoch: '1739210683000',
+              uri: MODEL_URI,
+              customProperties: {},
+            },
+          ],
+          size: 1,
+          pageSize: 10,
+          nextPageToken: '',
+        },
+      },
+    },
+  );
 };
 
 describe('Preconfigure deployment validated arguments', () => {
-  it('should render validated argument cards when validatedConfigurations is provided', () => {
+  it('should carry validated arguments from catalog deploy into the wizard', () => {
     initIntercepts();
-    modelServingWizard.visitWithValidatedConfigurations(mockValidatedConfigurationsInitialData);
+    modelDetailsPage.visit(SOURCE_ID, MODEL_NAME);
+
+    modelDetailsPage.findValidatedConfigurationsCard().should('be.visible');
+    modelDetailsPage.findToolCallingCard().should('contain.text', 'Tool calling');
+
+    modelCatalog.clickDeployModelButtonWithRetry();
 
     modelServingWizard.findPreconfigureStep().should('be.enabled');
     modelServingWizard.findValidatedConfigurationSection('args').should('be.visible');
     modelServingWizard.findValidatedConfigurationOption('tool-calling').should('be.visible');
     modelServingWizard
-      .findValidatedConfigurationOption('tool-calling')
-      .should('contain.text', 'Tool calling');
-  });
-
-  it('should toggle validated argument card selection', () => {
-    initIntercepts();
-    modelServingWizard.visitWithValidatedConfigurations(mockValidatedConfigurationsInitialData);
-
-    modelServingWizard.findValidatedConfigurationOptionCheckbox('tool-calling').click();
-    modelServingWizard
       .findValidatedConfigurationOptionCheckbox('tool-calling')
       .should('be.checked');
-
-    modelServingWizard.findValidatedConfigurationOptionCheckbox('tool-calling').click();
-    modelServingWizard
-      .findValidatedConfigurationOptionCheckbox('tool-calling')
-      .should('not.be.checked');
-  });
-
-  it('should display formatted CLI args in the view arguments popover', () => {
-    initIntercepts();
-    modelServingWizard.visitWithValidatedConfigurations(mockValidatedConfigurationsInitialData);
-
-    modelServingWizard.findValidatedConfigurationViewArguments('tool-calling').click();
-    modelServingWizard
-      .findValidatedConfigurationArgumentsPopoverContent('tool-calling')
-      .should('contain.text', '--enable-auto-tool-choice');
-    modelServingWizard
-      .findValidatedConfigurationArgumentsPopoverContent('tool-calling')
-      .should('contain.text', '--tool-call-parser hermes');
-  });
-
-  it('should not render validated arguments when validatedConfigurations is absent', () => {
-    initIntercepts();
-    modelServingWizard.visit();
-
-    modelServingWizard.findPreconfigureStep().should('be.enabled');
-    cy.findByTestId('validated-configuration-section-args').should('not.exist');
-  });
-
-  it('should not render option cards when a configuration has no options', () => {
-    initIntercepts();
-    modelServingWizard.visitWithValidatedConfigurations({
-      validatedConfigurations: [
-        {
-          forField: 'args',
-          title: 'Validated arguments',
-          description: 'No options available for this model.',
-          options: [],
-        },
-      ],
-    });
-
-    modelServingWizard.findPreconfigureStep().should('be.enabled');
-    modelServingWizard.findValidatedConfigurationSection('args').should('be.visible');
-    cy.findByTestId('validated-configuration-options-args')
-      .find('[data-testid^="validated-configuration-option-"]')
-      .should('not.exist');
   });
 });

--- a/packages/model-serving/modelRegistry/useNavigateToDeploymentWizardWithData.ts
+++ b/packages/model-serving/modelRegistry/useNavigateToDeploymentWizardWithData.ts
@@ -70,6 +70,7 @@ export const useNavigateToDeploymentWizardWithData = (
         },
       },
       validatedConfigurations: deployPrefillData.validatedConfigurations,
+      selectedValidatedConfigurations: deployPrefillData.selectedValidatedConfigurations,
     }),
     [deployPrefillData, connectionTypeObject, resourceName, maxLength],
   );

--- a/packages/model-serving/src/__tests__/mockUtils.ts
+++ b/packages/model-serving/src/__tests__/mockUtils.ts
@@ -230,6 +230,11 @@ export const mockDeploymentWizardState = (
           isVisible: true,
         },
         canCreateRoleBindings: true,
+        validatedConfigurationSelection: {
+          selectedValidatedConfigurations: {},
+          toggleOption: jest.fn(),
+          isOptionSelected: jest.fn().mockReturnValue(false),
+        },
       },
       loaded: {
         modelSourceLoaded: true,

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedArgumentsSection.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedArgumentsSection.tsx
@@ -21,10 +21,6 @@ export const ValidatedArgumentsSection: React.FC<ValidatedArgumentsSectionProps>
   configurations,
   selection,
 }) => {
-  if (configurations.length === 0) {
-    return null;
-  }
-
   return (
     <>
       {configurations.map((configuration) => (
@@ -45,7 +41,8 @@ export const ValidatedArgumentsSection: React.FC<ValidatedArgumentsSectionProps>
               <StackItem>
                 <Gallery
                   hasGutter
-                  minWidths={{ default: '100%', md: '300px' }}
+                  minWidths={{ default: '100%', md: '330px' }}
+                  maxWidths={{ default: '100%', md: '330px' }}
                   data-testid={`validated-configuration-options-${configuration.forField}`}
                 >
                   {configuration.options.map((option) => (

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedArgumentsSection.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedArgumentsSection.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  FormGroup,
+  Gallery,
+  GalleryItem,
+  HelperText,
+  HelperTextItem,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { ValidatedConfigurationOptionCard } from './ValidatedConfigurationOptionCard';
+import type { ValidatedConfigurationsFieldHook } from './useValidatedConfigurationsField';
+import type { ValidatedConfiguration } from '../../../../shared/types/form-data';
+
+type ValidatedArgumentsSectionProps = {
+  configurations: ValidatedConfiguration[];
+  selection: ValidatedConfigurationsFieldHook;
+};
+
+export const ValidatedArgumentsSection: React.FC<ValidatedArgumentsSectionProps> = ({
+  configurations,
+  selection,
+}) => {
+  if (configurations.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {configurations.map((configuration) => (
+        <div
+          key={configuration.forField}
+          data-testid={`validated-configuration-section-${configuration.forField}`}
+        >
+          <FormGroup
+            label={configuration.title}
+            fieldId={`validated-configuration-${configuration.forField}`}
+          >
+            <Stack hasGutter>
+              <StackItem>
+                <HelperText>
+                  <HelperTextItem>{configuration.description}</HelperTextItem>
+                </HelperText>
+              </StackItem>
+              <StackItem>
+                <Gallery
+                  hasGutter
+                  minWidths={{ default: '100%', md: '300px' }}
+                  data-testid={`validated-configuration-options-${configuration.forField}`}
+                >
+                  {configuration.options.map((option) => (
+                    <GalleryItem key={option.value}>
+                      <ValidatedConfigurationOptionCard
+                        option={option}
+                        isSelected={selection.isOptionSelected(
+                          configuration.forField,
+                          option.value,
+                        )}
+                        onSelectionChange={(checked) =>
+                          selection.toggleOption(configuration.forField, option.value, checked)
+                        }
+                      />
+                    </GalleryItem>
+                  ))}
+                </Gallery>
+              </StackItem>
+            </Stack>
+          </FormGroup>
+        </div>
+      ))}
+    </>
+  );
+};

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedConfigurationOptionCard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedConfigurationOptionCard.tsx
@@ -34,8 +34,8 @@ export const ValidatedConfigurationOptionCard: React.FC<ValidatedConfigurationOp
       isClickable
       isSelectable
       isSelected={isSelected}
+      isFullHeight
       data-testid={`validated-configuration-option-${optionSlug}`}
-      className="pf-v6-u-h-100"
     >
       <CardHeader
         selectableActions={{

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedConfigurationOptionCard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedConfigurationOptionCard.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Content,
+  Popover,
+} from '@patternfly/react-core';
+import {
+  formatValidatedOptionValueForDisplay,
+  slugifyValidatedOptionTitle,
+} from './validatedConfigurationUtils';
+import type { ValidatedConfigurationOption } from '../../../../shared/types/form-data';
+
+type ValidatedConfigurationOptionCardProps = {
+  option: ValidatedConfigurationOption;
+  isSelected: boolean;
+  onSelectionChange: (checked: boolean) => void;
+};
+
+export const ValidatedConfigurationOptionCard: React.FC<ValidatedConfigurationOptionCardProps> = ({
+  option,
+  isSelected,
+  onSelectionChange,
+}) => {
+  const optionSlug = slugifyValidatedOptionTitle(option.title);
+  const formattedArgs = formatValidatedOptionValueForDisplay(option.value);
+
+  return (
+    <Card
+      isClickable
+      isSelectable
+      isSelected={isSelected}
+      data-testid={`validated-configuration-option-${optionSlug}`}
+      className="pf-v6-u-h-100"
+    >
+      <CardHeader
+        selectableActions={{
+          selectableActionId: `validated-configuration-option-checkbox-${optionSlug}`,
+          selectableActionAriaLabel: `Select ${option.title}`,
+          name: `validated-configuration-option-${optionSlug}`,
+          variant: 'multiple',
+          onChange: (_event, checked) => onSelectionChange(checked),
+          isChecked: isSelected,
+          selectableActionProps: {
+            'data-testid': `validated-configuration-option-checkbox-${optionSlug}`,
+          },
+        }}
+      >
+        <CardTitle>{option.title}</CardTitle>
+      </CardHeader>
+      <CardBody>
+        <Content component="p">{option.description}</Content>
+      </CardBody>
+      <CardFooter>
+        <Popover
+          aria-label={`${option.title} arguments`}
+          headerContent={`${option.title} arguments`}
+          bodyContent={
+            <pre
+              data-testid={`validated-configuration-arguments-popover-content-${optionSlug}`}
+              className="pf-v6-u-font-family-monospace pf-v6-u-white-space-pre-wrap"
+            >
+              {formattedArgs}
+            </pre>
+          }
+        >
+          <Button
+            variant="link"
+            isInline
+            data-testid={`validated-configuration-view-arguments-${optionSlug}`}
+          >
+            View arguments
+          </Button>
+        </Popover>
+      </CardFooter>
+    </Card>
+  );
+};

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/__tests__/useValidatedConfigurationsField.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/__tests__/useValidatedConfigurationsField.spec.ts
@@ -1,0 +1,48 @@
+import { act } from '@testing-library/react';
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { TOOL_CALLING_VALIDATED_ARGS_VALUE } from '@odh-dashboard/internal/__mocks__/mockValidatedConfigurations';
+import { useValidatedConfigurationsField } from '../useValidatedConfigurationsField';
+
+describe('useValidatedConfigurationsField', () => {
+  it('should initialize with empty selection by default', () => {
+    const renderResult = testHook(useValidatedConfigurationsField)();
+
+    expect(renderResult.result.current.selectedValidatedConfigurations).toEqual({});
+    expect(
+      renderResult.result.current.isOptionSelected('args', TOOL_CALLING_VALIDATED_ARGS_VALUE),
+    ).toBe(false);
+  });
+
+  it('should initialize from provided selection state', () => {
+    const renderResult = testHook(useValidatedConfigurationsField)({
+      args: [TOOL_CALLING_VALIDATED_ARGS_VALUE],
+    });
+
+    expect(renderResult.result.current.selectedValidatedConfigurations).toEqual({
+      args: [TOOL_CALLING_VALIDATED_ARGS_VALUE],
+    });
+    expect(
+      renderResult.result.current.isOptionSelected('args', TOOL_CALLING_VALIDATED_ARGS_VALUE),
+    ).toBe(true);
+  });
+
+  it('should toggle option selection on and off', () => {
+    const renderResult = testHook(useValidatedConfigurationsField)();
+
+    act(() => {
+      renderResult.result.current.toggleOption('args', TOOL_CALLING_VALIDATED_ARGS_VALUE, true);
+    });
+
+    expect(renderResult.result.current.selectedValidatedConfigurations).toEqual({
+      args: [TOOL_CALLING_VALIDATED_ARGS_VALUE],
+    });
+
+    act(() => {
+      renderResult.result.current.toggleOption('args', TOOL_CALLING_VALIDATED_ARGS_VALUE, false);
+    });
+
+    expect(renderResult.result.current.selectedValidatedConfigurations).toEqual({
+      args: [],
+    });
+  });
+});

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/__tests__/validatedConfigurationUtils.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/__tests__/validatedConfigurationUtils.spec.ts
@@ -1,0 +1,19 @@
+import { TOOL_CALLING_VALIDATED_ARGS_VALUE } from '@odh-dashboard/internal/__mocks__/mockValidatedConfigurations';
+import {
+  formatValidatedOptionValueForDisplay,
+  slugifyValidatedOptionTitle,
+} from '../validatedConfigurationUtils';
+
+describe('formatValidatedOptionValueForDisplay', () => {
+  it('should format multi-line CLI args with line continuations', () => {
+    expect(formatValidatedOptionValueForDisplay(TOOL_CALLING_VALIDATED_ARGS_VALUE)).toBe(
+      '--enable-auto-tool-choice \\\n--tool-call-parser hermes \\\n--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+    );
+  });
+});
+
+describe('slugifyValidatedOptionTitle', () => {
+  it('should slugify option titles for test ids', () => {
+    expect(slugifyValidatedOptionTitle('Tool calling')).toBe('tool-calling');
+  });
+});

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/useValidatedConfigurationsField.ts
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/useValidatedConfigurationsField.ts
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export type ValidatedConfigurationsFieldHook = {
+  selectedValidatedConfigurations: Record<string, string[]>;
+  toggleOption: (forField: string, optionValue: string, checked: boolean) => void;
+  isOptionSelected: (forField: string, optionValue: string) => boolean;
+};
+
+export const useValidatedConfigurationsField = (
+  initialSelected?: Record<string, string[]>,
+): ValidatedConfigurationsFieldHook => {
+  const [selectedValidatedConfigurations, setSelectedValidatedConfigurations] = React.useState<
+    Record<string, string[]>
+  >(initialSelected ?? {});
+
+  const toggleOption = React.useCallback(
+    (forField: string, optionValue: string, checked: boolean) => {
+      setSelectedValidatedConfigurations((prev) => {
+        const current = prev[forField] ?? [];
+        const nextValues = checked
+          ? current.includes(optionValue)
+            ? current
+            : [...current, optionValue]
+          : current.filter((value) => value !== optionValue);
+
+        return {
+          ...prev,
+          [forField]: nextValues,
+        };
+      });
+    },
+    [],
+  );
+
+  const selectedSet = React.useMemo(() => {
+    const result: Partial<Record<string, Set<string>>> = {};
+    Object.entries(selectedValidatedConfigurations).forEach(([field, values]) => {
+      result[field] = new Set(values);
+    });
+    return result;
+  }, [selectedValidatedConfigurations]);
+
+  const isOptionSelected = React.useCallback(
+    (forField: string, optionValue: string) => selectedSet[forField]?.has(optionValue) ?? false,
+    [selectedSet],
+  );
+
+  return {
+    selectedValidatedConfigurations,
+    toggleOption,
+    isOptionSelected,
+  };
+};

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/validatedConfigurationUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/validatedConfigurationUtils.ts
@@ -1,0 +1,17 @@
+/**
+ * Formats a validated configuration option value for display in the "View arguments" popover.
+ * Normalizes line-continuation backslashes while preserving individual CLI arguments.
+ */
+export const formatValidatedOptionValueForDisplay = (value: string): string =>
+  value
+    .split('\n')
+    .map((line) => line.replace(/\\$/, '').trim())
+    .filter(Boolean)
+    .join(' \\\n');
+
+export const slugifyValidatedOptionTitle = (title: string): string =>
+  title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');

--- a/packages/model-serving/src/components/deploymentWizard/steps/PreconfigureDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/PreconfigureDeploymentStep.tsx
@@ -11,6 +11,7 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ODH_PRODUCT_NAME } from '@odh-dashboard/ui-core/utilities';
 import ProjectSelector from '@odh-dashboard/ui-core/components/projectSelector/ProjectSelector';
 import { UseModelDeploymentWizardState } from '../useDeploymentWizard';
+import { ValidatedArgumentsSection } from '../fields/validatedConfigurations/ValidatedArgumentsSection';
 
 type PreconfigureDeploymentStepProps = {
   wizardState: UseModelDeploymentWizardState;
@@ -22,6 +23,7 @@ export const PreconfigureDeploymentStepContent: React.FC<PreconfigureDeploymentS
   wizardState,
 }) => {
   const { initialProjectName, projectName, setProjectName } = wizardState.state.project;
+  const validatedConfigurations = wizardState.initialData?.validatedConfigurations ?? [];
 
   return (
     <Form>
@@ -54,6 +56,12 @@ export const PreconfigureDeploymentStepContent: React.FC<PreconfigureDeploymentS
           />
         )}
       </FormGroup>
+      {validatedConfigurations.length > 0 && (
+        <ValidatedArgumentsSection
+          configurations={validatedConfigurations}
+          selection={wizardState.state.validatedConfigurationSelection}
+        />
+      )}
     </Form>
   );
 };

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/PreconfigureDeploymentStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/PreconfigureDeploymentStep.test.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { mockToolCallingValidatedConfiguration } from '@odh-dashboard/internal/__mocks__/mockValidatedConfigurations';
 import { PreconfigureDeploymentStepContent } from '../PreconfigureDeploymentStep';
 import { mockDeploymentWizardState } from '../../../../__tests__/mockUtils';
 
@@ -96,5 +97,123 @@ describe('PreconfigureDeploymentStep', () => {
     const input = screen.getByTestId('preconfigure-project-name');
     expect(input).toBeDisabled();
     expect(input).toHaveValue('test-project');
+  });
+
+  it('should not render validated arguments when validatedConfigurations is empty', () => {
+    const wizardState = mockWizardStateWithoutProject();
+
+    render(
+      <MemoryRouter>
+        <ProjectsContext.Provider value={createProjectsContextValue()}>
+          <PreconfigureDeploymentStepContent wizardState={wizardState} />
+        </ProjectsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('validated-configuration-section-args')).not.toBeInTheDocument();
+  });
+
+  it('should render validated arguments section when validatedConfigurations is provided', () => {
+    const wizardState = mockDeploymentWizardState({
+      initialData: {
+        validatedConfigurations: [mockToolCallingValidatedConfiguration()],
+      },
+      state: {
+        project: {
+          initialProjectName: undefined,
+          projectName: undefined,
+          setProjectName: jest.fn(),
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <ProjectsContext.Provider value={createProjectsContextValue()}>
+          <PreconfigureDeploymentStepContent wizardState={wizardState} />
+        </ProjectsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('validated-configuration-section-args')).toBeInTheDocument();
+    expect(screen.getByText('Validated arguments')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'This model has runtime configurations that have been tested and validated by Red Hat. Selected configurations will be applied as runtime arguments in your deployment.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('validated-configuration-option-tool-calling')).toBeInTheDocument();
+  });
+
+  it('should toggle validated configuration selection via wizard state', () => {
+    const toggleOption = jest.fn();
+    const wizardState = mockDeploymentWizardState({
+      initialData: {
+        validatedConfigurations: [mockToolCallingValidatedConfiguration()],
+      },
+      state: {
+        project: {
+          initialProjectName: undefined,
+          projectName: undefined,
+          setProjectName: jest.fn(),
+        },
+        validatedConfigurationSelection: {
+          selectedValidatedConfigurations: {},
+          toggleOption,
+          isOptionSelected: jest.fn().mockReturnValue(false),
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <ProjectsContext.Provider value={createProjectsContextValue()}>
+          <PreconfigureDeploymentStepContent wizardState={wizardState} />
+        </ProjectsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByTestId('validated-configuration-option-checkbox-tool-calling'));
+
+    expect(toggleOption).toHaveBeenCalledWith(
+      'args',
+      mockToolCallingValidatedConfiguration().options[0].value,
+      true,
+    );
+  });
+
+  it('should not render any card when validatedConfigurations has no options for a field', () => {
+    // Simulates the upstream data producer (e.g. model catalog) omitting the tool-calling
+    // option entirely because the toolCalling feature flag was disabled or the model has no
+    // validated tool-calling config — the wizard step never needs to know why.
+    const wizardState = mockDeploymentWizardState({
+      initialData: {
+        validatedConfigurations: [
+          {
+            ...mockToolCallingValidatedConfiguration(),
+            options: [],
+          },
+        ],
+      },
+      state: {
+        project: {
+          initialProjectName: undefined,
+          projectName: undefined,
+          setProjectName: jest.fn(),
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <ProjectsContext.Provider value={createProjectsContextValue()}>
+          <PreconfigureDeploymentStepContent wizardState={wizardState} />
+        </ProjectsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByTestId('validated-configuration-option-tool-calling'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
@@ -22,6 +22,7 @@ import { useModelAvailabilityFields } from './fields/ModelAvailabilityFields';
 import { useCreateConnectionData } from './fields/CreateConnectionInputFields';
 import { useProjectSection } from './fields/ProjectSection';
 import { useDeploymentStrategyField } from './fields/DeploymentStrategyField';
+import { useValidatedConfigurationsField } from './fields/validatedConfigurations/useValidatedConfigurationsField';
 import {
   useDeploymentWizardReducer,
   wizardFormReducer,
@@ -150,6 +151,9 @@ export const useModelDeploymentWizard = (
     formState.modelServer,
     formState.deploymentMethod,
   );
+  const validatedConfigurationSelection = useValidatedConfigurationsField(
+    initialData?.selectedValidatedConfigurations,
+  );
 
   // Step 4: Summary
 
@@ -173,6 +177,7 @@ export const useModelDeploymentWizard = (
       modelAvailability,
       deploymentStrategy,
       canCreateRoleBindings,
+      validatedConfigurationSelection,
       ...formState,
     }),
     [
@@ -191,6 +196,7 @@ export const useModelDeploymentWizard = (
       modelAvailability,
       deploymentStrategy,
       canCreateRoleBindings,
+      validatedConfigurationSelection,
       formState,
     ],
   );

--- a/packages/model-serving/src/shared/index.ts
+++ b/packages/model-serving/src/shared/index.ts
@@ -74,4 +74,6 @@ export type { ModelServingFilterDataType } from './const';
 export { MODEL_CAPABILITIES_ANNOTATION, WELL_KNOWN_MODEL_CAPABILITIES } from './modelCapabilities';
 export type { WellKnownModelCapability, ModelCapability } from './modelCapabilities';
 
+export type { ValidatedConfiguration, ValidatedConfigurationOption } from './types/form-data';
+
 export { translateModelServingError } from './utils/errorUtils';

--- a/packages/model-serving/src/shared/types/form-data.ts
+++ b/packages/model-serving/src/shared/types/form-data.ts
@@ -33,6 +33,7 @@ import {
   type CreateConnectionData,
 } from '../../components/deploymentWizard/fields/CreateConnectionInputFields';
 import { useProjectSection } from '../../components/deploymentWizard/fields/ProjectSection';
+import type { ValidatedConfigurationsFieldHook } from '../../components/deploymentWizard/fields/validatedConfigurations/useValidatedConfigurationsField';
 import { NIMModelLocationKey } from '../../components/deploymentWizard/fields/modelLocationFields/NIMModelLocation';
 import { getStateKey } from '../../components/deploymentWizard/dynamicFormUtils';
 import type { DeploymentMethodFieldData } from '../../components/deploymentWizard/fields/DeploymentMethodSelectField';
@@ -156,6 +157,7 @@ export type InitialWizardFormData = {
   // deploying — serializable metadata merged onto the deployment during assembly
   navSourceMetadata?: K8sResourceCommon['metadata'];
   validatedConfigurations?: ValidatedConfiguration[];
+  selectedValidatedConfigurations?: Record<string, string[]>;
 } & Record<string, unknown>;
 
 export type WizardFormData = {
@@ -178,7 +180,7 @@ export type WizardFormData = {
     createConnectionData: ReturnType<typeof useCreateConnectionData>;
     deploymentStrategy: ReturnType<typeof useDeploymentStrategyField>;
     canCreateRoleBindings: boolean;
-    selectedValidatedConfigurations?: Record<string, string[]>;
+    validatedConfigurationSelection: ValidatedConfigurationsFieldHook;
     devFeatureFlags?: {
       vLLMDeploymentOnMaaS: boolean;
     };


### PR DESCRIPTION
Closes: https://redhat.atlassian.net/browse/RHOAIENG-69425

## Description
This PR aims to add the tool calling add on preconfigure step of deployment

<img width="1509" height="894" alt="Screenshot 2026-08-11 at 1 29 56 PM" src="https://github.com/user-attachments/assets/40325dc6-6d90-4f93-9923-a7969521441c" />
<img width="1201" height="731" alt="Screenshot 2026-08-11 at 1 30 05 PM" src="https://github.com/user-attachments/assets/1d475033-1e96-4370-aa3f-fb8e2aa75f72" />



## How Has This Been Tested?
This feature will be behind the feature flag called toolCalling 
and we will only be able to see this tool calling when we deploy from model catalog and the toolCalling featureFlag is on and the model being deployed has tool calling argument. 
After clicking on view arguments - it should should the tool calling configuration
and the card will be selected by default. 

## Test Impact
Added unit and cypress test t cover all the cases

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added validated configuration options to the deployment wizard.
  * Users can select options, view descriptions, and inspect formatted command-line arguments.
  * Existing selections are preserved when opening the wizard with prefilled deployment data.
  * Empty or unavailable configuration sections are hidden.

* **Bug Fixes**
  * Improved option selection and deselection without duplicate values.

* **Tests**
  * Added coverage for rendering, selection behavior, prefilled data, and argument formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->