### PR TITLE
feat(gen-ai): implement /v1/embeddings proxy handler with credential resolution [RHOAIENG-79576]

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -546,6 +546,7 @@ func (app *App) Routes() http.Handler {
 	// block the endpoint with a 503 when the MaaS BFF is not configured.
 	apiRouter.GET(constants.GenAIProxyNSModelsPath, app.GenAIProxyNSModelsHandler)
 	apiRouter.POST(constants.GenAIProxyNSChatCompletionsPath, app.GenAIProxyNSChatCompletionsHandler)
+	apiRouter.POST(constants.GenAIProxyNSEmbeddingsPath, app.GenAIProxyNSEmbeddingsHandler)
 
 	// App Router
 	appMux := http.NewServeMux()

--- a/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
@@ -1,0 +1,193 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
+	k8s "github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/gen-ai/internal/models"
+)
+
+// GenAIProxyNSEmbeddingsHandler handles POST /api/v1/genai-proxy/ns/:namespace/v1/embeddings.
+//
+// Accepts an OpenAI-compatible embeddings request, resolves the model to a concrete
+// endpoint and credentials, and proxies the request directly to the upstream model.
+// Returns the upstream response unchanged (transparent proxy).
+//
+// Auth is required: OGX forwards the user's JWT via X-OGX-Provider-Data →
+// forward_headers → x-forwarded-access-token header.
+func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace := ps.ByName("namespace")
+	if namespace == "" {
+		app.badRequestResponse(w, r, errors.New("missing namespace in path"))
+		return
+	}
+
+	ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, namespace)
+	r = r.WithContext(ctx)
+
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if !ok || identity == nil || identity.Token == "" {
+		app.unauthorizedResponse(w, r, errors.New("missing authentication identity"))
+		return
+	}
+
+	// Read and parse the request body to extract model field
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return
+	}
+	defer r.Body.Close()
+
+	var reqBody struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(body, &reqBody); err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("invalid JSON in request body: %w", err))
+		return
+	}
+	if reqBody.Model == "" {
+		app.badRequestResponse(w, r, errors.New("missing required field: model"))
+		return
+	}
+
+	// Resolve model → endpoint URL + credentials
+	baseURL, apiKey, err := app.resolveModelEndpoint(ctx, reqBody.Model, namespace)
+	if err != nil {
+		app.logger.Warn("Model resolution failed", "model", reqBody.Model, "error", err)
+		app.notFoundResponse(w, r)
+		return
+	}
+
+	// Normalize base URL to include /v1 if missing (per spike findings)
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	if !strings.HasSuffix(baseURL, "/v1") {
+		baseURL += "/v1"
+	}
+
+	// Proxy the request to upstream
+	upstreamURL := baseURL + "/embeddings"
+	proxyReq, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, strings.NewReader(string(body)))
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to create upstream request: %w", err))
+		return
+	}
+	proxyReq.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		proxyReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := app.httpClient.Do(proxyReq)
+	if err != nil {
+		app.errorResponse(w, r, &integrations.HTTPError{
+			StatusCode: http.StatusBadGateway,
+			ErrorResponse: integrations.ErrorResponse{
+				Code:    "502",
+				Message: fmt.Sprintf("upstream unreachable: %v", err),
+			},
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	// Forward the upstream response unchanged (transparent proxy)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to read upstream response: %w", err))
+		return
+	}
+
+	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+	w.WriteHeader(resp.StatusCode)
+	w.Write(respBody)
+}
+
+// resolveModelEndpoint resolves a model ID to its upstream endpoint URL and API key.
+// The model ID may be provider-qualified (e.g. "genai-bff-proxy/text-embedding-3-small")
+// or bare (e.g. "my-isvc-model"). Resolution follows the same priority as getProviderData:
+//  1. Custom endpoint (provider-qualified with known provider) → ConfigMap + Secret
+//  2. MaaS (maas- prefix) → MaaS BFF catalog URL + ephemeral token
+//  3. Namespace (bare name) → InferenceService/LLMInferenceService URL + user JWT
+func (app *App) resolveModelEndpoint(ctx context.Context, modelID, namespace string) (baseURL, apiKey string, err error) {
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if !ok || identity == nil {
+		return "", "", fmt.Errorf("missing RequestIdentity in context")
+	}
+
+	k8sClient, k8sErr := app.kubernetesClientFactory.GetClient(ctx)
+	if k8sErr != nil {
+		return "", "", fmt.Errorf("failed to get Kubernetes client: %w", k8sErr)
+	}
+
+	// Determine source type from model ID format
+	var effectiveSourceType models.ModelSourceTypeEnum
+	switch {
+	case strings.HasPrefix(modelID, constants.MaaSProviderPrefix):
+		effectiveSourceType = models.ModelSourceTypeMaaS
+	case strings.Contains(modelID, "/"):
+		// Provider-qualified model ID → try custom endpoint first
+		effectiveSourceType = models.ModelSourceTypeCustomEndpoint
+	default:
+		effectiveSourceType = models.ModelSourceTypeNamespace
+	}
+
+	switch effectiveSourceType {
+	case models.ModelSourceTypeCustomEndpoint:
+		extURL, extKey := app.getCustomEndpointBaseURLAndKey(ctx, modelID)
+		if extURL == "" {
+			// Fallback: might be a namespace model with a slash in the name
+			return app.resolveNamespaceModel(ctx, k8sClient, identity, namespace, modelID)
+		}
+		return extURL, extKey, nil
+
+	case models.ModelSourceTypeMaaS:
+		if app.bffClientFactory == nil || !app.bffClientFactory.IsTargetConfigured(bffclient.BFFTargetMaaS) {
+			return "", "", fmt.Errorf("MaaS is not available")
+		}
+		maasHeaders := map[string]string{constants.MaaSReturnAllModelsHeader: "true"}
+		maasClient := app.bffClientFactory.CreateClientWithHeaders(bffclient.BFFTargetMaaS, identity.Token, maasHeaders)
+		ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(bffclient.BFFTargetMaaS)), maasClient)
+
+		inferenceURL, urlErr := app.resolveMaaSModelInferenceURL(ctx, identity, modelID)
+		if urlErr != nil {
+			return "", "", fmt.Errorf("failed to resolve MaaS inference URL: %w", urlErr)
+		}
+		token := app.getMaaSTokenForModel(ctx, k8sClient, identity, namespace, modelID, "")
+		return inferenceURL, token, nil
+
+	default:
+		return app.resolveNamespaceModel(ctx, k8sClient, identity, namespace, modelID)
+	}
+}
+
+// resolveNamespaceModel resolves a namespace model (InferenceService/LLMInferenceService)
+// to its endpoint URL. Auth token is the user's JWT.
+func (app *App) resolveNamespaceModel(ctx context.Context, k8sClient k8s.KubernetesClientInterface, identity *integrations.RequestIdentity, namespace, modelID string) (string, string, error) {
+	// Strip provider prefix if present (e.g. "vllm-inference-1/model-name" → "model-name")
+	bareModelName := modelID
+	if idx := strings.Index(modelID, "/"); idx != -1 {
+		bareModelName = modelID[idx+1:]
+	}
+
+	isvcURL, err := k8sClient.GetInferenceServiceURL(ctx, identity, namespace, bareModelName)
+	if err != nil {
+		return "", "", fmt.Errorf("InferenceService not found for model %q: %w", bareModelName, err)
+	}
+	if isvcURL == "" {
+		return "", "", fmt.Errorf("empty URL for model %q", bareModelName)
+	}
+
+	return isvcURL, identity.Token, nil
+}

