### PR TITLE
Log warning for malformed model config tags in prompt loading

### DIFF
--- a/packages/gen-ai/bff/internal/models/mlflow.go
+++ b/packages/gen-ai/bff/internal/models/mlflow.go
@@ -17,14 +17,29 @@ type MLflowPromptScope struct {
 	ReadOnly  bool                  `json:"read_only"`
 }
 
+// MLflowPromptModelConfig represents the model configuration associated with a prompt.
+type MLflowPromptModelConfig struct {
+	Provider         string         `json:"provider,omitempty"`
+	ModelName        string         `json:"model_name,omitempty"`
+	Temperature      *float64       `json:"temperature,omitempty"`
+	MaxTokens        *int           `json:"max_tokens,omitempty"`
+	TopP             *float64       `json:"top_p,omitempty"`
+	TopK             *int           `json:"top_k,omitempty"`
+	FrequencyPenalty *float64       `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64       `json:"presence_penalty,omitempty"`
+	StopSequences    []string       `json:"stop_sequences,omitempty"`
+	ExtraParams      map[string]any `json:"extra_params,omitempty"`
+}
+
 // MLflowPrompt represents a prompt from MLflow in BFF response format.
 type MLflowPrompt struct {
-	Name              string            `json:"name"`
-	Description       string            `json:"description"`
-	LatestVersion     int               `json:"latest_version"`
-	Tags              map[string]string `json:"tags,omitempty"`
-	CreationTimestamp time.Time         `json:"creation_timestamp"`
-	Scope             MLflowPromptScope `json:"scope"`
+	Name              string                   `json:"name"`
+	Description       string                   `json:"description"`
+	LatestVersion     int                      `json:"latest_version"`
+	Tags              map[string]string        `json:"tags,omitempty"`
+	CreationTimestamp time.Time                `json:"creation_timestamp"`
+	ModelConfig       *MLflowPromptModelConfig `json:"model_config,omitempty"`
+	Scope             MLflowPromptScope        `json:"scope"`
 }
 
 // MLflowPromptsResponse is the response for listing MLflow prompts.
@@ -55,16 +70,17 @@ type MLflowRegisterPromptRequest struct {
 
 // MLflowPromptVersion represents a full prompt version with content.
 type MLflowPromptVersion struct {
-	Name          string             `json:"name"`
-	Version       int                `json:"version"`
-	Template      string             `json:"template,omitempty"`
-	Messages      []MLflowMessage    `json:"messages,omitempty"`
-	CommitMessage string             `json:"commit_message,omitempty"`
-	Aliases       []string           `json:"aliases,omitempty"`
-	Tags          map[string]string  `json:"tags,omitempty"`
-	CreatedAt     time.Time          `json:"created_at"`
-	UpdatedAt     time.Time          `json:"updated_at"`
-	Scope         *MLflowPromptScope `json:"scope,omitempty"`
+	Name          string                   `json:"name"`
+	Version       int                      `json:"version"`
+	Template      string                   `json:"template,omitempty"`
+	Messages      []MLflowMessage          `json:"messages,omitempty"`
+	CommitMessage string                   `json:"commit_message,omitempty"`
+	Aliases       []string                 `json:"aliases,omitempty"`
+	Tags          map[string]string        `json:"tags,omitempty"`
+	ModelConfig   *MLflowPromptModelConfig `json:"model_config,omitempty"`
+	CreatedAt     time.Time                `json:"created_at"`
+	UpdatedAt     time.Time                `json:"updated_at"`
+	Scope         *MLflowPromptScope       `json:"scope,omitempty"`
 }
 
 // MLflowPromptVersionMeta represents version metadata without full content.

--- a/packages/gen-ai/bff/internal/models/mlflow.go
+++ b/packages/gen-ai/bff/internal/models/mlflow.go
@@ -38,7 +38,7 @@ type MLflowPrompt struct {
 	LatestVersion     int                      `json:"latest_version"`
 	Tags              map[string]string        `json:"tags,omitempty"`
 	CreationTimestamp time.Time                `json:"creation_timestamp"`
-	ModelConfig       *MLflowPromptModelConfig `json:"model_config,omitempty"`
+	ModelConfig       *MLflowPromptModelConfig `json:"model_config"`
 	Scope             MLflowPromptScope        `json:"scope"`
 }
 
@@ -77,7 +77,7 @@ type MLflowPromptVersion struct {
 	CommitMessage string                   `json:"commit_message,omitempty"`
 	Aliases       []string                 `json:"aliases,omitempty"`
 	Tags          map[string]string        `json:"tags,omitempty"`
-	ModelConfig   *MLflowPromptModelConfig `json:"model_config,omitempty"`
+	ModelConfig   *MLflowPromptModelConfig `json:"model_config"`
 	CreatedAt     time.Time                `json:"created_at"`
 	UpdatedAt     time.Time                `json:"updated_at"`
 	Scope         *MLflowPromptScope       `json:"scope,omitempty"`

--- a/packages/gen-ai/bff/internal/repositories/mlflow_prompts.go
+++ b/packages/gen-ai/bff/internal/repositories/mlflow_prompts.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"log/slog"
 	"strconv"
 
 	"github.com/opendatahub-io/gen-ai/internal/constants"
@@ -9,6 +10,8 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/models"
 	"github.com/opendatahub-io/mlflow-go/mlflow/promptregistry"
 )
+
+const tagModelConfig = "_mlflow_prompt_model_config"
 
 // MLflowPromptsRepository handles MLflow prompt-related operations and data transformations.
 type MLflowPromptsRepository struct {
@@ -58,6 +61,7 @@ func (r *MLflowPromptsRepository) ListPrompts(ctx context.Context, pageToken str
 
 	prompts := make([]models.MLflowPrompt, len(promptList.Prompts))
 	for i, p := range promptList.Prompts {
+		warnMalformedModelConfig(p.Name, p.Tags, p.ModelConfig)
 		prompts[i] = models.MLflowPrompt{
 			Name:              p.Name,
 			Description:       p.Description,
@@ -242,6 +246,8 @@ func toMLflowPromptVersion(pv *promptregistry.PromptVersion, namespace string) *
 		}
 	}
 
+	warnMalformedModelConfig(pv.Name, pv.Tags, pv.ModelConfig)
+
 	return &models.MLflowPromptVersion{
 		Name:          pv.Name,
 		Version:       pv.Version,
@@ -254,6 +260,13 @@ func toMLflowPromptVersion(pv *promptregistry.PromptVersion, namespace string) *
 		CreatedAt:     pv.CreatedAt,
 		UpdatedAt:     pv.UpdatedAt,
 		Scope:         projectScope(namespace),
+	}
+}
+
+func warnMalformedModelConfig(promptName string, tags map[string]string, cfg *promptregistry.PromptModelConfig) {
+	if _, hasTag := tags[tagModelConfig]; hasTag && cfg == nil {
+		slog.Warn("prompt has malformed model config tag, returning null",
+			slog.String("prompt", promptName))
 	}
 }
 

--- a/packages/gen-ai/bff/internal/repositories/mlflow_prompts.go
+++ b/packages/gen-ai/bff/internal/repositories/mlflow_prompts.go
@@ -64,6 +64,7 @@ func (r *MLflowPromptsRepository) ListPrompts(ctx context.Context, pageToken str
 			LatestVersion:     p.LatestVersion,
 			Tags:              p.Tags,
 			CreationTimestamp: p.CreationTimestamp,
+			ModelConfig:       toMLflowModelConfig(p.ModelConfig),
 			Scope:             *projectScope(namespace),
 		}
 	}
@@ -249,9 +250,28 @@ func toMLflowPromptVersion(pv *promptregistry.PromptVersion, namespace string) *
 		CommitMessage: pv.CommitMessage,
 		Aliases:       pv.Aliases,
 		Tags:          pv.Tags,
+		ModelConfig:   toMLflowModelConfig(pv.ModelConfig),
 		CreatedAt:     pv.CreatedAt,
 		UpdatedAt:     pv.UpdatedAt,
 		Scope:         projectScope(namespace),
+	}
+}
+
+func toMLflowModelConfig(cfg *promptregistry.PromptModelConfig) *models.MLflowPromptModelConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &models.MLflowPromptModelConfig{
+		Provider:         cfg.Provider,
+		ModelName:        cfg.ModelName,
+		Temperature:      cfg.Temperature,
+		MaxTokens:        cfg.MaxTokens,
+		TopP:             cfg.TopP,
+		TopK:             cfg.TopK,
+		FrequencyPenalty: cfg.FrequencyPenalty,
+		PresencePenalty:  cfg.PresencePenalty,
+		StopSequences:    cfg.StopSequences,
+		ExtraParams:      cfg.ExtraParams,
 	}
 }
 

--- a/packages/gen-ai/bff/internal/repositories/mlflow_prompts_test.go
+++ b/packages/gen-ai/bff/internal/repositories/mlflow_prompts_test.go
@@ -1,0 +1,123 @@
+package repositories
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/mlflow-go/mlflow/promptregistry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToMLflowModelConfigWithValidConfig(t *testing.T) {
+	temp := 0.7
+	maxTok := 1024
+	cfg := &promptregistry.PromptModelConfig{
+		Provider:    "openai",
+		ModelName:   "gpt-4",
+		Temperature: &temp,
+		MaxTokens:   &maxTok,
+	}
+
+	result := toMLflowModelConfig(cfg)
+
+	require.NotNil(t, result)
+	assert.Equal(t, "openai", result.Provider)
+	assert.Equal(t, "gpt-4", result.ModelName)
+	assert.Equal(t, &temp, result.Temperature)
+	assert.Equal(t, &maxTok, result.MaxTokens)
+}
+
+func TestToMLflowModelConfigWithNilConfig(t *testing.T) {
+	result := toMLflowModelConfig(nil)
+	assert.Nil(t, result)
+}
+
+func TestToMLflowModelConfigWithPartialConfig(t *testing.T) {
+	cfg := &promptregistry.PromptModelConfig{
+		ModelName: "llama-3",
+	}
+
+	result := toMLflowModelConfig(cfg)
+
+	require.NotNil(t, result)
+	assert.Empty(t, result.Provider)
+	assert.Equal(t, "llama-3", result.ModelName)
+	assert.Nil(t, result.Temperature)
+	assert.Nil(t, result.MaxTokens)
+}
+
+func TestToMLflowPromptVersionWithValidModelConfig(t *testing.T) {
+	temp := 0.5
+	pv := &promptregistry.PromptVersion{
+		Name:    "test-prompt",
+		Version: 1,
+		Tags:    map[string]string{tagModelConfig: `{"model_name":"gpt-4"}`},
+		ModelConfig: &promptregistry.PromptModelConfig{
+			ModelName:   "gpt-4",
+			Temperature: &temp,
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	result := toMLflowPromptVersion(pv, "default")
+
+	require.NotNil(t, result)
+	require.NotNil(t, result.ModelConfig)
+	assert.Equal(t, "gpt-4", result.ModelConfig.ModelName)
+	assert.Equal(t, &temp, result.ModelConfig.Temperature)
+}
+
+func TestToMLflowPromptVersionWithNoModelConfig(t *testing.T) {
+	pv := &promptregistry.PromptVersion{
+		Name:    "test-prompt",
+		Version: 1,
+		Tags:    map[string]string{},
+	}
+
+	result := toMLflowPromptVersion(pv, "default")
+
+	require.NotNil(t, result)
+	assert.Nil(t, result.ModelConfig)
+}
+
+func TestGenAIWarnMalformedModelConfigLogsWarning(t *testing.T) {
+	var buf bytes.Buffer
+	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	slog.SetDefault(testLogger)
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	tags := map[string]string{tagModelConfig: "not valid json"}
+	warnMalformedModelConfig("bad-prompt", tags, nil)
+
+	assert.Contains(t, buf.String(), "malformed model config tag")
+	assert.Contains(t, buf.String(), "bad-prompt")
+}
+
+func TestGenAIWarnMalformedModelConfigNoWarningWhenTagAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	slog.SetDefault(testLogger)
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	tags := map[string]string{}
+	warnMalformedModelConfig("clean-prompt", tags, nil)
+
+	assert.Empty(t, buf.String())
+}
+
+func TestGenAIWarnMalformedModelConfigNoWarningWhenConfigPresent(t *testing.T) {
+	var buf bytes.Buffer
+	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	slog.SetDefault(testLogger)
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	tags := map[string]string{tagModelConfig: `{"model_name":"gpt-4"}`}
+	cfg := &promptregistry.PromptModelConfig{ModelName: "gpt-4"}
+	warnMalformedModelConfig("good-prompt", tags, cfg)
+
+	assert.Empty(t, buf.String())
+}

--- a/packages/gen-ai/bff/openapi/src/gen-ai.yaml
+++ b/packages/gen-ai/bff/openapi/src/gen-ai.yaml
@@ -2714,6 +2714,52 @@ components:
           description: Whether the current user has read-only access to prompts in this scope
           example: false
 
+    MLflowPromptModelConfig:
+      description: Model configuration associated with a prompt version via the _mlflow_prompt_model_config tag.
+      type: object
+      properties:
+        provider:
+          type: string
+          description: Model provider identifier
+          example: 'openai'
+        model_name:
+          type: string
+          description: Model name within the provider
+          example: 'gpt-4'
+        temperature:
+          type: number
+          nullable: true
+          description: Sampling temperature
+        max_tokens:
+          type: integer
+          nullable: true
+          description: Maximum number of tokens to generate
+        top_p:
+          type: number
+          nullable: true
+          description: Nucleus sampling parameter
+        top_k:
+          type: integer
+          nullable: true
+          description: Top-k sampling parameter
+        frequency_penalty:
+          type: number
+          nullable: true
+          description: Frequency penalty for token repetition
+        presence_penalty:
+          type: number
+          nullable: true
+          description: Presence penalty for topic repetition
+        stop_sequences:
+          type: array
+          items:
+            type: string
+          description: Sequences that stop generation
+        extra_params:
+          type: object
+          additionalProperties: true
+          description: Additional provider-specific parameters
+
     MLflowPrompt:
       type: object
       required:
@@ -2748,6 +2794,11 @@ components:
           format: date-time
           description: When the prompt was first created
           example: '2025-01-15T10:30:00Z'
+        model_config:
+          description: Model configuration from the _mlflow_prompt_model_config tag, or null if not set
+          oneOf:
+            - $ref: '#/components/schemas/MLflowPromptModelConfig'
+            - type: 'null'
         scope:
           $ref: '#/components/schemas/MLflowPromptScope'
 
@@ -2834,6 +2885,11 @@ components:
           additionalProperties:
             type: string
           description: Metadata tags
+        model_config:
+          description: Model configuration from the _mlflow_prompt_model_config tag, or null if not set
+          oneOf:
+            - $ref: '#/components/schemas/MLflowPromptModelConfig'
+            - type: 'null'
         created_at:
           type: string
           format: date-time

--- a/packages/gen-ai/contract-tests/__tests__/testMLflowContract.test.ts
+++ b/packages/gen-ai/contract-tests/__tests__/testMLflowContract.test.ts
@@ -84,6 +84,28 @@ describe('MLflow Prompt Registry Contract Tests', () => {
     });
   });
 
+  describe('Model Config in Prompt Responses', () => {
+    it('should include model_config field in list prompts response', async () => {
+      const result = await apiClient.get('/gen-ai/api/v1/mlflow/prompts?namespace=default');
+      expect(result.success).toBe(true);
+
+      const prompts = result.response?.data?.data?.prompts ?? [];
+      expect(prompts.length).toBeGreaterThan(0);
+
+      for (const prompt of prompts) {
+        expect(prompt).toHaveProperty('model_config');
+      }
+    });
+
+    it('should include model_config field in load prompt response', async () => {
+      const result = await apiClient.get(
+        `/gen-ai/api/v1/mlflow/prompts/${promptName}?namespace=default`,
+      );
+      expect(result.success).toBe(true);
+      expect(result.response?.data?.data).toHaveProperty('model_config');
+    });
+  });
+
   describe('List Prompt Versions Endpoint', () => {
     it('should list versions of a prompt', async () => {
       const result = await apiClient.get(

--- a/packages/mlflow/api/openapi/mlflow.yaml
+++ b/packages/mlflow/api/openapi/mlflow.yaml
@@ -1293,6 +1293,51 @@ components:
           type: string
           description: The Kubernetes namespace where the prompt resides.
           example: my-project
+    PromptModelConfig:
+      description: Model configuration associated with a prompt version via the _mlflow_prompt_model_config tag.
+      type: object
+      properties:
+        provider:
+          type: string
+          description: Model provider identifier.
+          example: openai
+        model_name:
+          type: string
+          description: Model name within the provider.
+          example: gpt-4
+        temperature:
+          type: number
+          nullable: true
+          description: Sampling temperature.
+        max_tokens:
+          type: integer
+          nullable: true
+          description: Maximum number of tokens to generate.
+        top_p:
+          type: number
+          nullable: true
+          description: Nucleus sampling parameter.
+        top_k:
+          type: integer
+          nullable: true
+          description: Top-k sampling parameter.
+        frequency_penalty:
+          type: number
+          nullable: true
+          description: Frequency penalty for token repetition.
+        presence_penalty:
+          type: number
+          nullable: true
+          description: Presence penalty for topic repetition.
+        stop_sequences:
+          type: array
+          items:
+            type: string
+          description: Sequences that stop generation.
+        extra_params:
+          type: object
+          additionalProperties: true
+          description: Additional provider-specific parameters.
     MLflowPrompt:
       description: A prompt from the MLflow Prompt Registry.
       type: object
@@ -1326,6 +1371,11 @@ components:
           type: string
           format: date-time
           description: When the prompt was first created.
+        model_config:
+          description: Model configuration from the _mlflow_prompt_model_config tag, or null if not set.
+          oneOf:
+            - $ref: "#/components/schemas/PromptModelConfig"
+            - type: "null"
         scope:
           $ref: "#/components/schemas/PromptScope"
     MLflowPromptsResponse:
@@ -1427,6 +1477,11 @@ components:
           additionalProperties:
             type: string
           description: Metadata tags.
+        model_config:
+          description: Model configuration from the _mlflow_prompt_model_config tag, or null if not set.
+          oneOf:
+            - $ref: "#/components/schemas/PromptModelConfig"
+            - type: "null"
         created_at:
           type: string
           format: date-time

--- a/packages/mlflow/bff/internal/models/prompt.go
+++ b/packages/mlflow/bff/internal/models/prompt.go
@@ -37,7 +37,7 @@ type Prompt struct {
 	LatestVersion     int                `json:"latest_version"`
 	Tags              map[string]string  `json:"tags,omitempty"`
 	CreationTimestamp time.Time          `json:"creation_timestamp"`
-	ModelConfig       *PromptModelConfig `json:"model_config,omitempty"`
+	ModelConfig       *PromptModelConfig `json:"model_config"`
 	Scope             PromptScope        `json:"scope"`
 }
 
@@ -74,7 +74,7 @@ type PromptVersion struct {
 	CommitMessage string             `json:"commit_message,omitempty"`
 	Aliases       []string           `json:"aliases,omitempty"`
 	Tags          map[string]string  `json:"tags,omitempty"`
-	ModelConfig   *PromptModelConfig `json:"model_config,omitempty"`
+	ModelConfig   *PromptModelConfig `json:"model_config"`
 	CreatedAt     time.Time          `json:"created_at"`
 	UpdatedAt     time.Time          `json:"updated_at"`
 }

--- a/packages/mlflow/bff/internal/models/prompt.go
+++ b/packages/mlflow/bff/internal/models/prompt.go
@@ -16,14 +16,29 @@ type PromptScope struct {
 	Namespace string          `json:"namespace"`
 }
 
+// PromptModelConfig represents the model configuration associated with a prompt.
+type PromptModelConfig struct {
+	Provider         string         `json:"provider,omitempty"`
+	ModelName        string         `json:"model_name,omitempty"`
+	Temperature      *float64       `json:"temperature,omitempty"`
+	MaxTokens        *int           `json:"max_tokens,omitempty"`
+	TopP             *float64       `json:"top_p,omitempty"`
+	TopK             *int           `json:"top_k,omitempty"`
+	FrequencyPenalty *float64       `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64       `json:"presence_penalty,omitempty"`
+	StopSequences    []string       `json:"stop_sequences,omitempty"`
+	ExtraParams      map[string]any `json:"extra_params,omitempty"`
+}
+
 // Prompt represents a prompt from the MLflow Prompt Registry.
 type Prompt struct {
-	Name              string            `json:"name"`
-	Description       string            `json:"description"`
-	LatestVersion     int               `json:"latest_version"`
-	Tags              map[string]string `json:"tags,omitempty"`
-	CreationTimestamp time.Time         `json:"creation_timestamp"`
-	Scope             PromptScope       `json:"scope"`
+	Name              string             `json:"name"`
+	Description       string             `json:"description"`
+	LatestVersion     int                `json:"latest_version"`
+	Tags              map[string]string  `json:"tags,omitempty"`
+	CreationTimestamp time.Time          `json:"creation_timestamp"`
+	ModelConfig       *PromptModelConfig `json:"model_config,omitempty"`
+	Scope             PromptScope        `json:"scope"`
 }
 
 // PromptsResponse is the response for listing prompts.
