### PR TITLE
RHOAIENG-80022: Add Deploy action for MCP Registry servers in embedded MLflow view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38826,15 +38826,21 @@
       "dependencies": {
         "@odh-dashboard/internal": "*",
         "@odh-dashboard/k8s-core": "*",
+        "@odh-dashboard/model-registry": "*",
         "@odh-dashboard/plugin-core": "*",
-        "@odh-dashboard/ui-core": "*"
+        "@odh-dashboard/ui-core": "*",
+        "js-yaml": "^4.1.1",
+        "mod-arch-core": "^1.15.4"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",
-        "@odh-dashboard/tsconfig": "*"
+        "@odh-dashboard/jest-config": "*",
+        "@odh-dashboard/tsconfig": "*",
+        "@types/js-yaml": "^4.0.9"
       },
       "peerDependencies": {
         "@module-federation/runtime": ">=0.15.0",
+        "@openshift/dynamic-plugin-sdk": "^5",
         "@patternfly/react-core": "^6",
         "@patternfly/react-icons": "^6",
         "react": "^18",

--- a/packages/cypress/cypress/pages/mcpDeployments.ts
+++ b/packages/cypress/cypress/pages/mcpDeployments.ts
@@ -160,10 +160,6 @@ class McpDeployModal {
     return this.findModal().findByTestId('mcp-deploy-oci-image-input');
   }
 
-  findProjectSelector(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.findModal().findByTestId('mcp-deploy-project-selector');
-  }
-
   findSubmitButton(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findModal().findByTestId('modal-submit-button');
   }

--- a/packages/cypress/cypress/pages/mcpRegistry.ts
+++ b/packages/cypress/cypress/pages/mcpRegistry.ts
@@ -1,0 +1,34 @@
+class McpRegistry {
+  visit(workspace?: string) {
+    const qs = workspace ? `?workspace=${workspace}` : '';
+    cy.visitWithLogin(`/ai-hub/mcp-servers/registry${qs}`);
+    this.wait();
+  }
+
+  private wait() {
+    cy.findByTestId('app-tab-page-title', { timeout: 30000 }).should('exist');
+    cy.testA11y();
+  }
+
+  findPageTitle() {
+    return cy.findByTestId('app-tab-page-title');
+  }
+
+  findMlflowUnavailableState() {
+    return cy.findByTestId('mlflow-unavailable-empty-state');
+  }
+
+  findProjectSelector() {
+    return cy.findByTestId('project-selector-toggle', { timeout: 30000 });
+  }
+
+  findProjectInDropdown(name: string) {
+    return cy.findByRole('menuitem', { name });
+  }
+
+  shouldHaveWorkspace(workspace: string) {
+    cy.url().should('include', `workspace=${workspace}`);
+  }
+}
+
+export const mcpRegistry = new McpRegistry();

--- a/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
@@ -261,7 +261,10 @@ describe('MCP Deployments', () => {
     mcpDeployModal.findTitle().should('contain.text', 'Edit MCP server deployment');
     mcpDeployModal.findNameInput().should('have.value', 'Kubernetes MCP');
     mcpDeployModal.findOciImageInput().should('have.value', 'quay.io/mcp-servers/kubernetes:1.0.0');
-    mcpDeployModal.findProjectSelector().should('have.value', 'test-project');
+    mcpDeployModal
+      .findProjectSelectorToggle()
+      .should('contain.text', 'Test Project')
+      .and('be.disabled');
     mcpDeployModal.findSubmitButton().should('contain.text', 'Save');
   });
 

--- a/packages/cypress/cypress/tests/mocked/mlflow/mcpRegistry.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mlflow/mcpRegistry.cy.ts
@@ -1,5 +1,6 @@
-import { mockDashboardConfig, mockK8sResourceList } from '@odh-dashboard/internal/__mocks__';
-import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
+import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
+import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { ProjectModel } from '../../../utils/models';

--- a/packages/cypress/cypress/tests/mocked/mlflow/mcpRegistry.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mlflow/mcpRegistry.cy.ts
@@ -1,0 +1,65 @@
+import { mockDashboardConfig, mockK8sResourceList } from '@odh-dashboard/internal/__mocks__';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { ProjectModel } from '../../../utils/models';
+import { asProductAdminUser } from '../../../utils/mockUsers';
+import { interceptMlflowEmbeddedRemoteFailure } from '../../../utils/mlflowUtils';
+import { mcpRegistry } from '../../../pages/mcpRegistry';
+
+const PROJECT_A = 'test-project-a';
+const PROJECT_B = 'test-project-b';
+
+const initIntercepts = () => {
+  asProductAdminUser();
+
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({ mcpCatalog: true, mcpRegistry: true, disableModelRegistry: false }),
+  );
+
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+        [DataScienceStackComponent.MLFLOW]: { managementState: 'Managed' },
+      },
+    }),
+  );
+
+  const projectA = mockProjectK8sResource({ k8sName: PROJECT_A, displayName: PROJECT_A });
+  const projectB = mockProjectK8sResource({ k8sName: PROJECT_B, displayName: PROJECT_B });
+  cy.interceptK8sList(ProjectModel, mockK8sResourceList([projectA, projectB]));
+  cy.interceptK8s(ProjectModel, projectA);
+};
+
+describe('MCP Registry tab wrapper', () => {
+  beforeEach(() => {
+    initIntercepts();
+  });
+
+  it('should redirect to the first project when no workspace is selected', () => {
+    interceptMlflowEmbeddedRemoteFailure();
+    cy.visitWithLogin('/ai-hub/mcp-servers/registry');
+    mcpRegistry.shouldHaveWorkspace(PROJECT_A);
+  });
+
+  it('should switch workspace when selecting a different project', () => {
+    interceptMlflowEmbeddedRemoteFailure();
+    mcpRegistry.visit(PROJECT_A);
+    mcpRegistry.findProjectSelector().should('contain', PROJECT_A);
+
+    mcpRegistry.findProjectSelector().click();
+    mcpRegistry.findProjectInDropdown(PROJECT_B).click();
+    mcpRegistry.shouldHaveWorkspace(PROJECT_B);
+  });
+
+  it('should show unavailable empty state when the MLflow remote fails to load', () => {
+    interceptMlflowEmbeddedRemoteFailure();
+    mcpRegistry.visit(PROJECT_A);
+
+    cy.wait('@mlflowEmbeddedRemoteEntry');
+    mcpRegistry.findMlflowUnavailableState().should('be.visible');
+  });
+});

--- a/packages/cypress/cypress/utils/mcpDeploymentUtils.ts
+++ b/packages/cypress/cypress/utils/mcpDeploymentUtils.ts
@@ -33,6 +33,8 @@ export const mockMcpDeployment = (overrides?: Partial<McpDeployment>): McpDeploy
   uid: 'test-uid-1234',
   creationTimestamp: '2026-03-10T14:30:00Z',
   image: 'quay.io/mcp-servers/kubernetes:1.0.0',
+  port: 8080,
+  path: '/sse',
   conditions: [acceptedValid(), readyCondition(McpConditionStatus.TRUE, McpReadyReason.AVAILABLE)],
   address: { url: 'http://kubernetes-mcp.test-project.svc:8080/sse' },
   ...overrides,

--- a/packages/mlflow-embedded/extensions.ts
+++ b/packages/mlflow-embedded/extensions.ts
@@ -18,6 +18,8 @@ import {
 } from '@odh-dashboard/internal/concepts/mlflow/const';
 // eslint-disable-next-line no-restricted-syntax
 import { PROMPT_MANAGEMENT_PAGE_TITLE } from './shared/const';
+// eslint-disable-next-line no-restricted-syntax
+import { MCP_REGISTRY_BASENAME } from './mcp-registry/const';
 
 /**
  * MLflow host-side extensions.
@@ -99,6 +101,21 @@ const extensions: (
       objectType: 'mcp-catalog',
       component: () => import('./mcp-registry/MlflowMcpRegistryTabContent'),
       group: '1b_registry',
+    },
+  },
+  // Full-page breakout for a single server's detail view. Registered as a
+  // separate app.route (rather than nested inside the tab's own component)
+  // so it renders outside the "MCP servers" tab page shell entirely. This
+  // path is more specific than the tab page's '/ai-hub/mcp-servers/*', so
+  // it always wins route matching for a specific server.
+  {
+    type: 'app.route',
+    flags: {
+      required: [SupportedArea.MLFLOW, SupportedArea.MCP_CATALOG, SupportedArea.MCP_REGISTRY],
+    },
+    properties: {
+      path: `${MCP_REGISTRY_BASENAME}/:serverName`,
+      component: () => import('./mcp-registry/MlflowMcpRegistryDetailPage'),
     },
   },
   {

--- a/packages/mlflow-embedded/jest.config.ts
+++ b/packages/mlflow-embedded/jest.config.ts
@@ -1,0 +1,16 @@
+import baseConfig from '@odh-dashboard/jest-config';
+
+export default {
+  ...baseConfig,
+  collectCoverageFrom: [
+    'extensions.ts',
+    'mcp-registry/**/*.{ts,tsx}',
+    'experiments/**/*.{ts,tsx}',
+    'prompts/**/*.{ts,tsx}',
+    'shared/**/*.{ts,tsx}',
+    '!**/__tests__/**',
+    '!**/__mocks__/**',
+    '!**/*.spec.{ts,tsx}',
+    '!**/*.d.ts',
+  ],
+};

--- a/packages/mlflow-embedded/mcp-registry/McpRegistryDeployAction.tsx
+++ b/packages/mlflow-embedded/mcp-registry/McpRegistryDeployAction.tsx
@@ -89,7 +89,11 @@ const McpRegistryDeployAction: React.FC<McpRegistryDeployActionProps> = ({
           server_version: deployData.registryVersion,
         });
         /* eslint-enable camelcase */
