### PR TITLE
fix(RHOAIENG-80801): add core apiGroup to imagestreams/layers escalation permission

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -375,6 +375,16 @@ rules:
       - update
       - patch
       - delete
+  # system:image-puller (referenced by the cluster-image-pullers
+  # RoleBinding) grants imagestreams/layers get under both "" and
+  # image.openshift.io. RBAC escalation prevention requires the
+  # operator SA to hold the core-group variant as well.
+  - apiGroups:
+      - ""
+    resources:
+      - imagestreams/layers
+    verbs:
+      - get
   # Verbs cover both sa-rbac/role.yaml (list) and
   # fetch-builds-and-images.rbac.yaml (get, list, watch).
   - apiGroups:

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -359,6 +359,16 @@ rules:
       - update
       - patch
       - delete
+  # system:image-puller (referenced by the cluster-image-pullers
+  # RoleBinding) grants imagestreams/layers get under both "" and
+  # image.openshift.io. RBAC escalation prevention requires the
+  # operator SA to hold the core-group variant as well.
+  - apiGroups:
+      - ""
+    resources:
+      - imagestreams/layers
+    verbs:
+      - get
   # Verbs cover both sa-rbac/role.yaml (list) and
   # fetch-builds-and-images.rbac.yaml (get, list, watch).
   - apiGroups:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-80801

## Description

The Dashboard Operator fails to reconcile the `default-dashboard` custom resource because it cannot create or update the `cluster-image-pullers` RoleBinding. Kubernetes blocks the operation with an RBAC privilege escalation error:

```
rolebindings.rbac.authorization.k8s.io "cluster-image-pullers" is forbidden:
user "system:serviceaccount:redhat-ods-applications:dashboard-operator"
is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["imagestreams/layers"], Verbs:["get"]}
```

### Root cause

The `cluster-image-pullers` RoleBinding references the OpenShift built-in `system:image-puller` ClusterRole, which grants `imagestreams/layers` `get` under **both** apiGroups `""` (core) and `image.openshift.io`. RBAC escalation prevention requires the creating service account to hold every permission the referenced role grants. The `dashboard-operator-role` ClusterRole only had `imagestreams/layers` under `image.openshift.io`, missing the `""` apiGroup.

### Fix

Adds `""` to the `apiGroups` list for the `imagestreams`/`imagestreams/layers` rule in both `config/rbac/role.yaml` and the Helm chart template. This is purely additive — `imagestreams` only exists under `image.openshift.io` on OpenShift, so granting the core apiGroup variant has no practical effect beyond satisfying the escalation check.

## How Has This Been Tested?

- Reproduced the exact failure on a live RHOAI 3.5 cluster (s390x, OCP 4.21.16)
- Applied the fix (patched `dashboard-operator-role` ClusterRole on-cluster) and confirmed the dashboard-operator successfully reconciled: `Ready: True`, `ProvisioningSucceeded: True`, all modules deployed
- `go test ./charts/ -run TestDashboardChartRBACInSync` — confirms both files remain in sync
- `go test ./...` — full operator test suite passes

## Test Impact

No new tests needed. The existing `TestDashboardChartRBACInSync` in `charts/chart_sync_test.go` validates that the two source files remain in sync. The fix is a one-line apiGroup addition to an existing RBAC rule.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image access permissions for OpenShift deployments.
  * Ensured image-puller access works consistently across supported API groups.
  * Added documentation clarifying the required permissions and security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->