### PR TITLE
feat(notebooks): add frontend integration for notebooks v2 plugin

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -59,6 +59,7 @@ export type DashboardConfig = K8sResourceCommon & {
       modelAsService: boolean;
       externalModels: boolean;
       mlflow: boolean;
+      workbenchesV2: boolean;
       mcpCatalog: boolean;
       mcpRegistry: boolean;
       agentOps: boolean;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -95,6 +95,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableKueue: true,
       disableLMEval: true,
       mlflow: true,
+      workbenchesV2: false,
       mcpCatalog: false,
       mcpRegistry: false,
       agentOps: false,

--- a/frontend/src/concepts/projects/projectDetails/useWorkbenchesV2Tab.tsx
+++ b/frontend/src/concepts/projects/projectDetails/useWorkbenchesV2Tab.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core';
+import { isProjectDetailsTab } from '@odh-dashboard/plugin-core/extension-points';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
+import { SectionDefinition } from '#~/pages/projects/components/GenericHorizontalBar';
+import { ProjectSectionID } from '#~/pages/projects/screens/detail/types';
+
+export const useWorkbenchesV2Tab = (): SectionDefinition[] => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const projectDetailsTabExtensions = useExtensions(isProjectDetailsTab);
+  const workbenchesV2Extension = projectDetailsTabExtensions.find(
+    (tab) => tab.properties.id === ProjectSectionID.WORKBENCHES_V2,
+  )?.properties.component;
+
+  if (!workbenchesV2Extension) {
+    return [];
+  }
+
+  return [
+    {
+      id: ProjectSectionID.WORKBENCHES_V2,
+      title: 'Workbenches v2 (Dev Preview)',
+      component: (
+        <LazyCodeRefComponent
+          component={workbenchesV2Extension}
+          props={{ namespace: currentProject.metadata.name }}
+        />
+      ),
+    },
+  ];
+};

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -24,6 +24,7 @@ import {
 } from '@odh-dashboard/k8s-core';
 import HeaderIcon from '@odh-dashboard/ui-core/design/HeaderIcon';
 import { useDeploymentsTab } from '#~/concepts/projects/projectDetails/useDeploymentsTab';
+import { useWorkbenchesV2Tab } from '#~/concepts/projects/projectDetails/useWorkbenchesV2Tab';
 
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import GenericHorizontalBar from '#~/pages/projects/components/GenericHorizontalBar';
@@ -59,6 +60,7 @@ const ProjectDetails: React.FC = () => {
   const settingsCardExtensions = useExtensions(isProjectDetailsSettingsCardExtension);
   const hasSettingsCards = settingsCardExtensions.length > 0 || biasMetricsAreaAvailable; // Bias metrics is not yet an extension
   const deploymentsTab = useDeploymentsTab();
+  const workbenchesV2Tab = useWorkbenchesV2Tab();
   const [searchParams, setSearchParams] = useSearchParams();
   const state = searchParams.get('section');
 
@@ -187,6 +189,7 @@ const ProjectDetails: React.FC = () => {
                   },
                 ]
               : []),
