### PR TITLE
fix: update leftover mock imports after #9144

### DIFF
--- a/frontend/src/api/k8s/__tests__/workloads.spec.ts
+++ b/frontend/src/api/k8s/__tests__/workloads.spec.ts
@@ -1,10 +1,10 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
 import type { PodKind } from '@odh-dashboard/k8s-core';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
+import { mockPodK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPodK8sResource';
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import { mockWorkloadK8sResource } from '#~/__mocks__/mockWorkloadK8sResource';
-import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
-import { mockPodK8sResource } from '#~/__mocks__/mockPodK8sResource';
 import { WorkloadKind } from '#~/k8sTypes';
 import {
   buildWorkloadMapForNotebooks,

--- a/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
@@ -2,9 +2,9 @@ import { renderHook } from '@testing-library/react';
 import type { PodKind } from '@odh-dashboard/k8s-core';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
-import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
+import { mockPodK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPodK8sResource';
 import { mockWorkloadK8sResource } from '#~/__mocks__/mockWorkloadK8sResource';
-import { mockPodK8sResource } from '#~/__mocks__/mockPodK8sResource';
 import type { WorkloadKind } from '#~/k8sTypes';
 import { WorkloadStatusType } from '#~/concepts/distributedWorkloads/utils';
 import {


### PR DESCRIPTION
## Description

Follow-up to #9144 (`RHOAIENG-79875`), which moved `mockInferenceServiceK8sResource` and `mockPodK8sResource` out of `frontend/src/__mocks__` into owning packages, but left two unit specs still importing the old `#~/__mocks__/…` paths.

## How Has This Been Tested?

- Confirmed `main` Type-Check fails with the same four `TS2307` errors for these mocks
- Confirmed no remaining `#~/__mocks__/mockInferenceServiceK8sResource` / `mockPodK8sResource` imports after this change
- Ran eslint on the two updated files (including import-order auto-fix)

## Test Impact

No new tests. This only corrects import paths so existing unit specs type-check again after the mock relocation in #9144.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`