### PR TITLE
Copy llmd topologies when deploying

### DIFF
--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -13,6 +13,7 @@ import type {
   AssembleModelResourceExtension,
   DeploymentWizardFieldOverrideExtension,
   ModelServingDeploymentTransformExtension,
+  WizardFieldDeploymentFunctionsExtension,
 } from '@odh-dashboard/model-serving/extension-points/deployment-wizard';
 import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
 import type {
@@ -86,52 +87,6 @@ const llmConfigOptionsFieldExtensionWithTemplates: WizardFieldExtension<
   },
 };
 
-const topologyTypeFieldExtension: WizardFieldExtension<TopologyTypeFieldType, LLMdDeployment> = {
-  type: 'model-serving.deployment/wizard-field',
-  properties: {
-    platform: LLMD_SERVING_ID,
-    field: () =>
-      import('../src/wizardFields/TopologyTypeField').then((m) => m.TopologyTypeFieldWizardField),
-  },
-  flags: {
-    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
-  },
-};
-
-const customTopologyConfigFieldExtension: WizardFieldExtension<
-  CustomTopologyConfigFieldType,
-  LLMdDeployment
-> = {
-  type: 'model-serving.deployment/wizard-field',
-  properties: {
-    platform: LLMD_SERVING_ID,
-    field: () =>
-      import('../src/wizardFields/CustomTopologyConfigField').then(
-        (m) => m.CustomTopologyConfigFieldWizardField,
-      ),
-  },
-  flags: {
-    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
-  },
-};
-
-const advancedRoutingFieldExtension: WizardFieldExtension<
-  AdvancedRoutingFieldType,
-  LLMdDeployment
-> = {
-  type: 'model-serving.deployment/wizard-field',
-  properties: {
-    platform: LLMD_SERVING_ID,
-    field: () =>
-      import('../src/wizardFields/AdvancedRoutingField').then(
-        (m) => m.AdvancedRoutingFieldWizardField,
-      ),
-  },
-  flags: {
-    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
-  },
-};
-
 const gatewaySelectFieldExtension: WizardFieldExtension<GatewaySelectFieldType, LLMdDeployment> = {
   type: 'model-serving.deployment/wizard-field',
   properties: {
@@ -180,9 +135,36 @@ const gatewaySelectExtractorExtension: WizardFieldExtractorExtension<
   },
 };
 
-// ─── Topology / Routing Apply + Extract Extensions ─────────────────────────────
+// ───────────────────Topology Config Extensions ───────────────────
 
