### PR TITLE
Cherry-pick #9147: fix broken Elastic Search Labs blog URL in elastic-app manifest

### DIFF
--- a/manifests/rhoai/apps/elastic/elastic-app.yaml
+++ b/manifests/rhoai/apps/elastic/elastic-app.yaml
@@ -49,7 +49,7 @@ spec:
 
     - Through features like chunking, [connectors](https://www.elastic.co/guide/en/enterprise-search/current/connectors.html), and web crawlers, Elastic ensures a seamless process for ingesting diverse datasets into the search 'layer'.
 
-    - Semantic search with ELSER - Elastic Learned Sparse EncodeR, the built-in machine learning model, and use the [E5 embedding model](https://www.elastic.co/search-labs/blog/articles/multilingual-vector-search-e5-embedding-model) for multilingual vector search.  These models, and others, address the need to ground LLMs, help prompt large language models like OpenAI, and pave the way for generative AI experiences.
+    - Semantic search with ELSER - Elastic Learned Sparse EncodeR, the built-in machine learning model, and use the [E5 embedding model](https://www.elastic.co/search-labs/blog/multilingual-vector-search-e5-embedding-model) for multilingual vector search.  These models, and others, address the need to ground LLMs, help prompt large language models like OpenAI, and pave the way for generative AI experiences.
 
     - Elastic's API-first approach is enhanced by the Elastic Open Inference API, which streamlines code and manages inference for developers, providing flexibility to change models. Whether you use the built-in ELSER model or integrate with embedding models from the ecosystem via Red Hat Openshift AI, Hugging Face, Cohere, OpenAI, or others for RAG workloads, a single, straightforward API call ensures clean code for managing hybrid inference deployment.
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-81303

Cherry-pick of https://github.com/opendatahub-io/odh-dashboard/pull/9147 onto `v3.5.0-fixes`.

## Description

The Elastic Search Labs blog URL for the E5 multilingual vector search article returns 404 in the Elasticsearch Explore app drawer, and fails `testManifestLinks` Cypress reachability checks.

**Broken URL:** `https://www.elastic.co/search-labs/blog/articles/multilingual-vector-search-e5-embedding-model` → 404  
**Correct URL:** `https://www.elastic.co/search-labs/blog/multilingual-vector-search-e5-embedding-model`

The `/articles/` path segment was removed from Elastic's blog URL structure. Same fix is already on `main` (#9147), `v3.3.0-fixes` (#9112), and `v3.4.0-fixes` (#9113).

## How Has This Been Tested?

- Cherry-picked commit `31e075dd6b` from #9147 onto `upstream/v3.5.0-fixes` with a clean apply
- Confirmed the corrected URL matches the merged `main` / release-branch fix

## Test Impact

No new tests. Existing Cypress e2e `testManifestLinks` covers external link reachability for app manifests; this change restores that link to a non-404 target.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)