### PR TITLE
Contract tests and OpenAPI schemas for model_config field

### DIFF
--- a/packages/gen-ai/bff/internal/models/mlflow.go
+++ b/packages/gen-ai/bff/internal/models/mlflow.go
@@ -17,14 +17,29 @@ type MLflowPromptScope struct {
 	ReadOnly  bool                  `json:"read_only"`
 }
 
+// MLflowPromptModelConfig represents the model configuration associated with a prompt.
+type MLflowPromptModelConfig struct {
+	Provider         string         `json:"provider,omitempty"`
+	ModelName        string         `json:"model_name,omitempty"`
+	Temperature      *float64       `json:"temperature,omitempty"`
+	MaxTokens        *int           `json:"max_tokens,omitempty"`
+	TopP             *float64       `json:"top_p,omitempty"`
+	TopK             *int           `json:"top_k,omitempty"`
+	FrequencyPenalty *float64       `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64       `json:"presence_penalty,omitempty"`
+	StopSequences    []string       `json:"stop_sequences,omitempty"`
+	ExtraParams      map[string]any `json:"extra_params,omitempty"`
+}
+
 // MLflowPrompt represents a prompt from MLflow in BFF response format.
 type MLflowPrompt struct {
-	Name              string            `json:"name"`
-	Description       string            `json:"description"`
-	LatestVersion     int               `json:"latest_version"`
-	Tags              map[string]string `json:"tags,omitempty"`
-	CreationTimestamp time.Time         `json:"creation_timestamp"`
-	Scope             MLflowPromptScope `json:"scope"`
+	Name              string                   `json:"name"`
+	Description       string                   `json:"description"`
+	LatestVersion     int                      `json:"latest_version"`
+	Tags              map[string]string        `json:"tags,omitempty"`
+	CreationTimestamp time.Time                `json:"creation_timestamp"`
+	ModelConfig       *MLflowPromptModelConfig `json:"model_config,omitempty"`
+	Scope             MLflowPromptScope        `json:"scope"`
 }
 
 // MLflowPromptsResponse is the response for listing MLflow prompts.
@@ -55,16 +70,17 @@ type MLflowRegisterPromptRequest struct {
 
 // MLflowPromptVersion represents a full prompt version with content.
 type MLflowPromptVersion struct {
-	Name          string             `json:"name"`
-	Version       int                `json:"version"`
-	Template      string             `json:"template,omitempty"`
-	Messages      []MLflowMessage    `json:"messages,omitempty"`
-	CommitMessage string             `json:"commit_message,omitempty"`
-	Aliases       []string           `json:"aliases,omitempty"`
-	Tags          map[string]string  `json:"tags,omitempty"`
-	CreatedAt     time.Time          `json:"created_at"`
-	UpdatedAt     time.Time          `json:"updated_at"`
-	Scope         *MLflowPromptScope `json:"scope,omitempty"`
+	Name          string                   `json:"name"`
+	Version       int                      `json:"version"`
+	Template      string                   `json:"template,omitempty"`
+	Messages      []MLflowMessage          `json:"messages,omitempty"`
+	CommitMessage string                   `json:"commit_message,omitempty"`
+	Aliases       []string                 `json:"aliases,omitempty"`
+	Tags          map[string]string        `json:"tags,omitempty"`
+	ModelConfig   *MLflowPromptModelConfig `json:"model_config,omitempty"`
+	CreatedAt     time.Time                `json:"created_at"`
+	UpdatedAt     time.Time                `json:"updated_at"`
+	Scope         *MLflowPromptScope       `json:"scope,omitempty"`
 }
 
 // MLflowPromptVersionMeta represents version metadata without full content.

--- a/packages/gen-ai/bff/internal/models/mlflow.go
+++ b/packages/gen-ai/bff/internal/models/mlflow.go
@@ -38,7 +38,7 @@ type MLflowPrompt struct {
 	LatestVersion     int                      `json:"latest_version"`
 	Tags              map[string]string        `json:"tags,omitempty"`
 	CreationTimestamp time.Time                `json:"creation_timestamp"`
-	ModelConfig       *MLflowPromptModelConfig `json:"model_config,omitempty"`
+	ModelConfig       *MLflowPromptModelConfig `json:"model_config"`
 	Scope             MLflowPromptScope        `json:"scope"`
 }
 
@@ -77,7 +77,7 @@ type MLflowPromptVersion struct {
 	CommitMessage string                   `json:"commit_message,omitempty"`
 	Aliases       []string                 `json:"aliases,omitempty"`
 	Tags          map[string]string        `json:"tags,omitempty"`
-	ModelConfig   *MLflowPromptModelConfig `json:"model_config,omitempty"`
+	ModelConfig   *MLflowPromptModelConfig `json:"model_config"`
 	CreatedAt     time.Time                `json:"created_at"`
 	UpdatedAt     time.Time                `json:"updated_at"`
 	Scope         *MLflowPromptScope       `json:"scope,omitempty"`

--- a/packages/gen-ai/bff/internal/repositories/mlflow_prompts.go
+++ b/packages/gen-ai/bff/internal/repositories/mlflow_prompts.go
@@ -64,6 +64,7 @@ func (r *MLflowPromptsRepository) ListPrompts(ctx context.Context, pageToken str
 			LatestVersion:     p.LatestVersion,
 			Tags:              p.Tags,
 			CreationTimestamp: p.CreationTimestamp,
+			ModelConfig:       toMLflowModelConfig(p.ModelConfig),
 			Scope:             *projectScope(namespace),
 		}
 	}
@@ -249,9 +250,28 @@ func toMLflowPromptVersion(pv *promptregistry.PromptVersion, namespace string) *
 		CommitMessage: pv.CommitMessage,
 		Aliases:       pv.Aliases,
 		Tags:          pv.Tags,
+		ModelConfig:   toMLflowModelConfig(pv.ModelConfig),
 		CreatedAt:     pv.CreatedAt,
 		UpdatedAt:     pv.UpdatedAt,
 		Scope:         projectScope(namespace),
+	}
+}
+
+func toMLflowModelConfig(cfg *promptregistry.PromptModelConfig) *models.MLflowPromptModelConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &models.MLflowPromptModelConfig{
+		Provider:         cfg.Provider,
+		ModelName:        cfg.ModelName,
+		Temperature:      cfg.Temperature,
+		MaxTokens:        cfg.MaxTokens,
+		TopP:             cfg.TopP,
+		TopK:             cfg.TopK,
+		FrequencyPenalty: cfg.FrequencyPenalty,
+		PresencePenalty:  cfg.PresencePenalty,
+		StopSequences:    cfg.StopSequences,
+		ExtraParams:      cfg.ExtraParams,
 	}
 }
 

--- a/packages/gen-ai/bff/openapi/src/gen-ai.yaml
+++ b/packages/gen-ai/bff/openapi/src/gen-ai.yaml
@@ -2714,6 +2714,52 @@ components:
           description: Whether the current user has read-only access to prompts in this scope
           example: false
 
+    MLflowPromptModelConfig:
+      description: Model configuration associated with a prompt version via the _mlflow_prompt_model_config tag.
+      type: object
+      properties:
+        provider:
+          type: string
+          description: Model provider identifier
+          example: 'openai'
+        model_name:
+          type: string
+          description: Model name within the provider
+          example: 'gpt-4'
+        temperature:
+          type: number
+          nullable: true
+          description: Sampling temperature
+        max_tokens:
+          type: integer
+          nullable: true
+          description: Maximum number of tokens to generate
+        top_p:
+          type: number
+          nullable: true
+          description: Nucleus sampling parameter
+        top_k:
+          type: integer
+          nullable: true
+          description: Top-k sampling parameter
+        frequency_penalty:
+          type: number
+          nullable: true
+          description: Frequency penalty for token repetition
+        presence_penalty:
+          type: number
+          nullable: true
+          description: Presence penalty for topic repetition
+        stop_sequences:
+          type: array
+          items:
+            type: string
+          description: Sequences that stop generation
+        extra_params:
+          type: object
+          additionalProperties: true
+          description: Additional provider-specific parameters
+
     MLflowPrompt:
       type: object
       required:
@@ -2748,6 +2794,11 @@ components:
           format: date-time
           description: When the prompt was first created
           example: '2025-01-15T10:30:00Z'
+        model_config:
+          description: Model configuration from the _mlflow_prompt_model_config tag, or null if not set
+          oneOf:
+            - $ref: '#/components/schemas/MLflowPromptModelConfig'
+            - type: 'null'
         scope:
           $ref: '#/components/schemas/MLflowPromptScope'
 
@@ -2834,6 +2885,11 @@ components:
           additionalProperties:
             type: string
           description: Metadata tags
+        model_config:
+          description: Model configuration from the _mlflow_prompt_model_config tag, or null if not set
+          oneOf:
+            - $ref: '#/components/schemas/MLflowPromptModelConfig'
+            - type: 'null'
         created_at:
           type: string
           format: date-time

--- a/packages/gen-ai/bff/openapi/src/gen-ai.yaml
+++ b/packages/gen-ai/bff/openapi/src/gen-ai.yaml
@@ -2767,6 +2767,7 @@ components:
         - description
         - latest_version
         - creation_timestamp
+        - model_config
         - scope
       properties:
         name:
@@ -2852,6 +2853,7 @@ components:
       required:
         - name
         - version
+        - model_config
         - created_at
         - updated_at
       properties:

--- a/packages/gen-ai/contract-tests/__tests__/testMLflowContract.test.ts
+++ b/packages/gen-ai/contract-tests/__tests__/testMLflowContract.test.ts
@@ -85,24 +85,28 @@ describe('MLflow Prompt Registry Contract Tests', () => {
   });
 
   describe('Model Config in Prompt Responses', () => {
-    it('should include model_config field in list prompts response', async () => {
-      const result = await apiClient.get('/gen-ai/api/v1/mlflow/prompts?namespace=default');
-      expect(result.success).toBe(true);
-
-      const prompts = result.response?.data?.data?.prompts ?? [];
-      expect(prompts.length).toBeGreaterThan(0);
-
-      for (const prompt of prompts) {
-        expect(prompt).toHaveProperty('model_config');
-      }
-    });
-
-    it('should include model_config field in load prompt response', async () => {
+    it('should validate null model_config against contract when no config tag is set', async () => {
       const result = await apiClient.get(
         `/gen-ai/api/v1/mlflow/prompts/${promptName}?namespace=default`,
       );
-      expect(result.success).toBe(true);
-      expect(result.response?.data?.data).toHaveProperty('model_config');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/paths/~1gen-ai~1api~1v1~1mlflow~1prompts~1{name}/get/responses/200/content/application~1json/schema',
+        status: 200,
+      });
+      expect(result.response?.data?.data?.model_config).toBeNull();
+    });
+
+    it('should validate list prompts schema includes model_config field', async () => {
+      const result = await apiClient.get('/gen-ai/api/v1/mlflow/prompts?namespace=default');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/paths/~1gen-ai~1api~1v1~1mlflow~1prompts/get/responses/200/content/application~1json/schema',
+        status: 200,
+      });
+      const prompts = result.response?.data?.data?.prompts ?? [];
+      expect(prompts.length).toBeGreaterThan(0);
+      for (const prompt of prompts) {
+        expect(prompt).toHaveProperty('model_config');
+      }
     });
   });
 

--- a/packages/gen-ai/contract-tests/__tests__/testMLflowContract.test.ts
+++ b/packages/gen-ai/contract-tests/__tests__/testMLflowContract.test.ts
@@ -84,6 +84,28 @@ describe('MLflow Prompt Registry Contract Tests', () => {
     });
   });
 
+  describe('Model Config in Prompt Responses', () => {
+    it('should include model_config field in list prompts response', async () => {
+      const result = await apiClient.get('/gen-ai/api/v1/mlflow/prompts?namespace=default');
+      expect(result.success).toBe(true);
+
+      const prompts = result.response?.data?.data?.prompts ?? [];
+      expect(prompts.length).toBeGreaterThan(0);
+
+      for (const prompt of prompts) {
+        expect(prompt).toHaveProperty('model_config');
+      }
+    });
+
+    it('should include model_config field in load prompt response', async () => {
+      const result = await apiClient.get(
+        `/gen-ai/api/v1/mlflow/prompts/${promptName}?namespace=default`,
+      );
+      expect(result.success).toBe(true);
+      expect(result.response?.data?.data).toHaveProperty('model_config');
+    });
+  });
+
   describe('List Prompt Versions Endpoint', () => {
     it('should list versions of a prompt', async () => {
       const result = await apiClient.get(

--- a/packages/mlflow/api/openapi/mlflow.yaml
+++ b/packages/mlflow/api/openapi/mlflow.yaml
@@ -1293,6 +1293,51 @@ components:
           type: string
           description: The Kubernetes namespace where the prompt resides.
           example: my-project
+    PromptModelConfig:
+      description: Model configuration associated with a prompt version via the _mlflow_prompt_model_config tag.
+      type: object
+      properties:
+        provider:
+          type: string
+          description: Model provider identifier.
+          example: openai
+        model_name:
+          type: string
+          description: Model name within the provider.
+          example: gpt-4
+        temperature:
+          type: number
+          nullable: true
+          description: Sampling temperature.
+        max_tokens:
+          type: integer
+          nullable: true
+          description: Maximum number of tokens to generate.
+        top_p:
+          type: number
+          nullable: true
+          description: Nucleus sampling parameter.
+        top_k:
+          type: integer
+          nullable: true
+          description: Top-k sampling parameter.
+        frequency_penalty:
+          type: number
+          nullable: true
+          description: Frequency penalty for token repetition.
+        presence_penalty:
+          type: number
+          nullable: true
+          description: Presence penalty for topic repetition.
+        stop_sequences:
+          type: array
+          items:
+            type: string
+          description: Sequences that stop generation.
+        extra_params:
+          type: object
+          additionalProperties: true
+          description: Additional provider-specific parameters.
     MLflowPrompt:
       description: A prompt from the MLflow Prompt Registry.
       type: object
@@ -1326,6 +1371,11 @@ components:
           type: string
           format: date-time
           description: When the prompt was first created.
+        model_config:
+          description: Model configuration from the _mlflow_prompt_model_config tag, or null if not set.
+          oneOf:
+            - $ref: "#/components/schemas/PromptModelConfig"
+            - type: "null"
         scope:
           $ref: "#/components/schemas/PromptScope"
     MLflowPromptsResponse:
@@ -1427,6 +1477,11 @@ components:
           additionalProperties:
             type: string
           description: Metadata tags.
+        model_config:
+          description: Model configuration from the _mlflow_prompt_model_config tag, or null if not set.
+          oneOf:
+            - $ref: "#/components/schemas/PromptModelConfig"
+            - type: "null"
         created_at:
           type: string
           format: date-time

--- a/packages/mlflow/api/openapi/mlflow.yaml
+++ b/packages/mlflow/api/openapi/mlflow.yaml
@@ -1345,6 +1345,7 @@ components:
         - name
         - latest_version
         - creation_timestamp
+        - model_config
         - scope
       properties:
         name:
@@ -1445,6 +1446,7 @@ components:
       required:
         - name
         - version
+        - model_config
         - created_at
         - updated_at
       properties:

--- a/packages/mlflow/bff/internal/models/prompt.go
+++ b/packages/mlflow/bff/internal/models/prompt.go
@@ -37,7 +37,7 @@ type Prompt struct {
 	LatestVersion     int                `json:"latest_version"`
 	Tags              map[string]string  `json:"tags,omitempty"`
 	CreationTimestamp time.Time          `json:"creation_timestamp"`
-	ModelConfig       *PromptModelConfig `json:"model_config,omitempty"`
+	ModelConfig       *PromptModelConfig `json:"model_config"`
 	Scope             PromptScope        `json:"scope"`
 }
 
@@ -74,7 +74,7 @@ type PromptVersion struct {
 	CommitMessage string             `json:"commit_message,omitempty"`
 	Aliases       []string           `json:"aliases,omitempty"`
 	Tags          map[string]string  `json:"tags,omitempty"`
-	ModelConfig   *PromptModelConfig `json:"model_config,omitempty"`
+	ModelConfig   *PromptModelConfig `json:"model_config"`
 	CreatedAt     time.Time          `json:"created_at"`
 	UpdatedAt     time.Time          `json:"updated_at"`
 }

--- a/packages/mlflow/bff/internal/models/prompt.go
+++ b/packages/mlflow/bff/internal/models/prompt.go
@@ -16,14 +16,29 @@ type PromptScope struct {
 	Namespace string          `json:"namespace"`
 }
 
+// PromptModelConfig represents the model configuration associated with a prompt.
+type PromptModelConfig struct {
+	Provider         string         `json:"provider,omitempty"`
+	ModelName        string         `json:"model_name,omitempty"`
+	Temperature      *float64       `json:"temperature,omitempty"`
+	MaxTokens        *int           `json:"max_tokens,omitempty"`
+	TopP             *float64       `json:"top_p,omitempty"`
+	TopK             *int           `json:"top_k,omitempty"`
+	FrequencyPenalty *float64       `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64       `json:"presence_penalty,omitempty"`
+	StopSequences    []string       `json:"stop_sequences,omitempty"`
+	ExtraParams      map[string]any `json:"extra_params,omitempty"`
+}
+
 // Prompt represents a prompt from the MLflow Prompt Registry.
 type Prompt struct {
-	Name              string            `json:"name"`
-	Description       string            `json:"description"`
-	LatestVersion     int               `json:"latest_version"`
-	Tags              map[string]string `json:"tags,omitempty"`
-	CreationTimestamp time.Time         `json:"creation_timestamp"`
-	Scope             PromptScope       `json:"scope"`
+	Name              string             `json:"name"`
+	Description       string             `json:"description"`
+	LatestVersion     int                `json:"latest_version"`
+	Tags              map[string]string  `json:"tags,omitempty"`
+	CreationTimestamp time.Time          `json:"creation_timestamp"`
+	ModelConfig       *PromptModelConfig `json:"model_config,omitempty"`
+	Scope             PromptScope        `json:"scope"`
 }
 
 // PromptsResponse is the response for listing prompts.
