### PR TITLE
Fix agentic-ci setup to use Node.js 20 module

### DIFF
--- a/.agentic-ci/config.yml
+++ b/.agentic-ci/config.yml
@@ -1,5 +1,5 @@
 setup:
   - name: Install Node.js
-    run: dnf install -y --nodocs nodejs npm && npm install -g npm@11.8.0
+    run: dnf module enable nodejs:20 -y && dnf install -y --nodocs nodejs npm
   - name: Install dependencies
     run: npm ci

--- a/.agentic-ci/config.yml
+++ b/.agentic-ci/config.yml
@@ -1,5 +1,5 @@
 setup:
   - name: Install Node.js
-    run: dnf module enable nodejs:20 -y && dnf install -y --nodocs nodejs npm
+    run: dnf module enable nodejs:22 -y && dnf install -y --nodocs nodejs npm && npm install -g npm@11.8.0
   - name: Install dependencies
     run: npm ci


### PR DESCRIPTION
## Summary
- The OpenShell base image was bumped to v0.0.94, which defaults to Node.js 16 via `dnf install nodejs`
- `npm@11.8.0` requires Node.js >=20.17.0, causing all autofix runs to fail with `EBADENGINE`
- Switch to `dnf module enable nodejs:20 -y && dnf install -y --nodocs nodejs npm` to get a compatible Node version

## Test plan
- [ ] Verify autofix pipeline runs successfully with the new Node.js install command
- [ ] Confirm `npm ci` completes without engine compatibility errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js setup process to enable Node.js 22 before installation.
  * Continued installing npm 11.8.0 globally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->