### PR TITLE
fix(RHOAIENG-81952): [v3.5.0] remove SSA-orphaned containers during upgrade

### DIFF
--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -279,6 +279,14 @@ func (r *DashboardReconciler) reconcileSidecar(
 		return ctrl.Result{}, fmt.Errorf("failed to sanitize deployment probes: %w", err)
 	}
 
+	if err := removeStaleContainers(ctx, r.Client, allResources); err != nil {
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("StaleContainerRemovalFailed"),
+			conditions.WithError(err))
+
+		return ctrl.Result{}, fmt.Errorf("failed to remove stale containers: %w", err)
+	}
+
 	deployer := deploy.NewDeployer(
 		deploy.WithFieldOwner("dashboard-operator"),
 		deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
@@ -389,6 +397,13 @@ func (r *DashboardReconciler) reconcileStandalone(
 			conditions.WithReason("ProbeSanitizeFailed"),
 			conditions.WithError(err))
 		return ctrl.Result{}, fmt.Errorf("failed to sanitize deployment probes: %w", err)
+	}
+
+	if err := removeStaleContainers(ctx, r.Client, allResources); err != nil {
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("StaleContainerRemovalFailed"),
+			conditions.WithError(err))
+		return ctrl.Result{}, fmt.Errorf("failed to remove stale containers: %w", err)
 	}
 
 	deployer := deploy.NewDeployer(

--- a/dashboard-operator/internal/controller/stale_containers.go
+++ b/dashboard-operator/internal/controller/stale_containers.go
@@ -1,0 +1,122 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// removeStaleContainers patches live Deployments to delete containers that
+// exist in the cluster but are absent from the desired manifests. This
+// resolves SSA field-manager splits where an old manager still owns
+// containers that a newer manager's manifest intentionally omits
+// (RHOAIENG-81952).
+func removeStaleContainers(ctx context.Context, cli client.Client, resources []unstructured.Unstructured) error {
+	logger := log.FromContext(ctx)
+
+	for i := range resources {
+		res := &resources[i]
+		if res.GetKind() != "Deployment" || res.GroupVersionKind().Group != "apps" {
+			continue
+		}
+
+		live := &unstructured.Unstructured{}
+		live.SetGroupVersionKind(res.GroupVersionKind())
+		key := client.ObjectKeyFromObject(res)
+
+		if err := cli.Get(ctx, key, live); err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("getting live deployment %s: %w", key, err)
+		}
+
+		patch, err := buildStaleContainerPatch(live, res)
+		if err != nil {
+			return fmt.Errorf("building stale container patch for %s: %w", key, err)
+		}
+		if patch == nil {
+			continue
+		}
+
+		patchBytes, err := json.Marshal(patch)
+		if err != nil {
+			return fmt.Errorf("marshalling stale container patch for %s: %w", key, err)
+		}
+
+		logger.Info("Removing stale containers before SSA", "deployment", key, "patch", string(patchBytes))
+
+		if err := cli.Patch(ctx, live, client.RawPatch(types.StrategicMergePatchType, patchBytes)); err != nil {
+			return fmt.Errorf("patching stale containers for %s: %w", key, err)
+		}
+	}
+
+	return nil
+}
+
+func buildStaleContainerPatch(live, desired *unstructured.Unstructured) (map[string]interface{}, error) {
+	liveContainers, liveFound, err := unstructured.NestedSlice(live.Object, "spec", "template", "spec", "containers")
+	if err != nil {
+		return nil, fmt.Errorf("reading live containers: %w", err)
+	}
+	if !liveFound {
+		return nil, nil
+	}
+
+	desiredContainers, desiredFound, err := unstructured.NestedSlice(desired.Object, "spec", "template", "spec", "containers")
+	if err != nil {
+		return nil, fmt.Errorf("reading desired containers: %w", err)
+	}
+	if !desiredFound || len(desiredContainers) == 0 {
+		return nil, fmt.Errorf("desired Deployment has no containers")
+	}
+
+	desiredNames := make(map[string]struct{}, len(desiredContainers))
+	for _, c := range desiredContainers {
+		cMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := cMap["name"].(string); ok {
+			desiredNames[name] = struct{}{}
+		}
+	}
+
+	var deleteEntries []interface{}
+	for _, c := range liveContainers {
+		cMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, ok := cMap["name"].(string)
+		if !ok {
+			continue
+		}
+		if _, wanted := desiredNames[name]; !wanted {
+			deleteEntries = append(deleteEntries, map[string]interface{}{
+				"$patch": "delete",
+				"name":   name,
+			})
+		}
+	}
+
+	if len(deleteEntries) == 0 {
+		return nil, nil
+	}
+
+	return map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": deleteEntries,
+				},
+			},
+		},
+	}, nil
+}