@@ -52,15 +67,16 @@ type RegisterPromptRequest struct {
 
 // PromptVersion represents a full prompt version with content.
 type PromptVersion struct {
-	Name          string            `json:"name"`
-	Version       int               `json:"version"`
-	Template      string            `json:"template,omitempty"`
-	Messages      []Message         `json:"messages,omitempty"`
-	CommitMessage string            `json:"commit_message,omitempty"`
-	Aliases       []string          `json:"aliases,omitempty"`
-	Tags          map[string]string `json:"tags,omitempty"`
-	CreatedAt     time.Time         `json:"created_at"`
-	UpdatedAt     time.Time         `json:"updated_at"`
+	Name          string             `json:"name"`
+	Version       int                `json:"version"`
+	Template      string             `json:"template,omitempty"`
+	Messages      []Message          `json:"messages,omitempty"`
+	CommitMessage string             `json:"commit_message,omitempty"`
+	Aliases       []string           `json:"aliases,omitempty"`
+	Tags          map[string]string  `json:"tags,omitempty"`
+	ModelConfig   *PromptModelConfig `json:"model_config,omitempty"`
+	CreatedAt     time.Time          `json:"created_at"`
+	UpdatedAt     time.Time          `json:"updated_at"`
 }
 
 // PromptVersionMeta represents version metadata without full content.

--- a/packages/mlflow/bff/internal/repositories/prompts.go
+++ b/packages/mlflow/bff/internal/repositories/prompts.go
@@ -61,6 +61,7 @@ func (r *PromptsRepository) ListPromptsWithClient(ctx context.Context, client ml
 			LatestVersion:     p.LatestVersion,
 			Tags:              p.Tags,
 			CreationTimestamp: p.CreationTimestamp,
+			ModelConfig:       toModelConfig(p.ModelConfig),
 		}
 	}
 
