### PR TITLE
Add expand button to MaaS YAML tab

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -1000,6 +1000,10 @@ class ViewSubscriptionPage {
     return new DashboardCodeEditor(() => cy.findByTestId('resource-yaml-tab-content'));
   }
 
+  findOpenFullscreenButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('open-fullscreen-button');
+  }
+
   findActionsToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('subscription-actions-toggle');
   }
@@ -1010,6 +1014,20 @@ class ViewSubscriptionPage {
 
   findEditActionButton(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByRole('menuitem', { name: 'Edit' });
+  }
+}
+
+class YamlFullscreenModal extends Modal {
+  constructor() {
+    super('YAML - read-only preview');
+  }
+
+  find(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('yaml-fullscreen-modal');
+  }
+
+  findYAMLCodeEditor() {
+    return new DashboardCodeEditor(() => this.find());
   }
 }
 
@@ -1303,6 +1321,10 @@ class ViewAuthPolicyPage {
 
   findYAMLCodeEditor() {
     return new DashboardCodeEditor(() => cy.findByTestId('resource-yaml-tab-content'));
+  }
+
+  findOpenFullscreenButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('open-fullscreen-button');
   }
 
   findDetailsSection(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -1903,3 +1925,4 @@ export const externalModelPathModal = new ExternalModelPathModal();
 export const externalModelProviderUrlModal = new ExternalModelProviderUrlModal();
 export const modelInfoPopover = new ModelInfoPopover();
 export const phaseModal = new PhaseModal();
+export const yamlFullscreenModal = new YamlFullscreenModal();

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -9,6 +9,7 @@ import {
   policyPage,
   subscriptionManagementPage,
   viewAuthPolicyPage,
+  yamlFullscreenModal,
 } from '../../../pages/modelsAsAService';
 import {
   mockAuthPolicies,
@@ -396,5 +397,10 @@ describe('View Auth Policy Page', () => {
       expect(downloads[0].content).to.include('apiVersion: maas.opendatahub.io/v1alpha1');
       expect(downloads[0].content).to.include('kind: MaaSAuthPolicy');
     });
+    viewAuthPolicyPage.findOpenFullscreenButton().click();
+    yamlFullscreenModal.shouldBeOpen();
+    yamlFullscreenModal.findYAMLCodeEditor().containsText('kind: MaaSAuthPolicy').should('exist');
+    yamlFullscreenModal.findCloseButton().click();
+    yamlFullscreenModal.shouldBeOpen(false);
   });
 });

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -12,6 +12,7 @@ import {
   viewSubscriptionPage,
   subscriptionManagementPage,
   phaseModal,
+  yamlFullscreenModal,
 } from '../../../pages/modelsAsAService';
 import {
   mockSubscriptions,
@@ -350,6 +351,12 @@ describe('View Subscription Page', () => {
       expect(downloads[0].content).to.include('apiVersion: maas.opendatahub.io/v1alpha1');
       expect(downloads[0].content).to.include('kind: MaaSSubscription');
     });
+
+    viewSubscriptionPage.findOpenFullscreenButton().click();
+    yamlFullscreenModal.shouldBeOpen();
+    yamlFullscreenModal.findYAMLCodeEditor().containsText('kind: MaaSSubscription').should('exist');
+    yamlFullscreenModal.findCloseButton().click();
+    yamlFullscreenModal.shouldBeOpen(false);
   });
 });
 

--- a/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionManagementYamlTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionManagementYamlTab.tsx
@@ -1,7 +1,19 @@
 import * as React from 'react';
-import { Bullseye, EmptyState, EmptyStateBody, PageSection, Spinner } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
+  PageSection,
+  Spinner,
+  Tooltip,
+} from '@patternfly/react-core';
 import { Language } from '@patternfly/react-code-editor';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, ExpandArrowsAltIcon } from '@patternfly/react-icons';
 import useDarkMode from '~/app/hooks/useDarkMode';
 import { useSubscriptionManagementYaml } from '~/app/hooks/useSubscriptionManagementYaml';
 
@@ -18,8 +30,26 @@ const SubscriptionManagementYamlTab: React.FC<SubscriptionManagementYamlTabProps
   resourceName,
   resourceType,
 }) => {
+  const titleContent = 'YAML - read-only preview';
   const isDarkMode = useDarkMode();
   const [yaml, loaded, loadError] = useSubscriptionManagementYaml(resourceName, resourceType);
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+
+  const handleModalToggle = () => {
+    setIsModalOpen((open) => !open);
+  };
+
+  const customToolbarControl = (
+    <Tooltip content="Open fullscreen">
+      <Button
+        variant="plain"
+        aria-label="Open fullscreen editor"
+        onClick={handleModalToggle}
+        icon={<ExpandArrowsAltIcon />}
+        data-testid="open-fullscreen-button"
+      />
+    </Tooltip>
+  );
 
   if (!loaded) {
     return (
@@ -60,7 +90,32 @@ const SubscriptionManagementYamlTab: React.FC<SubscriptionManagementYamlTabProps
           isLanguageLabelVisible
           downloadFileName={resourceName}
           height="600px"
+          headerMainContent={titleContent}
+          customControls={customToolbarControl}
         />
+        <Modal
+          variant={ModalVariant.large}
+          isOpen={isModalOpen}
+          onClose={handleModalToggle}
+          aria-label={titleContent}
+          data-testid="yaml-fullscreen-modal"
+        >
+          <ModalHeader title={titleContent} />
+          <ModalBody>
+            <CodeEditor
+              code={yaml}
+              language={Language.yaml}
+              isDarkTheme={isDarkMode}
+              isReadOnly
+              isCopyEnabled
+              isDownloadEnabled
+              isLanguageLabelVisible
+              downloadFileName={resourceName}
+              height="70vh"
+              headerMainContent={titleContent}
+            />
+          </ModalBody>
+        </Modal>
       </React.Suspense>
     </PageSection>
   );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
closes [RHOAIENG-82418](https://redhat.atlassian.net/browse/RHOAIENG-82418)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a custom control to the code editor which opens a modal showing the yaml


https://github.com/user-attachments/assets/f934c6c9-6bb4-4106-bbeb-c900e2bbb9a6




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
updates some mock tests to check for modal opening, content, and closing

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-82418]: https://redhat.atlassian.net/browse/RHOAIENG-82418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fullscreen option for viewing subscription and authorization-policy YAML.
  * Added a read-only preview title and expanded YAML editor modal for easier inspection.
  * Added controls to open and close the fullscreen YAML viewer.

* **Tests**
  * Added coverage verifying fullscreen YAML content displays correctly and closes as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->