### PR TITLE
Fix(RHOAIENG-82825):Added a new route for cluster access for gpuaas using the 9091 port

### DIFF
--- a/backend/src/routes/api/prometheus/index.ts
+++ b/backend/src/routes/api/prometheus/index.ts
@@ -6,7 +6,7 @@ import {
   PrometheusQueryResponse,
   QueryType,
 } from '../../../types';
-import { callPrometheusThanos } from '../../../utils/prometheusUtils';
+import { callPrometheusThanos, callPrometheusThanosCluster } from '../../../utils/prometheusUtils';
 import { createCustomError } from '../../../utils/requestUtils';
 import { logRequestDetails } from '../../../utils/fileUtils';
 
@@ -52,6 +52,39 @@ module.exports = async (fastify: KubeFastifyInstance) => {
       logRequestDetails(fastify, request);
       const { query } = request.body;
       return callPrometheusThanos<PrometheusQueryRangeResponse>(
+        fastify,
+        request,
+        query,
+        QueryType.QUERY_RANGE,
+      ).catch(handleError);
+    },
+  );
+
+  fastify.post(
+    '/cluster/query',
+    async (
+      request: OauthFastifyRequest<{
+        Body: { query: string };
+      }>,
+    ): Promise<{ code: number; response: PrometheusQueryResponse }> => {
+      logRequestDetails(fastify, request);
+      const { query } = request.body;
+      return callPrometheusThanosCluster<PrometheusQueryResponse>(fastify, request, query).catch(
+        handleError,
+      );
+    },
+  );
+
+  fastify.post(
+    '/cluster/queryRange',
+    async (
+      request: OauthFastifyRequest<{
+        Body: { query: string };
+      }>,
+    ): Promise<{ code: number; response: PrometheusQueryRangeResponse }> => {
+      logRequestDetails(fastify, request);
+      const { query } = request.body;
+      return callPrometheusThanosCluster<PrometheusQueryRangeResponse>(
         fastify,
         request,
         query,

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -189,6 +189,7 @@ export const DEFAULT_NOTEBOOK_SIZES: NotebookSize[] = [
 ];
 
 export const THANOS_RBAC_PORT = '9092';
+export const THANOS_WEB_PORT = '9091';
 export const THANOS_INSTANCE_NAME = 'thanos-querier';
 export const THANOS_NAMESPACE = 'openshift-monitoring';
 export const LABEL_SELECTOR_DASHBOARD_RESOURCE = `${KnownLabels.DASHBOARD_RESOURCE}=true`;

--- a/backend/src/utils/prometheusUtils.ts
+++ b/backend/src/utils/prometheusUtils.ts
@@ -1,5 +1,11 @@
 import { KubeFastifyInstance, OauthFastifyRequest, QueryType } from '../types';
-import { DEV_MODE, THANOS_INSTANCE_NAME, THANOS_NAMESPACE, THANOS_RBAC_PORT } from './constants';
+import {
+  DEV_MODE,
+  THANOS_INSTANCE_NAME,
+  THANOS_NAMESPACE,
+  THANOS_RBAC_PORT,
+  THANOS_WEB_PORT,
+} from './constants';
 import { createCustomError } from './requestUtils';
 import { proxyCall, ProxyError, ProxyErrorType } from './httpUtils';
 
@@ -95,6 +101,21 @@ export const callPrometheusThanos = <T>(
     request,
     query,
     generatePrometheusHostURL(fastify, THANOS_INSTANCE_NAME, THANOS_NAMESPACE, THANOS_RBAC_PORT),
+    queryType,
+    true,
+  );
+
+export const callPrometheusThanosCluster = <T>(
+  fastify: KubeFastifyInstance,
+  request: OauthFastifyRequest,
+  query: string,
+  queryType: QueryType = QueryType.QUERY,
+): Promise<{ code: number; response: T }> =>
+  callPrometheus<T>(
+    fastify,
+    request,
+    query,
+    generatePrometheusHostURL(fastify, THANOS_INSTANCE_NAME, THANOS_NAMESPACE, THANOS_WEB_PORT),
     queryType,
     true,
   );

--- a/packages/cypress/cypress/pages/infrastructure.ts
+++ b/packages/cypress/cypress/pages/infrastructure.ts
@@ -28,8 +28,16 @@ class InfrastructurePage {
     return cy.findByTestId('infrastructure-cluster-section');
   }
 
+  findClusterMetricsError() {
+    return cy.findByTestId('cluster-metrics-error');
+  }
+
   findHardwareUsageSection() {
     return cy.findByTestId('infrastructure-hardware-usage-section');
+  }
+
+  findHardwareUsageError() {
+    return cy.findByTestId('hardware-usage-error');
   }
 
   findClusterQueueUtilizationSection() {
@@ -66,6 +74,21 @@ class InfrastructurePage {
 
   findBorrowingEmptyState() {
     return cy.findByTestId('borrowing-empty-state');
+  }
+
+  findBorrowingError() {
+    return cy.findByTestId('borrowing-error');
+  }
+
+  findBorrowingChartOrEmptyState() {
+    return cy.get(
+      '[data-testid="borrowing-chart-has-data"], [data-testid="borrowing-empty-state"]',
+    );
+  }
+
+  shouldHaveBorrowingChartOrEmptyState() {
+    this.findBorrowingChartOrEmptyState().should('exist');
+    return this;
   }
 
   findCohortSelect() {

--- a/packages/cypress/cypress/support/commands/odh.ts
+++ b/packages/cypress/cypress/support/commands/odh.ts
@@ -396,6 +396,10 @@ declare global {
           response: OdhResponse<{ code: number; response: PrometheusQueryResponse }>,
         ) => Cypress.Chainable<null>) &
         ((
+          type: 'POST /api/prometheus/cluster/query',
+          response: OdhResponse<{ code: number; response: PrometheusQueryResponse }>,
+        ) => Cypress.Chainable<null>) &
+        ((
           type: 'POST /api/prometheus/serving',
           response: OdhResponse<{ code: number; response: PrometheusQueryRangeResponse }>,
         ) => Cypress.Chainable<null>) &
@@ -405,6 +409,10 @@ declare global {
         ) => Cypress.Chainable<null>) &
         ((
           type: 'POST /api/prometheus/queryRange',
+          response: OdhResponse<{ code: number; response: PrometheusQueryRangeResponse }>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'POST /api/prometheus/cluster/queryRange',
           response: OdhResponse<{ code: number; response: PrometheusQueryRangeResponse }>,
         ) => Cypress.Chainable<null>) &
         ((

--- a/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gpuaas/testGpuaasInfrastructure.cy.ts
@@ -10,7 +10,7 @@ describe('GPUaaS Infrastructure Page', () => {
 
   it(
     'Verify Infrastructure page is accessible for admin users and displays expected sections',
-    { tags: ['@Dashboard', '@GPUaaS'] },
+    { tags: ['@Dashboard', '@GPUaaS', '@GpuaasCI'] },
     () => {
       cy.step('Log in as admin user');
       cy.visitWithLogin('/', LDAP_ADMIN_USER);
@@ -28,15 +28,21 @@ describe('GPUaaS Infrastructure Page', () => {
 
       cy.step('Verify Cluster section is present');
       infrastructurePage.findClusterSection().should('exist');
+      infrastructurePage.findClusterMetricsError().should('not.exist');
+      infrastructurePage.findTotalAcceleratorsCard().should('be.visible');
 
       cy.step('Verify Hardware usage section is present');
       infrastructurePage.findHardwareUsageSection().should('exist');
+      infrastructurePage.findHardwareUsageError().should('not.exist');
 
       cy.step('Verify Borrowing section is present');
       infrastructurePage.findBorrowingSection().should('exist');
+      infrastructurePage.findBorrowingError().should('not.exist');
+      infrastructurePage.shouldHaveBorrowingChartOrEmptyState();
 
       cy.step('Verify Cluster queue utilization section is present');
       infrastructurePage.findClusterQueueUtilizationSection().should('exist');
+      infrastructurePage.findCQUtilizationError().should('not.exist');
     },
   );
 

--- a/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/gpuaas/infrastructure.cy.ts
@@ -150,7 +150,7 @@ const initIntercepts = ({
     mockK8sResourceList(resourceFlavors.map((opts) => mockResourceFlavorK8sResource(opts))),
   );
 
-  cy.interceptOdh('POST /api/prometheus/query', (req) => {
+  cy.interceptOdh('POST /api/prometheus/cluster/query', (req) => {
     const { query } = req.body;
 
     // DCGM per-model queries must come before the generic 'modelName' check because
@@ -218,7 +218,7 @@ const initIntercepts = ({
     }
   });
 
-  cy.interceptOdh('POST /api/prometheus/queryRange', (req) => {
+  cy.interceptOdh('POST /api/prometheus/cluster/queryRange', (req) => {
     if (req.body.query && req.body.query.includes('kueue_cluster_queue_resource_usage')) {
       req.reply(
         makePrometheusRangeResponse(

--- a/packages/gpuaas/src/components/BorrowingLendingChart.tsx
+++ b/packages/gpuaas/src/components/BorrowingLendingChart.tsx
@@ -107,7 +107,11 @@ const BorrowingLendingChart: React.FC<BorrowingLendingChartProps> = ({
     <>
       {!loaded && !error && <EmptyState icon={Spinner} titleText="Loading" headingLevel="h4" />}
       {error && (
-        <EmptyState titleText="Error loading metrics" headingLevel="h4">
+        <EmptyState
+          titleText="Error loading metrics"
+          headingLevel="h4"
+          data-testid="borrowing-error"
+        >
           <EmptyStateBody>{error.message}</EmptyStateBody>
         </EmptyState>
       )}

--- a/packages/gpuaas/src/const.ts
+++ b/packages/gpuaas/src/const.ts
@@ -1,6 +1,8 @@
 export const INFRASTRUCTURE_REFRESH_INTERVAL = 30_000;
 
 export const TREND_REFRESH_INTERVAL = 5 * 60 * 1000;
+export const PROMETHEUS_CLUSTER_QUERY_PATH = '/api/prometheus/cluster/query';
+export const PROMETHEUS_CLUSTER_QUERY_RANGE_PATH = '/api/prometheus/cluster/queryRange';
 
 export const INFRASTRUCTURE_SECTIONS = [
   {

--- a/packages/gpuaas/src/hooks/__tests__/useInfrastructureMetrics.spec.ts
+++ b/packages/gpuaas/src/hooks/__tests__/useInfrastructureMetrics.spec.ts
@@ -4,6 +4,7 @@ import { PrometheusQueryResponse } from '@odh-dashboard/internal/types';
 import useInfrastructureMetrics from '../useInfrastructureMetrics';
 import {
   INFRASTRUCTURE_REFRESH_INTERVAL,
+  PROMETHEUS_CLUSTER_QUERY_PATH,
   PROMQL_ACCELERATOR_ALLOCATABLE,
   PROMQL_ACCELERATOR_IN_USE,
   PROMQL_COMPUTE_UTILIZATION,
@@ -91,43 +92,43 @@ describe('useInfrastructureMetrics', () => {
     expect(usePrometheusQueryMock).toHaveBeenCalledTimes(QUERY_COUNT);
     expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
       1,
-      '/api/prometheus/query',
+      PROMETHEUS_CLUSTER_QUERY_PATH,
       PROMQL_ACCELERATOR_ALLOCATABLE,
       expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
     );
     expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
       2,
-      '/api/prometheus/query',
+      PROMETHEUS_CLUSTER_QUERY_PATH,
       PROMQL_ACCELERATOR_IN_USE,
       expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
     );
     expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
       3,
-      '/api/prometheus/query',
+      PROMETHEUS_CLUSTER_QUERY_PATH,
       PROMQL_COMPUTE_UTILIZATION,
       expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
     );
     expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
       4,
-      '/api/prometheus/query',
+      PROMETHEUS_CLUSTER_QUERY_PATH,
       PROMQL_MEMORY_UTILIZATION,
       expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
     );
     expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
       5,
-      '/api/prometheus/query',
+      PROMETHEUS_CLUSTER_QUERY_PATH,
       PROMQL_HARDWARE_TOTAL,
       expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
     );
     expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
       6,
-      '/api/prometheus/query',
+      PROMETHEUS_CLUSTER_QUERY_PATH,
       PROMQL_HARDWARE_IN_USE,
       expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
     );
     expect(usePrometheusQueryMock).toHaveBeenNthCalledWith(
       7,
-      '/api/prometheus/query',
+      PROMETHEUS_CLUSTER_QUERY_PATH,
       PROMQL_HARDWARE_NODE_LABELS,
       expect.objectContaining({ refreshRate: INFRASTRUCTURE_REFRESH_INTERVAL }),
     );

--- a/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
+++ b/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
@@ -9,6 +9,7 @@ import type {
 import {
   ACCELERATOR_RESOURCE_PREFIXES,
   ACCELERATOR_RESOURCE_REGEX,
+  PROMETHEUS_CLUSTER_QUERY_RANGE_PATH,
   SEVEN_DAYS_MS,
   TREND_REFRESH_INTERVAL,
 } from '../const';
@@ -17,7 +18,7 @@ import parseK8sQuantity from '../utils/parseK8sQuantity';
 
 const SEVEN_DAYS_IN_SECONDS = SEVEN_DAYS_MS / 1000;
 const HOURLY_STEP = 3600;
-const PROMETHEUS_API_PATH = '/api/prometheus/queryRange';
+const PROMETHEUS_API_PATH = PROMETHEUS_CLUSTER_QUERY_RANGE_PATH;
 
 const isAcceleratorResource = (resourceName: string): boolean =>
   ACCELERATOR_RESOURCE_PREFIXES.some((prefix) => resourceName.startsWith(prefix));

--- a/packages/gpuaas/src/hooks/useCQDcgmMetrics.ts
+++ b/packages/gpuaas/src/hooks/useCQDcgmMetrics.ts
@@ -4,6 +4,7 @@ import { PrometheusQueryResponse } from '@odh-dashboard/internal/types';
 import { CQDcgmResult } from '../types';
 import {
   INFRASTRUCTURE_REFRESH_INTERVAL,
+  PROMETHEUS_CLUSTER_QUERY_PATH,
   PROMQL_COMPUTE_BY_MODEL,
   PROMQL_MEMORY_BY_MODEL,
 } from '../const';
@@ -11,7 +12,7 @@ import { normalizeModelName } from '../utils/clusterQueueUtils';
 
 export type { CQDcgmResult };
 
-const PROMETHEUS_API = '/api/prometheus/query';
+const PROMETHEUS_API = PROMETHEUS_CLUSTER_QUERY_PATH;
 
 type ByModelResponse = PrometheusQueryResponse<{ metric?: { modelName?: string } }>;
 

--- a/packages/gpuaas/src/hooks/useInfrastructureMetrics.ts
+++ b/packages/gpuaas/src/hooks/useInfrastructureMetrics.ts
@@ -3,6 +3,7 @@ import usePrometheusQuery from '@odh-dashboard/internal/api/prometheus/usePromet
 import { PrometheusQueryResponse } from '@odh-dashboard/internal/types';
 import {
   INFRASTRUCTURE_REFRESH_INTERVAL,
+  PROMETHEUS_CLUSTER_QUERY_PATH,
   PROMQL_ACCELERATOR_ALLOCATABLE,
   PROMQL_ACCELERATOR_IN_USE,
   PROMQL_COMPUTE_UTILIZATION,
@@ -12,7 +13,7 @@ import {
   PROMQL_MEMORY_UTILIZATION,
 } from '../const';
 
-const PROMETHEUS_API = '/api/prometheus/query';
+const PROMETHEUS_API = PROMETHEUS_CLUSTER_QUERY_PATH;
 
 type AcceleratorMetrics = {
   total: number;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-81966](https://redhat.atlassian.net/browse/RHOAIENG-81966) against v3.5.0-fixes


## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes GPUaaS Infrastructure metrics failing on cluster with 400 Bad Request.

Cluster-wide PromQL queries were going through the existing /api/prometheus/query* routes, which proxy to Thanos tenancy port 9092 and expect a namespace param. GPUaaS doesn't send one, so requests fail before RBAC even runs. Local dev masked this because DEV_MODE hits the web route instead.

Adds dedicated cluster-wide routes on Thanos web port 9091 and points GPUaaS hooks at them. Existing prometheus routes are untouched.

Backend

POST /api/prometheus/cluster/query
POST /api/prometheus/cluster/queryRange
New callPrometheusThanosCluster() helper (port 9091, same user token pass-through)
GPUaaS

useInfrastructureMetrics, useCQDcgmMetrics, useBorrowingLendingMetrics now use cluster routes

### Regular User : 

<img width="1865" height="935" alt="Screenshot 2026-08-12 at 4 32 27 PM" src="https://github.com/user-attachments/assets/05fc9fe6-c624-4276-a7e3-88f4e2bf5d33" />

```
curl -sk -X POST yourclusterapi/api/prometheus/cluster/query" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"query":"count(kube_pod_info)"}'

```
for a regular user it would return no access to the promQL query data unless added to the cluster monitory explicitly
`{"statusCode":403,"code":"403","error":"Forbidden","message":"Prometheus call error"}` 

and we would not be able to see the route in the UI

### For admin user


https://github.com/user-attachments/assets/94e4c8a7-48c9-40ad-9b7e-015348060ffa

❯ TOKEN=$(oc whoami -t)
curl -sk -X POST "https://rh-ai.apps.ui-tangerine-1.dev.datahub.redhat.com/api/prometheus/cluster/query" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"query":"count(kube_pod_info)"}'
{"statusCode":400,"code":"400","error":"Bad Request","message":"Prometheus call error"}% without `cluster-monitoring-view`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Updated mocked Cypress intercepts + unit test paths
2. E2E checks for metric error states on Infrastructure page

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-81966]: https://redhat.atlassian.net/browse/RHOAIENG-81966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cluster-specific metrics querying for infrastructure, accelerator, and borrowing/lending data.
  * Infrastructure metrics now support dedicated cluster query and range-query endpoints.
  * Added clearer borrowing section states, displaying either a chart, an empty state, or an error indicator.

* **Bug Fixes**
  * Improved infrastructure-page handling when cluster metrics or hardware usage data cannot be loaded.
  * Updated monitoring-related checks to validate the appropriate cluster data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->