### PR TITLE
fix: align react-router peers and stop Dependabot tightening floors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
     labels:
       - "dependencies"
 
-    versioning-strategy: lockfile-only
+    versioning-strategy: increase-if-necessary
 
     cooldown:
       default-days: 14

--- a/distributions/base/package.json
+++ b/distributions/base/package.json
@@ -29,7 +29,7 @@
     "@patternfly/react-styles": "6.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.18.1"
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",

--- a/distributions/core-bff/frontend/package-lock.json
+++ b/distributions/core-bff/frontend/package-lock.json
@@ -21,8 +21,8 @@
         "mod-arch-core": "^1.10.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router": "^7.17.0",
-        "react-router-dom": "^7.17.0",
+        "react-router": "^7.18.2",
+        "react-router-dom": "^7.18.2",
         "showdown": "^2.1.0"
       },
       "devDependencies": {
@@ -20120,9 +20120,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -20142,12 +20142,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/distributions/core-bff/frontend/package.json
+++ b/distributions/core-bff/frontend/package.json
@@ -109,8 +109,8 @@
     "mod-arch-core": "^1.10.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.17.0",
-    "react-router-dom": "^7.17.0",
+    "react-router": "^7.18.2",
+    "react-router-dom": "^7.18.2",
     "showdown": "^2.1.0"
   },
   "optionalDependencies": {

--- a/distributions/rhaii/package.json
+++ b/distributions/rhaii/package.json
@@ -34,7 +34,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router": "^7.18.2",
-    "react-router-dom": "^7.18.1",
+    "react-router-dom": "^7.18.2",
     "yaml": "^2.9.0",
     "zod": "^3.25.76"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -108,7 +108,7 @@
     "react-markdown": "^10.1.0",
     "react-redux": "^8.1.3",
     "react-router": "^7.18.2",
-    "react-router-dom": "^7.18.1",
+    "react-router-dom": "^7.18.2",
     "redux": "^4.2.1",
     "redux-thunk": "^2.4.2",
     "rehype-raw": "^7.0.0",
@@ -223,8 +223,8 @@
   "overrides": {
     "@openshift/dynamic-plugin-sdk-utils": {
       "react-redux": "^8.1.3",
-      "react-router": "^7.17.0",
-      "react-router-dom": "^7.17.0",
+      "react-router": "^7.18.2",
+      "react-router-dom": "^7.18.2",
       "react": "^18.3.1",
       "react-dom": "^18.3.1",
       "@patternfly/react-core": "6.4.0",
@@ -236,7 +236,8 @@
     "@patternfly/react-topology": {
       "react": "^18.3.1"
     },
-    "react-router": "^7.17.0",
+    "react-router": "^7.18.2",
+    "react-router-dom": "^7.18.2",
     "ws": "^8.21.0",
     "dompurify": "^3.4.13",
     "redux": "^4.2.1",

--- a/frontend/src/package.json
+++ b/frontend/src/package.json
@@ -46,7 +46,7 @@
     "dompurify": "^3.4.13",
     "marked": "^15.0.12",
     "react-router": "^7.18.2",
-    "react-router-dom": "^7.18.1"
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -644,7 +644,7 @@
         "@patternfly/react-styles": "6.4.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.18.1"
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",
@@ -723,7 +723,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router": "^7.18.2",
-        "react-router-dom": "^7.18.1",
+        "react-router-dom": "^7.18.2",
         "yaml": "^2.9.0",
         "zod": "^3.25.76"
       },
@@ -752,41 +752,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "distributions/rhaii/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "distributions/rhaii/node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "frontend": {
@@ -838,7 +803,7 @@
         "react-markdown": "^10.1.0",
         "react-redux": "^8.1.3",
         "react-router": "^7.18.2",
-        "react-router-dom": "^7.18.1",
+        "react-router-dom": "^7.18.2",
         "redux": "^4.2.1",
         "redux-thunk": "^2.4.2",
         "rehype-raw": "^7.0.0",
@@ -1617,19 +1582,6 @@
         "node": ">=8"
       }
     },
-    "frontend/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "frontend/node_modules/cypress-mochawesome-reporter": {
       "version": "3.8.4",
       "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.8.4.tgz",
@@ -1689,28 +1641,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "frontend/node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
     },
     "frontend/node_modules/sass-loader": {
       "version": "16.0.8",
@@ -1820,7 +1750,7 @@
         "dompurify": "^3.4.13",
         "marked": "^15.0.12",
         "react-router": "^7.18.2",
-        "react-router-dom": "^7.18.1"
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*"
@@ -28948,9 +28878,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -28970,12 +28900,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -37002,8 +36932,8 @@
         "@patternfly/react-topology": "^6",
         "react": "^18",
         "react-dom": "^18",
-        "react-router": "^7.18.1",
-        "react-router-dom": "^7.18.1"
+        "react-router": "^7",
+        "react-router-dom": "^7"
       }
     },
     "packages/foundation": {
@@ -37050,7 +36980,7 @@
         "@patternfly/react-icons": "^6",
         "react": "^18",
         "react-dom": "^18",
-        "react-router-dom": "^7.18.1"
+        "react-router-dom": "^7"
       }
     },
     "packages/hardware-profiles": {
@@ -37076,8 +37006,8 @@
         "@patternfly/react-table": "^6",
         "react": "^18",
         "react-dom": "^18",
-        "react-router": "^7.18.1",
-        "react-router-dom": "^7.18.1"
+        "react-router": "^7",
+        "react-router-dom": "^7"
       }
     },
     "packages/jest-config": {
@@ -37278,7 +37208,7 @@
         "@patternfly/react-icons": "^6",
         "react": "^18",
         "react-dom": "^18",
-        "react-router-dom": "^7.18.1"
+        "react-router-dom": "^7"
       }
     },
     "packages/model-registry": {
@@ -37334,17 +37264,13 @@
         "@patternfly/react-table": "^6",
         "react": "^18",
         "react-dom": "^18",
-        "react-router": "^7.18.2",
-        "react-router-dom": "^7.18.1"
+        "react-router": "^7",
+        "react-router-dom": "^7"
       }
     },
     "packages/model-serving/cypress": {
       "name": "@odh-dashboard/model-serving-cypress",
       "version": "0.0.0",
-      "dependencies": {
-        "react-router": "^7.18.2",
-        "react-router-dom": "^7.18.1"
-      },
       "devDependencies": {
         "@odh-dashboard/cypress": "*",
         "@odh-dashboard/eslint-config": "*",
@@ -37354,41 +37280,6 @@
         "@odh-dashboard/plugin-core": "*",
         "@types/chai-subset": "^1.3.5",
         "cypress-plugin-steps": "^1.1.1"
-      }
-    },
-    "packages/model-serving/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "packages/model-serving/node_modules/react-router": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
-      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "packages/model-training": {
@@ -37417,7 +37308,7 @@
         "@patternfly/react-tokens": "^6",
         "react": "^18",
         "react-dom": "^18",
-        "react-router-dom": "^7.18.1"
+        "react-router-dom": "^7"
       }
     },
     "packages/nim-serving": {
@@ -37445,7 +37336,7 @@
         "@patternfly/react-icons": "^6",
         "react": "^18",
         "react-dom": "^18",
-        "react-router-dom": "^7.18.1"
+        "react-router-dom": "^7"
       }
     },
     "packages/notebooks": {
@@ -37491,7 +37382,7 @@
         "@tanstack/react-query": "^4.44.0",
         "react": "^18",
         "react-dom": "^18",
-        "react-router-dom": "^7.18.1",
+        "react-router-dom": "^7",
         "use-query-params": "^2.2.2"
       }
     },
