### PR TITLE
fix: repair vulnerability gates and Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,10 +48,14 @@ updates:
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
 
+    # Version updates: one PR per directory with all minor+patch bundled.
+    # Security updates: one PR per directory with all CVE fixes bundled.
+    # Dependabot hard limits (cannot work around in config):
+    # - No single PR across all directories for unrelated deps
+    # - group-by: dependency-name is version-updates only (not security/CVEs)
     groups:
       npm-updates:
         applies-to: version-updates
-        group-by: dependency-name
         patterns:
           - '*'
         update-types:
@@ -90,7 +94,6 @@ updates:
     groups:
       go-updates:
         applies-to: version-updates
-        group-by: dependency-name
         patterns:
           - '*'
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,6 +92,16 @@ updates:
       semver-patch-days: 3
 
     groups:
+      k8s-ecosystem:
+        applies-to: version-updates
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      aws-sdk:
+        applies-to: version-updates
+        patterns:
+          - "github.com/aws/*"
+          - "github.com/aws/smithy-go"
       go-updates:
         applies-to: version-updates
         group-by: dependency-name

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,14 +48,14 @@ updates:
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
 
-    # Version updates: one PR per directory with all minor+patch bundled.
-    # Security updates: one PR per directory with all CVE fixes bundled.
-    # Dependabot hard limits (cannot work around in config):
-    # - No single PR across all directories for unrelated deps
-    # - group-by: dependency-name is version-updates only (not security/CVEs)
+    # Version updates: one PR per dependency across all directories
+    # (group-by: dependency-name). Security updates: one PR per directory
+    # with all CVE fixes bundled. Dependabot hard limit: group-by applies
+    # to version-updates only, not security-updates.
     groups:
       npm-updates:
         applies-to: version-updates
+        group-by: dependency-name
         patterns:
           - '*'
         update-types:
@@ -94,6 +94,7 @@ updates:
     groups:
       go-updates:
         applies-to: version-updates
+        group-by: dependency-name
         patterns:
           - '*'
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,11 +48,44 @@ updates:
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
 
-    # Version updates: one PR per dependency across all directories
-    # (group-by: dependency-name). Security updates: one PR per directory
-    # with all CVE fixes bundled. Dependabot hard limit: group-by applies
-    # to version-updates only, not security-updates.
+    # Named groups bundle version-coupled families into 1 PR (matched
+    # before the catch-all). Catch-all uses group-by: dependency-name
+    # for remaining deps (1 PR per dep across dirs). Security catch-all
+    # bundles all CVEs. PatternFly version updates are fully ignored but
+    # security updates still need grouping.
     groups:
+      react:
+        applies-to: version-updates
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-router"
+          - "react-router-dom"
+        update-types:
+          - "minor"
+          - "patch"
+      material-ui:
+        applies-to: version-updates
+        patterns:
+          - "@mui/*"
+          - "@emotion/*"
+        update-types:
+          - "minor"
+          - "patch"
+      webpack-ecosystem:
+        applies-to: version-updates
+        patterns:
+          - "webpack*"
+        update-types:
+          - "minor"
+          - "patch"
+      testing-library:
+        applies-to: version-updates
+        patterns:
+          - "@testing-library/*"
+        update-types:
+          - "minor"
+          - "patch"
       npm-updates:
         applies-to: version-updates
         group-by: dependency-name
@@ -61,6 +94,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      patternfly-security:
+        applies-to: security-updates
+        patterns:
+          - "@patternfly/*"
       npm-security:
         applies-to: security-updates
         patterns:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -38,6 +38,23 @@ jobs:
             echo "touches_upstream=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Close upstream PRs
+        if: steps.upstream.outputs.touches_upstream == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          echo "Closing PR that modifies upstream-synced files"
+          gh pr close "$PR_URL" --comment "$(cat <<'EOF'
+          Closing: this PR modifies files under `/upstream/` which are managed by
+          [upstream-sync](https://github.com/opendatahub-io/odh-dashboard/tree/main/.claude/skills/upstream-sync).
+          Security fixes for these dependencies should be addressed in the upstream
+          repository and synced back. The security alert remains visible in the
+          Security tab for tracking.
+          EOF
+          )"
+          echo "::notice::Upstream PR closed"
+
       - name: Checkout base branch for version checks
         if: >
           steps.upstream.outputs.touches_upstream != 'true' &&
