### PR TITLE
fix: reword OCI host validation hint to avoid disconnected-readiness false positive

### DIFF
--- a/distributions/core-bff/bff/internal/api/connection_test_probes.go
+++ b/distributions/core-bff/bff/internal/api/connection_test_probes.go
@@ -461,10 +461,10 @@ func probeOCI(pc ProbeContext) models.ConnectionTestResult {
 	}
 	if _, port, err := net.SplitHostPort(ref.host); err == nil {
 		if _, portErr := strconv.Atoi(port); portErr != nil {
-			return failedResult(fmt.Sprintf("Invalid OCI host %q: port must be numeric — use host:port/repo:tag format", ref.host))
+			return failedResult(fmt.Sprintf("Invalid OCI host %q: port must be numeric — use <host>:<port>/<repository>:<tag> format", ref.host))
 		}
 	} else if strings.Contains(ref.host, ":") && !strings.Contains(ref.host, "[") {
-		return failedResult(fmt.Sprintf("Invalid OCI host %q: port must be numeric — use host:port/repo:tag format", ref.host))
+		return failedResult(fmt.Sprintf("Invalid OCI host %q: port must be numeric — use <host>:<port>/<repository>:<tag> format", ref.host))
 	}
 	if err := validateHostNotBlocked(pc.Ctx, ref.host); err != nil {
 		return failedResult(err.Error())


### PR DESCRIPTION
## Description

The `disconnected-readiness-scorer`'s `no-image-tags` rule flags the OCI_HOST port-validation error message in `connection_test_probes.go` as a hardcoded tagged image reference:

```
[blocker] distributions/core-bff/bff/internal/api/connection_test_probes.go:464 Image port/repo:tag uses tag ':tag' instead of digest. Tags cannot be reliably mirrored. Hardcoded in source code.
[blocker] distributions/core-bff/bff/internal/api/connection_test_probes.go:467 Image port/repo:tag uses tag ':tag' instead of digest. Tags cannot be reliably mirrored. Hardcoded in source code.
```

This is a false positive: the flagged text is the literal string `"...use host:port/repo:tag format"`, a documentation hint inside a `fmt.Sprintf` error message shown to the user when they supply an invalid `OCI_HOST` port — not an actual container image reference. The scanner is a plain regex text matcher (not an AST parser), so any `word/word:word`-shaped substring in source code gets matched regardless of context.

Rather than adding an exception to the scanner's central `config/config.yaml` (in the separate `disconnected-readiness-scorer` repo), this PR sidesteps the false match entirely by rewording the hint with angle-bracket placeholders (`<host>:<port>/<repository>:<tag>`), which no longer resembles an image reference to the scanner's regex while remaining just as clear to the user.

## How Has This Been Tested?

- Verified against the scanner's actual regex (`IMAGE_REF_PATTERN` in `no_image_tags.py`) that the new wording produces zero matches.
- Ran the full `TestProbeOCI*` suite in `distributions/core-bff/bff/internal/api` (17 tests, all passing), including `TestProbeOCI_NonNumericPort_Rejected` and `TestProbeOCI_IPv6Host_PortValidation`, which exercise this exact code path and assert on the (unchanged) `"port must be numeric"` substring.

## Test Impact

- No new tests added — existing tests (`TestProbeOCI_NonNumericPort_Rejected`, `TestProbeOCI_IPv6Host_PortValidation` in `connection_test_handler_test.go`) already cover this code path and continue to pass unchanged, since they only assert on the `"port must be numeric"` substring rather than the exact wording being changed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OCI host validation error messages to clearly show the accepted `<host>:<port>/<repository>:<tag>` format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->