### PR TITLE
fix(RHOAIENG-79525): include desired handler in probe sanitization patch [v3.5.0]

### DIFF
--- a/dashboard-operator/internal/controller/probe_sanitize.go
+++ b/dashboard-operator/internal/controller/probe_sanitize.go
@@ -89,9 +89,16 @@ func buildProbeCleanupPatch(live, desired *unstructured.Unstructured) map[string
 		for _, probeField := range []string{"livenessProbe", "readinessProbe", "startupProbe"} {
 			nullFields := conflictingHandlerFields(liveC, desiredC, probeField)
 			if len(nullFields) > 0 {
-				probePatch := make(map[string]interface{}, len(nullFields))
+				probePatch := make(map[string]interface{}, len(nullFields)+1)
 				for _, f := range nullFields {
 					probePatch[f] = nil
+				}
+				desiredProbe, _ := desiredC[probeField].(map[string]interface{})
+				for _, h := range probeHandlerTypes {
+					if val, ok := desiredProbe[h]; ok {
+						probePatch[h] = val
+						break
+					}
 				}
 				containerPatch[probeField] = probePatch
 				hasConflict = true

--- a/dashboard-operator/internal/controller/probe_sanitize_test.go
+++ b/dashboard-operator/internal/controller/probe_sanitize_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -177,10 +178,26 @@ func TestSanitizeDeploymentProbes_TcpSocketToExec(t *testing.T) {
 	if _, ok := lp["tcpSocket"]; ok {
 		t.Error("tcpSocket should have been removed from livenessProbe")
 	}
+	lpExec, ok := lp["exec"].(map[string]interface{})
+	if !ok {
+		t.Fatal("exec should have been added to livenessProbe")
+	}
+	wantLivenessCmd := []interface{}{"/bin/sh", "-c", "curl -s http://localhost:8080/"}
+	if !reflect.DeepEqual(lpExec["command"], wantLivenessCmd) {
+		t.Errorf("livenessProbe exec command = %v, want %v", lpExec["command"], wantLivenessCmd)
+	}
 
 	rp, _ := c["readinessProbe"].(map[string]interface{})
 	if _, ok := rp["httpGet"]; ok {
 		t.Error("httpGet should have been removed from readinessProbe")
+	}
+	rpExec, ok := rp["exec"].(map[string]interface{})
+	if !ok {
+		t.Fatal("exec should have been added to readinessProbe")
+	}
+	wantReadinessCmd := []interface{}{"/bin/sh", "-c", "curl -s http://localhost:8080/api/health"}
+	if !reflect.DeepEqual(rpExec["command"], wantReadinessCmd) {
+		t.Errorf("readinessProbe exec command = %v, want %v", rpExec["command"], wantReadinessCmd)
 	}
 }
 
@@ -258,6 +275,14 @@ func TestSanitizeDeploymentProbes_MultipleContainers(t *testing.T) {
 		case "rhods-dashboard":
 			if _, ok := lp["tcpSocket"]; ok {
 				t.Error("rhods-dashboard: tcpSocket should have been removed")
+			}
+			execHandler, ok := lp["exec"].(map[string]interface{})
+			if !ok {
+				t.Fatal("rhods-dashboard: exec should have been added")
+			}
+			wantCmd := []interface{}{"/bin/sh", "-c", "curl localhost:8080/"}
+			if !reflect.DeepEqual(execHandler["command"], wantCmd) {
+				t.Errorf("rhods-dashboard: exec command = %v, want %v", execHandler["command"], wantCmd)
 			}
 		case "kube-rbac-proxy":
 			if _, ok := lp["httpGet"]; !ok {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79525

## Description

Cherry-pick of #9077 to `v3.5.0-fixes`.

The probe sanitization patch was only nulling out stale handler types (e.g., `tcpSocket`, `httpGet`) without setting the desired handler (`exec`), leaving probes with no handler type — which Kubernetes rejects. The operator enters an error loop retrying every ~17 minutes.

The fix includes the desired handler value alongside the null stale handlers in the strategic merge patch, so the transition is atomic.

See #9077 for full details, root cause analysis, and cluster verification.

## How Has This Been Tested?

- Unit tests updated and passing (all 5 `TestSanitize*` tests pass)
- Verified on live 3.4→3.5 upgrade cluster — patch succeeded, pods rolled out 10/10, operator reconciled successfully

## Test Impact

Updated unit tests to verify exec handler command values after sanitization using `reflect.DeepEqual`.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`