### PR TITLE
[v3.5.0-fixes] fix(RHOAIENG-82319): increase dashboard-operator memory limits to prevent OOMKilled

### DIFF
--- a/dashboard-operator/charts/dashboard/values.yaml
+++ b/dashboard-operator/charts/dashboard/values.yaml
@@ -30,10 +30,10 @@ manager:
   resources:
     limits:
       cpu: 500m
-      memory: 128Mi
+      memory: 256Mi
     requests:
       cpu: 10m
-      memory: 64Mi
+      memory: 192Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/dashboard-operator/config/manager/manager.yaml
+++ b/dashboard-operator/config/manager/manager.yaml
@@ -77,10 +77,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 128Mi
+              memory: 256Mi
             requests:
               cpu: 10m
-              memory: 64Mi
+              memory: 192Mi
       volumes:
         - name: webhook-certs
           secret:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-82319
https://redhat.atlassian.net/browse/RHOAIENG-82400

Cherry-pick of https://github.com/opendatahub-io/odh-dashboard/pull/9204 into `v3.5.0-fixes`.

## Description

The dashboard-operator pod OOM-kills (exit code 137, CrashLoopBackOff) on **3.4→3.5 upgrade clusters** because its memory limit is set to **128Mi** — the scaffold default that was never bumped. The operator's measured steady-state usage is **165Mi** on upgrade clusters, exceeding the limit.

This PR updates the operator's resource configuration in both `dashboard-operator/config/manager/manager.yaml` and `dashboard-operator/charts/dashboard/values.yaml`:

- `memory.requests`: 64Mi → **192Mi** (slightly above steady-state for scheduling)
- `memory.limits`: 128Mi → **256Mi** (55% headroom above steady-state for GC spikes and future growth)

## How Has This Been Tested?

Same as base PR — verified on cluster `api.test-disconnect-pool-bjw2p.aws.rh-ods.com` (RHOAI 3.5 upgrade from 3.4). See https://github.com/opendatahub-io/odh-dashboard/pull/9204 for full details.

## Test Impact

No code changes — only YAML resource limit values updated. No unit or Cypress tests applicable.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`