### PR TITLE
Add Cypress tests for admin/non-admin unavailable model registry state

### DIFF
--- a/frontend/src/__mocks__/mockModelRegistryService.ts
+++ b/frontend/src/__mocks__/mockModelRegistryService.ts
@@ -11,16 +11,19 @@ type MockModelRegistry = {
   name?: string;
   description?: string;
   displayName?: string;
+  isAvailable?: boolean;
 };
 
 export const mockModelRegistry = ({
   name = 'modelregistry-sample',
   description = 'Model registry description',
   displayName = 'Model Registry Sample',
+  isAvailable,
 }: MockModelRegistry): ModelRegistry => ({
   name,
   description,
   displayName,
+  ...(isAvailable !== undefined && { isAvailable }),
 });
 
 export const mockModelRegistryService = ({

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -105,6 +105,7 @@ export type ModelRegistry = {
   displayName: string;
   description: string;
   serverAddress?: string;
+  isAvailable?: boolean;
 };
 
 export type AccessModeSettings = Partial<Record<AccessMode, boolean>>;

--- a/packages/cypress/cypress/pages/modelRegistry/unavailableModelRegistryPage.ts
+++ b/packages/cypress/cypress/pages/modelRegistry/unavailableModelRegistryPage.ts
@@ -1,0 +1,25 @@
+class UnavailableModelRegistryPage {
+  visit(registryName: string) {
+    cy.visitWithLogin(`/ai-hub/models/registry/${registryName}`);
+    this.wait();
+  }
+
+  private wait() {
+    this.findUnavailableState().should('exist');
+    cy.testA11y();
+  }
+
+  findUnavailableState() {
+    return cy.findByTestId('unavailable-model-registry');
+  }
+
+  findSettingsLink() {
+    return cy.findByTestId('registry-settings-link');
+  }
+
+  findWhosMyAdminLink() {
+    return cy.findByTestId('whos-my-admin-link');
+  }
+}
+
+export const unavailableModelRegistryPage = new UnavailableModelRegistryPage();

--- a/packages/cypress/cypress/tests/mocked/modelRegistry/modelRegistryUnavailable.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistry/modelRegistryUnavailable.cy.ts
@@ -1,0 +1,102 @@
+import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
+import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
+import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
+import { mockDsciStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDsciStatus';
+import {
+  mockModelRegistry,
+  mockModelRegistryService,
+} from '@odh-dashboard/internal/__mocks__/mockModelRegistryService';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { unavailableModelRegistryPage } from '../../../pages/modelRegistry/unavailableModelRegistryPage';
+import { ServiceModel } from '../../../utils/models';
+import { asClusterAdminUser, asProjectEditUser } from '../../../utils/mockUsers';
+
+const MODEL_REGISTRY_API_VERSION = 'v1';
+const UNAVAILABLE_REGISTRY_NAME = 'unavailable-registry';
+const UNAVAILABLE_REGISTRY_DISPLAY_NAME = 'Unavailable Registry';
+const REGISTRY_SETTINGS_URL = '/settings/model-resources-operations/model-registry';
+
+const initIntercepts = () => {
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableModelRegistry: false,
+    }),
+  );
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.MODEL_REGISTRY]: {
+          managementState: 'Managed',
+          registriesNamespace: 'odh-model-registries',
+        },
+      },
+    }),
+  );
+  cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({}));
+  cy.interceptK8sList(
+    ServiceModel,
+    mockK8sResourceList([mockModelRegistryService({ name: UNAVAILABLE_REGISTRY_NAME })]),
+  );
+
+  cy.interceptOdh(
+    `GET /model-registry/api/:apiVersion/namespaces`,
+    { path: { apiVersion: MODEL_REGISTRY_API_VERSION } },
+    { data: [{ metadata: { name: 'odh-model-registries' } }] },
+  );
+
+  cy.interceptOdh(
+    `GET /model-registry/api/:apiVersion/user`,
+    { path: { apiVersion: MODEL_REGISTRY_API_VERSION } },
+    { data: { userId: 'user@example.com', clusterAdmin: false } },
+  );
+
+  cy.interceptOdh(
+    `GET /model-registry/api/:apiVersion/model_registry`,
+    { path: { apiVersion: MODEL_REGISTRY_API_VERSION } },
+    {
+      data: [
+        mockModelRegistry({
+          name: UNAVAILABLE_REGISTRY_NAME,
+          displayName: UNAVAILABLE_REGISTRY_DISPLAY_NAME,
+          isAvailable: false,
+        }),
+      ],
+    },
+  );
+};
+
+describe('Model Registry Unavailable State', () => {
+  it('Admin user sees admin-specific unavailable messaging', () => {
+    asClusterAdminUser();
+    initIntercepts();
+
+    unavailableModelRegistryPage.visit(UNAVAILABLE_REGISTRY_NAME);
+
+    cy.contains('Model registry unavailable').should('be.visible');
+    cy.contains(
+      `The ${UNAVAILABLE_REGISTRY_DISPLAY_NAME} registry is currently unavailable. Check the registry configuration in settings to troubleshoot the issue.`,
+    ).should('be.visible');
+    unavailableModelRegistryPage
+      .findSettingsLink()
+      .should('be.visible')
+      .and('have.attr', 'href', REGISTRY_SETTINGS_URL);
+    unavailableModelRegistryPage.findWhosMyAdminLink().should('not.exist');
+  });
+
+  it('Non-admin user sees non-admin unavailable messaging', () => {
+    asProjectEditUser();
+    initIntercepts();
+
+    unavailableModelRegistryPage.visit(UNAVAILABLE_REGISTRY_NAME);
+
+    cy.contains('Model registry unavailable').should('be.visible');
+    cy.contains(
+      `The ${UNAVAILABLE_REGISTRY_DISPLAY_NAME} registry is currently unavailable. It might still be starting up, or there might be a configuration error. Wait a few minutes and try again. If the problem persists, contact your administrator.`,
+    ).should('be.visible');
+    unavailableModelRegistryPage.findWhosMyAdminLink().should('be.visible').click();
+    cy.contains('Your administrator might be:').should('be.visible');
+    unavailableModelRegistryPage.findSettingsLink().should('not.exist');
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->

<!--- All code change PRs should relate to an issue, reference it here; see example below -->

[RHOAIENG-80874](https://redhat.atlassian.net/browse/RHOAIENG-80874)

## Description

Adds Cypress mock coverage for admin vs. non-admin messaging when a selected model registry is unavailable.

* **Admin:** Shows troubleshooting copy with a link to settings.
* **Non-admin:** Shows contact-admin copy with a “Who’s my administrator?” link.

## How Has This Been Tested?

<img width="719" height="185" alt="Screenshot 2026-08-11 at 4 44 27 AM" src="https://github.com/user-attachments/assets/1b88210b-050d-48ab-aaf3-564c3acfe39d" />

From the repo root:

```bash
npm run install:modules
npx turbo run cypress:server:build
npx turbo run cypress:server
```

In another terminal:

```bash
cd packages/cypress && CY_MOCK=1 npx cypress run -b chrome --spec "cypress/tests/mocked/modelRegistry/modelRegistryUnavailable.cy.ts"
```

Verified that both test cases pass:

* Admin user sees the admin-specific unavailable messaging.
* Non-admin user sees the non-admin unavailable messaging.

## Test Impact

Added Cypress mock coverage for the unavailable model registry scenario for both admin and non-admin users.

## Request review criteria:

Self checklist (all need to be checked):

* [x] The developer has manually tested the changes and verified that the changes work
* [x] Testing instructions have been added in the PR body
* [x] The developer has added tests or explained why testing cannot be added
* [x] The code follows our [[Best Practices](https://chatgpt.com/docs/best-practices.md)](/docs/best-practices.md)

If you have UI changes:

* [x] Included any necessary screenshots or gifs if it was a UI change.
* [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:

* [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

[RHOAIENG-80874]: https://redhat.atlassian.net/browse/RHOAIENG-80874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **User Experience**
  - Improved handling of unavailable Model Registry states with clearer, context-specific messaging.
  - Added relevant links for cluster administrators and non-administrative users.
  - Improved accessibility coverage for the unavailable-state experience.

- **Tests**
  - Added end-to-end coverage for unavailable registry behavior across common dashboard scenarios.
  - Expanded test coverage to verify availability status is displayed and handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->