### PR TITLE
feat(gen-ai): implement /v1/chat/completions proxy handler (non-streaming) [RHOAIENG-79574]

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -535,6 +535,7 @@ func (app *App) Routes() http.Handler {
 	// No AttachBFFMaaSClient: MaaS fetch is best-effort inside the handler and must not
 	// block the endpoint with a 503 when the MaaS BFF is not configured.
 	apiRouter.GET(constants.GenAIProxyNSModelsPath, app.GenAIProxyNSModelsHandler)
+	apiRouter.POST(constants.GenAIProxyNSChatCompletionsPath, app.GenAIProxyNSChatCompletionsHandler)
 
 	// App Router
 	appMux := http.NewServeMux()

--- a/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler.go
@@ -53,9 +53,9 @@ func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *htt
 	}
 
 	var reqBody struct {
-		Model    string      `json:"model"`
-		Messages interface{} `json:"messages"`
-		Stream   *bool       `json:"stream"`
+		Model    string          `json:"model"`
+		Messages json.RawMessage `json:"messages"`
+		Stream   *bool           `json:"stream"`
 	}
 	if err := json.Unmarshal(body, &reqBody); err != nil {
 		app.badRequestResponse(w, r, fmt.Errorf("invalid JSON in request body: %w", err))
@@ -65,8 +65,13 @@ func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *htt
 		app.badRequestResponse(w, r, errors.New("missing required field: model"))
 		return
 	}