-const topologyTypeApplyExtension: WizardFieldApplyExtension<TopologyTypeFieldData, LLMdDeployment> =
+export type TopologyConfigsExtensionsType =
+  // Topology type
+  | WizardFieldExtension<TopologyTypeFieldType, LLMdDeployment>
+  | WizardFieldApplyExtension<TopologyTypeFieldData, LLMdDeployment>
+  | WizardFieldExtractorExtension<TopologyTypeFieldData, LLMdDeployment>
+  // Topology config
+  | WizardFieldExtension<CustomTopologyConfigFieldType, LLMdDeployment>
+  | WizardFieldApplyExtension<CustomTopologyConfigFieldData, LLMdDeployment>
+  | WizardFieldExtractorExtension<CustomTopologyConfigFieldData, LLMdDeployment>
+  | WizardFieldDeploymentFunctionsExtension<CustomTopologyConfigFieldData, LLMdDeployment>
+  // Router config
+  | WizardFieldExtension<AdvancedRoutingFieldType, LLMdDeployment>
+  | WizardFieldApplyExtension<AdvancedRoutingFieldData, LLMdDeployment>
+  | WizardFieldExtractorExtension<AdvancedRoutingFieldData, LLMdDeployment>;
+
+export const topologyConfigsExtensions: TopologyConfigsExtensionsType[] = [
+  // ─── Topology type ──────────────────────────────────────────────────
+  {
+    type: 'model-serving.deployment/wizard-field',
+    properties: {
+      platform: LLMD_SERVING_ID,
+      field: () =>
+        import('../src/wizardFields/TopologyTypeField').then((m) => m.TopologyTypeFieldWizardField),
+    },
+    flags: {
+      required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+    },
+  } satisfies WizardFieldExtension<TopologyTypeFieldType, LLMdDeployment>,
   {
     type: 'model-serving.deployment/wizard-field-apply',
     properties: {
@@ -191,84 +173,105 @@ const topologyTypeApplyExtension: WizardFieldApplyExtension<TopologyTypeFieldDat
       apply: () => import('../src/deployments/topology').then((m) => m.applyTopologyType),
     },
     flags: {
-      required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+      required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
     },
-  };
-
-const topologyTypeExtractorExtension: WizardFieldExtractorExtension<
-  TopologyTypeFieldData,
-  LLMdDeployment
-> = {
-  type: 'model-serving.deployment/wizard-field-extractor',
-  properties: {
-    fieldId: 'llmd-serving/topology-type',
-    platform: LLMD_SERVING_ID,
-    extract: () => import('../src/deployments/topology').then((m) => m.extractTopologyType),
+  } satisfies WizardFieldApplyExtension<TopologyTypeFieldData, LLMdDeployment>,
+  {
+    type: 'model-serving.deployment/wizard-field-extractor',
+    properties: {
+      fieldId: 'llmd-serving/topology-type',
+      platform: LLMD_SERVING_ID,
+      extract: () => import('../src/deployments/topology').then((m) => m.extractTopologyType),
+    },
+    flags: {
+      required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+    },
+  } satisfies WizardFieldExtractorExtension<TopologyTypeFieldData, LLMdDeployment>,
+  // ─── Topology config ──────────────────────────────────────────────────
+  {
+    type: 'model-serving.deployment/wizard-field',
+    properties: {
+      platform: LLMD_SERVING_ID,
+      field: () =>
+        import('../src/wizardFields/CustomTopologyConfigField').then(
+          (m) => m.CustomTopologyConfigFieldWizardField,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+    },
+  } satisfies WizardFieldExtension<CustomTopologyConfigFieldType, LLMdDeployment>,
+  {
+    type: 'model-serving.deployment/wizard-field-apply',
+    properties: {
+      fieldId: 'llmd-serving/custom-topology-config',
+      platform: LLMD_SERVING_ID,
+      apply: () => import('../src/deployments/topology').then((m) => m.applyTopologyConfig),
+    },
+    flags: {
+      required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+    },
+  } satisfies WizardFieldApplyExtension<CustomTopologyConfigFieldData, LLMdDeployment>,
+  {
+    type: 'model-serving.deployment/wizard-field-extractor',
+    properties: {
+      fieldId: 'llmd-serving/custom-topology-config',
+      platform: LLMD_SERVING_ID,
+      extract: () => import('../src/deployments/topology').then((m) => m.extractTopologyConfig),
+    },
+    flags: {
+      required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+    },
+  } satisfies WizardFieldExtractorExtension<CustomTopologyConfigFieldData, LLMdDeployment>,
+  {
+    type: 'model-serving.deployment/wizard-field-deployment-functions',
+    properties: {
+      fieldId: 'llmd-serving/custom-topology-config',
+      platform: LLMD_SERVING_ID,
+      preDeploy: () => import('../src/deployments/topology').then((m) => m.preDeployTopologyConfig),
+      postDeploy: null,
+    },
+    flags: {
+      required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+    },
   },
-  flags: {
-    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
-  },
-};
-
-const topologyConfigApplyExtension: WizardFieldApplyExtension<
-  CustomTopologyConfigFieldData,
-  LLMdDeployment
-> = {
-  type: 'model-serving.deployment/wizard-field-apply',
-  properties: {
-    fieldId: 'llmd-serving/custom-topology-config',
-    platform: LLMD_SERVING_ID,
-    apply: () => import('../src/deployments/topology').then((m) => m.applyTopologyConfig),
-  },
-  flags: {
-    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
-  },
-};
-
-const topologyConfigExtractorExtension: WizardFieldExtractorExtension<
-  CustomTopologyConfigFieldData,
-  LLMdDeployment
-> = {
-  type: 'model-serving.deployment/wizard-field-extractor',
-  properties: {
-    fieldId: 'llmd-serving/custom-topology-config',
-    platform: LLMD_SERVING_ID,
-    extract: () => import('../src/deployments/topology').then((m) => m.extractTopologyConfig),
-  },
-  flags: {
-    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
-  },
-};
-
-const routingConfigApplyExtension: WizardFieldApplyExtension<
-  AdvancedRoutingFieldData,
-  LLMdDeployment
-> = {
-  type: 'model-serving.deployment/wizard-field-apply',
-  properties: {
-    fieldId: 'llmd-serving/advanced-routing',
-    platform: LLMD_SERVING_ID,
-    apply: () => import('../src/deployments/topology').then((m) => m.applyRoutingConfig),
-  },
-  flags: {
-    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
-  },
-};
-
-const routingConfigExtractorExtension: WizardFieldExtractorExtension<
-  AdvancedRoutingFieldData,
-  LLMdDeployment
-> = {
-  type: 'model-serving.deployment/wizard-field-extractor',
-  properties: {
-    fieldId: 'llmd-serving/advanced-routing',
-    platform: LLMD_SERVING_ID,
-    extract: () => import('../src/deployments/topology').then((m) => m.extractRoutingConfig),
-  },
-  flags: {
-    required: [LLMD_SERVING_ID, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
-  },
-};
+  // ─── Router config ──────────────────────────────────────────────────
+  {
+    type: 'model-serving.deployment/wizard-field',
+    properties: {
+      platform: LLMD_SERVING_ID,
+      field: () =>
+        import('../src/wizardFields/AdvancedRoutingField').then(
+          (m) => m.AdvancedRoutingFieldWizardField,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+    },
+  } satisfies WizardFieldExtension<AdvancedRoutingFieldType, LLMdDeployment>,
+  {
+    type: 'model-serving.deployment/wizard-field-apply',
+    properties: {
+      fieldId: 'llmd-serving/advanced-routing',
+      platform: LLMD_SERVING_ID,
+      apply: () => import('../src/deployments/topology').then((m) => m.applyRoutingConfig),
+    },
+    flags: {
+      required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+    },
+  } satisfies WizardFieldApplyExtension<AdvancedRoutingFieldData, LLMdDeployment>,
+  {
+    type: 'model-serving.deployment/wizard-field-extractor',
+    properties: {
+      fieldId: 'llmd-serving/advanced-routing',
+      platform: LLMD_SERVING_ID,
+      extract: () => import('../src/deployments/topology').then((m) => m.extractRoutingConfig),
+    },
+    flags: {
+      required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
+    },
+  } satisfies WizardFieldExtractorExtension<AdvancedRoutingFieldData, LLMdDeployment>,
+];
 
 const deploymentMethodExtractorExtensionLllmdOnly: WizardFieldExtractorExtension<
   { method: string },
@@ -327,6 +330,7 @@ const extensions: (
   | WizardFieldApplyExtension<GatewaySelectFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<GatewaySelectFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<{ method: string }, LLMdDeployment>
+  | TopologyConfigsExtensionsType
   | HrefNavItemExtension
   | RouteExtension
   | TabRouteTabExtension
@@ -516,15 +520,7 @@ const extensions: (
   },
   llmConfigOptionsFieldExtensionNoTemplates,
   llmConfigOptionsFieldExtensionWithTemplates,
-  topologyTypeFieldExtension,
-  customTopologyConfigFieldExtension,
-  advancedRoutingFieldExtension,
-  topologyTypeApplyExtension,
-  topologyTypeExtractorExtension,
-  topologyConfigApplyExtension,
-  topologyConfigExtractorExtension,
-  routingConfigApplyExtension,
-  routingConfigExtractorExtension,
+  ...topologyConfigsExtensions,
   gatewaySelectFieldExtension,
   gatewaySelectApplyExtension,
   gatewaySelectExtractorExtension,

--- a/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
+++ b/packages/llmd-serving/src/api/LLMInferenceServiceConfigs.ts
@@ -1,8 +1,9 @@
 import React from 'react';
-import useFetch, { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
+import useFetch, { FetchStateObject, NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetch';
 import {
   k8sCreateResource,
   k8sDeleteResource,
+  k8sGetResource,
   k8sListResourceItems,
   k8sPatchResource,
   k8sUpdateResource,
@@ -13,6 +14,7 @@ import { createPatchesFromDiff, groupVersionKind } from '@odh-dashboard/internal
 import { K8sAPIOptions } from '@odh-dashboard/k8s-core';
 import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
+import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
 import { CONFIG_TYPE_LABEL } from '../const';
 import {
   LLMInferenceServiceConfigModel,
@@ -83,14 +85,58 @@ export const patchLLMInferenceServiceConfig = (
   );
 };
 
+export const getLLMInferenceServiceConfig = (
+  name: string,
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<LLMInferenceServiceConfigKind> =>
+  k8sGetResource<LLMInferenceServiceConfigKind>(
+    applyK8sAPIOptions(
+      {
+        model: LLMInferenceServiceConfigModel,
+        queryOptions: { name, ns: namespace },
+      },
+      opts,
+    ),
+  );
+
+export const useFetchLLMInferenceServiceConfig = (
+  name?: string,
+  namespace?: string,
+): FetchStateObject<LLMInferenceServiceConfigKind | null> => {
+  const fetchCallbackPromise = React.useCallback(
+    async (opts: K8sAPIOptions) => {
+      if (!name || !namespace) {
+        throw new NotReadyError('No config name or namespace');
+      }
+      return getLLMInferenceServiceConfig(name, namespace, opts).catch((e: unknown) => {
+        // If not found, just return `null`
+        if (getGenericErrorCode(e) === 404) {
+          return null;
+        }
+        throw e;
+      });
+    },
+    [name, namespace],
+  );
+
+  return useFetch(fetchCallbackPromise, null);
+};
+
 export const deleteLLMInferenceServiceConfig = (
   name: string,
   namespace: string,
+  opts?: K8sAPIOptions,
 ): Promise<K8sStatus> =>
-  k8sDeleteResource<typeof LLMInferenceServiceConfigModel, K8sStatus>({
-    model: LLMInferenceServiceConfigModel,
-    queryOptions: { name, ns: namespace },
-  });
+  k8sDeleteResource<LLMInferenceServiceConfigKind, K8sStatus>(
+    applyK8sAPIOptions(
+      {
+        model: LLMInferenceServiceConfigModel,
+        queryOptions: { name, ns: namespace },
+      },
+      opts,
+    ),
+  );
 
 /**
  * @returns Template versions of the LLMInferenceServiceConfigKind[] (filtered on 'opendatahub.io/config-type=accelerator')

--- a/packages/llmd-serving/src/api/LLMdDeployment.ts
+++ b/packages/llmd-serving/src/api/LLMdDeployment.ts
@@ -1,26 +1,41 @@
 import { k8sDeleteResource, K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
+import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
+import { deleteLLMInferenceServiceConfig } from './LLMInferenceServiceConfigs';
 import {
-  LLMInferenceServiceConfigModel,
   LLMInferenceServiceModel,
+  TOPOLOGY_CONFIG_REF_ANNOTATION,
   type LLMdDeployment,
 } from '../types';
 
 export const deleteDeployment = async (deployment: LLMdDeployment): Promise<void> => {
   const { name, namespace } = deployment.model.metadata;
 
-  const deleteService = k8sDeleteResource<typeof LLMInferenceServiceModel, K8sStatus>({
-    model: LLMInferenceServiceModel,
-    queryOptions: { name, ns: namespace },
-  });
+  const deletions: Promise<unknown>[] = [
+    k8sDeleteResource<typeof LLMInferenceServiceModel, K8sStatus>({
+      model: LLMInferenceServiceModel,
+      queryOptions: { name, ns: namespace },
+    }),
+  ];
 
+  // The accelerator config copy shares the deployment's name
   const hasMatchingConfig = deployment.model.spec.baseRefs?.some((ref) => ref.name === name);
   if (hasMatchingConfig) {
-    const deleteConfig = k8sDeleteResource<typeof LLMInferenceServiceConfigModel, K8sStatus>({
-      model: LLMInferenceServiceConfigModel,
-      queryOptions: { name, ns: namespace },
-    });
-    await Promise.all([deleteService, deleteConfig]);
-  } else {
-    await deleteService;
+    deletions.push(deleteLLMInferenceServiceConfig(name, namespace));
   }
+
+  // The local copy of the topology config is recorded on the deployment by annotation
+  const topologyConfigName =
+    deployment.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION];
+  if (topologyConfigName && topologyConfigName !== name) {
+    deletions.push(
+      deleteLLMInferenceServiceConfig(topologyConfigName, namespace).catch((e: unknown) => {
+        // Don't block the deletion if not found. It could be in the global namespace by accident
+        if (getGenericErrorCode(e) !== 404) {
+          throw e;
+        }
+      }),
+    );
+  }
+
+  await Promise.all(deletions);
 };

--- a/packages/llmd-serving/src/api/__tests__/LLMdDeployment.spec.ts
+++ b/packages/llmd-serving/src/api/__tests__/LLMdDeployment.spec.ts
@@ -1,0 +1,161 @@
+import { k8sDeleteResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { K8sStatusError } from '@odh-dashboard/k8s-core';
+import { mockLLMInferenceServiceK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceK8sResource';
+import { deleteDeployment } from '../LLMdDeployment';
+import {
+  LLMInferenceServiceConfigModel,
+  LLMInferenceServiceModel,
+  TOPOLOGY_CONFIG_REF_ANNOTATION,
+  type LLMdDeployment,
+  type LLMInferenceServiceKind,
+} from '../../types';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils');
+
+const mockK8sDeleteResource = jest.mocked(k8sDeleteResource);
+
+const DEPLOYMENT_NAME = 'test-llm-inference-service';
+const NAMESPACE = 'test-project';
+
+const makeDeployment = (
+  overrides?: Partial<{
+    baseRefs: LLMInferenceServiceKind['spec']['baseRefs'];
+    annotations: Record<string, string>;
+  }>,
+): LLMdDeployment => {
+  const model = mockLLMInferenceServiceK8sResource({
+    additionalAnnotations: overrides?.annotations,
+  });
+  if (overrides?.baseRefs) {
+    model.spec.baseRefs = overrides.baseRefs;
+  }
+  return { modelServingPlatformId: 'llmd-serving', model };
+};
+
+/** The names passed to k8sDeleteResource, grouped by the model they were deleted from. */
+const deletedNames = (
+  model: typeof LLMInferenceServiceConfigModel | typeof LLMInferenceServiceModel,
+) =>
+  mockK8sDeleteResource.mock.calls
+    .filter(([options]) => options.model === model)
+    .map(([options]) => options.queryOptions?.name);
+
+const k8sStatusError = (code: number) =>
+  new K8sStatusError({
+    apiVersion: 'v1',
+    kind: 'Status',
+    status: 'Failure',
+    code,
+    message: 'error',
+    reason: 'Error',
+  });
+
+describe('deleteDeployment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockK8sDeleteResource.mockResolvedValue({ kind: 'Status', status: 'Success' });
+  });
+
+  it('should delete only the deployment when it references no configs', async () => {
+    await deleteDeployment(makeDeployment());
+
+    expect(deletedNames(LLMInferenceServiceModel)).toEqual([DEPLOYMENT_NAME]);
+    expect(deletedNames(LLMInferenceServiceConfigModel)).toEqual([]);
+    expect(mockK8sDeleteResource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: LLMInferenceServiceModel,
+        queryOptions: { name: DEPLOYMENT_NAME, ns: NAMESPACE },
+      }),
+    );
+  });
+
+  it('should delete the accelerator config that shares the deployment name', async () => {
+    await deleteDeployment(makeDeployment({ baseRefs: [{ name: DEPLOYMENT_NAME }] }));
+
+    expect(deletedNames(LLMInferenceServiceModel)).toEqual([DEPLOYMENT_NAME]);
+    expect(deletedNames(LLMInferenceServiceConfigModel)).toEqual([DEPLOYMENT_NAME]);
+  });
+
+  it('should delete the local topology config copy named by the annotation', async () => {
+    const localConfigName = `${DEPLOYMENT_NAME}-multi-node-config`;
+    await deleteDeployment(
+      makeDeployment({
+        baseRefs: [{ name: localConfigName }],
+        annotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: localConfigName },
+      }),
+    );
+
+    expect(deletedNames(LLMInferenceServiceModel)).toEqual([DEPLOYMENT_NAME]);
+    expect(deletedNames(LLMInferenceServiceConfigModel)).toEqual([localConfigName]);
+    expect(mockK8sDeleteResource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: LLMInferenceServiceConfigModel,
+        queryOptions: expect.objectContaining({ name: localConfigName, ns: NAMESPACE }),
+      }),
+    );
+  });
+
+  it('should delete both the accelerator config and the local topology config copy', async () => {
+    const localConfigName = `${DEPLOYMENT_NAME}-multi-node-config`;
+    await deleteDeployment(
+      makeDeployment({
+        baseRefs: [{ name: DEPLOYMENT_NAME }, { name: localConfigName }],
+        annotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: localConfigName },
+      }),
+    );
+
+    expect(deletedNames(LLMInferenceServiceConfigModel)).toEqual([
+      DEPLOYMENT_NAME,
+      localConfigName,
+    ]);
+  });
+
+  it('should not delete the same config twice when the annotation matches the deployment name', async () => {
+    await deleteDeployment(
+      makeDeployment({
+        baseRefs: [{ name: DEPLOYMENT_NAME }],
+        annotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: DEPLOYMENT_NAME },
+      }),
+    );
+
+    expect(deletedNames(LLMInferenceServiceConfigModel)).toEqual([DEPLOYMENT_NAME]);
+  });
+
+  it('should not block deletion when the topology config is not found', async () => {
+    const localConfigName = `${DEPLOYMENT_NAME}-multi-node-config`;
+    mockK8sDeleteResource.mockImplementation((options) =>
+      options.queryOptions?.name === localConfigName
+        ? Promise.reject(k8sStatusError(404))
+        : Promise.resolve({ kind: 'Status', status: 'Success' }),
+    );
+
+    await expect(
+      deleteDeployment(
+        makeDeployment({
+          baseRefs: [{ name: localConfigName }],
+          annotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: localConfigName },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(deletedNames(LLMInferenceServiceModel)).toEqual([DEPLOYMENT_NAME]);
+  });
+
+  it('should propagate non-404 errors from the topology config deletion', async () => {
+    const localConfigName = `${DEPLOYMENT_NAME}-multi-node-config`;
+    mockK8sDeleteResource.mockImplementation((options) =>
+      options.queryOptions?.name === localConfigName
+        ? Promise.reject(k8sStatusError(403))
+        : Promise.resolve({ kind: 'Status', status: 'Success' }),
+    );
+
+    await expect(
+      deleteDeployment(
+        makeDeployment({
+          baseRefs: [{ name: localConfigName }],
+          annotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: localConfigName },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(K8sStatusError);
+  });
+});

--- a/packages/llmd-serving/src/const.ts
+++ b/packages/llmd-serving/src/const.ts
@@ -11,3 +11,8 @@ export const TOPOLOGY_TYPE_ANNOTATION = 'opendatahub.io/topology-type';
 export const TOPOLOGY_CONFIG_REF_ANNOTATION = 'opendatahub.io/topology-config-ref';
 export const ROUTING_CONFIG_REF_ANNOTATION = 'opendatahub.io/routing-config-ref';
 export const VLLM_ADDITIONAL_ARGS = 'VLLM_ADDITIONAL_ARGS';
+
+// --- Wizard field ids (declared here so fields can reference each other without import cycles) ---
+
+export const TOPOLOGY_TYPE_FIELD_ID = 'llmd-serving/topology-type';
+export const CUSTOM_TOPOLOGY_CONFIG_FIELD_ID = 'llmd-serving/custom-topology-config';

--- a/packages/llmd-serving/src/deployments/__tests__/topology.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/topology.spec.ts
@@ -1,5 +1,6 @@
 import { mockLLMInferenceServiceK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceK8sResource';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { K8sStatusError } from '@odh-dashboard/k8s-core';
 import {
   TOPOLOGY_TYPE_ANNOTATION,
   TOPOLOGY_CONFIG_REF_ANNOTATION,
@@ -174,6 +175,31 @@ describe('applyTopologyConfig', () => {
     expect(result.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION]).toBe(
       localConfigName('topo-1'),
     );
+  });
+
+  it('truncates the local copy name to the k8s name length limit', () => {
+    const deployment = makeDeployment();
+    const config = buildTopologyConfig('a'.repeat(250), TopologyType.MULTI_NODE);
+    const result = applyTopologyConfig(deployment, { selectedConfig: config });
+
+    const name = result.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION];
+    expect(name).toHaveLength(253);
+    expect(name).toEqual(expect.stringMatching(new RegExp(`^${DEPLOYMENT_NAME}-a+$`)));
+    expect(result.model.spec.baseRefs).toContainEqual({ name });
+  });
+
+  it('does not leave a trailing hyphen when truncating the local copy name', () => {
+    const deployment = makeDeployment();
+    // Positions the cut directly after a hyphen: prefix (27) + 225 chars + '-' === 253
+    const config = buildTopologyConfig(
+      `${'a'.repeat(225)}-${'b'.repeat(30)}`,
+      TopologyType.MULTI_NODE,
+    );
+    const result = applyTopologyConfig(deployment, { selectedConfig: config });
+
+    const name = result.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION];
+    expect(name).toBe(`${DEPLOYMENT_NAME}-${'a'.repeat(225)}`);
+    expect(name).not.toMatch(/-$/);
   });
 
   it('does not mutate the original deployment', () => {
@@ -376,6 +402,48 @@ describe('preDeploy config copies', () => {
     expect(created.metadata.annotations?.['openshift.io/display-name']).toBe(
       'Topology topo-1 (Local Copy)',
     );
+  });
+
+  it('recreates the copy when editing without changing the selected config', async () => {
+    const topologyConfig = buildTopologyConfig('topo-1', TopologyType.SINGLE_NODE);
+    const configRef = localConfigName('topo-1');
+
+    const existingDeployment = makeDeployment({
+      annotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: configRef },
+    });
+    let deployment = makeDeployment();
+    deployment = applyTopologyConfig(deployment, { selectedConfig: topologyConfig });
+
+    await preDeployTopologyConfig(
+      { selectedConfig: topologyConfig },
+      wizardState,
+      deployment,
+      existingDeployment,
+    );
+
+    expect(mockCreateConfig).toHaveBeenCalledTimes(1);
+    expect(mockCreateConfig.mock.calls[0][0].metadata.name).toBe(configRef);
+  });
+
+  it('tolerates a 409 when the local copy already exists', async () => {
+    const topologyConfig = buildTopologyConfig('topo-1', TopologyType.SINGLE_NODE);
+    mockCreateConfig.mockRejectedValue(
+      new K8sStatusError({
+        apiVersion: 'v1',
+        kind: 'Status',
+        status: 'Failure',
+        code: 409,
+        message: 'already exists',
+        reason: 'AlreadyExists',
+      }),
+    );
+
+    let deployment = makeDeployment();
+    deployment = applyTopologyConfig(deployment, { selectedConfig: topologyConfig });
+
+    await expect(
+      preDeployTopologyConfig({ selectedConfig: topologyConfig }, wizardState, deployment),
+    ).resolves.toBe(deployment);
   });
 });
 

--- a/packages/llmd-serving/src/deployments/__tests__/topology.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/topology.spec.ts
@@ -16,7 +16,6 @@ import {
   extractTopologyConfig,
   extractRoutingConfig,
   preDeployTopologyConfig,
-  preDeployRouterConfig,
 } from '../topology';
 import { createLLMInferenceServiceConfig } from '../../api/LLMInferenceServiceConfigs';
 
@@ -331,17 +330,6 @@ describe('preDeploy config copies', () => {
     expect(mockCreateConfig).toHaveBeenCalledTimes(1);
     const created = mockCreateConfig.mock.calls[0][0];
     expect(created.metadata.labels?.['opendatahub.io/config-type']).toBe(TopologyType.SINGLE_NODE);
-  });
-
-  it('carries the config type label onto the router config copy', async () => {
-    const routerConfig = buildRouterConfig('router-1');
-    const deployment = makeDeployment();
-
-    await preDeployRouterConfig({ selectedConfig: routerConfig }, wizardState, deployment);
-
-    expect(mockCreateConfig).toHaveBeenCalledTimes(1);
-    const created = mockCreateConfig.mock.calls[0][0];
-    expect(created.metadata.labels?.['opendatahub.io/config-type']).toBe('router');
   });
 
   it('does not carry the dashboard label onto the copy', async () => {

--- a/packages/llmd-serving/src/deployments/__tests__/topology.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/topology.spec.ts
@@ -42,6 +42,11 @@ const makeDeployment = (
   return { modelServingPlatformId: 'llmd-serving', model };
 };
 
+const DEPLOYMENT_NAME = 'test-llm-inference-service';
+
+/** Topology configs are copied into the deployment's namespace under a deployment-prefixed name. */
+const localConfigName = (configName: string) => `${DEPLOYMENT_NAME}-${configName}`;
+
 const buildTopologyConfig = (name: string, topologyType: TopologyType) =>
   mockLLMInferenceServiceConfigK8sResource({
     name,
@@ -97,13 +102,15 @@ describe('applyTopologyType', () => {
 // ─── applyTopologyConfig ────────────────────────────────────────────────────────
 
 describe('applyTopologyConfig', () => {
-  it('adds config name to baseRefs and stores annotation', () => {
+  it('adds the local config copy name to baseRefs and stores annotation', () => {
     const deployment = makeDeployment();
     const config = buildTopologyConfig('topo-1', TopologyType.MULTI_NODE);
     const result = applyTopologyConfig(deployment, { selectedConfig: config });
 
-    expect(result.model.spec.baseRefs).toContainEqual({ name: 'topo-1' });
-    expect(result.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION]).toBe('topo-1');
+    expect(result.model.spec.baseRefs).toContainEqual({ name: localConfigName('topo-1') });
+    expect(result.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION]).toBe(
+      localConfigName('topo-1'),
+    );
   });
 
   it('replaces a previous topology config baseRef', () => {
@@ -114,9 +121,11 @@ describe('applyTopologyConfig', () => {
     const config = buildTopologyConfig('new-topo', TopologyType.SINGLE_NODE_DISAGGREGATED);
     const result = applyTopologyConfig(deployment, { selectedConfig: config });
 
-    expect(result.model.spec.baseRefs).toContainEqual({ name: 'new-topo' });
+    expect(result.model.spec.baseRefs).toContainEqual({ name: localConfigName('new-topo') });
     expect(result.model.spec.baseRefs).not.toContainEqual({ name: 'old-topo' });
-    expect(result.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION]).toBe('new-topo');
+    expect(result.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION]).toBe(
+      localConfigName('new-topo'),
+    );
   });
 
   it('removes the topology baseRef when no config is selected', () => {
@@ -139,19 +148,32 @@ describe('applyTopologyConfig', () => {
 
     expect(result.model.spec.baseRefs).toContainEqual({ name: 'my-deployment' });
     expect(result.model.spec.baseRefs).toContainEqual({ name: 'some-other-ref' });
-    expect(result.model.spec.baseRefs).toContainEqual({ name: 'topo-1' });
+    expect(result.model.spec.baseRefs).toContainEqual({ name: localConfigName('topo-1') });
   });
 
   it('does not duplicate an existing baseRef', () => {
     const deployment = makeDeployment({
-      baseRefs: [{ name: 'topo-1' }],
-      annotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'topo-1' },
+      baseRefs: [{ name: localConfigName('topo-1') }],
+      annotations: { [TOPOLOGY_CONFIG_REF_ANNOTATION]: localConfigName('topo-1') },
     });
     const config = buildTopologyConfig('topo-1', TopologyType.MULTI_NODE);
     const result = applyTopologyConfig(deployment, { selectedConfig: config });
 
-    const matching = result.model.spec.baseRefs?.filter((r) => r.name === 'topo-1');
+    const matching = result.model.spec.baseRefs?.filter(
+      (r) => r.name === localConfigName('topo-1'),
+    );
     expect(matching).toHaveLength(1);
+  });
+
+  it('does not re-prefix a config that is already a local copy', () => {
+    const deployment = makeDeployment();
+    const config = buildTopologyConfig(localConfigName('topo-1'), TopologyType.MULTI_NODE);
+    const result = applyTopologyConfig(deployment, { selectedConfig: config });
+
+    expect(result.model.spec.baseRefs).toEqual([{ name: localConfigName('topo-1') }]);
+    expect(result.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION]).toBe(
+      localConfigName('topo-1'),
+    );
   });
 
   it('does not mutate the original deployment', () => {
@@ -246,7 +268,7 @@ describe('baseRefs ordering', () => {
     deployment = applyRoutingConfig(deployment, { selectedConfig: routerConfig });
 
     const names = deployment.model.spec.baseRefs?.map((r) => r.name) ?? [];
-    expect(names.indexOf('topo-1')).toBeLessThan(names.indexOf('router-1'));
+    expect(names.indexOf(localConfigName('topo-1'))).toBeLessThan(names.indexOf('router-1'));
   });
 
   it('coexists with existing accelerator config baseRef', () => {
@@ -259,7 +281,7 @@ describe('baseRefs ordering', () => {
 
     expect(deployment.model.spec.baseRefs).toEqual([
       { name: 'my-deployment' },
-      { name: 'topo-1' },
+      { name: localConfigName('topo-1') },
       { name: 'router-1' },
     ]);
   });

--- a/packages/llmd-serving/src/deployments/__tests__/topology.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/topology.spec.ts
@@ -15,7 +15,17 @@ import {
   extractTopologyType,
   extractTopologyConfig,
   extractRoutingConfig,
+  preDeployTopologyConfig,
+  preDeployRouterConfig,
 } from '../topology';
+import { createLLMInferenceServiceConfig } from '../../api/LLMInferenceServiceConfigs';
+
+jest.mock('../../api/LLMInferenceServiceConfigs', () => ({
+  createLLMInferenceServiceConfig: jest.fn(),
+  deleteLLMInferenceServiceConfig: jest.fn(),
+}));
+
+const mockCreateConfig = jest.mocked(createLLMInferenceServiceConfig);
 
 const makeDeployment = (
   overrides?: Partial<{
@@ -294,6 +304,68 @@ describe('extractTopologyConfig', () => {
   it('returns undefined when no annotation exists', () => {
     const deployment = makeDeployment();
     expect(extractTopologyConfig(deployment)).toBeUndefined();
+  });
+});
+
+// ─── preDeploy config copies ───────────────────────────────────────────────────
+
+describe('preDeploy config copies', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const wizardState = {} as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateConfig.mockResolvedValue(mockLLMInferenceServiceConfigK8sResource({}));
+  });
+
+  it('carries the config type label onto the topology config copy', async () => {
+    const topologyConfig = buildTopologyConfig('topo-1', TopologyType.SINGLE_NODE);
+    expect(topologyConfig.metadata.labels?.['opendatahub.io/config-type']).toBe(
+      TopologyType.SINGLE_NODE,
+    );
+
+    let deployment = makeDeployment();
+    deployment = applyTopologyConfig(deployment, { selectedConfig: topologyConfig });
+    await preDeployTopologyConfig({ selectedConfig: topologyConfig }, wizardState, deployment);
+
+    expect(mockCreateConfig).toHaveBeenCalledTimes(1);
+    const created = mockCreateConfig.mock.calls[0][0];
+    expect(created.metadata.labels?.['opendatahub.io/config-type']).toBe(TopologyType.SINGLE_NODE);
+  });
+
+  it('carries the config type label onto the router config copy', async () => {
+    const routerConfig = buildRouterConfig('router-1');
+    const deployment = makeDeployment();
+
+    await preDeployRouterConfig({ selectedConfig: routerConfig }, wizardState, deployment);
+
+    expect(mockCreateConfig).toHaveBeenCalledTimes(1);
+    const created = mockCreateConfig.mock.calls[0][0];
+    expect(created.metadata.labels?.['opendatahub.io/config-type']).toBe('router');
+  });
+
+  it('does not carry the dashboard label onto the copy', async () => {
+    const topologyConfig = buildTopologyConfig('topo-1', TopologyType.SINGLE_NODE);
+
+    let deployment = makeDeployment();
+    deployment = applyTopologyConfig(deployment, { selectedConfig: topologyConfig });
+    await preDeployTopologyConfig({ selectedConfig: topologyConfig }, wizardState, deployment);
+
+    const created = mockCreateConfig.mock.calls[0][0];
+    expect(created.metadata.labels?.['opendatahub.io/dashboard']).toBeUndefined();
+  });
+
+  it('marks the copy as a local copy in its display name', async () => {
+    const topologyConfig = buildTopologyConfig('topo-1', TopologyType.SINGLE_NODE);
+
+    let deployment = makeDeployment();
+    deployment = applyTopologyConfig(deployment, { selectedConfig: topologyConfig });
+    await preDeployTopologyConfig({ selectedConfig: topologyConfig }, wizardState, deployment);
+
+    const created = mockCreateConfig.mock.calls[0][0];
+    expect(created.metadata.annotations?.['openshift.io/display-name']).toBe(
+      'Topology topo-1 (Local Copy)',
+    );
   });
 });
 

--- a/packages/llmd-serving/src/deployments/deploy.ts
+++ b/packages/llmd-serving/src/deployments/deploy.ts
@@ -40,6 +40,7 @@ import {
   patchLLMInferenceServiceConfig,
   updateLLMInferenceServiceConfig,
 } from '../api/LLMInferenceServiceConfigs';
+import { cleanlyDuplicateConfig } from '../utils';
 
 export const BaseLLMInferenceService = (
   name?: string,
@@ -174,24 +175,20 @@ const assembleLLMInferenceServiceConfig = (
     const accelerators =
       data.template.metadata.annotations?.['opendatahub.io/recommended-accelerators'];
 
-    return {
-      ...data.template,
-      metadata: {
-        // Exclude other metadata to exclude existing resource version stuff
-        name: data.deploymentName,
-        namespace: data.deploymentNamespace,
-        annotations: {
-          ...data.template.metadata.annotations,
-          'opendatahub.io/template-name': templateName,
-          ...(templateVersion !== undefined && {
-            'opendatahub.io/runtime-version': templateVersion,
-          }),
-          ...(accelerators !== undefined && {
-            'opendatahub.io/recommended-accelerators': accelerators,
-          }),
-        },
+    return cleanlyDuplicateConfig(data.template, {
+      name: data.deploymentName,
+      namespace: data.deploymentNamespace,
+      annotations: {
+        ...data.template.metadata.annotations,
+        'opendatahub.io/template-name': templateName,
+        ...(templateVersion !== undefined && {
+          'opendatahub.io/runtime-version': templateVersion,
+        }),
+        ...(accelerators !== undefined && {
+          'opendatahub.io/recommended-accelerators': accelerators,
+        }),
       },
-    };
+    });
   }
   return undefined;
 };

--- a/packages/llmd-serving/src/deployments/topology.ts
+++ b/packages/llmd-serving/src/deployments/topology.ts
@@ -1,10 +1,17 @@
 import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
 import {
+  getDescriptionFromK8sResource,
+  getDisplayNameFromK8sResource,
+} from '@odh-dashboard/k8s-core';
+import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
+import {
+  CONFIG_TYPE_LABEL,
   TOPOLOGY_TYPE_ANNOTATION,
   TOPOLOGY_CONFIG_REF_ANNOTATION,
   ROUTING_CONFIG_REF_ANNOTATION,
   TopologyType,
   type LLMdDeployment,
+  LLMInferenceServiceConfigKind,
 } from '../types';
 import type { TopologyTypeFieldData } from '../wizardFields/TopologyTypeField';
 import {
@@ -12,8 +19,38 @@ import {
   type CustomTopologyConfigFieldData,
 } from '../wizardFields/CustomTopologyConfigField';
 import type { AdvancedRoutingFieldData } from '../wizardFields/AdvancedRoutingField';
+import {
+  createLLMInferenceServiceConfig,
+  deleteLLMInferenceServiceConfig,
+} from '../api/LLMInferenceServiceConfigs';
+import { cleanlyDuplicateConfig } from '../utils';
 
 const topologyTypeValues: string[] = Object.values(TopologyType);
+
+const createLocalConfigName = (
+  deployment: LLMdDeployment,
+  config: LLMInferenceServiceConfigKind,
+) => {
+  const prefix = `${deployment.model.metadata.name}-`;
+  return config.metadata.name.startsWith(prefix)
+    ? config.metadata.name
+    : `${prefix}${config.metadata.name}`;
+};
+
+const createLocalConfigMetadata = (
+  config: LLMInferenceServiceConfigKind,
+): { annotations: Record<string, string>; labels: Record<string, string> } => {
+  const configType = config.metadata.labels?.[CONFIG_TYPE_LABEL];
+  return {
+    annotations: {
+      'openshift.io/display-name': `${getDisplayNameFromK8sResource(config)} (Local Copy)`,
+      'openshift.io/description': getDescriptionFromK8sResource(config),
+    },
+    labels: {
+      ...(configType && { [CONFIG_TYPE_LABEL]: configType }),
+    },
+  };
+};
 
 // ─── Apply: Topology Type ──────────────────────────────────────────────────────
 
@@ -54,7 +91,7 @@ export const applyTopologyConfig = (
 
   const config = fieldData?.selectedConfig;
   if (config && config !== TOPOLOGY_CONFIG_DEFAULT) {
-    const configName = config.metadata.name;
+    const configName = createLocalConfigName(deployment, config);
     annotations[TOPOLOGY_CONFIG_REF_ANNOTATION] = configName;
 
     if (!result.model.spec.baseRefs) {
@@ -67,6 +104,58 @@ export const applyTopologyConfig = (
 
   result.model.metadata.annotations = annotations;
   return result;
+};
+
+// ─── PreDeploy: Topology Config ────────────────────────────────────────────────
+
+export const preDeployTopologyConfig = async (
+  fieldData: CustomTopologyConfigFieldData,
+  wizardState: WizardFormData['state'],
+  deployment: LLMdDeployment,
+  existingDeployment?: LLMdDeployment,
+  dryRun?: boolean,
+): Promise<LLMdDeployment> => {
+  const { namespace } = deployment.model.metadata;
+
+  const prevTopologyConfigName =
+    existingDeployment?.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION];
+  const newTopologyConfigName =
+    deployment.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION];
+
+  // clean up old topology config if switching to new one
+  if (prevTopologyConfigName && prevTopologyConfigName !== newTopologyConfigName) {
+    await deleteLLMInferenceServiceConfig(prevTopologyConfigName, namespace, { dryRun }).catch(
+      (e: unknown) => {
+        // Don't block if not found. It could be in the global namespace by accident
+        if (getGenericErrorCode(e) !== 404) {
+          throw e;
+        }
+      },
+    );
+  }
+
+  // create new topology config
+  if (
+    fieldData.selectedConfig &&
+    newTopologyConfigName &&
+    fieldData.selectedConfig !== TOPOLOGY_CONFIG_DEFAULT &&
+    prevTopologyConfigName !== newTopologyConfigName
+  ) {
+    const config = cleanlyDuplicateConfig(fieldData.selectedConfig, {
+      name: newTopologyConfigName,
+      namespace,
+      ...createLocalConfigMetadata(fieldData.selectedConfig),
+    });
+
+    await createLLMInferenceServiceConfig(config, { dryRun }).catch((e: unknown) => {
+      // Don't block if it already exists
+      if (getGenericErrorCode(e) !== 409) {
+        throw e;
+      }
+    });
+  }
+
+  return deployment;
 };
 
 // ─── Apply: Routing Config ─────────────────────────────────────────────────────

--- a/packages/llmd-serving/src/deployments/topology.ts
+++ b/packages/llmd-serving/src/deployments/topology.ts
@@ -27,14 +27,20 @@ import { cleanlyDuplicateConfig } from '../utils';
 
 const topologyTypeValues: string[] = Object.values(TopologyType);
 
+/** K8s DNS subdomain limit for resource names */
+const MAX_K8S_NAME_LENGTH = 253;
+
 const createLocalConfigName = (
   deployment: LLMdDeployment,
   config: LLMInferenceServiceConfigKind,
 ) => {
   const prefix = `${deployment.model.metadata.name}-`;
-  return config.metadata.name.startsWith(prefix)
-    ? config.metadata.name
-    : `${prefix}${config.metadata.name}`;
+  if (config.metadata.name.startsWith(prefix)) {
+    return config.metadata.name;
+  }
+  // Truncate the config portion so the prefixed name stays creatable; a trailing hyphen left
+  // behind by the cut is not a valid k8s name, so strip it
+  return `${prefix}${config.metadata.name}`.slice(0, MAX_K8S_NAME_LENGTH).replace(/-+$/, '');
 };
 
 const createLocalConfigMetadata = (
@@ -138,8 +144,7 @@ export const preDeployTopologyConfig = async (
   if (
     fieldData.selectedConfig &&
     newTopologyConfigName &&
-    fieldData.selectedConfig !== TOPOLOGY_CONFIG_DEFAULT &&
-    prevTopologyConfigName !== newTopologyConfigName
+    fieldData.selectedConfig !== TOPOLOGY_CONFIG_DEFAULT
   ) {
     const config = cleanlyDuplicateConfig(fieldData.selectedConfig, {
       name: newTopologyConfigName,

--- a/packages/llmd-serving/src/utils.ts
+++ b/packages/llmd-serving/src/utils.ts
@@ -81,3 +81,26 @@ export const isConfigEnabled = (config: LLMInferenceServiceConfigKind): boolean 
 
 export const isConfigEffectivelyEnabled = (config: LLMInferenceServiceConfigKind): boolean =>
   isUnsupportedUnaccepted(config) ? false : isConfigEnabled(config);
+
+export const cleanlyDuplicateConfig = (
+  existingConfig: LLMInferenceServiceConfigKind,
+  metadata: {
+    name?: string;
+    namespace?: string;
+    annotations?: Record<string, string>;
+    labels?: Record<string, string>;
+  },
+): LLMInferenceServiceConfigKind => {
+  const duplicatedConfig = structuredClone(existingConfig);
+
+  return {
+    ...duplicatedConfig,
+    metadata: {
+      // Exclude other metadata to exclude existing resource version stuff
+      name: metadata.name || duplicatedConfig.metadata.name,
+      namespace: metadata.namespace || duplicatedConfig.metadata.namespace,
+      ...(metadata.annotations && { annotations: metadata.annotations }),
+      ...(metadata.labels && { labels: metadata.labels }),
+    },
+  };
+};

--- a/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
+++ b/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
@@ -184,7 +184,7 @@ const CustomTopologyConfigFieldComponent: CustomTopologyConfigFieldType['compone
             placeholder="Select configuration"
             value={selectedValue}
             dataTestId="custom-topology-config-select"
-            isDisabled={!isLoaded || hasLoadError || noConfigsAvailable}
+            isDisabled={!isLoaded || noConfigsAvailable}
             autoSelectOnlyOption={false}
           />
           {hasLoadError ? (

--- a/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
+++ b/packages/llmd-serving/src/wizardFields/CustomTopologyConfigField.tsx
@@ -19,16 +19,19 @@ import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { LLMD_DEPLOYMENT_METHOD_KEY } from './deploymentMethodField';
 import {
   useTopologyTypeData,
+  resolveTopologyConfigsDependencies,
   isTopologyTypeFieldData,
   type TopologyTypeFieldData,
   type TopologyTypeExternalData,
+  type TopologyConfigsDependencies,
 } from './TopologyTypeField';
 import { TopologyType, type LLMInferenceServiceConfigKind } from '../types';
 import { isLLMInferenceServiceActive } from '../formUtils';
+import { CUSTOM_TOPOLOGY_CONFIG_FIELD_ID, TOPOLOGY_TYPE_FIELD_ID } from '../const';
 
 // --- Dependencies ---
 
-type CustomTopologyConfigDependencies = {
+type CustomTopologyConfigDependencies = TopologyConfigsDependencies & {
   topologyType?: TopologyTypeFieldData;
 };
 
@@ -238,14 +241,15 @@ const isActive = (wizardState: RecursivePartial<WizardFormData['state']>): boole
 // --- Field definition ---
 
 export const CustomTopologyConfigFieldWizardField: CustomTopologyConfigFieldType = {
-  id: 'llmd-serving/custom-topology-config',
+  id: CUSTOM_TOPOLOGY_CONFIG_FIELD_ID,
   step: 'modelDeployment',
   type: 'addition',
   isActive,
   reducerFunctions: {
-    resolveDependencies: (formData) => {
-      const rawTopologyData = formData['llmd-serving/topology-type'];
+    resolveDependencies: (formData, initialData) => {
+      const rawTopologyData = formData[TOPOLOGY_TYPE_FIELD_ID];
       return {
+        ...resolveTopologyConfigsDependencies(formData, initialData),
         topologyType: isTopologyTypeFieldData(rawTopologyData) ? rawTopologyData : undefined,
       };
     },

--- a/packages/llmd-serving/src/wizardFields/TopologyTypeField.tsx
+++ b/packages/llmd-serving/src/wizardFields/TopologyTypeField.tsx
@@ -132,7 +132,7 @@ export const useTopologyTypeData = (
     () => ({
       data: { configsByTopology },
       loaded: loaded && (!configRef || !projectName || referencedLoaded || !!referencedError),
-      loadError: error,
+      loadError: error ?? referencedError,
     }),
     [configsByTopology, loaded, error, configRef, projectName, referencedLoaded, referencedError],
   );

--- a/packages/llmd-serving/src/wizardFields/TopologyTypeField.tsx
+++ b/packages/llmd-serving/src/wizardFields/TopologyTypeField.tsx
@@ -9,6 +9,7 @@ import {
 } from '@patternfly/react-core';
 import { z } from 'zod';
 import type {
+  InitialWizardFormData,
   WizardField,
   WizardFormData,
   WizardReviewSection,
@@ -25,9 +26,42 @@ import {
   getConfigTopologyType,
 } from '../types';
 import { isConfigEnabled } from '../utils';
-import { useFetchTopologyConfigs } from '../api/LLMInferenceServiceConfigs';
+import {
+  useFetchTopologyConfigs,
+  useFetchLLMInferenceServiceConfig,
+} from '../api/LLMInferenceServiceConfigs';
 import { isLLMInferenceServiceActive } from '../formUtils';
 import { fireTopologyTypeSelected } from '../tracking/llmdTrackingConstants';
+import { CUSTOM_TOPOLOGY_CONFIG_FIELD_ID, TOPOLOGY_TYPE_FIELD_ID } from '../const';
+
+// --- Dependencies ---
+
+export type TopologyConfigsDependencies = {
+  project?: WizardFormData['state']['project'];
+  /** The config this deployment already references, from the edit extractor. */
+  configRef?: string;
+  /** The topology type this deployment was deployed with, from the edit extractor. */
+  initialTopologyType?: TopologyType;
+};
+
+const isRecord = (data: unknown): data is Record<string, unknown> =>
+  typeof data === 'object' && data !== null;
+
+const readProperty = (data: unknown, key: string): unknown =>
+  isRecord(data) ? data[key] : undefined;
+
+export const resolveTopologyConfigsDependencies = (
+  formData: WizardFormData['state'],
+  initialData?: InitialWizardFormData,
+): TopologyConfigsDependencies => {
+  const configRef = readProperty(initialData?.[CUSTOM_TOPOLOGY_CONFIG_FIELD_ID], 'configRef');
+  const initialTopologyType = readProperty(initialData?.[TOPOLOGY_TYPE_FIELD_ID], 'topologyType');
+  return {
+    project: formData.project,
+    configRef: typeof configRef === 'string' ? configRef : undefined,
+    initialTopologyType: Object.values(TopologyType).find((t) => t === initialTopologyType),
+  };
+};
 
 // --- External data hook ---
 
@@ -35,13 +69,31 @@ export type TopologyTypeExternalData = {
   configsByTopology: Record<TopologyType, LLMInferenceServiceConfigKind[]>;
 };
 
-export const useTopologyTypeData = (): {
+/**
+ * The dashboard configs, plus the config the deployment already references.
+ *
+ * On edit, baseRefs point at a copy of a config that lives in the deployment's own project
+ * namespace rather than in the dashboard namespace. That copy is fetched by name and folded into
+ * the configs for its topology type, so it is just another option to every consuming field — and
+ * so its topology type isn't reported as having no configurations.
+ */
+export const useTopologyTypeData = (
+  dependencies?: TopologyConfigsDependencies,
+): {
   data: TopologyTypeExternalData;
   loaded: boolean;
   loadError?: Error;
 } => {
   const { dashboardNamespace } = useDashboardNamespace();
   const { data: configs, loaded, error } = useFetchTopologyConfigs(dashboardNamespace);
+
+  const { configRef, initialTopologyType } = dependencies ?? {};
+  const projectName = dependencies?.project?.projectName;
+  const {
+    data: referencedConfig,
+    loaded: referencedLoaded,
+    error: referencedError,
+  } = useFetchLLMInferenceServiceConfig(configRef, projectName);
 
   const configsByTopology = React.useMemo(() => {
     const grouped: Record<TopologyType, LLMInferenceServiceConfigKind[]> = {
@@ -61,16 +113,28 @@ export const useTopologyTypeData = (): {
       }
     }
 
+    // If config has no topology type, use the deployment's type
+    const referencedTopoType = referencedConfig
+      ? getConfigTopologyType(referencedConfig) ?? initialTopologyType
+      : undefined;
+    if (
+      referencedConfig &&
+      referencedTopoType &&
+      !grouped[referencedTopoType].some((c) => c.metadata.name === referencedConfig.metadata.name)
+    ) {
+      grouped[referencedTopoType].push(referencedConfig);
+    }
+
     return grouped;
-  }, [configs]);
+  }, [configs, referencedConfig, initialTopologyType]);
 
   return React.useMemo(
     () => ({
       data: { configsByTopology },
-      loaded,
+      loaded: loaded && (!configRef || !projectName || referencedLoaded || !!referencedError),
       loadError: error,
     }),
-    [configsByTopology, loaded, error],
+    [configsByTopology, loaded, error, configRef, projectName, referencedLoaded, referencedError],
   );
 };
 
@@ -91,7 +155,11 @@ export const isTopologyTypeFieldData = (data: unknown): data is TopologyTypeFiel
   );
 };
 
-export type TopologyTypeFieldType = WizardField<TopologyTypeFieldData, TopologyTypeExternalData>;
+export type TopologyTypeFieldType = WizardField<
+  TopologyTypeFieldData,
+  TopologyTypeExternalData,
+  TopologyConfigsDependencies
+>;
 
 // --- Component ---
 
@@ -189,11 +257,12 @@ const isActive = (wizardState: RecursivePartial<WizardFormData['state']>): boole
 // --- Field definition ---
 
 export const TopologyTypeFieldWizardField: TopologyTypeFieldType = {
-  id: 'llmd-serving/topology-type',
+  id: TOPOLOGY_TYPE_FIELD_ID,
   step: 'modelDeployment',
   type: 'addition',
   isActive,
   reducerFunctions: {
+    resolveDependencies: resolveTopologyConfigsDependencies,
     setFieldData: (value: TopologyTypeFieldData) => value,
     getInitialFieldData: (existingFieldData?: TopologyTypeFieldData): TopologyTypeFieldData =>
       existingFieldData ?? { topologyType: TopologyType.SINGLE_NODE },

--- a/packages/llmd-serving/src/wizardFields/__tests__/CustomTopologyConfigField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/CustomTopologyConfigField.spec.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
-import { TopologyType } from '../../types';
+import { TopologyType, type LLMInferenceServiceConfigKind } from '../../types';
 import {
   CustomTopologyConfigFieldWizardField,
   TOPOLOGY_CONFIG_DEFAULT,
 } from '../CustomTopologyConfigField';
-import type { TopologyTypeExternalData } from '../TopologyTypeField';
 import type { CustomTopologyConfigFieldData } from '../CustomTopologyConfigField';
+import type { TopologyTypeExternalData } from '../TopologyTypeField';
 
 const { getInitialFieldData } = CustomTopologyConfigFieldWizardField.reducerFunctions;
 const CustomTopologyConfigFieldComponent = CustomTopologyConfigFieldWizardField.component;
@@ -29,6 +30,22 @@ const mockSingleNodePdConfig = mockLLMInferenceServiceConfigK8sResource({
   displayName: 'Single Node P/D Config',
   topologyType: TopologyType.SINGLE_NODE_DISAGGREGATED,
 });
+
+const mockLocalConfig: LLMInferenceServiceConfigKind = (() => {
+  const base = mockLLMInferenceServiceConfigK8sResource({
+    name: 'my-model-multi-node-config-1',
+    namespace: 'my-project',
+    displayName: 'Multi-node Config 1 (Local Copy)',
+    topologyType: TopologyType.MULTI_NODE,
+  });
+  return {
+    ...base,
+    metadata: {
+      ...base.metadata,
+      labels: { 'opendatahub.io/config-type': TopologyType.MULTI_NODE },
+    },
+  };
+})();
 
 const emptyConfigsByTopology: Record<
   TopologyType,
@@ -148,12 +165,9 @@ describe('CustomTopologyConfigField component — edit flow configRef resolution
         value={{ configRef: 'multi-node-config-1' }}
         onChange={onChange}
         externalData={{
-          data: {
-            configsByTopology: {
-              ...emptyConfigsByTopology,
-              [TopologyType.MULTI_NODE]: [mockMultiNodeConfig, mockMultiNodeConfig2],
-            },
-          },
+          data: buildExternalData({
+            [TopologyType.MULTI_NODE]: [mockMultiNodeConfig, mockMultiNodeConfig2],
+          }),
           loaded: true,
         }}
         dependencies={{ topologyType: { topologyType: TopologyType.MULTI_NODE } }}
@@ -168,12 +182,7 @@ describe('CustomTopologyConfigField component — edit flow configRef resolution
   it('should clear configRef and auto-select when it references a deleted config', async () => {
     const onChange = jest.fn();
     const externalData = {
-      data: {
-        configsByTopology: {
-          ...emptyConfigsByTopology,
-          [TopologyType.MULTI_NODE]: [mockMultiNodeConfig],
-        },
-      },
+      data: buildExternalData({ [TopologyType.MULTI_NODE]: [mockMultiNodeConfig] }),
       loaded: true,
     };
     const deps = { topologyType: { topologyType: TopologyType.MULTI_NODE } };
@@ -219,7 +228,7 @@ describe('CustomTopologyConfigField component — edit flow configRef resolution
         value={{ configRef: 'deleted-config' }}
         onChange={onChange}
         externalData={{
-          data: { configsByTopology: emptyConfigsByTopology },
+          data: buildExternalData(),
           loaded: true,
         }}
         dependencies={{ topologyType: { topologyType: TopologyType.SINGLE_NODE } }}
@@ -229,5 +238,90 @@ describe('CustomTopologyConfigField component — edit flow configRef resolution
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith({ selectedConfig: TOPOLOGY_CONFIG_DEFAULT });
     });
+  });
+
+  it('should resolve a configRef that points at the project namespace copy of a config', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <CustomTopologyConfigFieldComponent
+        id={fieldId}
+        value={{ configRef: 'my-model-multi-node-config-1' }}
+        onChange={onChange}
+        externalData={{
+          data: buildExternalData({
+            [TopologyType.MULTI_NODE]: [mockMultiNodeConfig, mockLocalConfig],
+          }),
+          loaded: true,
+        }}
+        dependencies={{ topologyType: { topologyType: TopologyType.MULTI_NODE } }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ selectedConfig: mockLocalConfig });
+    });
+    expect(onChange).not.toHaveBeenCalledWith({ configRef: undefined });
+  });
+
+  it('should show the project namespace copy of a config as an option', async () => {
+    render(
+      <CustomTopologyConfigFieldComponent
+        id={fieldId}
+        value={{ selectedConfig: mockLocalConfig }}
+        onChange={jest.fn()}
+        externalData={{
+          data: buildExternalData({
+            [TopologyType.MULTI_NODE]: [mockMultiNodeConfig, mockLocalConfig],
+          }),
+          loaded: true,
+        }}
+        dependencies={{ topologyType: { topologyType: TopologyType.MULTI_NODE } }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('custom-topology-config-select'));
+
+    expect(
+      await screen.findByTestId('topology-config-option-my-model-multi-node-config-1'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('CustomTopologyConfigField resolveDependencies', () => {
+  const { resolveDependencies } = CustomTopologyConfigFieldWizardField.reducerFunctions;
+
+  it('should expose the configRef from the initial data so only that config is fetched', () => {
+    const result = resolveDependencies?.(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      {
+        'llmd-serving/custom-topology-config': { configRef: 'my-model-multi-node-config-1' },
+      },
+    );
+
+    expect(result?.configRef).toBe('my-model-multi-node-config-1');
+  });
+
+  it('should not expose a configRef when the initial data has no ref', () => {
+    const result = resolveDependencies?.(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      { 'llmd-serving/custom-topology-config': { selectedConfig: mockMultiNodeConfig } },
+    );
+
+    expect(result?.configRef).toBeUndefined();
+  });
+
+  it('should expose the current topology type from the form state', () => {
+    const result = resolveDependencies?.(
+      {
+        'llmd-serving/topology-type': { topologyType: TopologyType.MULTI_NODE },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      undefined,
+    );
+
+    expect(result?.topologyType).toEqual({ topologyType: TopologyType.MULTI_NODE });
   });
 });

--- a/packages/llmd-serving/src/wizardFields/__tests__/TopologyTypeField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/TopologyTypeField.spec.tsx
@@ -1,22 +1,67 @@
 import React, { act } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/internal/__mocks__/mockLLMInferenceServiceConfigK8sResource';
+import { testHook } from '@odh-dashboard/jest-config/hooks';
 import { LlmdTrackingEvent } from '../../tracking/llmdTrackingConstants';
-import { TopologyType, TopologyTypeLabels } from '../../types';
+import { TopologyType, TopologyTypeLabels, type LLMInferenceServiceConfigKind } from '../../types';
 import {
   TopologyTypeFieldWizardField,
+  useTopologyTypeData,
   type TopologyTypeExternalData,
   type TopologyTypeFieldData,
 } from '../TopologyTypeField';
+import {
+  useFetchTopologyConfigs,
+  useFetchLLMInferenceServiceConfig,
+} from '../../api/LLMInferenceServiceConfigs';
 
 jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
   fireMiscTrackingEvent: jest.fn(),
 }));
 
+jest.mock('@odh-dashboard/internal/redux/selectors/project', () => ({
+  useDashboardNamespace: jest.fn(() => ({ dashboardNamespace: 'opendatahub' })),
+}));
+
+jest.mock('../../api/LLMInferenceServiceConfigs', () => ({
+  useFetchTopologyConfigs: jest.fn(),
+  useFetchLLMInferenceServiceConfig: jest.fn(),
+}));
+
 const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
+const mockUseFetchTopologyConfigs = jest.mocked(useFetchTopologyConfigs);
+const mockUseFetchLLMInferenceServiceConfig = jest.mocked(useFetchLLMInferenceServiceConfig);
 
 const TopologyTypeFieldComponent = TopologyTypeFieldWizardField.component;
+
+const mockMultiNodeConfig = mockLLMInferenceServiceConfigK8sResource({
+  name: 'multi-node-config-1',
+  displayName: 'Multi-node Config 1',
+  topologyType: TopologyType.MULTI_NODE,
+});
+
+/**
+ * The copy of a config that deploy makes in the deployment's own project namespace. It carries the
+ * config type label over from the source config, but not the dashboard label — it is looked up by
+ * name rather than listed alongside the administrator-defined configs.
+ */
+const mockLocalConfig: LLMInferenceServiceConfigKind = (() => {
+  const base = mockLLMInferenceServiceConfigK8sResource({
+    name: 'my-model-multi-node-config-1',
+    namespace: 'my-project',
+    displayName: 'Multi-node Config 1 (Local Copy)',
+    topologyType: TopologyType.MULTI_NODE,
+  });
+  return {
+    ...base,
+    metadata: {
+      ...base.metadata,
+      labels: { 'opendatahub.io/config-type': TopologyType.MULTI_NODE },
+    },
+  };
+})();
 
 describe('TopologyTypeField tracking', () => {
   const mockOnChange = jest.fn();
@@ -46,6 +91,10 @@ describe('TopologyTypeField tracking', () => {
       fireEvent.click(screen.getByTestId('topology-type-select'));
     });
   };
+
+  // The test id lands on the list item; aria-disabled lives on the option itself.
+  const getMultiNodeOption = () =>
+    within(screen.getByTestId(`topology-type-${TopologyType.MULTI_NODE}`)).getByRole('option');
 
   it('should fire topology type selected tracking with undefined previousPattern on first selection', async () => {
     renderComponent({
@@ -159,5 +208,268 @@ describe('TopologyTypeField tracking', () => {
     expect(
       screen.getByText(TopologyTypeLabels[TopologyType.MULTI_NODE_DISAGGREGATED]),
     ).toBeInTheDocument();
+  });
+
+  it('should disable a topology type that has no configurations', async () => {
+    renderComponent({
+      externalData: {
+        data: {
+          configsByTopology: {
+            [TopologyType.SINGLE_NODE]: [],
+            [TopologyType.MULTI_NODE]: [],
+            [TopologyType.SINGLE_NODE_DISAGGREGATED]: [],
+            [TopologyType.MULTI_NODE_DISAGGREGATED]: [],
+          },
+        },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    expect(getMultiNodeOption()).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should not disable a topology type whose only configuration is the project namespace copy', async () => {
+    renderComponent({
+      externalData: {
+        data: {
+          configsByTopology: {
+            [TopologyType.SINGLE_NODE]: [],
+            [TopologyType.MULTI_NODE]: [mockLocalConfig],
+            [TopologyType.SINGLE_NODE_DISAGGREGATED]: [],
+            [TopologyType.MULTI_NODE_DISAGGREGATED]: [],
+          },
+        },
+        loaded: true,
+      },
+    });
+
+    await openDropdown();
+
+    expect(getMultiNodeOption()).not.toHaveAttribute('aria-disabled', 'true');
+  });
+});
+
+describe('useTopologyTypeData', () => {
+  const mockProject = { projectName: 'my-project', setProjectName: jest.fn() };
+
+  const setDashboardConfigs = (configs: LLMInferenceServiceConfigKind[]) => {
+    mockUseFetchTopologyConfigs.mockReturnValue({
+      data: configs,
+      loaded: true,
+      refresh: jest.fn(),
+    });
+  };
+
+  const setReferencedConfig = (
+    config: LLMInferenceServiceConfigKind | null,
+    { loaded = true, error }: { loaded?: boolean; error?: Error } = {},
+  ) => {
+    mockUseFetchLLMInferenceServiceConfig.mockReturnValue({
+      data: config,
+      loaded,
+      error,
+      refresh: jest.fn(),
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setDashboardConfigs([mockMultiNodeConfig]);
+    setReferencedConfig(null);
+  });
+
+  it('should group the dashboard configs by topology type', () => {
+    const renderResult = testHook(useTopologyTypeData)({});
+
+    const { configsByTopology } = renderResult.result.current.data;
+    expect(configsByTopology[TopologyType.MULTI_NODE]).toEqual([mockMultiNodeConfig]);
+    expect(configsByTopology[TopologyType.SINGLE_NODE]).toEqual([]);
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+
+  it('should skip disabled dashboard configs', () => {
+    const disabledConfig = mockLLMInferenceServiceConfigK8sResource({
+      name: 'disabled-config',
+      topologyType: TopologyType.MULTI_NODE,
+    });
+    disabledConfig.metadata.annotations = {
+      ...disabledConfig.metadata.annotations,
+      'opendatahub.io/disabled': 'true',
+    };
+    setDashboardConfigs([mockMultiNodeConfig, disabledConfig]);
+
+    const renderResult = testHook(useTopologyTypeData)({});
+
+    expect(renderResult.result.current.data.configsByTopology[TopologyType.MULTI_NODE]).toEqual([
+      mockMultiNodeConfig,
+    ]);
+  });
+
+  it('should fetch the referenced config from the project namespace', () => {
+    testHook(useTopologyTypeData)({
+      configRef: 'my-model-multi-node-config-1',
+      project: mockProject,
+    });
+
+    expect(mockUseFetchLLMInferenceServiceConfig).toHaveBeenCalledWith(
+      'my-model-multi-node-config-1',
+      'my-project',
+    );
+  });
+
+  it('should add the referenced config to the configs for its own topology type', () => {
+    setReferencedConfig(mockLocalConfig);
+
+    const renderResult = testHook(useTopologyTypeData)({
+      configRef: 'my-model-multi-node-config-1',
+      project: mockProject,
+    });
+
+    const { configsByTopology } = renderResult.result.current.data;
+    expect(configsByTopology[TopologyType.MULTI_NODE]).toEqual([
+      mockMultiNodeConfig,
+      mockLocalConfig,
+    ]);
+    expect(configsByTopology[TopologyType.SINGLE_NODE]).toEqual([]);
+  });
+
+  it('should not duplicate a referenced config that is already a dashboard config', () => {
+    setReferencedConfig(mockMultiNodeConfig);
+
+    const renderResult = testHook(useTopologyTypeData)({
+      configRef: 'multi-node-config-1',
+      project: mockProject,
+    });
+
+    expect(renderResult.result.current.data.configsByTopology[TopologyType.MULTI_NODE]).toEqual([
+      mockMultiNodeConfig,
+    ]);
+  });
+
+  it('should not add a referenced config that has no topology type', () => {
+    setReferencedConfig(mockLLMInferenceServiceConfigK8sResource({ name: 'router-config' }));
+
+    const renderResult = testHook(useTopologyTypeData)({
+      configRef: 'router-config',
+      project: mockProject,
+    });
+
+    expect(renderResult.result.current.data.configsByTopology[TopologyType.MULTI_NODE]).toEqual([
+      mockMultiNodeConfig,
+    ]);
+  });
+
+  it("should fall back to the deployment's topology type for a copy that carries no config type", () => {
+    // Copies created before the config type label was carried over have no config type at all
+    const untypedCopy = mockLLMInferenceServiceConfigK8sResource({
+      name: 'my-model-single-node-config',
+      namespace: 'my-project',
+    });
+    untypedCopy.metadata.labels = {};
+    setReferencedConfig(untypedCopy);
+
+    const renderResult = testHook(useTopologyTypeData)({
+      configRef: 'my-model-single-node-config',
+      project: mockProject,
+      initialTopologyType: TopologyType.SINGLE_NODE,
+    });
+
+    expect(renderResult.result.current.data.configsByTopology[TopologyType.SINGLE_NODE]).toEqual([
+      untypedCopy,
+    ]);
+  });
+
+  it("should prefer the copy's own topology type over the deployment's", () => {
+    setReferencedConfig(mockLocalConfig);
+
+    const renderResult = testHook(useTopologyTypeData)({
+      configRef: 'my-model-multi-node-config-1',
+      project: mockProject,
+      initialTopologyType: TopologyType.SINGLE_NODE,
+    });
+
+    const { configsByTopology } = renderResult.result.current.data;
+    expect(configsByTopology[TopologyType.MULTI_NODE]).toContain(mockLocalConfig);
+    expect(configsByTopology[TopologyType.SINGLE_NODE]).toEqual([]);
+  });
+
+  it('should stay unloaded while the referenced config is still being fetched', () => {
+    setReferencedConfig(null, { loaded: false });
+
+    const renderResult = testHook(useTopologyTypeData)({
+      configRef: 'my-model-multi-node-config-1',
+      project: mockProject,
+    });
+
+    expect(renderResult.result.current.loaded).toBe(false);
+  });
+
+  it('should load without a load error when the referenced config cannot be read', () => {
+    setReferencedConfig(null, { loaded: false, error: new Error('Forbidden') });
+
+    const renderResult = testHook(useTopologyTypeData)({
+      configRef: 'my-model-multi-node-config-1',
+      project: mockProject,
+    });
+
+    expect(renderResult.result.current.loaded).toBe(true);
+    expect(renderResult.result.current.loadError).toBeUndefined();
+  });
+});
+
+describe('TopologyTypeField resolveDependencies', () => {
+  const { resolveDependencies } = TopologyTypeFieldWizardField.reducerFunctions;
+
+  it('should expose the configRef from the initial data so the referenced config is fetched', () => {
+    const result = resolveDependencies?.(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      {
+        'llmd-serving/custom-topology-config': { configRef: 'my-model-multi-node-config-1' },
+      },
+    );
+
+    expect(result?.configRef).toBe('my-model-multi-node-config-1');
+  });
+
+  it('should not expose a configRef when the initial data has no ref', () => {
+    const result = resolveDependencies?.(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      { 'llmd-serving/custom-topology-config': { selectedConfig: mockMultiNodeConfig } },
+    );
+
+    expect(result?.configRef).toBeUndefined();
+  });
+
+  it("should expose the deployment's topology type from the initial data", () => {
+    const result = resolveDependencies?.(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      { 'llmd-serving/topology-type': { topologyType: TopologyType.MULTI_NODE } },
+    );
+
+    expect(result?.initialTopologyType).toBe(TopologyType.MULTI_NODE);
+  });
+
+  it('should not expose an initial topology type for a new deployment', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = resolveDependencies?.({} as any, undefined);
+
+    expect(result?.initialTopologyType).toBeUndefined();
+  });
+
+  it('should not expose a configRef when the field value changes (avoiding a circular dependency)', () => {
+    const result = resolveDependencies?.(
+      {
+        'llmd-serving/custom-topology-config': { configRef: 'my-model-multi-node-config-1' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      undefined,
+    );
+
+    expect(result?.configRef).toBeUndefined();
   });
 });

--- a/packages/llmd-serving/src/wizardFields/__tests__/TopologyTypeField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/TopologyTypeField.spec.tsx
@@ -406,8 +406,21 @@ describe('useTopologyTypeData', () => {
     expect(renderResult.result.current.loaded).toBe(false);
   });
 
-  it('should load without a load error when the referenced config cannot be read', () => {
-    setReferencedConfig(null, { loaded: false, error: new Error('Forbidden') });
+  it('should surface a load error when the referenced config cannot be read', () => {
+    const referencedError = new Error('Forbidden');
+    setReferencedConfig(null, { loaded: false, error: referencedError });
+
+    const renderResult = testHook(useTopologyTypeData)({
+      configRef: 'my-model-multi-node-config-1',
+      project: mockProject,
+    });
+
+    expect(renderResult.result.current.loaded).toBe(true);
+    expect(renderResult.result.current.loadError).toBe(referencedError);
+  });
+
+  it('should load without a load error when the referenced config no longer exists', () => {
+    setReferencedConfig(null);
 
     const renderResult = testHook(useTopologyTypeData)({
       configRef: 'my-model-multi-node-config-1',

--- a/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maas-model-ref.ts
+++ b/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maas-model-ref.ts
@@ -35,6 +35,7 @@ export const preDeployMaaSModelRef = async (
   wizardState: WizardFormData['state'],
   deployment: LLMdDeployment,
   existingDeployment?: LLMdDeployment,
+  dryRun?: boolean,
 ): Promise<LLMdDeployment> => {
   if (typeof fieldData.isChecked !== 'boolean') {
     return deployment;
@@ -50,6 +51,11 @@ export const preDeployMaaSModelRef = async (
   const displayName = modelResource.metadata.annotations?.['openshift.io/display-name'] ?? name;
   const description = modelResource.metadata.annotations?.['openshift.io/description'] ?? '';
   const modelCapabilities = parseModelCapabilities(modelResource.metadata.annotations);
+
+  // real run is done in postDeploy
+  if (!dryRun) {
+    return deployment;
+  }
 
   if (existingDeployment) {
     if (!isChecked) {
@@ -110,18 +116,25 @@ export const preDeployMaaSModelRef = async (
  */
 export const postDeployMaaSModelRef = async (
   fieldData: MaaSFieldValue,
-  deployedModel: LLMdDeployment['model'],
+  deployedModel: LLMdDeployment,
   existingDeployment?: LLMdDeployment,
+  dryRun?: boolean,
 ): Promise<void> => {
-  const { name, namespace, uid } = deployedModel.metadata;
+  const { name, namespace, uid } = deployedModel.model.metadata;
   if (typeof fieldData.isChecked !== 'boolean' || !name || !namespace) {
     return;
   }
   const { isChecked } = fieldData;
   const modelRef = { kind: LLMINFERENCESERVICE_KIND, name };
-  const displayName = deployedModel.metadata.annotations?.['openshift.io/display-name'] ?? name;
-  const description = deployedModel.metadata.annotations?.['openshift.io/description'] ?? '';
-  const modelCapabilities = parseModelCapabilities(deployedModel.metadata.annotations);
+  const displayName =
+    deployedModel.model.metadata.annotations?.['openshift.io/display-name'] ?? name;
+  const description = deployedModel.model.metadata.annotations?.['openshift.io/description'] ?? '';
+  const modelCapabilities = parseModelCapabilities(deployedModel.model.metadata.annotations);
+
+  // Dryrun is done in preDeploy
+  if (dryRun) {
+    return;
+  }
 
   if (existingDeployment) {
     if (!isChecked) {

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -38,6 +38,7 @@ import {
   modelServingWizard,
   modelServingWizardEdit,
 } from '@odh-dashboard/cypress/cypress/pages/modelServing';
+import { deleteModal } from '@odh-dashboard/cypress/cypress/pages/components/DeleteModal';
 
 const buildTopologyConfig = (
   name: string,
@@ -793,6 +794,56 @@ describe('Model Serving LLMD Topology & Routing', () => {
         expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
       });
       cy.get('@createLLMInferenceServiceConfig.all').should('have.length', 0);
+    });
+  });
+
+  // The branch matrix (no config ref, accelerator config, 404 handling) is covered by the unit
+  // tests in llmd-serving/src/api/__tests__/LLMdDeployment.spec.ts. This covers the wiring: the
+  // deployment reaching the delete handler still carries the annotation naming its local copy.
+  describe('Delete deployment', () => {
+    it('should delete the local topology config copy referenced by the deployment', () => {
+      const deploymentName = 'test-llm-inference-service';
+      const localConfigName = `${deploymentName}-multi-node-config`;
+
+      initIntercepts();
+      cy.interceptK8sList(
+        { model: LLMInferenceServiceModel, ns: 'test-project' },
+        mockK8sResourceList([
+          mockLLMInferenceServiceK8sResource({
+            additionalAnnotations: {
+              [TOPOLOGY_TYPE_ANNOTATION]: TopologyType.MULTI_NODE,
+              [TOPOLOGY_CONFIG_REF_ANNOTATION]: localConfigName,
+            },
+            baseRefs: [{ name: localConfigName }],
+          }),
+        ]),
+      );
+      cy.intercept('DELETE', '**/llminferenceserviceconfigs/**', mock200Status({})).as(
+        'deleteLLMInferenceServiceConfig',
+      );
+      cy.interceptK8s(
+        'DELETE',
+        { model: LLMInferenceServiceModel, ns: 'test-project', name: deploymentName },
+        mock200Status({}),
+      ).as('deleteLLMInferenceService');
+
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal
+        .getModelRow('Test LLM Inference Service')
+        .findKebabAction(/^Delete/)
+        .click();
+
+      deleteModal.shouldBeOpen();
+      deleteModal.findInput().type('Test LLM Inference Service');
+      deleteModal.findSubmitButton().should('be.enabled').click();
+
+      cy.wait('@deleteLLMInferenceServiceConfig').then((interception) => {
+        expect(interception.request.url).to.include(
+          `/namespaces/test-project/llminferenceserviceconfigs/${localConfigName}`,
+        );
+      });
+      cy.wait('@deleteLLMInferenceService');
+      cy.get('@deleteLLMInferenceServiceConfig.all').should('have.length', 1);
     });
   });
 });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -11,6 +11,7 @@ import {
 import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
+import { mock200Status } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockGlobalScopedHardwareProfiles } from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
 import { mockStandardModelServingTemplateK8sResources } from '@odh-dashboard/internal/__mocks__/mockServingRuntimeTemplateK8sResource';
@@ -217,67 +218,38 @@ describe('Model Serving LLMD Topology & Routing', () => {
   });
 
   describe('hardware profile visibility', () => {
-    it('should show hardware profile for single node topology', () => {
+    it('hardware profile visibility', () => {
       initIntercepts();
       modelServingGlobal.visit('test-project');
       modelServingGlobal.findDeployModelButton().click();
       navigateToModelDeploymentStep();
 
+      cy.step('should show hardware profile for single node topology');
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('hardware-profile-select').should('exist');
-    });
 
-    it('should hide hardware profile for multi-node topology', () => {
-      initIntercepts();
-      modelServingGlobal.visit('test-project');
-      modelServingGlobal.findDeployModelButton().click();
-      navigateToModelDeploymentStep();
-
+      cy.step('should hide hardware profile for multi-node topology');
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('topology-type-select').click();
       cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
 
       cy.findByTestId('hardware-profile-select').should('not.exist');
-    });
 
-    it('should hide hardware profile for single node disaggregated topology', () => {
-      initIntercepts();
-      modelServingGlobal.visit('test-project');
-      modelServingGlobal.findDeployModelButton().click();
-      navigateToModelDeploymentStep();
-
+      cy.step('should hide hardware profile for single node disaggregated topology');
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('topology-type-select').click();
       cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE_DISAGGREGATED}`).click();
 
       cy.findByTestId('hardware-profile-select').should('not.exist');
-    });
 
-    it('should hide hardware profile for multi-node disaggregated topology', () => {
-      initIntercepts();
-      modelServingGlobal.visit('test-project');
-      modelServingGlobal.findDeployModelButton().click();
-      navigateToModelDeploymentStep();
-
+      cy.step('should hide hardware profile for multi-node disaggregated topology');
       modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
       cy.findByTestId('topology-type-select').click();
       cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE_DISAGGREGATED}`).click();
 
       cy.findByTestId('hardware-profile-select').should('not.exist');
-    });
 
-    it('should show hardware profile when switching back to single node', () => {
-      initIntercepts();
-      modelServingGlobal.visit('test-project');
-      modelServingGlobal.findDeployModelButton().click();
-      navigateToModelDeploymentStep();
-
-      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
-
-      cy.findByTestId('topology-type-select').click();
-      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
-      cy.findByTestId('hardware-profile-select').should('not.exist');
-
+      cy.step('should hide hardware profile for multi-node disaggregated topology');
       cy.findByTestId('topology-type-select').click();
       cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).click();
       cy.findByTestId('hardware-profile-select').should('exist');
@@ -574,6 +546,253 @@ describe('Model Serving LLMD Topology & Routing', () => {
         'Single node (default)',
       );
       modelServingWizardEdit.findNextButton().should('be.enabled');
+    });
+  });
+
+  describe('Deploy configs', () => {
+    const initDeployIntercepts = (deploymentName: string) => {
+      cy.interceptK8s(
+        'POST',
+        { model: LLMInferenceServiceConfigModel, ns: 'test-project' },
+        (req) => {
+          req.reply({ statusCode: 200, body: req.body });
+        },
+      ).as('createLLMInferenceServiceConfig');
+      cy.interceptK8s(
+        'POST',
+        { model: LLMInferenceServiceModel, ns: 'test-project' },
+        {
+          statusCode: 200,
+          body: mockLLMInferenceServiceK8sResource({ name: deploymentName }),
+        },
+      ).as('createLLMInferenceService');
+    };
+
+    // Step 3 (advanced options) — disable token auth to avoid needing auth resource intercepts
+    const completeWizard = () => {
+      modelServingWizard.findTokenAuthenticationCheckbox().click();
+      modelServingWizard.findNextButton().should('be.enabled').click();
+      modelServingWizard.findSubmitButton().should('be.enabled').click();
+    };
+
+    it('should not create new resources when using "Single node (default) selection', () => {
+      const deploymentName = 'test-single-node-default';
+      initIntercepts();
+      initDeployIntercepts(deploymentName);
+
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findModelDeploymentNameInput().type(deploymentName);
+
+      // Defaults: Single node topology with the pre-installed "Single node (default)" config
+      cy.findByTestId('topology-type-select').should('contain.text', 'Single node');
+      cy.findByTestId('custom-topology-config-select').should(
+        'contain.text',
+        'Single node (default)',
+      );
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      completeWizard();
+
+      // Dry run — no topology config ref is recorded on the deployment
+      cy.wait('@createLLMInferenceService').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.have.property(
+          TOPOLOGY_TYPE_ANNOTATION,
+          TopologyType.SINGLE_NODE,
+        );
+        expect(interception.request.body.metadata.annotations).to.not.have.property(
+          TOPOLOGY_CONFIG_REF_ANNOTATION,
+        );
+        expect(interception.request.body.spec.baseRefs ?? []).to.have.length(0);
+      });
+
+      // Actual request
+      cy.wait('@createLLMInferenceService').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.not.have.property(
+          TOPOLOGY_CONFIG_REF_ANNOTATION,
+        );
+        expect(interception.request.body.spec.baseRefs ?? []).to.have.length(0);
+      });
+
+      cy.get('@createLLMInferenceService.all').then((interceptions) => {
+        expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      });
+      // No local config copy is created for the default single node configuration
+      cy.get('@createLLMInferenceServiceConfig.all').should('have.length', 0);
+    });
+
+    it('should create new resources when selecting custom topology', () => {
+      const deploymentName = 'test-custom-topology';
+      const localConfigName = `${deploymentName}-multi-node-config`;
+      initIntercepts();
+      initDeployIntercepts(deploymentName);
+
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findModelDeploymentNameInput().type(deploymentName);
+
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId(`topology-type-${TopologyType.MULTI_NODE}`).click();
+      cy.findByTestId('custom-topology-config-select').click();
+      cy.findByTestId('topology-config-option-multi-node-config').click();
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      completeWizard();
+
+      // Dry run — a local copy of the selected config is created in the project namespace first
+      cy.wait('@createLLMInferenceServiceConfig').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+        expect(interception.request.body.metadata.name).to.equal(localConfigName);
+        expect(interception.request.body.metadata.namespace).to.equal('test-project');
+        expect(interception.request.body.metadata.annotations).to.include({
+          'openshift.io/display-name': 'Multi-node Data Parallel (Local Copy)',
+        });
+        expect(interception.request.body.metadata.labels).to.include({
+          'opendatahub.io/config-type': TopologyType.MULTI_NODE,
+        });
+        expect(interception.request.body.metadata.labels).to.not.have.property(
+          'opendatahub.io/dashboard',
+        );
+      });
+      cy.wait('@createLLMInferenceService').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.include({
+          [TOPOLOGY_TYPE_ANNOTATION]: TopologyType.MULTI_NODE,
+          [TOPOLOGY_CONFIG_REF_ANNOTATION]: localConfigName,
+        });
+        expect(interception.request.body.spec.baseRefs).to.deep.include({ name: localConfigName });
+      });
+
+      // Actual requests
+      cy.wait('@createLLMInferenceServiceConfig').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+        expect(interception.request.body.metadata.name).to.equal(localConfigName);
+      });
+      cy.wait('@createLLMInferenceService').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.include({
+          [TOPOLOGY_CONFIG_REF_ANNOTATION]: localConfigName,
+        });
+        expect(interception.request.body.spec.baseRefs).to.deep.include({ name: localConfigName });
+      });
+
+      cy.get('@createLLMInferenceServiceConfig.all').then((interceptions) => {
+        expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      });
+      cy.get('@createLLMInferenceService.all').then((interceptions) => {
+        expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      });
+    });
+
+    it('should create clean old resource when changing to "Single node (default)" ', () => {
+      initIntercepts();
+      cy.interceptK8sList(
+        { model: SecretModel, ns: 'test-project' },
+        mockK8sResourceList([mockURISecretK8sResource({ namespace: 'test-project' })]),
+      );
+      cy.interceptK8sList(
+        { model: LLMInferenceServiceModel, ns: 'test-project' },
+        mockK8sResourceList([
+          mockLLMInferenceServiceK8sResource({
+            additionalAnnotations: {
+              'opendatahub.io/connections': 'test-uri-secret',
+              // Auth is off so the update doesn't need auth resource intercepts
+              'security.opendatahub.io/enable-auth': 'false',
+              [TOPOLOGY_TYPE_ANNOTATION]: TopologyType.MULTI_NODE,
+              [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'multi-node-config',
+            },
+            baseRefs: [{ name: 'multi-node-config' }],
+          }),
+        ]),
+      );
+      cy.intercept('PUT', '**/llminferenceservices/**', (req) => {
+        req.reply({ statusCode: 200, body: req.body });
+      }).as('updateLLMInferenceService');
+      cy.interceptK8s(
+        'POST',
+        { model: LLMInferenceServiceConfigModel, ns: 'test-project' },
+        (req) => {
+          req.reply({ statusCode: 200, body: req.body });
+        },
+      ).as('createLLMInferenceServiceConfig');
+      cy.interceptK8s(
+        'DELETE',
+        { model: LLMInferenceServiceConfigModel, ns: 'test-project', name: 'multi-node-config' },
+        mock200Status({}),
+      ).as('deleteLLMInferenceServiceConfig');
+
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.getModelRow('Test LLM Inference Service').findKebabAction('Edit').click();
+
+      // Step 1: Model source
+      modelServingWizardEdit.findNextButton().should('be.enabled').click();
+
+      // Step 2: Model deployment — switch back to the default single node configuration
+      cy.findByTestId('custom-topology-config-select').should(
+        'contain.text',
+        'Multi-node Data Parallel',
+      );
+      cy.findByTestId('topology-type-select').click();
+      cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).click();
+      // The existing config stays selected until it is explicitly swapped for the default
+      cy.findByTestId('custom-topology-config-select').click();
+      cy.findByTestId('topology-config-option-single-node-default').click();
+      cy.findByTestId('custom-topology-config-select').should(
+        'contain.text',
+        'Single node (default)',
+      );
+      modelServingWizardEdit.findNextButton().should('be.enabled').click();
+
+      // Step 3: Advanced options
+      modelServingWizardEdit.findNextButton().should('be.enabled').click();
+
+      // Step 4: Summary
+      modelServingWizardEdit.findSubmitButton().should('be.enabled').click();
+
+      // Dry run — the previously referenced config is deleted, no new copy is created
+      cy.wait('@deleteLLMInferenceServiceConfig').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+      });
+      cy.wait('@updateLLMInferenceService').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.have.property(
+          TOPOLOGY_TYPE_ANNOTATION,
+          TopologyType.SINGLE_NODE,
+        );
+        expect(interception.request.body.metadata.annotations).to.not.have.property(
+          TOPOLOGY_CONFIG_REF_ANNOTATION,
+        );
+        expect(interception.request.body.spec.baseRefs ?? []).to.not.deep.include({
+          name: 'multi-node-config',
+        });
+      });
+
+      // Actual requests
+      cy.wait('@deleteLLMInferenceServiceConfig').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+      });
+      cy.wait('@updateLLMInferenceService').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.not.have.property(
+          TOPOLOGY_CONFIG_REF_ANNOTATION,
+        );
+        expect(interception.request.body.spec.baseRefs ?? []).to.not.deep.include({
+          name: 'multi-node-config',
+        });
+      });
+
+      cy.get('@deleteLLMInferenceServiceConfig.all').then((interceptions) => {
+        expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      });
+      cy.get('@createLLMInferenceServiceConfig.all').should('have.length', 0);
     });
   });
 });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingLlmdTopology.cy.ts
@@ -250,7 +250,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
 
       cy.findByTestId('hardware-profile-select').should('not.exist');
 
-      cy.step('should hide hardware profile for multi-node disaggregated topology');
+      cy.step('should show hardware profile again when switching back to single node topology');
       cy.findByTestId('topology-type-select').click();
       cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).click();
       cy.findByTestId('hardware-profile-select').should('exist');
@@ -693,11 +693,21 @@ describe('Model Serving LLMD Topology & Routing', () => {
       });
     });
 
-    it('should create clean old resource when changing to "Single node (default)" ', () => {
+    it('should clean old resource when changing to "Single node (default)" ', () => {
       initIntercepts();
       cy.interceptK8sList(
         { model: SecretModel, ns: 'test-project' },
         mockK8sResourceList([mockURISecretK8sResource({ namespace: 'test-project' })]),
+      );
+      cy.interceptK8s(
+        'GET',
+        { model: LLMInferenceServiceConfigModel, ns: 'test-project' },
+        mockLLMInferenceServiceConfigK8sResource({
+          name: 'test-llm-inference-service-multi-node-config',
+          displayName: 'Multi-node Data Parallel (Local Copy)',
+          namespace: 'test-project',
+          configType: TopologyType.MULTI_NODE,
+        }),
       );
       cy.interceptK8sList(
         { model: LLMInferenceServiceModel, ns: 'test-project' },
@@ -708,9 +718,9 @@ describe('Model Serving LLMD Topology & Routing', () => {
               // Auth is off so the update doesn't need auth resource intercepts
               'security.opendatahub.io/enable-auth': 'false',
               [TOPOLOGY_TYPE_ANNOTATION]: TopologyType.MULTI_NODE,
-              [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'multi-node-config',
+              [TOPOLOGY_CONFIG_REF_ANNOTATION]: 'test-llm-inference-service-multi-node-config',
             },
-            baseRefs: [{ name: 'multi-node-config' }],
+            baseRefs: [{ name: 'test-llm-inference-service-multi-node-config' }],
           }),
         ]),
       );
@@ -726,7 +736,11 @@ describe('Model Serving LLMD Topology & Routing', () => {
       ).as('createLLMInferenceServiceConfig');
       cy.interceptK8s(
         'DELETE',
-        { model: LLMInferenceServiceConfigModel, ns: 'test-project', name: 'multi-node-config' },
+        {
+          model: LLMInferenceServiceConfigModel,
+          ns: 'test-project',
+          name: 'test-llm-inference-service-multi-node-config',
+        },
         mock200Status({}),
       ).as('deleteLLMInferenceServiceConfig');
 
@@ -739,7 +753,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
       // Step 2: Model deployment — switch back to the default single node configuration
       cy.findByTestId('custom-topology-config-select').should(
         'contain.text',
-        'Multi-node Data Parallel',
+        'Multi-node Data Parallel (Local Copy)',
       );
       cy.findByTestId('topology-type-select').click();
       cy.findByTestId(`topology-type-${TopologyType.SINGLE_NODE}`).click();
@@ -772,7 +786,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
           TOPOLOGY_CONFIG_REF_ANNOTATION,
         );
         expect(interception.request.body.spec.baseRefs ?? []).to.not.deep.include({
-          name: 'multi-node-config',
+          name: 'test-llm-inference-service-multi-node-config',
         });
       });
 
@@ -786,7 +800,7 @@ describe('Model Serving LLMD Topology & Routing', () => {
           TOPOLOGY_CONFIG_REF_ANNOTATION,
         );
         expect(interception.request.body.spec.baseRefs ?? []).to.not.deep.include({
-          name: 'multi-node-config',
+          name: 'test-llm-inference-service-multi-node-config',
         });
       });
 

--- a/packages/model-serving/extension-points/deployment-wizard.ts
+++ b/packages/model-serving/extension-points/deployment-wizard.ts
@@ -221,10 +221,9 @@ export const isWizardFieldExtractorExtension = <T = unknown, D extends Deploymen
   extension.type === 'model-serving.deployment/wizard-field-extractor';
 
 /**
- * Extension for performing dry-run validation of side-effect resources before a deployment is saved.
+ * Extension for making side-effect resources before a deployment is saved.
  * This runs before the inference service is created, in the same phase as other dry runs,
  * allowing extensions to validate that their associated resources can be created without conflicts.
- * Unlike post-deploy, errors thrown here propagate and block the deployment.
  *
  * The `fieldId` links this to a specific WizardFieldExtension so it is only
  * executed when that field is active.
@@ -240,22 +239,23 @@ export type WizardFieldDeploymentFunctionsExtension<
     /** The platform this deployment functions extension applies to (e.g., 'llmd-serving') */
     platform: D['modelServingPlatformId'];
     /**
-     * Async function that dry-runs before the deployment is saved. Throw to block the deployment.
+     * Async function that runs before the deployment is saved. Throw to block the deployment.
      * @param fieldData - The current data from the associated wizard field
      * @param wizardState - The full wizard form state for context (includes project name, etc.)
      * @param modelResource - The assembled model resource (not yet created, may lack uid/namespace)
      * @param existingDeployment - The deployment before editing, or undefined for a create
      */
-    preDeploy: CodeRef<
+    preDeploy: null | CodeRef<
       (
         fieldData: T,
         wizardState: WizardFormData['state'],
         deployment: D,
         existingDeployment?: D,
+        dryRun?: boolean,
       ) => Promise<D>
     >;
-    postDeploy: CodeRef<
-      (fieldData: T, deployedModel: D['model'], existingDeployment?: D) => Promise<void>
+    postDeploy: null | CodeRef<
+      (fieldData: T, deployedModel: D, existingDeployment?: D, dryRun?: boolean) => Promise<void>
     >;
   }
 >;

--- a/packages/model-serving/extension-points/deployment-wizard.ts
+++ b/packages/model-serving/extension-points/deployment-wizard.ts
@@ -240,10 +240,16 @@ export type WizardFieldDeploymentFunctionsExtension<
     platform: D['modelServingPlatformId'];
     /**
      * Async function that runs before the deployment is saved. Throw to block the deployment.
+     *
+     * Called twice: first with `dryRun === true` alongside the other dry runs to validate,
+     * then again with `dryRun !== true` to perform the actual side effects before the
+     * deployment is created.
+     *
      * @param fieldData - The current data from the associated wizard field
      * @param wizardState - The full wizard form state for context (includes project name, etc.)
-     * @param modelResource - The assembled model resource (not yet created, may lack uid/namespace)
+     * @param deployment - The assembled deployment (not yet created, may lack uid/namespace)
      * @param existingDeployment - The deployment before editing, or undefined for a create
+     * @param dryRun - True for the validation pass, falsy for the real pass
      */
     preDeploy: null | CodeRef<
       (
@@ -254,6 +260,19 @@ export type WizardFieldDeploymentFunctionsExtension<
         dryRun?: boolean,
       ) => Promise<D>
     >;
+    /**
+     * Async function that runs after the deployment is saved.
+     *
+     * Called twice: first with `dryRun === true` alongside the other dry runs to validate,
+     * then again with `dryRun !== true` once the deployment has been created.
+     *
+     * @param fieldData - The current data from the associated wizard field
+     * @param deployedModel - The full deployment resource. On the dry run pass this is the
+     * assembled deployment; on the real pass it is the created deployment returned by the
+     * deploy method.
+     * @param existingDeployment - The deployment before editing, or undefined for a create
+     * @param dryRun - True for the validation pass, falsy for the real pass
+     */
     postDeploy: null | CodeRef<
       (fieldData: T, deployedModel: D, existingDeployment?: D, dryRun?: boolean) => Promise<void>
     >;

--- a/packages/model-serving/src/components/deploymentWizard/ExternalDataLoader.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ExternalDataLoader.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { HookNotify } from '@odh-dashboard/plugin-core';
 import { WizardFormAction, WizardFormState } from './useDeploymentWizardReducer';
 import { getFieldDependencies } from './dynamicFormUtils';
-import type { WizardField } from '../../shared/types/form-data';
+import type { InitialWizardFormData, WizardField } from '../../shared/types/form-data';
 
 export type ExternalDataMap = Record<string, { loaded: boolean; loadError?: Error; data: unknown }>;
 
 type ExternalDataLoaderProps = {
   fields: WizardField<unknown, unknown>[];
-  // initialData?: InitialWizardFormData; // We'll probably need this later
+  initialData?: InitialWizardFormData;
   formState: WizardFormState;
   setExternalData: React.Dispatch<React.SetStateAction<ExternalDataMap>>;
   dispatch: React.Dispatch<WizardFormAction>;
@@ -21,6 +21,7 @@ type ExternalDataLoaderProps = {
  */
 export const ExternalDataLoader: React.FC<ExternalDataLoaderProps> = ({
   fields,
+  initialData,
   formState,
   setExternalData,
   dispatch,
@@ -33,6 +34,7 @@ export const ExternalDataLoader: React.FC<ExternalDataLoaderProps> = ({
             <ExternalDataHookNotify
               key={f.id}
               field={f}
+              initialData={initialData}
               formState={formState}
               setExternalData={setExternalData}
               dispatch={dispatch}
@@ -47,15 +49,16 @@ export const ExternalDataLoader: React.FC<ExternalDataLoaderProps> = ({
 
 const ExternalDataHookNotify: React.FC<{
   field: WizardField;
+  initialData?: InitialWizardFormData;
   formState: WizardFormState;
   setExternalData: React.Dispatch<React.SetStateAction<ExternalDataMap>>;
   dispatch: React.Dispatch<WizardFormAction>;
-}> = ({ field, formState, setExternalData, dispatch }) => {
+}> = ({ field, initialData, formState, setExternalData, dispatch }) => {
   const hook = React.useMemo(() => field.externalDataHook, [field.externalDataHook]);
 
   const dependencies = React.useMemo(
-    () => getFieldDependencies(field, formState),
-    [field, formState],
+    () => getFieldDependencies(field, formState, initialData),
+    [field, formState, initialData],
   );
   const hookArgs: Parameters<NonNullable<WizardField['externalDataHook']>> = React.useMemo(
     () => [dependencies],

--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -145,6 +145,7 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
       >
         <ExternalDataLoader
           fields={wizardFormData.fields}
+          initialData={wizardFormData.initialData}
           formState={wizardFormData.state}
           setExternalData={setExternalData}
           dispatch={wizardFormData.dispatch}

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useWizardFieldPostDeploy.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useWizardFieldPostDeploy.ts
@@ -5,6 +5,12 @@ import { type Deployment } from '../../../../extension-points';
 import { isWizardFieldDeploymentFunctionsExtension } from '../../../../extension-points/deployment-wizard';
 import { useActiveFields } from '../dynamicFormUtils';
 
+export type RunPostDeployFns = (
+  deployedModel: Deployment,
+  existingDeployment?: Deployment,
+  dryRun?: boolean,
+) => Promise<void>;
+
 /**
  * Hook that returns an async function to run all active post-deploy extensions after
  * a deployment is saved. Each extension receives the field's current data, the newly
@@ -19,10 +25,7 @@ import { useActiveFields } from '../dynamicFormUtils';
 export const useWizardFieldPostDeploy = (
   wizardState: WizardFormData['state'],
 ): {
-  runPostDeploy: (
-    deployedModel: Deployment['model'],
-    existingDeployment?: Deployment,
-  ) => Promise<void>;
+  runPostDeploy: RunPostDeployFns;
   postDeployExtensionsLoaded: boolean;
   postDeployExtensionErrors: Error[];
 } => {
@@ -39,13 +42,19 @@ export const useWizardFieldPostDeploy = (
     [postDeployExtensions, activeFields],
   );
 
-  const runPostDeploy = React.useCallback(
-    async (deployedModel: Deployment['model'], existingDeployment?: Deployment): Promise<void> => {
+  const runPostDeploy = React.useCallback<RunPostDeployFns>(
+    async (
+      deployedModel: Deployment,
+      existingDeployment?: Deployment,
+      dryRun?: boolean,
+    ): Promise<void> => {
       for (const ext of activePostDeployExtensions) {
         const { fieldId } = ext.properties;
         const fieldData: unknown = wizardState[fieldId];
         try {
-          await ext.properties.postDeploy(fieldData, deployedModel, existingDeployment);
+          if (typeof ext.properties.postDeploy === 'function') {
+            await ext.properties.postDeploy(fieldData, deployedModel, existingDeployment, dryRun);
+          }
         } catch (error) {
           postDeployExtensionErrors.push(error instanceof Error ? error : new Error(String(error)));
         }

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useWizardFieldPostDeploy.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useWizardFieldPostDeploy.ts
@@ -17,9 +17,10 @@ export type RunPostDeployFns = (
  * saved model resource (which now has a uid), and the original deployment (if editing).
  *
  * Post-deploy extensions are only executed if their associated WizardField2 is active.
- * Errors thrown by individual extensions are caught; subsequent extensions
- * still run and the returned promise always resolves so errors don't block submission
- * and closing of the wizard
+ * On a real (non-dry) run, errors thrown by individual extensions are caught; subsequent
+ * extensions still run and the returned promise resolves so errors don't block submission
+ * and closing of the wizard. On a dry run, errors are rethrown so the caller can abort
+ * before any cluster state is changed.
  * @param wizardState - The current wizard form state at the point of submission
  */
 export const useWizardFieldPostDeploy = (
@@ -56,6 +57,11 @@ export const useWizardFieldPostDeploy = (
             await ext.properties.postDeploy(fieldData, deployedModel, existingDeployment, dryRun);
           }
         } catch (error) {
+          if (dryRun) {
+            // Dry runs validate before any cluster writes happen -- let the failure propagate
+            // so the deployment is aborted instead of partially applied.
+            throw error;
+          }
           postDeployExtensionErrors.push(error instanceof Error ? error : new Error(String(error)));
         }
       }

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useWizardFieldPreDeploy.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useWizardFieldPreDeploy.ts
@@ -5,6 +5,12 @@ import { type Deployment } from '../../../../extension-points';
 import { isWizardFieldDeploymentFunctionsExtension } from '../../../../extension-points/deployment-wizard';
 import { useActiveFields } from '../dynamicFormUtils';
 
+export type RunPreDeployFns = (
+  deployment: Deployment,
+  existingDeployment?: Deployment,
+  dryRun?: boolean,
+) => Promise<Deployment>;
+
 /**
  * Hook that returns an async function to dry-run all active pre-deploy extensions before
  * a deployment is saved. Each extension receives the field's current data, the full wizard
@@ -19,7 +25,7 @@ import { useActiveFields } from '../dynamicFormUtils';
 export const useWizardFieldPreDeploy = (
   wizardState: WizardFormData['state'],
 ): {
-  runPreDeploy: (deployment: Deployment, existingDeployment?: Deployment) => Promise<Deployment>;
+  runPreDeploy: RunPreDeployFns;
   preDeployExtensionsLoaded: boolean;
 } => {
   const [preDeployExtensions, preDeployExtensionsLoaded] = useResolvedExtensions(
@@ -36,18 +42,25 @@ export const useWizardFieldPreDeploy = (
     [preDeployExtensions, activeFields],
   );
 
-  const runPreDeploy = React.useCallback(
-    async (deployment: Deployment, existingDeployment?: Deployment): Promise<Deployment> => {
+  const runPreDeploy = React.useCallback<RunPreDeployFns>(
+    async (
+      deployment: Deployment,
+      existingDeployment?: Deployment,
+      dryRun?: boolean,
+    ): Promise<Deployment> => {
       let current = deployment;
       for (const ext of activePreDeployExtensions) {
         const { fieldId } = ext.properties;
         const fieldData: unknown = wizardState[fieldId];
-        current = await ext.properties.preDeploy(
-          fieldData,
-          wizardState,
-          current,
-          existingDeployment,
-        );
+        if (typeof ext.properties.preDeploy === 'function') {
+          current = await ext.properties.preDeploy(
+            fieldData,
+            wizardState,
+            current,
+            existingDeployment,
+            dryRun,
+          );
+        }
       }
       return current;
     },

--- a/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
@@ -3,6 +3,7 @@ import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import type { RecursivePartial } from '@odh-dashboard/foundation';
 import type {
   DeploymentWizardFieldOverride,
+  InitialWizardFormData,
   WizardField,
   WizardFormData,
 } from '../../shared/types/form-data';
@@ -53,8 +54,9 @@ export const useActiveFields = (
 export const getFieldDependencies = (
   field: WizardField<unknown>,
   formData: WizardFormData['state'],
+  initialData?: InitialWizardFormData,
 ): Record<string, unknown> => {
-  return field.reducerFunctions.resolveDependencies?.(formData) ?? {};
+  return field.reducerFunctions.resolveDependencies?.(formData, initialData) ?? {};
 };
 
 /**

--- a/packages/model-serving/src/components/deploymentWizard/fields/GenericFieldRenderer.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/GenericFieldRenderer.tsx
@@ -63,7 +63,7 @@ export const GenericFieldRenderer: React.FC<GenericFieldRendererProps> = ({
                 });
               }}
               externalData={externalData?.[field.id] ?? undefined}
-              dependencies={getFieldDependencies(field, wizardState.state)}
+              dependencies={getFieldDependencies(field, wizardState.state, wizardState.initialData)}
               isEditing={isEditing}
               isDisabled={isDisabled || hasDisabledOverride(wizardState.state[getStateKey(field)])}
             />

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardReducer.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardReducer.tsx
@@ -140,7 +140,8 @@ export const useDeploymentWizardReducer = (
             existingFieldData:
               action.payload.existingFieldData ?? initialData?.[getStateKey(field)],
             dependencies:
-              action.payload.dependencies ?? getFieldDependencies(field, mergedStateRef.current),
+              action.payload.dependencies ??
+              getFieldDependencies(field, mergedStateRef.current, initialData),
           },
         });
       } else {
@@ -164,8 +165,8 @@ export const useDeploymentWizardReducer = (
     for (const field of activeFields) {
       const isNew = !prevActiveFields.current.some((f) => f.id === field.id);
 
-      const dependencies = getFieldDependencies(field, formState);
-      const prevDependencies = getFieldDependencies(field, prevMergedState.current);
+      const dependencies = getFieldDependencies(field, formState, initialData);
+      const prevDependencies = getFieldDependencies(field, prevMergedState.current, initialData);
       const isDependenciesChanged = !isEqual(dependencies, prevDependencies);
 
       if (isNew || isDependenciesChanged) {

--- a/packages/model-serving/src/components/deploymentWizard/utils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/utils.ts
@@ -117,12 +117,12 @@ export const deployModel = async (
       wizardState.modelLocationData.selectedConnection,
     ),
   );
-  if (runPreDeploy && modelResource) {
+  if (runPreDeploy && dryRunModelResource) {
     dryRuns.push(
       runPreDeploy(
         {
           modelServingPlatformId: deployMethod.platform,
-          model: modelResource,
+          model: dryRunModelResource,
           server: serverResource,
         },
         existingDeployment,
@@ -130,27 +130,30 @@ export const deployModel = async (
       ),
     );
   }
-  dryRuns.push(
-    deployMethod.deploy(
-      wizardState,
-      projectName,
-      existingDeployment,
-      dryRunModelResource,
-      serverResource,
-      serverResourceTemplateName,
-      true,
-      undefined,
-      undefined,
-      initialWizardData,
-      applyFieldData,
-    ),
-  );
-  if (runPostDeploy && modelResource) {
+
+  if (!overwrite) {
+    dryRuns.push(
+      deployMethod.deploy(
+        wizardState,
+        projectName,
+        existingDeployment,
+        dryRunModelResource,
+        serverResource,
+        serverResourceTemplateName,
+        true,
+        undefined,
+        undefined,
+        initialWizardData,
+        applyFieldData,
+      ),
+    );
+  }
+  if (runPostDeploy && dryRunModelResource) {
     dryRuns.push(
       runPostDeploy(
         {
           modelServingPlatformId: deployMethod.platform,
-          model: modelResource,
+          model: dryRunModelResource,
           server: serverResource,
         },
         existingDeployment,
@@ -158,9 +161,7 @@ export const deployModel = async (
       ),
     );
   }
-  if (!overwrite) {
-    await Promise.all(dryRuns);
-  }
+  await Promise.all(dryRuns);
 
   // ----- Real Runs -----
 

--- a/packages/model-serving/src/components/deploymentWizard/utils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/utils.ts
@@ -17,6 +17,8 @@ import type {
 import type { SecretOps } from '@odh-dashboard/plugin-core/host-api';
 import { type TokenAuthenticationFieldData } from './fields/TokenAuthenticationField';
 import { DeployExtension } from './deploying/useDeployMethod';
+import { RunPreDeployFns } from './deploying/useWizardFieldPreDeploy';
+import { RunPostDeployFns } from './deploying/useWizardFieldPostDeploy';
 import {
   ModelLocationType,
   ModelLocationData,
@@ -78,11 +80,8 @@ export const deployModel = async (
   overwrite?: boolean,
   initialWizardData?: InitialWizardFormData,
   applyFieldData?: DeploymentAssemblyFn,
-  runPreDeploy?: (deployment: Deployment, existingDeployment?: Deployment) => Promise<Deployment>,
-  runPostDeploy?: (
-    deployedModel: Deployment['model'],
-    existingDeployment?: Deployment,
-  ) => Promise<void>,
+  runPreDeploy?: RunPreDeployFns,
+  runPostDeploy?: RunPostDeployFns,
 ): Promise<Deployment> => {
   const projectName = wizardState.project.projectName || modelResource?.metadata.namespace;
   if (!projectName) {
@@ -99,12 +98,15 @@ export const deployModel = async (
     throw new Error('Deploy method is required. Model serving platform could be missing.');
   }
 
+  // ----- Dry Runs -----
+
   // If connection name doesn't exist yet, it will fail the dry run
   const dryRunModelResource = structuredClone(modelResourceWithNamespace);
   delete dryRunModelResource?.metadata.annotations?.[MetadataAnnotation.ConnectionName];
 
-  // Dry runs
-  await Promise.all([
+  // Dry run order doesn't matter since they don't change cluster state
+  const dryRuns: Promise<unknown>[] = [];
+  dryRuns.push(
     handleConnectionCreation(
       secretOps,
       wizardState.createConnectionData.data,
@@ -114,34 +116,53 @@ export const deployModel = async (
       true,
       wizardState.modelLocationData.selectedConnection,
     ),
-    ...(!overwrite
-      ? [
-          deployMethod.deploy(
-            wizardState,
-            projectName,
-            existingDeployment,
-            dryRunModelResource,
-            serverResource,
-            serverResourceTemplateName,
-            true,
-            undefined,
-            undefined,
-            initialWizardData,
-            applyFieldData,
-          ),
-        ]
-      : []),
-  ]);
+  );
   if (runPreDeploy && modelResource) {
-    await runPreDeploy(
-      {
-        modelServingPlatformId: deployMethod.platform,
-        model: modelResource,
-        server: serverResource,
-      },
-      existingDeployment,
+    dryRuns.push(
+      runPreDeploy(
+        {
+          modelServingPlatformId: deployMethod.platform,
+          model: modelResource,
+          server: serverResource,
+        },
+        existingDeployment,
+        true,
+      ),
     );
   }
+  dryRuns.push(
+    deployMethod.deploy(
+      wizardState,
+      projectName,
+      existingDeployment,
+      dryRunModelResource,
+      serverResource,
+      serverResourceTemplateName,
+      true,
+      undefined,
+      undefined,
+      initialWizardData,
+      applyFieldData,
+    ),
+  );
+  if (runPostDeploy && modelResource) {
+    dryRuns.push(
+      runPostDeploy(
+        {
+          modelServingPlatformId: deployMethod.platform,
+          model: modelResource,
+          server: serverResource,
+        },
+        existingDeployment,
+        true,
+      ),
+    );
+  }
+  if (!overwrite) {
+    await Promise.all(dryRuns);
+  }
+
+  // ----- Real Runs -----
 
   // Create secret
   const newSecret = await handleConnectionCreation(
@@ -162,6 +183,16 @@ export const deployModel = async (
   if (modelResourceWithConnection?.metadata.annotations) {
     modelResourceWithConnection.metadata.annotations[MetadataAnnotation.ConnectionName] =
       createdSecretName;
+  }
+  if (runPreDeploy && modelResourceWithConnection) {
+    await runPreDeploy(
+      {
+        modelServingPlatformId: deployMethod.platform,
+        model: modelResourceWithConnection,
+        server: serverResource,
+      },
+      existingDeployment,
+    );
   }
   const deploymentResult = await deployMethod.deploy(
     wizardState,
@@ -190,7 +221,7 @@ export const deployModel = async (
     );
   }
   if (runPostDeploy) {
-    await runPostDeploy(deploymentResult.model, existingDeployment);
+    await runPostDeploy(deploymentResult, existingDeployment);
   }
 
   return deploymentResult;

--- a/packages/model-serving/src/shared/types/form-data.ts
+++ b/packages/model-serving/src/shared/types/form-data.ts
@@ -263,7 +263,10 @@ export type WizardField<
       externalData?: ExternalData,
       dependencies?: Dependencies,
     ) => FieldData;
-    resolveDependencies?: (formData: WizardFormData['state']) => Dependencies;
+    resolveDependencies?: (
+      formData: WizardFormData['state'],
+      initialData?: InitialWizardFormData,
+    ) => Dependencies;
     validationSchema?: z.ZodSchema<FieldData>;
     getFieldOverrides?: (
       effectiveValue: FieldData,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
towards [RHOAIENG-79541](https://redhat.atlassian.net/browse/RHOAIENG-79541) (this pr doesn't include router configs)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Copies the selected topology config into the deployment namespace. On edit, it shows the local copy as the one selected. If you switch to a different option, it will be deleted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a new llmd deployment, select the "Single node (default)", no LLMInferenceServiceConfig PUTs
2. Create a new llmd deployment, select something other than  "Single node (default)", there should now be LLMInferenceServiceConfig PUTs
3. Edit the llmd deployment, select another config, it should DELETE the old one, and PUT the other one
4. Delete the llmd deployment, make sure there is a DELETE on the topology config

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
cypress tests added for checking the resources that are created on deploy

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-79541]: https://redhat.atlassian.net/browse/RHOAIENG-79541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved topology configuration handling during deployment, including custom and namespace-local configurations.
  * Added support for editing deployments with previously referenced topology configurations.
  * Added configuration retrieval with clearer handling for missing resources.
  * Added dry-run support for deployment lifecycle actions.
* **Bug Fixes**
  * Deployments now clean up associated configuration resources reliably, including when topology settings change or resources are already missing.
  * Improved metadata handling for duplicated configuration resources.
  * Improved deployment wizard field initialization using existing configuration data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->