@@ -37649,7 +37540,7 @@
         "@openshift/dynamic-plugin-sdk": "^5",
         "@patternfly/react-core": "^6",
         "react": "^18",
-        "react-router-dom": "^7.18.1"
+        "react-router-dom": "^7"
       }
     },
     "packages/plugin-template": {
@@ -37701,7 +37592,7 @@
         "@patternfly/react-styles": "^6",
         "@patternfly/react-table": "^6",
         "react": "^18",
-        "react-router-dom": "^7.18.1",
+        "react-router-dom": "^7",
         "zod": "^3"
       }
     }

--- a/package.json
+++ b/package.json
@@ -116,8 +116,8 @@
   "overrides": {
     "@openshift/dynamic-plugin-sdk-utils": {
       "react-redux": "^8.1.3",
-      "react-router": "^7.17.0",
-      "react-router-dom": "^7.17.0",
+      "react-router": "^7.18.2",
+      "react-router-dom": "^7.18.2",
       "react": "^18.3.1",
       "react-dom": "^18.3.1",
       "@patternfly/react-core": "6.4.0",
@@ -131,7 +131,8 @@
     },
     "@types/react": "^18.3.31",
     "csstype": "^3.2.3",
-    "react-router": "^7.17.0",
+    "react-router": "^7.18.2",
+    "react-router-dom": "^7.18.2",
     "ws": "^8.21.0",
     "@types/ws": "^8.18.1",
     "dompurify": "^3.4.8",

--- a/packages/feature-store/package.json
+++ b/packages/feature-store/package.json
@@ -74,7 +74,7 @@
     "@patternfly/react-topology": "^6",
     "react": "^18",
     "react-dom": "^18",
-    "react-router": "^7.18.1",
-    "react-router-dom": "^7.18.1"
+    "react-router": "^7",
+    "react-router-dom": "^7"
   }
 }

