### PR TITLE
feat(RHAI-420): add InsecureSkipVerify safety guard to data-registry BFF

### DIFF
--- a/packages/data-registry/bff/cmd/main.go
+++ b/packages/data-registry/bff/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"os/signal"
@@ -67,6 +68,10 @@ func main() {
 	// Ensure the deprecated boolean fields are consistent with the new deployment mode
 	cfg.StandaloneMode = cfg.DeploymentMode.IsStandaloneMode()
 	cfg.FederatedPlatform = cfg.DeploymentMode.IsFederatedMode()
+
+	if err := validateInsecureSkipVerify(cfg.InsecureSkipVerify, certFile); err != nil {
+		os.Exit(1)
+	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: cfg.LogLevel,
@@ -139,4 +144,24 @@ func main() {
 
 	logger.Info("server stopped")
 	os.Exit(0)
+}
+
+func validateInsecureSkipVerify(insecureSkipVerify bool, certFile string) error {
+	if !insecureSkipVerify {
+		return nil
+	}
+
+	if certFile != "" {
+		slog.Error("SECURITY: InsecureSkipVerify cannot be used when TLS certificates are mounted",
+			"cert_file", certFile,
+			"insecure_skip_verify", insecureSkipVerify,
+			"fix", "Remove --insecure-skip-verify flag and INSECURE_SKIP_VERIFY env var",
+		)
+		return errors.New("InsecureSkipVerify cannot be used when TLS certificates are mounted (deployed environment detected)")
+	}
+
+	slog.Warn("SECURITY WARNING: TLS certificate verification is DISABLED (InsecureSkipVerify=true)",
+		"use_case", "local development only - NEVER use in production",
+	)
+	return nil
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAI-420

## Description

Add `validateInsecureSkipVerify` safety guard to the data-registry BFF, matching the gen-ai BFF pattern. Blocks startup if `--insecure-skip-verify` is used when TLS certificates are mounted, preventing accidental insecure configuration in production.

## How Has This Been Tested?

- `go build ./cmd` — compiles successfully
- `go test ./...` — all existing tests pass
- Ran the binary with conflicting flags (`--insecure-skip-verify --cert-file=/etc/tls/private/tls.crt`) — confirms it logs the security error and exits with code 1
- Ran the binary with `--insecure-skip-verify` only (no cert file) — confirms it logs a warning but proceeds (local dev scenario)

## Test Impact

No new tests added. The guard is a startup validation — it logs and exits before the server starts. Testing this would require a process-level integration test (spawn the binary with conflicting flags, assert exit code), which is not covered by any BFF in the repo today. The pattern is proven in gen-ai.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added startup validation to prevent insecure TLS verification when a certificate file is configured.
  * The server now logs a security error and exits for invalid TLS settings.
  * Added a warning when TLS certificate verification is disabled without a certificate file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->