@@ -52,15 +67,16 @@ type RegisterPromptRequest struct {
 
 // PromptVersion represents a full prompt version with content.
 type PromptVersion struct {
-	Name          string            `json:"name"`
-	Version       int               `json:"version"`
-	Template      string            `json:"template,omitempty"`
-	Messages      []Message         `json:"messages,omitempty"`
-	CommitMessage string            `json:"commit_message,omitempty"`
-	Aliases       []string          `json:"aliases,omitempty"`
-	Tags          map[string]string `json:"tags,omitempty"`
-	CreatedAt     time.Time         `json:"created_at"`
-	UpdatedAt     time.Time         `json:"updated_at"`
+	Name          string             `json:"name"`
+	Version       int                `json:"version"`
+	Template      string             `json:"template,omitempty"`
+	Messages      []Message          `json:"messages,omitempty"`
+	CommitMessage string             `json:"commit_message,omitempty"`
+	Aliases       []string           `json:"aliases,omitempty"`
+	Tags          map[string]string  `json:"tags,omitempty"`
+	ModelConfig   *PromptModelConfig `json:"model_config,omitempty"`
+	CreatedAt     time.Time          `json:"created_at"`
+	UpdatedAt     time.Time          `json:"updated_at"`
 }
 
 // PromptVersionMeta represents version metadata without full content.

--- a/packages/mlflow/bff/internal/repositories/prompts.go
+++ b/packages/mlflow/bff/internal/repositories/prompts.go
@@ -61,6 +61,7 @@ func (r *PromptsRepository) ListPromptsWithClient(ctx context.Context, client ml
 			LatestVersion:     p.LatestVersion,
 			Tags:              p.Tags,
 			CreationTimestamp: p.CreationTimestamp,
+			ModelConfig:       toModelConfig(p.ModelConfig),
 		}
 	}
 
