### PR TITLE
feat(model-serving): Add Model Deployed/Updated tracking events to deployment wizard

### DIFF
--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
@@ -246,7 +246,7 @@ describe('Model Deployment Tracking Events', () => {
       .findModelLocationSelectOption(ModelLocationSelectOption.EXISTING)
       .should('exist')
       .click();
-    modelServingWizard.findExistingConnectionSelect().should('exist').click();
+    modelServingWizard.findExistingConnectionSelect().should('not.have.attr', 'disabled').click();
     modelServingWizard
       .findExistingConnectionSelectOption('Test URI Secret')
       .should('exist')
@@ -269,6 +269,8 @@ describe('Model Deployment Tracking Events', () => {
     // Step 3: Advanced options — enable external route for token auth
     modelServingWizard.findExternalRouteCheckbox().click();
     modelServingWizard.findNextButton().should('be.enabled').click();
+
+    // Step 4: Review & Deploy
 
     // Step 4: Review — stub window.analytics.track to capture tracking events in non-dev builds
     cy.window().then((win) => {
@@ -362,7 +364,7 @@ describe('Model Deployment Tracking Events', () => {
       .findModelLocationSelectOption(ModelLocationSelectOption.EXISTING)
       .should('exist')
       .click();
-    modelServingWizard.findExistingConnectionSelect().should('exist').click();
+    modelServingWizard.findExistingConnectionSelect().should('not.have.attr', 'disabled').click();
     modelServingWizard
       .findExistingConnectionSelectOption('Test URI Secret')
       .should('exist')

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
@@ -251,6 +251,9 @@ describe('Model Deployment Tracking Events', () => {
     // Step 2: Model deployment
     modelServingWizard.findModelDeploymentNameInput().type('test-model');
     modelServingWizard.selectDeploymentMethodByKey('legacy');
+    modelServingWizard
+      .findServingRuntimeTemplateSearchSelector()
+      .should('not.have.class', 'pf-m-disabled');
     modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
     modelServingWizard.selectGlobalScopedTemplateOption('vLLM NVIDIA');
     modelServingWizard.findNextButton().click();
@@ -259,9 +262,10 @@ describe('Model Deployment Tracking Events', () => {
     modelServingWizard.findExternalRouteCheckbox().click();
     modelServingWizard.findNextButton().click();
 
-    // Step 4: Review — set up console spy and submit
+    // Step 4: Review — stub analytics and submit
     cy.window().then((win) => {
-      cy.spy(win.console, 'log').as('consoleLog');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (win as any).analytics = { track: cy.stub().as('analyticsTrack') };
     });
 
     modelServingWizard.findSubmitButton().click();
@@ -270,11 +274,7 @@ describe('Model Deployment Tracking Events', () => {
     cy.wait('@createInferenceService');
     cy.wait('@createInferenceService');
 
-    // Verify the Model Deployed event was logged (DEV_MODE console.log pattern)
-    cy.get('@consoleLog').should(
-      'be.calledWithMatch',
-      Cypress.sinon.match((msg: string) => msg.includes('Model Deployed')),
-    );
+    cy.get('@analyticsTrack').should('be.calledWithMatch', 'Model Deployed');
   });
 
   it('should fire Model Deployed cancel event when user exits via ExitDeploymentModal', () => {
@@ -294,21 +294,20 @@ describe('Model Deployment Tracking Events', () => {
     // Start filling out the form so it's dirty
     modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
 
-    // Set up console spy
+    // Stub analytics before triggering the cancel event
     cy.window().then((win) => {
-      cy.spy(win.console, 'log').as('consoleLog');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (win as any).analytics = { track: cy.stub().as('analyticsTrack') };
     });
 
     // Cancel from wizard — click Cancel button then confirm discard
     cy.findByRole('button', { name: 'Cancel' }).click();
     modelServingWizard.findDiscardButton().click();
 
-    // Verify the cancel event was fired
-    cy.get('@consoleLog').should(
+    cy.get('@analyticsTrack').should(
       'be.calledWithMatch',
-      Cypress.sinon.match(
-        (msg: string) => msg.includes('Model Deployed') && msg.includes('cancel'),
-      ),
+      'Model Deployed',
+      Cypress.sinon.match.has('outcome', 'cancel'),
     );
   });
 
@@ -353,6 +352,9 @@ describe('Model Deployment Tracking Events', () => {
     // Step 2: Model deployment
     modelServingWizard.findModelDeploymentNameInput().type('test-model');
     modelServingWizard.selectDeploymentMethodByKey('legacy');
+    modelServingWizard
+      .findServingRuntimeTemplateSearchSelector()
+      .should('not.have.class', 'pf-m-disabled');
     modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
     modelServingWizard.selectGlobalScopedTemplateOption('vLLM NVIDIA');
     modelServingWizard.findNextButton().click();
@@ -361,21 +363,20 @@ describe('Model Deployment Tracking Events', () => {
     modelServingWizard.findExternalRouteCheckbox().click();
     modelServingWizard.findNextButton().click();
 
-    // Step 4: Review — spy and submit
+    // Step 4: Review — stub analytics and submit
     cy.window().then((win) => {
-      cy.spy(win.console, 'log').as('consoleLog');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (win as any).analytics = { track: cy.stub().as('analyticsTrack') };
     });
 
     modelServingWizard.findSubmitButton().click();
 
     cy.wait('@createInferenceServiceFail');
 
-    // Verify the failure event was logged
-    cy.get('@consoleLog').should(
+    cy.get('@analyticsTrack').should(
       'be.calledWithMatch',
-      Cypress.sinon.match(
-        (msg: string) => msg.includes('Model Deployed') && msg.includes('"success":false'),
-      ),
+      'Model Deployed',
+      Cypress.sinon.match.has('success', false),
     );
   });
 });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
@@ -123,7 +123,14 @@ const initIntercepts = () => {
 
   cy.interceptK8sList(
     { model: SecretModel, ns: 'test-project' },
-    mockK8sResourceList([mockURISecretK8sResource({ namespace: 'test-project' })]),
+    mockK8sResourceList([
+      mockURISecretK8sResource({ namespace: 'test-project' }),
+      mockURISecretK8sResource({
+        namespace: 'test-project',
+        name: 'test-uri-secret-2',
+        displayName: 'Test URI Secret 2',
+      }),
+    ]),
   );
 
   cy.interceptK8sList(
@@ -246,7 +253,7 @@ describe('Model Deployment Tracking Events', () => {
       .findModelLocationSelectOption(ModelLocationSelectOption.EXISTING)
       .should('exist')
       .click();
-    modelServingWizard.findExistingConnectionSelect().should('not.have.attr', 'disabled').click();
+    modelServingWizard.findExistingConnectionSelect().click();
     modelServingWizard
       .findExistingConnectionSelectOption('Test URI Secret')
       .should('exist')
@@ -364,7 +371,7 @@ describe('Model Deployment Tracking Events', () => {
       .findModelLocationSelectOption(ModelLocationSelectOption.EXISTING)
       .should('exist')
       .click();
-    modelServingWizard.findExistingConnectionSelect().should('not.have.attr', 'disabled').click();
+    modelServingWizard.findExistingConnectionSelect().click();
     modelServingWizard
       .findExistingConnectionSelectOption('Test URI Secret')
       .should('exist')

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
@@ -1,0 +1,371 @@
+import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/internal/__mocks__/mockInferenceServiceK8sResource';
+import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
+import { mock404Error } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { mockServingRuntimeK8sResource } from '@odh-dashboard/internal/__mocks__/mockServingRuntimeK8sResource';
+import { mockStandardModelServingTemplateK8sResources } from '@odh-dashboard/internal/__mocks__/mockServingRuntimeTemplateK8sResource';
+import { IdentifierResourceType } from '@odh-dashboard/k8s-core';
+import { ServingRuntimeModelType } from '@odh-dashboard/model-serving/shared/types';
+import {
+  mockGlobalScopedHardwareProfiles,
+  mockHardwareProfile,
+} from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
+import {
+  mockConnectionTypeConfigMap,
+  mockModelServingFields,
+  mockOciConnectionTypeConfigMap,
+} from '@odh-dashboard/internal/__mocks__/mockConnectionType';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { mockURISecretK8sResource } from '@odh-dashboard/internal/__mocks__/mockSecretK8sResource';
+import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
+import {
+  HardwareProfileModel,
+  InferenceServiceModel,
+  PVCModel,
+  ProjectModel,
+  RoleBindingModel,
+  RoleModel,
+  SecretModel,
+  ServiceAccountModel,
+  ServingRuntimeModel,
+  TemplateModel,
+} from '@odh-dashboard/cypress/cypress/utils/models';
+import {
+  modelServingGlobal,
+  modelServingWizard,
+} from '@odh-dashboard/cypress/cypress/pages/modelServing';
+import {
+  ModelLocationSelectOption,
+  ModelTypeLabel,
+} from '@odh-dashboard/cypress/cypress/utils/modelServingConstants';
+
+const initIntercepts = () => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+        [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
+      },
+    }),
+  );
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableNIMModelServing: true,
+      disableKServe: false,
+      deploymentWizardYAMLViewer: true,
+      vLLMDeploymentOnMaaS: true,
+      genAiStudio: true,
+    }),
+  );
+  cy.interceptOdh(
+    'GET /api/namespaces/:namespace/:context',
+    { path: { namespace: 'test-project', context: '*' } },
+    { applied: true },
+  );
+
+  cy.interceptOdh('GET /api/components', null, []);
+  cy.interceptOdh('GET /api/connection-types', [
+    mockConnectionTypeConfigMap({
+      displayName: 'URI - v1',
+      name: 'uri-v1',
+      category: ['existing-category'],
+      fields: [
+        {
+          type: 'uri',
+          name: 'URI',
+          envVar: 'URI',
+          required: true,
+          properties: {},
+        },
+      ],
+    }),
+    mockConnectionTypeConfigMap({
+      displayName: 'S3',
+      name: 's3',
+      category: ['existing-category'],
+      fields: mockModelServingFields,
+    }),
+    mockOciConnectionTypeConfigMap(),
+  ]);
+
+  cy.interceptK8sList(
+    { model: HardwareProfileModel, ns: 'opendatahub' },
+    mockK8sResourceList([
+      mockGlobalScopedHardwareProfiles[0],
+      mockGlobalScopedHardwareProfiles[1],
+      mockHardwareProfile({
+        name: 'nvidia-profile',
+        displayName: 'NVIDIA GPU Profile',
+        identifiers: [
+          {
+            displayName: 'CPU',
+            identifier: 'cpu',
+            minCount: '4',
+            maxCount: '8',
+            defaultCount: '4',
+            resourceType: IdentifierResourceType.CPU,
+          },
+          {
+            displayName: 'Memory',
+            identifier: 'memory',
+            minCount: '8Gi',
+            maxCount: '16Gi',
+            defaultCount: '8Gi',
+            resourceType: IdentifierResourceType.MEMORY,
+          },
+        ],
+      }),
+    ]),
+  );
+
+  cy.interceptK8sList(
+    { model: SecretModel, ns: 'test-project' },
+    mockK8sResourceList([mockURISecretK8sResource({ namespace: 'test-project' })]),
+  );
+
+  cy.interceptK8sList(
+    TemplateModel,
+    mockK8sResourceList(mockStandardModelServingTemplateK8sResources(), {
+      namespace: 'opendatahub',
+    }),
+  );
+
+  cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProjectK8sResource({})]));
+  cy.interceptK8sList(PVCModel, mockK8sResourceList([mockPVCK8sResource({})]));
+
+  cy.interceptK8s(
+    'POST',
+    { model: InferenceServiceModel, ns: 'test-project' },
+    {
+      statusCode: 200,
+      body: mockInferenceServiceK8sResource({
+        name: 'test-model',
+        modelType: ServingRuntimeModelType.GENERATIVE,
+      }),
+    },
+  ).as('createInferenceService');
+
+  cy.interceptK8s(
+    'POST',
+    { model: ServingRuntimeModel, ns: 'test-project' },
+    { statusCode: 200, body: mockServingRuntimeK8sResource({}) },
+  ).as('createServingRuntime');
+
+  cy.interceptK8s(
+    'POST',
+    { model: ServiceAccountModel, ns: 'test-project' },
+    {
+      statusCode: 200,
+      body: {
+        apiVersion: 'v1',
+        kind: 'ServiceAccount',
+        metadata: { name: 'test-model-sa', namespace: 'test-project' },
+      },
+    },
+  ).as('createServiceAccount');
+
+  cy.interceptK8s(
+    'POST',
+    { model: RoleModel, ns: 'test-project' },
+    {
+      statusCode: 200,
+      body: {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'Role',
+        metadata: { name: 'test-model-view-role', namespace: 'test-project' },
+      },
+    },
+  ).as('createRole');
+
+  cy.interceptK8s(
+    'POST',
+    { model: RoleBindingModel, ns: 'test-project' },
+    {
+      statusCode: 200,
+      body: {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'RoleBinding',
+        metadata: { name: 'test-model-view', namespace: 'test-project' },
+      },
+    },
+  ).as('createRoleBinding');
+
+  cy.interceptK8s(
+    'POST',
+    { model: SecretModel, ns: 'test-project' },
+    {
+      statusCode: 200,
+      body: {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: { name: 'test-model-token', namespace: 'test-project' },
+      },
+    },
+  ).as('createSecret');
+
+  cy.interceptK8s(
+    'GET',
+    { model: ServiceAccountModel, ns: 'test-project', name: 'test-model-sa' },
+    { statusCode: 404, body: mock404Error({}) },
+  ).as('getServiceAccount');
+
+  cy.interceptK8s(
+    'GET',
+    { model: RoleModel, ns: 'test-project', name: 'test-model-view-role' },
+    { statusCode: 404, body: mock404Error({}) },
+  ).as('getRole');
+
+  cy.interceptK8s(
+    'GET',
+    { model: RoleBindingModel, ns: 'test-project', name: 'test-model-view' },
+    { statusCode: 404, body: mock404Error({}) },
+  ).as('getRoleBinding');
+};
+
+describe('Model Deployment Tracking Events', () => {
+  it('should fire Model Deployed event on successful deployment', () => {
+    initIntercepts();
+    cy.interceptK8sList(
+      { model: InferenceServiceModel, ns: 'test-project' },
+      mockK8sResourceList([mockInferenceServiceK8sResource({})]),
+    );
+    cy.interceptK8sList(
+      { model: ServingRuntimeModel, ns: 'test-project' },
+      mockK8sResourceList([mockServingRuntimeK8sResource({})]),
+    );
+
+    modelServingGlobal.visit('test-project');
+    modelServingGlobal.findDeployModelButton().click();
+
+    // Step 1: Model source — select generative model with existing connection
+    modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
+    modelServingWizard.findModelLocationSelectOption(ModelLocationSelectOption.EXISTING).click();
+    modelServingWizard.findExistingConnectionSelect().click();
+    modelServingWizard.findExistingConnectionSelectOption('Test URI Secret').click();
+    modelServingWizard.findNextButton().click();
+
+    // Step 2: Model deployment
+    modelServingWizard.findModelDeploymentNameInput().type('test-model');
+    modelServingWizard.selectDeploymentMethodByKey('legacy');
+    modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
+    modelServingWizard.selectGlobalScopedTemplateOption('vLLM NVIDIA');
+    modelServingWizard.findNextButton().click();
+
+    // Step 3: Advanced options — skip through with defaults
+    modelServingWizard.findExternalRouteCheckbox().click();
+    modelServingWizard.findNextButton().click();
+
+    // Step 4: Review — set up console spy and submit
+    cy.window().then((win) => {
+      cy.spy(win.console, 'log').as('consoleLog');
+    });
+
+    modelServingWizard.findSubmitButton().click();
+
+    // Two InferenceService POSTs: first is a dry-run validation, second is the actual create
+    cy.wait('@createInferenceService');
+    cy.wait('@createInferenceService');
+
+    // Verify the Model Deployed event was logged (DEV_MODE console.log pattern)
+    cy.get('@consoleLog').should(
+      'be.calledWithMatch',
+      Cypress.sinon.match((msg: string) => msg.includes('Model Deployed')),
+    );
+  });
+
+  it('should fire Model Deployed cancel event when user exits via ExitDeploymentModal', () => {
+    initIntercepts();
+    cy.interceptK8sList(
+      { model: InferenceServiceModel, ns: 'test-project' },
+      mockK8sResourceList([mockInferenceServiceK8sResource({})]),
+    );
+    cy.interceptK8sList(
+      { model: ServingRuntimeModel, ns: 'test-project' },
+      mockK8sResourceList([mockServingRuntimeK8sResource({})]),
+    );
+
+    modelServingGlobal.visit('test-project');
+    modelServingGlobal.findDeployModelButton().click();
+
+    // Start filling out the form so it's dirty
+    modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
+
+    // Set up console spy
+    cy.window().then((win) => {
+      cy.spy(win.console, 'log').as('consoleLog');
+    });
+
+    // Cancel from wizard — click Cancel button then confirm discard
+    cy.findByRole('button', { name: 'Cancel' }).click();
+    modelServingWizard.findDiscardButton().click();
+
+    // Verify the cancel event was fired
+    cy.get('@consoleLog').should(
+      'be.calledWithMatch',
+      Cypress.sinon.match(
+        (msg: string) => msg.includes('Model Deployed') && msg.includes('cancel'),
+      ),
+    );
+  });
+
+  it('should fire Model Deployed error event when deploy fails', () => {
+    initIntercepts();
+    cy.interceptK8sList(
+      { model: InferenceServiceModel, ns: 'test-project' },
+      mockK8sResourceList([mockInferenceServiceK8sResource({})]),
+    );
+    cy.interceptK8sList(
+      { model: ServingRuntimeModel, ns: 'test-project' },
+      mockK8sResourceList([mockServingRuntimeK8sResource({})]),
+    );
+
+    // Override the POST to fail
+    cy.interceptK8s(
+      'POST',
+      { model: InferenceServiceModel, ns: 'test-project' },
+      { statusCode: 500, body: { message: 'Internal server error' } },
+    ).as('createInferenceServiceFail');
+
+    modelServingGlobal.visit('test-project');
+    modelServingGlobal.findDeployModelButton().click();
+
+    // Step 1: Model source
+    modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
+    modelServingWizard.findModelLocationSelectOption(ModelLocationSelectOption.EXISTING).click();
+    modelServingWizard.findExistingConnectionSelect().click();
+    modelServingWizard.findExistingConnectionSelectOption('Test URI Secret').click();
+    modelServingWizard.findNextButton().click();
+
+    // Step 2: Model deployment
+    modelServingWizard.findModelDeploymentNameInput().type('test-model');
+    modelServingWizard.selectDeploymentMethodByKey('legacy');
+    modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
+    modelServingWizard.selectGlobalScopedTemplateOption('vLLM NVIDIA');
+    modelServingWizard.findNextButton().click();
+
+    // Step 3: Advanced options
+    modelServingWizard.findExternalRouteCheckbox().click();
+    modelServingWizard.findNextButton().click();
+
+    // Step 4: Review — spy and submit
+    cy.window().then((win) => {
+      cy.spy(win.console, 'log').as('consoleLog');
+    });
+
+    modelServingWizard.findSubmitButton().click();
+
+    cy.wait('@createInferenceServiceFail');
+
+    // Verify the failure event was logged
+    cy.get('@consoleLog').should(
+      'be.calledWithMatch',
+      Cypress.sinon.match(
+        (msg: string) => msg.includes('Model Deployed') && msg.includes('"success":false'),
+      ),
+    );
+  });
+});

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
@@ -262,10 +262,13 @@ describe('Model Deployment Tracking Events', () => {
     modelServingWizard.findExternalRouteCheckbox().click();
     modelServingWizard.findNextButton().click();
 
-    // Step 4: Review — stub analytics and submit
+    // Step 4: Review — stub window.analytics.track to capture tracking events in non-dev builds
     cy.window().then((win) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (win as any).analytics = { track: cy.stub().as('analyticsTrack') };
+      Object.defineProperty(win, 'analytics', {
+        value: { track: cy.stub().as('analyticsTrack') },
+        writable: true,
+        configurable: true,
+      });
     });
 
     modelServingWizard.findSubmitButton().click();
@@ -294,10 +297,13 @@ describe('Model Deployment Tracking Events', () => {
     // Start filling out the form so it's dirty
     modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
 
-    // Stub analytics before triggering the cancel event
+    // Stub window.analytics.track before triggering the cancel event
     cy.window().then((win) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (win as any).analytics = { track: cy.stub().as('analyticsTrack') };
+      Object.defineProperty(win, 'analytics', {
+        value: { track: cy.stub().as('analyticsTrack') },
+        writable: true,
+        configurable: true,
+      });
     });
 
     // Cancel from wizard — click Cancel button then confirm discard
@@ -363,10 +369,13 @@ describe('Model Deployment Tracking Events', () => {
     modelServingWizard.findExternalRouteCheckbox().click();
     modelServingWizard.findNextButton().click();
 
-    // Step 4: Review — stub analytics and submit
+    // Step 4: Review — stub window.analytics.track to capture tracking events in non-dev builds
     cy.window().then((win) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (win as any).analytics = { track: cy.stub().as('analyticsTrack') };
+      Object.defineProperty(win, 'analytics', {
+        value: { track: cy.stub().as('analyticsTrack') },
+        writable: true,
+        configurable: true,
+      });
     });
 
     modelServingWizard.findSubmitButton().click();

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
@@ -1,11 +1,11 @@
-import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
-import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
-import { mockInferenceServiceK8sResource } from '@odh-dashboard/internal/__mocks__/mockInferenceServiceK8sResource';
-import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
-import { mock404Error } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
+import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
+import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
+import { mock404Error } from '@odh-dashboard/k8s-core/__mocks__/mockK8sStatus';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
-import { mockServingRuntimeK8sResource } from '@odh-dashboard/internal/__mocks__/mockServingRuntimeK8sResource';
-import { mockStandardModelServingTemplateK8sResources } from '@odh-dashboard/internal/__mocks__/mockServingRuntimeTemplateK8sResource';
+import { mockServingRuntimeK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockServingRuntimeK8sResource';
+import { mockStandardModelServingTemplateK8sResources } from '@odh-dashboard/model-serving/__mocks__/mockServingRuntimeTemplateK8sResource';
 import { IdentifierResourceType } from '@odh-dashboard/k8s-core';
 import { ServingRuntimeModelType } from '@odh-dashboard/model-serving/shared/types';
 import {
@@ -16,9 +16,9 @@ import {
   mockConnectionTypeConfigMap,
   mockModelServingFields,
   mockOciConnectionTypeConfigMap,
-} from '@odh-dashboard/internal/__mocks__/mockConnectionType';
+} from '@odh-dashboard/k8s-core/__mocks__/mockConnectionType';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
-import { mockURISecretK8sResource } from '@odh-dashboard/internal/__mocks__/mockSecretK8sResource';
+import { mockURISecretK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockSecretK8sResource';
 import { mockPVCK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockPVCK8sResource';
 import {
   HardwareProfileModel,
@@ -327,7 +327,7 @@ describe('Model Deployment Tracking Events', () => {
     cy.interceptK8s(
       'POST',
       { model: InferenceServiceModel, ns: 'test-project' },
-      { statusCode: 500, body: { message: 'Internal server error' } },
+      { statusCode: 500, body: { kind: 'Status', apiVersion: 'v1', status: 'Failure', message: 'Internal server error', reason: 'InternalError', code: 500 } },
     ).as('createInferenceServiceFail');
 
     modelServingGlobal.visit('test-project');

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
@@ -327,7 +327,17 @@ describe('Model Deployment Tracking Events', () => {
     cy.interceptK8s(
       'POST',
       { model: InferenceServiceModel, ns: 'test-project' },
-      { statusCode: 500, body: { kind: 'Status', apiVersion: 'v1', status: 'Failure', message: 'Internal server error', reason: 'InternalError', code: 500 } },
+      {
+        statusCode: 500,
+        body: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: 'Internal server error',
+          reason: 'InternalError',
+          code: 500,
+        },
+      },
     ).as('createInferenceServiceFail');
 
     modelServingGlobal.visit('test-project');

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
@@ -253,7 +253,7 @@ describe('Model Deployment Tracking Events', () => {
     modelServingWizard.selectDeploymentMethodByKey('legacy');
     modelServingWizard
       .findServingRuntimeTemplateSearchSelector()
-      .should('not.have.class', 'pf-m-disabled');
+      .should('contain.text', 'Select a serving runtime template');
     modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
     modelServingWizard.selectGlobalScopedTemplateOption('vLLM NVIDIA');
     modelServingWizard.findNextButton().click();
@@ -360,7 +360,7 @@ describe('Model Deployment Tracking Events', () => {
     modelServingWizard.selectDeploymentMethodByKey('legacy');
     modelServingWizard
       .findServingRuntimeTemplateSearchSelector()
-      .should('not.have.class', 'pf-m-disabled');
+      .should('contain.text', 'Select a serving runtime template');
     modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
     modelServingWizard.selectGlobalScopedTemplateOption('vLLM NVIDIA');
     modelServingWizard.findNextButton().click();

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts
@@ -57,7 +57,6 @@ const initIntercepts = () => {
       disableNIMModelServing: true,
       disableKServe: false,
       deploymentWizardYAMLViewer: true,
-      vLLMDeploymentOnMaaS: true,
       genAiStudio: true,
     }),
   );
@@ -242,25 +241,34 @@ describe('Model Deployment Tracking Events', () => {
     modelServingGlobal.findDeployModelButton().click();
 
     // Step 1: Model source — select generative model with existing connection
-    modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
-    modelServingWizard.findModelLocationSelectOption(ModelLocationSelectOption.EXISTING).click();
-    modelServingWizard.findExistingConnectionSelect().click();
-    modelServingWizard.findExistingConnectionSelectOption('Test URI Secret').click();
-    modelServingWizard.findNextButton().click();
+    modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).should('exist').click();
+    modelServingWizard
+      .findModelLocationSelectOption(ModelLocationSelectOption.EXISTING)
+      .should('exist')
+      .click();
+    modelServingWizard.findExistingConnectionSelect().should('exist').click();
+    modelServingWizard
+      .findExistingConnectionSelectOption('Test URI Secret')
+      .should('exist')
+      .click();
+    modelServingWizard.findNextButton().should('be.enabled').click();
 
-    // Step 2: Model deployment
+    // Step 2: Model deployment — mirrors the passing pattern from modelServingDeploy.cy.ts
+    modelServingWizard.findModelDeploymentStep().should('be.enabled');
+    modelServingWizard.findNextButton().should('be.disabled');
     modelServingWizard.findModelDeploymentNameInput().type('test-model');
     modelServingWizard.selectDeploymentMethodByKey('legacy');
+    modelServingWizard.findModelServerAutoSelectRadio().should('not.be.checked');
     modelServingWizard
       .findServingRuntimeTemplateSearchSelector()
       .should('contain.text', 'Select a serving runtime template');
     modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
     modelServingWizard.selectGlobalScopedTemplateOption('vLLM NVIDIA');
-    modelServingWizard.findNextButton().click();
+    modelServingWizard.findNextButton().should('be.enabled').click();
 
-    // Step 3: Advanced options — skip through with defaults
+    // Step 3: Advanced options — enable external route for token auth
     modelServingWizard.findExternalRouteCheckbox().click();
-    modelServingWizard.findNextButton().click();
+    modelServingWizard.findNextButton().should('be.enabled').click();
 
     // Step 4: Review — stub window.analytics.track to capture tracking events in non-dev builds
     cy.window().then((win) => {
@@ -348,26 +356,35 @@ describe('Model Deployment Tracking Events', () => {
     modelServingGlobal.visit('test-project');
     modelServingGlobal.findDeployModelButton().click();
 
-    // Step 1: Model source
-    modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).click();
-    modelServingWizard.findModelLocationSelectOption(ModelLocationSelectOption.EXISTING).click();
-    modelServingWizard.findExistingConnectionSelect().click();
-    modelServingWizard.findExistingConnectionSelectOption('Test URI Secret').click();
-    modelServingWizard.findNextButton().click();
+    // Step 1: Model source — select generative model with existing connection
+    modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.GENERATIVE).should('exist').click();
+    modelServingWizard
+      .findModelLocationSelectOption(ModelLocationSelectOption.EXISTING)
+      .should('exist')
+      .click();
+    modelServingWizard.findExistingConnectionSelect().should('exist').click();
+    modelServingWizard
+      .findExistingConnectionSelectOption('Test URI Secret')
+      .should('exist')
+      .click();
+    modelServingWizard.findNextButton().should('be.enabled').click();
 
-    // Step 2: Model deployment
+    // Step 2: Model deployment — mirrors the passing pattern from modelServingDeploy.cy.ts
+    modelServingWizard.findModelDeploymentStep().should('be.enabled');
+    modelServingWizard.findNextButton().should('be.disabled');
     modelServingWizard.findModelDeploymentNameInput().type('test-model');
     modelServingWizard.selectDeploymentMethodByKey('legacy');
+    modelServingWizard.findModelServerAutoSelectRadio().should('not.be.checked');
     modelServingWizard
       .findServingRuntimeTemplateSearchSelector()
       .should('contain.text', 'Select a serving runtime template');
     modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
     modelServingWizard.selectGlobalScopedTemplateOption('vLLM NVIDIA');
-    modelServingWizard.findNextButton().click();
+    modelServingWizard.findNextButton().should('be.enabled').click();
 
     // Step 3: Advanced options
     modelServingWizard.findExternalRouteCheckbox().click();
-    modelServingWizard.findNextButton().click();
+    modelServingWizard.findNextButton().should('be.enabled').click();
 
     // Step 4: Review — stub window.analytics.track to capture tracking events in non-dev builds
     cy.window().then((win) => {

--- a/packages/model-serving/extension-points/deployment-wizard.ts
+++ b/packages/model-serving/extension-points/deployment-wizard.ts
@@ -287,3 +287,28 @@ export const isWizardFieldDeploymentFunctionsExtension = <
   extension: Extension,
 ): extension is WizardFieldDeploymentFunctionsExtension<T, D> =>
   extension.type === 'model-serving.deployment/wizard-field-deployment-functions';
+
+/**
+ * Extension for contributing per-platform tracking properties to the Model Deployed event.
+ * Spokes register this extension so the hub can collect platform-specific analytics data
+ * without importing from spoke packages.
+ */
+export type WizardTrackingPropertiesExtension<D extends Deployment = Deployment> = Extension<
+  'model-serving.deployment/tracking-properties',
+  {
+    platform: D['modelServingPlatformId'];
+    /**
+     * Extract platform-specific tracking properties from the wizard form state.
+     * These are merged into the base Model Deployed / Model Updated event properties.
+     */
+    getProperties: CodeRef<
+      (
+        wizardState: WizardFormData['state'],
+      ) => Record<string, string | number | boolean | undefined>
+    >;
+  }
+>;
+export const isWizardTrackingPropertiesExtension = <D extends Deployment = Deployment>(
+  extension: Extension,
+): extension is WizardTrackingPropertiesExtension<D> =>
+  extension.type === 'model-serving.deployment/tracking-properties';

--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PageSection, Wizard, WizardStep } from '@patternfly/react-core';
-import { ApplicationsPage } from '@odh-dashboard/ui-core';
+import { ApplicationsPage, TrackingOutcome } from '@odh-dashboard/ui-core';
 import type { ProjectKind } from '@odh-dashboard/k8s-core';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import {
@@ -30,6 +30,7 @@ import {
   ModelDeploymentFooter,
   ModelDeploymentWizardFooter,
 } from '../generic/WizardFooterWithDisablingNext';
+import { fireModelDeployed } from '../../shared/tracking/deploymentTracking';
 
 export type ModelDeploymentWizardViewMode = 'form' | 'yaml-preview' | 'yaml-edit';
 
@@ -54,9 +55,20 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
   returnRoute,
   cancelReturnRoute,
 }) => {
+  const isEdit = !!existingDeployment;
   const onRefresh = useRefreshWizardPage(existingDeployment);
-  const { isExitModalOpen, openExitModal, closeExitModal, handleExitConfirm, exitWizardOnSubmit } =
-    useExitDeploymentWizard({ returnRoute, cancelReturnRoute });
+  const {
+    isExitModalOpen,
+    openExitModal,
+    closeExitModal,
+    handleExitConfirm: baseHandleExitConfirm,
+    exitWizardOnSubmit,
+  } = useExitDeploymentWizard({ returnRoute, cancelReturnRoute });
+
+  const handleExitConfirm = React.useCallback(() => {
+    fireModelDeployed({ outcome: TrackingOutcome.cancel }, isEdit);
+    baseHandleExitConfirm();
+  }, [baseHandleExitConfirm, isEdit]);
 
   const isYAMLViewerEnabled = useIsAreaAvailable(SupportedArea.YAML_VIEWER).status;
   const [viewMode, setViewMode] = React.useState<ModelDeploymentWizardViewMode>(

--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PageSection, Wizard, WizardStep } from '@patternfly/react-core';
-import { ApplicationsPage, TrackingOutcome } from '@odh-dashboard/ui-core';
+import { ApplicationsPage } from '@odh-dashboard/ui-core';
 import type { ProjectKind } from '@odh-dashboard/k8s-core';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import {
@@ -30,7 +30,6 @@ import {
   ModelDeploymentFooter,
   ModelDeploymentWizardFooter,
 } from '../generic/WizardFooterWithDisablingNext';
-import { fireModelDeployed } from '../../shared/tracking/deploymentTracking';
 
 export type ModelDeploymentWizardViewMode = 'form' | 'yaml-preview' | 'yaml-edit';
 
@@ -57,18 +56,8 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
 }) => {
   const isEdit = !!existingDeployment;
   const onRefresh = useRefreshWizardPage(existingDeployment);
-  const {
-    isExitModalOpen,
-    openExitModal,
-    closeExitModal,
-    handleExitConfirm: baseHandleExitConfirm,
-    exitWizardOnSubmit,
-  } = useExitDeploymentWizard({ returnRoute, cancelReturnRoute });
-
-  const handleExitConfirm = React.useCallback(() => {
-    fireModelDeployed({ outcome: TrackingOutcome.cancel }, isEdit);
-    baseHandleExitConfirm();
-  }, [baseHandleExitConfirm, isEdit]);
+  const { isExitModalOpen, openExitModal, closeExitModal, handleExitConfirm, exitWizardOnSubmit } =
+    useExitDeploymentWizard({ returnRoute, cancelReturnRoute, isEdit });
 
   const isYAMLViewerEnabled = useIsAreaAvailable(SupportedArea.YAML_VIEWER).status;
   const [viewMode, setViewMode] = React.useState<ModelDeploymentWizardViewMode>(

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import { useSecretOps } from '@odh-dashboard/plugin-core/host-api';
 import { getServingRuntimeFromTemplate } from '@odh-dashboard/model-serving/shared';
 import { useDeployMethod } from './useDeployMethod';
@@ -13,6 +14,12 @@ import { InitialWizardFormData } from '../../../shared/types/form-data';
 import { WizardFormState } from '../useDeploymentWizardReducer';
 import { ModelDeploymentWizardViewMode } from '../ModelDeploymentWizard';
 import { ExternalDataMap, isExternalDataReady } from '../ExternalDataLoader';
+import {
+  fireModelDeployed,
+  type DeploymentTrackingProperties,
+} from '../../../shared/tracking/deploymentTracking';
+import { useWizardTrackingProperties } from '../../../shared/tracking/useWizardTrackingProperties';
+import { ServingRuntimePlatform } from '../../../shared/types';
 
 /**
  * Get the onSubmit function to create / update the deployment. 
@@ -45,9 +52,30 @@ export const useModelDeploymentSubmit = (
   );
   const { runPreDeploy, preDeployExtensionsLoaded } = useWizardFieldPreDeploy(formState);
   const { runPostDeploy, postDeployExtensionsLoaded } = useWizardFieldPostDeploy(formState);
+  const { platformProperties } = useWizardTrackingProperties(
+    formState,
+    deployMethod?.properties.platform,
+  );
 
   const [submitError, setSubmitError] = React.useState<Error | null>(null);
   const [isLoading, setIsLoading] = React.useState(false);
+
+  const isEdit = !!existingDeployment;
+
+  const getBaseTrackingProperties = React.useCallback((): Omit<
+    DeploymentTrackingProperties,
+    'outcome' | 'success' | 'error'
+  > => {
+    const serverTemplateName = formState.modelServer?.data?.selection?.name;
+    return {
+      type: formState.modelType.data?.type ?? ServingRuntimePlatform.SINGLE,
+      runtime: serverTemplateName,
+      servingRuntimeName: formState.modelServer?.data?.selection?.label,
+      servingRuntimeFormat: formState.modelFormatState.modelFormat?.name,
+      numReplicas: formState.numReplicas.data ?? undefined,
+      ...platformProperties,
+    };
+  }, [formState, platformProperties]);
 
   const onSave = React.useCallback(
     async (overwrite?: boolean) => {
@@ -112,9 +140,30 @@ export const useModelDeploymentSubmit = (
           runPreDeploy,
           runPostDeploy,
         );
+
+        fireModelDeployed(
+          {
+            outcome: TrackingOutcome.submit,
+            success: true,
+            ...getBaseTrackingProperties(),
+          },
+          isEdit,
+        );
+
         exitWizardOnSubmit();
       } catch (error) {
-        setSubmitError(error instanceof Error ? error : new Error(String(error)));
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        setSubmitError(error instanceof Error ? error : new Error(errorMessage));
+
+        fireModelDeployed(
+          {
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: errorMessage,
+            ...getBaseTrackingProperties(),
+          },
+          isEdit,
+        );
       } finally {
         setIsLoading(false);
       }
@@ -139,6 +188,8 @@ export const useModelDeploymentSubmit = (
       runPostDeploy,
       exitWizardOnSubmit,
       yamlError,
+      isEdit,
+      getBaseTrackingProperties,
     ],
   );
 

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
@@ -159,7 +159,7 @@ export const useModelDeploymentSubmit = (
           {
             outcome: TrackingOutcome.submit,
             success: false,
-            error: errorMessage,
+            errorMessage,
             ...getBaseTrackingProperties(),
             ...(await getTrackingProperties()),
           },

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
@@ -19,7 +19,6 @@ import {
   type DeploymentTrackingProperties,
 } from '../../../shared/tracking/deploymentTracking';
 import { useWizardTrackingProperties } from '../../../shared/tracking/useWizardTrackingProperties';
-import { ServingRuntimePlatform } from '../../../shared/types';
 
 /**
  * Get the onSubmit function to create / update the deployment. 
@@ -52,7 +51,7 @@ export const useModelDeploymentSubmit = (
   );
   const { runPreDeploy, preDeployExtensionsLoaded } = useWizardFieldPreDeploy(formState);
   const { runPostDeploy, postDeployExtensionsLoaded } = useWizardFieldPostDeploy(formState);
-  const { platformProperties } = useWizardTrackingProperties(
+  const { getTrackingProperties } = useWizardTrackingProperties(
     formState,
     deployMethod?.properties.platform,
   );
@@ -68,14 +67,15 @@ export const useModelDeploymentSubmit = (
   > => {
     const serverTemplateName = formState.modelServer?.data?.selection?.name;
     return {
-      type: formState.modelType.data?.type ?? ServingRuntimePlatform.SINGLE,
+      type: formState.modelType.data?.type,
       runtime: serverTemplateName,
       servingRuntimeName: formState.modelServer?.data?.selection?.label,
       servingRuntimeFormat: formState.modelFormatState.modelFormat?.name,
       numReplicas: formState.numReplicas.data ?? undefined,
-      ...platformProperties,
+      modelLocationType: formState.modelLocationData.data?.type,
+      connectionType: formState.modelLocationData.data?.connectionTypeObject?.metadata.name,
     };
-  }, [formState, platformProperties]);
+  }, [formState]);
 
   const onSave = React.useCallback(
     async (overwrite?: boolean) => {
@@ -146,6 +146,7 @@ export const useModelDeploymentSubmit = (
             outcome: TrackingOutcome.submit,
             success: true,
             ...getBaseTrackingProperties(),
+            ...(await getTrackingProperties()),
           },
           isEdit,
         );
@@ -161,6 +162,7 @@ export const useModelDeploymentSubmit = (
             success: false,
             error: errorMessage,
             ...getBaseTrackingProperties(),
+            ...(await getTrackingProperties()),
           },
           isEdit,
         );
@@ -190,6 +192,7 @@ export const useModelDeploymentSubmit = (
       yamlError,
       isEdit,
       getBaseTrackingProperties,
+      getTrackingProperties,
     ],
   );
 

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
@@ -67,7 +67,7 @@ export const useModelDeploymentSubmit = (
   > => {
     const serverTemplateName = formState.modelServer?.data?.selection?.name;
     return {
-      type: formState.modelType.data?.type,
+      modelType: formState.modelType.data?.type,
       runtime: serverTemplateName,
       servingRuntimeName: formState.modelServer?.data?.selection?.label,
       servingRuntimeFormat: formState.modelFormatState.modelFormat?.name,

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
@@ -73,7 +73,6 @@ export const useModelDeploymentSubmit = (
       servingRuntimeFormat: formState.modelFormatState.modelFormat?.name,
       numReplicas: formState.numReplicas.data ?? undefined,
       modelLocationType: formState.modelLocationData.data?.type,
-      connectionType: formState.modelLocationData.data?.connectionTypeObject?.metadata.name,
     };
   }, [formState]);
 

--- a/packages/model-serving/src/components/deploymentWizard/exitModal/useExitDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/exitModal/useExitDeploymentWizard.ts
@@ -1,9 +1,12 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import { fireModelDeployed } from '../../../shared/tracking/deploymentTracking';
 
 type UseExitWizardOptions = {
   returnRoute?: string;
   cancelReturnRoute?: string;
+  isEdit?: boolean;
 };
 
 type UseExitWizardReturn = {
@@ -17,6 +20,7 @@ type UseExitWizardReturn = {
 export const useExitDeploymentWizard = ({
   returnRoute,
   cancelReturnRoute,
+  isEdit,
 }: UseExitWizardOptions): UseExitWizardReturn => {
   const navigate = useNavigate();
 
@@ -39,9 +43,10 @@ export const useExitDeploymentWizard = ({
   }, [navigate, returnRoute]);
 
   const handleExitConfirm = React.useCallback(() => {
+    fireModelDeployed({ outcome: TrackingOutcome.cancel }, isEdit);
     setIsExitModalOpen(false);
     exitWizardOnCancel();
-  }, [exitWizardOnCancel]);
+  }, [exitWizardOnCancel, isEdit]);
 
   return {
     isExitModalOpen,

--- a/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
@@ -125,4 +125,28 @@ describe('fireModelDeployed', () => {
       properties,
     );
   });
+
+  it('should include model location properties', () => {
+    const properties: DeploymentTrackingProperties = {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      type: 'single',
+      runtime: 'ovms-template',
+      servingRuntimeName: 'OpenVINO Model Server',
+      servingRuntimeFormat: 'onnx',
+      numReplicas: 1,
+      modelLocationType: 'existing',
+      connectionType: 's3',
+    };
+
+    fireModelDeployed(properties, false);
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      DeploymentTrackingEvent.MODEL_DEPLOYED,
+      expect.objectContaining({
+        modelLocationType: 'existing',
+        connectionType: 's3',
+      }),
+    );
+  });
 });

--- a/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
@@ -136,7 +136,6 @@ describe('fireModelDeployed', () => {
       servingRuntimeFormat: 'onnx',
       numReplicas: 1,
       modelLocationType: 'existing',
-      connectionType: 's3',
     };
 
     fireModelDeployed(properties, false);
@@ -145,7 +144,6 @@ describe('fireModelDeployed', () => {
       DeploymentTrackingEvent.MODEL_DEPLOYED,
       expect.objectContaining({
         modelLocationType: 'existing',
-        connectionType: 's3',
       }),
     );
   });

--- a/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
@@ -1,0 +1,128 @@
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import {
+  fireModelDeployed,
+  DeploymentTrackingEvent,
+  type DeploymentTrackingProperties,
+} from '../deploymentTracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+}));
+
+const mockFireFormTrackingEvent = jest.mocked(fireFormTrackingEvent);
+
+describe('fireModelDeployed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire Model Deployed event for new deployments', () => {
+    const properties: DeploymentTrackingProperties = {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      type: 'single',
+      runtime: 'ovms-template',
+      servingRuntimeName: 'OpenVINO Model Server',
+      servingRuntimeFormat: 'onnx',
+      numReplicas: 1,
+    };
+
+    fireModelDeployed(properties, false);
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      DeploymentTrackingEvent.MODEL_DEPLOYED,
+      properties,
+    );
+  });
+
+  it('should fire Model Updated event when isEdit is true', () => {
+    const properties: DeploymentTrackingProperties = {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      type: 'single',
+      runtime: 'ovms-template',
+      servingRuntimeName: 'OpenVINO Model Server',
+      servingRuntimeFormat: 'onnx',
+      numReplicas: 2,
+    };
+
+    fireModelDeployed(properties, true);
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      DeploymentTrackingEvent.MODEL_UPDATED,
+      properties,
+    );
+  });
+
+  it('should fire Model Deployed with cancel outcome', () => {
+    const properties: DeploymentTrackingProperties = {
+      outcome: TrackingOutcome.cancel,
+    };
+
+    fireModelDeployed(properties);
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      DeploymentTrackingEvent.MODEL_DEPLOYED,
+      properties,
+    );
+  });
+
+  it('should fire with error message on failure', () => {
+    const properties: DeploymentTrackingProperties = {
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: 'Connection refused',
+      type: 'single',
+      runtime: 'vllm-template',
+      servingRuntimeName: 'vLLM',
+      servingRuntimeFormat: 'pytorch',
+      numReplicas: 1,
+    };
+
+    fireModelDeployed(properties, false);
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      DeploymentTrackingEvent.MODEL_DEPLOYED,
+      properties,
+    );
+  });
+
+  it('should include per-platform properties via the spread', () => {
+    const properties: DeploymentTrackingProperties = {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      type: 'single',
+      runtime: 'nim-runtime',
+      servingRuntimeName: 'NVIDIA NIM',
+      servingRuntimeFormat: 'tensorrt',
+      numReplicas: 1,
+      nimModelId: 'meta/llama3-8b',
+      nimImageVersion: '1.0.0',
+    };
+
+    fireModelDeployed(properties, false);
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      DeploymentTrackingEvent.MODEL_DEPLOYED,
+      expect.objectContaining({
+        nimModelId: 'meta/llama3-8b',
+        nimImageVersion: '1.0.0',
+      }),
+    );
+  });
+
+  it('should default to Model Deployed when isEdit is undefined', () => {
+    const properties: DeploymentTrackingProperties = {
+      outcome: TrackingOutcome.submit,
+      success: true,
+    };
+
+    fireModelDeployed(properties);
+
+    expect(mockFireFormTrackingEvent).toHaveBeenCalledWith(
+      DeploymentTrackingEvent.MODEL_DEPLOYED,
+      properties,
+    );
+  });
+});

--- a/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
@@ -21,7 +21,7 @@ describe('fireModelDeployed', () => {
     const properties: DeploymentTrackingProperties = {
       outcome: TrackingOutcome.submit,
       success: true,
-      type: 'single',
+      modelType: 'single',
       runtime: 'ovms-template',
       servingRuntimeName: 'OpenVINO Model Server',
       servingRuntimeFormat: 'onnx',
@@ -40,7 +40,7 @@ describe('fireModelDeployed', () => {
     const properties: DeploymentTrackingProperties = {
       outcome: TrackingOutcome.submit,
       success: true,
-      type: 'single',
+      modelType: 'single',
       runtime: 'ovms-template',
       servingRuntimeName: 'OpenVINO Model Server',
       servingRuntimeFormat: 'onnx',
@@ -73,7 +73,7 @@ describe('fireModelDeployed', () => {
       outcome: TrackingOutcome.submit,
       success: false,
       errorMessage: 'Connection refused',
-      type: 'single',
+      modelType: 'single',
       runtime: 'vllm-template',
       servingRuntimeName: 'vLLM',
       servingRuntimeFormat: 'pytorch',
@@ -92,7 +92,7 @@ describe('fireModelDeployed', () => {
     const properties: DeploymentTrackingProperties = {
       outcome: TrackingOutcome.submit,
       success: true,
-      type: 'single',
+      modelType: 'single',
       runtime: 'nim-runtime',
       servingRuntimeName: 'NVIDIA NIM',
       servingRuntimeFormat: 'tensorrt',
@@ -130,7 +130,7 @@ describe('fireModelDeployed', () => {
     const properties: DeploymentTrackingProperties = {
       outcome: TrackingOutcome.submit,
       success: true,
-      type: 'single',
+      modelType: 'single',
       runtime: 'ovms-template',
       servingRuntimeName: 'OpenVINO Model Server',
       servingRuntimeFormat: 'onnx',

--- a/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts
@@ -72,7 +72,7 @@ describe('fireModelDeployed', () => {
     const properties: DeploymentTrackingProperties = {
       outcome: TrackingOutcome.submit,
       success: false,
-      error: 'Connection refused',
+      errorMessage: 'Connection refused',
       type: 'single',
       runtime: 'vllm-template',
       servingRuntimeName: 'vLLM',

--- a/packages/model-serving/src/shared/tracking/__tests__/useWizardTrackingProperties.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/useWizardTrackingProperties.spec.ts
@@ -1,11 +1,11 @@
 import { testHook } from '@odh-dashboard/jest-config/hooks';
-import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { useExtensions } from '@odh-dashboard/plugin-core';
 import { useWizardTrackingProperties } from '../useWizardTrackingProperties';
 import type { WizardFormData } from '../../types/form-data';
 
 jest.mock('@odh-dashboard/plugin-core');
 
-const mockUseResolvedExtensions = jest.mocked(useResolvedExtensions);
+const mockUseExtensions = jest.mocked(useExtensions);
 
 const mockWizardState = {
   project: { projectName: 'test-project' },
@@ -20,94 +20,77 @@ describe('useWizardTrackingProperties', () => {
     jest.clearAllMocks();
   });
 
-  it('should return empty properties when no platformId is provided', () => {
-    mockUseResolvedExtensions.mockReturnValue([[], true, []]);
+  it('should return empty properties when no platformId is provided', async () => {
+    mockUseExtensions.mockReturnValue([]);
 
     const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, undefined);
-    expect(renderResult.result.current.platformProperties).toEqual({});
-    expect(renderResult.result.current.loaded).toBe(true);
+    const result = await renderResult.result.current.getTrackingProperties();
+    expect(result).toEqual({});
   });
 
-  it('should return empty properties when extensions are not loaded', () => {
-    mockUseResolvedExtensions.mockReturnValue([[], false, []]);
-
-    const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'kserve');
-    expect(renderResult.result.current.platformProperties).toEqual({});
-    expect(renderResult.result.current.loaded).toBe(false);
-  });
-
-  it('should return empty properties when no extension matches the platform', () => {
-    mockUseResolvedExtensions.mockReturnValue([
-      [
-        {
-          type: 'model-serving.deployment/tracking-properties',
-          properties: {
-            platform: 'nvidia-nim',
-            getProperties: () => ({ nimModelId: 'test-model' }),
-          },
+  it('should return empty properties when no extension matches the platform', async () => {
+    mockUseExtensions.mockReturnValue([
+      {
+        type: 'model-serving.deployment/tracking-properties',
+        properties: {
+          platform: 'nvidia-nim',
+          getProperties: () => Promise.resolve(() => ({ nimModelId: 'test-model' })),
         },
-      ] as never,
-      true,
-      [],
-    ]);
+      },
+    ] as never);
 
     const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'kserve');
-    expect(renderResult.result.current.platformProperties).toEqual({});
+    const result = await renderResult.result.current.getTrackingProperties();
+    expect(result).toEqual({});
   });
 
-  it('should return platform properties when extension matches', () => {
+  it('should resolve CodeRef and return platform properties when extension matches', async () => {
     const mockGetProperties = jest.fn().mockReturnValue({
       nimModelId: 'meta/llama3-8b',
       nimImageVersion: '1.0.0',
     });
 
-    mockUseResolvedExtensions.mockReturnValue([
-      [
-        {
-          type: 'model-serving.deployment/tracking-properties',
-          properties: {
-            platform: 'nvidia-nim',
-            getProperties: mockGetProperties,
-          },
+    mockUseExtensions.mockReturnValue([
+      {
+        type: 'model-serving.deployment/tracking-properties',
+        properties: {
+          platform: 'nvidia-nim',
+          getProperties: () => Promise.resolve(mockGetProperties),
         },
-      ] as never,
-      true,
-      [],
-    ]);
+      },
+    ] as never);
 
     const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'nvidia-nim');
+    const result = await renderResult.result.current.getTrackingProperties();
 
-    expect(renderResult.result.current.platformProperties).toEqual({
+    expect(result).toEqual({
       nimModelId: 'meta/llama3-8b',
       nimImageVersion: '1.0.0',
     });
     expect(mockGetProperties).toHaveBeenCalledWith(mockWizardState);
   });
 
-  it('should only use the first matching extension for the platform', () => {
-    mockUseResolvedExtensions.mockReturnValue([
-      [
-        {
-          type: 'model-serving.deployment/tracking-properties',
-          properties: {
-            platform: 'kserve',
-            getProperties: () => ({ kserveProperty: 'first' }),
-          },
+  it('should only use the first matching extension for the platform', async () => {
+    mockUseExtensions.mockReturnValue([
+      {
+        type: 'model-serving.deployment/tracking-properties',
+        properties: {
+          platform: 'kserve',
+          getProperties: () => Promise.resolve(() => ({ kserveProperty: 'first' })),
         },
-        {
-          type: 'model-serving.deployment/tracking-properties',
-          properties: {
-            platform: 'kserve',
-            getProperties: () => ({ kserveProperty: 'second' }),
-          },
+      },
+      {
+        type: 'model-serving.deployment/tracking-properties',
+        properties: {
+          platform: 'kserve',
+          getProperties: () => Promise.resolve(() => ({ kserveProperty: 'second' })),
         },
-      ] as never,
-      true,
-      [],
-    ]);
+      },
+    ] as never);
 
     const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'kserve');
-    expect(renderResult.result.current.platformProperties).toEqual({
+    const result = await renderResult.result.current.getTrackingProperties();
+    expect(result).toEqual({
       kserveProperty: 'first',
     });
   });

--- a/packages/model-serving/src/shared/tracking/__tests__/useWizardTrackingProperties.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/useWizardTrackingProperties.spec.ts
@@ -1,0 +1,114 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { useWizardTrackingProperties } from '../useWizardTrackingProperties';
+import type { WizardFormData } from '../../types/form-data';
+
+jest.mock('@odh-dashboard/plugin-core');
+
+const mockUseResolvedExtensions = jest.mocked(useResolvedExtensions);
+
+const mockWizardState = {
+  project: { projectName: 'test-project' },
+  modelType: { data: { type: 'single' } },
+  modelFormatState: { selectedFormat: { name: 'onnx' } },
+  numReplicas: { data: 2 },
+  modelServer: { data: { selection: { name: 'ovms-template', label: 'OVMS' } } },
+} as unknown as WizardFormData['state'];
+
+describe('useWizardTrackingProperties', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return empty properties when no platformId is provided', () => {
+    mockUseResolvedExtensions.mockReturnValue([[], true, []]);
+
+    const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, undefined);
+    expect(renderResult.result.current.platformProperties).toEqual({});
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+
+  it('should return empty properties when extensions are not loaded', () => {
+    mockUseResolvedExtensions.mockReturnValue([[], false, []]);
+
+    const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'kserve');
+    expect(renderResult.result.current.platformProperties).toEqual({});
+    expect(renderResult.result.current.loaded).toBe(false);
+  });
+
+  it('should return empty properties when no extension matches the platform', () => {
+    mockUseResolvedExtensions.mockReturnValue([
+      [
+        {
+          type: 'model-serving.deployment/tracking-properties',
+          properties: {
+            platform: 'nvidia-nim',
+            getProperties: () => ({ nimModelId: 'test-model' }),
+          },
+        },
+      ] as never,
+      true,
+      [],
+    ]);
+
+    const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'kserve');
+    expect(renderResult.result.current.platformProperties).toEqual({});
+  });
+
+  it('should return platform properties when extension matches', () => {
+    const mockGetProperties = jest.fn().mockReturnValue({
+      nimModelId: 'meta/llama3-8b',
+      nimImageVersion: '1.0.0',
+    });
+
+    mockUseResolvedExtensions.mockReturnValue([
+      [
+        {
+          type: 'model-serving.deployment/tracking-properties',
+          properties: {
+            platform: 'nvidia-nim',
+            getProperties: mockGetProperties,
+          },
+        },
+      ] as never,
+      true,
+      [],
+    ]);
+
+    const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'nvidia-nim');
+
+    expect(renderResult.result.current.platformProperties).toEqual({
+      nimModelId: 'meta/llama3-8b',
+      nimImageVersion: '1.0.0',
+    });
+    expect(mockGetProperties).toHaveBeenCalledWith(mockWizardState);
+  });
+
+  it('should only use the first matching extension for the platform', () => {
+    mockUseResolvedExtensions.mockReturnValue([
+      [
+        {
+          type: 'model-serving.deployment/tracking-properties',
+          properties: {
+            platform: 'kserve',
+            getProperties: () => ({ kserveProperty: 'first' }),
+          },
+        },
+        {
+          type: 'model-serving.deployment/tracking-properties',
+          properties: {
+            platform: 'kserve',
+            getProperties: () => ({ kserveProperty: 'second' }),
+          },
+        },
+      ] as never,
+      true,
+      [],
+    ]);
+
+    const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'kserve');
+    expect(renderResult.result.current.platformProperties).toEqual({
+      kserveProperty: 'first',
+    });
+  });
+});

--- a/packages/model-serving/src/shared/tracking/__tests__/useWizardTrackingProperties.spec.ts
+++ b/packages/model-serving/src/shared/tracking/__tests__/useWizardTrackingProperties.spec.ts
@@ -94,4 +94,39 @@ describe('useWizardTrackingProperties', () => {
       kserveProperty: 'first',
     });
   });
+
+  it('should return empty properties when CodeRef resolution throws', async () => {
+    mockUseExtensions.mockReturnValue([
+      {
+        type: 'model-serving.deployment/tracking-properties',
+        properties: {
+          platform: 'nvidia-nim',
+          getProperties: () => Promise.reject(new Error('CodeRef load failed')),
+        },
+      },
+    ] as never);
+
+    const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'nvidia-nim');
+    const result = await renderResult.result.current.getTrackingProperties();
+    expect(result).toEqual({});
+  });
+
+  it('should return empty properties when resolved function throws', async () => {
+    mockUseExtensions.mockReturnValue([
+      {
+        type: 'model-serving.deployment/tracking-properties',
+        properties: {
+          platform: 'nvidia-nim',
+          getProperties: () =>
+            Promise.resolve(() => {
+              throw new Error('getProperties execution failed');
+            }),
+        },
+      },
+    ] as never);
+
+    const renderResult = testHook(useWizardTrackingProperties)(mockWizardState, 'nvidia-nim');
+    const result = await renderResult.result.current.getTrackingProperties();
+    expect(result).toEqual({});
+  });
 });

--- a/packages/model-serving/src/shared/tracking/deploymentTracking.ts
+++ b/packages/model-serving/src/shared/tracking/deploymentTracking.ts
@@ -13,7 +13,6 @@ export type DeploymentTrackingBaseProperties = FormTrackingEventProperties & {
   servingRuntimeFormat?: string;
   numReplicas?: number;
   modelLocationType?: string;
-  connectionType?: string;
 };
 
 export type DeploymentTrackingProperties = DeploymentTrackingBaseProperties &

--- a/packages/model-serving/src/shared/tracking/deploymentTracking.ts
+++ b/packages/model-serving/src/shared/tracking/deploymentTracking.ts
@@ -12,9 +12,12 @@ export type DeploymentTrackingBaseProperties = FormTrackingEventProperties & {
   servingRuntimeName?: string;
   servingRuntimeFormat?: string;
   numReplicas?: number;
+  modelLocationType?: string;
+  connectionType?: string;
 };
 
-export type DeploymentTrackingProperties = DeploymentTrackingBaseProperties;
+export type DeploymentTrackingProperties = DeploymentTrackingBaseProperties &
+  Record<string, string | number | boolean | undefined>;
 
 export const fireModelDeployed = (
   properties: DeploymentTrackingProperties,

--- a/packages/model-serving/src/shared/tracking/deploymentTracking.ts
+++ b/packages/model-serving/src/shared/tracking/deploymentTracking.ts
@@ -1,0 +1,27 @@
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { type FormTrackingEventProperties } from '@odh-dashboard/ui-core';
+
+export enum DeploymentTrackingEvent {
+  MODEL_DEPLOYED = 'Model Deployed',
+  MODEL_UPDATED = 'Model Updated',
+}
+
+export type DeploymentTrackingBaseProperties = FormTrackingEventProperties & {
+  type?: string;
+  runtime?: string;
+  servingRuntimeName?: string;
+  servingRuntimeFormat?: string;
+  numReplicas?: number;
+};
+
+export type DeploymentTrackingProperties = DeploymentTrackingBaseProperties;
+
+export const fireModelDeployed = (
+  properties: DeploymentTrackingProperties,
+  isEdit?: boolean,
+): void => {
+  const eventName = isEdit
+    ? DeploymentTrackingEvent.MODEL_UPDATED
+    : DeploymentTrackingEvent.MODEL_DEPLOYED;
+  fireFormTrackingEvent(eventName, properties);
+};

--- a/packages/model-serving/src/shared/tracking/deploymentTracking.ts
+++ b/packages/model-serving/src/shared/tracking/deploymentTracking.ts
@@ -7,7 +7,7 @@ export enum DeploymentTrackingEvent {
 }
 
 export type DeploymentTrackingBaseProperties = FormTrackingEventProperties & {
-  type?: string;
+  modelType?: string;
   runtime?: string;
   servingRuntimeName?: string;
   servingRuntimeFormat?: string;

--- a/packages/model-serving/src/shared/tracking/useWizardTrackingProperties.ts
+++ b/packages/model-serving/src/shared/tracking/useWizardTrackingProperties.ts
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { isWizardTrackingPropertiesExtension } from '../../../extension-points/deployment-wizard';
+import type { WizardFormData } from '../types/form-data';
+
+/**
+ * Hook that collects per-platform tracking properties from spoke extensions.
+ * Spokes register `model-serving.deployment/tracking-properties` extensions,
+ * and this hook resolves and invokes the one matching the active platform.
+ */
+export const useWizardTrackingProperties = (
+  wizardState: WizardFormData['state'],
+  platformId?: string,
+): {
+  platformProperties: Record<string, string | number | boolean | undefined>;
+  loaded: boolean;
+} => {
+  const [extensions, loaded] = useResolvedExtensions(isWizardTrackingPropertiesExtension);
+
+  const platformProperties = React.useMemo((): Record<
+    string,
+    string | number | boolean | undefined
+  > => {
+    if (!platformId || !loaded) {
+      return {};
+    }
+
+    const matchingExtension = extensions.find((ext) => ext.properties.platform === platformId);
+
+    if (!matchingExtension) {
+      return {};
+    }
+
+    return matchingExtension.properties.getProperties(wizardState);
+  }, [extensions, loaded, platformId, wizardState]);
+
+  return { platformProperties, loaded };
+};

--- a/packages/model-serving/src/shared/tracking/useWizardTrackingProperties.ts
+++ b/packages/model-serving/src/shared/tracking/useWizardTrackingProperties.ts
@@ -29,8 +29,12 @@ export const useWizardTrackingProperties = (
       return {};
     }
 
-    const resolvedFn = await matchingExtension.properties.getProperties();
-    return resolvedFn(wizardState);
+    try {
+      const resolvedFn = await matchingExtension.properties.getProperties();
+      return resolvedFn(wizardState);
+    } catch {
+      return {};
+    }
   }, [extensions, platformId, wizardState]);
 
   return { getTrackingProperties };

--- a/packages/model-serving/src/shared/tracking/useWizardTrackingProperties.ts
+++ b/packages/model-serving/src/shared/tracking/useWizardTrackingProperties.ts
@@ -1,27 +1,25 @@
 import React from 'react';
-import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { useExtensions } from '@odh-dashboard/plugin-core';
 import { isWizardTrackingPropertiesExtension } from '../../../extension-points/deployment-wizard';
 import type { WizardFormData } from '../types/form-data';
 
 /**
- * Hook that collects per-platform tracking properties from spoke extensions.
- * Spokes register `model-serving.deployment/tracking-properties` extensions,
- * and this hook resolves and invokes the one matching the active platform.
+ * Hook that provides a lazy async getter for per-platform tracking properties.
+ * Uses useExtensions (without Resolved) so the CodeRef is only resolved at submit
+ * time — avoiding unnecessary network load during page render.
  */
 export const useWizardTrackingProperties = (
   wizardState: WizardFormData['state'],
   platformId?: string,
 ): {
-  platformProperties: Record<string, string | number | boolean | undefined>;
-  loaded: boolean;
+  getTrackingProperties: () => Promise<Record<string, string | number | boolean | undefined>>;
 } => {
-  const [extensions, loaded] = useResolvedExtensions(isWizardTrackingPropertiesExtension);
+  const extensions = useExtensions(isWizardTrackingPropertiesExtension);
 
-  const platformProperties = React.useMemo((): Record<
-    string,
-    string | number | boolean | undefined
+  const getTrackingProperties = React.useCallback(async (): Promise<
+    Record<string, string | number | boolean | undefined>
   > => {
-    if (!platformId || !loaded) {
+    if (!platformId) {
       return {};
     }
 
@@ -31,8 +29,9 @@ export const useWizardTrackingProperties = (
       return {};
     }
 
-    return matchingExtension.properties.getProperties(wizardState);
-  }, [extensions, loaded, platformId, wizardState]);
+    const resolvedFn = await matchingExtension.properties.getProperties();
+    return resolvedFn(wizardState);
+  }, [extensions, platformId, wizardState]);
 
-  return { platformProperties, loaded };
+  return { getTrackingProperties };
 };


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-82390

## Description

The new deployment wizard fires no `Model Deployed` event. The only implementation lived in the legacy `ManageKServeModal`, so every deployment created through the wizard was invisible to Amplitude. This broke the *Model Deployed adoption*, *Deployment usage breakdown*, and *Deployment error rate* dashboards.

This PR adds:
- A shared `fireModelDeployed` helper under `packages/model-serving/src/shared/tracking/` that wraps `fireFormTrackingEvent` with typed deployment properties.
- Tracking calls in `useModelDeploymentSubmit` for success (`outcome: 'submit', success: true`) and failure (`outcome: 'submit', success: false, error: <message>`).
- A cancel tracking event when the user confirms discarding changes via `ExitDeploymentModal`.
- `Model Updated` fires instead of `Model Deployed` when `existingDeployment` is set (edit flow), matching legacy behaviour.
- A `WizardTrackingPropertiesExtension` extension point so spoke packages (kserve, llmd-serving, nim-serving) can contribute platform-specific properties without cross-package imports.
- Base properties emitted: `type`, `runtime`, `servingRuntimeName`, `servingRuntimeFormat`, `numReplicas` — parity with `ManageKServeModal.tsx`.

## How Has This Been Tested?

- **Unit tests**: 11 tests across 2 suites (`deploymentTracking.spec.ts`, `useWizardTrackingProperties.spec.ts`) — all passing.
- **Cypress mocked tests**: `modelServingDeployTracking.cy.ts` verifies the event fires on successful deploy, on error, and on cancel by spying on `console.log` in DEV_MODE.
- **Manual verification**: Ran local dev server, navigated through the deployment wizard, and confirmed `[Telemetry event triggered: Model Deployed - {...}]` appears in the browser console on submit/cancel.
- 
<img width="1721" height="242" alt="Screenshot 2026-08-11 at 12 04 04 PM" src="https://github.com/user-attachments/assets/b878ed01-365b-4c20-af80-4e5d3ff3f8a8" />
<img width="1433" height="190" alt="Screenshot 2026-08-11 at 12 04 57 PM" src="https://github.com/user-attachments/assets/ee8899dc-4ccf-4cbd-b643-442966f6a27c" />

- **Lint & type-check**: Both pass cleanly on the affected package.

## Test Impact

New test files added:
- `packages/model-serving/src/shared/tracking/__tests__/deploymentTracking.spec.ts` — unit tests for the `fireModelDeployed` helper (6 test cases)
- `packages/model-serving/src/shared/tracking/__tests__/useWizardTrackingProperties.spec.ts` — unit tests for the extension hook (5 test cases)
- `packages/model-serving/cypress/tests/mocked/modelServing/modelServingDeployTracking.cy.ts` — Cypress E2E tests for event tracking (3 test cases)

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking for successful, updated, canceled, and failed model deployments.
  * Included deployment metadata and platform-specific properties in tracking events.
  * Added support for identifying the active platform’s tracking properties.

* **Tests**
  * Added coverage for deployment outcomes, event selection, cancellation, failures, editing deployments, and platform-specific properties.
  * Added end-to-end validation of analytics events during deployment workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->