--- a/packages/gpuaas/package.json
+++ b/packages/gpuaas/package.json
@@ -32,6 +32,6 @@
     "@patternfly/react-icons": "^6",
     "react": "^18",
     "react-dom": "^18",
-    "react-router-dom": "^7.18.1"
+    "react-router-dom": "^7"
   }
 }

--- a/packages/hardware-profiles/package.json
+++ b/packages/hardware-profiles/package.json
@@ -84,7 +84,7 @@
     "@patternfly/react-table": "^6",
     "react": "^18",
     "react-dom": "^18",
-    "react-router": "^7.18.1",
-    "react-router-dom": "^7.18.1"
+    "react-router": "^7",
+    "react-router-dom": "^7"
   }
 }

--- a/packages/maas/frontend/package-lock.json
+++ b/packages/maas/frontend/package-lock.json
@@ -24,8 +24,8 @@
         "mod-arch-core": "^1.16.1",
         "react": "^18",
         "react-dom": "^18",
-        "react-router": "^7.17.0",
-        "react-router-dom": "^7.17.0",
+        "react-router": "^7.18.2",
+        "react-router-dom": "^7.18.2",
         "showdown": "^2.1.0",
         "zod": "^3.25.76"
       },
@@ -20086,9 +20086,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -20108,12 +20108,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/packages/maas/frontend/package.json
+++ b/packages/maas/frontend/package.json
@@ -116,8 +116,8 @@
     "mod-arch-core": "^1.16.1",
     "react": "^18",
     "react-dom": "^18",
-    "react-router": "^7.17.0",
-    "react-router-dom": "^7.17.0",
+    "react-router": "^7.18.2",
+    "react-router-dom": "^7.18.2",
     "showdown": "^2.1.0",
     "zod": "^3.25.76"
   },

--- a/packages/mlflow-embedded/package.json
+++ b/packages/mlflow-embedded/package.json
@@ -59,6 +59,6 @@
     "@patternfly/react-icons": "^6",
     "react": "^18",
     "react-dom": "^18",
-    "react-router-dom": "^7.18.1"
+    "react-router-dom": "^7"
   }
 }

--- a/packages/model-serving/cypress/package.json
+++ b/packages/model-serving/cypress/package.json
@@ -20,9 +20,5 @@
     "@odh-dashboard/plugin-core": "*",
     "@types/chai-subset": "^1.3.5",
     "cypress-plugin-steps": "^1.1.1"