--- a/dashboard-operator/internal/controller/stale_containers_test.go
+++ b/dashboard-operator/internal/controller/stale_containers_test.go
@@ -1,0 +1,346 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func deploymentWithContainers(name, namespace string, containers []interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{"app": name},
+				},
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{"app": name},
+					},
+					"spec": map[string]interface{}{
+						"containers": containers,
+					},
+				},
+			},
+		},
+	}
+}
+
+func containerEntry(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":  name,
+		"image": name + ":latest",
+	}
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestRemoveStaleContainers_NoLiveDeployment(t *testing.T) {
+	s := newScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	desired := deploymentWithContainers("test", "ns", []interface{}{
+		containerEntry("main"),
+	})
+
+	err := removeStaleContainers(context.Background(), cli, []unstructured.Unstructured{*desired})
+	if err != nil {
+		t.Fatalf("expected no error for missing deployment, got: %v", err)
+	}
+}
+
+func TestRemoveStaleContainers_NoStaleContainers(t *testing.T) {
+	s := newScheme(t)
+
+	live := deploymentWithContainers("dashboard", "ns", []interface{}{
+		containerEntry("rhods-dashboard"),
+		containerEntry("kube-rbac-proxy"),
+	})
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(live).Build()
+
+	desired := deploymentWithContainers("dashboard", "ns", []interface{}{
+		containerEntry("rhods-dashboard"),
+		containerEntry("kube-rbac-proxy"),
+	})
+
+	err := removeStaleContainers(context.Background(), cli, []unstructured.Unstructured{*desired})
+	if err != nil {
+		t.Fatalf("expected no error when containers match, got: %v", err)
+	}
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(live.GroupVersionKind())
+	if err := cli.Get(context.Background(), keyFromUnstructured(live), got); err != nil {
+		t.Fatal(err)
+	}
+	containers, _, _ := unstructured.NestedSlice(got.Object, "spec", "template", "spec", "containers")
+	if len(containers) != 2 {
+		t.Errorf("expected 2 containers, got %d", len(containers))
+	}
+}
+
+func TestRemoveStaleContainers_RemovesOAuthProxy(t *testing.T) {
+	s := newScheme(t)
+
+	live := deploymentWithContainers("rhods-dashboard", "redhat-ods-applications", []interface{}{
+		containerEntry("rhods-dashboard"),
+		containerEntry("oauth-proxy"),
+		containerEntry("model-registry-ui"),
+		containerEntry("kube-rbac-proxy"),
+		containerEntry("core-bff"),
+	})
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(live).Build()
+
+	desired := deploymentWithContainers("rhods-dashboard", "redhat-ods-applications", []interface{}{
+		containerEntry("rhods-dashboard"),
+		containerEntry("model-registry-ui"),
+		containerEntry("kube-rbac-proxy"),
+		containerEntry("core-bff"),
+	})
+
+	err := removeStaleContainers(context.Background(), cli, []unstructured.Unstructured{*desired})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(live.GroupVersionKind())
+	if err := cli.Get(context.Background(), keyFromUnstructured(live), got); err != nil {
+		t.Fatal(err)
+	}
+
+	containers, _, _ := unstructured.NestedSlice(got.Object, "spec", "template", "spec", "containers")
+	if len(containers) != 4 {
+		t.Fatalf("expected 4 containers after removing oauth-proxy, got %d", len(containers))
+	}
+
+	for _, c := range containers {
+		cMap := c.(map[string]interface{})
+		if cMap["name"] == "oauth-proxy" {
+			t.Error("oauth-proxy should have been removed")
+		}
+	}
+}
+
+func TestRemoveStaleContainers_RemovesMultiple(t *testing.T) {
+	s := newScheme(t)
+
+	live := deploymentWithContainers("dashboard", "ns", []interface{}{
+		containerEntry("main"),
+		containerEntry("stale-a"),
+		containerEntry("stale-b"),
+	})
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(live).Build()
+
+	desired := deploymentWithContainers("dashboard", "ns", []interface{}{
+		containerEntry("main"),
+	})
+
+	err := removeStaleContainers(context.Background(), cli, []unstructured.Unstructured{*desired})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(live.GroupVersionKind())
+	if err := cli.Get(context.Background(), keyFromUnstructured(live), got); err != nil {
+		t.Fatal(err)
+	}
+
+	containers, _, _ := unstructured.NestedSlice(got.Object, "spec", "template", "spec", "containers")
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(containers))
+	}
+
+	cMap := containers[0].(map[string]interface{})
+	if cMap["name"] != "main" {
+		t.Errorf("expected remaining container to be 'main', got %v", cMap["name"])
+	}
+}
+
+func TestRemoveStaleContainers_SkipsNonDeployments(t *testing.T) {
+	s := newScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	svc := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "test-svc",
+				"namespace": "ns",
+			},
+		},
+	}
+
+	err := removeStaleContainers(context.Background(), cli, []unstructured.Unstructured{svc})
+	if err != nil {
+		t.Fatalf("expected no error for non-deployment resources, got: %v", err)
+	}
+}
+
+func TestRemoveStaleContainers_DesiredHasNewContainers(t *testing.T) {
+	s := newScheme(t)
+
+	live := deploymentWithContainers("dashboard", "ns", []interface{}{
+		containerEntry("main"),
+	})
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(live).Build()
+
+	desired := deploymentWithContainers("dashboard", "ns", []interface{}{
+		containerEntry("main"),
+		containerEntry("new-sidecar"),
+	})
+
+	err := removeStaleContainers(context.Background(), cli, []unstructured.Unstructured{*desired})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(live.GroupVersionKind())
+	if err := cli.Get(context.Background(), keyFromUnstructured(live), got); err != nil {
+		t.Fatal(err)
+	}
+
+	containers, _, _ := unstructured.NestedSlice(got.Object, "spec", "template", "spec", "containers")
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container (live unchanged), got %d", len(containers))
+	}
+}
+
+func TestBuildStaleContainerPatch_ReturnsNilWhenNoStale(t *testing.T) {
+	live := deploymentWithContainers("d", "ns", []interface{}{
+		containerEntry("a"),
+		containerEntry("b"),
+	})
+	desired := deploymentWithContainers("d", "ns", []interface{}{
+		containerEntry("a"),
+		containerEntry("b"),
+	})
+
+	patch, err := buildStaleContainerPatch(live, desired)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patch != nil {
+		t.Errorf("expected nil patch when no stale containers, got %v", patch)
+	}
+}
+
+func TestBuildStaleContainerPatch_BuildsDeleteEntries(t *testing.T) {
+	live := deploymentWithContainers("d", "ns", []interface{}{
+		containerEntry("keep"),
+		containerEntry("remove-me"),
+	})
+	desired := deploymentWithContainers("d", "ns", []interface{}{
+		containerEntry("keep"),
+	})
+
+	patch, err := buildStaleContainerPatch(live, desired)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patch == nil {
+		t.Fatal("expected non-nil patch")
+	}
+
+	spec := patch["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	podSpec := template["spec"].(map[string]interface{})
+	containers := podSpec["containers"].([]interface{})
+
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 delete entry, got %d", len(containers))
+	}
+
+	entry := containers[0].(map[string]interface{})
+	if entry["$patch"] != "delete" {
+		t.Errorf("expected $patch=delete, got %v", entry["$patch"])
+	}
+	if entry["name"] != "remove-me" {
+		t.Errorf("expected name=remove-me, got %v", entry["name"])
+	}
+}
+
+func TestBuildStaleContainerPatch_ErrorsOnEmptyDesiredContainers(t *testing.T) {
+	live := deploymentWithContainers("d", "ns", []interface{}{
+		containerEntry("main"),
+	})
+	desired := deploymentWithContainers("d", "ns", []interface{}{})
+
+	_, err := buildStaleContainerPatch(live, desired)
+	if err == nil {
+		t.Fatal("expected error when desired has no containers")
+	}
+}
+
+func TestBuildStaleContainerPatch_ErrorsOnMissingDesiredContainers(t *testing.T) {
+	live := deploymentWithContainers("d", "ns", []interface{}{
+		containerEntry("main"),
+	})
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "d", "namespace": "ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	_, err := buildStaleContainerPatch(live, desired)
+	if err == nil {
+		t.Fatal("expected error when desired has no containers field")
+	}
+}
+
+func TestBuildStaleContainerPatch_NilWhenLiveHasNoContainers(t *testing.T) {
+	live := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "d", "namespace": "ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+		},
+	}
+	desired := deploymentWithContainers("d", "ns", []interface{}{
+		containerEntry("main"),
+	})
+
+	patch, err := buildStaleContainerPatch(live, desired)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patch != nil {
+		t.Errorf("expected nil patch when live has no containers, got %v", patch)
+	}
+}