-	if reqBody.Messages == nil {
+	if len(reqBody.Messages) == 0 || string(reqBody.Messages) == "null" {
 		app.badRequestResponse(w, r, errors.New("missing required field: messages"))
+		return
+	}
+	// Validate messages is a JSON array
+	if reqBody.Messages[0] != '[' {
+		app.badRequestResponse(w, r, errors.New("messages must be a JSON array"))
 		return
 	}
 	if reqBody.Stream != nil && *reqBody.Stream {
@@ -86,13 +91,15 @@ func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Strip provider prefix from model ID in the proxied body
+	// Strip provider prefix from model ID in the proxied body.
+	// Use json.RawMessage-based rewrite to preserve numeric precision.
 	upstreamBody := body
 	if strings.Contains(reqBody.Model, "/") {
 		bareModel := reqBody.Model[strings.Index(reqBody.Model, "/")+1:]
-		var bodyMap map[string]interface{}
+		var bodyMap map[string]json.RawMessage
 		if err := json.Unmarshal(body, &bodyMap); err == nil {
-			bodyMap["model"] = bareModel
+			quotedModel, _ := json.Marshal(bareModel)
+			bodyMap["model"] = quotedModel
 			if rewritten, err := json.Marshal(bodyMap); err == nil {
 				upstreamBody = rewritten
 			}
@@ -106,14 +113,17 @@ func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *htt
 	}
 
 	// Proxy the request to upstream.
-	// Use a dedicated timeout context (3 min) — LLM chat completions can take longer
+	// Use a dedicated client with 3-min timeout — LLM chat completions can take longer
 	// than the BFF's default httpClient timeout (92s, tuned for ASR transcription).
+	// Reuse the same TLS transport for connection pooling and cert trust.
 	const chatCompletionTimeout = 3 * time.Minute
-	proxyCtx, proxyCancel := context.WithTimeout(ctx, chatCompletionTimeout)
-	defer proxyCancel()
+	proxyClient := &http.Client{
+		Timeout:   chatCompletionTimeout,
+		Transport: app.httpClient.Transport,
+	}
 
 	upstreamURL := baseURL + "/chat/completions"
-	proxyReq, err := http.NewRequestWithContext(proxyCtx, http.MethodPost, upstreamURL, strings.NewReader(string(upstreamBody)))
+	proxyReq, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, strings.NewReader(string(upstreamBody)))
 	if err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("failed to create upstream request: %w", err))
 		return
@@ -123,7 +133,7 @@ func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *htt
 		proxyReq.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 
-	resp, err := app.httpClient.Do(proxyReq)
+	resp, err := proxyClient.Do(proxyReq)
 	if err != nil {
 		app.errorResponse(w, r, &integrations.HTTPError{
 			StatusCode: http.StatusBadGateway,
@@ -138,18 +148,40 @@ func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *htt
 
 	// Forward the upstream response unchanged (transparent proxy).
 	// Limit read to 10MB to prevent memory exhaustion from malicious/faulty upstreams.
-	const maxResponseBytes = 10 * 1024 * 1024
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	// If the response exceeds the limit, return 502 instead of silently truncating.
+	const maxResponseBytes int64 = 10 * 1024 * 1024
+	limitedReader := io.LimitReader(resp.Body, maxResponseBytes+1)
+	respBody, err := io.ReadAll(limitedReader)
 	if err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("failed to read upstream response: %w", err))
 		return
 	}
+	if int64(len(respBody)) > maxResponseBytes {
+		app.errorResponse(w, r, &integrations.HTTPError{
+			StatusCode: http.StatusBadGateway,
+			ErrorResponse: integrations.ErrorResponse{
+				Code:    "502",
+				Message: "upstream response too large (exceeds 10MB limit)",
+			},
+		})
+		return
+	}
 
-	// Copy upstream response headers, excluding hop-by-hop and framing headers
-	// that may be invalidated by buffering/truncation (Content-Length, Transfer-Encoding).
+	// Copy upstream response headers, excluding hop-by-hop headers (RFC 7230 §6.1)
+	// and framing headers invalidated by buffering.
+	hopByHop := map[string]bool{
+		"connection":          true,
+		"keep-alive":          true,
+		"proxy-authenticate":  true,
+		"proxy-authorization": true,
+		"te":                  true,
+		"trailer":             true,
+		"transfer-encoding":   true,
+		"upgrade":             true,
+		"content-length":      true,
+	}
 	for key, values := range resp.Header {
-		lowerKey := strings.ToLower(key)
-		if lowerKey == "content-length" || lowerKey == "transfer-encoding" {
+		if hopByHop[strings.ToLower(key)] {
 			continue
 		}
 		for _, v := range values {

--- a/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/opendatahub-io/gen-ai/internal/constants"
@@ -104,9 +105,15 @@ func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *htt
 		baseURL += "/v1"
 	}
 
-	// Proxy the request to upstream
+	// Proxy the request to upstream.
+	// Use a dedicated timeout context (3 min) — LLM chat completions can take longer
+	// than the BFF's default httpClient timeout (92s, tuned for ASR transcription).
+	const chatCompletionTimeout = 3 * time.Minute
+	proxyCtx, proxyCancel := context.WithTimeout(ctx, chatCompletionTimeout)
+	defer proxyCancel()
+
 	upstreamURL := baseURL + "/chat/completions"
-	proxyReq, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, strings.NewReader(string(upstreamBody)))
+	proxyReq, err := http.NewRequestWithContext(proxyCtx, http.MethodPost, upstreamURL, strings.NewReader(string(upstreamBody)))
 	if err != nil {
 		app.serverErrorResponse(w, r, fmt.Errorf("failed to create upstream request: %w", err))
 		return
@@ -138,8 +145,13 @@ func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Copy all upstream response headers for transparent proxy behavior
+	// Copy upstream response headers, excluding hop-by-hop and framing headers
+	// that may be invalidated by buffering/truncation (Content-Length, Transfer-Encoding).
 	for key, values := range resp.Header {
+		lowerKey := strings.ToLower(key)
+		if lowerKey == "content-length" || lowerKey == "transfer-encoding" {
+			continue
+		}
 		for _, v := range values {
 			w.Header().Add(key, v)
 		}

--- a/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler.go
@@ -49,6 +49,17 @@ func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *htt
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			app.errorResponse(w, r, &integrations.HTTPError{
+				StatusCode: http.StatusRequestEntityTooLarge,
+				ErrorResponse: integrations.ErrorResponse{
+					Code:    "413",
+					Message: "request body exceeds the 5MB limit",
+				},
+			})
+			return
+		}
 		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
 		return
 	}

--- a/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler.go
@@ -45,7 +45,8 @@ func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Read the full request body — needed for model extraction and transparent proxying
+	r.Body = http.MaxBytesReader(w, r.Body, constants.ChatCompletionMaxBodySize)
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))

--- a/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler.go
@@ -1,0 +1,237 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
+	k8s "github.com/opendatahub-io/gen-ai/internal/integrations/kubernetes"
+)
+
+// GenAIProxyNSChatCompletionsHandler handles POST /api/v1/genai-proxy/ns/:namespace/v1/chat/completions.
+//
+// Accepts an OpenAI-compatible chat completion request (non-streaming only),
+// resolves the model to a concrete endpoint and credentials, and proxies the
+// request directly to the upstream model. Returns the upstream response unchanged.
+//
+// Streaming (stream:true) is handled by a separate endpoint (RHOAIENG-79575).
+//
+// Auth is required: OGX forwards the user's JWT via X-OGX-Provider-Data →
+// forward_headers → x-forwarded-access-token header.
+func (app *App) GenAIProxyNSChatCompletionsHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace := ps.ByName("namespace")
+	if namespace == "" {
+		app.badRequestResponse(w, r, errors.New("missing namespace in path"))
+		return
+	}
+
+	ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, namespace)
+	r = r.WithContext(ctx)
+
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if !ok || identity == nil || identity.Token == "" {
+		app.unauthorizedResponse(w, r, errors.New("missing authentication identity"))
+		return
+	}
+
+	// Read the full request body — needed for model extraction and transparent proxying
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return
+	}
+
+	var reqBody struct {
+		Model    string      `json:"model"`
+		Messages interface{} `json:"messages"`
+		Stream   *bool       `json:"stream"`
+	}
+	if err := json.Unmarshal(body, &reqBody); err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("invalid JSON in request body: %w", err))
+		return
+	}
+	if reqBody.Model == "" {
+		app.badRequestResponse(w, r, errors.New("missing required field: model"))
+		return
+	}
+	if reqBody.Messages == nil {
+		app.badRequestResponse(w, r, errors.New("missing required field: messages"))
+		return
+	}
+	if reqBody.Stream != nil && *reqBody.Stream {
+		app.badRequestResponse(w, r, errors.New("streaming is not supported on this endpoint; use the streaming endpoint instead"))
+		return
+	}
+
+	// Resolve model → endpoint URL + credentials
+	baseURL, apiKey, resolveErr := app.resolveProxyModelEndpoint(ctx, reqBody.Model, namespace)
+	if resolveErr != nil {
+		app.logger.Warn("Model resolution failed", "model", reqBody.Model, "error", resolveErr)
+		if isProxyInfraError(resolveErr) {
+			app.serverErrorResponse(w, r, fmt.Errorf("failed to resolve model %q: %w", reqBody.Model, resolveErr))
+		} else {
+			app.notFoundResponse(w, r)
+		}
+		return
+	}
+
+	// Strip provider prefix from model ID in the proxied body
+	upstreamBody := body
+	if strings.Contains(reqBody.Model, "/") {
+		bareModel := reqBody.Model[strings.Index(reqBody.Model, "/")+1:]
+		var bodyMap map[string]interface{}
+		if err := json.Unmarshal(body, &bodyMap); err == nil {
+			bodyMap["model"] = bareModel
+			if rewritten, err := json.Marshal(bodyMap); err == nil {
+				upstreamBody = rewritten
+			}
+		}
+	}
+
+	// Normalize base URL to include /v1 if missing
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	if !strings.HasSuffix(baseURL, "/v1") {
+		baseURL += "/v1"
+	}
+
+	// Proxy the request to upstream
+	upstreamURL := baseURL + "/chat/completions"
+	proxyReq, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, strings.NewReader(string(upstreamBody)))
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to create upstream request: %w", err))
+		return
+	}
+	proxyReq.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		proxyReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := app.httpClient.Do(proxyReq)
+	if err != nil {
+		app.errorResponse(w, r, &integrations.HTTPError{
+			StatusCode: http.StatusBadGateway,
+			ErrorResponse: integrations.ErrorResponse{
+				Code:    "502",
+				Message: fmt.Sprintf("upstream unreachable: %v", err),
+			},
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	// Forward the upstream response unchanged (transparent proxy).
+	// Limit read to 10MB to prevent memory exhaustion from malicious/faulty upstreams.
+	const maxResponseBytes = 10 * 1024 * 1024
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to read upstream response: %w", err))
+		return
+	}
+
+	// Copy all upstream response headers for transparent proxy behavior
+	for key, values := range resp.Header {
+		for _, v := range values {
+			w.Header().Add(key, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(respBody)
+}
+
+// resolveProxyModelEndpoint resolves a model ID to its upstream endpoint URL and API key.
+// Reuses the same resolution logic as the embeddings handler.
+func (app *App) resolveProxyModelEndpoint(ctx context.Context, modelID, namespace string) (baseURL, apiKey string, err error) {
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if !ok || identity == nil {
+		return "", "", fmt.Errorf("missing RequestIdentity in context")
+	}
+
+	k8sClient, k8sErr := app.kubernetesClientFactory.GetClient(ctx)
+	if k8sErr != nil {
+		return "", "", &proxyInfraError{msg: fmt.Sprintf("failed to get Kubernetes client: %v", k8sErr)}
+	}
+
+	// Resolution priority:
+	// 1. MaaS (maas- prefix) → MaaS BFF catalog URL + ephemeral token
+	// 2. Custom endpoint (provider-qualified with "/") → ConfigMap + Secret
+	// 3. Namespace ISVC fallback (bare name) → InferenceService URL + user JWT
+	if strings.HasPrefix(modelID, constants.MaaSProviderPrefix) {
+		if app.bffClientFactory == nil || !app.bffClientFactory.IsTargetConfigured(bffclient.BFFTargetMaaS) {
+			return "", "", &proxyInfraError{msg: "MaaS is not available"}
+		}
+		maasHeaders := map[string]string{constants.MaaSReturnAllModelsHeader: "true"}
+		maasClient := app.bffClientFactory.CreateClientWithHeaders(bffclient.BFFTargetMaaS, identity.Token, maasHeaders)
+		ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(bffclient.BFFTargetMaaS)), maasClient)
+
+		inferenceURL, urlErr := app.resolveMaaSModelInferenceURL(ctx, identity, modelID)
+		if urlErr != nil {
+			return "", "", fmt.Errorf("failed to resolve MaaS inference URL: %w", urlErr)
+		}
+		token := app.getMaaSTokenForModel(ctx, k8sClient, identity, namespace, modelID, "")
+		if token == "" {
+			return "", "", &proxyInfraError{msg: fmt.Sprintf("failed to obtain auth token for MaaS model %q", modelID)}
+		}
+		return inferenceURL, token, nil
+	}
+
+	// Try custom endpoint for provider-qualified IDs (contains "/")
+	if strings.Contains(modelID, "/") {
+		extURL, extKey := app.getCustomEndpointBaseURLAndKey(ctx, modelID)
+		if extURL != "" {
+			return extURL, extKey, nil
+		}
+	}
+
+	// Fallback: namespace ISVC (bare name or failed custom endpoint lookup)
+	return app.resolveProxyNamespaceModel(ctx, k8sClient, identity, namespace, modelID)
+}
+
+// resolveProxyNamespaceModel resolves a namespace model to its endpoint URL.
+func (app *App) resolveProxyNamespaceModel(ctx context.Context, k8sClient k8s.KubernetesClientInterface, identity *integrations.RequestIdentity, namespace, modelID string) (string, string, error) {
+	bareModelName := modelID
+	if idx := strings.Index(modelID, "/"); idx != -1 {
+		bareModelName = modelID[idx+1:]
+	}
+
+	isvcURL, err := k8sClient.GetInferenceServiceURL(ctx, identity, namespace, bareModelName)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return "", "", fmt.Errorf("model %q not found: %w", bareModelName, err)
+		}
+		return "", "", &proxyInfraError{msg: fmt.Sprintf("failed to resolve model %q: %v", bareModelName, err)}
+	}
+	if isvcURL == "" {
+		return "", "", fmt.Errorf("empty URL for model %q", bareModelName)
+	}
+
+	return isvcURL, identity.Token, nil
+}
+
+// proxyInfraError signals an infrastructure failure (K8s client unavailable, MaaS down)
+// as opposed to a "model not found" scenario. Used to distinguish 500/502 from 404.
+type proxyInfraError struct {
+	msg string
+}
+
+func (e *proxyInfraError) Error() string { return e.msg }
+
+func isProxyInfraError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ie *proxyInfraError
+	if errors.As(err, &ie) {
+		return true
+	}
+	return strings.Contains(err.Error(), "failed to get Kubernetes client")
+}

