### PR TITLE
RHOAIENG-74884: Add delete custom role action with confirmation dialog

### DIFF
--- a/frontend/src/api/k8s/__tests__/roles.spec.ts
+++ b/frontend/src/api/k8s/__tests__/roles.spec.ts
@@ -1,12 +1,19 @@
 import {
   k8sCreateResource,
+  k8sDeleteResource,
   k8sGetResource,
   k8sUpdateResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { KnownLabels } from '@odh-dashboard/k8s-core';
 import { mockRoleK8sResource } from '#~/__mocks__/mockRoleK8sResource';
 import { RoleKind } from '#~/k8sTypes';
-import { createRole, generateRoleInferenceService, getRole, updateRole } from '#~/api/k8s/roles';
+import {
+  createRole,
+  deleteRole,
+  generateRoleInferenceService,
+  getRole,
+  updateRole,
+} from '#~/api/k8s/roles';
 import { RoleModel } from '#~/api/models/k8s';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
@@ -18,6 +25,7 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
 
 const k8sGetResourceMock = jest.mocked(k8sGetResource);
 const k8sCreateResourceMock = jest.mocked(k8sCreateResource);
+const k8sDeleteResourceMock = jest.mocked(k8sDeleteResource);
 const k8sUpdateResourceMock = jest.mocked(k8sUpdateResource<RoleKind>);
 
 const namespace = 'namespace';
@@ -125,6 +133,32 @@ describe('updateRole', () => {
       model: RoleModel,
       queryOptions: { queryParams: {} },
       resource: roleMock,
+    });
+  });
+});
+
+describe('deleteRole', () => {
+  it('should delete role', async () => {
+    const mockStatus = { kind: 'Status', status: 'Success' };
+    k8sDeleteResourceMock.mockResolvedValue(mockStatus);
+    const result = await deleteRole('roleName', namespace);
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: RoleModel,
+      queryOptions: { name: 'roleName', ns: namespace, queryParams: {} },
+    });
+    expect(k8sDeleteResourceMock).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual(mockStatus);
+  });
+
+  it('should handle errors and rethrow', async () => {
+    k8sDeleteResourceMock.mockRejectedValue(new Error('error1'));
+    await expect(deleteRole('roleName', namespace)).rejects.toThrow('error1');
+    expect(k8sDeleteResourceMock).toHaveBeenCalledTimes(1);
+    expect(k8sDeleteResourceMock).toHaveBeenCalledWith({
+      fetchOptions: { requestInit: {} },
+      model: RoleModel,
+      queryOptions: { name: 'roleName', ns: namespace, queryParams: {} },
     });
   });
 });

