### PR TITLE
add kueue status to model deployment

### DIFF
--- a/frontend/src/api/k8s/__tests__/workloads.spec.ts
+++ b/frontend/src/api/k8s/__tests__/workloads.spec.ts
@@ -491,4 +491,20 @@ describe('buildWorkloadMapForDeployments', () => {
     expect(result[isKey(IS_NAME)]).toEqual([]);
     expect(Object.keys(result)).toEqual([isKey(IS_NAME)]);
   });
+
+  it("a dead (terminated) pod does not shadow a healthy replacement pod's Workload for the same IS", () => {
+    const deadUid = 'uid-dead-pod';
+    const liveUid = 'uid-live-pod';
+    const deadPod = isPod('predictor-old', IS_NAME, deadUid);
+    const terminatedDeadPod = { ...deadPod, status: { ...deadPod.status, phase: 'Failed' } };
+    const livePod = isPod('predictor-new', IS_NAME, liveUid);
+    const wlDead = workloadWithPodOwnerRef('wl-dead', deadUid);
+    const wlLive = workloadWithPodOwnerRef('wl-live', liveUid);
+    const result = buildWorkloadMapForDeployments(
+      [wlDead, wlLive],
+      [terminatedDeadPod, livePod],
+      [inferenceService(IS_NAME)],
+    );
+    expect(result[IS_NAME]).toEqual([wlLive]);
+  });
 });

--- a/frontend/src/api/k8s/__tests__/workloads.spec.ts
+++ b/frontend/src/api/k8s/__tests__/workloads.spec.ts
@@ -505,6 +505,6 @@ describe('buildWorkloadMapForDeployments', () => {
       [terminatedDeadPod, livePod],
       [inferenceService(IS_NAME)],
     );
-    expect(result[IS_NAME]).toEqual([wlLive]);
+    expect(result[isKey(IS_NAME)]).toEqual([wlLive]);
   });
 });

--- a/frontend/src/api/k8s/workloads.ts
+++ b/frontend/src/api/k8s/workloads.ts
@@ -120,6 +120,8 @@ export const buildWorkloadMapForDeployments = (
     const pod = podByUID.get(podRef.uid);
     if (!pod) continue; // Pod gone (scale-down, rolling update) — skip orphaned Workload.
 
+    if (pod.status?.phase === 'Succeeded' || pod.status?.phase === 'Failed') continue;
+
     const labels = pod.metadata.labels ?? {};
 
     // IS: serving.kserve.io/inferenceservice. LLMIS: component=llminferenceservice-workload + name.

--- a/frontend/src/concepts/kueue/__tests__/messageUtils.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/messageUtils.spec.ts
@@ -2,6 +2,7 @@ import { KueueWorkloadStatus, type KueueWorkloadStatusWithMessage } from '#~/con
 import {
   getHumanReadableKueueMessage,
   getKueueSubStepInfo,
+  getDeploymentKueueSubStepMessage,
   getPreemptionToastBody,
   getEvictionToastBody,
   getRequeuedMessage,
@@ -453,6 +454,80 @@ describe('getKueueSubStepInfo', () => {
       );
       expect(result.label).not.toContain('in queue');
     });
+  });
+});
+
+describe('getDeploymentKueueSubStepMessage', () => {
+  it('formats Queued as "Queued: <reason>"', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'my-queue',
+    });
+    expect(result).toBe('Queued: Waiting for quota in my-queue');
+  });
+
+  it('formats Preempted as "Preempted: Deployment re-queued, waiting for resource"', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Preempted,
+      queueName: 'my-queue',
+    });
+    expect(result).toBe('Preempted: Deployment re-queued, waiting for resource');
+  });
+
+  it('formats a quota-exceeded Failed status using the raw Kueue message verbatim', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Failed,
+      queueName: 'my-queue',
+      message: 'Requested 8 GPUs exceed 4 GPUs queue quota.',
+    });
+    expect(result).toBe('Failed: Requested 8 GPUs exceed 4 GPUs queue quota.');
+  });
+
+  it('formats a quota-exceeded Inadmissible status using the raw Kueue message verbatim', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Inadmissible,
+      queueName: 'my-queue',
+      message: 'insufficient unused quota for nvidia.com/gpu',
+    });
+    expect(result).toBe('Inadmissible: insufficient unused quota for nvidia.com/gpu');
+  });
+
+  it('falls back to the generic templated message when Failed has no quota-shaped raw message', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Failed,
+      queueName: 'my-queue',
+      message: 'some other failure',
+    });
+    expect(result).toBe('Failed: some other failure');
+  });
+
+  it('appends the partial-admission suffix when podAdmissionCounts.total > 1', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'my-queue',
+      podAdmissionCounts: { admitted: 3, total: 5 },
+    });
+    expect(result).toBe('Queued: Waiting for quota in my-queue (3 of 5 pods admitted)');
+  });
+
+  it('appends the partial-admission suffix to the Preempted message too', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Preempted,
+      queueName: 'my-queue',
+      podAdmissionCounts: { admitted: 2, total: 4 },
+    });
+    expect(result).toBe(
+      'Preempted: Deployment re-queued, waiting for resource (2 of 4 pods admitted)',
+    );
+  });
+
+  it('omits the suffix when podAdmissionCounts.total is 1 (single replica)', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'my-queue',
+      podAdmissionCounts: { admitted: 0, total: 1 },
+    });
+    expect(result).toBe('Queued: Waiting for quota in my-queue');
   });
 });
 

--- a/frontend/src/concepts/kueue/index.ts
+++ b/frontend/src/concepts/kueue/index.ts
@@ -12,7 +12,7 @@ import {
   type KueueStatusInfo,
   type KueueWorkloadStatusWithMessage,
 } from './types';
-import { isInadmissibleQuotaCondition } from './messageUtils';
+import { getDeploymentKueueSubStepMessage, isInadmissibleQuotaCondition } from './messageUtils';
 
 export const KUEUE_QUEUE_LABEL = 'kueue.x-k8s.io/queue-name';
 
@@ -317,6 +317,13 @@ const AGGREGATE_PRIORITY_ORDER: KueueWorkloadStatus[] = [
  *
  * Returns null when workloads array is empty (model has no correlated Workload CRs).
  */
+/** Statuses that count as "this Pod's Workload has been admitted" for the partial-admission count. */
+const ADMITTED_STATUSES: KueueWorkloadStatus[] = [
+  KueueWorkloadStatus.Admitted,
+  KueueWorkloadStatus.Running,
+  KueueWorkloadStatus.Complete,
+];
+
 export const aggregateKueueStatusForModel = (
   workloads: WorkloadKind[],
 ): KueueWorkloadStatusWithMessage | null => {
@@ -325,9 +332,49 @@ export const aggregateKueueStatusForModel = (
     ...getKueueWorkloadStatusWithMessage(wl),
     workloadName: wl.metadata?.name,
   }));
+
+  // Only meaningful with multiple replicas — a single Workload is fully captured by its own
+  // status already, so "1 of 1 admitted" would be redundant noise.
+  const podAdmissionCounts =
+    statuses.length > 1
+      ? {
+          admitted: statuses.filter((s) => ADMITTED_STATUSES.includes(s.status)).length,
+          total: statuses.length,
+        }
+      : undefined;
+
   for (const target of AGGREGATE_PRIORITY_ORDER) {
     const match = statuses.find((s) => s.status === target);
-    if (match) return match;
+    if (match) return { ...match, podAdmissionCounts };
   }
-  return statuses[0];
+  return { ...statuses[0], podAdmissionCounts };
+};
+
+/** Generic (package-agnostic) condition status values used by the deployment progress tree. */
+export type GenericConditionStatus = 'True' | 'False' | 'Warning' | 'Unknown';
+
+/** Maps a Kueue status level (danger/warning/success) to a generic condition status. */
+export const getKueueConditionStatus = (status: KueueWorkloadStatus): GenericConditionStatus => {
+  const level = getKueueStatusInfo(status).status;
+  if (level === 'danger') return 'False';
+  if (level === 'warning') return 'Warning';
+  if (level === 'success') return 'True';
+  return 'Unknown';
+};
+
+export const getKueueSchedulingSubStep = (
+  kueueStatus: KueueWorkloadStatusWithMessage | null | undefined,
+): {
+  type: string;
+  label: string;
+  messageStatus: GenericConditionStatus;
+  lastTransitionTime?: string;
+} | null => {
+  if (!kueueStatus) return null;
+  return {
+    type: 'kueue',
+    label: getDeploymentKueueSubStepMessage(kueueStatus),
+    messageStatus: getKueueConditionStatus(kueueStatus.status),
+    lastTransitionTime: kueueStatus.timestamp,
+  };
 };

--- a/frontend/src/concepts/kueue/messageUtils.ts
+++ b/frontend/src/concepts/kueue/messageUtils.ts
@@ -160,6 +160,14 @@ export const formatQueuePosition = (position: number, queue: string): string =>
   `${toOrdinal(position)} in ${queue}`;
 
 /**
+ * Formats the multi-Pod partial-admission breakdown for model deployments, e.g. (3, 5) →
+ * "3 of 5 pods admitted". Only meaningful when `total > 1` (see podAdmissionCounts on
+ * KueueWorkloadStatusWithMessage) — callers should gate on that before using this.
+ */
+export const formatPodAdmissionCounts = (admitted: number, total: number): string =>
+  `${admitted} of ${total} pods admitted`;
+
+/**
  * Formats a preemption toast body message with the workbench name and timestamp.
  */
 export const getPreemptionToastBody = (workbenchName: string, timestamp?: string): string => {
@@ -247,6 +255,53 @@ export const getKueueAnalyticsSubState = (
     default:
       return 'none';
   }
+};
+
+const DEPLOYMENT_SUBSTEP_PREFIX: Partial<Record<KueueWorkloadStatus, string>> = {
+  [KueueWorkloadStatus.Queued]: 'Queued',
+  [KueueWorkloadStatus.Requeued]: 'Queued',
+  [KueueWorkloadStatus.Inadmissible]: 'Inadmissible',
+  [KueueWorkloadStatus.Failed]: 'Failed',
+  [KueueWorkloadStatus.Preempted]: 'Preempted',
+  [KueueWorkloadStatus.Evicted]: 'Evicted',
+  [KueueWorkloadStatus.BlockedOnPreemptionGates]: 'Blocked',
+  [KueueWorkloadStatus.AdmissionCheck]: 'Admission check',
+};
+
+export const getDeploymentKueueSubStepMessage = (
+  kueueStatus: KueueWorkloadStatusWithMessage,
+): string => {
+  const { status, queueName, message, podAdmissionCounts } = kueueStatus;
+  const prefix = DEPLOYMENT_SUBSTEP_PREFIX[status];
+
+  // Multi-replica partial-admission detail, e.g. "(3 of 5 pods admitted)" — same suffix shown
+  // in the table row subtitle (getDeploymentStatusSubtitle), so the modal sub-step and the
+  // table stay consistent. Only meaningful for >1 correlated Workload CR.
+  const admissionSuffix =
+    podAdmissionCounts && podAdmissionCounts.total > 1
+      ? ` (${formatPodAdmissionCounts(podAdmissionCounts.admitted, podAdmissionCounts.total)})`
+      : '';
+
+  if (status === KueueWorkloadStatus.Preempted) {
+    return `Preempted: Deployment re-queued, waiting for resource${admissionSuffix}`;
+  }
+
+  const rawMessage = message?.trim() || undefined;
+  const isQuotaShaped =
+    (status === KueueWorkloadStatus.Failed || status === KueueWorkloadStatus.Inadmissible) &&
+    rawMessage != null &&
+    (QUOTA_REGEX.test(rawMessage) || FLAVOR_REGEX.test(rawMessage));
+
+  const body = isQuotaShaped
+    ? rawMessage
+    : status === KueueWorkloadStatus.Requeued
+    ? getRequeuedMessage(kueueStatus)
+    : getHumanReadableKueueMessage(status, message, queueName);
+
+  // Queue-position suffix (e.g. "Position 3 of 8 in queue") intentionally omitted here:
+  // queuePosition/queueTotal aren't populated for model deployments yet (only workbenches,
+  // via useQueuePositions). Tracked as a follow-up PR.
+  return `${prefix ? `${prefix}: ${body}` : body}${admissionSuffix}`;
 };
 
 /**

--- a/frontend/src/concepts/kueue/types.ts
+++ b/frontend/src/concepts/kueue/types.ts
@@ -30,6 +30,15 @@ export type KueueWorkloadStatusWithMessage = {
     count: number;
     requeueAt?: string;
   };
+  /**
+   * Multi-Pod admission breakdown (model deployments only — one Workload CR per replica Pod).
+   * Present only when there's more than one correlated Workload CR for the model, so the UI can
+   * show e.g. "3 of 5 pods admitted" instead of a single pass/fail status.
+   */
+  podAdmissionCounts?: {
+    admitted: number;
+    total: number;
+  };
 };
 
 export type KueueStatusInfo = {
@@ -51,6 +60,18 @@ export const KUEUE_STATUSES_OVERRIDE_WORKBENCH: KueueWorkloadStatus[] = [
   KueueWorkloadStatus.Preempted,
   KueueWorkloadStatus.Evicted,
   KueueWorkloadStatus.Requeued,
+  KueueWorkloadStatus.Complete,
+];
+
+/**
+ * Kueue considers a Workload admitted only once QuotaReserved AND all AdmissionChecks are
+ * ready — AdmissionCheck therefore represents a still-pending, potentially-blocking state and
+ * must NOT be treated as past admission (see kueue.sigs.k8s.io AdmissionCheck docs). A pending
+ * or retrying check can still prevent the Pod from being created.
+ */
+export const KUEUE_STATUSES_PAST_ADMISSION: KueueWorkloadStatus[] = [
+  KueueWorkloadStatus.Admitted,
+  KueueWorkloadStatus.Running,
   KueueWorkloadStatus.Complete,
 ];
 

--- a/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
@@ -246,10 +246,10 @@ describe('useKueueStatusForDeployments', () => {
         annotations: { 'serving.kserve.io/stop': 'true' },
       },
     };
-    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'test-model': [] });
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'InferenceService/test-model': [] });
 
     const { result } = renderHook(() => useKueueStatusForDeployments([is], project));