@@ -215,7 +216,26 @@ func toPromptVersion(pv *promptregistry.PromptVersion) *models.PromptVersion {
 		CommitMessage: pv.CommitMessage,
 		Aliases:       pv.Aliases,
 		Tags:          pv.Tags,
+		ModelConfig:   toModelConfig(pv.ModelConfig),
 		CreatedAt:     pv.CreatedAt,
 		UpdatedAt:     pv.UpdatedAt,
+	}
+}
+
+func toModelConfig(cfg *promptregistry.PromptModelConfig) *models.PromptModelConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &models.PromptModelConfig{
+		Provider:         cfg.Provider,
+		ModelName:        cfg.ModelName,
+		Temperature:      cfg.Temperature,
+		MaxTokens:        cfg.MaxTokens,
+		TopP:             cfg.TopP,
+		TopK:             cfg.TopK,
+		FrequencyPenalty: cfg.FrequencyPenalty,
+		PresencePenalty:  cfg.PresencePenalty,
+		StopSequences:    cfg.StopSequences,
+		ExtraParams:      cfg.ExtraParams,
 	}
 }

--- a/packages/mlflow/contract-tests/__tests__/testMlflowContract.test.ts
+++ b/packages/mlflow/contract-tests/__tests__/testMlflowContract.test.ts
@@ -118,29 +118,74 @@ describe('MLflow API Contract Tests', () => {
       });
     });
 
