### PR TITLE
Feat(RHOAIENG-81945): feast registry cleanup and kubernettes auth

### DIFF
--- a/packages/cypress/cypress/fixtures/resources/yaml/feast.yaml
+++ b/packages/cypress/cypress/fixtures/resources/yaml/feast.yaml
@@ -42,7 +42,7 @@ spec:
       local:
         persistence:
           file:
-            path: s3://${awsBucketName}/feast-test/credit_scoring_local/registry.pb
+            path: s3://${awsBucketName}/feast-test/${namespace}/credit_scoring_local/registry.pb
         server:
           envFrom:
           - secretRef:

--- a/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreFeatures.cy.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../utils/api/featureStoreRest';
 import { featureMetricsOverview } from '../../../pages/featureStore/featureMetrics';
 import { getCustomResource } from '../../../utils/oc_commands/customResources';
+import { deleteFeastRegistryFiles } from '../../../utils/oc_commands/s3Cleanup';
 
 describe('Feature Store Page Validation', () => {
   let testData: FeatureStoreTestData;
@@ -109,6 +110,9 @@ describe('Feature Store Page Validation', () => {
       cy.log('Skipping cleanup: Tests were skipped');
       return;
     }
+
+    cy.log(`Removing S3 registry files for: ${projectName}`);
+    deleteFeastRegistryFiles(projectName);
 
     cy.log(`Deleting Namespace: ${projectName}`);
     deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });

--- a/packages/cypress/cypress/utils/api/featureStoreRest.ts
+++ b/packages/cypress/cypress/utils/api/featureStoreRest.ts
@@ -1,18 +1,46 @@
 /**
+ * Gets the OpenShift Bearer token from the current oc session.
+ * Required for Feast REST API calls when Kubernetes auth is enabled.
+ *
+ * @returns {Cypress.Chainable} The Bearer token
+ */
+export const getOCToken = (): Cypress.Chainable => {
+  return cy.exec('oc whoami -t', { failOnNonZeroExit: false }).then((result) => {
+    if (!result.stdout.trim()) {
+      throw new Error(`Failed to get OC token: ${result.stderr}`);
+    }
+    return cy.wrap(result.stdout.trim());
+  });
+};
+
+/**
+ * Builds the authorization headers for Feast REST API requests.
+ */
+const authHeaders = (token: string): Record<string, string> => ({
+  accept: 'application/json',
+  Authorization: `Bearer ${token}`,
+});
+
+/**
  * Gets entity count and returns it
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The entity count
  */
-export const getEntityCount = (routeUrl: string, project: string): Cypress.Chainable<number> => {
+export const getEntityCount = (
+  routeUrl: string,
+  project: string,
+  token: string,
+): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/entities?project=${project}&allow_cache=true&include_relationships=false`;
 
   return cy
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -21,25 +49,30 @@ export const getEntityCount = (routeUrl: string, project: string): Cypress.Chain
       }
       const count = response.body.entities.length;
       cy.log(`Entity count: ${count}`);
-      return cy.wrap<number>(count); // Wrap the return value with proper typing
+      return cy.wrap<number>(count);
     });
 };
 
 /**
- * Gets feature count  and returns it
+ * Gets feature count and returns it
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The feature count
  */
-export const getFeatureCount = (routeUrl: string, project: string): Cypress.Chainable<number> => {
+export const getFeatureCount = (
+  routeUrl: string,
+  project: string,
+  token: string,
+): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/features?project=${project}&include_relationships=false&allow_cache=true`;
 
   return cy
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -48,7 +81,7 @@ export const getFeatureCount = (routeUrl: string, project: string): Cypress.Chai
       }
       const count = response.body.features.length;
       cy.log(`Feature count: ${count}`);
-      return cy.wrap<number>(count); // Wrap the return value with proper typing
+      return cy.wrap<number>(count);
     });
 };
 
@@ -57,11 +90,13 @@ export const getFeatureCount = (routeUrl: string, project: string): Cypress.Chai
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The feature view count
  */
 export const getFeatureViewCount = (
   routeUrl: string,
   project: string,
+  token: string,
 ): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/feature_views?project=${project}&allow_cache=true&include_relationships=false`;
 
@@ -69,7 +104,7 @@ export const getFeatureViewCount = (
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -87,11 +122,13 @@ export const getFeatureViewCount = (
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The feature service count
  */
 export const getFeatureServicesCount = (
   routeUrl: string,
   project: string,
+  token: string,
 ): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/feature_services?project=${project}&include_relationships=false&allow_cache=true`;
 
