### PR TITLE
feat(observability): add auth decisions Perses dashboard

### DIFF
--- a/manifests/observability/odh/kustomization.yaml
+++ b/manifests/observability/odh/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - perses-dashboard-cluster.yaml
   - perses-dashboard-model.yaml
   - perses-dashboard-model-admin.yaml
+  - perses-dashboard-auth.yaml

--- a/manifests/observability/odh/perses-dashboard-auth.yaml
+++ b/manifests/observability/odh/perses-dashboard-auth.yaml
@@ -1,0 +1,329 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: dashboard-2-auth
+spec:
+  config:
+    display:
+      name: Auth decisions
+    duration: 1h
+    variables:
+      - kind: ListVariable
+        spec:
+          name: authconfig
+          display:
+            name: Auth policy
+            description: Filter by AuthConfig policy
+          allowMultiple: true
+          allowAllValue: true
+          customAllValue: ".*"
+          defaultValue: "$__all"
+          plugin:
+            kind: PrometheusLabelValuesVariable
+            spec:
+              datasource:
+                kind: PrometheusDatasource
+                name: cluster-prometheus-tenancy-datasource
+              labelName: authconfig
+              matchers:
+                - maas:auth_decisions:rate5m
+    panels:
+      # Overview Stats
+      totalDecisionRate:
+        kind: Panel
+        spec:
+          display:
+            name: Auth decisions/sec
+          plugin:
+            kind: StatChart
+            spec:
+              calculation: last-number
+              format:
+                unit: decimal
+                decimalPlaces: 2
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    query: sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig"}) or vector(0)
+                    seriesNameFormat: Decisions/sec
+      overallDenyRate:
+        kind: Panel
+        spec:
+          display:
+            name: Deny rate
+          plugin:
+            kind: StatChart
+            spec:
+              calculation: last-number
+              format:
+                unit: percent-decimal
+                decimalPlaces: 1
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    # Aggregate deny rate across selected policies
+                    query: (sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig",status!="OK"}) / sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig"})) or vector(0)
+                    seriesNameFormat: Deny rate
+      p95Latency:
+        kind: Panel
+        spec:
+          display:
+            name: P95 auth latency
+          plugin:
+            kind: StatChart
+            spec:
+              calculation: last-number
+              format:
+                unit: seconds
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    # Average P95 latency across selected policies, filter NaN with > -Inf
+                    query: avg(maas:auth_latency_p95:5m{authconfig=~"$authconfig"} > -Inf) or vector(0)
+                    seriesNameFormat: P95 latency
+      activePolicies:
+        kind: Panel
+        spec:
+          display:
+            name: Active policies
+          plugin:
+            kind: StatChart
+            spec:
+              calculation: last-number
+              format:
+                unit: decimal
+                decimalPlaces: 0
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    query: count(group by (authconfig) (maas:auth_decisions:rate5m{authconfig=~"$authconfig"})) or vector(0)
+                    seriesNameFormat: Policies
+      # Time Series Charts
+      decisionsByStatus:
+        kind: Panel
+        spec:
+          display:
+            name: Auth decisions by status
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              legend:
+                mode: list
+                position: bottom
+                values: []
+              visual:
+                areaOpacity: 0.6
+                connectNulls: false
+                display: line
+                lineWidth: 1.5
+                stack: all
+              yAxis:
+                format:
+                  unit: decimal
+                min: 0
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    query: sum by (status) (maas:auth_decisions:rate5m{authconfig=~"$authconfig"})
+                    seriesNameFormat: "{{status}}"
+      decisionsByPolicy:
+        kind: Panel
+        spec:
+          display:
+            name: Auth decisions by policy
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              legend:
+                mode: list
+                position: bottom
+                values: []
+              visual:
+                areaOpacity: 0
+                connectNulls: false
+                display: line
+                lineWidth: 1.5
+              yAxis:
+                format:
+                  unit: decimal
+                min: 0
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    query: sum by (authconfig) (maas:auth_decisions:rate5m{authconfig=~"$authconfig"})
+                    seriesNameFormat: "{{authconfig}}"
+      denyRatioByPolicy:
+        kind: Panel
+        spec:
+          display:
+            name: Deny ratio by policy
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              legend:
+                mode: list
+                position: bottom
+                values: []
+              visual:
+                areaOpacity: 0
+                connectNulls: false
+                display: line
+                lineWidth: 1.5
+              yAxis:
+                format:
+                  unit: percent-decimal
+                min: 0
+                max: 1
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    query: maas:auth_deny_ratio:rate5m{authconfig=~"$authconfig"}
+                    seriesNameFormat: "{{authconfig}}"
+      latencyByPolicy:
+        kind: Panel
+        spec:
+          display:
+            name: P95 auth latency by policy
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              legend:
+                mode: list
+                position: bottom
+                values: []
+              visual:
+                areaOpacity: 0
+                connectNulls: false
+                display: line
+                lineWidth: 1.5
+              yAxis:
+                format:
+                  unit: seconds
+                min: 0
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    # Filter NaN from histogram_quantile with > -Inf
+                    query: maas:auth_latency_p95:5m{authconfig=~"$authconfig"} > -Inf
+                    seriesNameFormat: "{{authconfig}}"
+    layouts:
+      # Overview Stats Row
+      - kind: Grid
+        spec:
+          display:
+            title: Overview
+            collapse:
+              open: true
+          items:
+            - x: 0
+              'y': 0
+              width: 6
+              height: 4
+              content:
+                '$ref': '#/spec/panels/totalDecisionRate'
+            - x: 6
+              'y': 0
+              width: 6
+              height: 4
+              content:
+                '$ref': '#/spec/panels/overallDenyRate'
+            - x: 12
+              'y': 0
+              width: 6
+              height: 4
+              content:
+                '$ref': '#/spec/panels/p95Latency'
+            - x: 18
+              'y': 0
+              width: 6
+              height: 4
+              content:
+                '$ref': '#/spec/panels/activePolicies'
+      # Auth Decision Trends
+      - kind: Grid
+        spec:
+          display:
+            title: Auth decision trends
+            collapse:
+              open: true
+          items:
+            - x: 0
+              'y': 0
+              width: 12
+              height: 8
+              content:
+                '$ref': '#/spec/panels/decisionsByStatus'
+            - x: 12
+              'y': 0
+              width: 12
+              height: 8
+              content:
+                '$ref': '#/spec/panels/decisionsByPolicy'
+      # Per-Policy Details
+      - kind: Grid
+        spec:
+          display:
+            title: Per-policy details
+            collapse:
+              open: true
+          items:
+            - x: 0
+              'y': 0
+              width: 12
+              height: 8
+              content:
+                '$ref': '#/spec/panels/denyRatioByPolicy'
+            - x: 12
+              'y': 0
+              width: 12
+              height: 8
+              content:
+                '$ref': '#/spec/panels/latencyByPolicy'

