### PR TITLE
feat(RHOAIENG-69427): wire validated catalog args into runtime args

### DIFF
--- a/packages/kserve/src/__tests__/deployUtils.spec.ts
+++ b/packages/kserve/src/__tests__/deployUtils.spec.ts
@@ -1,0 +1,59 @@
+import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import { applyRuntimeArgs } from '../deployUtils';
+
+describe('applyRuntimeArgs', () => {
+  const baseInferenceService = {
+    apiVersion: 'serving.kserve.io/v1beta1',
+    kind: 'InferenceService',
+    metadata: { name: 'test', namespace: 'test' },
+    spec: {
+      predictor: {
+        model: {
+          modelFormat: { name: 'vLLM' },
+        },
+      },
+    },
+  } as InferenceServiceKind;
+
+  it('should apply runtime args and strip comment headers', () => {
+    const result = applyRuntimeArgs(baseInferenceService, {
+      enabled: true,
+      args: [
+        '# Validated arguments for Tool calling',
+        '--enable-auto-tool-choice',
+        '--tool-call-parser hermes',
+      ],
+    });
+
+    expect(result.spec.predictor.model?.args).toEqual([
+      '--enable-auto-tool-choice',
+      '--tool-call-parser hermes',
+    ]);
+  });
+
+  it('should delete args when only comment lines remain', () => {
+    const result = applyRuntimeArgs(baseInferenceService, {
+      enabled: true,
+      args: ['# Validated arguments for Tool calling', ''],
+    });
+
+    expect(result.spec.predictor.model?.args).toBeUndefined();
+  });
+
+  it('should delete args when runtime args are disabled', () => {
+    const withArgs = {
+      ...baseInferenceService,
+      spec: {
+        predictor: {
+          model: {
+            modelFormat: { name: 'vLLM' },
+            args: ['--existing'],
+          },
+        },
+      },
+    } as InferenceServiceKind;
+
+    const result = applyRuntimeArgs(withArgs, { enabled: false, args: ['--existing'] });
+    expect(result.spec.predictor.model?.args).toBeUndefined();
+  });
+});

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -50,6 +50,7 @@ import {
   type DeploymentMethodFieldData,
   deploymentStrategyRolling,
   deploymentStrategyRecreate,
+  filterRuntimeArgsForContainer,
 } from '@odh-dashboard/model-serving/shared/wizard-fields';
 import { LEGACY_GENERATIVE_DEPLOYMENT_METHOD_KEY } from './wizardFields/deploymentMethodField';
 import type { CreatingInferenceServiceObject } from './deployModel';