--- a/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler_test.go
@@ -99,6 +99,79 @@ var _ = Describe("GenAIProxyNSChatCompletionsHandler", func() {
 		assert.Contains(t, errResp["error"].(map[string]interface{})["message"], "streaming")
 	})
 
+	It("should return 400 when messages is not a JSON array", func() {
+		t := GinkgoT()
+		body := `{"model":"some-model","messages":{"role":"user","content":"hi"}}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSChatCompletionsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		var errResp map[string]interface{}
+		err := json.Unmarshal(rr.Body.Bytes(), &errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp["error"].(map[string]interface{})["message"], "array")
+	})
+
+	It("should return 413 when request body exceeds size limit", func() {
+		t := GinkgoT()
+		oversized := `{"model":"m","messages":[{"role":"user","content":"` + strings.Repeat("x", 6*1024*1024) + `"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/chat/completions", strings.NewReader(oversized))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSChatCompletionsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+	})
+
+	It("should strip provider prefix from model ID when proxying", func() {
+		t := GinkgoT()
+
+		var receivedModel string
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqBody, _ := io.ReadAll(r.Body)
+			var parsed map[string]interface{}
+			_ = json.Unmarshal(reqBody, &parsed)
+			receivedModel, _ = parsed["model"].(string)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"id":"chatcmpl-1","object":"chat.completion","choices":[]}`)
+		}))
+		defer upstream.Close()
+
+		app.httpClient = &http.Client{
+			Transport: &redirectTransport{target: upstream.URL},
+		}
+
+		body := `{"model":"vllm-1/llama-32-3b-instruct","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/mock-test-namespace-1/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "mock-test-namespace-1")
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "mock-test-namespace-1"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSChatCompletionsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "llama-32-3b-instruct", receivedModel)
+	})
+
 	It("should return 404 when model is not found", func() {
 		t := GinkgoT()
 		body := `{"model":"nonexistent-model","messages":[{"role":"user","content":"hi"}]}`
@@ -169,7 +242,8 @@ type redirectTransport struct {
 }
 
 func (t *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.URL.Scheme = "http"
-	req.URL.Host = strings.TrimPrefix(t.target, "http://")
-	return http.DefaultTransport.RoundTrip(req)
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = "http"
+	clone.URL.Host = strings.TrimPrefix(t.target, "http://")
+	return http.DefaultTransport.RoundTrip(clone)
 }

--- a/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -113,5 +115,46 @@ var _ = Describe("GenAIProxyNSChatCompletionsHandler", func() {
 		app.GenAIProxyNSChatCompletionsHandler(rr, req, params)
 
 		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	It("should proxy request to upstream and return response (happy path)", func() {
+		t := GinkgoT()
+
+		upstreamResponse := `{"id":"chatcmpl-123","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"Hello!"}}]}`
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			reqBody, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var parsed map[string]interface{}
+			require.NoError(t, json.Unmarshal(reqBody, &parsed))
+			assert.Equal(t, "llama-32-3b-instruct", parsed["model"])
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, upstreamResponse)
+		}))
+		defer upstream.Close()
+
+		app.httpClient = upstream.Client()
+
+		body := fmt.Sprintf(`{"model":"llama-32-3b-instruct","messages":[{"role":"user","content":"hi"}]}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/mock-test-namespace-1/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "mock-test-namespace-1")
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "mock-test-namespace-1"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSChatCompletionsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+		assert.Contains(t, rr.Body.String(), "chatcmpl-123")
 	})
 })

--- a/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler_test.go
@@ -123,7 +123,7 @@ var _ = Describe("GenAIProxyNSChatCompletionsHandler", func() {
 		upstreamResponse := `{"id":"chatcmpl-123","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"Hello!"}}]}`
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+			assert.Contains(t, r.URL.Path, "/chat/completions")
 			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
 			reqBody, err := io.ReadAll(r.Body)
@@ -138,9 +138,12 @@ var _ = Describe("GenAIProxyNSChatCompletionsHandler", func() {
 		}))
 		defer upstream.Close()
 
-		app.httpClient = upstream.Client()
+		// Redirect all outgoing HTTP to our test server regardless of target URL.
+		app.httpClient = &http.Client{
+			Transport: &redirectTransport{target: upstream.URL},
+		}
 
-		body := fmt.Sprintf(`{"model":"llama-32-3b-instruct","messages":[{"role":"user","content":"hi"}]}`)
+		body := `{"model":"llama-32-3b-instruct","messages":[{"role":"user","content":"hi"}]}`
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/mock-test-namespace-1/v1/chat/completions", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 
@@ -158,3 +161,15 @@ var _ = Describe("GenAIProxyNSChatCompletionsHandler", func() {
 		assert.Contains(t, rr.Body.String(), "chatcmpl-123")
 	})
 })
+
+// redirectTransport intercepts all HTTP requests and rewrites their URL to point
+// at a local test server, preserving the original path and query.
+type redirectTransport struct {
+	target string
+}
+
+func (t *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(t.target, "http://")
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/genai_proxy_chat_handler_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = Describe("GenAIProxyNSChatCompletionsHandler", func() {
+	var app App
+
+	BeforeEach(func() {
+		app = NewK8sLSTestApp()
+	})
+
+	It("should return 401 without auth identity", func() {
+		body := `{"model":"some-model","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSChatCompletionsHandler(rr, req, params)
+
+		assert.Equal(GinkgoT(), http.StatusUnauthorized, rr.Code)
+	})
+
+	It("should return 400 when model field is missing", func() {
+		t := GinkgoT()
+		body := `{"messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSChatCompletionsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		var errResp map[string]interface{}
+		err := json.Unmarshal(rr.Body.Bytes(), &errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp["error"].(map[string]interface{})["message"], "model")
+	})
+
+	It("should return 400 when messages field is missing", func() {
+		t := GinkgoT()
+		body := `{"model":"some-model"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSChatCompletionsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		var errResp map[string]interface{}
+		err := json.Unmarshal(rr.Body.Bytes(), &errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp["error"].(map[string]interface{})["message"], "messages")
+	})
+
+	It("should return 400 when stream is true", func() {
+		t := GinkgoT()
+		body := `{"model":"some-model","messages":[{"role":"user","content":"hi"}],"stream":true}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSChatCompletionsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		var errResp map[string]interface{}
+		err := json.Unmarshal(rr.Body.Bytes(), &errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp["error"].(map[string]interface{})["message"], "streaming")
+	})
+
+	It("should return 404 when model is not found", func() {
+		t := GinkgoT()
+		body := `{"model":"nonexistent-model","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/genai-proxy/ns/test-ns/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "test-ns")
+		req = req.WithContext(ctx)
+
+		params := httprouter.Params{{Key: "namespace", Value: "test-ns"}}
+		rr := httptest.NewRecorder()
+		app.GenAIProxyNSChatCompletionsHandler(rr, req, params)
+
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+})

--- a/packages/gen-ai/bff/internal/constants/api_constants.go
+++ b/packages/gen-ai/bff/internal/constants/api_constants.go
@@ -82,5 +82,6 @@ const (
 
 	// GenAI Proxy — OpenAI-compatible surface for OGX's remote::passthrough provider.
 	// OGX base_url must include the namespace: .../api/v1/genai-proxy/ns/<namespace>
-	GenAIProxyNSModelsPath = ApiPathPrefix + "/genai-proxy/ns/:namespace/v1/models"
+	GenAIProxyNSModelsPath          = ApiPathPrefix + "/genai-proxy/ns/:namespace/v1/models"
+	GenAIProxyNSChatCompletionsPath = ApiPathPrefix + "/genai-proxy/ns/:namespace/v1/chat/completions"
 )

--- a/packages/gen-ai/bff/internal/constants/limits.go
+++ b/packages/gen-ai/bff/internal/constants/limits.go
@@ -27,6 +27,10 @@ const (
 	// initial body parsing. Set to the largest per-type limit (currently 10MB).
 	MediaUploadMaxBodySize = 10 << 20 // 10MB
 
+	// ChatCompletionMaxBodySize caps the request body for POST /v1/chat/completions proxy.
+	// Chat payloads are JSON with messages array; 5MB accommodates large conversation history.
+	ChatCompletionMaxBodySize = 5 << 20 // 5MB
+
 	// OGXFileRetrievalTimeout is the timeout for retrieving file content from OGX.
 	OGXFileRetrievalTimeout = 10 * time.Second
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-79574

## Description

Implement `POST /api/v1/genai-proxy/ns/:namespace/v1/chat/completions` — a transparent proxy that accepts OpenAI-compatible chat completion requests (non-streaming), resolves the model to a concrete upstream endpoint with credentials, and forwards the request directly to the underlying model.

### What was added

- `genai_proxy_chat_handler.go` — POST handler + `resolveProxyModelEndpoint()` + `resolveProxyNamespaceModel()` + `proxyInfraError` type
- `genai_proxy_chat_handler_test.go` — 5 unit tests covering error paths
- `GenAIProxyNSChatCompletionsPath` constant
- Route registration in `app.go`

### How model resolution works

Same chain as the embeddings handler (PR #9245):
- **MaaS models** (`maas-` prefix): resolves inference URL via MaaS BFF catalog + ephemeral token
- **Custom endpoints** (provider-qualified with `/`): resolves from `gen-ai-aa-custom-model-endpoints` ConfigMap + K8s Secret
- **Namespace models** (bare name): resolves InferenceService/LLMInferenceService URL + user JWT

Provider prefix is stripped from the `model` field before proxying (upstream expects bare model name).

### Streaming explicitly rejected

Requests with `"stream": true` are rejected with 400 and a clear message directing to the streaming endpoint. Streaming is handled by a separate story ([RHOAIENG-79575](https://redhat.atlassian.net/browse/RHOAIENG-79575)) which requires SSE passthrough infrastructure.

### Design decisions

**Dedicated 3-minute timeout:** LLM chat completions with long context windows or complex reasoning can exceed the BFF's default httpClient timeout (92s, tuned for ASR). The handler uses a request-scoped context with 3-minute timeout .

**Filtered response headers:** `Content-Length` and `Transfer-Encoding` are excluded when copying upstream headers. The handler buffers the response (up to 10MB) before writing, so the original framing headers would cause clients to hang or see truncated data.

**Infrastructure error classification:** `proxyInfraError` type distinguishes K8s/MaaS failures (500) from model-not-found (404). Same pattern as embeddings handler.

**Reference:** Architecture validated in spike [RHOAIENG-78871](https://redhat.atlassian.net/browse/RHOAIENG-78871): "POST /api/v1/genai-proxy/ns/:namespace/v1/chat/completions — resolves endpoint + credentials via K8s, proxies directly to model (streaming supported)."

## How Has This Been Tested?

### Unit tests

- `make test` — all specs pass
- 5 handler-specific tests: 401 (no auth), 400 (missing model), 400 (missing messages), 400 (stream:true rejected), 404 (model not found)

### End-to-end cluster validation

Deployed custom BFF image on an OpenShift cluster (RHOAI 3.6-ea.1). Validated via port-forward to the `gen-ai-ui` pod.

**Error path validation:**

```bash
TOKEN=$(oc whoami -t)
oc port-forward deploy/gen-ai-ui -n redhat-ods-applications 8143:8143 &

# 401
curl -sk -X POST "https://localhost:8143/api/v1/genai-proxy/ns/test-ns/v1/chat/completions" \
  -H "Content-Type: application/json" -d '{"model":"x","messages":[{"role":"user","content":"hi"}]}'
# → 401 "missing required Header: x-forwarded-access-token"

# 400 missing model
curl -sk -X POST "https://localhost:8143/api/v1/genai-proxy/ns/test-ns/v1/chat/completions" \
  -H "x-forwarded-access-token: $TOKEN" -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"hi"}]}'
# → 400 "missing required field: model"

# 400 stream:true
curl -sk -X POST "https://localhost:8143/api/v1/genai-proxy/ns/test-ns/v1/chat/completions" \
  -H "x-forwarded-access-token: $TOKEN" -H "Content-Type: application/json" \
  -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"stream":true}'
# → 400 "streaming is not supported on this endpoint; use the streaming endpoint instead"

# 404 model not found
curl -sk -X POST "https://localhost:8143/api/v1/genai-proxy/ns/gaizka-test/v1/chat/completions" \
  -H "x-forwarded-access-token: $TOKEN" -H "Content-Type: application/json" \
  -d '{"model":"nonexistent","messages":[{"role":"user","content":"hi"}]}'
# → 404 "the requested resource could not be found"
```

**Happy path (200 — real chat completion from Qwen via LiteMaaS):**

```bash
# Custom endpoint pointing to LiteMaaS with Qwen model
curl -sk -X POST "https://localhost:8143/api/v1/genai-proxy/ns/gaizka-test/v1/chat/completions" \
  -H "x-forwarded-access-token: $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"model":"litellm-chat/Qwen3.6-35B-A3B","messages":[{"role":"user","content":"Say hi in one word"}]}'
```

**Result:**
```json
{
  "model": "qwen36-35b-a3b-fp8",
  "choices": [{"finish_reason": "stop", "message": {"content": "\n\nHi", "role": "assistant"}}],
  "usage": {"completion_tokens": 381, "prompt_tokens": 15, "total_tokens": 396}
}
```
HTTP 200 ✅ — Full chain: ConfigMap → Secret → provider prefix stripped → LiteMaaS → Qwen → real chat response.

## Jira

- **Ticket:** [RHOAIENG-79574](https://redhat.atlassian.net/browse/RHOAIENG-79574)
- **Epic:** [RHOAIENG-79569](https://redhat.atlassian.net/browse/RHOAIENG-79569) (OGX Zero-Restart — BFF /v1/ Proxy Endpoints)
- **Feature:** [RHAISTRAT-1921](https://redhat.atlassian.net/browse/RHAISTRAT-1921)
- **Spike:** [RHOAIENG-78871](https://redhat.atlassian.net/browse/RHOAIENG-78871)

[RHOAIENG-79574]: https://redhat.atlassian.net/browse/RHOAIENG-79574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RHOAIENG-79575]: https://redhat.atlassian.net/browse/RHOAIENG-79575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAI-compatible chat completions endpoint for namespace-scoped GenAI requests.
  * Supports MaaS, custom, and namespace-backed models.
  * Preserves compatible upstream responses and headers.
  * Limits request bodies to 5 MB and supports non-streaming completions.

* **Bug Fixes**
  * Added validation for authentication, model names, messages, and unsupported streaming requests.
  * Improved handling of unavailable models and infrastructure failures.

* **Tests**
  * Added coverage for authentication, request validation, streaming rejection, and missing-model scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->