### PR TITLE
feat(notebooks): add notebooksV2 feature flag

### DIFF
--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -37,6 +37,7 @@ export const devTemporaryFeatureFlags = {
   nimWizard: false,
   agentOpsDeploy: false,
   agentsCatalog: false,
+  notebooksV2: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Group 1: Core Dashboard Features
@@ -303,6 +304,9 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.MODEL_CAPABILITIES]: {
     featureFlags: ['modelCapabilities'],
     reliantAreas: [SupportedArea.MODEL_SERVING],
+  },
+  [SupportedArea.PLUGIN_NOTEBOOKS]: {
+    featureFlags: ['notebooksV2'],
   },
 };
 

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -321,6 +321,7 @@ export type DashboardCommonConfig = {
   connectionTest?: boolean;
   modelCapabilities?: boolean;
   modelDeploymentSettings?: boolean;
+  notebooksV2?: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {

--- a/packages/plugin-core/src/areas/types.ts
+++ b/packages/plugin-core/src/areas/types.ts
@@ -87,6 +87,7 @@ export enum SupportedArea {
   /* Plugins */
   PLUGIN_MODEL_SERVING = 'plugin-model-serving',
   PLUGIN_GEN_AI = 'plugin-gen-ai',
+  PLUGIN_NOTEBOOKS = 'plugin-notebooks',
 
   /* LM Eval */
   LM_EVAL = 'lm-eval',


### PR DESCRIPTION


<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
Introduce a Dev/Feature flag for Notebooks 2.0 onboarding
Related: #9154

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Applied the updated OdhDashboardConfig CRD with the notebooksV2 field
2. Set notebooksV2: true via oc patch odhdashboardconfig
3. Built and deployed a custom dashboard image containing the feature flag type (DashboardCommonConfig.notebooksV2), SupportedArea.PLUGIN_NOTEBOOKS, and SupportedAreasStateMap entry
4. Verified the notebooks federated module extensions load when the flag is enabled and are hidden when disabled
5. Ran npm run type-check locally to confirm no type errors from the new flag and SupportedArea additions

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Feature flag registration only — no new runtime logic to test. The changes add:
- A type definition (notebooksV2?: boolean in DashboardCommonConfig)
- An enum entry (PLUGIN_NOTEBOOKS in SupportedArea)
- A flag default (notebooksV2: false in devTemporaryFeatureFlags)
- An area-to-flag mapping in SupportedAreasStateMap
- 
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying the Notebooks area as a distinct application area.
  * Introduced a temporary, disabled Notebooks v2 feature flag for controlled rollout.
  * Added configuration support for enabling or disabling Notebooks v2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->