@@ -151,7 +168,7 @@ jobs:
           if [ "$ELIGIBLE" = "true" ]; then
             echo "### ✅ Auto-merge labels applied" | tee -a "$GITHUB_STEP_SUMMARY"
           elif [ "$TOUCHES_UPSTREAM" = "true" ]; then
-            echo "### ⏭️ Skipped — PR modifies upstream (subtree) files" | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "### 🚫 Closed — PR modifies upstream (subtree) files" | tee -a "$GITHUB_STEP_SUMMARY"
           else
             echo "### ⏭️ Skipped — not eligible for auto-merge" | tee -a "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,10 +26,14 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          upstream_files=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" \
-            --paginate -q '.[].filename | select(contains("/upstream/"))' || true)
+          all_files=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --paginate -q '.[].filename')
+          upstream_files=$(echo "$all_files" | grep '/upstream/' || true)
 
-          if [ -n "$upstream_files" ]; then
+          if [ -z "$all_files" ]; then
+            echo "::error::Failed to fetch PR files — treating as unsafe"
+            echo "touches_upstream=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "$upstream_files" ]; then
             echo "PR modifies upstream files:"
             echo "$upstream_files"
             echo "touches_upstream=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -8,9 +8,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # Do not cancel on labeled/unlabeled — auto-merge adding lgtm/approved was
+  # Cancel on synchronize (new push) so stale scans don't waste runners.
+  # Keep running on labeled/unlabeled — auto-merge adding lgtm/approved was
   # cancelling in-flight audit runs before they finished.
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 
 jobs:
   detect-dirs:

--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -42,6 +42,10 @@ jobs:
           DIRS="[]"
           while IFS= read -r -d '' file; do
             dir=$(dirname "$file")
+            # Exclude upstream-synced packages
+            case "$dir" in
+              */upstream/*) continue ;;
+            esac
             DIRS=$(echo "$DIRS" | jq -c --arg d "$dir" 'if (. | index($d)) then . else . + [$d] end')
           done < /tmp/changed-locks
 

--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -8,7 +8,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Do not cancel on labeled/unlabeled — auto-merge adding lgtm/approved was
+  # cancelling in-flight audit runs before they finished.
+  cancel-in-progress: false
 
 jobs:
   detect-dirs:
@@ -16,6 +18,10 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+    # Ignore label noise except ok-to-skip-audit (bypass re-evaluation).
+    if: >
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'ok-to-skip-audit'
     outputs:
       dirs: ${{ steps.dirs.outputs.dirs }}
     steps:
@@ -28,13 +34,20 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git diff -z --diff-filter=ACMRT "$BASE_SHA"..HEAD -- '**/package-lock.json' > /tmp/changed-locks
+          # --name-only is required: git diff -z without it emits a full patch
+          # with no NULs, so the read loop never iterates and dirs stays [].
+          git diff -z --name-only --diff-filter=ACMRT "$BASE_SHA"..HEAD -- \
+            ':(glob)**/package-lock.json' > /tmp/changed-locks
 
           DIRS="[]"
           while IFS= read -r -d '' file; do
             dir=$(dirname "$file")
-            DIRS=$(echo "$DIRS" | jq -c --arg d "$dir" '. + [$d]')
+            DIRS=$(echo "$DIRS" | jq -c --arg d "$dir" 'if (. | index($d)) then . else . + [$d] end')
           done < /tmp/changed-locks
+
+          if [ "$DIRS" = "[]" ]; then
+            echo "::warning::No package-lock.json dirs detected from git diff; npm audit will be skipped"
+          fi
 
           echo "dirs=$(echo "$DIRS" | jq -c '.')" >> "$GITHUB_OUTPUT"
           echo "Directories to audit: $DIRS"

--- a/.github/workflows/go-vulnerability-validation.yml
+++ b/.github/workflows/go-vulnerability-validation.yml
@@ -9,9 +9,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # Do not cancel on labeled/unlabeled — auto-merge adding lgtm/approved was
+  # Cancel on synchronize (new push) so stale scans don't waste runners.
+  # Keep running on labeled/unlabeled — auto-merge adding lgtm/approved was
   # cancelling in-flight govulncheck runs before they finished.
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 
 jobs:
   detect-modules:

