### PR TITLE
Add startupProbe to Notebook container, update types and add test

### DIFF
--- a/backend/src/__tests__/notebookUtils.spec.ts
+++ b/backend/src/__tests__/notebookUtils.spec.ts
@@ -1,0 +1,123 @@
+jest.mock('../utils/resourceUtils', () => {
+  const original = jest.requireActual('../utils/resourceUtils');
+  return {
+    ...original,
+    getClusterStatus: () => ({ components: { mlflowoperator: { managementState: 'Managed' } } }),
+  };
+});
+
+import { assembleNotebook } from '../utils/notebookUtils';
+import { KubeFastifyInstance, NotebookData, NotebookState } from '../types';
+
+const mockFastify = {
+  kube: {
+    namespace: 'test-namespace',
+    customObjectsApi: {
+      getNamespacedCustomObject: jest.fn().mockResolvedValue({
+        body: {
+          metadata: {
+            name: 'code-server-notebook',
+            annotations: {},
+          },
+          status: {
+            dockerImageRepository: 'registry.example.com/code-server-notebook',
+            tags: [{ tag: '2023.2' }],
+          },
+          spec: {
+            tags: [
+              {
+                name: '2023.2',
+                annotations: {},
+                from: {
+                  kind: 'DockerImage',
+                  name: 'registry.example.com/code-server-notebook:2023.2',
+                },
+              },
+            ],
+          },
+        },
+      }),
+    },
+  },
+  log: {
+    error: jest.fn(),
+  },
+} as unknown as KubeFastifyInstance;
+
+const baseNotebookData: NotebookData = {
+  imageName: 'code-server-notebook',
+  imageTagName: '2023.2',
+  state: NotebookState.Started,
+  podSpecOptions: {
+    resources: {
+      requests: {
+        cpu: '1',
+        memory: '2Gi',
+      },
+      limits: {
+        cpu: '1',
+        memory: '2Gi',
+      },
+    },
+    tolerations: [],
+    nodeSelector: {},
+    affinity: {},
+  },
+  envVars: {
+    configMap: {},
+    secrets: {},
+  },
+};
+
+describe('assembleNotebook', () => {
+  it('includes startupProbe with the correct timing and http settings while preserving existing probes', async () => {
+    const notebook = await assembleNotebook(
+      mockFastify,
+      baseNotebookData,
+      'jdoe',
+      'http://localhost',
+      'jdoe-notebook',
+      'test-namespace',
+      'jdoe-pvc',
+      'jdoe-env',
+    );
+
+    const container = notebook.spec.template.spec.containers[0];
+
+    expect(container.startupProbe).toEqual({
+      periodSeconds: 10,
+      timeoutSeconds: 1,
+      successThreshold: 1,
+      failureThreshold: 18,
+      httpGet: {
+        scheme: 'HTTP',
+        path: '/notebook/test-namespace/jdoe-notebook/api',
+        port: 'notebook-port',
+      },
+    });
+    expect(container.livenessProbe).toEqual({
+      initialDelaySeconds: 10,
+      periodSeconds: 5,
+      timeoutSeconds: 1,
+      successThreshold: 1,
+      failureThreshold: 3,
+      httpGet: {
+        scheme: 'HTTP',
+        path: '/notebook/test-namespace/jdoe-notebook/api',
+        port: 'notebook-port',
+      },
+    });
+    expect(container.readinessProbe).toEqual({
+      initialDelaySeconds: 10,
+      periodSeconds: 5,
+      timeoutSeconds: 1,
+      successThreshold: 1,
+      failureThreshold: 3,
+      httpGet: {
+        scheme: 'HTTP',
+        path: '/notebook/test-namespace/jdoe-notebook/api',
+        port: 'notebook-port',
+      },
+    });
+  });
+});

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -451,6 +451,7 @@ export type NotebookContainer = {
   resources?: ContainerResources;
   livenessProbe?: Record<string, unknown>;
   readinessProbe?: Record<string, unknown>;
+  startupProbe?: Record<string, unknown>;
   volumeMounts?: VolumeMount[];
 };
 

--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -275,6 +275,17 @@ export const assembleNotebook = async (
                   protocol: 'TCP',
                 },
               ],
+              startupProbe: {
+                periodSeconds: 10,
+                timeoutSeconds: 1,
+                successThreshold: 1,
+                failureThreshold: 18,
+                httpGet: {
+                  scheme: 'HTTP',
+                  path: `/notebook/${namespace}/${name}/api`,
+                  port: 'notebook-port',
+                },
+              },
               livenessProbe: {
                 initialDelaySeconds: 10,
                 periodSeconds: 5,


### PR DESCRIPTION
Related to opendatahub-io/notebooks#4255.

## Description

Adds a startup probe to dashboard-created Notebook containers.

The startup probe allows the workbench’s main container to finish starting before Kubernetes begins its readiness and liveness checks. This prevents slower-starting workbenches from being treated as unhealthy during initialization.

This change:

* Adds `startupProbe` to the Notebook container type
* Adds the startup probe when assembling a dashboard-created workbench
* Adds focused unit-test coverage for the resulting Notebook container configuration

This is a backend-only change with no UI or visual changes.

## How Has This Been Tested?

Tested locally using Node.js 22 with the following commands:

```bash
npm run test:jest --prefix backend -- --runInBand src/__tests__/notebookUtils.spec.ts
npm run type-check --prefix backend
npm run test:lint --prefix backend
npx prettier --check backend/src/utils/notebookUtils.ts backend/src/types.ts backend/src/__tests__/notebookUtils.spec.ts
git diff --check
```

All checks passed.

The change has not yet been tested on a cluster using the image produced by this PR.

## Test Impact

Added a focused backend unit test that assembles a Notebook and verifies that its container configuration includes the expected startup probe.

No existing tests were removed or disabled.

## Request review criteria:

Self checklist (all need to be checked):

* [ ] The developer has manually tested the changes and verified that the changes work
* [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
* [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

this PR contains no UI or visual changes.

After the PR is posted & before it merges:

* [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup health checks for notebooks, verifying the notebook API during initialization.
  * Notebooks now allow additional startup time before being marked as unavailable.

* **Bug Fixes**
  * Improved notebook readiness handling by validating startup, liveness, and readiness conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->