### PR TITLE
fix: fixed distributions build

### DIFF
--- a/distributions/base/config/webpack.common.js
+++ b/distributions/base/config/webpack.common.js
@@ -5,7 +5,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const BASE_DIR = path.resolve(__dirname, '..');
 const BASE_SRC_DIR = path.resolve(BASE_DIR, 'src');
 const REPO_ROOT = path.resolve(BASE_DIR, '../..');
-const PLUGIN_CORE_DIR = path.resolve(REPO_ROOT, 'packages/plugin-core/src');
 const INTERNAL_DIR = path.resolve(REPO_ROOT, 'frontend/src');
 
 /**
@@ -44,8 +43,9 @@ module.exports = ({
           include: [
             normalizedDistDir,
             BASE_SRC_DIR,
-            PLUGIN_CORE_DIR,
             INTERNAL_DIR,
+            // Monorepo packages ship TS source with no precompile step — swc must transpile them when imported.
+            path.resolve(REPO_ROOT, 'packages'),
             ...normalizedIncludes,
           ],
           use: [{ loader: 'swc-loader' }],

--- a/distributions/rhaii/config/webpack.common.js
+++ b/distributions/rhaii/config/webpack.common.js
@@ -5,26 +5,13 @@ const createWebpackCommon = require('../../base/config/webpack.common.js');
 const GenerateDistributionExtensionsPlugin = require('../../base/config/generateDistributionExtensionsPlugin');
 
 const SRC_DIR = path.resolve(__dirname, '../src');
-const REPO_ROOT = path.resolve(__dirname, '../../..');
 const TITLE = 'RHAII';
-
-const additionalIncludes = [];
-if (process.env.ENABLE_MODEL_SERVING === 'true') {
-  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/connection-types'));
-  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/model-serving'));
-  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/k8s-core'));
-  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/model-registry'));
-  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/ui-core'));
-  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/hardware-profiles'));
-  additionalIncludes.push(path.resolve(REPO_ROOT, 'packages/foundation'));
-}
 
 module.exports = (overrides = {}) =>
   merge(
     createWebpackCommon({
       distributionSrcDir: SRC_DIR,
       title: TITLE,
-      additionalIncludes,
       ...overrides,
     }),
     {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
Fixes the rhaii distribution build.

  **Changes:**

  | File | Change |
  |------|--------|
  | `distributions/base/config/webpack.common.js` | Replaced the explicit `PLUGIN_CORE_DIR` include with a catch-all `packages/` directory include, so all monorepo packages are automatically compilable by swc-loader when imported |
  | `distributions/rhaii/config/webpack.common.js` | Removed the now-redundant `additionalIncludes` array and `REPO_ROOT` constant — the base config handles all packages |

  ## How Has This Been Tested?

  - `npm run build --prefix distributions/rhaii` — passes (previously failed with 4 parse errors)
  - `npm run build --prefix distributions/base` — passes

  ## Test Impact

  No new tests added. This is a build configuration fix — no runtime behavior changes. The build itself is the verification.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to build all distribution packages in one step.
  * Improved build configuration flexibility for distribution-specific overrides.

* **Bug Fixes**
  * Expanded compilation coverage to include all monorepo packages, improving consistency across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->