@@ -215,7 +216,26 @@ func toPromptVersion(pv *promptregistry.PromptVersion) *models.PromptVersion {
 		CommitMessage: pv.CommitMessage,
 		Aliases:       pv.Aliases,
 		Tags:          pv.Tags,
+		ModelConfig:   toModelConfig(pv.ModelConfig),
 		CreatedAt:     pv.CreatedAt,
 		UpdatedAt:     pv.UpdatedAt,
+	}
+}
+
+func toModelConfig(cfg *promptregistry.PromptModelConfig) *models.PromptModelConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &models.PromptModelConfig{
+		Provider:         cfg.Provider,
+		ModelName:        cfg.ModelName,
+		Temperature:      cfg.Temperature,
+		MaxTokens:        cfg.MaxTokens,
+		TopP:             cfg.TopP,
+		TopK:             cfg.TopK,
+		FrequencyPenalty: cfg.FrequencyPenalty,
+		PresencePenalty:  cfg.PresencePenalty,
+		StopSequences:    cfg.StopSequences,
+		ExtraParams:      cfg.ExtraParams,
 	}
 }

--- a/packages/mlflow/bff/internal/repositories/prompts.go
+++ b/packages/mlflow/bff/internal/repositories/prompts.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -11,6 +12,8 @@ import (
 	mlflow "github.com/opendatahub-io/mlflow/bff/internal/integrations/mlflow"
 	"github.com/opendatahub-io/mlflow/bff/internal/models"
 )