+            ...workbenchesV2Tab,
             ...(pipelinesEnabled
               ? [
                   {
@@ -247,6 +250,7 @@ const ProjectDetails: React.FC = () => {
           ],
           [
             workbenchEnabled,
+            workbenchesV2Tab,
             pipelinesEnabled,
             deploymentsTab,
             projectSharingEnabled,

--- a/frontend/src/pages/projects/screens/detail/const.ts
+++ b/frontend/src/pages/projects/screens/detail/const.ts
@@ -11,6 +11,7 @@ export const ProjectSectionTitles: ProjectSectionTitlesType = {
   [ProjectSectionID.ROLES]: 'Roles',
   [ProjectSectionID.SETTINGS]: 'Settings',
   [ProjectSectionID.FEATURE_STORE]: 'Feature Store',
+  [ProjectSectionID.WORKBENCHES_V2]: 'Workbenches v2 (Dev Preview)',
 };
 
 /**

--- a/frontend/src/pages/projects/screens/detail/types.ts
+++ b/frontend/src/pages/projects/screens/detail/types.ts
@@ -9,6 +9,7 @@ export enum ProjectSectionID {
   ROLES = 'roles',
   SETTINGS = 'settings',
   FEATURE_STORE = 'feature-store-integration',
+  WORKBENCHES_V2 = 'workbenches-v2',
 }
 
 export type ProjectSectionTitlesType = {

--- a/packages/k8s-core/src/__mocks__/mockDashboardConfig.ts
+++ b/packages/k8s-core/src/__mocks__/mockDashboardConfig.ts
@@ -52,6 +52,7 @@ export type MockDashboardConfigType = {
   observabilityDashboard?: boolean;
   hardwareProfileOrder?: string[];
   pvcSize?: string;
+  workbenchesV2?: boolean;
   mcpCatalog?: boolean;
   mcpRegistry?: boolean;
   toolCalling?: boolean;
@@ -82,6 +83,7 @@ export type MockDashboardConfigType = {
 };
 
 export const mockDashboardConfig = ({
+  workbenchesV2 = false,
   projectRBAC = false,
   disableInfo = false,
   disableSupport = false,
@@ -275,6 +277,7 @@ export const mockDashboardConfig = ({
   },
   spec: {
     dashboardConfig: {
+      workbenchesV2,
       projectRBAC,
       enablement: true,
       disableInfo,

--- a/packages/notebooks/upstream/workspaces/frontend/src/odh/extensions.ts
+++ b/packages/notebooks/upstream/workspaces/frontend/src/odh/extensions.ts
@@ -1,18 +1,19 @@
+/* eslint-disable @cspell/spellchecker */
 import type {
   AreaExtension,
   NavExtension,
+  ProjectDetailsTab,
   RouteExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
 
-const reliantAreas = ['workbenches'];
-const PLUGIN_NOTEBOOKS = 'notebooks-plugin';
+// This must match SupportedArea.NOTEBOOKS_V2 in frontend/src/concepts/areas/types.ts
+const PLUGIN_NOTEBOOKS = 'plugin-notebooks';
 
-const extensions: (NavExtension | RouteExtension | AreaExtension)[] = [
+const extensions: (NavExtension | RouteExtension | AreaExtension | ProjectDetailsTab)[] = [
   {
     type: 'app.area',
     properties: {
       id: PLUGIN_NOTEBOOKS,
-      reliantAreas,
       featureFlags: ['workbenchesV2'],
     },
   },
@@ -22,26 +23,11 @@ const extensions: (NavExtension | RouteExtension | AreaExtension)[] = [
       required: [PLUGIN_NOTEBOOKS],
     },
     properties: {
-      id: 'notebooks-kf-workspaces',
-      title: 'Workspaces',
-      href: '/notebooks/workspaces',
-      section: 'ai-hub',
-      path: '/notebooks/workspaces/*',
-      group: '1_aihub',
-    },
-  },
-  {
-    type: 'app.navigation/href',
-    flags: {
-      required: [PLUGIN_NOTEBOOKS],
-    },
-    properties: {
       id: 'notebooks-kf-workspacekinds',
-      title: 'Workspace Kinds',
+      title: 'Workbench templates (Dev Preview)',
       href: '/notebooks/workspacekinds',
-      section: 'ai-hub',
+      section: 'settings-environment-setup',
       path: '/notebooks/workspacekinds/*',
-      group: '1_aihub',
     },
   },
   {
@@ -52,6 +38,17 @@ const extensions: (NavExtension | RouteExtension | AreaExtension)[] = [
     properties: {
       path: '/notebooks/*',
       component: () => import('./NotebooksWrapper'),
+    },
+  },
+  {
+    type: 'app.project-details/tab',
+    properties: {
+      id: 'workbenches-v2',
+      title: 'Workbenches v2 (Dev Preview)',
+      component: () => import('./WorkspacesProjectDetailsTab'),
+    },
+    flags: {
+      required: [PLUGIN_NOTEBOOKS],
     },
   },
 ];


### PR DESCRIPTION
Related: #9225 #9154
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Add workbenchesV2 field to backend DashboardConfig type and defaults
- Add workbenchesV2 to mock dashboard config
- Add WORKBENCHES_V2 ProjectSectionID enum value
- Add useWorkbenchesV2Tab hook for project details tab integration
- Integrate workbenches v2 tab into ProjectDetails component
- Update notebooks plugin extensions: switch from dev-flag-gated notebooks-plugin area to feature-flag-gated notebooks-v2 area, add project-details/tab extension, rename nav items
- Fix Dockerfile.workspace: remove stale backend replace directive, use /tmp for build output path, add URL_PREFIX ARG

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a RHOAI OpenShift cluster (ROSA) with all three branches combined (manifests, feature flags, frontend integration):

1. Built and deployed a custom dashboard image containing the frontend changes
2. Deployed the notebooks-ui standalone pod with the updated extensions (featureFlags: ['workbenchesV2'], app.project-details/tab, renamed nav items)
3. Enabled workbenchesV2: true on the cluster's OdhDashboardConfig
4. Verified:
  - "Workbench Templates" appears in the sidebar under Settings
  - "Workbenches v2" tab appears in Project Details
  - Routes /notebooks/workspaces and /notebooks/workspacekinds load without 404
  - notebooks/remoteEntry.js loads successfully in browser DevTools Network tab
5. Verified the backend blankDashboardCR includes workbenchesV2: false as the default
6. Ran npm run type-check locally to confirm no type errors

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No new tests added. The changes are integration glue between the host and the federated notebooks module:

- extensions.ts — extension definitions validated at runtime by the existing PluginStore and isExtensionInUse logic (covered by plugin-core tests)
- useWorkbenchesV2Tab.tsx — thin hook that resolves a ProjectDetailsTab extension; the extension point mechanism is covered by existing tests in plugin-core
- ProjectDetails.tsx — adds the hook call and spreads the result into the tabs array; existing ProjectDetails test coverage applies
- backend/src/types.ts and constants.ts — type and default value additions with no runtime logic to test
- mockDashboardConfig.ts — test utility update to support workbenchesV2 in mocks

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Workbenches v2 project-details section.
  * Workbenches v2 can now be enabled through dashboard configuration.
  * The section appears in project navigation when the feature is available.

* **Improvements**
  * Added configuration defaults to keep Workbenches v2 disabled unless explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->