### PR TITLE
RHOAIENG-82807: Split HostApi into Core/Infra contexts

### DIFF
--- a/frontend/src/api/prometheus/usePrometheusQueryRange.ts
+++ b/frontend/src/api/prometheus/usePrometheusQueryRange.ts
@@ -1,22 +1,23 @@
-import * as React from 'react';
-import useFetchState, {
-  FetchOptions,
-  FetchState,
-  FetchStateCallbackPromise,
-  NotReadyError,
-} from '@odh-dashboard/ui-core/hooks/useFetchState';
-import type {
-  PrometheusQueryRangeResponse,
-  PrometheusQueryRangeResponseData,
-  PrometheusQueryRangeResponseDataResult,
-  PrometheusQueryRangeResultValue,
-} from '@odh-dashboard/ui-core/types/metrics';
+import type { FetchOptions, FetchState } from '@odh-dashboard/ui-core/hooks/useFetchState';
+import type { PrometheusQueryRangeResultValue } from '@odh-dashboard/ui-core/types/metrics';
+import baseUsePrometheusQueryRange, {
+  type PrometheusPostFn,
+  type ResponsePredicate,
+} from '@odh-dashboard/ui-core/utilities/metrics/usePrometheusQueryRange';
 import axios from '#~/utilities/axios';
 
-export type ResponsePredicate<T = PrometheusQueryRangeResultValue> = (
-  data: PrometheusQueryRangeResponseData,
-) => T[];
+export type { ResponsePredicate } from '@odh-dashboard/ui-core/utilities/metrics/usePrometheusQueryRange';
+export {
+  defaultResponsePredicate,
+  prometheusQueryRangeResponsePredicate,
+} from '@odh-dashboard/ui-core/utilities/metrics/usePrometheusQueryRange';
 
+const axiosPost: PrometheusPostFn = (url, body) =>
+  axios.post(url, body).then((response) => response.data);
+
+/**
+ * Frontend-specific wrapper that binds the dashboard's axios instance.
+ */
 const usePrometheusQueryRange = <T = PrometheusQueryRangeResultValue>(
   active: boolean,
   apiPath: string,
@@ -27,46 +28,18 @@ const usePrometheusQueryRange = <T = PrometheusQueryRangeResultValue>(
   responsePredicate: ResponsePredicate<T>,
   namespace: string,
   fetchOptions?: Partial<FetchOptions>,
-): [...FetchState<T[]>, boolean] => {
-  const pendingRef = React.useRef(active);
-  const fetchData = React.useCallback<FetchStateCallbackPromise<T[]>>(() => {
-    const endInS = endInMs / 1000;
-    const start = endInS - span;
-
-    if (!active) {
-      return Promise.reject(new NotReadyError('Prometheus query is not active'));
-    }
-
-    return axios
-      .post<{ response: PrometheusQueryRangeResponse }>(apiPath, {
-        query: new URLSearchParams({
-          namespace,
-          query: queryLang,
-          start: start.toString(),
-          end: endInS.toString(),
-          step: step.toString(),
-        }).toString(),
-      })
-      .then((response) => responsePredicate(response.data.response.data))
-      .finally(() => {
-        pendingRef.current = false;
-      });
-  }, [endInMs, span, active, apiPath, namespace, queryLang, step, responsePredicate]);
-
-  // The query is pending if fetchData changes because it will trigger useFetchState to re-fetch
-  React.useMemo(() => {
-    pendingRef.current = active;
-    // We do not reference fetchData but need to react to it changing
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, fetchData]);
-
-  return [...useFetchState<T[]>(fetchData, [], fetchOptions), pendingRef.current];
-};
-
-export const defaultResponsePredicate: ResponsePredicate = (data) => data.result?.[0]?.values || [];
-
-export const prometheusQueryRangeResponsePredicate: ResponsePredicate<
-  PrometheusQueryRangeResponseDataResult
-> = (data) => data.result || [];
+): [...FetchState<T[]>, boolean] =>
+  baseUsePrometheusQueryRange<T>(
+    active,
+    apiPath,
+    queryLang,
+    span,
+    endInMs,
+    step,
+    responsePredicate,
+    namespace,
+    fetchOptions,
+    axiosPost,
+  );
 
 export default usePrometheusQueryRange;

--- a/frontend/src/api/prometheus/usePrometheusQueryRange.ts
+++ b/frontend/src/api/prometheus/usePrometheusQueryRange.ts
@@ -1,5 +1,8 @@
 import type { FetchOptions, FetchState } from '@odh-dashboard/ui-core/hooks/useFetchState';