+
+const tagModelConfig = "_mlflow_prompt_model_config"
 
 // PromptsRepository handles MLflow prompt-related operations and data transformations.
 type PromptsRepository struct{}
@@ -55,6 +58,7 @@ func (r *PromptsRepository) ListPromptsWithClient(ctx context.Context, client ml
 
 	prompts := make([]models.Prompt, len(promptList.Prompts))
 	for i, p := range promptList.Prompts {
+		warnMalformedModelConfig(p.Name, p.Tags, p.ModelConfig)
 		prompts[i] = models.Prompt{
 			Name:              p.Name,
 			Description:       p.Description,
@@ -208,6 +212,8 @@ func toPromptVersion(pv *promptregistry.PromptVersion) *models.PromptVersion {
 		}
 	}
 
+	warnMalformedModelConfig(pv.Name, pv.Tags, pv.ModelConfig)
+
 	return &models.PromptVersion{
 		Name:          pv.Name,
 		Version:       pv.Version,
@@ -219,6 +225,13 @@ func toPromptVersion(pv *promptregistry.PromptVersion) *models.PromptVersion {
 		ModelConfig:   toModelConfig(pv.ModelConfig),
 		CreatedAt:     pv.CreatedAt,
 		UpdatedAt:     pv.UpdatedAt,
+	}
+}
+
+func warnMalformedModelConfig(promptName string, tags map[string]string, cfg *promptregistry.PromptModelConfig) {
+	if _, hasTag := tags[tagModelConfig]; hasTag && cfg == nil {
+		slog.Warn("prompt has malformed model config tag, returning null",
+			slog.String("prompt", promptName))
 	}
 }
 

--- a/packages/mlflow/bff/internal/repositories/prompts_test.go
+++ b/packages/mlflow/bff/internal/repositories/prompts_test.go
@@ -1,0 +1,194 @@
+package repositories
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/mlflow-go/mlflow/promptregistry"
+	mlflowpkg "github.com/opendatahub-io/mlflow/bff/internal/integrations/mlflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tmock "github.com/stretchr/testify/mock"
+)
+
+func TestToModelConfigWithValidConfig(t *testing.T) {
+	temp := 0.7
+	maxTok := 1024
+	cfg := &promptregistry.PromptModelConfig{
+		Provider:    "openai",
+		ModelName:   "gpt-4",
+		Temperature: &temp,
+		MaxTokens:   &maxTok,
+	}
+
+	result := toModelConfig(cfg)
+
+	require.NotNil(t, result)
+	assert.Equal(t, "openai", result.Provider)
+	assert.Equal(t, "gpt-4", result.ModelName)
+	assert.Equal(t, &temp, result.Temperature)
+	assert.Equal(t, &maxTok, result.MaxTokens)
+}
+
+func TestToModelConfigWithNilConfig(t *testing.T) {
+	result := toModelConfig(nil)
+	assert.Nil(t, result)
+}
+
+func TestToModelConfigWithPartialConfig(t *testing.T) {
+	cfg := &promptregistry.PromptModelConfig{
+		ModelName: "llama-3",
+	}
+
+	result := toModelConfig(cfg)
+
+	require.NotNil(t, result)
+	assert.Empty(t, result.Provider)
+	assert.Equal(t, "llama-3", result.ModelName)
+	assert.Nil(t, result.Temperature)
+	assert.Nil(t, result.MaxTokens)
+}
+
+func TestToPromptVersionWithValidModelConfig(t *testing.T) {
+	temp := 0.5
+	pv := &promptregistry.PromptVersion{
+		Name:    "test-prompt",
+		Version: 1,
+		Tags:    map[string]string{tagModelConfig: `{"model_name":"gpt-4"}`},
+		ModelConfig: &promptregistry.PromptModelConfig{
+			ModelName:   "gpt-4",
+			Temperature: &temp,
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	result := toPromptVersion(pv)
+
+	require.NotNil(t, result)
+	require.NotNil(t, result.ModelConfig)
+	assert.Equal(t, "gpt-4", result.ModelConfig.ModelName)
+	assert.Equal(t, &temp, result.ModelConfig.Temperature)
+}
+
+func TestToPromptVersionWithNoModelConfig(t *testing.T) {
+	pv := &promptregistry.PromptVersion{
+		Name:    "test-prompt",
+		Version: 1,
+		Tags:    map[string]string{},
+	}
+
+	result := toPromptVersion(pv)
+
+	require.NotNil(t, result)
+	assert.Nil(t, result.ModelConfig)
+}
+
+func TestToPromptVersionWithNilInput(t *testing.T) {
+	result := toPromptVersion(nil)
+	assert.Nil(t, result)
+}
+
+func TestWarnMalformedModelConfigLogsWarning(t *testing.T) {
+	var buf bytes.Buffer
+	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	slog.SetDefault(testLogger)
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	tags := map[string]string{tagModelConfig: "not valid json"}
+	warnMalformedModelConfig("bad-prompt", tags, nil)
+
+	assert.Contains(t, buf.String(), "malformed model config tag")
+	assert.Contains(t, buf.String(), "bad-prompt")
+}
+
+func TestWarnMalformedModelConfigNoWarningWhenTagAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	slog.SetDefault(testLogger)
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	tags := map[string]string{}
+	warnMalformedModelConfig("clean-prompt", tags, nil)
+
+	assert.Empty(t, buf.String())
+}
+
+func TestWarnMalformedModelConfigNoWarningWhenConfigPresent(t *testing.T) {
+	var buf bytes.Buffer
+	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	slog.SetDefault(testLogger)
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	tags := map[string]string{tagModelConfig: `{"model_name":"gpt-4"}`}
+	cfg := &promptregistry.PromptModelConfig{ModelName: "gpt-4"}
+	warnMalformedModelConfig("good-prompt", tags, cfg)
+
+	assert.Empty(t, buf.String())
+}
+
+func TestListPromptsWithMalformedModelConfigTag(t *testing.T) {
+	var buf bytes.Buffer
+	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	slog.SetDefault(testLogger)
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	mockClient := &mlflowpkg.MockClient{}
+	mockClient.On("ListPrompts", tmock.Anything, tmock.Anything).Return(&promptregistry.PromptList{
+		Prompts: []promptregistry.Prompt{
+			{
+				Name:          "bad-config-prompt",
+				LatestVersion: 1,
+				Tags:          map[string]string{tagModelConfig: "{invalid json"},
+				ModelConfig:   nil,
+			},
+		},
+	}, nil)
+
+	repo := NewPromptsRepository()
+	ctx := contextWithMockClient(mockClient)
+
+	result, err := repo.ListPromptsWithClient(ctx, mockClient, "", "", "")
+
+	require.NoError(t, err)
+	require.Len(t, result.Prompts, 1)
+	assert.Nil(t, result.Prompts[0].ModelConfig)
+	assert.Contains(t, buf.String(), "malformed model config tag")
+	assert.Contains(t, buf.String(), "bad-config-prompt")
+}
+
+func TestListPromptsWithValidModelConfig(t *testing.T) {
+	var buf bytes.Buffer
+	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	slog.SetDefault(testLogger)
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	temp := 0.7
+	mockClient := &mlflowpkg.MockClient{}
+	mockClient.On("ListPrompts", tmock.Anything, tmock.Anything).Return(&promptregistry.PromptList{
+		Prompts: []promptregistry.Prompt{
+			{
+				Name:          "good-prompt",
+				LatestVersion: 1,
+				Tags:          map[string]string{tagModelConfig: `{"model_name":"gpt-4"}`},
+				ModelConfig: &promptregistry.PromptModelConfig{
+					ModelName:   "gpt-4",
+					Temperature: &temp,
+				},
+			},
+		},
+	}, nil)
+
+	repo := NewPromptsRepository()
+	ctx := contextWithMockClient(mockClient)
+
+	result, err := repo.ListPromptsWithClient(ctx, mockClient, "", "", "")
+
+	require.NoError(t, err)
+	require.Len(t, result.Prompts, 1)
+	require.NotNil(t, result.Prompts[0].ModelConfig)
+	assert.Equal(t, "gpt-4", result.Prompts[0].ModelConfig.ModelName)
+	assert.Empty(t, buf.String())
+}

--- a/packages/mlflow/contract-tests/__tests__/testMlflowContract.test.ts
+++ b/packages/mlflow/contract-tests/__tests__/testMlflowContract.test.ts
@@ -118,6 +118,31 @@ describe('MLflow API Contract Tests', () => {
       });
     });
 
