### PR TITLE
chore: add data-registry team to OWNERS and OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -20,6 +20,7 @@ filters:
       - autorag-approvers
       - automl-approvers
       - eval-hub-approvers
+      - data-registry-approvers
       - mlflow-approvers
       - distributions-approvers
 
@@ -211,6 +212,15 @@ filters:
       - distributions-reviewers
     labels:
       - 'area/distributions'
+
+  # Data Registry
+  'packages/data-registry/.*':
+    approvers:
+      - data-registry-approvers
+    reviewers:
+      - data-registry-reviewers
+    labels:
+      - 'area/data-registry'
 
   # MLflow
   'packages/mlflow.*/.*':

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -280,14 +280,14 @@ aliases:
 
   # Data Registry
   data-registry-approvers:
-    - MStokluska
-    - Fiona-Waters
     - briangallagher
+    - Fiona-Waters
+    - MStokluska
   data-registry-reviewers:
-    - MStokluska
-    - Fiona-Waters
-    - Slowlybomb
     - briangallagher
+    - Fiona-Waters
+    - MStokluska
+    - Slowlybomb
 
   # MLflow
   mlflow-approvers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -278,6 +278,17 @@ aliases:
   distributions-reviewers:
     - jenny-s51
 
+  # Data Registry
+  data-registry-approvers:
+    - MStokluska
+    - Fiona-Waters
+    - briangallagher
+  data-registry-reviewers:
+    - MStokluska
+    - Fiona-Waters
+    - Slowlybomb
+    - briangallagher
+
   # MLflow
   mlflow-approvers:
     - caponetto


### PR DESCRIPTION
## Description

Adds OWNERS aliases and file filters for the data-registry team so the PR bot can auto-suggest reviewers and grant the approved label for changes under `packages/data-registry/`.

**Approvers:** MStokluska, Fiona-Waters, briangallagher
**Reviewers:** MStokluska, Fiona-Waters, Slowlybomb, briangallagher

## How Has This Been Tested?

Non-code change — config-only update to OWNERS files.

## Test Impact

Not applicable — no code changes.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`