-        notification.success('Deployed and registered');
+        // "Submitted" rather than "Deployed": creating the CR and registering
+        // the endpoint don't confirm the pod actually came up (image pull,
+        // readiness, etc. happen asynchronously afterward) -- the caller
+        // already navigates to the Deployments tab for real status.
+        notification.success('Deployment submitted');
       } catch (endpointError) {
         // A superseded deploy aborts its own in-flight registration call --
         // that's an intentional cancellation, not a failure, so don't show
@@ -98,7 +102,7 @@ const McpRegistryDeployAction: React.FC<McpRegistryDeployActionProps> = ({
           return;
         }
         notification.warning(
-          'Deployed, but registration failed',
+          'Deployment submitted, but endpoint registration failed',
           (endpointError instanceof Error && endpointError.message) ||
             'Failed to register the MCP access endpoint.',
         );

--- a/packages/mlflow-embedded/mcp-registry/McpRegistryDeployAction.tsx
+++ b/packages/mlflow-embedded/mcp-registry/McpRegistryDeployAction.tsx
@@ -43,8 +43,9 @@ const McpRegistryDeployAction: React.FC<McpRegistryDeployActionProps> = ({
     [server, version, namespace],
   );
 
+  const isVersionDeployable = version?.status === 'active';
   const isAvailable = extensionsLoaded && extensions.length > 0;
-  const canDeploy = Boolean(version) && isAvailable && Boolean(namespace);
+  const canDeploy = Boolean(version) && isVersionDeployable && isAvailable && Boolean(namespace);
 
   // Surface *why* Deploy is disabled instead of leaving the button greyed out with no
   // explanation. The Registry tab that hosts this button already requires MCP_CATALOG to be
@@ -52,6 +53,8 @@ const McpRegistryDeployAction: React.FC<McpRegistryDeployActionProps> = ({
   // the model-registry remote failed to load, not a disabled feature — reloading should fix it.
   const disabledReason = !version
     ? 'Select a server version to deploy'
+    : !isVersionDeployable
+    ? 'Change this version to Active before deploying'
     : !namespace
     ? 'Select a project to deploy to'
     : !extensionsLoaded

--- a/packages/mlflow-embedded/mcp-registry/McpRegistryDeployAction.tsx
+++ b/packages/mlflow-embedded/mcp-registry/McpRegistryDeployAction.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Button, Tooltip } from '@patternfly/react-core';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { useNotification } from '@odh-dashboard/ui-core/contexts/NotificationContext';
+import type { APIOptions } from 'mod-arch-core';
+import type { McpDeployment } from '@odh-dashboard/model-registry/types/mcpDeploymentTypes';
+import { isMcpCatalogDeployModalExtension } from './extension-points';
+import { createMcpAccessEndpoint } from './api';
+import { buildMcpAccessEndpointUrl } from './buildMcpAccessEndpointUrl';
+import { registryVersionToDeployData } from './registryVersionToDeployData';
+import { DEFAULT_MCP_PATH } from './const';
+import { MCPServer, MCPServerVersion } from './types';
+
+type McpRegistryDeployActionProps = {
+  server: MCPServer;
+  version?: MCPServerVersion;
+  namespace: string; // MCP Registry's project
+};
+
+// Deploy button for MCP Registry detail page. Creates MCPServer CR, then registers MCPAccessEndpoint.
+const McpRegistryDeployAction: React.FC<McpRegistryDeployActionProps> = ({
+  server,
+  version,
+  namespace,
+}) => {
+  const [extensions, extensionsLoaded] = useResolvedExtensions(isMcpCatalogDeployModalExtension);
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const notification = useNotification();
+  const abortControllerRef = React.useRef<AbortController>();
+
+  // Mirrors McpDeployModal's own cleanup: abort any in-flight endpoint registration if this
+  // component unmounts (e.g. the user navigates away) so it doesn't keep running in the
+  // background with nothing left to receive its result.
+  React.useEffect(
+    () => () => {
+      abortControllerRef.current?.abort();
+    },
+    [],
+  );
+
+  const deployData = React.useMemo(
+    () => (version ? { ...registryVersionToDeployData(server, version), namespace } : undefined),
+    [server, version, namespace],
+  );
+
+  const isAvailable = extensionsLoaded && extensions.length > 0;
+  const canDeploy = Boolean(version) && isAvailable && Boolean(namespace);
+
+  // Surface *why* Deploy is disabled instead of leaving the button greyed out with no
+  // explanation. The Registry tab that hosts this button already requires MCP_CATALOG to be
+  // enabled (mcp-catalog.server/deploy-modal's own gate), so extensions.length === 0 here means
+  // the model-registry remote failed to load, not a disabled feature — reloading should fix it.
+  const disabledReason = !version
+    ? 'Select a server version to deploy'
+    : !namespace
+    ? 'Select a project to deploy to'
+    : !extensionsLoaded
+    ? 'Checking deploy availability...'
+    : extensions.length === 0
+    ? 'Deploying is temporarily unavailable. Try reloading the page.'
+    : undefined;
+
+  const handleDeployed = React.useCallback(
+    async (deployment: McpDeployment) => {
+      if (!deployData) {
+        return;
+      }
+
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      const opts: APIOptions = { signal: controller.signal };
+
+      try {
+        /* eslint-disable camelcase */
+        await createMcpAccessEndpoint(deployData.registryServer, deployment.namespace)(opts, {
+          // Use deployment's actual applied config, not registry metadata
+          endpoint_url: buildMcpAccessEndpointUrl(
+            deployment.name,
+            deployment.namespace,
+            deployment.port,
+            deployment.path || DEFAULT_MCP_PATH,
+          ),
+          transport_type: deployData.transportType,
+          // server_alias is mutually exclusive with server_version in mlflow BFF
+          server_version: deployData.registryVersion,
+        });
+        /* eslint-enable camelcase */
+        notification.success('Deployed and registered');
+      } catch (endpointError) {
+        notification.warning(
+          'Deployed, but registration failed',
+          (endpointError instanceof Error && endpointError.message) ||
+            'Failed to register the MCP access endpoint.',
+        );
+      }
+    },
+    [deployData, notification],
+  );
+
+  const button = (
+    <Button
+      variant="primary"
+      // isAriaDisabled keeps the button focusable (for the tooltip) but does not
+      // block clicks/keyboard activation, so guard the handler with the same condition.
+      onClick={() => {
+        if (canDeploy) {
+          setIsModalOpen(true);
+        }
+      }}
+      isAriaDisabled={!canDeploy}
+      data-testid="mcp-registry-deploy-action-button"
+    >
+      Deploy
+    </Button>
+  );
+
+  // Render only the first resolved extension (matches NamespaceSelectorFieldWrapper's
+  // convention) so a second registered provider can't fire a duplicate deploy from one click.
+  let modal: React.ReactNode = null;
+  if (isModalOpen && version && deployData && extensions.length > 0) {
+    const extension = extensions[0];
+    const ModalComponent = extension.properties.modalComponent;
+    modal = (
+      <ModalComponent
+        key={extension.uid}
+        data={deployData}
+        onClose={() => setIsModalOpen(false)}
+        onDeployed={handleDeployed}
+      />
+    );
+  }
+
+  return (
+    <>
+      {disabledReason ? <Tooltip content={disabledReason}>{button}</Tooltip> : button}
+      {modal}
+    </>
+  );
+};
+
+export default McpRegistryDeployAction;

--- a/packages/mlflow-embedded/mcp-registry/McpRegistryDeployAction.tsx
+++ b/packages/mlflow-embedded/mcp-registry/McpRegistryDeployAction.tsx
@@ -91,6 +91,12 @@ const McpRegistryDeployAction: React.FC<McpRegistryDeployActionProps> = ({
         /* eslint-enable camelcase */
         notification.success('Deployed and registered');
       } catch (endpointError) {
+        // A superseded deploy aborts its own in-flight registration call --
+        // that's an intentional cancellation, not a failure, so don't show
+        // a misleading "registration failed" toast for it.
+        if (controller.signal.aborted) {
+          return;
+        }
         notification.warning(
           'Deployed, but registration failed',
           (endpointError instanceof Error && endpointError.message) ||

--- a/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryDetailPage.tsx
+++ b/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryDetailPage.tsx
@@ -1,0 +1,98 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
+import { Navigate, useSearchParams } from 'react-router-dom';
+import { loadRemote } from '@module-federation/runtime';
+import { LazyCodeRefComponent } from '@odh-dashboard/plugin-core';
+import { ApplicationsPage } from '@odh-dashboard/ui-core';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
+import { getStoredPreferredProject } from '@odh-dashboard/ui-core/context/getStoredPreferredProject';
+import { WORKSPACE_QUERY_PARAM } from '@odh-dashboard/internal/routes/pipelines/mlflow';
+import { MCP_REGISTRY_BASENAME, mcpRegistryBaseRoute } from './const';
+import useHostRouteSync from './useHostRouteSync';
+import McpRegistryDeployAction from './McpRegistryDeployAction';
+import { MCPServer, MCPServerVersion } from './types';
+import MLflowUnavailable from '../shared/MLflowUnavailable';
+import MlflowBreadcrumbs, { BreadcrumbEntry } from '../shared/MlflowBreadcrumbs';
+
+/**
+ * Full-screen breakout for a single MCP server's detail page.
+ *
+ * Registered as a standalone `app.route` (see extensions.ts) so it renders
+ * outside of the "MCP servers" tab page shell (no page title, no tab bar).
+ * The remote reports breadcrumb segments (with the resolved server display
+ * name) via `onBreadcrumbChange`; its own internal breadcrumb is hidden
+ * when embedded so only this host-rendered one shows.
+ */
+const MlflowMcpRegistryDetailPage: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const workspace = searchParams.get(WORKSPACE_QUERY_PARAM) ?? '';
+  const { projects, preferredProject } = React.useContext(ProjectsContext);
+  const storedProject = getStoredPreferredProject(projects);
+  const syncHostRoute = useHostRouteSync();
+  const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbEntry[]>([]);
+
+  const handleBreadcrumbChange = useCallback(
+    (segments: BreadcrumbEntry[]) => {
+      syncHostRoute();
+      setBreadcrumbs(segments);
+    },
+    [syncHostRoute],
+  );
+
+  const renderDetailActions = useCallback(
+    (server: MCPServer, version?: MCPServerVersion) => (
+      <McpRegistryDeployAction server={server} version={version} namespace={workspace} />
+    ),
+    [workspace],
+  );
+
+  const loadWrapper = useMemo(
+    () => () =>
+      loadRemote<{ default: React.ComponentType }>('mlflowEmbedded/MlflowMcpRegistryWrapper')
+        .then((mod) => mod ?? { default: MLflowUnavailable })
+        .catch(() => ({ default: MLflowUnavailable })),
+    [],
+  );
+
+  if (!workspace && projects.length > 0) {
+    const defaultProject = storedProject ?? preferredProject ?? projects[0];
+    return <Navigate to={mcpRegistryBaseRoute(defaultProject.metadata.name)} replace />;
+  }
+
+  return (
+    <ApplicationsPage
+      loaded
+      empty={false}
+      noHeader
+      breadcrumb={
+        breadcrumbs.length > 0 ? (
+          <MlflowBreadcrumbs
+            basePath={MCP_REGISTRY_BASENAME}
+            workspace={workspace}
+            breadcrumbs={breadcrumbs}
+          />
+        ) : undefined
+      }
+      keepBodyWrapper={false}
+    >
+      <LazyCodeRefComponent
+        key={workspace}
+        component={loadWrapper}
+        props={{
+          basename: MCP_REGISTRY_BASENAME,
+          onBreadcrumbChange: handleBreadcrumbChange,
+          renderDetailActions,
+        }}
+        fallback={
+          <PageSection hasBodyWrapper={false}>
+            <Bullseye>
+              <Spinner />
+            </Bullseye>
+          </PageSection>
+        }
+      />
+    </ApplicationsPage>
+  );
+};
+
+export default MlflowMcpRegistryDetailPage;

--- a/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryDetailPage.tsx
+++ b/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryDetailPage.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useParams, useSearchParams } from 'react-router-dom';
 import { loadRemote } from '@module-federation/runtime';
 import { LazyCodeRefComponent } from '@odh-dashboard/plugin-core';
 import { ApplicationsPage } from '@odh-dashboard/ui-core';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { getStoredPreferredProject } from '@odh-dashboard/ui-core/context/getStoredPreferredProject';
 import { WORKSPACE_QUERY_PARAM } from '@odh-dashboard/internal/routes/pipelines/mlflow';
-import { MCP_REGISTRY_BASENAME, mcpRegistryBaseRoute } from './const';
+import { MCP_REGISTRY_BASENAME, mcpRegistryBaseRoute, mcpServerDetailRoute } from './const';
 import useHostRouteSync from './useHostRouteSync';
 import McpRegistryDeployAction from './McpRegistryDeployAction';
 import { MCPServer, MCPServerVersion } from './types';
@@ -24,6 +24,7 @@ import MlflowBreadcrumbs, { BreadcrumbEntry } from '../shared/MlflowBreadcrumbs'
  * when embedded so only this host-rendered one shows.
  */
 const MlflowMcpRegistryDetailPage: React.FC = () => {
+  const { serverName } = useParams<{ serverName: string }>();
   const [searchParams] = useSearchParams();
   const workspace = searchParams.get(WORKSPACE_QUERY_PARAM) ?? '';
   const { projects, preferredProject } = React.useContext(ProjectsContext);
@@ -56,7 +57,12 @@ const MlflowMcpRegistryDetailPage: React.FC = () => {
 
   if (!workspace && projects.length > 0) {
     const defaultProject = storedProject ?? preferredProject ?? projects[0];
-    return <Navigate to={mcpRegistryBaseRoute(defaultProject.metadata.name)} replace />;
+    // Preserve the requested server (e.g. a bookmarked/shared detail URL
+    // without a workspace param) instead of dropping back to the list.
+    const redirectTo = serverName
+      ? mcpServerDetailRoute(serverName, defaultProject.metadata.name)
+      : mcpRegistryBaseRoute(defaultProject.metadata.name);
+    return <Navigate to={redirectTo} replace />;
   }
 
   return (

--- a/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx
+++ b/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   Bullseye,
   Content,
@@ -18,9 +18,13 @@ import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/P
 import { IconSize } from '@odh-dashboard/internal/types';
 import ProjectSelectorNavigator from '@odh-dashboard/ui-core/components/projectSelector/ProjectSelectorNavigator';
 import { WORKSPACE_QUERY_PARAM } from '@odh-dashboard/internal/routes/pipelines/mlflow';
+import McpRegistryDeployAction from './McpRegistryDeployAction';
+import { MCPServer, MCPServerVersion } from './types';
 import MLflowUnavailable from '../shared/MLflowUnavailable';
 
 const MCP_REGISTRY_BASENAME = '/ai-hub/mcp-servers/registry';
+// Stable reference so LazyCodeRefComponent's spread props don't change identity every render.
+const NOOP = () => undefined;
 
 const mcpRegistryBaseRoute = (namespace?: string): string => {
   if (!namespace) {
@@ -41,6 +45,13 @@ const MlflowMcpRegistryTabContent: React.FC = () => {
         .then((mod) => mod ?? { default: MLflowUnavailable })
         .catch(() => ({ default: MLflowUnavailable })),
     [],
+  );
+
+  const renderDetailActions = useCallback(
+    (server: MCPServer, version?: MCPServerVersion) => (
+      <McpRegistryDeployAction server={server} version={version} namespace={workspace} />
+    ),
+    [workspace],
   );
 
   if (!workspace && projects.length > 0) {
@@ -68,7 +79,7 @@ const MlflowMcpRegistryTabContent: React.FC = () => {
                 alignItems={{ default: 'alignItemsCenter' }}
               >
                 <FlexItem>
-                  <Bullseye>Project</Bullseye>
+                  <span>Project</span>
                 </FlexItem>
                 <FlexItem>
                   <ProjectSelectorNavigator
@@ -84,7 +95,11 @@ const MlflowMcpRegistryTabContent: React.FC = () => {
       <LazyCodeRefComponent
         key={workspace}
         component={loadWrapper}
-        props={{ basename: MCP_REGISTRY_BASENAME, onBreadcrumbChange: () => undefined }}
+        props={{
+          basename: MCP_REGISTRY_BASENAME,
+          onBreadcrumbChange: NOOP,
+          renderDetailActions,
+        }}
         fallback={
           <PageSection hasBodyWrapper={false}>
             <Bullseye>

--- a/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx
+++ b/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import {
   Bullseye,
   Content,
@@ -18,26 +18,16 @@ import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/P
 import { IconSize } from '@odh-dashboard/internal/types';
 import ProjectSelectorNavigator from '@odh-dashboard/ui-core/components/projectSelector/ProjectSelectorNavigator';
 import { WORKSPACE_QUERY_PARAM } from '@odh-dashboard/internal/routes/pipelines/mlflow';
-import McpRegistryDeployAction from './McpRegistryDeployAction';
-import { MCPServer, MCPServerVersion } from './types';
+import { MCP_REGISTRY_BASENAME, mcpRegistryBaseRoute } from './const';
+import useHostRouteSync from './useHostRouteSync';
 import MLflowUnavailable from '../shared/MLflowUnavailable';
-
-const MCP_REGISTRY_BASENAME = '/ai-hub/mcp-servers/registry';
-// Stable reference so LazyCodeRefComponent's spread props don't change identity every render.
-const NOOP = () => undefined;
-
-const mcpRegistryBaseRoute = (namespace?: string): string => {
-  if (!namespace) {
-    return MCP_REGISTRY_BASENAME;
-  }
-  return `${MCP_REGISTRY_BASENAME}?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(namespace)}`;
-};
 
 const MlflowMcpRegistryTabContent: React.FC = () => {
   const [searchParams] = useSearchParams();
   const workspace = searchParams.get(WORKSPACE_QUERY_PARAM) ?? '';
   const { projects, preferredProject } = React.useContext(ProjectsContext);
   const storedProject = getStoredPreferredProject(projects);
+  const syncHostRoute = useHostRouteSync();
 
   const loadWrapper = useMemo(
     () => () =>
@@ -45,13 +35,6 @@ const MlflowMcpRegistryTabContent: React.FC = () => {
         .then((mod) => mod ?? { default: MLflowUnavailable })
         .catch(() => ({ default: MLflowUnavailable })),
     [],
-  );
-
-  const renderDetailActions = useCallback(
-    (server: MCPServer, version?: MCPServerVersion) => (
-      <McpRegistryDeployAction server={server} version={version} namespace={workspace} />
-    ),
-    [workspace],
   );
 
   if (!workspace && projects.length > 0) {
@@ -95,11 +78,7 @@ const MlflowMcpRegistryTabContent: React.FC = () => {
       <LazyCodeRefComponent
         key={workspace}
         component={loadWrapper}
-        props={{
-          basename: MCP_REGISTRY_BASENAME,
-          onBreadcrumbChange: NOOP,
-          renderDetailActions,
-        }}
+        props={{ basename: MCP_REGISTRY_BASENAME, onBreadcrumbChange: syncHostRoute }}
         fallback={
           <PageSection hasBodyWrapper={false}>
             <Bullseye>

--- a/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx
+++ b/packages/mlflow-embedded/mcp-registry/MlflowMcpRegistryTabContent.tsx
@@ -79,7 +79,7 @@ const MlflowMcpRegistryTabContent: React.FC = () => {
                 alignItems={{ default: 'alignItemsCenter' }}
               >
                 <FlexItem>
-                  <span>Project</span>
+                  <Content>Project</Content>
                 </FlexItem>
                 <FlexItem>
                   <ProjectSelectorNavigator

--- a/packages/mlflow-embedded/mcp-registry/__tests__/McpRegistryDeployAction.spec.tsx
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/McpRegistryDeployAction.spec.tsx
@@ -1,6 +1,7 @@
 // Mock fixtures use the external MCP Registry's snake_case field names.
 /* eslint-disable camelcase */
 import * as React from 'react';
+import { act } from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -449,6 +450,47 @@ describe('McpRegistryDeployAction', () => {
       'endpoint creation failed',
     );
     expect(mockNotification.success).not.toHaveBeenCalled();
+  });
+
+  it('should not show a misleading warning toast when a newer deploy aborts an in-flight registration', async () => {
+    let rejectFirstCall: (reason?: unknown) => void = () => undefined;
+    const firstCall = jest.fn().mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectFirstCall = reject;
+      }),
+    );
+    const secondCall = jest.fn().mockResolvedValue({
+      id: 'endpoint-1',
+      server_name: 'kubernetes-mcp',
+      endpoint_url: 'http://kubernetes-mcp.test-project.svc.cluster.local:8080/mcp',
+      transport_type: 'streamable-http',
+    });
+    mockCreateMcpAccessEndpoint.mockReturnValueOnce(firstCall).mockReturnValueOnce(secondCall);
+
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-modal-stub-deployed'));
+    const [firstOpts] = firstCall.mock.calls[0] as [{ signal: AbortSignal }];
+
+    // A second deploy (e.g. a quick redeploy) aborts the first's still-pending
+    // registration call before it settles.
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-modal-stub-deployed'));
+    expect(firstOpts.signal.aborted).toBe(true);
+
+    // Simulate the aborted request actually rejecting, as a real fetch would.
+    await act(async () => {
+      rejectFirstCall(new DOMException('The operation was aborted.', 'AbortError'));
+      await Promise.resolve();
+    });
+
+    expect(mockNotification.warning).not.toHaveBeenCalled();
+    expect(mockNotification.success).toHaveBeenCalledWith('Deployed and registered');
   });
 
   it('should show the fallback detail message when the error has no message', async () => {

--- a/packages/mlflow-embedded/mcp-registry/__tests__/McpRegistryDeployAction.spec.tsx
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/McpRegistryDeployAction.spec.tsx
@@ -33,6 +33,7 @@ const mockServer: MCPServer = { name: 'kubernetes-mcp', display_name: 'Kubernete
 const mockVersion: MCPServerVersion = {
   name: 'kubernetes-mcp',
   version: '1.0.0',
+  status: 'active',
   server_json: {
     name: 'kubernetes-mcp',
     version: '1.0.0',
@@ -137,6 +138,41 @@ describe('McpRegistryDeployAction', () => {
 
     await userEvent.hover(button);
     expect(await screen.findByText('Select a server version to deploy')).toBeInTheDocument();
+  });
+
+  it.each(['draft', 'deprecated', 'deleted'] as const)(
+    'should disable the Deploy button and explain why when the selected version is %s',
+    async (status) => {
+      render(
+        <McpRegistryDeployAction
+          server={mockServer}
+          version={{ ...mockVersion, status }}
+          namespace="test-project"
+        />,
+      );
+
+      const button = screen.getByTestId('mcp-registry-deploy-action-button');
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+
+      await userEvent.hover(button);
+      expect(
+        await screen.findByText('Change this version to Active before deploying'),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it('should not open the deploy modal when clicked while the selected version is not active', async () => {
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={{ ...mockVersion, status: 'draft' }}
+        namespace="test-project"
+      />,
+    );
+
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+
+    expect(screen.queryByTestId('mcp-registry-deploy-modal-stub')).not.toBeInTheDocument();
   });
 
   it('should disable the Deploy button and explain why while the deploy modal extension has not resolved', async () => {

--- a/packages/mlflow-embedded/mcp-registry/__tests__/McpRegistryDeployAction.spec.tsx
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/McpRegistryDeployAction.spec.tsx
@@ -374,7 +374,7 @@ describe('McpRegistryDeployAction', () => {
         server_version: '1.0.0',
       },
     );
-    expect(mockNotification.success).toHaveBeenCalledWith('Deployed and registered');
+    expect(mockNotification.success).toHaveBeenCalledWith('Deployment submitted');
     expect(mockNotification.warning).not.toHaveBeenCalled();
   });
 
@@ -446,7 +446,7 @@ describe('McpRegistryDeployAction', () => {
     await userEvent.click(screen.getByTestId('mcp-registry-deploy-modal-stub-deployed'));
 
     expect(mockNotification.warning).toHaveBeenCalledWith(
-      'Deployed, but registration failed',
+      'Deployment submitted, but endpoint registration failed',
       'endpoint creation failed',
     );
     expect(mockNotification.success).not.toHaveBeenCalled();
@@ -490,7 +490,7 @@ describe('McpRegistryDeployAction', () => {
     });
 
     expect(mockNotification.warning).not.toHaveBeenCalled();
-    expect(mockNotification.success).toHaveBeenCalledWith('Deployed and registered');
+    expect(mockNotification.success).toHaveBeenCalledWith('Deployment submitted');
   });
 
   it('should show the fallback detail message when the error has no message', async () => {
@@ -507,7 +507,7 @@ describe('McpRegistryDeployAction', () => {
     await userEvent.click(screen.getByTestId('mcp-registry-deploy-modal-stub-deployed'));
 
     expect(mockNotification.warning).toHaveBeenCalledWith(
-      'Deployed, but registration failed',
+      'Deployment submitted, but endpoint registration failed',
       'Failed to register the MCP access endpoint.',
     );
   });

--- a/packages/mlflow-embedded/mcp-registry/__tests__/McpRegistryDeployAction.spec.tsx
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/McpRegistryDeployAction.spec.tsx
@@ -1,0 +1,436 @@
+// Mock fixtures use the external MCP Registry's snake_case field names.
+/* eslint-disable camelcase */
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { useNotification } from '@odh-dashboard/ui-core/contexts/NotificationContext';
+import type { McpDeployModalData } from '@odh-dashboard/model-registry/types/mcpDeploymentTypes';
+import McpRegistryDeployAction from '../McpRegistryDeployAction';
+import { createMcpAccessEndpoint } from '../api';
+import { MCPServer, MCPServerVersion, MCPTransportType, RHAI_DEPLOY_SPEC_META_KEY } from '../types';
+
+jest.mock('@odh-dashboard/plugin-core', () => ({
+  useResolvedExtensions: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/ui-core/contexts/NotificationContext', () => ({
+  useNotification: jest.fn(),
+}));
+
+jest.mock('../api', () => ({
+  createMcpAccessEndpoint: jest.fn(),
+}));
+
+const mockUseResolvedExtensions = jest.mocked(useResolvedExtensions);
+const mockUseNotification = jest.mocked(useNotification);
+const mockCreateMcpAccessEndpoint = jest.mocked(createMcpAccessEndpoint);
+
+const mockServer: MCPServer = { name: 'kubernetes-mcp', display_name: 'Kubernetes MCP' };
+// Registry metadata (port 5555, /other-path) differs from deployed config (8080, /mcp)
+// — proves we use the deployment's own applied config, not registry metadata.
+const mockVersion: MCPServerVersion = {
+  name: 'kubernetes-mcp',
+  version: '1.0.0',
+  server_json: {
+    name: 'kubernetes-mcp',
+    version: '1.0.0',
+    _meta: {
+      [RHAI_DEPLOY_SPEC_META_KEY]: {
+        source: { containerImage: { ref: 'ghcr.io/kubernetes/mcp-server:1.0.0' } },
+        config: { port: 9090 },
+      },
+    },
+    packages: [
+      {
+        registryType: 'oci',
+        identifier: 'ghcr.io/kubernetes/mcp-server',
+        transport: {
+          type: MCPTransportType.STREAMABLE_HTTP,
+          url: 'http://localhost:5555/other-path',
+        },
+      },
+    ],
+  },
+};
+
+const mockDeployedDeployment = {
+  name: 'kubernetes-mcp',
+  namespace: 'test-project',
+  port: 8080,
+  path: '/mcp',
+};
+
+const mockModalComponent = jest.fn(
+  ({
+    data,
+    onClose,
+    onDeployed,
+  }: {
+    data?: McpDeployModalData;
+    onClose: (saved?: boolean) => void;
+    onDeployed?: (deployment: {
+      name: string;
+      namespace: string;
+      port: number;
+      path?: string;
+    }) => void | Promise<void>;
+  }) => (
+    <div data-testid="mcp-registry-deploy-modal-stub">
+      <span data-testid="mcp-registry-deploy-modal-stub-image">{data?.image}</span>
+      <span data-testid="mcp-registry-deploy-modal-stub-namespace">{data?.namespace}</span>
+      <button
+        type="button"
+        data-testid="mcp-registry-deploy-modal-stub-close"
+        onClick={() => onClose()}
+      >
+        Close
+      </button>
+      <button
+        type="button"
+        data-testid="mcp-registry-deploy-modal-stub-deployed"
+        onClick={() => onDeployed?.(mockDeployedDeployment)}
+      >
+        Simulate deploy
+      </button>
+      <button
+        type="button"
+        data-testid="mcp-registry-deploy-modal-stub-deployed-no-path"
+        onClick={() => onDeployed?.({ ...mockDeployedDeployment, path: undefined })}
+      >
+        Simulate deploy without a path
+      </button>
+    </div>
+  ),
+);
+
+const mockNotification = { success: jest.fn(), warning: jest.fn(), error: jest.fn() };
+
+const mockResolvedExtension = () =>
+  mockUseResolvedExtensions.mockReturnValue([
+    [
+      {
+        type: 'mcp-catalog.server/deploy-modal',
+        uid: 'test-ext',
+        pluginName: 'test',
+        properties: { modalComponent: mockModalComponent },
+        flags: {},
+      } as never,
+    ],
+    true,
+    [],
+  ]);
+
+describe('McpRegistryDeployAction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNotification.mockReturnValue(mockNotification as never);
+    mockResolvedExtension();
+  });
+
+  it('should disable the Deploy button and explain why when no version is selected', async () => {
+    render(<McpRegistryDeployAction server={mockServer} namespace="test-project" />);
+
+    const button = screen.getByTestId('mcp-registry-deploy-action-button');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.hover(button);
+    expect(await screen.findByText('Select a server version to deploy')).toBeInTheDocument();
+  });
+
+  it('should disable the Deploy button and explain why while the deploy modal extension has not resolved', async () => {
+    mockUseResolvedExtensions.mockReturnValue([[], false, []]);
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+
+    const button = screen.getByTestId('mcp-registry-deploy-action-button');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.hover(button);
+    expect(await screen.findByText('Checking deploy availability...')).toBeInTheDocument();
+  });
+
+  it('should disable the Deploy button and explain why the deploy modal extension is unavailable', async () => {
+    mockUseResolvedExtensions.mockReturnValue([[], true, []]);
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+
+    const button = screen.getByTestId('mcp-registry-deploy-action-button');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.hover(button);
+    expect(
+      await screen.findByText('Deploying is temporarily unavailable. Try reloading the page.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should disable the Deploy button and explain why when there is no current project', async () => {
+    render(<McpRegistryDeployAction server={mockServer} version={mockVersion} namespace="" />);
+
+    const button = screen.getByTestId('mcp-registry-deploy-action-button');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.hover(button);
+    expect(await screen.findByText('Select a project to deploy to')).toBeInTheDocument();
+  });
+
+  it('should enable the Deploy button once a version is selected and the extension is available', () => {
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+
+    expect(screen.getByTestId('mcp-registry-deploy-action-button')).not.toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+  });
+
+  it('should open the borrowed deploy modal prefilled from the version and current project when clicked', async () => {
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+
+    expect(screen.queryByTestId('mcp-registry-deploy-modal-stub')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+
+    expect(screen.getByTestId('mcp-registry-deploy-modal-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('mcp-registry-deploy-modal-stub-image')).toHaveTextContent(
+      'ghcr.io/kubernetes/mcp-server:1.0.0',
+    );
+    expect(screen.getByTestId('mcp-registry-deploy-modal-stub-namespace')).toHaveTextContent(
+      'test-project',
+    );
+  });
+
+  it('should render only the first resolved extension if more than one provider registers the deploy modal', async () => {
+    const secondModalComponent = jest.fn(() => (
+      <div data-testid="mcp-registry-deploy-modal-stub-second" />
+    ));
+    mockUseResolvedExtensions.mockReturnValue([
+      [
+        {
+          type: 'mcp-catalog.server/deploy-modal',
+          uid: 'test-ext',
+          pluginName: 'test',
+          properties: { modalComponent: mockModalComponent },
+          flags: {},
+        },
+        {
+          type: 'mcp-catalog.server/deploy-modal',
+          uid: 'test-ext-2',
+          pluginName: 'test-2',
+          properties: { modalComponent: secondModalComponent },
+          flags: {},
+        },
+      ] as never,
+      true,
+      [],
+    ]);
+
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+
+    expect(screen.getByTestId('mcp-registry-deploy-modal-stub')).toBeInTheDocument();
+    expect(screen.queryByTestId('mcp-registry-deploy-modal-stub-second')).not.toBeInTheDocument();
+  });
+
+  it('should close the deploy modal when onClose is called', async () => {
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+    expect(screen.getByTestId('mcp-registry-deploy-modal-stub')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-modal-stub-close'));
+
+    expect(screen.queryByTestId('mcp-registry-deploy-modal-stub')).not.toBeInTheDocument();
+  });
+
+  it('should not open the deploy modal when clicked without a version selected', async () => {
+    render(<McpRegistryDeployAction server={mockServer} namespace="test-project" />);
+
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+
+    expect(screen.queryByTestId('mcp-registry-deploy-modal-stub')).not.toBeInTheDocument();
+  });
+
+  it('should not open the deploy modal when clicked with no current project (empty namespace)', async () => {
+    render(<McpRegistryDeployAction server={mockServer} version={mockVersion} namespace="" />);
+
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+
+    expect(screen.queryByTestId('mcp-registry-deploy-modal-stub')).not.toBeInTheDocument();
+  });
+
+  it('should not open the deploy modal when clicked while the deploy modal extension has not resolved', async () => {
+    mockUseResolvedExtensions.mockReturnValue([[], false, []]);
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+
+    expect(screen.queryByTestId('mcp-registry-deploy-modal-stub')).not.toBeInTheDocument();
+  });
+
+  it('should register an MCPAccessEndpoint with the deployed CR config and show success toast', async () => {
+    const mockCreateEndpointCall = jest.fn().mockResolvedValue({
+      id: 'endpoint-1',
+      server_name: 'kubernetes-mcp',
+      endpoint_url: 'http://kubernetes-mcp.test-project.svc.cluster.local:8080/mcp',
+      transport_type: 'streamable-http',
+    });
+    mockCreateMcpAccessEndpoint.mockReturnValue(mockCreateEndpointCall);
+
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-modal-stub-deployed'));
+
+    // workspace comes from deployed CR namespace, port/path from applied config
+    expect(mockCreateMcpAccessEndpoint).toHaveBeenCalledWith('kubernetes-mcp', 'test-project');
+    expect(mockCreateEndpointCall).toHaveBeenCalledWith(
+      { signal: expect.any(AbortSignal) },
+      {
+        endpoint_url: 'http://kubernetes-mcp.test-project.svc.cluster.local:8080/mcp',
+        transport_type: 'streamable-http',
+        server_version: '1.0.0',
+      },
+    );
+    expect(mockNotification.success).toHaveBeenCalledWith('Deployed and registered');
+    expect(mockNotification.warning).not.toHaveBeenCalled();
+  });
+
+  it('should abort the in-flight endpoint registration request when the component unmounts', async () => {
+    const mockCreateEndpointCall = jest.fn().mockReturnValue(
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      new Promise<never>(() => {}),
+    );
+    mockCreateMcpAccessEndpoint.mockReturnValue(mockCreateEndpointCall);
+
+    const { unmount } = render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-modal-stub-deployed'));
+
+    const [opts] = mockCreateEndpointCall.mock.calls[0] as [{ signal: AbortSignal }];
+    expect(opts.signal.aborted).toBe(false);
+
+    unmount();
+
+    expect(opts.signal.aborted).toBe(true);
+  });
+
+  it('should fall back to the default path when the deployment reports no path', async () => {
+    const mockCreateEndpointCall = jest.fn().mockResolvedValue({
+      id: 'endpoint-1',
+      server_name: 'kubernetes-mcp',
+      endpoint_url: 'http://kubernetes-mcp.test-project.svc.cluster.local:8080/mcp',
+      transport_type: 'streamable-http',
+    });
+    mockCreateMcpAccessEndpoint.mockReturnValue(mockCreateEndpointCall);
+
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-modal-stub-deployed-no-path'));
+
+    expect(mockCreateEndpointCall).toHaveBeenCalledWith(
+      { signal: expect.any(AbortSignal) },
+      expect.objectContaining({
+        endpoint_url: 'http://kubernetes-mcp.test-project.svc.cluster.local:8080/mcp',
+      }),
+    );
+  });
+
+  it('should show a warning toast (not fail) when MCPAccessEndpoint registration fails', async () => {
+    mockCreateMcpAccessEndpoint.mockReturnValue(
+      jest.fn().mockRejectedValue(new Error('endpoint creation failed')),
+    );
+
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-modal-stub-deployed'));
+
+    expect(mockNotification.warning).toHaveBeenCalledWith(
+      'Deployed, but registration failed',
+      'endpoint creation failed',
+    );
+    expect(mockNotification.success).not.toHaveBeenCalled();
+  });
+
+  it('should show the fallback detail message when the error has no message', async () => {
+    mockCreateMcpAccessEndpoint.mockReturnValue(jest.fn().mockRejectedValue(new Error()));
+
+    render(
+      <McpRegistryDeployAction
+        server={mockServer}
+        version={mockVersion}
+        namespace="test-project"
+      />,
+    );
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-action-button'));
+    await userEvent.click(screen.getByTestId('mcp-registry-deploy-modal-stub-deployed'));
+
+    expect(mockNotification.warning).toHaveBeenCalledWith(
+      'Deployed, but registration failed',
+      'Failed to register the MCP access endpoint.',
+    );
+  });
+});

--- a/packages/mlflow-embedded/mcp-registry/__tests__/MlflowMcpRegistryDetailPage.spec.tsx
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/MlflowMcpRegistryDetailPage.spec.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
+// MlflowBreadcrumbs renders react-router-dom's <Link>, which needs a Router
+// context -- this import resolves through the mock below, which spreads the
+// real module, so MemoryRouter here is the genuine implementation.
+import { MemoryRouter } from 'react-router-dom';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
+import type { ProjectKind } from '@odh-dashboard/k8s-core';
+import MlflowMcpRegistryDetailPage from '../MlflowMcpRegistryDetailPage';
+import { MCP_REGISTRY_BASENAME } from '../const';
+
+const mockSyncHostRoute = jest.fn();
+jest.mock('../useHostRouteSync', () => ({
+  __esModule: true,
+  default: () => mockSyncHostRoute,
+}));
+
+// McpRegistryDeployAction pulls in ./api, which imports the ESM-only
+// mod-arch-core package that Jest can't transform -- stub it out, matching
+// McpRegistryDeployAction.spec.tsx's own approach of mocking that boundary.
+jest.mock('../McpRegistryDeployAction', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+let mockSearchParams = new URLSearchParams();
+const mockNavigateEl = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual<typeof import('react-router-dom')>('react-router-dom'),
+  useSearchParams: () => [mockSearchParams],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Navigate: (props: any) => {
+    mockNavigateEl(props);
+    return <div data-testid="navigate" />;
+  },
+}));
+
+jest.mock('@module-federation/runtime', () => ({ loadRemote: jest.fn() }));
+
+type LazyCodeRefProps = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  props: { basename: string; onBreadcrumbChange: (segments: any[]) => void };
+};
+let capturedWrapperProps: LazyCodeRefProps['props'] | undefined;
+jest.mock('@odh-dashboard/plugin-core', () => ({
+  LazyCodeRefComponent: (p: LazyCodeRefProps) => {
+    capturedWrapperProps = p.props;
+    return <div data-testid="lazy-wrapper" />;
+  },
+}));
+
+jest.mock('@odh-dashboard/ui-core', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ApplicationsPage: ({
+    breadcrumb,
+    children,
+  }: {
+    breadcrumb?: React.ReactNode;
+    children?: React.ReactNode;
+  }) => (
+    <div>
+      <div data-testid="breadcrumb-slot">{breadcrumb}</div>
+      {children}
+    </div>
+  ),
+}));
+
+const mockProject = { metadata: { name: 'my-project' } } as ProjectKind;
+
+const renderPage = ({
+  workspace,
+  projects = [mockProject],
+}: {
+  workspace?: string;
+  projects?: ProjectKind[];
+} = {}) => {
+  mockSearchParams = new URLSearchParams(workspace ? { workspace } : {});
+  return render(
+    <MemoryRouter>
+      <ProjectsContext.Provider
+        value={{
+          projects,
+          modelServingProjects: projects,
+          nonActiveProjects: [],
+          preferredProject: projects[0] ?? null,
+          updatePreferredProject: () => undefined,
+          waitForProject: () => Promise.resolve(),
+          loaded: true,
+          loadError: undefined,
+        }}
+      >
+        <MlflowMcpRegistryDetailPage />
+      </ProjectsContext.Provider>
+    </MemoryRouter>,
+  );
+};
+
+describe('MlflowMcpRegistryDetailPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedWrapperProps = undefined;
+  });
+
+  it('should redirect to the default project when no workspace is selected and projects exist', () => {
+    renderPage({ workspace: undefined, projects: [mockProject] });
+
+    expect(mockNavigateEl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: `${MCP_REGISTRY_BASENAME}?workspace=my-project`,
+        replace: true,
+      }),
+    );
+    expect(screen.queryByTestId('lazy-wrapper')).not.toBeInTheDocument();
+  });
+
+  it('should mount the wrapper with the correct basename when a workspace is selected', () => {
+    renderPage({ workspace: 'my-project' });
+
+    expect(screen.getByTestId('lazy-wrapper')).toBeInTheDocument();
+    expect(mockNavigateEl).not.toHaveBeenCalled();
+    expect(capturedWrapperProps?.basename).toBe(MCP_REGISTRY_BASENAME);
+  });
+
+  it('should mount the wrapper even with no projects (no redirect target available)', () => {
+    renderPage({ workspace: undefined, projects: [] });
+
+    expect(screen.getByTestId('lazy-wrapper')).toBeInTheDocument();
+    expect(mockNavigateEl).not.toHaveBeenCalled();
+  });
+
+  it('should not render a breadcrumb before the remote reports any segments', () => {
+    renderPage({ workspace: 'my-project' });
+
+    expect(screen.getByTestId('breadcrumb-slot').textContent).toBe('');
+  });
+
+  it('should sync the host route and render the breadcrumb once the remote reports segments', () => {
+    renderPage({ workspace: 'my-project' });
+
+    act(() => {
+      capturedWrapperProps?.onBreadcrumbChange([
+        { label: 'My MCP Server', path: '/my-mcp-server' },
+      ]);
+    });
+
+    expect(mockSyncHostRoute).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('mlflow-breadcrumb-active').textContent).toBe('My MCP Server');
+  });
+
+  it('should clear the breadcrumb again once the remote reports an empty segment list', () => {
+    renderPage({ workspace: 'my-project' });
+
+    act(() => {
+      capturedWrapperProps?.onBreadcrumbChange([
+        { label: 'My MCP Server', path: '/my-mcp-server' },
+      ]);
+    });
+    expect(screen.getByTestId('mlflow-breadcrumb-active')).toBeInTheDocument();
+
+    act(() => {
+      capturedWrapperProps?.onBreadcrumbChange([]);
+    });
+
+    expect(screen.getByTestId('breadcrumb-slot').textContent).toBe('');
+    expect(mockSyncHostRoute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/mlflow-embedded/mcp-registry/__tests__/MlflowMcpRegistryDetailPage.spec.tsx
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/MlflowMcpRegistryDetailPage.spec.tsx
@@ -3,8 +3,8 @@ import { act } from 'react';
 import { render, screen } from '@testing-library/react';
 // MlflowBreadcrumbs renders react-router-dom's <Link>, which needs a Router
 // context -- this import resolves through the mock below, which spreads the
-// real module, so MemoryRouter here is the genuine implementation.
-import { MemoryRouter } from 'react-router-dom';
+// real module, so MemoryRouter/Routes/Route here are the genuine implementation.
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import type { ProjectKind } from '@odh-dashboard/k8s-core';
 import MlflowMcpRegistryDetailPage from '../MlflowMcpRegistryDetailPage';
@@ -71,27 +71,36 @@ const mockProject = { metadata: { name: 'my-project' } } as ProjectKind;
 const renderPage = ({
   workspace,
   projects = [mockProject],
+  serverName = 'my-server',
 }: {
   workspace?: string;
   projects?: ProjectKind[];
+  serverName?: string;
 } = {}) => {
   mockSearchParams = new URLSearchParams(workspace ? { workspace } : {});
   return render(
-    <MemoryRouter>
-      <ProjectsContext.Provider
-        value={{
-          projects,
-          modelServingProjects: projects,
-          nonActiveProjects: [],
-          preferredProject: projects[0] ?? null,
-          updatePreferredProject: () => undefined,
-          waitForProject: () => Promise.resolve(),
-          loaded: true,
-          loadError: undefined,
-        }}
-      >
-        <MlflowMcpRegistryDetailPage />
-      </ProjectsContext.Provider>
+    <MemoryRouter initialEntries={[`${MCP_REGISTRY_BASENAME}/${serverName}`]}>
+      <Routes>
+        <Route
+          path={`${MCP_REGISTRY_BASENAME}/:serverName`}
+          element={
+            <ProjectsContext.Provider
+              value={{
+                projects,
+                modelServingProjects: projects,
+                nonActiveProjects: [],
+                preferredProject: projects[0] ?? null,
+                updatePreferredProject: () => undefined,
+                waitForProject: () => Promise.resolve(),
+                loaded: true,
+                loadError: undefined,
+              }}
+            >
+              <MlflowMcpRegistryDetailPage />
+            </ProjectsContext.Provider>
+          }
+        />
+      </Routes>
     </MemoryRouter>,
   );
 };
@@ -102,16 +111,34 @@ describe('MlflowMcpRegistryDetailPage', () => {
     capturedWrapperProps = undefined;
   });
 
-  it('should redirect to the default project when no workspace is selected and projects exist', () => {
-    renderPage({ workspace: undefined, projects: [mockProject] });
+  it('should redirect to the default project while preserving the requested server when no workspace is selected', () => {
+    renderPage({ workspace: undefined, projects: [mockProject], serverName: 'my-server' });
 
+    // A bookmarked/shared detail URL without a workspace param should still
+    // land on the same server once a default project is picked, not bounce
+    // back to the bare list.
     expect(mockNavigateEl).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: `${MCP_REGISTRY_BASENAME}?workspace=my-project`,
+        to: `${MCP_REGISTRY_BASENAME}/my-server?workspace=my-project`,
         replace: true,
       }),
     );
     expect(screen.queryByTestId('lazy-wrapper')).not.toBeInTheDocument();
+  });
+
+  it('should URL-encode the server name when preserving it in the redirect', () => {
+    renderPage({
+      workspace: undefined,
+      projects: [mockProject],
+      serverName: encodeURIComponent('io.github.acme/widget-server'),
+    });
+
+    expect(mockNavigateEl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: `${MCP_REGISTRY_BASENAME}/io.github.acme%2Fwidget-server?workspace=my-project`,
+        replace: true,
+      }),
+    );
   });
 
   it('should mount the wrapper with the correct basename when a workspace is selected', () => {

--- a/packages/mlflow-embedded/mcp-registry/__tests__/api.spec.ts
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/api.spec.ts
@@ -1,0 +1,108 @@
+// Request/response fixtures use the mlflow BFF's snake_case field names.
+/* eslint-disable camelcase */
+import * as modArchCore from 'mod-arch-core';
+import { createMcpAccessEndpoint } from '../api';
+import { MCPTransportType } from '../types';
+
+// mod-arch-core is ESM-only; full mock avoids transformIgnorePatterns
+jest.mock('mod-arch-core', () => ({
+  handleRestFailures: jest.fn((p: Promise<unknown>) => p),
+  restCREATE: jest.fn(),
+  isModArchResponse: jest.fn(
+    (response: unknown) => typeof response === 'object' && response !== null && 'data' in response,
+  ),
+}));
+
+const mockRestCREATE = jest.mocked(modArchCore.restCREATE);
+const mockHandleRestFailures = jest.mocked(modArchCore.handleRestFailures);
+
+describe('createMcpAccessEndpoint', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHandleRestFailures.mockImplementation((p: Promise<unknown>) => p);
+  });
+
+  it('posts the request body directly, without wrapping it in a mod-arch `{ data }` envelope', async () => {
+    mockRestCREATE.mockResolvedValue({
+      data: {
+        id: 'endpoint-1',
+        server_name: 'io.github.example/weather-server',
+        endpoint_url: 'http://weather-server.my-project.svc.cluster.local:8080/mcp',
+        transport_type: MCPTransportType.STREAMABLE_HTTP,
+      },
+    });
+
+    const requestBody = {
+      endpoint_url: 'http://weather-server.my-project.svc.cluster.local:8080/mcp',
+      transport_type: MCPTransportType.STREAMABLE_HTTP,
+      server_version: '1.2.0',
+    };
+    await createMcpAccessEndpoint('io.github.example/weather-server', 'my-project')(
+      {},
+      requestBody,
+    );
+
+    expect(mockRestCREATE).toHaveBeenCalledWith(
+      '',
+      '/_bff/mlflow/api/v1/mcp-registry/servers/io.github.example/weather-server/endpoints',
+      requestBody,
+      { workspace: 'my-project' },
+      {},
+    );
+  });
+
+  it('resolves with the created endpoint from the response envelope', async () => {
+    const endpoint = {
+      id: 'endpoint-1',
+      server_name: 'io.github.example/weather-server',
+      endpoint_url: 'http://weather-server.my-project.svc.cluster.local:8080/mcp',
+      transport_type: MCPTransportType.STREAMABLE_HTTP,
+    };
+    mockRestCREATE.mockResolvedValue({ data: endpoint });
+
+    const result = await createMcpAccessEndpoint('io.github.example/weather-server', 'my-project')(
+      {},
+      { endpoint_url: endpoint.endpoint_url },
+    );
+
+    expect(result).toEqual(endpoint);
+  });
+
+  it.each(['../servers/other', '..', '.', 'weather-server/../other', 'weather-server/'])(
+    'rejects a registry server name with a path-traversal segment (%s)',
+    (registryServerName) => {
+      // Throws synchronously while building the request URL, before any network call is made.
+      expect(() =>
+        createMcpAccessEndpoint(registryServerName, 'my-project')({}, { endpoint_url: 'x' }),
+      ).toThrow('Invalid MCP registry server name');
+      expect(mockRestCREATE).not.toHaveBeenCalled();
+    },
+  );
+
+  it('throws when the mod-arch-wrapped response data is missing required endpoint fields', async () => {
+    mockRestCREATE.mockResolvedValue({ data: null });
+
+    await expect(
+      createMcpAccessEndpoint('io.github.example/weather-server', 'my-project')(
+        {},
+        { endpoint_url: 'http://weather-server.my-project.svc.cluster.local:8080/mcp' },
+      ),
+    ).rejects.toThrow('Invalid response format');
+  });
+
+  it('throws when the response is not mod-arch wrapped', async () => {
+    mockRestCREATE.mockResolvedValue({
+      id: 'endpoint-1',
+      server_name: 'io.github.example/weather-server',
+      endpoint_url: 'http://weather-server.my-project.svc.cluster.local:8080/mcp',
+      transport_type: MCPTransportType.STREAMABLE_HTTP,
+    });
+
+    await expect(
+      createMcpAccessEndpoint('io.github.example/weather-server', 'my-project')(
+        {},
+        { endpoint_url: 'http://weather-server.my-project.svc.cluster.local:8080/mcp' },
+      ),
+    ).rejects.toThrow('Invalid response format');
+  });
+});

--- a/packages/mlflow-embedded/mcp-registry/__tests__/buildMcpAccessEndpointUrl.spec.ts
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/buildMcpAccessEndpointUrl.spec.ts
@@ -1,0 +1,44 @@
+import { buildMcpAccessEndpointUrl } from '../buildMcpAccessEndpointUrl';
+
+describe('buildMcpAccessEndpointUrl', () => {
+  it('builds the deterministic cluster-internal URL from name, namespace, port, and path', () => {
+    expect(buildMcpAccessEndpointUrl('weather-server', 'my-project', 8080, '/mcp')).toBe(
+      'http://weather-server.my-project.svc.cluster.local:8080/mcp',
+    );
+  });
+
+  it('matches a live-verified example from a real MCPServer on a test cluster', () => {
+    expect(
+      buildMcpAccessEndpointUrl(
+        'test-openshift-mcp-server-from-catalog',
+        'juntao-test',
+        8080,
+        '/mcp',
+      ),
+    ).toBe('http://test-openshift-mcp-server-from-catalog.juntao-test.svc.cluster.local:8080/mcp');
+  });
+
+  it('reflects a non-default port and path verbatim', () => {
+    expect(buildMcpAccessEndpointUrl('weather-server', 'my-project', 9090, '/api/mcp')).toBe(
+      'http://weather-server.my-project.svc.cluster.local:9090/api/mcp',
+    );
+  });
+
+  it('rejects a path that smuggles userinfo into the authority (e.g. "@host/")', () => {
+    expect(() =>
+      buildMcpAccessEndpointUrl('weather-server', 'my-project', 8080, '@169.254.169.254/'),
+    ).toThrow('MCP endpoint path must remain on the deployed service');
+  });
+
+  it('rejects a protocol-relative path that redirects to a different host (e.g. "//host/")', () => {
+    expect(() =>
+      buildMcpAccessEndpointUrl('weather-server', 'my-project', 8080, '//169.254.169.254/'),
+    ).toThrow('MCP endpoint path must remain on the deployed service');
+  });
+
+  it('rejects a path that is not rooted at the service (relative path)', () => {
+    expect(() => buildMcpAccessEndpointUrl('weather-server', 'my-project', 8080, 'mcp')).toThrow(
+      'MCP endpoint path must remain on the deployed service',
+    );
+  });
+});

--- a/packages/mlflow-embedded/mcp-registry/__tests__/const.spec.ts
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/const.spec.ts
@@ -1,4 +1,4 @@
-import { MCP_REGISTRY_BASENAME, mcpRegistryBaseRoute } from '../const';
+import { MCP_REGISTRY_BASENAME, mcpRegistryBaseRoute, mcpServerDetailRoute } from '../const';
 
 describe('mcpRegistryBaseRoute', () => {
   it('should return the bare basename when no namespace is provided', () => {
@@ -18,6 +18,24 @@ describe('mcpRegistryBaseRoute', () => {
   it('should URL-encode namespace values with special characters', () => {
     expect(mcpRegistryBaseRoute('team a/b')).toBe(
       `${MCP_REGISTRY_BASENAME}?workspace=team%20a%2Fb`,
+    );
+  });
+});
+
+describe('mcpServerDetailRoute', () => {
+  it('should return the server path without a query string when no namespace is provided', () => {
+    expect(mcpServerDetailRoute('my-server')).toBe(`${MCP_REGISTRY_BASENAME}/my-server`);
+  });
+
+  it('should append the workspace query param when a namespace is provided', () => {
+    expect(mcpServerDetailRoute('my-server', 'my-project')).toBe(
+      `${MCP_REGISTRY_BASENAME}/my-server?workspace=my-project`,
+    );
+  });
+
+  it('should URL-encode server names with special characters', () => {
+    expect(mcpServerDetailRoute('io.github.acme/widget-server', 'my-project')).toBe(
+      `${MCP_REGISTRY_BASENAME}/io.github.acme%2Fwidget-server?workspace=my-project`,
     );
   });
 });

--- a/packages/mlflow-embedded/mcp-registry/__tests__/const.spec.ts
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/const.spec.ts
@@ -1,0 +1,23 @@
+import { MCP_REGISTRY_BASENAME, mcpRegistryBaseRoute } from '../const';
+
+describe('mcpRegistryBaseRoute', () => {
+  it('should return the bare basename when no namespace is provided', () => {
+    expect(mcpRegistryBaseRoute()).toBe(MCP_REGISTRY_BASENAME);
+  });
+
+  it('should return the bare basename when namespace is an empty string', () => {
+    expect(mcpRegistryBaseRoute('')).toBe(MCP_REGISTRY_BASENAME);
+  });
+
+  it('should append the workspace query param when a namespace is provided', () => {
+    expect(mcpRegistryBaseRoute('my-project')).toBe(
+      `${MCP_REGISTRY_BASENAME}?workspace=my-project`,
+    );
+  });
+
+  it('should URL-encode namespace values with special characters', () => {
+    expect(mcpRegistryBaseRoute('team a/b')).toBe(
+      `${MCP_REGISTRY_BASENAME}?workspace=team%20a%2Fb`,
+    );
+  });
+});

--- a/packages/mlflow-embedded/mcp-registry/__tests__/registryVersionToDeployData.spec.ts
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/registryVersionToDeployData.spec.ts
@@ -1,0 +1,243 @@
+// Mock fixtures use the external MCP Registry's snake_case field names.
+/* eslint-disable camelcase */
+import { registryVersionToDeployData } from '../registryVersionToDeployData';
+import {
+  MCPServer,
+  MCPServerDeploySpec,
+  MCPServerVersion,
+  MCPTransportType,
+  RHAI_DEPLOY_SPEC_META_KEY,
+} from '../types';
+
+const mockServer = (overrides: Partial<MCPServer> = {}): MCPServer => ({
+  name: 'io.github.example/weather-server',
+  display_name: 'Weather Server',
+  ...overrides,
+});
+
+const mockDeploySpec = (overrides: Partial<MCPServerDeploySpec> = {}): MCPServerDeploySpec => ({
+  source: { containerImage: { ref: 'quay.io/mcp/weather:1.2.0' } },
+  config: { port: 8080, path: '/mcp' },
+  ...overrides,
+});
+
+const mockVersion = (overrides: Partial<MCPServerVersion> = {}): MCPServerVersion => ({
+  name: 'io.github.example/weather-server',
+  version: '1.2.0',
+  server_json: {
+    name: 'io.github.example/weather-server',
+    version: '1.2.0',
+    _meta: {
+      [RHAI_DEPLOY_SPEC_META_KEY]: mockDeploySpec(),
+    },
+  },
+  ...overrides,
+});
+
+describe('registryVersionToDeployData', () => {
+  it('maps the registry server name and version', () => {
+    const result = registryVersionToDeployData(mockServer(), mockVersion());
+    expect(result.registryServer).toBe('io.github.example/weather-server');
+    expect(result.registryVersion).toBe('1.2.0');
+  });
+
+  it('prefers the server display_name, falling back to name, and appends version', () => {
+    expect(registryVersionToDeployData(mockServer(), mockVersion()).displayName).toBe(
+      'Weather Server - 1.2.0',
+    );
+    expect(
+      registryVersionToDeployData(mockServer({ display_name: undefined }), mockVersion())
+        .displayName,
+    ).toBe('io.github.example/weather-server - 1.2.0');
+  });
+
+  it("uses the deploy-spec meta's source.containerImage.ref as the image", () => {
+    const result = registryVersionToDeployData(mockServer(), mockVersion());
+    expect(result.image).toBe('quay.io/mcp/weather:1.2.0');
+  });
+
+  it('falls back to an empty image and yaml when the deploy-spec meta key is missing', () => {
+    const result = registryVersionToDeployData(
+      mockServer(),
+      mockVersion({
+        server_json: {
+          name: 'io.github.example/weather-server',
+          version: '1.2.0',
+        },
+      }),
+    );
+    expect(result.image).toBe('');
+    expect(result.yaml).toBe('');
+  });
+
+  it('falls back to an empty image when the deploy-spec source has no containerImage', () => {
+    const result = registryVersionToDeployData(
+      mockServer(),
+      mockVersion({
+        server_json: {
+          name: 'io.github.example/weather-server',
+          version: '1.2.0',
+          _meta: {
+            [RHAI_DEPLOY_SPEC_META_KEY]: mockDeploySpec({ source: {} }),
+          },
+        },
+      }),
+    );
+    expect(result.image).toBe('');
+  });
+
+  it("re-serializes the deploy-spec meta's config as the yaml", () => {
+    const result = registryVersionToDeployData(mockServer(), mockVersion());
+    expect(result.yaml).toBe('config:\n  port: 8080\n  path: /mcp\n');
+  });
+
+  it('includes runtime before config in the yaml when present', () => {
+    const result = registryVersionToDeployData(
+      mockServer(),
+      mockVersion({
+        server_json: {
+          name: 'io.github.example/weather-server',
+          version: '1.2.0',
+          _meta: {
+            [RHAI_DEPLOY_SPEC_META_KEY]: mockDeploySpec({
+              runtime: { security: { serviceAccountName: 'mcp-sa' } },
+            }),
+          },
+        },
+      }),
+    );
+    expect(result.yaml).toBe(
+      'runtime:\n  security:\n    serviceAccountName: mcp-sa\nconfig:\n  port: 8080\n  path: /mcp\n',
+    );
+  });
+
+  it('does not leak the deploy-spec source (image) into the yaml', () => {
+    const result = registryVersionToDeployData(mockServer(), mockVersion());
+    expect(result.yaml).not.toContain('containerImage');
+    expect(result.yaml).not.toContain('quay.io');
+  });
+
+  it('does not include port or path (come from deployment config, not registry metadata)', () => {
+    const version = mockVersion({
+      server_json: {
+        name: 'io.github.example/weather-server',
+        version: '1.2.0',
+        packages: [
+          {
+            registryType: 'oci',
+            identifier: 'quay.io/mcp/weather',
+            transport: {
+              type: MCPTransportType.STREAMABLE_HTTP,
+              url: 'http://localhost:9090/api/mcp',
+            },
+          },
+        ],
+      },
+    });
+
+    const result = registryVersionToDeployData(mockServer(), version);
+    expect(result).not.toHaveProperty('port');
+    expect(result).not.toHaveProperty('path');
+  });
+
+  it('defaults transportType to streamable-http when no packages are present', () => {
+    const result = registryVersionToDeployData(mockServer(), mockVersion());
+    expect(result.transportType).toBe(MCPTransportType.STREAMABLE_HTTP);
+  });
+
+  it('defaults transportType to streamable-http for a stdio-only package', () => {
+    const version = mockVersion({
+      server_json: {
+        name: 'io.github.example/weather-server',
+        version: '1.2.0',
+        packages: [
+          {
+            registryType: 'npm',
+            identifier: '@example/weather-server',
+            transport: { type: MCPTransportType.STDIO },
+          },
+        ],
+      },
+    });
+
+    expect(registryVersionToDeployData(mockServer(), version).transportType).toBe(
+      MCPTransportType.STREAMABLE_HTTP,
+    );
+  });
+
+  it('uses transportType sse when the picked package advertises it', () => {
+    const version = mockVersion({
+      server_json: {
+        name: 'io.github.example/weather-server',
+        version: '1.2.0',
+        packages: [
+          {
+            registryType: 'oci',
+            identifier: 'quay.io/mcp/weather',
+            transport: { type: MCPTransportType.SSE, url: 'http://localhost:9090/sse' },
+          },
+        ],
+      },
+    });
+
+    expect(registryVersionToDeployData(mockServer(), version).transportType).toBe(
+      MCPTransportType.SSE,
+    );
+  });
+
+  it('derives transportType from remotes for a remotes-only server (no packages)', () => {
+    // Per the MCP registry server.json spec, a remote server can declare its endpoint solely
+    // via `remotes`, with no `packages` entry at all.
+    const version = mockVersion({
+      server_json: {
+        name: 'io.github.example/weather-server',
+        version: '1.2.0',
+        remotes: [{ type: MCPTransportType.SSE, url: 'https://weather.example.com/sse' }],
+      },
+    });
+
+    expect(registryVersionToDeployData(mockServer(), version).transportType).toBe(
+      MCPTransportType.SSE,
+    );
+  });
+
+  it('prefers remotes over packages when both are present', () => {
+    // A hybrid server.json can declare packages using stdio (for local install) alongside a
+    // remotes entry for the actual network endpoint -- remotes should win.
+    const version = mockVersion({
+      server_json: {
+        name: 'io.github.example/weather-server',
+        version: '1.2.0',
+        packages: [
+          {
+            registryType: 'npm',
+            identifier: '@example/weather-server',
+            transport: { type: MCPTransportType.STDIO },
+          },
+        ],
+        remotes: [{ type: MCPTransportType.SSE, url: 'https://weather.example.com/sse' }],
+      },
+    });
+
+    expect(registryVersionToDeployData(mockServer(), version).transportType).toBe(
+      MCPTransportType.SSE,
+    );
+  });
+
+  it('prefers a streamable-http remote over an sse remote when both are advertised', () => {
+    const version = mockVersion({
+      server_json: {
+        name: 'io.github.example/weather-server',
+        version: '1.2.0',
+        remotes: [
+          { type: MCPTransportType.SSE, url: 'https://weather.example.com/sse' },
+          { type: MCPTransportType.STREAMABLE_HTTP, url: 'https://weather.example.com/mcp' },
+        ],
+      },
+    });
+
+    expect(registryVersionToDeployData(mockServer(), version).transportType).toBe(
+      MCPTransportType.STREAMABLE_HTTP,
+    );
+  });
+});

--- a/packages/mlflow-embedded/mcp-registry/__tests__/registryVersionToDeployData.spec.ts
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/registryVersionToDeployData.spec.ts
@@ -224,6 +224,26 @@ describe('registryVersionToDeployData', () => {
     );
   });
 
+  it('selects an sse remote over a leading stdio remote (does not blindly use remotes[0])', () => {
+    // `stdio` isn't a network-reachable transport and should never be selected from `remotes`,
+    // even when it appears first in the array -- a valid `sse`/`streamable-http` entry elsewhere
+    // in the list must win instead of falling back to remotes[0].
+    const version = mockVersion({
+      server_json: {
+        name: 'io.github.example/weather-server',
+        version: '1.2.0',
+        remotes: [
+          { type: MCPTransportType.STDIO },
+          { type: MCPTransportType.SSE, url: 'https://weather.example.com/sse' },
+        ],
+      },
+    });
+
+    expect(registryVersionToDeployData(mockServer(), version).transportType).toBe(
+      MCPTransportType.SSE,
+    );
+  });
+
   it('prefers a streamable-http remote over an sse remote when both are advertised', () => {
     const version = mockVersion({
       server_json: {

--- a/packages/mlflow-embedded/mcp-registry/__tests__/useHostRouteSync.spec.ts
+++ b/packages/mlflow-embedded/mcp-registry/__tests__/useHostRouteSync.spec.ts
@@ -1,0 +1,57 @@
+import '@testing-library/jest-dom';
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import useHostRouteSync from '../useHostRouteSync';
+
+const mockNavigate = jest.fn();
+let mockLocation = { pathname: '/ai-hub/mcp-servers/registry', search: '' };
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual<typeof import('react-router-dom')>('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation,
+}));
+
+describe('useHostRouteSync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocation = { pathname: '/ai-hub/mcp-servers/registry', search: '' };
+  });
+
+  it('does not navigate when window.location already matches the host location', () => {
+    window.history.pushState({}, '', '/ai-hub/mcp-servers/registry');
+
+    const { result } = renderHook(() => useHostRouteSync(), { wrapper: MemoryRouter });
+    result.current();
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates the host router when the remote pushed a new pathname', () => {
+    window.history.pushState({}, '', '/ai-hub/mcp-servers/registry/my-server?workspace=team1');
+
+    const { result } = renderHook(() => useHostRouteSync(), { wrapper: MemoryRouter });
+    result.current();
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/ai-hub/mcp-servers/registry/my-server?workspace=team1',
+      { replace: true },
+    );
+  });
+
+  it('navigates when only the search string changed', () => {
+    mockLocation = {
+      pathname: '/ai-hub/mcp-servers/registry/my-server',
+      search: '?workspace=team1',
+    };
+    window.history.pushState({}, '', '/ai-hub/mcp-servers/registry/my-server?workspace=team2');
+
+    const { result } = renderHook(() => useHostRouteSync(), { wrapper: MemoryRouter });
+    result.current();
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/ai-hub/mcp-servers/registry/my-server?workspace=team2',
+      { replace: true },
+    );
+  });
+});

--- a/packages/mlflow-embedded/mcp-registry/api.ts
+++ b/packages/mlflow-embedded/mcp-registry/api.ts
@@ -1,0 +1,56 @@
+import { APIOptions, handleRestFailures, isModArchResponse, restCREATE } from 'mod-arch-core';
+import { MLFLOW_BFF_PATH } from './const';
+import { CreateMcpAccessEndpointRequest, McpAccessEndpoint } from './deployTypes';
+import { MCPTransportType } from './types';
+
+const INVALID_PATH_SEGMENTS = new Set(['', '.', '..']);
+
+const VALID_TRANSPORT_TYPES = new Set<string>(Object.values(MCPTransportType));
+
+// isModArchResponse<T>'s generic is a compile-time cast, not a runtime check of T's shape --
+// it only verifies the response has a `data` property. Without this, a malformed payload
+// (e.g. `{ data: null }`) would be reported as a successfully registered endpoint by callers.
+const isMcpAccessEndpoint = (value: unknown): value is McpAccessEndpoint => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const record = Object.fromEntries(Object.entries(value));
+  return (
+    typeof record.id === 'string' &&
+    typeof record.server_name === 'string' &&
+    typeof record.endpoint_url === 'string' &&
+    typeof record.transport_type === 'string' &&
+    VALID_TRANSPORT_TYPES.has(record.transport_type)
+  );
+};
+
+// Escape "/" per segment; literal "/" in middle survives encoding. Reject
+// empty/"."/".." segments so a crafted name (e.g. "../servers/other") can't
+// traverse to a different server's BFF route (CWE-22).
+const mcpServerNamePathSegment = (name: string): string => {
+  const segments = name.split('/');
+  if (segments.some((segment) => INVALID_PATH_SEGMENTS.has(segment))) {
+    throw new Error(`Invalid MCP registry server name: ${name}`);
+  }
+  return segments.map(encodeURIComponent).join('/');
+};
+
+export const createMcpAccessEndpoint =
+  (registryServerName: string, workspace: string) =>
+  (opts: APIOptions, data: CreateMcpAccessEndpointRequest): Promise<McpAccessEndpoint> =>
+    handleRestFailures(
+      restCREATE(
+        '',
+        `${MLFLOW_BFF_PATH}/mcp-registry/servers/${mcpServerNamePathSegment(
+          registryServerName,
+        )}/endpoints`,
+        data,
+        { workspace },
+        opts,
+      ),
+    ).then((response) => {
+      if (isModArchResponse<McpAccessEndpoint>(response) && isMcpAccessEndpoint(response.data)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });

--- a/packages/mlflow-embedded/mcp-registry/buildMcpAccessEndpointUrl.ts
+++ b/packages/mlflow-embedded/mcp-registry/buildMcpAccessEndpointUrl.ts
@@ -1,0 +1,19 @@
+// Deterministic cluster-internal URL matching mcp-lifecycle-operator's status.address.url.
+// `path` comes from the deployment's applied spec.config.path, which is user-authored YAML;
+// require it to stay on the service's own origin so it can't smuggle a different
+// host/userinfo (e.g. "@169.254.169.254/") into the resulting URL (CWE-918 SSRF).
+export const buildMcpAccessEndpointUrl = (
+  name: string,
+  namespace: string,
+  port: number,
+  path: string,
+): string => {
+  const serviceUrl = new URL(`http://${name}.${namespace}.svc.cluster.local:${port}`);
+  const endpointUrl = new URL(path, serviceUrl);
+
+  if (!path.startsWith('/') || endpointUrl.origin !== serviceUrl.origin) {
+    throw new Error('MCP endpoint path must remain on the deployed service');
+  }
+
+  return endpointUrl.toString();
+};

--- a/packages/mlflow-embedded/mcp-registry/const.ts
+++ b/packages/mlflow-embedded/mcp-registry/const.ts
@@ -13,4 +13,12 @@ export const mcpRegistryBaseRoute = (namespace?: string): string => {
   return `${MCP_REGISTRY_BASENAME}?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(namespace)}`;
 };
 
+export const mcpServerDetailRoute = (serverName: string, namespace?: string): string => {
+  const basePath = `${MCP_REGISTRY_BASENAME}/${encodeURIComponent(serverName)}`;
+  if (!namespace) {
+    return basePath;
+  }
+  return `${basePath}?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(namespace)}`;
+};
+
 export { MLFLOW_BFF_PATH, DEFAULT_MCP_PATH };

--- a/packages/mlflow-embedded/mcp-registry/const.ts
+++ b/packages/mlflow-embedded/mcp-registry/const.ts
@@ -1,5 +1,16 @@
+import { WORKSPACE_QUERY_PARAM } from '@odh-dashboard/internal/routes/pipelines/mlflow';
+
 const BFF_API_VERSION = 'v1';
 const MLFLOW_BFF_PATH = `/_bff/mlflow/api/${BFF_API_VERSION}`;
 const DEFAULT_MCP_PATH = '/mcp'; // Fallback for optional spec.config.path
+
+export const MCP_REGISTRY_BASENAME = '/ai-hub/mcp-servers/registry';
+
+export const mcpRegistryBaseRoute = (namespace?: string): string => {
+  if (!namespace) {
+    return MCP_REGISTRY_BASENAME;
+  }
+  return `${MCP_REGISTRY_BASENAME}?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(namespace)}`;
+};
 
 export { MLFLOW_BFF_PATH, DEFAULT_MCP_PATH };

--- a/packages/mlflow-embedded/mcp-registry/const.ts
+++ b/packages/mlflow-embedded/mcp-registry/const.ts
@@ -1,0 +1,5 @@
+const BFF_API_VERSION = 'v1';
+const MLFLOW_BFF_PATH = `/_bff/mlflow/api/${BFF_API_VERSION}`;
+const DEFAULT_MCP_PATH = '/mcp'; // Fallback for optional spec.config.path
+
+export { MLFLOW_BFF_PATH, DEFAULT_MCP_PATH };

--- a/packages/mlflow-embedded/mcp-registry/deployTypes.ts
+++ b/packages/mlflow-embedded/mcp-registry/deployTypes.ts
@@ -1,0 +1,27 @@
+// Field names mirror the mlflow BFF's MCP Registry API (snake_case).
+/* eslint-disable camelcase */
+import { MCPTransportType } from './types';
+
+export type McpRegistryDeployData = {
+  registryServer: string;
+  registryVersion: string;
+  displayName: string;
+  namespace: string; // Fixed to the MCP Registry's project
+  image: string; // From _meta['com.redhat/deploy-spec'].source.containerImage.ref; may be empty
+  yaml: string; // From _meta['com.redhat/deploy-spec'].config/runtime, re-serialized; may be empty
+  transportType: MCPTransportType; // streamable-http or sse
+};
+
+export type CreateMcpAccessEndpointRequest = {
+  endpoint_url: string;
+  transport_type?: MCPTransportType;
+  server_version?: string;
+  server_alias?: string; // Never sent; mutually exclusive with server_version
+};
+
+export type McpAccessEndpoint = {
+  id: string;
+  server_name: string;
+  endpoint_url: string;
+  transport_type: MCPTransportType;
+};

--- a/packages/mlflow-embedded/mcp-registry/extension-points.ts
+++ b/packages/mlflow-embedded/mcp-registry/extension-points.ts
@@ -1,0 +1,27 @@
+import type { Extension, CodeRef } from '@openshift/dynamic-plugin-sdk';
+// eslint-disable-next-line no-restricted-syntax
+import { createExtensionGuard } from '@odh-dashboard/plugin-core/extension-points';
+import type {
+  McpDeployModalData,
+  McpDeployment,
+} from '@odh-dashboard/model-registry/types/mcpDeploymentTypes';
+
+// Local mirror of model-registry's mcp-catalog.server/deploy-modal.
+// Can't import across Module Federation boundary, so keep type string in sync.
+export type McpCatalogDeployModalExtension = Extension<
+  'mcp-catalog.server/deploy-modal',
+  {
+    modalComponent: CodeRef<
+      React.ComponentType<{
+        data?: McpDeployModalData;
+        isLoading?: boolean;
+        loadError?: Error;
+        onClose: (saved?: boolean) => void;
+        onDeployed?: (deployment: McpDeployment) => void | Promise<void>;
+      }>
+    >;
+  }
+>;
+
+export const isMcpCatalogDeployModalExtension =
+  createExtensionGuard<McpCatalogDeployModalExtension>('mcp-catalog.server/deploy-modal');

--- a/packages/mlflow-embedded/mcp-registry/registryVersionToDeployData.ts
+++ b/packages/mlflow-embedded/mcp-registry/registryVersionToDeployData.ts
@@ -20,7 +20,8 @@ const pickRemoteCapablePackage = (
   ) ?? packages?.[0];
 
 const pickRemoteEntry = (remotes?: MCPServerJSONRemote[]): MCPServerJSONRemote | undefined =>
-  remotes?.find((remote) => remote.type === MCPTransportType.STREAMABLE_HTTP) ?? remotes?.[0];
+  remotes?.find((remote) => remote.type === MCPTransportType.STREAMABLE_HTTP) ??
+  remotes?.find((remote) => remote.type === MCPTransportType.SSE);
 
 // `remotes` is the field that actually declares a network-reachable transport (see
 // MCPServerJSONRemote); `packages` frequently use `stdio` for locally-launched processes.

--- a/packages/mlflow-embedded/mcp-registry/registryVersionToDeployData.ts
+++ b/packages/mlflow-embedded/mcp-registry/registryVersionToDeployData.ts
@@ -1,0 +1,69 @@
+import yaml from 'js-yaml';
+import {
+  MCPServer,
+  MCPServerDeploySpec,
+  MCPServerJSONPackage,
+  MCPServerJSONRemote,
+  MCPServerVersion,
+  MCPTransportType,
+  RHAI_DEPLOY_SPEC_META_KEY,
+} from './types';
+import { McpRegistryDeployData } from './deployTypes';
+
+const pickRemoteCapablePackage = (
+  packages?: MCPServerJSONPackage[],
+): MCPServerJSONPackage | undefined =>
+  packages?.find(
+    (pkg) =>
+      pkg.transport.type === MCPTransportType.STREAMABLE_HTTP ||
+      pkg.transport.type === MCPTransportType.SSE,
+  ) ?? packages?.[0];
+
+const pickRemoteEntry = (remotes?: MCPServerJSONRemote[]): MCPServerJSONRemote | undefined =>
+  remotes?.find((remote) => remote.type === MCPTransportType.STREAMABLE_HTTP) ?? remotes?.[0];
+
+// `remotes` is the field that actually declares a network-reachable transport (see
+// MCPServerJSONRemote); `packages` frequently use `stdio` for locally-launched processes.
+// Prefer `remotes` when present, and only fall back to inspecting `packages` for registry
+// entries published without a `remotes` array.
+const resolveEndpointTransportType = (
+  remote?: MCPServerJSONRemote,
+  pkg?: MCPServerJSONPackage,
+): MCPTransportType => {
+  const transportType = remote?.type ?? pkg?.transport.type;
+  return transportType === MCPTransportType.SSE
+    ? MCPTransportType.SSE
+    : MCPTransportType.STREAMABLE_HTTP;
+};
+
+// Mirrors model-registry's `mcpServerCRToYaml`.
+const deploySpecToYaml = (deploySpec?: MCPServerDeploySpec): string => {
+  if (!deploySpec) {
+    return '';
+  }
+  const editableSpec: Record<string, unknown> = {};
+  if (deploySpec.runtime) {
+    editableSpec.runtime = deploySpec.runtime;
+  }
+  editableSpec.config = deploySpec.config;
+
+  return yaml.dump(editableSpec, { lineWidth: -1, noRefs: true });
+};
+
+export const registryVersionToDeployData = (
+  server: MCPServer,
+  version: MCPServerVersion,
+): Omit<McpRegistryDeployData, 'namespace'> => {
+  const remote = pickRemoteEntry(version.server_json.remotes);
+  const pkg = pickRemoteCapablePackage(version.server_json.packages);
+  const deploySpec = version.server_json._meta?.[RHAI_DEPLOY_SPEC_META_KEY];
+
+  return {
+    registryServer: server.name,
+    registryVersion: version.version,
+    displayName: `${server.display_name ?? server.name} - ${version.version}`,
+    image: deploySpec?.source.containerImage?.ref ?? '',
+    yaml: deploySpecToYaml(deploySpec),
+    transportType: resolveEndpointTransportType(remote, pkg),
+  };
+};

--- a/packages/mlflow-embedded/mcp-registry/types.ts
+++ b/packages/mlflow-embedded/mcp-registry/types.ts
@@ -15,10 +15,13 @@ export interface MCPServer {
   latest_version?: string;
 }
 
+export type MCPServerVersionStatus = 'draft' | 'active' | 'deprecated' | 'deleted';
+
 export interface MCPServerVersion {
   name: string;
   version: string;
   server_json: MCPServerJSONPayload;
+  status?: MCPServerVersionStatus;
 }
 
 export interface MCPServerJSONTransport {

--- a/packages/mlflow-embedded/mcp-registry/types.ts
+++ b/packages/mlflow-embedded/mcp-registry/types.ts
@@ -1,0 +1,74 @@
+// Field names mirror the external MCP Registry API (snake_case).
+/* eslint-disable camelcase */
+/** Local mirrors of MCP Registry types. Can't import across Module Federation boundary. */
+
+export enum MCPTransportType {
+  STDIO = 'stdio',
+  STREAMABLE_HTTP = 'streamable-http',
+  SSE = 'sse',
+}
+
+export interface MCPServer {
+  name: string;
+  display_name?: string;
+  description?: string;
+  latest_version?: string;
+}
+
+export interface MCPServerVersion {
+  name: string;
+  version: string;
+  server_json: MCPServerJSONPayload;
+}
+
+export interface MCPServerJSONTransport {
+  type: MCPTransportType;
+  url?: string;
+}
+
+export interface MCPServerJSONPackage {
+  registryType: string;
+  identifier: string;
+  transport: MCPServerJSONTransport;
+  version?: string;
+}
+
+/**
+ * A remote (network-reachable) endpoint the registry advertises for this server version.
+ * Per the MCP registry server.json spec, `remotes` is the field that actually declares a
+ * server is remotely reachable; `packages` commonly use `stdio` for locally-launched
+ * processes and can coexist with a separate `remotes` array for the same version.
+ */
+export interface MCPServerJSONRemote {
+  type: MCPTransportType;
+  url?: string;
+}
+
+/** Matches `RHAI_DEPLOY_SPEC_META_KEY` in the model-registry package's `catalogToRegistry.ts`. */
+export const RHAI_DEPLOY_SPEC_META_KEY = 'com.redhat/deploy-spec';
+
+/** Local mirror of `MCPServerCR['spec']` (model-registry's `mcpDeploymentTypes.ts`). */
+export interface MCPServerDeploySpec {
+  source: {
+    containerImage?: {
+      ref: string;
+    };
+  };
+  config: Record<string, unknown>;
+  runtime?: Record<string, unknown>;
+}
+
+/** Metadata set by the MCP catalog's publish flow; the deploy-spec key may be missing. */
+export interface MCPServerJSONMeta {
+  [RHAI_DEPLOY_SPEC_META_KEY]?: MCPServerDeploySpec;
+}
+
+export interface MCPServerJSONPayload {
+  name: string;
+  version: string;
+  title?: string;
+  description?: string;
+  packages?: MCPServerJSONPackage[];
+  remotes?: MCPServerJSONRemote[];
+  _meta?: MCPServerJSONMeta;
+}

--- a/packages/mlflow-embedded/mcp-registry/useHostRouteSync.ts
+++ b/packages/mlflow-embedded/mcp-registry/useHostRouteSync.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+/**
+ * Keeps the host's react-router in sync with URL changes made by the
+ * federated MLflow remote's own (separate, v6) BrowserRouter instance.
+ *
+ * The remote navigates via its own history object, which updates
+ * `window.location` via `pushState`/`replaceState` but fires no event the
+ * host's router listens for -- the two router instances don't know about
+ * each other. Without this, the host never re-evaluates which top-level
+ * route/component should be mounted (e.g. switching between the tabbed
+ * list view and the full-screen server detail breakout) even though the
+ * visible URL has already changed.
+ *
+ * Pass the returned function as the wrapper's `onBreadcrumbChange` prop --
+ * the remote already calls it on every internal navigation, so it doubles
+ * as a reliable "the URL may have changed under you" signal.
+ */
+const useHostRouteSync = (): (() => void) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return useCallback(() => {
+    const target = `${window.location.pathname}${window.location.search}`;
+    const current = `${location.pathname}${location.search}`;
+    if (target !== current) {
+      navigate(target, { replace: true });
+    }
+  }, [location.pathname, location.search, navigate]);
+};
+
+export default useHostRouteSync;

--- a/packages/mlflow-embedded/package.json
+++ b/packages/mlflow-embedded/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "type-check": "tsc --noEmit",
     "test-unit": "jest --silent --passWithNoTests",
-    "test-unit-coverage": "jest --silent --coverage --passWithNoTests"
+    "test-unit-coverage": "jest --silent --coverage --passWithNoTests",
+    "type-check": "tsc --noEmit"
   },
   "module-federation": {
     "name": "mlflowEmbedded",

--- a/packages/mlflow-embedded/package.json
+++ b/packages/mlflow-embedded/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test-unit": "jest --silent --passWithNoTests",
+    "test-unit-coverage": "jest --silent --coverage --passWithNoTests"
   },
   "module-federation": {
     "name": "mlflowEmbedded",
@@ -46,15 +48,21 @@
   "dependencies": {
     "@odh-dashboard/internal": "*",
     "@odh-dashboard/k8s-core": "*",
+    "@odh-dashboard/model-registry": "*",
     "@odh-dashboard/plugin-core": "*",
-    "@odh-dashboard/ui-core": "*"
+    "@odh-dashboard/ui-core": "*",
+    "js-yaml": "^4.1.1",
+    "mod-arch-core": "^1.15.4"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",
-    "@odh-dashboard/tsconfig": "*"
+    "@odh-dashboard/jest-config": "*",
+    "@odh-dashboard/tsconfig": "*",
+    "@types/js-yaml": "^4.0.9"
   },
   "peerDependencies": {
     "@module-federation/runtime": ">=0.15.0",
+    "@openshift/dynamic-plugin-sdk": "^5",
     "@patternfly/react-core": "^6",
     "@patternfly/react-icons": "^6",
     "react": "^18",

--- a/packages/model-registry/src/projectSelector/ProjectSelectorField.tsx
+++ b/packages/model-registry/src/projectSelector/ProjectSelectorField.tsx
@@ -51,6 +51,8 @@ const ProjectSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
   cannotCheck,
   registryName,
   selectorOnly,
+  isDisabled,
+  isFullWidth,
 }) => {
   const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
   const noProjects = projectsLoaded && projects.length === 0;
@@ -144,8 +146,9 @@ const ProjectSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
       namespace={selectedNamespace}
       onSelection={onSelect}
       placeholder="Select a project"
-      isFullWidth={!selectorOnly}
+      isFullWidth={isFullWidth ?? !selectorOnly}
       isLoading={!projectsLoaded}
+      isDisabled={isDisabled}
     />
   );
 

--- a/packages/model-registry/src/projectSelector/__tests__/ProjectSelectorField.spec.tsx
+++ b/packages/model-registry/src/projectSelector/__tests__/ProjectSelectorField.spec.tsx
@@ -181,4 +181,14 @@ describe('ProjectSelectorField', () => {
     renderComponent({ selectorOnly: true });
     expect(screen.getByTestId('project-selector')).toHaveAttribute('data-full-width', 'false');
   });
+
+  it('should preserve an explicit false isFullWidth value', () => {
+    renderComponent({ isFullWidth: false, selectorOnly: false });
+    expect(screen.getByTestId('project-selector')).toHaveAttribute('data-full-width', 'false');
+  });
+
+  it('should default isFullWidth to true when selectorOnly is false', () => {
+    renderComponent({ selectorOnly: false });
+    expect(screen.getByTestId('project-selector')).toHaveAttribute('data-full-width', 'true');
+  });
 });

--- a/packages/model-registry/src/projectSelector/__tests__/ProjectSelectorField.spec.tsx
+++ b/packages/model-registry/src/projectSelector/__tests__/ProjectSelectorField.spec.tsx
@@ -5,19 +5,26 @@ import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext'
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import ProjectSelectorField from '../ProjectSelectorField';
 
-jest.mock('@odh-dashboard/internal/concepts/projects/ProjectSelector', () => {
+jest.mock('@odh-dashboard/ui-core/components/projectSelector/ProjectSelector', () => {
   function MockProjectSelector(props: {
     namespace: string;
     onSelection: (projectName: string) => void;
     isLoading?: boolean;
+    isDisabled?: boolean;
+    isFullWidth?: boolean;
   }) {
     return (
-      <div data-testid="project-selector">
+      <div
+        data-testid="project-selector"
+        data-disabled={props.isDisabled ?? false}
+        data-full-width={props.isFullWidth ?? false}
+      >
         <span data-testid="selected-namespace">{props.namespace}</span>
         {props.isLoading && <span data-testid="selector-loading">Loading</span>}
         <button
           type="button"
           data-testid="select-project-btn"
+          disabled={props.isDisabled}
           onClick={() => props.onSelection('new-project')}
         >
           select
@@ -151,5 +158,27 @@ describe('ProjectSelectorField', () => {
     renderComponent({ onSelect });
     screen.getByTestId('select-project-btn').click();
     expect(onSelect).toHaveBeenCalledWith('new-project');
+  });
+
+  it('should disable the project selector when isDisabled is true', () => {
+    renderComponent({ isDisabled: true });
+    expect(screen.getByTestId('project-selector')).toHaveAttribute('data-disabled', 'true');
+    expect(screen.getByTestId('select-project-btn')).toBeDisabled();
+  });
+
+  it('should not disable the project selector by default', () => {
+    renderComponent();
+    expect(screen.getByTestId('project-selector')).toHaveAttribute('data-disabled', 'false');
+    expect(screen.getByTestId('select-project-btn')).toBeEnabled();
+  });
+
+  it('should forward an explicit isFullWidth to the underlying selector', () => {
+    renderComponent({ isFullWidth: true, selectorOnly: false });
+    expect(screen.getByTestId('project-selector')).toHaveAttribute('data-full-width', 'true');
+  });
+
+  it('should default isFullWidth to the inverse of selectorOnly when not explicitly set', () => {
+    renderComponent({ selectorOnly: true });
+    expect(screen.getByTestId('project-selector')).toHaveAttribute('data-full-width', 'false');
   });
 });

--- a/packages/model-registry/upstream/bff/internal/api/errors.go
+++ b/packages/model-registry/upstream/bff/internal/api/errors.go
@@ -44,7 +44,6 @@ func (app *App) badRequestResponse(w http.ResponseWriter, r *http.Request, err e
 }
 
 func (app *App) forbiddenResponse(w http.ResponseWriter, r *http.Request, message string) {
-	// Log the detailed error message as a warning
 	app.logger.Warn("Access forbidden", "message", message, "method", r.Method, "uri", r.URL.RequestURI())
 
 	httpError := &httpclient.HTTPError{
@@ -119,11 +118,16 @@ func (app *App) notFoundResponse(w http.ResponseWriter, r *http.Request) {
 func (app *App) conflictResponse(w http.ResponseWriter, r *http.Request, message string) {
 	app.logger.Warn("Conflict detected", "message", message, "method", r.Method, "uri", r.URL.RequestURI())
 
+	displayMessage := message
+	if displayMessage == "" {
+		displayMessage = "the resource was modified by another request, please retry"
+	}
+
 	httpError := &httpclient.HTTPError{
 		StatusCode: http.StatusConflict,
 		ErrorResponse: httpclient.ErrorResponse{
 			Code:    strconv.Itoa(http.StatusConflict),
-			Message: "the resource was modified by another request, please retry",
+			Message: displayMessage,
 		},
 	}
 	app.errorResponse(w, r, httpError)

--- a/packages/model-registry/upstream/bff/internal/models/mcp_deployment.go
+++ b/packages/model-registry/upstream/bff/internal/models/mcp_deployment.go
@@ -15,16 +15,23 @@ type McpDeploymentAddress struct {
 // McpDeployment represents a deployed MCPServer instance, flattened from the
 // mcp.x-k8s.io/v1alpha1 MCPServer CRD for API consumption.
 type McpDeployment struct {
-	Name              string                   `json:"name"`
-	DisplayName       string                   `json:"displayName,omitempty"`
-	ServerName        string                   `json:"serverName,omitempty"`
-	Namespace         string                   `json:"namespace"`
-	UID               string                   `json:"uid"`
-	CreationTimestamp string                   `json:"creationTimestamp"`
-	Image             string                   `json:"image"`
-	YAML              string                   `json:"yaml,omitempty"`
-	Conditions        []McpDeploymentCondition `json:"conditions"`
-	Address           *McpDeploymentAddress    `json:"address,omitempty"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName,omitempty"`
+	ServerName  string `json:"serverName,omitempty"`
+	// RegistryServer and RegistryVersion trace deployments from MCP Registry; ServerName traces catalog.
+	RegistryServer    string `json:"registryServer,omitempty"`
+	RegistryVersion   string `json:"registryVersion,omitempty"`
+	Namespace         string `json:"namespace"`
+	UID               string `json:"uid"`
+	CreationTimestamp string `json:"creationTimestamp"`
+	Image             string `json:"image"`
+	// Port and Path are from spec.config; consumers can build an access endpoint
+	// URL without guessing the deployed container's listen address.
+	Port       int32                    `json:"port"`
+	Path       string                   `json:"path,omitempty"`
+	YAML       string                   `json:"yaml,omitempty"`
+	Conditions []McpDeploymentCondition `json:"conditions"`
+	Address    *McpDeploymentAddress    `json:"address,omitempty"`
 }
 
 type McpDeploymentList struct {
@@ -33,18 +40,22 @@ type McpDeploymentList struct {
 }
 
 type McpDeploymentCreateRequest struct {
-	Name        string `json:"name,omitempty"`
-	DisplayName string `json:"displayName,omitempty"`
-	ServerName  string `json:"serverName,omitempty"`
-	Image       string `json:"image"`
-	YAML        string `json:"yaml,omitempty"`
+	Name            string `json:"name,omitempty"`
+	DisplayName     string `json:"displayName,omitempty"`
+	ServerName      string `json:"serverName,omitempty"`
+	RegistryServer  string `json:"registryServer,omitempty"`
+	RegistryVersion string `json:"registryVersion,omitempty"`
+	Image           string `json:"image"`
+	YAML            string `json:"yaml,omitempty"`
 }
 
 type McpDeploymentUpdateRequest struct {
-	DisplayName *string `json:"displayName,omitempty"`
-	ServerName  *string `json:"serverName,omitempty"`
-	Image       *string `json:"image,omitempty"`
-	YAML        *string `json:"yaml,omitempty"`
+	DisplayName     *string `json:"displayName,omitempty"`
+	ServerName      *string `json:"serverName,omitempty"`
+	RegistryServer  *string `json:"registryServer,omitempty"`
+	RegistryVersion *string `json:"registryVersion,omitempty"`
+	Image           *string `json:"image,omitempty"`
+	YAML            *string `json:"yaml,omitempty"`
 }
 
 // McpSpecBody holds the config and runtime sections parsed from YAML.

--- a/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository.go
+++ b/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository.go
@@ -345,6 +345,14 @@ func convertUnstructuredToMcpDeployment(obj unstructured.Unstructured) (models.M
 		Path:              server.Spec.Config.Path,
 	}
 
+	// A pre-existing CR created without spec.config.port (e.g. via kubectl, or an earlier
+	// version of this tool) would otherwise report Port: 0 here, which buildMcpAccessEndpointUrl
+	// expands to an unroutable ":0" address. Mirrors the same default applied on the create/patch
+	// paths (buildMcpServerFromCreateRequest, buildMcpDeploymentPatch).
+	if deployment.Port == 0 {
+		deployment.Port = defaultMcpPort
+	}
+
 	if server.Metadata.Annotations != nil {
 		deployment.DisplayName = server.Metadata.Annotations[mcpDisplayNameAnnotation]
 		deployment.ServerName = server.Metadata.Annotations[mcpCatalogServerAnnotation]

--- a/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository.go
+++ b/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository.go
@@ -37,11 +37,13 @@ var mcpServerGVR = schema.GroupVersionResource{
 }
 
 const (
-	mcpServerAPIVersion        = "mcp.x-k8s.io/v1alpha1"
-	mcpServerKind              = "MCPServer"
-	mcpDisplayNameAnnotation   = "mcp.opendatahub.io/display-name"
-	mcpCatalogServerAnnotation = "mcp.opendatahub.io/catalog-server"
-	defaultMcpPort             = int32(8080)
+	mcpServerAPIVersion          = "mcp.x-k8s.io/v1alpha1"
+	mcpServerKind                = "MCPServer"
+	mcpDisplayNameAnnotation     = "mcp.opendatahub.io/display-name"
+	mcpCatalogServerAnnotation   = "mcp.opendatahub.io/catalog-server"
+	mcpRegistryServerAnnotation  = "mcp.opendatahub.io/registry-server"
+	mcpRegistryVersionAnnotation = "mcp.opendatahub.io/registry-version"
+	defaultMcpPort               = int32(8080)
 )
 
 type McpDeploymentRepository struct {
@@ -261,7 +263,9 @@ func buildMcpServerFromCreateRequest(namespace string, req models.McpDeploymentC
 		APIVersion: mcpServerAPIVersion,
 		Kind:       mcpServerKind,
 		Metadata: models.MCPMetadata{
-			Name:      name,
+			Name: name,
+			// Always the URL path parameter, never read from req/YAML, so the caller can't
+			// target a different namespace than the one it was authorized against.
 			Namespace: namespace,
 		},
 		Spec: models.MCPServerSpec{
@@ -274,7 +278,7 @@ func buildMcpServerFromCreateRequest(namespace string, req models.McpDeploymentC
 		},
 	}
 
-	if req.DisplayName != "" || req.ServerName != "" {
+	if req.DisplayName != "" || req.ServerName != "" || req.RegistryServer != "" || req.RegistryVersion != "" {
 		server.Metadata.Annotations = map[string]string{}
 		if req.DisplayName != "" {
 			server.Metadata.Annotations[mcpDisplayNameAnnotation] = req.DisplayName
@@ -282,12 +286,18 @@ func buildMcpServerFromCreateRequest(namespace string, req models.McpDeploymentC
 		if req.ServerName != "" {
 			server.Metadata.Annotations[mcpCatalogServerAnnotation] = req.ServerName
 		}
+		if req.RegistryServer != "" {
+			server.Metadata.Annotations[mcpRegistryServerAnnotation] = req.RegistryServer
+		}
+		if req.RegistryVersion != "" {
+			server.Metadata.Annotations[mcpRegistryVersionAnnotation] = req.RegistryVersion
+		}
 	}
 
 	if req.YAML != "" {
 		spec, err := parseSpecYAML(req.YAML)
 		if err != nil {
-			return models.MCPServer{}, fmt.Errorf("invalid configuration YAML: %w", err)
+			return models.MCPServer{}, fmt.Errorf("%w: invalid configuration YAML: %v", ErrMcpDeploymentValidation, err)
 		}
 		if spec.Config != nil {
 			server.Spec.Config = *spec.Config
@@ -331,11 +341,15 @@ func convertUnstructuredToMcpDeployment(obj unstructured.Unstructured) (models.M
 		Namespace:         server.Metadata.Namespace,
 		UID:               string(obj.GetUID()),
 		CreationTimestamp: obj.GetCreationTimestamp().UTC().Format("2006-01-02T15:04:05Z"),
+		Port:              server.Spec.Config.Port,
+		Path:              server.Spec.Config.Path,
 	}
 
 	if server.Metadata.Annotations != nil {
 		deployment.DisplayName = server.Metadata.Annotations[mcpDisplayNameAnnotation]
 		deployment.ServerName = server.Metadata.Annotations[mcpCatalogServerAnnotation]
+		deployment.RegistryServer = server.Metadata.Annotations[mcpRegistryServerAnnotation]
+		deployment.RegistryVersion = server.Metadata.Annotations[mcpRegistryVersionAnnotation]
 	}
 
 	if server.Spec.Source.ContainerImage != nil {
@@ -357,13 +371,19 @@ func convertUnstructuredToMcpDeployment(obj unstructured.Unstructured) (models.M
 func buildMcpDeploymentPatch(req models.McpDeploymentUpdateRequest) (map[string]interface{}, error) {
 	patch := map[string]interface{}{}
 
-	if req.DisplayName != nil || req.ServerName != nil {
+	if req.DisplayName != nil || req.ServerName != nil || req.RegistryServer != nil || req.RegistryVersion != nil {
 		annotations := map[string]interface{}{}
 		if req.DisplayName != nil {
 			annotations[mcpDisplayNameAnnotation] = *req.DisplayName
 		}
 		if req.ServerName != nil {
 			annotations[mcpCatalogServerAnnotation] = *req.ServerName
+		}
+		if req.RegistryServer != nil {
+			annotations[mcpRegistryServerAnnotation] = *req.RegistryServer
+		}
+		if req.RegistryVersion != nil {
+			annotations[mcpRegistryVersionAnnotation] = *req.RegistryVersion
 		}
 		patch["metadata"] = map[string]interface{}{
 			"annotations": annotations,
@@ -395,10 +415,17 @@ func buildMcpDeploymentPatch(req models.McpDeploymentUpdateRequest) (map[string]
 		} else {
 			spec, err := parseSpecYAML(*req.YAML)
 			if err != nil {
-				return nil, fmt.Errorf("invalid configuration YAML: %w", err)
+				return nil, fmt.Errorf("%w: invalid configuration YAML: %v", ErrMcpDeploymentValidation, err)
 			}
 
 			if spec.Config != nil {
+				// A partial config YAML that omits port would otherwise serialize as
+				// "port": 0 (Port has no `omitempty`) and, via JSON merge patch semantics,
+				// overwrite the CR's real listening port with 0. Default it the same way
+				// buildMcpServerFromCreateRequest does, instead of silently zeroing it out.
+				if spec.Config.Port == 0 {
+					spec.Config.Port = defaultMcpPort
+				}
 				configMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(spec.Config)
 				if err != nil {
 					return nil, fmt.Errorf("failed to convert config to patch: %w", err)

--- a/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository_test.go
+++ b/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository_test.go
@@ -128,6 +128,32 @@ func TestBuildMcpServerFromCreateRequest_WithDisplayNameAndServerName(t *testing
 	}
 }
 
+func TestBuildMcpServerFromCreateRequest_WithRegistryServerAndVersion(t *testing.T) {
+	req := models.McpDeploymentCreateRequest{
+		Name:            "registry-mcp",
+		RegistryServer:  "io.github.example/weather-server",
+		RegistryVersion: "1.2.0",
+		Image:           "quay.io/mcp/weather:1.2.0",
+	}
+
+	server, err := buildMcpServerFromCreateRequest("default", req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if server.Metadata.Annotations == nil {
+		t.Fatal("expected annotations to be set")
+	}
+	if server.Metadata.Annotations[mcpRegistryServerAnnotation] != "io.github.example/weather-server" {
+		t.Fatalf("expected registry server annotation %q, got %q",
+			"io.github.example/weather-server", server.Metadata.Annotations[mcpRegistryServerAnnotation])
+	}
+	if server.Metadata.Annotations[mcpRegistryVersionAnnotation] != "1.2.0" {
+		t.Fatalf("expected registry version annotation %q, got %q",
+			"1.2.0", server.Metadata.Annotations[mcpRegistryVersionAnnotation])
+	}
+}
+
 func TestBuildMcpServerFromCreateRequest_DefaultPort(t *testing.T) {
 	req := models.McpDeploymentCreateRequest{
 		Image: "quay.io/mcp/test:1.0",
@@ -209,6 +235,9 @@ func TestBuildMcpServerFromCreateRequest_InvalidYAML(t *testing.T) {
 	_, err := buildMcpServerFromCreateRequest("default", req)
 	if err == nil {
 		t.Fatal("expected error for invalid YAML")
+	}
+	if !errors.Is(err, ErrMcpDeploymentValidation) {
+		t.Fatalf("expected ErrMcpDeploymentValidation so the handler returns 400, got %v", err)
 	}
 }
 
@@ -371,6 +400,122 @@ func TestConvertUnstructuredToMcpDeployment_WithServerAnnotation(t *testing.T) {
 	}
 	if deployment.ServerName != "kubernetes-mcp-server" {
 		t.Fatalf("expected serverName 'kubernetes-mcp-server', got %q", deployment.ServerName)
+	}
+}
+
+func TestConvertUnstructuredToMcpDeployment_PortAndPathFromAppliedConfig(t *testing.T) {
+	obj := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": mcpServerAPIVersion,
+			"kind":       mcpServerKind,
+			"metadata": map[string]interface{}{
+				"name":              "k8s-mcp",
+				"namespace":         "test-ns",
+				"uid":               "test-uid-port",
+				"creationTimestamp": "2026-03-30T10:00:00Z",
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"type": "ContainerImage",
+					"containerImage": map[string]interface{}{
+						"ref": "quay.io/mcp/k8s:1.0",
+					},
+				},
+				"config": map[string]interface{}{
+					"port": int64(9090),
+					"path": "/api/mcp",
+				},
+			},
+		},
+	}
+
+	deployment, err := convertUnstructuredToMcpDeployment(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if deployment.Port != 9090 {
+		t.Fatalf("expected port 9090, got %d", deployment.Port)
+	}
+	if deployment.Path != "/api/mcp" {
+		t.Fatalf("expected path '/api/mcp', got %q", deployment.Path)
+	}
+}
+
+func TestConvertUnstructuredToMcpDeployment_EmptyPathWhenUnset(t *testing.T) {
+	obj := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": mcpServerAPIVersion,
+			"kind":       mcpServerKind,
+			"metadata": map[string]interface{}{
+				"name":              "k8s-mcp",
+				"namespace":         "test-ns",
+				"uid":               "test-uid-nopath",
+				"creationTimestamp": "2026-03-30T10:00:00Z",
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"type": "ContainerImage",
+					"containerImage": map[string]interface{}{
+						"ref": "quay.io/mcp/k8s:1.0",
+					},
+				},
+				"config": map[string]interface{}{
+					"port": int64(8080),
+				},
+			},
+		},
+	}
+
+	deployment, err := convertUnstructuredToMcpDeployment(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if deployment.Path != "" {
+		t.Fatalf("expected empty path when unset, got %q", deployment.Path)
+	}
+}
+
+func TestConvertUnstructuredToMcpDeployment_WithRegistryAnnotations(t *testing.T) {
+	obj := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": mcpServerAPIVersion,
+			"kind":       mcpServerKind,
+			"metadata": map[string]interface{}{
+				"name":              "registry-mcp",
+				"namespace":         "test-ns",
+				"uid":               "test-uid-999",
+				"creationTimestamp": "2026-03-30T10:00:00Z",
+				"annotations": map[string]interface{}{
+					mcpRegistryServerAnnotation:  "io.github.example/weather-server",
+					mcpRegistryVersionAnnotation: "1.2.0",
+				},
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"type": "ContainerImage",
+					"containerImage": map[string]interface{}{
+						"ref": "quay.io/mcp/weather:1.2.0",
+					},
+				},
+				"config": map[string]interface{}{
+					"port": int64(8080),
+				},
+			},
+		},
+	}
+
+	deployment, err := convertUnstructuredToMcpDeployment(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if deployment.RegistryServer != "io.github.example/weather-server" {
+		t.Fatalf("expected registryServer 'io.github.example/weather-server', got %q", deployment.RegistryServer)
+	}
+	if deployment.RegistryVersion != "1.2.0" {
+		t.Fatalf("expected registryVersion '1.2.0', got %q", deployment.RegistryVersion)
 	}
 }
 
@@ -723,6 +868,38 @@ func TestBuildMcpDeploymentPatch_DisplayNameOnly(t *testing.T) {
 	}
 }
 
+func TestBuildMcpDeploymentPatch_RegistryServerAndVersion(t *testing.T) {
+	registryServer := "io.github.example/weather-server"
+	registryVersion := "1.2.0"
+	req := models.McpDeploymentUpdateRequest{
+		RegistryServer:  &registryServer,
+		RegistryVersion: &registryVersion,
+	}
+
+	patch, err := buildMcpDeploymentPatch(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	metadata, ok := patch["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected metadata in patch")
+	}
+	annotations, ok := metadata["annotations"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected annotations in metadata")
+	}
+	if annotations[mcpRegistryServerAnnotation] != registryServer {
+		t.Fatalf("expected registry server annotation %q, got %v", registryServer, annotations[mcpRegistryServerAnnotation])
+	}
+	if annotations[mcpRegistryVersionAnnotation] != registryVersion {
+		t.Fatalf("expected registry version annotation %q, got %v", registryVersion, annotations[mcpRegistryVersionAnnotation])
+	}
+	if _, exists := patch["spec"]; exists {
+		t.Fatal("expected no spec in patch when only registry fields are set")
+	}
+}
+
 func TestBuildMcpDeploymentPatch_YAMLOnly(t *testing.T) {
 	yamlStr := `config:
   port: 3000
@@ -952,6 +1129,41 @@ func TestBuildMcpDeploymentPatch_InvalidYAMLReturnsError(t *testing.T) {
 	_, err := buildMcpDeploymentPatch(req)
 	if err == nil {
 		t.Fatal("expected error for invalid YAML in patch")
+	}
+	if !errors.Is(err, ErrMcpDeploymentValidation) {
+		t.Fatalf("expected ErrMcpDeploymentValidation so the handler returns 400, got %v", err)
+	}
+}
+
+func TestBuildMcpDeploymentPatch_PartialYAMLWithoutPortDefaultsInsteadOfZeroing(t *testing.T) {
+	// A caller updating only path/env via YAML, without repeating port, must not
+	// silently zero out the CR's listening port via the JSON merge patch.
+	yamlStr := `config:
+  path: /new-path`
+	req := models.McpDeploymentUpdateRequest{
+		YAML: &yamlStr,
+	}
+
+	patch, err := buildMcpDeploymentPatch(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	specPatch, ok := patch["spec"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected spec in patch")
+	}
+	configPatch, ok := specPatch["config"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected config in spec patch")
+	}
+	// This branch goes through runtime.DefaultUnstructuredConverter.ToUnstructured, which
+	// (like the assertions in TestBuildMcpDeploymentPatch_YAMLOnly) yields int64, not int32.
+	if configPatch["port"] != int64(defaultMcpPort) {
+		t.Fatalf("expected port to default to %d instead of being zeroed out, got %v", defaultMcpPort, configPatch["port"])
+	}
+	if configPatch["path"] != "/new-path" {
+		t.Fatalf("expected path '/new-path', got %v", configPatch["path"])
 	}
 }
 

--- a/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository_test.go
+++ b/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository_test.go
@@ -477,6 +477,45 @@ func TestConvertUnstructuredToMcpDeployment_EmptyPathWhenUnset(t *testing.T) {
 	}
 }
 
+func TestConvertUnstructuredToMcpDeployment_DefaultsPortWhenZero(t *testing.T) {
+	// A pre-existing CR created without spec.config.port (e.g. via kubectl, or an earlier
+	// version of this tool) must not report Port: 0, since callers build access-endpoint URLs
+	// directly from it (an unroutable ":0" address). Mirrors the same default applied on the
+	// create/patch paths.
+	obj := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": mcpServerAPIVersion,
+			"kind":       mcpServerKind,
+			"metadata": map[string]interface{}{
+				"name":              "k8s-mcp",
+				"namespace":         "test-ns",
+				"uid":               "test-uid-zeroport",
+				"creationTimestamp": "2026-03-30T10:00:00Z",
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"type": "ContainerImage",
+					"containerImage": map[string]interface{}{
+						"ref": "quay.io/mcp/k8s:1.0",
+					},
+				},
+				"config": map[string]interface{}{
+					"port": int64(0),
+				},
+			},
+		},
+	}
+
+	deployment, err := convertUnstructuredToMcpDeployment(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if deployment.Port != defaultMcpPort {
+		t.Fatalf("expected port to default to %d instead of being zeroed out, got %d", defaultMcpPort, deployment.Port)
+	}
+}
+
 func TestConvertUnstructuredToMcpDeployment_WithRegistryAnnotations(t *testing.T) {
 	obj := unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/packages/model-registry/upstream/frontend/src/__mocks__/mockMcpDeployment.ts
+++ b/packages/model-registry/upstream/frontend/src/__mocks__/mockMcpDeployment.ts
@@ -44,6 +44,8 @@ export const mockMcpDeployment = (overrides?: Partial<McpDeployment>): McpDeploy
   uid: 'test-uid-1234',
   creationTimestamp: '2026-03-10T14:30:00Z',
   image: 'quay.io/mcp-servers/kubernetes:1.0.0',
+  port: 8080,
+  path: '/sse',
   conditions: mockReadyConditions(),
   address: { url: 'http://kubernetes-mcp.test-project.svc:8080/sse' },
   ...overrides,

--- a/packages/model-registry/upstream/frontend/src/concepts/k8s/NamespaceSelectorField/NamespaceSelectorField.tsx
+++ b/packages/model-registry/upstream/frontend/src/concepts/k8s/NamespaceSelectorField/NamespaceSelectorField.tsx
@@ -46,6 +46,8 @@ export type NamespaceSelectorFieldProps = {
   cannotCheck?: boolean;
   registryName?: string;
   selectorOnly?: boolean;
+  isDisabled?: boolean;
+  isFullWidth?: boolean;
 };
 
 const NamespaceSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
@@ -57,6 +59,8 @@ const NamespaceSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
   cannotCheck,
   registryName,
   selectorOnly,
+  isDisabled,
+  isFullWidth,
 }) => {
   const labelHelpRef = useRef<HTMLSpanElement>(null);
   const [namespaces, namespacesLoaded, namespacesLoadError] = useNamespaces();
@@ -122,6 +126,7 @@ const NamespaceSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
       onBlur={handleTextInputBlur}
       placeholder="Enter a namespace name"
       aria-label="Namespace"
+      isDisabled={isDisabled}
     />
   ) : (
     <div data-testid="form-namespace-selector-trigger">
@@ -130,8 +135,8 @@ const NamespaceSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
         value={selectedNamespace}
         onChange={handleChange}
         placeholder="Select a namespace"
-        isDisabled={namespaces.length === 0}
-        isFullWidth={!selectorOnly}
+        isDisabled={namespaces.length === 0 || isDisabled}
+        isFullWidth={isFullWidth ?? !selectorOnly}
         isScrollable
         maxMenuHeight="300px"
         dataTestId="form-namespace-selector"

--- a/packages/model-registry/upstream/frontend/src/odh/components/McpDeployModal.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/McpDeployModal.tsx
@@ -24,7 +24,7 @@ import { K8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionFi
 import { MAX_K8S_NAME_LENGTH } from '~/concepts/k8s/K8sNameDescriptionField/utils';
 import { createMcpDeployment, updateMcpDeployment } from '~/odh/api/mcpCatalogDeployment/service';
 import { mcpDeploymentsUrl } from '~/app/routes/mcpCatalog/mcpCatalog';
-import { McpDeployModalData } from '~/odh/types/mcpDeploymentTypes';
+import { McpDeployment, McpDeployModalData } from '~/odh/types/mcpDeploymentTypes';
 
 type McpDeployModalProps = {
   isOpen?: boolean;
@@ -32,6 +32,11 @@ type McpDeployModalProps = {
   data?: McpDeployModalData;
   isLoading?: boolean;
   loadError?: Error;
+  /**
+   * Called after the CR is created, before `onClose`, for caller-specific follow-up.
+   * Should catch and report its own errors — a rejection here doesn't fail the deploy itself.
+   */
+  onDeployed?: (deployment: McpDeployment) => void | Promise<void>;
 };
 
 const McpDeployModal: React.FC<McpDeployModalProps> = ({
@@ -40,8 +45,14 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
   data,
   isLoading,
   loadError,
+  onDeployed,
 }) => {
   const isEdit = !!data?.name;
+  // Sole discriminator between the "registry" prefill flow (image editable, project fixed)
+  // and the "catalog" flow (image read-only, project selectable) -- see the doc comment on
+  // McpDeployModalData.registryServer. Centralized here so the three usages below can't drift
+  // from each other or from this convention.
+  const isRegistryPrefill = !!data?.registryServer;
   const navigate = useNavigate();
   const { theme } = useThemeContext();
 
@@ -91,10 +102,27 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
   const [selectedNamespace, setSelectedNamespace] = React.useState(data?.namespace ?? '');
   const queryParams = React.useMemo(() => ({ namespace: selectedNamespace }), [selectedNamespace]);
   const [yamlContent, setYamlContent] = React.useState(data?.yaml ?? '');
-  const ociImageValue = data?.image ?? '';
+  const [ociImageValue, setOciImageValue] = React.useState(data?.image ?? '');
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [submitError, setSubmitError] = React.useState<Error>();
   const abortControllerRef = React.useRef<AbortController>();
+
+  // `data` can arrive after this modal has already mounted (e.g. the catalog flow opens the
+  // modal immediately on click, before its CR-to-YAML converter resolves). useState's initial
+  // value only applies once, so without these the image/YAML fields would stay stuck at their
+  // initial (possibly empty) values forever. `!== undefined` (rather than truthiness) so a
+  // field that resolves to an empty value still overwrites a stale non-empty one.
+  React.useEffect(() => {
+    if (data?.image !== undefined) {
+      setOciImageValue(data.image);
+    }
+  }, [data?.image]);
+
+  React.useEffect(() => {
+    if (data?.yaml !== undefined) {
+      setYamlContent(data.yaml);
+    }
+  }, [data?.yaml]);
 
   React.useEffect(
     () => () => {
@@ -133,13 +161,26 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
         );
         onClose(true);
       } else {
-        await createMcpDeployment('', { ...queryParams, namespace: selectedNamespace })(opts, {
+        const created = await createMcpDeployment('', {
+          ...queryParams,
+          namespace: selectedNamespace,
+        })(opts, {
           name: effectiveK8sName,
           displayName: displayNameValue,
           serverName: data?.serverName,
+          registryServer: data?.registryServer,
+          registryVersion: data?.registryVersion,
           image: ociImageValue,
           yaml: yamlContent,
         });
+        // The CR is already created at this point. `onDeployed`'s contract requires
+        // implementations to handle their own errors, but don't let a caller that breaks that
+        // contract report a deploy failure when the deployment actually succeeded.
+        try {
+          await onDeployed?.(created);
+        } catch {
+          // Intentionally swallowed — see comment above.
+        }
         onClose(true);
         navigate(mcpDeploymentsUrl(selectedNamespace));
       }
@@ -160,6 +201,7 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
     isEdit,
     queryParams,
     onClose,
+    onDeployed,
     navigate,
   ]);
 
@@ -216,32 +258,41 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
               isRequired
               fieldId="mcp-deploy-oci-image"
               labelHelp={
-                <FieldGroupHelpLabelIcon content="This is the container image associated with the MCP server that you selected from the catalog. This cannot be edited." />
+                <FieldGroupHelpLabelIcon
+                  content={
+                    isRegistryPrefill
+                      ? "Prefilled from the selected MCP server when available. If it's missing, enter the container image to deploy."
+                      : 'This is the container image associated with the MCP server that you selected from the catalog. This cannot be edited.'
+                  }
+                />
               }
             >
               <TextInput
                 id="mcp-deploy-oci-image"
                 value={ociImageValue}
-                isDisabled
+                isDisabled={!isRegistryPrefill}
+                onChange={(_event, value) => setOciImageValue(value)}
+                placeholder="e.g. quay.io/mcp/weather:1.2.0"
                 data-testid="mcp-deploy-oci-image-input"
               />
             </FormGroup>
 
-            {isEdit ? (
-              <FormGroup label="Project" isRequired fieldId="mcp-deploy-project">
-                <TextInput
-                  id="mcp-deploy-project"
-                  value={selectedNamespace}
-                  isDisabled
-                  data-testid="mcp-deploy-project-selector"
-                />
-              </FormGroup>
-            ) : (
+            <FormGroup
+              label="Project"
+              isRequired
+              fieldId="mcp-deploy-project"
+              labelHelp={
+                <FieldGroupHelpLabelIcon content="Select the project to deploy this MCP server to." />
+              }
+            >
               <NamespaceSelectorFieldWrapper
                 selectedNamespace={selectedNamespace}
                 onSelect={handleNamespaceSelect}
+                isDisabled={isEdit || isRegistryPrefill}
+                selectorOnly
+                isFullWidth
               />
-            )}
+            </FormGroup>
 
             <FormGroup
               label="YAML configuration"

--- a/packages/model-registry/upstream/frontend/src/odh/components/__tests__/McpDeployModal.spec.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/__tests__/McpDeployModal.spec.tsx
@@ -1,0 +1,438 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import McpDeployModal from '~/odh/components/McpDeployModal';
+import { createMcpDeployment, updateMcpDeployment } from '~/odh/api/mcpCatalogDeployment/service';
+import { McpDeployModalData } from '~/odh/types/mcpDeploymentTypes';
+import { mockMcpDeployment } from '~/__mocks__/mockMcpDeployment';
+
+jest.mock('~/odh/api/mcpCatalogDeployment/service', () => ({
+  createMcpDeployment: jest.fn(),
+  updateMcpDeployment: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/app/ThemeContext', () => ({
+  useThemeContext: () => ({ theme: 'light' }),
+}));
+
+jest.mock('@patternfly/react-code-editor', () => ({
+  Language: { yaml: 'yaml' },
+  CodeEditor: ({
+    code,
+    onCodeChange,
+    'data-testid': dataTestId,
+  }: {
+    code: string;
+    onCodeChange: (value: string) => void;
+    'data-testid'?: string;
+  }) => (
+    <textarea
+      data-testid={dataTestId}
+      value={code}
+      onChange={(e) => onCodeChange(e.target.value)}
+    />
+  ),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('~/odh/components/NamespaceSelectorFieldWrapper', () => {
+  function MockNamespaceSelectorFieldWrapper({
+    selectedNamespace,
+    onSelect,
+    isDisabled,
+  }: {
+    selectedNamespace: string;
+    onSelect: (ns: string) => void;
+    isDisabled?: boolean;
+  }) {
+    return (
+      <button
+        type="button"
+        data-testid="mcp-deploy-namespace-select"
+        onClick={() => onSelect('test-project')}
+        disabled={isDisabled}
+      >
+        {selectedNamespace || 'Select a project'}
+      </button>
+    );
+  }
+  return MockNamespaceSelectorFieldWrapper;
+});
+
+const mockCreateMcpDeployment = jest.mocked(createMcpDeployment);
+const mockUpdateMcpDeployment = jest.mocked(updateMcpDeployment);
+
+const mockDeployment = () =>
+  mockMcpDeployment({
+    name: 'my-server',
+    namespace: 'test-project',
+    uid: 'uid-1',
+    creationTimestamp: '2026-01-01T00:00:00Z',
+    image: 'quay.io/mcp/weather:1.2.0',
+    conditions: [],
+  });
+
+const renderModal = (data?: McpDeployModalData, onDeployed?: jest.Mock, onClose = jest.fn()) =>
+  render(
+    <MemoryRouter>
+      <McpDeployModal data={data} onClose={onClose} onDeployed={onDeployed} />
+    </MemoryRouter>,
+  );
+
+describe('McpDeployModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should disable the OCI image field for catalog deployments', () => {
+    renderModal({ image: 'quay.io/mcp/weather:1.2.0', serverName: 'weather' });
+
+    const imageInput = screen.getByTestId('mcp-deploy-oci-image-input');
+    expect(imageInput).toHaveValue('quay.io/mcp/weather:1.2.0');
+    expect(imageInput).toBeDisabled();
+  });
+
+  it('should leave the OCI image field editable for registry deployments', async () => {
+    renderModal({
+      image: 'quay.io/mcp/weather:1.2.0',
+      registryServer: 'io.github.example/weather-server',
+      registryVersion: '1.2.0',
+      namespace: 'test-project',
+    });
+
+    const imageInput = screen.getByTestId('mcp-deploy-oci-image-input');
+    expect(imageInput).toHaveValue('quay.io/mcp/weather:1.2.0');
+    expect(imageInput).not.toBeDisabled();
+
+    await userEvent.clear(imageInput);
+    await userEvent.type(imageInput, 'quay.io/mcp/weather:2.0.0');
+    expect(imageInput).toHaveValue('quay.io/mcp/weather:2.0.0');
+  });
+
+  it('should render a normal, editable YAML editor whether or not configuration was prefilled', async () => {
+    renderModal({ image: 'quay.io/mcp/weather:1.2.0', yaml: '', serverName: 'weather' });
+
+    const yamlEditor = screen.getByTestId('mcp-deploy-yaml-editor');
+    expect(yamlEditor).toHaveValue('');
+
+    await userEvent.type(yamlEditor, 'config:\n  port: 8080\n');
+    expect(yamlEditor).toHaveValue('config:\n  port: 8080\n');
+  });
+
+  it('should disable the project selector for registry-sourced deploys', () => {
+    renderModal({
+      image: 'quay.io/mcp/weather:1.2.0',
+      displayName: 'Weather MCP',
+      registryServer: 'io.github.example/weather-server',
+      registryVersion: '1.2.0',
+      namespace: 'test-project',
+    });
+
+    const nsButton = screen.getByTestId('mcp-deploy-namespace-select');
+    expect(nsButton).toBeDisabled();
+    expect(nsButton).toHaveTextContent('test-project');
+  });
+
+  it('should forward registryServer and registryVersion when deploying from the MCP Registry flow', async () => {
+    mockCreateMcpDeployment.mockReturnValue(jest.fn().mockResolvedValue(mockDeployment()));
+
+    renderModal({
+      image: 'quay.io/mcp/weather:1.2.0',
+      displayName: 'Weather MCP',
+      registryServer: 'io.github.example/weather-server',
+      registryVersion: '1.2.0',
+      namespace: 'test-project',
+    });
+
+    await userEvent.click(screen.getByTestId('modal-submit-button'));
+
+    await waitFor(() => expect(mockCreateMcpDeployment).toHaveBeenCalled());
+    const createCall = mockCreateMcpDeployment.mock.results[0].value as jest.Mock;
+    expect(createCall).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        registryServer: 'io.github.example/weather-server',
+        registryVersion: '1.2.0',
+      }),
+    );
+  });
+
+  it('should call onDeployed and navigate to the deployments page for registry-sourced deploys', async () => {
+    const onDeployed = jest.fn();
+    const created = mockDeployment();
+    mockCreateMcpDeployment.mockReturnValue(jest.fn().mockResolvedValue(created));
+
+    renderModal(
+      {
+        image: 'quay.io/mcp/weather:1.2.0',
+        displayName: 'Weather MCP',
+        registryServer: 'io.github.example/weather-server',
+        registryVersion: '1.2.0',
+        namespace: 'test-project',
+      },
+      onDeployed,
+    );
+
+    await userEvent.click(screen.getByTestId('modal-submit-button'));
+
+    await waitFor(() => expect(onDeployed).toHaveBeenCalledWith(created));
+    expect(mockNavigate).toHaveBeenCalledWith('/ai-hub/mcp-servers/deployments/test-project');
+  });
+
+  it('should still treat the deploy as successful if onDeployed rejects', async () => {
+    const created = mockDeployment();
+    mockCreateMcpDeployment.mockReturnValue(jest.fn().mockResolvedValue(created));
+    const onDeployed = jest.fn().mockRejectedValue(new Error('registration failed'));
+    const onClose = jest.fn();
+
+    renderModal(
+      {
+        image: 'quay.io/mcp/weather:1.2.0',
+        displayName: 'Weather MCP',
+        registryServer: 'io.github.example/weather-server',
+        registryVersion: '1.2.0',
+        namespace: 'test-project',
+      },
+      onDeployed,
+      onClose,
+    );
+
+    await userEvent.click(screen.getByTestId('modal-submit-button'));
+
+    await waitFor(() => expect(onDeployed).toHaveBeenCalledWith(created));
+    expect(onClose).toHaveBeenCalledWith(true);
+    expect(mockNavigate).toHaveBeenCalledWith('/ai-hub/mcp-servers/deployments/test-project');
+    expect(screen.queryByText('registration failed')).not.toBeInTheDocument();
+  });
+
+  it('should navigate to deployments page after a successful catalog deploy', async () => {
+    mockCreateMcpDeployment.mockReturnValue(jest.fn().mockResolvedValue(mockDeployment()));
+
+    renderModal({
+      image: 'quay.io/mcp/weather:1.2.0',
+      displayName: 'Weather MCP',
+      serverName: 'weather',
+    });
+
+    await userEvent.click(screen.getByTestId('mcp-deploy-namespace-select'));
+    await userEvent.click(screen.getByTestId('modal-submit-button'));
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/ai-hub/mcp-servers/deployments/test-project'),
+    );
+  });
+
+  it('should call createMcpDeployment without registry fields for the catalog flow', async () => {
+    mockCreateMcpDeployment.mockReturnValue(jest.fn().mockResolvedValue(mockDeployment()));
+
+    renderModal({
+      image: 'quay.io/mcp/weather:1.2.0',
+      displayName: 'Weather MCP',
+      serverName: 'weather',
+    });
+
+    await userEvent.click(screen.getByTestId('mcp-deploy-namespace-select'));
+    await userEvent.click(screen.getByTestId('modal-submit-button'));
+
+    await waitFor(() => expect(mockCreateMcpDeployment).toHaveBeenCalled());
+    const createCall = mockCreateMcpDeployment.mock.results[0].value as jest.Mock;
+    expect(createCall).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        serverName: 'weather',
+        registryServer: undefined,
+        registryVersion: undefined,
+      }),
+    );
+  });
+
+  it('should sync the OCI image field when data arrives after the modal has already mounted', () => {
+    const onClose = jest.fn();
+    const { rerender } = render(
+      <MemoryRouter>
+        <McpDeployModal data={undefined} onClose={onClose} isLoading />
+      </MemoryRouter>,
+    );
+
+    rerender(
+      <MemoryRouter>
+        <McpDeployModal
+          data={{ image: 'quay.io/mcp/weather:1.2.0', serverName: 'weather' }}
+          onClose={onClose}
+          isLoading={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('mcp-deploy-oci-image-input')).toHaveValue(
+      'quay.io/mcp/weather:1.2.0',
+    );
+  });
+
+  it('should sync the YAML field when data arrives after the modal has already mounted', () => {
+    const onClose = jest.fn();
+    const { rerender } = render(
+      <MemoryRouter>
+        <McpDeployModal data={undefined} onClose={onClose} isLoading />
+      </MemoryRouter>,
+    );
+
+    rerender(
+      <MemoryRouter>
+        <McpDeployModal
+          data={{
+            image: 'quay.io/mcp/weather:1.2.0',
+            yaml: 'config:\n  port: 8080\n',
+            serverName: 'weather',
+          }}
+          onClose={onClose}
+          isLoading={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('mcp-deploy-yaml-editor')).toHaveValue('config:\n  port: 8080\n');
+  });
+
+  it('should sync the image and yaml fields when they transition to an empty value', () => {
+    const onClose = jest.fn();
+    const { rerender } = render(
+      <MemoryRouter>
+        <McpDeployModal
+          data={{
+            image: 'quay.io/mcp/weather:1.2.0',
+            yaml: 'config:\n  port: 8080\n',
+            serverName: 'weather',
+          }}
+          onClose={onClose}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('mcp-deploy-oci-image-input')).toHaveValue(
+      'quay.io/mcp/weather:1.2.0',
+    );
+
+    rerender(
+      <MemoryRouter>
+        <McpDeployModal data={{ image: '', yaml: '', serverName: 'weather' }} onClose={onClose} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('mcp-deploy-oci-image-input')).toHaveValue('');
+    expect(screen.getByTestId('mcp-deploy-yaml-editor')).toHaveValue('');
+  });
+
+  it('should prefill empty image and yaml fields when missing from data, and leave the image field editable', () => {
+    renderModal({
+      image: '',
+      yaml: '',
+      displayName: 'Weather MCP',
+      registryServer: 'io.github.example/weather-server',
+      registryVersion: '1.2.0',
+      namespace: 'test-project',
+    });
+
+    const imageInput = screen.getByTestId('mcp-deploy-oci-image-input') as HTMLInputElement;
+    const yamlEditor = screen.getByTestId('mcp-deploy-yaml-editor') as HTMLTextAreaElement;
+
+    expect(imageInput.value).toBe('');
+    expect(yamlEditor.value).toBe('');
+    // The PR's stated contract is "left empty AND user-editable" -- assert both halves
+    // together so a regression that re-disables the field when it's empty (e.g. an
+    // `isDisabled={!ociImageValue}` mistake) would be caught here, not just by the
+    // separately-prefilled-value editability test above.
+    expect(imageInput).not.toBeDisabled();
+  });
+
+  it('should show the project as a fixed, disabled field when editing an existing deployment', () => {
+    renderModal({
+      name: 'my-server',
+      displayName: 'Weather MCP',
+      image: 'quay.io/mcp/weather:1.2.0',
+      namespace: 'test-project',
+    });
+
+    const nsButton = screen.getByTestId('mcp-deploy-namespace-select');
+    expect(nsButton).toBeDisabled();
+    expect(nsButton).toHaveTextContent('test-project');
+  });
+
+  it('should call updateMcpDeployment and close without navigating when saving an existing deployment', async () => {
+    mockUpdateMcpDeployment.mockReturnValue(jest.fn().mockResolvedValue(mockDeployment()));
+    const onClose = jest.fn();
+
+    renderModal(
+      {
+        name: 'my-server',
+        displayName: 'Weather MCP',
+        image: 'quay.io/mcp/weather:1.2.0',
+        yaml: '',
+        namespace: 'test-project',
+      },
+      undefined,
+      onClose,
+    );
+
+    expect(screen.getByTestId('mcp-deploy-modal-title')).toHaveTextContent(
+      'Edit MCP server deployment',
+    );
+
+    await userEvent.click(screen.getByTestId('modal-submit-button'));
+
+    await waitFor(() => expect(mockUpdateMcpDeployment).toHaveBeenCalled());
+    const updateCall = mockUpdateMcpDeployment.mock.results[0].value as jest.Mock;
+    expect(updateCall).toHaveBeenCalledWith(
+      expect.anything(),
+      'my-server',
+      expect.objectContaining({
+        displayName: 'Weather MCP',
+        image: 'quay.io/mcp/weather:1.2.0',
+        yaml: '',
+      }),
+    );
+
+    expect(onClose).toHaveBeenCalledWith(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockCreateMcpDeployment).not.toHaveBeenCalled();
+  });
+
+  it('should surface an error and keep the modal open when updating an existing deployment fails', async () => {
+    mockUpdateMcpDeployment.mockReturnValue(
+      jest.fn().mockRejectedValue(new Error('update failed')),
+    );
+    const onClose = jest.fn();
+
+    renderModal(
+      {
+        name: 'my-server',
+        displayName: 'Weather MCP',
+        image: 'quay.io/mcp/weather:1.2.0',
+        namespace: 'test-project',
+      },
+      undefined,
+      onClose,
+    );
+
+    await userEvent.click(screen.getByTestId('modal-submit-button'));
+
+    await waitFor(() => expect(screen.getByText('update failed')).toBeInTheDocument());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should call onClose when the Cancel button is clicked', async () => {
+    const onClose = jest.fn();
+    renderModal({ image: 'quay.io/mcp/weather:1.2.0', serverName: 'weather' }, undefined, onClose);
+
+    await userEvent.click(screen.getByTestId('modal-cancel-button'));
+
+    expect(onClose).toHaveBeenCalledWith();
+  });
+});

--- a/packages/model-registry/upstream/frontend/src/odh/extension-points/deploy.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/extension-points/deploy.ts
@@ -2,6 +2,27 @@ import type { Extension, CodeRef } from '@openshift/dynamic-plugin-sdk';
 import { createExtensionGuard } from '@odh-dashboard/plugin-core/extension-points';
 import type { ModelDeployPrefillInfo } from '@odh-dashboard/model-registry/shared';
 import type { ModelRegistryDeploymentListItem } from '~/odh/k8sTypes';
+import type { McpDeployment, McpDeployModalData } from '~/odh/types/mcpDeploymentTypes';
+
+/** Slot for `McpDeployModal`, lets other packages reuse it without a static import across the Module Federation boundary. */
+export type McpCatalogDeployModalExtension = Extension<
+  'mcp-catalog.server/deploy-modal',
+  {
+    modalComponent: CodeRef<
+      React.ComponentType<{
+        data?: McpDeployModalData;
+        isLoading?: boolean;
+        loadError?: Error;
+        onClose: (saved?: boolean) => void;
+        /** Called after the CR is created, before `onClose`. Must not throw — implementations should catch and report their own errors. */
+        onDeployed?: (deployment: McpDeployment) => void | Promise<void>;
+      }>
+    >;
+  }
+>;
+
+export const isMcpCatalogDeployModalExtension =
+  createExtensionGuard<McpCatalogDeployModalExtension>('mcp-catalog.server/deploy-modal');
 
 export type ModelRegistryDeployModalExtension = Extension<
   'model-registry.model-version/deploy-modal',

--- a/packages/model-registry/upstream/frontend/src/odh/extensions.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/extensions.ts
@@ -6,6 +6,7 @@ import type {
   AreaExtension,
   TabRouteTabExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
+import type { McpCatalogDeployModalExtension } from '~/odh/extension-points';
 import {
   CATALOG_SETTINGS_PAGE_TITLE,
   catalogSettingsUrl,
@@ -27,6 +28,7 @@ const extensions: (
   | RouteExtension
   | AreaExtension
   | TabRouteTabExtension
+  | McpCatalogDeployModalExtension
   | Extension
 )[] = [
   {
@@ -309,6 +311,15 @@ const extensions: (
       label: 'Deploy model',
       group: 'model-catalog.deploy',
       component: () => import('./components/CatalogDeployAction'),
+    },
+  },
+  {
+    type: 'mcp-catalog.server/deploy-modal',
+    flags: {
+      required: [SupportedArea.MCP_CATALOG],
+    },
+    properties: {
+      modalComponent: () => import('./components/McpDeployModal').then((m) => m.default),
     },
   },
 ];

--- a/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/__tests__/mcpDeploymentTestUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/__tests__/mcpDeploymentTestUtils.ts
@@ -46,6 +46,7 @@ export const createMockDeployment = (overrides: Partial<McpDeployment> = {}): Mc
   uid: 'test-uid-1234',
   creationTimestamp: '2026-03-10T14:30:00Z',
   image: 'quay.io/mcp-servers/kubernetes:1.0.0',
+  port: 8080,
   conditions: mockReadyConditions(),
   ...overrides,
 });

--- a/packages/model-registry/upstream/frontend/src/odh/types/mcpDeploymentTypes.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/types/mcpDeploymentTypes.ts
@@ -98,10 +98,16 @@ export type McpDeployment = {
   name: string;
   displayName?: string;
   serverName?: string;
+  /** Distinct from `serverName`, which traces catalog (not registry) deployments. */
+  registryServer?: string;
+  registryVersion?: string;
   namespace: string;
   uid: string;
   creationTimestamp: string;
   image: string;
+  /** Actually-applied spec.config values, not requested ones. */
+  port: number;
+  path?: string;
   yaml?: string;
   conditions: McpDeploymentCondition[];
   address?: McpDeploymentAddress;
@@ -116,6 +122,8 @@ export type McpDeploymentCreateRequest = {
   name?: string;
   displayName?: string;
   serverName?: string;
+  registryServer?: string;
+  registryVersion?: string;
   image: string;
   yaml?: string;
 };
@@ -123,6 +131,8 @@ export type McpDeploymentCreateRequest = {
 export type McpDeploymentUpdateRequest = {
   displayName?: string;
   serverName?: string;
+  registryServer?: string;
+  registryVersion?: string;
   image?: string;
   yaml?: string;
 };
@@ -132,6 +142,17 @@ export type McpDeployModalData = {
   displayName?: string;
   namespace?: string;
   serverName?: string;
+  /**
+   * Distinct from `serverName`, which traces catalog (not registry) deployments.
+   *
+   * McpDeployModal also uses this field's presence as its sole signal for whether it's
+   * prefilling from an external MCP Registry ("registry" flow, image editable, project
+   * fixed) vs. from the internal catalog ("catalog" flow, image read-only, project
+   * selectable). If you add a new caller/flow, set (or deliberately omit) `registryServer`
+   * to match the UI behavior you want -- see `isRegistryPrefill` in McpDeployModal.
+   */
+  registryServer?: string;
+  registryVersion?: string;
   image: string;
   yaml?: string;
 };

--- a/packages/ui-core/src/components/projectSelector/ProjectSelector.tsx
+++ b/packages/ui-core/src/components/projectSelector/ProjectSelector.tsx
@@ -32,6 +32,7 @@ type ProjectSelectorProps = {
   namespacesOverride?: Namespace[];
   appendTo?: 'inline' | (() => HTMLElement) | HTMLElement;
   pinnedNamespace?: { name: string; label: string };
+  isDisabled?: boolean;
 };
 
 const ProjectSelector: React.FC<ProjectSelectorProps> = ({
@@ -50,6 +51,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   namespacesOverride,
   appendTo,
   pinnedNamespace,
+  isDisabled,
 }) => {
   const { projects } = React.useContext(ProjectsContext);
   const namespaces =
@@ -114,7 +116,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       searchPlaceholder="Project name"
       searchValue={searchText}
       isLoading={isLoading}
-      isDisabled={isLoading}
+      isDisabled={isLoading || isDisabled}
       appendTo={appendTo}
       toggleContent={toggleLabel}
       toggleVariant={primary ? 'primary' : undefined}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-80022
https://issues.redhat.com/browse/RHOAIENG-82813

## Description

Adds a "Deploy" button + deploy modal to the embedded MLflow MCP Registry server details page (`packages/mlflow-embedded`). Clicking Deploy opens model-registry's existing "Deploy MCP server" modal, prefilled from the selected registry server/version (fields absent from the registry's `server.json` metadata are left empty and editable). Submitting:

1. Creates the `MCPServer` CR via model-registry's BFF (reused via a new `mcp-catalog.server/deploy-modal` extension point, so mlflow-embedded doesn't duplicate CR-creation logic or import model-registry internals).
2. Registers an `MCPAccessEndpoint` with the mlflow BFF, non-fatally (a deploy that succeeds but fails endpoint registration still leaves a usable MCPServer; the user gets a warning toast, not a hard failure).

The access-endpoint URL's port/path come from the deployment's own applied `spec.config` (returned by model-registry's BFF as new `port`/`path` fields on `McpDeployment`), not from registry metadata — registry metadata (e.g. a package's advertised transport URL) can advertise an unrelated port/path that has nothing to do with where the deployed container actually listens.

### Also includes: full-screen MCP server detail page ([RHOAIENG-82813](https://redhat.atlassian.net/browse/RHOAIENG-82813))

The MCP server detail view previously rendered inside the "MCP servers" tab page shell (page title + Catalog/Registry/Deployments tab bar + the Registry tab's own project-selector header), which squeezed the available space. This adds:

- A standalone full-screen `app.route` (`MlflowMcpRegistryDetailPage.tsx`) registered at `/ai-hub/mcp-servers/registry/:serverName`, more specific than the tab page's route so it always wins route matching for a given server — the list stays in the tab, the detail view breaks out to full screen with just a breadcrumb at the top.
- A host-rendered breadcrumb ("MCP Registry" → server display name) driven by segments reported from the embedded remote's `McpRegistryBreadcrumbReporter`, which now resolves the real display name (instead of the raw server key) and reports immediately on navigation rather than waiting for the fetch to resolve, avoiding a multi-stage loading flicker. The remote's own internal breadcrumb is hidden when embedded to avoid doubling up.
- A `useHostRouteSync` hook that keeps the host's router in sync with the embedded remote's own (separate, v6) `BrowserRouter` — the remote navigates via its own history object, which updates the URL but doesn't notify the host's router, so without this the host wouldn't know to swap between the tabbed list view and the full-screen detail breakout on client-side navigation.
- The `renderDetailActions` (Deploy button) wiring moved from the tab content onto the new full-screen detail page, since that's now where the detail view actually renders.

## How Has This Been Tested?

- Automated: Go BFF unit tests, Jest unit tests (mlflow-embedded + model-registry), and a new Cypress mock test for the Deploy flow — all passing locally.
- Manual: deployed an MCPServer end-to-end from the MCP Registry details page against a local model-registry BFF + real cluster; MCPServer CR creation verified working, including the Deploy button/modal UI and prefill behavior.
- **Not manually verified**: the access-endpoint registration call against a live MLflow server. The only cluster instance available during development runs an MLflow image that predates the "access endpoints" API this PR calls, so that request 404s in my environment for reasons unrelated to this PR's code (confirmed by tracing the routing/request-parsing logic directly). I was not able to confirm the full round trip succeeds against a live server with that API deployed.
- For the full-screen breakout: verified the list → detail → back-to-list navigation (including via the breadcrumb) correctly swaps between the tabbed shell and the full-screen page, and that the flicker previously seen on client-side navigation is resolved.

## Test Impact

- Go: unit tests in `mcp_deployment_repository_test.go` covering `port`/`path` propagation from the CR's applied config into the API response, including the case where `path` is unset.
- Jest: unit tests for `registryVersionToDeployData`, `buildMcpAccessEndpointUrl`, `api.ts`, and `McpRegistryDeployAction` (including a case proving the access-endpoint URL is built from the deployment's own config and not from differing registry metadata), plus new/updated tests for `McpDeployModal`.
- Jest (new, [RHOAIENG-82813](https://redhat.atlassian.net/browse/RHOAIENG-82813)): `const.spec.ts` (`mcpRegistryBaseRoute`), `useHostRouteSync.spec.ts` (host/remote router sync logic), and `MlflowMcpRegistryDetailPage.spec.tsx` (redirect-to-default-project, wrapper mounting, breadcrumb sync from reported segments).
- Cypress: new mock test (`mcpRegistry.cy.ts`) covering the Deploy button and modal flow with mocked network requests.
- Gap: no live end-to-end test against a real MLflow server exposing the access-endpoints API (see "Not manually verified" above) — reviewers with access to a cluster running a newer MLflow image should verify this before merge.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


## Summary by CodeRabbit

- **New Features**
  - Added MCP Registry server detail pages with deployment actions, configuration, provider selection, and access endpoint registration.
  - Added a full-screen MCP server detail view that breaks out of the MCP servers tab shell, with a host-rendered breadcrumb.
  - Added automatic server configuration based on available transport options.
  - Added success and failure notifications during registration.
- **Improvements**
  - Project selectors can now be disabled when switching is unavailable.
  - Added workspace-aware navigation, project switching, and breadcrumb synchronization.
- **Bug Fixes**
  - Improved handling of unavailable registry services and invalid deployment configurations.
  - Fixed a loading flicker when navigating from the server list to the detail page.


[RHOAIENG-82813]: https://redhat.atlassian.net/browse/RHOAIENG-82813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP Registry server detail pages with workspace-aware routing, breadcrumbs, project selection, and unavailable-state handling.
  * Added deployment actions for configuring servers, opening deployment dialogs, and registering MCP access endpoints.
  * Added support for server transports, deployment metadata, endpoint paths, and custom ports.
* **Bug Fixes**
  * Project selectors can now be disabled during deployment workflows.
  * Improved route synchronization and project redirection behavior.
* **Tests**
  * Added comprehensive coverage for registry navigation, deployment, endpoint creation, routing, and selector behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->