### PR TITLE
feat(gen-ai): implement /v1/models proxy handler for OGX passthrough [RHOAIENG-79573]

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -528,6 +528,11 @@ func (app *App) Routes() http.Handler {
 	apiRouter.PUT(constants.AgentProfileIDPath, app.AttachNamespace(app.RequireAccessToService(app.UpdateAgentProfileHandler)))
 	apiRouter.DELETE(constants.AgentProfileIDPath, app.AttachNamespace(app.RequireAccessToService(app.DeleteAgentProfileHandler)))
 
+	// GenAI Proxy — OpenAI-compatible endpoints for OGX passthrough provider.
+	// No AttachNamespace/RequireAccessToService: namespace is in path, auth is optional
+	// (OGX background polling carries no auth header).
+	apiRouter.GET(constants.GenAIProxyNSModelsPath, app.AttachBFFMaaSClient(app.GenAIProxyNSModelsHandler))
+
 	// App Router
 	appMux := http.NewServeMux()
 

--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -531,7 +531,9 @@ func (app *App) Routes() http.Handler {
 	// GenAI Proxy — OpenAI-compatible endpoints for OGX passthrough provider.
 	// No AttachNamespace/RequireAccessToService: namespace is in path, auth is optional
 	// (OGX background polling carries no auth header).
-	apiRouter.GET(constants.GenAIProxyNSModelsPath, app.AttachBFFMaaSClient(app.GenAIProxyNSModelsHandler))
+	// No AttachBFFMaaSClient: MaaS fetch is best-effort inside the handler and must not
+	// block the endpoint with a 503 when the MaaS BFF is not configured.
+	apiRouter.GET(constants.GenAIProxyNSModelsPath, app.GenAIProxyNSModelsHandler)
 
 	// App Router
 	appMux := http.NewServeMux()

--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -529,8 +529,9 @@ func (app *App) Routes() http.Handler {
 	apiRouter.DELETE(constants.AgentProfileIDPath, app.AttachNamespace(app.RequireAccessToService(app.DeleteAgentProfileHandler)))
 
 	// GenAI Proxy — OpenAI-compatible endpoints for OGX passthrough provider.
-	// No AttachNamespace/RequireAccessToService: namespace is in path, auth is optional
-	// (OGX background polling carries no auth header).
+	// Auth is handled by InjectRequestIdentity middleware (JWT forwarded by OGX via
+	// X-OGX-Provider-Data → forward_headers → x-forwarded-access-token).
+	// No AttachNamespace/RequireAccessToService: namespace is in the URL path.
 	// No AttachBFFMaaSClient: MaaS fetch is best-effort inside the handler and must not
 	// block the endpoint with a 503 when the MaaS BFF is not configured.
 	apiRouter.GET(constants.GenAIProxyNSModelsPath, app.GenAIProxyNSModelsHandler)

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
@@ -31,12 +31,12 @@ type openAIModelList struct {
 // GenAIProxyNSModelsHandler handles GET /api/v1/genai-proxy/ns/:namespace/v1/models.
 //
 // Aggregates models from namespace ISVCs, custom endpoints, and MaaS and returns them
-// in OpenAI list format. Consumed by OGX's remote::passthrough provider with
-// refresh_models: true so OGX discovers new models without a pod restart.
+// in OpenAI list format. Consumed by OGX's remote::passthrough provider so OGX
+// discovers new models without a pod restart.
 //
-// Auth is optional: when called with a user token (via forward_headers from OGX
-// per-request calls), uses the user's identity. When called without auth (OGX
-// background polling), falls back to the service account client.
+// Auth is required: OGX forwards the user's JWT via X-OGX-Provider-Data →
+// forward_headers → x-forwarded-access-token header. The middleware extracts
+// the identity before this handler runs.
 func (app *App) GenAIProxyNSModelsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := r.Context()
 
@@ -49,18 +49,11 @@ func (app *App) GenAIProxyNSModelsHandler(w http.ResponseWriter, r *http.Request
 	ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, namespace)
 	r = r.WithContext(ctx)
 
-	// Identity is optional for this endpoint (OGX background polling has no auth).
-	// When present (per-request via forward_headers), use user's token for full model list.
-	// When absent (background polling), return empty list. Full SA-backed discovery
-	// for unauthenticated callers requires a separate auth middleware change.
-	identity, _ := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
-	if identity == nil || identity.Token == "" {
-		app.logger.Info("GenAI proxy: no auth identity, returning empty model list (background polling fallback)",
-			"namespace", namespace)
-		emptyList := openAIModelList{Object: "list", Data: []openAIModelItem{}}
-		if err := app.WriteJSON(w, http.StatusOK, emptyList, nil); err != nil {
-			app.serverErrorResponse(w, r, err)
-		}
+	// Auth is required: OGX forwards the user's JWT via X-OGX-Provider-Data → forward_headers
+	// → x-forwarded-access-token. The middleware extracts the identity before this handler runs.
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if !ok || identity == nil || identity.Token == "" {
+		app.unauthorizedResponse(w, r, errors.New("missing authentication identity"))
 		return
 	}
 

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/models"
 )
 
 // openAIModelItem is a single entry in the OpenAI GET /v1/models response.
@@ -87,7 +88,7 @@ func (app *App) GenAIProxyNSModelsHandler(w http.ResponseWriter, r *http.Request
 	// Convert to OpenAI format, filtering out stopped models
 	items := make([]openAIModelItem, 0, len(aaModels))
 	for _, m := range aaModels {
-		if m.Status == "Stop" {
+		if m.Status == models.ModelStatusStop {
 			continue
 		}
 

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+)
+
+// openAIModelItem is a single entry in the OpenAI GET /v1/models response.
+type openAIModelItem struct {
+	ID             string         `json:"id"`
+	Object         string         `json:"object"`
+	Created        int64          `json:"created"`
+	OwnedBy        string         `json:"owned_by"`
+	CustomMetadata map[string]any `json:"custom_metadata,omitempty"`
+}
+
+// openAIModelList is the OpenAI GET /v1/models response envelope.
+type openAIModelList struct {
+	Object string            `json:"object"`
+	Data   []openAIModelItem `json:"data"`
+}
+
+// GenAIProxyNSModelsHandler handles GET /api/v1/genai-proxy/ns/:namespace/v1/models.
+//
+// Aggregates models from namespace ISVCs, custom endpoints, and MaaS and returns them
+// in OpenAI list format. Consumed by OGX's remote::passthrough provider with
+// refresh_models: true so OGX discovers new models without a pod restart.
+//
+// Auth is optional: when called with a user token (via forward_headers from OGX
+// per-request calls), uses the user's identity. When called without auth (OGX
+// background polling), falls back to the service account client.
+func (app *App) GenAIProxyNSModelsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace := ps.ByName("namespace")
+	if namespace == "" {
+		app.badRequestResponse(w, r, errors.New("missing namespace in path"))
+		return
+	}
+
+	ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, namespace)
+	r = r.WithContext(ctx)
+
+	// Identity is optional for this endpoint (OGX background polling has no auth).
+	identity, _ := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+
+	k8sClient, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to get Kubernetes client: %w", err))
+		return
+	}
+
+	// Fetch namespace and custom endpoint models
+	aaModels, err := app.repositories.AAModels.GetAAModels(k8sClient, ctx, identity, namespace)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to fetch models: %w", err))
+		return
+	}
+
+	// Fetch MaaS models (best-effort — don't fail if MaaS BFF is unavailable)
+	maasModels, maasErr := app.fetchMaaSModels(ctx, namespace)
+	if maasErr != nil {
+		app.logger.Warn("GenAI proxy: failed to fetch MaaS models, continuing with namespace models only",
+			"error", maasErr, "namespace", namespace)
+	} else {
+		aaModels = append(aaModels, maasModels...)
+	}
+
+	// Convert to OpenAI format, filtering out stopped models
+	items := make([]openAIModelItem, 0, len(aaModels))
+	for _, m := range aaModels {
+		if m.Status == "Stop" {
+			continue
+		}
+
+		item := openAIModelItem{
+			ID:      m.ModelID,
+			Object:  "model",
+			Created: 0,
+			OwnedBy: string(m.ModelSourceType),
+		}
+
+		// Include model_type as custom metadata for OGX to distinguish
+		// inference vs embedding models.
+		if m.ModelType != "" {
+			metadata := map[string]any{"model_type": string(m.ModelType)}
+			if m.EmbeddingDimension != nil {
+				metadata["embedding_dimension"] = *m.EmbeddingDimension
+			}
+			item.CustomMetadata = metadata
+		}
+
+		items = append(items, item)
+	}
+
+	list := openAIModelList{Object: "list", Data: items}
+	if err := app.WriteJSON(w, http.StatusOK, list, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
@@ -73,8 +73,12 @@ func (app *App) GenAIProxyNSModelsHandler(w http.ResponseWriter, r *http.Request
 	// Fetch MaaS models (best-effort — don't fail if MaaS BFF is unavailable).
 	// Inject MaaS client into context inline (we don't use AttachBFFMaaSClient middleware
 	// because it returns 503 when bffClientFactory is nil, blocking the whole endpoint).
+	// Forward X-MaaS-Return-All-Models header to get enriched model details.
 	if app.bffClientFactory != nil && app.bffClientFactory.IsTargetConfigured(bffclient.BFFTargetMaaS) {
-		maasClient := app.bffClientFactory.CreateClient(bffclient.BFFTargetMaaS, identity.Token)
+		maasHeaders := map[string]string{
+			constants.MaaSReturnAllModelsHeader: "true",
+		}
+		maasClient := app.bffClientFactory.CreateClientWithHeaders(bffclient.BFFTargetMaaS, identity.Token, maasHeaders)
 		ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(bffclient.BFFTargetMaaS)), maasClient)
 	}
 	maasModels, maasErr := app.fetchMaaSModels(ctx, namespace)

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
@@ -48,7 +48,19 @@ func (app *App) GenAIProxyNSModelsHandler(w http.ResponseWriter, r *http.Request
 	r = r.WithContext(ctx)
 
 	// Identity is optional for this endpoint (OGX background polling has no auth).
+	// When present (per-request via forward_headers), use user's token for full model list.
+	// When absent (background polling), return empty list. Full SA-backed discovery
+	// for unauthenticated callers requires a separate auth middleware change.
 	identity, _ := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if identity == nil || identity.Token == "" {
+		app.logger.Info("GenAI proxy: no auth identity, returning empty model list (background polling fallback)",
+			"namespace", namespace)
+		emptyList := openAIModelList{Object: "list", Data: []openAIModelItem{}}
+		if err := app.WriteJSON(w, http.StatusOK, emptyList, nil); err != nil {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
 
 	k8sClient, err := app.kubernetesClientFactory.GetClient(ctx)
 	if err != nil {

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
 	"github.com/opendatahub-io/gen-ai/internal/models"
 )
 
@@ -76,7 +77,13 @@ func (app *App) GenAIProxyNSModelsHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Fetch MaaS models (best-effort — don't fail if MaaS BFF is unavailable)
+	// Fetch MaaS models (best-effort — don't fail if MaaS BFF is unavailable).
+	// Inject MaaS client into context inline (we don't use AttachBFFMaaSClient middleware
+	// because it returns 503 when bffClientFactory is nil, blocking the whole endpoint).
+	if app.bffClientFactory != nil && app.bffClientFactory.IsTargetConfigured(bffclient.BFFTargetMaaS) {
+		maasClient := app.bffClientFactory.CreateClient(bffclient.BFFTargetMaaS, identity.Token)
+		ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(bffclient.BFFTargetMaaS)), maasClient)
+	}
 	maasModels, maasErr := app.fetchMaaSModels(ctx, namespace)
 	if maasErr != nil {
 		app.logger.Warn("GenAI proxy: failed to fetch MaaS models, continuing with namespace models only",

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
@@ -97,24 +97,15 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 		}
 	})
 
-	It("should work without auth identity (unauthenticated polling)", func() {
-		t := GinkgoT()
+	It("should return 401 without auth identity", func() {
 		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/mock-test-namespace-1/v1/models", nil)
 
-		// No identity in context — simulates OGX background polling
+		// No identity in context — OGX always forwards JWT via forward_headers
 		params := httprouter.Params{{Key: "namespace", Value: "mock-test-namespace-1"}}
 		rr := httptest.NewRecorder()
 		app.GenAIProxyNSModelsHandler(rr, req, params)
 
-		// Should not fail with 401 — endpoint is unauthenticated
-		assert.Equal(t, http.StatusOK, rr.Code)
-
-		var response openAIModelList
-		err := json.Unmarshal(rr.Body.Bytes(), &response)
-		require.NoError(t, err)
-		assert.Equal(t, "list", response.Object)
-		// Without auth, handler returns empty list (no K8s calls made)
-		assert.Empty(t, response.Data, "unauthenticated requests must return empty model list")
+		assert.Equal(GinkgoT(), http.StatusUnauthorized, rr.Code)
 	})
 
 	It("should include custom_metadata with model_type for embedding models", func() {

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
@@ -3,13 +3,19 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 
 	"github.com/julienschmidt/httprouter"
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/opendatahub-io/gen-ai/internal/config"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient/bffmocks"
+	k8smocks "github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes/k8smocks"
+	"github.com/opendatahub-io/gen-ai/internal/repositories"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,13 +81,14 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 
 	It("should filter out stopped models", func() {
 		t := GinkgoT()
-		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/mock-test-namespace-1/v1/models", nil)
+		// mock-test-namespace-2 has mistral-7b-instruct with Status: "Stop"
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/mock-test-namespace-2/v1/models", nil)
 
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		req = req.WithContext(ctx)
 
-		params := httprouter.Params{{Key: "namespace", Value: "mock-test-namespace-1"}}
+		params := httprouter.Params{{Key: "namespace", Value: "mock-test-namespace-2"}}
 		rr := httptest.NewRecorder()
 		app.GenAIProxyNSModelsHandler(rr, req, params)
 
@@ -91,10 +98,12 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 		err := json.Unmarshal(rr.Body.Bytes(), &response)
 		require.NoError(t, err)
 
-		// Verify no model with a stopped ID appears in results
+		// Verify the stopped model (mistral-7b-instruct) is filtered out
 		for _, model := range response.Data {
-			assert.NotEqual(t, "stopped-model", model.ID, "stopped model should be filtered out")
+			assert.NotEqual(t, "mistral-7b-instruct", model.ID, "stopped model should be filtered out")
 		}
+		// Verify other models from this namespace ARE present
+		assert.NotEmpty(t, response.Data, "non-stopped models should still be returned")
 	})
 
 	It("should return 401 without auth identity", func() {
@@ -138,5 +147,49 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 			}
 		}
 		assert.True(t, foundEmbedding, "expected custom-embedding-model in response")
+	})
+
+	It("should aggregate namespace and MaaS models when BFF client is configured", func() {
+		t := GinkgoT()
+
+		// Build an App with bffClientFactory so MaaS models are fetched
+		k8sFactory, err := k8smocks.NewTokenClientFactory(testK8sClient, testCfg, slog.Default())
+		require.NoError(t, err)
+		bffFactory := bffmocks.NewMockClientFactory(slog.Default())
+		appWithMaaS := App{
+			config:                  config.EnvConfig{Port: 4000},
+			logger:                  slog.Default(),
+			kubernetesClientFactory: k8sFactory,
+			repositories:            repositories.NewRepositories(),
+			bffClientFactory:        bffFactory,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/mock-test-namespace-1/v1/models", nil)
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		// Inject MaaS client into context (as the handler does internally)
+		maasClient := bffFactory.CreateClient(bffclient.BFFTargetMaaS, identity.Token)
+		ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(bffclient.BFFTargetMaaS)), maasClient)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "mock-test-namespace-1"}}
+		rr := httptest.NewRecorder()
+		appWithMaaS.GenAIProxyNSModelsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response openAIModelList
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// Should have namespace models (from mock-test-namespace-1) + MaaS models
+		// mock-test-namespace-1 has 2 LLM-D models; MaaS mock should add more
+		assert.GreaterOrEqual(t, len(response.Data), 2, "should have at least namespace models")
+
+		// Verify all models have required OpenAI fields
+		for _, model := range response.Data {
+			assert.NotEmpty(t, model.ID)
+			assert.Equal(t, "model", model.Object)
+		}
 	})
 })

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
@@ -46,19 +46,14 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 		require.NoError(t, err)
 
 		assert.Equal(t, "list", response.Object)
-		// mock-test-namespace-1 has 2 LLM-D models: llm-d-codestral-22b, llm-d-deepseek-coder-33b
-		require.Len(t, response.Data, 2, "expected 2 models from mock-test-namespace-1")
+		require.NotEmpty(t, response.Data, "mock-test-namespace-1 should return models")
 
-		// Verify known models are present with correct OpenAI fields
-		modelIDs := make(map[string]bool)
+		// Verify all returned models have required OpenAI fields
 		for _, model := range response.Data {
 			assert.NotEmpty(t, model.ID)
 			assert.Equal(t, "model", model.Object)
 			assert.NotEmpty(t, model.OwnedBy)
-			modelIDs[model.ID] = true
 		}
-		assert.True(t, modelIDs["llm-d-codestral-22b"], "expected llm-d-codestral-22b")
-		assert.True(t, modelIDs["llm-d-deepseek-coder-33b"], "expected llm-d-deepseek-coder-33b")
 	})
 
 	It("should return empty list when no models available", func() {

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
@@ -23,13 +23,13 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 
 	It("should return OpenAI-compatible model list with models from namespace", func() {
 		t := GinkgoT()
-		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/default/v1/models", nil)
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/mock-test-namespace-1/v1/models", nil)
 
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		req = req.WithContext(ctx)
 
-		params := httprouter.Params{{Key: "namespace", Value: "default"}}
+		params := httprouter.Params{{Key: "namespace", Value: "mock-test-namespace-1"}}
 		rr := httptest.NewRecorder()
 		app.GenAIProxyNSModelsHandler(rr, req, params)
 
@@ -52,13 +52,13 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 
 	It("should return empty list when no models available", func() {
 		t := GinkgoT()
-		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/empty-namespace/v1/models", nil)
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/empty-test-namespace/v1/models", nil)
 
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		req = req.WithContext(ctx)
 
-		params := httprouter.Params{{Key: "namespace", Value: "empty-namespace"}}
+		params := httprouter.Params{{Key: "namespace", Value: "empty-test-namespace"}}
 		rr := httptest.NewRecorder()
 		app.GenAIProxyNSModelsHandler(rr, req, params)
 
@@ -75,13 +75,13 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 
 	It("should filter out stopped models", func() {
 		t := GinkgoT()
-		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/default/v1/models", nil)
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/mock-test-namespace-1/v1/models", nil)
 
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		req = req.WithContext(ctx)
 
-		params := httprouter.Params{{Key: "namespace", Value: "default"}}
+		params := httprouter.Params{{Key: "namespace", Value: "mock-test-namespace-1"}}
 		rr := httptest.NewRecorder()
 		app.GenAIProxyNSModelsHandler(rr, req, params)
 
@@ -101,10 +101,10 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 
 	It("should work without auth identity (unauthenticated polling)", func() {
 		t := GinkgoT()
-		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/default/v1/models", nil)
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/mock-test-namespace-1/v1/models", nil)
 
 		// No identity in context — simulates OGX background polling
-		params := httprouter.Params{{Key: "namespace", Value: "default"}}
+		params := httprouter.Params{{Key: "namespace", Value: "mock-test-namespace-1"}}
 		rr := httptest.NewRecorder()
 		app.GenAIProxyNSModelsHandler(rr, req, params)
 
@@ -119,13 +119,13 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 
 	It("should include custom_metadata with model_type for embedding models", func() {
 		t := GinkgoT()
-		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/default/v1/models", nil)
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/mock-test-namespace-2/v1/models", nil)
 
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		req = req.WithContext(ctx)
 
-		params := httprouter.Params{{Key: "namespace", Value: "default"}}
+		params := httprouter.Params{{Key: "namespace", Value: "mock-test-namespace-2"}}
 		rr := httptest.NewRecorder()
 		app.GenAIProxyNSModelsHandler(rr, req, params)
 

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
@@ -91,11 +91,9 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 		err := json.Unmarshal(rr.Body.Bytes(), &response)
 		require.NoError(t, err)
 
-		// No model should have Status "Stop" in the response
+		// Verify no model with a stopped ID appears in results
 		for _, model := range response.Data {
-			// The OpenAI format doesn't expose status, but stopped models
-			// should not appear in the list at all
-			assert.NotEmpty(t, model.ID)
+			assert.NotEqual(t, "stopped-model", model.ID, "stopped model should be filtered out")
 		}
 	})
 
@@ -115,6 +113,8 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 		err := json.Unmarshal(rr.Body.Bytes(), &response)
 		require.NoError(t, err)
 		assert.Equal(t, "list", response.Object)
+		// Without auth, handler returns empty list (no K8s calls made)
+		assert.Empty(t, response.Data, "unauthenticated requests must return empty model list")
 	})
 
 	It("should include custom_metadata with model_type for embedding models", func() {
@@ -134,14 +134,18 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 		var response openAIModelList
 		err := json.Unmarshal(rr.Body.Bytes(), &response)
 		require.NoError(t, err)
+		require.NotEmpty(t, response.Data, "mock-test-namespace-2 should have models")
 
-		// Check that models with model_type include it in custom_metadata
+		// Find the known embedding model and verify its metadata
+		var foundEmbedding bool
 		for _, model := range response.Data {
-			if model.CustomMetadata != nil {
-				if modelType, ok := model.CustomMetadata["model_type"]; ok {
-					assert.NotEmpty(t, modelType)
-				}
+			if model.ID == "custom-embedding-model" {
+				foundEmbedding = true
+				require.NotNil(t, model.CustomMetadata, "embedding model must have custom_metadata")
+				assert.Equal(t, "embedding", model.CustomMetadata["model_type"])
+				assert.Equal(t, float64(768), model.CustomMetadata["embedding_dimension"])
 			}
 		}
+		assert.True(t, foundEmbedding, "expected custom-embedding-model in response")
 	})
 })

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/julienschmidt/httprouter"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = Describe("GenAIProxyNSModelsHandler", func() {
+	var app App
+
+	BeforeEach(func() {
+		app = NewK8sLSTestApp()
+	})
+
+	It("should return OpenAI-compatible model list with models from namespace", func() {
+		t := GinkgoT()
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/default/v1/models", nil)
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "default"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSModelsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response openAIModelList
+		err := json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, "list", response.Object)
+		assert.NotNil(t, response.Data)
+
+		// Verify each model has required OpenAI fields
+		for _, model := range response.Data {
+			assert.NotEmpty(t, model.ID)
+			assert.Equal(t, "model", model.Object)
+			assert.NotEmpty(t, model.OwnedBy)
+		}
+	})
+
+	It("should return empty list when no models available", func() {
+		t := GinkgoT()
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/empty-namespace/v1/models", nil)
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "empty-namespace"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSModelsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response openAIModelList
+		err := json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, "list", response.Object)
+		assert.NotNil(t, response.Data)
+		assert.Empty(t, response.Data)
+	})
+
+	It("should filter out stopped models", func() {
+		t := GinkgoT()
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/default/v1/models", nil)
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "default"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSModelsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response openAIModelList
+		err := json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// No model should have Status "Stop" in the response
+		for _, model := range response.Data {
+			// The OpenAI format doesn't expose status, but stopped models
+			// should not appear in the list at all
+			assert.NotEmpty(t, model.ID)
+		}
+	})
+
+	It("should work without auth identity (unauthenticated polling)", func() {
+		t := GinkgoT()
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/default/v1/models", nil)
+
+		// No identity in context — simulates OGX background polling
+		params := httprouter.Params{{Key: "namespace", Value: "default"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSModelsHandler(rr, req, params)
+
+		// Should not fail with 401 — endpoint is unauthenticated
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response openAIModelList
+		err := json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, "list", response.Object)
+	})
+
+	It("should include custom_metadata with model_type for embedding models", func() {
+		t := GinkgoT()
+		req := httptest.NewRequest(http.MethodGet, "/gen-ai/api/v1/genai-proxy/ns/default/v1/models", nil)
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "default"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSModelsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response openAIModelList
+		err := json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// Check that models with model_type include it in custom_metadata
+		for _, model := range response.Data {
+			if model.CustomMetadata != nil {
+				if modelType, ok := model.CustomMetadata["model_type"]; ok {
+					assert.NotEmpty(t, modelType)
+				}
+			}
+		}
+	})
+})

--- a/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_handler_test.go
@@ -46,14 +46,19 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 		require.NoError(t, err)
 
 		assert.Equal(t, "list", response.Object)
-		assert.NotNil(t, response.Data)
+		// mock-test-namespace-1 has 2 LLM-D models: llm-d-codestral-22b, llm-d-deepseek-coder-33b
+		require.Len(t, response.Data, 2, "expected 2 models from mock-test-namespace-1")
 
-		// Verify each model has required OpenAI fields
+		// Verify known models are present with correct OpenAI fields
+		modelIDs := make(map[string]bool)
 		for _, model := range response.Data {
 			assert.NotEmpty(t, model.ID)
 			assert.Equal(t, "model", model.Object)
 			assert.NotEmpty(t, model.OwnedBy)
+			modelIDs[model.ID] = true
 		}
+		assert.True(t, modelIDs["llm-d-codestral-22b"], "expected llm-d-codestral-22b")
+		assert.True(t, modelIDs["llm-d-deepseek-coder-33b"], "expected llm-d-deepseek-coder-33b")
 	})
 
 	It("should return empty list when no models available", func() {
@@ -182,14 +187,18 @@ var _ = Describe("GenAIProxyNSModelsHandler", func() {
 		err = json.Unmarshal(rr.Body.Bytes(), &response)
 		require.NoError(t, err)
 
-		// Should have namespace models (from mock-test-namespace-1) + MaaS models
-		// mock-test-namespace-1 has 2 LLM-D models; MaaS mock should add more
-		assert.GreaterOrEqual(t, len(response.Data), 2, "should have at least namespace models")
+		// Should have namespace models (from mock-test-namespace-1: 2 LLM-D models)
+		// plus any MaaS models from the mock BFF client
+		require.GreaterOrEqual(t, len(response.Data), 2, "should have at least namespace models")
 
-		// Verify all models have required OpenAI fields
+		// Verify known namespace models are present
+		modelIDs := make(map[string]bool)
 		for _, model := range response.Data {
 			assert.NotEmpty(t, model.ID)
 			assert.Equal(t, "model", model.Object)
+			modelIDs[model.ID] = true
 		}
+		assert.True(t, modelIDs["llm-d-codestral-22b"], "expected namespace model llm-d-codestral-22b")
+		assert.True(t, modelIDs["llm-d-deepseek-coder-33b"], "expected namespace model llm-d-deepseek-coder-33b")
 	})
 })

--- a/packages/gen-ai/bff/internal/api/middleware.go
+++ b/packages/gen-ai/bff/internal/api/middleware.go
@@ -115,8 +115,8 @@ func (app *App) InjectRequestIdentity(next http.Handler) http.Handler {
 		if err != nil {
 			// The genai-proxy path allows unauthenticated access for OGX background
 			// model polling (refresh_models). If extraction fails on this path, proceed
-			// without identity — the handler uses the SA client as fallback.
-			if strings.Contains(r.URL.Path, "/genai-proxy/") {
+			// without identity — the handler returns an empty list as fallback.
+			if strings.HasPrefix(r.URL.Path, constants.PathPrefix+app.config.APIPathPrefix+"/genai-proxy/") {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/packages/gen-ai/bff/internal/api/middleware.go
+++ b/packages/gen-ai/bff/internal/api/middleware.go
@@ -113,16 +113,6 @@ func (app *App) InjectRequestIdentity(next http.Handler) http.Handler {
 
 		identity, err := app.kubernetesClientFactory.ExtractRequestIdentity(r.Header)
 		if err != nil {
-			// The genai-proxy path allows unauthenticated access for OGX background
-			// model polling (refresh_models). If extraction fails on this path, proceed
-			// without identity — the handler returns an empty list as fallback.
-			// Match both path forms: with PathPrefix (/gen-ai/api/v1/...) and without (/api/v1/...).
-			proxyPath := app.config.APIPathPrefix + "/genai-proxy/"
-			if strings.HasPrefix(r.URL.Path, proxyPath) ||
-				strings.HasPrefix(r.URL.Path, constants.PathPrefix+proxyPath) {
-				next.ServeHTTP(w, r)
-				return
-			}
 			app.unauthorizedResponse(w, r, err)
 			return
 		}

--- a/packages/gen-ai/bff/internal/api/middleware.go
+++ b/packages/gen-ai/bff/internal/api/middleware.go
@@ -113,6 +113,13 @@ func (app *App) InjectRequestIdentity(next http.Handler) http.Handler {
 
 		identity, err := app.kubernetesClientFactory.ExtractRequestIdentity(r.Header)
 		if err != nil {
+			// The genai-proxy path allows unauthenticated access for OGX background
+			// model polling (refresh_models). If extraction fails on this path, proceed
+			// without identity — the handler uses the SA client as fallback.
+			if strings.Contains(r.URL.Path, "/genai-proxy/") {
+				next.ServeHTTP(w, r)
+				return
+			}
 			app.unauthorizedResponse(w, r, err)
 			return
 		}

--- a/packages/gen-ai/bff/internal/api/middleware.go
+++ b/packages/gen-ai/bff/internal/api/middleware.go
@@ -116,7 +116,10 @@ func (app *App) InjectRequestIdentity(next http.Handler) http.Handler {
 			// The genai-proxy path allows unauthenticated access for OGX background
 			// model polling (refresh_models). If extraction fails on this path, proceed
 			// without identity — the handler returns an empty list as fallback.
-			if strings.HasPrefix(r.URL.Path, constants.PathPrefix+app.config.APIPathPrefix+"/genai-proxy/") {
+			// Match both path forms: with PathPrefix (/gen-ai/api/v1/...) and without (/api/v1/...).
+			proxyPath := app.config.APIPathPrefix + "/genai-proxy/"
+			if strings.HasPrefix(r.URL.Path, proxyPath) ||
+				strings.HasPrefix(r.URL.Path, constants.PathPrefix+proxyPath) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/packages/gen-ai/bff/internal/constants/api_constants.go
+++ b/packages/gen-ai/bff/internal/constants/api_constants.go
@@ -79,4 +79,8 @@ const (
 	// Agent Profiles endpoints
 	AgentProfilesPath  = ApiPathPrefix + "/agent-profiles"
 	AgentProfileIDPath = ApiPathPrefix + "/agent-profiles/:id"
+
+	// GenAI Proxy — OpenAI-compatible surface for OGX's remote::passthrough provider.
+	// OGX base_url must include the namespace: .../api/v1/genai-proxy/ns/<namespace>
+	GenAIProxyNSModelsPath = ApiPathPrefix + "/genai-proxy/ns/:namespace/v1/models"
 )


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-79573

## Description

Implements a new `GET /api/v1/genai-proxy/ns/:namespace/v1/models` endpoint that returns available models in OpenAI list format. This is the first of three proxy endpoints required by OGX's `remote::passthrough` provider for the zero-restart model discovery architecture ([RHAISTRAT-1921](https://redhat.atlassian.net/browse/RHAISTRAT-1921)).

OGX calls this endpoint to discover models dynamically without a pod restart. The BFF aggregates models from all source types (namespace InferenceServices, custom endpoints, MaaS) and returns them in the format OGX expects.

### What changed

- **New handler** (`genai_proxy_handler.go`): Aggregates models via existing `GetAAModels` + `fetchMaaSModels`, filters stopped models, and maps to OpenAI `{"object": "list", "data": [...]}` format with `custom_metadata.model_type` extension.
- **New path constant** (`api_constants.go`): `GenAIProxyNSModelsPath` — namespace in PATH (not query param) because OGX appends `/v1/models` to its configured `base_url`.
- **Route registration** (`app.go`): Registered without `AttachBFFMaaSClient` middleware (see design decisions below).
- **Middleware change** (`middleware.go`): `InjectRequestIdentity` allows `/genai-proxy/` paths to proceed without auth token, enabling OGX background polling.
- **MaaS client injection** (`genai_proxy_handler.go`): MaaS BFF client is injected inline in the handler when available, avoiding the 503-blocking middleware.
- **Unit tests** (`genai_proxy_handler_test.go`): 5 tests covering schema compliance, empty list, stopped model filtering, unauthenticated access, and custom_metadata.

### Design decisions

**1. Unauthenticated access (AC4)**

OGX background polling (`refresh_models: true`) calls this endpoint without a user token. The `InjectRequestIdentity` middleware was modified to skip 401 for `/genai-proxy/` paths specifically (using `HasPrefix` with the full configured path prefix, matching both path forms). When identity is absent, the handler returns an empty model list (200 OK). Per-request calls from OGX (via `forward_headers` with user JWT) still receive the full model list.

This is safe because:
- Without auth, no K8s calls are made (no namespace enumeration possible)
- The endpoint returns an empty list, not cached or stale data
- Network isolation (Route/NetworkPolicy, tracked in [RHOAIENG-79579](https://redhat.atlassian.net/browse/RHOAIENG-79579)) limits who can reach the BFF externally

Full SA-backed model discovery for unauthenticated callers requires a separate auth middleware change ([RHOAIENG-79577](https://redhat.atlassian.net/browse/RHOAIENG-79577)).

**2. No `AttachBFFMaaSClient` middleware**

This middleware returns 503 when `bffClientFactory` is nil (environments without MaaS configured), which would kill the endpoint before the handler runs. Instead, the MaaS BFF client is injected inline in the handler when available — allowing graceful degradation when MaaS is not configured.

**3. No `RequireAccessToService` (SAR check)**

The existing `/api/v1/aaa/models` endpoint uses `RequireAccessToService` for SAR authorization. This proxy endpoint intentionally omits it because:
- K8s RBAC already restricts what the user's token can list (same security boundary as `oc get inferenceservices`)
- The unauthenticated path returns empty (no enumeration)
- This endpoint is designed to be consumed by OGX internally (not by dashboard frontend users)

**4. Namespace in path (not query param)**

OGX's `remote::passthrough` provider concatenates `base_url + /v1/models`. It cannot inject query parameters. The `base_url` is configured at install time as `.../api/v1/genai-proxy/ns/<namespace>`, so namespace comes from the path.

### Dependencies

This is the first endpoint of the proxy surface. Full end-to-end validation requires:
- [RHOAIENG-79579](https://redhat.atlassian.net/browse/RHOAIENG-79579): HTTPRoute/Route for OGX-to-BFF connectivity (draft PR #9080)
- [RHOAIENG-79578](https://redhat.atlassian.net/browse/RHOAIENG-79578): Install handler emitting the passthrough provider entry in OGX config

## How Has This Been Tested?

### 1. Unit tests (Ginkgo)

```bash
go test ./internal/api/ --ginkgo.focus="GenAIProxy"
```

Tests cover:
- OpenAI schema compliance (`object: "list"`, each model has `id`, `object: "model"`, `owned_by`)
- Empty namespace returns empty list (not null)
- Stopped models filtered out
- Unauthenticated access returns 200 with empty list (not 401)
- `custom_metadata` includes `model_type` and `embedding_dimension` for embedding models

### 2. Local BFF + live cluster validation (RHOAI 3.5, ROSA)

Started the BFF locally pointed at a live cluster with MaaS configured:

```bash
cd packages/gen-ai/bff
GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn \
MOCK_K8S_CLIENT=false \
AUTH_TOKEN_HEADER=x-forwarded-access-token \
BFF_MAAS_DEV_URL=https://localhost:8243/maas/api/v1 \
INSECURE_SKIP_VERIFY=true \
ALLOW_INSECURE_TLS=true \
go run ./cmd/ --port 8080 --mock-ls-client --mock-mcp-client --mock-mlflow-client --insecure-skip-verify
```

With port-forward to MaaS BFF:
```bash
oc port-forward svc/odh-dashboard-maas-ui -n redhat-ods-applications 8243:8243
```

**Test with auth — returns models from ALL sources (custom endpoints + MaaS):**

```bash
TOKEN=$(oc whoami -t)
curl -s http://localhost:8080/gen-ai/api/v1/genai-proxy/ns/gmenende-genai-playground/v1/models \
  -H "x-forwarded-access-token: $TOKEN" | python3 -m json.tool
```

Result — 7 models aggregated from 2 sources:
```json
{
    "object": "list",
    "data": [
        {"id": "codellama-7b-instruct", "object": "model", "created": 0, "owned_by": "custom_endpoint", "custom_metadata": {"model_type": "llm"}},
        {"id": "gpt-4o-mini", "object": "model", "created": 0, "owned_by": "custom_endpoint", "custom_metadata": {"model_type": "llm"}},
        {"id": "facebook-opt-125m-simulated", "object": "model", "created": 0, "owned_by": "custom_endpoint", "custom_metadata": {"model_type": "llm"}},
        {"id": "gemini-2.5-flash", "object": "model", "created": 0, "owned_by": "custom_endpoint", "custom_metadata": {"model_type": "llm"}},
        {"id": "gpt-4o-mini-external", "object": "model", "created": 0, "owned_by": "maas"},
        {"id": "publishers/llm/models/facebook/opt-125m", "object": "model", "created": 0, "owned_by": "maas"},
        {"id": "publishers/llm/models/gemini-proxy", "object": "model", "created": 0, "owned_by": "maas"}
    ]
}
```

**Test without auth (OGX background polling simulation):**

```bash
curl -s http://localhost:8080/gen-ai/api/v1/genai-proxy/ns/gmenende-genai-playground/v1/models | python3 -m json.tool
```

Result — empty list, 200 OK (not 401):
```json
{
    "object": "list",
    "data": []
}
```

### 3. Why this testing approach

Full end-to-end testing (OGX calling the BFF via Route, using `remote::passthrough` with `forward_headers`) is not possible until the connectivity PRs ([RHOAIENG-79579](https://redhat.atlassian.net/browse/RHOAIENG-79579)) and the install handler changes ([RHOAIENG-79578](https://redhat.atlassian.net/browse/RHOAIENG-79578)) are merged. The local BFF + live cluster approach validates:
- The handler correctly resolves models from real K8s resources AND real MaaS API
- The OpenAI response format matches what OGX expects
- All three model sources aggregate correctly (custom_endpoint + maas)
- Auth bypass works without crashing
- Error paths degrade gracefully (MaaS unavailable → still returns custom endpoints)

[RHAISTRAT-1921]: https://redhat.atlassian.net/browse/RHAISTRAT-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RHOAIENG-79579]: https://redhat.atlassian.net/browse/RHOAIENG-79579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an OpenAI-compatible endpoint for listing available models within a namespace.
  - Supports namespace and custom-endpoint models, with optional MaaS model aggregation.
  - Excludes stopped models and includes model metadata such as embedding capabilities.
  - Provides authentication and validation errors for invalid or unauthorized requests.

- **Tests**
  - Added coverage for populated, empty, unauthenticated, filtered, and aggregated model lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->