### PR TITLE
feat(autox): add segment event tracking

### DIFF
--- a/packages/automl/frontend/src/app/components/AutomlRunsTable/AutomlRunsTableRow.tsx
+++ b/packages/automl/frontend/src/app/components/AutomlRunsTable/AutomlRunsTableRow.tsx
@@ -71,7 +71,7 @@ const AutomlRunsTableRow: React.FC<AutomlRunsTableRowProps> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
   const [stopInitiated, setStopInitiated] = React.useState(false);
   const { handleRetry, handleConfirmStop, handleDelete, isRetrying, isTerminating, isDeleting } =
-    useAutomlRunActions(namespace, run.run_id, onActionComplete);
+    useAutomlRunActions(namespace, run.run_id, 'runsList', onActionComplete);
 
   const baseRunTerminatable = isRunTerminatable(run.state);
   const runTerminatable = baseRunTerminatable && !stopInitiated;
@@ -107,6 +107,17 @@ const AutomlRunsTableRow: React.FC<AutomlRunsTableRowProps> = ({
     }
   }, [handleDelete]);
 
+  const ReconfigureLink = React.useCallback(
+    (props: React.ComponentProps<typeof Link>) => (
+      <Link
+        {...props}
+        to={`${automlReconfigurePathname}/${namespace}/${run.run_id}`}
+        state={{ from: 'runsList' }}
+      />
+    ),
+    [namespace, run.run_id],
+  );
+
   const actions = React.useMemo(() => {
     const items: React.ComponentProps<typeof ActionsColumn>['items'] = [];
 
@@ -128,8 +139,7 @@ const AutomlRunsTableRow: React.FC<AutomlRunsTableRowProps> = ({
 
     items.push({
       title: <span data-testid="reconfigure-run-action">Reconfigure</span>,
-      component: Link,
-      to: `${automlReconfigurePathname}/${namespace}/${run.run_id}`,
+      component: ReconfigureLink,
     });
 
     if (runDeletable) {
@@ -153,8 +163,7 @@ const AutomlRunsTableRow: React.FC<AutomlRunsTableRowProps> = ({
     isTerminating,
     isStopModalOpen,
     isDeleting,
-    namespace,
-    run.run_id,
+    ReconfigureLink,
   ]);
 
   return (
@@ -190,6 +199,7 @@ const AutomlRunsTableRow: React.FC<AutomlRunsTableRowProps> = ({
         onConfirm={handleStop}
         isTerminating={isTerminating}
         runName={run.display_name}
+        source="runsList"
       />
       <DeleteRunModal
         isOpen={isDeleteModalOpen}

--- a/packages/automl/frontend/src/app/components/common/AutomlConnectionModal.tsx
+++ b/packages/automl/frontend/src/app/components/common/AutomlConnectionModal.tsx
@@ -20,6 +20,7 @@ import type {
 } from '@odh-dashboard/k8s-core';
 import { useK8sNameDescriptionFieldData } from '@odh-dashboard/ui-core/components/K8sNameDescriptionField';
 import { createSecret } from '@odh-dashboard/internal/api/k8s/secrets';
+import { fireAutomlS3ConnectionCreated, TrackingOutcome } from '~/app/utilities/tracking';
 
 const S3_REQUIRED_ENV_VARS = ['AWS_DEFAULT_REGION', 'AWS_S3_BUCKET'];
 
@@ -141,6 +142,7 @@ const AutomlConnectionModal: React.FC<Props> = ({
     <Modal
       isOpen
       onClose={() => {
+        fireAutomlS3ConnectionCreated({ outcome: TrackingOutcome.cancel });
         onClose();
       }}
       variant="medium"
@@ -176,7 +178,10 @@ const AutomlConnectionModal: React.FC<Props> = ({
       <ModalFooter>
         <DashboardModalFooter
           submitLabel="Add connection"
-          onCancel={onClose}
+          onCancel={() => {
+            fireAutomlS3ConnectionCreated({ outcome: TrackingOutcome.cancel });
+            onClose();
+          }}
           onSubmit={() => {
             setIsSaving(true);
             setSubmitError(undefined);
@@ -201,11 +206,17 @@ const AutomlConnectionModal: React.FC<Props> = ({
             createSecret(assembledConnection)
               .then(async () => {
                 await onSubmit(assembledConnection);
+                fireAutomlS3ConnectionCreated({ outcome: TrackingOutcome.submit, success: true });
                 onClose(true);
               })
               .catch((e) => {
                 setSubmitError(e);
                 setIsSaving(false);
+                fireAutomlS3ConnectionCreated({
+                  outcome: TrackingOutcome.submit,
+                  success: false,
+                  error: e instanceof Error ? e.message : undefined,
+                });
               });
           }}
           error={submitError}

--- a/packages/automl/frontend/src/app/components/configure/AutomlConfigure.tsx
+++ b/packages/automl/frontend/src/app/components/configure/AutomlConfigure.tsx
@@ -104,11 +104,14 @@ import './AutomlConfigure.scss';
 type AutomlConfigureProps = {
   initialValues?: Partial<ConfigureSchema>;
   initialInputDataSecret?: SecretSelection;
+  /** Reports whether the currently selected prediction type matches the recommendation derived from the target column. */
+  onRecommendationChange?: (isRecommended: boolean) => void;
 };
 
 function AutomlConfigure({
   initialValues,
   initialInputDataSecret,
+  onRecommendationChange,
 }: AutomlConfigureProps): React.JSX.Element {
   const { namespace } = useParams();
   const queryClient = useQueryClient();
@@ -288,6 +291,11 @@ function AutomlConfigure({
       notification.warning('Column schema error', columnsError.message);
     }
   }, [columnsError, notification]);
+
+  // Report whether the selected prediction type matches the target column's recommended type
+  useEffect(() => {
+    onRecommendationChange?.(!selectedColumn?.task_type || taskType === selectedColumn.task_type);
+  }, [selectedColumn, taskType, onRecommendationChange]);
 
   // Sync bucket from the resolved secret object (skips mount to preserve pre-populated values in reconfigure)
   useReconfigureSafeEffect(() => {

--- a/packages/automl/frontend/src/app/components/configure/AutomlConfigure.tsx
+++ b/packages/automl/frontend/src/app/components/configure/AutomlConfigure.tsx
@@ -94,6 +94,10 @@ import {
   TRAINING_DATA_UPLOAD_NATIVE_ACCEPT,
 } from '~/app/utilities/automlTrainingDataFile';
 import { findEquivalentMetric, formatMetricName } from '~/app/utilities/utils';
+import {
+  fireAutomlTargetColumnConfigured,
+  fireAutomlTrainingDataConfigured,
+} from '~/app/utilities/tracking';
 import LoadingFormField from './LoadingFormField';
 import AutomlPredictionTypeHelperText from './AutomlPredictionTypeHelperText';
 import AutomlPredictionTypeSelector from './AutomlPredictionTypeSelector';
@@ -296,6 +300,24 @@ function AutomlConfigure({
   useEffect(() => {
     onRecommendationChange?.(!selectedColumn?.task_type || taskType === selectedColumn.task_type);
   }, [selectedColumn, taskType, onRecommendationChange]);
+
+  // Funnel milestone tracking — fires once per configure-step visit when each section is
+  // first completed, to measure retention through the multi-section configure flow.
+  const hasFiredTrainingDataMilestoneRef = useRef(false);
+  useEffect(() => {
+    if (isFileSelected && !hasFiredTrainingDataMilestoneRef.current) {
+      hasFiredTrainingDataMilestoneRef.current = true;
+      fireAutomlTrainingDataConfigured(trainingDataSourceMode);
+    }
+  }, [isFileSelected, trainingDataSourceMode]);
+
+  const hasFiredTargetColumnMilestoneRef = useRef(false);
+  useEffect(() => {
+    if (isTargetColumnSelected && !hasFiredTargetColumnMilestoneRef.current) {
+      hasFiredTargetColumnMilestoneRef.current = true;
+      fireAutomlTargetColumnConfigured();
+    }
+  }, [isTargetColumnSelected]);
 
   // Sync bucket from the resolved secret object (skips mount to preserve pre-populated values in reconfigure)
   useReconfigureSafeEffect(() => {

--- a/packages/automl/frontend/src/app/components/configure/__tests__/AutomlConfigure.spec.tsx
+++ b/packages/automl/frontend/src/app/components/configure/__tests__/AutomlConfigure.spec.tsx
@@ -7,13 +7,21 @@ import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 import type { ExplorerFiles } from '@odh-dashboard/internal/concepts/fileExplorer/types';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutomlConfigure from '~/app/components/configure/AutomlConfigure';
 import { useS3GetFileSchemaQuery } from '~/app/hooks/queries';
 import { createConfigureSchema } from '~/app/schemas/configure.schema';
+import { AUTOML_EVENTS } from '~/app/utilities/tracking';
 import {
   AUTOML_TRAINING_UPLOAD_MAX_BYTES,
   AUTOML_TRAINING_UPLOAD_TOO_MANY_FILES_DETAIL,
 } from '~/app/utilities/automlTrainingDataFile';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireMiscTrackingEventMock = jest.mocked(fireMiscTrackingEvent);
 
 const mockNotificationError = jest.fn();
 
@@ -911,6 +919,63 @@ describe('AutomlConfigure', () => {
         expect(screen.getByTestId('prediction-type-helper-no-target')).toBeInTheDocument();
         expect(screen.queryByTestId('task-type-card-binary')).not.toBeInTheDocument();
         expect(screen.getByTestId('target_column-select')).toHaveTextContent('Select a column');
+      });
+    });
+
+    describe('Funnel milestone tracking', () => {
+      it('should fire AutoML Training Data Configured once when a file is selected from the bucket', () => {
+        renderComponent();
+        selectSecretAndFile();
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+          AUTOML_EVENTS.TRAINING_DATA_CONFIGURED,
+          { trainingDataSourceType: 'select' },
+        );
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('should fire AutoML Training Data Configured with trainingDataSourceType "upload" when a file is uploaded', async () => {
+        renderComponent();
+        fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+        fireEvent.click(screen.getByRole('button', { name: 'Upload file' }));
+
+        const goodFile = new File(['hello'], 'training.csv', { type: 'text/csv' });
+        dropFilesOnTrainingDataUploadZone([goodFile]);
+
+        await waitFor(() => {
+          expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+            AUTOML_EVENTS.TRAINING_DATA_CONFIGURED,
+            { trainingDataSourceType: 'upload' },
+          );
+        });
+      });
+
+      it('should fire AutoML Target Column Configured once when a target column is selected', () => {
+        renderComponent();
+        selectSecretAndFile();
+        fireMiscTrackingEventMock.mockClear();
+
+        selectTargetColumn();
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+          AUTOML_EVENTS.TARGET_COLUMN_CONFIGURED,
+          {},
+        );
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('should NOT re-fire AutoML Target Column Configured when a different prediction type is picked afterward', () => {
+        renderComponent();
+        selectSecretAndFile();
+        selectTargetColumn(); // fires once
+        fireMiscTrackingEventMock.mockClear();
+
+        selectPredictionType('multiclass');
+
+        expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+          AUTOML_EVENTS.TARGET_COLUMN_CONFIGURED,
+          expect.anything(),
+        );
       });
     });
 

--- a/packages/automl/frontend/src/app/components/run-results/AutomlLeaderboard.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlLeaderboard.tsx
@@ -42,6 +42,7 @@ import {
   orderModelsByLeaderboardRank,
   resolveEvalMetric,
 } from '~/app/utilities/utils';
+import { fireAutomlLeaderboardSorted, type ModelActionSource } from '~/app/utilities/tracking';
 import ManageColumnsModal from './ManageColumnsModal';
 import './AutomlLeaderboard.scss';
 
@@ -379,8 +380,8 @@ const MetricCell: React.FC<{ value: number | string }> = ({ value }) => (
 
 type AutomlLeaderboardProps = {
   onViewDetails?: (modelName: string, rank: number) => void;
-  onClickSaveNotebook?: (modelName: string) => void;
-  onRegisterModel?: (modelName: string) => void;
+  onClickSaveNotebook?: (modelName: string, source: ModelActionSource) => void;
+  onRegisterModel?: (modelName: string, source: ModelActionSource) => void;
 };
 
 function AutomlLeaderboard({
@@ -646,10 +647,14 @@ function AutomlLeaderboard({
   // Memoized sort callback - stable reference shared by all columns
   const handleSort = React.useCallback(
     (_event: React.MouseEvent, index: number, direction: 'asc' | 'desc') => {
+      const sortColumnId = sortableColumnIds[index];
       setActiveSort((prev) => ({
-        id: sortableColumnIds[index] || prev.id,
+        id: sortColumnId || prev.id,
         direction,
       }));
+      if (sortColumnId) {
+        fireAutomlLeaderboardSorted(getColumnName(sortColumnId, sortColumnId), direction);
+      }
     },
     [sortableColumnIds],
   );
@@ -1005,13 +1010,13 @@ function AutomlLeaderboard({
                         {
                           title: 'Register model',
                           onClick: () => {
-                            onRegisterModel?.(entry.modelKey);
+                            onRegisterModel?.(entry.modelKey, 'leaderboard');
                           },
                         },
                         {
                           title: 'Save notebook',
                           onClick: () => {
-                            onClickSaveNotebook?.(entry.modelKey);
+                            onClickSaveNotebook?.(entry.modelKey, 'leaderboard');
                           },
                         },
                       ]}

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/AutomlModelDetailsModal.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/AutomlModelDetailsModal.tsx
@@ -19,6 +19,12 @@ import { useAutomlResultsContext } from '~/app/context/AutomlResultsContext';
 import { computeRankMap, resolveEvalMetric } from '~/app/utilities/utils';
 import { TASK_TYPE_TIMESERIES } from '~/app/utilities/const';
 import { useModelEvaluationArtifactsQuery } from '~/app/hooks/queries';
+import {
+  fireAutomlMetricViewed,
+  fireAutomlModelDetailsDownloaded,
+  mapOptimizationMetric,
+  type ModelActionSource,
+} from '~/app/utilities/tracking';
 import { getVisibleTabs, type TabDefinition } from './tabConfig';
 import AutomlModelDetailsModalHeader from './AutomlModelDetailsModalHeader';
 import './AutomlModelDetailsModal.scss';
@@ -28,8 +34,17 @@ type AutomlModelDetailsModalProps = {
   onClose: () => void;
   modelName: string;
   rank: number;
-  onClickSaveNotebook?: (modelName: string) => void;
-  onRegisterModel?: (modelName: string) => void;
+  onClickSaveNotebook?: (modelName: string, source: ModelActionSource) => void;
+  onRegisterModel?: (modelName: string, source: ModelActionSource) => void;
+};
+
+const MODEL_ACTION_SOURCE: ModelActionSource = 'modelDetailsModal';
+
+/** Maps evaluation tabs to the specific metric they surface, for AutoML Metric Viewed tracking. */
+const EVALUATION_TAB_METRIC: Record<string, string | undefined> = {
+  'model-evaluation': undefined, // uses the run's optimized eval metric
+  'roc-curve': 'rocAuc',
+  'precision-recall': 'precision',
 };
 
 /** Group tabs by their section for sidebar rendering. */
@@ -103,7 +118,10 @@ const AutomlModelDetailsModal: React.FC<AutomlModelDetailsModalProps> = ({
     if (!isPrinting) {
       return;
     }
-    const handleAfterPrint = () => setIsPrinting(false);
+    const handleAfterPrint = () => {
+      setIsPrinting(false);
+      fireAutomlModelDetailsDownloaded();
+    };
     window.addEventListener('afterprint', handleAfterPrint);
     window.print();
     return () => {
@@ -113,6 +131,19 @@ const AutomlModelDetailsModal: React.FC<AutomlModelDetailsModalProps> = ({
 
   const activeTab = visibleTabs.find((t) => t.key === activeTabKey);
   const ActiveComponent = activeTab?.component;
+
+  React.useEffect(() => {
+    if (!isOpen || !activeTab || activeTab.section !== 'Evaluation') {
+      return;
+    }
+    if (!(activeTab.key in EVALUATION_TAB_METRIC)) {
+      return;
+    }
+    const metricName = EVALUATION_TAB_METRIC[activeTab.key] ?? mapOptimizationMetric(evalMetric);
+    fireAutomlMetricViewed(metricName);
+    // Fire once per tab/model selection change, not on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, activeTabKey, selectedModelName]);
 
   const handleBacktestMetricsChange = React.useCallback((metrics: string[]) => {
     backtestMetricsRef.current = metrics;
@@ -160,7 +191,7 @@ const AutomlModelDetailsModal: React.FC<AutomlModelDetailsModalProps> = ({
             onSaveNotebook={
               onClickSaveNotebook
                 ? () => {
-                    onClickSaveNotebook(selectedModelName);
+                    onClickSaveNotebook(selectedModelName, MODEL_ACTION_SOURCE);
                   }
                 : undefined
             }
@@ -168,7 +199,7 @@ const AutomlModelDetailsModal: React.FC<AutomlModelDetailsModalProps> = ({
               onRegisterModel
                 ? () => {
                     onClose();
-                    onRegisterModel(selectedModelName);
+                    onRegisterModel(selectedModelName, MODEL_ACTION_SOURCE);
                   }
                 : undefined
             }

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/AutomlModelDetailsModal.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/AutomlModelDetailsModal.tsx
@@ -20,9 +20,8 @@ import { computeRankMap, resolveEvalMetric } from '~/app/utilities/utils';
 import { TASK_TYPE_TIMESERIES } from '~/app/utilities/const';
 import { useModelEvaluationArtifactsQuery } from '~/app/hooks/queries';
 import {
-  fireAutomlMetricViewed,
   fireAutomlModelDetailsDownloaded,
-  mapOptimizationMetric,
+  fireAutomlModelDetailsTabViewed,
   type ModelActionSource,
 } from '~/app/utilities/tracking';
 import { getVisibleTabs, type TabDefinition } from './tabConfig';
@@ -39,13 +38,6 @@ type AutomlModelDetailsModalProps = {
 };
 
 const MODEL_ACTION_SOURCE: ModelActionSource = 'modelDetailsModal';
-
-/** Maps evaluation tabs to the specific metric they surface, for AutoML Metric Viewed tracking. */
-const EVALUATION_TAB_METRIC: Record<string, string | undefined> = {
-  'model-evaluation': undefined, // uses the run's optimized eval metric
-  'roc-curve': 'rocAuc',
-  'precision-recall': 'precision',
-};
 
 /** Group tabs by their section for sidebar rendering. */
 function groupTabsBySection(tabs: TabDefinition[]): Map<string, TabDefinition[]> {
@@ -133,14 +125,10 @@ const AutomlModelDetailsModal: React.FC<AutomlModelDetailsModalProps> = ({
   const ActiveComponent = activeTab?.component;
 
   React.useEffect(() => {
-    if (!isOpen || !activeTab || activeTab.section !== 'Evaluation') {
+    if (!isOpen || !activeTab) {
       return;
     }
-    if (!(activeTab.key in EVALUATION_TAB_METRIC)) {
-      return;
-    }
-    const metricName = EVALUATION_TAB_METRIC[activeTab.key] ?? mapOptimizationMetric(evalMetric);
-    fireAutomlMetricViewed(metricName);
+    fireAutomlModelDetailsTabViewed(activeTab.key, taskType);
     // Fire once per tab/model selection change, not on every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, activeTabKey, selectedModelName]);

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/__tests__/AutomlModelDetailsModal.spec.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/__tests__/AutomlModelDetailsModal.spec.tsx
@@ -285,7 +285,7 @@ describe('AutomlModelDetailsModal', () => {
     await user.click(screen.getByTestId('model-details-actions-toggle'));
     await user.click(screen.getByRole('menuitem', { name: 'Save as notebook' }));
 
-    expect(onClickSaveNotebook).toHaveBeenCalledWith('CatBoost_BAG_L2_FULL');
+    expect(onClickSaveNotebook).toHaveBeenCalledWith('CatBoost_BAG_L2_FULL', 'modelDetailsModal');
     expect(onClickSaveNotebook).toHaveBeenCalledTimes(1);
   });
 
@@ -309,7 +309,10 @@ describe('AutomlModelDetailsModal', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Save as notebook' }));
 
     // Should be called with the newly selected model
-    expect(onClickSaveNotebook).toHaveBeenCalledWith('RandomForest_BAG_L1_FULL');
+    expect(onClickSaveNotebook).toHaveBeenCalledWith(
+      'RandomForest_BAG_L1_FULL',
+      'modelDetailsModal',
+    );
   });
 
   it('should call onRegisterModel and onClose when "Register model" is clicked', async () => {
@@ -331,7 +334,7 @@ describe('AutomlModelDetailsModal', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Register model' }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
-    expect(onRegisterModel).toHaveBeenCalledWith('CatBoost_BAG_L2_FULL');
+    expect(onRegisterModel).toHaveBeenCalledWith('CatBoost_BAG_L2_FULL', 'modelDetailsModal');
     expect(onRegisterModel).toHaveBeenCalledTimes(1);
   });
 
@@ -360,7 +363,7 @@ describe('AutomlModelDetailsModal', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Register model' }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
-    expect(onRegisterModel).toHaveBeenCalledWith('RandomForest_BAG_L1_FULL');
+    expect(onRegisterModel).toHaveBeenCalledWith('RandomForest_BAG_L1_FULL', 'modelDetailsModal');
   });
 
   it('should render print portal with all visible tabs when download is clicked', async () => {

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/components/BacktestWindowChart.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/components/BacktestWindowChart.tsx
@@ -15,6 +15,7 @@ import {
 } from '@patternfly/react-core';
 import type { BackTestingPerWindowMetric } from '~/app/types';
 import { findMetricValue, formatMetricName, getMetricDescription } from '~/app/utilities/utils';
+import { fireAutomlBacktestWindowMetricViewed } from '~/app/utilities/tracking';
 import InlineTooltip from '~/app/components/InlineTooltip';
 import {
   BACKTEST_CHART_PADDING,
@@ -333,6 +334,9 @@ const BacktestWindowChart: React.FC<BacktestWindowChartProps> = ({
   onSelectedMetricsChange,
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
+  // Tracks which metrics have already fired AutoML Backtest Window Metric Viewed this mount,
+  // so toggling a metric off and back on doesn't re-fire it for the same modal session.
+  const trackedMetricsRef = React.useRef<Set<string>>(new Set());
 
   const metricKeys = React.useMemo(
     () => (perWindowMetrics.length > 0 ? Object.keys(perWindowMetrics[0].metrics) : []),
@@ -381,10 +385,15 @@ const BacktestWindowChart: React.FC<BacktestWindowChartProps> = ({
       if (strValue === SHOW_ALL) {
         updateMetrics(isAllSelected ? [normalizedEvalMetric] : [...metricKeys]);
       } else {
-        const next = selectedMetrics.includes(strValue)
-          ? selectedMetrics.filter((m) => m !== strValue)
-          : [...selectedMetrics, strValue];
+        const isAdding = !selectedMetrics.includes(strValue);
+        const next = isAdding
+          ? [...selectedMetrics, strValue]
+          : selectedMetrics.filter((m) => m !== strValue);
         updateMetrics(next.length === 0 ? [normalizedEvalMetric] : next);
+        if (isAdding && !trackedMetricsRef.current.has(strValue)) {
+          trackedMetricsRef.current.add(strValue);
+          fireAutomlBacktestWindowMetricViewed(strValue);
+        }
       }
     },
     [isAllSelected, normalizedEvalMetric, metricKeys, selectedMetrics, updateMetrics],

--- a/packages/automl/frontend/src/app/components/run-results/AutomlResults.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlResults.tsx
@@ -14,6 +14,7 @@ import {
   isRunInTerminalState,
   normalizePipelineRunState,
 } from '~/app/utilities/utils';
+import { fireAutomlNotebookDownloaded, type ModelActionSource } from '~/app/utilities/tracking';
 import type { PipelineTreeLoadingMode } from './pipelineStatusLabels';
 import AutomlLeaderboard from './AutomlLeaderboard';
 import AutomlModelDetailsModal from './AutomlModelDetailsModal/AutomlModelDetailsModal';
@@ -24,6 +25,11 @@ import './AutomlResults.scss';
 type ModalState = {
   modelName: string;
   rank: number;
+};
+
+type RegisterModelState = {
+  modelName: string;
+  source: ModelActionSource;
 };
 
 type NotebookDownloadError = {
@@ -143,15 +149,17 @@ function AutomlResults(): React.JSX.Element {
     runId,
   ]);
   const [modalState, setModalState] = React.useState<ModalState | null>(null);
-  const [registerModelName, setRegisterModelName] = React.useState<string | null>(null);
+  const [registerModelState, setRegisterModelState] = React.useState<RegisterModelState | null>(
+    null,
+  );
   const [downloadError, setDownloadError] = React.useState<NotebookDownloadError | null>(null);
 
   const handleViewDetails = React.useCallback((modelName: string, rank: number) => {
     setModalState({ modelName, rank });
   }, []);
 
-  const handleRegisterModel = React.useCallback((modelName: string) => {
-    setRegisterModelName(modelName);
+  const handleRegisterModel = React.useCallback((modelName: string, source: ModelActionSource) => {
+    setRegisterModelState({ modelName, source });
   }, []);
 
   const sanitizeFilename = (str: string): string =>
@@ -165,7 +173,7 @@ function AutomlResults(): React.JSX.Element {
       .trim() || 'unknown';
 
   const handleSaveNotebook = React.useCallback(
-    async (modelName: string) => {
+    async (modelName: string, source: ModelActionSource) => {
       // Clear any previous errors
       setDownloadError(null);
 
@@ -202,6 +210,7 @@ function AutomlResults(): React.JSX.Element {
         const safeModelName = sanitizeFilename(modelName);
         const notebookFilename = `${displayName}_${safeModelName}_notebook.ipynb`;
         downloadBlob(notebook, notebookFilename);
+        fireAutomlNotebookDownloaded(source);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
         setDownloadError({
@@ -258,10 +267,11 @@ function AutomlResults(): React.JSX.Element {
           onRegisterModel={handleRegisterModel}
         />
       )}
-      {registerModelName && (
+      {registerModelState && (
         <RegisterModelModal
-          onClose={() => setRegisterModelName(null)}
-          modelName={registerModelName}
+          onClose={() => setRegisterModelState(null)}
+          modelName={registerModelState.modelName}
+          source={registerModelState.source}
         />
       )}
     </>

--- a/packages/automl/frontend/src/app/components/run-results/DeleteRunModal.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/DeleteRunModal.tsx
@@ -11,6 +11,8 @@ import {
   StackItem,
   TextInput,
 } from '@patternfly/react-core';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { AUTOML_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
 
 type DeleteRunModalProps = {
   isOpen: boolean;
@@ -33,6 +35,10 @@ const DeleteRunModal: React.FC<DeleteRunModalProps> = ({
 
   const handleClose = React.useCallback(() => {
     setConfirmInputValue('');
+    fireFormTrackingEvent(AUTOML_EVENTS.RUN_DELETED, {
+      outcome: TrackingOutcome.cancel,
+      source: 'runsList',
+    });
     onClose();
   }, [onClose]);
 

--- a/packages/automl/frontend/src/app/components/run-results/RegisterModelModal.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/RegisterModelModal.tsx
@@ -28,13 +28,19 @@ import { registerModel } from '~/app/api/modelRegistry';
 import type { ModelRegistry, RegisterModelRequest } from '~/app/types';
 import { useAutomlResultsContext } from '~/app/context/AutomlResultsContext';
 import { useNotification } from '~/app/hooks/useNotification';
+import {
+  fireAutomlModelRegistered,
+  TrackingOutcome,
+  type ModelActionSource,
+} from '~/app/utilities/tracking';
 
 type RegisterModelModalProps = {
   onClose: () => void;
   modelName: string;
+  source: ModelActionSource;
 };
 
-const RegisterModelModal: React.FC<RegisterModelModalProps> = ({ onClose, modelName }) => {
+const RegisterModelModal: React.FC<RegisterModelModalProps> = ({ onClose, modelName, source }) => {
   const { namespace } = useParams<{ namespace: string }>();
   const { models, pipelineRun } = useAutomlResultsContext();
   const notification = useNotification();
@@ -118,13 +124,23 @@ const RegisterModelModal: React.FC<RegisterModelModalProps> = ({ onClose, modelN
           onClick: () => window.open(modelDetailsUrl, '_blank', 'noopener,noreferrer'),
         },
       ]);
+      fireAutomlModelRegistered({
+        outcome: TrackingOutcome.submit,
+        success: true,
+        source,
+        registryTarget: variables.registryName,
+      });
       onClose();
     },
     onError: (error: unknown) => {
-      notification.error(
-        'Failed to register model',
-        error instanceof Error ? error.message : 'An unexpected error occurred',
-      );
+      const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred';
+      notification.error('Failed to register model', errorMessage);
+      fireAutomlModelRegistered({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        source,
+        error: errorMessage,
+      });
     },
   });
 
@@ -330,7 +346,10 @@ const RegisterModelModal: React.FC<RegisterModelModalProps> = ({ onClose, modelN
         </Button>
         <Button
           variant="link"
-          onClick={onClose}
+          onClick={() => {
+            fireAutomlModelRegistered({ outcome: TrackingOutcome.cancel, source });
+            onClose();
+          }}
           isDisabled={isSubmitting}
           data-testid="register-model-cancel"
         >

--- a/packages/automl/frontend/src/app/components/run-results/StopRunModal.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/StopRunModal.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { AUTOML_EVENTS, TrackingOutcome, type RunActionSource } from '~/app/utilities/tracking';
 
 type StopRunModalProps = {
   isOpen: boolean;
@@ -7,6 +9,7 @@ type StopRunModalProps = {
   onConfirm: () => void | Promise<void>;
   isTerminating: boolean;
   runName?: string;
+  source: RunActionSource;
 };
 
 const StopRunModal: React.FC<StopRunModalProps> = ({
@@ -15,6 +18,7 @@ const StopRunModal: React.FC<StopRunModalProps> = ({
   onConfirm,
   isTerminating,
   runName,
+  source,
 }) => {
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
@@ -29,10 +33,17 @@ const StopRunModal: React.FC<StopRunModalProps> = ({
     setIsSubmitting(true);
     try {
       await onConfirm();
+    } catch {
+      // Error notification and tracking are handled by the confirm handler (useAutomlRunActions).
     } finally {
       setIsSubmitting(false);
     }
   }, [onConfirm]);
+
+  const handleCancel = React.useCallback(() => {
+    fireFormTrackingEvent(AUTOML_EVENTS.RUN_STOPPED, { outcome: TrackingOutcome.cancel, source });
+    onClose();
+  }, [onClose, source]);
 
   const isDisabled = isSubmitting || isTerminating;
 
@@ -54,7 +65,7 @@ const StopRunModal: React.FC<StopRunModalProps> = ({
         >
           Stop
         </Button>
-        <Button variant="link" onClick={onClose} isDisabled={isDisabled}>
+        <Button variant="link" onClick={handleCancel} isDisabled={isDisabled}>
           Cancel
         </Button>
       </ModalFooter>

--- a/packages/automl/frontend/src/app/components/run-results/__tests__/AutomlLeaderboard.spec.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/__tests__/AutomlLeaderboard.spec.tsx
@@ -1031,7 +1031,7 @@ describe('AutomlLeaderboard component', () => {
       fireEvent.click(saveNotebookAction);
 
       // XGBoost is rank 1 — callback receives the map key
-      expect(mockOnClickSaveNotebook).toHaveBeenCalledWith('model-3');
+      expect(mockOnClickSaveNotebook).toHaveBeenCalledWith('model-3', 'leaderboard');
       expect(mockOnClickSaveNotebook).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/automl/frontend/src/app/components/run-results/__tests__/RegisterModelModal.spec.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/__tests__/RegisterModelModal.spec.tsx
@@ -91,6 +91,7 @@ const renderModal = (
                 <RegisterModelModal
                   onClose={props.onClose ?? jest.fn()}
                   modelName={props.modelName ?? 'TestModel'}
+                  source="leaderboard"
                 />
               </AutomlResultsContext.Provider>
             }

--- a/packages/automl/frontend/src/app/components/run-results/__tests__/StopRunModal.spec.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/__tests__/StopRunModal.spec.tsx
@@ -10,6 +10,7 @@ describe('StopRunModal', () => {
     onClose: jest.fn(),
     onConfirm: jest.fn(),
     isTerminating: false,
+    source: 'runsList' as const,
   };
 
   beforeEach(() => {

--- a/packages/automl/frontend/src/app/hooks/useAutomlRunActions.ts
+++ b/packages/automl/frontend/src/app/hooks/useAutomlRunActions.ts
@@ -6,6 +6,13 @@ import {
   useTerminatePipelineRunMutation,
 } from '~/app/hooks/mutations';
 import { useNotification } from '~/app/hooks/useNotification';
+import {
+  fireAutomlRunDeleted,
+  fireAutomlRunRetried,
+  fireAutomlRunStopped,
+  TrackingOutcome,
+  type RunActionSource,
+} from '~/app/utilities/tracking';
 
 type AutomlRunActions = {
   handleRetry: () => Promise<void>;
@@ -23,6 +30,7 @@ type AutomlRunActions = {
 export const useAutomlRunActions = (
   namespace: string,
   runId: string,
+  source: RunActionSource,
   onActionComplete?: () => void | Promise<void>,
 ): AutomlRunActions => {
   const queryClient = useQueryClient();
@@ -39,11 +47,16 @@ export const useAutomlRunActions = (
         'Retry submitted successfully',
         'The process is asynchronous and may take some time to take effect',
       );
+      fireAutomlRunRetried({ outcome: TrackingOutcome.submit, success: true, source });
     } catch (error) {
-      notification.error(
-        'Failed to retry run',
-        error instanceof Error ? error.message : 'An unknown error occurred',
-      );
+      const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+      notification.error('Failed to retry run', errorMessage);
+      fireAutomlRunRetried({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: errorMessage,
+        source,
+      });
       throw error;
     }
     try {
@@ -51,7 +64,7 @@ export const useAutomlRunActions = (
     } catch {
       // Caller refresh failure should not mask a successful retry.
     }
-  }, [retryMutation, queryClient, runId, namespace, onActionComplete, notification]);
+  }, [retryMutation, queryClient, runId, namespace, onActionComplete, notification, source]);
 
   const handleConfirmStop = React.useCallback(async () => {
     try {
@@ -61,11 +74,16 @@ export const useAutomlRunActions = (
         'Stop submitted successfully',
         'The process is asynchronous and may take some time to take effect',
       );
+      fireAutomlRunStopped({ outcome: TrackingOutcome.submit, success: true, source });
     } catch (error) {
-      notification.error(
-        'Failed to stop run',
-        error instanceof Error ? error.message : 'An unknown error occurred',
-      );
+      const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+      notification.error('Failed to stop run', errorMessage);
+      fireAutomlRunStopped({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: errorMessage,
+        source,
+      });
       throw error;
     }
     try {
@@ -73,7 +91,7 @@ export const useAutomlRunActions = (
     } catch {
       // Caller refresh failure should not mask a successful stop.
     }
-  }, [terminateMutation, queryClient, runId, namespace, onActionComplete, notification]);
+  }, [terminateMutation, queryClient, runId, namespace, onActionComplete, notification, source]);
 
   const handleDelete = React.useCallback(async () => {
     try {
@@ -83,11 +101,16 @@ export const useAutomlRunActions = (
         'Run deleted successfully',
         'The pipeline run has been permanently removed',
       );
+      fireAutomlRunDeleted({ outcome: TrackingOutcome.submit, success: true, source });
     } catch (error) {
-      notification.error(
-        'Failed to delete run',
-        error instanceof Error ? error.message : 'An unknown error occurred',
-      );
+      const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+      notification.error('Failed to delete run', errorMessage);
+      fireAutomlRunDeleted({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: errorMessage,
+        source,
+      });
       throw error;
     }
     try {
@@ -95,7 +118,7 @@ export const useAutomlRunActions = (
     } catch {
       // Caller refresh failure should not mask a successful delete.
     }
-  }, [deleteMutation, queryClient, runId, namespace, onActionComplete, notification]);
+  }, [deleteMutation, queryClient, runId, namespace, onActionComplete, notification, source]);
 
   return {
     handleRetry,

--- a/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
@@ -17,6 +17,7 @@ import { ApplicationsPage } from 'mod-arch-shared';
 import React, { useCallback, useState } from 'react';
 import { FieldPath, FormProvider, useForm, useWatch } from 'react-hook-form';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutomlHeader from '~/app/components/common/AutomlHeader/AutomlHeader';
 import AutomlConfigure from '~/app/components/configure/AutomlConfigure';
 import AutomlCreate from '~/app/components/create/AutomlCreate';
@@ -27,6 +28,14 @@ import { useNotification } from '~/app/hooks/useNotification';
 import type { SecretSelection } from '~/app/components/common/SecretSelector';
 import { ConfigureSchema, createConfigureSchema } from '~/app/schemas/configure.schema';
 import { automlExperimentsPathname, automlResultsPathname } from '~/app/utilities/routes';
+import {
+  fireAutomlRunCreated,
+  fireAutomlRunReconfigured,
+  mapOptimizationMetric,
+  mapPredictionType,
+  TrackingOutcome,
+  type RunActionSource,
+} from '~/app/utilities/tracking';
 
 const configureSchema = createConfigureSchema();
 const createFields = ['display_name', 'description'] as const satisfies Array<
@@ -52,11 +61,17 @@ function AutomlConfigurePage({
   const navigate = useNavigate();
   const location = useLocation();
   const notification = useNotification();
-  const fromResultsPage =
-    location.state != null &&
-    typeof location.state === 'object' &&
-    'from' in location.state &&
-    location.state.from === 'results';
+  const locationFrom =
+    location.state != null && typeof location.state === 'object' && 'from' in location.state
+      ? location.state.from
+      : undefined;
+  const fromResultsPage = locationFrom === 'results';
+  const reconfigureSource: RunActionSource | undefined =
+    locationFrom === 'results'
+      ? 'resultsPage'
+      : locationFrom === 'runsList'
+        ? 'runsList'
+        : undefined;
 
   const { namespace } = useParams();
   const { namespaces, namespacesLoaded, namespacesLoadError } =
@@ -82,8 +97,16 @@ function AutomlConfigurePage({
   });
 
   const [step, setStep] = useState<'create' | 'configure'>('create');
+  const isRecommendedRef = React.useRef(true);
 
-  const onCancel = useCallback(() => navigate(-1), [navigate]);
+  const onCancel = useCallback(() => {
+    const eventName = sourceRunId ? 'AutoML Run Reconfigured' : 'AutoML Run Created';
+    fireFormTrackingEvent(eventName, {
+      outcome: TrackingOutcome.cancel,
+      ...(sourceRunId && { source: reconfigureSource }),
+    });
+    navigate(-1);
+  }, [navigate, sourceRunId, reconfigureSource]);
 
   const handleBackToCreate = useCallback(() => {
     // New runs only: clear configure-step values so Back → Next does not show stale S3/file UI.
@@ -224,14 +247,64 @@ function AutomlConfigurePage({
 
             form.handleSubmit(
               async (data: ConfigureSchema) => {
+                const trackingProperties = {
+                  predictionType: mapPredictionType(data.task_type),
+                  optimizationMetric: mapOptimizationMetric(data.eval_metric),
+                  hasTargetColumn: Boolean(data.target_column || data.target || data.label_column),
+                  isRecommended: isRecommendedRef.current,
+                  hasS3Connection: Boolean(data.train_data_secret_name),
+                };
                 try {
                   const pipelineRun = await pipelineRunsMutation.mutateAsync(data);
+                  if (sourceRunId) {
+                    const changedFields: string[] = [];
+                    if (data.task_type !== initialValues?.task_type) {
+                      changedFields.push('predictionType');
+                    }
+                    if (data.eval_metric !== initialValues?.eval_metric) {
+                      changedFields.push('optimizationMetric');
+                    }
+                    if (data.target_column !== initialValues?.target_column) {
+                      changedFields.push('targetColumn');
+                    }
+                    if (data.train_data_secret_name !== initialValues?.train_data_secret_name) {
+                      changedFields.push('s3Connection');
+                    }
+                    fireAutomlRunReconfigured({
+                      ...trackingProperties,
+                      changedFields,
+                      outcome: TrackingOutcome.submit,
+                      success: true,
+                      source: reconfigureSource,
+                    });
+                  } else {
+                    fireAutomlRunCreated({
+                      ...trackingProperties,
+                      outcome: TrackingOutcome.submit,
+                      success: true,
+                    });
+                  }
                   navigate(`${automlResultsPathname}/${namespace}/${pipelineRun.run_id}`);
                 } catch (error) {
-                  notification.error(
-                    'Failed to create pipeline run',
-                    error instanceof Error ? error.message : '',
-                  );
+                  const errorMessage = error instanceof Error ? error.message : '';
+                  if (sourceRunId) {
+                    fireAutomlRunReconfigured({
+                      ...trackingProperties,
+                      changedFields: [],
+                      outcome: TrackingOutcome.submit,
+                      success: false,
+                      error: errorMessage,
+                      source: reconfigureSource,
+                    });
+                  } else {
+                    fireAutomlRunCreated({
+                      ...trackingProperties,
+                      outcome: TrackingOutcome.submit,
+                      success: false,
+                      error: errorMessage,
+                    });
+                  }
+                  notification.error('Failed to create pipeline run', errorMessage);
                 }
               },
               // this `onInvalid` case should be impossible to hit
@@ -255,6 +328,9 @@ function AutomlConfigurePage({
                 <AutomlConfigure
                   initialValues={initialValues}
                   initialInputDataSecret={initialInputDataSecret}
+                  onRecommendationChange={(isRecommended) => {
+                    isRecommendedRef.current = isRecommended;
+                  }}
                 />
               )}
             </PageSection>

--- a/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
@@ -250,9 +250,7 @@ function AutomlConfigurePage({
                 const trackingProperties = {
                   predictionType: mapPredictionType(data.task_type),
                   optimizationMetric: mapOptimizationMetric(data.eval_metric),
-                  hasTargetColumn: Boolean(data.target_column || data.target || data.label_column),
                   isRecommended: isRecommendedRef.current,
-                  hasS3Connection: Boolean(data.train_data_secret_name),
                 };
                 try {
                   const pipelineRun = await pipelineRunsMutation.mutateAsync(data);

--- a/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import classNames from 'classnames';
 import { ApplicationsPage } from 'mod-arch-shared';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { FieldPath, FormProvider, useForm, useWatch } from 'react-hook-form';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
@@ -29,11 +29,14 @@ import type { SecretSelection } from '~/app/components/common/SecretSelector';
 import { ConfigureSchema, createConfigureSchema } from '~/app/schemas/configure.schema';
 import { automlExperimentsPathname, automlResultsPathname } from '~/app/utilities/routes';
 import {
+  fireAutomlFlowExited,
   fireAutomlRunCreated,
   fireAutomlRunReconfigured,
   mapOptimizationMetric,
   mapPredictionType,
   TrackingOutcome,
+  type AutomlExitDestination,
+  type AutomlFunnelStep,
   type RunActionSource,
 } from '~/app/utilities/tracking';
 
@@ -98,6 +101,26 @@ function AutomlConfigurePage({
 
   const [step, setStep] = useState<'create' | 'configure'>('create');
   const isRecommendedRef = React.useRef(true);
+  const funnelStepRef = React.useRef<AutomlFunnelStep>('defineDetails');
+  // Cancel is only rendered on step 'create'; reconfigure flows are entered from the runs
+  // list/results page rather than the experiments list, so `navigate(-1)` lands elsewhere.
+  const cancelExitDestination: AutomlExitDestination = sourceRunId
+    ? 'otherAutoml'
+    : 'experimentsList';
+
+  useEffect(() => {
+    if (step === 'configure') {
+      funnelStepRef.current = 'trainingData';
+    }
+  }, [step]);
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      fireAutomlFlowExited('abandon', funnelStepRef.current, 'none');
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, []);
 
   const onCancel = useCallback(() => {
     const eventName = sourceRunId ? 'AutoML Run Reconfigured' : 'AutoML Run Created';
@@ -105,8 +128,9 @@ function AutomlConfigurePage({
       outcome: TrackingOutcome.cancel,
       ...(sourceRunId && { source: reconfigureSource }),
     });
+    fireAutomlFlowExited('navigate', funnelStepRef.current, cancelExitDestination);
     navigate(-1);
-  }, [navigate, sourceRunId, reconfigureSource]);
+  }, [navigate, sourceRunId, reconfigureSource, cancelExitDestination]);
 
   const handleBackToCreate = useCallback(() => {
     // New runs only: clear configure-step values so Back → Next does not show stale S3/file UI.
@@ -211,11 +235,23 @@ function AutomlConfigurePage({
         (step === 'configure' || sourceRunId) && (
           <Breadcrumb>
             <BreadcrumbItem>
-              <Link to={getRedirectPath(namespace!)}>AutoML: {namespace}</Link>
+              <Link
+                to={getRedirectPath(namespace!)}
+                onClick={() =>
+                  fireAutomlFlowExited('navigate', funnelStepRef.current, 'experimentsList')
+                }
+              >
+                AutoML: {namespace}
+              </Link>
             </BreadcrumbItem>
             {fromResultsPage && sourceRunId && sourceRunName && (
               <BreadcrumbItem data-testid="configure-breadcrumb-source-run">
-                <Link to={`${automlResultsPathname}/${namespace}/${sourceRunId}`}>
+                <Link
+                  to={`${automlResultsPathname}/${namespace}/${sourceRunId}`}
+                  onClick={() =>
+                    fireAutomlFlowExited('navigate', funnelStepRef.current, 'otherAutoml')
+                  }
+                >
                   <Truncate content={sourceRunName} />
                 </Link>
               </BreadcrumbItem>

--- a/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
@@ -264,7 +264,10 @@ function AutomlConfigurePage({
                     if (data.eval_metric !== initialValues?.eval_metric) {
                       changedFields.push('optimizationMetric');
                     }
-                    if (data.target_column !== initialValues?.target_column) {
+                    // The submit transformer deletes `target_column`, moving its value to
+                    // `target` (timeseries) or `label_column` (tabular) — compare against
+                    // whichever one is populated post-transform.
+                    if ((data.target ?? data.label_column) !== initialValues?.target_column) {
                       changedFields.push('targetColumn');
                     }
                     if (data.train_data_secret_name !== initialValues?.train_data_secret_name) {

--- a/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
@@ -17,7 +17,6 @@ import { ApplicationsPage } from 'mod-arch-shared';
 import React, { useCallback, useEffect, useState } from 'react';
 import { FieldPath, FormProvider, useForm, useWatch } from 'react-hook-form';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
-import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutomlHeader from '~/app/components/common/AutomlHeader/AutomlHeader';
 import AutomlConfigure from '~/app/components/configure/AutomlConfigure';
 import AutomlCreate from '~/app/components/create/AutomlCreate';
@@ -31,6 +30,7 @@ import { automlExperimentsPathname, automlResultsPathname } from '~/app/utilitie
 import {
   fireAutomlFlowExited,
   fireAutomlRunCreated,
+  fireAutomlRunDetailsDefined,
   fireAutomlRunReconfigured,
   mapOptimizationMetric,
   mapPredictionType,
@@ -123,14 +123,10 @@ function AutomlConfigurePage({
   }, []);
 
   const onCancel = useCallback(() => {
-    const eventName = sourceRunId ? 'AutoML Run Reconfigured' : 'AutoML Run Created';
-    fireFormTrackingEvent(eventName, {
-      outcome: TrackingOutcome.cancel,
-      ...(sourceRunId && { source: reconfigureSource }),
-    });
+    fireAutomlRunDetailsDefined(TrackingOutcome.cancel, Boolean(description?.trim()));
     fireAutomlFlowExited('navigate', funnelStepRef.current, cancelExitDestination);
     navigate(-1);
-  }, [navigate, sourceRunId, reconfigureSource, cancelExitDestination]);
+  }, [navigate, description, cancelExitDestination]);
 
   const handleBackToCreate = useCallback(() => {
     // New runs only: clear configure-step values so Back → Next does not show stale S3/file UI.
@@ -277,6 +273,7 @@ function AutomlConfigurePage({
             event.preventDefault();
 
             if (step === 'create') {
+              fireAutomlRunDetailsDefined(TrackingOutcome.submit, Boolean(description?.trim()));
               setStep('configure');
               return;
             }

--- a/packages/automl/frontend/src/app/pages/AutomlResultsPage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlResultsPage.tsx
@@ -42,6 +42,7 @@ function AutomlResultsPage(): React.JSX.Element {
   const { handleRetry, handleConfirmStop, isRetrying, isTerminating } = useAutomlRunActions(
     namespace ?? '',
     runId ?? '',
+    'resultsPage',
   );
 
   const noNamespaces = namespacesLoaded && namespaces.length === 0;
@@ -295,6 +296,7 @@ function AutomlResultsPage(): React.JSX.Element {
         onConfirm={handleStop}
         isTerminating={isTerminating}
         runName={pipelineRun?.display_name}
+        source="resultsPage"
       />
     </AutomlResultsContext.Provider>
   );

--- a/packages/automl/frontend/src/app/pages/__tests__/AutomlConfigurePage.spec.tsx
+++ b/packages/automl/frontend/src/app/pages/__tests__/AutomlConfigurePage.spec.tsx
@@ -324,6 +324,42 @@ describe('AutomlConfigurePage', () => {
       expect(await screen.findByText('Configure details')).toBeInTheDocument();
       expect(screen.queryByLabelText(/Name/i)).not.toBeInTheDocument();
     });
+
+    it('should fire AutoML Run Details Defined with outcome:submit and hasDescription:false when no description is entered', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutomlConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await waitFor(() => expect(nextButton).toBeEnabled());
+      await user.click(nextButton);
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.RUN_DETAILS_DEFINED, {
+        outcome: 'submit',
+        hasDescription: false,
+      });
+    });
+
+    it('should fire AutoML Run Details Defined with hasDescription:true when a description is entered', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutomlConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+      const descriptionInput = await screen.findByLabelText(/Description/i);
+      await user.type(descriptionInput, 'Some description');
+
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await waitFor(() => expect(nextButton).toBeEnabled());
+      await user.click(nextButton);
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.RUN_DETAILS_DEFINED, {
+        outcome: 'submit',
+        hasDescription: true,
+      });
+    });
   });
 
   describe('Create step - Cancel button', () => {
@@ -333,6 +369,18 @@ describe('AutomlConfigurePage', () => {
       const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
       await user.click(cancelButton);
       expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+
+    it('should fire AutoML Run Details Defined with outcome:cancel when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutomlConfigurePage />);
+      const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+      await user.click(cancelButton);
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.RUN_DETAILS_DEFINED, {
+        outcome: 'cancel',
+        hasDescription: false,
+      });
     });
 
     it('should fire AutoML Flow Exited with defineDetails and experimentsList', async () => {

--- a/packages/automl/frontend/src/app/pages/__tests__/AutomlConfigurePage.spec.tsx
+++ b/packages/automl/frontend/src/app/pages/__tests__/AutomlConfigurePage.spec.tsx
@@ -5,11 +5,15 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { BrowserRouter } from 'react-router';
-import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutomlConfigurePage from '~/app/pages/AutomlConfigurePage';
 import { AUTOML_EVENTS } from '~/app/utilities/tracking';
 
 const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
+const fireMiscTrackingEventMock = jest.mocked(fireMiscTrackingEvent);
 
 const mockNavigate = jest.fn();
 const mockUseParams = jest.fn();
@@ -22,8 +26,18 @@ jest.mock('react-router', () => ({
   useNavigate: () => mockNavigate,
   useParams: () => mockUseParams(),
   useLocation: () => ({ state: mockLocationState, pathname: '', search: '', hash: '', key: '' }),
-  Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
-    <a href={to}>{children}</a>
+  Link: ({
+    to,
+    children,
+    onClick,
+  }: {
+    to: string;
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <a href={to} onClick={onClick}>
+      {children}
+    </a>
   ),
 }));
 
@@ -75,6 +89,7 @@ jest.mock('~/app/hooks/useNotification', () => ({
 
 jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
   fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
 }));
 
 jest.mock('mod-arch-shared', () => ({
@@ -319,6 +334,18 @@ describe('AutomlConfigurePage', () => {
       await user.click(cancelButton);
       expect(mockNavigate).toHaveBeenCalledWith(-1);
     });
+
+    it('should fire AutoML Flow Exited with defineDetails and experimentsList', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutomlConfigurePage />);
+      const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+      await user.click(cancelButton);
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.FLOW_EXITED, {
+        exitType: 'navigate',
+        lastFunnelStep: 'defineDetails',
+        exitDestination: 'experimentsList',
+      });
+    });
   });
 
   describe('Configure step', () => {
@@ -359,6 +386,17 @@ describe('AutomlConfigurePage', () => {
       expect(await screen.findByText('AutoML: test-namespace')).toBeInTheDocument();
       const breadcrumbName = await screen.findByTestId('configure-breadcrumb-name');
       expect(breadcrumbName).toHaveTextContent('My Experiment');
+    });
+
+    it('should fire AutoML Flow Exited with trainingData and experimentsList when the breadcrumb is clicked', async () => {
+      const user = userEvent.setup();
+      const breadcrumbLink = await screen.findByText('AutoML: test-namespace');
+      await user.click(breadcrumbLink);
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.FLOW_EXITED, {
+        exitType: 'navigate',
+        lastFunnelStep: 'trainingData',
+        exitDestination: 'experimentsList',
+      });
     });
 
     it('should render "Create run" button', async () => {

--- a/packages/automl/frontend/src/app/pages/__tests__/AutomlConfigurePage.spec.tsx
+++ b/packages/automl/frontend/src/app/pages/__tests__/AutomlConfigurePage.spec.tsx
@@ -5,7 +5,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { BrowserRouter } from 'react-router';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutomlConfigurePage from '~/app/pages/AutomlConfigurePage';
+import { AUTOML_EVENTS } from '~/app/utilities/tracking';
+
+const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
 
 const mockNavigate = jest.fn();
 const mockUseParams = jest.fn();
@@ -67,6 +71,10 @@ jest.mock('~/app/hooks/useNotification', () => ({
   useNotification: jest.fn(() => ({
     error: mockNotificationError,
   })),
+}));
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
 }));
 
 jest.mock('mod-arch-shared', () => ({
@@ -1075,6 +1083,98 @@ describe('AutomlConfigurePage', () => {
         expect(screen.getByTestId('aws-secret-selector-value')).toHaveTextContent('aws-secret-1');
         expect(screen.getByText('train.csv')).toBeInTheDocument();
         expect(screen.getByTestId('task-type-card-binary')).toHaveClass('pf-m-selected');
+      });
+    });
+
+    describe('AutoML Run Reconfigured tracking - changedFields', () => {
+      const tabularInitialValues = {
+        display_name: 'Reconfigured Run',
+        description: 'A reconfigured experiment',
+        train_data_secret_name: 'Test AWS Secret',
+        train_data_bucket_name: 'test-bucket',
+        train_data_file_key: 'my-data/train.csv',
+        task_type: 'binary' as const,
+        target_column: 'column1',
+        // Real AutomlReconfigureLoader always resolves and pre-fills eval_metric — mirror that
+        // here so the assertions aren't polluted by a spurious optimizationMetric diff.
+        eval_metric: 'accuracy' as const,
+        top_n: 7,
+      };
+      const tabularInitialSecret = {
+        uuid: 'aws-secret-1',
+        name: 'Test AWS Secret',
+        displayName: 'Test AWS Secret',
+        data: { AWS_S3_BUCKET: 'test-bucket', AWS_DEFAULT_REGION: 'us-east-1' },
+        type: 's3',
+        invalid: false,
+      };
+
+      it('should NOT include targetColumn in changedFields when the target column is unchanged', async () => {
+        const user = userEvent.setup();
+        mockMutateAsync.mockResolvedValue({ run_id: 'reconfigured-run-1' });
+
+        renderWithProviders(
+          <AutomlConfigurePage
+            initialValues={tabularInitialValues}
+            initialInputDataSecret={tabularInitialSecret}
+            sourceRunId="run-1"
+          />,
+        );
+
+        const nextButton = await screen.findByRole('button', { name: 'Next' });
+        await waitFor(() => expect(nextButton).toBeEnabled());
+        await user.click(nextButton);
+
+        const submitButton = await screen.findByRole('button', { name: 'Create new run' });
+        await waitFor(() => expect(submitButton).toBeEnabled());
+        await user.click(submitButton);
+
+        await waitFor(() => expect(mockMutateAsync).toHaveBeenCalled());
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTOML_EVENTS.RUN_RECONFIGURED,
+          expect.objectContaining({ changedFields: '' }),
+        );
+      });
+
+      it('should include targetColumn in changedFields when the target column is changed', async () => {
+        const user = userEvent.setup();
+        mockMutateAsync.mockResolvedValue({ run_id: 'reconfigured-run-2' });
+
+        renderWithProviders(
+          <AutomlConfigurePage
+            initialValues={tabularInitialValues}
+            initialInputDataSecret={tabularInitialSecret}
+            sourceRunId="run-1"
+          />,
+        );
+
+        const nextButton = await screen.findByRole('button', { name: 'Next' });
+        await waitFor(() => expect(nextButton).toBeEnabled());
+        await user.click(nextButton);
+
+        // Change the target column to a different column
+        const targetColumnSelect = await screen.findByTestId('target_column-select');
+        await user.click(targetColumnSelect);
+        const columnOption = await screen.findByRole('option', { name: /column2/i });
+        await user.click(columnOption);
+
+        // Re-select the prediction type, since changing the target column resets it
+        const regressionCard = await screen.findByTestId('task-type-card-regression');
+        await user.click(regressionCard);
+
+        const submitButton = await screen.findByRole('button', { name: 'Create new run' });
+        await waitFor(() => expect(submitButton).toBeEnabled());
+        await user.click(submitButton);
+
+        await waitFor(() => expect(mockMutateAsync).toHaveBeenCalled());
+        // Switching prediction type also recomputes the default optimization metric for the
+        // new task type, so that legitimately shows up as changed too.
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTOML_EVENTS.RUN_RECONFIGURED,
+          expect.objectContaining({
+            changedFields: 'predictionType,optimizationMetric,targetColumn',
+          }),
+        );
       });
     });
   });

--- a/packages/automl/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/automl/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -6,6 +6,7 @@ import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   AUTOML_EVENTS,
   fireAutomlBacktestWindowMetricViewed,
+  fireAutomlFlowExited,
   fireAutomlLeaderboardSorted,
   fireAutomlModelDetailsDownloaded,
   fireAutomlModelDetailsTabViewed,
@@ -276,6 +277,26 @@ describe('AutoML tracking event firers', () => {
     expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.LEADERBOARD_SORTED, {
       sortColumn: 'Model name',
       sortDirection: 'desc',
+    });
+  });
+
+  it('should fire AutoML Flow Exited with exitType, lastFunnelStep, and exitDestination', () => {
+    fireAutomlFlowExited('navigate', 'defineDetails', 'experimentsList');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.FLOW_EXITED, {
+      exitType: 'navigate',
+      lastFunnelStep: 'defineDetails',
+      exitDestination: 'experimentsList',
+    });
+  });
+
+  it('should fire AutoML Flow Exited with exitType: abandon and exitDestination: none', () => {
+    fireAutomlFlowExited('abandon', 'trainingData', 'none');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.FLOW_EXITED, {
+      exitType: 'abandon',
+      lastFunnelStep: 'trainingData',
+      exitDestination: 'none',
     });
   });
 });

--- a/packages/automl/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/automl/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -6,9 +6,7 @@ import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   AUTOML_EVENTS,
   fireAutomlBacktestWindowMetricViewed,
-  fireAutomlLeaderboardFilterApplied,
   fireAutomlLeaderboardSorted,
-  fireAutomlModelCompared,
   fireAutomlModelDetailsDownloaded,
   fireAutomlModelDetailsTabViewed,
   fireAutomlModelRegistered,
@@ -278,23 +276,6 @@ describe('AutoML tracking event firers', () => {
     expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.LEADERBOARD_SORTED, {
       sortColumn: 'Model name',
       sortDirection: 'desc',
-    });
-  });
-
-  it('should fire AutoML Leaderboard Filter Applied with filterType', () => {
-    fireAutomlLeaderboardFilterApplied('taskType');
-
-    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
-      AUTOML_EVENTS.LEADERBOARD_FILTER_APPLIED,
-      { filterType: 'taskType' },
-    );
-  });
-
-  it('should fire AutoML Model Compared with countOfModelsCompared', () => {
-    fireAutomlModelCompared(3);
-
-    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.MODEL_COMPARED, {
-      countOfModelsCompared: 3,
     });
   });
 });

--- a/packages/automl/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/automl/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -14,10 +14,13 @@ import {
   fireAutomlNotebookDownloaded,
   fireAutomlRunCreated,
   fireAutomlRunDeleted,
+  fireAutomlRunDetailsDefined,
   fireAutomlRunReconfigured,
   fireAutomlRunRetried,
   fireAutomlRunStopped,
   fireAutomlS3ConnectionCreated,
+  fireAutomlTargetColumnConfigured,
+  fireAutomlTrainingDataConfigured,
   mapModelDetailsTabName,
   mapOptimizationMetric,
   mapPredictionType,
@@ -119,6 +122,41 @@ describe('mapModelDetailsTabName', () => {
 describe('AutoML tracking event firers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('should fire AutoML Run Details Defined with outcome and hasDescription', () => {
+    fireAutomlRunDetailsDefined(TrackingOutcome.submit, true);
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.RUN_DETAILS_DEFINED, {
+      outcome: TrackingOutcome.submit,
+      hasDescription: true,
+    });
+  });
+
+  it('should fire AutoML Run Details Defined with outcome:cancel', () => {
+    fireAutomlRunDetailsDefined(TrackingOutcome.cancel, false);
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.RUN_DETAILS_DEFINED, {
+      outcome: TrackingOutcome.cancel,
+      hasDescription: false,
+    });
+  });
+
+  it('should fire AutoML Training Data Configured with the training data source type', () => {
+    fireAutomlTrainingDataConfigured('upload');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.TRAINING_DATA_CONFIGURED, {
+      trainingDataSourceType: 'upload',
+    });
+  });
+
+  it('should fire AutoML Target Column Configured with no properties', () => {
+    fireAutomlTargetColumnConfigured();
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+      AUTOML_EVENTS.TARGET_COLUMN_CONFIGURED,
+      {},
+    );
   });
 
   it('should fire AutoML Run Created via fireFormTrackingEvent with the given properties', () => {

--- a/packages/automl/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/automl/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -128,9 +128,7 @@ describe('AutoML tracking event firers', () => {
       success: true,
       predictionType: 'binaryClassification',
       optimizationMetric: 'accuracy',
-      hasTargetColumn: true,
       isRecommended: true,
-      hasS3Connection: true,
     });
 
     expect(fireFormTrackingEventMock).toHaveBeenCalledTimes(1);
@@ -139,9 +137,7 @@ describe('AutoML tracking event firers', () => {
       success: true,
       predictionType: 'binaryClassification',
       optimizationMetric: 'accuracy',
-      hasTargetColumn: true,
       isRecommended: true,
-      hasS3Connection: true,
     });
   });
 
@@ -151,9 +147,7 @@ describe('AutoML tracking event firers', () => {
       success: true,
       predictionType: 'regression',
       optimizationMetric: 'r2',
-      hasTargetColumn: true,
       isRecommended: false,
-      hasS3Connection: true,
       changedFields: ['predictionType', 'targetColumn'],
       source: 'resultsPage',
     });
@@ -171,9 +165,7 @@ describe('AutoML tracking event firers', () => {
     fireAutomlRunReconfigured({
       outcome: TrackingOutcome.submit,
       success: false,
-      hasTargetColumn: false,
       isRecommended: false,
-      hasS3Connection: false,
       changedFields: [],
     });
 

--- a/packages/automl/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/automl/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -1,0 +1,308 @@
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import {
+  AUTOML_EVENTS,
+  fireAutomlBacktestWindowMetricViewed,
+  fireAutomlLeaderboardFilterApplied,
+  fireAutomlLeaderboardSorted,
+  fireAutomlModelCompared,
+  fireAutomlModelDetailsDownloaded,
+  fireAutomlModelDetailsTabViewed,
+  fireAutomlModelRegistered,
+  fireAutomlNotebookDownloaded,
+  fireAutomlRunCreated,
+  fireAutomlRunDeleted,
+  fireAutomlRunReconfigured,
+  fireAutomlRunRetried,
+  fireAutomlRunStopped,
+  fireAutomlS3ConnectionCreated,
+  mapModelDetailsTabName,
+  mapOptimizationMetric,
+  mapPredictionType,
+} from '~/app/utilities/tracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
+const fireMiscTrackingEventMock = jest.mocked(fireMiscTrackingEvent);
+
+describe('mapPredictionType', () => {
+  it('should map binary to binaryClassification', () => {
+    expect(mapPredictionType('binary')).toBe('binaryClassification');
+  });
+
+  it('should map multiclass to multiclassClassification', () => {
+    expect(mapPredictionType('multiclass')).toBe('multiclassClassification');
+  });
+
+  it('should map regression to regression', () => {
+    expect(mapPredictionType('regression')).toBe('regression');
+  });
+
+  it('should map timeseries to timeSeriesForecasting', () => {
+    expect(mapPredictionType('timeseries')).toBe('timeSeriesForecasting');
+  });
+
+  it('should pass through unknown task types unchanged', () => {
+    expect(mapPredictionType('anomaly')).toBe('anomaly');
+  });
+
+  it('should return undefined for undefined input', () => {
+    expect(mapPredictionType(undefined)).toBeUndefined();
+  });
+
+  it('should return undefined for empty string input', () => {
+    expect(mapPredictionType('')).toBeUndefined();
+  });
+});
+
+describe('mapOptimizationMetric', () => {
+  it('should map accuracy to accuracy', () => {
+    expect(mapOptimizationMetric('accuracy')).toBe('accuracy');
+  });
+
+  it('should map roc_auc to rocAuc', () => {
+    expect(mapOptimizationMetric('roc_auc')).toBe('rocAuc');
+  });
+
+  it('should map f1 to f1Score', () => {
+    expect(mapOptimizationMetric('f1')).toBe('f1Score');
+  });
+
+  it('should map log_loss to logLoss', () => {
+    expect(mapOptimizationMetric('log_loss')).toBe('logLoss');
+  });
+
+  it('should map balanced_accuracy to balancedAccuracy', () => {
+    expect(mapOptimizationMetric('balanced_accuracy')).toBe('balancedAccuracy');
+  });
+
+  it('should be case-insensitive', () => {
+    expect(mapOptimizationMetric('ROC_AUC')).toBe('rocAuc');
+  });
+
+  it('should pass through metrics outside the fixed taxonomy unchanged (e.g. regression/timeseries metrics)', () => {
+    expect(mapOptimizationMetric('r2')).toBe('r2');
+    expect(mapOptimizationMetric('MASE')).toBe('MASE');
+  });
+
+  it('should return undefined for undefined input', () => {
+    expect(mapOptimizationMetric(undefined)).toBeUndefined();
+  });
+
+  it('should return undefined for empty string input', () => {
+    expect(mapOptimizationMetric('')).toBeUndefined();
+  });
+});
+
+describe('mapModelDetailsTabName', () => {
+  it('should map every tabConfig.ts tab key to a camelCase name', () => {
+    expect(mapModelDetailsTabName('model-information')).toBe('modelInformation');
+    expect(mapModelDetailsTabName('feature-summary')).toBe('featureSummary');
+    expect(mapModelDetailsTabName('model-evaluation')).toBe('modelEvaluation');
+    expect(mapModelDetailsTabName('confusion-matrix')).toBe('confusionMatrix');
+    expect(mapModelDetailsTabName('roc-curve')).toBe('rocCurve');
+    expect(mapModelDetailsTabName('precision-recall')).toBe('precisionRecall');
+    expect(mapModelDetailsTabName('backtest-window')).toBe('backtestWindow');
+  });
+
+  it('should pass through unknown tab keys unchanged', () => {
+    expect(mapModelDetailsTabName('some-future-tab')).toBe('some-future-tab');
+  });
+});
+
+describe('AutoML tracking event firers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fire AutoML Run Created via fireFormTrackingEvent with the given properties', () => {
+    fireAutomlRunCreated({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      predictionType: 'binaryClassification',
+      optimizationMetric: 'accuracy',
+      hasTargetColumn: true,
+      isRecommended: true,
+      hasS3Connection: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledTimes(1);
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.RUN_CREATED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      predictionType: 'binaryClassification',
+      optimizationMetric: 'accuracy',
+      hasTargetColumn: true,
+      isRecommended: true,
+      hasS3Connection: true,
+    });
+  });
+
+  it('should fire AutoML Run Reconfigured with changedFields joined into a comma-separated string', () => {
+    fireAutomlRunReconfigured({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      predictionType: 'regression',
+      optimizationMetric: 'r2',
+      hasTargetColumn: true,
+      isRecommended: false,
+      hasS3Connection: true,
+      changedFields: ['predictionType', 'targetColumn'],
+      source: 'resultsPage',
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTOML_EVENTS.RUN_RECONFIGURED,
+      expect.objectContaining({
+        changedFields: 'predictionType,targetColumn',
+        source: 'resultsPage',
+      }),
+    );
+  });
+
+  it('should fire AutoML Run Reconfigured with an empty string when changedFields is empty', () => {
+    fireAutomlRunReconfigured({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      hasTargetColumn: false,
+      isRecommended: false,
+      hasS3Connection: false,
+      changedFields: [],
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTOML_EVENTS.RUN_RECONFIGURED,
+      expect.objectContaining({ changedFields: '' }),
+    );
+  });
+
+  it('should fire AutoML Run Stopped with source', () => {
+    fireAutomlRunStopped({ outcome: TrackingOutcome.cancel, source: 'runsList' });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.RUN_STOPPED, {
+      outcome: TrackingOutcome.cancel,
+      source: 'runsList',
+    });
+  });
+
+  it('should fire AutoML Run Retried', () => {
+    fireAutomlRunRetried({ outcome: TrackingOutcome.submit, success: false, error: 'boom' });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.RUN_RETRIED, {
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: 'boom',
+    });
+  });
+
+  it('should fire AutoML Run Deleted', () => {
+    fireAutomlRunDeleted({ outcome: TrackingOutcome.submit, success: true, source: 'runsList' });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.RUN_DELETED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      source: 'runsList',
+    });
+  });
+
+  it('should fire AutoML Model Details Tab Viewed with the mapped tab name and predictionType', () => {
+    fireAutomlModelDetailsTabViewed('roc-curve', 'binary');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.MODEL_DETAILS_TAB_VIEWED, {
+      tabName: 'rocCurve',
+      predictionType: 'binaryClassification',
+    });
+  });
+
+  it('should fire AutoML Model Details Tab Viewed with undefined predictionType when taskType is omitted', () => {
+    fireAutomlModelDetailsTabViewed('model-information');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.MODEL_DETAILS_TAB_VIEWED, {
+      tabName: 'modelInformation',
+      predictionType: undefined,
+    });
+  });
+
+  it('should fire AutoML Backtest Window Metric Viewed with the raw metric name', () => {
+    fireAutomlBacktestWindowMetricViewed('WQL');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+      AUTOML_EVENTS.BACKTEST_WINDOW_METRIC_VIEWED,
+      { metricName: 'WQL' },
+    );
+  });
+
+  it('should fire AutoML Notebook Downloaded with downloadType and source', () => {
+    fireAutomlNotebookDownloaded('leaderboard');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.NOTEBOOK_DOWNLOADED, {
+      downloadType: 'notebook',
+      source: 'leaderboard',
+    });
+  });
+
+  it('should fire AutoML Model Details Downloaded with downloadType', () => {
+    fireAutomlModelDetailsDownloaded();
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.MODEL_DETAILS_DOWNLOADED, {
+      downloadType: 'modelDetails',
+    });
+  });
+
+  it('should fire AutoML Model Registered with registryTarget and source', () => {
+    fireAutomlModelRegistered({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      source: 'modelDetailsModal',
+      registryTarget: 'my-registry',
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.MODEL_REGISTERED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      source: 'modelDetailsModal',
+      registryTarget: 'my-registry',
+    });
+  });
+
+  it('should fire AutoML S3 Connection Created', () => {
+    fireAutomlS3ConnectionCreated({ outcome: TrackingOutcome.cancel });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.S3_CONNECTION_CREATED, {
+      outcome: TrackingOutcome.cancel,
+    });
+  });
+
+  it('should fire AutoML Leaderboard Sorted with sortColumn and sortDirection', () => {
+    fireAutomlLeaderboardSorted('Model name', 'desc');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.LEADERBOARD_SORTED, {
+      sortColumn: 'Model name',
+      sortDirection: 'desc',
+    });
+  });
+
+  it('should fire AutoML Leaderboard Filter Applied with filterType', () => {
+    fireAutomlLeaderboardFilterApplied('taskType');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+      AUTOML_EVENTS.LEADERBOARD_FILTER_APPLIED,
+      { filterType: 'taskType' },
+    );
+  });
+
+  it('should fire AutoML Model Compared with countOfModelsCompared', () => {
+    fireAutomlModelCompared(3);
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTOML_EVENTS.MODEL_COMPARED, {
+      countOfModelsCompared: 3,
+    });
+  });
+});

--- a/packages/automl/frontend/src/app/utilities/tracking.ts
+++ b/packages/automl/frontend/src/app/utilities/tracking.ts
@@ -67,9 +67,7 @@ export const mapOptimizationMetric = (metric?: string): string | undefined =>
 export type RunConfigTrackingProperties = {
   predictionType?: string;
   optimizationMetric?: string;
-  hasTargetColumn: boolean;
   isRecommended: boolean;
-  hasS3Connection: boolean;
 };
 
 /** Distinguishes which page/control a run action (retry, stop, delete, reconfigure) was triggered from. */

--- a/packages/automl/frontend/src/app/utilities/tracking.ts
+++ b/packages/automl/frontend/src/app/utilities/tracking.ts
@@ -26,6 +26,7 @@ export const AUTOML_EVENTS = {
   MODEL_REGISTERED: 'AutoML Model Registered',
   S3_CONNECTION_CREATED: 'AutoML S3 Connection Created',
   LEADERBOARD_SORTED: 'AutoML Leaderboard Sorted',
+  FLOW_EXITED: 'AutoML Flow Exited',
 } as const;
 
 /** Maps AutoML's internal task_type values to the product-wide predictionType taxonomy. */
@@ -70,6 +71,12 @@ export type RunConfigTrackingProperties = {
 
 /** Distinguishes which page/control a run action (retry, stop, delete, reconfigure) was triggered from. */
 export type RunActionSource = 'runsList' | 'resultsPage';
+
+/** Identifies where the user was in the configure flow when they exited without completing it. */
+export type AutomlFunnelStep = 'defineDetails' | 'trainingData' | 'predictionType' | 'run';
+
+/** Where the user ended up after exiting the configure flow. `'none'` covers cases (e.g. tab close) where the destination can't be determined. */
+export type AutomlExitDestination = 'experimentsList' | 'home' | 'otherAutoml' | 'none';
 
 /**
  * Distinguishes which control triggered a per-model action. Several model actions (save notebook,
@@ -168,4 +175,17 @@ export const fireAutomlLeaderboardSorted = (
   sortDirection: 'asc' | 'desc',
 ): void => {
   fireMiscTrackingEvent(AUTOML_EVENTS.LEADERBOARD_SORTED, { sortColumn, sortDirection });
+};
+
+/**
+ * Fires when the user leaves the configure flow before creating a run — either via an explicit
+ * in-app action (Cancel, breadcrumb) or by abandoning the tab/browser entirely. Not fired on a
+ * successful run creation, nor when navigating between steps within the flow (e.g. Back).
+ */
+export const fireAutomlFlowExited = (
+  exitType: 'abandon' | 'navigate',
+  lastFunnelStep: AutomlFunnelStep,
+  exitDestination: AutomlExitDestination,
+): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.FLOW_EXITED, { exitType, lastFunnelStep, exitDestination });
 };

--- a/packages/automl/frontend/src/app/utilities/tracking.ts
+++ b/packages/automl/frontend/src/app/utilities/tracking.ts
@@ -14,6 +14,9 @@ import type { TaskType } from '~/app/types';
 export { TrackingOutcome };
 
 export const AUTOML_EVENTS = {
+  RUN_DETAILS_DEFINED: 'AutoML Run Details Defined',
+  TRAINING_DATA_CONFIGURED: 'AutoML Training Data Configured',
+  TARGET_COLUMN_CONFIGURED: 'AutoML Target Column Configured',
   RUN_CREATED: 'AutoML Run Created',
   RUN_RECONFIGURED: 'AutoML Run Reconfigured',
   RUN_STOPPED: 'AutoML Run Stopped',
@@ -97,6 +100,39 @@ export type ModelActionOutcomeProperties = {
   success?: boolean;
   error?: string;
   source?: ModelActionSource;
+};
+
+/**
+ * Fires when the user leaves the "define details" (name/description) step of the configure
+ * flow — either moving forward (outcome: submit) or cancelling out (outcome: cancel). This is
+ * a pure local step transition with no backend call, so unlike other outcome-bearing events
+ * there's no success/error to report.
+ */
+export const fireAutomlRunDetailsDefined = (
+  outcome: TrackingOutcome,
+  hasDescription: boolean,
+): void => {
+  fireFormTrackingEvent(AUTOML_EVENTS.RUN_DETAILS_DEFINED, { outcome, hasDescription });
+};
+
+/**
+ * Fires once when the user completes the training data section of the configure flow
+ * (an S3 connection plus a file are selected, whether picked from the bucket or uploaded).
+ * Used to measure funnel retention through the multi-section AutoML configure page.
+ */
+export const fireAutomlTrainingDataConfigured = (
+  trainingDataSourceType: 'select' | 'upload',
+): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.TRAINING_DATA_CONFIGURED, { trainingDataSourceType });
+};
+
+/**
+ * Fires once when the user selects a target column in the configure flow. Used to measure
+ * funnel retention through the multi-section AutoML configure page. Prediction type and
+ * whether it matched the recommendation are captured later, at run creation time.
+ */
+export const fireAutomlTargetColumnConfigured = (): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.TARGET_COLUMN_CONFIGURED, {});
 };
 
 export const fireAutomlRunCreated = (

--- a/packages/automl/frontend/src/app/utilities/tracking.ts
+++ b/packages/automl/frontend/src/app/utilities/tracking.ts
@@ -26,8 +26,6 @@ export const AUTOML_EVENTS = {
   MODEL_REGISTERED: 'AutoML Model Registered',
   S3_CONNECTION_CREATED: 'AutoML S3 Connection Created',
   LEADERBOARD_SORTED: 'AutoML Leaderboard Sorted',
-  LEADERBOARD_FILTER_APPLIED: 'AutoML Leaderboard Filter Applied',
-  MODEL_COMPARED: 'AutoML Model Compared',
 } as const;
 
 /** Maps AutoML's internal task_type values to the product-wide predictionType taxonomy. */
@@ -170,12 +168,4 @@ export const fireAutomlLeaderboardSorted = (
   sortDirection: 'asc' | 'desc',
 ): void => {
   fireMiscTrackingEvent(AUTOML_EVENTS.LEADERBOARD_SORTED, { sortColumn, sortDirection });
-};
-
-export const fireAutomlLeaderboardFilterApplied = (filterType: string): void => {
-  fireMiscTrackingEvent(AUTOML_EVENTS.LEADERBOARD_FILTER_APPLIED, { filterType });
-};
-
-export const fireAutomlModelCompared = (countOfModelsCompared: number): void => {
-  fireMiscTrackingEvent(AUTOML_EVENTS.MODEL_COMPARED, { countOfModelsCompared });
 };

--- a/packages/automl/frontend/src/app/utilities/tracking.ts
+++ b/packages/automl/frontend/src/app/utilities/tracking.ts
@@ -1,0 +1,161 @@
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  TASK_TYPE_BINARY,
+  TASK_TYPE_MULTICLASS,
+  TASK_TYPE_REGRESSION,
+  TASK_TYPE_TIMESERIES,
+} from '~/app/utilities/const';
+import type { TaskType } from '~/app/types';
+
+export { TrackingOutcome };
+
+export const AUTOML_EVENTS = {
+  RUN_CREATED: 'AutoML Run Created',
+  RUN_RECONFIGURED: 'AutoML Run Reconfigured',
+  RUN_STOPPED: 'AutoML Run Stopped',
+  RUN_RETRIED: 'AutoML Run Retried',
+  RUN_DELETED: 'AutoML Run Deleted',
+  METRIC_VIEWED: 'AutoML Metric Viewed',
+  NOTEBOOK_DOWNLOADED: 'AutoML Notebook Downloaded',
+  MODEL_DETAILS_DOWNLOADED: 'AutoML Model Details Downloaded',
+  MODEL_REGISTERED: 'AutoML Model Registered',
+  S3_CONNECTION_CREATED: 'AutoML S3 Connection Created',
+  LEADERBOARD_SORTED: 'AutoML Leaderboard Sorted',
+  LEADERBOARD_FILTER_APPLIED: 'AutoML Leaderboard Filter Applied',
+  MODEL_COMPARED: 'AutoML Model Compared',
+} as const;
+
+/** Maps AutoML's internal task_type values to the product-wide predictionType taxonomy. */
+const PREDICTION_TYPE_MAP: Record<TaskType, string> = {
+  [TASK_TYPE_BINARY]: 'binaryClassification',
+  [TASK_TYPE_MULTICLASS]: 'multiclassClassification',
+  [TASK_TYPE_REGRESSION]: 'regression',
+  [TASK_TYPE_TIMESERIES]: 'timeSeriesForecasting',
+};
+
+/** Maps AutoML's internal eval_metric keys (any case) to the product-wide optimizationMetric taxonomy. */
+/* eslint-disable camelcase -- keys mirror the BFF's snake_case eval_metric values */
+const OPTIMIZATION_METRIC_MAP: Record<string, string> = {
+  accuracy: 'accuracy',
+  roc_auc: 'rocAuc',
+  f1: 'f1Score',
+  precision: 'precision',
+  recall: 'recall',
+  log_loss: 'logLoss',
+  balanced_accuracy: 'balancedAccuracy',
+};
+/* eslint-enable camelcase */
+
+const isKnownTaskType = (value: string): value is TaskType => value in PREDICTION_TYPE_MAP;
+
+export const mapPredictionType = (taskType?: string): string | undefined => {
+  if (!taskType) {
+    return undefined;
+  }
+  return isKnownTaskType(taskType) ? PREDICTION_TYPE_MAP[taskType] : taskType;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- metric may be undefined at runtime
+export const mapOptimizationMetric = (metric?: string): string | undefined =>
+  metric ? (OPTIMIZATION_METRIC_MAP[metric.toLowerCase()] ?? metric) : undefined;
+
+export type RunConfigTrackingProperties = {
+  predictionType?: string;
+  optimizationMetric?: string;
+  hasTargetColumn: boolean;
+  isRecommended: boolean;
+  hasS3Connection: boolean;
+};
+
+/** Distinguishes which page/control a run action (retry, stop, delete, reconfigure) was triggered from. */
+export type RunActionSource = 'runsList' | 'resultsPage';
+
+/**
+ * Distinguishes which control triggered a per-model action. Several model actions (save notebook,
+ * register model) are reachable both from the leaderboard row kebab and from the model details
+ * modal's "Save as" menu.
+ */
+export type ModelActionSource = 'leaderboard' | 'modelDetailsModal';
+
+export type RunOutcomeTrackingProperties = {
+  outcome: TrackingOutcome;
+  success?: boolean;
+  error?: string;
+  source?: RunActionSource;
+};
+
+export type ModelActionOutcomeProperties = {
+  outcome: TrackingOutcome;
+  success?: boolean;
+  error?: string;
+  source?: ModelActionSource;
+};
+
+export const fireAutomlRunCreated = (
+  properties: RunConfigTrackingProperties & RunOutcomeTrackingProperties,
+): void => {
+  fireFormTrackingEvent(AUTOML_EVENTS.RUN_CREATED, properties);
+};
+
+export const fireAutomlRunReconfigured = (
+  properties: RunConfigTrackingProperties &
+    RunOutcomeTrackingProperties & { changedFields: string[] },
+): void => {
+  fireFormTrackingEvent(AUTOML_EVENTS.RUN_RECONFIGURED, {
+    ...properties,
+    changedFields: properties.changedFields.join(','),
+  });
+};
+
+export const fireAutomlRunStopped = (properties: RunOutcomeTrackingProperties): void => {
+  fireFormTrackingEvent(AUTOML_EVENTS.RUN_STOPPED, properties);
+};
+
+export const fireAutomlRunRetried = (properties: RunOutcomeTrackingProperties): void => {
+  fireFormTrackingEvent(AUTOML_EVENTS.RUN_RETRIED, properties);
+};
+
+export const fireAutomlRunDeleted = (properties: RunOutcomeTrackingProperties): void => {
+  fireFormTrackingEvent(AUTOML_EVENTS.RUN_DELETED, properties);
+};
+
+export const fireAutomlMetricViewed = (metricName?: string): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.METRIC_VIEWED, { metricName });
+};
+
+export const fireAutomlNotebookDownloaded = (source: ModelActionSource): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.NOTEBOOK_DOWNLOADED, { downloadType: 'notebook', source });
+};
+
+export const fireAutomlModelDetailsDownloaded = (): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.MODEL_DETAILS_DOWNLOADED, { downloadType: 'modelDetails' });
+};
+
+export const fireAutomlModelRegistered = (
+  properties: ModelActionOutcomeProperties & { registryTarget?: string },
+): void => {
+  fireFormTrackingEvent(AUTOML_EVENTS.MODEL_REGISTERED, properties);
+};
+
+export const fireAutomlS3ConnectionCreated = (properties: RunOutcomeTrackingProperties): void => {
+  fireFormTrackingEvent(AUTOML_EVENTS.S3_CONNECTION_CREATED, properties);
+};
+
+export const fireAutomlLeaderboardSorted = (
+  sortColumn: string,
+  sortDirection: 'asc' | 'desc',
+): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.LEADERBOARD_SORTED, { sortColumn, sortDirection });
+};
+
+export const fireAutomlLeaderboardFilterApplied = (filterType: string): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.LEADERBOARD_FILTER_APPLIED, { filterType });
+};
+
+export const fireAutomlModelCompared = (countOfModelsCompared: number): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.MODEL_COMPARED, { countOfModelsCompared });
+};

--- a/packages/automl/frontend/src/app/utilities/tracking.ts
+++ b/packages/automl/frontend/src/app/utilities/tracking.ts
@@ -19,7 +19,8 @@ export const AUTOML_EVENTS = {
   RUN_STOPPED: 'AutoML Run Stopped',
   RUN_RETRIED: 'AutoML Run Retried',
   RUN_DELETED: 'AutoML Run Deleted',
-  METRIC_VIEWED: 'AutoML Metric Viewed',
+  MODEL_DETAILS_TAB_VIEWED: 'AutoML Model Details Tab Viewed',
+  BACKTEST_WINDOW_METRIC_VIEWED: 'AutoML Backtest Window Metric Viewed',
   NOTEBOOK_DOWNLOADED: 'AutoML Notebook Downloaded',
   MODEL_DETAILS_DOWNLOADED: 'AutoML Model Details Downloaded',
   MODEL_REGISTERED: 'AutoML Model Registered',
@@ -123,8 +124,29 @@ export const fireAutomlRunDeleted = (properties: RunOutcomeTrackingProperties): 
   fireFormTrackingEvent(AUTOML_EVENTS.RUN_DELETED, properties);
 };
 
-export const fireAutomlMetricViewed = (metricName?: string): void => {
-  fireMiscTrackingEvent(AUTOML_EVENTS.METRIC_VIEWED, { metricName });
+/** Maps tabConfig.ts tab keys (kebab-case) to camelCase names for AutoML Model Details Tab Viewed tracking. */
+const MODEL_DETAILS_TAB_NAME_MAP: Record<string, string> = {
+  'model-information': 'modelInformation',
+  'feature-summary': 'featureSummary',
+  'model-evaluation': 'modelEvaluation',
+  'confusion-matrix': 'confusionMatrix',
+  'roc-curve': 'rocCurve',
+  'precision-recall': 'precisionRecall',
+  'backtest-window': 'backtestWindow',
+};
+
+export const mapModelDetailsTabName = (tabKey: string): string =>
+  MODEL_DETAILS_TAB_NAME_MAP[tabKey] ?? tabKey;
+
+export const fireAutomlModelDetailsTabViewed = (tabKey: string, taskType?: string): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.MODEL_DETAILS_TAB_VIEWED, {
+    tabName: mapModelDetailsTabName(tabKey),
+    predictionType: mapPredictionType(taskType),
+  });
+};
+
+export const fireAutomlBacktestWindowMetricViewed = (metricName: string): void => {
+  fireMiscTrackingEvent(AUTOML_EVENTS.BACKTEST_WINDOW_METRIC_VIEWED, { metricName });
 };
 
 export const fireAutomlNotebookDownloaded = (source: ModelActionSource): void => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
