### PR TITLE
RHOAIENG-63027: Integrate operator-chaos shift-left validation (L1-L2)

### DIFF
--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: dashboard-operator/go.mod
 
@@ -65,7 +65,7 @@ jobs:
           exit "$status"
 
       - name: Checkout base branch assets
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base-branch

--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -1,0 +1,117 @@
+name: Chaos Validation
+
+on:
+  pull_request:
+    paths:
+      - 'chaos/**'
+      - 'dashboard-operator/internal/**'
+      - 'dashboard-operator/api/**'
+      - 'dashboard-operator/config/**'
+      - 'dashboard-operator/cmd/**'
+      - '.github/workflows/operator-chaos.yml'
+
+permissions:
+  contents: read
+
+env:
+  OPERATOR_CHAOS_VERSION: "v0.0.0-20260521100204-4dab974d613c"
+
+jobs:
+  validate:
+    name: Operator Chaos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: dashboard-operator/go.mod
+
+      - name: Install operator-chaos
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          GOBIN="${RUNNER_TEMP}/bin" go install "github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@${OPERATOR_CHAOS_VERSION}"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Validate knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos validate --knowledge chaos/knowledge/dashboard.yaml
+
+      - name: Local preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos preflight --knowledge chaos/knowledge/dashboard.yaml --local
+
+      - name: Validate all experiments
+        shell: bash
+        run: |
+          set -euo pipefail
+          status=0
+          for f in chaos/experiments/*.yaml; do
+            echo "--- $f ---"
+            if ! operator-chaos validate "$f"; then
+              status=1
+            fi
+          done
+          exit "$status"
+
+      - name: Checkout base branch assets
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-branch
+          persist-credentials: false
+          sparse-checkout: chaos/knowledge
+          sparse-checkout-cone-mode: false
+
+      - name: Detect breaking changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -d "base-branch/chaos/knowledge" ]; then
+            echo "No base knowledge model found — skipping diff (first-time integration)"
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          knowledge_diff_json="${output_dir}/knowledge-diff.json"
+
+          operator-chaos diff \
+            --source base-branch/chaos/knowledge \
+            --target chaos/knowledge \
+            --breaking \
+            --format json > "${knowledge_diff_json}"
+          operator-chaos diff \
+            --source base-branch/chaos/knowledge \
+            --target chaos/knowledge \
+            --breaking
+
+          knowledge_breaking=$(jq -r '.summary.breakingChanges // 0' "${knowledge_diff_json}")
+          if (( knowledge_breaking > 0 )); then
+            echo "operator-chaos detected ${knowledge_breaking} breaking knowledge change(s)."
+            exit 1
+          fi
+
+      - name: Simulate upgrade
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -d "base-branch/chaos/knowledge" ]; then
+            echo "No base knowledge model found — skipping simulate-upgrade (first-time integration)"
+            exit 0
+          fi
+
+          operator-chaos simulate-upgrade \
+            --source base-branch/chaos/knowledge \
+            --target chaos/knowledge \
+            --dry-run

--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   OPERATOR_CHAOS_VERSION: "v0.0.0-20260521100204-4dab974d613c"
+  KNOWLEDGE_FILE: "chaos/knowledge/dashboard.yaml"
 
 jobs:
   validate:
@@ -30,6 +31,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: dashboard-operator/go.mod
+          cache: true
 
       - name: Install operator-chaos
         shell: bash
@@ -43,13 +45,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          operator-chaos validate --knowledge chaos/knowledge/dashboard.yaml
+          operator-chaos validate --knowledge "${KNOWLEDGE_FILE}"
 
       - name: Local preflight
         shell: bash
         run: |
           set -euo pipefail
-          operator-chaos preflight --knowledge chaos/knowledge/dashboard.yaml --local
+          operator-chaos preflight --knowledge "${KNOWLEDGE_FILE}" --local
 
       - name: Validate all experiments
         shell: bash
@@ -90,11 +92,8 @@ jobs:
             --source base-branch/chaos/knowledge \
             --target chaos/knowledge \
             --breaking \
-            --format json > "${knowledge_diff_json}"
-          operator-chaos diff \
-            --source base-branch/chaos/knowledge \
-            --target chaos/knowledge \
-            --breaking
+            --format json \
+            | tee "${knowledge_diff_json}"
 
           knowledge_breaking=$(jq -r '.summary.breakingChanges // 0' "${knowledge_diff_json}")
           if (( knowledge_breaking > 0 )); then

--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -11,9 +11,6 @@ on:
       - 'dashboard-operator/cmd/**'
       - '.github/workflows/operator-chaos.yml'
 
-permissions:
-  contents: read
-
 env:
   KNOWLEDGE_FILE: "chaos/knowledge/dashboard.yaml"
 
@@ -21,6 +18,8 @@ jobs:
   validate:
     name: Operator Chaos
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version=$(grep '^OPERATOR_CHAOS_VERSION' dashboard-operator/Makefile | head -1 | sed 's/.*?= *//')
+          version=$(grep '^OPERATOR_CHAOS_VERSION' dashboard-operator/Makefile | head -1 | sed 's/^[^=]*= *//')
           mkdir -p "${RUNNER_TEMP}/bin"
           GOBIN="${RUNNER_TEMP}/bin" go install "github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@${version}"
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"

