### PR TITLE
[DO NOT MERGE] Test sync for kubeflow/hub#3056

### DIFF
--- a/packages/model-registry/upstream/bff/internal/api/app.go
+++ b/packages/model-registry/upstream/bff/internal/api/app.go
@@ -99,6 +99,7 @@ const (
 	McpServerPath                 = McpServerListPath + "/:" + McpServerId
 	McpServersToolListPath        = McpServerPath + "/tools"
 	MCPServerConverterPath        = McpServerPath + "/mcpserver"
+	McpServerLogoPath             = McpServerPath + "/logo"
 
 	// Swagger UI (interactive API docs)
 	SwaggerPath    = ApiPathPrefix + "/swagger"
@@ -456,6 +457,7 @@ func (app *App) Routes() http.Handler {
 		apiRouter.GET(McpServerFilterOptionListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServersFiltersHandler))))
 		apiRouter.GET(McpServerPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServerHandler))))
 		apiRouter.GET(McpServersToolListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServersToolsHandler))))
+		apiRouter.GET(McpServerLogoPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServerLogoHandler))))
 
 		// MCP catalog settings page
 		apiRouter.GET(McpCatalogSettingsSourceConfigListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.GetAllMcpCatalogSourceConfigsHandler)))

--- a/packages/model-registry/upstream/bff/internal/api/errors.go
+++ b/packages/model-registry/upstream/bff/internal/api/errors.go
@@ -57,6 +57,28 @@ func (app *App) forbiddenResponse(w http.ResponseWriter, r *http.Request, messag
 	app.errorResponse(w, r, httpError)
 }
 
+// httpErrorFromRaw converts a non-2xx RawResponse into the structured HTTPError
+// used across the API. GETRaw (unlike GET) does not turn upstream error statuses
+// into HTTPErrors, so callers that proxy a RawResponse must translate failures
+// themselves rather than forwarding the upstream's plaintext body verbatim. It
+// prefers a JSON error body from upstream and falls back to a generic message.
+func httpErrorFromRaw(resp *httpclient.RawResponse) *httpclient.HTTPError {
+	var errorResponse httpclient.ErrorResponse
+	if err := json.Unmarshal(resp.Body, &errorResponse); err != nil {
+		errorResponse = httpclient.ErrorResponse{
+			Code:    strconv.Itoa(resp.StatusCode),
+			Message: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(resp.Body)),
+		}
+	}
+	if errorResponse.Code == "" {
+		errorResponse.Code = strconv.Itoa(resp.StatusCode)
+	}
+	return &httpclient.HTTPError{
+		StatusCode:    resp.StatusCode,
+		ErrorResponse: errorResponse,
+	}
+}
+
 func (app *App) errorResponse(w http.ResponseWriter, r *http.Request, error *httpclient.HTTPError) {
 
 	env := ErrorEnvelope{Error: error}

--- a/packages/model-registry/upstream/bff/internal/api/mcp_servers_catalog_handler.go
+++ b/packages/model-registry/upstream/bff/internal/api/mcp_servers_catalog_handler.go
@@ -150,3 +150,68 @@ func (app *App) GetMcpServersToolsHandler(w http.ResponseWriter, r *http.Request
 		app.serverErrorResponse(w, r, err)
 	}
 }