-    expect(result.current.kueueStatusByISName['test-model']).toBeNull();
+    expect(result.current.kueueStatusByDeploymentKey['InferenceService/test-model']).toBeNull();
   });
 
   it('includes queueName from IS label in the status', () => {
@@ -277,10 +277,14 @@ describe('useKueueStatusForDeployments', () => {
       },
     };
     const wl = workloadWithPodOwnerRef('wl-1', POD_UID);
-    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-llm-model': [wl] });
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({
+      'LLMInferenceService/my-llm-model': [wl],
+    });
 
     const { result } = renderHook(() => useKueueStatusForDeployments([], project, [llmis]));
-    expect(result.current.kueueStatusByISName['my-llm-model']?.queueName).toBe('llm-team-queue');
+    expect(
+      result.current.kueueStatusByDeploymentKey['LLMInferenceService/my-llm-model']?.queueName,
+    ).toBe('llm-team-queue');
   });
 
   it('multi-replica: most-restrictive status wins (Inadmissible beats Running)', () => {

--- a/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
@@ -234,6 +234,24 @@ describe('useKueueStatusForDeployments', () => {
     );
   });
 
+  it('returns null when no Workload CR exists yet, even if the IS has a queueName label (e.g. stopped deployments keep the label)', () => {
+    // Mirrors workbench: no Workload CR → null, regardless of queueName label presence. The
+    // label alone can't distinguish "not yet admitted" from "stopped" (the label persists on
+    // the IS even while stopped), so we don't guess a "Queued" status from it.
+    const is = {
+      ...inferenceService('test-model'),
+      metadata: {
+        ...inferenceService('test-model').metadata,
+        labels: { 'kueue.x-k8s.io/queue-name': 'default' },
+        annotations: { 'serving.kserve.io/stop': 'true' },
+      },
+    };
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'test-model': [] });
+
+    const { result } = renderHook(() => useKueueStatusForDeployments([is], project));
+    expect(result.current.kueueStatusByISName['test-model']).toBeNull();
+  });
+
   it('includes queueName from IS label in the status', () => {
     const is = {
       ...inferenceService('my-model'),
@@ -249,6 +267,20 @@ describe('useKueueStatusForDeployments', () => {
     expect(result.current.kueueStatusByDeploymentKey['InferenceService/my-model']?.queueName).toBe(
       'team-queue',
     );
+  });
+
+  it('includes queueName from LLMIS label in the status (not just plain InferenceServices)', () => {
+    const llmis = {
+      metadata: {
+        name: 'my-llm-model',
+        labels: { 'kueue.x-k8s.io/queue-name': 'llm-team-queue' },
+      },
+    };
+    const wl = workloadWithPodOwnerRef('wl-1', POD_UID);
+    buildWorkloadMapForDeploymentsMock.mockReturnValue({ 'my-llm-model': [wl] });
+
+    const { result } = renderHook(() => useKueueStatusForDeployments([], project, [llmis]));
+    expect(result.current.kueueStatusByISName['my-llm-model']?.queueName).toBe('llm-team-queue');
   });
 
   it('multi-replica: most-restrictive status wins (Inadmissible beats Running)', () => {

--- a/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
+++ b/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
@@ -65,11 +65,22 @@ export const useKueueStatusForDeployments = (
       inferenceServices,
       llmInferenceServices,
     );
-    const isByKey = new Map(
-      inferenceServices
+    const isByKey = new Map<string, NamedModelResource>([
+      ...inferenceServices
         .filter((is): is is typeof is & { metadata: { name: string } } => Boolean(is.metadata.name))
-        .map((is) => [buildModelDeploymentKey('InferenceService', is.metadata.name), is]),
-    );
+        .map((is): [string, NamedModelResource] => [
+          buildModelDeploymentKey('InferenceService', is.metadata.name),
+          is,
+        ]),
+      ...llmInferenceServices
+        .filter((llmis): llmis is typeof llmis & { metadata: { name: string } } =>
+          Boolean(llmis.metadata.name),
+        )
+        .map((llmis): [string, NamedModelResource] => [
+          buildModelDeploymentKey('LLMInferenceService', llmis.metadata.name),
+          llmis,
+        ]),
+    ]);
     const statusMap: Record<string, KueueWorkloadStatusWithMessage | null> = {};
     for (const [deploymentKey, isWorkloads] of Object.entries(workloadMap)) {
       // Mirrors useKueueStatusForNotebooks: no matching Workload CR → null, full stop. No

--- a/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
+++ b/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
@@ -13,7 +13,7 @@ import {
 import { aggregateKueueStatusForModel, KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
 
 // Avoids importing @odh-dashboard/llmd-serving/types (not a frontend dep).
-type NamedModelResource = { metadata: { name: string } };
+type NamedModelResource = { metadata: { name: string; labels?: Record<string, string> } };
 
 export type KueueStatusForDeploymentsResult = {
   /** Keys are `buildModelDeploymentKey(kind, name)` e.g. `InferenceService/foo`. */
@@ -72,6 +72,9 @@ export const useKueueStatusForDeployments = (
     );
     const statusMap: Record<string, KueueWorkloadStatusWithMessage | null> = {};
     for (const [deploymentKey, isWorkloads] of Object.entries(workloadMap)) {
+      // Mirrors useKueueStatusForNotebooks: no matching Workload CR → null, full stop. No
+      // queueName-based fallback — the queue label stays on the IS/LLMIS even while stopped, so
+      // guessing a status here (e.g. "Queued") from label presence alone is unreliable.
       const aggregated = aggregateKueueStatusForModel(isWorkloads);
       if (!aggregated) {
         statusMap[deploymentKey] = null;
@@ -83,6 +86,7 @@ export const useKueueStatusForDeployments = (
         queueName: is?.metadata.labels?.[KUEUE_QUEUE_LABEL],
       };
     }
+
     return statusMap;
   }, [useKueue, workloads, isPods, llmisPods, inferenceServices, llmInferenceServices]);
 

--- a/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
+++ b/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
@@ -15,6 +15,19 @@ import { aggregateKueueStatusForModel, KUEUE_QUEUE_LABEL } from '#~/concepts/kue
 // Avoids importing @odh-dashboard/llmd-serving/types (not a frontend dep).
 type NamedModelResource = { metadata: { name: string; labels?: Record<string, string> } };
 
+const EMPTY_STATUS_MAP: Record<string, KueueWorkloadStatusWithMessage | null> = {};
+
+const useStableStatusMap = (
+  statusMap: Record<string, KueueWorkloadStatusWithMessage | null>,
+): Record<string, KueueWorkloadStatusWithMessage | null> => {
+  const ref = React.useRef({ serialized: '', value: EMPTY_STATUS_MAP });
+  const serialized = JSON.stringify(statusMap);
+  if (serialized !== ref.current.serialized) {
+    ref.current = { serialized, value: statusMap };
+  }
+  return ref.current.value;
+};
+
 export type KueueStatusForDeploymentsResult = {
   /** Keys are `buildModelDeploymentKey(kind, name)` e.g. `InferenceService/foo`. */
   kueueStatusByDeploymentKey: Record<string, KueueWorkloadStatusWithMessage | null>;
@@ -54,9 +67,9 @@ export const useKueueStatusForDeployments = (
     useKueue ? namespace : undefined,
   );
 
-  const kueueStatusByDeploymentKey = React.useMemo(() => {
+  const rawKueueStatusByDeploymentKey = React.useMemo(() => {
     if (!useKueue) {
-      return {};
+      return EMPTY_STATUS_MAP;
     }
     const allPods = [...isPods, ...llmisPods];
     const workloadMap = buildWorkloadMapForDeployments(
@@ -100,6 +113,8 @@ export const useKueueStatusForDeployments = (
 
     return statusMap;
   }, [useKueue, workloads, isPods, llmisPods, inferenceServices, llmInferenceServices]);
+
+  const kueueStatusByDeploymentKey = useStableStatusMap(rawKueueStatusByDeploymentKey);
 
   return {
     kueueStatusByDeploymentKey,

--- a/frontend/src/utilities/useDebouncedTrueValue.ts
+++ b/frontend/src/utilities/useDebouncedTrueValue.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+const useDebouncedTrueValue = (value: boolean, delayMs = 8000): boolean => {
+  const [debounced, setDebounced] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!value) {
+      setDebounced(false);
+      return undefined;
+    }
+    const timer = setTimeout(() => setDebounced(true), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+};
+
+export default useDebouncedTrueValue;

--- a/packages/kserve/src/__tests__/deploymentStatus.spec.ts
+++ b/packages/kserve/src/__tests__/deploymentStatus.spec.ts
@@ -1,6 +1,7 @@
 import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
 import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import { KueueWorkloadStatus } from '@odh-dashboard/internal/concepts/kueue/types';
 import { getKServeDeploymentConditions } from '../deploymentStatus';
 
 describe('getKServeDeploymentConditions', () => {
@@ -142,7 +143,58 @@ describe('getKServeDeploymentConditions', () => {
     const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.UNKNOWN);
 
     expect(conditions).toHaveLength(1);
-    expect(conditions[0].type).toBe('DeploymentRequested');
+    expect(conditions.map((c) => c.type)).toEqual(['DeploymentRequested']);
+  });
+
+  it('should omit CreatePod entirely for non-Kueue deployments (no kueueStatus)', () => {
+    const isvc: InferenceServiceKind = {
+      ...mockInferenceServiceK8sResource({}),
+      status: {
+        url: '',
+        conditions: [
+          {
+            type: 'PredictorReady',
+            status: 'True',
+            lastTransitionTime: '2026-05-26T13:49:27Z',
+          },
+        ],
+      },
+    };
+    const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.LOADED, null);
+
+    expect(conditions.find((c) => c.type === 'CreatePod')).toBeUndefined();
+  });
+
+  it('should mark CreatePod as True once Kueue reports Admitted (quota reserved, scheduling gate lifted)', () => {
+    const isvc: InferenceServiceKind = {
+      ...mockInferenceServiceK8sResource({ missingStatus: true }),
+    };
+    const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.UNKNOWN, {
+      status: KueueWorkloadStatus.Admitted,
+      queueName: 'test-queue',
+      timestamp: '2026-05-26T13:49:00Z',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).toBe('True');
+    expect(createPod?.inProgress).toBe(false);
+    expect(createPod?.message).toBeUndefined();
+    expect(createPod?.lastTransitionTime).toBe('2026-05-26T13:49:00Z');
+  });
+
+  it('should mark CreatePod as True once Kueue confirms the workload is Running (PodsReady)', () => {
+    const isvc: InferenceServiceKind = {
+      ...mockInferenceServiceK8sResource({ missingStatus: true }),
+    };
+    const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.UNKNOWN, {
+      status: KueueWorkloadStatus.Running,
+      queueName: 'test-queue',
+      timestamp: '2026-05-26T13:50:00Z',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).toBe('True');
+    expect(createPod?.lastTransitionTime).toBe('2026-05-26T13:50:00Z');
   });
 
   it('should include all conditions in correct order for a ready deployment', () => {
@@ -169,14 +221,22 @@ describe('getKServeDeploymentConditions', () => {
         ],
       },
     };
-    const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.LOADED);
+    const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.LOADED, {
+      status: KueueWorkloadStatus.Admitted,
+      queueName: 'test-queue',
+      timestamp: '2026-05-26T13:49:01Z',
+    });
 
     expect(conditions.map((c) => c.type)).toEqual([
       'DeploymentRequested',
+      'CreatePod',
       'PredictorReady',
       'IngressReady',
       'LatestDeploymentReady',
     ]);
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).toBe('True');
+    expect(createPod?.lastTransitionTime).toBe('2026-05-26T13:49:01Z');
   });
 
   it('should show LatestDeploymentReady as warning when model is serving but condition is False', () => {
@@ -237,5 +297,65 @@ describe('getKServeDeploymentConditions', () => {
     expect(deploymentReady?.status).toBe('False');
     expect(deploymentReady?.label).toBe('Deployment ready');
     expect(deploymentReady?.message).toBe('Deployment has timed out.');
+  });
+
+  it('should mirror workbench severity: a missing queue shows Warning, not False, on CreatePod', () => {
+    const isvc = mockInferenceServiceK8sResource({ missingStatus: true });
+    const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.PENDING, {
+      status: KueueWorkloadStatus.Inadmissible,
+      message: 'LocalQueue no-lq does not exist',
+      queueName: 'no-lq',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).toBe('Warning');
+    expect(createPod?.messageStatus).toBe('Warning');
+    expect(createPod?.inProgress).toBe(false);
+  });
+
+  it('should show CreatePod as Unknown with an in-progress spinner while merely Queued', () => {
+    const isvc = mockInferenceServiceK8sResource({ missingStatus: true });
+    const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.PENDING, {
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'test-queue',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).toBe('Unknown');
+    expect(createPod?.inProgress).toBe(true);
+  });
+
+  it('should show CreatePod as False when the Kueue workload has Failed', () => {
+    const isvc = mockInferenceServiceK8sResource({ missingStatus: true });
+    const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.PENDING, {
+      status: KueueWorkloadStatus.Failed,
+      queueName: 'test-queue',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).toBe('False');
+    expect(createPod?.inProgress).toBe(false);
+  });
+
+  it('should still show the Kueue sub-step while BlockedOnPreemptionGates (quota reserved but pod creation still held)', () => {
+    const isvc = mockInferenceServiceK8sResource({ missingStatus: true });
+    const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.PENDING, {
+      status: KueueWorkloadStatus.BlockedOnPreemptionGates,
+      queueName: 'test-queue',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).not.toBe('True');
+  });
+
+  it('should NOT mark CreatePod as True while AdmissionCheck is pending (Kueue only admits once all checks are ready)', () => {
+    const isvc = mockInferenceServiceK8sResource({ missingStatus: true });
+    const conditions = getKServeDeploymentConditions(isvc, ModelDeploymentState.PENDING, {
+      status: KueueWorkloadStatus.AdmissionCheck,
+      queueName: 'test-queue',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).not.toBe('True');
   });
 });

--- a/packages/kserve/src/__tests__/deployments.spec.ts
+++ b/packages/kserve/src/__tests__/deployments.spec.ts
@@ -16,9 +16,21 @@ jest.mock('@odh-dashboard/plugin-core', () => ({
   useResolvedExtensions: jest.fn(() => [[], true, []]),
 }));
 
+// Mock Kueue status - not under test here, exercised by useKueueStatusForDeployments.spec.ts
+jest.mock('@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments', () => ({
+  useKueueStatusForDeployments: jest.fn(() => ({
+    kueueStatusByISName: {},
+    isLoading: false,
+    error: null,
+  })),
+}));
+
 const mockUseWatchInferenceServices = watchModule.useWatchInferenceServices as jest.Mock;
 const mockUseWatchServingRuntimes = watchModule.useWatchServingRuntimes as jest.Mock;
 const mockUseWatchDeploymentPods = watchModule.useWatchDeploymentPods as jest.Mock;
+const mockUseKueueStatusForDeployments = jest.requireMock(
+  '@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments',
+).useKueueStatusForDeployments as jest.Mock;
 
 // Type helper for hook return value
 type DeploymentHookResult = [KServeDeployment[] | undefined, boolean, Error[] | undefined];
@@ -183,6 +195,21 @@ describe('useWatchDeployments', () => {
     expect(errors).toContain(mockError);
   });
 
+  it('should surface Kueue watch errors (e.g. 403 for missing RBAC) instead of silently dropping them', () => {
+    mockUseKueueStatusForDeployments.mockReturnValue({
+      kueueStatusByISName: {},
+      isLoading: false,
+      error: 'Forbidden',
+    });
+
+    const renderResult = testHook(useWatchDeployments)(mockProject, undefined, undefined);
+
+    const [, , errors] = renderResult.result.current as DeploymentHookResult;
+
+    expect(errors).toHaveLength(1);
+    expect(errors?.[0].message).toBe('Forbidden');
+  });
+
   it('should update deployments when filterFn changes', () => {
     const filterFn1 = (inferenceService: InferenceServiceKind) =>
       inferenceService.metadata.labels?.app === 'test';
@@ -234,6 +261,20 @@ describe('useWatchDeployments', () => {
     [deployments] = renderResult.result.current as DeploymentHookResult;
 
     expect(deployments).toHaveLength(4);
+  });
+
+  it('should default status.kueueStatus to null (not undefined) when the IS has no entry in kueueStatusByISName', () => {
+    mockUseKueueStatusForDeployments.mockReturnValue({
+      kueueStatusByISName: {},
+      isLoading: false,
+      error: null,
+    });
+
+    const renderResult = testHook(useWatchDeployments)(mockProject, undefined, undefined);
+
+    const [deployments] = renderResult.result.current as DeploymentHookResult;
+
+    expect(deployments?.[0]?.status?.kueueStatus).toBeNull();
   });
 
   it('should include all deployment properties', () => {

--- a/packages/kserve/src/__tests__/deployments.spec.ts
+++ b/packages/kserve/src/__tests__/deployments.spec.ts
@@ -19,7 +19,7 @@ jest.mock('@odh-dashboard/plugin-core', () => ({
 // Mock Kueue status - not under test here, exercised by useKueueStatusForDeployments.spec.ts
 jest.mock('@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments', () => ({
   useKueueStatusForDeployments: jest.fn(() => ({
-    kueueStatusByISName: {},
+    kueueStatusByDeploymentKey: {},
     isLoading: false,
     error: null,
   })),
@@ -197,7 +197,7 @@ describe('useWatchDeployments', () => {
 
   it('should surface Kueue watch errors (e.g. 403 for missing RBAC) instead of silently dropping them', () => {
     mockUseKueueStatusForDeployments.mockReturnValue({
-      kueueStatusByISName: {},
+      kueueStatusByDeploymentKey: {},
       isLoading: false,
       error: 'Forbidden',
     });
@@ -263,9 +263,9 @@ describe('useWatchDeployments', () => {
     expect(deployments).toHaveLength(4);
   });
 
-  it('should default status.kueueStatus to null (not undefined) when the IS has no entry in kueueStatusByISName', () => {
+  it('should default status.kueueStatus to null (not undefined) when the IS has no entry in kueueStatusByDeploymentKey', () => {
     mockUseKueueStatusForDeployments.mockReturnValue({
-      kueueStatusByISName: {},
+      kueueStatusByDeploymentKey: {},
       isLoading: false,
       error: null,
     });

--- a/packages/kserve/src/deploymentStatus.ts
+++ b/packages/kserve/src/deploymentStatus.ts
@@ -1,5 +1,6 @@
 import type { PodKind } from '@odh-dashboard/k8s-core';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import { KUEUE_STATUSES_PAST_ADMISSION } from '@odh-dashboard/internal/concepts/kueue/types';
 import {
   checkModelPodStatus,
   getInferenceServiceModelState,
@@ -14,6 +15,8 @@ import { toConditionStatus } from '@odh-dashboard/model-serving/extension-points
 import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { InferenceServiceModel } from '@odh-dashboard/internal/api/models/kserve';
 import { getModelDeploymentStoppedStates } from '@odh-dashboard/model-serving/utils';
+import { getKueueSchedulingSubStep } from '@odh-dashboard/internal/concepts/kueue/index';
+import type { KueueWorkloadStatusWithMessage } from '@odh-dashboard/internal/concepts/kueue/types';
 import { KServeDeployment } from './deployments';
 
 export const patchDeploymentStoppedStatus = (
@@ -46,9 +49,25 @@ const KSERVE_CONDITION_ORDER = ['PredictorReady', 'IngressReady', 'LatestDeploym
 export const getKServeDeploymentConditions = (
   inferenceService: InferenceServiceKind,
   deploymentState: ModelDeploymentState,
+  kueueStatus?: KueueWorkloadStatusWithMessage | null,
 ): DeploymentCondition[] => {
   const rawConditions = inferenceService.status?.conditions ?? [];
   const isModelServing = deploymentState === ModelDeploymentState.LOADED;
+
+  // "Create pod" needs a real "the pod is up" signal. Rather than cross-referencing a separate
+  // pod watch (fragile for multi-replica: has to require *every* pod scheduled, not just one,
+  // and duplicates correlation logic that already exists for the Kueue watch), use Kueue's own
+  // Workload conditions directly. `kueueStatus` is already the worst-of-all-Workloads aggregate
+  // (see aggregateKueueStatusForModel), so once it reaches Admitted or later (quota reserved,
+  // Kueue's scheduling gate lifted for every replica) the pod creation step Kueue was gating is
+  // done — normal k8s scheduling takes over from there. Statuses before that
+  // (Queued/Inadmissible/Preempted/Evicted/Requeued/BlockedOnPreemptionGates/Failed) mean at
+  // least one replica is still blocked, so keep showing the Kueue sub-step.
+  const isPastAdmission = Boolean(
+    kueueStatus?.status && KUEUE_STATUSES_PAST_ADMISSION.includes(kueueStatus.status),
+  );
+  const kueueSubStep =
+    kueueStatus?.status && !isPastAdmission ? getKueueSchedulingSubStep(kueueStatus) : null;
 
   const conditions: DeploymentCondition[] = [
     {
@@ -58,6 +77,21 @@ export const getKServeDeploymentConditions = (
       lastTransitionTime: inferenceService.metadata.creationTimestamp,
     },
   ];
+
+  if (kueueStatus) {
+    // Once past admission, clear the Kueue message entirely rather than pairing a green
+    // checkmark with a stale "Admitted to queue"/"Queued" label underneath it.
+    conditions.push({
+      type: 'CreatePod',
+      label: 'Create pod',
+      status: isPastAdmission ? 'True' : kueueSubStep ? kueueSubStep.messageStatus : 'Unknown',
+      messageStatus: isPastAdmission ? undefined : kueueSubStep?.messageStatus,
+      inProgress:
+        !isPastAdmission && (kueueSubStep ? kueueSubStep.messageStatus === 'Unknown' : true),
+      message: isPastAdmission ? undefined : kueueSubStep?.label,
+      lastTransitionTime: kueueSubStep?.lastTransitionTime ?? kueueStatus.timestamp,
+    });
+  }
 
   const stoppedCondition = rawConditions.find((c) => c.type === 'Stopped' && c.status === 'True');
 
@@ -102,6 +136,7 @@ export const getKServeDeploymentConditions = (
 export const getKServeDeploymentStatus = (
   inferenceService: InferenceServiceKind,
   deploymentPods: PodKind[],
+  kueueStatus?: KueueWorkloadStatusWithMessage | null,
 ): DeploymentStatus => {
   const deploymentPod = deploymentPods.find(
     (pod) =>
@@ -119,7 +154,7 @@ export const getKServeDeploymentStatus = (
     deploymentPod,
   );
 
-  const conditions = getKServeDeploymentConditions(inferenceService, state);
+  const conditions = getKServeDeploymentConditions(inferenceService, state, kueueStatus);
 
-  return { state, message, stoppedStates, conditions };
+  return { state, message, stoppedStates, conditions, kueueStatus };
 };

--- a/packages/kserve/src/deployments.ts
+++ b/packages/kserve/src/deployments.ts
@@ -17,12 +17,14 @@ import {
   getInferenceService,
   getInferenceServicePods,
 } from '@odh-dashboard/internal/api/index';
-import { getKServeDeploymentEndpoints } from './deploymentEndpoints';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import { useKueueStatusForDeployments } from '@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments';
 import {
   useWatchDeploymentPods,
   useWatchServingRuntimes,
   useWatchInferenceServices,
 } from './api/watch';
+import { getKServeDeploymentEndpoints } from './deploymentEndpoints';
 import { getKServeDeploymentStatus } from './deploymentStatus';
 import { KSERVE_ID } from '../extensions';
 
@@ -72,24 +74,32 @@ export const useWatchDeployments = (
     return services;
   }, [inferenceServices, kserveExclusions, filterFn]);
 
+  const { kueueStatusByISName, error: kueueError } = useKueueStatusForDeployments(
+    filteredInferenceServices,
+    project,
+  );
+
   const deployments: KServeDeployment[] = React.useMemo(
     () =>
       filteredInferenceServices.map((inferenceService) => {
         const servingRuntime = servingRuntimes.find(
           (sr) => sr.metadata.name === inferenceService.spec.predictor.model?.runtime,
         );
+        const kueueStatus = inferenceService.metadata.name
+          ? kueueStatusByISName[inferenceService.metadata.name] ?? null
+          : null;
         return {
           modelServingPlatformId: KSERVE_ID,
           model: inferenceService,
           server: servingRuntime,
-          status: getKServeDeploymentStatus(inferenceService, deploymentPods),
+          status: getKServeDeploymentStatus(inferenceService, deploymentPods, kueueStatus),
           endpoints: getKServeDeploymentEndpoints(inferenceService),
           apiProtocol: servingRuntime
             ? getAPIProtocolFromServingRuntime(servingRuntime)
             : undefined,
         };
       }),
-    [filteredInferenceServices, servingRuntimes, deploymentPods],
+    [filteredInferenceServices, servingRuntimes, deploymentPods, kueueStatusByISName],
   );
 
   const effectivelyLoaded = Boolean(
@@ -100,10 +110,16 @@ export const useWatchDeployments = (
   );
 
   const errors = React.useMemo(() => {
-    return [inferenceServiceError, servingRuntimeError, deploymentPodsError].filter(
-      (error): error is Error => Boolean(error),
-    );
-  }, [inferenceServiceError, servingRuntimeError, deploymentPodsError]);
+    // Kueue watch failures (e.g. 403 for users without kueue.x-k8s.io/workloads list RBAC) are
+    // surfaced here rather than silently dropped — otherwise every deployment would appear to
+    // have no Kueue status with no indication the data is actually just inaccessible.
+    return [
+      inferenceServiceError,
+      servingRuntimeError,
+      deploymentPodsError,
+      kueueError ? new Error(kueueError) : undefined,
+    ].filter((error): error is Error => Boolean(error));
+  }, [inferenceServiceError, servingRuntimeError, deploymentPodsError, kueueError]);
 
   return [deployments, effectivelyLoaded, errors];
 };

--- a/packages/kserve/src/deployments.ts
+++ b/packages/kserve/src/deployments.ts
@@ -19,6 +19,8 @@ import {
 } from '@odh-dashboard/internal/api/index';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { useKueueStatusForDeployments } from '@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import { buildModelDeploymentKey } from '@odh-dashboard/internal/api/k8s/workloads';
 import {
   useWatchDeploymentPods,
   useWatchServingRuntimes,
@@ -74,10 +76,11 @@ export const useWatchDeployments = (
     return services;
   }, [inferenceServices, kserveExclusions, filterFn]);
 
-  const { kueueStatusByISName, error: kueueError } = useKueueStatusForDeployments(
-    filteredInferenceServices,
-    project,
-  );
+  const {
+    kueueStatusByDeploymentKey,
+    isLoading: kueueLoading,
+    error: kueueError,
+  } = useKueueStatusForDeployments(filteredInferenceServices, project);
 
   const deployments: KServeDeployment[] = React.useMemo(
     () =>
@@ -86,7 +89,9 @@ export const useWatchDeployments = (
           (sr) => sr.metadata.name === inferenceService.spec.predictor.model?.runtime,
         );
         const kueueStatus = inferenceService.metadata.name
-          ? kueueStatusByISName[inferenceService.metadata.name] ?? null
+          ? kueueStatusByDeploymentKey[
+              buildModelDeploymentKey('InferenceService', inferenceService.metadata.name)
+            ] ?? null
           : null;
         return {
           modelServingPlatformId: KSERVE_ID,
@@ -99,13 +104,14 @@ export const useWatchDeployments = (
             : undefined,
         };
       }),
-    [filteredInferenceServices, servingRuntimes, deploymentPods, kueueStatusByISName],
+    [filteredInferenceServices, servingRuntimes, deploymentPods, kueueStatusByDeploymentKey],
   );
 
   const effectivelyLoaded = Boolean(
     (inferenceServiceLoaded || inferenceServiceError) &&
       (servingRuntimeLoaded || servingRuntimeError) &&
       (deploymentPodsLoaded || deploymentPodsError) &&
+      (!kueueLoading || kueueError) &&
       exclusionsResolved,
   );
 

--- a/packages/llmd-serving/src/deployments/__tests__/status.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/status.spec.ts
@@ -1,3 +1,4 @@
+import { KueueWorkloadStatus } from '@odh-dashboard/internal/concepts/kueue/types';
 import { mockLLMInferenceServiceK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceK8sResource';
 import type { LLMInferenceServiceKind } from '../../types';
 import { getLLMdDeploymentConditions } from '../status';
@@ -233,6 +234,103 @@ describe('getLLMdDeploymentConditions', () => {
     const conditions = getLLMdDeploymentConditions(isvc);
 
     expect(conditions).toHaveLength(1);
-    expect(conditions[0].type).toBe('DeploymentRequested');
+    expect(conditions.map((c) => c.type)).toEqual(['DeploymentRequested']);
+  });
+
+  it('should omit CreatePod entirely for non-Kueue deployments (no kueueStatus)', () => {
+    const isvc: LLMInferenceServiceKind = {
+      ...mockLLMInferenceServiceK8sResource({}),
+      status: {
+        conditions: [
+          {
+            type: 'PresetsCombined',
+            status: 'Unknown',
+            lastTransitionTime: '2026-05-26T13:49:27Z',
+          },
+        ],
+      },
+    };
+    const conditions = getLLMdDeploymentConditions(isvc, null);
+
+    expect(conditions.find((c) => c.type === 'CreatePod')).toBeUndefined();
+  });
+
+  it('should show CreatePod as Unknown with an in-progress spinner while merely Queued', () => {
+    const isvc: LLMInferenceServiceKind = {
+      ...mockLLMInferenceServiceK8sResource({}),
+      status: undefined,
+    };
+    const conditions = getLLMdDeploymentConditions(isvc, {
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'test-queue',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).toBe('Unknown');
+    expect(createPod?.inProgress).toBe(true);
+  });
+
+  it('should mark CreatePod as True once Kueue reports Admitted (quota reserved, scheduling gate lifted)', () => {
+    const isvc: LLMInferenceServiceKind = {
+      ...mockLLMInferenceServiceK8sResource({}),
+      status: undefined,
+    };
+    const conditions = getLLMdDeploymentConditions(isvc, {
+      status: KueueWorkloadStatus.Admitted,
+      queueName: 'test-queue',
+      timestamp: '2026-05-26T13:49:00Z',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).toBe('True');
+    expect(createPod?.inProgress).toBe(false);
+    expect(createPod?.message).toBeUndefined();
+    expect(createPod?.lastTransitionTime).toBe('2026-05-26T13:49:00Z');
+  });
+
+  it('should mark CreatePod as True once Kueue confirms the workload is Running (PodsReady)', () => {
+    const isvc: LLMInferenceServiceKind = {
+      ...mockLLMInferenceServiceK8sResource({}),
+      status: undefined,
+    };
+    const conditions = getLLMdDeploymentConditions(isvc, {
+      status: KueueWorkloadStatus.Running,
+      queueName: 'test-queue',
+      timestamp: '2026-05-26T13:50:00Z',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).toBe('True');
+    expect(createPod?.inProgress).toBe(false);
+    expect(createPod?.message).toBeUndefined();
+    expect(createPod?.lastTransitionTime).toBe('2026-05-26T13:50:00Z');
+  });
+
+  it('should still show the Kueue sub-step while BlockedOnPreemptionGates (quota reserved but pod creation still held)', () => {
+    const isvc: LLMInferenceServiceKind = {
+      ...mockLLMInferenceServiceK8sResource({}),
+      status: undefined,
+    };
+    const conditions = getLLMdDeploymentConditions(isvc, {
+      status: KueueWorkloadStatus.BlockedOnPreemptionGates,
+      queueName: 'test-queue',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).not.toBe('True');
+  });
+
+  it('should NOT mark CreatePod as True while AdmissionCheck is pending (Kueue only admits once all checks are ready)', () => {
+    const isvc: LLMInferenceServiceKind = {
+      ...mockLLMInferenceServiceK8sResource({}),
+      status: undefined,
+    };
+    const conditions = getLLMdDeploymentConditions(isvc, {
+      status: KueueWorkloadStatus.AdmissionCheck,
+      queueName: 'test-queue',
+    });
+
+    const createPod = conditions.find((c) => c.type === 'CreatePod');
+    expect(createPod?.status).not.toBe('True');
   });
 });

--- a/packages/llmd-serving/src/deployments/status.ts
+++ b/packages/llmd-serving/src/deployments/status.ts
@@ -15,6 +15,9 @@ import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
 import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
 import type { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 import { getModelDeploymentStoppedStates } from '@odh-dashboard/model-serving/utils';
+import { getKueueSchedulingSubStep } from '@odh-dashboard/internal/concepts/kueue/index';
+import { KUEUE_STATUSES_PAST_ADMISSION } from '@odh-dashboard/internal/concepts/kueue/types';
+import type { KueueWorkloadStatusWithMessage } from '@odh-dashboard/internal/concepts/kueue/types';
 import {
   LLMdDeployment,
   LLMInferenceServiceKind,
@@ -97,8 +100,24 @@ const buildConditionFromRaw = (
 
 export const getLLMdDeploymentConditions = (
   inferenceService: LLMInferenceServiceKind,
+  kueueStatus?: KueueWorkloadStatusWithMessage | null,
 ): DeploymentCondition[] => {
   const rawConditions = inferenceService.status?.conditions;
+  // "Create pod" needs a real "the pod is up" signal. Rather than cross-referencing a separate
+  // pod watch (fragile for multi-replica: has to require *every* pod scheduled, not just one,
+  // and duplicates correlation logic that already exists for the Kueue watch), use Kueue's own
+  // Workload conditions directly. `kueueStatus` is already the worst-of-all-Workloads aggregate
+  // (see aggregateKueueStatusForModel), so once it reaches Admitted or later (quota reserved,
+  // Kueue's scheduling gate lifted for every replica) the pod creation step Kueue was gating is
+  // done — normal k8s scheduling takes over from there. Statuses before that
+  // (Queued/Inadmissible/Preempted/Evicted/Requeued/BlockedOnPreemptionGates/Failed) mean at
+  // least one replica is still blocked, so keep showing the Kueue sub-step.
+  const isPastAdmission = Boolean(
+    kueueStatus?.status && KUEUE_STATUSES_PAST_ADMISSION.includes(kueueStatus.status),
+  );
+  const kueueSubStep =
+    kueueStatus?.status && !isPastAdmission ? getKueueSchedulingSubStep(kueueStatus) : null;
+
   const conditions: DeploymentCondition[] = [
     {
       type: 'DeploymentRequested',
@@ -107,6 +126,19 @@ export const getLLMdDeploymentConditions = (
       lastTransitionTime: inferenceService.metadata.creationTimestamp,
     },
   ];
+
+  if (kueueStatus) {
+    conditions.push({
+      type: 'CreatePod',
+      label: 'Create pod',
+      status: isPastAdmission ? 'True' : kueueSubStep ? kueueSubStep.messageStatus : 'Unknown',
+      messageStatus: isPastAdmission ? undefined : kueueSubStep?.messageStatus,
+      inProgress:
+        !isPastAdmission && (kueueSubStep ? kueueSubStep.messageStatus === 'Unknown' : true),
+      message: isPastAdmission ? undefined : kueueSubStep?.label,
+      lastTransitionTime: kueueSubStep?.lastTransitionTime ?? kueueStatus.timestamp,
+    });
+  }
 
   for (const spec of LLMD_CONDITION_SPECS) {
     const parentCondition = buildConditionFromRaw(rawConditions, spec);
@@ -159,6 +191,7 @@ export const getLLMdDeploymentConditions = (
 export const getLLMdDeploymentStatus = (
   inferenceService: LLMInferenceServiceKind,
   deploymentPods: PodKind[],
+  kueueStatus?: KueueWorkloadStatusWithMessage | null,
 ): DeploymentStatus => {
   const deploymentPod = deploymentPods.length > 0 ? deploymentPods[0] : undefined;
 
@@ -173,9 +206,9 @@ export const getLLMdDeploymentStatus = (
     deploymentPod,
   );
 
-  const conditions = getLLMdDeploymentConditions(inferenceService);
+  const conditions = getLLMdDeploymentConditions(inferenceService, kueueStatus);
 
-  return { state, message, stoppedStates, conditions };
+  return { state, message, stoppedStates, conditions, kueueStatus };
 };
 
 export const patchDeploymentStoppedStatus = (

--- a/packages/llmd-serving/src/deployments/useWatchDeployments.ts
+++ b/packages/llmd-serving/src/deployments/useWatchDeployments.ts
@@ -2,6 +2,8 @@ import React from 'react';
 import type { K8sAPIOptions, ProjectKind } from '@odh-dashboard/k8s-core';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { useKueueStatusForDeployments } from '@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import { buildModelDeploymentKey } from '@odh-dashboard/internal/api/k8s/workloads';
 import { getLLMdDeploymentEndpoints } from './endpoints';
 import { getLLMdDeploymentStatus, useLLMInferenceServicePods } from './status';
 import { useWatchLLMInferenceService } from '../api/LLMInferenceService';
@@ -34,11 +36,11 @@ export const useWatchDeployments = (
     opts,
   );
 
-  const { kueueStatusByISName, error: kueueError } = useKueueStatusForDeployments(
-    [],
-    project,
-    filteredLLMInferenceServices,
-  );
+  const {
+    kueueStatusByDeploymentKey,
+    isLoading: kueueLoading,
+    error: kueueError,
+  } = useKueueStatusForDeployments([], project, filteredLLMInferenceServices);
 
   const deployments = React.useMemo(() => {
     return filteredLLMInferenceServices.map((llmInferenceService) => {
@@ -52,7 +54,10 @@ export const useWatchDeployments = (
         (baseRef) => baseRef.name === llmInferenceService.metadata.name,
       );
 
-      const kueueStatus = kueueStatusByISName[llmInferenceService.metadata.name] ?? null;
+      const kueueStatus =
+        kueueStatusByDeploymentKey[
+          buildModelDeploymentKey('LLMInferenceService', llmInferenceService.metadata.name)
+        ] ?? null;
 
       return {
         modelServingPlatformId: LLMD_SERVING_ID,
@@ -71,13 +76,14 @@ export const useWatchDeployments = (
     filteredLLMInferenceServices,
     deploymentPods,
     llmInferenceServiceConfigs,
-    kueueStatusByISName,
+    kueueStatusByDeploymentKey,
   ]);
 
   const effectivelyLoaded = Boolean(
     (llmInferenceServiceLoaded || llmInferenceServiceError) &&
       (llmInferenceServiceConfigsLoaded || llmInferenceServiceConfigsError) &&
-      (deploymentPodsLoaded || deploymentPodsError),
+      (deploymentPodsLoaded || deploymentPodsError) &&
+      (!kueueLoading || kueueError),
   );
 
   const errors = React.useMemo(() => {

--- a/packages/llmd-serving/src/deployments/useWatchDeployments.ts
+++ b/packages/llmd-serving/src/deployments/useWatchDeployments.ts
@@ -1,11 +1,13 @@
 import React from 'react';
 import type { K8sAPIOptions, ProjectKind } from '@odh-dashboard/k8s-core';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import { useKueueStatusForDeployments } from '@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments';
 import { getLLMdDeploymentEndpoints } from './endpoints';
 import { getLLMdDeploymentStatus, useLLMInferenceServicePods } from './status';
-import { type LLMdDeployment, type LLMInferenceServiceKind } from '../types';
-import { LLMD_SERVING_ID } from '../../extensions/extensions';
 import { useWatchLLMInferenceService } from '../api/LLMInferenceService';
 import { useWatchLLMInferenceServiceConfigs } from '../api/LLMInferenceServiceConfigs';
+import { type LLMdDeployment, type LLMInferenceServiceKind } from '../types';
+import { LLMD_SERVING_ID } from '../../extensions/extensions';
 
 export const useWatchDeployments = (
   project: ProjectKind,
@@ -32,6 +34,12 @@ export const useWatchDeployments = (
     opts,
   );
 
+  const { kueueStatusByISName, error: kueueError } = useKueueStatusForDeployments(
+    [],
+    project,
+    filteredLLMInferenceServices,
+  );
+
   const deployments = React.useMemo(() => {
     return filteredLLMInferenceServices.map((llmInferenceService) => {
       const pods = deploymentPods.filter(
@@ -44,6 +52,8 @@ export const useWatchDeployments = (
         (baseRef) => baseRef.name === llmInferenceService.metadata.name,
       );
 
+      const kueueStatus = kueueStatusByISName[llmInferenceService.metadata.name] ?? null;
+
       return {
         modelServingPlatformId: LLMD_SERVING_ID,
         model: llmInferenceService,
@@ -54,10 +64,15 @@ export const useWatchDeployments = (
           : undefined,
         apiProtocol: 'REST', // vLLM uses REST so I assume it's the same for LLMd
         endpoints: getLLMdDeploymentEndpoints(llmInferenceService),
-        status: getLLMdDeploymentStatus(llmInferenceService, pods),
+        status: getLLMdDeploymentStatus(llmInferenceService, pods, kueueStatus),
       };
     });
-  }, [filteredLLMInferenceServices, deploymentPods, llmInferenceServiceConfigs]);
+  }, [
+    filteredLLMInferenceServices,
+    deploymentPods,
+    llmInferenceServiceConfigs,
+    kueueStatusByISName,
+  ]);
 
   const effectivelyLoaded = Boolean(
     (llmInferenceServiceLoaded || llmInferenceServiceError) &&
@@ -66,10 +81,13 @@ export const useWatchDeployments = (
   );
 
   const errors = React.useMemo(() => {
-    return [llmInferenceServiceError, llmInferenceServiceConfigsError, deploymentPodsError].filter(
-      (error): error is Error => Boolean(error),
-    );
-  }, [llmInferenceServiceError, llmInferenceServiceConfigsError, deploymentPodsError]);
+    return [
+      llmInferenceServiceError,
+      llmInferenceServiceConfigsError,
+      deploymentPodsError,
+      kueueError ? new Error(kueueError) : undefined,
+    ].filter((error): error is Error => Boolean(error));
+  }, [llmInferenceServiceError, llmInferenceServiceConfigsError, deploymentPodsError, kueueError]);
 
   return React.useMemo(
     () => [deployments, effectivelyLoaded, errors],

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -9,6 +9,7 @@ import type {
 import type { ModelServingPodSpecOptionsState } from '@odh-dashboard/hardware-profiles/shared';
 import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
+import type { KueueWorkloadStatusWithMessage } from '@odh-dashboard/internal/concepts/kueue/types';
 import type { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
 
 export type DeploymentConditionStatus = 'True' | 'False' | 'Warning' | 'Unknown';
@@ -26,6 +27,14 @@ export type DeploymentCondition = {
   status?: DeploymentConditionStatus;
   reason?: string;
   message?: string;
+  /**
+   * Severity to color the message text with, when it differs from `status` — e.g. a step
+   * that's still in-progress (spinner) but whose message should still read as a warning.
+   * Falls back to `status` when omitted.
+   */
+  messageStatus?: DeploymentConditionStatus;
+  /** Renders an active spinner icon instead of the default variant icon. */
+  inProgress?: boolean;
   lastTransitionTime?: string;
   children?: DeploymentCondition[];
 };
@@ -35,6 +44,8 @@ export type DeploymentStatus = {
   message?: string;
   stoppedStates?: ToggleState;
   conditions?: DeploymentCondition[];
+  /** Kueue scheduling status for this deployment, when Kueue is enabled for the project. */
+  kueueStatus?: KueueWorkloadStatusWithMessage | null;
 };
 
 export type DeploymentEndpoint = {

--- a/packages/model-serving/src/components/deployments/DeploymentResourcesTab.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentResourcesTab.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import {
+  Content,
+  ContentVariants,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Skeleton,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
+import { getAllConsumedResources } from '@odh-dashboard/internal/utilities/clusterQueueUtils';
+import useAssignedFlavor from '@odh-dashboard/internal/utilities/useAssignedFlavor';
+import useClusterQueue from '@odh-dashboard/internal/utilities/useClusterQueue';
+import useClusterQueueFromLocalQueue from '../../shared/kueue/useClusterQueueFromLocalQueue';
+
+type DeploymentResourcesTabProps = {
+  localQueueName: string | undefined;
+  namespace: string;
+  deploymentName: string | undefined;
+};
+
+const DeploymentResourcesTab: React.FC<DeploymentResourcesTabProps> = ({
+  localQueueName,
+  namespace,
+  deploymentName,
+}) => {
+  const {
+    clusterQueueName,
+    loaded: clusterQueueNameLoaded,
+    error: clusterQueueNameError,
+  } = useClusterQueueFromLocalQueue(localQueueName, namespace);
+
+  const shouldFetchClusterQueue = Boolean(localQueueName && clusterQueueName);
+
+  const {
+    clusterQueue,
+    loaded: clusterQueueLoaded,
+    error: clusterQueueError,
+  } = useClusterQueue(shouldFetchClusterQueue ? clusterQueueName : undefined);
+
+  const assignedFlavorName = useAssignedFlavor(namespace, localQueueName, deploymentName);
+
+  const quotaSource = clusterQueue?.spec.cohortName ?? '-';
+  const consumedResources = clusterQueue
+    ? getAllConsumedResources(clusterQueue, assignedFlavorName)
+    : [];
+
+  const hasError = Boolean(clusterQueueNameError || clusterQueueError);
+  const loaded = clusterQueueNameLoaded && (!clusterQueueName || clusterQueueLoaded);
+
+  if (!localQueueName || (clusterQueueNameLoaded && !clusterQueueName && !hasError)) {
+    return (
+      <Content data-testid="deployment-resources-no-queue">
+        No cluster queue information for this deployment.
+      </Content>
+    );
+  }
+
+  if (!loaded && !hasError) {
+    return (
+      <Stack hasGutter data-testid="deployment-resources-tab">
+        <StackItem>
+          <Skeleton data-testid="cluster-queue-section" />
+        </StackItem>
+        <StackItem>
+          <Skeleton data-testid="quotas-section" />
+        </StackItem>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack hasGutter={false} data-testid="deployment-resources-tab">
+      <StackItem>
+        <DescriptionList
+          isHorizontal
+          horizontalTermWidthModifier={{ default: '5ch' }}
+          data-testid="cluster-queue-section"
+          isCompact
+        >
+          <Title headingLevel="h6" size="md">
+            Cluster queue
+          </Title>
+          <DescriptionListGroup>
+            <DescriptionListTerm style={{ fontWeight: 'normal' }}>Queue:</DescriptionListTerm>
+            <DescriptionListDescription data-testid="queue-value">
+              {hasError ? '-' : clusterQueueName ?? '-'}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+      </StackItem>
+      <StackItem className="pf-v6-u-mt-md pf-v6-u-mb-md">
+        <Stack hasGutter data-testid="quotas-section">
+          <StackItem>
+            <Title headingLevel="h6" size="md">
+              Quotas and consumption
+            </Title>
+          </StackItem>
+          <StackItem>
+            <DescriptionList isHorizontal horizontalTermWidthModifier={{ default: '10ch' }}>
+              <DescriptionListGroup>
+                <DescriptionListTerm style={{ fontWeight: 'normal' }}>
+                  Quota source:
+                </DescriptionListTerm>
+                <DescriptionListDescription data-testid="quota-source-value">
+                  {hasError ? '-' : quotaSource}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </StackItem>
+          {hasError ? (
+            <StackItem>
+              <Content>Unable to load consumption data.</Content>
+            </StackItem>
+          ) : (
+            consumedResources.map((resource) => (
+              <StackItem key={resource.name}>
+                <Content component={ContentVariants.dd}>
+                  {resource.label.charAt(0).toUpperCase() + resource.label.slice(1)}
+                </Content>
+                <Stack hasGutter={false} className="pf-v6-u-pl-md">
+                  <StackItem>
+                    <Content>Total: {resource.total}</Content>
+                  </StackItem>
+                  <StackItem>
+                    <Content data-testid="consumed-quota-value">
+                      Consumed: {resource.consumed} ({resource.percentage}%)
+                    </Content>
+                  </StackItem>
+                </Stack>
+              </StackItem>
+            ))
+          )}
+        </Stack>
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default DeploymentResourcesTab;

--- a/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
@@ -5,6 +5,7 @@ import {
   ContentVariants,
   Flex,
   FlexItem,
+  Icon,
   // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- custom modal with ProgressStepper timeline and embedded status badge; ContentModal does not support this layout
   Modal,
   // eslint-disable-next-line @odh-dashboard/no-restricted-imports
@@ -19,12 +20,22 @@ import {
   ProgressStepVariant,
   ProgressStepper,
   Spinner,
+  Stack,
+  StackItem,
+  Tab,
+  Tabs,
+  TabTitleText,
   Timestamp,
   TimestampTooltipVariant,
 } from '@patternfly/react-core';
+import { InProgressIcon } from '@patternfly/react-icons';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
-import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
+import { useKueueConfiguration } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
+import { KUEUE_QUEUE_LABEL } from '@odh-dashboard/internal/concepts/kueue/index';
 import { ModelStatusIcon } from '@odh-dashboard/model-serving/shared/components';
+import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
+import DeploymentResourcesTab from './DeploymentResourcesTab';
 import type {
   Deployment,
   DeploymentCondition,
@@ -78,20 +89,35 @@ const getMessageColor = (status: DeploymentConditionStatus | undefined): string 
   }
 };
 
+/** In-progress steps (e.g. waiting on Kueue) render a spinner instead of the default variant icon. */
+const InProgressStepIcon: React.FC = () => (
+  <Icon isInline>
+    <InProgressIcon
+      className="ai-u-spin"
+      style={{ color: 'var(--pf-t--global--icon--color--brand--default)' }}
+    />
+  </Icon>
+);
+
 const ConditionDescription: React.FC<{
   condition: DeploymentCondition;
 }> = ({ condition }) => {
-  const messageColor = getMessageColor(condition.status);
+  const messageStatus = condition.messageStatus ?? condition.status;
+  const messageColor = getMessageColor(messageStatus);
+  const showMessage =
+    Boolean(condition.message) &&
+    (messageStatus === 'False' || messageStatus === 'Warning' || messageStatus === 'Unknown');
   return (
     <>
       <ConditionTimestamp isoString={condition.lastTransitionTime} />
-      {(condition.status === 'False' || condition.status === 'Warning') &&
-        condition.message &&
-        messageColor && (
-          <Content component={ContentVariants.small} style={{ color: messageColor }}>
-            {condition.message}
-          </Content>
-        )}
+      {showMessage && (
+        <Content
+          component={ContentVariants.small}
+          style={messageColor ? { color: messageColor } : undefined}
+        >
+          {condition.message}
+        </Content>
+      )}
     </>
   );
 };
@@ -104,6 +130,7 @@ const ConditionChildren: React.FC<{
       <ProgressStep
         key={child.type}
         variant={getStepVariant(child.status)}
+        icon={child.inProgress ? <InProgressStepIcon /> : undefined}
         aria-label={`${child.label}: ${child.status ?? 'pending'}`}
         id={`condition-child-${child.type}`}
         titleId={`condition-child-${child.type}-title`}
@@ -116,6 +143,37 @@ const ConditionChildren: React.FC<{
   </ProgressStepper>
 );
 
+const ConditionsProgressStepper: React.FC<{ conditions: DeploymentCondition[] }> = ({
+  conditions,
+}) => (
+  <ProgressStepper isVertical data-testid="deployment-status-steps">
+    {conditions.map((condition) => (
+      <ProgressStep
+        key={condition.type}
+        variant={getStepVariant(condition.status)}
+        icon={condition.inProgress ? <InProgressStepIcon /> : undefined}
+        aria-label={`${condition.label}: ${condition.status ?? 'pending'}`}
+        id={`condition-${condition.type}`}
+        titleId={`condition-${condition.type}-title`}
+        description={
+          <>
+            <ConditionDescription condition={condition} />
+            {condition.children && condition.children.length > 0 && (
+              <ConditionChildren>{condition.children}</ConditionChildren>
+            )}
+          </>
+        }
+        data-testid={`deployment-condition-${condition.type}`}
+      >
+        {condition.label}
+      </ProgressStep>
+    ))}
+  </ProgressStepper>
+);
+
+const PROGRESS_TAB = 'progress';
+const RESOURCES_TAB = 'resources';
+
 const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
   deployment,
   onClose,
@@ -125,6 +183,23 @@ const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
 }) => {
   const conditions = deployment.status?.conditions ?? [];
   const displayName = getDisplayNameFromK8sResource(deployment.model);
+  const { namespace } = deployment.model.metadata;
+
+  const { projects } = React.useContext(ProjectsContext);
+  const project = projects.find((p) => p.metadata.name === namespace);
+  const { isKueueFeatureEnabled, isProjectKueueEnabled } = useKueueConfiguration(project);
+  const localQueueName = deployment.model.metadata.labels?.[KUEUE_QUEUE_LABEL];
+  const showResourcesTab = Boolean(
+    isKueueFeatureEnabled && isProjectKueueEnabled && localQueueName,
+  );
+
+  const [activeTab, setActiveTab] = React.useState<string>(PROGRESS_TAB);
+
+  React.useEffect(() => {
+    if (!showResourcesTab && activeTab === RESOURCES_TAB) {
+      setActiveTab(PROGRESS_TAB);
+    }
+  }, [showResourcesTab, activeTab]);
 
   return (
     <Modal
@@ -142,6 +217,7 @@ const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
               <ModelStatusIcon
                 state={deployment.status?.state ?? ModelDeploymentState.UNKNOWN}
                 stoppedStates={deployment.status?.stoppedStates}
+                kueueStatus={deployment.status?.kueueStatus}
                 isCompact
               />
             </FlexItem>
@@ -149,34 +225,45 @@ const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
         }
       />
       <ModalBody>
-        <Content
-          component={ContentVariants.p}
-          style={{ marginBottom: 'var(--pf-t--global--spacer--md)' }}
-        >
-          {displayName}
-        </Content>
-        <ProgressStepper isVertical data-testid="deployment-status-steps">
-          {conditions.map((condition) => (
-            <ProgressStep
-              key={condition.type}
-              variant={getStepVariant(condition.status)}
-              aria-label={`${condition.label}: ${condition.status ?? 'pending'}`}
-              id={`condition-${condition.type}`}
-              titleId={`condition-${condition.type}-title`}
-              description={
-                <>
-                  <ConditionDescription condition={condition} />
-                  {condition.children && condition.children.length > 0 && (
-                    <ConditionChildren>{condition.children}</ConditionChildren>
-                  )}
-                </>
-              }
-              data-testid={`deployment-condition-${condition.type}`}
-            >
-              {condition.label}
-            </ProgressStep>
-          ))}
-        </ProgressStepper>
+        <Stack hasGutter>
+          <StackItem>
+            <Content component={ContentVariants.p}>{displayName}</Content>
+          </StackItem>
+          {showResourcesTab && (
+            <StackItem>
+              <Tabs
+                activeKey={activeTab}
+                onSelect={(_event, tabKey) => setActiveTab(String(tabKey))}
+                aria-label="Deployment status tabs"
+                data-testid="deployment-status-tabs"
+              >
+                <Tab
+                  eventKey={PROGRESS_TAB}
+                  aria-label={PROGRESS_TAB}
+                  title={<TabTitleText>Progress</TabTitleText>}
+                  data-testid="deployment-status-progress-tab"
+                />
+                <Tab
+                  eventKey={RESOURCES_TAB}
+                  aria-label={RESOURCES_TAB}
+                  title={<TabTitleText>Resources</TabTitleText>}
+                  data-testid="deployment-status-resources-tab"
+                />
+              </Tabs>
+            </StackItem>
+          )}
+          <StackItem>
+            {showResourcesTab && activeTab === RESOURCES_TAB && namespace ? (
+              <DeploymentResourcesTab
+                localQueueName={localQueueName}
+                namespace={namespace}
+                deploymentName={deployment.model.metadata.name}
+              />
+            ) : (
+              <ConditionsProgressStepper conditions={conditions} />
+            )}
+          </StackItem>
+        </Stack>
       </ModalBody>
       <ModalFooter>
         <Flex gap={{ default: 'gapMd' }}>

--- a/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
@@ -189,9 +189,10 @@ const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
   const project = projects.find((p) => p.metadata.name === namespace);
   const { isKueueFeatureEnabled, isProjectKueueEnabled } = useKueueConfiguration(project);
   const localQueueName = deployment.model.metadata.labels?.[KUEUE_QUEUE_LABEL];
-  const showResourcesTab = Boolean(
-    isKueueFeatureEnabled && isProjectKueueEnabled && localQueueName,
-  );
+  // Tab visibility depends only on Kueue being enabled for this project — not on whether this
+  // particular deployment has a queue label. A missing label is handled as an empty state inside
+  // DeploymentResourcesTab, so the tab strip stays consistent across all deployment states.
+  const showResourcesTab = Boolean(isKueueFeatureEnabled && isProjectKueueEnabled);
 
   const [activeTab, setActiveTab] = React.useState<string>(PROGRESS_TAB);
 
@@ -210,15 +211,16 @@ const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
       data-testid="deployment-status-modal"
     >
       <ModalHeader
+        data-testid="deployment-status-modal-header"
         title={
           <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }}>
-            <FlexItem>Deployment status</FlexItem>
+            <FlexItem>{displayName} status</FlexItem>
             <FlexItem>
               <ModelStatusIcon
                 state={deployment.status?.state ?? ModelDeploymentState.UNKNOWN}
                 stoppedStates={deployment.status?.stoppedStates}
                 kueueStatus={deployment.status?.kueueStatus}
-                isCompact
+                variant="filled"
               />
             </FlexItem>
           </Flex>
@@ -226,9 +228,6 @@ const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
       />
       <ModalBody>
         <Stack hasGutter>
-          <StackItem>
-            <Content component={ContentVariants.p}>{displayName}</Content>
-          </StackItem>
           {showResourcesTab && (
             <StackItem>
               <Tabs

--- a/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
@@ -228,29 +228,31 @@ const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
       />
       <ModalBody>
         <Stack hasGutter>
-          {showResourcesTab && (
-            <StackItem>
-              <Tabs
-                activeKey={activeTab}
-                onSelect={(_event, tabKey) => setActiveTab(String(tabKey))}
-                aria-label="Deployment status tabs"
-                data-testid="deployment-status-tabs"
-              >
-                <Tab
-                  eventKey={PROGRESS_TAB}
-                  aria-label={PROGRESS_TAB}
-                  title={<TabTitleText>Progress</TabTitleText>}
-                  data-testid="deployment-status-progress-tab"
-                />
+          <StackItem>
+            {/* Tab strip is always shown, even when Resources is the only conditional tab, so
+                the modal shape stays consistent as more tabs (e.g. Events) are added later. */}
+            <Tabs
+              activeKey={activeTab}
+              onSelect={(_event, tabKey) => setActiveTab(String(tabKey))}
+              aria-label="Deployment status tabs"
+              data-testid="deployment-status-tabs"
+            >
+              <Tab
+                eventKey={PROGRESS_TAB}
+                aria-label={PROGRESS_TAB}
+                title={<TabTitleText>Progress</TabTitleText>}
+                data-testid="deployment-status-progress-tab"
+              />
+              {showResourcesTab && (
                 <Tab
                   eventKey={RESOURCES_TAB}
                   aria-label={RESOURCES_TAB}
                   title={<TabTitleText>Resources</TabTitleText>}
                   data-testid="deployment-status-resources-tab"
                 />
-              </Tabs>
-            </StackItem>
-          )}
+              )}
+            </Tabs>
+          </StackItem>
           <StackItem>
             {showResourcesTab && activeTab === RESOURCES_TAB && namespace ? (
               <DeploymentResourcesTab

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentStatusModal.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentStatusModal.spec.tsx
@@ -188,6 +188,16 @@ describe('DeploymentStatusModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('should always show the tab strip with a Progress tab, even when Kueue/Resources is not available', () => {
+    const deployment = createMockDeployment([]);
+
+    render(<DeploymentStatusModal deployment={deployment} onClose={jest.fn()} />);
+
+    expect(screen.getByTestId('deployment-status-tabs')).toBeInTheDocument();
+    expect(screen.getByTestId('deployment-status-progress-tab')).toBeInTheDocument();
+    expect(screen.queryByTestId('deployment-status-resources-tab')).not.toBeInTheDocument();
+  });
+
   it('should handle deployment with no conditions', () => {
     const deployment: Deployment = {
       modelServingPlatformId: 'kserve',

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentStatusModal.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentStatusModal.spec.tsx
@@ -41,8 +41,7 @@ describe('DeploymentStatusModal', () => {
 
     render(<DeploymentStatusModal deployment={deployment} onClose={jest.fn()} />);
 
-    expect(screen.getByText('Deployment status')).toBeInTheDocument();
-    expect(screen.getByText('Test Model')).toBeInTheDocument();
+    expect(screen.getByText('Test Model status')).toBeInTheDocument();
     expect(screen.getByText('Deployment requested')).toBeInTheDocument();
   });
 
@@ -210,8 +209,7 @@ describe('DeploymentStatusModal', () => {
 
     render(<DeploymentStatusModal deployment={deployment} onClose={jest.fn()} />);
 
-    expect(screen.getByText('Deployment status')).toBeInTheDocument();
-    expect(screen.getByText('Test Model')).toBeInTheDocument();
+    expect(screen.getByText('Test Model status')).toBeInTheDocument();
     expect(screen.getByTestId('deployment-status-steps')).toBeInTheDocument();
   });
 });

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Spinner } from '@patternfly/react-core';
+import { Flex, FlexItem, Icon, Popover, Spinner } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { Td, Tbody } from '@patternfly/react-table';
 import {
   ResourceActionsColumn,
@@ -9,8 +10,15 @@ import {
 } from '@odh-dashboard/ui-core';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { useKueueConfiguration } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
+import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
+import UnderlinedTruncateButton from '@odh-dashboard/internal/components/UnderlinedTruncateButton';
 import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
-import { ModelStatusIcon } from '@odh-dashboard/model-serving/shared/components';
+import {
+  ModelStatusIcon,
+  getDeploymentStatusSubtitle,
+  getDeploymentStatusSubtitleColor,
+} from '@odh-dashboard/model-serving/shared/components';
 import { DeploymentHardwareProfileCell } from './DeploymentHardwareProfileCell';
 import { DeploymentRowExpandedSection } from './DeploymentsTableRowExpandedSection';
 import { useNavigateToDeploymentWizard } from '../../deploymentWizard/useNavigateToDeploymentWizard';
@@ -63,7 +71,27 @@ export const DeploymentRow: React.FC<{
 
   const { watchDeployment } = useModelDeploymentNotification(deployment);
 
+  const { projects } = React.useContext(ProjectsContext);
+  const { namespace } = deployment.model.metadata;
+  const project = projects.find((p) => p.metadata.name === namespace);
+  const { isKueueFeatureEnabled, isProjectKueueEnabled } = useKueueConfiguration(project);
+  // Anomaly = Kueue manages this namespace but no Workload CR was correlated to this deployment
+  // (i.e. Kueue isn't actually scheduling it). Checking the IS's own queue label isn't reliable:
+  // the label of record lives on the child Deployment's pod template, not necessarily the IS,
+  // and a present label doesn't guarantee correlation actually succeeded (e.g. RBAC or
+  // multi-pod-role gaps). Skip the check entirely while stopped/stopping — no pods, no Workload
+  // CRs, by design — so it isn't a scheduling anomaly.
+  const isStoppedOrStopping = Boolean(
+    deployment.status?.stoppedStates?.isStopped || deployment.status?.stoppedStates?.isStopping,
+  );
+  const showKueueAnomalyIndicator =
+    isKueueFeatureEnabled &&
+    isProjectKueueEnabled &&
+    !isStoppedOrStopping &&
+    deployment.status?.kueueStatus === null;
+
   const navigateToDeploymentWizard = useNavigateToDeploymentWizard(deployment);
+  const statusSubtitle = getDeploymentStatusSubtitle(deployment.status);
 
   const [formDataExtensions, formDataResolved] = useResolvedExtensions(
     isModelServingDeploymentFormDataExtension,
@@ -119,15 +147,39 @@ export const DeploymentRow: React.FC<{
             <Td />
           ))}
         <Td dataLabel="Name">
-          <ResourceNameTooltip resource={deployment.model}>
-            {shouldShowDeploymentMetricsLink(deployment, metricsExtension) ? (
-              <DeploymentMetricsLink deployment={deployment} />
-            ) : (
-              <span data-testid="deployed-model-name">
-                {getDisplayNameFromK8sResource(deployment.model)}
-              </span>
+          <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+            <FlexItem>
+              <ResourceNameTooltip resource={deployment.model}>
+                {shouldShowDeploymentMetricsLink(deployment, metricsExtension) ? (
+                  <DeploymentMetricsLink deployment={deployment} />
+                ) : (
+                  <span data-testid="deployed-model-name">
+                    {getDisplayNameFromK8sResource(deployment.model)}
+                  </span>
+                )}
+              </ResourceNameTooltip>
+            </FlexItem>
+            {showKueueAnomalyIndicator && (
+              <FlexItem>
+                <Popover
+                  aria-label="Kueue scheduling not enabled"
+                  bodyContent="This model deployment doesn't use Kueue scheduling. To enable it, edit the deployment and assign a hardware profile with a local queue."
+                  data-testid="kueue-anomaly-popover"
+                >
+                  <Icon
+                    role="button"
+                    status="warning"
+                    data-testid="kueue-anomaly-indicator"
+                    aria-label="Model deployment bypasses Kueue queue management"
+                    tabIndex={0}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    <ExclamationTriangleIcon />
+                  </Icon>
+                </Popover>
+              </FlexItem>
             )}
-          </ResourceNameTooltip>
+          </Flex>
         </Td>
         {platformColumns.map((column) => (
           <Td key={column.field} dataLabel={column.label}>
@@ -157,13 +209,28 @@ export const DeploymentRow: React.FC<{
           <DeploymentLastDeployed deployment={deployment} />
         </Td>
         <Td dataLabel="Status">
-          <ModelStatusIcon
-            state={deployment.status?.state ?? ModelDeploymentState.UNKNOWN}
-            bodyContent={deployment.status?.message}
-            defaultHeaderContent="Inference Service Status"
-            stoppedStates={deployment.status?.stoppedStates}
-            onClick={() => setStatusModalOpen(true)}
-          />
+          <Flex direction={{ default: 'column' }} gap={{ default: 'gapXs' }}>
+            <FlexItem>
+              <ModelStatusIcon
+                state={deployment.status?.state ?? ModelDeploymentState.UNKNOWN}
+                bodyContent={deployment.status?.message}
+                defaultHeaderContent="Inference Service Status"
+                stoppedStates={deployment.status?.stoppedStates}
+                kueueStatus={deployment.status?.kueueStatus}
+                onClick={() => setStatusModalOpen(true)}
+              />
+            </FlexItem>
+            {statusSubtitle != null && (
+              <FlexItem>
+                <UnderlinedTruncateButton
+                  data-testid="deployment-status-subtitle"
+                  content={statusSubtitle}
+                  color={getDeploymentStatusSubtitleColor(deployment.status)}
+                  onClick={() => setStatusModalOpen(true)}
+                />
+              </FlexItem>
+            )}
+          </Flex>
         </Td>
         <Td dataLabel="State toggle">
           {startStopActionExtension && deployment.status?.stoppedStates ? (

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -13,6 +13,7 @@ import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import { useKueueConfiguration } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import UnderlinedTruncateButton from '@odh-dashboard/internal/components/UnderlinedTruncateButton';
+import useDebouncedTrueValue from '@odh-dashboard/internal/utilities/useDebouncedTrueValue';
 import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
 import {
   ModelStatusIcon,
@@ -84,11 +85,16 @@ export const DeploymentRow: React.FC<{
   const isStoppedOrStopping = Boolean(
     deployment.status?.stoppedStates?.isStopped || deployment.status?.stoppedStates?.isStopping,
   );
-  const showKueueAnomalyIndicator =
+  const isKueueAnomalyCandidate =
     isKueueFeatureEnabled &&
     isProjectKueueEnabled &&
     !isStoppedOrStopping &&
     deployment.status?.kueueStatus === null;
+  // The Workload/Pod correlation above is built from 3 independent watch streams that don't
+  // update atomically, so `isKueueAnomalyCandidate` can blip `true` transiently (deploy,
+  // rolling update, scale event) even when Kueue is scheduling this deployment correctly.
+  // Debounce so only a sustained mismatch surfaces as a warning.
+  const showKueueAnomalyIndicator = useDebouncedTrueValue(isKueueAnomalyCandidate);
 
   const navigateToDeploymentWizard = useNavigateToDeploymentWizard(deployment);
   const statusSubtitle = getDeploymentStatusSubtitle(deployment.status);

--- a/packages/model-serving/src/shared/components/ModelStatusIcon.tsx
+++ b/packages/model-serving/src/shared/components/ModelStatusIcon.tsx
@@ -25,6 +25,8 @@ type ModelStatusIconProps = {
   hideLabel?: boolean;
   /** Kueue scheduling status. When present and "interesting" (queued/failed/etc.), overrides the normal state. */
   kueueStatus?: KueueWorkloadStatusWithMessage | null;
+  /** PatternFly Label variant. "filled" renders a taller, higher-contrast label than the default "outline". */
+  variant?: LabelProps['variant'];
 };
 
 export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
@@ -36,6 +38,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
   stoppedStates,
   hideLabel,
   kueueStatus,
+  variant,
 }) => {
   const statusSettings = React.useMemo((): {
     label: string;
@@ -136,6 +139,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
   ) : (
     <Label
       isCompact={isCompact}
+      variant={variant}
       color={statusSettings.color}
       status={statusSettings.status}
       icon={statusSettings.icon}

--- a/packages/model-serving/src/shared/components/ModelStatusIcon.tsx
+++ b/packages/model-serving/src/shared/components/ModelStatusIcon.tsx
@@ -8,6 +8,11 @@ import {
   OutlinedQuestionCircleIcon,
 } from '@patternfly/react-icons';
 import type { ToggleState } from '@odh-dashboard/ui-core';
+import { getKueueStatusInfo } from '@odh-dashboard/internal/concepts/kueue/index';
+import {
+  KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT,
+  type KueueWorkloadStatusWithMessage,
+} from '@odh-dashboard/internal/concepts/kueue/types';
 import { ModelDeploymentState } from '../types';
 
 type ModelStatusIconProps = {
@@ -18,6 +23,8 @@ type ModelStatusIconProps = {
   onClick?: LabelProps['onClick'];
   stoppedStates?: ToggleState;
   hideLabel?: boolean;
+  /** Kueue scheduling status. When present and "interesting" (queued/failed/etc.), overrides the normal state. */
+  kueueStatus?: KueueWorkloadStatusWithMessage | null;
 };
 
 export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
@@ -28,6 +35,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
   onClick,
   stoppedStates,
   hideLabel,
+  kueueStatus,
 }) => {
   const statusSettings = React.useMemo((): {
     label: string;
@@ -55,6 +63,21 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
           'Waiting for the deployment to stop. You can still delete or restart the deployment.',
       };
     }
+
+    if (
+      kueueStatus?.status &&
+      KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT.includes(kueueStatus.status)
+    ) {
+      const info = getKueueStatusInfo(kueueStatus.status);
+      return {
+        label: info.label,
+        color: info.color,
+        status: info.status,
+        icon: <info.IconComponent className={info.iconClassName} />,
+        message: kueueStatus.message,
+      };
+    }
+
     // Show 'Starting' for optimistic updates or for loading/pending states from the backend.
     if (
       stoppedStates?.isStarting ||
@@ -98,7 +121,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
           icon: <OutlinedQuestionCircleIcon />,
         };
     }
-  }, [state, defaultHeaderContent, stoppedStates]);
+  }, [state, defaultHeaderContent, stoppedStates, kueueStatus]);
 
   const content = hideLabel ? (
     <Icon

--- a/packages/model-serving/src/shared/components/getDeploymentStatusSubtitle.ts
+++ b/packages/model-serving/src/shared/components/getDeploymentStatusSubtitle.ts
@@ -1,0 +1,79 @@
+import {
+  t_global_text_color_regular as RegularColor,
+  t_global_text_color_status_danger_default as DangerColor,
+  t_global_color_status_warning_300 as WarningColor,
+} from '@patternfly/react-tokens';
+import { getKueueStatusInfo } from '@odh-dashboard/internal/concepts/kueue/index';
+import {
+  formatPodAdmissionCounts,
+  getHumanReadableKueueMessage,
+  getRequeuedMessage,
+} from '@odh-dashboard/internal/concepts/kueue/messageUtils';
+import {
+  KueueWorkloadStatus,
+  KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT,
+} from '@odh-dashboard/internal/concepts/kueue/types';
+import { ModelDeploymentState } from '../types';
+import type { DeploymentStatus } from '../../../extension-points';
+
+/**
+ * Subtitle text shown next to the deployment status label (mirrors the workbench status
+ * subtitle): the human-readable Kueue scheduling message when one is "interesting"
+ * (queued/failed/etc.), otherwise the deployment's own failure message.
+ */
+export const getDeploymentStatusSubtitle = (status?: DeploymentStatus | null): string | null => {
+  if (!status) {
+    return null;
+  }
+  const { kueueStatus, message, state } = status;
+
+  if (
+    kueueStatus?.status &&
+    KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT.includes(kueueStatus.status)
+  ) {
+    if (kueueStatus.status === KueueWorkloadStatus.Requeued) {
+      return getRequeuedMessage(kueueStatus);
+    }
+    const humanMessage = getHumanReadableKueueMessage(
+      kueueStatus.status,
+      kueueStatus.message,
+      kueueStatus.queueName,
+    );
+
+    // Queue position isn't included here yet — queuePosition/queueTotal aren't populated for
+    // model deployments (only workbenches, via useQueuePositions). Tracked as a follow-up PR.
+    const suffixes: string[] = [];
+    if (kueueStatus.podAdmissionCounts && kueueStatus.podAdmissionCounts.total > 1) {
+      suffixes.push(
+        formatPodAdmissionCounts(
+          kueueStatus.podAdmissionCounts.admitted,
+          kueueStatus.podAdmissionCounts.total,
+        ),
+      );
+    }
+
+    return suffixes.length > 0 ? `${humanMessage} (${suffixes.join(', ')})` : humanMessage;
+  }
+
+  if (state === ModelDeploymentState.FAILED_TO_LOAD && message) {
+    return message;
+  }
+
+  return null;
+};
+
+/** Text color for the status subtitle, matching the severity of what it's reporting. */
+export const getDeploymentStatusSubtitleColor = (status?: DeploymentStatus | null): string => {
+  if (
+    status?.kueueStatus?.status &&
+    KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT.includes(status.kueueStatus.status)
+  ) {
+    const level = getKueueStatusInfo(status.kueueStatus.status).status;
+    if (level === 'danger') return DangerColor.var;
+    if (level === 'warning') return WarningColor.var;
+  }
+  if (status?.state === ModelDeploymentState.FAILED_TO_LOAD) {
+    return DangerColor.var;
+  }
+  return RegularColor.var;
+};

--- a/packages/model-serving/src/shared/components/index.ts
+++ b/packages/model-serving/src/shared/components/index.ts
@@ -1,4 +1,8 @@
 export { ModelStatusIcon } from './ModelStatusIcon';
+export {
+  getDeploymentStatusSubtitle,
+  getDeploymentStatusSubtitleColor,
+} from './getDeploymentStatusSubtitle';
 export { renderDeploymentResourceVersionLabels } from './renderDeploymentResourceVersionLabels';
 /** @deprecated Use renderDeploymentResourceVersionLabels instead. */
 export { default as ServingRuntimeVersionLabel } from './ServingRuntimeVersionLabel';

--- a/packages/model-serving/src/shared/kueue/useClusterQueueFromLocalQueue.ts
+++ b/packages/model-serving/src/shared/kueue/useClusterQueueFromLocalQueue.ts
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import type { LocalQueueKind } from '@odh-dashboard/k8s-core';
+import useFetch, { NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetch';
+import { getClusterQueueNameFromLocalQueues } from '@odh-dashboard/hardware-profiles/pages/utils';
+import { listLocalQueues } from '@odh-dashboard/internal/api/k8s/localQueues';
+
+type UseClusterQueueFromLocalQueueResult = {
+  clusterQueueName: string | undefined;
+  loaded: boolean;
+  error: Error | undefined;
+};
+
+const useClusterQueueFromLocalQueue = (
+  localQueueName: string | undefined,
+  namespace: string | undefined,
+): UseClusterQueueFromLocalQueueResult => {
+  const {
+    data: localQueues,
+    loaded,
+    error,
+  } = useFetch<LocalQueueKind[]>(
+    React.useCallback(() => {
+      if (!namespace || !localQueueName) {
+        return Promise.reject(new NotReadyError('Missing namespace or local queue name'));
+      }
+      return listLocalQueues(namespace);
+    }, [namespace, localQueueName]),
+    [],
+    { initialPromisePurity: true },
+  );
+
+  const clusterQueueName = React.useMemo(
+    () => getClusterQueueNameFromLocalQueues(localQueueName, { data: localQueues, loaded }),
+    [localQueueName, localQueues, loaded],
+  );
+
+  return { clusterQueueName, loaded, error };
+};
+
+export default useClusterQueueFromLocalQueue;


### PR DESCRIPTION

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79912
https://redhat.atlassian.net/browse/RHOAIENG-79910

## Description
<img width="1307" height="687" alt="pod" src="https://github.com/user-attachments/assets/bb52d409-2951-4e70-997a-ed77b596a081" />
<img width="1307" height="687" alt="deployment-status-10" src="https://github.com/user-attachments/assets/ed940424-9a12-4291-b5f0-45f138837f79" />
<img width="1307" height="687" alt="deployment-status-11" src="https://github.com/user-attachments/assets/9721cb98-10f4-42cc-a465-3474802d06d8" />
<img width="1307" height="687" alt="deployment-12" src="https://github.com/user-attachments/assets/89093469-8b08-4cb0-a738-d0649ad14493" />


<img width="1284" height="623" alt="anomaly-indicator" src="https://github.com/user-attachments/assets/d81449a3-8417-4d19-bb37-acb5b20d5f0e" />



<br class="Apple-interchange-newline">[llama-3.2-3b-instruct](https://rh-ai.apps.ui-tangerine-1.dev.datahub.redhat.com/projects/kueue-phase2-dev/metrics/model/llama-32-3b-instruct)

This change adds Kueue-aware deployment status handling to model serving, including KServe and LLMd deployment status calculations, the deployment status modal, and the status subtitle/icon presentation.
It also introduces a dedicated Resources tab in the deployment status modal when Kueue is enabled and a local queue is present, plus shared Kueue helpers for cluster-queue lookup and deployment status formatting.

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Turn on the disableKueue feature flag and deploy the model within kueue managed project
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added unit tests
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Kueue scheduling progress and workload status to deployment views.
- Deployment status modals now show progress steps, scheduling messages, queue details, and quota consumption.
- Added Resources tabs, status subtitles, severity indicators, scheduling warnings, and partial pod-admission counts.

## Bug Fixes
- Improved feedback for pod creation and delayed scheduling.
- Excluded completed or failed pods from active workload status.
- Improved handling of scheduling errors, missing workload details, and deployment readiness states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->