@@ -257,12 +258,13 @@ export const applyRuntimeArgs = (
   runtimeArgs: RuntimeArgsFieldData,
 ): InferenceServiceKind => {
   const result = structuredClone(inferenceService);
+  const containerArgs = filterRuntimeArgsForContainer(runtimeArgs.args);
   result.spec.predictor.model = {
     ...result.spec.predictor.model,
-    ...(runtimeArgs.enabled && { args: runtimeArgs.args }),
+    ...(runtimeArgs.enabled && containerArgs.length > 0 && { args: containerArgs }),
   };
 
-  if (!runtimeArgs.enabled) {
+  if (!runtimeArgs.enabled || containerArgs.length === 0) {
     delete result.spec.predictor.model.args;
   }
 

--- a/packages/llmd-serving/src/deployments/model.ts
+++ b/packages/llmd-serving/src/deployments/model.ts
@@ -10,7 +10,10 @@ import {
   getPVCNameFromURI,
   isPVCUri,
 } from '@odh-dashboard/model-serving/shared';
-import type { ModelTypeFieldData } from '@odh-dashboard/model-serving/shared/wizard-fields';
+import {
+  filterRuntimeArgsForContainer,
+  type ModelTypeFieldData,
+} from '@odh-dashboard/model-serving/shared/wizard-fields';
 import {
   ModelLocationData,
   ModelLocationType,
@@ -127,7 +130,10 @@ export const applyModelEnvVarsAndArgs = (
     envHolder.push(...modelEnvVars.variables);
   }
   if (modelArgs?.enabled) {
-    envHolder.push({ name: VLLM_ADDITIONAL_ARGS, value: modelArgs.args.join(' ') });
+    const containerArgs = filterRuntimeArgsForContainer(modelArgs.args);
+    if (containerArgs.length > 0) {
+      envHolder.push({ name: VLLM_ADDITIONAL_ARGS, value: containerArgs.join(' ') });
+    }
   }
   mainContainer.env = envHolder;
   return result;

--- a/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
@@ -251,7 +251,7 @@ const navigateToAdvancedOptions = () => {
 };
 
 describe('Preconfigure deployment validated arguments', () => {
-  it('should carry validated arguments from catalog deploy into the wizard', () => {
+  it('should carry validated arguments from catalog deploy through advanced and review', () => {
     openWizardFromCatalog();
 
     modelServingWizard.findValidatedConfigurationSection('args').should('be.visible');
@@ -259,14 +259,19 @@ describe('Preconfigure deployment validated arguments', () => {
     modelServingWizard
       .findValidatedConfigurationOptionCheckbox('tool-calling')
       .should('be.checked');
-  });
 
-  it('should pre-populate runtime args from selected validated configurations', () => {
-    openWizardFromCatalog();
     navigateToAdvancedOptions();
 
     modelServingWizard.findRuntimeArgsCheckbox().should('be.checked');
     modelServingWizard.findRuntimeArgsTextBox().should('have.value', EXPECTED_RUNTIME_ARGS);
+
+    modelServingWizard.findNextButton().should('be.enabled').click();
+
+    modelServingWizard.findReviewStepModelDetailsSection().should('exist');
+    cy.contains('Additional runtime arguments').should('exist');
+    cy.contains('--enable-auto-tool-choice').should('exist');
+    cy.contains('--tool-call-parser').should('exist');
+    cy.contains('# Validated arguments').should('not.exist');
   });
 
   it('should remove validated args on uncheck and preserve user edits', () => {
@@ -295,17 +300,5 @@ describe('Preconfigure deployment validated arguments', () => {
 
     modelServingWizard.findAdvancedOptionsStep().click();
     modelServingWizard.findRuntimeArgsTextBox().should('have.value', '--user-custom-arg');
-  });
-
-  it('should show validated args on the review step', () => {
-    openWizardFromCatalog();
-    navigateToAdvancedOptions();
-    modelServingWizard.findNextButton().should('be.enabled').click();
-
-    modelServingWizard.findReviewStepModelDetailsSection().should('exist');
-    cy.contains('Additional runtime arguments').should('exist');
-    cy.contains('--enable-auto-tool-choice').should('exist');
-    cy.contains('--tool-call-parser').should('exist');
-    cy.contains('# Validated arguments').should('not.exist');
   });
 });

--- a/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
@@ -1,12 +1,25 @@
 import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
 import { mockDsciStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDsciStatus';
-import { mockConnectionTypeConfigMap } from '@odh-dashboard/k8s-core/__mocks__/mockConnectionType';
+import {
+  mockConnectionTypeConfigMap,
+  mockOciConnectionTypeConfigMap,
+} from '@odh-dashboard/k8s-core/__mocks__/mockConnectionType';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
+import { IdentifierResourceType } from '@odh-dashboard/k8s-core';
+import {
+  mockGlobalScopedHardwareProfiles,
+  mockHardwareProfile,
+} from '@odh-dashboard/hardware-profiles/__mocks__/mockHardwareProfile';
+import { mockStandardModelServingTemplateK8sResources } from '@odh-dashboard/model-serving/__mocks__/mockServingRuntimeTemplateK8sResource';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
 import { asProductAdminUser } from '@odh-dashboard/cypress/cypress/utils/mockUsers';
-import { ProjectModel } from '@odh-dashboard/cypress/cypress/utils/models';
+import {
+  HardwareProfileModel,
+  ProjectModel,
+  TemplateModel,
+} from '@odh-dashboard/cypress/cypress/utils/models';
 import { modelDetailsPage } from '@odh-dashboard/cypress/cypress/pages/modelCatalog/modelDetailsPage';
 import { modelCatalog } from '@odh-dashboard/cypress/cypress/pages/modelCatalog/modelCatalog';
 import { modelServingWizard } from '@odh-dashboard/cypress/cypress/pages/modelServing';
@@ -16,6 +29,13 @@ const SOURCE_ID = 'sample-source';
 const MODEL_NAME = 'validated-model';
 const REGISTRIES_NAMESPACE = 'odh-model-registries';
 const MODEL_URI = 'oci://quay.io/test-org/validated-model:latest';
+
+const EXPECTED_RUNTIME_ARGS = [
+  '# Validated arguments for Tool calling',
+  '--enable-auto-tool-choice',
+  '--tool-call-parser granite',
+  '--chat-template opt/app-root/template/tool_chat_template_granite.jinja',
+].join('\n');
 
 /* eslint-disable camelcase -- catalog API payloads use snake_case field names */
 const catalogModel = {
@@ -69,6 +89,7 @@ const initIntercepts = () => {
       disableModelCatalog: false,
       disableModelRegistry: false,
       toolCalling: true,
+      vLLMDeploymentOnMaaS: true,
     }),
   );
   cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({}));
@@ -88,7 +109,57 @@ const initIntercepts = () => {
         },
       ],
     }),
+    mockOciConnectionTypeConfigMap(),
   ]);
+  cy.interceptOdh(
+    'GET /api/namespaces/:namespace/:context',
+    { path: { namespace: 'test-project', context: '*' } },
+    { applied: true },
+  );
+
+  cy.interceptK8sList(
+    { model: HardwareProfileModel, ns: 'opendatahub' },
+    mockK8sResourceList([
+      mockGlobalScopedHardwareProfiles[0],
+      mockGlobalScopedHardwareProfiles[1],
+      mockHardwareProfile({
+        name: 'nvidia-profile',
+        displayName: 'NVIDIA GPU Profile',
+        identifiers: [
+          {
+            displayName: 'CPU',
+            identifier: 'cpu',
+            minCount: '4',
+            maxCount: '8',
+            defaultCount: '4',
+            resourceType: IdentifierResourceType.CPU,
+          },
+          {
+            displayName: 'Memory',
+            identifier: 'memory',
+            minCount: '8Gi',
+            maxCount: '16Gi',
+            defaultCount: '8Gi',
+            resourceType: IdentifierResourceType.MEMORY,
+          },
+          {
+            displayName: 'GPU',
+            identifier: 'nvidia.com/gpu',
+            minCount: 1,
+            maxCount: 4,
+            defaultCount: 1,
+            resourceType: IdentifierResourceType.ACCELERATOR,
+          },
+        ],
+      }),
+    ]),
+  );
+  cy.interceptK8sList(
+    TemplateModel,
+    mockK8sResourceList(mockStandardModelServingTemplateK8sResources(), {
+      namespace: 'opendatahub',
+    }),
+  );
   cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProjectK8sResource({})]));
 
   cy.interceptOdh(
@@ -155,21 +226,86 @@ const initIntercepts = () => {
   );
 };
 