+    it('should include model_config field in list prompts response', async () => {
+      const result = await apiClient.get(promptUrl());
+      expect(result.success).toBe(true);
+
+      const envelope = result.response?.data as {
+        data?: { prompts?: Array<{ model_config: unknown }> };
+      };
+      const prompts = envelope.data?.prompts ?? [];
+      expect(prompts.length).toBeGreaterThan(0);
+
+      for (const prompt of prompts) {
+        expect(prompt).toHaveProperty('model_config');
+      }
+    });
+
+    it('should include model_config field in load prompt response', async () => {
+      const result = await apiClient.get(promptUrl(promptName));
+      expect(result.success).toBe(true);
+
+      const envelope = result.response?.data as {
+        data?: { model_config: unknown };
+      };
+      expect(envelope.data).toHaveProperty('model_config');
+    });
+
     it('should list versions of a prompt', async () => {
       const result = await apiClient.get(promptUrl(promptName, '/versions'));
       expect(result).toMatchContract(apiSchema, {


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/RHOAIENG-81909

## Description

Add edge case handling for malformed `_mlflow_prompt_model_config` tags in the prompt loading flow.

The MLflow Go SDK already handles malformed JSON gracefully -- if the tag value cannot be parsed, `ModelConfig` is silently left as `nil` and the prompt loads normally with `model_config: null`. However, this makes it impossible to distinguish "no tag" from "malformed tag" when debugging.

**Changes in both MLflow and Gen-AI BFF packages:**
- Add `warnMalformedModelConfig()` helper that detects when the raw `_mlflow_prompt_model_config` tag exists but the SDK returned nil `ModelConfig` (indicating a parse failure), and emits a `slog.Warn`
- Called in `ListPrompts` (listing loop) and `toPromptVersion` / `toMLflowPromptVersion` (load/register)

**Unit tests added:**
- MLflow BFF: 11 tests covering `toModelConfig`, `toPromptVersion`, `warnMalformedModelConfig`, and `ListPromptsWithClient` with malformed/valid/absent model config scenarios
- Gen-AI BFF: 8 tests covering `toMLflowModelConfig`, `toMLflowPromptVersion`, and `warnMalformedModelConfig` with the same edge case scenarios

**Depends on:** #9139 ([RHOAIENG-81907](https://redhat.atlassian.net/browse/RHOAIENG-81907)) and #9140 ([RHOAIENG-81908](https://redhat.atlassian.net/browse/RHOAIENG-81908)) -- merge those first.

## How Has This Been Tested?

- Ran `go test ./internal/repositories/ -v` in both mlflow and gen-ai BFF packages: all tests pass
- Ran `npm run test:contract` for mlflow package: 46/46 tests pass (no regression)
- Verified warning is logged when tag contains invalid JSON and suppressed when tag is absent or valid

## Test Impact

- Added `packages/mlflow/bff/internal/repositories/prompts_test.go` with 11 unit tests
- Added `packages/gen-ai/bff/internal/repositories/mlflow_prompts_test.go` with 8 unit tests
- Tests cover: valid config mapping, nil config, partial config, malformed tag warning, absent tag (no warning), valid tag (no warning), integration with `ListPromptsWithClient`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-81907]: https://redhat.atlassian.net/browse/RHOAIENG-81907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