### PR TITLE
fix(llmd-serving): allow selecting an accelerator config in the llm-d wizard using clone-to-project pattern from topology configs [RHOAIENG-66855]

### DIFF
--- a/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdTopology.cy.ts
+++ b/packages/llmd-serving/cypress/tests/mocked/modelServingLlmdTopology.cy.ts
@@ -1,3 +1,4 @@
+import type { Interception } from 'cypress/types/net-stubbing';
 import { mockLLMInferenceServiceConfigK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceConfigK8sResource';
 import { mockLLMInferenceServiceK8sResource } from '@odh-dashboard/llmd-serving/__mocks__/mockLLMInferenceServiceK8sResource';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -76,12 +77,24 @@ const mockRouterConfigs = [
   }),
 ];
 
+const mockAcceleratorConfigs = [
+  mockLLMInferenceServiceConfigK8sResource({
+    name: 'vllm-rocm',
+    displayName: 'vLLM ROCm',
+    configType: ConfigType.ACCELERATOR,
+    recommendedAccelerators: 'amd.com/gpu',
+    supportedTopologies: [TopologyType.SINGLE_NODE],
+  }),
+];
+
 const initIntercepts = ({
   topologyConfigs = mockTopologyConfigs,
   routerConfigs = mockRouterConfigs,
+  acceleratorConfigs = mockAcceleratorConfigs,
 }: {
   topologyConfigs?: ReturnType<typeof mockLLMInferenceServiceConfigK8sResource>[];
   routerConfigs?: ReturnType<typeof mockLLMInferenceServiceConfigK8sResource>[];
+  acceleratorConfigs?: ReturnType<typeof mockLLMInferenceServiceConfigK8sResource>[];
 } = {}) => {
   cy.interceptOdh(
     'GET /api/dsc/status',
@@ -147,7 +160,7 @@ const initIntercepts = ({
   cy.interceptK8sList(LLMInferenceServiceModel, mockK8sResourceList([]));
   cy.interceptK8sList(
     { model: LLMInferenceServiceConfigModel, ns: 'opendatahub' },
-    mockK8sResourceList([...topologyConfigs, ...routerConfigs]),
+    mockK8sResourceList([...topologyConfigs, ...routerConfigs, ...acceleratorConfigs]),
   );
   cy.interceptK8sList(
     { model: LLMInferenceServiceConfigModel, ns: 'test-project' },
@@ -691,6 +704,115 @@ describe('Model Serving LLMD Topology & Routing', () => {
       cy.get('@createLLMInferenceService.all').then((interceptions) => {
         expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
       });
+    });
+
+    it('should create an accelerator config and append its baseRef after the topology baseRef', () => {
+      const deploymentName = 'test-accelerator-config';
+      const localTopologyConfigName = `${deploymentName}-single-node-config`;
+      const localAcceleratorConfigName = `${deploymentName}-vllm-rocm`;
+      initIntercepts();
+      initDeployIntercepts(deploymentName);
+
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findModelDeploymentNameInput().type(deploymentName);
+
+      // Stay on Single node topology — the accelerator field's isActive only renders it for
+      // Single node (see AcceleratorConfigField.tsx isActive). Pick a real (non-default) single
+      // node topology config so we can assert ordering: topology baseRef is added first, then
+      // the accelerator baseRef is appended after it.
+      cy.findByTestId('topology-type-select').should('contain.text', 'Single node');
+      cy.findByTestId('custom-topology-config-select').click();
+      cy.findByTestId('topology-config-option-single-node-config').click();
+      cy.findByTestId('custom-topology-config-select').should('contain.text', 'Single Node Config');
+
+      // The accelerator field uses the shared ModelServerTemplateSelectField (Manual selection is
+      // the default). Open the manual dropdown and pick the ROCm config; the selected config's
+      // display name shows in the dropdown toggle.
+      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
+      modelServingWizard.selectGlobalScopedTemplateOption('vLLM ROCm');
+      modelServingWizard
+        .findServingRuntimeTemplateSearchSelector()
+        .should('contain.text', 'vLLM ROCm');
+
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      completeWizard();
+
+      // Actual requests — the accelerator config is created in the project namespace
+      cy.wait('@createLLMInferenceServiceConfig').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+      });
+      cy.wait('@createLLMInferenceServiceConfig').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+      });
+      cy.wait('@createLLMInferenceService').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+        expect(interception.request.body.spec.baseRefs).to.deep.equal([
+          { name: localTopologyConfigName },
+          { name: localAcceleratorConfigName },
+        ]);
+      });
+
+      cy.wait('@createLLMInferenceServiceConfig').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+      });
+      cy.wait('@createLLMInferenceServiceConfig').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+      });
+      cy.wait('@createLLMInferenceService').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+        expect(interception.request.body.spec.baseRefs).to.deep.equal([
+          { name: localTopologyConfigName },
+          { name: localAcceleratorConfigName },
+        ]);
+      });
+
+      cy.get<Interception[]>('@createLLMInferenceServiceConfig.all').then((interceptions) => {
+        const names = interceptions.map((i) => i.request.body.metadata.name);
+        expect(names).to.include(localAcceleratorConfigName);
+        expect(names).to.include(localTopologyConfigName);
+        expect(interceptions).to.have.length(4); // 2 configs x (1 dry-run + 1 actual)
+      });
+    });
+
+    it('should not create an accelerator config when left at "Built-in image (default)"', () => {
+      const deploymentName = 'test-accelerator-default';
+      initIntercepts();
+      initDeployIntercepts(deploymentName);
+
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+      navigateToModelDeploymentStep();
+
+      modelServingWizard.selectDeploymentMethodByKey('llm-inference-service-llmd');
+      modelServingWizard.findModelDeploymentNameInput().type(deploymentName);
+
+      // Defaults: Single node topology, accelerator field left at the built-in image default
+      // (the shared ModelServerTemplateSelectField shows it as the manual selection).
+      modelServingWizard
+        .findServingRuntimeTemplateSearchSelector()
+        .should('contain.text', 'Built-in image (default)');
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      completeWizard();
+
+      cy.wait('@createLLMInferenceService').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+        expect(interception.request.body.spec.baseRefs ?? []).to.have.length(0);
+      });
+      cy.wait('@createLLMInferenceService').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+        expect(interception.request.body.spec.baseRefs ?? []).to.have.length(0);
+      });
+
+      cy.get('@createLLMInferenceService.all').then((interceptions) => {
+        expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+      });
+      cy.get('@createLLMInferenceServiceConfig.all').should('have.length', 0);
     });
 
     it('should clean old resource when changing to "Single node (default)" ', () => {

--- a/packages/llmd-serving/extensions/__tests__/extensions.spec.ts
+++ b/packages/llmd-serving/extensions/__tests__/extensions.spec.ts
@@ -202,3 +202,20 @@ describe('llm-d routing configuration extensions', () => {
     });
   });
 });
+
+const applyFieldId = (ext: unknown): string | undefined => {
+  const e = ext as { type?: string; properties?: { fieldId?: string } };
+  return e.type === 'model-serving.deployment/wizard-field-apply'
+    ? e.properties?.fieldId
+    : undefined;
+};
+
+describe('llmd-serving apply extension ordering', () => {
+  it('registers the accelerator apply after the topology config apply', () => {
+    const applyIds = extensions.map(applyFieldId).filter(Boolean) as string[];
+    const topoIdx = applyIds.indexOf('llmd-serving/custom-topology-config');
+    const accelIdx = applyIds.indexOf('llmd-serving/accelerator-config');
+    expect(topoIdx).toBeGreaterThanOrEqual(0);
+    expect(accelIdx).toBeGreaterThan(topoIdx);
+  });
+});

--- a/packages/llmd-serving/extensions/__tests__/extensions.spec.ts
+++ b/packages/llmd-serving/extensions/__tests__/extensions.spec.ts
@@ -203,7 +203,7 @@ describe('llm-d routing configuration extensions', () => {
   });
 });
 
-const applyFieldId = (ext: unknown): string | undefined => {
+const getFieldIdForApplyExtension = (ext: unknown): string | undefined => {
   const e = ext as { type?: string; properties?: { fieldId?: string } };
   return e.type === 'model-serving.deployment/wizard-field-apply'
     ? e.properties?.fieldId
@@ -212,7 +212,7 @@ const applyFieldId = (ext: unknown): string | undefined => {
 
 describe('llmd-serving apply extension ordering', () => {
   it('registers the accelerator apply after the topology config apply', () => {
-    const applyIds = extensions.map(applyFieldId).filter(Boolean) as string[];
+    const applyIds = extensions.map(getFieldIdForApplyExtension).filter(Boolean) as string[];
     const topoIdx = applyIds.indexOf('llmd-serving/custom-topology-config');
     const accelIdx = applyIds.indexOf('llmd-serving/accelerator-config');
     expect(topoIdx).toBeGreaterThanOrEqual(0);

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -267,7 +267,7 @@ export const topologyConfigsExtensions: TopologyConfigsExtensionsType[] = [
     flags: {
       required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
     },
-  },
+  } satisfies WizardFieldDeploymentFunctionsExtension<CustomTopologyConfigFieldData, LLMdDeployment>,
   // ─── Router config ──────────────────────────────────────────────────
   {
     type: 'model-serving.deployment/wizard-field',
@@ -345,7 +345,7 @@ export const topologyConfigsExtensions: TopologyConfigsExtensionsType[] = [
       postDeploy: null,
     },
     flags: { required: [SupportedArea.LLMD_SERVING, SupportedArea.VLLM_ON_MAAS] },
-  },
+  } satisfies WizardFieldDeploymentFunctionsExtension<AcceleratorConfigFieldData, LLMdDeployment>,
 ];
 
 const deploymentMethodExtractorExtensionLllmdOnly: WizardFieldExtractorExtension<

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -41,6 +41,10 @@ import type {
   GatewaySelectFieldData,
   GatewaySelectFieldType,
 } from '../src/wizardFields/gateway/GatewaySelectField';
+import type {
+  AcceleratorConfigFieldData,
+  AcceleratorConfigFieldType,
+} from '../src/wizardFields/AcceleratorConfigField';
 
 export const LLMD_SERVING_ID = 'llmd-serving';
 const ADMIN_USER = 'ADMIN_USER';
@@ -174,7 +178,12 @@ export type TopologyConfigsExtensionsType =
   // Router config
   | WizardFieldExtension<AdvancedRoutingFieldType, LLMdDeployment>
   | WizardFieldApplyExtension<AdvancedRoutingFieldData, LLMdDeployment>
-  | WizardFieldExtractorExtension<AdvancedRoutingFieldData, LLMdDeployment>;
+  | WizardFieldExtractorExtension<AdvancedRoutingFieldData, LLMdDeployment>
+  // Accelerator config
+  | WizardFieldExtension<AcceleratorConfigFieldType, LLMdDeployment>
+  | WizardFieldApplyExtension<AcceleratorConfigFieldData, LLMdDeployment>
+  | WizardFieldExtractorExtension<AcceleratorConfigFieldData, LLMdDeployment>
+  | WizardFieldDeploymentFunctionsExtension<AcceleratorConfigFieldData, LLMdDeployment>;
 
 export const topologyConfigsExtensions: TopologyConfigsExtensionsType[] = [
   // ─── Topology type ──────────────────────────────────────────────────
@@ -295,6 +304,48 @@ export const topologyConfigsExtensions: TopologyConfigsExtensionsType[] = [
       required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
     },
   } satisfies WizardFieldExtractorExtension<AdvancedRoutingFieldData, LLMdDeployment>,
+  // ─── Accelerator config ─────────────────────────────
+  {
+    type: 'model-serving.deployment/wizard-field',
+    properties: {
+      platform: LLMD_SERVING_ID,
+      field: () =>
+        import('../src/wizardFields/AcceleratorConfigField').then(
+          (m) => m.AcceleratorConfigFieldWizardField,
+        ),
+    },
+    flags: { required: [SupportedArea.LLMD_SERVING, SupportedArea.VLLM_ON_MAAS] },
+  } satisfies WizardFieldExtension<AcceleratorConfigFieldType, LLMdDeployment>,
+  {
+    type: 'model-serving.deployment/wizard-field-apply',
+    properties: {
+      fieldId: 'llmd-serving/accelerator-config',
+      platform: LLMD_SERVING_ID,
+      apply: () => import('../src/deployments/accelerator').then((m) => m.applyAcceleratorConfig),
+    },
+    flags: { required: [SupportedArea.LLMD_SERVING, SupportedArea.VLLM_ON_MAAS] },
+  } satisfies WizardFieldApplyExtension<AcceleratorConfigFieldData, LLMdDeployment>,
+  {
+    type: 'model-serving.deployment/wizard-field-extractor',
+    properties: {
+      fieldId: 'llmd-serving/accelerator-config',
+      platform: LLMD_SERVING_ID,
+      extract: () =>
+        import('../src/deployments/accelerator').then((m) => m.extractAcceleratorConfig),
+    },
+    flags: { required: [SupportedArea.LLMD_SERVING, SupportedArea.VLLM_ON_MAAS] },
+  } satisfies WizardFieldExtractorExtension<AcceleratorConfigFieldData, LLMdDeployment>,
+  {
+    type: 'model-serving.deployment/wizard-field-deployment-functions',
+    properties: {
+      fieldId: 'llmd-serving/accelerator-config',
+      platform: LLMD_SERVING_ID,
+      preDeploy: () =>
+        import('../src/deployments/accelerator').then((m) => m.preDeployAcceleratorConfig),
+      postDeploy: null,
+    },
+    flags: { required: [SupportedArea.LLMD_SERVING, SupportedArea.VLLM_ON_MAAS] },
+  },
 ];
 
 const deploymentMethodExtractorExtensionLllmdOnly: WizardFieldExtractorExtension<

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -267,7 +267,10 @@ export const topologyConfigsExtensions: TopologyConfigsExtensionsType[] = [
     flags: {
       required: [SupportedArea.LLMD_SERVING, SupportedArea.LLMD_TOPOLOGY_CONFIGS],
     },
-  } satisfies WizardFieldDeploymentFunctionsExtension<CustomTopologyConfigFieldData, LLMdDeployment>,
+  } satisfies WizardFieldDeploymentFunctionsExtension<
+    CustomTopologyConfigFieldData,
+    LLMdDeployment
+  >,
   // ─── Router config ──────────────────────────────────────────────────
   {
     type: 'model-serving.deployment/wizard-field',

--- a/packages/llmd-serving/src/api/LLMdDeployment.ts
+++ b/packages/llmd-serving/src/api/LLMdDeployment.ts
@@ -4,6 +4,7 @@ import { deleteLLMInferenceServiceConfig } from './LLMInferenceServiceConfigs';
 import {
   LLMInferenceServiceModel,
   TOPOLOGY_CONFIG_REF_ANNOTATION,
+  ACCELERATOR_CONFIG_REF_ANNOTATION,
   type LLMdDeployment,
 } from '../types';
 
@@ -17,24 +18,31 @@ export const deleteDeployment = async (deployment: LLMdDeployment): Promise<void
     }),
   ];
 