+const openWizardFromCatalog = () => {
+  initIntercepts();
+  modelDetailsPage.visit(SOURCE_ID, MODEL_NAME);
+  modelCatalog.clickDeployModelButtonWithRetry();
+  modelServingWizard.findPreconfigureStep().should('be.enabled');
+};
+
+const navigateToAdvancedOptions = () => {
+  modelServingWizard.findPreconfigureProjectSelector().click();
+  modelServingWizard.findPreconfigureProjectSelectorOption('Test Project').click();
+  modelServingWizard.findNextButton().should('be.enabled').click();
+
+  modelServingWizard.findModelSourceStep().should('be.enabled');
+  modelServingWizard.findNextButton().should('be.enabled').click();
+
+  modelServingWizard.findModelDeploymentStep().should('be.enabled');
+  modelServingWizard.selectDeploymentMethodByKey('legacy');
+  modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
+  modelServingWizard.selectGlobalScopedTemplateOption('vLLM NVIDIA');
+  modelServingWizard.findNextButton().should('be.enabled').click();
+
+  modelServingWizard.findAdvancedOptionsStep().should('be.enabled');
+};
+
 describe('Preconfigure deployment validated arguments', () => {
   it('should carry validated arguments from catalog deploy into the wizard', () => {
-    initIntercepts();
-    modelDetailsPage.visit(SOURCE_ID, MODEL_NAME);
+    openWizardFromCatalog();
 
-    modelDetailsPage.findValidatedConfigurationsCard().should('be.visible');
-    modelDetailsPage.findToolCallingCard().should('contain.text', 'Tool calling');
-
-    modelCatalog.clickDeployModelButtonWithRetry();
-
-    modelServingWizard.findPreconfigureStep().should('be.enabled');
     modelServingWizard.findValidatedConfigurationSection('args').should('be.visible');
     modelServingWizard.findValidatedConfigurationOption('tool-calling').should('be.visible');
     modelServingWizard
       .findValidatedConfigurationOptionCheckbox('tool-calling')
       .should('be.checked');
+  });
+
+  it('should pre-populate runtime args from selected validated configurations', () => {
+    openWizardFromCatalog();
+    navigateToAdvancedOptions();
+
+    modelServingWizard.findRuntimeArgsCheckbox().should('be.checked');
+    modelServingWizard.findRuntimeArgsTextBox().should('have.value', EXPECTED_RUNTIME_ARGS);
+  });
+
+  it('should remove validated args on uncheck and preserve user edits', () => {
+    openWizardFromCatalog();
+
+    modelServingWizard
+      .findValidatedConfigurationOptionCheckbox('tool-calling')
+      .should('be.checked')
+      .click()
+      .should('not.be.checked');
+    modelServingWizard
+      .findValidatedConfigurationOptionCheckbox('tool-calling')
+      .click()
+      .should('be.checked');
+
+    navigateToAdvancedOptions();
+
+    modelServingWizard.findRuntimeArgsTextBox().should('have.value', EXPECTED_RUNTIME_ARGS);
+    modelServingWizard.findRuntimeArgsTextBox().type('{moveToEnd}\n--user-custom-arg');
+
+    modelServingWizard.findPreconfigureStep().click();
+    modelServingWizard
+      .findValidatedConfigurationOptionCheckbox('tool-calling')
+      .click()
+      .should('not.be.checked');
+
+    modelServingWizard.findAdvancedOptionsStep().click();
+    modelServingWizard.findRuntimeArgsTextBox().should('have.value', '--user-custom-arg');
+  });
+
+  it('should show validated args on the review step', () => {
+    openWizardFromCatalog();
+    navigateToAdvancedOptions();
+    modelServingWizard.findNextButton().should('be.enabled').click();
+
+    modelServingWizard.findReviewStepModelDetailsSection().should('exist');
+    cy.contains('Additional runtime arguments').should('exist');
+    cy.contains('--enable-auto-tool-choice').should('exist');
+    cy.contains('--tool-call-parser').should('exist');
+    cy.contains('# Validated arguments').should('not.exist');
   });
 });

--- a/packages/model-serving/src/components/deploymentWizard/fields/RuntimeArgsField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/RuntimeArgsField.tsx
@@ -27,10 +27,20 @@ export const isValidRuntimeArgs = (value: unknown): value is RuntimeArgsFieldDat
   return runtimeArgsFieldSchema.safeParse(value).success;
 };
 
