### PR TITLE
chore(RHOAIENG-80923): Add modelCapabilities feature flag to OdhDashboardConfig CRD

### DIFF
--- a/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -188,10 +188,10 @@ spec:
                       description: 'When true, enables the Agents Catalog page.'
                     toolCalling:
                       type: boolean
-                      description: 'When true, enables tool-calling configuration for supported models in the model catalog.'
+                      description: 'When true, enables tool-calling configuration for supported models in the model catalog and the deployment wizard.'
                     modelCapabilities:
                       type: boolean
-                      description: 'When true, enables model capabilities selection in the deployment wizard and the Capabilities column on the deployments table. Tech Preview.'
+                      description: 'When true, enables model capabilities selection in the deployment wizard and the Capabilities column on the deployments table.'
                     projectRBAC:
                       type: boolean
                       description: 'When true, enables project-level RBAC (Role-Based Access Control) settings.'

--- a/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -189,6 +189,9 @@ spec:
                     toolCalling:
                       type: boolean
                       description: 'When true, enables tool-calling configuration for supported models in the model catalog.'
+                    modelCapabilities:
+                      type: boolean
+                      description: 'When true, enables model capabilities selection in the deployment wizard and the Capabilities column on the deployments table. Tech Preview.'
                     projectRBAC:
                       type: boolean
                       description: 'When true, enables project-level RBAC (Role-Based Access Control) settings.'


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-80923

## Description

Adds the `modelCapabilities` tech preview flag to the `OdhDashboardConfig` CRD schema so it can be enabled via the supported cluster configuration path (`spec.dashboardConfig.modelCapabilities`), consistent with other tech preview flags (same pattern as `llmdTemplates` in #8855).

The flag already exists in frontend/backend defaults (false) from #9041; this change only exposes it in the CRD. No default is set on the CRD field — runtime default remains `false` until explicitly enabled:

```yaml
spec:
  dashboardConfig:
    modelCapabilities: true
```

Also updates the existing `toolCalling` CRD field description so it covers both the model catalog and the deployment wizard (stage-2 tool-calling stays behind the same flag).

## How Has This Been Tested?

- Verified `modelCapabilities` is already present and defaults to `false` in `frontend/src/concepts/areas/const.ts` and `backend/src/utils/constants.ts`.
- Confirmed the CRD field follows the existing tech-preview flag pattern (boolean + description, no CRD `default`).
- Diff reviewed against prior CRD flag addition (`llmdTemplates`).
- Updated `toolCalling` description to reflect catalog + deployment wizard usage.

## Test Impact

No new automated tests. This is a CRD schema exposure of an existing boolean flag plus a description-only update to `toolCalling`; behavior is covered by existing UI/tests gated on those flags. Manual cluster validation: set `spec.dashboardConfig.modelCapabilities: true` on OdhDashboardConfig and confirm the flag is accepted by the API.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`