### PR DESCRIPTION
Cherry-pick of #9253 into `v3.5.0-fixes`.

https://issues.redhat.com/browse/RHOAIENG-81952

## Description

During RHOAI 2.25→3.5 upgrades, the `rhods-dashboard` Deployment ends up with **both** `oauth-proxy` and `kube-rbac-proxy` containers, causing a port 8443 collision and CrashLoopBackOff.

**Root cause:** The old operator (field manager `dashboard`) and new operator (field manager `dashboard-operator`) both apply containers via SSA. Because they use different field manager names, Kubernetes merges rather than replaces the containers list. The stale `oauth-proxy` owned by the old manager persists because SSA's `ForceOwnership` only steals fields that are *present* in the new manifest — it cannot remove fields it doesn't mention.

**Fix:** Add a pre-deploy step (`removeStaleContainers`) that runs before `deployer.Deploy()` in both `reconcileSidecar` and `reconcileStandalone`. It compares live Deployment container names against the rendered manifest and issues a Strategic Merge Patch with `$patch: delete` to remove any containers present in the cluster but absent from the desired spec.

## Cherry-picked commits

- `888768c` fix([RHOAIENG-81952](https://redhat.atlassian.net/browse/RHOAIENG-81952)): remove SSA-orphaned containers during upgrade
- `816bc84` fix: validate container lists in buildStaleContainerPatch

[RHOAIENG-81952]: https://redhat.atlassian.net/browse/RHOAIENG-81952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