### PR TITLE
[RHOAIENG-80966] Add missing E2E CI tags for ConnectionTypes, HardwareProfiles, and MlflowEmbedded

### DIFF
--- a/packages/connection-types/package.json
+++ b/packages/connection-types/package.json
@@ -11,6 +11,9 @@
     "lint:fix": "eslint . --fix",
     "type-check": "tsc --noEmit"
   },
+  "e2eCiTags": [
+    "@ConnectionTypesCI"
+  ],
   "dependencies": {
     "@odh-dashboard/k8s-core": "*",
     "@odh-dashboard/plugin-core": "*",

--- a/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
@@ -71,7 +71,14 @@ describe('Verify MLflow Experiments page', () => {
   it(
     'Verify MLflow Experiments page',
     {
-      tags: ['@Sanity', '@SanitySet1', '@MLflow', '@MLflowExperiments', '@NonConcurrent'],
+      tags: [
+        '@Sanity',
+        '@SanitySet1',
+        '@MLflow',
+        '@MLflowExperiments',
+        '@NonConcurrent',
+        '@MLflowEmbeddedCI',
+      ],
     },
     () => {
       const experiment = testData.experiments[0];

--- a/packages/cypress/cypress/tests/e2e/promptManagement/testPromptManagement.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/promptManagement/testPromptManagement.cy.ts
@@ -56,7 +56,14 @@ describe('Verify Prompt Management page', () => {
   it(
     'Create a prompt and verify it appears in the prompts table',
     {
-      tags: ['@Sanity', '@SanitySet1', '@PromptManagement', '@MLflow', '@NonConcurrent'],
+      tags: [
+        '@Sanity',
+        '@SanitySet1',
+        '@PromptManagement',
+        '@MLflow',
+        '@NonConcurrent',
+        '@MLflowEmbeddedCI',
+      ],
     },
     () => {
       const prompt = testData.prompts[0];

--- a/packages/cypress/cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts
@@ -205,7 +205,7 @@ describe('Verify Connection Type Creation', () => {
   it(
     'Verify User Can Duplicate, Edit and Delete a Connection Type',
     {
-      tags: ['@Smoke', '@SmokeSet2', '@Dashboard', '@ConnectionTypes'],
+      tags: ['@Smoke', '@SmokeSet2', '@Dashboard', '@ConnectionTypes', '@ConnectionTypesCI'],
     },
     () => {
       cy.step('Log into the application');

--- a/packages/cypress/cypress/tests/e2e/settings/connectionTypes/testPreInstalledConnectionTypes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/connectionTypes/testPreInstalledConnectionTypes.cy.ts
@@ -17,7 +17,7 @@ describe('Verify OOTB Connection Types', () => {
 
   it(
     'should have pre-installed label and unable to be edited or deleted',
-    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard'] },
+    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard', '@ConnectionTypes', '@ConnectionTypesCI'] },
     () => {
       cy.step('Navigate to Connection Types view');
       cy.visitWithLogin(

--- a/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
@@ -105,6 +105,7 @@ describe('ModelServing - tolerations tests', () => {
         '@Smoke',
         '@SmokeSet3',
         '@ModelServing',
+        '@HardwareProfilesCI',
       ],
     },
     () => {

--- a/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testNotebookTolerations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testNotebookTolerations.cy.ts
@@ -47,7 +47,14 @@ describe('Notebooks - tolerations tests', () => {
   it(
     'Verify Juypter Notebook Creation using Hardware Profiles and applying Tolerations',
     {
-      tags: ['@Dashboard', '@HardwareProfiles', '@Smoke', '@SmokeSet2', '@NonConcurrent'],
+      tags: [
+        '@Dashboard',
+        '@HardwareProfiles',
+        '@Smoke',
+        '@SmokeSet2',
+        '@NonConcurrent',
+        '@HardwareProfilesCI',
+      ],
     },
     () => {
       // Authentication and navigation

--- a/packages/hardware-profiles/package.json
+++ b/packages/hardware-profiles/package.json
@@ -64,6 +64,9 @@
     "lint:fix": "eslint . --fix",
     "type-check": "tsc --noEmit"
   },
+  "e2eCiTags": [
+    "@HardwareProfilesCI"
+  ],
   "dependencies": {
     "@odh-dashboard/foundation": "*",
     "@odh-dashboard/internal": "*",

--- a/packages/mlflow-embedded/package.json
+++ b/packages/mlflow-embedded/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/mlflow-embedded",
   "description": "Embeds selected pages from the external MLflow frontend into the dashboard.",
   "version": "0.0.0",
+  "e2eCiTags": ["@MLflowEmbeddedCI"],
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-80966

Parent initiative: https://redhat.atlassian.net/browse/RHOAIENG-69659 (Identify e2e tests for each Dashboard module)

## Description

The PR-CI E2E pipeline (`.github/workflows/cypress-e2e-test.yml`) auto-detects changed modules and maps them to Cypress `@<Module>CI` grep tags, but that only works if the corresponding tests actually carry the tag in their `it()` blocks. This PR closes the gaps called out in [RHOAIENG-80966](https://redhat.atlassian.net/browse/RHOAIENG-80966) for `ConnectionTypes`, `HardwareProfiles`, and `MlflowEmbedded` so PR CI picks up module-relevant tests instead of only catching failures in the nightly run.

**What changed:**
- **ConnectionTypes** — added the already-registered `@ConnectionTypesCI` tag (see `.github/frontend-ci-tags.json`) to the two E2E tests that were missing it:
  - `packages/cypress/cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts`
  - `packages/cypress/cypress/tests/e2e/settings/connectionTypes/testPreInstalledConnectionTypes.cy.ts` (also added the `@ConnectionTypes` team tag it was missing)
- **HardwareProfiles** — added the already-registered `@HardwareProfilesCI` tag to the two E2E tests that were missing it:
  - `packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts`
  - `packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testNotebookTolerations.cy.ts`
- **MlflowEmbedded** — this module had no CI tag defined at all, so:
  - Added `"e2eCiTags": ["@MLflowEmbeddedCI"]` to `packages/mlflow-embedded/package.json` (Layer 1 Turbo-based auto-detection, matching the pattern already used by `packages/agent-ops` → `@AgentOpsCI` and `packages/mlflow` → `@MLflowCI`)
  - Added `@MLflowEmbeddedCI` to the two E2E tests that exercise `mlflow-embedded`'s wrapper pages:
    - `packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts`
    - `packages/cypress/cypress/tests/e2e/promptManagement/testPromptManagement.cy.ts`

Note: `packages/mlflow` (the separate ODH-native MLflow product/BFF, distinct from the `mlflow-embedded` host wrapper around the external upstream MLflow UI) already declares `@MLflowCI` in its `e2eCiTags`, but has no dedicated E2E spec yet — that's tracked separately and intentionally out of scope here.

## How Has This Been Tested?

This is a metadata-only change (Cypress `tags` arrays and `package.json` `e2eCiTags`) — no test logic, page objects, or application code changed. Verified by:
- Running `npm run lint -- --fix` in `packages/cypress` (0 errors, 2 pre-existing unrelated warnings)
- Reviewing the full diff to confirm only tag arrays were touched

## Test Impact

No new test files. Existing test files updated (tag-only changes):
- `packages/cypress/cypress/tests/e2e/settings/connectionTypes/testCreateConnectionTypes.cy.ts`
- `packages/cypress/cypress/tests/e2e/settings/connectionTypes/testPreInstalledConnectionTypes.cy.ts`
- `packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts`
- `packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testNotebookTolerations.cy.ts`
- `packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts`
- `packages/cypress/cypress/tests/e2e/promptManagement/testPromptManagement.cy.ts`
- `packages/mlflow-embedded/package.json`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

This is a non-UI, CI-metadata-only change, so the UI-change checklist items do not apply.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

[RHOAIENG-80966]: https://redhat.atlassian.net/browse/RHOAIENG-80966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test categorization for MLflow Experiments, prompt management, connection types, and hardware profiles.
  * Added dedicated CI tags to improve test selection, execution, and reporting.

* **Chores**
  * Added CI test metadata for embedded MLflow, connection types, and hardware profiles.
  * Standardized test tag formatting for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->