### PR TITLE
Fix(RHOAIENG-80937): added same name length collision errors for workbench status

### DIFF
--- a/frontend/src/api/k8s/__tests__/workloads.spec.ts
+++ b/frontend/src/api/k8s/__tests__/workloads.spec.ts
@@ -148,6 +148,16 @@ describe('buildWorkloadMapForNotebooks', () => {
     expect(result[TEST_NOTEBOOK_NAME]).toBe(wl);
   });
 
+  it('does not match a pod ownerRef when the owner name only shares a same-length prefix', () => {
+    const notebooks = [notebook('preempt-winner'), notebook('preempt-victim')];
+    const wl = workloadWithOwnerRefs('wl-collision', [{ kind: 'Pod', name: 'preempt-winner-0' }]);
+
+    const result = buildWorkloadMapForNotebooks([wl], notebooks);
+
+    expect(result['preempt-winner']).toBe(wl);
+    expect(result['preempt-victim']).toBeNull();
+  });
+
   it('compares ownerRef kind case-insensitively', () => {
     const wl = workloadWithOwnerRefs('wl-lower', [
       { kind: 'pod', name: `${TEST_NOTEBOOK_NAME}-0` },

--- a/frontend/src/api/k8s/workloads.ts
+++ b/frontend/src/api/k8s/workloads.ts
@@ -21,8 +21,10 @@ export const listWorkloads = async (
 
 const isStatefulSetPodName = (ownerName: string, notebookName: string): boolean => {
   if (ownerName === notebookName) return true;
-  const suffix = ownerName.slice(notebookName.length);
-  return suffix.length > 1 && suffix[0] === '-' && /^\d+$/.test(suffix.slice(1));
+  const prefix = `${notebookName}-`;
+  if (!ownerName.startsWith(prefix)) return false;
+  const suffix = ownerName.slice(prefix.length);
+  return suffix.length > 0 && /^\d+$/.test(suffix);
 };
 
 const workloadMatchesNotebook = (wl: WorkloadKind, notebookName: string): boolean => {


### PR DESCRIPTION
Closes [RHOAIENG-80937](https://redhat.atlassian.net/browse/RHOAIENG-80937)

## Description

Fixes a bug where a workbench's Kueue status badge could show the wrong state — displaying another workbench's "Preempted" or "Paused by higher-priority job" status even though the workbench itself was running fine.
<img width="2784" height="1632" alt="image" src="https://github.com/user-attachments/assets/2db1bba1-a786-4098-b549-541d2a4cc1e3" />

**What was happening**

When two workbenches in the same namespace had names of the exact same character length (e.g. `preempt-winner` and `preempt-victim`, both 14 chars), the frontend's notebook-to-Workload matching logic could accidentally resolve one workbench's Kueue Workload to the other's. The healthy workbench would then display the preempted workbench's status badge.

This only triggers when both workbenches lack the `kueue.x-k8s.io/job-name` label (Kueue does not always set it), forcing the code to fall back to matching by pod owner reference names — and that fallback had the length-collision flaw.

**What was fixed**

The pod name matching now verifies the owner name actually starts with `<notebookName>-` before checking the numeric replica suffix. Before the fix it was only slicing at a fixed index, which coincidentally produced a valid `-0` suffix from an unrelated same-length name.

**Impact**

- No change for workbenches with unique-length names — unaffected code path.
- Workbenches with same-length names in the same namespace now correctly show their own Kueue status.
- No API or data model changes — purely in-memory matching logic.

## How Has This Been Tested?

**Cluster verification** — `kueue-phase2-dev` namespace contains the exact reproduce case:
- `preempt-winner` (Admitted: True) and `preempt-victim` (Admitted: False), both 14-char names, both with `-0` pod replicas, neither carrying the `kueue.x-k8s.io/job-name` label (so ownerRef matching is the only code path exercised).

```bash
# Confirm ownerRef names
kubectl get workload statefulset-preempt-victim-7acb2 statefulset-preempt-winner-1abae \
  -n kueue-phase2-dev \
  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.ownerReferences[*].name}{"\n"}{end}'

# Confirm admission states
kubectl get workload -n kueue-phase2-dev \
  -o custom-columns='NAME:.metadata.name,ADMITTED:.status.conditions[?(@.type=="Admitted")].status'
```

**UI verification**

1. Open the Workbenches list in the `kueue-phase2-dev` namespace (or any namespace containing two same-length-named workbenches).
2. Confirm `preempt-winner` badge shows **Admitted** / running state.
3. Confirm `preempt-victim` badge shows **Preempted** / "Paused by higher-priority job".
4. Before this fix, `preempt-winner` incorrectly displayed the victim's preempted state.

## Test Impact

**Unit tests** (`frontend/src/api/k8s/__tests__/workloads.spec.ts`)

- Added: `does not match a pod ownerRef when the owner name only shares a same-length prefix` — uses the real cluster names (`preempt-winner` / `preempt-victim`, both 14 chars) to assert the false-positive match no longer occurs.
- All 26 existing tests pass; no regressions in Job, Notebook, StatefulSet, or Pod ownerRef matching.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-80937]: https://redhat.atlassian.net/browse/RHOAIENG-80937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workload matching for notebook names with shared prefixes.
  * Pod ownership is now correctly assigned to the intended notebook.
  * Improved validation of derived pod names while preserving direct-name matches.

* **Tests**
  * Added regression coverage for similarly prefixed notebook names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->