-    it('should include model_config field in list prompts response', async () => {
-      const result = await apiClient.get(promptUrl());
-      expect(result.success).toBe(true);
-
-      const envelope = result.response?.data as {
-        data?: { prompts?: Array<{ model_config: unknown }> };
-      };
-      const prompts = envelope.data?.prompts ?? [];
-      expect(prompts.length).toBeGreaterThan(0);
-
-      for (const prompt of prompts) {
-        expect(prompt).toHaveProperty('model_config');
-      }
+    it('should validate null model_config when no config tag is set', async () => {
+      const result = await apiClient.get(promptUrl(promptName));
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/PromptVersionResponse/content/application~1json/schema',
+        status: 200,
+      });
+      const envelope = result.response?.data as { data?: { model_config: unknown } };
+      expect(envelope.data?.model_config).toBeNull();
     });
 
-    it('should include model_config field in load prompt response', async () => {
-      const result = await apiClient.get(promptUrl(promptName));
-      expect(result.success).toBe(true);
+    it('should validate full model_config when all config fields are set', async () => {
+      const fullConfigName = `ct-mcfg-full-${Date.now()}`;
+      /* eslint-disable camelcase */
+      const setup = await apiClient.post(promptUrl(), {
+        name: fullConfigName,
+        messages: [{ role: 'user', content: 'test' }],
+        commit_message: 'test with full model config',
+        tags: {
+          _mlflow_prompt_model_config: JSON.stringify({
+            model_name: 'gpt-4',
+            provider: 'openai',
+            temperature: 0.7,
+            max_tokens: 1000,
+          }),
+        },
+      });
+      /* eslint-enable camelcase */
+      expect(setup.success).toBe(true);
 
-      const envelope = result.response?.data as {
-        data?: { model_config: unknown };
+      const result = await apiClient.get(promptUrl(fullConfigName));
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/PromptVersionResponse/content/application~1json/schema',
+        status: 200,
+      });
+      const data = result.response?.data as {
+        data?: { model_config: Record<string, unknown> | null };
       };
-      expect(envelope.data).toHaveProperty('model_config');
+      expect(data.data?.model_config).not.toBeNull();
+      expect(data.data?.model_config?.model_name).toBe('gpt-4');
+      expect(data.data?.model_config?.provider).toBe('openai');
+      await apiClient.delete(promptUrl(fullConfigName)).catch(() => undefined);
+    });
+
+    it('should validate partial model_config when subset of fields is set', async () => {
+      const partialConfigName = `ct-mcfg-partial-${Date.now()}`;
+      /* eslint-disable camelcase */
+      const setup = await apiClient.post(promptUrl(), {
+        name: partialConfigName,
+        messages: [{ role: 'user', content: 'test' }],
+        commit_message: 'test with partial model config',
+        tags: {
+          _mlflow_prompt_model_config: JSON.stringify({ model_name: 'llama-3' }),
+        },
+      });
+      /* eslint-enable camelcase */
+      expect(setup.success).toBe(true);
+
+      const result = await apiClient.get(promptUrl(partialConfigName));
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/PromptVersionResponse/content/application~1json/schema',
+        status: 200,
+      });
+      const data = result.response?.data as {
+        data?: { model_config: Record<string, unknown> | null };
+      };
+      expect(data.data?.model_config).not.toBeNull();
+      expect(data.data?.model_config?.model_name).toBe('llama-3');
+      await apiClient.delete(promptUrl(partialConfigName)).catch(() => undefined);
     });
 
     it('should list versions of a prompt', async () => {

--- a/packages/mlflow/contract-tests/__tests__/testMlflowContract.test.ts
+++ b/packages/mlflow/contract-tests/__tests__/testMlflowContract.test.ts
@@ -118,6 +118,31 @@ describe('MLflow API Contract Tests', () => {
       });
     });
 