--- a/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
@@ -131,7 +131,13 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 	limitedReader := io.LimitReader(resp.Body, maxResponseBytes+1)
 	respBody, err := io.ReadAll(limitedReader)
 	if err != nil {
-		app.serverErrorResponse(w, r, fmt.Errorf("failed to read upstream response: %w", err))
+		app.errorResponse(w, r, &integrations.HTTPError{
+			StatusCode: http.StatusBadGateway,
+			ErrorResponse: integrations.ErrorResponse{
+				Code:    "502",
+				Message: fmt.Sprintf("upstream body read failed: %v", err),
+			},
+		})
 		return
 	}
 	if int64(len(respBody)) > maxResponseBytes {
@@ -159,9 +165,9 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 		"upgrade":             true,
 		"content-length":      true,
 	}
-	// Also exclude headers nominated by the upstream Connection header
-	if connHeaders := resp.Header.Get("Connection"); connHeaders != "" {
-		for _, h := range strings.Split(connHeaders, ",") {
+	// Also exclude headers nominated by ALL upstream Connection header values
+	for _, connValue := range resp.Header.Values("Connection") {
+		for _, h := range strings.Split(connValue, ",") {
 			hopByHop[strings.ToLower(strings.TrimSpace(h))] = true
 		}
 	}

--- a/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
@@ -140,7 +140,7 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 		}
 	}
 	w.WriteHeader(resp.StatusCode)
-	w.Write(respBody)
+	_, _ = w.Write(respBody)
 }
 
 // resolveModelEndpoint resolves a model ID to its upstream endpoint URL and API key.