+
+func (app *App) GetMcpServerLogoHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	serverId := ps.ByName(McpServerId)
+
+	if serverId == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("server_id is required"))
+		return
+	}
+
+	resp, err := app.repositories.ModelCatalogClient.GetMcpServerLogo(client, serverId)
+
+	// GetMcpServerLogo uses GETRaw, which only returns an error for transport-level
+	// failures (never for upstream error statuses), so any non-nil err is a server error.
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	// Faithfully proxy the catalog logo response. For plain external-URL logos the
+	// catalog replies with a redirect, which we pass through so the browser follows it;
+	// for inline data-URI logos it replies with the decoded image bytes.
+	if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode < http.StatusBadRequest {
+		if location := resp.Header.Get("Location"); location != "" {
+			w.Header().Set("Location", location)
+		}
+		w.WriteHeader(resp.StatusCode)
+		return
+	}
+
+	// GETRaw passes upstream error statuses through untouched, so translate any 4xx/5xx
+	// into the structured JSON error the rest of the API returns instead of forwarding
+	// the catalog's plaintext body (e.g. "404 page not found") verbatim.
+	if resp.StatusCode >= http.StatusBadRequest {
+		app.errorResponse(w, r, httpErrorFromRaw(resp))
+		return
+	}
+
+	// Forward an allowlist of upstream headers. Besides Content-Type and Cache-Control,
+	// this MUST include the catalog's protective headers (X-Content-Type-Options: nosniff
+	// and the SVG Content-Security-Policy): since we re-serve these bytes under the
+	// dashboard's own origin, dropping them would re-open the stored-XSS vector on
+	// SVG logos that those headers exist to prevent.
+	for _, h := range []string{
+		"Content-Type",
+		"Cache-Control",
+		"X-Content-Type-Options",
+		"Content-Security-Policy",
+	} {
+		if v := resp.Header.Get(h); v != "" {
+			w.Header().Set(h, v)
+		}
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	if _, err := w.Write(resp.Body); err != nil {
+		app.logger.Error("failed to write mcp server logo response", "error", err)
+	}
+}

--- a/packages/model-registry/upstream/bff/internal/api/mcp_servers_catalog_handler_test.go
+++ b/packages/model-registry/upstream/bff/internal/api/mcp_servers_catalog_handler_test.go
@@ -80,5 +80,40 @@ var _ = Describe("TestMcpServersCatalogHandler", func() {
 			Expect(actual.Data.Size).To(Equal(expected.Data.Size))
 			Expect(len(actual.Data.Items)).To(Equal(len(expected.Data.Items)))
 		})
+
+		It("should retrieve the MCP server logo image", func() {
+			By("fetching the MCP server logo by server_id")
+			requestIdentity := kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			}
+
+			rs, body, err := serveApiTest(http.MethodGet, "/api/v1/mcp_catalog/mcp_servers/1/logo?namespace=kubeflow", nil, kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("should return the raw logo image bytes with an image content type")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(rs.Header.Get("Content-Type")).To(HavePrefix("image/"))
+			Expect(len(body)).To(BeNumerically(">", 0))
+
+			By("should preserve the catalog's protective headers so re-serving under the dashboard origin does not re-open stored XSS on SVG logos")
+			Expect(rs.Header.Get("X-Content-Type-Options")).To(Equal("nosniff"))
+			Expect(rs.Header.Get("Content-Security-Policy")).To(Equal("default-src 'none'; style-src 'unsafe-inline'; sandbox"))
+		})
+
+		It("should translate an upstream logo error into a structured JSON error", func() {
+			By("fetching a logo whose catalog response is a non-2xx status")
+			requestIdentity := kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			}
+
+			rs, body, err := serveApiTest(http.MethodGet, "/api/v1/mcp_catalog/mcp_servers/missing/logo?namespace=kubeflow", nil, kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("should return the upstream status as a structured JSON error, not the raw plaintext body")
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+			Expect(rs.Header.Get("Content-Type")).To(Equal("application/json"))
+			Expect(string(body)).To(ContainSubstring(`"error"`))
+			Expect(string(body)).NotTo(Equal("404 page not found"))
+		})
 	})
 })

--- a/packages/model-registry/upstream/bff/internal/api/test_utils.go
+++ b/packages/model-registry/upstream/bff/internal/api/test_utils.go
@@ -20,14 +20,17 @@ import (
 	"github.com/kubeflow/hub/ui/bff/internal/repositories"
 )
 
