### PR TITLE
fix(RHOAIENG-79913): use kind/name keys for model Kueue status maps

### DIFF
--- a/frontend/src/api/k8s/__tests__/workloads.spec.ts
+++ b/frontend/src/api/k8s/__tests__/workloads.spec.ts
@@ -7,6 +7,7 @@ import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServi
 import { mockPodK8sResource } from '#~/__mocks__/mockPodK8sResource';
 import { WorkloadKind } from '#~/k8sTypes';
 import {
+  buildModelDeploymentKey,
   buildWorkloadMapForNotebooks,
   buildWorkloadMapForDeployments,
   listWorkloads,
@@ -328,11 +329,21 @@ function workloadWithPodOwnerRef(workloadName: string, podUid: string): Workload
   };
 }
 
+describe('buildModelDeploymentKey', () => {
+  it('should build kind/name keys so IS and LLMIS names do not collide', () => {
+    expect(buildModelDeploymentKey('InferenceService', 'foo')).toBe('InferenceService/foo');
+    expect(buildModelDeploymentKey('LLMInferenceService', 'foo')).toBe('LLMInferenceService/foo');
+  });
+});
+
 describe('buildWorkloadMapForDeployments', () => {
+  const isKey = (name: string) => buildModelDeploymentKey('InferenceService', name);
+  const llmisKey = (name: string) => buildModelDeploymentKey('LLMInferenceService', name);
+
   it('seeds every IS with an empty array even when no workloads exist', () => {
     const result = buildWorkloadMapForDeployments([], [], [inferenceService(IS_NAME)]);
-    expect(result[IS_NAME]).toEqual([]);
-    expect(result[IS_NAME]).not.toBeNull();
+    expect(result[isKey(IS_NAME)]).toEqual([]);
+    expect(result[isKey(IS_NAME)]).not.toBeNull();
   });
 
   it('seeds LLMIS entries alongside IS entries', () => {
@@ -342,15 +353,15 @@ describe('buildWorkloadMapForDeployments', () => {
       [inferenceService(IS_NAME)],
       [llmInferenceService(LLMIS_NAME)],
     );
-    expect(result[IS_NAME]).toEqual([]);
-    expect(result[LLMIS_NAME]).toEqual([]);
+    expect(result[isKey(IS_NAME)]).toEqual([]);
+    expect(result[llmisKey(LLMIS_NAME)]).toEqual([]);
   });
 
   it('correlates Workload to IS via Pod UID + serving.kserve.io/inferenceservice label', () => {
     const pod = isPod('model-predictor-abc', IS_NAME);
     const wl = workloadWithPodOwnerRef('wl-1', POD_UID);
     const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
-    expect(result[IS_NAME]).toEqual([wl]);
+    expect(result[isKey(IS_NAME)]).toEqual([wl]);
   });
 
   it('correlates Workload to LLMIS via Pod UID + app.kubernetes.io/name label', () => {
@@ -363,13 +374,34 @@ describe('buildWorkloadMapForDeployments', () => {
       [],
       [llmInferenceService(LLMIS_NAME)],
     );
-    expect(result[LLMIS_NAME]).toEqual([wl]);
+    expect(result[llmisKey(LLMIS_NAME)]).toEqual([wl]);
+  });
+
+  it('keeps same-name IS and LLMIS as independent map entries', () => {
+    const sharedName = 'shared-name';
+    const isUid = 'uid-is-same-name';
+    const llmisUid = 'uid-llmis-same-name';
+    const pod = isPod('predictor-is', sharedName, isUid);
+    const llmPod = llmisPod('predictor-llmis', sharedName, llmisUid);
+    const wl = workloadWithPodOwnerRef('wl-is', isUid);
+    const llmWl = workloadWithPodOwnerRef('wl-llmis', llmisUid);
+    const result = buildWorkloadMapForDeployments(
+      [wl, llmWl],
+      [pod, llmPod],
+      [inferenceService(sharedName)],
+      [llmInferenceService(sharedName)],
+    );
+    expect(result[isKey(sharedName)]).toEqual([wl]);
+    expect(result[llmisKey(sharedName)]).toEqual([llmWl]);
+    expect(Object.keys(result).toSorted()).toEqual(
+      [isKey(sharedName), llmisKey(sharedName)].toSorted(),
+    );
   });
 
   it('returns empty array when Workload ownerRef Pod UID not in pods list (orphaned)', () => {
     const wl = workloadWithPodOwnerRef('wl-orphan', 'nonexistent-uid');
     const result = buildWorkloadMapForDeployments([wl], [], [inferenceService(IS_NAME)]);
-    expect(result[IS_NAME]).toEqual([]);
+    expect(result[isKey(IS_NAME)]).toEqual([]);
   });
 
   it('returns empty array when Pod found but has no model-serving label', () => {
@@ -377,14 +409,14 @@ describe('buildWorkloadMapForDeployments', () => {
     const pod = { ...rawPod, metadata: { ...rawPod.metadata, uid: POD_UID } };
     const wl = workloadWithPodOwnerRef('wl-1', POD_UID);
     const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
-    expect(result[IS_NAME]).toEqual([]);
+    expect(result[isKey(IS_NAME)]).toEqual([]);
   });
 
   it('skips Workloads with no Pod ownerRef', () => {
     const rawWl = mockWorkloadK8sResource({ k8sName: 'wl-no-pod-ref', namespace: NS });
     const wl = { ...rawWl, metadata: { ...rawWl.metadata, ownerReferences: [] } };
     const result = buildWorkloadMapForDeployments([wl], [], [inferenceService(IS_NAME)]);
-    expect(result[IS_NAME]).toEqual([]);
+    expect(result[isKey(IS_NAME)]).toEqual([]);
   });
 
   it('multi-replica IS: all per-Pod Workloads are collected', () => {
@@ -399,9 +431,9 @@ describe('buildWorkloadMapForDeployments', () => {
       [pod0, pod1],
       [inferenceService(IS_NAME)],
     );
-    expect(result[IS_NAME]).toHaveLength(2);
-    expect(result[IS_NAME]).toContain(wl0);
-    expect(result[IS_NAME]).toContain(wl1);
+    expect(result[isKey(IS_NAME)]).toHaveLength(2);
+    expect(result[isKey(IS_NAME)]).toContain(wl0);
+    expect(result[isKey(IS_NAME)]).toContain(wl1);
   });
 
   it('Workload for one IS does not bleed into another IS entry', () => {
@@ -416,8 +448,8 @@ describe('buildWorkloadMapForDeployments', () => {
       [podA, podB],
       [inferenceService('model-a'), inferenceService('model-b')],
     );
-    expect(result['model-a']).toEqual([wlA]);
-    expect(result['model-b']).toEqual([wlB]);
+    expect(result[isKey('model-a')]).toEqual([wlA]);
+    expect(result[isKey('model-b')]).toEqual([wlB]);
   });
 
   it('IS and LLMIS Workloads are isolated in the result map', () => {
@@ -433,8 +465,8 @@ describe('buildWorkloadMapForDeployments', () => {
       [inferenceService(IS_NAME)],
       [llmInferenceService(LLMIS_NAME)],
     );
-    expect(result[IS_NAME]).toEqual([wl]);
-    expect(result[LLMIS_NAME]).toEqual([llmWl]);
+    expect(result[isKey(IS_NAME)]).toEqual([wl]);
+    expect(result[llmisKey(LLMIS_NAME)]).toEqual([llmWl]);
   });
 
   it('matches ownerRef kind case-insensitively', () => {
@@ -448,7 +480,7 @@ describe('buildWorkloadMapForDeployments', () => {
     };
     const pod = isPod('predictor-abc', IS_NAME);
     const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
-    expect(result[IS_NAME]).toEqual([wl]);
+    expect(result[isKey(IS_NAME)]).toEqual([wl]);
   });
 
   it('Workload for unknown model name does not add an extra key to result', () => {
@@ -456,7 +488,7 @@ describe('buildWorkloadMapForDeployments', () => {
     const pod = isPod('predictor-unknown', 'unknown-model', uid);
     const wl = workloadWithPodOwnerRef('wl-unknown', uid);
     const result = buildWorkloadMapForDeployments([wl], [pod], [inferenceService(IS_NAME)]);
-    expect(result[IS_NAME]).toEqual([]);
-    expect(Object.keys(result)).toEqual([IS_NAME]);
+    expect(result[isKey(IS_NAME)]).toEqual([]);
+    expect(Object.keys(result)).toEqual([isKey(IS_NAME)]);
   });
 });

--- a/frontend/src/api/k8s/workloads.ts
+++ b/frontend/src/api/k8s/workloads.ts
@@ -66,19 +66,25 @@ export const buildWorkloadMapForNotebooks = (
   return result;
 };
 
-// Minimal structural type for a named model deployment.
 // Avoids importing @odh-dashboard/llmd-serving/types which is not a frontend dep.
 type NamedModelResource = { metadata: { name: string } };
 
+/** K8s kinds used as model-deployment map keys (name alone is not unique across kinds). */
+export type ModelDeploymentResourceKind = 'InferenceService' | 'LLMInferenceService';
+
+/** Stable map key: `InferenceService/foo` vs `LLMInferenceService/foo`. */
+export const buildModelDeploymentKey = (kind: ModelDeploymentResourceKind, name: string): string =>
+  `${kind}/${name}`;
+
 /**
  * Two-hop Workload-to-IS/LLMIS correlation (confirmed on live RHOAI + RHBoK cluster):
- * Workload CR ownerRef (kind: Pod) → Pod lookup by UID → Pod label → model name.
+ * Workload CR ownerRef (kind: Pod) → Pod lookup by UID → Pod label → typed deployment key.
  *
  * InferenceService pods carry: `serving.kserve.io/inferenceservice` = IS name
  * LLMInferenceService pods carry: `app.kubernetes.io/component = llminferenceservice-workload`
  *   (discriminator) and `app.kubernetes.io/name` = LLMIS name.
  *
- * Returns model name → WorkloadKind[] (1:many when replicas > 1).
+ * Returns `kind/name` → WorkloadKind[] (1:many when replicas > 1).
  * Workloads whose Pod UID is not in pods (orphaned) are silently skipped.
  */
 export const buildWorkloadMapForDeployments = (
@@ -97,11 +103,11 @@ export const buildWorkloadMapForDeployments = (
   const result: Record<string, WorkloadKind[]> = {};
   for (const is of inferenceServices) {
     if (is.metadata.name) {
-      result[is.metadata.name] = [];
+      result[buildModelDeploymentKey('InferenceService', is.metadata.name)] = [];
     }
   }
   for (const llmis of llmInferenceServices) {
-    result[llmis.metadata.name] = [];
+    result[buildModelDeploymentKey('LLMInferenceService', llmis.metadata.name)] = [];
   }
 
   for (const wl of workloads) {
@@ -117,16 +123,21 @@ export const buildWorkloadMapForDeployments = (
     const labels = pod.metadata.labels ?? {};
 
     // IS: serving.kserve.io/inferenceservice. LLMIS: component=llminferenceservice-workload + name.
-    const modelName =
-      labels['serving.kserve.io/inferenceservice'] ??
-      (labels['app.kubernetes.io/component'] === 'llminferenceservice-workload'
-        ? labels['app.kubernetes.io/name']
-        : undefined);
+    const isName = labels['serving.kserve.io/inferenceservice'];
+    let deploymentKey: string | undefined;
+    if (isName) {
+      deploymentKey = buildModelDeploymentKey('InferenceService', isName);
+    } else if (labels['app.kubernetes.io/component'] === 'llminferenceservice-workload') {
+      const llmisName = labels['app.kubernetes.io/name'];
+      if (llmisName) {
+        deploymentKey = buildModelDeploymentKey('LLMInferenceService', llmisName);
+      }
+    }
 
-    if (!modelName) continue; // Not a model serving Pod.
+    if (!deploymentKey) continue; // Not a model serving Pod.
 
-    if (Object.prototype.hasOwnProperty.call(result, modelName)) {
-      result[modelName].push(wl);
+    if (Object.prototype.hasOwnProperty.call(result, deploymentKey)) {
+      result[deploymentKey].push(wl);
     }
   }
 

--- a/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
@@ -21,7 +21,13 @@ import { useKueueStatusForDeployments } from '#~/pages/modelServing/useKueueStat
 import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
 
 jest.mock('#~/concepts/hardwareProfiles/kueueUtils');
-jest.mock('#~/api/k8s/workloads');
+jest.mock('#~/api/k8s/workloads', () => ({
+  ...jest.requireActual('#~/api/k8s/workloads'),
+  useWatchWorkloads: jest.fn(),
+  useWatchISPods: jest.fn(),
+  useWatchLLMISPods: jest.fn(),
+  buildWorkloadMapForDeployments: jest.fn(),
+}));
 jest.mock('#~/concepts/kueue/index', () => ({
   ...jest.requireActual('#~/concepts/kueue/index'),
   KUEUE_QUEUE_LABEL: 'kueue.x-k8s.io/queue-name',
@@ -110,7 +116,7 @@ describe('useKueueStatusForDeployments', () => {
     const { result } = renderHook(() =>
       useKueueStatusForDeployments([inferenceService('my-model')], project),
     );
-    expect(result.current.kueueStatusByISName).toEqual({});
+    expect(result.current.kueueStatusByDeploymentKey).toEqual({});
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
   });
@@ -139,7 +145,10 @@ describe('useKueueStatusForDeployments', () => {
     useWatchWorkloadsMock.mockReturnValue([workloads, true, undefined]);
     useWatchISPodsMock.mockReturnValue([[isPodResource], true, undefined]);
     useWatchLLMISPodsMock.mockReturnValue([[llmisPodResource], true, undefined]);
-    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-model': [], 'my-llm': [] });
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({
+      'InferenceService/my-model': [],
+      'LLMInferenceService/my-llm': [],
+    });
 
     renderHook(() => useKueueStatusForDeployments([is], project, [llmis]));
 
@@ -203,11 +212,11 @@ describe('useKueueStatusForDeployments', () => {
   });
 
   it('returns null status when workload map has no entry for an IS', () => {
-    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-model': [] });
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'InferenceService/my-model': [] });
     const { result } = renderHook(() =>
       useKueueStatusForDeployments([inferenceService('my-model')], project),
     );
-    expect(result.current.kueueStatusByISName['my-model']).toBeNull();
+    expect(result.current.kueueStatusByDeploymentKey['InferenceService/my-model']).toBeNull();
   });
 
   it('returns aggregated status when workload map has entries', () => {
@@ -215,12 +224,12 @@ describe('useKueueStatusForDeployments', () => {
     const pod = isPod('my-model', uid);
     const wl = workloadWithPodOwnerRef('wl-1', uid, WorkloadStatusType.Inadmissible);
     useWatchISPodsMock.mockReturnValue([[pod], true, undefined]);
-    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-model': [wl] });
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'InferenceService/my-model': [wl] });
 
     const { result } = renderHook(() =>
       useKueueStatusForDeployments([inferenceService('my-model')], project),
     );
-    expect(result.current.kueueStatusByISName['my-model']?.status).toBe(
+    expect(result.current.kueueStatusByDeploymentKey['InferenceService/my-model']?.status).toBe(
       KueueWorkloadStatus.Inadmissible,
     );
   });
@@ -234,10 +243,12 @@ describe('useKueueStatusForDeployments', () => {
       },
     };
     const wl = workloadWithPodOwnerRef('wl-1', POD_UID);
-    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-model': [wl] });
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'InferenceService/my-model': [wl] });
 
     const { result } = renderHook(() => useKueueStatusForDeployments([is], project));
-    expect(result.current.kueueStatusByISName['my-model']?.queueName).toBe('team-queue');
+    expect(result.current.kueueStatusByDeploymentKey['InferenceService/my-model']?.queueName).toBe(
+      'team-queue',
+    );
   });
 
   it('multi-replica: most-restrictive status wins (Inadmissible beats Running)', () => {
@@ -250,13 +261,13 @@ describe('useKueueStatusForDeployments', () => {
       WorkloadStatusType.Inadmissible,
     );
     buildWorkloadMapForDeploymentsMock.mockReturnValue({
-      'my-model': [wlRunning, wlInadmissible],
+      'InferenceService/my-model': [wlRunning, wlInadmissible],
     });
 
     const { result } = renderHook(() =>
       useKueueStatusForDeployments([inferenceService('my-model')], project),
     );
-    expect(result.current.kueueStatusByISName['my-model']?.status).toBe(
+    expect(result.current.kueueStatusByDeploymentKey['InferenceService/my-model']?.status).toBe(
       KueueWorkloadStatus.Inadmissible,
     );
   });
@@ -272,24 +283,28 @@ describe('useKueueStatusForDeployments', () => {
       WorkloadStatusType.Inadmissible,
     );
     buildWorkloadMapForDeploymentsMock.mockReturnValue({
-      'my-model': [wlRunning, wlInadmissible],
+      'InferenceService/my-model': [wlRunning, wlInadmissible],
     });
 
     const { result } = renderHook(() =>
       useKueueStatusForDeployments([inferenceService('my-model')], project),
     );
-    expect(result.current.kueueStatusByISName['my-model']?.workloadName).toBe('wl-inadmissible');
+    expect(
+      result.current.kueueStatusByDeploymentKey['InferenceService/my-model']?.workloadName,
+    ).toBe('wl-inadmissible');
   });
 
   it('all-running: aggregation returns Running', () => {
     const wl0 = workloadWithPodOwnerRef('wl-0', 'uid-0', WorkloadStatusType.Running);
     const wl1 = workloadWithPodOwnerRef('wl-1', 'uid-1', WorkloadStatusType.Running);
-    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-model': [wl0, wl1] });
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({
+      'InferenceService/my-model': [wl0, wl1],
+    });
 
     const { result } = renderHook(() =>
       useKueueStatusForDeployments([inferenceService('my-model')], project),
     );
-    expect(result.current.kueueStatusByISName['my-model']?.status).toBe(
+    expect(result.current.kueueStatusByDeploymentKey['InferenceService/my-model']?.status).toBe(
       KueueWorkloadStatus.Running,
     );
   });
@@ -298,8 +313,8 @@ describe('useKueueStatusForDeployments', () => {
     const wlA = workloadWithPodOwnerRef('wl-a', 'uid-a', WorkloadStatusType.Inadmissible);
     const wlB = workloadWithPodOwnerRef('wl-b', 'uid-b', WorkloadStatusType.Running);
     buildWorkloadMapForDeploymentsMock.mockReturnValue({
-      'model-a': [wlA],
-      'model-b': [wlB],
+      'InferenceService/model-a': [wlA],
+      'InferenceService/model-b': [wlB],
     });
 
     const { result } = renderHook(() =>
@@ -308,9 +323,33 @@ describe('useKueueStatusForDeployments', () => {
         project,
       ),
     );
-    expect(result.current.kueueStatusByISName['model-a']?.status).toBe(
+    expect(result.current.kueueStatusByDeploymentKey['InferenceService/model-a']?.status).toBe(
       KueueWorkloadStatus.Inadmissible,
     );
-    expect(result.current.kueueStatusByISName['model-b']?.status).toBe(KueueWorkloadStatus.Running);
+    expect(result.current.kueueStatusByDeploymentKey['InferenceService/model-b']?.status).toBe(
+      KueueWorkloadStatus.Running,
+    );
+  });
+
+  it('same-name IS and LLMIS retain independent Kueue statuses', () => {
+    const shared = 'shared-name';
+    const wlIs = workloadWithPodOwnerRef('wl-is', 'uid-is', WorkloadStatusType.Inadmissible);
+    const wlLlmis = workloadWithPodOwnerRef('wl-llmis', 'uid-llmis', WorkloadStatusType.Running);
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({
+      [`InferenceService/${shared}`]: [wlIs],
+      [`LLMInferenceService/${shared}`]: [wlLlmis],
+    });
+
+    const { result } = renderHook(() =>
+      useKueueStatusForDeployments([inferenceService(shared)], project, [
+        { metadata: { name: shared } },
+      ]),
+    );
+    expect(result.current.kueueStatusByDeploymentKey[`InferenceService/${shared}`]?.status).toBe(
+      KueueWorkloadStatus.Inadmissible,
+    );
+    expect(result.current.kueueStatusByDeploymentKey[`LLMInferenceService/${shared}`]?.status).toBe(
+      KueueWorkloadStatus.Running,
+    );
   });
 });

--- a/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
+++ b/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
@@ -4,6 +4,7 @@ import type { ProjectKind } from '@odh-dashboard/k8s-core';
 import { useKueueConfiguration } from '#~/concepts/hardwareProfiles/kueueUtils';
 import type { KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
 import {
+  buildModelDeploymentKey,
   buildWorkloadMapForDeployments,
   useWatchWorkloads,
   useWatchISPods,
@@ -15,7 +16,8 @@ import { aggregateKueueStatusForModel, KUEUE_QUEUE_LABEL } from '#~/concepts/kue
 type NamedModelResource = { metadata: { name: string } };
 
 export type KueueStatusForDeploymentsResult = {
-  kueueStatusByISName: Record<string, KueueWorkloadStatusWithMessage | null>;
+  /** Keys are `buildModelDeploymentKey(kind, name)` e.g. `InferenceService/foo`. */
+  kueueStatusByDeploymentKey: Record<string, KueueWorkloadStatusWithMessage | null>;
   isLoading: boolean;
   error: string | null;
 };
@@ -28,6 +30,9 @@ export type KueueStatusForDeploymentsResult = {
  *   IS:    Workload ownerRef → Pod (by UID) → Pod label `serving.kserve.io/inferenceservice`
  *   LLMIS: Workload ownerRef → Pod (by UID) → Pod label `app.kubernetes.io/name`
  *          (filtered by `app.kubernetes.io/component = llminferenceservice-workload`)
+ *
+ * Status map keys are typed (`InferenceService/name`, `LLMInferenceService/name`) so same-name
+ * IS and LLMIS in one namespace stay independent.
  *
  * For multi-replica models the most-restrictive Kueue state across all per-Pod Workload CRs
  * is shown. Only runs when Kueue is enabled for the project.
@@ -49,7 +54,7 @@ export const useKueueStatusForDeployments = (
     useKueue ? namespace : undefined,
   );
 
-  const kueueStatusByISName = React.useMemo(() => {
+  const kueueStatusByDeploymentKey = React.useMemo(() => {
     if (!useKueue) {
       return {};
     }
@@ -60,20 +65,20 @@ export const useKueueStatusForDeployments = (
       inferenceServices,
       llmInferenceServices,
     );
-    const isByName = new Map(
+    const isByKey = new Map(
       inferenceServices
         .filter((is): is is typeof is & { metadata: { name: string } } => Boolean(is.metadata.name))
-        .map((is) => [is.metadata.name, is]),
+        .map((is) => [buildModelDeploymentKey('InferenceService', is.metadata.name), is]),
     );
     const statusMap: Record<string, KueueWorkloadStatusWithMessage | null> = {};
-    for (const [name, isWorkloads] of Object.entries(workloadMap)) {
+    for (const [deploymentKey, isWorkloads] of Object.entries(workloadMap)) {
       const aggregated = aggregateKueueStatusForModel(isWorkloads);
       if (!aggregated) {
-        statusMap[name] = null;
+        statusMap[deploymentKey] = null;
         continue;
       }
-      const is = isByName.get(name);
-      statusMap[name] = {
+      const is = isByKey.get(deploymentKey);
+      statusMap[deploymentKey] = {
         ...aggregated, // includes workloadName from the winning Workload
         queueName: is?.metadata.labels?.[KUEUE_QUEUE_LABEL],
       };
@@ -82,7 +87,7 @@ export const useKueueStatusForDeployments = (
   }, [useKueue, workloads, isPods, llmisPods, inferenceServices, llmInferenceServices]);
 
   return {
-    kueueStatusByISName,
+    kueueStatusByDeploymentKey,
     isLoading: useKueue && (!workloadsLoaded || !isPodsLoaded || !llmisPodsLoaded),
     error: useKueue
       ? (watchError ?? isPodsWatchError ?? llmisPodsWatchError)?.message ?? null


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79913

## Description
Follow-up to #9076 (CodeRabbit: typed deployment keys).

Workload→model maps and the Kueue status hook now key by `InferenceService/<name>` or `LLMInferenceService/<name>` via `buildModelDeploymentKey`, so a same-name IS and LLMIS in one namespace no longer overwrite or merge statuses.

Hook result field renamed: `kueueStatusByISName` → `kueueStatusByDeploymentKey` (no UI callers yet).

## How Has This Been Tested?
- Unit tests: `npm run test:unit -- --testPathPattern='workloads.spec|useKueueStatusForDeployments.spec' --coverage=false` (71 passed)

## Test Impact
- Updated existing map/hook specs for typed keys
- Added same-name IS+LLMIS regression tests

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload and queue-status tracking for deployments with identical names but different resource types.
  * InferenceService and LLMInferenceService deployments are now kept separate, preventing status or replica information from being mixed.
  * Preserved existing handling for orphaned deployments, labels, owner references, replicas, and unknown models.
* **Tests**
  * Added coverage for same-name deployments and independent workload and queue-status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->