--- a/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
@@ -74,6 +74,20 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Strip provider prefix from model ID in the proxied body.
+	// OGX sends "provider/model-name" but the upstream expects just "model-name".
+	upstreamBody := body
+	if strings.Contains(reqBody.Model, "/") {
+		bareModel := reqBody.Model[strings.Index(reqBody.Model, "/")+1:]
+		var bodyMap map[string]interface{}
+		if err := json.Unmarshal(body, &bodyMap); err == nil {
+			bodyMap["model"] = bareModel
+			if rewritten, err := json.Marshal(bodyMap); err == nil {
+				upstreamBody = rewritten
+			}
+		}
+	}
+
 	// Normalize base URL to include /v1 if missing (per spike findings)
 	baseURL = strings.TrimSuffix(baseURL, "/")
 	if !strings.HasSuffix(baseURL, "/v1") {
@@ -82,7 +96,7 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 
 	// Proxy the request to upstream
 	upstreamURL := baseURL + "/embeddings"
-	proxyReq, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, strings.NewReader(string(body)))
+	proxyReq, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, strings.NewReader(string(upstreamBody)))
 	if err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("failed to create upstream request: %w", err))
 		return

--- a/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
@@ -64,10 +64,14 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	// Resolve model → endpoint URL + credentials
-	baseURL, apiKey, err := app.resolveModelEndpoint(ctx, reqBody.Model, namespace)
-	if err != nil {
-		app.logger.Warn("Model resolution failed", "model", reqBody.Model, "error", err)
-		app.notFoundResponse(w, r)
+	baseURL, apiKey, resolveErr := app.resolveModelEndpoint(ctx, reqBody.Model, namespace)
+	if resolveErr != nil {
+		app.logger.Warn("Model resolution failed", "model", reqBody.Model, "error", resolveErr)
+		if isInfraError(resolveErr) {
+			app.serverErrorResponse(w, r, fmt.Errorf("failed to resolve model %q: %w", reqBody.Model, resolveErr))
+		} else {
+			app.notFoundResponse(w, r)
+		}
 		return
 	}
 
@@ -128,33 +132,39 @@ func (app *App) resolveModelEndpoint(ctx context.Context, modelID, namespace str
 
 	k8sClient, k8sErr := app.kubernetesClientFactory.GetClient(ctx)
 	if k8sErr != nil {
-		return "", "", fmt.Errorf("failed to get Kubernetes client: %w", k8sErr)
+		return "", "", &infraError{msg: fmt.Sprintf("failed to get Kubernetes client: %v", k8sErr)}
 	}
 
-	// Determine source type from model ID format
+	// Determine source type from model ID format.
+	// Priority: maas- prefix → custom endpoint (try lookup) → namespace ISVC fallback.
+	// Custom endpoints can have bare IDs (e.g. "custom-embedding-model") or provider-qualified
+	// IDs (e.g. "custom-provider/model-name"), so we always try custom endpoint lookup first
+	// for non-MaaS models before falling back to namespace.
 	var effectiveSourceType models.ModelSourceTypeEnum
 	switch {
 	case strings.HasPrefix(modelID, constants.MaaSProviderPrefix):
 		effectiveSourceType = models.ModelSourceTypeMaaS
-	case strings.Contains(modelID, "/"):
-		// Provider-qualified model ID → try custom endpoint first
-		effectiveSourceType = models.ModelSourceTypeCustomEndpoint
 	default:
-		effectiveSourceType = models.ModelSourceTypeNamespace
+		// Try custom endpoint first (handles both bare and provider-qualified IDs),
+		// fall back to namespace ISVC if not found.
+		effectiveSourceType = models.ModelSourceTypeCustomEndpoint
 	}
 
 	switch effectiveSourceType {
 	case models.ModelSourceTypeCustomEndpoint:
-		extURL, extKey := app.getCustomEndpointBaseURLAndKey(ctx, modelID)
-		if extURL == "" {
-			// Fallback: might be a namespace model with a slash in the name
-			return app.resolveNamespaceModel(ctx, k8sClient, identity, namespace, modelID)
+		// Only attempt custom endpoint resolution for provider-qualified IDs (contains "/")
+		if strings.Contains(modelID, "/") {
+			extURL, extKey := app.getCustomEndpointBaseURLAndKey(ctx, modelID)
+			if extURL != "" {
+				return extURL, extKey, nil
+			}
 		}
-		return extURL, extKey, nil
+		// Fallback to namespace ISVC for bare IDs or if custom endpoint lookup failed
+		return app.resolveNamespaceModel(ctx, k8sClient, identity, namespace, modelID)
 
 	case models.ModelSourceTypeMaaS:
 		if app.bffClientFactory == nil || !app.bffClientFactory.IsTargetConfigured(bffclient.BFFTargetMaaS) {
-			return "", "", fmt.Errorf("MaaS is not available")
+			return "", "", &infraError{msg: "MaaS is not available"}
 		}
 		maasHeaders := map[string]string{constants.MaaSReturnAllModelsHeader: "true"}
 		maasClient := app.bffClientFactory.CreateClientWithHeaders(bffclient.BFFTargetMaaS, identity.Token, maasHeaders)
@@ -165,6 +175,9 @@ func (app *App) resolveModelEndpoint(ctx context.Context, modelID, namespace str
 			return "", "", fmt.Errorf("failed to resolve MaaS inference URL: %w", urlErr)
 		}
 		token := app.getMaaSTokenForModel(ctx, k8sClient, identity, namespace, modelID, "")
+		if token == "" {
+			return "", "", &infraError{msg: fmt.Sprintf("failed to obtain auth token for MaaS model %q", modelID)}
+		}
 		return inferenceURL, token, nil
 
 	default:
@@ -190,4 +203,24 @@ func (app *App) resolveNamespaceModel(ctx context.Context, k8sClient k8s.Kuberne
 	}
 
 	return isvcURL, identity.Token, nil
+}
+
+// infraError signals an infrastructure failure (K8s client unavailable, MaaS down)
+// as opposed to a "model not found" scenario. Used to distinguish 500/502 from 404.
+type infraError struct {
+	msg string
+}
+
+func (e *infraError) Error() string { return e.msg }
+
+func isInfraError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ie *infraError
+	if errors.As(err, &ie) {
+		return true
+	}
+	// K8s client errors are infra errors
+	return strings.Contains(err.Error(), "failed to get Kubernetes client")
 }

--- a/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/opendatahub-io/gen-ai/internal/integrations"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
 	k8s "github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes"
-	"github.com/opendatahub-io/gen-ai/internal/models"
 )
 
 // GenAIProxyNSEmbeddingsHandler handles POST /api/v1/genai-proxy/ns/:namespace/v1/embeddings.
@@ -43,13 +42,13 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Read and parse the request body to extract model field
+	// Read the full request body — needed both for model extraction and transparent
+	// proxying to upstream (body forwarded unchanged).
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
 		return
 	}
