### PR TITLE
RHOAIENG-81833: [v3.5.0-fixes] read About dialog version from DSC instead of DSCI

### DIFF
--- a/frontend/src/app/AboutDialog.tsx
+++ b/frontend/src/app/AboutDialog.tsx
@@ -7,7 +7,6 @@ import { DataScienceStackComponentMap } from '#~/concepts/areas/const';
 import { useUser, useClusterInfo } from '#~/redux/selectors';
 import { useAppContext } from '#~/app/AppContext';
 import useFetchDscStatus from '#~/concepts/areas/useFetchDscStatus';
-import useFetchDsciStatus from '#~/concepts/areas/useFetchDsciStatus';
 import { useWatchOperatorSubscriptionStatus } from '#~/utilities/useWatchOperatorSubscriptionStatus';
 import ExternalLink from '#~/components/ExternalLink';
 import { useThemeContext } from './ThemeContext';
@@ -33,11 +32,9 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
   const { theme } = useThemeContext();
   const { serverURL } = useClusterInfo();
   const [dscStatus, loadedDsc, errorDsc] = useFetchDscStatus();
-  const [dsciStatus, loadedDsci, errorDsci] = useFetchDsciStatus();
   const [subStatus, loadedSubStatus, errorSubStatus] = useWatchOperatorSubscriptionStatus();
-  const error = errorDsci || errorSubStatus;
-  const loading =
-    (!errorDsci && !loadedDsci && !loadedDsc) || (!errorSubStatus && !loadedSubStatus && !errorDsc);
+  const error = errorDsc || errorSubStatus;
+  const loading = (!errorDsc && !loadedDsc) || (!errorSubStatus && !loadedSubStatus);
 
   // Group components by display name while merging releases
   const groupedComponents = useMemo(() => {
@@ -107,12 +104,12 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
           ) : null}
           <Content component="dl" style={{ visibility: loading ? 'hidden' : 'visible' }}>
             <Content component="dt" data-testid="about-product-name">