--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'chaos/**'
+      - 'manifests/**'
       - 'dashboard-operator/internal/**'
       - 'dashboard-operator/api/**'
       - 'dashboard-operator/config/**'
@@ -14,7 +15,6 @@ permissions:
   contents: read
 
 env:
-  OPERATOR_CHAOS_VERSION: "v0.0.0-20260521100204-4dab974d613c"
   KNOWLEDGE_FILE: "chaos/knowledge/dashboard.yaml"
 
 jobs:
@@ -37,8 +37,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          version=$(grep '^OPERATOR_CHAOS_VERSION' dashboard-operator/Makefile | head -1 | sed 's/.*?= *//')
           mkdir -p "${RUNNER_TEMP}/bin"
-          GOBIN="${RUNNER_TEMP}/bin" go install "github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@${OPERATOR_CHAOS_VERSION}"
+          GOBIN="${RUNNER_TEMP}/bin" go install "github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@${version}"
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
 
       - name: Validate knowledge model
@@ -46,12 +47,6 @@ jobs:
         run: |
           set -euo pipefail
           operator-chaos validate --knowledge "${KNOWLEDGE_FILE}"
-
-      - name: Local preflight
-        shell: bash
-        run: |
-          set -euo pipefail
-          operator-chaos preflight --knowledge "${KNOWLEDGE_FILE}" --local
 
       - name: Validate all experiments
         shell: bash
@@ -65,6 +60,12 @@ jobs:
             fi
           done
           exit "$status"
+
+      - name: Local preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos preflight --knowledge "${KNOWLEDGE_FILE}" --local
 
       - name: Checkout base branch assets
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -9,6 +9,7 @@ on:
       - 'dashboard-operator/api/**'
       - 'dashboard-operator/config/**'
       - 'dashboard-operator/cmd/**'
+      - 'dashboard-operator/Makefile'
       - '.github/workflows/operator-chaos.yml'
 
 env:

--- a/chaos/experiments/network-partition.yaml
+++ b/chaos/experiments/network-partition.yaml
@@ -1,0 +1,35 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: dashboard-network-partition
+spec:
+  tier: 2
+  target:
+    operator: dashboard
+    component: odh-dashboard
+    resource: Deployment/odh-dashboard
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: odh-dashboard
+        namespace: opendatahub
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: NetworkPartition
+    parameters:
+      labelSelector: app=odh-dashboard
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When odh-dashboard pods are network-partitioned from the API server,
+      the dashboard UI should become unavailable as the kube-rbac-proxy
+      sidecar cannot verify authentication. Once the partition is removed,
+      the dashboard should resume serving without manual intervention.
+    recoveryTimeout: 180s
+  blastRadius:
+    maxPodsAffected: 2
+    allowedNamespaces:
+      - opendatahub