@@ -99,7 +136,7 @@ export const getFeatureServicesCount = (
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -117,11 +154,13 @@ export const getFeatureServicesCount = (
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The data source count
  */
 export const getDataSourceCount = (
   routeUrl: string,
   project: string,
+  token: string,
 ): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/data_sources?project=${project}&include_relationships=false&allow_cache=true`;
 
@@ -129,7 +168,7 @@ export const getDataSourceCount = (
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -147,16 +186,21 @@ export const getDataSourceCount = (
  *
  * @param {string} routeUrl - The Feature Store route URL
  * @param {string} project - The project name
+ * @param {string} token - The Bearer token for authentication
  * @returns {Cypress.Chainable<number>} The saved dataset count
  */
-export const getDatasetsCount = (routeUrl: string, project: string): Cypress.Chainable<number> => {
+export const getDatasetsCount = (
+  routeUrl: string,
+  project: string,
+  token: string,
+): Cypress.Chainable<number> => {
   const apiUrl = `${routeUrl}/api/v1/saved_datasets?project=${project}&allow_cache=true&include_relationships=false`;
 
   return cy
     .request({
       method: 'GET',
       url: apiUrl,
-      headers: { accept: 'application/json' },
+      headers: authHeaders(token),
       failOnStatusCode: false,
     })
     .then((response) => {
@@ -237,23 +281,27 @@ export const getAllFeatureStoreCounts = (
   featureViewCount: number;
   featureServiceCount: number;
 }> => {
-  return getFeatureCount(routeUrl, project).then((featuresCount) => {
-    return getEntityCount(routeUrl, project).then((entitiesCount) => {
-      return getDatasetsCount(routeUrl, project).then((datasetsCount) => {
-        return getDataSourceCount(routeUrl, project).then((dataSourcesCount) => {
-          return getFeatureViewCount(routeUrl, project).then((featureViewsCount) => {
-            return getFeatureServicesCount(routeUrl, project).then((featureServicesCount) => {
-              const allCounts = {
-                featureCount: featuresCount,
-                entityCount: entitiesCount,
-                datasetCount: datasetsCount,
-                dataSourceCount: dataSourcesCount,
-                featureViewCount: featureViewsCount,
-                featureServiceCount: featureServicesCount,
-              };
+  return getOCToken().then((token) => {
+    return getFeatureCount(routeUrl, project, token).then((featuresCount) => {
+      return getEntityCount(routeUrl, project, token).then((entitiesCount) => {
+        return getDatasetsCount(routeUrl, project, token).then((datasetsCount) => {
+          return getDataSourceCount(routeUrl, project, token).then((dataSourcesCount) => {
+            return getFeatureViewCount(routeUrl, project, token).then((featureViewsCount) => {
+              return getFeatureServicesCount(routeUrl, project, token).then(
+                (featureServicesCount) => {
+                  const allCounts = {
+                    featureCount: featuresCount,
+                    entityCount: entitiesCount,
+                    datasetCount: datasetsCount,
+                    dataSourceCount: dataSourcesCount,
+                    featureViewCount: featureViewsCount,
+                    featureServiceCount: featureServicesCount,
+                  };
 
-              cy.log('All Feature Store counts fetched:', allCounts);
-              return cy.wrap(allCounts);
+                  cy.log('All Feature Store counts fetched:', allCounts);
+                  return cy.wrap(allCounts);
+                },
+              );
             });
           });
         });

--- a/packages/cypress/cypress/utils/api/featureStoreRest.ts
+++ b/packages/cypress/cypress/utils/api/featureStoreRest.ts
@@ -5,11 +5,11 @@
  * @returns {Cypress.Chainable} The Bearer token
  */
 export const getOCToken = (): Cypress.Chainable => {
-  return cy.exec('oc whoami -t', { failOnNonZeroExit: false }).then((result) => {
+  return cy.exec('oc whoami -t', { failOnNonZeroExit: false, log: false }).then((result) => {
     if (!result.stdout.trim()) {
       throw new Error(`Failed to get OC token: ${result.stderr}`);
     }
-    return cy.wrap(result.stdout.trim());
+    return cy.wrap(result.stdout.trim(), { log: false });
   });
 };
 

--- a/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
+++ b/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
@@ -59,6 +59,12 @@ export const deleteS3TestFiles = (
  * @param namespace  The test namespace (also used as the S3 path segment)
  */
 export const deleteFeastRegistryFiles = (namespace: string): void => {
+  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(namespace)) {
+    throw new Error(
+      `Invalid namespace: ${namespace}. Must be a valid DNS label (lowercase alphanumeric and hyphens).`,
+    );
+  }
+
   const bucketConfig = AWS_BUCKETS.BUCKET_1;
   const podName = `feast-s3-cleanup-${Date.now()}`;
   const s3Path = `s3://${bucketConfig.NAME}/feast-test/${namespace}/`;

--- a/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
+++ b/packages/cypress/cypress/utils/oc_commands/s3Cleanup.ts
@@ -46,3 +46,31 @@ export const deleteS3TestFiles = (
     { failOnNonZeroExit: false, log: false, timeout: 120000 },
   );
 };
+
+/**
+ * Delete the Feast registry files for a given test namespace from S3.
+ *
+ * Removes `feast-test/<namespace>/` recursively from BUCKET_1. Uses an
+ * ephemeral pod so that no `aws` CLI is required on the runner.
+ *
+ * Must be called **before** `deleteOpenShiftProject` because the pod
+ * runs inside that namespace.
+ *
+ * @param namespace  The test namespace (also used as the S3 path segment)
+ */
+export const deleteFeastRegistryFiles = (namespace: string): void => {
+  const bucketConfig = AWS_BUCKETS.BUCKET_1;
+  const podName = `feast-s3-cleanup-${Date.now()}`;
+  const s3Path = `s3://${bucketConfig.NAME}/feast-test/${namespace}/`;
+
+  cy.exec(
+    `oc run ${podName} -n ${namespace} ` +
+      `--image=amazon/aws-cli:latest ` +
+      `--restart=Never --rm --attach ` +
+      `--env=AWS_ACCESS_KEY_ID=${shQuote(AWS_BUCKETS.AWS_ACCESS_KEY_ID)} ` +
+      `--env=AWS_SECRET_ACCESS_KEY=${shQuote(AWS_BUCKETS.AWS_SECRET_ACCESS_KEY)} ` +
+      `--env=AWS_DEFAULT_REGION=${shQuote(bucketConfig.REGION)} ` +
+      `-- s3 rm ${shQuote(s3Path)} --recursive`,
+    { failOnNonZeroExit: false, log: false, timeout: 120000 },
+  );
+};


### PR DESCRIPTION
Closes [RHOAIENG-81945](https://redhat.atlassian.net/browse/RHOAIENG-81945)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds Kubernetes/OpenShift Bearer token auth to Feast Feature Store REST API calls in Cypress E2E tests. Previously all API requests sent no auth header, which fails when the Feast instance has Kubernetes auth enabled.

Changes:

1. featureStoreRest.ts: Added getOCToken() (runs oc whoami -t) and authHeaders() helper. All five count functions (getEntityCount, getFeatureCount, getFeatureViewCount, getFeatureServicesCount, getDataSourceCount) now accept a token param and include Authorization: Bearer <token>.

2. feast.yaml: Registry S3 path now scoped per namespace (s3://.../feast-test/${namespace}/...) instead of a shared path — prevents cross-test registry collisions.

3. s3Cleanup.ts: New deleteFeastRegistryFiles utility to remove S3 registry objects after test run.
testFeatureStoreFeatures.cy.ts: Calls deleteFeastRegistryFiles in after() before deleting the namespace.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No new unit tests (Cypress E2E utility changes only)
Existing Feature Store E2E tests updated to pass token through

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-81945]: https://redhat.atlassian.net/browse/RHOAIENG-81945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Feature Store test reliability by authenticating API requests with an OpenShift token.
  - Updated registry storage paths to include the project namespace, helping prevent conflicts between projects.

- **Test Improvements**
  - Added automatic cleanup of Feast registry files from S3 after Feature Store tests.
  - Cleanup runs before the associated OpenShift project is removed, leaving test environments cleaner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->