### PR TITLE
MaaS Admin events (deploy wizard, subscriptions, auth policies)

### DIFF
--- a/packages/maas/frontend/config/jestEnvironment.js
+++ b/packages/maas/frontend/config/jestEnvironment.js
@@ -1,0 +1,31 @@
+/**
+ * jest-runtime@30.4 calls moduleMocker.clearMocksOnScope() during resetModules.
+ * jest-environment-jsdom@30.2 still builds its mocker from jest-mock@30.2, which
+ * lacks that method. Bridge the gap without bumping lockfile deps.
+ */
+const { TestEnvironment } = require('jest-environment-jsdom');
+
+class MaasJestEnvironment extends TestEnvironment {
+  constructor(config, context) {
+    super(config, context);
+
+    const mocker = this.moduleMocker;
+    if (mocker && typeof mocker.clearMocksOnScope !== 'function') {
+      mocker.clearMocksOnScope = (scope) => {
+        for (const key of Object.keys(scope)) {
+          const value = scope[key];
+          if (
+            value != null &&
+            (typeof value === 'object' || typeof value === 'function') &&
+            '_isMockFunction' in value &&
+            typeof value.mockClear === 'function'
+          ) {
+            value.mockClear();
+          }
+        }
+      };
+    }
+  }
+}
+
+module.exports = MaasJestEnvironment;

--- a/packages/maas/frontend/jest.config.js
+++ b/packages/maas/frontend/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
       '<rootDir>/config/transform.file.js',
     '~/(.*)': '<rootDir>/src/$1',
   },
-  testEnvironment: 'jest-environment-jsdom',
+  testEnvironment: '<rootDir>/config/jestEnvironment.js',
   transformIgnorePatterns: [
     'node_modules/(?!yaml|lodash-es|uuid|@patternfly|delaunator|mod-arch-core)',
   ],