-	defer r.Body.Close()
 
 	var reqBody struct {
 		Model string `json:"model"`
@@ -135,34 +134,11 @@ func (app *App) resolveModelEndpoint(ctx context.Context, modelID, namespace str
 		return "", "", &infraError{msg: fmt.Sprintf("failed to get Kubernetes client: %v", k8sErr)}
 	}
 
-	// Determine source type from model ID format.
-	// Priority: maas- prefix → custom endpoint (try lookup) → namespace ISVC fallback.
-	// Custom endpoints can have bare IDs (e.g. "custom-embedding-model") or provider-qualified
-	// IDs (e.g. "custom-provider/model-name"), so we always try custom endpoint lookup first
-	// for non-MaaS models before falling back to namespace.
-	var effectiveSourceType models.ModelSourceTypeEnum
-	switch {
-	case strings.HasPrefix(modelID, constants.MaaSProviderPrefix):
-		effectiveSourceType = models.ModelSourceTypeMaaS
-	default:
-		// Try custom endpoint first (handles both bare and provider-qualified IDs),
-		// fall back to namespace ISVC if not found.
-		effectiveSourceType = models.ModelSourceTypeCustomEndpoint
-	}
-
-	switch effectiveSourceType {
-	case models.ModelSourceTypeCustomEndpoint:
-		// Only attempt custom endpoint resolution for provider-qualified IDs (contains "/")
-		if strings.Contains(modelID, "/") {
-			extURL, extKey := app.getCustomEndpointBaseURLAndKey(ctx, modelID)
-			if extURL != "" {
-				return extURL, extKey, nil
-			}
-		}
-		// Fallback to namespace ISVC for bare IDs or if custom endpoint lookup failed
-		return app.resolveNamespaceModel(ctx, k8sClient, identity, namespace, modelID)
-
-	case models.ModelSourceTypeMaaS:
+	// Resolution priority:
+	// 1. MaaS (maas- prefix) → MaaS BFF catalog URL + ephemeral token
+	// 2. Custom endpoint (provider-qualified with "/") → ConfigMap + Secret
+	// 3. Namespace ISVC fallback (bare name) → InferenceService URL + user JWT
+	if strings.HasPrefix(modelID, constants.MaaSProviderPrefix) {
 		if app.bffClientFactory == nil || !app.bffClientFactory.IsTargetConfigured(bffclient.BFFTargetMaaS) {
 			return "", "", &infraError{msg: "MaaS is not available"}
 		}
@@ -179,10 +155,18 @@ func (app *App) resolveModelEndpoint(ctx context.Context, modelID, namespace str
 			return "", "", &infraError{msg: fmt.Sprintf("failed to obtain auth token for MaaS model %q", modelID)}
 		}
 		return inferenceURL, token, nil
-
-	default:
-		return app.resolveNamespaceModel(ctx, k8sClient, identity, namespace, modelID)
 	}
+
+	// Try custom endpoint for provider-qualified IDs (contains "/")
+	if strings.Contains(modelID, "/") {
+		extURL, extKey := app.getCustomEndpointBaseURLAndKey(ctx, modelID)
+		if extURL != "" {
+			return extURL, extKey, nil
+		}
+	}
+
+	// Fallback: namespace ISVC (bare name or failed custom endpoint lookup)
+	return app.resolveNamespaceModel(ctx, k8sClient, identity, namespace, modelID)
 }
 
 // resolveNamespaceModel resolves a namespace model (InferenceService/LLMInferenceService)

--- a/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
@@ -126,15 +126,28 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 
 	// Forward the upstream response unchanged (transparent proxy).
 	// Limit read to 10MB to prevent memory exhaustion from malicious/faulty upstreams.
-	const maxResponseBytes = 10 * 1024 * 1024
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	// If the response exceeds the limit, return 502 instead of silently truncating.
+	const maxResponseBytes int64 = 10 * 1024 * 1024
+	limitedReader := io.LimitReader(resp.Body, maxResponseBytes+1)
+	respBody, err := io.ReadAll(limitedReader)
 	if err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("failed to read upstream response: %w", err))
 		return
 	}