--- a/manifests/observability/odh/perses-dashboard-auth.yaml
+++ b/manifests/observability/odh/perses-dashboard-auth.yaml
@@ -73,14 +73,14 @@ spec:
                     datasource:
                       kind: PrometheusDatasource
                       name: cluster-prometheus-tenancy-datasource
-                    # Aggregate deny rate across selected policies
-                    query: (sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig",status!="OK"}) / sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig"})) or vector(0)
+                    # Aggregate deny rate across selected policies; filter NaN (zero traffic) before fallback
+                    query: ((sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig",status!="OK"}) / sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig"})) > -Inf) or vector(0)
                     seriesNameFormat: Deny rate
       p95Latency:
         kind: Panel
         spec:
           display:
-            name: P95 auth latency
+            name: Avg policy P95 auth latency
           plugin:
             kind: StatChart
             spec:

--- a/manifests/observability/rhoai/kustomization.yaml
+++ b/manifests/observability/rhoai/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - perses-dashboard-cluster.yaml
   - perses-dashboard-model.yaml
   - perses-dashboard-model-admin.yaml
+  - perses-dashboard-auth.yaml

--- a/manifests/observability/rhoai/perses-dashboard-auth.yaml
+++ b/manifests/observability/rhoai/perses-dashboard-auth.yaml
@@ -1,0 +1,329 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: dashboard-2-auth
+spec:
+  config:
+    display:
+      name: Auth decisions
+    duration: 1h
+    variables:
+      - kind: ListVariable
+        spec:
+          name: authconfig
+          display:
+            name: Auth policy
+            description: Filter by AuthConfig policy
+          allowMultiple: true
+          allowAllValue: true
+          customAllValue: ".*"
+          defaultValue: "$__all"
+          plugin:
+            kind: PrometheusLabelValuesVariable
+            spec:
+              datasource:
+                kind: PrometheusDatasource
+                name: cluster-prometheus-tenancy-datasource
+              labelName: authconfig
+              matchers:
+                - maas:auth_decisions:rate5m
+    panels:
+      # Overview Stats
+      totalDecisionRate:
+        kind: Panel
+        spec:
+          display:
+            name: Auth decisions/sec
+          plugin:
+            kind: StatChart
+            spec:
+              calculation: last-number
+              format:
+                unit: decimal
+                decimalPlaces: 2
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    query: sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig"}) or vector(0)
+                    seriesNameFormat: Decisions/sec
+      overallDenyRate:
+        kind: Panel
+        spec:
+          display:
+            name: Deny rate
+          plugin:
+            kind: StatChart
+            spec:
+              calculation: last-number
+              format:
+                unit: percent-decimal
+                decimalPlaces: 1
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    # Aggregate deny rate across selected policies
+                    query: (sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig",status!="OK"}) / sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig"})) or vector(0)
+                    seriesNameFormat: Deny rate
+      p95Latency:
+        kind: Panel
+        spec:
+          display:
+            name: P95 auth latency
+          plugin:
+            kind: StatChart
+            spec:
+              calculation: last-number
+              format:
+                unit: seconds
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    # Average P95 latency across selected policies, filter NaN with > -Inf
+                    query: avg(maas:auth_latency_p95:5m{authconfig=~"$authconfig"} > -Inf) or vector(0)
+                    seriesNameFormat: P95 latency
+      activePolicies:
+        kind: Panel
+        spec:
+          display:
+            name: Active policies
+          plugin:
+            kind: StatChart
+            spec:
+              calculation: last-number
+              format:
+                unit: decimal
+                decimalPlaces: 0
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    query: count(group by (authconfig) (maas:auth_decisions:rate5m{authconfig=~"$authconfig"})) or vector(0)
+                    seriesNameFormat: Policies
+      # Time Series Charts
+      decisionsByStatus:
+        kind: Panel
+        spec:
+          display:
+            name: Auth decisions by status
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              legend:
+                mode: list
+                position: bottom
+                values: []
+              visual:
+                areaOpacity: 0.6
+                connectNulls: false
+                display: line
+                lineWidth: 1.5
+                stack: all
+              yAxis:
+                format:
+                  unit: decimal
+                min: 0
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    query: sum by (status) (maas:auth_decisions:rate5m{authconfig=~"$authconfig"})
+                    seriesNameFormat: "{{status}}"
+      decisionsByPolicy:
+        kind: Panel
+        spec:
+          display:
+            name: Auth decisions by policy
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              legend:
+                mode: list
+                position: bottom
+                values: []
+              visual:
+                areaOpacity: 0
+                connectNulls: false
+                display: line
+                lineWidth: 1.5
+              yAxis:
+                format:
+                  unit: decimal
+                min: 0
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    query: sum by (authconfig) (maas:auth_decisions:rate5m{authconfig=~"$authconfig"})
+                    seriesNameFormat: "{{authconfig}}"
+      denyRatioByPolicy:
+        kind: Panel
+        spec:
+          display:
+            name: Deny ratio by policy
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              legend:
+                mode: list
+                position: bottom
+                values: []
+              visual:
+                areaOpacity: 0
+                connectNulls: false
+                display: line
+                lineWidth: 1.5
+              yAxis:
+                format:
+                  unit: percent-decimal
+                min: 0
+                max: 1
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    query: maas:auth_deny_ratio:rate5m{authconfig=~"$authconfig"}
+                    seriesNameFormat: "{{authconfig}}"
+      latencyByPolicy:
+        kind: Panel
+        spec:
+          display:
+            name: P95 auth latency by policy
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              legend:
+                mode: list
+                position: bottom
+                values: []
+              visual:
+                areaOpacity: 0
+                connectNulls: false
+                display: line
+                lineWidth: 1.5
+              yAxis:
+                format:
+                  unit: seconds
+                min: 0
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    datasource:
+                      kind: PrometheusDatasource
+                      name: cluster-prometheus-tenancy-datasource
+                    # Filter NaN from histogram_quantile with > -Inf
+                    query: maas:auth_latency_p95:5m{authconfig=~"$authconfig"} > -Inf
+                    seriesNameFormat: "{{authconfig}}"
+    layouts:
+      # Overview Stats Row
+      - kind: Grid
+        spec:
+          display:
+            title: Overview
+            collapse:
+              open: true
+          items:
+            - x: 0
+              'y': 0
+              width: 6
+              height: 4
+              content:
+                '$ref': '#/spec/panels/totalDecisionRate'
+            - x: 6
+              'y': 0
+              width: 6
+              height: 4
+              content:
+                '$ref': '#/spec/panels/overallDenyRate'
+            - x: 12
+              'y': 0
+              width: 6
+              height: 4
+              content:
+                '$ref': '#/spec/panels/p95Latency'
+            - x: 18
+              'y': 0
+              width: 6
+              height: 4
+              content:
+                '$ref': '#/spec/panels/activePolicies'
+      # Auth Decision Trends
+      - kind: Grid
+        spec:
+          display:
+            title: Auth decision trends
+            collapse:
+              open: true
+          items:
+            - x: 0
+              'y': 0
+              width: 12
+              height: 8
+              content:
+                '$ref': '#/spec/panels/decisionsByStatus'
+            - x: 12
+              'y': 0
+              width: 12
+              height: 8
+              content:
+                '$ref': '#/spec/panels/decisionsByPolicy'
+      # Per-Policy Details
+      - kind: Grid
+        spec:
+          display:
+            title: Per-policy details
+            collapse:
+              open: true
+          items:
+            - x: 0
+              'y': 0
+              width: 12
+              height: 8
+              content:
+                '$ref': '#/spec/panels/denyRatioByPolicy'
+            - x: 12
+              'y': 0
+              width: 12
+              height: 8
+              content:
+                '$ref': '#/spec/panels/latencyByPolicy'