--- a/chaos/experiments/network-partition.yaml
+++ b/chaos/experiments/network-partition.yaml
@@ -20,7 +20,7 @@ spec:
   injection:
     type: NetworkPartition
     parameters:
-      labelSelector: app=odh-dashboard
+      labelSelector: deployment=odh-dashboard
     ttl: "300s"
   hypothesis:
     description: >-

--- a/chaos/experiments/pdb-block.yaml
+++ b/chaos/experiments/pdb-block.yaml
@@ -1,0 +1,36 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: dashboard-pdb-block
+spec:
+  tier: 2
+  target:
+    operator: dashboard
+    component: odh-dashboard
+    resource: Deployment/rhods-dashboard
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: rhods-dashboard
+        namespace: redhat-ods-applications
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: PDBBlock
+    dangerLevel: high
+    parameters:
+      labelSelector: app=rhods-dashboard
+    ttl: "10s"
+  hypothesis:
+    description: >-
+      Creating a PDB with maxUnavailable=0 blocks all voluntary
+      evictions. Tests whether the operator's pods can be drained
+      for node maintenance or cluster upgrades.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 2
+    allowDangerous: true
+    allowedNamespaces:
+      - redhat-ods-applications

--- a/chaos/experiments/pdb-block.yaml
+++ b/chaos/experiments/pdb-block.yaml
@@ -7,21 +7,21 @@ spec:
   target:
     operator: dashboard
     component: odh-dashboard
-    resource: Deployment/rhods-dashboard
+    resource: Deployment/odh-dashboard
   steadyState:
     checks:
       - type: conditionTrue
         apiVersion: apps/v1
         kind: Deployment
-        name: rhods-dashboard
-        namespace: redhat-ods-applications
+        name: odh-dashboard
+        namespace: opendatahub
         conditionType: Available
     timeout: "30s"
   injection:
     type: PDBBlock
     dangerLevel: high
     parameters:
-      labelSelector: app=rhods-dashboard
+      labelSelector: app=odh-dashboard
     ttl: "10s"
   hypothesis:
     description: >-
@@ -33,4 +33,4 @@ spec:
     maxPodsAffected: 2
     allowDangerous: true
     allowedNamespaces:
-      - redhat-ods-applications
+      - opendatahub

--- a/chaos/experiments/pdb-block.yaml
+++ b/chaos/experiments/pdb-block.yaml
@@ -21,7 +21,7 @@ spec:
     type: PDBBlock
     dangerLevel: high
     parameters:
-      labelSelector: app=odh-dashboard
+      labelSelector: deployment=odh-dashboard
     ttl: "10s"
   hypothesis:
     description: >-

--- a/chaos/experiments/pod-kill.yaml
+++ b/chaos/experiments/pod-kill.yaml
@@ -1,0 +1,36 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: dashboard-pod-kill
+spec:
+  tier: 1
+  target:
+    operator: dashboard
+    component: odh-dashboard
+    resource: Deployment/odh-dashboard
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: odh-dashboard
+        namespace: opendatahub
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: PodKill
+    parameters:
+      labelSelector: app=odh-dashboard
+    count: 1
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When one odh-dashboard pod is killed, the remaining replica should
+      continue serving traffic. Kubernetes should recreate the killed pod
+      within the recovery timeout and the deployment should return to 2/2
+      ready replicas.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - opendatahub

--- a/chaos/experiments/pod-kill.yaml
+++ b/chaos/experiments/pod-kill.yaml
@@ -20,7 +20,7 @@ spec:
   injection:
     type: PodKill
     parameters:
-      labelSelector: app=odh-dashboard
+      labelSelector: deployment=odh-dashboard
     count: 1
     ttl: "300s"
   hypothesis:

--- a/chaos/knowledge/dashboard.yaml
+++ b/chaos/knowledge/dashboard.yaml
@@ -1,0 +1,57 @@
+operator:
+  name: dashboard
+  namespace: opendatahub
+  repository: https://github.com/opendatahub-io/odh-dashboard
+
+components:
+  - name: odh-dashboard
+    controller: DataScienceCluster
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: odh-dashboard
+        namespace: opendatahub
+        labels:
+          deployment: odh-dashboard
+          app: odh-dashboard
+          app.kubernetes.io/part-of: odh-dashboard
+        expectedSpec:
+          replicas: 2
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: odh-dashboard
+        namespace: opendatahub
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: odh-dashboard
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: odh-dashboard-auth-delegator
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: odh-dashboard-monitoring
+      - apiVersion: v1
+        kind: Service
+        name: odh-dashboard
+        namespace: opendatahub
+      - apiVersion: v1
+        kind: ConfigMap
+        name: kube-rbac-proxy-config
+        namespace: opendatahub
+      - apiVersion: route.openshift.io/v1
+        kind: Route
+        name: odh-dashboard
+        namespace: opendatahub
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: odh-dashboard
+          namespace: opendatahub
+          conditionType: Available
+      timeout: "60s"
+
+recovery:
+  reconcileTimeout: "300s"
+  maxReconcileCycles: 10

--- a/chaos/knowledge/dashboard.yaml
+++ b/chaos/knowledge/dashboard.yaml
@@ -38,6 +38,10 @@ components:
         kind: ConfigMap
         name: kube-rbac-proxy-config
         namespace: opendatahub
+      - apiVersion: policy/v1
+        kind: PodDisruptionBudget
+        name: odh-dashboard
+        namespace: opendatahub
       - apiVersion: gateway.networking.k8s.io/v1
         kind: HTTPRoute
         name: odh-dashboard

--- a/chaos/knowledge/dashboard.yaml
+++ b/chaos/knowledge/dashboard.yaml
@@ -5,6 +5,9 @@ operator:
 
 components:
   - name: odh-dashboard
+    # controller refers to the upstream opendatahub-operator reconciler that
+    # owns the Dashboard lifecycle (DataScienceCluster CRD). The in-repo
+    # DashboardReconciler is a downstream module controller managed by it.
     controller: DataScienceCluster
     managedResources:
       - apiVersion: apps/v1
@@ -13,6 +16,9 @@ components:
         namespace: opendatahub
         labels:
           deployment: odh-dashboard
+          # Labels below are injected by the ODH kustomize overlay
+          # (manifests/odh/kustomization.yaml), not the base manifest.
+          # RHOAI deployments may use different overlay labels.
           app: odh-dashboard
           app.kubernetes.io/part-of: odh-dashboard
         expectedSpec:

--- a/chaos/knowledge/dashboard.yaml
+++ b/chaos/knowledge/dashboard.yaml
@@ -38,8 +38,8 @@ components:
         kind: ConfigMap
         name: kube-rbac-proxy-config
         namespace: opendatahub
-      - apiVersion: route.openshift.io/v1
-        kind: Route
+      - apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
         name: odh-dashboard
         namespace: opendatahub
     steadyState:

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -96,6 +96,28 @@ docker-build: ## Build container image (run from repo root).
 docker-push: ## Push container image.
 	docker push $(IMG)
 
