### PR TITLE
[v3.5.0-fixes] fix(RHOAIENG-80801): add core apiGroup to imagestreams/layers escalation permission

### DIFF
--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -375,6 +375,16 @@ rules:
       - update
       - patch
       - delete
+  # system:image-puller (referenced by the cluster-image-pullers
+  # RoleBinding) grants imagestreams/layers get under both "" and
+  # image.openshift.io. RBAC escalation prevention requires the
+  # operator SA to hold the core-group variant as well.
+  - apiGroups:
+      - ""
+    resources:
+      - imagestreams/layers
+    verbs:
+      - get
   # Verbs cover both sa-rbac/role.yaml (list) and
   # fetch-builds-and-images.rbac.yaml (get, list, watch).
   - apiGroups:

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -359,6 +359,16 @@ rules:
       - update
       - patch
       - delete
+  # system:image-puller (referenced by the cluster-image-pullers
+  # RoleBinding) grants imagestreams/layers get under both "" and
+  # image.openshift.io. RBAC escalation prevention requires the
+  # operator SA to hold the core-group variant as well.
+  - apiGroups:
+      - ""
+    resources:
+      - imagestreams/layers
+    verbs:
+      - get
   # Verbs cover both sa-rbac/role.yaml (list) and
   # fetch-builds-and-images.rbac.yaml (get, list, watch).
   - apiGroups:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-80801

Cherry-pick of #9093 onto `v3.5.0-fixes`.

## Description

The Dashboard Operator fails to reconcile the `default-dashboard` custom resource because it cannot create the `cluster-image-pullers` RoleBinding. The OpenShift built-in `system:image-puller` ClusterRole grants `imagestreams/layers` `get` under both apiGroups `""` and `image.openshift.io`, but the operator's ClusterRole only had `image.openshift.io`. RBAC escalation prevention blocks the RoleBinding creation.

### Fix

Adds a separate least-privilege rule granting only `get` on `imagestreams/layers` under the core apiGroup `""`, satisfying the escalation check without broadening existing permissions.

## How Has This Been Tested?

- Reproduced and fix-verified on a live RHOAI 3.5 cluster (s390x, OCP 4.21.16)
- `go test ./charts/ -run TestDashboardChartRBACInSync` passes (chart sync)
- `go test ./...` passes (full operator test suite)

## Test Impact

No new tests needed. Existing `TestDashboardChartRBACInSync` validates file sync. The fix is a single additional RBAC rule.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`