--- a/manifests/observability/rhoai/perses-dashboard-auth.yaml
+++ b/manifests/observability/rhoai/perses-dashboard-auth.yaml
@@ -73,14 +73,14 @@ spec:
                     datasource:
                       kind: PrometheusDatasource
                       name: cluster-prometheus-tenancy-datasource
-                    # Aggregate deny rate across selected policies
-                    query: (sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig",status!="OK"}) / sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig"})) or vector(0)
+                    # Aggregate deny rate across selected policies; filter NaN (zero traffic) before fallback
+                    query: ((sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig",status!="OK"}) / sum(maas:auth_decisions:rate5m{authconfig=~"$authconfig"})) > -Inf) or vector(0)
                     seriesNameFormat: Deny rate
       p95Latency:
         kind: Panel
         spec:
           display:
-            name: P95 auth latency
+            name: Avg policy P95 auth latency
           plugin:
             kind: StatChart
             spec:


### PR DESCRIPTION
## Summary

- Add a Perses dashboard (`dashboard-2-auth`) for Authorino auth decision monitoring to both ODH and RHOAI observability overlays
- Dashboard consumes recording rules from [models-as-a-service PR #1363](https://github.com/opendatahub-io/models-as-a-service/pull/1363): `maas:auth_decisions:rate5m`, `maas:auth_deny_ratio:rate5m`, `maas:auth_latency_p95:5m`
- Follows existing v1alpha2 PersesDashboard patterns (datasource, variables, layouts, NaN/cold-start handling)

### Panels

**Overview stats row**: auth decisions/sec, deny rate, P95 auth latency, active policies

**Auth decision trends**: decisions by status (stacked area), decisions by policy (line)

**Per-policy details**: deny ratio by policy, P95 latency by policy

### Dependencies

- Requires recording rules from models-as-a-service [PR #1363](https://github.com/opendatahub-io/models-as-a-service/pull/1363) to be deployed (via `install-observability.sh`)
- Without recording rules deployed, panels show zero/no-data gracefully (`or vector(0)`, `> -Inf` NaN filter)

Ref: [RHAISTRAT-2418](https://redhat.atlassian.net/browse/RHAISTRAT-2418)

## Test plan

- [x] Verify kustomize build passes for both `manifests/observability/odh/` and `manifests/observability/rhoai/`
- [ ] Deploy recording rules via `install-observability.sh` on a cluster with MaaS and active auth traffic
- [ ] Verify dashboard renders in Perses UI with data populated in all panels
- [x] Verify dashboard handles cold start (no auth traffic) gracefully — stat panels show 0, time series show no data
- [x] Verify authconfig variable populates with AuthConfig hash labels

[RHAISTRAT-2418]: https://redhat.atlassian.net/browse/RHAISTRAT-2418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added authentication observability dashboards for monitoring AuthConfig decisions.
  * Added policy filtering and overview metrics for decision rate, deny rate, P95 latency, and active policies.
  * Added time-series views for decision status, policy activity, deny ratios, and latency.
  * Organized dashboards into overview, trend, and per-policy sections.
  * Enabled the dashboards across supported observability environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->