--- a/packages/maas/frontend/src/app/hooks/__tests__/useSubscriptionModels.spec.ts
+++ b/packages/maas/frontend/src/app/hooks/__tests__/useSubscriptionModels.spec.ts
@@ -170,6 +170,7 @@ describe('useSubscriptionModels', () => {
 
     expect(renderResult.result.current.models[0].tokenRateLimits).toEqual(newLimits);
     expect(renderResult.result.current.models[1].tokenRateLimits).toEqual([]);
+    expect(renderResult.result.current.editLimitsTarget).toBeNull();
   });
 
   it('should report allModelsHaveRateLimits correctly', () => {

--- a/packages/maas/frontend/src/app/hooks/useSubscriptionModels.ts
+++ b/packages/maas/frontend/src/app/hooks/useSubscriptionModels.ts
@@ -1,9 +1,12 @@
 import React from 'react';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   MaaSModelRefSummary,
   SubscriptionModelEntry,
   TokenRateLimit,
 } from '~/app/types/subscriptions';
+import { MaaSEvents } from '~/app/types/event-tracking';
 
 /** Returns the corrected edit-modal row index after deletions, or null if that row was removed. */
 export const reindexAfterRemove = (
@@ -86,6 +89,10 @@ export const useSubscriptionModels = (
 
   const handleSaveRateLimits = React.useCallback(
     (rateLimits: TokenRateLimit[]) => {
+      fireFormTrackingEvent(MaaSEvents.SUBSCRIPTION_TOKEN_LIMITS_CONFIGURED, {
+        outcome: TrackingOutcome.submit,
+        limitCount: rateLimits.length,
+      });
       if (editLimitsTarget == null) {
         return;
       }
@@ -100,6 +107,9 @@ export const useSubscriptionModels = (
 
   const handleCloseRateLimitsModal = React.useCallback(() => {
     setEditLimitsTarget(null);
+    fireFormTrackingEvent(MaaSEvents.SUBSCRIPTION_TOKEN_LIMITS_CONFIGURED, {
+      outcome: TrackingOutcome.cancel,
+    });
   }, []);
 
   return {

--- a/packages/maas/frontend/src/app/hooks/useSubscriptionModels.ts
+++ b/packages/maas/frontend/src/app/hooks/useSubscriptionModels.ts
@@ -101,6 +101,7 @@ export const useSubscriptionModels = (
           i === editLimitsTarget ? { ...entry, tokenRateLimits: rateLimits } : entry,
         ),
       );
+      setEditLimitsTarget(null);
     },
     [editLimitsTarget],
   );

--- a/packages/maas/frontend/src/app/pages/auth-policies/EditAuthPolicyPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/EditAuthPolicyPage.tsx
@@ -5,6 +5,7 @@ import { ApplicationsPage } from '@odh-dashboard/ui-core';
 import { useGetPolicyInfo } from '~/app/hooks/useGetPolicyInfo';
 import { useMaaSGovernanceContext } from '~/app/context/MaaSGovernanceContext';
 import { getBackUrl } from '~/app/utilities/subscriptionManagementNavigation';
+import { EventTrackingEditSource } from '~/app/types/event-tracking';
 import PolicyForm from './policyForm/PolicyForm';
 
 const EditAuthPolicyPage: React.FC = () => {
@@ -21,6 +22,15 @@ const EditAuthPolicyPage: React.FC = () => {
     loaded: formLoaded,
     error: formError,
   } = useMaaSGovernanceContext();
+
+  const editSource =
+    state != null &&
+    typeof state === 'object' &&
+    'editSource' in state &&
+    (state.editSource === EventTrackingEditSource.LIST_KEBAB ||
+      state.editSource === EventTrackingEditSource.DETAIL_KEBAB)
+      ? state.editSource
+      : undefined;
 
   const loaded = policyLoaded && formLoaded;
   const loadError = policyError ?? formError;
@@ -50,6 +60,7 @@ const EditAuthPolicyPage: React.FC = () => {
           policies={policies}
           initialPolicy={policyInfo.policy}
           returnTo={returnTo}
+          editSource={editSource}
         />
       )}
     </ApplicationsPage>

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -27,6 +27,7 @@ import MaasModelsSection from '~/app/shared/MaasModelsSection';
 import {
   EventTrackingResourceType,
   EventTrackingSource,
+  EventTrackingEditSource,
   MaaSEvents,
   EventTrackingContext,
 } from '~/app/types/event-tracking';
@@ -51,7 +52,9 @@ const PolicyActions: React.FC<PolicyActionsProps> = ({ policy, returnTo }) => {
   const navigate = useNavigate();
   const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
   const backUrl = returnTo ?? getSectionUrl('auth-policies');
-  const navState = returnTo ? { state: { returnTo } } : undefined;
+  const navState = returnTo
+    ? { state: { returnTo, editSource: EventTrackingEditSource.DETAIL_KEBAB } }
+    : undefined;
 
   return (
     <>

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
@@ -21,6 +21,7 @@ import {
   EventTrackingExpandedSection,
   EventTrackingResourceType,
   EventTrackingSource,
+  EventTrackingEditSource,
   MaaSEvents,
   EventTrackingPopoverType,
   convertStringToPopoverViewedStatus,
@@ -45,7 +46,9 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
   returnTo,
 }) => {
   const navigate = useNavigate();
-  const navState = returnTo ? { state: { returnTo } } : undefined;
+  const navState = returnTo
+    ? { state: { returnTo, editSource: EventTrackingEditSource.LIST_KEBAB } }
+    : undefined;
   const [expandedPanel, setExpandedPanel] = React.useState<ExpandedPanel>(null);
   const { affectedModels, overviewLoaded } = usePolicyAffectedModels(authPolicy);
 

--- a/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
@@ -23,6 +23,8 @@ import { isK8sNameDescriptionDataValid } from '@odh-dashboard/k8s-core';
 import { useZodFormValidation } from '@odh-dashboard/ui-core/hooks/useZodFormValidation';
 import { APIOptions } from 'mod-arch-core';
 import { z } from 'zod';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import AddModelsModal from '~/app/shared/AddModelsModal';
 import MaasModelsSection from '~/app/shared/MaasModelsSection';
 import { createAuthPolicy, updateAuthPolicy } from '~/app/api/auth-policies';
@@ -31,6 +33,17 @@ import { MaaSAuthPolicy, MaaSModelRefSummary, MaaSSubscription } from '~/app/typ
 import { modelRefsToSummaries } from '~/app/utilities/authpolicies';
 import { getSectionUrl } from '~/app/utilities/subscriptionManagementNavigation';
 import { useMaaSGovernanceContext } from '~/app/context/MaaSGovernanceContext';
+import {
+  AuthPolicyCreatedCancelProperties,
+  AuthPolicyCreatedErrorProperties,
+  AuthPolicyCreatedSuccessProperties,
+  AuthPolicyUpdatedCancelProperties,
+  AuthPolicyUpdatedErrorProperties,
+  AuthPolicyUpdatedSuccessProperties,
+  EventTrackingEditSource,
+  EventTrackingPrefillSource,
+  MaaSEvents,
+} from '~/app/types/event-tracking';
 
 const policyFormSchema = z.object({
   groups: z.array(z.string()).min(1, 'One or more groups must be selected'),
@@ -45,6 +58,7 @@ export type PolicyFormProps = {
   initialPolicy?: MaaSAuthPolicy;
   returnTo?: string;
   preSelectedModel?: { name: string; namespace?: string };
+  editSource?: EventTrackingEditSource;
 };
 
 const PolicyForm: React.FC<PolicyFormProps> = ({
@@ -55,6 +69,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
   initialPolicy,
   returnTo,
   preSelectedModel,
+  editSource,
 }) => {
   const navigate = useNavigate();
   const { refresh } = useMaaSGovernanceContext();
@@ -151,13 +166,19 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
       if (!initialPolicy) {
         const request: CreatePolicyRequest = { name: nameDescData.k8sName.value, ...sharedFields };
         await createAuthPolicy()(apiOpts, request);
+        fireFormTrackingEvent(MaaSEvents.AUTH_POLICY_CREATED, submitCreateTrackingEventProperties);
       } else {
         const request: UpdatePolicyRequest = sharedFields;
         await updateAuthPolicy(initialPolicy.name)(apiOpts, request);
+        fireFormTrackingEvent(MaaSEvents.AUTH_POLICY_UPDATED, submitUpdateTrackingEventProperties);
       }
       refresh();
       navigate(returnTo ?? getSectionUrl('auth-policies'));
     } catch (e) {
+      fireFormTrackingEvent(
+        initialPolicy ? MaaSEvents.AUTH_POLICY_UPDATED : MaaSEvents.AUTH_POLICY_CREATED,
+        initialPolicy ? errorUpdateTrackingEventProperties : errorCreateTrackingEventProperties,
+      );
       setSubmitError(e instanceof Error ? e.message : 'Failed to save policy');
     } finally {
       setIsSubmitting(false);
@@ -166,6 +187,49 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
 
   const primaryLabel = initialPolicy ? 'Save changes' : 'Create authorization policy';
   const primaryLoadingLabel = initialPolicy ? 'Saving...' : 'Creating...';
+
+  const cancelUpdateTrackingEventProperties: AuthPolicyUpdatedCancelProperties = {
+    outcome: TrackingOutcome.cancel,
+    editSource,
+  };
+
+  const cancelCreateTrackingEventProperties: AuthPolicyCreatedCancelProperties = {
+    outcome: TrackingOutcome.cancel,
+  };
+
+  const errorUpdateTrackingEventProperties: AuthPolicyUpdatedErrorProperties = {
+    outcome: TrackingOutcome.submit,
+    success: false,
+    error: submitError ?? 'Failed to update authorization policy',
+    editSource,
+  };
+
+  const errorCreateTrackingEventProperties: AuthPolicyCreatedErrorProperties = {
+    outcome: TrackingOutcome.submit,
+    success: false,
+    error: submitError ?? 'Failed to create authorization policy',
+  };
+
+  const submitUpdateTrackingEventProperties: AuthPolicyUpdatedSuccessProperties = {
+    outcome: TrackingOutcome.submit,
+    success: true,
+    groupCount: selectedGroupNames.length,
+    modelCount: selectedModels.length,
+    hasDescription: nameDescData.description.trim() !== '',
+    editSource,
+  };
+
+  const submitCreateTrackingEventProperties: AuthPolicyCreatedSuccessProperties = {
+    outcome: TrackingOutcome.submit,
+    success: true,
+    groupCount: selectedGroupNames.length,
+    modelCount: selectedModels.length,
+    hasDescription: nameDescData.description.trim() !== '',
+    modelCountAvailable: modelRefs.length,
+    prefillSource: preSelectedModel
+      ? EventTrackingPrefillSource.MODEL
+      : EventTrackingPrefillSource.NONE,
+  };
 
   return (
     <PageSection hasBodyWrapper={false}>
@@ -286,7 +350,15 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
           </Button>
           <Button
             variant="link"
-            onClick={() => navigate(returnTo ?? getSectionUrl('auth-policies'))}
+            onClick={() => {
+              navigate(returnTo ?? getSectionUrl('auth-policies'));
+              fireFormTrackingEvent(
+                initialPolicy ? MaaSEvents.AUTH_POLICY_UPDATED : MaaSEvents.AUTH_POLICY_CREATED,
+                initialPolicy
+                  ? cancelUpdateTrackingEventProperties
+                  : cancelCreateTrackingEventProperties,
+              );
+            }}
             isDisabled={isSubmitting}
             data-testid="policy-cancel-button"
           >

--- a/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
@@ -186,14 +186,12 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
               ...errorUpdateTrackingEventProperties,
               outcome: TrackingOutcome.submit,
               success: false,
-              error: errMsg,
               editSource,
             }
           : {
               ...errorCreateTrackingEventProperties,
               outcome: TrackingOutcome.submit,
               success: false,
-              error: errMsg,
             },
       );
       setSubmitError(errMsg);
@@ -217,14 +215,12 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
   const errorUpdateTrackingEventProperties: AuthPolicyUpdatedErrorProperties = {
     outcome: TrackingOutcome.submit,
     success: false,
-    error: submitError ?? 'Failed to update authorization policy',
     editSource,
   };
 
   const errorCreateTrackingEventProperties: AuthPolicyCreatedErrorProperties = {
     outcome: TrackingOutcome.submit,
     success: false,
-    error: submitError ?? 'Failed to create authorization policy',
   };
 
   const submitUpdateTrackingEventProperties: AuthPolicyUpdatedSuccessProperties = {

--- a/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
@@ -175,11 +175,28 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
       refresh();
       navigate(returnTo ?? getSectionUrl('auth-policies'));
     } catch (e) {
+      const errMsg =
+        e instanceof Error
+          ? e.message
+          : `Failed to ${initialPolicy ? 'update' : 'create'} authorization policy`;
       fireFormTrackingEvent(
         initialPolicy ? MaaSEvents.AUTH_POLICY_UPDATED : MaaSEvents.AUTH_POLICY_CREATED,
-        initialPolicy ? errorUpdateTrackingEventProperties : errorCreateTrackingEventProperties,
+        initialPolicy
+          ? {
+              ...errorUpdateTrackingEventProperties,
+              outcome: TrackingOutcome.submit,
+              success: false,
+              error: errMsg,
+              editSource,
+            }
+          : {
+              ...errorCreateTrackingEventProperties,
+              outcome: TrackingOutcome.submit,
+              success: false,
+              error: errMsg,
+            },
       );
-      setSubmitError(e instanceof Error ? e.message : 'Failed to save policy');
+      setSubmitError(errMsg);
     } finally {
       setIsSubmitting(false);
     }

--- a/packages/maas/frontend/src/app/pages/subscriptions/EditSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/EditSubscriptionPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '~/app/utilities/subscriptionManagementNavigation';
 import { useGetSubscriptionInfo } from '~/app/hooks/useGetSubscriptionInfo';
 import { useMaaSGovernanceContext } from '~/app/context/MaaSGovernanceContext';
+import { EventTrackingEditSource } from '~/app/types/event-tracking';
 import CreateSubscriptionForm from './createSubscription/CreateSubscriptionForm';
 
 const EditSubscriptionPage: React.FC = () => {
@@ -31,6 +32,15 @@ const EditSubscriptionPage: React.FC = () => {
     subscriptionInfo?.subscription.displayName ||
     subscriptionInfo?.subscription.name ||
     subscriptionName;
+
+  const editSource =
+    state != null &&
+    typeof state === 'object' &&
+    'editSource' in state &&
+    (state.editSource === EventTrackingEditSource.LIST_KEBAB ||
+      state.editSource === EventTrackingEditSource.DETAIL_KEBAB)
+      ? state.editSource
+      : undefined;
 
   return (
     <ApplicationsPage
@@ -69,6 +79,7 @@ const EditSubscriptionPage: React.FC = () => {
           policies={policies}
           subscriptionInfo={subscriptionInfo}
           returnTo={returnTo}
+          editSource={editSource}
         />
       )}
     </ApplicationsPage>

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -32,6 +32,7 @@ import { modelRefsToSummaries } from '~/app/utilities/authpolicies';
 import {
   EventTrackingResourceType,
   EventTrackingSource,
+  EventTrackingEditSource,
   MaaSEvents,
   EventTrackingContext,
 } from '~/app/types/event-tracking';
@@ -48,7 +49,12 @@ const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription,
   const navigate = useNavigate();
   const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
   const backUrl = returnTo ?? getSectionUrl('subscriptions');
-  const navState = returnTo ? { state: { returnTo } } : undefined;
+  const navState = {
+    state: {
+      ...(returnTo ? { returnTo } : {}),
+      editSource: EventTrackingEditSource.DETAIL_KEBAB,
+    },
+  };
 
   return (
     <>

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
@@ -24,6 +24,7 @@ import {
   EventTrackingResourceType,
   EventTrackingSource,
   convertStringToPopoverViewedStatus,
+  EventTrackingEditSource,
   MaaSEvents,
   SubscriptionManagementStatusPopoverViewedProperties,
 } from '~/app/types/event-tracking';
@@ -45,7 +46,12 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
   returnTo,
 }) => {
   const navigate = useNavigate();
-  const navState = returnTo ? { state: { returnTo } } : undefined;
+  const navState = {
+    state: {
+      ...(returnTo ? { returnTo } : {}),
+      editSource: EventTrackingEditSource.LIST_KEBAB,
+    },
+  };
   const [expandedPanel, setExpandedPanel] = React.useState<ExpandedPanel>(null);
   const { affectedModels, overviewLoaded } = useSubscriptionAffectedModels(subscription);
 

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -297,13 +297,11 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
               ...errorEditTrackingEventProperties,
               outcome: TrackingOutcome.submit,
               success: false,
-              error: errMsg,
             }
           : {
               ...errorCreateTrackingEventProperties,
               outcome: TrackingOutcome.submit,
               success: false,
-              error: errMsg,
             },
       );
       setSubmitError(errMsg);
@@ -353,13 +351,11 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
   const errorCreateTrackingEventProperties: SubscriptionCreatedErrorProperties = {
     outcome: TrackingOutcome.submit,
     success: false,
-    error: submitError ?? 'Failed to create subscription',
   };
 
   const errorEditTrackingEventProperties: SubscriptionUpdatedErrorProperties = {
     outcome: TrackingOutcome.submit,
     success: false,
-    error: submitError ?? 'Failed to update subscription',
     editSource,
   };
 

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -26,6 +26,8 @@ import { useZodFormValidation } from '@odh-dashboard/ui-core/hooks/useZodFormVal
 import { APIOptions } from 'mod-arch-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { z } from 'zod';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { getSectionUrl } from '~/app/utilities/subscriptionManagementNavigation';
 import { createSubscription, updateSubscription } from '~/app/api/subscriptions';
 import { useMaaSGovernanceContext } from '~/app/context/MaaSGovernanceContext';
@@ -41,6 +43,17 @@ import {
 } from '~/app/types/subscriptions';
 import AddModelsModal from '~/app/shared/AddModelsModal';
 import MaasModelsSection from '~/app/shared/MaasModelsSection';
+import {
+  EventTrackingEditSource,
+  EventTrackingPrefillSource,
+  MaaSEvents,
+  SubscriptionCreatedCancelProperties,
+  SubscriptionCreatedErrorProperties,
+  SubscriptionCreatedSuccessProperties,
+  SubscriptionUpdatedCancelProperties,
+  SubscriptionUpdatedErrorProperties,
+  SubscriptionUpdatedSuccessProperties,
+} from '~/app/types/event-tracking';
 import EditRateLimitsModal from './EditRateLimitsModal';
 
 type CreateSubscriptionFormProps = {
@@ -51,6 +64,7 @@ type CreateSubscriptionFormProps = {
   subscriptionInfo?: SubscriptionInfoResponse;
   returnTo?: string;
   preSelectedModel?: { name: string; namespace?: string };
+  editSource?: EventTrackingEditSource;
 };
 const MAX_PRIORITY = 1000000;
 const MIN_PRIORITY = -1000000;
@@ -90,6 +104,7 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
   subscriptionInfo,
   returnTo,
   preSelectedModel,
+  editSource,
 }) => {
   const navigate = useNavigate();
   const { refresh } = useMaaSGovernanceContext();
@@ -226,6 +241,12 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
     isPriorityValid &&
     !isSubmitting;
 
+  const modelRefsPayload = models.map((m) => ({
+    name: m.modelRefSummary.name,
+    namespace: m.modelRefSummary.namespace,
+    tokenRateLimits: m.tokenRateLimits,
+  }));
+
   const handleSubmit = async () => {
     if (priority == null || Number.isNaN(priority)) {
       return;
@@ -233,12 +254,6 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
 
     setIsSubmitting(true);
     setSubmitError(null);
-
-    const modelRefsPayload = models.map((m) => ({
-      name: m.modelRefSummary.name,
-      namespace: m.modelRefSummary.namespace,
-      tokenRateLimits: m.tokenRateLimits,
-    }));
 
     try {
       const apiOpts: APIOptions = {};
@@ -253,6 +268,7 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
           modelRefs: modelRefsPayload,
           priority,
         };
+        fireFormTrackingEvent(MaaSEvents.SUBSCRIPTION_UPDATED, submitEditTrackingEventProperties);
         await updateSubscription()(apiOpts, subscription.name, request);
       } else {
         const request: CreateSubscriptionRequest = {
@@ -264,11 +280,16 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
           priority,
           createAuthPolicy,
         };
+        fireFormTrackingEvent(MaaSEvents.SUBSCRIPTION_CREATED, submitCreateTrackingEventProperties);
         await createSubscription()(apiOpts, request);
       }
       refresh();
       navigate(returnTo ?? getSectionUrl('subscriptions'));
     } catch (e) {
+      fireFormTrackingEvent(
+        isEditing ? MaaSEvents.SUBSCRIPTION_UPDATED : MaaSEvents.SUBSCRIPTION_CREATED,
+        isEditing ? errorEditTrackingEventProperties : errorCreateTrackingEventProperties,
+      );
       setSubmitError(
         e instanceof Error
           ? e.message
@@ -280,6 +301,55 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
 
   const showNoModelsWarning = !isEditing && modelRefs.length === 0 && models.length === 0;
   const canAddModels = modelRefs.length > 0;
+
+  const cancelEditTrackingEventProperties: SubscriptionUpdatedCancelProperties = {
+    outcome: TrackingOutcome.cancel,
+    editSource,
+  };
+
+  const cancelCreateTrackingEventProperties: SubscriptionCreatedCancelProperties = {
+    outcome: TrackingOutcome.cancel,
+    modelCount: models.length,
+    modelCountWoLimit: modelRefsPayload.filter((m) => m.tokenRateLimits.length === 0).length,
+  };
+
+  const submitEditTrackingEventProperties: SubscriptionUpdatedSuccessProperties = {
+    outcome: TrackingOutcome.submit,
+    success: true,
+    groupCount: selectedGroupNames.length,
+    modelCount: models.length,
+    hasDescription: nameDescData.description.trim() !== '',
+    hasMatchingPolicy: formData.policies.some((p) => p.name === subscription?.name),
+    priority: priority ?? 0,
+  };
+
+  const prefillSource = preSelectedModel
+    ? EventTrackingPrefillSource.MODEL
+    : EventTrackingPrefillSource.NONE;
+  const submitCreateTrackingEventProperties: SubscriptionCreatedSuccessProperties = {
+    outcome: TrackingOutcome.submit,
+    success: true,
+    groupCount: selectedGroupNames.length,
+    modelCount: models.length,
+    hasDescription: nameDescData.description.trim() !== '',
+    modelCountAvailable: modelRefsPayload.length,
+    hasMatchingPolicy: formData.policies.some((p) => p.name === subscription?.name),
+    priority: priority ?? 0,
+    prefillSource,
+  };
+
+  const errorCreateTrackingEventProperties: SubscriptionCreatedErrorProperties = {
+    outcome: TrackingOutcome.submit,
+    success: false,
+    error: submitError ?? 'Failed to create subscription',
+  };
+
+  const errorEditTrackingEventProperties: SubscriptionUpdatedErrorProperties = {
+    outcome: TrackingOutcome.submit,
+    success: false,
+    error: submitError ?? 'Failed to update subscription',
+    editSource,
+  };
 
   return (
     <PageSection hasBodyWrapper={false}>
@@ -525,7 +595,13 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
           </Button>
           <Button
             variant="link"
-            onClick={() => navigate(returnTo ?? getSectionUrl('subscriptions'))}
+            onClick={() => {
+              navigate(returnTo ?? getSectionUrl('subscriptions'));
+              fireFormTrackingEvent(
+                isEditing ? MaaSEvents.SUBSCRIPTION_UPDATED : MaaSEvents.SUBSCRIPTION_CREATED,
+                isEditing ? cancelEditTrackingEventProperties : cancelCreateTrackingEventProperties,
+              );
+            }}
             isDisabled={isSubmitting}
             data-testid="cancel-subscription-button"
           >

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -268,8 +268,8 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
           modelRefs: modelRefsPayload,
           priority,
         };
-        fireFormTrackingEvent(MaaSEvents.SUBSCRIPTION_UPDATED, submitEditTrackingEventProperties);
         await updateSubscription()(apiOpts, subscription.name, request);
+        fireFormTrackingEvent(MaaSEvents.SUBSCRIPTION_UPDATED, submitEditTrackingEventProperties);
       } else {
         const request: CreateSubscriptionRequest = {
           name: nameDescData.k8sName.value,
@@ -280,21 +280,33 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
           priority,
           createAuthPolicy,
         };
-        fireFormTrackingEvent(MaaSEvents.SUBSCRIPTION_CREATED, submitCreateTrackingEventProperties);
         await createSubscription()(apiOpts, request);
+        fireFormTrackingEvent(MaaSEvents.SUBSCRIPTION_CREATED, submitCreateTrackingEventProperties);
       }
       refresh();
       navigate(returnTo ?? getSectionUrl('subscriptions'));
     } catch (e) {
-      fireFormTrackingEvent(
-        isEditing ? MaaSEvents.SUBSCRIPTION_UPDATED : MaaSEvents.SUBSCRIPTION_CREATED,
-        isEditing ? errorEditTrackingEventProperties : errorCreateTrackingEventProperties,
-      );
-      setSubmitError(
+      const errMsg =
         e instanceof Error
           ? e.message
-          : `Failed to ${isEditing ? 'update' : 'create'} subscription`,
+          : `Failed to ${isEditing ? 'update' : 'create'} subscription`;
+      fireFormTrackingEvent(
+        isEditing ? MaaSEvents.SUBSCRIPTION_UPDATED : MaaSEvents.SUBSCRIPTION_CREATED,
+        isEditing
+          ? {
+              ...errorEditTrackingEventProperties,
+              outcome: TrackingOutcome.submit,
+              success: false,
+              error: errMsg,
+            }
+          : {
+              ...errorCreateTrackingEventProperties,
+              outcome: TrackingOutcome.submit,
+              success: false,
+              error: errMsg,
+            },
       );
+      setSubmitError(errMsg);
       setIsSubmitting(false);
     }
   };
@@ -321,6 +333,7 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
     hasDescription: nameDescData.description.trim() !== '',
     hasMatchingPolicy: formData.policies.some((p) => p.name === subscription?.name),
     priority: priority ?? 0,
+    editSource,
   };
 
   const prefillSource = preSelectedModel
@@ -332,7 +345,7 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
     groupCount: selectedGroupNames.length,
     modelCount: models.length,
     hasDescription: nameDescData.description.trim() !== '',
-    modelCountAvailable: modelRefsPayload.length,
+    modelCountAvailable: formData.modelRefs.length,
     hasMatchingPolicy: formData.policies.some((p) => p.name === subscription?.name),
     priority: priority ?? 0,
     prefillSource,

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -331,7 +331,6 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
     groupCount: selectedGroupNames.length,
     modelCount: models.length,
     hasDescription: nameDescData.description.trim() !== '',
-    hasMatchingPolicy: formData.policies.some((p) => p.name === subscription?.name),
     priority: priority ?? 0,
     editSource,
   };
@@ -345,8 +344,8 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
     groupCount: selectedGroupNames.length,
     modelCount: models.length,
     hasDescription: nameDescData.description.trim() !== '',
-    modelCountAvailable: formData.modelRefs.length,
-    hasMatchingPolicy: formData.policies.some((p) => p.name === subscription?.name),
+    modelCountAvailable: modelRefs.length,
+    hasMatchingPolicy: createAuthPolicy,
     priority: priority ?? 0,
     prefillSource,
   };

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/EditRateLimitsModal.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/EditRateLimitsModal.tsx
@@ -63,7 +63,6 @@ const EditRateLimitsModal: React.FC<EditRateLimitsModalProps> = ({
       return;
     }
     onSave(localLimits.map(toTokenRateLimit));
-    onClose();
   };
 
   const title = `Edit subscription token limits`;

--- a/packages/maas/frontend/src/app/types/event-tracking.ts
+++ b/packages/maas/frontend/src/app/types/event-tracking.ts
@@ -54,20 +54,20 @@ export type AuthPolicyUpdatedSuccessProperties = {
   groupCount: number;
   modelCount: number;
   hasDescription: boolean;
-  hasMatchingSubscription: boolean;
-  editSource: EventTrackingEditSource;
+  hasMatchingSubscription?: boolean;
+  editSource?: EventTrackingEditSource;
 };
 
 export type AuthPolicyUpdatedErrorProperties = {
   outcome: TrackingOutcome;
   success: boolean;
   error: string;
-  editSource: EventTrackingEditSource;
+  editSource?: EventTrackingEditSource;
 };
 
 export type AuthPolicyUpdatedCancelProperties = {
   outcome: TrackingOutcome;
-  editSource: EventTrackingEditSource;
+  editSource?: EventTrackingEditSource;
 };
 
 export type AuthPolicyCreatedSuccessProperties = {
@@ -77,7 +77,7 @@ export type AuthPolicyCreatedSuccessProperties = {
   modelCount: number;
   modelCountAvailable: number;
   hasDescription: boolean;
-  hasMatchingSubscription: boolean;
+  hasMatchingSubscription?: boolean;
   prefillSource: EventTrackingPrefillSource;
 };
 
@@ -100,7 +100,7 @@ export type SubscriptionCreatedSuccessProperties = {
   hasDescription: boolean;
   hasMatchingPolicy: boolean;
   priority: number;
-  prefillSource: EventTrackingPrefillSource;
+  prefillSource?: EventTrackingPrefillSource;
 };
 
 export type SubscriptionCreatedErrorProperties = {
@@ -120,21 +120,25 @@ export type SubscriptionUpdatedSuccessProperties = {
   groupCount: number;
   modelCount: number;
   hasDescription: boolean;
-  hasMatchingPolicy: boolean;
+  hasMatchingPolicy?: boolean;
   priority: number;
-  editSource: EventTrackingEditSource;
+  editSource?: EventTrackingEditSource;
 };
 
 export type SubscriptionUpdatedErrorProperties = {
   outcome: TrackingOutcome;
   success: boolean;
   error: string;
-  editSource: EventTrackingEditSource;
+  editSource?: EventTrackingEditSource;
 };
 
 export type SubscriptionUpdatedCancelProperties = {
   outcome: TrackingOutcome;
-  editSource: EventTrackingEditSource;
+  editSource?: EventTrackingEditSource;
+};
+
+export type SubscriptionTokenLimitsConfiguredCancelProperties = {
+  outcome: TrackingOutcome;
 };
 
 export type SubscriptionTokenLimitsConfiguredSuccessProperties = {

--- a/packages/maas/frontend/src/app/types/event-tracking.ts
+++ b/packages/maas/frontend/src/app/types/event-tracking.ts
@@ -23,7 +23,135 @@ export const MaaSEvents = {
   EXTERNAL_MODELS_PROVIDER_LABELS_EXPANDED: 'External Models Provider Labels Expanded',
   EXTERNAL_MODELS_INFO_POPOVER_VIEWED: 'External Models Info Popover Viewed',
   EXTERNAL_MODEL_PROVIDER_DETAIL_VIEWED: 'External Model Provider Detail Viewed',
+  SUBSCRIPTION_CREATED: 'Subscription Created',
+  SUBSCRIPTION_UPDATED: 'Subscription Updated',
+  SUBSCRIPTION_TOKEN_LIMITS_CONFIGURED: 'Subscription Token Limits Configured',
+  AUTH_POLICY_CREATED: 'Auth Policy Created',
+  AUTH_POLICY_UPDATED: 'Auth Policy Updated',
+  MODEL_AS_MAAS_PUBLISHED: 'Model as Maas Published',
 };
+
+export type ModelAsMaasPublishedProperties = {
+  outcome: TrackingOutcome;
+  success: boolean;
+  source: PublishedAsMaasSource;
+  addedAsMaas: boolean;
+  mode: ModelDeploymentMode;
+};
+
+export enum PublishedAsMaasSource {
+  MODEL_DEPLOYMENT_WIZARD = 'deployment_wizard',
+}
+
+export enum ModelDeploymentMode {
+  CREATE = 'create',
+  EDIT = 'edit',
+}
+
+export type AuthPolicyUpdatedSuccessProperties = {
+  outcome: TrackingOutcome;
+  success: boolean;
+  groupCount: number;
+  modelCount: number;
+  hasDescription: boolean;
+  hasMatchingSubscription: boolean;
+  editSource: EventTrackingEditSource;
+};
+
+export type AuthPolicyUpdatedErrorProperties = {
+  outcome: TrackingOutcome;
+  success: boolean;
+  error: string;
+  editSource: EventTrackingEditSource;
+};
+
+export type AuthPolicyUpdatedCancelProperties = {
+  outcome: TrackingOutcome;
+  editSource: EventTrackingEditSource;
+};
+
+export type AuthPolicyCreatedSuccessProperties = {
+  outcome: TrackingOutcome;
+  success: boolean;
+  groupCount: number;
+  modelCount: number;
+  modelCountAvailable: number;
+  hasDescription: boolean;
+  hasMatchingSubscription: boolean;
+  prefillSource: EventTrackingPrefillSource;
+};
+
+export type AuthPolicyCreatedErrorProperties = {
+  outcome: TrackingOutcome;
+  success: boolean;
+  error: string;
+};
+
+export type AuthPolicyCreatedCancelProperties = {
+  outcome: TrackingOutcome;
+};
+
+export type SubscriptionCreatedSuccessProperties = {
+  outcome: TrackingOutcome;
+  success: boolean;
+  groupCount: number;
+  modelCount: number;
+  modelCountAvailable: number;
+  hasDescription: boolean;
+  hasMatchingPolicy: boolean;
+  priority: number;
+  prefillSource: EventTrackingPrefillSource;
+};
+
+export type SubscriptionCreatedErrorProperties = {
+  outcome: TrackingOutcome;
+  success: boolean;
+  error: string;
+};
+
+export type SubscriptionCreatedCancelProperties = {
+  outcome: TrackingOutcome;
+  modelCount: number;
+  modelCountWoLimit: number;
+};
+export type SubscriptionUpdatedSuccessProperties = {
+  outcome: TrackingOutcome;
+  success: boolean;
+  groupCount: number;
+  modelCount: number;
+  hasDescription: boolean;
+  hasMatchingPolicy: boolean;
+  priority: number;
+  editSource: EventTrackingEditSource;
+};
+
+export type SubscriptionUpdatedErrorProperties = {
+  outcome: TrackingOutcome;
+  success: boolean;
+  error: string;
+  editSource: EventTrackingEditSource;
+};
+
+export type SubscriptionUpdatedCancelProperties = {
+  outcome: TrackingOutcome;
+  editSource: EventTrackingEditSource;
+};
+
+export type SubscriptionTokenLimitsConfiguredSuccessProperties = {
+  outcome: TrackingOutcome;
+  limitCount: number;
+};
+
+export enum EventTrackingPrefillSource {
+  MODEL = 'model',
+  GROUP = 'group',
+  NONE = 'none',
+}
+
+export enum EventTrackingEditSource {
+  LIST_KEBAB = 'list-kebab',
+  DETAIL_KEBAB = 'detail-kebab',
+}
 
 export type MaaSResourceDeletedProperties = {
   resourceType: EventTrackingResourceType;

--- a/packages/maas/frontend/src/app/types/event-tracking.ts
+++ b/packages/maas/frontend/src/app/types/event-tracking.ts
@@ -61,7 +61,6 @@ export type AuthPolicyUpdatedSuccessProperties = {
 export type AuthPolicyUpdatedErrorProperties = {
   outcome: TrackingOutcome;
   success: boolean;
-  error: string;
   editSource?: EventTrackingEditSource;
 };
 
@@ -84,7 +83,6 @@ export type AuthPolicyCreatedSuccessProperties = {
 export type AuthPolicyCreatedErrorProperties = {
   outcome: TrackingOutcome;
   success: boolean;
-  error: string;
 };
 
 export type AuthPolicyCreatedCancelProperties = {
@@ -106,7 +104,6 @@ export type SubscriptionCreatedSuccessProperties = {
 export type SubscriptionCreatedErrorProperties = {
   outcome: TrackingOutcome;
   success: boolean;
-  error: string;
 };
 
 export type SubscriptionCreatedCancelProperties = {
@@ -128,7 +125,6 @@ export type SubscriptionUpdatedSuccessProperties = {
 export type SubscriptionUpdatedErrorProperties = {
   outcome: TrackingOutcome;
   success: boolean;
-  error: string;
   editSource?: EventTrackingEditSource;
 };
 

--- a/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/MaaSEndpointCheckbox.tsx
+++ b/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/MaaSEndpointCheckbox.tsx
@@ -1,12 +1,21 @@
 import React from 'react';
 import { Checkbox, Flex, FlexItem, Stack, StackItem } from '@patternfly/react-core';
+import { useLocation } from 'react-router-dom';
 import { z } from 'zod';
 import type {
   WizardField,
+  WizardFormData,
   WizardStateOverrides,
 } from '@odh-dashboard/model-serving/shared/types/form-data';
 import { isLLMInferenceServiceActive } from '@odh-dashboard/llmd-serving/formUtils';
+import { ModelDeploymentMode } from '~/app/types/event-tracking';
 import { MAAS_DEFAULT_GATEWAY } from './maasDeploymentTransformer';
+import {
+  endMaaSPublishTrackingSession,
+  isDeploymentWizardPath,
+  startMaaSPublishTrackingSession,
+  updateMaaSPublishTrackingSession,
+} from './maasPublishTracking';
 
 export type MaaSFieldValue = {
   isChecked: boolean;
@@ -19,6 +28,56 @@ export const maasFieldSchema = z.object({
 const setMaaSFieldData = (value: MaaSFieldValue): MaaSFieldValue => value;
 const getInitialMaaSFieldData = (value?: MaaSFieldValue): MaaSFieldValue =>
   value ?? { isChecked: false };
+
+const isMaaSFieldValue = (value: unknown): value is MaaSFieldValue =>
+  value != null &&
+  typeof value === 'object' &&
+  'isChecked' in value &&
+  typeof value.isChecked === 'boolean';
+
+type MaaSTrackingDependencies = {
+  addedAsMaas: boolean;
+};
+
+const resolveMaaSTrackingDependencies = (
+  formData: WizardFormData['state'],
+): MaaSTrackingDependencies => {
+  const raw: unknown = formData['maas/save-as-maas-checkbox'];
+  return { addedAsMaas: isMaaSFieldValue(raw) ? raw.isChecked : false };
+};
+
+/**
+ * Keeps a publish-tracking session alive for the whole wizard while this field is
+ * active (not only while the Advanced settings step is mounted). On wizard exit
+ * without submit, fires cancel.
+ */
+const useMaaSPublishTrackingSession = (
+  dependencies?: MaaSTrackingDependencies,
+): { data: null; loaded: true } => {
+  const location = useLocation();
+  const isEditing = Boolean(
+    location.state?.existingDeployment || location.state?.initialData?.isEditing,
+  );
+  const mode = isEditing ? ModelDeploymentMode.EDIT : ModelDeploymentMode.CREATE;
+  const addedAsMaas = dependencies?.addedAsMaas ?? false;
+
+  React.useEffect(() => {
+    startMaaSPublishTrackingSession(mode);
+  }, [mode]);
+
+  React.useEffect(() => {
+    updateMaaSPublishTrackingSession(addedAsMaas);
+  }, [addedAsMaas]);
+
+  React.useEffect(
+    () => () => {
+      endMaaSPublishTrackingSession(!isDeploymentWizardPath(window.location.pathname));
+    },
+    [],
+  );
+
+  return { data: null, loaded: true };
+};
 
 type MaaSFieldProps = {
   id: string;
@@ -58,7 +117,7 @@ const MaaSField: React.FC<MaaSFieldProps> = ({ id, value, onChange, isDisabled }
   );
 };
 
-export type MaaSFieldType = WizardField<MaaSFieldValue>;
+export type MaaSFieldType = WizardField<MaaSFieldValue, null, MaaSTrackingDependencies>;
 
 export const MaaSEndpointFieldWizardField: MaaSFieldType = {
   id: 'maas/save-as-maas-checkbox',
@@ -70,6 +129,7 @@ export const MaaSEndpointFieldWizardField: MaaSFieldType = {
     setFieldData: setMaaSFieldData,
     getInitialFieldData: getInitialMaaSFieldData,
     validationSchema: maasFieldSchema,
+    resolveDependencies: resolveMaaSTrackingDependencies,
     getFieldOverrides: (fieldValue) => {
       const overrides: WizardStateOverrides = {};
       if (fieldValue.isChecked) {
@@ -82,6 +142,7 @@ export const MaaSEndpointFieldWizardField: MaaSFieldType = {
     },
   },
   component: MaaSField,
+  externalDataHook: useMaaSPublishTrackingSession,
   getReviewSections: (value) => [
     {
       title: 'Advanced settings',

--- a/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/__tests__/maasPublishTracking.test.ts
+++ b/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/__tests__/maasPublishTracking.test.ts
@@ -1,0 +1,120 @@
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { MaaSEvents, ModelDeploymentMode, PublishedAsMaasSource } from '~/app/types/event-tracking';
+import {
+  endMaaSPublishTrackingSession,
+  fireMaaSPublishTrackingEvent,
+  isDeploymentWizardPath,
+  markMaaSPublishSubmitAttempted,
+  resetMaaSPublishTrackingSession,
+  startMaaSPublishTrackingSession,
+  updateMaaSPublishTrackingSession,
+} from '~/odh/modelServingExtensions/modelDeploymentWizard/maasPublishTracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+}));
+
+const mockFireFormTrackingEvent = jest.mocked(fireFormTrackingEvent);
+
+describe('maasPublishTracking', () => {
+  beforeEach(() => {
+    resetMaaSPublishTrackingSession();
+    mockFireFormTrackingEvent.mockClear();
+  });
+
+  describe('isDeploymentWizardPath', () => {
+    it('should return true for the deploy wizard path', () => {
+      expect(isDeploymentWizardPath('/ai-hub/models/deployments/deploy')).toBe(true);
+      expect(isDeploymentWizardPath('/ai-hub/models/deployments/deploy/extra')).toBe(true);
+    });
+
+    it('should return false for non-wizard paths', () => {
+      expect(isDeploymentWizardPath('/ai-hub/models/deployments')).toBe(false);
+      expect(isDeploymentWizardPath('/ai-hub/models/deployments/test-project')).toBe(false);
+    });
+  });
+
+  describe('fireMaaSPublishTrackingEvent', () => {
+    it('should not fire when no session is active', () => {
+      fireMaaSPublishTrackingEvent(TrackingOutcome.submit, true);
+      expect(mockFireFormTrackingEvent).not.toHaveBeenCalled();
+    });
+
+    it('should fire submit success with session and override values', () => {
+      startMaaSPublishTrackingSession(ModelDeploymentMode.CREATE);
+      updateMaaSPublishTrackingSession(false);
+
+      fireMaaSPublishTrackingEvent(TrackingOutcome.submit, true, {
+        addedAsMaas: true,
+        mode: ModelDeploymentMode.EDIT,
+      });
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledTimes(1);
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(MaaSEvents.MODEL_AS_MAAS_PUBLISHED, {
+        outcome: TrackingOutcome.submit,
+        success: true,
+        source: PublishedAsMaasSource.MODEL_DEPLOYMENT_WIZARD,
+        addedAsMaas: true,
+        mode: ModelDeploymentMode.EDIT,
+      });
+    });
+
+    it('should fire only once per session', () => {
+      startMaaSPublishTrackingSession(ModelDeploymentMode.CREATE);
+      fireMaaSPublishTrackingEvent(TrackingOutcome.submit, true);
+      fireMaaSPublishTrackingEvent(TrackingOutcome.cancel, false);
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('endMaaSPublishTrackingSession', () => {
+    it('should fire cancel when leaving the wizard without a prior event', () => {
+      startMaaSPublishTrackingSession(ModelDeploymentMode.CREATE);
+      updateMaaSPublishTrackingSession(true);
+
+      endMaaSPublishTrackingSession(true);
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(MaaSEvents.MODEL_AS_MAAS_PUBLISHED, {
+        outcome: TrackingOutcome.cancel,
+        success: false,
+        source: PublishedAsMaasSource.MODEL_DEPLOYMENT_WIZARD,
+        addedAsMaas: true,
+        mode: ModelDeploymentMode.CREATE,
+      });
+    });
+
+    it('should fire submit failure when leaving after a failed deploy attempt', () => {
+      startMaaSPublishTrackingSession(ModelDeploymentMode.EDIT);
+      updateMaaSPublishTrackingSession(true);
+      markMaaSPublishSubmitAttempted();
+
+      endMaaSPublishTrackingSession(true);
+
+      expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(MaaSEvents.MODEL_AS_MAAS_PUBLISHED, {
+        outcome: TrackingOutcome.submit,
+        success: false,
+        source: PublishedAsMaasSource.MODEL_DEPLOYMENT_WIZARD,
+        addedAsMaas: true,
+        mode: ModelDeploymentMode.EDIT,
+      });
+    });
+
+    it('should not fire when the field becomes inactive while still on the wizard', () => {
+      startMaaSPublishTrackingSession(ModelDeploymentMode.CREATE);
+      endMaaSPublishTrackingSession(false);
+      expect(mockFireFormTrackingEvent).not.toHaveBeenCalled();
+    });
+
+    it('should not fire cancel after a successful submit', () => {
+      startMaaSPublishTrackingSession(ModelDeploymentMode.CREATE);
+      fireMaaSPublishTrackingEvent(TrackingOutcome.submit, true);
+      mockFireFormTrackingEvent.mockClear();
+
+      endMaaSPublishTrackingSession(true);
+
+      expect(mockFireFormTrackingEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maas-model-ref.ts
+++ b/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maas-model-ref.ts
@@ -1,11 +1,28 @@
 import type { LLMdDeployment } from '@odh-dashboard/llmd-serving/types';
 import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
 import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { createMaaSModelRef, deleteMaaSModelRef, updateMaaSModelRef } from '~/app/api/maas-models';
+import { ModelDeploymentMode } from '~/app/types/event-tracking';
 import type { MaaSFieldValue } from './MaaSEndpointCheckbox';
+import {
+  fireMaaSPublishTrackingEvent,
+  markMaaSPublishSubmitAttempted,
+} from './maasPublishTracking';
 
 const LLMINFERENCESERVICE_KIND = 'LLMInferenceService';
 const MODEL_CAPABILITIES_ANNOTATION = 'opendatahub.io/model-capabilities';
+
+const getDeploymentMode = (existingDeployment?: LLMdDeployment): ModelDeploymentMode =>
+  existingDeployment ? ModelDeploymentMode.EDIT : ModelDeploymentMode.CREATE;
+
+const trackingOverrides = (
+  fieldData: MaaSFieldValue,
+  existingDeployment?: LLMdDeployment,
+): { addedAsMaas: boolean; mode: ModelDeploymentMode } => ({
+  addedAsMaas: fieldData.isChecked === true,
+  mode: getDeploymentMode(existingDeployment),
+});
 
 /** Parse the JSON-string-array annotation value from a K8s object's annotations. Returns undefined when absent or malformed. */
 const parseModelCapabilities = (annotations?: Record<string, string>): string[] | undefined => {
@@ -38,6 +55,8 @@ export const preDeployMaaSModelRef = async (
   existingDeployment?: LLMdDeployment,
   dryRun?: boolean,
 ): Promise<DeploymentHookPayloadFor<LLMdDeployment>> => {
+  markMaaSPublishSubmitAttempted();
+
   if (typeof fieldData.isChecked !== 'boolean') {
     return deployment;
   }
@@ -55,52 +74,58 @@ export const preDeployMaaSModelRef = async (
   const displayName = modelResource.metadata.annotations?.['openshift.io/display-name'] ?? name;
   const description = modelResource.metadata.annotations?.['openshift.io/description'] ?? '';
   const modelCapabilities = parseModelCapabilities(modelResource.metadata.annotations);
+  const overrides = trackingOverrides(fieldData, existingDeployment);
 
   // real run is done in postDeploy
   if (!dryRun) {
     return deployment;
   }
 
-  if (existingDeployment) {
-    if (!isChecked) {
-      try {
-        await deleteMaaSModelRef(namespace, name, '', true)({});
-      } catch (err) {
-        // Tolerate 404 — the MaaSModelRef may have been cleaned up already
-        const message = err instanceof Error ? err.message : String(err);
-        if (!message.includes('not found') && !message.includes('404')) {
-          throw err;
+  try {
+    if (existingDeployment) {
+      if (!isChecked) {
+        try {
+          await deleteMaaSModelRef(namespace, name, '', true)({});
+        } catch (err) {
+          // Tolerate 404 — the MaaSModelRef may have been cleaned up already
+          const message = err instanceof Error ? err.message : String(err);
+          if (!message.includes('not found') && !message.includes('404')) {
+            throw err;
+          }
         }
-      }
-    } else {
-      try {
-        await updateMaaSModelRef(
-          namespace,
-          name,
-          { modelRef, displayName, description, modelCapabilities },
-          '',
-          true,
-        )({});
-      } catch (err) {
-        // If the MaaSModelRef was somehow removed externally, dry-run the create instead
-        const message = err instanceof Error ? err.message : String(err);
-        if (message.includes('not found') || message.includes('404')) {
-          await createMaaSModelRef(
+      } else {
+        try {
+          await updateMaaSModelRef(
+            namespace,
+            name,
+            { modelRef, displayName, description, modelCapabilities },
             '',
-            { name, namespace, modelRef, uid: '', displayName, description, modelCapabilities },
             true,
           )({});
-        } else {
-          throw err;
+        } catch (err) {
+          // If the MaaSModelRef was somehow removed externally, dry-run the create instead
+          const message = err instanceof Error ? err.message : String(err);
+          if (message.includes('not found') || message.includes('404')) {
+            await createMaaSModelRef(
+              '',
+              { name, namespace, modelRef, uid: '', displayName, description, modelCapabilities },
+              true,
+            )({});
+          } else {
+            throw err;
+          }
         }
       }
+    } else if (isChecked) {
+      await createMaaSModelRef(
+        '',
+        { name, namespace, modelRef, uid: '', displayName, description, modelCapabilities },
+        true,
+      )({});
     }
-  } else if (isChecked) {
-    await createMaaSModelRef(
-      '',
-      { name, namespace, modelRef, uid: '', displayName, description, modelCapabilities },
-      true,
-    )({});
+  } catch (err) {
+    fireMaaSPublishTrackingEvent(TrackingOutcome.submit, false, overrides);
+    throw err;
   }
   return deployment;
 };
@@ -128,6 +153,13 @@ export const postDeployMaaSModelRef = async (
   if (dryRun || !deployedModel.model) {
     return;
   }
+  // Deploy succeeded while this field was active; record before any early return so
+  // wizard exit cleanup does not emit cancel.
+  fireMaaSPublishTrackingEvent(
+    TrackingOutcome.submit,
+    true,
+    trackingOverrides(fieldData, existingDeployment),
+  );
 
   const { name, namespace, uid } = deployedModel.model.metadata;
   if (typeof fieldData.isChecked !== 'boolean' || !name || !namespace) {

--- a/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maas-model-ref.ts
+++ b/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maas-model-ref.ts
@@ -153,7 +153,14 @@ export const postDeployMaaSModelRef = async (
   if (dryRun || !deployedModel.model) {
     return;
   }
+
   // Deploy succeeded while this field was active; record before any early return so
+  const { name, namespace, uid } = deployedModel.model.metadata;
+  if (typeof fieldData.isChecked !== 'boolean' || !name || !namespace) {
+    return;
+  }
+
+  // Deploy succeeded while this field was active; record before side effects so
   // wizard exit cleanup does not emit cancel.
   fireMaaSPublishTrackingEvent(
     TrackingOutcome.submit,
@@ -161,10 +168,6 @@ export const postDeployMaaSModelRef = async (
     trackingOverrides(fieldData, existingDeployment),
   );
 
-  const { name, namespace, uid } = deployedModel.model.metadata;
-  if (typeof fieldData.isChecked !== 'boolean' || !name || !namespace) {
-    return;
-  }
   const { isChecked } = fieldData;
   const modelRef = { kind: LLMINFERENCESERVICE_KIND, name };
   const displayName =

--- a/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maasPublishTracking.ts
+++ b/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maasPublishTracking.ts
@@ -1,0 +1,102 @@
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import {
+  MaaSEvents,
+  ModelDeploymentMode,
+  type ModelAsMaasPublishedProperties,
+  PublishedAsMaasSource,
+} from '~/app/types/event-tracking';
+
+const DEPLOYMENT_WIZARD_PATH = '/ai-hub/models/deployments/deploy';
+
+type MaaSPublishTrackingSession = {
+  addedAsMaas: boolean;
+  mode: ModelDeploymentMode;
+  completed: boolean;
+  submitAttempted: boolean;
+};
+
+let session: MaaSPublishTrackingSession | null = null;
+
+export const isDeploymentWizardPath = (pathname: string): boolean =>
+  pathname.includes(DEPLOYMENT_WIZARD_PATH);
+
+export const startMaaSPublishTrackingSession = (mode: ModelDeploymentMode): void => {
+  if (!session) {
+    session = {
+      addedAsMaas: false,
+      mode,
+      completed: false,
+      submitAttempted: false,
+    };
+  } else {
+    session.mode = mode;
+  }
+};
+
+export const updateMaaSPublishTrackingSession = (addedAsMaas: boolean): void => {
+  if (session) {
+    session.addedAsMaas = addedAsMaas;
+  }
+};
+
+export const markMaaSPublishSubmitAttempted = (): void => {
+  if (session) {
+    session.submitAttempted = true;
+  }
+};
+
+const buildProperties = (
+  outcome: TrackingOutcome,
+  success: boolean,
+  overrides?: Partial<Pick<ModelAsMaasPublishedProperties, 'addedAsMaas' | 'mode'>>,
+): ModelAsMaasPublishedProperties | undefined => {
+  if (!session || session.completed) {
+    return undefined;
+  }
+  return {
+    outcome,
+    success,
+    source: PublishedAsMaasSource.MODEL_DEPLOYMENT_WIZARD,
+    addedAsMaas: overrides?.addedAsMaas ?? session.addedAsMaas,
+    mode: overrides?.mode ?? session.mode,
+  };
+};
+
+/**
+ * Fires the Model as Maas Published event once per wizard session when the
+ * Publish as MaaS checkbox field is active.
+ */
+export const fireMaaSPublishTrackingEvent = (
+  outcome: TrackingOutcome,
+  success: boolean,
+  overrides?: Partial<Pick<ModelAsMaasPublishedProperties, 'addedAsMaas' | 'mode'>>,
+): void => {
+  const properties = buildProperties(outcome, success, overrides);
+  if (!properties) {
+    return;
+  }
+  session = session ? { ...session, completed: true } : null;
+  fireFormTrackingEvent(MaaSEvents.MODEL_AS_MAAS_PUBLISHED, properties);
+};
+
+/**
+ * Ends the tracking session. When leaving the deployment wizard without a prior
+ * event: fires submit/error if a deploy was attempted, otherwise cancel. When the
+ * field only becomes inactive while still on the wizard route, clears without firing.
+ */
+export const endMaaSPublishTrackingSession = (leftWizard: boolean): void => {
+  if (leftWizard && session && !session.completed) {
+    if (session.submitAttempted) {
+      fireMaaSPublishTrackingEvent(TrackingOutcome.submit, false);
+    } else {
+      fireMaaSPublishTrackingEvent(TrackingOutcome.cancel, false);
+    }
+  }
+  session = null;
+};
+
+/** Test-only: reset module session between tests. */
+export const resetMaaSPublishTrackingSession = (): void => {
+  session = null;
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-81925](https://redhat.atlassian.net/browse/RHOAIENG-81925)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
[events doc ](https://docs.google.com/document/d/1NkG9K7HkyLUxAdP3yv2bn6J7PAMDFdDJDtUYcHUzAk4/edit?tab=t.0)
implements the remaining maas admin events we had yet to add, mostly regarding sub/policy creation and update success/error/cancel scenarios and some token limits events
also added events to capture the maas checkbox in the deployment wizard, it runs every time the checkbox is visible in the wizard
  - [x] maas model deployed -> in wizard //runs when the checkbox is displayed
  - [x] Subscription created
    - [x] success
      - [x] only implementing the Model part of prefill source (we don't have the group view yet)
    - [x] cancel
    - [x] error
  - [x] subscription updated
    - [x] success
      - [x] leaving out hasMatchingPolicy
    - [x] cancel
    - [x] error
  - [x] subscription token limits configured 
    - [x] success
    - [x] cancel
  - [x] auth policy created
    - [x] success
      - [x] only implementing the Model part of prefill source (we don't have the group view yet)
      - [x] not implementing the hasMatchingSub
    - [x] cancel
    - [x] error
  - [x] auth policy updated
    - [x] success
      - [x] not implementing the hasMatchingSub
    - [x] cancel 
    - [x] error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally

to test:

- perform the events listed above ^ in success, error, and cancel scenarios and match the returned content with the expected content in the events doc
- The events will show in devtools

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-81925]: https://redhat.atlassian.net/browse/RHOAIENG-81925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tracking for subscription creation, updates, cancellations, token-limit configuration, authorization-policy actions, and model publishing.
  - Edit actions now record whether they originated from list or detail views.
  - Model deployment workflows track successful submissions, failures, and cancellations.

- **Improvements**
  - Enhanced reporting for form submission errors and cancellation actions.
  - Added context for subscription and policy activity analytics.
  - Improved reliability of deployment and analytics behavior.

- **Bug Fixes**
  - Rate-limit editing now clears the saved target correctly and keeps the modal open after saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->