### PR TITLE
RHOAIENG-81833: read About dialog version from DSC instead of DSCI (#…

### DIFF
--- a/frontend/src/app/AboutDialog.tsx
+++ b/frontend/src/app/AboutDialog.tsx
@@ -7,7 +7,6 @@ import { DataScienceStackComponentMap } from '#~/concepts/areas/const';
 import { useUser, useClusterInfo } from '#~/redux/selectors';
 import { useAppContext } from '#~/app/AppContext';
 import useFetchDscStatus from '#~/concepts/areas/useFetchDscStatus';
-import useFetchDsciStatus from '#~/concepts/areas/useFetchDsciStatus';
 import { useWatchOperatorSubscriptionStatus } from '#~/utilities/useWatchOperatorSubscriptionStatus';
 import ExternalLink from '#~/components/ExternalLink';
 import { useThemeContext } from './ThemeContext';
@@ -33,11 +32,9 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
   const { theme } = useThemeContext();
   const { serverURL } = useClusterInfo();
   const [dscStatus, loadedDsc, errorDsc] = useFetchDscStatus();
-  const [dsciStatus, loadedDsci, errorDsci] = useFetchDsciStatus();
   const [subStatus, loadedSubStatus, errorSubStatus] = useWatchOperatorSubscriptionStatus();
-  const error = errorDsci || errorSubStatus;
-  const loading =
-    (!errorDsci && !loadedDsci && !loadedDsc) || (!errorSubStatus && !loadedSubStatus && !errorDsc);
+  const error = errorDsc || errorSubStatus;
+  const loading = (!errorDsc && !loadedDsc) || (!errorSubStatus && !loadedSubStatus);
 
   // Group components by display name while merging releases
   const groupedComponents = useMemo(() => {
@@ -107,12 +104,12 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
           ) : null}
           <Content component="dl" style={{ visibility: loading ? 'hidden' : 'visible' }}>
             <Content component="dt" data-testid="about-product-name">
-              {dsciStatus?.release?.name ||
+              {dscStatus?.release?.name ||
                 (isRHOAI ? RhoaiDefaultReleaseName : OdhDefaultReleaseName)}{' '}
               version
             </Content>
             <Content component="dd" data-testid="about-version">
-              {dsciStatus?.release?.version || 'Unknown'}
+              {dscStatus?.release?.version || 'Unknown'}
             </Content>
             <Content component="dt">Channel</Content>
             <Content component="dd" data-testid="about-channel">

--- a/frontend/src/app/__tests__/AboutDialog.spec.tsx
+++ b/frontend/src/app/__tests__/AboutDialog.spec.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import type {
-  DashboardConfigKind,
-  DataScienceClusterInitializationKindStatus,
-  DataScienceClusterKindStatus,
-} from '@odh-dashboard/k8s-core';
+import type { DashboardConfigKind, DataScienceClusterKindStatus } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { FetchState } from '@odh-dashboard/ui-core/hooks/useFetchState';
 import { ClusterState, UserState } from '#~/redux/selectors/types';
 import { useUser, useClusterInfo } from '#~/redux/selectors';
 import { useAppContext } from '#~/app/AppContext';
-import useFetchDsciStatus from '#~/concepts/areas/useFetchDsciStatus';
 import useFetchDscStatus from '#~/concepts/areas/useFetchDscStatus';
 import { mockDashboardConfig } from '#~/__mocks__';
 import { BuildStatus, SubscriptionStatusData } from '#~/types';
@@ -31,11 +26,6 @@ jest.mock('#~/redux/selectors', () => ({
   useClusterInfo: jest.fn(),
 }));
 
-jest.mock('#~/concepts/areas/useFetchDsciStatus', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
 jest.mock('#~/concepts/areas/useFetchDscStatus', () => ({
   __esModule: true,
   default: jest.fn(),
@@ -49,7 +39,6 @@ jest.mock('#~/utilities/useWatchOperatorSubscriptionStatus', () => ({
 const useUserMock = jest.mocked(useUser);
 const useAppContextMock = jest.mocked(useAppContext);
 const useClusterInfoMock = jest.mocked(useClusterInfo);
-const useFetchDsciStatusMock = jest.mocked(useFetchDsciStatus);
 const useFetchDscStatusMock = jest.mocked(useFetchDscStatus);
 const useWatchOperatorSubscriptionStatusMock = jest.mocked(useWatchOperatorSubscriptionStatus);
 
@@ -65,8 +54,6 @@ describe('AboutDialog', () => {
   };
   let userInfo: UserState;
   const clusterInfo: ClusterState = { serverURL: 'https://test-server.com' };
-  let dsciStatus: DataScienceClusterInitializationKindStatus;
-  let dsciFetchStatus: FetchState<DataScienceClusterInitializationKindStatus>;
   let dscStatus: DataScienceClusterKindStatus;
   let dscFetchStatus: FetchState<DataScienceClusterKindStatus>;
   let operatorSubscriptionStatus: SubscriptionStatusData;
@@ -84,14 +71,6 @@ describe('AboutDialog', () => {
       isRHOAI: false,
       refreshDashboardConfig: jest.fn(),
     };
-    dsciStatus = {
-      conditions: [],
-      release: {
-        // eslint-disable-next-line no-restricted-syntax
-        name: 'Open Data Hub Operator',
-        version: '1.0.1',
-      },
-    };
     dscStatus = {
       components: {
         [DataScienceStackComponent.K_SERVE]: {
@@ -105,8 +84,12 @@ describe('AboutDialog', () => {
         },
       },
       conditions: [],
+      release: {
+        // eslint-disable-next-line no-restricted-syntax
+        name: 'Open Data Hub Operator',
+        version: '1.0.1',
+      },
     };
-    dsciFetchStatus = [dsciStatus, true, undefined, () => Promise.resolve(dsciStatus)];
     dscFetchStatus = [dscStatus, true, undefined, () => Promise.resolve(dscStatus)];
     userInfo = {
       username: 'test-user',
@@ -132,7 +115,6 @@ describe('AboutDialog', () => {
     useAppContextMock.mockReturnValue(appContext);
     useUserMock.mockReturnValue(userInfo);
     useClusterInfoMock.mockReturnValue(clusterInfo);
-    useFetchDsciStatusMock.mockReturnValue(dsciFetchStatus);
     useFetchDscStatusMock.mockReturnValue(dscFetchStatus);
     useWatchOperatorSubscriptionStatusMock.mockReturnValue(operatorSubscriptionFetchStatus);
 
@@ -174,13 +156,12 @@ describe('AboutDialog', () => {
     }
     appContext.isRHOAI = true;
     userInfo.isAdmin = true;
-    if (dsciStatus.release) {
-      dsciStatus.release.name = 'OpenShift AI Self-Managed version';
+    if (dscStatus.release) {
+      dscStatus.release.name = 'OpenShift AI Self-Managed version';
     }
     useAppContextMock.mockReturnValue(appContext);
     useUserMock.mockReturnValue(userInfo);
     useClusterInfoMock.mockReturnValue(clusterInfo);
-    useFetchDsciStatusMock.mockReturnValue(dsciFetchStatus);
     useFetchDscStatusMock.mockReturnValue(dscFetchStatus);
     useWatchOperatorSubscriptionStatusMock.mockReturnValue(operatorSubscriptionFetchStatus);
 

--- a/packages/cypress/cypress/pages/genAiPlayground.ts
+++ b/packages/cypress/cypress/pages/genAiPlayground.ts
@@ -26,7 +26,7 @@ class GenAiPlayground {
   navigateToPlaygroundWithRetry(projectName: string) {
     const playgroundUrl = `/gen-ai-studio/playground/${projectName}?${GEN_AI_CUSTOM_ENDPOINTS_FLAG}`;
     cy.visit(playgroundUrl);
-    cy.findByTestId('chatbot-model-selector-toggle', { timeout: 120000 }).should('be.visible');
+    cy.findByTestId('settings-model-selector-toggle', { timeout: 120000 }).should('be.visible');
   }
 
   findEmptyState() {
@@ -50,7 +50,7 @@ class GenAiPlayground {
   }
 
   findModelToggleButton() {
-    return cy.findByTestId('chatbot-model-selector-toggle');
+    return cy.findByTestId('settings-model-selector-toggle');
   }
 
   findMessageInput() {

--- a/packages/cypress/cypress/tests/mocked/applications/application.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/applications/application.cy.ts
@@ -120,13 +120,10 @@ describe('Application', () => {
       channel: 'fast',
       lastUpdated: '2024-06-25T05:36:37Z',
     });
-    cy.interceptOdh('GET /api/dsci/status', {
-      conditions: [],
-      release: {
-        name: 'test application',
-        version: '1.0.1',
-      },
-    });
+    cy.interceptOdh(
+      'GET /api/dsc/status',
+      mockDscStatus({ release: { name: 'test application', version: '1.0.1' } }),
+    );
 
     appChrome.visit();
     aboutDialog.show();
@@ -163,13 +160,10 @@ describe('Application', () => {
       channel: 'fast',
       lastUpdated: '2024-06-25T05:36:37Z',
     });
-    // Handle no release name returned
-    cy.interceptOdh('GET /api/dsci/status', {
-      conditions: [],
-      release: {
-        version: '1.0.1',
-      },
-    });
+    cy.interceptOdh(
+      'GET /api/dsc/status',
+      mockDscStatus({ release: { name: '', version: '1.0.1' } }),
+    );
     appChrome.visit();
     aboutDialog.show();
 
@@ -186,12 +180,6 @@ describe('Application', () => {
     cy.interceptOdh('GET /api/operator-subscription-status', {
       channel: 'fast',
       lastUpdated: '2024-06-25T05:36:37Z',
-    });
-    cy.interceptOdh('GET /api/dsci/status', {
-      conditions: [],
-      release: {
-        version: '1.0.1',
-      },
     });
     cy.interceptOdh(
       'GET /api/dsc/status',


### PR DESCRIPTION
…9114)

The About dialog was reading release name and version from the DSCI (DataScienceClusterInitialization) CR, which returns 0.0.0 after the dashboard-operator migration. Switch to reading from the DSC (DataScienceCluster) CR, which is already fetched in the same component and correctly populated by the ODH Operator.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
cherrypick https://github.com/opendatahub-io/odh-dashboard/pull/9114 to 3.5
We need to backport to address the potential bug. https://redhat.atlassian.net/browse/RHOAIENG-81833.
Also backport minor e2e pr https://github.com/opendatahub-io/odh-dashboard/pull/8955 

