### PR TITLE
fix(roles): remove minus icons from label column headers

### DIFF
--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.scss
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.scss
@@ -1,0 +1,6 @@
+.odh-role-labels__header-spacer {
+  width: calc(
+    var(--pf-t--global--font--size--body--default) +
+      2 * var(--pf-t--global--spacer--action--horizontal--plain--default)
+  );
+}

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.scss
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.scss
@@ -1,6 +1,0 @@
-.odh-role-labels__header-spacer {
-  width: calc(
-    var(--pf-t--global--font--size--body--default)
-      + 2 * var(--pf-t--global--spacer--action--horizontal--plain--default)
-  );
-}

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.scss
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.scss
@@ -1,6 +1,6 @@
 .odh-role-labels__header-spacer {
   width: calc(
-    var(--pf-t--global--font--size--body--default) +
-      2 * var(--pf-t--global--spacer--action--horizontal--plain--default)
+    var(--pf-t--global--font--size--body--default)
+      + 2 * var(--pf-t--global--spacer--action--horizontal--plain--default)
   );
 }

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -20,7 +20,6 @@ import { ExclamationCircleIcon, MinusCircleIcon, PlusCircleIcon } from '@pattern
 import { LABELS_FORM_DESCRIPTION } from './const';
 import { validateLabelKey, validateLabelValue } from './labelUtils';
 import type { LabelEntry } from './types';
-import './RoleLabelsSection.scss';
 
 type RoleLabelsSectionProps = {
   labels: LabelEntry[];
@@ -129,7 +128,12 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({
               Value
             </Content>
           </FlexItem>
-          <FlexItem className="odh-role-labels__header-spacer" />
+          {/* Reserves space to align headers with the per-row remove button column */}
+          <FlexItem style={{ visibility: 'hidden' }}>
+            <Button variant="plain" aria-hidden tabIndex={-1}>
+              <MinusCircleIcon />
+            </Button>
+          </FlexItem>
         </Flex>
       )}
       {labels.length > 0 && (

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -128,11 +128,6 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({
               Value
             </Content>
           </FlexItem>
-          <FlexItem className="pf-v6-u-visibility-hidden">
-            <Button variant="plain" aria-hidden tabIndex={-1}>
-              <MinusCircleIcon />
-            </Button>
-          </FlexItem>
         </Flex>
       )}
       {labels.length > 0 && (

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -128,6 +128,11 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({
               Value
             </Content>
           </FlexItem>
+          <FlexItem>
+            <Button variant="plain" style={{ visibility: 'hidden' }} tabIndex={-1} aria-hidden>
+              <MinusCircleIcon />
+            </Button>
+          </FlexItem>
         </Flex>
       )}
       {labels.length > 0 && (

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -20,6 +20,7 @@ import { ExclamationCircleIcon, MinusCircleIcon, PlusCircleIcon } from '@pattern
 import { LABELS_FORM_DESCRIPTION } from './const';
 import { validateLabelKey, validateLabelValue } from './labelUtils';
 import type { LabelEntry } from './types';
+import './RoleLabelsSection.scss';
 
 type RoleLabelsSectionProps = {
   labels: LabelEntry[];
@@ -128,11 +129,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({
               Value
             </Content>
           </FlexItem>
-          <FlexItem>
-            <Button variant="plain" style={{ visibility: 'hidden' }} tabIndex={-1} aria-hidden>
-              <MinusCircleIcon />
-            </Button>
-          </FlexItem>
+          <FlexItem className="odh-role-labels__header-spacer" />
         </Flex>
       )}
       {labels.length > 0 && (


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78232

## Description

The Key/Value column headers in the Labels section of the custom role creation form (Settings > Custom Role Creation) rendered a `MinusCircleIcon` button wrapped in `pf-v6-u-visibility-hidden` as a layout spacer to align with the per-row remove buttons. This created unnecessary visual clutter.

This PR removes the hidden spacer element entirely from the header row so only the "Key" and "Value" header text is shown. The per-row remove buttons for individual label entries are unaffected.

**Bug:**

<img width="1179" height="258" alt="Screenshot 2026-08-06 at 5 21 31 PM" src="https://github.com/user-attachments/assets/3f644e7b-e8f1-4f75-ab6b-898bf62f62d7" />

**After fix:**

<img width="1192" height="231" alt="Screenshot 2026-08-06 at 5 21 11 PM" src="https://github.com/user-attachments/assets/0bf02a1c-4c42-4935-b5ba-ffd80021791a" />

## How Has This Been Tested?

- Ran all 22 `RoleLabelsSection` unit tests — all pass
- Type-check (`tsc --noEmit`) passes with no errors
- Lint checks pass (verified by pre-commit hook)

## Test Impact

Existing unit tests in `RoleLabelsSection.spec.tsx` cover label rendering, add/remove, editing, and validation. No tests referenced the removed hidden spacer element, so no test updates were needed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved alignment of the label remove-button column header while keeping the spacer hidden from view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->