### PR TITLE
fix: CVE bumps for 3.4.4 (brace-expansion, postcss, tmp)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "fast-uri": "^3.1.5",
         "js-cookie": "^3.0.7",
         "jsonpath-plus": "^10.3.0",
+        "postcss": "^8.5.23",
         "tar": "^7.5.21",
         "tough-cookie": "^4.1.3",
         "ws": "^8.21.0"
@@ -10992,9 +10993,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -25041,10 +25042,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -26781,10 +26781,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -26801,7 +26800,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -30865,7 +30864,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -32074,9 +32072,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "fast-uri": "^3.1.5",
     "ws": "^8.21.0",
     "tar": "^7.5.21",
-    "js-cookie": "^3.0.7"
+    "js-cookie": "^3.0.7",
+    "postcss": "^8.5.23"
   },
   "devDependencies": {
     "cross-env": "^10.1.0",
@@ -123,7 +124,7 @@
     "axios": "^1.16.0",
     "fast-uri": "^3.1.5",
     "protobufjs": "^7.6.3",
-    "brace-expansion": "^2.0.3",
+    "brace-expansion": "^2.1.4",
     "shell-quote": "^1.8.4",
     "xmlbuilder2": {
       "js-yaml": "^4.2.0"
@@ -131,6 +132,8 @@
     "@cypress/code-coverage": {
       "js-yaml": "^4.2.0"
     },
-    "tar": "^7.5.21"
+    "tar": "^7.5.21",
+    "postcss": "^8.5.23",
+    "tmp": "^0.2.6"
   }
 }


### PR DESCRIPTION
## Summary

Fixes 3 npm CVEs via dependency bumps for 3.4.4.

| Package | Version Change | CVEs Fixed | Trackers |
|---------|---------------|------------|----------|
| brace-expansion | ^2.0.3 → ^2.1.4 | CVE-2026-69152 (DoS) | 6 |
| postcss | new dep + override ^8.5.23 (8.5.26) | CVE-2026-45623 (XSS, path traversal) | 7 |
| tmp | new override ^0.2.6 (0.2.7) | CVE-2026-44705 (path traversal) | 7 |

### Jira Trackers (20)

**CVE-2026-69152 (brace-expansion):** RHOAIENG-80171, 80170, 80169, 80168, 80167, 80166
**CVE-2026-45623 (postcss):** RHOAIENG-79466, 79465, 79464, 79463, 79461, 79460, 79459
**CVE-2026-44705 (tmp):** RHOAIENG-81049, 81048, 81046, 81041, 81038, 81035, 81031

### Also resolved (no code change needed — already fixed by previous PRs)

- **react-router CVE-55685** (7 trackers): already covered by 7.18.2 from PR #9148
- **protobufjs CVE-48712** (7 trackers): already covered by 7.6.5 from PR #8429

### Notes

- postcss added as direct dep + override (same pattern as fast-uri, tar) — override alone drops the package from node_modules, breaking css-loader
- tmp is transitive via `@kubernetes/client-node` → `tmp-promise` — used for pod file copy (not called by dashboard)

## Test Results
- Unit tests: 11/11 pass
- Type-check: 17/17 pass
- Build: compiled with 42 warnings, 0 errors
- k8s client runtime load: OK