+	if int64(len(respBody)) > maxResponseBytes {
+		app.errorResponse(w, r, &integrations.HTTPError{
+			StatusCode: http.StatusBadGateway,
+			ErrorResponse: integrations.ErrorResponse{
+				Code:    "502",
+				Message: "upstream response too large (exceeds 10MB limit)",
+			},
+		})
+		return
+	}
 
-	// Copy upstream response headers, excluding hop-by-hop headers (RFC 7230 §6.1)
-	// and framing headers invalidated by buffering.
+	// Copy upstream response headers, excluding hop-by-hop headers (RFC 7230 §6.1),
+	// framing headers invalidated by buffering, and any headers nominated by the
+	// upstream Connection header.
 	hopByHop := map[string]bool{
 		"connection":          true,
 		"keep-alive":          true,
@@ -145,6 +158,12 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 		"transfer-encoding":   true,
 		"upgrade":             true,
 		"content-length":      true,
+	}
+	// Also exclude headers nominated by the upstream Connection header
+	if connHeaders := resp.Header.Get("Connection"); connHeaders != "" {
+		for _, h := range strings.Split(connHeaders, ",") {
+			hopByHop[strings.ToLower(strings.TrimSpace(h))] = true
+		}
 	}
 	for key, values := range resp.Header {
 		if hopByHop[strings.ToLower(key)] {
@@ -221,14 +240,13 @@ func (app *App) resolveNamespaceModel(ctx context.Context, k8sClient k8s.Kuberne
 
 	isvcURL, err := k8sClient.GetInferenceServiceURL(ctx, identity, namespace, bareModelName)
 	if err != nil {
-		// Distinguish between "model doesn't exist" (not found) and K8s API errors (infra)
-		if strings.Contains(err.Error(), "not found") {
-			return "", "", fmt.Errorf("model %q not found: %w", bareModelName, err)
-		}
+		// GetInferenceServiceURL returns ("", nil) for model-not-found.
+		// Any non-nil error is an infrastructure failure (K8s API unreachable, RBAC, etc).
 		return "", "", &infraError{msg: fmt.Sprintf("failed to resolve model %q: %v", bareModelName, err)}
 	}
 	if isvcURL == "" {
-		return "", "", fmt.Errorf("empty URL for model %q", bareModelName)
+		// ("", nil) means model not found per the KubernetesClientInterface contract.
+		return "", "", fmt.Errorf("model %q not found in namespace", bareModelName)
 	}
 
 	return isvcURL, identity.Token, nil

--- a/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
@@ -51,7 +51,8 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	var reqBody struct {
-		Model string `json:"model"`
+		Model string      `json:"model"`
+		Input interface{} `json:"input"`
 	}
 	if err := json.Unmarshal(body, &reqBody); err != nil {
 		app.badRequestResponse(w, r, fmt.Errorf("invalid JSON in request body: %w", err))
@@ -59,6 +60,10 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 	}
 	if reqBody.Model == "" {
 		app.badRequestResponse(w, r, errors.New("missing required field: model"))
+		return
+	}
+	if reqBody.Input == nil {
+		app.badRequestResponse(w, r, errors.New("missing required field: input"))
 		return
 	}
 
@@ -119,14 +124,21 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 	}
 	defer resp.Body.Close()
 
-	// Forward the upstream response unchanged (transparent proxy)
-	respBody, err := io.ReadAll(resp.Body)
+	// Forward the upstream response unchanged (transparent proxy).
+	// Limit read to 10MB to prevent memory exhaustion from malicious/faulty upstreams.
+	const maxResponseBytes = 10 * 1024 * 1024
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("failed to read upstream response: %w", err))
 		return
 	}
 
