### PR TITLE
feat(feature-store): Connect Feature Store admin pages to dashboard navigation

### DIFF
--- a/packages/cypress/cypress/pages/featureStore/featureStoreManage.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureStoreManage.ts
@@ -1,7 +1,7 @@
 class FeatureStoreManagePage {
   visit() {
     cy.visitWithLogin(
-      '/develop-train/feature-store/manage?devFeatureFlags=Feature+store+plugin%3Dtrue',
+      '/settings/environment-setup/feature-stores?devFeatureFlags=Feature+store+plugin%3Dtrue',
     );
     this.wait();
   }

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureStoreCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureStoreCreate.cy.ts
@@ -79,7 +79,10 @@ describe('Feature Store Create Page', () => {
     featureStoreCreatePage.findBackButton().should('be.disabled');
   });
 
-  it('should navigate back to overview when Cancel is clicked', () => {
+  it('should navigate back to the previous page when Cancel is clicked', () => {
+    cy.visitWithLogin(
+      '/develop-train/feature-store/overview?devFeatureFlags=Feature+store+plugin%3Dtrue',
+    );
     featureStoreCreatePage.visit();
     featureStoreCreatePage.findCancelButton().click();
     cy.url().should('include', '/feature-store/overview');

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureStoreManage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureStoreManage.cy.ts
@@ -331,7 +331,7 @@ describe('Feature Store Manage Page', () => {
       initIntercepts({ enableAdmin: false });
 
       cy.visitWithLogin(
-        '/develop-train/feature-store/manage?devFeatureFlags=Feature+store+plugin%3Dtrue',
+        '/settings/environment-setup/feature-stores?devFeatureFlags=Feature+store+plugin%3Dtrue',
       );
 
       cy.wait('@odh-config');

--- a/packages/feature-store/extensions.ts
+++ b/packages/feature-store/extensions.ts
@@ -138,6 +138,34 @@ const extensions: (
     },
   },
   {
+    type: 'app.navigation/href',
+    flags: {
+      required: [PLUGIN_FEATURE_STORE_ADMIN],
+    },
+    properties: {
+      id: 'settings-feature-stores',
+      title: 'Feature stores',
+      href: '/settings/environment-setup/feature-stores',
+      section: 'settings-environment-setup',
+      path: '/settings/environment-setup/feature-stores/*',
+      accessReview: {
+        group: 'feast.dev',
+        resource: 'featurestores',
+        verb: 'list',
+      },
+    },
+  },
+  {
+    type: 'app.route',
+    flags: {
+      required: [PLUGIN_FEATURE_STORE_ADMIN],
+    },
+    properties: {
+      path: '/settings/environment-setup/feature-stores/*',
+      component: () => import('./src/screens/manage/FeatureStoreManageRoutes'),
+    },
+  },
+  {
     type: 'app.route',
     flags: {
       required: [PLUGIN_FEATURE_STORE],

--- a/packages/feature-store/src/FeatureStoreRoutes.tsx
+++ b/packages/feature-store/src/FeatureStoreRoutes.tsx
@@ -22,7 +22,6 @@ import DataSources from './screens/dataSources/DataSources';
 import DataSourceDetailsPage from './screens/dataSources/dataSourceDetails/DataSourceDetailsPage';
 import CreateFeatureStoreProject from './screens/create/CreateFeatureStoreProject';
 import DeploymentProgressPage from './screens/create/DeploymentProgressPage';
-import FeatureStoreListPage from './screens/manage/FeatureStoreListPage';
 
 export const featureStoreRootRoute = (): string => `/develop-train/feature-store`;
 
@@ -41,11 +40,6 @@ export const featureRoute = (
 ): string =>
   `${featureStoreRootRoute()}/features/${featureStoreProject}/${featureViewName}/${featureName}`;
 
-const AreaGatedManagePage = conditionalArea(
-  SupportedArea.FEATURE_STORE_ADMIN,
-  true,
-)(accessAllowedRouteHoC(verbModelAccess('list', FeatureStoreModel))(FeatureStoreListPage));
-
 const AreaGatedCreatePage = conditionalArea(
   SupportedArea.FEATURE_STORE_ADMIN,
   true,
@@ -58,7 +52,6 @@ const AreaGatedDeployPage = conditionalArea(
 
 const FeatureStoreRoutes: React.FC = () => (
   <Routes>
-    <Route path="manage/*" element={<AreaGatedManagePage />} />
     <Route path="create" element={<AreaGatedCreatePage />} />
     <Route path="create/deploy/:namespace/:name" element={<AreaGatedDeployPage />} />
     <Route

--- a/packages/feature-store/src/__tests__/routes.spec.ts
+++ b/packages/feature-store/src/__tests__/routes.spec.ts
@@ -1,6 +1,16 @@
-import { featureStoreFeaturesListRoute, featureStoreRootRoute } from '../routes';
+import {
+  featureStoreFeaturesListRoute,
+  featureStoreRootRoute,
+  featureStoreManageRoute,
+} from '../routes';
 
 describe('routes', () => {
+  describe('featureStoreManageRoute', () => {
+    it('returns settings environment setup path', () => {
+      expect(featureStoreManageRoute()).toBe('/settings/environment-setup/feature-stores');
+    });
+  });
+
   describe('featureStoreFeaturesListRoute', () => {
     const baseFeaturesPath = `${featureStoreRootRoute()}/features`;
 

--- a/packages/feature-store/src/hooks/__tests__/useExistingFeatureStores.spec.tsx
+++ b/packages/feature-store/src/hooks/__tests__/useExistingFeatureStores.spec.tsx
@@ -50,7 +50,12 @@ const createWrapper = (projects: ProjectKind[], loaded = true) => {
 
 describe('useExistingFeatureStores', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('should load feature stores from all project namespaces', async () => {
@@ -199,6 +204,28 @@ describe('useExistingFeatureStores', () => {
 
     expect(result.current.loaded).toBe(false);
     expect(listFeatureStoresMock).not.toHaveBeenCalled();
+  });
+
+  it('should poll for updates at regular intervals', async () => {
+    listFeatureStoresMock.mockResolvedValue([makeStore('store-1', 'ns-1', 'proj-1')]);
+
+    const { result } = renderHook(() => useExistingFeatureStores(), {
+      wrapper: createWrapper([makeProject('ns-1')]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(listFeatureStoresMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    await waitFor(() => {
+      expect(listFeatureStoresMock).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('should support manual refresh', async () => {

--- a/packages/feature-store/src/hooks/useExistingFeatureStores.ts
+++ b/packages/feature-store/src/hooks/useExistingFeatureStores.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ProjectKind } from '@odh-dashboard/k8s-core';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
+import { POLL_INTERVAL } from '@odh-dashboard/internal/utilities/const';
 import { FeatureStoreKind } from '../k8sTypes';
 import { listFeatureStores } from '../api/featureStores';
 import {
@@ -82,8 +83,10 @@ const useExistingFeatureStores = (): UseExistingFeatureStoresReturn => {
     };
 
     fetchAll();
+    const interval = setInterval(() => setRefreshKey((k) => k + 1), POLL_INTERVAL);
     return () => {
       cancelled = true;
+      clearInterval(interval);
     };
   }, [projects, projectsLoaded, refreshKey]);
 

--- a/packages/feature-store/src/routes.ts
+++ b/packages/feature-store/src/routes.ts
@@ -2,6 +2,8 @@ import { FeatureStoreObject } from './const';
 
 export const featureStoreRootRoute = (): string => `/develop-train/feature-store`;
 
+export const featureStoreManageRoute = (): string => '/settings/environment-setup/feature-stores';
+
 export const featureStoreRoute = (
   featureStoreObject: FeatureStoreObject,
   featureStoreProject?: string,

--- a/packages/feature-store/src/screens/create/CreateFeatureStoreProjectWizard.tsx
+++ b/packages/feature-store/src/screens/create/CreateFeatureStoreProjectWizard.tsx
@@ -21,8 +21,7 @@ import AdvancedStep from './steps/AdvancedStep';
 import ReviewStep from './steps/ReviewStep';
 import { createFeatureStore } from '../../api/featureStores';
 import { FeatureStoreKind } from '../../k8sTypes';
-import { FeatureStoreObject } from '../../const';
-import { featureStoreRoute, featureStoreDeployRoute } from '../../routes';
+import { featureStoreDeployRoute } from '../../routes';
 import useNamespaceSecrets from '../../hooks/useNamespaceSecrets';
 import useNamespaceConfigMaps from '../../hooks/useNamespaceConfigMaps';
 import useAccessibleNamespaces from '../../hooks/useAccessibleNamespaces';
@@ -165,10 +164,7 @@ const CreateFeatureStoreProjectWizard: React.FC<CreateFeatureStoreProjectWizardP
 
   return (
     <div data-testid="feast-create-wizard">
-      <Wizard
-        onClose={() => navigate(featureStoreRoute(FeatureStoreObject.OVERVIEW))}
-        footer={wizardFooter}
-      >
+      <Wizard onClose={() => navigate(-1)} footer={wizardFooter}>
         <WizardStep name="Details" id="project-basics-step">
           <ProjectBasicsStep
             data={data}

--- a/packages/feature-store/src/screens/create/DeploymentProgressPage.tsx
+++ b/packages/feature-store/src/screens/create/DeploymentProgressPage.tsx
@@ -36,7 +36,7 @@ import useWatchFeatureStoreDeployment, {
   DeploymentPhase,
 } from '../../hooks/useWatchFeatureStoreDeployment';
 import { FeatureStoreObject } from '../../const';
-import { featureStoreRoute } from '../../routes';
+import { featureStoreRoute, featureStoreManageRoute } from '../../routes';
 import {
   hasConditionFailure,
   humanizeConditionType,
@@ -339,6 +339,13 @@ const DeploymentProgressPage: React.FC = () => {
           </StackItem>
         )}
 
+        {!error && !isComplete && !isFailed && (
+          <StackItem>
+            <Title headingLevel="h6" size="md">
+              Deployment in progress
+            </Title>
+          </StackItem>
+        )}
         <StackItem>
           <Split hasGutter>
             <SplitItem>
@@ -350,13 +357,15 @@ const DeploymentProgressPage: React.FC = () => {
                 {isComplete ? 'Go to feature store' : 'Back to overview'}
               </Button>
             </SplitItem>
-            {!isComplete && !isFailed && (
-              <SplitItem>
-                <Title headingLevel="h6" size="md">
-                  Deployment in progress
-                </Title>
-              </SplitItem>
-            )}
+            <SplitItem>
+              <Button
+                variant="secondary"
+                onClick={() => navigate(featureStoreManageRoute())}
+                data-testid="manage-feature-stores"
+              >
+                Manage feature stores
+              </Button>
+            </SplitItem>
           </Split>
         </StackItem>
       </Stack>

--- a/packages/feature-store/src/screens/create/__tests__/CreateFeatureStoreProjectWizard.spec.tsx
+++ b/packages/feature-store/src/screens/create/__tests__/CreateFeatureStoreProjectWizard.spec.tsx
@@ -201,10 +201,10 @@ describe('CreateFeatureStoreProjectWizard', () => {
     expect(screen.getByTestId('feast-wizard-submit')).toHaveTextContent('Create feature store');
   });
 
-  it('navigates to overview on cancel', async () => {
+  it('navigates back on cancel', async () => {
     renderWizard();
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
-    expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/feature-store/overview'));
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
   });
 
   describe('submit flow', () => {

--- a/packages/feature-store/src/screens/create/__tests__/DeploymentProgressPage.spec.tsx
+++ b/packages/feature-store/src/screens/create/__tests__/DeploymentProgressPage.spec.tsx
@@ -158,6 +158,17 @@ describe('DeploymentProgressPage', () => {
     expect(screen.getByText('Resource not found')).toBeInTheDocument();
   });
 
+  it('suppresses "Deployment in progress" when error is present with stale data', () => {
+    const useWatchMock = jest.requireMock('../../../hooks/useWatchFeatureStoreDeployment').default;
+    useWatchMock.mockReturnValue({
+      ...mockDeploymentStatus,
+      loaded: true,
+      error: new Error('Watch connection lost'),
+    });
+    renderPage();
+    expect(screen.queryByText('Deployment in progress')).not.toBeInTheDocument();
+  });
+
   it('renders conditions with Complete/Pending/Failed labels based on status, reason, and message', () => {
     const useWatchMock = jest.requireMock('../../../hooks/useWatchFeatureStoreDeployment').default;
     useWatchMock.mockReturnValue({

--- a/packages/feature-store/src/screens/manage/FeatureStoreListPage.tsx
+++ b/packages/feature-store/src/screens/manage/FeatureStoreListPage.tsx
@@ -4,6 +4,11 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateFooter,
+  EmptyStateVariant,
+  EmptyStateActions,
+  PageSection,
+  SearchInput,
+  Title,
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
@@ -21,6 +26,7 @@ import { verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR/utils
 import DeleteFeatureStoreModal from './DeleteFeatureStoreModal';
 import FeatureStoreTableRow from './FeatureStoreTableRow';
 import useExistingFeatureStores from '../../hooks/useExistingFeatureStores';
+import FeatureStoreObjectIcon from '../../components/FeatureStoreObjectIcon';
 import { FEATURE_STORE_UI_LABEL_KEY, FEATURE_STORE_UI_LABEL_VALUE } from '../../const';
 import { FeatureStoreKind } from '../../k8sTypes';
 
@@ -38,7 +44,7 @@ const columns: SortableData<FeatureStoreKind>[] = [
   },
   {
     field: 'namespace',
-    label: 'Namespace',
+    label: 'Project',
     width: 20,
     sortable: (a, b) => a.metadata.namespace.localeCompare(b.metadata.namespace),
   },
@@ -89,6 +95,19 @@ const FeatureStoreListPage: React.FC = () => {
   const [canDelete] = useAccessAllowed(verbModelAccess('delete', FeatureStoreModel));
   const [deleteTarget, setDeleteTarget] = React.useState<FeatureStoreKind | undefined>();
   const [expandedRows, setExpandedRows] = React.useState<Set<string>>(new Set());
+  const [nameFilter, setNameFilter] = React.useState('');
+
+  const filteredStores = React.useMemo(() => {
+    if (!nameFilter) {
+      return featureStores;
+    }
+    const lower = nameFilter.toLowerCase();
+    return featureStores.filter(
+      (fs) =>
+        fs.metadata.name.toLowerCase().includes(lower) ||
+        fs.metadata.namespace.toLowerCase().includes(lower),
+    );
+  }, [featureStores, nameFilter]);
 
   const toggleRowExpansion = React.useCallback((name: string) => {
     setExpandedRows((prev) => {
@@ -110,23 +129,39 @@ const FeatureStoreListPage: React.FC = () => {
   };
 
   const emptyStatePage = (
-    <EmptyState
-      headingLevel="h2"
-      titleText="No feature stores yet"
-      icon={CubesIcon}
-      data-testid="empty-feature-stores"
-    >
-      <EmptyStateBody>To get started, create a feature store.</EmptyStateBody>
-      {canCreate && (
-        <EmptyStateFooter>
-          <CreateFeatureStoreButton data-testid="create-feature-store-empty-btn" />
-        </EmptyStateFooter>
-      )}
-    </EmptyState>
+    <PageSection isFilled>
+      <EmptyState
+        variant={EmptyStateVariant.full}
+        data-testid="empty-feature-stores"
+        icon={CubesIcon}
+      >
+        <Title data-testid="no-available-feature-stores" headingLevel="h5" size="lg">
+          No feature stores yet
+        </Title>
+        <EmptyStateBody>To get started, create a feature store.</EmptyStateBody>
+        {canCreate && (
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <CreateFeatureStoreButton data-testid="create-feature-store-empty-btn" />
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        )}
+      </EmptyState>
+    </PageSection>
   );
 
   const toolbarContent = (
     <ToolbarGroup>
+      <ToolbarItem>
+        <SearchInput
+          aria-label="Filter by name or project"
+          placeholder="Filter by name or project"
+          value={nameFilter}
+          onChange={(_event: React.FormEvent, value: string) => setNameFilter(value)}
+          onClear={() => setNameFilter('')}
+          data-testid="feature-store-filter-input"
+        />
+      </ToolbarItem>
       {canCreate && (
         <ToolbarItem>
           <CreateFeatureStoreButton data-testid="create-feature-store-toolbar-btn" />
@@ -138,8 +173,8 @@ const FeatureStoreListPage: React.FC = () => {
   return (
     <>
       <ApplicationsPage
-        title="Feature stores"
-        description="View and manage your feature store instances."
+        title={<FeatureStoreObjectIcon objectType="feature_store" title="Feature stores" />}
+        description="Manage feature store instances for your organization."
         loaded={loaded}
         loadError={error}
         empty={featureStores.length === 0}
@@ -150,11 +185,12 @@ const FeatureStoreListPage: React.FC = () => {
           data-testid="feature-store-list-table"
           id="feature-store-list-table"
           enablePagination
-          data={featureStores}
+          data={filteredStores}
+          onClearFilters={() => setNameFilter('')}
           columns={columns}
           defaultSortColumn={1}
           toolbarContent={toolbarContent}
-          emptyTableView={<DashboardEmptyTableView onClearFilters={() => undefined} />}
+          emptyTableView={<DashboardEmptyTableView onClearFilters={() => setNameFilter('')} />}
           rowRenderer={(fs, rowIndex) => (
             <FeatureStoreTableRow
               key={fs.metadata.uid}

--- a/packages/feature-store/src/screens/manage/FeatureStoreManageRoutes.tsx
+++ b/packages/feature-store/src/screens/manage/FeatureStoreManageRoutes.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { Route, Routes } from 'react-router-dom';
+import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
+import { accessAllowedRouteHoC } from '@odh-dashboard/internal/concepts/userSSAR/accessAllowedRouteHoC';
+import { verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR/utils';
+import FeatureStoreListPage from './FeatureStoreListPage';
+
+const GatedListPage = accessAllowedRouteHoC(verbModelAccess('list', FeatureStoreModel))(
+  FeatureStoreListPage,
+);
+
+const FeatureStoreManageRoutes: React.FC = () => (
+  <Routes>
+    <Route index element={<GatedListPage />} />
+    <Route path="*" element={<GatedListPage />} />
+  </Routes>
+);
+
+export default FeatureStoreManageRoutes;

--- a/packages/feature-store/src/screens/manage/FeatureStoreTableRow.tsx
+++ b/packages/feature-store/src/screens/manage/FeatureStoreTableRow.tsx
@@ -190,7 +190,7 @@ const FeatureStoreTableRow: React.FC<FeatureStoreTableRowProps> = ({
             </>
           )}
         </Td>
-        <Td dataLabel="Namespace">{fs.metadata.namespace}</Td>
+        <Td dataLabel="Project">{fs.metadata.namespace}</Td>
         <Td dataLabel="Status">
           {phaseLabel(resolveEffectivePhase(fs.status?.phase, fs.status?.conditions))}
         </Td>

--- a/packages/feature-store/src/screens/manage/__tests__/FeatureStoreListPage.spec.tsx
+++ b/packages/feature-store/src/screens/manage/__tests__/FeatureStoreListPage.spec.tsx
@@ -13,6 +13,12 @@ jest.mock('@odh-dashboard/internal/concepts/userSSAR/utils', () => ({
   verbModelAccess: jest.fn((...args: unknown[]) => args),
 }));
 jest.mock('../../../hooks/useExistingFeatureStores');
+jest.mock('../../../components/FeatureStoreObjectIcon', () => ({
+  __esModule: true,
+  default: ({ title }: { title: React.ReactNode }) => (
+    <span data-testid="title-with-icon">{title}</span>
+  ),
+}));
 jest.mock('@odh-dashboard/ui-core', () => ({
   ApplicationsPage: ({
     children,
@@ -114,7 +120,9 @@ describe('FeatureStoreListPage', () => {
       </MemoryRouter>,
     );
     expect(screen.getByTestId('empty-feature-stores')).toBeInTheDocument();
-    expect(screen.getByText('No feature stores yet')).toBeInTheDocument();
+    expect(screen.getByTestId('no-available-feature-stores')).toHaveTextContent(
+      'No feature stores yet',
+    );
   });
 
   it('should show create button in empty state when user has create permission', () => {
@@ -254,6 +262,94 @@ describe('FeatureStoreListPage', () => {
     await user.click(getByTestId('confirm-delete'));
     expect(refreshMock).toHaveBeenCalled();
     expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument();
+  });
+
+  it('should filter stores by name', async () => {
+    const stores = [makeStore('alpha-store', 'ns-1'), makeStore('beta-store', 'ns-2')];
+    useExistingFeatureStoresMock.mockReturnValue({
+      featureStores: stores,
+      loaded: true,
+      error: undefined,
+      existingProjectNames: ['alpha-store', 'beta-store'],
+      existingResourceNames: ['alpha-store', 'beta-store'],
+      hasUILabeledStore: false,
+      primaryStore: undefined,
+      refresh: jest.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('row-alpha-store')).toBeInTheDocument();
+    expect(screen.getByTestId('row-beta-store')).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    const filterInput = screen.getByRole('textbox', { name: 'Filter by name or project' });
+    await user.type(filterInput, 'alpha');
+
+    expect(screen.getByTestId('row-alpha-store')).toBeInTheDocument();
+    expect(screen.queryByTestId('row-beta-store')).not.toBeInTheDocument();
+  });
+
+  it('should filter stores by project (namespace)', async () => {
+    const stores = [makeStore('store-a', 'project-one'), makeStore('store-b', 'project-two')];
+    useExistingFeatureStoresMock.mockReturnValue({
+      featureStores: stores,
+      loaded: true,
+      error: undefined,
+      existingProjectNames: ['store-a', 'store-b'],
+      existingResourceNames: ['store-a', 'store-b'],
+      hasUILabeledStore: false,
+      primaryStore: undefined,
+      refresh: jest.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    const filterInput = screen.getByRole('textbox', { name: 'Filter by name or project' });
+    await user.type(filterInput, 'project-two');
+
+    expect(screen.queryByTestId('row-store-a')).not.toBeInTheDocument();
+    expect(screen.getByTestId('row-store-b')).toBeInTheDocument();
+  });
+
+  it('should show all stores when filter is cleared', async () => {
+    const stores = [makeStore('alpha-store', 'ns-1'), makeStore('beta-store', 'ns-2')];
+    useExistingFeatureStoresMock.mockReturnValue({
+      featureStores: stores,
+      loaded: true,
+      error: undefined,
+      existingProjectNames: ['alpha-store', 'beta-store'],
+      existingResourceNames: ['alpha-store', 'beta-store'],
+      hasUILabeledStore: false,
+      primaryStore: undefined,
+      refresh: jest.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <FeatureStoreListPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    const filterInput = screen.getByRole('textbox', { name: 'Filter by name or project' });
+    await user.type(filterInput, 'alpha');
+
+    expect(screen.queryByTestId('row-beta-store')).not.toBeInTheDocument();
+
+    await user.clear(filterInput);
+
+    expect(screen.getByTestId('row-alpha-store')).toBeInTheDocument();
+    expect(screen.getByTestId('row-beta-store')).toBeInTheDocument();
   });
 
   it('should close delete modal without refresh on cancel', async () => {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-61269 

## Description

Connects Feature Store admin pages (manage, create wizard, deployment progress) to the dashboard
navigation so users can discover them without needing direct URLs.

- Added "Feature stores" entry under **Settings > Environment setup**
  with a dedicated route (`/settings/environment-setup/feature-stores`) that renders the
  `FeatureStoreListPage` with RBAC gating (`list` access on FeatureStore resources) and the
  `featureStoreAdmin` feature flag.
- Updated `FeatureStoreListPage` to follow settings page conventions


<img width="1487" height="709" alt="Screenshot 2026-08-11 at 12 52 39 PM" src="https://github.com/user-attachments/assets/9ff8aed3-5372-4392-ade3-d97225e7acf7" />

<img width="1487" height="709" alt="Screenshot 2026-08-11 at 1 13 06 PM" src="https://github.com/user-attachments/assets/d97ae43f-5bd1-49c4-8c0f-8e99ec26e705" />

Full video is uploaded at https://drive.google.com/file/d/1fQ_W4Bver0ZCXTN0WJdr185kabZ1CpLm/view?usp=sharing 

## How Has This Been Tested?

- Manually tested on cluster by deploying the built image (`quay.io/nkathole/odh-dashboard:[RHOAIENG-61269](https://redhat.atlassian.net/browse/RHOAIENG-61269)`).
- Verified "Feature stores" appears under Settings > Environment setup for admin users with the feature flag enabled.
- Verified settings page renders feature store icon, "Project" column, search filter, and correct empty state.
- Verified old `/develop-train/feature-store/manage` route no longer resolves.
- Verified no regression to existing browse flows.

## Test Impact

- Updated `routes.spec.ts` — added test for `featureStoreManageRoute()`.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-61269]: https://redhat.atlassian.net/browse/RHOAIENG-61269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an admin-only Feature Stores page under **Settings > Environment Setup**.
- Added search filtering by feature store name or project, with clear and empty-state controls.
- Added a **Manage feature stores** option during deployment.
- Added automatic refresh of feature store data during extended sessions.

## Improvements
- Renamed the table’s “Namespace” column to “Project”.
- Improved empty-state messaging and page layout.
- Canceling the creation wizard now returns to the previous page.

## Bug Fixes
- Improved deployment status handling when updates cannot be monitored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->