-func setupApiTest[T any](method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string) (T, *http.Response, error) {
+// serveApiTest builds the test App with mocked clients, serves the request and returns
+// the raw response together with its (already read) body. Use it directly for non-JSON
+// responses (e.g. binary payloads); setupApiTest wraps it for JSON envelope responses.
+func serveApiTest(method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string) (*http.Response, []byte, error) {
 	mockMRClient, err := mocks.NewModelRegistryClient(nil)
 	if err != nil {
-		return *new(T), nil, err
+		return nil, nil, err
 	}
 	mockModelCatalogClient, err := mocks.NewModelCatalogClientMock(nil)
 	if err != nil {
-		return *new(T), nil, err
+		return nil, nil, err
 	}
 
 	mockClient := new(mocks.MockHTTPClient)
@@ -50,17 +53,17 @@ func setupApiTest[T any](method string, url string, body interface{}, k8Factory 
 	if body != nil {
 		r, err := json.Marshal(body)
 		if err != nil {
-			return *new(T), nil, err
+			return nil, nil, err
 		}
 		bytes.NewReader(r)
 		req, err = http.NewRequest(method, url, bytes.NewReader(r))
 		if err != nil {
-			return *new(T), nil, err
+			return nil, nil, err
 		}
 	} else {
 		req, err = http.NewRequest(method, url, nil)
 		if err != nil {
-			return *new(T), nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -87,6 +90,15 @@ func setupApiTest[T any](method string, url string, body interface{}, k8Factory 
 	rs := rr.Result()
 	defer rs.Body.Close()
 	respBody, err := io.ReadAll(rs.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rs, respBody, nil
+}
+
+func setupApiTest[T any](method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string) (T, *http.Response, error) {
+	rs, respBody, err := serveApiTest(method, url, body, k8Factory, requestIdentity, namespace)
 	if err != nil {
 		return *new(T), nil, err
 	}

--- a/packages/model-registry/upstream/bff/internal/integrations/httpclient/http.go
+++ b/packages/model-registry/upstream/bff/internal/integrations/httpclient/http.go
@@ -16,9 +16,19 @@ import (
 
 type HTTPClientInterface interface {
 	GET(url string) ([]byte, error)
+	GETRaw(url string) (*RawResponse, error)
 	POST(url string, body io.Reader) ([]byte, error)
 	POSTWithContentType(url string, body io.Reader, contentType string) ([]byte, error)
 	PATCH(url string, body io.Reader) ([]byte, error)
+}
+
+// RawResponse is an unprocessed upstream response. Unlike GET, it preserves the
+// status code and headers and does not treat non-200 responses as errors, so
+// callers can faithfully proxy binary payloads (e.g. logo images) and redirects.
+type RawResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
 }
 
 type HTTPClient struct {
@@ -115,6 +125,50 @@ func (c *HTTPClient) GET(url string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+func (c *HTTPClient) GETRaw(url string) (*RawResponse, error) {
+	requestId := uuid.NewString()
+
+	fullURL := c.baseURL + url
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	c.applyHeaders(req)
+
+	logUpstreamReq(c.logger, requestId, req)
+
+	// Use a redirect-disabled client so upstream 3xx responses are returned as-is
+	// (ErrUseLastResponse yields the redirect response instead of following it). This
+	// lets us proxy the catalog logo endpoint faithfully: image bytes for inline
+	// data-URI logos, or a pass-through redirect for plain external URLs. It reuses the
+	// shared Transport without mutating the shared client's redirect policy.
+	noRedirectClient := &http.Client{
+		Transport: c.client.Transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	response, err := noRedirectClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	logUpstreamResp(c.logger, requestId, response, body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	return &RawResponse{
+		StatusCode: response.StatusCode,
+		Header:     response.Header,
+		Body:       body,
+	}, nil
 }
 
 func (c *HTTPClient) POST(url string, body io.Reader) ([]byte, error) {

--- a/packages/model-registry/upstream/bff/internal/mocks/http_mock.go
+++ b/packages/model-registry/upstream/bff/internal/mocks/http_mock.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"io"
 
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/httpclient"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -17,6 +18,11 @@ func (c *MockHTTPClient) GetModelRegistryID() string {
 func (m *MockHTTPClient) GET(url string) ([]byte, error) {
 	args := m.Called(url)
 	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *MockHTTPClient) GETRaw(url string) (*httpclient.RawResponse, error) {
+	args := m.Called(url)
+	return args.Get(0).(*httpclient.RawResponse), args.Error(1)
 }
 
 func (m *MockHTTPClient) POST(url string, body io.Reader) ([]byte, error) {

--- a/packages/model-registry/upstream/bff/internal/mocks/model_catalog_client_mock.go
+++ b/packages/model-registry/upstream/bff/internal/mocks/model_catalog_client_mock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -464,6 +465,33 @@ func (m *ModelCatalogClientMock) GetMcpServersTools(client httpclient.HTTPClient
 	mcpServerTools := GetMcpToolListMock()
 
 	return &mcpServerTools, nil
+}
+
+func (m *ModelCatalogClientMock) GetMcpServerLogo(client httpclient.HTTPClientInterface, serverId string) (*httpclient.RawResponse, error) {
+	// Simulate an upstream failure so tests can verify the BFF translates a raw
+	// non-2xx response into a structured JSON error rather than forwarding the
+	// catalog's plaintext body verbatim. GETRaw surfaces such responses without erroring.
+	if serverId == "missing" {
+		return &httpclient.RawResponse{
+			StatusCode: http.StatusNotFound,
+			Header:     http.Header{},
+			Body:       []byte("404 page not found"),
+		}, nil
+	}
+
+	svg := []byte(`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"></svg>`)
+	// Mirror the catalog logo handler's protective headers for SVG so tests can
+	// verify they survive the BFF passthrough.
+	header := http.Header{}
+	header.Set("Content-Type", "image/svg+xml")
+	header.Set("X-Content-Type-Options", "nosniff")
+	header.Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
+
+	return &httpclient.RawResponse{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       svg,
+	}, nil
 }
 
 // filterAgentsByQuery parses a simple filterQuery (e.g. "framework='LangGraph' AND category IN ('Web search','MCP')")

--- a/packages/model-registry/upstream/bff/internal/repositories/mcp_server_catalog.go
+++ b/packages/model-registry/upstream/bff/internal/repositories/mcp_server_catalog.go
@@ -17,6 +17,7 @@ type McpServerCatalogInterface interface {
 	GetMcpServersFilter(client httpclient.HTTPClientInterface) (*models.FilterOptionsList, error)
 	GetMcpServer(client httpclient.HTTPClientInterface, serverId string, pageValues url.Values) (*models.McpServer, error)
 	GetMcpServersTools(client httpclient.HTTPClientInterface, serverId string) (*models.McpToolList, error)
+	GetMcpServerLogo(client httpclient.HTTPClientInterface, serverId string) (*httpclient.RawResponse, error)
 }
 
 type McpServerCatalog struct {
@@ -115,4 +116,23 @@ func (a *McpServerCatalog) GetMcpServersTools(client httpclient.HTTPClientInterf
 		Size:          mcpServerTools.Size,
 		Items:         wrappedItems,
 	}, nil
+}
+
+// GetMcpServerLogo fetches the raw logo response for an MCP server. It returns the
+// upstream status, headers and body unprocessed so the caller can faithfully proxy
+// either the decoded image bytes (inline data-URI logos) or a redirect (external URLs).
+func (a *McpServerCatalog) GetMcpServerLogo(client httpclient.HTTPClientInterface, serverId string) (*httpclient.RawResponse, error) {
+	path, err := url.JoinPath(mcpServerPath, serverId, "logo")
+
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.GETRaw(path)
+
+	if err != nil {
+		return nil, fmt.Errorf("error fetching mcp server logo: %w", err)
+	}
+
+	return resp, nil
 }


### PR DESCRIPTION
## Description

**This is a temporary test sync and should not be merged.**

This PR syncs the changes from [kubeflow/hub#3056](https://github.com/kubeflow/hub/pull/3056) into odh-dashboard so they can be tested before the upstream PR merges. The branch is available for local testing or CI validation.

Note: only the `clients/ui/bff` portion of the upstream PR is included (commit `dab077f8`). The other commit (`3539118b`, the catalog-service logo handler) lives outside this package's subtree (`clients/ui`) and is a separate service not vendored in odh-dashboard.

Note: the standard `--pr` sync tooling's ancestor check failed because this upstream PR branched before a later, already-synced upstream commit (`85aa6a90`) — so this sync was done via manual patch application scoped to the one relevant commit, rather than the automated script. See the PR diff for the resulting changes.

## How Has This Been Tested?

Ran `go build ./...` and `go test ./internal/...` in `packages/model-registry/upstream/bff`.

## Test Impact

Upstream changes include their own tests, manually ported.

Made with [Cursor](https://cursor.com)