### PR TITLE
Enable Gen AI E2E tests for CI auto-detection

### DIFF
--- a/packages/cypress/cypress/tests/e2e/gen-ai/testCustomEndpoints.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testCustomEndpoints.cy.ts
@@ -57,7 +57,7 @@ describe('Verify Custom Endpoints in Playground - Full Lifecycle', () => {
   it(
     'Verify custom endpoint full lifecycle: create, verify, playground, delete',
     {
-      tags: ['@GenAI', '@FeatureFlagged', '@NonConcurrent'],
+      tags: ['@GenAI', '@GenAICI', '@FeatureFlagged', '@NonConcurrent', '@Playground'],
     },
     () => {
       cy.step('Log into the application with custom endpoints enabled');

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testCustomEndpoints.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testCustomEndpoints.cy.ts
@@ -57,7 +57,7 @@ describe('Verify Custom Endpoints in Playground - Full Lifecycle', () => {
   it(
     'Verify custom endpoint full lifecycle: create, verify, playground, delete',
     {
-      tags: ['@GenAI', '@GenAICI', '@FeatureFlagged', '@NonConcurrent', '@Playground'],
+      tags: ['@GenAI', '@GenAICI', '@FeatureFlagged', '@Playground'],
     },
     () => {
       cy.step('Log into the application with custom endpoints enabled');

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testGenAi.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testGenAi.cy.ts
@@ -83,10 +83,10 @@ describe('Verify Gen AI Namespace - Creation and Connection', () => {
         '@Sanity',
         '@SanitySet1',
         '@GenAI',
+        '@GenAICI',
         '@ModelServing',
         '@Deployment',
         '@Playground',
-        '@NonConcurrent',
       ],
     },
     () => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://redhat.atlassian.net/browse/RHOAIENG-81123

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add @GenAICI tag to gen-ai e2e tests so they are picked up by the CI workflow when Turbo detects changes to @odh-dashboard/gen-ai.
- testGenAi.cy.ts: add @GenAICI, remove @NonConcurrent (test uses unique UUID project names and namespace-scoped resources, safe for parallel PR execution)
- testCustomEndpoints.cy.ts: add @GenAICI, keep @NonConcurrent (modifies cluster-scoped OdhDashboardConfig, not yet parallel-safe)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test categorization for custom endpoint and generative AI scenarios.
  * Added AI and Playground test tags where applicable.
  * Removed outdated non-concurrent scheduling tags to align test execution with current categorization.
  * Updated test metadata to support more consistent grouping and scheduling across generative AI coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->