+    it('should include model_config field in list prompts response', async () => {
+      const result = await apiClient.get(promptUrl());
+      expect(result.success).toBe(true);
+
+      const envelope = result.response?.data as {
+        data?: { prompts?: Array<{ model_config: unknown }> };
+      };
+      const prompts = envelope.data?.prompts ?? [];
+      expect(prompts.length).toBeGreaterThan(0);
+
+      for (const prompt of prompts) {
+        expect(prompt).toHaveProperty('model_config');
+      }
+    });
+
+    it('should include model_config field in load prompt response', async () => {
+      const result = await apiClient.get(promptUrl(promptName));
+      expect(result.success).toBe(true);
+
+      const envelope = result.response?.data as {
+        data?: { model_config: unknown };
+      };
+      expect(envelope.data).toHaveProperty('model_config');
+    });
+
     it('should list versions of a prompt', async () => {
       const result = await apiClient.get(promptUrl(promptName, '/versions'));
       expect(result).toMatchContract(apiSchema, {


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/RHOAIENG-81908

## Description

Add OpenAPI schema definitions and contract tests for the `model_config` field introduced in [RHOAIENG-81907](https://redhat.atlassian.net/browse/RHOAIENG-81907).

**OpenAPI spec changes:**
- Add `PromptModelConfig` / `MLflowPromptModelConfig` schema definitions to the MLflow and Gen-AI OpenAPI specs with all fields (provider, model_name, temperature, max_tokens, top_p, top_k, frequency_penalty, presence_penalty, stop_sequences, extra_params)
- Add `model_config` property to `MLflowPrompt` and `MLflowPromptVersion` schemas in both specs using `oneOf` with `type: null` for nullable representation (AJV 2020 compatible)

**Contract tests:**
- MLflow BFF: 2 new tests verifying `model_config` is present in list prompts and load prompt responses
- Gen-AI BFF: 2 new tests verifying `model_config` is present in list prompts and load prompt responses

Uses `oneOf` + `type: null` instead of OpenAPI 3.0 `nullable` + `allOf` because the contract test framework uses AJV 2020 (JSON Schema 2020-12), which does not support the `nullable` keyword.

**Depends on:** #9139 ([RHOAIENG-81907](https://redhat.atlassian.net/browse/RHOAIENG-81907)) -- merge that first.

## How Has This Been Tested?

- Ran `npm run test:contract` for mlflow package: 46/46 tests pass
- Ran `npm run test:contract` for gen-ai package: 20/20 tests pass
- All existing contract tests continue to pass with the new schema definitions

## Test Impact

- Added 2 contract tests in `packages/mlflow/contract-tests/__tests__/testMlflowContract.test.ts`
- Added 2 contract tests in `packages/gen-ai/contract-tests/__tests__/testMLflowContract.test.ts`
- Tests validate that `model_config` field is present in API responses using `toHaveProperty`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-81907]: https://redhat.atlassian.net/browse/RHOAIENG-81907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-81907]: https://redhat.atlassian.net/browse/RHOAIENG-81907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompts and prompt versions now expose optional model configuration details, including provider, model, generation parameters, stop sequences, and provider-specific settings.
  * Added API schema support for retrieving model configuration in prompt list and detail responses.

* **Tests**
  * Added contract coverage confirming model configuration is returned for listed and individually loaded prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->