-  },
-  "dependencies": {
-    "react-router": "^7.18.2",
-    "react-router-dom": "^7.18.1"
   }
 }

--- a/packages/model-serving/package.json
+++ b/packages/model-serving/package.json
@@ -97,7 +97,7 @@
     "@patternfly/react-table": "^6",
     "react": "^18",
     "react-dom": "^18",
-    "react-router": "^7.18.2",
-    "react-router-dom": "^7.18.1"
+    "react-router": "^7",
+    "react-router-dom": "^7"
   }
 }

--- a/packages/model-training/package.json
+++ b/packages/model-training/package.json
@@ -43,6 +43,6 @@
     "@patternfly/react-tokens": "^6",
     "react": "^18",
     "react-dom": "^18",
-    "react-router-dom": "^7.18.1"
+    "react-router-dom": "^7"
   }
 }

--- a/packages/nim-serving/package.json
+++ b/packages/nim-serving/package.json
@@ -39,6 +39,6 @@
     "@patternfly/react-icons": "^6",
     "react": "^18",
     "react-dom": "^18",
-    "react-router-dom": "^7.18.1"
+    "react-router-dom": "^7"
   }
 }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -68,7 +68,7 @@
     "@tanstack/react-query": "^4.44.0",
     "react": "^18",
     "react-dom": "^18",
-    "react-router-dom": "^7.18.1",
+    "react-router-dom": "^7",
     "use-query-params": "^2.2.2"
   }
 }

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -34,6 +34,6 @@
     "@openshift/dynamic-plugin-sdk": "^5",
     "@patternfly/react-core": "^6",
     "react": "^18",
-    "react-router-dom": "^7.18.1"
+    "react-router-dom": "^7"
   }
 }

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -114,7 +114,7 @@
     "@patternfly/react-styles": "^6",
     "@patternfly/react-table": "^6",
     "react": "^18",
-    "react-router-dom": "^7.18.1",
+    "react-router-dom": "^7",
     "zod": "^3"
   }
 }


### PR DESCRIPTION
## Description

Dependabot auto merge has been disabled until all CI checks are required.

Dependabot PRs (#8672, #9188) tightened federated package `peerDependencies` for `react-router` / `react-router-dom` from `^7` to patch floors (`^7.18.1` / `^7.18.2`), while `react-router-dom` stayed on `7.18.1`. That left the tree on `react-router@7.18.1` with peers requiring `^7.18.2`.

Full-repo `npm ci` could still succeed locally (invalid peers, default `strict-peer-deps=false`), but **module Dockerfiles** (`Dockerfile.workspace` and similar) run `npm ci` against a **partial workspace** and re-resolve, which fails with `ERESOLVE`.

This PR:
- Restores package peer ranges to major-only `^7` (same style as `react: ^18`)
- Aligns host app deps and root/frontend overrides to `react-router` + `react-router-dom` `^7.18.2`
- Removes the Dependabot-added `dependencies` block from `model-serving/cypress`
- Switches Dependabot `versioning-strategy` from `lockfile-only` to `increase-if-necessary` so ranges that already allow a release (including `^7` peers) are left alone — `lockfile-only` still rewrote peers under npm workspaces

## How Has This Been Tested?
- Verified peer ranges are `^7` on federated packages and host deps/overrides are aligned at `^7.18.2`
- `npm ci --ignore-scripts` succeeds with a single hoisted `react-router@7.18.2` / `react-router-dom@7.18.2` (no nested copies)

## Test Impact
No new automated tests — dependency/manifest-only change. Coverage is install resolution (`npm ci`) and Dependabot config.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated routing components to React Router 7.18.2 for improved consistency and compatibility.
  * Broadened compatibility across React Router 7 releases.
  * Removed unnecessary routing packages from Cypress tooling.
  * Updated dependency management settings to support automatic version increases when needed.
  * Applied routing updates consistently across the application, distributions, and platform components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->