### PR TITLE
Fix failing gen-ai e2e test [v3.5.0]

### DIFF
--- a/packages/cypress/cypress/pages/genAiPlayground.ts
+++ b/packages/cypress/cypress/pages/genAiPlayground.ts
@@ -26,7 +26,7 @@ class GenAiPlayground {
   navigateToPlaygroundWithRetry(projectName: string) {
     const playgroundUrl = `/gen-ai-studio/playground/${projectName}?${GEN_AI_CUSTOM_ENDPOINTS_FLAG}`;
     cy.visit(playgroundUrl);
-    cy.findByTestId('chatbot-model-selector-toggle', { timeout: 120000 }).should('be.visible');
+    cy.findByTestId('settings-model-selector-toggle', { timeout: 120000 }).should('be.visible');
   }
 
   findEmptyState() {
@@ -50,7 +50,7 @@ class GenAiPlayground {
   }
 
   findModelToggleButton() {
-    return cy.findByTestId('chatbot-model-selector-toggle');
+    return cy.findByTestId('settings-model-selector-toggle');
   }
 
   findMessageInput() {


### PR DESCRIPTION
Cherry-pick of #8955 to `v3.5.0-fixes`.

## Description

Fix failing gen-ai e2e test by updating selector in `genAiPlayground.ts` file.

See #8955 for the full details.

## How Has This Been Tested?

Same as #8955 — locally and on cluster.

## Test Impact

No additional tests needed — this is a test file fix.

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our Best Practices (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:

- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)