--- a/.github/workflows/go-vulnerability-validation.yml
+++ b/.github/workflows/go-vulnerability-validation.yml
@@ -9,7 +9,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Do not cancel on labeled/unlabeled — auto-merge adding lgtm/approved was
+  # cancelling in-flight govulncheck runs before they finished.
+  cancel-in-progress: false
 
 jobs:
   detect-modules:
@@ -17,6 +19,10 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+    # Ignore label noise except ok-to-skip-audit (bypass re-evaluation).
+    if: >
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'ok-to-skip-audit'
     outputs:
       dirs: ${{ steps.dirs.outputs.dirs }}
     steps:
@@ -29,7 +35,10 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git diff -z --diff-filter=ACMRT "$BASE_SHA"..HEAD -- '**/go.mod' '**/go.sum' > /tmp/changed-go
+          # --name-only is required: git diff -z without it emits a full patch
+          # with no NULs, so the read loop never iterates and dirs stays [].
+          git diff -z --name-only --diff-filter=ACMRT "$BASE_SHA"..HEAD -- \
+            ':(glob)**/go.mod' ':(glob)**/go.sum' > /tmp/changed-go
 
           DIRS="[]"
           while IFS= read -r -d '' file; do
@@ -40,6 +49,10 @@ jobs:
             esac
             DIRS=$(echo "$DIRS" | jq -c --arg d "$dir" 'if (. | index($d)) then . else . + [$d] end')
           done < /tmp/changed-go
+
+          if [ "$DIRS" = "[]" ]; then
+            echo "::warning::No Go module dirs detected from git diff; govulncheck will be skipped"
+          fi
 
           echo "dirs=$(echo "$DIRS" | jq -c '.')" >> "$GITHUB_OUTPUT"
           echo "Go modules to scan: $DIRS"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-80315
https://issues.redhat.com/browse/RHOAIENG-80316

## Description

Follow-up to #9085 after production verification of the first Dependabot run.

### Critical: vulnerability gates were no-ops

Both `go-vulnerability-validation.yml` and `dependency-validation.yml` used:

```bash
git diff -z --diff-filter=ACMRT "$BASE_SHA"..HEAD -- '**/...'
```

**without `--name-only`**. `git diff -z` only emits NUL separators with `--name-only`/`--name-status`/`--raw`. Without it, the full patch has **zero NULs**, the `while read -d ''` loop never iterates, and `dirs` stays `[]` — so govulncheck/npm audit were always skipped (`Go modules to scan: []` / `Directories to audit: []` on every post-merge Dependabot PR).

**Fix:** add `--name-only` and `:(glob)` pathspecs; warn when detection returns empty.

### Grouping (kept from #9085)

Keep `group-by: dependency-name` on version-update groups. For this monorepo that is the better mode:

- Same dep across 8 directories → **1 PR** (matches post-merge behavior and historical pain like `dompurify` × 31)
- Security/CVE groups stay per-directory (`group-by` is version-updates only — Dependabot hard limit)

| Group | Behavior |
|---|---|
| `npm-updates` / `go-updates` | One PR per dependency across directories (`group-by: dependency-name`) |
| `npm-security` / `go-security` | All CVE fixes in one PR **per directory** |

### Label/concurrency fix

Auto-merge adding `lgtm`/`approved` was re-triggering these workflows and cancelling in-flight scans. Now:

- `cancel-in-progress: false`
- Jobs only re-run on `labeled`/`unlabeled` when the label is `ok-to-skip-audit`

## How Has This Been Tested?

- Reproduced the gate bug locally against PR #9127 merge commit: without `--name-only` → `nul_count=0`, `DIRS=[]`; with fix → 9 Go module dirs detected
- `check-jsonschema` against Dependabot + GitHub Actions schemas — passed
- Python `yaml.safe_load` on changed files — passed

**After merge:** confirm a Go Dependabot PR shows non-empty `Go modules to scan` and govulncheck matrix jobs run; confirm an npm lockfile PR shows non-empty `Directories to audit`.

## Test Impact

CI workflow / Dependabot config only. No application code. No unit/Cypress tests apply; validation is schema checks + local reproduction of the detect script + post-merge observation.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update grouping for Go ecosystem packages.
  * Enhanced dependency validation to reliably detect changed lockfiles and Go modules.
  * Validation workflows now provide warnings when no applicable modules or directories are found.
  * Dependency checks remain active when relevant labels change.

* **Bug Fixes**
  * Dependabot updates affecting upstream-managed files are now automatically closed with an explanatory notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->