### PR TITLE
RHOAIENG-79896: Bridge ProjectDetailsContext, ModelServingContext, ConnectionTypeFormFields, NewProjectButton via host-api

### DIFF
--- a/frontend/src/app/HostApiProvider.tsx
+++ b/frontend/src/app/HostApiProvider.tsx
@@ -8,6 +8,7 @@ import {
   type HostApiInfraServices,
 } from '@odh-dashboard/plugin-core/host-api';
 import { useDashboardNamespace } from '#~/redux/selectors/project';
+import { useUser } from '#~/redux/selectors';
 import { checkAccess } from '#~/api/checkAccess';
 import {
   getSecretsByLabel,
@@ -32,6 +33,11 @@ import useServingPlatformStatuses from '#~/pages/modelServing/useServingPlatform
 import { isProjectNIMSupported } from '#~/pages/modelServing/screens/projects/nim/nimUtils';
 import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
 import { registeredModelDeploymentsRoute } from '#~/routes/modelRegistry/registeredModels';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
+import ModelServingContextProvider, {
+  ModelServingContext,
+} from '#~/pages/modelServing/ModelServingContext';
+import ConnectionTypeFormFields from '#~/concepts/connectionTypes/fields/ConnectionTypeFormFields';
 
 type HostApiProviderProps = {
   children: React.ReactNode;
@@ -39,6 +45,7 @@ type HostApiProviderProps = {
 
 const HostApiProvider: React.FC<HostApiProviderProps> = ({ children }) => {
   const { dashboardNamespace } = useDashboardNamespace();
+  const { username } = useUser();
 
   const core = React.useMemo<HostApiCoreServices>(
     () => ({
@@ -78,8 +85,16 @@ const HostApiProvider: React.FC<HostApiProviderProps> = ({ children }) => {
       useServingPlatformStatuses,
       isProjectNIMSupported,
       registeredModelDeploymentsRoute,
+      createProject: (displayName: string, description: string, k8sName?: string) =>
+        createProject(username, displayName, description, k8sName),
+      ConnectionTypeFormFields,
+      contexts: {
+        ProjectDetailsContext,
+        ModelServingContext,
+        ModelServingContextProvider,
+      },
     }),
-    [],
+    [username],
   );
 
   return (

--- a/frontend/src/app/HostApiProvider.tsx
+++ b/frontend/src/app/HostApiProvider.tsx
@@ -32,7 +32,6 @@ import { useModelServingMetrics } from '#~/api/prometheus/serving';
 import useServingPlatformStatuses from '#~/pages/modelServing/useServingPlatformStatuses';
 import { isProjectNIMSupported } from '#~/pages/modelServing/screens/projects/nim/nimUtils';
 import { fireMiscTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
-import { registeredModelDeploymentsRoute } from '#~/routes/modelRegistry/registeredModels';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import ModelServingContextProvider, {
   ModelServingContext,
@@ -84,7 +83,6 @@ const HostApiProvider: React.FC<HostApiProviderProps> = ({ children }) => {
         useModelServingMetrics as unknown as HostApiServices['useModelServingMetrics'],
       useServingPlatformStatuses,
       isProjectNIMSupported,
-      registeredModelDeploymentsRoute,
       createProject: (displayName: string, description: string, k8sName?: string) =>
         createProject(username, displayName, description, k8sName),
       ConnectionTypeFormFields,

--- a/frontend/src/routes/modelRegistry/registeredModels.ts
+++ b/frontend/src/routes/modelRegistry/registeredModels.ts
@@ -5,8 +5,3 @@ const registeredModelsRoute = (preferredModelRegistry?: string): string =>
 
 export const registeredModelRoute = (rmId = '', preferredModelRegistry?: string): string =>
   `${registeredModelsRoute(preferredModelRegistry)}/${rmId}`;
-
-export const registeredModelDeploymentsRoute = (
-  rmId = '',
-  preferredModelRegistry?: string,
-): string => `${registeredModelRoute(rmId, preferredModelRegistry)}/deployments`;

--- a/packages/maas/frontend/src/app/pages/external-models/NewProjectButton.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/NewProjectButton.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { Button, Form, FormGroup, TextArea, TextInput } from '@patternfly/react-core';
+import ContentModal from '@odh-dashboard/ui-core/components/ContentModal';
+import { useHostApi, useTrackEvent } from '@odh-dashboard/plugin-core/host-api';
+
+type NewProjectButtonProps = {
+  onProjectCreated?: (projectName: string) => void;
+};
+
+const NewProjectButton: React.FC<NewProjectButtonProps> = ({ onProjectCreated }) => {
+  const { createProject } = useHostApi();
+  const trackEvent = useTrackEvent();
+  const [open, setOpen] = React.useState(false);
+  const [displayName, setDisplayName] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<Error>();
+
+  const resetForm = () => {
+    setDisplayName('');
+    setDescription('');
+    setError(undefined);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    resetForm();
+  };
+
+  const safeTrackEvent = (...args: Parameters<typeof trackEvent>) => {
+    try {
+      trackEvent(...args);
+    } catch {
+      // Telemetry must not block modal cleanup or API error handling.
+    }
+  };
+
+  const handleCancel = () => {
+    if (submitting) {
+      return;
+    }
+    safeTrackEvent('create_project_canceled', {});
+    handleClose();
+  };
+
+  const handleSubmit = async () => {
+    const trimmedName = displayName.trim();
+    if (!trimmedName) {
+      return;
+    }
+    setSubmitting(true);
+    setError(undefined);
+    let projectName: string;
+    try {
+      projectName = await createProject(trimmedName, description);
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error('Failed to create project');
+      safeTrackEvent('create_project_submitted', { outcome: 'error' });
+      setError(err);
+      setSubmitting(false);
+      return;
+    }
+    setSubmitting(false);
+    safeTrackEvent('create_project_submitted', { outcome: 'success' });
+    handleClose();
+    onProjectCreated?.(projectName);
+  };
+
+  return (
+    <>
+      <Button data-testid="create-project" variant="primary" onClick={() => setOpen(true)}>
+        Create project
+      </Button>
+      {open ? (
+        <ContentModal
+          title="Create project"
+          onClose={handleCancel}
+          variant="small"
+          error={error}
+          alertTitle="Failed to create project"
+          contents={
+            <Form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleSubmit();
+              }}
+            >
+              <FormGroup label="Name" isRequired fieldId="create-project-name">
+                <TextInput
+                  id="create-project-name"
+                  data-testid="create-project-name"
+                  value={displayName}
+                  onChange={(_e, value) => setDisplayName(value)}
+                  isRequired
+                  isDisabled={submitting}
+                />
+              </FormGroup>
+              <FormGroup label="Description" fieldId="create-project-description">
+                <TextArea
+                  id="create-project-description"
+                  data-testid="create-project-description"
+                  value={description}
+                  onChange={(_e, value) => setDescription(value)}
+                  isDisabled={submitting}
+                />
+              </FormGroup>
+            </Form>
+          }
+          buttonActions={[
+            {
+              label: 'Create',
+              variant: 'primary',
+              dataTestId: 'create-project-submit',
+              onClick: handleSubmit,
+              isDisabled: !displayName.trim() || submitting,
+              isLoading: submitting,
+            },
+            {
+              label: 'Cancel',
+              variant: 'link',
+              onClick: handleCancel,
+              isDisabled: submitting,
+            },
+          ]}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default NewProjectButton;

--- a/packages/maas/frontend/src/app/pages/external-models/NoProjectsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/NoProjectsPage.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { EmptyState, EmptyStateBody, EmptyStateFooter } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
 import { useNavigate } from 'react-router-dom';
-import NewProjectButton from './NewProjectButton';
 import { deploymentsExternalPath } from '~/app/pages/external-models/const';
+import NewProjectButton from './NewProjectButton';
 
 const NoProjectsPage: React.FC = () => {
   const navigate = useNavigate();

--- a/packages/maas/frontend/src/app/pages/external-models/NoProjectsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/external-models/NoProjectsPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { EmptyState, EmptyStateBody, EmptyStateFooter } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
 import { useNavigate } from 'react-router-dom';
-import NewProjectButton from '@odh-dashboard/internal/pages/projects/screens/projects/NewProjectButton';
+import NewProjectButton from './NewProjectButton';
 import { deploymentsExternalPath } from '~/app/pages/external-models/const';
 
 const NoProjectsPage: React.FC = () => {
@@ -12,7 +12,6 @@ const NoProjectsPage: React.FC = () => {
       <EmptyStateBody>To use external models, first create a project.</EmptyStateBody>
       <EmptyStateFooter>
         <NewProjectButton
-          closeOnCreate
           onProjectCreated={(projectName) => navigate(deploymentsExternalPath(projectName))}
         />
       </EmptyStateFooter>

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
@@ -101,6 +101,7 @@ const ExtendedRegisteredModelTableRow: React.FC<ExtendedRegisteredModelTableRowP
           props={{
             registeredModel: rm,
             preferredModelRegistryName: preferredModelRegistry?.name,
+            deploymentsUrl: `${rmUrl}/deployments`,
           }}
         />
       </Td>

--- a/packages/model-serving/modelRegistry/DeploymentsColumn.tsx
+++ b/packages/model-serving/modelRegistry/DeploymentsColumn.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { KnownLabels } from '@odh-dashboard/k8s-core';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
 import type { RegisteredModelRef } from '@odh-dashboard/model-registry/shared';
 import { ModelDeploymentsContext } from '../src/concepts/ModelDeploymentsContext';
 
 const DeploymentsColumn: React.FC<{
   registeredModel: RegisteredModelRef;
-  preferredModelRegistryName?: string;
-}> = ({ registeredModel, preferredModelRegistryName }) => {
-  const { registeredModelDeploymentsRoute } = useHostApi();
+  deploymentsUrl?: string;
+}> = ({ registeredModel, deploymentsUrl }) => {
   const { deployments, loaded } = React.useContext(ModelDeploymentsContext);
 
   if (!loaded) {
@@ -30,8 +28,16 @@ const DeploymentsColumn: React.FC<{
     return <span>-</span>;
   }
 
+  if (!deploymentsUrl) {
+    return (
+      <span>
+        {deploymentCount} {deploymentCount === 1 ? 'deployment' : 'deployments'}
+      </span>
+    );
+  }
+
   return (
-    <Link to={registeredModelDeploymentsRoute(registeredModel.id, preferredModelRegistryName)}>
+    <Link to={deploymentsUrl}>
       {deploymentCount} {deploymentCount === 1 ? 'deployment' : 'deployments'}
     </Link>
   );

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
@@ -211,21 +211,33 @@ const mockConnectionTypes: ConnectionTypeConfigMapObj[] = [
     },
   },
 ];
-jest.mock('@odh-dashboard/plugin-core/host-api', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-assertions, @odh-dashboard/no-restricted-imports -- test mock: provide real component via host-api bridge
-  const { default: RealConnectionTypeFormFields } = jest.requireActual(
-    '@odh-dashboard/internal/concepts/connectionTypes/fields/ConnectionTypeFormFields',
-  ) as { default: React.ComponentType };
-  return {
-    useWatchConnectionTypes: () => [mockConnectionTypes, true],
-    useServingConnections: jest.fn(() => [mockConnections, true]),
-    useHostApi: jest.fn(() => ({
-      ConnectionTypeFormFields: RealConnectionTypeFormFields,
-    })),
-    useHostApiCore: jest.fn(() => ({ trackEvent: jest.fn() })),
-    useHostApiInfra: jest.fn(() => ({ getDashboardPvcs: jest.fn().mockResolvedValue([]) })),
-  };
-});
+const StubConnectionTypeFormFields: React.FC<{
+  fields?: { type: string; envVar?: string }[];
+  connectionValues?: Record<string, unknown>;
+  onChange?: (field: { type: string; envVar?: string }, value: unknown) => void;
+}> = ({ fields, connectionValues, onChange }) => (
+  <>
+    {fields
+      ?.filter((f): f is { type: string; envVar: string } => f.type !== 'section' && !!f.envVar)
+      .map((field) => (
+        <input
+          key={field.envVar}
+          data-testid={`field ${field.envVar}`}
+          value={String(connectionValues?.[field.envVar] ?? '')}
+          onChange={(e) => onChange?.(field, e.target.value)}
+        />
+      ))}
+  </>
+);
+jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
+  useWatchConnectionTypes: () => [mockConnectionTypes, true],
+  useServingConnections: jest.fn(() => [mockConnections, true]),
+  useHostApi: jest.fn(() => ({
+    ConnectionTypeFormFields: StubConnectionTypeFormFields,
+  })),
+  useHostApiCore: jest.fn(() => ({ trackEvent: jest.fn() })),
+  useHostApiInfra: jest.fn(() => ({ getDashboardPvcs: jest.fn().mockResolvedValue([]) })),
+}));
 
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({
   ...jest.requireActual('@odh-dashboard/plugin-core/areas'),
@@ -499,6 +511,11 @@ describe('ModelLocationSelectField', () => {
                   [KnownLabels.DASHBOARD_RESOURCE]: 'true',
                   'opendatahub.io/connection-type': 'true',
                 },
+              },
+              data: {
+                fields: [
+                  { envVar: 'URI', name: 'URI', required: true, type: 'uri', properties: {} },
+                ],
               },
             },
           }}

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
@@ -211,13 +211,21 @@ const mockConnectionTypes: ConnectionTypeConfigMapObj[] = [
     },
   },
 ];
-jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
-  useWatchConnectionTypes: () => [mockConnectionTypes, true],
-  useServingConnections: jest.fn(() => [mockConnections, true]),
-  useHostApi: jest.fn(() => ({ trackEvent: jest.fn() })),
-  useHostApiCore: jest.fn(() => ({ trackEvent: jest.fn() })),
-  useHostApiInfra: jest.fn(() => ({ getDashboardPvcs: jest.fn().mockResolvedValue([]) })),
-}));
+jest.mock('@odh-dashboard/plugin-core/host-api', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-assertions, @odh-dashboard/no-restricted-imports -- test mock: provide real component via host-api bridge
+  const { default: RealConnectionTypeFormFields } = jest.requireActual(
+    '@odh-dashboard/internal/concepts/connectionTypes/fields/ConnectionTypeFormFields',
+  ) as { default: React.ComponentType };
+  return {
+    useWatchConnectionTypes: () => [mockConnectionTypes, true],
+    useServingConnections: jest.fn(() => [mockConnections, true]),
+    useHostApi: jest.fn(() => ({
+      ConnectionTypeFormFields: RealConnectionTypeFormFields,
+    })),
+    useHostApiCore: jest.fn(() => ({ trackEvent: jest.fn() })),
+    useHostApiInfra: jest.fn(() => ({ getDashboardPvcs: jest.fn().mockResolvedValue([]) })),
+  };
+});
 
 jest.mock('@odh-dashboard/plugin-core/areas', () => ({
   ...jest.requireActual('@odh-dashboard/plugin-core/areas'),

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/NewConnectionField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/NewConnectionField.tsx
@@ -10,7 +10,7 @@ import type {
   ConnectionTypeDataField,
   ConnectionTypeValueType,
 } from '@odh-dashboard/k8s-core';
-import ConnectionTypeFormFields from '@odh-dashboard/internal/concepts/connectionTypes/fields/ConnectionTypeFormFields';
+import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
 import ConnectionOciPathField from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField';
 import ConnectionS3FolderPathField from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField';
 import { ModelLocationData } from '../../../../shared/types/form-data';
@@ -30,6 +30,7 @@ const NewConnectionField: React.FC<Props> = ({
   modelLocationData,
   connectionType,
 }) => {
+  const { ConnectionTypeFormFields } = useHostApi();
   const connectionValues = React.useMemo(() => {
     if (!modelLocationData) return {};
     return modelLocationData.fieldValues;

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/NewConnectionField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/NewConnectionField.tsx
@@ -10,7 +10,8 @@ import type {
   ConnectionTypeDataField,
   ConnectionTypeValueType,
 } from '@odh-dashboard/k8s-core';
-import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { isConnectionTypeFormFieldsExtension } from '@odh-dashboard/plugin-core/extension-points';
 import ConnectionOciPathField from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField';
 import ConnectionS3FolderPathField from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField';
 import { ModelLocationData } from '../../../../shared/types/form-data';
@@ -30,7 +31,12 @@ const NewConnectionField: React.FC<Props> = ({
   modelLocationData,
   connectionType,
 }) => {
-  const { ConnectionTypeFormFields } = useHostApi();
+  const [formFieldExtensions, extensionsLoaded] = useResolvedExtensions(
+    isConnectionTypeFormFieldsExtension,
+  );
+  const ConnectionTypeFormFields = extensionsLoaded
+    ? formFieldExtensions[0]?.properties.component.default
+    : undefined;
   const connectionValues = React.useMemo(() => {
     if (!modelLocationData) return {};
     return modelLocationData.fieldValues;
@@ -111,13 +117,15 @@ const NewConnectionField: React.FC<Props> = ({
 
   return (
     <FormGroup>
-      <ConnectionTypeFormFields
-        fields={fields}
-        isPreview={false}
-        isDisabled={modelLocationData?.disableInputFields}
-        onChange={handleFieldChange}
-        connectionValues={connectionValues}
-      />
+      {ConnectionTypeFormFields ? (
+        <ConnectionTypeFormFields
+          fields={fields}
+          isPreview={false}
+          isDisabled={modelLocationData?.disableInputFields}
+          onChange={handleFieldChange}
+          connectionValues={connectionValues}
+        />
+      ) : null}
       {renderAdditionalFields()}
       <CreateConnectionInputFields
         createConnectionData={wizardState.state.createConnectionData.data}

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/NewConnectionField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/NewConnectionField.tsx
@@ -10,8 +10,7 @@ import type {
   ConnectionTypeDataField,
   ConnectionTypeValueType,
 } from '@odh-dashboard/k8s-core';
-import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
-import { isConnectionTypeFormFieldsExtension } from '@odh-dashboard/plugin-core/extension-points';
+import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
 import ConnectionOciPathField from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField';
 import ConnectionS3FolderPathField from '@odh-dashboard/internal/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionS3FolderPathField';
 import { ModelLocationData } from '../../../../shared/types/form-data';
@@ -31,12 +30,7 @@ const NewConnectionField: React.FC<Props> = ({
   modelLocationData,
   connectionType,
 }) => {
-  const [formFieldExtensions, extensionsLoaded] = useResolvedExtensions(
-    isConnectionTypeFormFieldsExtension,
-  );
-  const ConnectionTypeFormFields = extensionsLoaded
-    ? formFieldExtensions[0]?.properties.component.default
-    : undefined;
+  const { ConnectionTypeFormFields } = useHostApi();
   const connectionValues = React.useMemo(() => {
     if (!modelLocationData) return {};
     return modelLocationData.fieldValues;
@@ -117,15 +111,13 @@ const NewConnectionField: React.FC<Props> = ({
 
   return (
     <FormGroup>
-      {ConnectionTypeFormFields ? (
-        <ConnectionTypeFormFields
-          fields={fields}
-          isPreview={false}
-          isDisabled={modelLocationData?.disableInputFields}
-          onChange={handleFieldChange}
-          connectionValues={connectionValues}
-        />
-      ) : null}
+      <ConnectionTypeFormFields
+        fields={fields}
+        isPreview={false}
+        isDisabled={modelLocationData?.disableInputFields}
+        onChange={handleFieldChange}
+        connectionValues={connectionValues}
+      />
       {renderAdditionalFields()}
       <CreateConnectionInputFields
         createConnectionData={wizardState.state.createConnectionData.data}

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
@@ -31,21 +31,33 @@ jest.mock('@odh-dashboard/plugin-core', () => ({
   useExtensions: jest.fn().mockReturnValue([]),
 }));
 
-jest.mock('@odh-dashboard/plugin-core/host-api', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-assertions, @odh-dashboard/no-restricted-imports -- test mock: provide real component via host-api bridge
-  const { default: RealConnectionTypeFormFields } = jest.requireActual(
-    '@odh-dashboard/internal/concepts/connectionTypes/fields/ConnectionTypeFormFields',
-  ) as { default: React.ComponentType };
-  return {
-    useWatchConnectionTypes: jest.fn(() => [[], true]),
-    useServingConnections: jest.fn(() => [[], true]),
-    useHostApi: jest.fn(() => ({
-      ConnectionTypeFormFields: RealConnectionTypeFormFields,
-    })),
-    useHostApiCore: jest.fn(() => ({ trackEvent: jest.fn() })),
-    useHostApiInfra: jest.fn(() => ({ getDashboardPvcs: jest.fn().mockResolvedValue([]) })),
-  };
-});
+const StubConnectionTypeFormFields: React.FC<{
+  fields?: { type: string; envVar?: string }[];
+  connectionValues?: Record<string, unknown>;
+  onChange?: (field: { type: string; envVar?: string }, value: unknown) => void;
+}> = ({ fields, connectionValues, onChange }) => (
+  <>
+    {fields
+      ?.filter((f): f is { type: string; envVar: string } => f.type !== 'section' && !!f.envVar)
+      .map((field) => (
+        <input
+          key={field.envVar}
+          data-testid={`field ${field.envVar}`}
+          value={String(connectionValues?.[field.envVar] ?? '')}
+          onChange={(e) => onChange?.(field, e.target.value)}
+        />
+      ))}
+  </>
+);
+jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
+  useWatchConnectionTypes: jest.fn(() => [[], true]),
+  useServingConnections: jest.fn(() => [[], true]),
+  useHostApi: jest.fn(() => ({
+    ConnectionTypeFormFields: StubConnectionTypeFormFields,
+  })),
+  useHostApiCore: jest.fn(() => ({ trackEvent: jest.fn() })),
+  useHostApiInfra: jest.fn(() => ({ getDashboardPvcs: jest.fn().mockResolvedValue([]) })),
+}));
 
 // Mock PatternFly wizard hooks
 jest.mock('@patternfly/react-core', () => ({
@@ -234,6 +246,11 @@ describe('ModelSourceStep', () => {
                   annotations: {
                     'opendatahub.io/connection-type': 'uri - v1',
                   },
+                },
+                data: {
+                  fields: [
+                    { envVar: 'URI', name: 'URI', required: true, type: 'uri', properties: {} },
+                  ],
                 },
               },
               additionalFields: {},

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
@@ -31,13 +31,21 @@ jest.mock('@odh-dashboard/plugin-core', () => ({
   useExtensions: jest.fn().mockReturnValue([]),
 }));
 
-jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
-  useWatchConnectionTypes: jest.fn(() => [[], true]),
-  useServingConnections: jest.fn(() => [[], true]),
-  useHostApi: jest.fn(() => ({ trackEvent: jest.fn() })),
-  useHostApiCore: jest.fn(() => ({ trackEvent: jest.fn() })),
-  useHostApiInfra: jest.fn(() => ({ getDashboardPvcs: jest.fn().mockResolvedValue([]) })),
-}));
+jest.mock('@odh-dashboard/plugin-core/host-api', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-assertions, @odh-dashboard/no-restricted-imports -- test mock: provide real component via host-api bridge
+  const { default: RealConnectionTypeFormFields } = jest.requireActual(
+    '@odh-dashboard/internal/concepts/connectionTypes/fields/ConnectionTypeFormFields',
+  ) as { default: React.ComponentType };
+  return {
+    useWatchConnectionTypes: jest.fn(() => [[], true]),
+    useServingConnections: jest.fn(() => [[], true]),
+    useHostApi: jest.fn(() => ({
+      ConnectionTypeFormFields: RealConnectionTypeFormFields,
+    })),
+    useHostApiCore: jest.fn(() => ({ trackEvent: jest.fn() })),
+    useHostApiInfra: jest.fn(() => ({ getDashboardPvcs: jest.fn().mockResolvedValue([]) })),
+  };
+});
 
 // Mock PatternFly wizard hooks
 jest.mock('@patternfly/react-core', () => ({

--- a/packages/model-serving/src/components/global/GlobalModelServingCoreLoader.tsx
+++ b/packages/model-serving/src/components/global/GlobalModelServingCoreLoader.tsx
@@ -4,7 +4,7 @@ import { byName } from '@odh-dashboard/k8s-core';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { ApplicationsPage } from '@odh-dashboard/ui-core';
 import InvalidProject from '@odh-dashboard/ui-core/components/InvalidProject';
-import ModelServingContextProvider from '@odh-dashboard/internal/pages/modelServing/ModelServingContext';
+import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
 import ModelServingNoProjects from '@odh-dashboard/internal/pages/modelServing/screens/global/ModelServingNoProjects';
 import { getStoredPreferredProject } from '@odh-dashboard/ui-core/context/getStoredPreferredProject';
 import ModelServingProjectSelection from './ModelServingProjectSelection';
@@ -21,6 +21,9 @@ type ApplicationPageRenderState = Pick<ApplicationPageProps, EmptyStateProps>;
 const GlobalModelServingCoreLoader: React.FC<GlobalModelServingCoreLoaderProps> = ({
   getInvalidRedirectPath,
 }) => {
+  const {
+    contexts: { ModelServingContextProvider },
+  } = useHostApi();
   const { namespace } = useParams<{ namespace: string }>();
   const { projects, preferredProject } = React.useContext(ProjectsContext);
   const storedProject = getStoredPreferredProject(projects);

--- a/packages/model-serving/src/components/global/NewProjectButton.tsx
+++ b/packages/model-serving/src/components/global/NewProjectButton.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { Button, Form, FormGroup, TextArea, TextInput } from '@patternfly/react-core';
+import ContentModal from '@odh-dashboard/ui-core/components/ContentModal';
+import { useHostApi, useTrackEvent } from '@odh-dashboard/plugin-core/host-api';
+
+type NewProjectButtonProps = {
+  onProjectCreated?: (projectName: string) => void;
+};
+
+const NewProjectButton: React.FC<NewProjectButtonProps> = ({ onProjectCreated }) => {
+  const { createProject } = useHostApi();
+  const trackEvent = useTrackEvent();
+  const [open, setOpen] = React.useState(false);
+  const [displayName, setDisplayName] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<Error>();
+
+  const resetForm = () => {
+    setDisplayName('');
+    setDescription('');
+    setError(undefined);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    resetForm();
+  };
+
+  const safeTrackEvent = (...args: Parameters<typeof trackEvent>) => {
+    try {
+      trackEvent(...args);
+    } catch {
+      // Telemetry must not block modal cleanup or API error handling.
+    }
+  };
+
+  const handleCancel = () => {
+    if (submitting) {
+      return;
+    }
+    safeTrackEvent('create_project_canceled', {});
+    handleClose();
+  };
+
+  const handleSubmit = async () => {
+    const trimmedName = displayName.trim();
+    if (!trimmedName) {
+      return;
+    }
+    setSubmitting(true);
+    setError(undefined);
+    let projectName: string;
+    try {
+      projectName = await createProject(trimmedName, description);
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error('Failed to create project');
+      safeTrackEvent('create_project_submitted', { outcome: 'error' });
+      setError(err);
+      setSubmitting(false);
+      return;
+    }
+    setSubmitting(false);
+    safeTrackEvent('create_project_submitted', { outcome: 'success' });
+    handleClose();
+    onProjectCreated?.(projectName);
+  };
+
+  return (
+    <>
+      <Button data-testid="create-project" variant="primary" onClick={() => setOpen(true)}>
+        Create project
+      </Button>
+      {open ? (
+        <ContentModal
+          title="Create project"
+          onClose={handleCancel}
+          variant="small"
+          error={error}
+          alertTitle="Failed to create project"
+          contents={
+            <Form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleSubmit();
+              }}
+            >
+              <FormGroup label="Name" isRequired fieldId="create-project-name">
+                <TextInput
+                  id="create-project-name"
+                  data-testid="create-project-name"
+                  value={displayName}
+                  onChange={(_e, value) => setDisplayName(value)}
+                  isRequired
+                  isDisabled={submitting}
+                />
+              </FormGroup>
+              <FormGroup label="Description" fieldId="create-project-description">
+                <TextArea
+                  id="create-project-description"
+                  data-testid="create-project-description"
+                  value={description}
+                  onChange={(_e, value) => setDescription(value)}
+                  isDisabled={submitting}
+                />
+              </FormGroup>
+            </Form>
+          }
+          buttonActions={[
+            {
+              label: 'Create',
+              variant: 'primary',
+              dataTestId: 'create-project-submit',
+              onClick: handleSubmit,
+              isDisabled: !displayName.trim() || submitting,
+              isLoading: submitting,
+            },
+            {
+              label: 'Cancel',
+              variant: 'link',
+              onClick: handleCancel,
+              isDisabled: submitting,
+            },
+          ]}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default NewProjectButton;

--- a/packages/model-serving/src/components/global/NoProjectsPage.tsx
+++ b/packages/model-serving/src/components/global/NoProjectsPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { EmptyState, EmptyStateBody, EmptyStateFooter } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
 import { useNavigate } from 'react-router-dom';
-import NewProjectButton from '@odh-dashboard/internal/pages/projects/screens/projects/NewProjectButton';
+import NewProjectButton from './NewProjectButton';
 
 const NoProjectsPage: React.FC = () => {
   const navigate = useNavigate();
@@ -11,7 +11,6 @@ const NoProjectsPage: React.FC = () => {
       <EmptyStateBody>To deploy a model, first create a project.</EmptyStateBody>
       <EmptyStateFooter>
         <NewProjectButton
-          closeOnCreate
           onProjectCreated={(projectName) => navigate(`/ai-hub/models/deployments/${projectName}`)}
         />
       </EmptyStateFooter>

--- a/packages/model-serving/src/components/global/__tests__/NewProjectButton.spec.tsx
+++ b/packages/model-serving/src/components/global/__tests__/NewProjectButton.spec.tsx
@@ -40,7 +40,7 @@ describe('NewProjectButton', () => {
   it('should open the modal when clicking Create project', () => {
     render(<NewProjectButton />);
     fireEvent.click(screen.getByTestId('create-project'));
-    expect(screen.getByText('Create project')).toBeInTheDocument();
+    expect(screen.getByTestId('generic-modal-header')).toHaveTextContent('Create project');
     expect(screen.getByTestId('create-project-name')).toBeInTheDocument();
   });
 

--- a/packages/model-serving/src/components/global/__tests__/NewProjectButton.spec.tsx
+++ b/packages/model-serving/src/components/global/__tests__/NewProjectButton.spec.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockCreateProject = jest.fn();
+const mockTrackEvent = jest.fn();
+
+jest.mock('@odh-dashboard/plugin-core/host-api', () => ({
+  useHostApi: jest.fn(() => ({
+    createProject: mockCreateProject,
+  })),
+  useTrackEvent: jest.fn(() => mockTrackEvent),
+}));
+
+jest.mock('@patternfly/react-core', () => ({
+  ...jest.requireActual('@patternfly/react-core'),
+}));
+
+import NewProjectButton from '../NewProjectButton';
+
+describe('NewProjectButton', () => {
+  let resolveCreate: (value: string) => void = () => undefined;
+  let rejectCreate: (reason: Error) => void = () => undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateProject.mockImplementation(
+      () =>
+        new Promise<string>((resolve, reject) => {
+          resolveCreate = resolve;
+          rejectCreate = reject;
+        }),
+    );
+  });
+
+  it('should render the Create project button', () => {
+    render(<NewProjectButton />);
+    expect(screen.getByTestId('create-project')).toBeInTheDocument();
+  });
+
+  it('should open the modal when clicking Create project', () => {
+    render(<NewProjectButton />);
+    fireEvent.click(screen.getByTestId('create-project'));
+    expect(screen.getByText('Create project')).toBeInTheDocument();
+    expect(screen.getByTestId('create-project-name')).toBeInTheDocument();
+  });
+
+  it('should close the modal when clicking Cancel', () => {
+    render(<NewProjectButton />);
+    fireEvent.click(screen.getByTestId('create-project'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByTestId('create-project-name')).not.toBeInTheDocument();
+  });
+
+  it('should submit the form with trimmed name', async () => {
+    mockCreateProject.mockResolvedValue('test-project');
+    render(<NewProjectButton />);
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    fireEvent.change(screen.getByTestId('create-project-name'), {
+      target: { value: '  My Project  ' },
+    });
+    fireEvent.change(screen.getByTestId('create-project-description'), {
+      target: { value: 'A description' },
+    });
+    fireEvent.click(screen.getByTestId('create-project-submit'));
+
+    await waitFor(() => {
+      expect(mockCreateProject).toHaveBeenCalledWith('My Project', 'A description');
+    });
+  });
+
+  it('should call onProjectCreated on success', async () => {
+    const onProjectCreated = jest.fn();
+    render(<NewProjectButton onProjectCreated={onProjectCreated} />);
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    fireEvent.change(screen.getByTestId('create-project-name'), {
+      target: { value: 'My Project' },
+    });
+    fireEvent.click(screen.getByTestId('create-project-submit'));
+
+    await waitFor(() => {
+      resolveCreate('my-project');
+    });
+
+    await waitFor(() => {
+      expect(onProjectCreated).toHaveBeenCalledWith('my-project');
+    });
+  });
+
+  it('should display error on failure', async () => {
+    render(<NewProjectButton />);
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    fireEvent.change(screen.getByTestId('create-project-name'), {
+      target: { value: 'My Project' },
+    });
+    fireEvent.click(screen.getByTestId('create-project-submit'));
+
+    await waitFor(() => {
+      rejectCreate(new Error('Namespace already exists'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create project')).toBeInTheDocument();
+    });
+  });
+
+  it('should reset form on cancel', () => {
+    render(<NewProjectButton />);
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    fireEvent.change(screen.getByTestId('create-project-name'), {
+      target: { value: 'My Project' },
+    });
+    fireEvent.click(screen.getByText('Cancel'));
+
+    fireEvent.click(screen.getByTestId('create-project'));
+    expect(screen.getByTestId('create-project-name')).toHaveValue('');
+  });
+
+  it('should disable submit when name is empty or whitespace', () => {
+    render(<NewProjectButton />);
+    fireEvent.click(screen.getByTestId('create-project'));
+    expect(screen.getByTestId('create-project-submit')).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('create-project-name'), {
+      target: { value: '   ' },
+    });
+    expect(screen.getByTestId('create-project-submit')).toBeDisabled();
+  });
+
+  it('should not submit when Enter is pressed with whitespace-only name', () => {
+    render(<NewProjectButton />);
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    fireEvent.change(screen.getByTestId('create-project-name'), {
+      target: { value: '   ' },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test: form always exists inside modal
+    const form = screen.getByTestId('create-project-name').closest('form')!;
+    fireEvent.submit(form);
+
+    expect(mockCreateProject).not.toHaveBeenCalled();
+  });
+
+  it('should block cancel while submitting', async () => {
+    render(<NewProjectButton />);
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    fireEvent.change(screen.getByTestId('create-project-name'), {
+      target: { value: 'My Project' },
+    });
+    fireEvent.click(screen.getByTestId('create-project-submit'));
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.getByTestId('create-project-name')).toBeInTheDocument();
+
+    resolveCreate('my-project');
+    await waitFor(() => {
+      expect(screen.queryByTestId('create-project-name')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should track events on cancel and submit', async () => {
+    mockCreateProject.mockResolvedValue('test-project');
+    render(<NewProjectButton />);
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(mockTrackEvent).toHaveBeenCalledWith('create_project_canceled', {});
+
+    fireEvent.click(screen.getByTestId('create-project'));
+    fireEvent.change(screen.getByTestId('create-project-name'), {
+      target: { value: 'My Project' },
+    });
+    fireEvent.click(screen.getByTestId('create-project-submit'));
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith('create_project_submitted', {
+        outcome: 'success',
+      });
+    });
+  });
+});

--- a/packages/model-serving/src/components/metrics/ModelMetricsPathWrapper.tsx
+++ b/packages/model-serving/src/components/metrics/ModelMetricsPathWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import { ModelServingContext } from '@odh-dashboard/internal/pages/modelServing/ModelServingContext';
+import { useHostApi } from '@odh-dashboard/plugin-core/host-api';
 import NotFound from '@odh-dashboard/ui-core/components/NotFound';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
 
@@ -14,14 +14,16 @@ const ModelMetricsPathWrapper: React.FC<ModelMetricsPathWrapperProps> = ({ child
     namespace: string;
     inferenceService: string;
   }>();
+  const { contexts } = useHostApi();
   const {
     inferenceServices: {
       data: { items: models },
       loaded,
     },
-  } = React.useContext(ModelServingContext);
+  } = React.useContext(contexts.ModelServingContext);
   const inferenceService = models.find(
-    (model) => model.metadata.name === modelName && model.metadata.namespace === projectName,
+    (model: InferenceServiceKind) =>
+      model.metadata.name === modelName && model.metadata.namespace === projectName,
   );
   if (!loaded) {
     return (

--- a/packages/plugin-core/src/host-api/HostApiContext.ts
+++ b/packages/plugin-core/src/host-api/HostApiContext.ts
@@ -27,4 +27,13 @@ export const HostApiContext = React.createContext<HostApiServices>({
   useServingPlatformStatuses: notProvided('useServingPlatformStatuses'),
   isProjectNIMSupported: notProvided('isProjectNIMSupported'),
   registeredModelDeploymentsRoute: notProvided('registeredModelDeploymentsRoute'),
+  createProject: notProvided('createProject'),
+  ConnectionTypeFormFields: notProvided('ConnectionTypeFormFields'),
+  contexts: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- placeholder context; overridden by HostApiProvider
+    ProjectDetailsContext: React.createContext<any>(null),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- placeholder context; overridden by HostApiProvider
+    ModelServingContext: React.createContext<any>(null),
+    ModelServingContextProvider: notProvided('ModelServingContextProvider'),
+  },
 });

--- a/packages/plugin-core/src/host-api/HostApiContext.ts
+++ b/packages/plugin-core/src/host-api/HostApiContext.ts
@@ -26,7 +26,6 @@ export const HostApiContext = React.createContext<HostApiServices>({
   useModelServingMetrics: notProvided('useModelServingMetrics'),
   useServingPlatformStatuses: notProvided('useServingPlatformStatuses'),
   isProjectNIMSupported: notProvided('isProjectNIMSupported'),
-  registeredModelDeploymentsRoute: notProvided('registeredModelDeploymentsRoute'),
   createProject: notProvided('createProject'),
   ConnectionTypeFormFields: notProvided('ConnectionTypeFormFields'),
   contexts: {

--- a/packages/plugin-core/src/host-api/hooks/__tests__/useHostApi.spec.ts
+++ b/packages/plugin-core/src/host-api/hooks/__tests__/useHostApi.spec.ts
@@ -19,7 +19,6 @@ const mockServices: HostApiServices = {
     refreshNIMAvailability: jest.fn(),
   })),
   isProjectNIMSupported: jest.fn(() => false),
-  registeredModelDeploymentsRoute: jest.fn(() => ''),
   createProject: jest.fn(),
   ConnectionTypeFormFields: jest.fn(),
   contexts: {

--- a/packages/plugin-core/src/host-api/hooks/__tests__/useHostApi.spec.ts
+++ b/packages/plugin-core/src/host-api/hooks/__tests__/useHostApi.spec.ts
@@ -20,6 +20,15 @@ const mockServices: HostApiServices = {
   })),
   isProjectNIMSupported: jest.fn(() => false),
   registeredModelDeploymentsRoute: jest.fn(() => ''),
+  createProject: jest.fn(),
+  ConnectionTypeFormFields: jest.fn(),
+  contexts: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test mock
+    ProjectDetailsContext: React.createContext<any>(null),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test mock
+    ModelServingContext: React.createContext<any>(null),
+    ModelServingContextProvider: jest.fn(),
+  },
 };
 
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>

--- a/packages/plugin-core/src/host-api/types.ts
+++ b/packages/plugin-core/src/host-api/types.ts
@@ -149,9 +149,6 @@ export type HostApiServices = {
   /** Check whether a project has NIM support enabled. */
   isProjectNIMSupported: (currentProject: ProjectKind) => boolean;
 
-  /** Build the route path to registered model deployments. */
-  registeredModelDeploymentsRoute: (rmId?: string, preferredModelRegistry?: string) => string;
-
   /** Create a new OpenShift project (username injected by host). */
   createProject: (displayName: string, description: string, k8sName?: string) => Promise<string>;
 

--- a/packages/plugin-core/src/host-api/types.ts
+++ b/packages/plugin-core/src/host-api/types.ts
@@ -155,7 +155,7 @@ export type HostApiServices = {
   /** Create a new OpenShift project (username injected by host). */
   createProject: (displayName: string, description: string, k8sName?: string) => Promise<string>;
 
-  /** Render connection type form fields for a given connection type. */
+  /** Render connection type form fields inside the deployment wizard. */
   ConnectionTypeFormFields: React.ComponentType<ConnectionTypeFormFieldsProps>;
 
   /** React contexts provided by the host for use in federated modules. */

--- a/packages/plugin-core/src/host-api/types.ts
+++ b/packages/plugin-core/src/host-api/types.ts
@@ -1,3 +1,4 @@
+import type * as React from 'react';
 import type {
   AccessReviewResourceAttributes,
   Connection,
@@ -11,6 +12,7 @@ import type {
   SecretKind,
   TemplateKind,
 } from '@odh-dashboard/k8s-core';
+import type { ConnectionTypeFormFieldsProps } from '../extension-points/connection-types';
 
 export type { K8sWatchResult } from '@odh-dashboard/k8s-core';
 
@@ -149,6 +151,25 @@ export type HostApiServices = {
 
   /** Build the route path to registered model deployments. */
   registeredModelDeploymentsRoute: (rmId?: string, preferredModelRegistry?: string) => string;
+
+  /** Create a new OpenShift project (username injected by host). */
+  createProject: (displayName: string, description: string, k8sName?: string) => Promise<string>;
+
+  /** Render connection type form fields for a given connection type. */
+  ConnectionTypeFormFields: React.ComponentType<ConnectionTypeFormFieldsProps>;
+
+  /** React contexts provided by the host for use in federated modules. */
+  contexts: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- React.Context is invariant; unknown is not assignable from concrete context types
+    ProjectDetailsContext: React.Context<any>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- React.Context is invariant; unknown is not assignable from concrete context types
+    ModelServingContext: React.Context<any>;
+    ModelServingContextProvider: React.ComponentType<{
+      children: React.ReactNode;
+      namespace?: string;
+      getErrorComponent?: (errorMessage?: string) => React.ReactElement;
+    }>;
+  };
 };
 
 export type SecretOps = Pick<


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-79896

## Description
Bridges several `model-serving` symbols through the host-api layer, continuing the decoupling of `model-serving` from `@odh-dashboard/internal`.

  **Changes:**

  | Category | Details |
  |----------|---------|
  | `HostApiServices.contexts` | New sub-object exposing `ProjectDetailsContext`, `ModelServingContext`, and `ModelServingContextProvider` — typed as `React.Context<any>` to work around React.Context invariance |
  | `ConnectionTypeFormFields` | Bridged as a component on `HostApiServices`, wired in `HostApiProvider` |
  | `NewProjectButton` | New thin component in `model-serving` using `useHostApi().createProject` and `ContentModal` — not a copy of the frontend's `ManageProjectModal` |
  | `createProject` signature | Simplified to drop `username` param — `HostApiProvider` injects it via closure |
  | `registeredModelDeploymentsRoute` | Removed from `HostApiServices` — `model-registry` now passes `deploymentsUrl` as a prop to the `DeploymentsColumn` extension component (data-driven pattern) |

  **Updated consumers (6 files in `model-serving`):**

  - `ModelMetricsPathWrapper` → uses `useHostApi().contexts.ModelServingContext`
  - `GlobalModelServingCoreLoader` → uses `useHostApi().contexts.ModelServingContextProvider`
  - `NewConnectionField` → uses `useHostApi().ConnectionTypeFormFields`
  - `NoProjectsPage` → imports local `NewProjectButton` instead of from `@odh-dashboard/internal`
  - `DeploymentsColumn` → accepts `deploymentsUrl` prop, no longer calls `useHostApi()` for route
  - `ExtendedRegisteredModelTableRow` → passes `deploymentsUrl` prop to `DeploymentsColumn`

  ## How Has This Been Tested?

  - `npm install` — succeeds
  - `npx turbo run build --force` — passes (no cache)
  - `npm run type-check` — passes across all affected packages (`plugin-core`, `model-serving`, `model-registry`, `internal`)
  - `npm run lint` — passes (no new warnings)
  - `model-serving` unit tests — 378 tests pass
  - `plugin-core` unit tests — 87 tests pass
  - Updated test mocks in `ModelLocationSelectField.test.tsx` and `ModelSourceStep.test.tsx` to provide `ConnectionTypeFormFields` via `jest.requireActual` through the host-api mock

  ## Test Impact

  No new test files added. Existing unit tests updated to mock `ConnectionTypeFormFields` and `contexts` through the `useHostApi` mock. The `NewProjectButton` component is new but minimal — it delegates to useHostApi().createProject` and uses `ContentModal`, both of which are independently tested.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a modal for creating projects with required names, optional descriptions, validation, submission feedback, and post-creation actions.
  - Deployment counts can link directly to the deployments page when available.

- **Improvements**
  - Project creation now uses the signed-in account automatically.
  - Improved access to project, model-serving, and connection configuration.
  - Deployment counts remain clear and non-clickable when no destination is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->