### PR TITLE
Update OWNERS_ALIASES: add liday-rh as platform approver, remove rsun19

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -106,13 +106,13 @@ aliases:
   # General Dashboard infrastructure
   platform-approvers:
     - christianvogt
+    - liday-rh
     - lucferbux
   platform-reviewers:
     - christianvogt
     - jenny-s51
     - liday-rh
     - lucferbux
-    - rsun19
 
   # Quality / E2E testing
   quality-e2e-testing-approvers:


### PR DESCRIPTION
Non-code tooling change — no Jira attached.

## Description
Update platform team ownership:
- **Add `liday-rh`** to `platform-approvers` in OWNERS_ALIASES
- **Remove `rsun19`** from `platform-reviewers` in OWNERS_ALIASES (no longer on the team)

## How Has This Been Tested?
N/A — ownership file change only.

## Test Impact
No tests applicable — this is a tooling/configuration change.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform approval assignments.
  * Added `liday-rh` as an approver and removed `rsun19` from the reviewer list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->