### PR TITLE
Fix(RHOAIENG-81200): Model Registry empty states and access messaging show wrong content for admin vs non-admin users

### DIFF
--- a/packages/cypress/cypress/pages/modelRegistry.ts
+++ b/packages/cypress/cypress/pages/modelRegistry.ts
@@ -63,6 +63,11 @@ class ModelRegistry {
     this.waitForRegistryLoaded();
   }
 
+  visitEmptyState(registryName = 'modelregistry-sample') {
+    cy.visitWithLogin(`/ai-hub/models/registry/${registryName}`);
+    cy.findByTestId('empty-model-registries-state', { timeout: 60000 }).should('be.visible');
+  }
+
   visitWithRegistry(registryName: string) {
     this.visit(registryName);
   }

--- a/packages/cypress/cypress/tests/mocked/modelRegistry/adminHelpAction.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistry/adminHelpAction.cy.ts
@@ -1,0 +1,146 @@
+import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
+import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
+import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
+import { mockDsciStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDsciStatus';
+import {
+  mockModelRegistry,
+  mockModelRegistryService,
+} from '@odh-dashboard/internal/__mocks__/mockModelRegistryService';
+import { mockRegisteredModelList } from '@odh-dashboard/internal/__mocks__/mockRegisteredModelsList';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { modelRegistry } from '../../../pages/modelRegistry';
+import { ServiceModel } from '../../../utils/models';
+import { asClusterAdminUser, asProjectEditUser } from '../../../utils/mockUsers';
+
+const MODEL_REGISTRY_API_VERSION = 'v1';
+const REGISTRY_SETTINGS_URL = '/settings/model-resources-operations/model-registry';
+
+const initCommon = () => {
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ disableModelRegistry: false }));
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.MODEL_REGISTRY]: {
+          managementState: 'Managed',
+          registriesNamespace: 'odh-model-registries',
+        },
+      },
+    }),
+  );
+  cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({}));
+  cy.interceptK8sList(
+    ServiceModel,
+    mockK8sResourceList([mockModelRegistryService({ name: 'modelregistry-sample' })]),
+  );
+  cy.interceptOdh(
+    `GET /model-registry/api/:apiVersion/namespaces`,
+    { path: { apiVersion: MODEL_REGISTRY_API_VERSION } },
+    { data: [{ metadata: { name: 'odh-model-registries' } }] },
+  );
+  cy.interceptOdh(
+    `GET /model-registry/api/:apiVersion/user`,
+    { path: { apiVersion: MODEL_REGISTRY_API_VERSION } },
+    { data: { userId: 'user@example.com', clusterAdmin: false } },
+  );
+};
+
+// No registries -> empty-model-registries-state (OdhModelRegistryCoreLoader.createEmptyStatePage)
+const initNoRegistries = () => {
+  initCommon();
+  cy.interceptOdh(
+    `GET /model-registry/api/:apiVersion/model_registry`,
+    { path: { apiVersion: MODEL_REGISTRY_API_VERSION } },
+    { data: [] },
+  );
+};
+
+// One registry -> selector toolbar renders AdminHelpAction ("Need another registry?")
+const initWithRegistry = () => {
+  initCommon();
+  cy.interceptOdh(
+    `GET /model-registry/api/:apiVersion/model_registry`,
+    { path: { apiVersion: MODEL_REGISTRY_API_VERSION } },
+    { data: [mockModelRegistry({ name: 'modelregistry-sample' })] },
+  );
+  cy.interceptOdh(
+    `GET /model-registry/api/:apiVersion/model_registry/:modelRegistryName/registered_models`,
+    { path: { modelRegistryName: 'modelregistry-sample', apiVersion: MODEL_REGISTRY_API_VERSION } },
+    { data: mockRegisteredModelList({ items: [] }) },
+  );
+};
+
+describe('AdminHelpAction - admin vs non-admin messaging', () => {
+  describe('No registries available (empty state)', () => {
+    it('admin sees the settings link and no WhosMyAdministrator', () => {
+      asClusterAdminUser();
+      initNoRegistries();
+      modelRegistry.visit();
+
+      cy.findByTestId('empty-model-registries-state').should('be.visible');
+      cy.findByTestId('empty-model-registries-state').within(() => {
+        cy.findByRole('link', { name: /Go to/i })
+          .should('be.visible')
+          .and('have.attr', 'href', REGISTRY_SETTINGS_URL);
+      });
+      cy.findByTestId('whos-my-admin-link').should('not.exist');
+    });
+
+    it('should show request-access description and no Settings link', () => {
+      asProjectEditUser();
+      initNoRegistries();
+
+      modelRegistry.visit();
+
+      cy.findByTestId('empty-model-registries-state', { timeout: 10000 })
+        .should('be.visible')
+        .and(
+          'contain.text',
+          'To request a new model registry, or to request permission to access an existing model registry, contact your administrator',
+        );
+
+      cy.findByTestId('empty-model-registries-state').within(() => {
+        cy.findByRole('link', { name: /Go to/i }).should('not.exist');
+        cy.findByRole('button', { name: /Who's my administrator/i }).should('exist');
+      });
+    });
+  });
+
+  describe('Registry available (selector "Need another registry?")', () => {
+    it('admin sees "create a new model registry" content with settings link', () => {
+      asClusterAdminUser();
+      initWithRegistry();
+      modelRegistry.visit();
+
+      modelRegistry.shouldModelRegistrySelectorExist();
+      modelRegistry.findHelpContentButton().should('be.visible').click();
+
+      modelRegistry
+        .findHelpContentPopover()
+        .should('be.visible')
+        .and('contain.text', 'To create a new model registry');
+      modelRegistry.findHelpContentPopover().within(() => {
+        cy.findByRole('link', { name: /Go to/i })
+          .should('be.visible')
+          .and('have.attr', 'href', REGISTRY_SETTINGS_URL);
+      });
+    });
+
+    it('non-admin sees "contact your administrator" content with no settings link', () => {
+      asProjectEditUser();
+      initWithRegistry();
+      modelRegistry.visit();
+
+      modelRegistry.shouldModelRegistrySelectorExist();
+      modelRegistry.findHelpContentButton().should('be.visible').click();
+
+      modelRegistry
+        .findHelpContentPopover()
+        .should('be.visible')
+        .and('contain.text', 'contact your administrator');
+      modelRegistry.findHelpContentPopover().within(() => {
+        cy.findByRole('link', { name: /Go to/i }).should('not.exist');
+      });
+    });
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/modelRegistry/adminHelpAction.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistry/adminHelpAction.cy.ts
@@ -79,7 +79,7 @@ describe('AdminHelpAction - admin vs non-admin messaging', () => {
 
       cy.findByTestId('empty-model-registries-state').should('be.visible');
       cy.findByTestId('empty-model-registries-state').within(() => {
-        cy.findByRole('link', { name: /Go to/i })
+        cy.findByTestId('model-registry-settings-link')
           .should('be.visible')
           .and('have.attr', 'href', REGISTRY_SETTINGS_URL);
       });
@@ -100,8 +100,8 @@ describe('AdminHelpAction - admin vs non-admin messaging', () => {
         );
 
       cy.findByTestId('empty-model-registries-state').within(() => {
-        cy.findByRole('link', { name: /Go to/i }).should('not.exist');
-        cy.findByRole('button', { name: /Who's my administrator/i }).should('exist');
+        cy.findByTestId('model-registry-settings-link').should('not.exist');
+        cy.findByTestId('whos-my-admin-link').should('exist');
       });
     });
   });
@@ -120,7 +120,7 @@ describe('AdminHelpAction - admin vs non-admin messaging', () => {
         .should('be.visible')
         .and('contain.text', 'To create a new model registry');
       modelRegistry.findHelpContentPopover().within(() => {
-        cy.findByRole('link', { name: /Go to/i })
+        cy.findByTestId('model-registry-settings-link')
           .should('be.visible')
           .and('have.attr', 'href', REGISTRY_SETTINGS_URL);
       });
@@ -139,7 +139,7 @@ describe('AdminHelpAction - admin vs non-admin messaging', () => {
         .should('be.visible')
         .and('contain.text', 'contact your administrator');
       modelRegistry.findHelpContentPopover().within(() => {
-        cy.findByRole('link', { name: /Go to/i }).should('not.exist');
+        cy.findByTestId('model-registry-settings-link').should('not.exist');
       });
     });
   });

--- a/packages/cypress/cypress/tests/mocked/modelRegistry/adminHelpAction.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistry/adminHelpAction.cy.ts
@@ -75,7 +75,7 @@ describe('AdminHelpAction - admin vs non-admin messaging', () => {
     it('admin sees the settings link and no WhosMyAdministrator', () => {
       asClusterAdminUser();
       initNoRegistries();
-      modelRegistry.visit();
+      modelRegistry.visitEmptyState();
 
       cy.findByTestId('empty-model-registries-state').should('be.visible');
       cy.findByTestId('empty-model-registries-state').within(() => {
@@ -90,7 +90,7 @@ describe('AdminHelpAction - admin vs non-admin messaging', () => {
       asProjectEditUser();
       initNoRegistries();
 
-      modelRegistry.visit();
+      modelRegistry.visitEmptyState();
 
       cy.findByTestId('empty-model-registries-state', { timeout: 10000 })
         .should('be.visible')

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/ModelCatalogRoutes.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/ModelCatalogRoutes.tsx
@@ -5,8 +5,8 @@ import { isDetailTabExtension } from '@odh-dashboard/plugin-core/extension-point
 import { ModelCatalogContextProvider } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { ModelDetailsTab } from '~/concepts/modelCatalog/const';
 import OdhModelCatalogCoreLoader from '~/odh/components/OdhModelCatalogCoreLoader';
+import OdhModelDetailsPage from '~/odh/components/OdhModelDetailsPage';
 import { MODEL_CATALOG_DETAILS_GROUP } from './screens/ModelDetailsTabs';
-import ModelDetailsPage from './screens/ModelDetailsPage';
 import RegisterCatalogModelPage from './screens/RegisterCatalogModelPage';
 import ModelCatalog from './screens/ModelCatalog';
 
@@ -22,16 +22,16 @@ const ModelCatalogRoutes: React.FC = () => {
             <Route index element={<Navigate to={ModelDetailsTab.OVERVIEW} replace />} />
             <Route
               path={ModelDetailsTab.OVERVIEW}
-              element={<ModelDetailsPage tab={ModelDetailsTab.OVERVIEW} />}
+              element={<OdhModelDetailsPage tab={ModelDetailsTab.OVERVIEW} />}
             />
             <Route
               path={ModelDetailsTab.PERFORMANCE_INSIGHTS}
-              element={<ModelDetailsPage tab={ModelDetailsTab.PERFORMANCE_INSIGHTS} />}
+              element={<OdhModelDetailsPage tab={ModelDetailsTab.PERFORMANCE_INSIGHTS} />}
             />
             {generateExtensionTabRoutes({
               tabExtensions: allTabExtensions,
               group: MODEL_CATALOG_DETAILS_GROUP,
-              renderElement: (tabId) => <ModelDetailsPage tab={tabId} />,
+              renderElement: (tabId) => <OdhModelDetailsPage tab={tabId} />,
             })}
             <Route path="register" element={<RegisterCatalogModelPage />} />
             <Route path="*" element={<Navigate to="." />} />

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -48,9 +48,10 @@ const MODEL_CATALOG_DEPLOY_GROUP = 'model-catalog.deploy';
 
 type ModelDetailsPageProps = {
   tab: string;
+  customNoRegistriesButton?: (variant: 'primary' | 'secondary') => React.ReactNode;
 };
 
-const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
+const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab, customNoRegistriesButton }) => {
   const params = useParams<CatalogModelDetailsParams>();
   const decodedParams = decodeParams(params);
   const navigate = useNavigate();
@@ -128,10 +129,14 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
     }
 
     return modelRegistries.length === 0 ? (
-      registerButtonTooltip(
-        'Request access to a model registry',
-        'To request a new model registry, or to request permission to access an existing model registry, contact your administrator.',
-        variant,
+      customNoRegistriesButton ? (
+        customNoRegistriesButton(variant)
+      ) : (
+        registerButtonTooltip(
+          'Request access to a model registry',
+          'To request a new model registry, or to request permission to access an existing model registry, contact your administrator.',
+          variant,
+        )
       )
     ) : artifacts.items.length === 0 || !hasModelArtifacts(artifacts.items) ? (
       registerButtonTooltip('', 'Model location is unavailable', variant)

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/components/AdminHelpAction.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/components/AdminHelpAction.tsx
@@ -38,6 +38,7 @@ const AdminHelpAction: React.FC<AdminHelpActionProps> = ({
             <p>
               To create a new model registry, go to the <b>{settingsTitle}</b> page.
             </p>
+            <br />
             <Link to={settingsUrl}>
               Go to <b>{settingsTitle}</b>
             </Link>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/components/AdminHelpAction.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/components/AdminHelpAction.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
+import { Button, Popover, PopoverPosition, Stack, StackItem } from '@patternfly/react-core';
 import { WhosMyAdministrator, KubeflowDocs } from 'mod-arch-shared';
 import { useThemeContext } from 'mod-arch-kubeflow';
 import { useAdminStatus } from '~/odh/context/AdminStatusContext';
@@ -34,15 +34,16 @@ const AdminHelpAction: React.FC<AdminHelpActionProps> = ({
       <Popover
         headerContent={headerContent}
         bodyContent={
-          <div data-testid={contentTestId}>
-            <p>
+          <Stack hasGutter data-testid={contentTestId}>
+            <StackItem>
               To create a new model registry, go to the <b>{settingsTitle}</b> page.
-            </p>
-            <br />
-            <Link to={settingsUrl}>
-              Go to <b>{settingsTitle}</b>
-            </Link>
-          </div>
+            </StackItem>
+            <StackItem>
+              <Link to={settingsUrl}>
+                Go to <b>{settingsTitle}</b>
+              </Link>
+            </StackItem>
+          </Stack>
         }
         position={popoverPosition}
       >

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/components/AdminHelpAction.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/components/AdminHelpAction.tsx
@@ -39,7 +39,7 @@ const AdminHelpAction: React.FC<AdminHelpActionProps> = ({
               To create a new model registry, go to the <b>{settingsTitle}</b> page.
             </StackItem>
             <StackItem>
-              <Link to={settingsUrl}>
+              <Link to={settingsUrl} data-testid="model-registry-settings-link">
                 Go to <b>{settingsTitle}</b>
               </Link>
             </StackItem>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/components/AdminHelpAction.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/components/AdminHelpAction.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
 import { WhosMyAdministrator, KubeflowDocs } from 'mod-arch-shared';
 import { useThemeContext } from 'mod-arch-kubeflow';
-import { PopoverPosition } from '@patternfly/react-core';
+import { useAdminStatus } from '~/odh/context/AdminStatusContext';
 
 type AdminHelpActionProps = {
   buttonLabel?: string;
@@ -21,10 +23,35 @@ const AdminHelpAction: React.FC<AdminHelpActionProps> = ({
   popoverPosition = PopoverPosition.left,
 }) => {
   const { isMUITheme } = useThemeContext();
+  const { isAdmin, loaded, settingsUrl, settingsTitle } = useAdminStatus();
 
   if (isMUITheme) {
     return <KubeflowDocs buttonLabel={buttonLabel} linkTestId={linkTestId} />;
   }
+
+  if (loaded && isAdmin) {
+    return (
+      <Popover
+        headerContent={headerContent}
+        bodyContent={
+          <div data-testid={contentTestId}>
+            <p>
+              To create a new model registry, go to the <b>{settingsTitle}</b> page.
+            </p>
+            <Link to={settingsUrl}>
+              Go to <b>{settingsTitle}</b>
+            </Link>
+          </div>
+        }
+        position={popoverPosition}
+      >
+        <Button variant="link" data-testid={linkTestId}>
+          {buttonLabel}
+        </Button>
+      </Popover>
+    );
+  }
+
   return (
     <WhosMyAdministrator
       buttonLabel={buttonLabel}

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/components/__tests__/AdminHelpAction.spec.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/components/__tests__/AdminHelpAction.spec.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { useThemeContext } from 'mod-arch-kubeflow';
+import { AdminStatusProvider } from '~/odh/context/AdminStatusContext';
+import AdminHelpAction from '~/app/pages/modelRegistry/screens/components/AdminHelpAction';
+
+jest.mock('mod-arch-shared', () => ({
+  WhosMyAdministrator: ({
+    buttonLabel,
+    linkTestId,
+    leadText,
+    contentTestId,
+  }: {
+    buttonLabel?: string;
+    linkTestId?: string;
+    leadText?: string;
+    contentTestId?: string;
+  }) => (
+    <div data-testid="whos-my-admin">
+      <button type="button" data-testid={linkTestId}>
+        {buttonLabel}
+      </button>
+      <div data-testid={contentTestId}>{leadText}</div>
+    </div>
+  ),
+  KubeflowDocs: ({ buttonLabel }: { buttonLabel?: string }) => (
+    <div data-testid="kubeflow-docs">{buttonLabel}</div>
+  ),
+}));
+
+jest.mock('mod-arch-kubeflow', () => ({
+  useThemeContext: jest.fn(() => ({ isMUITheme: false })),
+}));
+
+const mockUseThemeContext = jest.mocked(useThemeContext);
+
+const SETTINGS_URL = '/settings/model-resources-operations/model-registry';
+const SETTINGS_TITLE = 'Model registry settings';
+
+describe('AdminHelpAction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeContext.mockReturnValue({ isMUITheme: false } as ReturnType<
+      typeof useThemeContext
+    >);
+  });
+
+  it('should render WhosMyAdministrator for non-admin users', () => {
+    render(
+      <MemoryRouter>
+        <AdminStatusProvider
+          isAdmin={false}
+          loaded
+          settingsUrl={SETTINGS_URL}
+          settingsTitle={SETTINGS_TITLE}
+        >
+          <AdminHelpAction
+            buttonLabel="Need another registry?"
+            headerContent="Need another registry?"
+          />
+        </AdminStatusProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('whos-my-admin')).toBeInTheDocument();
+    expect(screen.getByText('Need another registry?')).toBeInTheDocument();
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('should render admin popover with settings link for admin users', () => {
+    render(
+      <MemoryRouter>
+        <AdminStatusProvider
+          isAdmin
+          loaded
+          settingsUrl={SETTINGS_URL}
+          settingsTitle={SETTINGS_TITLE}
+        >
+          <AdminHelpAction
+            buttonLabel="Need another registry?"
+            linkTestId="model-registry-help-button"
+            headerContent="Need another registry?"
+            contentTestId="model-registry-help-content"
+          />
+        </AdminStatusProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('whos-my-admin')).not.toBeInTheDocument();
+
+    const triggerButton = screen.getByTestId('model-registry-help-button');
+    expect(triggerButton).toHaveTextContent('Need another registry?');
+
+    fireEvent.click(triggerButton);
+
+    const settingsLink = screen.getByRole('link');
+    expect(settingsLink).toHaveAttribute('href', SETTINGS_URL);
+    expect(settingsLink).toHaveTextContent(`Go to ${SETTINGS_TITLE}`);
+  });
+
+  it('should render WhosMyAdministrator when admin status has not loaded', () => {
+    render(
+      <MemoryRouter>
+        <AdminStatusProvider
+          isAdmin
+          loaded={false}
+          settingsUrl={SETTINGS_URL}
+          settingsTitle={SETTINGS_TITLE}
+        >
+          <AdminHelpAction />
+        </AdminStatusProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('whos-my-admin')).toBeInTheDocument();
+  });
+
+  it('should render WhosMyAdministrator when no AdminStatusProvider wraps it', () => {
+    render(
+      <MemoryRouter>
+        <AdminHelpAction />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('whos-my-admin')).toBeInTheDocument();
+  });
+
+  it('should render KubeflowDocs when MUI theme is active regardless of admin status', () => {
+    mockUseThemeContext.mockReturnValue({ isMUITheme: true } as ReturnType<typeof useThemeContext>);
+
+    render(
+      <MemoryRouter>
+        <AdminStatusProvider
+          isAdmin
+          loaded
+          settingsUrl={SETTINGS_URL}
+          settingsTitle={SETTINGS_TITLE}
+        >
+          <AdminHelpAction buttonLabel="Help" />
+        </AdminStatusProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('kubeflow-docs')).toBeInTheDocument();
+    expect(screen.queryByTestId('whos-my-admin')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/packages/model-registry/upstream/frontend/src/odh/components/OdhModelCatalogCoreLoader.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/OdhModelCatalogCoreLoader.tsx
@@ -3,8 +3,14 @@ import { Link } from 'react-router-dom';
 import { Bullseye } from '@patternfly/react-core';
 import { useResolvedExtensions, useExtensions } from '@odh-dashboard/plugin-core';
 import ModelCatalogCoreLoader from '~/app/pages/modelCatalog/ModelCatalogCoreLoader';
-import { isAdminCheckExtension, isCatalogSettingsUrlExtension } from '~/odh/extension-points';
+import {
+  isAdminCheckExtension,
+  isCatalogSettingsUrlExtension,
+  isRegistrySettingsUrlExtension,
+} from '~/odh/extension-points';
 import { catalogSettingsUrl } from '~/app/routes/modelCatalogSettings/modelCatalogSettings';
+import { REGISTRY_SETTINGS_PAGE_TITLE, REGISTRY_SETTINGS_URL } from '~/odh/const';
+import { AdminStatusProvider } from '~/odh/context/AdminStatusContext';
 
 const ADMIN_EMPTY_STATE_TITLE = 'Configure model sources';
 
@@ -18,6 +24,7 @@ const OdhModelCatalogCoreLoader: React.FC = () => {
   const [adminCheckExtensions, adminCheckExtensionsLoaded] =
     useResolvedExtensions(isAdminCheckExtension);
   const catalogSettingsUrlExtensions = useExtensions(isCatalogSettingsUrlExtension);
+  const registrySettingsUrlExtensions = useExtensions(isRegistrySettingsUrlExtension);
 
   const getCatalogSettingsUrl = (): string => {
     if (catalogSettingsUrlExtensions.length > 0) {
@@ -28,6 +35,15 @@ const OdhModelCatalogCoreLoader: React.FC = () => {
 
   const catalogSettingsTitle =
     catalogSettingsUrlExtensions.length > 0 ? catalogSettingsUrlExtensions[0].properties.title : '';
+
+  const registrySettingsUrl =
+    registrySettingsUrlExtensions.length > 0
+      ? registrySettingsUrlExtensions[0].properties.url
+      : REGISTRY_SETTINGS_URL;
+  const registrySettingsTitle =
+    registrySettingsUrlExtensions.length > 0
+      ? registrySettingsUrlExtensions[0].properties.title
+      : REGISTRY_SETTINGS_PAGE_TITLE;
 
   const adminEmptyStateDescription = (
     <>
@@ -55,16 +71,22 @@ const OdhModelCatalogCoreLoader: React.FC = () => {
           if (!loaded) {
             return <Bullseye>Loading...</Bullseye>;
           }
-          if (isAdmin) {
-            return (
+          return (
+            <AdminStatusProvider
+              isAdmin={isAdmin}
+              loaded={loaded}
+              settingsUrl={registrySettingsUrl}
+              settingsTitle={registrySettingsTitle}
+            >
               <ModelCatalogCoreLoader
-                customAction={adminAction}
-                customEmptyStateTitle={ADMIN_EMPTY_STATE_TITLE}
-                customEmptyStateDescription={adminEmptyStateDescription}
+                {...(isAdmin && {
+                  customAction: adminAction,
+                  customEmptyStateTitle: ADMIN_EMPTY_STATE_TITLE,
+                  customEmptyStateDescription: adminEmptyStateDescription,
+                })}
               />
-            );
-          }
-          return <ModelCatalogCoreLoader />;
+            </AdminStatusProvider>
+          );
         }}
       </AdminCheckComponent>
     );

--- a/packages/model-registry/upstream/frontend/src/odh/components/OdhModelDetailsPage.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/OdhModelDetailsPage.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Button, Tooltip } from '@patternfly/react-core';
+import ModelDetailsPage from '~/app/pages/modelCatalog/screens/ModelDetailsPage';
+import { useAdminStatus } from '~/odh/context/AdminStatusContext';
+
+type OdhModelDetailsPageProps = {
+  tab: string;
+};
+
+const OdhModelDetailsPage: React.FC<OdhModelDetailsPageProps> = ({ tab }) => {
+  const { isAdmin, loaded, settingsTitle } = useAdminStatus();
+
+  if (!loaded || !isAdmin) {
+    return <ModelDetailsPage tab={tab} />;
+  }
+
+  return (
+    <ModelDetailsPage
+      tab={tab}
+      customNoRegistriesButton={(variant) => (
+        <Tooltip
+          content={
+            <div>
+              <strong>No model registries available</strong>
+              <div>To create a new model registry, go to {settingsTitle}.</div>
+            </div>
+          }
+          data-testid="register-catalog-model-tooltip"
+        >
+          <Button variant={variant} isAriaDisabled data-testid="register-model-button">
+            Register model
+          </Button>
+        </Tooltip>
+      )}
+    />
+  );
+};
+
+export default OdhModelDetailsPage;

--- a/packages/model-registry/upstream/frontend/src/odh/components/OdhModelRegistryCoreLoader.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/OdhModelRegistryCoreLoader.tsx
@@ -58,9 +58,9 @@ const OdhModelRegistryCoreLoader: React.FC<OdhModelRegistryCoreLoaderProps> = ({
         }
         customAction={
           !isAdmin ? (
-            <WhosMyAdministrator />
+            <WhosMyAdministrator linkTestId="whos-my-admin-link" />
           ) : (
-            <Link to={settingsUrl}>
+            <Link to={settingsUrl} data-testid="model-registry-settings-link">
               Go to <b>{settingsTitle}</b>
             </Link>
           )

--- a/packages/model-registry/upstream/frontend/src/odh/components/OdhModelRegistryCoreLoader.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/OdhModelRegistryCoreLoader.tsx
@@ -8,6 +8,7 @@ import EmptyModelRegistryState from '~/app/pages/modelRegistry/screens/component
 import ModelRegistryCoreLoader from '~/app/pages/modelRegistry/ModelRegistryCoreLoader';
 import { isAdminCheckExtension, isRegistrySettingsUrlExtension } from '~/odh/extension-points';
 import { REGISTRY_SETTINGS_PAGE_TITLE, REGISTRY_SETTINGS_URL } from '~/odh/const';
+import { AdminStatusProvider } from '~/odh/context/AdminStatusContext';
 import OdhUnavailableModelRegistry from './OdhUnavailableModelRegistry';
 
 type OdhModelRegistryCoreLoaderProps = {
@@ -93,11 +94,18 @@ const OdhModelRegistryCoreLoader: React.FC<OdhModelRegistryCoreLoaderProps> = ({
             return <Bullseye>Loading...</Bullseye>;
           }
           return (
-            <ModelRegistryCoreLoader
-              getInvalidRedirectPath={getInvalidRedirectPath}
-              emptyStatePage={createEmptyStatePage(isAdmin)}
-              unavailableStatePage={createUnavailableStatePage(isAdmin)}
-            />
+            <AdminStatusProvider
+              isAdmin={isAdmin}
+              loaded={loaded}
+              settingsUrl={settingsUrl}
+              settingsTitle={settingsTitle}
+            >
+              <ModelRegistryCoreLoader
+                getInvalidRedirectPath={getInvalidRedirectPath}
+                emptyStatePage={createEmptyStatePage(isAdmin)}
+                unavailableStatePage={createUnavailableStatePage(isAdmin)}
+              />
+            </AdminStatusProvider>
           );
         }}
       </AdminCheckComponent>

--- a/packages/model-registry/upstream/frontend/src/odh/components/__tests__/OdhModelDetailsPage.spec.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/__tests__/OdhModelDetailsPage.spec.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { AdminStatusProvider } from '~/odh/context/AdminStatusContext';
+import OdhModelDetailsPage from '~/odh/components/OdhModelDetailsPage';
+
+jest.mock('~/app/pages/modelCatalog/screens/ModelDetailsPage', () => {
+  const MockModelDetailsPage = ({
+    customNoRegistriesButton,
+  }: {
+    customNoRegistriesButton?: (variant: 'primary' | 'secondary') => React.ReactNode;
+  }) => (
+    <div data-testid="model-details-page">
+      {customNoRegistriesButton ? (
+        <div data-testid="custom-button-slot">{customNoRegistriesButton('primary')}</div>
+      ) : (
+        <div data-testid="default-button-slot">default register button</div>
+      )}
+    </div>
+  );
+  return { __esModule: true, default: MockModelDetailsPage };
+});
+
+const SETTINGS_URL = '/settings/model-resources-operations/model-registry';
+const SETTINGS_TITLE = 'Model registry settings';
+
+describe('OdhModelDetailsPage', () => {
+  it('should pass the default register button when user is not admin', () => {
+    render(
+      <MemoryRouter>
+        <AdminStatusProvider
+          isAdmin={false}
+          loaded
+          settingsUrl={SETTINGS_URL}
+          settingsTitle={SETTINGS_TITLE}
+        >
+          <OdhModelDetailsPage tab="overview" />
+        </AdminStatusProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('default-button-slot')).toBeInTheDocument();
+    expect(screen.queryByTestId('custom-button-slot')).not.toBeInTheDocument();
+  });
+
+  it('should pass the default register button when admin status has not loaded', () => {
+    render(
+      <MemoryRouter>
+        <AdminStatusProvider
+          isAdmin
+          loaded={false}
+          settingsUrl={SETTINGS_URL}
+          settingsTitle={SETTINGS_TITLE}
+        >
+          <OdhModelDetailsPage tab="overview" />
+        </AdminStatusProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('default-button-slot')).toBeInTheDocument();
+    expect(screen.queryByTestId('custom-button-slot')).not.toBeInTheDocument();
+  });
+
+  it('should provide an admin-specific disabled register button for admin users', () => {
+    render(
+      <MemoryRouter>
+        <AdminStatusProvider
+          isAdmin
+          loaded
+          settingsUrl={SETTINGS_URL}
+          settingsTitle={SETTINGS_TITLE}
+        >
+          <OdhModelDetailsPage tab="overview" />
+        </AdminStatusProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('default-button-slot')).not.toBeInTheDocument();
+    expect(screen.getByTestId('custom-button-slot')).toBeInTheDocument();
+
+    const registerButton = screen.getByTestId('register-model-button');
+    expect(registerButton).toHaveTextContent('Register model');
+    expect(registerButton).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should pass the default register button when no provider wraps the component', () => {
+    render(
+      <MemoryRouter>
+        <OdhModelDetailsPage tab="overview" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('default-button-slot')).toBeInTheDocument();
+    expect(screen.queryByTestId('custom-button-slot')).not.toBeInTheDocument();
+  });
+});

--- a/packages/model-registry/upstream/frontend/src/odh/context/AdminStatusContext.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/context/AdminStatusContext.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+type AdminStatusContextType = {
+  isAdmin: boolean;
+  loaded: boolean;
+  settingsUrl: string;
+  settingsTitle: string;
+};
+
+const defaultValue: AdminStatusContextType = {
+  isAdmin: false,
+  loaded: false,
+  settingsUrl: '',
+  settingsTitle: '',
+};
+
+const AdminStatusContext = React.createContext<AdminStatusContextType>(defaultValue);
+
+export const useAdminStatus = (): AdminStatusContextType => React.useContext(AdminStatusContext);
+
+export const AdminStatusProvider: React.FC<
+  React.PropsWithChildren<{
+    isAdmin: boolean;
+    loaded: boolean;
+    settingsUrl: string;
+    settingsTitle: string;
+  }>
+> = ({ isAdmin, loaded, settingsUrl, settingsTitle, children }) => {
+  const value = React.useMemo(
+    () => ({ isAdmin, loaded, settingsUrl, settingsTitle }),
+    [isAdmin, loaded, settingsUrl, settingsTitle],
+  );
+  return <AdminStatusContext.Provider value={value}>{children}</AdminStatusContext.Provider>;
+};
+
+export default AdminStatusContext;


### PR DESCRIPTION

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://redhat.atlassian.net/browse/RHOAIENG-81200

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Model Registry empty states and disabled-action messaging did not correctly reflect the user's privilege level. Admin users saw "contact your administrator" messaging and non-admin "request access" copy in places where they should see role-appropriate guidance.

Non-Admin:
<img width="1920" height="1009" alt="Screenshot 2026-08-27 at 13 11 29" src="https://github.com/user-attachments/assets/8e97c2c3-d2b9-4f89-aa51-1accbf674c1e" />
<img width="1924" height="1022" alt="Screenshot 2026-08-27 at 13 10 50" src="https://github.com/user-attachments/assets/a9b64885-dafd-429b-927c-23813464b7c5" />


Admin:
<img width="1907" height="1018" alt="Screenshot 2026-08-27 at 13 11 11" src="https://github.com/user-attachments/assets/12daf5d4-aeb1-47af-80e6-aee65cabf34c" />
<img width="1919" height="1030" alt="Screenshot 2026-08-27 at 13 10 28" src="https://github.com/user-attachments/assets/ff82c25d-e32a-4ff3-aec5-0083a42fb62f" />



This PR fixes the remaining bug (BUG 3 from the ticket) by making two components admin-aware using the existing `AdminCheck` extension pattern:

**Register button tooltip (ModelDetailsPage):**
- Admin with no registries: "No model registries available — To create a new model registry, go to Model registry settings."
- Non-admin (unchanged): "Request access to a model registry — contact your administrator."

**"Need another registry?" popover (AdminHelpAction):**
- Admin: Popover with link to Model registry settings page
- Non-admin (unchanged): "Who's my administrator?" popover


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 9 unit tests added (4 for OdhModelDetailsPage, 5 for AdminHelpAction) covering admin, non-admin, unloaded, no-provider, and MUI theme scenarios
- All tests verify both presence of correct content AND absence of wrong content (anti-tautological)
- Full test suite passes: 952/952 tests, lint clean, TypeScript clean
- Manual testing on [PSI-16](https://redhat.atlassian.net/browse/PSI-16) cluster with admin (cluster-admin) and non-admin (regularuser2) users

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- `OdhModelDetailsPage.spec.tsx` — 4 tests covering admin/non-admin register button rendering
- `AdminHelpAction.spec.tsx` — 5 tests covering admin/non-admin popover content, MUI theme fallback
- Tests follow the same pattern as existing `OdhUnavailableModelRegistry.spec.tsx`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[PSI-16]: https://redhat.atlassian.net/browse/PSI-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for administrator help actions.
  * Verified administrator-contact messaging and role-specific settings links.
  * Added scenarios for both empty and populated model-registry environments.
  * Covered cluster-administrator and project-editor access scenarios.
  * Expanded validation of model-registry empty-state navigation and related dashboard integrations.
  * Confirmed consistent behavior across dashboard, registry, namespace, and registered-model states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->