+##@ Chaos
+
+OPERATOR_CHAOS ?= $(LOCALBIN)/operator-chaos
+OPERATOR_CHAOS_VERSION ?= v0.0.0-20260521100204-4dab974d613c
+
+.PHONY: operator-chaos
+operator-chaos: $(OPERATOR_CHAOS) ## Download operator-chaos locally if necessary.
+$(OPERATOR_CHAOS): $(LOCALBIN)
+	test -s $(LOCALBIN)/operator-chaos || GOBIN=$(LOCALBIN) go install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@$(OPERATOR_CHAOS_VERSION)
+
+.PHONY: chaos-validate
+chaos-validate: operator-chaos ## Validate chaos knowledge model and experiments.
+	$(OPERATOR_CHAOS) validate --knowledge ../chaos/knowledge/dashboard.yaml
+	@status=0; \
+	for f in ../chaos/experiments/*.yaml; do \
+		echo "--- $$f ---"; \
+		if ! $(OPERATOR_CHAOS) validate "$$f"; then \
+			status=1; \
+		fi; \
+	done; \
+	exit $$status
+
 ##@ Dependencies
 
 LOCALBIN ?= $(shell pwd)/bin

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -98,21 +98,21 @@ docker-push: ## Push container image.
 
 ##@ Chaos
 
-OPERATOR_CHAOS ?= $(LOCALBIN)/operator-chaos
 OPERATOR_CHAOS_VERSION ?= v0.0.0-20260521100204-4dab974d613c
+OPERATOR_CHAOS ?= $(LOCALBIN)/operator-chaos-$(OPERATOR_CHAOS_VERSION)
 
 .PHONY: operator-chaos
 operator-chaos: $(OPERATOR_CHAOS) ## Download operator-chaos locally if necessary.
 $(OPERATOR_CHAOS): $(LOCALBIN)
-	test -s $(LOCALBIN)/operator-chaos || GOBIN=$(LOCALBIN) go install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@$(OPERATOR_CHAOS_VERSION)
+	$(call go-install-tool,$(OPERATOR_CHAOS),github.com/opendatahub-io/operator-chaos/cmd/operator-chaos,$(OPERATOR_CHAOS_VERSION))
 
 .PHONY: chaos-validate
 chaos-validate: operator-chaos ## Validate chaos knowledge model and experiments.
-	$(OPERATOR_CHAOS) validate --knowledge ../chaos/knowledge/dashboard.yaml
+	"$(OPERATOR_CHAOS)" validate --knowledge ../chaos/knowledge/dashboard.yaml
 	@status=0; \
 	for f in ../chaos/experiments/*.yaml; do \
 		echo "--- $$f ---"; \
-		if ! $(OPERATOR_CHAOS) validate "$$f"; then \
+		if ! "$(OPERATOR_CHAOS)" validate "$$f"; then \
 			status=1; \
 		fi; \
 	done; \

--- a/docs/dashboard-operator.md
+++ b/docs/dashboard-operator.md
@@ -499,7 +499,7 @@ make operator-chaos
 
 ### CI
 
-The `Chaos Validation` workflow (`.github/workflows/operator-chaos.yml`) runs on PRs that touch `chaos/`, `manifests/`, or `dashboard-operator/` source. It validates the knowledge model, runs preflight checks, detects breaking changes against the base branch, and simulates upgrades with `--dry-run`.
+The `Chaos Validation` workflow (`.github/workflows/operator-chaos.yml`) runs on PRs that touch `chaos/`, `manifests/`, `dashboard-operator/{internal,api,config,cmd}/`, or `dashboard-operator/Makefile`. It validates the knowledge model, runs preflight checks, detects breaking changes against the base branch, and simulates upgrades with `--dry-run`. Breaking-change detection and upgrade simulation are skipped when the base branch has no `chaos/knowledge` directory (first-time integration).
 
 ### Maintenance
 

--- a/docs/dashboard-operator.md
+++ b/docs/dashboard-operator.md
@@ -481,6 +481,40 @@ make generate && make manifests
 
 For details on envtest integration tests — what they are, how to write them, and how to debug failures — see [envtest Integration Tests](envtest-integration-tests.md).
 
+## Chaos Validation (operator-chaos)
+
+The operator integrates [operator-chaos](https://github.com/opendatahub-io/operator-chaos) for shift-left resilience validation. The knowledge model (`chaos/knowledge/dashboard.yaml`) describes all managed resources and their steady-state expectations. Experiment files (`chaos/experiments/*.yaml`) define chaos scenarios (pod-kill, network-partition, PDB-block) that run during pre-release qualification.
+
+### Local Usage
+
+```bash
+cd dashboard-operator
+
+# Validate knowledge model + all experiments
+make chaos-validate
+
+# Download the operator-chaos CLI only
+make operator-chaos
+```
+
+### CI
+
+The `Chaos Validation` workflow (`.github/workflows/operator-chaos.yml`) runs on PRs that touch `chaos/`, `manifests/`, or `dashboard-operator/` source. It validates the knowledge model, runs preflight checks, detects breaking changes against the base branch, and simulates upgrades with `--dry-run`.
+
+### Maintenance
+
+Update `chaos/knowledge/dashboard.yaml` when:
+- A managed resource is added, removed, or renamed (Deployment, Service, ConfigMap, etc.)
+- The expected replica count or labels change
+- The ingress resource kind or apiVersion changes
+
+Update `chaos/experiments/*.yaml` when:
+- A new chaos scenario is needed for a resource type
+- Recovery timeouts or blast radius parameters need adjustment
+- The target workload selector changes
+
+The `operator-chaos` CLI version is pinned in `dashboard-operator/Makefile` (`OPERATOR_CHAOS_VERSION`). The CI workflow reads this value, so bumping the version in the Makefile is sufficient.
+
 ## Cluster Deployment
 
 ### Standalone (Helm)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-63027

## Description

Integrates [operator-chaos](https://github.com/opendatahub-io/operator-chaos) shift-left validation for the Dashboard operator at **L1-L2 maturity**, following the patterns established by [model-registry-operator PR #525](https://github.com/opendatahub-io/model-registry-operator/pull/525) (L1-L3) and [mlflow-operator PR #128](https://github.com/opendatahub-io/mlflow-operator/pull/128) (L1).

### What's included

**L1 — GitHub Action on PRs:**
- New `.github/workflows/operator-chaos.yml` triggers on changes to `chaos/`, `dashboard-operator/internal/`, `dashboard-operator/api/`, `dashboard-operator/config/`, `dashboard-operator/cmd/`
- Validates the knowledge model and all experiment files
- Runs local preflight checks
- Detects breaking knowledge changes against the base branch (gracefully skips on first-time bootstrap)
- Simulates upgrades with `--dry-run`

**L2 — Knowledge model and experiments:**
- `chaos/knowledge/dashboard.yaml` — describes all Dashboard managed resources (Deployment, ServiceAccount, ClusterRoleBindings, Service, ConfigMap, Route) with steady-state checks and recovery parameters
- `chaos/experiments/pod-kill.yaml` (Tier 1) — basic pod recovery
- `chaos/experiments/network-partition.yaml` (Tier 2) — informer reconnection / health check honesty
- `chaos/experiments/pdb-block.yaml` (Tier 2) — PodDisruptionBudget eviction behavior

**Makefile targets:**
- `make chaos-validate` — local validation of knowledge model + experiments
- `make operator-chaos` — download the operator-chaos CLI

### What's NOT included (future L3-L4)
- ChaosClient SDK integration into controller tests (L3)
- Upgrade playbook YAML / OLM channel-hop simulation (L4)

## How Has This Been Tested?

This is an offline/shift-left validation integration — no cluster required for the CI workflow. The knowledge model and experiment files match the upstream [operator-chaos dashboard knowledge](https://github.com/opendatahub-io/operator-chaos/blob/main/knowledge/dashboard.yaml) and [experiments](https://github.com/opendatahub-io/operator-chaos/tree/main/experiments/dashboard/). The GHA workflow follows the same pattern as model-registry-operator and mlflow-operator which are already merged and running in CI.

## Test Impact

No runtime tests are added at L1-L2. The GitHub Actions workflow validates YAML schemas and detects breaking changes at PR time. Actual chaos experiments (pod-kill, network-partition, pdb-block) run on live clusters during pre-release qualification, not in CI. L3 (ChaosClient SDK tests) would add Go integration tests in a follow-up.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added resilience testing for dashboard network partitions, pod termination, and disruption budget blocking.
  - Added dashboard health and recovery expectations, including availability, replica count, authentication behavior, and automatic recovery.

- **Chores**
  - Added automated pull-request validation and dry-run resilience checks.
  - Added commands for installing validation tools and checking experiment configurations.

- **Documentation**
  - Added guidance for running resilience validation locally and maintaining experiment definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->