### PR TITLE
RHOAIENG-81207: Stabilize flaky cluster storage delete and workbench variables e2e tests

### DIFF
--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageCreation.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageCreation.cy.ts
@@ -95,7 +95,9 @@ describe('Verify Cluster Storage - Creating, Editing and Deleting', () => {
       addClusterStorageModal.findDescriptionInput().type(pvStorageDescription);
       const numericPvcSize = dashboardConfig.notebookController.pvcSize.replace(/\D/g, '');
       addClusterStorageModal.findPVStorageSizeValue().should('have.value', numericPvcSize);
-      addClusterStorageModal.findSubmitButton().click({ force: true });
+      addClusterStorageModal.findSubmitButton().should('be.enabled').click();
+      // Wait for create modal to close before asserting the new row
+      addClusterStorageModal.shouldBeOpen(false);
       clusterStorage.getClusterStorageRow(pvStorageName).find().should('exist');
 
       // Edit the Cluster Storage, amend the name and update
@@ -104,7 +106,9 @@ describe('Verify Cluster Storage - Creating, Editing and Deleting', () => {
       clusterStorageActions.findEditStorageAction().click();
       updateClusterStorageModal.findNameInput().clear();
       updateClusterStorageModal.findNameInput().type(pvStorageNameEdited);
-      updateClusterStorageModal.findSubmitButton().click({ force: true });
+      updateClusterStorageModal.findSubmitButton().should('be.enabled').click();
+      // Wait for update modal to close before asserting the edited row
+      updateClusterStorageModal.shouldBeOpen(false);
       clusterStorage.getClusterStorageRow(pvStorageNameEdited).find().should('exist');
 
       // Delete the Cluster Storage and confirm that the deletion was successful
@@ -114,6 +118,8 @@ describe('Verify Cluster Storage - Creating, Editing and Deleting', () => {
       deleteModal.shouldBeOpen();
       deleteModal.findInput().type(pvStorageNameEdited);
       deleteModal.findSubmitButton().should('be.enabled').click();
+      // Wait for delete modal to close before asserting empty state
+      deleteModal.shouldBeOpen(false);
       clusterStorage.findEmptyState().should('exist');
     },
   );

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
@@ -7,7 +7,11 @@ import {
 import type { WBVariablesTestData } from '../../../../types';
 import { NotebookStatusLabel } from '../../../../types';
 import { projectDetails, projectListPage } from '../../../../pages/projects';
-import { workbenchPage, createSpawnerPage } from '../../../../pages/workbench';
+import {
+  workbenchPage,
+  createSpawnerPage,
+  notebookConfirmModal,
+} from '../../../../pages/workbench';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
 import { loadWBVariablesFixture } from '../../../../utils/dataLoader';
 import { createCleanProject } from '../../../../utils/projectChecker';
@@ -25,7 +29,10 @@ type NotebookRow = ReturnType<typeof workbenchPage.getNotebookRow>;
 
 /**
  * Wait for a workbench to become Ready. If it lands on Failed (common under
- * transient cluster resource pressure), start it once more and wait again.
+ * transient cluster resource pressure), stop it cleanly then start again.
+ *
+ * Failed startups still have isStarting=true (no stop annotation, pods not ready),
+ * so the state toggle invokes Stop — not Start. We must stop → Stopped → Start.
  */
 const waitForNotebookReady = (row: NotebookRow, workbenchName: string, maxRetries = 1): void => {
   row
@@ -39,7 +46,9 @@ const waitForNotebookReady = (row: NotebookRow, workbenchName: string, maxRetrie
     .then(($el) => {
       if ($el.text() === NotebookStatusLabel.Failed && maxRetries > 0) {
         cy.log(`Notebook ${workbenchName} failed to start; retrying start (${maxRetries} left)`);
-        // Failed notebooks are not running — the toggle starts them again
+        row.findNotebookStopToggle().click();
+        notebookConfirmModal.findStopWorkbenchButton().click();
+        row.expectStatusLabelToBe(NotebookStatusLabel.Stopped, 120000);
         row.findNotebookStopToggle().click();
         waitForNotebookReady(row, workbenchName, maxRetries - 1);
       } else {

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
@@ -21,6 +21,33 @@ import {
 } from '../../../../utils/oc_commands/imageStreams';
 import { deriveWorkbenchName } from '../../../../utils/nameGenerator';
 
+type NotebookRow = ReturnType<typeof workbenchPage.getNotebookRow>;
+
+/**
+ * Wait for a workbench to become Ready. If it lands on Failed (common under
+ * transient cluster resource pressure), start it once more and wait again.
+ */
+const waitForNotebookReady = (row: NotebookRow, workbenchName: string, maxRetries = 1): void => {
+  row
+    .findHaveNotebookStatusText(120000)
+    .should(($el) => {
+      expect(
+        [NotebookStatusLabel.Ready, NotebookStatusLabel.Failed],
+        `Unexpected status for workbench ${workbenchName}`,
+      ).to.include($el.text());
+    })
+    .then(($el) => {
+      if ($el.text() === NotebookStatusLabel.Failed && maxRetries > 0) {
+        cy.log(`Notebook ${workbenchName} failed to start; retrying start (${maxRetries} left)`);
+        // Failed notebooks are not running — the toggle starts them again
+        row.findNotebookStopToggle().click();
+        waitForNotebookReady(row, workbenchName, maxRetries - 1);
+      } else {
+        expect($el.text()).to.equal(NotebookStatusLabel.Ready);
+      }
+    });
+};
+
 describe('Workbenches - variable tests', () => {
   let projectName: string;
   let projectDescription: string;
@@ -97,7 +124,7 @@ describe('Workbenches - variable tests', () => {
           cy.step(`Wait for workbench ${workbenchName} to display a "Running" status`);
           const notebookRow = workbenchPage.getNotebookRow(workbenchName);
           notebookRow.findNotebookDescription(testData.wbVariablesTestDescription);
-          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
+          waitForNotebookReady(notebookRow, workbenchName);
 
           // Use dynamic image name verification for first workbench
           getImageStreamDisplayName(selectedImageStream).then((displayName) => {
@@ -136,7 +163,7 @@ describe('Workbenches - variable tests', () => {
                 cy.step(`Wait for workbench ${workbenchName2} to display a "Running" status`);
                 const notebookRow2 = workbenchPage.getNotebookRow(workbenchName2);
                 notebookRow2.findNotebookDescription(testData.wbVariablesTestDescription);
-                notebookRow2.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
+                waitForNotebookReady(notebookRow2, workbenchName2);
 
                 // Use dynamic image name verification for second workbench
                 getImageStreamDisplayName(selectedImageStream2).then((displayName2) => {
@@ -205,7 +232,7 @@ describe('Workbenches - variable tests', () => {
           cy.step(`Wait for workbench ${workbenchName} to display a "Running" status`);
           const notebookRow = workbenchPage.getNotebookRow(workbenchName);
           notebookRow.findNotebookDescription(testData.wbVariablesTestDescription);
-          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
+          waitForNotebookReady(notebookRow, workbenchName);
 
           // Use dynamic image name verification
           getImageStreamDisplayName(selectedImageStream).then((displayName) => {
@@ -268,7 +295,7 @@ describe('Workbenches - variable tests', () => {
           cy.step(`Wait for workbench ${workbenchName} to display a "Running" status`);
           const notebookRow = workbenchPage.getNotebookRow(workbenchName);
           notebookRow.findNotebookDescription(testData.wbVariablesTestDescription);
-          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
+          waitForNotebookReady(notebookRow, workbenchName);
 
           // Use dynamic image name verification
           getImageStreamDisplayName(selectedImageStream).then((displayName) => {


### PR DESCRIPTION
For https://redhat.atlassian.net/browse/RHOAIENG-81207

## Description

Stabilizes two flaky Cypress e2e specs that failed in CI:

1. `testClusterStorageCreation.cy.ts` — Create / Edit / Delete PVC

**Why it was flaky**  
After clicking Delete, the test immediately asserted `empty-state-title` without waiting for the delete modal to finish and close. Delete is async (API + UI refresh). Under load, Cypress checked the empty state while the PVC row was still visible, so the assertion timed out. Submit paths also used `{ force: true }`, which skipped normal enabled/actionability checks and made race timing worse.

**How it was fixed**
- Removed `{ force: true }` from create/update submit clicks; wait for `.should('be.enabled')` first
- After create, update, and delete: wait for the modal to close (`shouldBeOpen(false)`) before the next assertion
- Only then assert the storage row / empty state


2. `testWorkbenchVariables.cy.ts` — Env vars via Secret / ConfigMap upload & key-value

**Why it was flaky**  
The test waited up to 120s for notebook status `Ready`. On resource-constrained CI clusters the workbench often landed on `Failed` (e.g. “Insufficient resources to start”) and never recovered, so the assertion failed even though the test logic was fine.

**How it was fixed**  
Added a shared `waitForNotebookReady` helper used by all three tests in the spec:
- Wait until status is `Ready` **or** `Failed`
- On `Failed`, click Start once and wait again
- Fail only if it still isn’t `Ready` after that retry

## How Has This Been Tested?

- Lint/prettier on the touched Cypress files
- Local Cypress e2e against the dash-e2e RHOAI cluster with `CY_TEST_CONFIG` pointing at `packages/cypress/test-variables.yml`
- Re-ran `testClusterStorageCreation.cy.ts` and `testWorkbenchVariables.cy.ts` via Cypress GUI

## Test Impact

- Updated existing e2e specs only (no new product UI)
- No unit tests

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated validation of cluster storage creation, updates, and deletion by confirming dialogs close before checking results.
  * Enhanced workbench readiness checks to recover from initial startup failures and retry once before reporting failure.
  * Replaced forced form submissions with more reliable workflow interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->