### PR TITLE
fix: restore Type-Check after mock factory move race (#9144 / #9076)

### DIFF
--- a/frontend/src/api/k8s/__tests__/workloads.spec.ts
+++ b/frontend/src/api/k8s/__tests__/workloads.spec.ts
@@ -1,10 +1,10 @@
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
 import type { PodKind } from '@odh-dashboard/k8s-core';
+import { mockPodK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPodK8sResource';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import { mockWorkloadK8sResource } from '#~/__mocks__/mockWorkloadK8sResource';
-import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
-import { mockPodK8sResource } from '#~/__mocks__/mockPodK8sResource';
 import { WorkloadKind } from '#~/k8sTypes';
 import {
   buildWorkloadMapForNotebooks,

--- a/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useKueueStatusForDeployments.spec.ts
@@ -1,10 +1,10 @@
 import { renderHook } from '@testing-library/react';
 import type { PodKind } from '@odh-dashboard/k8s-core';
+import { mockPodK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPodK8sResource';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
-import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
 import { mockWorkloadK8sResource } from '#~/__mocks__/mockWorkloadK8sResource';
-import { mockPodK8sResource } from '#~/__mocks__/mockPodK8sResource';
 import type { WorkloadKind } from '#~/k8sTypes';
 import { WorkloadStatusType } from '#~/concepts/distributedWorkloads/utils';
 import {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-3333

## Description

`main` Type-Check is broken after a same-day merge race:

1. https://github.com/opendatahub-io/odh-dashboard/pull/9076 (merged ~05:33 UTC) added Kueue/workloads tests importing `#~/__mocks__/mockInferenceServiceK8sResource` and `#~/__mocks__/mockPodK8sResource`
2. https://github.com/opendatahub-io/odh-dashboard/pull/9144 (merged ~12:08 UTC) moved those mock factories to `@odh-dashboard/model-serving` / `@odh-dashboard/k8s-core`, but did not update the new test files from #9076

Result: every PR on current `main` fails Type-Check with TS2307 for those imports.

This PR updates the two leftover call sites to the new package exports.

## How Has This Been Tested?

* `npm run type-check --workspace=@odh-dashboard/internal`
* Confirmed the two files import from:
  * `@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource`
  * `@odh-dashboard/k8s-core/__mocks__/mockPodK8sResource`

## Test Impact

No new tests. Fixes import paths in existing unit tests so Type-Check can pass again.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to use shared Kubernetes mock packages.
  * Improved consistency and maintainability of workload and model-serving test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->