-	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+	// Copy all upstream response headers for transparent proxy behavior
+	for key, values := range resp.Header {
+		for _, v := range values {
+			w.Header().Add(key, v)
+		}
+	}
 	w.WriteHeader(resp.StatusCode)
 	w.Write(respBody)
 }
@@ -194,7 +206,11 @@ func (app *App) resolveNamespaceModel(ctx context.Context, k8sClient k8s.Kuberne
 
 	isvcURL, err := k8sClient.GetInferenceServiceURL(ctx, identity, namespace, bareModelName)
 	if err != nil {
-		return "", "", fmt.Errorf("InferenceService not found for model %q: %w", bareModelName, err)
+		// Distinguish between "model doesn't exist" (not found) and K8s API errors (infra)
+		if strings.Contains(err.Error(), "not found") {
+			return "", "", fmt.Errorf("model %q not found: %w", bareModelName, err)
+		}
+		return "", "", &infraError{msg: fmt.Sprintf("failed to resolve model %q: %v", bareModelName, err)}
 	}
 	if isvcURL == "" {
 		return "", "", fmt.Errorf("empty URL for model %q", bareModelName)

--- a/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler.go
@@ -22,8 +22,8 @@ import (
 // endpoint and credentials, and proxies the request directly to the upstream model.
 // Returns the upstream response unchanged (transparent proxy).
 //
-// Auth is required: OGX forwards the user's JWT via X-OGX-Provider-Data →
-// forward_headers → x-forwarded-access-token header.
+// Auth is required: the user's JWT arrives via the x-forwarded-access-token
+// header (forwarded by OGX).
 func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := r.Context()
 
@@ -133,8 +133,23 @@ func (app *App) GenAIProxyNSEmbeddingsHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Copy all upstream response headers for transparent proxy behavior
+	// Copy upstream response headers, excluding hop-by-hop headers (RFC 7230 §6.1)
+	// and framing headers invalidated by buffering.
+	hopByHop := map[string]bool{
+		"connection":          true,
+		"keep-alive":          true,
+		"proxy-authenticate":  true,
+		"proxy-authorization": true,
+		"te":                  true,
+		"trailer":             true,
+		"transfer-encoding":   true,
+		"upgrade":             true,
+		"content-length":      true,
+	}
 	for key, values := range resp.Header {
+		if hopByHop[strings.ToLower(key)] {
+			continue
+		}
 		for _, v := range values {
 			w.Header().Add(key, v)
 		}

--- a/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_embeddings_handler_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = Describe("GenAIProxyNSEmbeddingsHandler", func() {
+	var app App
+
+	BeforeEach(func() {
+		app = NewK8sLSTestApp()
+	})
+
+	It("should return 401 without auth identity", func() {
+		body := `{"model": "some-model", "input": "hello"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/embeddings", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSEmbeddingsHandler(rr, req, params)
+
+		assert.Equal(GinkgoT(), http.StatusUnauthorized, rr.Code)
+	})
+
+	It("should return 400 when model field is missing", func() {
+		t := GinkgoT()
+		body := `{"input": "hello world"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/embeddings", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSEmbeddingsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var errResp map[string]interface{}
+		err := json.Unmarshal(rr.Body.Bytes(), &errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp["error"].(map[string]interface{})["message"], "model")
+	})
+
+	It("should return 400 for invalid JSON body", func() {
+		t := GinkgoT()
+		body := `{invalid json`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/embeddings", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSEmbeddingsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	It("should return 404 when model is not found", func() {
+		t := GinkgoT()
+		body := `{"model": "nonexistent-model", "input": "hello"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/embeddings", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "test-ns")
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSEmbeddingsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+})

--- a/packages/gen-ai/bff/internal/constants/api_constants.go
+++ b/packages/gen-ai/bff/internal/constants/api_constants.go
@@ -84,4 +84,5 @@ const (
 	// OGX base_url must include the namespace: .../api/v1/genai-proxy/ns/<namespace>
 	GenAIProxyNSModelsPath          = ApiPathPrefix + "/genai-proxy/ns/:namespace/v1/models"
 	GenAIProxyNSChatCompletionsPath = ApiPathPrefix + "/genai-proxy/ns/:namespace/v1/chat/completions"
+	GenAIProxyNSEmbeddingsPath      = ApiPathPrefix + "/genai-proxy/ns/:namespace/v1/embeddings"
 )


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79576

## Description

Implement `POST /api/v1/genai-proxy/ns/:namespace/v1/embeddings` — a transparent proxy that accepts OpenAI-compatible embeddings requests from OGX, resolves the model to a concrete upstream endpoint with credentials, and forwards the request directly to the underlying model.

### What was added

- `genai_proxy_embeddings_handler.go` — POST handler + `resolveModelEndpoint()` helper + `resolveNamespaceModel()` helper + `infraError` type
- `genai_proxy_embeddings_handler_test.go` — 4 unit tests covering error paths
- `GenAIProxyNSEmbeddingsPath` constant in `api_constants.go`
- Route registration in `app.go`

### How model resolution works

The handler extracts the `model` field from the request body and resolves it to an upstream URL + API key based on the model ID format:

- **MaaS models** (`maas-` prefix): resolves inference URL via MaaS BFF catalog + obtains ephemeral token
- **Custom endpoints** (provider-qualified with `/`): resolves from `gen-ai-aa-custom-model-endpoints` ConfigMap + K8s Secret
- **Namespace models** (bare name): resolves InferenceService/LLMInferenceService URL + uses user JWT

The provider prefix is stripped from the `model` field before proxying. OGX sends `provider/model-name` but upstreams expect just `model-name`.

### URL normalization

The base URL is normalized to include `/v1` if missing. The spike validated that some model endpoints return URLs without the `/v1` suffix, which would cause 404s on the upstream's `/v1/embeddings` path.

### Design decisions

**Transparent proxy:** The response body is returned unchanged — status code, headers, and body from the upstream flow through directly. OGX expects OpenAI-compatible responses from the upstream, not BFF-wrapped errors.

**Infrastructure errors vs not-found:** A dedicated `infraError` type separates K8s client failures and MaaS unavailability (returned as 500) from genuine "model not found" scenarios (returned as 404). Without this, a cluster outage would mask as "model not found".

**Provider prefix stripped from body:** Validated during cluster testing — LiteLLM returned `key_model_access_denied` when receiving the full provider-qualified ID instead of the bare model name. The handler rewrites the `model` field in the body before forwarding.

**Reusable resolver:** `resolveModelEndpoint()` is extracted as a shared helper that will be reused by the upcoming `/v1/chat/completions` handler ([RHOAIENG-79574](https://redhat.atlassian.net/browse/RHOAIENG-79574)) which follows the same resolution pattern.

**Reference:** Architecture validated in spike [RHOAIENG-78871](https://redhat.atlassian.net/browse/RHOAIENG-78871): "POST /api/v1/genai-proxy/ns/:namespace/v1/embeddings — resolves model → {endpoint, token} by searching K8s and proxies directly to the underlying model. BFF normalizes base URL to include /v1 if missing."

### Why this approach and not a mock/stub

The handler is a transparent proxy — its core logic is network I/O (resolve model, call upstream, forward response). A mock HTTP server in a unit test would only validate that `http.Client.Do` works, which is Go standard library behavior. The real value is in validating the full chain: ConfigMap parsing → Secret fetch → URL construction → TLS handshake → upstream response forwarding. This requires a real cluster with real credentials, which is why the E2E cluster validation is the primary test evidence.

## How Has This Been Tested?

### Unit tests

- `make test` — all specs pass (0 failures across all packages)
- 4 handler-specific tests covering: 401 (no auth), 400 (missing model), 400 (invalid JSON), 404 (model not found)

### End-to-end cluster validation

Deployed custom BFF image on an OpenShift cluster (RHOAI 3.6-ea.1) via CSV patching. Validated via port-forward to the `gen-ai-ui` pod.

**Error path validation:**

```bash
TOKEN=$(oc whoami -t)
oc port-forward deploy/gen-ai-ui -n redhat-ods-applications 8143:8143 &

# 401 — no auth
curl -sk -X POST "https://localhost:8143/api/v1/genai-proxy/ns/test-ns/v1/embeddings" \
  -H "Content-Type: application/json" -d '{"model":"x","input":"hi"}'
# → {"error":{"code":"401","message":"missing required Header: x-forwarded-access-token"}}

# 400 — missing model field
curl -sk -X POST "https://localhost:8143/api/v1/genai-proxy/ns/test-ns/v1/embeddings" \
  -H "x-forwarded-access-token: $TOKEN" -H "Content-Type: application/json" -d '{"input":"hi"}'
# → {"error":{"code":"400","message":"missing required field: model"}}

# 404 — nonexistent model
curl -sk -X POST "https://localhost:8143/api/v1/genai-proxy/ns/gaizka-test/v1/embeddings" \
  -H "x-forwarded-access-token: $TOKEN" -H "Content-Type: application/json" \
  -d '{"model":"nonexistent-xyz","input":"hi"}'
# → {"error":{"code":"404","message":"the requested resource could not be found"}}

# 502 — unreachable upstream (custom endpoint pointing to https://unreachable.invalid)
curl -sk -X POST "https://localhost:8143/api/v1/genai-proxy/ns/gaizka-test/v1/embeddings" \
  -H "x-forwarded-access-token: $TOKEN" -H "Content-Type: application/json" \
  -d '{"model":"dead-provider/dead-model","input":"test"}'
# → {"error":{"code":"502","message":"upstream unreachable: dial tcp: lookup unreachable.invalid: no such host"}}
```

**Happy path validation (200 — real embeddings from Nomic via LiteMaaS):**

```bash
# 1. Create custom endpoint pointing to LiteMaaS
cat <<'INNER' | oc apply -n gaizka-test -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: gen-ai-aa-custom-model-endpoints
  labels:
    opendatahub.io/dashboard: "true"
data:
  config.yaml: |
    providers:
      inference:
        - provider_id: litellm-embed
          provider_type: remote::openai
          config:
            base_url: https://litemaas.rhoai.rh-aiservices-bu.com/v1
            allowed_models:
              - Nomic-embed-text-v2-moe
            custom_gen_ai:
              api_key:
                secretRef:
                  name: litellm-secret
                  key: api_key
    registered_resources:
      models:
        - provider_id: litellm-embed
          model_id: Nomic-embed-text-v2-moe
          model_type: embedding
INNER
oc create secret generic litellm-secret -n gaizka-test --from-literal=api_key='<litellm-key>'

# 2. Call the proxy endpoint
curl -sk -X POST "https://localhost:8143/api/v1/genai-proxy/ns/gaizka-test/v1/embeddings" \
  -H "x-forwarded-access-token: $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"model":"litellm-embed/Nomic-embed-text-v2-moe","input":"Hello world","encoding_format":"float"}'
```

**Result:**
```json
{
  "model": "nomic-embed-text-v2-moe",
  "data": [{"embedding": [0.0058, 0.0263, -0.0102, ...], "index": 0, "object": "embedding"}],
  "object": "list",
  "usage": {"prompt_tokens": 4, "total_tokens": 4}
}
```
HTTP 200 ✅ — Full chain validated: ConfigMap resolution → Secret fetch → provider prefix stripped → URL construction → TLS to LiteMaaS → LiteMaaS routed to Nomic → real embedding vector returned transparently.

## Jira

- **Ticket:** [RHOAIENG-79576](https://redhat.atlassian.net/browse/RHOAIENG-79576)
- **Epic:** [RHOAIENG-79569](https://redhat.atlassian.net/browse/RHOAIENG-79569) (OGX Zero-Restart — BFF /v1/ Proxy Endpoints)
- **Feature:** [RHAISTRAT-1921](https://redhat.atlassian.net/browse/RHAISTRAT-1921)
- **Spike:** [RHOAIENG-78871](https://redhat.atlassian.net/browse/RHOAIENG-78871)

[RHOAIENG-79576]: https://redhat.atlassian.net/browse/RHOAIENG-79576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an OpenAI-compatible embeddings endpoint for namespace-scoped GenAI proxy requests.
  - Supports authenticated requests, model validation, provider-specific routing, and namespace-based model services.
  - Transparently forwards valid embedding requests and returns upstream responses.

- **Bug Fixes**
  - Added clear handling for unauthorized requests, malformed input, missing models, and unavailable services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-79574]: https://redhat.atlassian.net/browse/RHOAIENG-79574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