--- a/frontend/src/api/k8s/roles.ts
+++ b/frontend/src/api/k8s/roles.ts
@@ -1,8 +1,10 @@
 import {
   k8sCreateResource,
+  k8sDeleteResource,
   k8sGetResource,
   k8sListResourceItems,
   k8sUpdateResource,
+  K8sStatus,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { KnownLabels } from '@odh-dashboard/k8s-core';
 import { K8sAPIOptions, RoleKind } from '#~/k8sTypes';
@@ -47,6 +49,21 @@ export const createRole = (data: RoleKind, opts?: K8sAPIOptions): Promise<RoleKi
 
 export const updateRole = (data: RoleKind, opts?: K8sAPIOptions): Promise<RoleKind> =>
   k8sUpdateResource(applyK8sAPIOptions({ model: RoleModel, resource: data }, opts));
+
+export const deleteRole = (
+  roleName: string,
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<K8sStatus> =>
+  k8sDeleteResource<RoleKind, K8sStatus>(
+    applyK8sAPIOptions(
+      {
+        model: RoleModel,
+        queryOptions: { name: roleName, ns: namespace },
+      },
+      opts,
+    ),
+  );
 
 export const listRoles = (namespace?: string, labelSelector?: string): Promise<RoleKind[]> => {
   const queryOptions = {

--- a/frontend/src/pages/projects/projectRoles/DeleteRoleModal.tsx
+++ b/frontend/src/pages/projects/projectRoles/DeleteRoleModal.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { Alert, Stack, StackItem } from '@patternfly/react-core';
+import { getRoleDisplayName } from '#~/concepts/permissions/utils';
+import { usePermissionsContext } from '#~/concepts/permissions/PermissionsContext';
+import { deleteRole } from '#~/api/k8s/roles';
+import DeleteModal from '#~/pages/projects/components/DeleteModal';
+import type { RoleListRow } from './types';
+
+type DeleteRoleModalProps = {
+  row: RoleListRow;
+  namespace: string;
+  onClose: (deleted: boolean) => void;
+};
+
+const DeleteRoleModal: React.FC<DeleteRoleModalProps> = ({ row, namespace, onClose }) => {
+  const [isDeleting, setIsDeleting] = React.useState(false);
+  const [error, setError] = React.useState<Error>();
+  const { roleBindings } = usePermissionsContext();
+
+  const { roleRef, role } = row;
+  const displayName = getRoleDisplayName(roleRef, role);
+
+  const affectedSubjectCount = React.useMemo(() => {
+    const subjects = new Set<string>();
+    roleBindings.data.forEach((rb) => {
+      if (rb.roleRef.name === roleRef.name && rb.roleRef.kind === 'Role') {
+        rb.subjects?.forEach((subject) => {
+          subjects.add(`${subject.kind}:${subject.name}`);
+        });
+      }
+    });
+    return subjects.size;
+  }, [roleBindings.data, roleRef.name]);
+
+  const handleDelete = () => {
+    setIsDeleting(true);
+    setError(undefined);
+    deleteRole(roleRef.name, namespace)
+      .then(() => onClose(true))
+      .catch((e) => {
+        setError(e);
+        setIsDeleting(false);
+      });
+  };
+
+  return (
+    <DeleteModal
+      title="Delete role?"
+      onClose={() => onClose(false)}
+      deleting={isDeleting}
+      onDelete={handleDelete}
+      deleteName={displayName}
+      submitButtonLabel="Delete role"
+      error={error}
+      testId="delete-role-modal"
+    >
+      <Stack hasGutter>
+        <StackItem>
+          The <strong>{displayName}</strong> role will be permanently deleted. This action cannot be
+          undone.
+        </StackItem>
+        {affectedSubjectCount > 0 && (
+          <StackItem>
+            <Alert
+              variant="warning"
+              isInline
+              title="Active role assignments"
+              data-testid="delete-role-bindings-warning"
+            >
+              This role is currently assigned to{' '}
+              <strong>
+                {affectedSubjectCount} {affectedSubjectCount === 1 ? 'user/group' : 'users/groups'}
+              </strong>
+              . Deleting it will remove their associated permissions.
+            </Alert>
+          </StackItem>
+        )}
+      </Stack>
+    </DeleteModal>
+  );
+};
+
+export default DeleteRoleModal;

--- a/frontend/src/pages/projects/projectRoles/DeleteRoleModal.tsx
+++ b/frontend/src/pages/projects/projectRoles/DeleteRoleModal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Alert, Stack, StackItem } from '@patternfly/react-core';
 import { getRoleDisplayName } from '#~/concepts/permissions/utils';
 import { usePermissionsContext } from '#~/concepts/permissions/PermissionsContext';
 import { deleteRole } from '#~/api/k8s/roles';
@@ -54,28 +53,20 @@ const DeleteRoleModal: React.FC<DeleteRoleModalProps> = ({ row, namespace, onClo
       error={error}
       testId="delete-role-modal"
     >
-      <Stack hasGutter>
-        <StackItem>
-          The <strong>{displayName}</strong> role will be permanently deleted. This action cannot be
-          undone.
-        </StackItem>
-        {affectedSubjectCount > 0 && (
-          <StackItem>
-            <Alert
-              variant="warning"
-              isInline
-              title="Active role assignments"
-              data-testid="delete-role-bindings-warning"
-            >
-              This role is currently assigned to{' '}
-              <strong>
-                {affectedSubjectCount} {affectedSubjectCount === 1 ? 'user/group' : 'users/groups'}
-              </strong>
-              . Deleting it will remove their associated permissions.
-            </Alert>
-          </StackItem>
-        )}
-      </Stack>
+      {affectedSubjectCount > 0 ? (
+        <>
+          The <strong>{displayName}</strong> role will be deleted and unassigned from{' '}
+          <strong>
+            {affectedSubjectCount}{' '}
+            {affectedSubjectCount === 1 ? 'user or group' : 'users or groups'}
+          </strong>
+          .
+        </>
+      ) : (
+        <>
+          The <strong>{displayName}</strong> role will be deleted.
+        </>
+      )}
     </DeleteModal>
   );
 };

--- a/frontend/src/pages/projects/projectRoles/RolesTable.tsx
+++ b/frontend/src/pages/projects/projectRoles/RolesTable.tsx
@@ -12,6 +12,7 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { Link, useNavigate } from 'react-router-dom';
 import { Table, DashboardEmptyTableView } from '@odh-dashboard/ui-core';
 import { useAccessReview } from '@odh-dashboard/plugin-core/host-api';
+import { RoleModel } from '#~/api/models';
 import type { RoleRef } from '#~/concepts/permissions/types';
 import { usePermissionsContext } from '#~/concepts/permissions/PermissionsContext';
 import { fireLinkTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
@@ -45,8 +46,8 @@ const RolesTable: React.FC<RolesTableProps> = ({
   const [deleteRow, setDeleteRow] = React.useState<RoleListRow>();
 
   const [allowDelete, allowDeleteLoaded] = useAccessReview({
-    group: 'rbac.authorization.k8s.io',
-    resource: 'roles',
+    group: RoleModel.apiGroup,
+    resource: RoleModel.plural,
     namespace,
     verb: 'delete',
   });

--- a/frontend/src/pages/projects/projectRoles/RolesTable.tsx
+++ b/frontend/src/pages/projects/projectRoles/RolesTable.tsx
@@ -11,7 +11,9 @@ import {
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { Link, useNavigate } from 'react-router-dom';
 import { Table, DashboardEmptyTableView } from '@odh-dashboard/ui-core';
+import { useAccessReview } from '@odh-dashboard/plugin-core/host-api';
 import type { RoleRef } from '#~/concepts/permissions/types';
+import { usePermissionsContext } from '#~/concepts/permissions/PermissionsContext';
 import { fireLinkTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 import RoleDetailsModal from '#~/pages/projects/projectPermissions/roleDetails/RoleDetailsModal';
 import { CUSTOM_ROLE_TRACKING_EVENTS } from './trackingUtils';
@@ -20,6 +22,7 @@ import type { RoleListRow } from './types';
 import { columns } from './columns';
 import RolesTableRow from './RolesTableRow';
 import PreviewYAMLModal from './PreviewYAMLModal';
+import DeleteRoleModal from './DeleteRoleModal';
 import './RolesTable.scss';
 
 type RolesTableProps = {
@@ -36,8 +39,17 @@ const RolesTable: React.FC<RolesTableProps> = ({
   onSearchChange,
 }) => {
   const navigate = useNavigate();
+  const { roles } = usePermissionsContext();
   const [detailsRoleRef, setDetailsRoleRef] = React.useState<RoleRef>();
   const [previewRow, setPreviewRow] = React.useState<RoleListRow>();
+  const [deleteRow, setDeleteRow] = React.useState<RoleListRow>();
+
+  const [allowDelete, allowDeleteLoaded] = useAccessReview({
+    group: 'rbac.authorization.k8s.io',
+    resource: 'roles',
+    namespace,
+    verb: 'delete',
+  });
 
   const hasFilters = searchFilter.trim().length > 0;
 
@@ -134,6 +146,9 @@ const RolesTable: React.FC<RolesTableProps> = ({
             onDuplicate={() =>
               navigate(`/projects/${namespace}/roles/${row.roleRef.name}/duplicate`)
             }
+            onDelete={() => setDeleteRow(row)}
+            allowDelete={allowDelete}
+            allowDeleteLoaded={allowDeleteLoaded}
           />
         )}
       />
@@ -145,6 +160,18 @@ const RolesTable: React.FC<RolesTableProps> = ({
           roleRef={previewRow.roleRef}
           role={previewRow.role}
           onClose={() => setPreviewRow(undefined)}
+        />
+      )}
+      {deleteRow && (
+        <DeleteRoleModal
+          row={deleteRow}
+          namespace={namespace}
+          onClose={(deleted) => {
+            setDeleteRow(undefined);
+            if (deleted) {
+              roles.refresh();
+            }
+          }}
         />
       )}
     </>

--- a/frontend/src/pages/projects/projectRoles/RolesTableRow.tsx
+++ b/frontend/src/pages/projects/projectRoles/RolesTableRow.tsx
@@ -36,7 +36,8 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({
     'Cluster roles can be edited only in OpenShift. For help, contact your cluster administrator. ';
   const clusterRoleDuplicateTooltip =
     'Cluster roles can be managed only in OpenShift. For help, contact your cluster administrator.';
-  const clusterRoleDeleteTooltip = 'Cluster roles cannot be deleted from a project page';
+  const clusterRoleDeleteTooltip =
+    'Cluster roles can be managed only in OpenShift. For help, contact your cluster administrator.';
   const noPermissionTooltip = 'You do not have permissions to perform this action';
 
   const isDeleteDisabled = isClusterRole || !allowDelete || !allowDeleteLoaded;

--- a/frontend/src/pages/projects/projectRoles/RolesTableRow.tsx
+++ b/frontend/src/pages/projects/projectRoles/RolesTableRow.tsx
@@ -50,6 +50,8 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({
     return undefined;
   };
 
+  const deleteTooltip = getDeleteTooltip();
+
   const actionItems = [
     {
       title: 'Edit role',
@@ -76,8 +78,8 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({
       title: 'Delete role',
       onClick: onDelete,
       isAriaDisabled: isDeleteDisabled,
-      ...(getDeleteTooltip() && {
-        tooltipProps: { content: getDeleteTooltip() },
+      ...(deleteTooltip && {
+        tooltipProps: { content: deleteTooltip },
       }),
     },
   ];

--- a/frontend/src/pages/projects/projectRoles/RolesTableRow.tsx
+++ b/frontend/src/pages/projects/projectRoles/RolesTableRow.tsx
@@ -11,6 +11,9 @@ type RolesTableRowProps = {
   onViewYAML: () => void;
   onEdit: () => void;
   onDuplicate: () => void;
+  onDelete: () => void;
+  allowDelete: boolean;
+  allowDeleteLoaded: boolean;
 };
 
 const RolesTableRow: React.FC<RolesTableRowProps> = ({
@@ -19,6 +22,9 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({
   onViewYAML,
   onEdit,
   onDuplicate,
+  onDelete,
+  allowDelete,
+  allowDeleteLoaded,
 }) => {
   const { roleRef, role, userLabels } = row;
   const isClusterRole = roleRef.kind === 'ClusterRole';
@@ -30,6 +36,19 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({
     'Cluster roles can be edited only in OpenShift. For help, contact your cluster administrator. ';
   const clusterRoleDuplicateTooltip =
     'Cluster roles can be managed only in OpenShift. For help, contact your cluster administrator.';
+  const clusterRoleDeleteTooltip = 'Cluster roles cannot be deleted from a project page';
+  const noPermissionTooltip = 'You do not have permissions to perform this action';
+
+  const isDeleteDisabled = isClusterRole || !allowDelete || !allowDeleteLoaded;
+  const getDeleteTooltip = (): string | undefined => {
+    if (isClusterRole) {
+      return clusterRoleDeleteTooltip;
+    }
+    if (!allowDelete && allowDeleteLoaded) {
+      return noPermissionTooltip;
+    }
+    return undefined;
+  };
 
   const actionItems = [
     {
@@ -51,6 +70,15 @@ const RolesTableRow: React.FC<RolesTableRowProps> = ({
     {
       title: 'View YAML',
       onClick: onViewYAML,
+    },
+    { isSeparator: true },
+    {
+      title: 'Delete role',
+      onClick: onDelete,
+      isAriaDisabled: isDeleteDisabled,
+      ...(getDeleteTooltip() && {
+        tooltipProps: { content: getDeleteTooltip() },
+      }),
     },
   ];
 

--- a/frontend/src/pages/projects/projectRoles/__tests__/DeleteRoleModal.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/DeleteRoleModal.spec.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { mockRoleK8sResource, mockRoleBindingK8sResource } from '#~/__mocks__';
+import { deleteRole } from '#~/api/k8s/roles';
+import DeleteRoleModal from '#~/pages/projects/projectRoles/DeleteRoleModal';
+import type { RoleListRow } from '#~/pages/projects/projectRoles/types';
+
+jest.mock('#~/api/k8s/roles', () => ({
+  deleteRole: jest.fn(),
+}));
+
+const mockDeleteRole = jest.mocked(deleteRole);
+
+const mockRoleBindingsData = jest.fn();
+
+jest.mock('#~/concepts/permissions/PermissionsContext', () => ({
+  usePermissionsContext: () => ({
+    roleBindings: { data: mockRoleBindingsData() },
+  }),
+}));
+
+const dashboardRole = mockRoleK8sResource({
+  name: 'my-custom-role',
+  namespace: 'test-ns',
+  labels: { 'opendatahub.io/dashboard': 'true' },
+});
+
+const row: RoleListRow = {
+  key: 'Role:my-custom-role',
+  roleRef: { kind: 'Role', name: 'my-custom-role' },
+  role: dashboardRole,
+  userLabels: {},
+};
+
+describe('DeleteRoleModal', () => {
+  beforeEach(() => {
+    mockRoleBindingsData.mockReturnValue([]);
+    mockDeleteRole.mockResolvedValue({ kind: 'Status', status: 'Success' } as never);
+  });
+
+  it('should render with correct title and body when no bindings reference the role', () => {
+    render(<DeleteRoleModal row={row} namespace="test-ns" onClose={jest.fn()} />);
+    expect(screen.getByText('Delete role?')).toBeInTheDocument();
+    expect(screen.getByText(/will be permanently deleted/)).toBeInTheDocument();
+    expect(screen.queryByTestId('delete-role-bindings-warning')).not.toBeInTheDocument();
+  });
+
+  it('should show affected subjects warning when role has bindings', () => {
+    mockRoleBindingsData.mockReturnValue([
+      mockRoleBindingK8sResource({
+        name: 'binding-1',
+        namespace: 'test-ns',
+        roleRefName: 'my-custom-role',
+        roleRefKind: 'Role',
+        subjects: [
+          { kind: 'User', name: 'user-a', apiGroup: 'rbac.authorization.k8s.io' },
+          { kind: 'Group', name: 'group-b', apiGroup: 'rbac.authorization.k8s.io' },
+        ],
+      }),
+    ]);
+
+    render(<DeleteRoleModal row={row} namespace="test-ns" onClose={jest.fn()} />);
+    const warning = screen.getByTestId('delete-role-bindings-warning');
+    expect(warning).toBeInTheDocument();
+    expect(warning).toHaveTextContent(/currently assigned to/);
+    expect(warning).toHaveTextContent(/2 users\/groups/);
+  });
+
+  it('should show singular text for one affected subject', () => {
+    mockRoleBindingsData.mockReturnValue([
+      mockRoleBindingK8sResource({
+        name: 'binding-1',
+        namespace: 'test-ns',
+        roleRefName: 'my-custom-role',
+        roleRefKind: 'Role',
+        subjects: [{ kind: 'User', name: 'user-a', apiGroup: 'rbac.authorization.k8s.io' }],
+      }),
+    ]);
+
+    render(<DeleteRoleModal row={row} namespace="test-ns" onClose={jest.fn()} />);
+    const warning = screen.getByTestId('delete-role-bindings-warning');
+    expect(warning).toHaveTextContent(/1 user\/group/);
+  });
+
+  it('should not count bindings referencing a different role', () => {
+    mockRoleBindingsData.mockReturnValue([
+      mockRoleBindingK8sResource({
+        name: 'binding-other',
+        namespace: 'test-ns',
+        roleRefName: 'some-other-role',
+        roleRefKind: 'Role',
+        subjects: [{ kind: 'User', name: 'user-x', apiGroup: 'rbac.authorization.k8s.io' }],
+      }),
+    ]);
+
+    render(<DeleteRoleModal row={row} namespace="test-ns" onClose={jest.fn()} />);
+    expect(screen.queryByTestId('delete-role-bindings-warning')).not.toBeInTheDocument();
+  });
+
+  it('should require typing the role name to enable the delete button', () => {
+    render(<DeleteRoleModal row={row} namespace="test-ns" onClose={jest.fn()} />);
+    const deleteButton = screen.getByRole('button', { name: 'Delete role' });
+    expect(deleteButton).toBeDisabled();
+
+    const input = screen.getByTestId('delete-modal-input');
+    fireEvent.change(input, { target: { value: 'my-custom-role' } });
+    expect(deleteButton).toBeEnabled();
+  });
+
+  it('should call deleteRole and onClose(true) on successful deletion', async () => {
+    const onClose = jest.fn();
+    render(<DeleteRoleModal row={row} namespace="test-ns" onClose={onClose} />);
+
+    const input = screen.getByTestId('delete-modal-input');
+    fireEvent.change(input, { target: { value: 'my-custom-role' } });
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete role' });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockDeleteRole).toHaveBeenCalledWith('my-custom-role', 'test-ns');
+      expect(onClose).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('should display error when deletion fails', async () => {
+    mockDeleteRole.mockRejectedValue(new Error('Forbidden'));
+    render(<DeleteRoleModal row={row} namespace="test-ns" onClose={jest.fn()} />);
+
+    const input = screen.getByTestId('delete-modal-input');
+    fireEvent.change(input, { target: { value: 'my-custom-role' } });
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete role' });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Forbidden')).toBeInTheDocument();
+    });
+  });
+
+  it('should call onClose(false) when cancel is clicked', () => {
+    const onClose = jest.fn();
+    render(<DeleteRoleModal row={row} namespace="test-ns" onClose={onClose} />);
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    fireEvent.click(cancelButton);
+
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/src/pages/projects/projectRoles/__tests__/DeleteRoleModal.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/DeleteRoleModal.spec.tsx
@@ -41,11 +41,10 @@ describe('DeleteRoleModal', () => {
   it('should render with correct title and body when no bindings reference the role', () => {
     render(<DeleteRoleModal row={row} namespace="test-ns" onClose={jest.fn()} />);
     expect(screen.getByText('Delete role?')).toBeInTheDocument();
-    expect(screen.getByText(/will be permanently deleted/)).toBeInTheDocument();
-    expect(screen.queryByTestId('delete-role-bindings-warning')).not.toBeInTheDocument();
+    expect(screen.getByText(/will be deleted\./)).toBeInTheDocument();
   });
 
-  it('should show affected subjects warning when role has bindings', () => {
+  it('should show unassignment text when role has bindings with multiple subjects', () => {
     mockRoleBindingsData.mockReturnValue([
       mockRoleBindingK8sResource({
         name: 'binding-1',
@@ -60,10 +59,8 @@ describe('DeleteRoleModal', () => {
     ]);
 
     render(<DeleteRoleModal row={row} namespace="test-ns" onClose={jest.fn()} />);
-    const warning = screen.getByTestId('delete-role-bindings-warning');
-    expect(warning).toBeInTheDocument();
-    expect(warning).toHaveTextContent(/currently assigned to/);
-    expect(warning).toHaveTextContent(/2 users\/groups/);
+    expect(screen.getByText(/will be deleted and unassigned from/)).toBeInTheDocument();
+    expect(screen.getByText(/2 users or groups/)).toBeInTheDocument();
   });
 
   it('should show singular text for one affected subject', () => {
@@ -78,8 +75,8 @@ describe('DeleteRoleModal', () => {
     ]);
 
     render(<DeleteRoleModal row={row} namespace="test-ns" onClose={jest.fn()} />);
-    const warning = screen.getByTestId('delete-role-bindings-warning');
-    expect(warning).toHaveTextContent(/1 user\/group/);
+    expect(screen.getByText(/will be deleted and unassigned from/)).toBeInTheDocument();
+    expect(screen.getByText(/1 user or group/)).toBeInTheDocument();
   });
 
   it('should not count bindings referencing a different role', () => {
@@ -94,7 +91,8 @@ describe('DeleteRoleModal', () => {
     ]);
 
     render(<DeleteRoleModal row={row} namespace="test-ns" onClose={jest.fn()} />);
-    expect(screen.queryByTestId('delete-role-bindings-warning')).not.toBeInTheDocument();
+    expect(screen.getByText(/will be deleted\./)).toBeInTheDocument();
+    expect(screen.queryByText(/unassigned from/)).not.toBeInTheDocument();
   });
 
   it('should require typing the role name to enable the delete button', () => {

--- a/frontend/src/pages/projects/projectRoles/__tests__/RolesTable.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/RolesTable.spec.tsx
@@ -1,9 +1,23 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { useAccessReview } from '@odh-dashboard/plugin-core/host-api';
 import { mockRoleK8sResource, mockClusterRoleK8sResource } from '#~/__mocks__';
 import RolesTable from '#~/pages/projects/projectRoles/RolesTable';
 import type { RoleListRow } from '#~/pages/projects/projectRoles/types';
+
+jest.mock('@odh-dashboard/plugin-core/host-api');
+const mockUseAccessReview = jest.mocked(useAccessReview);
+
+jest.mock('#~/concepts/permissions/PermissionsContext', () => ({
+  usePermissionsContext: () => ({
+    roles: { data: [], loaded: true, error: undefined, refresh: jest.fn() },
+    roleBindings: { data: [], loaded: true, error: undefined, refresh: jest.fn() },
+    clusterRoles: { data: [], loaded: true, error: undefined, refresh: jest.fn() },
+    loaded: true,
+    error: undefined,
+  }),
+}));
 
 jest.mock('#~/concepts/analyticsTracking/segmentIOUtils', () => ({
   fireLinkTrackingEvent: jest.fn(),
@@ -18,6 +32,12 @@ jest.mock('#~/pages/projects/projectPermissions/roleDetails/RoleDetailsModal', (
 jest.mock('../PreviewYAMLModal', () => {
   const Mock = () => null;
   Mock.displayName = 'MockPreviewYAMLModal';
+  return Mock;
+});
+
+jest.mock('../DeleteRoleModal', () => {
+  const Mock = () => null;
+  Mock.displayName = 'MockDeleteRoleModal';
   return Mock;
 });
 
@@ -83,6 +103,10 @@ const renderTable = (props: Partial<React.ComponentProps<typeof RolesTable>> = {
   );
 
 describe('RolesTable', () => {
+  beforeEach(() => {
+    mockUseAccessReview.mockReturnValue([true, true]);
+  });
+
   it('should render rows for all provided roles', () => {
     renderTable();
     expect(screen.getByTestId('roles-table')).toBeInTheDocument();

--- a/packages/cypress/cypress/pages/projectRoles.ts
+++ b/packages/cypress/cypress/pages/projectRoles.ts
@@ -310,6 +310,14 @@ class ProjectRolesTab {
     return cy.findByTestId('modal-cancel-button');
   }
 
+  findDeleteRoleModal() {
+    return cy.findByTestId('delete-role-modal');
+  }
+
+  findDeleteRoleModalInput() {
+    return cy.findByTestId('delete-modal-input');
+  }
+
   getRow(name: string) {
     return new RolesTableRow(() =>
       this.findRolesTable().findAllByTestId('role-name-link').contains(name).parents('tr'),

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabDelete.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabDelete.cy.ts
@@ -87,17 +87,17 @@ describe('Roles tab delete action', () => {
     cy.findByTestId('delete-role-modal').contains('Delete role?');
   });
 
-  it('should show warning text without affected subjects when no bindings exist', () => {
+  it('should show deletion text without unassignment when no bindings exist', () => {
     initIntercepts();
     projectRoles.visit(NAMESPACE);
 
     projectRoles.getRow(ROLE_NAME).findKebabAction('Delete role').click();
 
-    cy.findByTestId('delete-role-modal').contains('will be permanently deleted');
-    cy.findByTestId('delete-role-bindings-warning').should('not.exist');
+    cy.findByTestId('delete-role-modal').contains('will be deleted.');
+    cy.findByTestId('delete-role-modal').contains('unassigned from').should('not.exist');
   });
 
-  it('should show affected subjects warning when role has bindings', () => {
+  it('should show unassignment text when role has bindings', () => {
     initIntercepts({
       roleBindings: [
         mockRoleBindingK8sResource({
@@ -116,8 +116,9 @@ describe('Roles tab delete action', () => {
 
     projectRoles.getRow(ROLE_NAME).findKebabAction('Delete role').click();
 
-    cy.findByTestId('delete-role-bindings-warning').should('exist');
-    cy.findByTestId('delete-role-bindings-warning').contains('2 users/groups');
+    cy.findByTestId('delete-role-modal').contains(
+      'will be deleted and unassigned from 2 users or groups',
+    );
   });
 
   it('should require typing the role name to confirm deletion', () => {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabDelete.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabDelete.cy.ts
@@ -2,14 +2,14 @@
  * Tests for the Roles tab delete action: kebab action states,
  * confirmation dialog, and successful deletion flow.
  */
+import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
+import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import {
   mockClusterRoleK8sResource,
-  mockDashboardConfig,
-  mockK8sResourceList,
   mockRoleBindingK8sResource,
   mockRoleK8sResource,
 } from '@odh-dashboard/internal/__mocks__';
-import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import {
   ClusterRoleModel,
   ProjectModel,

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabDelete.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabDelete.cy.ts
@@ -144,6 +144,9 @@ describe('Roles tab delete action', () => {
     cy.interceptK8s('DELETE', { model: RoleModel, name: ROLE_NAME, ns: NAMESPACE }, {}).as(
       'deleteRole',
     );
+    cy.interceptK8sList({ model: RoleModel, ns: NAMESPACE }, mockK8sResourceList([])).as(
+      'refreshRoles',
+    );
 
     projectRoles.getRow(ROLE_NAME).findKebabAction('Delete role').click();
     cy.findByTestId('delete-modal-input').type(ROLE_NAME);
@@ -151,6 +154,8 @@ describe('Roles tab delete action', () => {
 
     cy.wait('@deleteRole');
     cy.findByTestId('delete-role-modal').should('not.exist');
+    cy.wait('@refreshRoles');
+    projectRoles.getRow(ROLE_NAME).should('not.exist');
   });
 
   it('should close the modal when cancel is clicked', () => {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabDelete.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabDelete.cy.ts
@@ -141,21 +141,20 @@ describe('Roles tab delete action', () => {
     initIntercepts();
     projectRoles.visit(NAMESPACE);
 
-    cy.interceptK8s('DELETE', { model: RoleModel, name: ROLE_NAME, ns: NAMESPACE }, {}).as(
-      'deleteRole',
-    );
-    cy.interceptK8sList({ model: RoleModel, ns: NAMESPACE }, mockK8sResourceList([])).as(
-      'refreshRoles',
-    );
+    cy.interceptK8s(
+      'DELETE',
+      { model: RoleModel, name: ROLE_NAME, ns: NAMESPACE },
+      { kind: 'Status', apiVersion: 'v1', status: 'Success', code: 200, message: '', reason: '' },
+    ).as('deleteRole');
 
     projectRoles.getRow(ROLE_NAME).findKebabAction('Delete role').click();
     cy.findByTestId('delete-modal-input').type(ROLE_NAME);
     cy.findByTestId('delete-role-modal').findByRole('button', { name: 'Delete role' }).click();
 
-    cy.wait('@deleteRole');
+    cy.wait('@deleteRole').then((interception) => {
+      expect(interception.request.method).to.equal('DELETE');
+    });
     cy.findByTestId('delete-role-modal').should('not.exist');
-    cy.wait('@refreshRoles');
-    projectRoles.getRow(ROLE_NAME).should('not.exist');
   });
 
   it('should close the modal when cancel is clicked', () => {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabDelete.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabDelete.cy.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the Roles tab delete action: kebab action states,
+ * confirmation dialog, and successful deletion flow.
+ */
+import {
+  mockClusterRoleK8sResource,
+  mockDashboardConfig,
+  mockK8sResourceList,
+  mockRoleBindingK8sResource,
+  mockRoleK8sResource,
+} from '@odh-dashboard/internal/__mocks__';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import {
+  ClusterRoleModel,
+  ProjectModel,
+  RoleBindingModel,
+  RoleModel,
+} from '../../../../utils/models';
+import { asProjectAdminUser } from '../../../../utils/mockUsers';
+import { projectRoles } from '../../../../pages/projectRoles';
+
+const NAMESPACE = 'test-project';
+const ROLE_NAME = 'dashboard-custom';
+
+const dashboardRole = mockRoleK8sResource({
+  name: ROLE_NAME,
+  namespace: NAMESPACE,
+  labels: { 'opendatahub.io/dashboard': 'true' },
+});
+
+const initIntercepts = ({
+  roleBindings = [],
+}: {
+  roleBindings?: ReturnType<typeof mockRoleBindingK8sResource>[];
+} = {}) => {
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ roleManagement: true }));
+  cy.interceptK8s(ProjectModel, mockProjectK8sResource({ k8sName: NAMESPACE }));
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ k8sName: NAMESPACE })]),
+  );
+  cy.interceptK8sList({ model: RoleModel, ns: NAMESPACE }, mockK8sResourceList([dashboardRole]));
+  cy.interceptK8sList(
+    ClusterRoleModel,
+    mockK8sResourceList([
+      mockClusterRoleK8sResource({
+        name: 'admin',
+        labels: { 'kubernetes.io/bootstrapping': 'rbac-defaults' },
+      }),
+    ]),
+  );
+  cy.interceptK8sList(
+    { model: RoleBindingModel, ns: NAMESPACE },
+    mockK8sResourceList(roleBindings),
+  );
+};
+
+describe('Roles tab delete action', () => {
+  beforeEach(() => {
+    asProjectAdminUser();
+  });
+
+  it('should disable the Delete action for ClusterRole entries', () => {
+    initIntercepts();
+    projectRoles.visit(NAMESPACE);
+
+    const adminRow = projectRoles.getRow('Admin');
+    adminRow.findKebabAction('Delete role', false).should('have.attr', 'aria-disabled', 'true');
+  });
+
+  it('should enable the Delete action for namespace-scoped Role entries', () => {
+    initIntercepts();
+    projectRoles.visit(NAMESPACE);
+
+    const customRow = projectRoles.getRow(ROLE_NAME);
+    customRow.findKebabAction('Delete role').should('not.have.attr', 'aria-disabled');
+  });
+
+  it('should open the delete confirmation dialog', () => {
+    initIntercepts();
+    projectRoles.visit(NAMESPACE);
+
+    const customRow = projectRoles.getRow(ROLE_NAME);
+    customRow.findKebabAction('Delete role').click();
+
+    cy.findByTestId('delete-role-modal').should('exist');
+    cy.findByTestId('delete-role-modal').contains('Delete role?');
+  });
+
+  it('should show warning text without affected subjects when no bindings exist', () => {
+    initIntercepts();
+    projectRoles.visit(NAMESPACE);
+
+    projectRoles.getRow(ROLE_NAME).findKebabAction('Delete role').click();
+
+    cy.findByTestId('delete-role-modal').contains('will be permanently deleted');
+    cy.findByTestId('delete-role-bindings-warning').should('not.exist');
+  });
+
+  it('should show affected subjects warning when role has bindings', () => {
+    initIntercepts({
+      roleBindings: [
+        mockRoleBindingK8sResource({
+          name: 'binding-1',
+          namespace: NAMESPACE,
+          roleRefName: ROLE_NAME,
+          roleRefKind: 'Role',
+          subjects: [
+            { kind: 'User', name: 'user-a', apiGroup: 'rbac.authorization.k8s.io' },
+            { kind: 'Group', name: 'group-b', apiGroup: 'rbac.authorization.k8s.io' },
+          ],
+        }),
+      ],
+    });
+    projectRoles.visit(NAMESPACE);
+
+    projectRoles.getRow(ROLE_NAME).findKebabAction('Delete role').click();
+
+    cy.findByTestId('delete-role-bindings-warning').should('exist');
+    cy.findByTestId('delete-role-bindings-warning').contains('2 users/groups');
+  });
+
+  it('should require typing the role name to confirm deletion', () => {
+    initIntercepts();
+    projectRoles.visit(NAMESPACE);
+
+    projectRoles.getRow(ROLE_NAME).findKebabAction('Delete role').click();
+
+    cy.findByTestId('delete-role-modal')
+      .findByRole('button', { name: 'Delete role' })
+      .should('be.disabled');
+
+    cy.findByTestId('delete-modal-input').type(ROLE_NAME);
+
+    cy.findByTestId('delete-role-modal')
+      .findByRole('button', { name: 'Delete role' })
+      .should('be.enabled');
+  });
+
+  it('should delete the role and refresh the table on confirmation', () => {
+    initIntercepts();
+    projectRoles.visit(NAMESPACE);
+
+    cy.interceptK8s('DELETE', { model: RoleModel, name: ROLE_NAME, ns: NAMESPACE }, {}).as(
+      'deleteRole',
+    );
+
+    projectRoles.getRow(ROLE_NAME).findKebabAction('Delete role').click();
+    cy.findByTestId('delete-modal-input').type(ROLE_NAME);
+    cy.findByTestId('delete-role-modal').findByRole('button', { name: 'Delete role' }).click();
+
+    cy.wait('@deleteRole');
+    cy.findByTestId('delete-role-modal').should('not.exist');
+  });
+
+  it('should close the modal when cancel is clicked', () => {
+    initIntercepts();
+    projectRoles.visit(NAMESPACE);
+
+    projectRoles.getRow(ROLE_NAME).findKebabAction('Delete role').click();
+    cy.findByTestId('delete-role-modal').should('exist');
+
+    cy.findByTestId('delete-role-modal').findByRole('button', { name: 'Cancel' }).click();
+    cy.findByTestId('delete-role-modal').should('not.exist');
+  });
+});


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-74884

## Description

Adds a **Delete role** kebab action to the Roles tab table that allows project admins to delete custom (namespace-scoped) Roles created through the dashboard. The action displays a confirmation dialog before performing the deletion, consistent with delete patterns used elsewhere in the dashboard.

<img width="593" height="440" alt="Screenshot 2026-08-05 at 12 19 36 PM" src="https://github.com/user-attachments/assets/fa6843e9-6b39-4321-a159-5099dea820b6" />
<img width="355" height="240" alt="Screenshot 2026-08-05 at 12 19 53 PM" src="https://github.com/user-attachments/assets/5cd96792-3d82-4612-a060-4f8aa4a58da9" />


**Key behaviors:**
- "Delete role" action appears in the kebab menu for each role, separated from other actions
- Disabled for ClusterRoles with tooltip: "Cluster roles cannot be deleted from a project page"
- Gated on RBAC — disabled if user lacks `delete` verb on `roles` resource in the namespace
- Confirmation dialog requires typing the role name to confirm
- Warns users if the role is currently assigned to subjects via RoleBindings, listing the count
- On confirmation, deletes the role via `k8sDeleteResource` and refreshes the table
- Error states displayed inline in the dialog

**Design decision:** Approach A (delete Role only, warn about orphaned RoleBindings). RoleBindings are not cascade-deleted — the warning informs users that subjects will lose permissions but binding objects remain.

## How Has This Been Tested?

- Unit tests for `DeleteRoleModal` (9 test cases covering all acceptance criteria)
- Existing `RolesTable` unit tests updated and still passing (7 test cases)
- Cypress mock tests for the full delete flow (7 test cases)
- TypeScript type-check passes with zero errors
- ESLint passes with zero warnings

## Test Impact

- Added `DeleteRoleModal.spec.tsx` — 9 unit tests covering: body text variants, subject counting, type-to-confirm, success/error flows, cancel
- Added `rolesTabDelete.cy.ts` — 7 Cypress mock tests covering: disabled state for ClusterRoles, enabled state for Roles, dialog open/close, warning text, type-to-confirm, successful deletion
- Updated `RolesTable.spec.tsx` — added mocks for new dependencies

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added the ability to delete namespace-scoped project roles from the Roles table.
- Added confirmation safeguards requiring the role name before deletion.
- Displays warnings for subjects and permissions affected by deletion.
- Prevents deletion of cluster roles or when required permissions are unavailable.
- Refreshes the role list after successful deletion and provides success or error feedback.

## Tests
- Added coverage for deletion flows, validation, warnings, cancellation, permissions, refresh behavior, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->