-              {dsciStatus?.release?.name ||
+              {dscStatus?.release?.name ||
                 (isRHOAI ? RhoaiDefaultReleaseName : OdhDefaultReleaseName)}{' '}
               version
             </Content>
             <Content component="dd" data-testid="about-version">
-              {dsciStatus?.release?.version || 'Unknown'}
+              {dscStatus?.release?.version || 'Unknown'}
             </Content>
             <Content component="dt">Channel</Content>
             <Content component="dd" data-testid="about-channel">

--- a/frontend/src/app/__tests__/AboutDialog.spec.tsx
+++ b/frontend/src/app/__tests__/AboutDialog.spec.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import type {
-  DashboardConfigKind,
-  DataScienceClusterInitializationKindStatus,
-  DataScienceClusterKindStatus,
-} from '@odh-dashboard/k8s-core';
+import type { DashboardConfigKind, DataScienceClusterKindStatus } from '@odh-dashboard/k8s-core';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { FetchState } from '@odh-dashboard/ui-core/hooks/useFetchState';
 import { ClusterState, UserState } from '#~/redux/selectors/types';
 import { useUser, useClusterInfo } from '#~/redux/selectors';
 import { useAppContext } from '#~/app/AppContext';
-import useFetchDsciStatus from '#~/concepts/areas/useFetchDsciStatus';
 import useFetchDscStatus from '#~/concepts/areas/useFetchDscStatus';
 import { mockDashboardConfig } from '#~/__mocks__';
 import { BuildStatus, SubscriptionStatusData } from '#~/types';
@@ -31,11 +26,6 @@ jest.mock('#~/redux/selectors', () => ({
   useClusterInfo: jest.fn(),
 }));
 
-jest.mock('#~/concepts/areas/useFetchDsciStatus', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
 jest.mock('#~/concepts/areas/useFetchDscStatus', () => ({
   __esModule: true,
   default: jest.fn(),
@@ -49,7 +39,6 @@ jest.mock('#~/utilities/useWatchOperatorSubscriptionStatus', () => ({
 const useUserMock = jest.mocked(useUser);
 const useAppContextMock = jest.mocked(useAppContext);
 const useClusterInfoMock = jest.mocked(useClusterInfo);
-const useFetchDsciStatusMock = jest.mocked(useFetchDsciStatus);
 const useFetchDscStatusMock = jest.mocked(useFetchDscStatus);
 const useWatchOperatorSubscriptionStatusMock = jest.mocked(useWatchOperatorSubscriptionStatus);
 
@@ -65,8 +54,6 @@ describe('AboutDialog', () => {
   };
   let userInfo: UserState;
   const clusterInfo: ClusterState = { serverURL: 'https://test-server.com' };
-  let dsciStatus: DataScienceClusterInitializationKindStatus;
-  let dsciFetchStatus: FetchState<DataScienceClusterInitializationKindStatus>;
   let dscStatus: DataScienceClusterKindStatus;
   let dscFetchStatus: FetchState<DataScienceClusterKindStatus>;
   let operatorSubscriptionStatus: SubscriptionStatusData;
@@ -84,14 +71,6 @@ describe('AboutDialog', () => {
       isRHOAI: false,
       refreshDashboardConfig: jest.fn(),
     };
-    dsciStatus = {
-      conditions: [],
-      release: {
-        // eslint-disable-next-line no-restricted-syntax
-        name: 'Open Data Hub Operator',
-        version: '1.0.1',
-      },
-    };
     dscStatus = {
       components: {
         [DataScienceStackComponent.K_SERVE]: {
@@ -105,8 +84,12 @@ describe('AboutDialog', () => {
         },
       },
       conditions: [],
+      release: {
+        // eslint-disable-next-line no-restricted-syntax
+        name: 'Open Data Hub Operator',
+        version: '1.0.1',
+      },
     };
-    dsciFetchStatus = [dsciStatus, true, undefined, () => Promise.resolve(dsciStatus)];
     dscFetchStatus = [dscStatus, true, undefined, () => Promise.resolve(dscStatus)];
     userInfo = {
       username: 'test-user',
@@ -132,7 +115,6 @@ describe('AboutDialog', () => {
     useAppContextMock.mockReturnValue(appContext);
     useUserMock.mockReturnValue(userInfo);
     useClusterInfoMock.mockReturnValue(clusterInfo);
-    useFetchDsciStatusMock.mockReturnValue(dsciFetchStatus);
     useFetchDscStatusMock.mockReturnValue(dscFetchStatus);
     useWatchOperatorSubscriptionStatusMock.mockReturnValue(operatorSubscriptionFetchStatus);
 
@@ -174,13 +156,12 @@ describe('AboutDialog', () => {
     }
     appContext.isRHOAI = true;
     userInfo.isAdmin = true;
-    if (dsciStatus.release) {
-      dsciStatus.release.name = 'OpenShift AI Self-Managed version';
+    if (dscStatus.release) {
+      dscStatus.release.name = 'OpenShift AI Self-Managed version';
     }
     useAppContextMock.mockReturnValue(appContext);
     useUserMock.mockReturnValue(userInfo);
     useClusterInfoMock.mockReturnValue(clusterInfo);
-    useFetchDsciStatusMock.mockReturnValue(dsciFetchStatus);
     useFetchDscStatusMock.mockReturnValue(dscFetchStatus);
     useWatchOperatorSubscriptionStatusMock.mockReturnValue(operatorSubscriptionFetchStatus);
 

--- a/packages/cypress/cypress/tests/mocked/applications/application.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/applications/application.cy.ts
@@ -120,13 +120,10 @@ describe('Application', () => {
       channel: 'fast',
       lastUpdated: '2024-06-25T05:36:37Z',
     });
-    cy.interceptOdh('GET /api/dsci/status', {
-      conditions: [],
-      release: {
-        name: 'test application',
-        version: '1.0.1',
-      },
-    });
+    cy.interceptOdh(
+      'GET /api/dsc/status',
+      mockDscStatus({ release: { name: 'test application', version: '1.0.1' } }),
+    );
 
     appChrome.visit();
     aboutDialog.show();
@@ -163,13 +160,10 @@ describe('Application', () => {
       channel: 'fast',
       lastUpdated: '2024-06-25T05:36:37Z',
     });
-    // Handle no release name returned
-    cy.interceptOdh('GET /api/dsci/status', {
-      conditions: [],
-      release: {
-        version: '1.0.1',
-      },
-    });
+    cy.interceptOdh(
+      'GET /api/dsc/status',
+      mockDscStatus({ release: { name: '', version: '1.0.1' } }),
+    );
     appChrome.visit();
     aboutDialog.show();
 
@@ -186,12 +180,6 @@ describe('Application', () => {
     cy.interceptOdh('GET /api/operator-subscription-status', {
       channel: 'fast',
       lastUpdated: '2024-06-25T05:36:37Z',
-    });
-    cy.interceptOdh('GET /api/dsci/status', {
-      conditions: [],
-      release: {
-        version: '1.0.1',
-      },
     });
     cy.interceptOdh(
       'GET /api/dsc/status',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-81833

## Description

Cherry-pick of #9114 into `v3.5.0-fixes`.

The About dialog was reading release name and version from the DSCI (`DataScienceClusterInitialization`) CR via `useFetchDsciStatus()`. After the dashboard-operator migration, the DSCI CR returns `0.0.0` for the version, causing the About dialog to show "Unknown".

This cherry-pick switches the About dialog to read from the DSC (`DataScienceCluster`) CR instead, which is correctly populated by the ODH Operator.

**Changes:**
- `AboutDialog.tsx`: Removed `useFetchDsciStatus` import/hook, switched to `dscStatus?.release?.name` / `dscStatus?.release?.version`, simplified error/loading state
- `AboutDialog.spec.tsx`: Removed DSCI mock, added `release` data to the existing DSC mock
- `application.cy.ts`: Switched Cypress mock tests from intercepting `GET /api/dsci/status` to using `mockDscStatus()` with `GET /api/dsc/status`

## How Has This Been Tested?

- This is a clean cherry-pick of #9114 (commit a1abec94) with no conflicts
- Original PR was manually tested on a ROSA cluster, with passing unit tests, lint, and type-check
- Verified on cluster `api.test-disconnect-pool-bjw2p.aws.rh-ods.com` that the DSC contains `release.version: 3.5.0`

## Test Impact

- Unit test (`AboutDialog.spec.tsx`) updated to mock DSC instead of DSCI
- Cypress mock tests (`application.cy.ts`) updated to intercept DSC instead of DSCI
- No new tests needed — this is a cherry-pick of an already-tested change

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`