### PR TITLE
feat(maas-customer-portal): add static AreaContext provider

### DIFF
--- a/distributions/maas-customer-portal/config/webpack.common.js
+++ b/distributions/maas-customer-portal/config/webpack.common.js
@@ -36,6 +36,22 @@ module.exports = (overrides = {}) =>
       ...overrides,
     }),
     {
+      module: {
+        rules: [
+          // gen-ai playground → @patternfly/chatbot → monaco-editor (codicon.ttf, etc.)
+          {
+            test: /\.(svg|ttf|eot|woff|woff2)$/,
+            include: [path.resolve(REPO_ROOT, 'node_modules/monaco-editor')],
+            use: {
+              loader: 'file-loader',
+              options: {
+                outputPath: 'fonts',
+                name: '[name].[ext]',
+              },
+            },
+          },
+        ],
+      },
       resolve: {
         modules: [path.resolve(DIST_DIR, 'node_modules'), 'node_modules'],
         plugins: [new ContextualTildeResolverPlugin(tildeMappings)],

--- a/distributions/maas-customer-portal/package.json
+++ b/distributions/maas-customer-portal/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.18.0"
   },
   "scripts": {
     "dev": "npm run start:dev",
@@ -28,11 +28,11 @@
     "mod-arch-shared": "^1.15.4",
     "@openshift/dynamic-plugin-sdk": "^5.0.1",
     "@openshift/dynamic-plugin-sdk-utils": "^5.0.0",
-    "@patternfly/patternfly": "^6.4.0",
-    "@patternfly/react-core": "^6.4.1",
-    "@patternfly/react-icons": "^6.4.0",
-    "@patternfly/react-styles": "^6.4.0",
-    "@patternfly/react-table": "^6.4.0",
+    "@patternfly/patternfly": "~6.5.2",
+    "@patternfly/react-core": "~6.5.1",
+    "@patternfly/react-icons": "~6.5.1",
+    "@patternfly/react-styles": "~6.5.1",
+    "@patternfly/react-table": "~6.5.1",
     "lodash-es": "^4.18.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -49,7 +49,7 @@
     "css-loader": "^5.2.7",
     "file-loader": "^6.2.0",
     "fork-ts-checker-webpack-plugin": "^9.1.0",
-    "html-webpack-plugin": "^5.6.7",
+    "html-webpack-plugin": "^5.6.8",
     "raw-loader": "^4.0.2",
     "sass": "^1.100.0",
     "sass-loader": "^13.3.3",

--- a/distributions/maas-customer-portal/src/PortalAreaContextProvider.tsx
+++ b/distributions/maas-customer-portal/src/PortalAreaContextProvider.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { AreaContext, type AreaContextState } from '@odh-dashboard/plugin-core/areas';
+
+/** Static portal area state: no DSC/DSCI; all areas unavailable via useIsAreaAvailable fallback. */
+const portalAreaContext: AreaContextState = {
+  dscStatus: null,
+  dsciStatus: null,
+  areasStatus: {},
+};
+
+type PortalAreaContextProviderProps = {
+  children: React.ReactNode;
+};
+
+const PortalAreaContextProvider: React.FC<PortalAreaContextProviderProps> = ({ children }) => (
+  <AreaContext.Provider value={portalAreaContext}>{children}</AreaContext.Provider>
+);
+
+export default PortalAreaContextProvider;

--- a/distributions/maas-customer-portal/src/PortalContextProvider.tsx
+++ b/distributions/maas-customer-portal/src/PortalContextProvider.tsx
@@ -6,6 +6,7 @@ import {
   useSettings,
   type ModularArchConfig,
 } from 'mod-arch-core';
+import PortalAreaContextProvider from './PortalAreaContextProvider';
 
 const ADMIN_USER_FLAG = 'ADMIN_USER';
 
@@ -31,7 +32,7 @@ const FlagsSync: React.FC = () => {
 const PortalContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <ModularArchContextProvider config={modularArchConfig}>
     <FlagsSync />
-    {children}
+    <PortalAreaContextProvider>{children}</PortalAreaContextProvider>
   </ModularArchContextProvider>
 );
 

--- a/distributions/maas-customer-portal/src/__tests__/PortalAreaContextProvider.spec.tsx
+++ b/distributions/maas-customer-portal/src/__tests__/PortalAreaContextProvider.spec.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import {
-  AreaContext,
-  SupportedArea,
-  useIsAreaAvailable,
-  type AreaContextState,
-  type IsAreaAvailableStatus,
-  type SupportedAreaType,
-} from '@odh-dashboard/plugin-core/areas';
+import { renderHook } from '@testing-library/react';
+import { AreaContext, SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
 import PortalAreaContextProvider from '../PortalAreaContextProvider';
+import PortalContextProvider from '../PortalContextProvider';
+
+jest.mock('mod-arch-core', () => ({
+  ModularArchContextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSettings: () => ({ userSettings: null }),
+  DeploymentMode: { Standalone: 'Standalone' },
+}));
+
+jest.mock('@openshift/dynamic-plugin-sdk', () => ({
+  usePluginStore: () => ({
+    setFeatureFlags: jest.fn(),
+  }),
+}));
 
 const AREA_SAMPLES = [
   SupportedArea.MODEL_SERVING,
@@ -16,83 +22,49 @@ const AREA_SAMPLES = [
   SupportedArea.DS_PIPELINES,
 ] as const;
 
-const AreaContextReader: React.FC = () => {
-  const ctx = React.useContext(AreaContext);
-  return <pre data-testid="area-context">{JSON.stringify(ctx)}</pre>;
-};
+const areaWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <PortalAreaContextProvider>{children}</PortalAreaContextProvider>
+);
 
-const AreaHookReader: React.FC<{ area: SupportedAreaType }> = ({ area }) => {
-  const result = useIsAreaAvailable(area);
-  return <pre data-testid={`hook-${area}`}>{JSON.stringify(result)}</pre>;
-};
-
-const AreaHookCapture: React.FC<{
-  area: SupportedAreaType;
-  setResult: (result: IsAreaAvailableStatus) => void;
-}> = ({ area, setResult }) => {
-  const result = useIsAreaAvailable(area);
-  React.useLayoutEffect(() => {
-    setResult(result);
-  }, [result, setResult]);
-  return null;
-};
-
-const getContext = (): AreaContextState => {
-  const el = screen.getByTestId('area-context');
-  return JSON.parse(String(el.textContent));
-};
+const portalWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <PortalContextProvider>{children}</PortalContextProvider>
+);
 
 describe('PortalAreaContextProvider', () => {
   describe('static context value', () => {
     it('should set dscStatus and dsciStatus to null', () => {
-      render(
-        <PortalAreaContextProvider>
-          <AreaContextReader />
-        </PortalAreaContextProvider>,
-      );
-      const ctx = getContext();
-      expect(ctx.dscStatus).toBeNull();
-      expect(ctx.dsciStatus).toBeNull();
+      const { result } = renderHook(() => React.useContext(AreaContext), { wrapper: areaWrapper });
+      expect(result.current.dscStatus).toBeNull();
+      expect(result.current.dsciStatus).toBeNull();
     });
 
     it('should provide an empty areasStatus map', () => {
-      render(
-        <PortalAreaContextProvider>
-          <AreaContextReader />
-        </PortalAreaContextProvider>,
-      );
-      expect(getContext().areasStatus).toEqual({});
+      const { result } = renderHook(() => React.useContext(AreaContext), { wrapper: areaWrapper });
+      expect(result.current.areasStatus).toEqual({});
     });
   });
 
   describe('useIsAreaAvailable', () => {
     it.each(AREA_SAMPLES)('should return status false for %s via hook fallback', (area) => {
-      render(
-        <PortalAreaContextProvider>
-          <AreaHookReader area={area} />
-        </PortalAreaContextProvider>,
-      );
-      const result = JSON.parse(String(screen.getByTestId(`hook-${area}`).textContent));
-      expect(result.status).toBe(false);
+      const { result } = renderHook(() => useIsAreaAvailable(area), { wrapper: areaWrapper });
+      expect(result.current.status).toBe(false);
     });
-
-    it.each(AREA_SAMPLES)(
-      'should keep %s unavailable even when the passed condition function reports true',
-      (area) => {
-        const bag: { result: IsAreaAvailableStatus | null } = { result: null };
-        render(
-          <PortalAreaContextProvider>
-            <AreaHookCapture
-              area={area}
-              setResult={(result) => {
-                bag.result = result;
-              }}
-            />
-          </PortalAreaContextProvider>,
-        );
-        expect(bag.result?.customCondition).toEqual(expect.any(Function));
-        expect(bag.result?.customCondition(() => true)).toBe(false);
-      },
-    );
   });
+});
+
+describe('PortalContextProvider AreaContext composition', () => {
+  it('should expose AreaContext through the production provider tree', () => {
+    const { result } = renderHook(() => React.useContext(AreaContext), { wrapper: portalWrapper });
+    expect(result.current.dscStatus).toBeNull();
+    expect(result.current.dsciStatus).toBeNull();
+    expect(result.current.areasStatus).toEqual({});
+  });
+
+  it.each(AREA_SAMPLES)(
+    'should return status false for %s via useIsAreaAvailable under PortalContextProvider',
+    (area) => {
+      const { result } = renderHook(() => useIsAreaAvailable(area), { wrapper: portalWrapper });
+      expect(result.current.status).toBe(false);
+    },
+  );
 });

--- a/distributions/maas-customer-portal/src/__tests__/PortalAreaContextProvider.spec.tsx
+++ b/distributions/maas-customer-portal/src/__tests__/PortalAreaContextProvider.spec.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  AreaContext,
+  SupportedArea,
+  useIsAreaAvailable,
+  type AreaContextState,
+  type IsAreaAvailableStatus,
+  type SupportedAreaType,
+} from '@odh-dashboard/plugin-core/areas';
+import PortalAreaContextProvider from '../PortalAreaContextProvider';
+
+const AREA_SAMPLES = [
+  SupportedArea.MODEL_SERVING,
+  SupportedArea.DS_PROJECTS_VIEW,
+  SupportedArea.DS_PIPELINES,
+] as const;
+
+const AreaContextReader: React.FC = () => {
+  const ctx = React.useContext(AreaContext);
+  return <pre data-testid="area-context">{JSON.stringify(ctx)}</pre>;
+};
+
+const AreaHookReader: React.FC<{ area: SupportedAreaType }> = ({ area }) => {
+  const result = useIsAreaAvailable(area);
+  return <pre data-testid={`hook-${area}`}>{JSON.stringify(result)}</pre>;
+};
+
+const AreaHookCapture: React.FC<{
+  area: SupportedAreaType;
+  setResult: (result: IsAreaAvailableStatus) => void;
+}> = ({ area, setResult }) => {
+  const result = useIsAreaAvailable(area);
+  React.useLayoutEffect(() => {
+    setResult(result);
+  }, [result, setResult]);
+  return null;
+};
+
+const getContext = (): AreaContextState => {
+  const el = screen.getByTestId('area-context');
+  return JSON.parse(String(el.textContent));
+};
+
+describe('PortalAreaContextProvider', () => {
+  describe('static context value', () => {
+    it('should set dscStatus and dsciStatus to null', () => {
+      render(
+        <PortalAreaContextProvider>
+          <AreaContextReader />
+        </PortalAreaContextProvider>,
+      );
+      const ctx = getContext();
+      expect(ctx.dscStatus).toBeNull();
+      expect(ctx.dsciStatus).toBeNull();
+    });
+
+    it('should provide an empty areasStatus map', () => {
+      render(
+        <PortalAreaContextProvider>
+          <AreaContextReader />
+        </PortalAreaContextProvider>,
+      );
+      expect(getContext().areasStatus).toEqual({});
+    });
+  });
+
+  describe('useIsAreaAvailable', () => {
+    it.each(AREA_SAMPLES)('should return status false for %s via hook fallback', (area) => {
+      render(
+        <PortalAreaContextProvider>
+          <AreaHookReader area={area} />
+        </PortalAreaContextProvider>,
+      );
+      const result = JSON.parse(String(screen.getByTestId(`hook-${area}`).textContent));
+      expect(result.status).toBe(false);
+    });
+
+    it.each(AREA_SAMPLES)(
+      'should keep %s unavailable even when the passed condition function reports true',
+      (area) => {
+        const bag: { result: IsAreaAvailableStatus | null } = { result: null };
+        render(
+          <PortalAreaContextProvider>
+            <AreaHookCapture
+              area={area}
+              setResult={(result) => {
+                bag.result = result;
+              }}
+            />
+          </PortalAreaContextProvider>,
+        );
+        expect(bag.result?.customCondition).toEqual(expect.any(Function));
+        expect(bag.result?.customCondition(() => true)).toBe(false);
+      },
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1215,11 +1215,11 @@
         "@odh-dashboard/ui-core": "*",
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
         "@openshift/dynamic-plugin-sdk-utils": "^5.0.0",
-        "@patternfly/patternfly": "^6.4.0",
-        "@patternfly/react-core": "^6.4.1",
-        "@patternfly/react-icons": "^6.4.0",
-        "@patternfly/react-styles": "^6.4.0",
-        "@patternfly/react-table": "^6.4.0",
+        "@patternfly/patternfly": "~6.5.2",
+        "@patternfly/react-core": "~6.5.1",
+        "@patternfly/react-icons": "~6.5.1",
+        "@patternfly/react-styles": "~6.5.1",
+        "@patternfly/react-table": "~6.5.1",
         "lodash-es": "^4.18.1",
         "mod-arch-core": "^1.16.1",
         "mod-arch-shared": "^1.15.4",
@@ -1238,7 +1238,7 @@
         "css-loader": "^5.2.7",
         "file-loader": "^6.2.0",
         "fork-ts-checker-webpack-plugin": "^9.1.0",
-        "html-webpack-plugin": "^5.6.7",
+        "html-webpack-plugin": "^5.6.8",
         "raw-loader": "^4.0.2",
         "sass": "^1.100.0",
         "sass-loader": "^13.3.3",
@@ -1253,7 +1253,7 @@
         "webpack-merge": "^6.0.1"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.18.0"
       }
     },
     "distributions/maas-customer-portal/node_modules/@mui/core-downloads-tracker": {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-82801

## Description

Three related MaaS Consumer Portal changes:

### 1. Static `AreaContext` provider ([RHOAIENG-82801](https://redhat.atlassian.net/browse/RHOAIENG-82801))

The portal had no `AreaContext.Provider`, so `useIsAreaAvailable()` returned `{ status: false }` only because the default context is empty. That is fragile: adding a full DSC-driven `AreaContextProvider` later could flip areas on and break planned UI leakage gates.

This PR adds a thin `PortalAreaContextProvider` that provides a static `AreaContextState` with `dscStatus: null`, `dsciStatus: null`, and `areasStatus: {}`. All areas resolve to unavailable via the hook fallback. `PortalContextProvider` composes it around children.

Plugin feature flags from `distribution.yaml` (e.g. `modelAsService`) are unchanged and remain a separate gating mechanism.

### 2. Monaco font loader (build fix)

Portal webpack failed when bundling gen-ai playground because `@patternfly/chatbot` pulls in `monaco-editor` fonts (`codicon.ttf`) with no loader. Added a `file-loader` rule for `node_modules/monaco-editor`, consistent with how distribution base handles PatternFly fonts (and with the main dashboard’s monaco font include).

### 3. PatternFly ~6.5 dep alignment ([#8660](https://github.com/opendatahub-io/odh-dashboard/pull/8660) FUP)

Bring `maas-customer-portal` in line with the shared PatternFly ~6.5 bump from #8660 (`~6.5.x` pins, Node engines `>=22.18.0`, `html-webpack-plugin` patch bump).

## How Has This Been Tested?

- Unit tests: `npm run test-unit --workspace=@odh-dashboard/maas-customer-portal-distribution`
- Lint / type-check for the portal package
- Manual smoke on local portal (`npm run dev`): temporarily enabled `SupportedArea.HOME` and rendered a conditional banner on AI Assets; confirmed banner appeared when `status: true` and disappeared when `status: false`; then reverted smoke harness
- Confirmed portal webpack builds without the monaco `codicon.ttf` parse error after the loader fix

## Test Impact

- New unit tests in `PortalAreaContextProvider.spec.tsx` cover null DSC/DSCI, empty `areasStatus`, and `useIsAreaAvailable` fallback (`status: false` / `customCondition` stays false)
- Webpack and package.json changes rely on manual / local build verification (no new automated tests)

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

[RHOAIENG-82801]: https://redhat.atlassian.net/browse/RHOAIENG-82801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added area context support to the customer portal.
  * Portal areas now provide consistent default availability and status information.

* **Bug Fixes**
  * Improved handling of Monaco Editor font and vector assets.

* **Chores**
  * Updated supported Node.js runtime requirements and frontend package versions.
  * Updated the HTML Webpack plugin version.

* **Tests**
  * Added coverage for portal area status and availability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->