### PR TITLE
RHOAIENG-82097: Name operator and autox CI jobs for Tide

### DIFF
--- a/.github/workflows/autox-core-services-tests.yml
+++ b/.github/workflows/autox-core-services-tests.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   test:
+    name: AutoX Core Services Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/dashboard-operator-tests.yml
+++ b/.github/workflows/dashboard-operator-tests.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   test:
+    name: Dashboard Operator Tests
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Prerequisite for [RHOAIENG-82097](https://redhat.atlassian.net/browse/RHOAIENG-82097): give path-filtered workflow jobs explicit GitHub check names so Tide can require them via `required-if-present-contexts` in `openshift/release`.

- `dashboard-operator-tests.yml`: job check name `Dashboard Operator Tests` (was generic `test`)
- `autox-core-services-tests.yml`: job check name `AutoX Core Services Tests` (was generic `test`)

Package BFF/frontend workflows were already renamed in #9187.

## Test plan

- [ ] Merge this PR first
- [ ] Open a PR touching `dashboard-operator/**` and confirm the check reports as `Dashboard Operator Tests`
- [ ] Open a PR touching `packages/autox-core/services/**` and confirm the check reports as `AutoX Core Services Tests`
- [ ] Merge companion `openshift/release` PR ([RHOAIENG-82097](https://redhat.atlassian.net/browse/RHOAIENG-82097)) to enable Tide gating

[RHOAIENG-82097]: https://redhat.atlassian.net/browse/RHOAIENG-82097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