+/**
+ * Drops blank lines and `#` comment headers before writing args onto a container.
+ * Comment lines are useful in the wizard textarea but are not valid container argv.
+ */
+export const filterRuntimeArgsForContainer = (args: string[]): string[] =>
+  args.filter((line) => {
+    const trimmed = line.trim();
+    return trimmed.length > 0 && !trimmed.startsWith('#');
+  });
+
 // Hook
 export type RuntimeArgsFieldHook = {
   data: RuntimeArgsFieldData | undefined;
-  setData: (data: RuntimeArgsFieldData) => void;
+  setData: React.Dispatch<React.SetStateAction<RuntimeArgsFieldData | undefined>>;
 };
 
 export const useRuntimeArgsField = (existingData?: RuntimeArgsFieldData): RuntimeArgsFieldHook => {

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/RuntimeArgsField.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/RuntimeArgsField.spec.ts
@@ -1,0 +1,15 @@
+import { filterRuntimeArgsForContainer } from '../RuntimeArgsField';
+
+describe('filterRuntimeArgsForContainer', () => {
+  it('should strip comment headers and blank lines', () => {
+    expect(
+      filterRuntimeArgsForContainer([
+        '# Validated arguments for Tool calling',
+        '',
+        '--enable-auto-tool-choice',
+        '  # indented comment',
+        '--tool-call-parser hermes',
+      ]),
+    ).toEqual(['--enable-auto-tool-choice', '--tool-call-parser hermes']);
+  });
+});

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedArgumentsSection.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedArgumentsSection.tsx
@@ -63,16 +63,15 @@ export const ValidatedArgumentsSection: React.FC<ValidatedArgumentsSectionProps>
                         )}
                         onSelectionChange={(checked) => {
                           selection.toggleOption(configuration.forField, option.value, checked);
-                          if (configuration.forField !== 'args') {
-                            return;
+                          if (configuration.forField === 'args') {
+                            runtimeArgs.setData((prev) => {
+                              const currentArgs = prev?.args ?? [];
+                              const nextArgs = checked
+                                ? mergeValidatedOptionIntoArgs(currentArgs, option)
+                                : removeValidatedOptionFromArgs(currentArgs, option);
+                              return toRuntimeArgsFieldData(nextArgs);
+                            });
                           }
-                          runtimeArgs.setData((prev) => {
-                            const currentArgs = prev?.args ?? [];
-                            const nextArgs = checked
-                              ? mergeValidatedOptionIntoArgs(currentArgs, option)
-                              : removeValidatedOptionFromArgs(currentArgs, option);
-                            return toRuntimeArgsFieldData(nextArgs);
-                          });
                         }}
                       />
                     </GalleryItem>

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedArgumentsSection.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/ValidatedArgumentsSection.tsx
@@ -9,17 +9,25 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import { ValidatedConfigurationOptionCard } from './ValidatedConfigurationOptionCard';
+import {
+  mergeValidatedOptionIntoArgs,
+  removeValidatedOptionFromArgs,
+  toRuntimeArgsFieldData,
+} from './validatedConfigurationUtils';
 import type { ValidatedConfigurationsFieldHook } from './useValidatedConfigurationsField';
+import type { RuntimeArgsFieldHook } from '../RuntimeArgsField';
 import type { ValidatedConfiguration } from '../../../../shared/types/form-data';
 
 type ValidatedArgumentsSectionProps = {
   configurations: ValidatedConfiguration[];
   selection: ValidatedConfigurationsFieldHook;
+  runtimeArgs: RuntimeArgsFieldHook;
 };
 
 export const ValidatedArgumentsSection: React.FC<ValidatedArgumentsSectionProps> = ({
   configurations,
   selection,
+  runtimeArgs,
 }) => {
   return (
     <>
@@ -53,9 +61,19 @@ export const ValidatedArgumentsSection: React.FC<ValidatedArgumentsSectionProps>
                           configuration.forField,
                           option.value,
                         )}
-                        onSelectionChange={(checked) =>
-                          selection.toggleOption(configuration.forField, option.value, checked)
-                        }
+                        onSelectionChange={(checked) => {
+                          selection.toggleOption(configuration.forField, option.value, checked);
+                          if (configuration.forField !== 'args') {
+                            return;
+                          }
+                          runtimeArgs.setData((prev) => {
+                            const currentArgs = prev?.args ?? [];
+                            const nextArgs = checked
+                              ? mergeValidatedOptionIntoArgs(currentArgs, option)
+                              : removeValidatedOptionFromArgs(currentArgs, option);
+                            return toRuntimeArgsFieldData(nextArgs);
+                          });
+                        }}
                       />
                     </GalleryItem>
                   ))}

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/__tests__/validatedConfigurationUtils.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/__tests__/validatedConfigurationUtils.spec.ts
@@ -1,7 +1,16 @@
-import { TOOL_CALLING_VALIDATED_ARGS_VALUE } from '@odh-dashboard/internal/__mocks__/mockValidatedConfigurations';
 import {
+  TOOL_CALLING_VALIDATED_ARGS_VALUE,
+  mockToolCallingValidatedConfiguration,
+} from '@odh-dashboard/internal/__mocks__/mockValidatedConfigurations';
+import {
+  buildRuntimeArgsFromValidatedSelections,
   formatValidatedOptionValueForDisplay,
+  getValidatedArgCommentHeader,
+  mergeValidatedOptionIntoArgs,
+  optionValueToArgLines,
+  removeValidatedOptionFromArgs,
   slugifyValidatedOptionTitle,
+  toRuntimeArgsFieldData,
 } from '../validatedConfigurationUtils';
 
 describe('formatValidatedOptionValueForDisplay', () => {
@@ -15,5 +24,98 @@ describe('formatValidatedOptionValueForDisplay', () => {
 describe('slugifyValidatedOptionTitle', () => {
   it('should slugify option titles for test ids', () => {
     expect(slugifyValidatedOptionTitle('Tool calling')).toBe('tool-calling');
+  });
+});
+
+describe('optionValueToArgLines', () => {
+  it('should strip trailing backslashes and return individual arg lines', () => {
+    expect(optionValueToArgLines(TOOL_CALLING_VALIDATED_ARGS_VALUE)).toEqual([
+      '--enable-auto-tool-choice',
+      '--tool-call-parser hermes',
+      '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+    ]);
+  });
+});
+
+describe('mergeValidatedOptionIntoArgs / removeValidatedOptionFromArgs', () => {
+  const option = mockToolCallingValidatedConfiguration().options[0];
+  const header = getValidatedArgCommentHeader(option.title);
+
+  it('should append comment header and arg lines when checking an option', () => {
+    expect(mergeValidatedOptionIntoArgs([], option)).toEqual([
+      header,
+      '--enable-auto-tool-choice',
+      '--tool-call-parser hermes',
+      '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+    ]);
+  });
+
+  it('should not duplicate when the header is already present', () => {
+    const existing = mergeValidatedOptionIntoArgs([], option);
+    expect(mergeValidatedOptionIntoArgs(existing, option)).toEqual(existing);
+  });
+
+  it('should remove only known validated lines and preserve user edits', () => {
+    const withUserEdits = [
+      '--my-custom-arg',
+      header,
+      '--enable-auto-tool-choice',
+      '--tool-call-parser hermes',
+      '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+      '--another-user-arg',
+    ];
+
+    expect(removeValidatedOptionFromArgs(withUserEdits, option)).toEqual([
+      '--my-custom-arg',
+      '--another-user-arg',
+    ]);
+  });
+
+  it('should leave user-edited validated lines that no longer match exactly', () => {
+    const withEditedLine = [
+      header,
+      '--enable-auto-tool-choice=true',
+      '--tool-call-parser hermes',
+      '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+    ];
+
+    expect(removeValidatedOptionFromArgs(withEditedLine, option)).toEqual([
+      '--enable-auto-tool-choice=true',
+    ]);
+  });
+
+  it('should set enabled false when no args remain', () => {
+    const merged = mergeValidatedOptionIntoArgs([], option);
+    expect(toRuntimeArgsFieldData(removeValidatedOptionFromArgs(merged, option))).toEqual({
+      enabled: false,
+      args: [],
+    });
+  });
+});
+
+describe('buildRuntimeArgsFromValidatedSelections', () => {
+  it('should return undefined when nothing is selected', () => {
+    expect(
+      buildRuntimeArgsFromValidatedSelections([mockToolCallingValidatedConfiguration()], {}),
+    ).toBeUndefined();
+  });
+
+  it('should seed runtime args from selected validated configurations', () => {
+    const configuration = mockToolCallingValidatedConfiguration();
+    const option = configuration.options[0];
+
+    expect(
+      buildRuntimeArgsFromValidatedSelections([configuration], {
+        args: [option.value],
+      }),
+    ).toEqual({
+      enabled: true,
+      args: [
+        getValidatedArgCommentHeader(option.title),
+        '--enable-auto-tool-choice',
+        '--tool-call-parser hermes',
+        '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+      ],
+    });
   });
 });

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/__tests__/validatedConfigurationUtils.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/__tests__/validatedConfigurationUtils.spec.ts
@@ -91,6 +91,44 @@ describe('mergeValidatedOptionIntoArgs / removeValidatedOptionFromArgs', () => {
       args: [],
     });
   });
+
+  it('should preserve duplicate user args outside the validated block', () => {
+    const withDuplicateUserArg = [
+      '--enable-auto-tool-choice',
+      header,
+      '--enable-auto-tool-choice',
+      '--tool-call-parser hermes',
+      '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+    ];
+
+    expect(removeValidatedOptionFromArgs(withDuplicateUserArg, option)).toEqual([
+      '--enable-auto-tool-choice',
+    ]);
+  });
+
+  it('should preserve overlapping args that belong to another validated block', () => {
+    const otherOption = {
+      title: 'Other calling',
+      description: 'Another validated configuration',
+      value: '--enable-auto-tool-choice \\\n--other-flag',
+    };
+    const otherHeader = getValidatedArgCommentHeader(otherOption.title);
+    const args = [
+      header,
+      '--enable-auto-tool-choice',
+      '--tool-call-parser hermes',
+      '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+      otherHeader,
+      '--enable-auto-tool-choice',
+      '--other-flag',
+    ];
+
+    expect(removeValidatedOptionFromArgs(args, option)).toEqual([
+      otherHeader,
+      '--enable-auto-tool-choice',
+      '--other-flag',
+    ]);
+  });
 });
 
 describe('buildRuntimeArgsFromValidatedSelections', () => {

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/validatedConfigurationUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/validatedConfigurationUtils.ts
@@ -22,8 +22,10 @@ export const slugifyValidatedOptionTitle = (title: string): string =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 
+export const VALIDATED_ARG_HEADER_PREFIX = '# Validated arguments for ';
+
 export const getValidatedArgCommentHeader = (optionTitle: string): string =>
-  `# Validated arguments for ${optionTitle}`;
+  `${VALIDATED_ARG_HEADER_PREFIX}${optionTitle}`;
 
 /** Converts an option value into runtime-arg textarea lines (no shell `\` continuations). */
 export const optionValueToArgLines = (value: string): string[] =>
@@ -57,15 +59,41 @@ export const mergeValidatedOptionIntoArgs = (
 };
 
 /**
- * Removes only the comment header and known arg lines for this option.
- * Leaves all other lines (including user edits) in place.
+ * Removes only this option's validated block (header + expected arg lines).
+ * Preserves identical lines before the header, after the block, or in other
+ * validated blocks — including duplicate user args and overlapping option args.
  */
 export const removeValidatedOptionFromArgs = (
   currentArgs: string[],
   option: ValidatedConfigurationOption,
 ): string[] => {
-  const linesToRemove = new Set(getValidatedOptionArgBlock(option));
-  return currentArgs.filter((line) => !linesToRemove.has(line));
+  const header = getValidatedArgCommentHeader(option.title);
+  const remainingLines = new Map<string, number>();
+
+  for (const line of optionValueToArgLines(option.value)) {
+    remainingLines.set(line, (remainingLines.get(line) ?? 0) + 1);
+  }
+
+  let inTargetBlock = false;
+  return currentArgs.filter((line) => {
+    if (line === header) {
+      inTargetBlock = true;
+      return false;
+    }
+    if (inTargetBlock && line.startsWith(VALIDATED_ARG_HEADER_PREFIX)) {
+      inTargetBlock = false;
+    }
+    if (!inTargetBlock) {
+      return true;
+    }
+
+    const count = remainingLines.get(line) ?? 0;
+    if (count === 0) {
+      return true;
+    }
+    remainingLines.set(line, count - 1);
+    return false;
+  });
 };
 
 /**

--- a/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/validatedConfigurationUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/fields/validatedConfigurations/validatedConfigurationUtils.ts
@@ -1,3 +1,9 @@
+import type {
+  RuntimeArgsFieldData,
+  ValidatedConfiguration,
+  ValidatedConfigurationOption,
+} from '../../../../shared/types/form-data';
+
 /**
  * Formats a validated configuration option value for display in the "View arguments" popover.
  * Normalizes line-continuation backslashes while preserving individual CLI arguments.
@@ -15,3 +21,81 @@ export const slugifyValidatedOptionTitle = (title: string): string =>
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
+
+export const getValidatedArgCommentHeader = (optionTitle: string): string =>
+  `# Validated arguments for ${optionTitle}`;
+
+/** Converts an option value into runtime-arg textarea lines (no shell `\` continuations). */
+export const optionValueToArgLines = (value: string): string[] =>
+  value
+    .split('\n')
+    .map((line) => line.replace(/\\$/, '').trim())
+    .filter(Boolean);
+
+export const getValidatedOptionArgBlock = (option: ValidatedConfigurationOption): string[] => [
+  getValidatedArgCommentHeader(option.title),
+  ...optionValueToArgLines(option.value),
+];
+
+export const toRuntimeArgsFieldData = (args: string[]): RuntimeArgsFieldData => ({
+  enabled: args.length > 0,
+  args,
+});
+
+/**
+ * Appends a validated option's comment header + arg lines. No-op if the header is already present.
+ */
+export const mergeValidatedOptionIntoArgs = (
+  currentArgs: string[],
+  option: ValidatedConfigurationOption,
+): string[] => {
+  const header = getValidatedArgCommentHeader(option.title);
+  if (currentArgs.includes(header)) {
+    return currentArgs;
+  }
+  return [...currentArgs, ...getValidatedOptionArgBlock(option)];
+};
+
+/**
+ * Removes only the comment header and known arg lines for this option.
+ * Leaves all other lines (including user edits) in place.
+ */
+export const removeValidatedOptionFromArgs = (
+  currentArgs: string[],
+  option: ValidatedConfigurationOption,
+): string[] => {
+  const linesToRemove = new Set(getValidatedOptionArgBlock(option));
+  return currentArgs.filter((line) => !linesToRemove.has(line));
+};
+
+/**
+ * Seeds runtime args from initially selected validated configurations (e.g. catalog deploy).
+ * Returns undefined when nothing is selected so the runtime-args hook keeps its empty default.
+ */
+export const buildRuntimeArgsFromValidatedSelections = (
+  configurations: ValidatedConfiguration[] | undefined,
+  selected: Record<string, string[]> | undefined,
+): RuntimeArgsFieldData | undefined => {
+  if (!configurations?.length || !selected) {
+    return undefined;
+  }
+
+  let args: string[] = [];
+  for (const configuration of configurations) {
+    if (configuration.forField !== 'args') {
+      continue;
+    }
+    const selectedValues = selected[configuration.forField] ?? [];
+    for (const option of configuration.options) {
+      if (selectedValues.includes(option.value)) {
+        args = mergeValidatedOptionIntoArgs(args, option);
+      }
+    }
+  }
+
+  if (args.length === 0) {
+    return undefined;
+  }
+
+  return toRuntimeArgsFieldData(args);
+};

--- a/packages/model-serving/src/components/deploymentWizard/steps/PreconfigureDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/PreconfigureDeploymentStep.tsx
@@ -60,6 +60,7 @@ export const PreconfigureDeploymentStepContent: React.FC<PreconfigureDeploymentS
         <ValidatedArgumentsSection
           configurations={validatedConfigurations}
           selection={wizardState.state.validatedConfigurationSelection}
+          runtimeArgs={wizardState.state.runtimeArgs}
         />
       )}
     </Form>

--- a/packages/model-serving/src/components/deploymentWizard/steps/ReviewStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ReviewStep.tsx
@@ -25,6 +25,7 @@ import {
   resolveFieldValue,
 } from '../../../shared/types/form-data';
 import { deploymentStrategyRecreate } from '../fields/DeploymentStrategyField';
+import { filterRuntimeArgsForContainer } from '../fields/RuntimeArgsField';
 import { ExternalDataMap } from '../ExternalDataLoader';
 import { isWizardStepTitle } from '../utils';
 
@@ -322,9 +323,12 @@ const getStatusSections = (
             if (!runtimeArgs || !runtimeArgs.enabled || runtimeArgs.args.length === 0) {
               return undefined;
             }
-            const allArgs = runtimeArgs.args.flatMap((arg) =>
+            const allArgs = filterRuntimeArgsForContainer(runtimeArgs.args).flatMap((arg) =>
               arg.trim().split(/\s+/).filter(Boolean),
             );
+            if (allArgs.length === 0) {
+              return undefined;
+            }
             return (
               <>
                 <div>{allArgs.length}</div>

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/PreconfigureDeploymentStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/PreconfigureDeploymentStep.test.tsx
@@ -147,6 +147,7 @@ describe('PreconfigureDeploymentStep', () => {
 
   it('should toggle validated configuration selection via wizard state', () => {
     const toggleOption = jest.fn();
+    const setRuntimeArgs = jest.fn();
     const wizardState = mockDeploymentWizardState({
       initialData: {
         validatedConfigurations: [mockToolCallingValidatedConfiguration()],
@@ -156,6 +157,10 @@ describe('PreconfigureDeploymentStep', () => {
           initialProjectName: undefined,
           projectName: undefined,
           setProjectName: jest.fn(),
+        },
+        runtimeArgs: {
+          data: { enabled: false, args: [] },
+          setData: setRuntimeArgs,
         },
         validatedConfigurationSelection: {
           selectedValidatedConfigurations: {},
@@ -180,6 +185,69 @@ describe('PreconfigureDeploymentStep', () => {
       mockToolCallingValidatedConfiguration().options[0].value,
       true,
     );
+    expect(setRuntimeArgs).toHaveBeenCalledTimes(1);
+    expect(typeof setRuntimeArgs.mock.calls[0][0]).toBe('function');
+    expect(setRuntimeArgs.mock.calls[0][0]({ enabled: false, args: [] })).toEqual({
+      enabled: true,
+      args: [
+        '# Validated arguments for Tool calling',
+        '--enable-auto-tool-choice',
+        '--tool-call-parser hermes',
+        '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+      ],
+    });
+  });
+
+  it('should remove validated runtime args when unchecking a configuration', () => {
+    const toggleOption = jest.fn();
+    const setRuntimeArgs = jest.fn();
+    const option = mockToolCallingValidatedConfiguration().options[0];
+    const wizardState = mockDeploymentWizardState({
+      initialData: {
+        validatedConfigurations: [mockToolCallingValidatedConfiguration()],
+      },
+      state: {
+        project: {
+          initialProjectName: undefined,
+          projectName: undefined,
+          setProjectName: jest.fn(),
+        },
+        runtimeArgs: {
+          data: {
+            enabled: true,
+            args: [
+              '# Validated arguments for Tool calling',
+              '--enable-auto-tool-choice',
+              '--tool-call-parser hermes',
+              '--chat-template /etc/vllm/templates/tool_chat_template_hermes.jinja',
+              '--user-arg',
+            ],
+          },
+          setData: setRuntimeArgs,
+        },
+        validatedConfigurationSelection: {
+          selectedValidatedConfigurations: { args: [option.value] },
+          toggleOption,
+          isOptionSelected: jest.fn().mockReturnValue(true),
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <ProjectsContext.Provider value={createProjectsContextValue()}>
+          <PreconfigureDeploymentStepContent wizardState={wizardState} />
+        </ProjectsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByTestId('validated-configuration-option-checkbox-tool-calling'));
+
+    expect(toggleOption).toHaveBeenCalledWith('args', option.value, false);
+    expect(setRuntimeArgs.mock.calls[0][0](wizardState.state.runtimeArgs.data)).toEqual({
+      enabled: true,
+      args: ['--user-arg'],
+    });
   });
 
   it('should not render any card when validatedConfigurations has no options for a field', () => {

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
@@ -23,6 +23,7 @@ import { useCreateConnectionData } from './fields/CreateConnectionInputFields';
 import { useProjectSection } from './fields/ProjectSection';
 import { useDeploymentStrategyField } from './fields/DeploymentStrategyField';
 import { useValidatedConfigurationsField } from './fields/validatedConfigurations/useValidatedConfigurationsField';
+import { buildRuntimeArgsFromValidatedSelections } from './fields/validatedConfigurations/validatedConfigurationUtils';
 import {
   useDeploymentWizardReducer,
   wizardFormReducer,
@@ -142,7 +143,13 @@ export const useModelDeploymentWizard = (
     canCreateRoleBindings,
   );
 
-  const runtimeArgs = useRuntimeArgsField(initialData?.runtimeArgs ?? undefined);
+  const runtimeArgs = useRuntimeArgsField(
+    initialData?.runtimeArgs ??
+      buildRuntimeArgsFromValidatedSelections(
+        initialData?.validatedConfigurations,
+        initialData?.selectedValidatedConfigurations,
+      ),
+  );
   const environmentVariables = useEnvironmentVariablesField(
     initialData?.environmentVariables ?? undefined,
   );

--- a/packages/model-serving/src/shared/wizard-fields.ts
+++ b/packages/model-serving/src/shared/wizard-fields.ts
@@ -56,6 +56,7 @@ export {
   RuntimeArgsField,
   runtimeArgsFieldSchema,
   isValidRuntimeArgs,
+  filterRuntimeArgsForContainer,
   useRuntimeArgsField,
   type RuntimeArgsFieldData,
   type RuntimeArgsFieldHook,

--- a/packages/nim-serving/src/api/nimservices/k8s.ts
+++ b/packages/nim-serving/src/api/nimservices/k8s.ts
@@ -11,6 +11,7 @@ import type {
   EnvironmentVariablesFieldData,
   RuntimeArgsFieldData,
 } from '@odh-dashboard/model-serving/shared/types/form-data';
+import { filterRuntimeArgsForContainer } from '@odh-dashboard/model-serving/shared/wizard-fields';
 import type { HardwareProfileConfig } from '@odh-dashboard/hardware-profiles/shared';
 import { applyHardwareProfileConfig } from '@odh-dashboard/hardware-profiles/shared';
 import {
@@ -187,7 +188,12 @@ export const assembleNIMService = (
   }
 
   if (runtimeArgs?.enabled && runtimeArgs.args.length > 0) {
-    nimService.spec.args = runtimeArgs.args;
+    const containerArgs = filterRuntimeArgsForContainer(runtimeArgs.args);
+    if (containerArgs.length > 0) {
+      nimService.spec.args = containerArgs;
+    } else {
+      delete nimService.spec.args;
+    }
   } else {
     delete nimService.spec.args;
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-69427

## Description

Wires selected validated configurations from the model catalog into the deployment wizard's runtime args field.

- Checkbox handlers on validated configuration cards immediately merge/remove args (with `# Validated arguments for {name}` headers) into `runtimeArgs` — no `useEffect` sync
- Catalog deploy default-checked options seed `runtimeArgs` at wizard init so Advanced Settings starts populated
- `#` comment lines are stripped at submit in KServe / LLMD / NIM apply paths (comments are UX-only in the textarea)
- Review step hides comment headers when summarizing args

https://github.com/user-attachments/assets/b61a84c7-7a22-432d-a65a-f5d046f53f05

## How Has This Been Tested?

Manual testing on a cluster via model catalog deploy for a model with validated configurations (e.g. Tool calling):

- Prefill: Advanced Settings shows validated args with “Add custom runtime arguments” enabled
- Check/uncheck validated card merges/removes only the validated block
- Custom textarea edits are preserved across toggle
- Review step shows additional runtime arguments without `#` comment headers
- Unit tests and Cypress mocked coverage for merge/remove/review paths

Also covered by automated tests listed under Test Impact.

## Test Impact

- Unit: `validatedConfigurationUtils.spec.ts`, `RuntimeArgsField.spec.ts`, `PreconfigureDeploymentStep.test.tsx`, `deployUtils.spec.ts` (comment strip on apply)
- Cypress mocked: `preconfigureValidatedArguments.cy.ts` (check adds args, uncheck removes, user edits preserved, review displays)

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Validated deployment selections now automatically populate runtime arguments.
  * Removing a selection removes only its generated arguments while preserving custom entries.
  * Review screens display only runtime arguments supported by the serving container.
* **Bug Fixes**
  * Blank lines and comments are excluded from deployed configurations.
  * Empty or disabled runtime-argument settings are no longer submitted.
  * Runtime arguments now apply consistently across supported serving deployments.
* **Tests**
  * Added coverage for filtering, selection, removal, preservation, and review behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->