-import type { PrometheusQueryRangeResultValue } from '@odh-dashboard/ui-core/types/metrics';
+import type {
+  PrometheusQueryRangeResponse,
+  PrometheusQueryRangeResultValue,
+} from '@odh-dashboard/ui-core/types/metrics';
 import baseUsePrometheusQueryRange, {
   type PrometheusPostFn,
   type ResponsePredicate,
@@ -13,7 +16,9 @@ export {
 } from '@odh-dashboard/ui-core/utilities/metrics/usePrometheusQueryRange';
 
 const axiosPost: PrometheusPostFn = (url, body) =>
-  axios.post(url, body).then((response) => response.data);
+  axios
+    .post<{ response: PrometheusQueryRangeResponse }>(url, body)
+    .then((response) => response.data);
 
 /**
  * Frontend-specific wrapper that binds the dashboard's axios instance.

--- a/frontend/src/app/HostApiProvider.tsx
+++ b/frontend/src/app/HostApiProvider.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { HostApiContext, type HostApiServices } from '@odh-dashboard/plugin-core/host-api';
+import {
+  HostApiContext,
+  HostApiCoreContext,
+  HostApiInfraContext,
+  type HostApiServices,
+  type HostApiCoreServices,
+  type HostApiInfraServices,
+} from '@odh-dashboard/plugin-core/host-api';
 import { useDashboardNamespace } from '#~/redux/selectors/project';
 import { checkAccess } from '#~/api/checkAccess';
 import {
@@ -33,20 +40,34 @@ type HostApiProviderProps = {
 const HostApiProvider: React.FC<HostApiProviderProps> = ({ children }) => {
   const { dashboardNamespace } = useDashboardNamespace();
 
-  const value = React.useMemo<HostApiServices>(
+  const core = React.useMemo<HostApiCoreServices>(
     () => ({
       dashboardNamespace,
       checkAccess,
-      getSecretsByLabel,
-      getDashboardPvcs,
+      trackEvent: fireMiscTrackingEvent,
       fetchDashboardConfig,
-      useTemplates,
-      setProjectServingPlatform: addSupportServingPlatformProject,
+    }),
+    [dashboardNamespace],
+  );
+
+  const infra = React.useMemo<HostApiInfraServices>(
+    () => ({
       createSecret,
       getSecret,
       deleteSecret,
+      getSecretsByLabel,
       patchSecretWithOwnerReference,
       patchSecretWithProtocolAnnotation,
+      createProject,
+      getDashboardPvcs,
+    }),
+    [],
+  );
+
+  const domain = React.useMemo<HostApiServices>(
+    () => ({
+      useTemplates,
+      setProjectServingPlatform: addSupportServingPlatformProject,
       useWatchConnectionTypes,
       useServingConnections,
       getDashboardConfigTemplateOrder,
@@ -56,14 +77,18 @@ const HostApiProvider: React.FC<HostApiProviderProps> = ({ children }) => {
         useModelServingMetrics as unknown as HostApiServices['useModelServingMetrics'],
       useServingPlatformStatuses,
       isProjectNIMSupported,
-      trackEvent: fireMiscTrackingEvent,
-      createProject,
       registeredModelDeploymentsRoute,
     }),
-    [dashboardNamespace],
+    [],
   );
 
-  return <HostApiContext.Provider value={value}>{children}</HostApiContext.Provider>;
+  return (
+    <HostApiCoreContext.Provider value={core}>
+      <HostApiInfraContext.Provider value={infra}>
+        <HostApiContext.Provider value={domain}>{children}</HostApiContext.Provider>
+      </HostApiInfraContext.Provider>
+    </HostApiCoreContext.Provider>
+  );
 };
 
 export default HostApiProvider;

--- a/frontend/src/concepts/userSSAR/AccessReviewContext.tsx
+++ b/frontend/src/concepts/userSSAR/AccessReviewContext.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { AccessReviewResourceAttributes } from '@odh-dashboard/k8s-core';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
+import { useHostApiCore } from '@odh-dashboard/plugin-core/host-api';
 import useNamespaces from '#~/pages/notebookController/useNamespaces';
 
 type AccessReviewCacheData = {
@@ -25,7 +25,7 @@ export const AccessReviewContext = React.createContext<AccessReviewContextType>(
 export const AccessReviewProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [accessReviewCache, setAccessReviewCache] = React.useState<AccessReviewCacheType>({});
   const keysRef = React.useRef(new Set());
-  const { checkAccess } = useHostApi();
+  const { checkAccess } = useHostApiCore();
   // If namespace is not provided in the data, assume it means the dashboard deployment namespace
   const { dashboardNamespace } = useNamespaces();
 

--- a/packages/feature-store/src/hooks/__tests__/useAccessibleNamespaces.spec.tsx
+++ b/packages/feature-store/src/hooks/__tests__/useAccessibleNamespaces.spec.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
+import { useHostApiCore } from '@odh-dashboard/plugin-core/host-api';
 import { ProjectKind } from '@odh-dashboard/k8s-core';
 import useAccessibleNamespaces from '../useAccessibleNamespaces';
 
 jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
-  useHostApi: jest.fn(),
+  useHostApiCore: jest.fn(),
 }));
 
 jest.mock('@odh-dashboard/ui-core/hooks/useFetch', () => {
@@ -14,7 +14,7 @@ jest.mock('@odh-dashboard/ui-core/hooks/useFetch', () => {
   return actual;
 });
 
-const mockUseHostApi = jest.mocked(useHostApi);
+const mockUseHostApiCore = jest.mocked(useHostApiCore);
 const checkAccessMock = jest.fn();
 
 const makeProject = (name: string, displayName?: string): ProjectKind =>
@@ -42,8 +42,8 @@ const createWrapper = (projects: ProjectKind[], loaded = true) => {
 describe('useAccessibleNamespaces', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseHostApi.mockReturnValue({ checkAccess: checkAccessMock } as unknown as ReturnType<
-      typeof useHostApi
+    mockUseHostApiCore.mockReturnValue({ checkAccess: checkAccessMock } as unknown as ReturnType<
+      typeof useHostApiCore
     >);
   });
 

--- a/packages/feature-store/src/hooks/useAccessibleNamespaces.ts
+++ b/packages/feature-store/src/hooks/useAccessibleNamespaces.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ProjectKind } from '@odh-dashboard/k8s-core';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
+import { useHostApiCore } from '@odh-dashboard/plugin-core/host-api';
 import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
 import useFetch, {
   FetchStateCallbackPromise,
@@ -21,7 +21,7 @@ type UseAccessibleNamespacesReturn = {
 
 const useAccessibleNamespaces = (): UseAccessibleNamespacesReturn => {
   const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
-  const { checkAccess } = useHostApi();
+  const { checkAccess } = useHostApiCore();
 
   const fetchAccessibleNamespaces = React.useCallback<
     FetchStateCallbackPromise<NamespaceInfo[]>

--- a/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
+++ b/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import usePrometheusQueryRange from '@odh-dashboard/ui-core/utilities/metrics/usePrometheusQueryRange';
+import usePrometheusQueryRange from '@odh-dashboard/internal/api/prometheus/usePrometheusQueryRange';
 import { ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import type {
   PrometheusQueryRangeResponseData,

--- a/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
+++ b/packages/gpuaas/src/hooks/useBorrowingLendingMetrics.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import usePrometheusQueryRange from '@odh-dashboard/internal/api/prometheus/usePrometheusQueryRange';
+import usePrometheusQueryRange from '@odh-dashboard/ui-core/utilities/metrics/usePrometheusQueryRange';
 import { ClusterQueueKind } from '@odh-dashboard/k8s-core';
 import type {
   PrometheusQueryRangeResponseData,

--- a/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/DeploymentMethodSelectField.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { z } from 'zod';
 import type { RecursivePartial } from '@odh-dashboard/foundation';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
+import { useHostApiCore } from '@odh-dashboard/plugin-core/host-api';
 import { ServingRuntimeModelType } from '@odh-dashboard/model-serving/shared';
 import {
   useModelServingClusterSettings,
@@ -105,7 +105,7 @@ const DeploymentMethodSelectField: DeploymentMethodSelectFieldType['component'] 
   externalData,
   isEditing,
 }) => {
-  const { trackEvent } = useHostApi();
+  const { trackEvent } = useHostApiCore();
   const options = externalData?.data.options ?? [];
 
   return (

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/DeploymentMethodSelectField.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
+import { useHostApiCore } from '@odh-dashboard/plugin-core/host-api';
 import { ModelServingTrackingEvent } from '../../../../shared/tracking/modelServingTrackingConstants';
 import {
   DeploymentMethodSelectFieldWizardField,
@@ -12,11 +12,11 @@ import {
 import type { DeploymentMethodFieldOverride } from '../../../../shared/types/form-data';
 
 jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
-  useHostApi: jest.fn(),
+  useHostApiCore: jest.fn(),
 }));
 
 const mockTrackEvent = jest.fn();
-(useHostApi as jest.Mock).mockReturnValue({ trackEvent: mockTrackEvent });
+(useHostApiCore as jest.Mock).mockReturnValue({ trackEvent: mockTrackEvent });
 
 const DeploymentMethodSelectFieldComponent = DeploymentMethodSelectFieldWizardField.component;
 

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
@@ -215,6 +215,8 @@ jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
   useWatchConnectionTypes: () => [mockConnectionTypes, true],
   useServingConnections: jest.fn(() => [mockConnections, true]),
   useHostApi: jest.fn(() => ({ trackEvent: jest.fn() })),
+  useHostApiCore: jest.fn(() => ({ trackEvent: jest.fn() })),
+  useHostApiInfra: jest.fn(() => ({ getDashboardPvcs: jest.fn().mockResolvedValue([]) })),
 }));
 
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
@@ -35,6 +35,8 @@ jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
   useWatchConnectionTypes: jest.fn(() => [[], true]),
   useServingConnections: jest.fn(() => [[], true]),
   useHostApi: jest.fn(() => ({ trackEvent: jest.fn() })),
+  useHostApiCore: jest.fn(() => ({ trackEvent: jest.fn() })),
+  useHostApiInfra: jest.fn(() => ({ getDashboardPvcs: jest.fn().mockResolvedValue([]) })),
 }));
 
 // Mock PatternFly wizard hooks

--- a/packages/model-serving/src/concepts/__tests__/useModelServingClusterSettings.spec.ts
+++ b/packages/model-serving/src/concepts/__tests__/useModelServingClusterSettings.spec.ts
@@ -1,14 +1,14 @@
 import { testHook, standardUseFetchStateObject } from '@odh-dashboard/jest-config/hooks';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
+import { useHostApiCore } from '@odh-dashboard/plugin-core/host-api';
 import type { DashboardConfigKind } from '@odh-dashboard/k8s-core';
 import { useModelServingClusterSettings } from '../useModelServingClusterSettings';
 
 jest.mock('@odh-dashboard/plugin-core/host-api');
 
 const mockFetchDashboardConfig = jest.fn();
-jest.mocked(useHostApi).mockReturnValue({
+jest.mocked(useHostApiCore).mockReturnValue({
   fetchDashboardConfig: mockFetchDashboardConfig,
-} as unknown as ReturnType<typeof useHostApi>);
+} as unknown as ReturnType<typeof useHostApiCore>);
 
 describe('useModelServingClusterSettings', () => {
   beforeEach(() => {

--- a/packages/model-serving/src/concepts/auth.ts
+++ b/packages/model-serving/src/concepts/auth.ts
@@ -6,7 +6,7 @@ import useFetch, {
   type FetchStateObject,
 } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { LABEL_SELECTOR_DASHBOARD_RESOURCE } from '@odh-dashboard/ui-core/utilities';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
+import { useHostApiInfra } from '@odh-dashboard/plugin-core/host-api';
 import type { Deployment } from '../../extension-points';
 
 const getModelServingRuntimeName = (namespace: string): string => `model-server-${namespace}`;
@@ -46,7 +46,7 @@ const useDeploymentSecrets = (
   namespace?: string,
   fetchOptions?: Partial<FetchOptions>,
 ): FetchStateObject<SecretKind[]> => {
-  const { getSecretsByLabel } = useHostApi();
+  const { getSecretsByLabel } = useHostApiInfra();
 
   const fetchSecrets = React.useCallback(() => {
     if (!namespace) {

--- a/packages/model-serving/src/concepts/useModelServingClusterSettings.tsx
+++ b/packages/model-serving/src/concepts/useModelServingClusterSettings.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
+import { useHostApiCore } from '@odh-dashboard/plugin-core/host-api';
 import useFetch, { type FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 
 export type ModelServingClusterSettings = {
@@ -10,7 +10,7 @@ export type ModelServingClusterSettings = {
 export const useModelServingClusterSettings = (): FetchStateObject<
   ModelServingClusterSettings | null | undefined
 > => {
-  const { fetchDashboardConfig } = useHostApi();
+  const { fetchDashboardConfig } = useHostApiCore();
 
   const fetchCallbackPromise = React.useCallback(async () => {
     return fetchDashboardConfig().then((config) => config.spec.modelServing ?? null);

--- a/packages/model-serving/src/concepts/usePvcs.ts
+++ b/packages/model-serving/src/concepts/usePvcs.ts
@@ -5,10 +5,10 @@ import useFetch, {
   FetchStateObject,
   NotReadyError,
 } from '@odh-dashboard/ui-core/hooks/useFetch';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
+import { useHostApiInfra } from '@odh-dashboard/plugin-core/host-api';
 
 export default function usePvcs(namespace?: string): FetchStateObject<PersistentVolumeClaimKind[]> {
-  const { getDashboardPvcs } = useHostApi();
+  const { getDashboardPvcs } = useHostApiInfra();
 
   const callback = React.useCallback<
     FetchStateCallbackPromise<PersistentVolumeClaimKind[]>

--- a/packages/plugin-core/src/host-api/HostApiContext.ts
+++ b/packages/plugin-core/src/host-api/HostApiContext.ts
@@ -7,7 +7,11 @@ const notProvided = (name: string) => () => {
 
 /**
  * Domain-specific services bridged from the host to federated modules.
- * These shrink over time as domain logic relocates into owning packages.
+ *
+ * This is the backward-compatible Domain bridge — the shrinking leftover of the
+ * original host API, retained so existing `useHostApi()` consumers keep working.
+ * Prefer HostApiCoreContext / HostApiInfraContext for new code; removal of this
+ * bridge is tracked by RHOAIENG-79894 / RHOAIENG-79895.
  *
  * For core infrastructure (namespace, access, tracking, config) use HostApiCoreContext.
  * For K8s operations (secrets, projects, PVCs) use HostApiInfraContext.

--- a/packages/plugin-core/src/host-api/HostApiContext.ts
+++ b/packages/plugin-core/src/host-api/HostApiContext.ts
@@ -6,29 +6,15 @@ const notProvided = (name: string) => () => {
 };
 
 /**
- * Shared React context for host-level K8s/OpenShift API services.
+ * Domain-specific services bridged from the host to federated modules.
+ * These shrink over time as domain logic relocates into owning packages.
  *
- * Main app provides the implementations:
- *   <HostApiContext.Provider value={hostServices}>
- *
- * Federated modules consume via the hooks exported from this module:
- *   const { dashboardNamespace } = useDashboardNamespace();
- *   const [allowed, loaded] = useAccessReview(attrs);
- *   const { getSecretsByLabel } = useHostApi();
+ * For core infrastructure (namespace, access, tracking, config) use HostApiCoreContext.
+ * For K8s operations (secrets, projects, PVCs) use HostApiInfraContext.
  */
 export const HostApiContext = React.createContext<HostApiServices>({
-  dashboardNamespace: '',
-  checkAccess: notProvided('checkAccess'),
-  getSecretsByLabel: notProvided('getSecretsByLabel'),
-  getDashboardPvcs: notProvided('getDashboardPvcs'),
-  fetchDashboardConfig: notProvided('fetchDashboardConfig'),
   useTemplates: notProvided('useTemplates'),
   setProjectServingPlatform: notProvided('setProjectServingPlatform'),
-  createSecret: notProvided('createSecret'),
-  getSecret: notProvided('getSecret'),
-  deleteSecret: notProvided('deleteSecret'),
-  patchSecretWithOwnerReference: notProvided('patchSecretWithOwnerReference'),
-  patchSecretWithProtocolAnnotation: notProvided('patchSecretWithProtocolAnnotation'),
   useWatchConnectionTypes: notProvided('useWatchConnectionTypes'),
   useServingConnections: notProvided('useServingConnections'),
   getDashboardConfigTemplateOrder: notProvided('getDashboardConfigTemplateOrder'),
@@ -36,7 +22,5 @@ export const HostApiContext = React.createContext<HostApiServices>({
   useModelServingMetrics: notProvided('useModelServingMetrics'),
   useServingPlatformStatuses: notProvided('useServingPlatformStatuses'),
   isProjectNIMSupported: notProvided('isProjectNIMSupported'),
-  trackEvent: notProvided('trackEvent'),
-  createProject: notProvided('createProject'),
   registeredModelDeploymentsRoute: notProvided('registeredModelDeploymentsRoute'),
 });

--- a/packages/plugin-core/src/host-api/HostApiCoreContext.ts
+++ b/packages/plugin-core/src/host-api/HostApiCoreContext.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import type { HostApiCoreServices } from './types';
+
+const notProvided = (name: string) => () => {
+  throw new Error(`HostApiCoreContext not provided: ${name}`);
+};
+
+export const HostApiCoreContext = React.createContext<HostApiCoreServices>({
+  dashboardNamespace: '',
+  checkAccess: notProvided('checkAccess'),
+  trackEvent: notProvided('trackEvent'),
+  fetchDashboardConfig: notProvided('fetchDashboardConfig'),
+});

--- a/packages/plugin-core/src/host-api/HostApiInfraContext.ts
+++ b/packages/plugin-core/src/host-api/HostApiInfraContext.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import type { HostApiInfraServices } from './types';
+
+const notProvided = (name: string) => () => {
+  throw new Error(`HostApiInfraContext not provided: ${name}`);
+};
+
+export const HostApiInfraContext = React.createContext<HostApiInfraServices>({
+  createSecret: notProvided('createSecret'),
+  getSecret: notProvided('getSecret'),
+  deleteSecret: notProvided('deleteSecret'),
+  getSecretsByLabel: notProvided('getSecretsByLabel'),
+  patchSecretWithOwnerReference: notProvided('patchSecretWithOwnerReference'),
+  patchSecretWithProtocolAnnotation: notProvided('patchSecretWithProtocolAnnotation'),
+  createProject: notProvided('createProject'),
+  getDashboardPvcs: notProvided('getDashboardPvcs'),
+});

--- a/packages/plugin-core/src/host-api/hooks/__tests__/useAccessReview.spec.ts
+++ b/packages/plugin-core/src/host-api/hooks/__tests__/useAccessReview.spec.ts
@@ -1,14 +1,14 @@
 import React, { act } from 'react';
 import { renderHook } from '@odh-dashboard/jest-config/hooks';
-import type { HostApiServices } from '../../types';
-import { HostApiContext } from '../../HostApiContext';
+import type { HostApiCoreServices } from '../../types';
+import { HostApiCoreContext } from '../../HostApiCoreContext';
 import { useAccessReview } from '../useAccessReview';
 
 function createWrapper(checkAccess: jest.Mock): React.FC<{ children: React.ReactNode }> {
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
     React.createElement(
-      HostApiContext.Provider,
-      { value: { checkAccess } as unknown as HostApiServices },
+      HostApiCoreContext.Provider,
+      { value: { checkAccess } as unknown as HostApiCoreServices },
       children,
     );
   Wrapper.displayName = 'Wrapper';

--- a/packages/plugin-core/src/host-api/hooks/__tests__/useDashboardNamespace.spec.ts
+++ b/packages/plugin-core/src/host-api/hooks/__tests__/useDashboardNamespace.spec.ts
@@ -1,14 +1,14 @@
 import React from 'react';
 import { renderHook } from '@odh-dashboard/jest-config/hooks';
-import type { HostApiServices } from '../../types';
-import { HostApiContext } from '../../HostApiContext';
+import type { HostApiCoreServices } from '../../types';
+import { HostApiCoreContext } from '../../HostApiCoreContext';
 import { useDashboardNamespace } from '../useDashboardNamespace';
 
 function createWrapper(namespace: string): React.FC<{ children: React.ReactNode }> {
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
     React.createElement(
-      HostApiContext.Provider,
-      { value: { dashboardNamespace: namespace } as HostApiServices },
+      HostApiCoreContext.Provider,
+      { value: { dashboardNamespace: namespace } as HostApiCoreServices },
       children,
     );
   Wrapper.displayName = 'Wrapper';

--- a/packages/plugin-core/src/host-api/hooks/__tests__/useHostApi.spec.ts
+++ b/packages/plugin-core/src/host-api/hooks/__tests__/useHostApi.spec.ts
@@ -5,18 +5,8 @@ import { HostApiContext } from '../../HostApiContext';
 import { useHostApi } from '../useHostApi';
 
 const mockServices: HostApiServices = {
-  dashboardNamespace: 'test-ns',
-  checkAccess: jest.fn(),
-  getSecretsByLabel: jest.fn(),
-  getDashboardPvcs: jest.fn(),
-  fetchDashboardConfig: jest.fn(),
   useTemplates: jest.fn(() => [[], false, undefined]),
   setProjectServingPlatform: jest.fn(),
-  createSecret: jest.fn(),
-  getSecret: jest.fn(),
-  deleteSecret: jest.fn(),
-  patchSecretWithOwnerReference: jest.fn(),
-  patchSecretWithProtocolAnnotation: jest.fn(),
   useWatchConnectionTypes: jest.fn(() => [[], false, undefined, jest.fn()]),
   useServingConnections: jest.fn(() => [[], false, undefined, jest.fn()]),
   getDashboardConfigTemplateOrder: jest.fn(),
@@ -29,8 +19,6 @@ const mockServices: HostApiServices = {
     refreshNIMAvailability: jest.fn(),
   })),
   isProjectNIMSupported: jest.fn(() => false),
-  trackEvent: jest.fn(),
-  createProject: jest.fn(),
   registeredModelDeploymentsRoute: jest.fn(() => ''),
 };
 
@@ -45,15 +33,8 @@ describe('useHostApi', () => {
 
   it('should throw when context is not provided and a service is called', () => {
     const { result } = renderHook(() => useHostApi());
-    expect(() =>
-      result.current.checkAccess({
-        group: '',
-        resource: '',
-        subresource: '',
-        verb: 'get',
-        name: '',
-        namespace: '',
-      }),
-    ).toThrow('HostApiContext not provided: checkAccess');
+    expect(() => result.current.useTemplates('test-ns')).toThrow(
+      'HostApiContext not provided: useTemplates',
+    );
   });
 });

--- a/packages/plugin-core/src/host-api/hooks/useAccessReview.ts
+++ b/packages/plugin-core/src/host-api/hooks/useAccessReview.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { AccessReviewResourceAttributes } from '@odh-dashboard/k8s-core';
-import { HostApiContext } from '../HostApiContext';
+import { HostApiCoreContext } from '../HostApiCoreContext';
 
 /**
  * Used for a non-cached SSAR request.
@@ -14,7 +14,7 @@ export const useAccessReview = (
   resourceAttributes: AccessReviewResourceAttributes,
   shouldRunCheck = true,
 ): [boolean, boolean] => {
-  const { checkAccess } = React.useContext(HostApiContext);
+  const { checkAccess } = React.useContext(HostApiCoreContext);
   const [isLoaded, setIsLoaded] = React.useState(false);
   const [isAllowed, setAllowed] = React.useState(false);
 

--- a/packages/plugin-core/src/host-api/hooks/useDashboardNamespace.ts
+++ b/packages/plugin-core/src/host-api/hooks/useDashboardNamespace.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { HostApiContext } from '../HostApiContext';
+import { HostApiCoreContext } from '../HostApiCoreContext';
 
 export const useDashboardNamespace = (): { dashboardNamespace: string } => {
-  const { dashboardNamespace } = React.useContext(HostApiContext);
+  const { dashboardNamespace } = React.useContext(HostApiCoreContext);
   return React.useMemo(() => ({ dashboardNamespace }), [dashboardNamespace]);
 };

--- a/packages/plugin-core/src/host-api/hooks/useHostApi.ts
+++ b/packages/plugin-core/src/host-api/hooks/useHostApi.ts
@@ -2,4 +2,10 @@ import * as React from 'react';
 import { HostApiContext } from '../HostApiContext';
 import type { HostApiServices } from '../types';
 
+/**
+ * Domain-services bridge (metrics, NIM, serving, connections, routing) retained
+ * for backward compatibility. This is the shrinking leftover of the original host
+ * API, not the full surface — prefer `useHostApiCore` / `useHostApiInfra` for new
+ * code. Removal of the domain bridge is tracked by RHOAIENG-79894 / RHOAIENG-79895.
+ */
 export const useHostApi = (): HostApiServices => React.useContext(HostApiContext);

--- a/packages/plugin-core/src/host-api/hooks/useHostApiCore.ts
+++ b/packages/plugin-core/src/host-api/hooks/useHostApiCore.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { HostApiCoreContext } from '../HostApiCoreContext';
+import type { HostApiCoreServices } from '../types';
+
+export const useHostApiCore = (): HostApiCoreServices => React.useContext(HostApiCoreContext);

--- a/packages/plugin-core/src/host-api/hooks/useHostApiInfra.ts
+++ b/packages/plugin-core/src/host-api/hooks/useHostApiInfra.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { HostApiInfraContext } from '../HostApiInfraContext';
+import type { HostApiInfraServices } from '../types';
+
+export const useHostApiInfra = (): HostApiInfraServices => React.useContext(HostApiInfraContext);

--- a/packages/plugin-core/src/host-api/hooks/useSecretOps.ts
+++ b/packages/plugin-core/src/host-api/hooks/useSecretOps.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { HostApiContext } from '../HostApiContext';
+import { HostApiInfraContext } from '../HostApiInfraContext';
 import type { SecretOps } from '../types';
 
 export const useSecretOps = (): SecretOps => {
@@ -9,7 +9,7 @@ export const useSecretOps = (): SecretOps => {
     deleteSecret,
     patchSecretWithOwnerReference,
     patchSecretWithProtocolAnnotation,
-  } = React.useContext(HostApiContext);
+  } = React.useContext(HostApiInfraContext);
   return React.useMemo(
     () => ({
       createSecret,

--- a/packages/plugin-core/src/host-api/hooks/useTrackEvent.ts
+++ b/packages/plugin-core/src/host-api/hooks/useTrackEvent.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { HostApiContext } from '../HostApiContext';
+import { HostApiCoreContext } from '../HostApiCoreContext';
 
 export const useTrackEvent = (): ((
   eventName: string,
   properties: Record<string, string | number | boolean | undefined>,
 ) => void) => {
-  const { trackEvent } = React.useContext(HostApiContext);
+  const { trackEvent } = React.useContext(HostApiCoreContext);
   return trackEvent;
 };

--- a/packages/plugin-core/src/host-api/index.ts
+++ b/packages/plugin-core/src/host-api/index.ts
@@ -1,6 +1,10 @@
 /* eslint-disable no-barrel-files/no-barrel-files */
 export { HostApiContext } from './HostApiContext';
+export { HostApiCoreContext } from './HostApiCoreContext';
+export { HostApiInfraContext } from './HostApiInfraContext';
 export { useHostApi } from './hooks/useHostApi';
+export { useHostApiCore } from './hooks/useHostApiCore';
+export { useHostApiInfra } from './hooks/useHostApiInfra';
 export { useDashboardNamespace } from './hooks/useDashboardNamespace';
 export { useAccessReview } from './hooks/useAccessReview';
 export { useTemplates } from './hooks/useTemplates';
@@ -12,6 +16,8 @@ export { useServingPlatformStatuses } from './hooks/useServingPlatformStatuses';
 export { useIsProjectNIMSupported } from './hooks/useIsProjectNIMSupported';
 export { useTrackEvent } from './hooks/useTrackEvent';
 export type {
+  HostApiCoreServices,
+  HostApiInfraServices,
   HostApiServices,
   HostApiFetchState,
   HostApiFetchStateObject,

--- a/packages/plugin-core/src/host-api/index.ts
+++ b/packages/plugin-core/src/host-api/index.ts
@@ -1,4 +1,7 @@
 /* eslint-disable no-barrel-files/no-barrel-files */
+// `HostApiContext` / `useHostApi` are the backward-compatible Domain bridge,
+// retained until the domain surface is fully migrated (RHOAIENG-79894 /
+// RHOAIENG-79895). Prefer the Core and Infra APIs below for new code.
 export { HostApiContext } from './HostApiContext';
 export { HostApiCoreContext } from './HostApiCoreContext';
 export { HostApiInfraContext } from './HostApiInfraContext';

--- a/packages/plugin-core/src/host-api/types.ts
+++ b/packages/plugin-core/src/host-api/types.ts
@@ -44,27 +44,64 @@ export type ServingPlatformStatuses = {
 };
 
 /**
- * Services provided by the host application to federated modules via HostApiContext.
- *
- * Federated modules must not import host internals directly; instead they consume
- * these services through the context bridge.
+ * Core infrastructure primitives every federated module needs.
+ * Stable, rarely changes. Provided via HostApiCoreContext.
  */
-export type HostApiServices = {
-  /** The namespace where the dashboard operator is installed (e.g. "opendatahub" or "redhat-ods-applications"). */
+export type HostApiCoreServices = {
+  /** The namespace where the dashboard operator is installed. */
   dashboardNamespace: string;
 
   /** Perform a SelfSubjectAccessReview to check whether the current user has a specific permission. */
   checkAccess: (attrs: Required<AccessReviewResourceAttributes>) => Promise<boolean>;
 
-  /** Fetch all secrets in a namespace that match a given label selector. */
-  getSecretsByLabel: (label: string, namespace: string) => Promise<SecretKind[]>;
-
-  /** Fetch all PVCs in a project that are managed by the dashboard. */
-  getDashboardPvcs: (projectName: string) => Promise<PersistentVolumeClaimKind[]>;
+  /** Fire a tracking event with arbitrary properties. */
+  trackEvent: (
+    eventName: string,
+    properties: Record<string, string | number | boolean | undefined>,
+  ) => void;
 
   /** Fetch (or refresh) the DashboardConfig CR that controls feature flags and platform settings. */
   fetchDashboardConfig: (forceRefresh?: boolean) => Promise<DashboardConfigKind>;
+};
 
+/**
+ * Stable K8s operations available to all federated modules.
+ * Provided via HostApiInfraContext.
+ */
+export type HostApiInfraServices = {
+  /** Create a new Secret resource. */
+  createSecret: (data: SecretKind, opts?: { dryRun?: boolean }) => Promise<SecretKind>;
+  /** Fetch a Secret by namespace and name. */
+  getSecret: (namespace: string, name: string) => Promise<SecretKind>;
+  /** Delete a Secret by namespace and name. */
+  deleteSecret: (namespace: string, name: string) => Promise<unknown>;
+  /** Fetch all secrets in a namespace that match a given label selector. */
+  getSecretsByLabel: (label: string, namespace: string) => Promise<SecretKind[]>;
+  /** Patch a Secret to add an owner reference, linking it to a parent resource. */
+  patchSecretWithOwnerReference: (
+    secret: SecretKind,
+    owner: K8sResourceCommon & { metadata: { name: string } },
+    uid: string,
+  ) => Promise<SecretKind>;
+  /** Patch a Secret to set the connection-type protocol annotation. */
+  patchSecretWithProtocolAnnotation: (secret: SecretKind, protocol: string) => Promise<SecretKind>;
+  /** Create a new OpenShift project and return the project name. */
+  createProject: (
+    username: string,
+    displayName: string,
+    description: string,
+    k8sName?: string,
+  ) => Promise<string>;
+  /** Fetch all PVCs in a project that are managed by the dashboard. */
+  getDashboardPvcs: (projectName: string) => Promise<PersistentVolumeClaimKind[]>;
+};
+
+/**
+ * Domain-specific services bridged from the host to federated modules.
+ * These shrink over time as domain logic relocates into owning packages.
+ * Provided via HostApiContext (the domain bridge).
+ */
+export type HostApiServices = {
   /** Watch serving runtime templates in a namespace. Returns a K8s watch-style tuple. */
   useTemplates: (namespace?: string) => K8sWatchResult<TemplateKind[]>;
 
@@ -74,21 +111,6 @@ export type HostApiServices = {
     servingPlatform: NamespaceApplicationCase,
     dryRun?: boolean,
   ) => Promise<string>;
-
-  /** Create a new Secret resource. */
-  createSecret: (data: SecretKind, opts?: { dryRun?: boolean }) => Promise<SecretKind>;
-  /** Fetch a Secret by namespace and name. */
-  getSecret: (namespace: string, name: string) => Promise<SecretKind>;
-  /** Delete a Secret by namespace and name. */
-  deleteSecret: (namespace: string, name: string) => Promise<unknown>;
-  /** Patch a Secret to add an owner reference, linking it to a parent resource. */
-  patchSecretWithOwnerReference: (
-    secret: SecretKind,
-    owner: K8sResourceCommon & { metadata: { name: string } },
-    uid: string,
-  ) => Promise<SecretKind>;
-  /** Patch a Secret to set the connection-type protocol annotation. */
-  patchSecretWithProtocolAnnotation: (secret: SecretKind, protocol: string) => Promise<SecretKind>;
 
   /** Watch connection types, optionally filtered for model-serving compatibility. */
   useWatchConnectionTypes: (
@@ -125,26 +147,12 @@ export type HostApiServices = {
   /** Check whether a project has NIM support enabled. */
   isProjectNIMSupported: (currentProject: ProjectKind) => boolean;
 
-  /** Fire a tracking event with arbitrary properties. */
-  trackEvent: (
-    eventName: string,
-    properties: Record<string, string | number | boolean | undefined>,
-  ) => void;
-
-  /** Create a new OpenShift project and return the project name. */
-  createProject: (
-    username: string,
-    displayName: string,
-    description: string,
-    k8sName?: string,
-  ) => Promise<string>;
-
   /** Build the route path to registered model deployments. */
   registeredModelDeploymentsRoute: (rmId?: string, preferredModelRegistry?: string) => string;
 };
 
 export type SecretOps = Pick<
-  HostApiServices,
+  HostApiInfraServices,
   | 'createSecret'
   | 'getSecret'
   | 'deleteSecret'

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -24,6 +24,7 @@
     "./design/TitleWithIcon": "./src/design/TitleWithIcon.tsx",
     "./utilities/fetchState": "./src/utilities/fetchState.ts",
     "./utilities/metrics": "./src/utilities/metrics.ts",
+    "./utilities/metrics/usePrometheusQueryRange": "./src/utilities/metrics/usePrometheusQueryRange.ts",
     "./utilities/time": "./src/utilities/time.ts",
     "./components/detail": "./src/components/detail/index.ts",
     "./components/detail/OverviewCard": "./src/components/detail/OverviewCard.tsx",

--- a/packages/ui-core/src/utilities/metrics/__tests__/usePrometheusQueryRange.spec.ts
+++ b/packages/ui-core/src/utilities/metrics/__tests__/usePrometheusQueryRange.spec.ts
@@ -1,0 +1,201 @@
+import { act } from 'react';
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import type {
+  PrometheusQueryRangeResponse,
+  PrometheusQueryRangeResponseData,
+  PrometheusQueryRangeResponseDataResult,
+} from '../../../types/metrics';
+import usePrometheusQueryRange, {
+  defaultResponsePredicate,
+  type PrometheusPostFn,
+} from '../usePrometheusQueryRange';
+
+// These tests cover the behavior this file introduces on top of the relocated
+// hook: the injectable `post` transport seam and its `defaultPost` fetch-based
+// default. The relocated core logic is additionally exercised end-to-end by the
+// frontend axios wrapper's own test.
+
+const queryLang = 'testQuery';
+const span = 60;
+const endInMs = 123456;
+const step = 30;
+const namespace = 'testNamespace';
+const apiPath = '/api/prometheus/serving';
+const expectedQuery = 'namespace=testNamespace&query=testQuery&start=63.456&end=123.456&step=30';
+
+const responseData: PrometheusQueryRangeResponseData = {
+  resultType: 'matrix',
+  result: [{ values: [[1704899825.644, '16']] } as PrometheusQueryRangeResponseDataResult],
+};
+
+const responseEnvelope: { response: PrometheusQueryRangeResponse } = {
+  response: { status: 'success', data: responseData },
+};
+
+describe('usePrometheusQueryRange', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('should use the injected post transport and pass its result to the predicate', async () => {
+    const post = jest.fn<ReturnType<PrometheusPostFn>, Parameters<PrometheusPostFn>>(() =>
+      Promise.resolve(responseEnvelope),
+    );
+
+    const renderResult = testHook(usePrometheusQueryRange)(
+      true,
+      apiPath,
+      queryLang,
+      span,
+      endInMs,
+      step,
+      defaultResponsePredicate,
+      namespace,
+      undefined,
+      post,
+    );
+
+    // pending flag is true while active and awaiting the first fetch
+    expect(renderResult).hookToStrictEqual([[], false, undefined, expect.any(Function), true]);
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith(apiPath, { query: expectedQuery });
+
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual([
+      [[1704899825.644, '16']],
+      true,
+      undefined,
+      expect.any(Function),
+      false,
+    ]);
+  });
+
+  it('should not call the transport when inactive', () => {
+    const post = jest.fn<ReturnType<PrometheusPostFn>, Parameters<PrometheusPostFn>>();
+
+    const renderResult = testHook(usePrometheusQueryRange)(
+      false,
+      apiPath,
+      queryLang,
+      span,
+      endInMs,
+      step,
+      defaultResponsePredicate,
+      namespace,
+      undefined,
+      post,
+    );
+
+    expect(renderResult).hookToStrictEqual([[], false, undefined, expect.any(Function), false]);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('should default to a fetch-based POST when no transport is provided', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(responseEnvelope),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const renderResult = testHook(usePrometheusQueryRange)(
+      true,
+      apiPath,
+      queryLang,
+      span,
+      endInMs,
+      step,
+      defaultResponsePredicate,
+      namespace,
+    );
+
+    await renderResult.waitForNextUpdate();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      apiPath,
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: expectedQuery }),
+      }),
+    );
+    expect(renderResult).hookToStrictEqual([
+      [[1704899825.644, '16']],
+      true,
+      undefined,
+      expect.any(Function),
+      false,
+    ]);
+  });
+
+  it('should surface an error when the default fetch response is not ok', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.resolve({}),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const renderResult = testHook(usePrometheusQueryRange)(
+      true,
+      apiPath,
+      queryLang,
+      span,
+      endInMs,
+      step,
+      defaultResponsePredicate,
+      namespace,
+    );
+
+    await renderResult.waitForNextUpdate();
+
+    const [data, loaded, error] = renderResult.result.current;
+    expect(data).toEqual([]);
+    expect(loaded).toBe(false);
+    expect(error).toEqual(new Error('Prometheus query failed: 500 Internal Server Error'));
+  });
+
+  it('should stabilize the refresh callback across an unchanged rerender', async () => {
+    const post = jest.fn<ReturnType<PrometheusPostFn>, Parameters<PrometheusPostFn>>(() =>
+      Promise.resolve(responseEnvelope),
+    );
+
+    const renderResult = testHook(usePrometheusQueryRange)(
+      true,
+      apiPath,
+      queryLang,
+      span,
+      endInMs,
+      step,
+      defaultResponsePredicate,
+      namespace,
+      undefined,
+      post,
+    );
+
+    await renderResult.waitForNextUpdate();
+
+    const refreshBefore = renderResult.result.current[3];
+    await act(async () => {
+      renderResult.rerender(
+        true,
+        apiPath,
+        queryLang,
+        span,
+        endInMs,
+        step,
+        defaultResponsePredicate,
+        namespace,
+        undefined,
+        post,
+      );
+    });
+
+    expect(renderResult.result.current[3]).toBe(refreshBefore);
+  });
+});

--- a/packages/ui-core/src/utilities/metrics/__tests__/usePrometheusQueryRange.spec.ts
+++ b/packages/ui-core/src/utilities/metrics/__tests__/usePrometheusQueryRange.spec.ts
@@ -11,9 +11,10 @@ import usePrometheusQueryRange, {
 } from '../usePrometheusQueryRange';
 
 // These tests cover the behavior this file introduces on top of the relocated
-// hook: the injectable `post` transport seam and its `defaultPost` fetch-based
-// default. The relocated core logic is additionally exercised end-to-end by the
-// frontend axios wrapper's own test.
+// hook: the required `post` transport seam. There is intentionally no plain-fetch
+// default — runtime callers must inject an authenticated transport. The relocated
+// core logic is additionally exercised end-to-end by the frontend axios wrapper's
+// own test.
 
 const queryLang = 'testQuery';
 const span = 60;
@@ -33,11 +34,8 @@ const responseEnvelope: { response: PrometheusQueryRangeResponse } = {
 };
 
 describe('usePrometheusQueryRange', () => {
-  const originalFetch = global.fetch;
-
   afterEach(() => {
     jest.restoreAllMocks();
-    global.fetch = originalFetch;
   });
 
   it('should use the injected post transport and pass its result to the predicate', async () => {
@@ -92,72 +90,6 @@ describe('usePrometheusQueryRange', () => {
 
     expect(renderResult).hookToStrictEqual([[], false, undefined, expect.any(Function), false]);
     expect(post).not.toHaveBeenCalled();
-  });
-
-  it('should default to a fetch-based POST when no transport is provided', async () => {
-    const fetchMock = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(responseEnvelope),
-    });
-    global.fetch = fetchMock as unknown as typeof fetch;
-
-    const renderResult = testHook(usePrometheusQueryRange)(
-      true,
-      apiPath,
-      queryLang,
-      span,
-      endInMs,
-      step,
-      defaultResponsePredicate,
-      namespace,
-    );
-
-    await renderResult.waitForNextUpdate();
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      apiPath,
-      expect.objectContaining({
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query: expectedQuery }),
-      }),
-    );
-    expect(renderResult).hookToStrictEqual([
-      [[1704899825.644, '16']],
-      true,
-      undefined,
-      expect.any(Function),
-      false,
-    ]);
-  });
-
-  it('should surface an error when the default fetch response is not ok', async () => {
-    const fetchMock = jest.fn().mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
-      json: () => Promise.resolve({}),
-    });
-    global.fetch = fetchMock as unknown as typeof fetch;
-
-    const renderResult = testHook(usePrometheusQueryRange)(
-      true,
-      apiPath,
-      queryLang,
-      span,
-      endInMs,
-      step,
-      defaultResponsePredicate,
-      namespace,
-    );
-
-    await renderResult.waitForNextUpdate();
-
-    const [data, loaded, error] = renderResult.result.current;
-    expect(data).toEqual([]);
-    expect(loaded).toBe(false);
-    expect(error).toEqual(new Error('Prometheus query failed: 500 Internal Server Error'));
   });
 
   it('should stabilize the refresh callback across an unchanged rerender', async () => {

--- a/packages/ui-core/src/utilities/metrics/index.ts
+++ b/packages/ui-core/src/utilities/metrics/index.ts
@@ -1,6 +1,0 @@
-export { default as usePrometheusQueryRange } from './usePrometheusQueryRange';
-export type { ResponsePredicate, PrometheusPostFn } from './usePrometheusQueryRange';
-export {
-  defaultResponsePredicate,
-  prometheusQueryRangeResponsePredicate,
-} from './usePrometheusQueryRange';

--- a/packages/ui-core/src/utilities/metrics/index.ts
+++ b/packages/ui-core/src/utilities/metrics/index.ts
@@ -1,0 +1,6 @@
+export { default as usePrometheusQueryRange } from './usePrometheusQueryRange';
+export type { ResponsePredicate, PrometheusPostFn } from './usePrometheusQueryRange';
+export {
+  defaultResponsePredicate,
+  prometheusQueryRangeResponsePredicate,
+} from './usePrometheusQueryRange';

--- a/packages/ui-core/src/utilities/metrics/usePrometheusQueryRange.ts
+++ b/packages/ui-core/src/utilities/metrics/usePrometheusQueryRange.ts
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import useFetchState, {
+  FetchOptions,
+  FetchState,
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '../../hooks/useFetchState';
+import type {
+  PrometheusQueryRangeResponse,
+  PrometheusQueryRangeResponseData,
+  PrometheusQueryRangeResponseDataResult,
+  PrometheusQueryRangeResultValue,
+} from '../../types/metrics';
+
+export type ResponsePredicate<T = PrometheusQueryRangeResultValue> = (
+  data: PrometheusQueryRangeResponseData,
+) => T[];
+
+/**
+ * POST function signature for Prometheus queries.
+ * Accepts a URL and body string, returns the parsed response data.
+ */
+export type PrometheusPostFn = (
+  url: string,
+  body: { query: string },
+) => Promise<{ response: PrometheusQueryRangeResponse }>;
+
+const defaultPost: PrometheusPostFn = async (url, body) => {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Prometheus query failed: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+};
+
+const usePrometheusQueryRange = <T = PrometheusQueryRangeResultValue>(
+  active: boolean,
+  apiPath: string,
+  queryLang: string,
+  span: number,
+  endInMs: number,
+  step: number,
+  responsePredicate: ResponsePredicate<T>,
+  namespace: string,
+  fetchOptions?: Partial<FetchOptions>,
+  post: PrometheusPostFn = defaultPost,
+): [...FetchState<T[]>, boolean] => {
+  const pendingRef = React.useRef(active);
+  const fetchData = React.useCallback<FetchStateCallbackPromise<T[]>>(() => {
+    const endInS = endInMs / 1000;
+    const start = endInS - span;
+
+    if (!active) {
+      return Promise.reject(new NotReadyError('Prometheus query is not active'));
+    }
+
+    return post(apiPath, {
+      query: new URLSearchParams({
+        namespace,
+        query: queryLang,
+        start: start.toString(),
+        end: endInS.toString(),
+        step: step.toString(),
+      }).toString(),
+    })
+      .then((response) => responsePredicate(response.response.data))
+      .finally(() => {
+        pendingRef.current = false;
+      });
+  }, [endInMs, span, active, apiPath, namespace, queryLang, step, responsePredicate, post]);
+
+  // The query is pending if fetchData changes because it will trigger useFetchState to re-fetch
+  React.useMemo(() => {
+    pendingRef.current = active;
+    // We do not reference fetchData but need to react to it changing
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, fetchData]);
+
+  return [...useFetchState<T[]>(fetchData, [], fetchOptions), pendingRef.current];
+};
+
+export const defaultResponsePredicate: ResponsePredicate = (data) => data.result?.[0]?.values || [];
+
+export const prometheusQueryRangeResponsePredicate: ResponsePredicate<
+  PrometheusQueryRangeResponseDataResult
+> = (data) => data.result || [];
+
+export default usePrometheusQueryRange;

--- a/packages/ui-core/src/utilities/metrics/usePrometheusQueryRange.ts
+++ b/packages/ui-core/src/utilities/metrics/usePrometheusQueryRange.ts
@@ -25,18 +25,11 @@ export type PrometheusPostFn = (
   body: { query: string },
 ) => Promise<{ response: PrometheusQueryRangeResponse }>;
 
-const defaultPost: PrometheusPostFn = async (url, body) => {
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    throw new Error(`Prometheus query failed: ${res.status} ${res.statusText}`);
-  }
-  return res.json();
-};
-
+// `post` is intentionally required (no plain-`fetch` default). Runtime callers
+// must inject a transport bound to the dashboard's authenticated instance so
+// requests carry cookies, CSRF, `x-odh-feature-flags`, and interceptors. The
+// frontend wrapper (`frontend/src/api/prometheus/usePrometheusQueryRange.ts`)
+// supplies an axios-backed transport.
 const usePrometheusQueryRange = <T = PrometheusQueryRangeResultValue>(
   active: boolean,
   apiPath: string,
@@ -46,8 +39,8 @@ const usePrometheusQueryRange = <T = PrometheusQueryRangeResultValue>(
   step: number,
   responsePredicate: ResponsePredicate<T>,
   namespace: string,
-  fetchOptions?: Partial<FetchOptions>,
-  post: PrometheusPostFn = defaultPost,
+  fetchOptions: Partial<FetchOptions> | undefined,
+  post: PrometheusPostFn,
 ): [...FetchState<T[]>, boolean] => {
   const pendingRef = React.useRef(active);
   const fetchData = React.useCallback<FetchStateCallbackPromise<T[]>>(() => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-82807

## Description

Splits the 22-member `HostApiServices` into three layered contexts per the [decoupling proposal](https://gist.github.com/caponetto/e10c98b9ce2d664fd1fe5b94e8570035):

- **Core** (4): `dashboardNamespace`, `checkAccess`, `trackEvent`, `fetchDashboardConfig`
- **Infra** (8): secrets, projects, PVCs
- **Domain** (10): serving, metrics, NIM, connections (backward-compat, shrinks over time)

The **Domain** context is an intentional Step 2 backward-compat bridge, not the final state — `useHostApi()` keeps working for domain services with no consumer breakage. Slimming the provider to Core + Infra only (removing the domain bridge) is tracked by [RHOAIENG-79894](https://redhat.atlassian.net/browse/RHOAIENG-79894) / RHOAIENG-79895, so "slim the provider" is not a merge blocker for this PR.

Also promotes `usePrometheusQueryRange` to the explicit subpath `@odh-dashboard/ui-core/utilities/metrics/usePrometheusQueryRange` (not re-exported from the `metrics` timeframe-constants barrel). The base hook takes a **required** `post` transport — there is deliberately no plain-`fetch` default, since that would silently bypass the dashboard's authenticated instance (cookies, CSRF, `x-odh-feature-flags`, interceptors). Runtime callers must inject a transport; the frontend axios wrapper (`frontend/src/api/prometheus/usePrometheusQueryRange.ts`) supplies one.

> Note: the epic AC references the instant-query `usePrometheusQuery`; this PR promotes the range hook `usePrometheusQueryRange`. The AC name should be updated to match.

## How Has This Been Tested?

- `type-check`: all packages pass
- `lint`: 0 warnings
- Unit tests pass (the two `defaultPost` fetch tests were removed with the default)

## Test Impact

Existing tests updated to mock the correct contexts (Core/Infra). No new product tests needed (structural refactor only).

## Request review criteria:

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our [Best Practices](/docs/best-practices.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable Prometheus range-query support with query construction, loading states, response parsing, refresh handling, and error reporting.
  * Added dedicated access points for core, infrastructure, and domain services while preserving backward compatibility.
* **Improvements**
  * Improved consistency for access checks, dashboard configuration, secret operations, PVC retrieval, event tracking, and deployment settings.
* **Tests**
  * Added coverage for Prometheus querying, inactive states, response handling, loading transitions, and refresh behavior.
  * Updated service mocks and integration tests for revised service access patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[RHOAIENG-79894]: https://redhat.atlassian.net/browse/RHOAIENG-79894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