-  // The accelerator config copy shares the deployment's name
+  // The simple-vLLM config copy shares the deployment's name
   const hasMatchingConfig = deployment.model.spec.baseRefs?.some((ref) => ref.name === name);
   if (hasMatchingConfig) {
     deletions.push(deleteLLMInferenceServiceConfig(name, namespace));
   }
 
-  // The local copy of the topology config is recorded on the deployment by annotation
-  const topologyConfigName =
-    deployment.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION];
-  if (topologyConfigName && topologyConfigName !== name) {
-    deletions.push(
-      deleteLLMInferenceServiceConfig(topologyConfigName, namespace).catch((e: unknown) => {
-        // Don't block the deletion if not found. It could be in the global namespace by accident
-        if (getGenericErrorCode(e) !== 404) {
-          throw e;
-        }
-      }),
-    );
+  // Local copies of admin configs are recorded on the deployment by annotation. Each is created
+  // in the deployment's own namespace at deploy time and must be cleaned up on delete.
+  // RHOAIENG-79541 will add ROUTING_CONFIG_REF_ANNOTATION here once routing configs also copy.
+  const CONFIG_COPY_ANNOTATIONS = [
+    TOPOLOGY_CONFIG_REF_ANNOTATION,
+    ACCELERATOR_CONFIG_REF_ANNOTATION,
+  ];
+  for (const annotationKey of CONFIG_COPY_ANNOTATIONS) {
+    const configName = deployment.model.metadata.annotations?.[annotationKey];
+    if (configName && configName !== name) {
+      deletions.push(
+        deleteLLMInferenceServiceConfig(configName, namespace).catch((e: unknown) => {
+          // Don't block the deletion if not found. It could be in the global namespace by accident
+          if (getGenericErrorCode(e) !== 404) {
+            throw e;
+          }
+        }),
+      );
+    }
   }
 
   await Promise.all(deletions);

--- a/packages/llmd-serving/src/api/__tests__/LLMdDeployment.spec.ts
+++ b/packages/llmd-serving/src/api/__tests__/LLMdDeployment.spec.ts
@@ -6,6 +6,7 @@ import {
   LLMInferenceServiceConfigModel,
   LLMInferenceServiceModel,
   TOPOLOGY_CONFIG_REF_ANNOTATION,
+  ACCELERATOR_CONFIG_REF_ANNOTATION,
   type LLMdDeployment,
   type LLMInferenceServiceKind,
 } from '../../types';
@@ -119,6 +120,25 @@ describe('deleteDeployment', () => {
     );
 
     expect(deletedNames(LLMInferenceServiceConfigModel)).toEqual([DEPLOYMENT_NAME]);
+  });
+
+  it('should delete the local accelerator config copy named by the annotation', async () => {
+    const localConfigName = `${DEPLOYMENT_NAME}-rocm`;
+    await deleteDeployment(
+      makeDeployment({
+        baseRefs: [{ name: localConfigName }],
+        annotations: { [ACCELERATOR_CONFIG_REF_ANNOTATION]: localConfigName },
+      }),
+    );
+
+    expect(deletedNames(LLMInferenceServiceModel)).toEqual([DEPLOYMENT_NAME]);
+    expect(deletedNames(LLMInferenceServiceConfigModel)).toEqual([localConfigName]);
+    expect(mockK8sDeleteResource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: LLMInferenceServiceConfigModel,
+        queryOptions: expect.objectContaining({ name: localConfigName, ns: NAMESPACE }),
+      }),
+    );
   });
 
   it('should not block deletion when the topology config is not found', async () => {

--- a/packages/llmd-serving/src/const.ts
+++ b/packages/llmd-serving/src/const.ts
@@ -10,9 +10,11 @@ export const DASHBOARD_RESOURCE_LABEL = 'opendatahub.io/dashboard';
 export const TOPOLOGY_TYPE_ANNOTATION = 'opendatahub.io/topology-type';
 export const TOPOLOGY_CONFIG_REF_ANNOTATION = 'opendatahub.io/topology-config-ref';
 export const ROUTING_CONFIG_REF_ANNOTATION = 'opendatahub.io/routing-config-ref';
+export const ACCELERATOR_CONFIG_REF_ANNOTATION = 'opendatahub.io/accelerator-config-ref';
 export const VLLM_ADDITIONAL_ARGS = 'VLLM_ADDITIONAL_ARGS';
 
 // --- Wizard field ids (declared here so fields can reference each other without import cycles) ---
 
 export const TOPOLOGY_TYPE_FIELD_ID = 'llmd-serving/topology-type';
 export const CUSTOM_TOPOLOGY_CONFIG_FIELD_ID = 'llmd-serving/custom-topology-config';
+export const ACCELERATOR_CONFIG_FIELD_ID = 'llmd-serving/accelerator-config';

--- a/packages/llmd-serving/src/const.ts
+++ b/packages/llmd-serving/src/const.ts
@@ -19,7 +19,7 @@ export const TOPOLOGY_TYPE_FIELD_ID = 'llmd-serving/topology-type';
 export const CUSTOM_TOPOLOGY_CONFIG_FIELD_ID = 'llmd-serving/custom-topology-config';
 export const ACCELERATOR_CONFIG_FIELD_ID = 'llmd-serving/accelerator-config';
 
-// Sentinel persisted when the user keeps the built-in image instead of an accelerator config.
+// Placeholder value persisted when the user keeps the built-in image instead of an accelerator config.
 // Uses characters that are invalid in a Kubernetes object name, so it can never collide with a
 // real LLMInferenceServiceConfig name. Lives here (not in the field module) so the deploy path can
 // reference it without importing React.

--- a/packages/llmd-serving/src/const.ts
+++ b/packages/llmd-serving/src/const.ts
@@ -18,3 +18,9 @@ export const VLLM_ADDITIONAL_ARGS = 'VLLM_ADDITIONAL_ARGS';
 export const TOPOLOGY_TYPE_FIELD_ID = 'llmd-serving/topology-type';
 export const CUSTOM_TOPOLOGY_CONFIG_FIELD_ID = 'llmd-serving/custom-topology-config';
 export const ACCELERATOR_CONFIG_FIELD_ID = 'llmd-serving/accelerator-config';
+
+// Sentinel persisted when the user keeps the built-in image instead of an accelerator config.
+// Uses characters that are invalid in a Kubernetes object name, so it can never collide with a
+// real LLMInferenceServiceConfig name. Lives here (not in the field module) so the deploy path can
+// reference it without importing React.
+export const ACCELERATOR_CONFIG_DEFAULT = '__built-in-image__' as const;

--- a/packages/llmd-serving/src/deployments/__tests__/accelerator.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/accelerator.spec.ts
@@ -1,5 +1,5 @@
 import { applyAcceleratorConfig, extractAcceleratorConfig } from '../accelerator';
-import { ACCELERATOR_CONFIG_DEFAULT } from '../../wizardFields/AcceleratorConfigField';
+import { ACCELERATOR_CONFIG_DEFAULT } from '../../const';
 import {
   ACCELERATOR_CONFIG_REF_ANNOTATION,
   type LLMdDeployment,

--- a/packages/llmd-serving/src/deployments/__tests__/accelerator.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/accelerator.spec.ts
@@ -41,7 +41,7 @@ describe('applyAcceleratorConfig', () => {
     expect(result.model.spec.router?.scheduler).toEqual({});
   });
 
-  it('adds no baseRef for the built-in (sentinel) selection', () => {
+  it('adds no baseRef for the built-in (placeholder) selection', () => {
     const result = applyAcceleratorConfig(makeDeployment(), {
       selectedConfig: ACCELERATOR_CONFIG_DEFAULT,
     });

--- a/packages/llmd-serving/src/deployments/__tests__/accelerator.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/accelerator.spec.ts
@@ -1,0 +1,76 @@
+import { applyAcceleratorConfig, extractAcceleratorConfig } from '../accelerator';
+import { ACCELERATOR_CONFIG_DEFAULT } from '../../wizardFields/AcceleratorConfigField';
+import {
+  ACCELERATOR_CONFIG_REF_ANNOTATION,
+  type LLMdDeployment,
+  type LLMInferenceServiceConfigKind,
+} from '../../types';
+import { applyTopologyConfig } from '../topology';
+
+const makeDeployment = (): LLMdDeployment => ({
+  modelServingPlatformId: 'llmd-serving',
+  model: {
+    apiVersion: 'serving.kserve.io/v1alpha2',
+    kind: 'LLMInferenceService',
+    metadata: { name: 'my-deployment', namespace: 'ns', annotations: {} },
+    spec: { model: { uri: '', name: 'my-deployment' }, router: { scheduler: {} } },
+  },
+});
+
+const makeConfig = (name: string): LLMInferenceServiceConfigKind => ({
+  apiVersion: 'serving.kserve.io/v1alpha2',
+  kind: 'LLMInferenceServiceConfig',
+  metadata: { name, namespace: 'dashboard', labels: {} },
+});
+
+describe('applyAcceleratorConfig', () => {
+  it('adds the accelerator baseRef and annotation', () => {
+    const result = applyAcceleratorConfig(makeDeployment(), {
+      selectedConfig: makeConfig('rocm'),
+    });
+    expect(result.model.spec.baseRefs).toEqual([{ name: 'my-deployment-rocm' }]);
+    expect(result.model.metadata.annotations?.[ACCELERATOR_CONFIG_REF_ANNOTATION]).toBe(
+      'my-deployment-rocm',
+    );
+  });
+
+  it('keeps spec.router.scheduler (stays llm-d)', () => {
+    const result = applyAcceleratorConfig(makeDeployment(), {
+      selectedConfig: makeConfig('rocm'),
+    });
+    expect(result.model.spec.router?.scheduler).toEqual({});
+  });
+
+  it('adds no baseRef for the built-in (sentinel) selection', () => {
+    const result = applyAcceleratorConfig(makeDeployment(), {
+      selectedConfig: ACCELERATOR_CONFIG_DEFAULT,
+    });
+    expect(result.model.spec.baseRefs ?? []).toEqual([]);
+  });
+
+  it('appends the accelerator ref AFTER the topology ref', () => {
+    // Simulate apply order: topology first, then accelerator
+    let d = applyTopologyConfig(makeDeployment(), {
+      selectedConfig: makeConfig('single-node'),
+    });
+    d = applyAcceleratorConfig(d, { selectedConfig: makeConfig('rocm') });
+    expect(d.model.spec.baseRefs).toEqual([
+      { name: 'my-deployment-single-node' },
+      { name: 'my-deployment-rocm' },
+    ]);
+  });
+});
+
+describe('extractAcceleratorConfig', () => {
+  it('returns configRef from the annotation', () => {
+    const d = makeDeployment();
+    d.model.metadata.annotations = {
+      [ACCELERATOR_CONFIG_REF_ANNOTATION]: 'my-deployment-rocm',
+    };
+    expect(extractAcceleratorConfig(d)).toEqual({ configRef: 'my-deployment-rocm' });
+  });
+
+  it('returns undefined when the annotation is absent', () => {
+    expect(extractAcceleratorConfig(makeDeployment())).toBeUndefined();
+  });
+});

--- a/packages/llmd-serving/src/deployments/__tests__/configs.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/configs.spec.ts
@@ -58,12 +58,12 @@ describe('applyConfigRef', () => {
     expect(next.model.metadata.annotations?.[ANN]).toBe('my-deployment-accel-b');
   });
 
-  it('removes the ref and annotation for a sentinel selection', () => {
+  it('removes the ref and annotation for a placeholder selection', () => {
     const prev = applyConfigRef(makeDeployment(), { selectedConfig: makeConfig('accel-a') }, opts);
     const next = applyConfigRef(
       prev,
       { selectedConfig: 'default' },
-      { ...opts, isSentinel: (c) => c === 'default' },
+      { ...opts, isDefaultPlaceholder: (c) => c === 'default' },
     );
     expect(next.model.spec.baseRefs ?? []).toEqual([]);
     expect(next.model.metadata.annotations?.[ANN]).toBeUndefined();
@@ -155,9 +155,9 @@ describe('preDeployConfigCopy', () => {
     expect(deleteSpy).not.toHaveBeenCalled();
   });
 
-  it('does not clone for a sentinel selection', async () => {
+  it('does not clone for a placeholder selection', async () => {
     await preDeployConfigCopy(
-      { annotationKey: ANN, isSentinel: (c) => c === 'default' },
+      { annotationKey: ANN, isDefaultPlaceholder: (c) => c === 'default' },
       { selectedConfig: 'default' },
       withAnnotation(undefined),
     );

--- a/packages/llmd-serving/src/deployments/__tests__/configs.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/configs.spec.ts
@@ -1,0 +1,165 @@
+import { K8sStatusError } from '@odh-dashboard/k8s-core';
+import { applyConfigRef, createLocalConfigName, preDeployConfigCopy } from '../configs';
+import { type LLMdDeployment, type LLMInferenceServiceConfigKind } from '../../types';
+import * as configApi from '../../api/LLMInferenceServiceConfigs';
+
+jest.mock('../../api/LLMInferenceServiceConfigs');
+
+const createSpy = jest.mocked(configApi.createLLMInferenceServiceConfig);
+const deleteSpy = jest.mocked(configApi.deleteLLMInferenceServiceConfig);
+
+const ANN = 'opendatahub.io/test-config-ref';
+
+const makeDeployment = (overrides?: Partial<LLMdDeployment['model']['spec']>): LLMdDeployment => ({
+  modelServingPlatformId: 'llmd-serving',
+  model: {
+    apiVersion: 'serving.kserve.io/v1alpha2',
+    kind: 'LLMInferenceService',
+    metadata: { name: 'my-deployment', namespace: 'ns', annotations: {} },
+    spec: { model: { uri: '', name: 'my-deployment' }, router: { scheduler: {} }, ...overrides },
+  },
+});
+
+const makeConfig = (name: string): LLMInferenceServiceConfigKind => ({
+  apiVersion: 'serving.kserve.io/v1alpha2',
+  kind: 'LLMInferenceServiceConfig',
+  metadata: { name, namespace: 'dashboard', labels: {} },
+});
+
+const opts = {
+  annotationKey: ANN,
+  configName: createLocalConfigName,
+};
+
+describe('applyConfigRef', () => {
+  it('adds a baseRef and annotation for a selected config', () => {
+    const result = applyConfigRef(
+      makeDeployment(),
+      { selectedConfig: makeConfig('accel-a') },
+      opts,
+    );
+    expect(result.model.spec.baseRefs).toEqual([{ name: 'my-deployment-accel-a' }]);
+    expect(result.model.metadata.annotations?.[ANN]).toBe('my-deployment-accel-a');
+  });
+
+  it('does not touch spec.router.scheduler', () => {
+    const result = applyConfigRef(
+      makeDeployment(),
+      { selectedConfig: makeConfig('accel-a') },
+      opts,
+    );
+    expect(result.model.spec.router?.scheduler).toEqual({});
+  });
+
+  it('replaces a previous ref when switching configs', () => {
+    const prev = applyConfigRef(makeDeployment(), { selectedConfig: makeConfig('accel-a') }, opts);
+    const next = applyConfigRef(prev, { selectedConfig: makeConfig('accel-b') }, opts);
+    expect(next.model.spec.baseRefs).toEqual([{ name: 'my-deployment-accel-b' }]);
+    expect(next.model.metadata.annotations?.[ANN]).toBe('my-deployment-accel-b');
+  });
+
+  it('removes the ref and annotation for a sentinel selection', () => {
+    const prev = applyConfigRef(makeDeployment(), { selectedConfig: makeConfig('accel-a') }, opts);
+    const next = applyConfigRef(
+      prev,
+      { selectedConfig: 'default' },
+      { ...opts, isSentinel: (c) => c === 'default' },
+    );
+    expect(next.model.spec.baseRefs ?? []).toEqual([]);
+    expect(next.model.metadata.annotations?.[ANN]).toBeUndefined();
+  });
+
+  it('leaves the deployment unchanged when configRef is set but unresolved', () => {
+    const deployment = makeDeployment();
+    const result = applyConfigRef(deployment, { configRef: 'x' }, opts);
+    expect(result).toEqual(deployment);
+  });
+});
+
+describe('preDeployConfigCopy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createSpy.mockResolvedValue({} as LLMInferenceServiceConfigKind);
+    deleteSpy.mockResolvedValue({} as never);
+  });
+
+  const withAnnotation = (name?: string): LLMdDeployment => {
+    const d = makeDeployment();
+    d.model.metadata.annotations = name ? { [ANN]: name } : {};
+    return d;
+  };
+
+  it('clones the selected config into the deployment namespace', async () => {
+    await preDeployConfigCopy(
+      { annotationKey: ANN },
+      { selectedConfig: makeConfig('accel-a') },
+      withAnnotation('my-deployment-accel-a'),
+    );
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    const [created] = createSpy.mock.calls[0];
+    expect(created.metadata.name).toBe('my-deployment-accel-a');
+    expect(created.metadata.namespace).toBe('ns');
+  });
+
+  it('deletes the old copy when switching configs', async () => {
+    await preDeployConfigCopy(
+      { annotationKey: ANN },
+      { selectedConfig: makeConfig('accel-b') },
+      withAnnotation('my-deployment-accel-b'),
+      withAnnotation('my-deployment-accel-a'),
+    );
+    expect(deleteSpy).toHaveBeenCalledWith('my-deployment-accel-a', 'ns', { dryRun: undefined });
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not clone for a sentinel selection', async () => {
+    await preDeployConfigCopy(
+      { annotationKey: ANN, isSentinel: (c) => c === 'default' },
+      { selectedConfig: 'default' },
+      withAnnotation(undefined),
+    );
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows a 409 on create', async () => {
+    createSpy.mockRejectedValue(
+      new K8sStatusError({
+        apiVersion: 'v1',
+        kind: 'Status',
+        status: 'Failure',
+        code: 409,
+        message: 'already exists',
+        reason: 'AlreadyExists',
+      }),
+    );
+    await expect(
+      preDeployConfigCopy(
+        { annotationKey: ANN },
+        { selectedConfig: makeConfig('accel-a') },
+        withAnnotation('my-deployment-accel-a'),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it('swallows a 404 on delete', async () => {
+    deleteSpy.mockRejectedValue(
+      new K8sStatusError({
+        apiVersion: 'v1',
+        kind: 'Status',
+        status: 'Failure',
+        code: 404,
+        message: 'not found',
+        reason: 'NotFound',
+      }),
+    );
+    await expect(
+      preDeployConfigCopy(
+        { annotationKey: ANN },
+        { selectedConfig: makeConfig('accel-b') },
+        withAnnotation('my-deployment-accel-b'),
+        withAnnotation('my-deployment-accel-a'),
+      ),
+    ).resolves.toBeDefined();
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/llmd-serving/src/deployments/__tests__/configs.spec.ts
+++ b/packages/llmd-serving/src/deployments/__tests__/configs.spec.ts
@@ -112,6 +112,49 @@ describe('preDeployConfigCopy', () => {
     expect(createSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('creates the new copy before deleting the old one', async () => {
+    const order: string[] = [];
+    createSpy.mockImplementation(async () => {
+      order.push('create');
+      return {} as LLMInferenceServiceConfigKind;
+    });
+    deleteSpy.mockImplementation(async () => {
+      order.push('delete');
+      return {} as never;
+    });
+    await preDeployConfigCopy(
+      { annotationKey: ANN },
+      { selectedConfig: makeConfig('accel-b') },
+      withAnnotation('my-deployment-accel-b'),
+      withAnnotation('my-deployment-accel-a'),
+    );
+    expect(order).toEqual(['create', 'delete']);
+  });
+
+  it('does not delete the old copy when creating the new one fails', async () => {
+    // A non-409 create failure must leave the previous copy intact so the deployment never ends up
+    // referencing a config that was already deleted.
+    createSpy.mockRejectedValue(
+      new K8sStatusError({
+        apiVersion: 'v1',
+        kind: 'Status',
+        status: 'Failure',
+        code: 500,
+        message: 'server error',
+        reason: 'InternalError',
+      }),
+    );
+    await expect(
+      preDeployConfigCopy(
+        { annotationKey: ANN },
+        { selectedConfig: makeConfig('accel-b') },
+        withAnnotation('my-deployment-accel-b'),
+        withAnnotation('my-deployment-accel-a'),
+      ),
+    ).rejects.toThrow();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
   it('does not clone for a sentinel selection', async () => {
     await preDeployConfigCopy(
       { annotationKey: ANN, isSentinel: (c) => c === 'default' },

--- a/packages/llmd-serving/src/deployments/accelerator.ts
+++ b/packages/llmd-serving/src/deployments/accelerator.ts
@@ -2,10 +2,8 @@ import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/f
 import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
 import { applyConfigRef, createLocalConfigName, preDeployConfigCopy } from './configs';
 import { ACCELERATOR_CONFIG_REF_ANNOTATION, type LLMdDeployment } from '../types';
-import {
-  ACCELERATOR_CONFIG_DEFAULT,
-  type AcceleratorConfigFieldData,
-} from '../wizardFields/AcceleratorConfigField';
+import { ACCELERATOR_CONFIG_DEFAULT } from '../const';
+import type { AcceleratorConfigFieldData } from '../wizardFields/AcceleratorConfigField';
 
 const isSentinel = (c: unknown): boolean => c === ACCELERATOR_CONFIG_DEFAULT;
 

--- a/packages/llmd-serving/src/deployments/accelerator.ts
+++ b/packages/llmd-serving/src/deployments/accelerator.ts
@@ -1,11 +1,16 @@
 import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
 import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
 import { applyConfigRef, createLocalConfigName, preDeployConfigCopy } from './configs';
-import { ACCELERATOR_CONFIG_REF_ANNOTATION, type LLMdDeployment } from '../types';
+import {
+  ACCELERATOR_CONFIG_REF_ANNOTATION,
+  LLMInferenceServiceConfigKind,
+  type LLMdDeployment,
+} from '../types';
 import { ACCELERATOR_CONFIG_DEFAULT } from '../const';
 import type { AcceleratorConfigFieldData } from '../wizardFields/AcceleratorConfigField';
 
-const isSentinel = (c: unknown): boolean => c === ACCELERATOR_CONFIG_DEFAULT;
+const isDefaultPlaceholder = (c: string | LLMInferenceServiceConfigKind): boolean =>
+  c === ACCELERATOR_CONFIG_DEFAULT;
 
 export const applyAcceleratorConfig = (
   deployment: LLMdDeployment,
@@ -14,7 +19,7 @@ export const applyAcceleratorConfig = (
   applyConfigRef(deployment, fieldData, {
     annotationKey: ACCELERATOR_CONFIG_REF_ANNOTATION,
     configName: createLocalConfigName,
-    isSentinel,
+    isDefaultPlaceholder,
   });
 
 export const preDeployAcceleratorConfig = (
@@ -25,7 +30,7 @@ export const preDeployAcceleratorConfig = (
   dryRun?: boolean,
 ): Promise<DeploymentHookPayloadFor<LLMdDeployment>> =>
   preDeployConfigCopy(
-    { annotationKey: ACCELERATOR_CONFIG_REF_ANNOTATION, isSentinel },
+    { annotationKey: ACCELERATOR_CONFIG_REF_ANNOTATION, isDefaultPlaceholder },
     fieldData,
     deployment,
     existingDeployment,

--- a/packages/llmd-serving/src/deployments/accelerator.ts
+++ b/packages/llmd-serving/src/deployments/accelerator.ts
@@ -1,0 +1,45 @@
+import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
+import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
+import { applyConfigRef, createLocalConfigName, preDeployConfigCopy } from './configs';
+import { ACCELERATOR_CONFIG_REF_ANNOTATION, type LLMdDeployment } from '../types';
+import {
+  ACCELERATOR_CONFIG_DEFAULT,
+  type AcceleratorConfigFieldData,
+} from '../wizardFields/AcceleratorConfigField';
+
+const isSentinel = (c: unknown): boolean => c === ACCELERATOR_CONFIG_DEFAULT;
+
+export const applyAcceleratorConfig = (
+  deployment: LLMdDeployment,
+  fieldData?: AcceleratorConfigFieldData,
+): LLMdDeployment =>
+  applyConfigRef(deployment, fieldData, {
+    annotationKey: ACCELERATOR_CONFIG_REF_ANNOTATION,
+    configName: createLocalConfigName,
+    isSentinel,
+  });
+
+export const preDeployAcceleratorConfig = (
+  fieldData: AcceleratorConfigFieldData,
+  wizardState: WizardFormData['state'],
+  deployment: DeploymentHookPayloadFor<LLMdDeployment>,
+  existingDeployment?: LLMdDeployment,
+  dryRun?: boolean,
+): Promise<DeploymentHookPayloadFor<LLMdDeployment>> =>
+  preDeployConfigCopy(
+    { annotationKey: ACCELERATOR_CONFIG_REF_ANNOTATION, isSentinel },
+    fieldData,
+    deployment,
+    existingDeployment,
+    dryRun,
+  );
+
+export const extractAcceleratorConfig = (
+  deployment: LLMdDeployment,
+): AcceleratorConfigFieldData | undefined => {
+  const configRef = deployment.model.metadata.annotations?.[ACCELERATOR_CONFIG_REF_ANNOTATION];
+  if (!configRef) {
+    return undefined;
+  }
+  return { configRef };
+};

--- a/packages/llmd-serving/src/deployments/configs.ts
+++ b/packages/llmd-serving/src/deployments/configs.ts
@@ -144,18 +144,13 @@ export const preDeployConfigCopy = async (
   const prevName = existingDeployment?.model.metadata.annotations?.[options.annotationKey];
   const newName = deployment.model.metadata.annotations?.[options.annotationKey];
 
-  if (prevName && prevName !== newName) {
-    await deleteLLMInferenceServiceConfig(prevName, namespace, { dryRun }).catch((e: unknown) => {
-      // Don't block if not found. It could be in the global namespace by accident
-      if (getGenericErrorCode(e) !== 404) {
-        throw e;
-      }
-    });
-  }
-
   const config = fieldData.selectedConfig;
   const isRealConfig =
     config !== undefined && typeof config !== 'string' && !options.isSentinel?.(config);
+
+  // Create the new local copy BEFORE deleting the previous one, so a failed create never leaves the
+  // deployment referencing a config we already removed. Delete-on-switch happens only after the new
+  // copy exists (or when switching to a sentinel, which has nothing to create).
   if (isRealConfig && newName) {
     const copy = cleanlyDuplicateConfig(config, {
       name: newName,
@@ -165,6 +160,15 @@ export const preDeployConfigCopy = async (
     await createLLMInferenceServiceConfig(copy, { dryRun }).catch((e: unknown) => {
       // Don't block if it already exists
       if (getGenericErrorCode(e) !== 409) {
+        throw e;
+      }
+    });
+  }
+
+  if (prevName && prevName !== newName) {
+    await deleteLLMInferenceServiceConfig(prevName, namespace, { dryRun }).catch((e: unknown) => {
+      // Don't block if not found. It could be in the global namespace by accident
+      if (getGenericErrorCode(e) !== 404) {
         throw e;
       }
     });

--- a/packages/llmd-serving/src/deployments/configs.ts
+++ b/packages/llmd-serving/src/deployments/configs.ts
@@ -1,0 +1,174 @@
+import {
+  getDescriptionFromK8sResource,
+  getDisplayNameFromK8sResource,
+} from '@odh-dashboard/k8s-core';
+import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
+import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
+import { CONFIG_TYPE_LABEL, type LLMdDeployment, LLMInferenceServiceConfigKind } from '../types';
+import {
+  createLLMInferenceServiceConfig,
+  deleteLLMInferenceServiceConfig,
+} from '../api/LLMInferenceServiceConfigs';
+import { cleanlyDuplicateConfig } from '../utils';
+
+/** K8s DNS subdomain limit for resource names */
+const MAX_K8S_NAME_LENGTH = 253;
+
+/**
+ * Name for a deployment-local copy of an admin config: `{deployment}-{config}`, truncated to the
+ * k8s name limit. Idempotent if the config name is already prefixed.
+ */
+export const createLocalConfigName = (
+  deployment: LLMdDeployment,
+  config: LLMInferenceServiceConfigKind,
+): string => {
+  const prefix = `${deployment.model.metadata.name}-`;
+  if (config.metadata.name.startsWith(prefix)) {
+    return config.metadata.name;
+  }
+  // Truncate the config portion so the prefixed name stays creatable; a trailing hyphen left
+  // behind by the cut is not a valid k8s name, so strip it
+  return `${prefix}${config.metadata.name}`.slice(0, MAX_K8S_NAME_LENGTH).replace(/-+$/, '');
+};
+
+/**
+ * Metadata for a deployment-local copy of an admin config. Carries over the config-type label
+ * (so the copy's topology type is still discoverable) and marks the display name as a local copy.
+ */
+export const createLocalConfigMetadata = (
+  config: LLMInferenceServiceConfigKind,
+): { annotations: Record<string, string>; labels: Record<string, string> } => {
+  const configType = config.metadata.labels?.[CONFIG_TYPE_LABEL];
+  return {
+    annotations: {
+      'openshift.io/display-name': `${getDisplayNameFromK8sResource(config)} (Local Copy)`,
+      'openshift.io/description': getDescriptionFromK8sResource(config),
+    },
+    labels: {
+      ...(configType && { [CONFIG_TYPE_LABEL]: configType }),
+    },
+  };
+};
+
+// ─── Apply: Config Ref ──────────────────────────────────────────────────────
+
+type ConfigRefFieldData = {
+  selectedConfig?: LLMInferenceServiceConfigKind | string;
+  configRef?: string;
+};
+
+export type ApplyConfigRefOptions = {
+  /** The annotation used to track which baseRef belongs to this config kind. */
+  annotationKey: string;
+  /** Produces the baseRef name for the selected config (usually createLocalConfigName). */
+  configName: (deployment: LLMdDeployment, config: LLMInferenceServiceConfigKind) => string;
+  /** True when the selection is a "no config" sentinel (e.g. topology default / built-in image). */
+  isSentinel?: (config: LLMInferenceServiceConfigKind | string) => boolean;
+};
+
+/**
+ * Swap the baseRef + tracking annotation for one kind of config on a deployment.
+ * - Removes any previously tracked ref for this annotation.
+ * - If a real (non-sentinel) config is selected, pushes its ref to the END of baseRefs and records
+ *   the annotation. baseRef ordering across config kinds is a registration-order concern (the
+ *   accelerator apply is registered after topology so its image wins).
+ * - Never touches spec.router.scheduler.
+ */
+export const applyConfigRef = (
+  deployment: LLMdDeployment,
+  fieldData: ConfigRefFieldData | undefined,
+  options: ApplyConfigRefOptions,
+): LLMdDeployment => {
+  // If a ref was extracted (edit) but not yet resolved to a config object, leave things alone to
+  // avoid dropping the existing ref.
+  if (fieldData?.configRef && !fieldData.selectedConfig) {
+    return deployment;
+  }
+
+  const result = structuredClone(deployment);
+  const annotations = { ...result.model.metadata.annotations };
+
+  const prevRef = annotations[options.annotationKey];
+  if (prevRef && result.model.spec.baseRefs) {
+    result.model.spec.baseRefs = result.model.spec.baseRefs.filter((r) => r.name !== prevRef);
+  }
+  delete annotations[options.annotationKey];
+
+  const config = fieldData?.selectedConfig;
+  const isRealConfig =
+    config !== undefined && typeof config !== 'string' && !options.isSentinel?.(config);
+  if (isRealConfig) {
+    const name = options.configName(result, config);
+    annotations[options.annotationKey] = name;
+    if (!result.model.spec.baseRefs) {
+      result.model.spec.baseRefs = [];
+    }
+    if (!result.model.spec.baseRefs.some((r) => r.name === name)) {
+      result.model.spec.baseRefs.push({ name });
+    }
+  }
+
+  result.model.metadata.annotations = annotations;
+  return result;
+};
+
+// ─── PreDeploy: Config Copy ─────────────────────────────────────────────────
+
+export type PreDeployConfigCopyOptions = {
+  /** The annotation used to track which deployment-local copy belongs to this config kind. */
+  annotationKey: string;
+  /** True when the selection is a "no config" sentinel (e.g. topology default / built-in image). */
+  isSentinel?: (config: LLMInferenceServiceConfigKind | string) => boolean;
+};
+
+/**
+ * Create/replace the deployment-local copy of one config kind.
+ * - Deletes the previously tracked copy when switching (404 ignored).
+ * - Clones the selected config into the deployment namespace (409 ignored).
+ * - No-op for a sentinel selection.
+ * Called twice by the wizard: first with dryRun=true, then for real.
+ */
+export const preDeployConfigCopy = async (
+  options: PreDeployConfigCopyOptions,
+  fieldData: { selectedConfig?: LLMInferenceServiceConfigKind | string },
+  deployment: DeploymentHookPayloadFor<LLMdDeployment>,
+  existingDeployment?: LLMdDeployment,
+  dryRun?: boolean,
+): Promise<DeploymentHookPayloadFor<LLMdDeployment>> => {
+  // The model resource may not be assembled yet on the pre-deploy hook payload; nothing to copy.
+  if (!deployment.model) {
+    return deployment;
+  }
+  const { namespace } = deployment.model.metadata;
+
+  const prevName = existingDeployment?.model.metadata.annotations?.[options.annotationKey];
+  const newName = deployment.model.metadata.annotations?.[options.annotationKey];
+
+  if (prevName && prevName !== newName) {
+    await deleteLLMInferenceServiceConfig(prevName, namespace, { dryRun }).catch((e: unknown) => {
+      // Don't block if not found. It could be in the global namespace by accident
+      if (getGenericErrorCode(e) !== 404) {
+        throw e;
+      }
+    });
+  }
+
+  const config = fieldData.selectedConfig;
+  const isRealConfig =
+    config !== undefined && typeof config !== 'string' && !options.isSentinel?.(config);
+  if (isRealConfig && newName) {
+    const copy = cleanlyDuplicateConfig(config, {
+      name: newName,
+      namespace,
+      ...createLocalConfigMetadata(config),
+    });
+    await createLLMInferenceServiceConfig(copy, { dryRun }).catch((e: unknown) => {
+      // Don't block if it already exists
+      if (getGenericErrorCode(e) !== 409) {
+        throw e;
+      }
+    });
+  }
+
+  return deployment;
+};

--- a/packages/llmd-serving/src/deployments/configs.ts
+++ b/packages/llmd-serving/src/deployments/configs.ts
@@ -62,14 +62,14 @@ export type ApplyConfigRefOptions = {
   annotationKey: string;
   /** Produces the baseRef name for the selected config (usually createLocalConfigName). */
   configName: (deployment: LLMdDeployment, config: LLMInferenceServiceConfigKind) => string;
-  /** True when the selection is a "no config" sentinel (e.g. topology default / built-in image). */
-  isSentinel?: (config: LLMInferenceServiceConfigKind | string) => boolean;
+  /** True when the selection is a "no config" placeholder (e.g. topology default / built-in image). */
+  isDefaultPlaceholder?: (config: LLMInferenceServiceConfigKind | string) => boolean;
 };
 
 /**
  * Swap the baseRef + tracking annotation for one kind of config on a deployment.
  * - Removes any previously tracked ref for this annotation.
- * - If a real (non-sentinel) config is selected, pushes its ref to the END of baseRefs and records
+ * - If a real (non-placeholder) config is selected, pushes its ref to the END of baseRefs and records
  *   the annotation. baseRef ordering across config kinds is a registration-order concern (the
  *   accelerator apply is registered after topology so its image wins).
  * - Never touches spec.router.scheduler.
@@ -96,7 +96,7 @@ export const applyConfigRef = (
 
   const config = fieldData?.selectedConfig;
   const isRealConfig =
-    config !== undefined && typeof config !== 'string' && !options.isSentinel?.(config);
+    config !== undefined && typeof config !== 'string' && !options.isDefaultPlaceholder?.(config);
   if (isRealConfig) {
     const name = options.configName(result, config);
     annotations[options.annotationKey] = name;
@@ -117,15 +117,15 @@ export const applyConfigRef = (
 export type PreDeployConfigCopyOptions = {
   /** The annotation used to track which deployment-local copy belongs to this config kind. */
   annotationKey: string;
-  /** True when the selection is a "no config" sentinel (e.g. topology default / built-in image). */
-  isSentinel?: (config: LLMInferenceServiceConfigKind | string) => boolean;
+  /** True when the selection is a "no config" placeholder (e.g. topology default / built-in image). */
+  isDefaultPlaceholder?: (config: LLMInferenceServiceConfigKind | string) => boolean;
 };
 
 /**
  * Create/replace the deployment-local copy of one config kind.
  * - Deletes the previously tracked copy when switching (404 ignored).
  * - Clones the selected config into the deployment namespace (409 ignored).
- * - No-op for a sentinel selection.
+ * - No-op for a placeholder selection.
  * Called twice by the wizard: first with dryRun=true, then for real.
  */
 export const preDeployConfigCopy = async (
@@ -146,11 +146,11 @@ export const preDeployConfigCopy = async (
 
   const config = fieldData.selectedConfig;
   const isRealConfig =
-    config !== undefined && typeof config !== 'string' && !options.isSentinel?.(config);
+    config !== undefined && typeof config !== 'string' && !options.isDefaultPlaceholder?.(config);
 
   // Create the new local copy BEFORE deleting the previous one, so a failed create never leaves the
   // deployment referencing a config we already removed. Delete-on-switch happens only after the new
-  // copy exists (or when switching to a sentinel, which has nothing to create).
+  // copy exists (or when switching to a placeholder, which has nothing to create).
   if (isRealConfig && newName) {
     const copy = cleanlyDuplicateConfig(config, {
       name: newName,

--- a/packages/llmd-serving/src/deployments/topology.ts
+++ b/packages/llmd-serving/src/deployments/topology.ts
@@ -43,7 +43,7 @@ export const applyTopologyConfig = (
   applyConfigRef(deployment, fieldData, {
     annotationKey: TOPOLOGY_CONFIG_REF_ANNOTATION,
     configName: createLocalConfigName,
-    isSentinel: (c) => c === TOPOLOGY_CONFIG_DEFAULT,
+    isDefaultPlaceholder: (c) => c === TOPOLOGY_CONFIG_DEFAULT,
   });
 
 // ─── PreDeploy: Topology Config ────────────────────────────────────────────────
@@ -58,7 +58,7 @@ export const preDeployTopologyConfig = (
   preDeployConfigCopy(
     {
       annotationKey: TOPOLOGY_CONFIG_REF_ANNOTATION,
-      isSentinel: (c) => c === TOPOLOGY_CONFIG_DEFAULT,
+      isDefaultPlaceholder: (c) => c === TOPOLOGY_CONFIG_DEFAULT,
     },
     fieldData,
     deployment,

--- a/packages/llmd-serving/src/deployments/topology.ts
+++ b/packages/llmd-serving/src/deployments/topology.ts
@@ -1,18 +1,12 @@
 import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
 import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
+import { applyConfigRef, createLocalConfigName, preDeployConfigCopy } from './configs';
 import {
-  getDescriptionFromK8sResource,
-  getDisplayNameFromK8sResource,
-} from '@odh-dashboard/k8s-core';
-import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
-import {
-  CONFIG_TYPE_LABEL,
   TOPOLOGY_TYPE_ANNOTATION,
   TOPOLOGY_CONFIG_REF_ANNOTATION,
   ROUTING_CONFIG_REF_ANNOTATION,
   TopologyType,
   type LLMdDeployment,
-  LLMInferenceServiceConfigKind,
 } from '../types';
 import type { TopologyTypeFieldData } from '../wizardFields/TopologyTypeField';
 import {
@@ -20,44 +14,8 @@ import {
   type CustomTopologyConfigFieldData,
 } from '../wizardFields/CustomTopologyConfigField';
 import type { AdvancedRoutingFieldData } from '../wizardFields/AdvancedRoutingField';
-import {
-  createLLMInferenceServiceConfig,
-  deleteLLMInferenceServiceConfig,
-} from '../api/LLMInferenceServiceConfigs';
-import { cleanlyDuplicateConfig } from '../utils';
 
 const topologyTypeValues: string[] = Object.values(TopologyType);
-
-/** K8s DNS subdomain limit for resource names */
-const MAX_K8S_NAME_LENGTH = 253;
-
-const createLocalConfigName = (
-  deployment: LLMdDeployment,
-  config: LLMInferenceServiceConfigKind,
-) => {
-  const prefix = `${deployment.model.metadata.name}-`;
-  if (config.metadata.name.startsWith(prefix)) {
-    return config.metadata.name;
-  }
-  // Truncate the config portion so the prefixed name stays creatable; a trailing hyphen left
-  // behind by the cut is not a valid k8s name, so strip it
-  return `${prefix}${config.metadata.name}`.slice(0, MAX_K8S_NAME_LENGTH).replace(/-+$/, '');
-};
-
-const createLocalConfigMetadata = (
-  config: LLMInferenceServiceConfigKind,
-): { annotations: Record<string, string>; labels: Record<string, string> } => {
-  const configType = config.metadata.labels?.[CONFIG_TYPE_LABEL];
-  return {
-    annotations: {
-      'openshift.io/display-name': `${getDisplayNameFromK8sResource(config)} (Local Copy)`,
-      'openshift.io/description': getDescriptionFromK8sResource(config),
-    },
-    labels: {
-      ...(configType && { [CONFIG_TYPE_LABEL]: configType }),
-    },
-  };
-};
 
 // ─── Apply: Topology Type ──────────────────────────────────────────────────────
 
@@ -81,91 +39,32 @@ export const applyTopologyType = (
 export const applyTopologyConfig = (
   deployment: LLMdDeployment,
   fieldData?: CustomTopologyConfigFieldData,
-): LLMdDeployment => {
-  // If configRef is set but not yet resolved, leave deployment unchanged to avoid data loss
-  if (fieldData?.configRef && !fieldData.selectedConfig) {
-    return deployment;
-  }
-
-  const result = structuredClone(deployment);
-  const annotations = { ...result.model.metadata.annotations };
-
-  const prevRef = annotations[TOPOLOGY_CONFIG_REF_ANNOTATION];
-  if (prevRef && result.model.spec.baseRefs) {
-    result.model.spec.baseRefs = result.model.spec.baseRefs.filter((r) => r.name !== prevRef);
-  }
-  delete annotations[TOPOLOGY_CONFIG_REF_ANNOTATION];
-
-  const config = fieldData?.selectedConfig;
-  if (config && config !== TOPOLOGY_CONFIG_DEFAULT) {
-    const configName = createLocalConfigName(deployment, config);
-    annotations[TOPOLOGY_CONFIG_REF_ANNOTATION] = configName;
-
-    if (!result.model.spec.baseRefs) {
-      result.model.spec.baseRefs = [];
-    }
-    if (!result.model.spec.baseRefs.some((r) => r.name === configName)) {
-      result.model.spec.baseRefs.push({ name: configName });
-    }
-  }
-
-  result.model.metadata.annotations = annotations;
-  return result;
-};
+): LLMdDeployment =>
+  applyConfigRef(deployment, fieldData, {
+    annotationKey: TOPOLOGY_CONFIG_REF_ANNOTATION,
+    configName: createLocalConfigName,
+    isSentinel: (c) => c === TOPOLOGY_CONFIG_DEFAULT,
+  });
 
 // ─── PreDeploy: Topology Config ────────────────────────────────────────────────
 
-export const preDeployTopologyConfig = async (
+export const preDeployTopologyConfig = (
   fieldData: CustomTopologyConfigFieldData,
   wizardState: WizardFormData['state'],
   deployment: DeploymentHookPayloadFor<LLMdDeployment>,
   existingDeployment?: LLMdDeployment,
   dryRun?: boolean,
-): Promise<DeploymentHookPayloadFor<LLMdDeployment>> => {
-  if (!deployment.model) {
-    return deployment;
-  }
-  const { namespace } = deployment.model.metadata;
-
-  const prevTopologyConfigName =
-    existingDeployment?.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION];
-  const newTopologyConfigName =
-    deployment.model.metadata.annotations?.[TOPOLOGY_CONFIG_REF_ANNOTATION];
-
-  // clean up old topology config if switching to new one
-  if (prevTopologyConfigName && prevTopologyConfigName !== newTopologyConfigName) {
-    await deleteLLMInferenceServiceConfig(prevTopologyConfigName, namespace, { dryRun }).catch(
-      (e: unknown) => {
-        // Don't block if not found. It could be in the global namespace by accident
-        if (getGenericErrorCode(e) !== 404) {
-          throw e;
-        }
-      },
-    );
-  }
-
-  // create new topology config
-  if (
-    fieldData.selectedConfig &&
-    newTopologyConfigName &&
-    fieldData.selectedConfig !== TOPOLOGY_CONFIG_DEFAULT
-  ) {
-    const config = cleanlyDuplicateConfig(fieldData.selectedConfig, {
-      name: newTopologyConfigName,
-      namespace,
-      ...createLocalConfigMetadata(fieldData.selectedConfig),
-    });
-
-    await createLLMInferenceServiceConfig(config, { dryRun }).catch((e: unknown) => {
-      // Don't block if it already exists
-      if (getGenericErrorCode(e) !== 409) {
-        throw e;
-      }
-    });
-  }
-
-  return deployment;
-};
+): Promise<DeploymentHookPayloadFor<LLMdDeployment>> =>
+  preDeployConfigCopy(
+    {
+      annotationKey: TOPOLOGY_CONFIG_REF_ANNOTATION,
+      isSentinel: (c) => c === TOPOLOGY_CONFIG_DEFAULT,
+    },
+    fieldData,
+    deployment,
+    existingDeployment,
+    dryRun,
+  );
 
 // ─── Apply: Routing Config ─────────────────────────────────────────────────────
 
@@ -239,23 +138,3 @@ export const extractRoutingConfig = (
   }
   return { configRef };
 };
-
-// ─── Unused-import guard for WizardFormData (required by apply extension sig) ─
-
-export type TopologyApplyFn = (
-  deployment: LLMdDeployment,
-  fieldData: TopologyTypeFieldData,
-  wizardState: WizardFormData['state'],
-) => LLMdDeployment;
-
-export type TopologyConfigApplyFn = (
-  deployment: LLMdDeployment,
-  fieldData: CustomTopologyConfigFieldData,
-  wizardState: WizardFormData['state'],
-) => LLMdDeployment;
-
-export type RoutingConfigApplyFn = (
-  deployment: LLMdDeployment,
-  fieldData: AdvancedRoutingFieldData,
-  wizardState: WizardFormData['state'],
-) => LLMdDeployment;

--- a/packages/llmd-serving/src/settings/topologyConfigs/__tests__/TopologyConfigurationCreateEdit.spec.tsx
+++ b/packages/llmd-serving/src/settings/topologyConfigs/__tests__/TopologyConfigurationCreateEdit.spec.tsx
@@ -57,7 +57,7 @@ const renderAtDuplicate = (config: LLMInferenceServiceConfigKind) =>
     </MemoryRouter>,
   );
 
-// Renders the add route with an arbitrary :topologyType, plus a sentinel list
+// Renders the add route with an arbitrary :topologyType, plus a placeholder list
 // route so a redirect away from the form lands somewhere assertable.
 const renderAtAdd = (topologyType: string) =>
   render(
@@ -75,7 +75,7 @@ const renderAtAdd = (topologyType: string) =>
   );
 
 // Renders the edit route for a configName with the given configs available in
-// context, plus a sentinel list route.
+// context, plus a placeholder list route.
 const renderAtEdit = (configName: string, configs: LLMInferenceServiceConfigKind[]) =>
   render(
     <MemoryRouter initialEntries={[`${TOPOLOGY_CONFIGS_TAB_PATH}/edit/${configName}`]}>
@@ -92,7 +92,7 @@ const renderAtEdit = (configName: string, configs: LLMInferenceServiceConfigKind
   );
 
 // Renders the duplicate route for a configName with the given configs available
-// in context, plus a sentinel list route.
+// in context, plus a placeholder list route.
 const renderAtDuplicateByName = (configName: string, configs: LLMInferenceServiceConfigKind[]) =>
   render(
     <MemoryRouter initialEntries={[`${TOPOLOGY_CONFIGS_TAB_PATH}/duplicate/${configName}`]}>

--- a/packages/llmd-serving/src/types.ts
+++ b/packages/llmd-serving/src/types.ts
@@ -16,6 +16,7 @@ export {
   TOPOLOGY_TYPE_ANNOTATION,
   TOPOLOGY_CONFIG_REF_ANNOTATION,
   ROUTING_CONFIG_REF_ANNOTATION,
+  ACCELERATOR_CONFIG_REF_ANNOTATION,
 } from './const';
 import {
   MAAS_ENDPOINT_LABEL,
@@ -25,6 +26,7 @@ import {
   TOPOLOGY_TYPE_ANNOTATION,
   TOPOLOGY_CONFIG_REF_ANNOTATION,
   ROUTING_CONFIG_REF_ANNOTATION,
+  ACCELERATOR_CONFIG_REF_ANNOTATION,
 } from './const';
 
 export enum ConfigType {
@@ -113,6 +115,7 @@ export type LLMInferenceServiceKind = K8sResourceCommon & {
       [TOPOLOGY_TYPE_ANNOTATION]?: TopologyType;
       [TOPOLOGY_CONFIG_REF_ANNOTATION]?: string;
       [ROUTING_CONFIG_REF_ANNOTATION]?: string;
+      [ACCELERATOR_CONFIG_REF_ANNOTATION]?: string;
     };
     labels?: {
       'opendatahub.io/genai-asset'?: 'true' | 'false';

--- a/packages/llmd-serving/src/wizardFields/AcceleratorConfigField.tsx
+++ b/packages/llmd-serving/src/wizardFields/AcceleratorConfigField.tsx
@@ -163,9 +163,13 @@ const suggestConfig = (
 
 // Map an accelerator config to a ModelServerOption (mirrors LlmConfigOptionsField so the shared
 // ModelServerTemplateSelectField renders version labels + hardware-profile compatibility labels).
+// A config living in the deployment's own project namespace (the local copy folded in on edit) is
+// marked project-scoped so the dropdown groups/labels it correctly; dashboard admin configs are left
+// unscoped (rendered as global).
 const toModelServerOption = (
   config: LLMInferenceServiceConfigKind,
   hardwareProfile?: HardwareProfileKind,
+  projectName?: string,
 ): ModelServerOption => ({
   name: config.metadata.name,
   namespace: config.metadata.namespace,
@@ -173,6 +177,7 @@ const toModelServerOption = (
   version: config.metadata.annotations?.[RUNTIME_VERSION_ANNOTATION],
   template: config,
   compatibleWithHardwareProfile: isConfigCompatible(config, hardwareProfile),
+  scope: projectName && config.metadata.namespace === projectName ? 'project' : undefined,
 });
 
 // --- Visibility ---
@@ -208,6 +213,7 @@ export const AcceleratorConfigFieldComponent: AcceleratorConfigFieldType['compon
 }) => {
   const topologyType = dependencies?.topologyFieldData?.topologyType;
   const hardwareProfile = dependencies?.hardwareProfile;
+  const projectName = dependencies?.project?.projectName;
   const configs = React.useMemo(() => externalData?.data.configs ?? [], [externalData?.data]);
   const isLoaded = externalData?.loaded ?? false;
 
@@ -221,9 +227,9 @@ export const AcceleratorConfigFieldComponent: AcceleratorConfigFieldType['compon
   const options: ModelServerOption[] = React.useMemo(
     () => [
       BUILT_IN_IMAGE_OPTION,
-      ...visibleConfigs.map((c) => toModelServerOption(c, hardwareProfile)),
+      ...visibleConfigs.map((c) => toModelServerOption(c, hardwareProfile, projectName)),
     ],
-    [visibleConfigs, hardwareProfile],
+    [visibleConfigs, hardwareProfile, projectName],
   );
 
   // Resolve configRef from the edit extractor into a real selectedConfig once configs load.
@@ -244,14 +250,14 @@ export const AcceleratorConfigFieldComponent: AcceleratorConfigFieldType['compon
     [visibleConfigs, hardwareProfile],
   );
   const suggestionOption = React.useMemo(
-    () => (suggestion ? toModelServerOption(suggestion, hardwareProfile) : undefined),
-    [suggestion, hardwareProfile],
+    () => (suggestion ? toModelServerOption(suggestion, hardwareProfile, projectName) : undefined),
+    [suggestion, hardwareProfile, projectName],
   );
 
   const autoSelect = value?.autoSelect ?? false;
   const selection: ModelServerOption =
     existingSelection && existingSelection !== ACCELERATOR_CONFIG_DEFAULT
-      ? toModelServerOption(existingSelection, hardwareProfile)
+      ? toModelServerOption(existingSelection, hardwareProfile, projectName)
       : BUILT_IN_IMAGE_OPTION;
 
   const modelServerData: ModelServerSelectFieldData = {

--- a/packages/llmd-serving/src/wizardFields/AcceleratorConfigField.tsx
+++ b/packages/llmd-serving/src/wizardFields/AcceleratorConfigField.tsx
@@ -30,9 +30,7 @@ import {
   useFetchLLMInferenceServiceConfigs,
 } from '../api/LLMInferenceServiceConfigs';
 import { isLLMInferenceServiceActive } from '../formUtils';
-import { ACCELERATOR_CONFIG_FIELD_ID } from '../const';
-
-export const ACCELERATOR_CONFIG_DEFAULT = 'default' as const;
+import { ACCELERATOR_CONFIG_FIELD_ID, ACCELERATOR_CONFIG_DEFAULT } from '../const';
 
 // Synthetic "no override / use the built-in image" option surfaced in the Manual selection list.
 // Its `name` doubles as the sentinel we persist (ACCELERATOR_CONFIG_DEFAULT); it carries no
@@ -183,11 +181,12 @@ const configSupportsTopology = (
   config: LLMInferenceServiceConfigKind,
   topologyType?: TopologyType,
 ): boolean => {
-  if (topologyType === TopologyType.SINGLE_NODE) {
+  // An absent topology field (LLMD_TOPOLOGY_CONFIGS off) means the deployment is implicitly
+  // single-node — same as isActive treats it — so all single-node configs are visible. Without this,
+  // visibleConfigs would be empty in the vLLMDeploymentOnMaaS-on / llmdTemplates-off combination and
+  // no accelerator config could be selected.
+  if (topologyType === TopologyType.SINGLE_NODE || !topologyType) {
     return true;
-  }
-  if (!topologyType) {
-    return false;
   }
   return getConfigSupportedTopologies(config).includes(topologyType);
 };

--- a/packages/llmd-serving/src/wizardFields/AcceleratorConfigField.tsx
+++ b/packages/llmd-serving/src/wizardFields/AcceleratorConfigField.tsx
@@ -1,0 +1,368 @@
+import React from 'react';
+import { z } from 'zod';
+import type {
+  InitialWizardFormData,
+  WizardField,
+  WizardFormData,
+  WizardReviewSection,
+} from '@odh-dashboard/model-serving/shared/types/form-data';
+import type { RecursivePartial } from '@odh-dashboard/foundation';
+import {
+  ModelServerTemplateSelectField,
+  type ModelServerOption,
+  type ModelServerSelectFieldData,
+} from '@odh-dashboard/model-serving/shared/wizard-fields';
+import { RUNTIME_VERSION_ANNOTATION } from '@odh-dashboard/model-serving/concepts/versions';
+import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
+import type { HardwareProfileKind } from '@odh-dashboard/k8s-core';
+import { isCompatibleWithIdentifier } from '@odh-dashboard/internal/pages/projects/screens/spawner/spawnerUtils';
+import { LLMD_DEPLOYMENT_METHOD_KEY } from './deploymentMethodField';
+import { isTopologyTypeFieldData, type TopologyTypeFieldData } from './TopologyTypeField';
+import {
+  TopologyType,
+  type LLMInferenceServiceConfigKind,
+  getConfigSupportedTopologies,
+} from '../types';
+import { isConfigEffectivelyEnabled } from '../utils';
+import {
+  useFetchLLMInferenceServiceConfig,
+  useFetchLLMInferenceServiceConfigs,
+} from '../api/LLMInferenceServiceConfigs';
+import { isLLMInferenceServiceActive } from '../formUtils';
+import { ACCELERATOR_CONFIG_FIELD_ID } from '../const';
+
+export const ACCELERATOR_CONFIG_DEFAULT = 'default' as const;
+
+// Synthetic "no override / use the built-in image" option surfaced in the Manual selection list.
+// Its `name` doubles as the sentinel we persist (ACCELERATOR_CONFIG_DEFAULT); it carries no
+// `template`, so ModelServerTemplateSelectField renders no version labels for it.
+const BUILT_IN_IMAGE_OPTION: ModelServerOption = {
+  name: ACCELERATOR_CONFIG_DEFAULT,
+  // needs-ux: wording
+  label: 'Built-in image (default)',
+};
+
+// --- Dependencies ---
+
+type AcceleratorConfigDependencies = {
+  topologyFieldData?: TopologyTypeFieldData;
+  hardwareProfile?: HardwareProfileKind;
+  project?: WizardFormData['state']['project'];
+  /** The accelerator config this deployment already references, from the edit extractor. */
+  configRef?: string;
+};
+
+const isRecord = (data: unknown): data is Record<string, unknown> =>
+  typeof data === 'object' && data !== null;
+
+const readProperty = (data: unknown, key: string): unknown =>
+  isRecord(data) ? data[key] : undefined;
+
+const resolveAcceleratorConfigDependencies = (
+  formData: WizardFormData['state'],
+  initialData?: InitialWizardFormData,
+): AcceleratorConfigDependencies => {
+  const rawTopologyData = formData['llmd-serving/topology-type'];
+  const configRef = readProperty(initialData?.[ACCELERATOR_CONFIG_FIELD_ID], 'configRef');
+  return {
+    topologyFieldData: isTopologyTypeFieldData(rawTopologyData) ? rawTopologyData : undefined,
+    hardwareProfile: formData.hardwareProfileConfig.formData.selectedProfile,
+    project: formData.project,
+    configRef: typeof configRef === 'string' ? configRef : undefined,
+  };
+};
+
+// --- External data hook ---
+
+export type AcceleratorConfigExternalData = { configs: LLMInferenceServiceConfigKind[] };
+
+/**
+ * The dashboard accelerator configs, plus the config the deployment already references on edit.
+ *
+ * On edit, the deployment's accelerator baseRef points at a copy of the config that lives in the
+ * deployment's own project namespace (created at deploy time), not in the dashboard namespace.
+ * That copy is fetched by name from the project namespace and folded into the configs so the edit
+ * form can resolve + pre-select it.
+ */
+export const useAcceleratorConfigData = (
+  dependencies?: AcceleratorConfigDependencies,
+): {
+  data: AcceleratorConfigExternalData;
+  loaded: boolean;
+  loadError?: Error;
+} => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const { data: configs, loaded, error } = useFetchLLMInferenceServiceConfigs(dashboardNamespace);
+
+  const { configRef } = dependencies ?? {};
+  const projectName = dependencies?.project?.projectName;
+  const {
+    data: referencedConfig,
+    loaded: referencedLoaded,
+    error: referencedError,
+  } = useFetchLLMInferenceServiceConfig(configRef, projectName);
+
+  const combined = React.useMemo(() => {
+    const enabled = configs.filter(isConfigEffectivelyEnabled);
+    if (
+      referencedConfig &&
+      !enabled.some((c) => c.metadata.name === referencedConfig.metadata.name)
+    ) {
+      return [...enabled, referencedConfig];
+    }
+    return enabled;
+  }, [configs, referencedConfig]);
+
+  return React.useMemo(
+    () => ({
+      data: { configs: combined },
+      // The referenced config only matters for an existing selection, so an unreadable project
+      // namespace shouldn't hold up the field.
+      loaded: loaded && (!configRef || !projectName || referencedLoaded || !!referencedError),
+      loadError: error,
+    }),
+    [combined, loaded, error, configRef, projectName, referencedLoaded, referencedError],
+  );
+};
+
+// --- Field value ---
+
+export type AcceleratorConfigFieldData = {
+  selectedConfig?: LLMInferenceServiceConfigKind | typeof ACCELERATOR_CONFIG_DEFAULT;
+  configRef?: string;
+  /**
+   * Whether the user chose "Automatic selection" (vs. picking a config manually). This only drives
+   * the shared component's radio state — `selectedConfig` still holds the resolved config either
+   * way, so the deploy pipeline is identical for automatic and manual selections.
+   */
+  autoSelect?: boolean;
+};
+
+export type AcceleratorConfigFieldType = WizardField<
+  AcceleratorConfigFieldData,
+  AcceleratorConfigExternalData,
+  AcceleratorConfigDependencies
+>;
+
+// --- Compatibility / suggestion ---
+
+const isConfigCompatible = (
+  config: LLMInferenceServiceConfigKind,
+  hardwareProfile?: HardwareProfileKind,
+): boolean =>
+  hardwareProfile?.spec.identifiers?.some((identifier) =>
+    isCompatibleWithIdentifier(identifier.identifier, config),
+  ) ?? false;
+
+const suggestConfig = (
+  configs: LLMInferenceServiceConfigKind[],
+  hardwareProfile?: HardwareProfileKind,
+): LLMInferenceServiceConfigKind | undefined => {
+  const compatible = configs.filter((c) => isConfigCompatible(c, hardwareProfile));
+  return compatible.length === 1 ? compatible[0] : undefined;
+};
+
+// Map an accelerator config to a ModelServerOption (mirrors LlmConfigOptionsField so the shared
+// ModelServerTemplateSelectField renders version labels + hardware-profile compatibility labels).
+const toModelServerOption = (
+  config: LLMInferenceServiceConfigKind,
+  hardwareProfile?: HardwareProfileKind,
+): ModelServerOption => ({
+  name: config.metadata.name,
+  namespace: config.metadata.namespace,
+  label: getDisplayNameFromK8sResource(config),
+  version: config.metadata.annotations?.[RUNTIME_VERSION_ANNOTATION],
+  template: config,
+  compatibleWithHardwareProfile: isConfigCompatible(config, hardwareProfile),
+});
+
+// --- Visibility ---
+
+const configSupportsTopology = (
+  config: LLMInferenceServiceConfigKind,
+  topologyType?: TopologyType,
+): boolean => {
+  if (topologyType === TopologyType.SINGLE_NODE) {
+    return true;
+  }
+  if (!topologyType) {
+    return false;
+  }
+  return getConfigSupportedTopologies(config).includes(topologyType);
+};
+
+// --- Component ---
+//
+// Renders the shared ModelServerTemplateSelectField (Automatic/Manual radios, version labels,
+// project-scoped search) but keeps this field's persisted data model as
+// { selectedConfig, configRef }. The component bridges to/from the component's
+// ModelServerSelectFieldData ({ selection, autoSelect, suggestion }) internally so the deploy
+// pipeline (apply/extract/preDeploy in ../deployments/accelerator) is unchanged.
+
+export const AcceleratorConfigFieldComponent: AcceleratorConfigFieldType['component'] = ({
+  value,
+  onChange,
+  externalData,
+  dependencies,
+  isEditing,
+}) => {
+  const topologyType = dependencies?.topologyFieldData?.topologyType;
+  const hardwareProfile = dependencies?.hardwareProfile;
+  const configs = React.useMemo(() => externalData?.data.configs ?? [], [externalData?.data]);
+  const isLoaded = externalData?.loaded ?? false;
+
+  const visibleConfigs = React.useMemo(
+    () => configs.filter((c) => configSupportsTopology(c, topologyType)),
+    [configs, topologyType],
+  );
+
+  // Options presented to the shared component: the "Built-in image (default)" sentinel first,
+  // then the topology-compatible accelerator configs.
+  const options: ModelServerOption[] = React.useMemo(
+    () => [
+      BUILT_IN_IMAGE_OPTION,
+      ...visibleConfigs.map((c) => toModelServerOption(c, hardwareProfile)),
+    ],
+    [visibleConfigs, hardwareProfile],
+  );
+
+  // Resolve configRef from the edit extractor into a real selectedConfig once configs load.
+  const configRef = value?.configRef;
+  const existingSelection = value?.selectedConfig;
+  React.useEffect(() => {
+    if (!configRef || existingSelection || !isLoaded) {
+      return;
+    }
+    const resolved = configs.find((c) => c.metadata.name === configRef);
+    onChange(resolved ? { selectedConfig: resolved } : { configRef: undefined });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configRef, isLoaded, existingSelection, configs]);
+
+  // Bridge our persisted { selectedConfig } → the component's ModelServerSelectFieldData.
+  const suggestion = React.useMemo(
+    () => suggestConfig(visibleConfigs, hardwareProfile),
+    [visibleConfigs, hardwareProfile],
+  );
+  const suggestionOption = React.useMemo(
+    () => (suggestion ? toModelServerOption(suggestion, hardwareProfile) : undefined),
+    [suggestion, hardwareProfile],
+  );
+
+  const autoSelect = value?.autoSelect ?? false;
+  const selection: ModelServerOption =
+    existingSelection && existingSelection !== ACCELERATOR_CONFIG_DEFAULT
+      ? toModelServerOption(existingSelection, hardwareProfile)
+      : BUILT_IN_IMAGE_OPTION;
+
+  const modelServerData: ModelServerSelectFieldData = {
+    selection,
+    // Persisted so the "Automatic selection" radio stays checked and renders its read-only summary;
+    // otherwise clicking Automatic would immediately snap back to Manual on the next render.
+    autoSelect,
+    suggestion: suggestionOption,
+  };
+
+  return (
+    <ModelServerTemplateSelectField
+      label="Accelerator configuration"
+      // needs-ux: wording
+      helperText="Optionally override the container image with an accelerator-specific configuration."
+      isEditing={isEditing}
+      modelServerState={{
+        data: modelServerData,
+        options,
+        setData: (data: ModelServerSelectFieldData) => {
+          const picked = data.autoSelect ? data.suggestion : data.selection;
+          if (!picked || picked.name === ACCELERATOR_CONFIG_DEFAULT) {
+            onChange({ selectedConfig: ACCELERATOR_CONFIG_DEFAULT, autoSelect: data.autoSelect });
+            return;
+          }
+          const config = visibleConfigs.find((c) => c.metadata.name === picked.name);
+          onChange({
+            selectedConfig: config ?? value?.selectedConfig,
+            autoSelect: data.autoSelect,
+          });
+        },
+      }}
+    />
+  );
+};
+
+// --- Review ---
+
+const getReviewSections = (value: AcceleratorConfigFieldData): WizardReviewSection[] => [
+  {
+    title: 'Model deployment',
+    items: [
+      {
+        key: 'accelerator-config',
+        label: 'Accelerator configuration',
+        value: () =>
+          value.selectedConfig && value.selectedConfig !== ACCELERATOR_CONFIG_DEFAULT
+            ? getDisplayNameFromK8sResource(value.selectedConfig)
+            : 'Built-in image (default)',
+      },
+    ],
+  },
+];
+
+// --- isActive ---
+
+const isActive = (wizardState: RecursivePartial<WizardFormData['state']>): boolean => {
+  if (!isLLMInferenceServiceActive(wizardState)) {
+    return false;
+  }
+  if (wizardState.deploymentMethod?.method !== LLMD_DEPLOYMENT_METHOD_KEY) {
+    return false;
+  }
+  const rawTopology = wizardState['llmd-serving/topology-type'];
+  const topologyType = isTopologyTypeFieldData(rawTopology) ? rawTopology.topologyType : undefined;
+  // The field is flag-gated on VLLM_ON_MAAS (not LLMD_TOPOLOGY_CONFIGS), so it can be active even
+  // when the topology field isn't present (llmdTemplates off) — in that case the deployment is
+  // implicitly single-node, so show the field. When the topology field IS present, restrict to
+  // single node (other topologies rely on supported-topologies, gated in the component's
+  // visibleConfigs). `undefined` = topology feature off → eligible.
+  return topologyType === undefined || topologyType === TopologyType.SINGLE_NODE;
+};
+
+// --- Field definition ---
+
+export const AcceleratorConfigFieldWizardField: AcceleratorConfigFieldType = {
+  id: ACCELERATOR_CONFIG_FIELD_ID,
+  step: 'modelDeployment',
+  type: 'addition',
+  isActive,
+  reducerFunctions: {
+    resolveDependencies: resolveAcceleratorConfigDependencies,
+    setFieldData: (value: AcceleratorConfigFieldData) => value,
+    getInitialFieldData: (
+      existingFieldData?: AcceleratorConfigFieldData,
+      externalData?: AcceleratorConfigExternalData,
+      dependencies?: AcceleratorConfigDependencies,
+    ): AcceleratorConfigFieldData => {
+      if (existingFieldData) {
+        return existingFieldData;
+      }
+      const suggestion = suggestConfig(externalData?.configs ?? [], dependencies?.hardwareProfile);
+      // A suggestion means the hardware profile uniquely matches a config → start on Automatic
+      // (mirrors LlmConfigOptionsField). No suggestion → Manual with the built-in image default.
+      return suggestion
+        ? { selectedConfig: suggestion, autoSelect: true }
+        : { selectedConfig: ACCELERATOR_CONFIG_DEFAULT, autoSelect: false };
+    },
+    validationSchema: z.object({
+      selectedConfig: z.union([
+        z.custom<LLMInferenceServiceConfigKind>(
+          (val) => typeof val === 'object' && val !== null && 'kind' in val,
+        ),
+        z.literal(ACCELERATOR_CONFIG_DEFAULT),
+      ]),
+      configRef: z.string().optional(),
+      autoSelect: z.boolean().optional(),
+    }),
+  },
+  externalDataHook: useAcceleratorConfigData,
+  component: AcceleratorConfigFieldComponent,
+  getReviewSections,
+};

--- a/packages/llmd-serving/src/wizardFields/AcceleratorConfigField.tsx
+++ b/packages/llmd-serving/src/wizardFields/AcceleratorConfigField.tsx
@@ -33,7 +33,7 @@ import { isLLMInferenceServiceActive } from '../formUtils';
 import { ACCELERATOR_CONFIG_FIELD_ID, ACCELERATOR_CONFIG_DEFAULT } from '../const';
 
 // Synthetic "no override / use the built-in image" option surfaced in the Manual selection list.
-// Its `name` doubles as the sentinel we persist (ACCELERATOR_CONFIG_DEFAULT); it carries no
+// Its `name` doubles as the placeholder we persist (ACCELERATOR_CONFIG_DEFAULT); it carries no
 // `template`, so ModelServerTemplateSelectField renders no version labels for it.
 const BUILT_IN_IMAGE_OPTION: ModelServerOption = {
   name: ACCELERATOR_CONFIG_DEFAULT,
@@ -222,7 +222,7 @@ export const AcceleratorConfigFieldComponent: AcceleratorConfigFieldType['compon
     [configs, topologyType],
   );
 
-  // Options presented to the shared component: the "Built-in image (default)" sentinel first,
+  // Options presented to the shared component: the "Built-in image (default)" placeholder first,
   // then the topology-compatible accelerator configs.
   const options: ModelServerOption[] = React.useMemo(
     () => [

--- a/packages/llmd-serving/src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { testHook } from '@odh-dashboard/jest-config/hooks';
 import {
   AcceleratorConfigFieldWizardField,
@@ -200,6 +200,34 @@ describe('AcceleratorConfigFieldComponent edit configRef resolution', () => {
     );
     fireEvent.click(screen.getByTestId('serving-runtime-template-selection-toggle'));
     expect(screen.getByTestId(`servingRuntime ${rocm.metadata.name}`)).toBeInTheDocument();
+  });
+
+  it('labels a config from the deployment project namespace as project-scoped', () => {
+    // The local copy created at deploy time lives in the deployment's project namespace and is folded
+    // into the list on edit; it must render under the project-scoped group, not global.
+    const localCopy: LLMInferenceServiceConfigKind = {
+      ...makeConfig('my-deployment-rocm'),
+      metadata: { name: 'my-deployment-rocm', namespace: 'my-project', labels: {} },
+    };
+    const onChange = jest.fn();
+    render(
+      <AcceleratorConfigFieldComponent
+        id="accelerator-config"
+        value={{ selectedConfig: localCopy, autoSelect: false }}
+        onChange={onChange}
+        externalData={{ data: { configs: [localCopy] }, loaded: true }}
+        dependencies={{
+          topologyFieldData: { topologyType: TopologyType.SINGLE_NODE },
+          project: { projectName: 'my-project', setProjectName: jest.fn() },
+        }}
+        isEditing={false}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('serving-runtime-template-selection-toggle'));
+    const menuItem = screen.getByTestId('servingRuntime my-deployment-rocm');
+    expect(within(screen.getByTestId('project-scoped-serving-runtimes')).getByTestId(
+      'servingRuntime my-deployment-rocm',
+    )).toBe(menuItem);
   });
 
   it('resolves a configRef into the referenced config on edit', () => {

--- a/packages/llmd-serving/src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx
@@ -4,13 +4,13 @@ import { testHook } from '@odh-dashboard/jest-config/hooks';
 import {
   AcceleratorConfigFieldWizardField,
   AcceleratorConfigFieldComponent,
-  ACCELERATOR_CONFIG_DEFAULT,
   useAcceleratorConfigData,
 } from '../AcceleratorConfigField';
 import {
   LLMD_DEPLOYMENT_METHOD_KEY,
   SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY,
 } from '../deploymentMethodField';
+import { ACCELERATOR_CONFIG_DEFAULT } from '../../const';
 import { TopologyType, type LLMInferenceServiceConfigKind } from '../../types';
 import {
   useFetchLLMInferenceServiceConfig,
@@ -159,6 +159,60 @@ describe('AcceleratorConfigFieldComponent radio behavior', () => {
       selectedConfig: ACCELERATOR_CONFIG_DEFAULT,
       autoSelect: false,
     });
+  });
+});
+
+describe('AcceleratorConfigFieldComponent edit configRef resolution', () => {
+  const rocm = makeConfig('rocm', '["amd.com/gpu"]');
+
+  const renderWithConfigs = (
+    value: React.ComponentProps<typeof AcceleratorConfigFieldComponent>['value'],
+    configs: LLMInferenceServiceConfigKind[],
+  ) => {
+    const onChange = jest.fn();
+    render(
+      <AcceleratorConfigFieldComponent
+        id="accelerator-config"
+        value={value}
+        onChange={onChange}
+        externalData={{ data: { configs }, loaded: true }}
+        dependencies={{ topologyFieldData: { topologyType: TopologyType.SINGLE_NODE } }}
+        isEditing={false}
+      />,
+    );
+    return onChange;
+  };
+
+  it('lists accelerator configs when no topology field is present (llmdTemplates off)', () => {
+    // Regression: with the topology field absent the deployment is implicitly single-node, so
+    // single-node configs must still be selectable. Previously visibleConfigs was empty here, so the
+    // Manual dropdown only offered the built-in option in the vLLMDeploymentOnMaaS-on/llmdTemplates-off combo.
+    const onChange = jest.fn();
+    render(
+      <AcceleratorConfigFieldComponent
+        id="accelerator-config"
+        value={{ selectedConfig: ACCELERATOR_CONFIG_DEFAULT, autoSelect: false }}
+        onChange={onChange}
+        externalData={{ data: { configs: [rocm] }, loaded: true }}
+        dependencies={{}}
+        isEditing={false}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('serving-runtime-template-selection-toggle'));
+    expect(screen.getByTestId(`servingRuntime ${rocm.metadata.name}`)).toBeInTheDocument();
+  });
+
+  it('resolves a configRef into the referenced config on edit', () => {
+    const onChange = renderWithConfigs({ configRef: 'rocm' }, [rocm]);
+    expect(onChange).toHaveBeenCalledWith({ selectedConfig: rocm });
+  });
+
+  it('clears an unresolvable configRef', () => {
+    // The project-namespace copy was deleted/renamed/unreadable, so the ref can't resolve to a
+    // config. (Robustly falling back to a representable state when this happens on edit is deferred
+    // to a follow-up that fixes the pattern across the llm-d config fields uniformly.)
+    const onChange = renderWithConfigs({ configRef: 'missing-copy' }, [rocm]);
+    expect(onChange).toHaveBeenCalledWith({ configRef: undefined });
   });
 });
 

--- a/packages/llmd-serving/src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx
@@ -87,7 +87,7 @@ describe('AcceleratorConfigFieldWizardField.getInitialFieldData', () => {
     expect(result).toBe(existing);
   });
 
-  it('defaults to the built-in sentinel (Manual) when nothing matches', () => {
+  it('defaults to the built-in placeholder (Manual) when nothing matches', () => {
     const result = getInitialFieldData(undefined, { configs: [makeConfig('rocm')] }, {});
     expect(result.selectedConfig).toBe(ACCELERATOR_CONFIG_DEFAULT);
     expect(result.autoSelect).toBe(false);

--- a/packages/llmd-serving/src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx
@@ -225,9 +225,11 @@ describe('AcceleratorConfigFieldComponent edit configRef resolution', () => {
     );
     fireEvent.click(screen.getByTestId('serving-runtime-template-selection-toggle'));
     const menuItem = screen.getByTestId('servingRuntime my-deployment-rocm');
-    expect(within(screen.getByTestId('project-scoped-serving-runtimes')).getByTestId(
-      'servingRuntime my-deployment-rocm',
-    )).toBe(menuItem);
+    expect(
+      within(screen.getByTestId('project-scoped-serving-runtimes')).getByTestId(
+        'servingRuntime my-deployment-rocm',
+      ),
+    ).toBe(menuItem);
   });
 
   it('resolves a configRef into the referenced config on edit', () => {

--- a/packages/llmd-serving/src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx
@@ -1,0 +1,236 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import {
+  AcceleratorConfigFieldWizardField,
+  AcceleratorConfigFieldComponent,
+  ACCELERATOR_CONFIG_DEFAULT,
+  useAcceleratorConfigData,
+} from '../AcceleratorConfigField';
+import {
+  LLMD_DEPLOYMENT_METHOD_KEY,
+  SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY,
+} from '../deploymentMethodField';
+import { TopologyType, type LLMInferenceServiceConfigKind } from '../../types';
+import {
+  useFetchLLMInferenceServiceConfig,
+  useFetchLLMInferenceServiceConfigs,
+} from '../../api/LLMInferenceServiceConfigs';
+
+jest.mock('@odh-dashboard/internal/redux/selectors/project', () => ({
+  useDashboardNamespace: jest.fn(() => ({ dashboardNamespace: 'opendatahub' })),
+}));
+
+jest.mock('../../api/LLMInferenceServiceConfigs', () => ({
+  useFetchLLMInferenceServiceConfigs: jest.fn(),
+  useFetchLLMInferenceServiceConfig: jest.fn(),
+}));
+
+const mockUseFetchLLMInferenceServiceConfigs = jest.mocked(useFetchLLMInferenceServiceConfigs);
+const mockUseFetchLLMInferenceServiceConfig = jest.mocked(useFetchLLMInferenceServiceConfig);
+
+const { isActive, reducerFunctions } = AcceleratorConfigFieldWizardField;
+
+const state = (method: string, topologyType?: TopologyType) => ({
+  deploymentMethod: { method },
+  'llmd-serving/topology-type': topologyType ? { topologyType } : undefined,
+});
+
+describe('AcceleratorConfigFieldWizardField.isActive', () => {
+  it('is active for llm-d + single node', () => {
+    expect(isActive(state(LLMD_DEPLOYMENT_METHOD_KEY, TopologyType.SINGLE_NODE) as never)).toBe(
+      true,
+    );
+  });
+
+  it('is inactive for the simple vLLM method', () => {
+    expect(
+      isActive(state(SIMPLE_VLLM_DEPLOYMENT_METHOD_KEY, TopologyType.SINGLE_NODE) as never),
+    ).toBe(false);
+  });
+
+  it('is inactive for llm-d + multi-node (no supporting configs known at isActive time)', () => {
+    expect(isActive(state(LLMD_DEPLOYMENT_METHOD_KEY, TopologyType.MULTI_NODE) as never)).toBe(
+      false,
+    );
+  });
+
+  it('is active for llm-d with no topology field present (llmdTemplates off → implicitly single node)', () => {
+    // VLLM_ON_MAAS gates the field, not LLMD_TOPOLOGY_CONFIGS; when the topology field is absent
+    // the deployment is implicitly single node and the accelerator field should still show.
+    expect(isActive(state(LLMD_DEPLOYMENT_METHOD_KEY) as never)).toBe(true);
+  });
+});
+
+const makeConfig = (
+  name: string,
+  recommendedAccelerators?: string,
+): LLMInferenceServiceConfigKind => ({
+  apiVersion: 'serving.kserve.io/v1alpha2',
+  kind: 'LLMInferenceServiceConfig',
+  metadata: {
+    name,
+    namespace: 'dashboard',
+    labels: {},
+    annotations: recommendedAccelerators
+      ? { 'opendatahub.io/recommended-accelerators': recommendedAccelerators }
+      : {},
+  },
+});
+
+describe('AcceleratorConfigFieldWizardField.getInitialFieldData', () => {
+  const { getInitialFieldData } = reducerFunctions;
+
+  it('returns existing field data unchanged when already set (edit flow)', () => {
+    const existing = { selectedConfig: makeConfig('rocm', '["amd.com/gpu"]') };
+    const result = getInitialFieldData(existing, { configs: [] }, {});
+    expect(result).toBe(existing);
+  });
+
+  it('defaults to the built-in sentinel (Manual) when nothing matches', () => {
+    const result = getInitialFieldData(undefined, { configs: [makeConfig('rocm')] }, {});
+    expect(result.selectedConfig).toBe(ACCELERATOR_CONFIG_DEFAULT);
+    expect(result.autoSelect).toBe(false);
+  });
+
+  it('auto-suggests the config compatible with the selected hardware profile and starts on Automatic', () => {
+    const rocm = makeConfig('rocm', '["amd.com/gpu"]');
+    const hardwareProfile = {
+      spec: { identifiers: [{ identifier: 'amd.com/gpu' }] },
+    } as never;
+    const result = getInitialFieldData(
+      undefined,
+      { configs: [rocm, makeConfig('cuda')] },
+      { hardwareProfile },
+    );
+    expect(result.selectedConfig).toEqual(rocm);
+    expect(result.autoSelect).toBe(true);
+  });
+});
+
+describe('AcceleratorConfigFieldComponent radio behavior', () => {
+  const rocm = makeConfig('rocm', '["amd.com/gpu"]');
+  const hardwareProfile = {
+    spec: { identifiers: [{ identifier: 'amd.com/gpu' }] },
+  } as never;
+
+  const renderComponent = (
+    value: React.ComponentProps<typeof AcceleratorConfigFieldComponent>['value'],
+    onChange = jest.fn(),
+  ) => {
+    render(
+      <AcceleratorConfigFieldComponent
+        id="accelerator-config"
+        value={value}
+        onChange={onChange}
+        externalData={{ data: { configs: [rocm] }, loaded: true }}
+        dependencies={{
+          topologyFieldData: { topologyType: TopologyType.SINGLE_NODE },
+          hardwareProfile,
+        }}
+        isEditing={false}
+      />,
+    );
+    return onChange;
+  };
+
+  it('checks the Automatic radio when the persisted value is autoSelect', () => {
+    renderComponent({ selectedConfig: rocm, autoSelect: true });
+    expect(screen.getByTestId('model-server-auto-select-radio')).toBeChecked();
+    // The read-only suggestion summary renders (not the manual dropdown).
+    expect(screen.getByTestId('model-server-auto-select-suggestion')).toBeInTheDocument();
+  });
+
+  it('persists autoSelect=true (with the suggested config) when Automatic is clicked', () => {
+    // Regression: clicking Automatic used to only change the manual dropdown selection because
+    // autoSelect was never persisted, so the radio snapped back to Manual on re-render.
+    const onChange = renderComponent({
+      selectedConfig: ACCELERATOR_CONFIG_DEFAULT,
+      autoSelect: false,
+    });
+    fireEvent.click(screen.getByTestId('model-server-auto-select-radio'));
+    expect(onChange).toHaveBeenCalledWith({ selectedConfig: rocm, autoSelect: true });
+  });
+
+  it('persists autoSelect=false when Manual is re-selected', () => {
+    const onChange = renderComponent({ selectedConfig: rocm, autoSelect: true });
+    fireEvent.click(screen.getByTestId('model-server-manual-select-radio'));
+    expect(onChange).toHaveBeenCalledWith({
+      selectedConfig: ACCELERATOR_CONFIG_DEFAULT,
+      autoSelect: false,
+    });
+  });
+});
+
+describe('useAcceleratorConfigData', () => {
+  const mockProject = { projectName: 'my-project', setProjectName: jest.fn() };
+
+  const setDashboardConfigs = (configs: LLMInferenceServiceConfigKind[]) => {
+    mockUseFetchLLMInferenceServiceConfigs.mockReturnValue({
+      data: configs,
+      loaded: true,
+      refresh: jest.fn(),
+    });
+  };
+
+  const setReferencedConfig = (
+    config: LLMInferenceServiceConfigKind | null,
+    { loaded = true, error }: { loaded?: boolean; error?: Error } = {},
+  ) => {
+    mockUseFetchLLMInferenceServiceConfig.mockReturnValue({
+      data: config,
+      loaded,
+      error,
+      refresh: jest.fn(),
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setDashboardConfigs([makeConfig('rocm')]);
+    setReferencedConfig(null);
+  });
+
+  it('returns the enabled dashboard configs', () => {
+    const renderResult = testHook(useAcceleratorConfigData)({});
+    expect(renderResult.result.current.data.configs).toEqual([makeConfig('rocm')]);
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+
+  it('fetches the referenced config by name from the project namespace (edit flow)', () => {
+    testHook(useAcceleratorConfigData)({
+      configRef: 'my-deployment-rocm',
+      project: mockProject,
+    });
+    expect(mockUseFetchLLMInferenceServiceConfig).toHaveBeenCalledWith(
+      'my-deployment-rocm',
+      'my-project',
+    );
+  });
+
+  it('folds the referenced local-copy config into the configs so edit can resolve it', () => {
+    // The persisted accelerator baseRef points at a project-namespace local copy that is NOT in the
+    // dashboard config list; it must be added so the edit form can pre-select it.
+    const localCopy: LLMInferenceServiceConfigKind = {
+      ...makeConfig('my-deployment-rocm'),
+      metadata: { name: 'my-deployment-rocm', namespace: 'my-project', labels: {} },
+    };
+    setReferencedConfig(localCopy);
+
+    const renderResult = testHook(useAcceleratorConfigData)({
+      configRef: 'my-deployment-rocm',
+      project: mockProject,
+    });
+
+    expect(renderResult.result.current.data.configs).toEqual([makeConfig('rocm'), localCopy]);
+  });
+
+  it('does not duplicate the referenced config if it is already a dashboard config', () => {
+    setReferencedConfig(makeConfig('rocm'));
+    const renderResult = testHook(useAcceleratorConfigData)({
+      configRef: 'rocm',
+      project: mockProject,
+    });
+    expect(renderResult.result.current.data.configs).toEqual([makeConfig('rocm')]);
+  });
+});

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -14,6 +14,7 @@ const EXPLICIT_TOPOLOGY_FIELD_IDS = [
   'llmd-serving/topology-type',
   'llmd-serving/custom-topology-config',
   'llmd-serving/advanced-routing',
+  'llmd-serving/accelerator-config',
 ];
 
 type ModelDeploymentStepProps = {
@@ -104,6 +105,12 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
         />
         <GenericFieldRenderer
           fieldId="llmd-serving/advanced-routing"
+          wizardState={wizardState}
+          externalData={externalData}
+          isEditing={wizardState.initialData?.isEditing}
+        />
+        <GenericFieldRenderer
+          fieldId="llmd-serving/accelerator-config"
           wizardState={wizardState}
           externalData={externalData}
           isEditing={wizardState.initialData?.isEditing}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-66855

Field newly available in the llm-d deployment flow:

<img width="1184" height="270" alt="image" src="https://github.com/user-attachments/assets/dea5948e-5dda-4623-b91f-c0597943ebb8" />

Automatic selection available if the selected hardware profile matches exactly one accelerator configuration (to test this on the zaffre cluster, you can use the “Fake Test Accelerator Profile” and see that it selects the “Fake Test Accelerator” config):
<img width="881" height="228" alt="image" src="https://github.com/user-attachments/assets/41d77d29-6ff2-452c-83b5-14d14080f23f" />

When editing, the project-local copy of the config renders as a project-scoped resource (reusing existing project-scoped options in this component even though we don't have real support for user-created project-scoped configs):

<img width="1229" height="269" alt="image" src="https://github.com/user-attachments/assets/c743baf1-a77d-492a-8669-360a797bf21a" />

Placement relative to other fields:

<img width="786" height="985" alt="image" src="https://github.com/user-attachments/assets/4f1c29d1-7085-4fc8-ae6e-ca78635ccbde" />

## Description

In the **"LLM inference service deployment with llm-d"** wizard path, users could not select a vLLM accelerator config (e.g. `vLLM AMD ROCm GPU`). Only topology and routing configs were selectable, so AMD hardware profiles silently received the built-in CUDA image and the pod failed to start.

This adds an optional **"Accelerator configuration"** field to the llm-d path, reusing existing components also used for selecting an accelerator configuration as the “deployment resource” in non-llm-d flows. When selected, the accelerator config is cloned into the project namespace at deploy time and appended **last** in `spec.baseRefs` so its container image overrides the topology config's image **without** touching `spec.router.scheduler` (the deployment stays llm-d). This refactoring was necessary because reuse of the existing accelerator config selection logic would have stripped the scheduler and not deployed as llm-d.

Key design points:
- **Reuses the shared `ModelServerTemplateSelectField`** (the same Automatic/Manual selection component the simple-vLLM `LlmConfigOptionsField` uses), per review — so it gets the Automatic/Manual radios, hardware-profile auto-suggest, and version labels for free. "Built-in image (default)" is the initial Manual selection (choosing it = no override → built-in image). The field keeps its own persisted data model (`{ selectedConfig, configRef }`) and deploy pipeline; the component's `ModelServerSelectFieldData` shape is bridged internally, so the apply/extract/preDeploy path is unchanged. The shared component drives its radio state from `autoSelect`, so the field persists that flag too (deriving it as a constant `false` left the "Automatic selection" radio unable to stay checked); `selectedConfig` still holds the resolved config in both modes, so the deploy pipeline is identical whether the config was picked automatically or manually.
- **Clone-to-namespace pattern** mirrors the merged topology work (#9104): shared helpers `applyConfigRef` and `preDeployConfigCopy` live in `src/deployments/configs.ts` (topology refactored to use them, accelerator as a second caller). Coordinated with @emilys314 so the routing side of [RHOAIENG-79541](https://issues.redhat.com/browse/RHOAIENG-79541) can adopt the same `configs.ts` as a third caller.
- **baseRef ordering is load-bearing**: the accelerator apply extension is registered *after* the topology apply, and `applyFieldData` iterates in registration order, so the accelerator baseRef lands last. Enforced by a guard test.
- **Scheduler is never stripped** on this path — the clone uses a prefixed name (`{deployment}-{config}`), never the bare deployment name that would trigger `applyConfigBaseRef`'s scheduler removal.
- **Delete cleanup**: `deleteDeployment` removes cloned config copies via an annotation-key loop (topology + accelerator; a comment marks where routing plugs in for [RHOAIENG-79541](https://redhat.atlassian.net/browse/RHOAIENG-79541)).
- **Feature-flag gating** (per review): the accelerator field is gated on **`vLLMDeploymentOnMaaS`** (the "choose any vLLM for your LLMInferenceService" capability), matching the accelerator-config admin page and the sibling simple-vLLM field — **not** `llmdTemplates` (which gates the topology/routing selections). This resolves the earlier inconsistency where the field appeared but its admin page was hidden.
- **Edit pre-select fix**: on edit, the accelerator baseRef points at the project-namespace local copy, which the field's data hook didn't fetch (it only listed dashboard-namespace admin configs), so the saved selection didn't pre-select. The hook now fetches the referenced config by name from the project namespace and folds it in — mirroring the topology field.

**Gated to single-node topology** when the topology field is present (current accelerator configs are single-node; the component filters by `supported-topologies` for future multi-node). When `llmdTemplates` is off there is no topology field, so the deployment is implicitly single-node and the accelerator field still shows.

## How Has This Been Tested?

- **Unit tests**: `@odh-dashboard/llmd-serving` **410/410** and `@odh-dashboard/model-serving` **504/504** passing — including `applyConfigRef`, `preDeployConfigCopy` (incl. **create-before-delete ordering** and no-delete-on-create-failure), the accelerator apply/extract/preDeploy wrappers, the **baseRef-last ordering** assertion, the field's `isActive` (incl. the no-topology-field case) + auto-suggest + edit short-circuit + the **referenced-local-copy fold-in** (edit pre-select) + the **Automatic/Manual radio round-trip** + the **no-topology-field config visibility** + the **project-scoped labelling of the local-copy on edit**, the extension registration-order guard, and the delete cleanup.
- **Cypress (mock)**: `modelServingLlmdTopology.cy.ts` — the two accelerator cases pass locally (22 passing; the one unrelated failure is a pre-existing flaky routing test, `should disable routing dropdown when no router configs exist`, which passes on rerun):
  - ✓ creates an accelerator config and appends its baseRef **after** the topology baseRef
  - ✓ does **not** create an accelerator config when left at "Built-in image (default)"
- **Type-check**: clean (root `npm run type-check`). **Lint**: 0 errors (pre-existing `no-restricted-imports` warning on the `spawnerUtils` import, shared with the sibling `LlmConfigOptionsField`).
- **Manual testing** on a live cluster confirmed the field behavior, resource wiring (baseRefs / local-copy clone / scheduler preserved), edit/delete flows, and all four feature-flag combinations.

## Test Impact

**Added / updated:**
- `src/deployments/__tests__/configs.spec.ts` — `applyConfigRef` + `preDeployConfigCopy` (add/remove/replace ref, sentinel no-op, unresolved-configRef no-op, clone/delete-on-switch, 409/404 guards, dry-run).
- `src/deployments/__tests__/accelerator.spec.ts` — accelerator wiring, **baseRef-last-vs-topology ordering**, scheduler-kept, sentinel, extract.
- `src/wizardFields/__tests__/AcceleratorConfigField.spec.tsx` — `isActive` gating (incl. topology-field-absent), option/default behavior, hardware-profile auto-suggest (starts on Automatic when a suggestion exists), existing-selection short-circuit, the `useAcceleratorConfigData` referenced-local-copy fetch/fold-in, and the **Automatic/Manual radio behavior** (radio checked from persisted `autoSelect`, clicking Automatic persists `autoSelect: true` + the suggested config, Manual re-select persists `autoSelect: false`).
- `extensions/__tests__/extensions.spec.ts` — apply-order guard (accelerator after topology).
- `src/api/__tests__/LLMdDeployment.spec.ts` — accelerator copy delete cleanup.
- `packages/model-serving/cypress/.../modelServingLlmdTopology.cy.ts` — deploy-with-accel (asserts config PUT + baseRef order) and built-in-default (asserts no accel config PUT), driven via the shared `ModelServerTemplateSelectField` page-object helpers.

Existing topology/simple-vLLM tests stay green, confirming the shared-helper + shared-component reuse is behavior-preserving.

## Follow-up (tracked separately)

- **externalDataHook duplication** across the `LLMInferenceServiceConfig` wizard fields (each with a dedicated `externalDataHook`). Tracked in [RHOAIENG-85315](https://issues.redhat.com/browse/RHOAIENG-85315): extract a shared `llmd-serving` core (externalDataHook + config→option mapper + suggestion logic + a thin wrapper over `ModelServerTemplateSelectField`) consumed by both `AcceleratorConfigField` and `LlmConfigOptionsField` (and topology/routing where it fits), while keeping the two fields' distinct deploy paths (scheduler-strip for simple-vLLM vs. appended local-copy baseRef with scheduler kept for accelerator). The ticket also assesses which pieces can move into `ModelServerTemplateSelectField` without breaking its generic, cross-package boundary.
- **`createLocalConfigName` truncation collision** ([RHOAIENG-88033](https://issues.redhat.com/browse/RHOAIENG-88033)): two distinct long source-config names can truncate to the same local-copy name at the k8s 253-char limit. Pre-existing behavior inherited from the merged topology clone-to-namespace work (#9104), now shared across topology/accelerator/routing. Fix will add a deterministic hash suffix on truncation (+ boundary test) in the shared `createLocalConfigName` so it's fixed for all three.

Neither of the above is in scope for this PR.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-79541]: https://redhat.atlassian.net/browse/RHOAIENG-79541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added accelerator configuration selection to the LLMD deployment wizard.
  - Supports automatic or manual selection, compatible options, referenced configurations, and built-in defaults.
  - Applies accelerator settings during deployment while preserving configuration order.

- **Bug Fixes**
  - Improved cleanup of local topology and accelerator configuration copies when deployments are deleted.
  - Handles missing or already-removed configuration resources without interrupting deletion.

- **Tests**
  - Added coverage for wizard behavior, configuration handling, accelerator settings, and end-to-end deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


