### PR TITLE
fix: register json-patch+json content-type parser for Fastify 5

### DIFF
--- a/backend/src/__tests__/patchContentTypeParsers.spec.ts
+++ b/backend/src/__tests__/patchContentTypeParsers.spec.ts
@@ -1,0 +1,74 @@
+import { fastify } from 'fastify';
+import { registerPatchContentTypeParsers } from '../utils/patchContentTypeParsers';
+
+describe('registerPatchContentTypeParsers', () => {
+  const patchPayload = [{ op: 'add', path: '/metadata/annotations/test', value: 'enabled' }];
+
+  it.each(['application/json-patch+json', 'application/merge-patch+json'])(
+    'should parse PATCH requests with %s',
+    async (contentType) => {
+      const app = fastify();
+      registerPatchContentTypeParsers(app);
+
+      app.patch('/test', async (request) => request.body);
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/test',
+        headers: {
+          'content-type': contentType,
+        },
+        payload: JSON.stringify(patchPayload),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual(patchPayload);
+
+      await app.close();
+    },
+  );
+
+  it.each(['application/json-patch+json', 'application/merge-patch+json'])(
+    'should parse PATCH requests with %s and charset',
+    async (contentType) => {
+      const app = fastify();
+      registerPatchContentTypeParsers(app);
+
+      app.patch('/test', async (request) => request.body);
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/test',
+        headers: {
+          'content-type': `${contentType};charset=UTF-8`,
+        },
+        payload: JSON.stringify(patchPayload),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual(patchPayload);
+
+      await app.close();
+    },
+  );
+
+  it('should reject unsupported PATCH content types with 415', async () => {
+    const app = fastify();
+    registerPatchContentTypeParsers(app);
+
+    app.patch('/test', async (request) => request.body);
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/test',
+      headers: {
+        'content-type': 'application/vnd.example+json',
+      },
+      payload: JSON.stringify(patchPayload),
+    });
+
+    expect(response.statusCode).toBe(415);
+
+    await app.close();
+  });
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,6 +2,7 @@ import { fastify } from 'fastify';
 import pino from 'pino';
 import { APP_ENV, PORT, IP, LOG_LEVEL } from './utils/constants';
 import { initializeApp } from './app';
+import { registerPatchContentTypeParsers } from './utils/patchContentTypeParsers';
 import { AddressInfo } from 'net';
 import https from 'https';
 import fs from 'fs';
@@ -37,20 +38,8 @@ const app = fastify({
   pluginTimeout: 10000,
 });
 
-// Allow the fastify server to parse the merge-patch/json content type
-app.addContentTypeParser(
-  'application/merge-patch+json',
-  { parseAs: 'string' },
-  function (req, body, done) {
-    try {
-      const json = JSON.parse(String(body));
-      done(null, json);
-    } catch (err) {
-      err.statusCode = 400;
-      done(err, undefined);
-    }
-  },
-);
+// Fastify 5 requires explicit parsers for K8s PATCH content types (json-patch and merge-patch).
+registerPatchContentTypeParsers(app);
 
 app.register(initializeApp);
 

--- a/backend/src/utils/patchContentTypeParsers.ts
+++ b/backend/src/utils/patchContentTypeParsers.ts
@@ -1,0 +1,28 @@
+import type { FastifyInstance } from 'fastify';
+
+const PATCH_CONTENT_TYPES = [
+  'application/merge-patch+json',
+  'application/json-patch+json',
+] as const;
+
+const parseJsonBody = (
+  _req: unknown,
+  body: string | Buffer,
+  done: (err: Error | null, result?: unknown) => void,
+): void => {
+  try {
+    done(null, JSON.parse(String(body)));
+  } catch (err) {
+    (err as Error & { statusCode?: number }).statusCode = 400;
+    done(err as Error, undefined);
+  }
+};
+
+/** Fastify 5 requires explicit parsers for K8s PATCH content types used by the dashboard. */
+export const registerPatchContentTypeParsers = (
+  app: Pick<FastifyInstance, 'addContentTypeParser'>,
+): void => {
+  PATCH_CONTENT_TYPES.forEach((contentType) => {
+    app.addContentTypeParser(contentType, { parseAs: 'string' }, parseJsonBody);
+  });
+};


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-81841

## Description

PR #9202 upgraded Fastify 4→5 but did not register a content-type parser for `application/json-patch+json`. Fastify 5 requires explicit parsers for non-default content types — the built-in `application/json` parser does **not** match `+json` subtypes like it did in Fastify 4.

This causes **415 Unsupported Media Type** on all `k8sPatchResource` calls that use JSON Patch (`{ op: "add", ... }` payloads), including:
- Workbench start/stop
- InferenceService / LLMInferenceService enable/disable (accelerator, topology, routing)
- Any other `k8sPatchResource` caller via the `/api/k8s/*` pass-through

The existing `application/merge-patch+json` parser (added in PR #3168) was already registered and continued to work, but `application/json-patch+json` was never explicitly registered, and Fastify 4 happened to accept it implicitly.

**Root cause context:** This is the same class of bug as the April Fastify 5 attempt (PR #6727, reverted in #7387). That incident fixed `merge-patch` only. This upgrade repeated the gap.

## How Has This Been Tested?

### Automated
- `npm run test:lint` (backend) — Pass (0 errors, 0 warnings)
- `npm run test:type-check` (backend) — Pass
- `npm run test:jest` (backend) — 208/208 pass
- New unit tests: 5 tests covering `json-patch+json`, `merge-patch+json`, charset suffix variants, and 415 rejection

### Manual verification needed
- [ ] Workbench start/stop on cluster
- [ ] InferenceService / LLMInferenceService PATCH toggles on cluster

## Test Impact

Added `backend/src/__tests__/patchContentTypeParsers.spec.ts` with 5 tests

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`