### PR TITLE
Feat(RHOAIENG-79911/RHOAIENG-79914): Added stop start Kueue readmission and Queue positioning API changes

### DIFF
--- a/frontend/src/api/k8s/workloads.ts
+++ b/frontend/src/api/k8s/workloads.ts
@@ -7,6 +7,8 @@ import { PodModel } from '#~/api/models';
 import { groupVersionKind } from '#~/api/k8sUtils';
 import { CustomWatchK8sResult } from '#~/types';
 import useK8sWatchResourceList from '#~/utilities/useK8sWatchResourceList';
+import { aggregateKueueStatusForModel, KUEUE_QUEUE_LABEL } from '#~/concepts/kueue/index';
+import type { KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
 
 export const listWorkloads = async (
   namespace?: string,
@@ -144,6 +146,69 @@ export const buildWorkloadMapForDeployments = (
   }
 
   return result;
+};
+
+/** Live (non-terminal) model-serving Pods for a typed deployment key. */
+export const countActiveModelDeploymentPods = (deploymentKey: string, pods: PodKind[]): number => {
+  const isTerminal = (phase?: string): boolean => phase === 'Succeeded' || phase === 'Failed';
+
+  if (deploymentKey.startsWith('InferenceService/')) {
+    const name = deploymentKey.slice('InferenceService/'.length);
+    return pods.filter((pod) => {
+      const labels = pod.metadata.labels ?? {};
+      return (
+        labels['serving.kserve.io/inferenceservice'] === name && !isTerminal(pod.status?.phase)
+      );
+    }).length;
+  }
+
+  if (deploymentKey.startsWith('LLMInferenceService/')) {
+    const name = deploymentKey.slice('LLMInferenceService/'.length);
+    return pods.filter((pod) => {
+      const labels = pod.metadata.labels ?? {};
+      return (
+        labels['app.kubernetes.io/name'] === name &&
+        labels['app.kubernetes.io/component'] === 'llminferenceservice-workload' &&
+        !isTerminal(pod.status?.phase)
+      );
+    }).length;
+  }
+
+  return 0;
+};
+
+/**
+ * One-shot Kueue status for a single InferenceService (used by KServe fetchDeploymentStatus poll).
+ * Mirrors the aggregation in useKueueStatusForDeployments without a watch subscription.
+ */
+export const resolveKueueStatusForInferenceService = async (
+  inferenceService: InferenceServiceKind,
+  pods: PodKind[],
+): Promise<KueueWorkloadStatusWithMessage | null> => {
+  const { namespace, name } = inferenceService.metadata;
+  if (!namespace || !name) {
+    return null;
+  }
+
+  try {
+    const workloads = await listWorkloads(namespace);
+    const deploymentKey = buildModelDeploymentKey('InferenceService', name);
+    const workloadMap = buildWorkloadMapForDeployments(workloads, pods, [inferenceService]);
+    const isWorkloads = workloadMap[deploymentKey] ?? [];
+    const aggregated = aggregateKueueStatusForModel(isWorkloads, {
+      activePodCount: countActiveModelDeploymentPods(deploymentKey, pods),
+    });
+    if (!aggregated) {
+      return null;
+    }
+    return {
+      ...aggregated,
+      queueName: inferenceService.metadata.labels?.[KUEUE_QUEUE_LABEL],
+    };
+  } catch {
+    // RBAC denial or missing CRD — fall back to KServe-only status on the poll path.
+    return null;
+  }
 };
 
 /**

--- a/frontend/src/concepts/kueue/__tests__/index.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/index.spec.ts
@@ -610,6 +610,39 @@ describe('aggregateKueueStatusForModel', () => {
     expect(result?.podAdmissionCounts).toEqual({ admitted: 1, total: 2 });
   });
 
+  it('uses activePodCount for total when more live pods than correlated Workloads', () => {
+    const queued = workloadWithConditions([
+      {
+        type: 'QuotaReserved',
+        status: 'False',
+        reason: 'Pending',
+        message: 'waiting for quota',
+        lastTransitionTime: '2026-02-16T08:00:00Z',
+      },
+    ]);
+    const admitted = workloadWithConditions([
+      {
+        type: 'QuotaReserved',
+        status: 'True',
+        reason: 'QuotaReserved',
+        message: 'Quota reserved',
+        lastTransitionTime: '2026-02-16T08:00:00Z',
+      },
+      {
+        type: 'Admitted',
+        status: 'True',
+        reason: 'Admitted',
+        message: 'Admitted',
+        lastTransitionTime: '2026-02-16T08:00:00Z',
+      },
+    ]);
+
+    const result = aggregateKueueStatusForModel([queued, admitted], { activePodCount: 5 });
+
+    expect(result?.status).toBe(KueueWorkloadStatus.Queued);
+    expect(result?.podAdmissionCounts).toEqual({ admitted: 1, total: 5 });
+  });
+
   it('rapid state flapping: re-aggregating after conditions change (Queued -> Evicted -> Requeued) reflects the latest snapshot each time', () => {
     const queued = workloadWithConditions([
       {

--- a/frontend/src/concepts/kueue/__tests__/messageUtils.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/messageUtils.spec.ts
@@ -9,6 +9,9 @@ import {
   getKueueAnalyticsSubState,
   toOrdinal,
   formatQueuePosition,
+  appendQueuePositionToKueueMessage,
+  appendModelDeploymentPodAdmissionSuffix,
+  getModelDeploymentKueueDetailMessage,
   isInadmissibleQuotaCondition,
 } from '#~/concepts/kueue/messageUtils';
 
@@ -343,8 +346,81 @@ describe('formatQueuePosition', () => {
   it.each<[number, string, string]>([
     [3, 'my-queue', '3rd in my-queue'],
     [2, 'test-queue', '2nd in test-queue'],
+    [1, 'default', '1st in default queue'],
+    [1, 'default-user-queue', '1st in default-user-queue'],
   ])('formats position %s in %s as %s', (position, queue, expected) => {
     expect(formatQueuePosition(position, queue)).toBe(expected);
+  });
+});
+
+describe('getModelDeploymentKueueDetailMessage', () => {
+  it('returns position only for Queued when queuePosition is set', () => {
+    const result = getModelDeploymentKueueDetailMessage({
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'my-queue',
+      queuePosition: 2,
+    });
+    expect(result).toBe('2nd in my-queue');
+  });
+
+  it('falls back to human-readable message when queuePosition is missing', () => {
+    const result = getModelDeploymentKueueDetailMessage({
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'default',
+    });
+    expect(result).toBe('Waiting for quota in default queue');
+  });
+
+  it('returns position only for Inadmissible when queuePosition is set', () => {
+    const result = getModelDeploymentKueueDetailMessage({
+      status: KueueWorkloadStatus.Inadmissible,
+      queueName: 'my-queue',
+      queuePosition: 4,
+      message: 'insufficient unused quota for nvidia.com/gpu',
+    });
+    expect(result).toBe('4th in my-queue');
+  });
+});
+
+describe('appendModelDeploymentPodAdmissionSuffix', () => {
+  it('appends pod admission counts when total > 1', () => {
+    const result = appendModelDeploymentPodAdmissionSuffix('2nd in my-queue', {
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'my-queue',
+      queuePosition: 2,
+      podAdmissionCounts: { admitted: 3, total: 5 },
+    });
+    expect(result).toBe('2nd in my-queue (3 of 5 pods admitted)');
+  });
+
+  it('returns detail unchanged when total is 1', () => {
+    const result = appendModelDeploymentPodAdmissionSuffix('2nd in my-queue', {
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'my-queue',
+      queuePosition: 2,
+      podAdmissionCounts: { admitted: 0, total: 1 },
+    });
+    expect(result).toBe('2nd in my-queue');
+  });
+});
+
+describe('appendQueuePositionToKueueMessage', () => {
+  it('appends position for Queued status', () => {
+    const result = appendQueuePositionToKueueMessage('Waiting for quota', {
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'my-queue',
+      queuePosition: 2,
+    });
+    expect(result).toBe('Waiting for quota (2nd in my-queue)');
+  });
+
+  it('returns message unchanged for Admitted status even when queuePosition is set', () => {
+    const result = appendQueuePositionToKueueMessage('Waiting for quota', {
+      status: KueueWorkloadStatus.Admitted,
+      queueName: 'my-queue',
+      queuePosition: 2,
+    });
+    expect(result).toBe('Waiting for quota');
   });
 });
 
@@ -474,6 +550,18 @@ describe('getDeploymentKueueSubStepMessage', () => {
     expect(result).toBe('Preempted: Deployment re-queued, waiting for resource');
   });
 
+  it('formats Requeued with its own prefix, not Queued', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Requeued,
+      queueName: 'test-queue',
+      requeueInfo: { count: 2, requeueAt: '2026-07-15T10:05:00Z' },
+    });
+    expect(result).toMatch(/^Requeued: /);
+    expect(result).not.toMatch(/^Queued: /);
+    expect(result).toContain('attempt 2');
+    expect(result).toContain('test-queue');
+  });
+
   it('formats a quota-exceeded Failed status using the raw Kueue message verbatim', () => {
     const result = getDeploymentKueueSubStepMessage({
       status: KueueWorkloadStatus.Failed,
@@ -528,6 +616,25 @@ describe('getDeploymentKueueSubStepMessage', () => {
       podAdmissionCounts: { admitted: 0, total: 1 },
     });
     expect(result).toBe('Queued: Waiting for quota in my-queue');
+  });
+
+  it('shows position only when queuePosition is set for Queued status', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'my-queue',
+      queuePosition: 3,
+    });
+    expect(result).toBe('Queued: 3rd in my-queue');
+  });
+
+  it('shows position and pod admission suffix when both are set', () => {
+    const result = getDeploymentKueueSubStepMessage({
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'my-queue',
+      queuePosition: 3,
+      podAdmissionCounts: { admitted: 3, total: 5 },
+    });
+    expect(result).toBe('Queued: 3rd in my-queue (3 of 5 pods admitted)');
   });
 });
 

--- a/frontend/src/concepts/kueue/index.ts
+++ b/frontend/src/concepts/kueue/index.ts
@@ -326,6 +326,7 @@ const ADMITTED_STATUSES: KueueWorkloadStatus[] = [
 
 export const aggregateKueueStatusForModel = (
   workloads: WorkloadKind[],
+  options?: { activePodCount?: number },
 ): KueueWorkloadStatusWithMessage | null => {
   if (workloads.length === 0) return null;
   const statuses = workloads.map((wl) => ({
@@ -333,13 +334,14 @@ export const aggregateKueueStatusForModel = (
     workloadName: wl.metadata?.name,
   }));
 
-  // Only meaningful with multiple replicas — a single Workload is fully captured by its own
-  // status already, so "1 of 1 admitted" would be redundant noise.
+  const totalPods = Math.max(statuses.length, options?.activePodCount ?? 0);
+  // Multi-replica partial admission — total includes live Pods even when not all have a
+  // correlated Workload CR yet (scale-up / watch lag), so e.g. "3 of 5 pods admitted" can show.
   const podAdmissionCounts =
-    statuses.length > 1
+    totalPods > 1
       ? {
           admitted: statuses.filter((s) => ADMITTED_STATUSES.includes(s.status)).length,
-          total: statuses.length,
+          total: totalPods,
         }
       : undefined;
 

--- a/frontend/src/concepts/kueue/messageUtils.ts
+++ b/frontend/src/concepts/kueue/messageUtils.ts
@@ -155,9 +155,63 @@ export const toOrdinal = (n: number): string => {
   return `${n}th`;
 };
 
-/** e.g. (3, 'my-queue') → "3rd in my-queue" */
+/** e.g. (1, 'default') → "1st in default queue"; (3, 'my-queue') → "3rd in my-queue" */
 export const formatQueuePosition = (position: number, queue: string): string =>
-  `${toOrdinal(position)} in ${queue}`;
+  `${toOrdinal(position)} in ${queue.endsWith('queue') ? queue : `${queue} queue`}`;
+
+const PENDING_QUEUE_POSITION_STATUSES: KueueWorkloadStatus[] = [
+  KueueWorkloadStatus.Queued,
+  KueueWorkloadStatus.Inadmissible,
+];
+
+/** Appends Visibility API queue position when populated (mirrors NotebookStateStatus subtitle). */
+export const appendQueuePositionToKueueMessage = (
+  message: string,
+  kueueStatus: KueueWorkloadStatusWithMessage,
+): string => {
+  if (
+    kueueStatus.queuePosition != null &&
+    kueueStatus.queueName &&
+    PENDING_QUEUE_POSITION_STATUSES.includes(kueueStatus.status)
+  ) {
+    return `${message} (${formatQueuePosition(kueueStatus.queuePosition, kueueStatus.queueName)})`;
+  }
+  return message;
+};
+
+/**
+ * Detail line for model deployment Kueue subtitle and modal sub-step body.
+ * When Visibility API provides queue position for Queued/Inadmissible, show position only;
+ * otherwise fall back to human-readable (or quota-shaped raw) message.
+ */
+export const getModelDeploymentKueueDetailMessage = (
+  kueueStatus: KueueWorkloadStatusWithMessage,
+): string => {
+  const { queuePosition, queueName, status, message } = kueueStatus;
+  const isPendingWithPosition =
+    queuePosition != null && queueName && PENDING_QUEUE_POSITION_STATUSES.includes(status);
+
+  if (isPendingWithPosition) {
+    return formatQueuePosition(queuePosition, queueName);
+  }
+
+  const displayQueueName =
+    queueName && !queueName.endsWith('queue') ? `${queueName} queue` : queueName;
+
+  const rawMessage = message?.trim() || undefined;
+  const isQuotaShaped =
+    (status === KueueWorkloadStatus.Failed || status === KueueWorkloadStatus.Inadmissible) &&
+    rawMessage != null &&
+    (QUOTA_REGEX.test(rawMessage) || FLAVOR_REGEX.test(rawMessage));
+
+  if (isQuotaShaped) {
+    return rawMessage;
+  }
+  if (status === KueueWorkloadStatus.Requeued) {
+    return getRequeuedMessage(kueueStatus);
+  }
+  return getHumanReadableKueueMessage(status, message, displayQueueName);
+};
 
 /**
  * Formats the multi-Pod partial-admission breakdown for model deployments, e.g. (3, 5) →
@@ -166,6 +220,21 @@ export const formatQueuePosition = (position: number, queue: string): string =>
  */
 export const formatPodAdmissionCounts = (admitted: number, total: number): string =>
   `${admitted} of ${total} pods admitted`;
+
+/** Appends partial-admission suffix when multi-replica podAdmissionCounts are present. */
+export const appendModelDeploymentPodAdmissionSuffix = (
+  detail: string,
+  kueueStatus: KueueWorkloadStatusWithMessage,
+): string => {
+  const { podAdmissionCounts } = kueueStatus;
+  if (!podAdmissionCounts || podAdmissionCounts.total <= 1) {
+    return detail;
+  }
+  return `${detail} (${formatPodAdmissionCounts(
+    podAdmissionCounts.admitted,
+    podAdmissionCounts.total,
+  )})`;
+};
 
 /**
  * Formats a preemption toast body message with the workbench name and timestamp.
@@ -259,7 +328,7 @@ export const getKueueAnalyticsSubState = (
 
 const DEPLOYMENT_SUBSTEP_PREFIX: Partial<Record<KueueWorkloadStatus, string>> = {
   [KueueWorkloadStatus.Queued]: 'Queued',
-  [KueueWorkloadStatus.Requeued]: 'Queued',
+  [KueueWorkloadStatus.Requeued]: 'Requeued',
   [KueueWorkloadStatus.Inadmissible]: 'Inadmissible',
   [KueueWorkloadStatus.Failed]: 'Failed',
   [KueueWorkloadStatus.Preempted]: 'Preempted',
@@ -271,37 +340,20 @@ const DEPLOYMENT_SUBSTEP_PREFIX: Partial<Record<KueueWorkloadStatus, string>> = 
 export const getDeploymentKueueSubStepMessage = (
   kueueStatus: KueueWorkloadStatusWithMessage,
 ): string => {
-  const { status, queueName, message, podAdmissionCounts } = kueueStatus;
+  const { status } = kueueStatus;
   const prefix = DEPLOYMENT_SUBSTEP_PREFIX[status];
 
-  // Multi-replica partial-admission detail, e.g. "(3 of 5 pods admitted)" — same suffix shown
-  // in the table row subtitle (getDeploymentStatusSubtitle), so the modal sub-step and the
-  // table stay consistent. Only meaningful for >1 correlated Workload CR.
-  const admissionSuffix =
-    podAdmissionCounts && podAdmissionCounts.total > 1
-      ? ` (${formatPodAdmissionCounts(podAdmissionCounts.admitted, podAdmissionCounts.total)})`
-      : '';
-
   if (status === KueueWorkloadStatus.Preempted) {
-    return `Preempted: Deployment re-queued, waiting for resource${admissionSuffix}`;
+    return appendModelDeploymentPodAdmissionSuffix(
+      'Preempted: Deployment re-queued, waiting for resource',
+      kueueStatus,
+    );
   }
 
-  const rawMessage = message?.trim() || undefined;
-  const isQuotaShaped =
-    (status === KueueWorkloadStatus.Failed || status === KueueWorkloadStatus.Inadmissible) &&
-    rawMessage != null &&
-    (QUOTA_REGEX.test(rawMessage) || FLAVOR_REGEX.test(rawMessage));
+  const body = getModelDeploymentKueueDetailMessage(kueueStatus);
+  const message = prefix ? `${prefix}: ${body}` : body;
 
-  const body = isQuotaShaped
-    ? rawMessage
-    : status === KueueWorkloadStatus.Requeued
-    ? getRequeuedMessage(kueueStatus)
-    : getHumanReadableKueueMessage(status, message, queueName);
-
-  // Queue-position suffix (e.g. "Position 3 of 8 in queue") intentionally omitted here:
-  // queuePosition/queueTotal aren't populated for model deployments yet (only workbenches,
-  // via useQueuePositions). Tracked as a follow-up PR.
-  return `${prefix ? `${prefix}: ${body}` : body}${admissionSuffix}`;
+  return appendModelDeploymentPodAdmissionSuffix(message, kueueStatus);
 };
 
 /**

--- a/frontend/src/pages/modelServing/__tests__/useQueuePositionsForDeployments.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useQueuePositionsForDeployments.spec.ts
@@ -1,0 +1,106 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { getPendingWorkloads } from '#~/api/k8s/pendingWorkloads';
+import { KueueWorkloadStatus, type KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
+import { useQueuePositionsForDeployments } from '#~/pages/modelServing/useQueuePositionsForDeployments';
+import { PendingWorkload } from '#~/k8sTypes';
+
+jest.mock('#~/api/k8s/pendingWorkloads', () => ({
+  getPendingWorkloads: jest.fn(),
+}));
+
+const getPendingWorkloadsMock = jest.mocked(getPendingWorkloads);
+
+function makeStatus(
+  status: KueueWorkloadStatus,
+  queueName?: string,
+  workloadName?: string,
+): KueueWorkloadStatusWithMessage {
+  return { status, queueName, workloadName };
+}
+
+function mockPendingWorkload(
+  name: string,
+  namespace: string,
+  positionInLocalQueue: number,
+  positionInClusterQueue = positionInLocalQueue,
+): PendingWorkload {
+  return {
+    metadata: { name, namespace },
+    priority: 0,
+    localQueueName: 'user-queue',
+    positionInClusterQueue,
+    positionInLocalQueue,
+  };
+}
+
+describe('useQueuePositionsForDeployments', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each<[string, string | undefined, Record<string, KueueWorkloadStatusWithMessage | null>]>([
+    [
+      'namespace is undefined',
+      undefined,
+      { 'InferenceService/my-model': makeStatus(KueueWorkloadStatus.Queued, 'user-queue', 'wl-1') },
+    ],
+    [
+      'status is not pending',
+      'test-ns',
+      {
+        'InferenceService/my-model': makeStatus(KueueWorkloadStatus.Running, 'user-queue', 'wl-1'),
+        'InferenceService/other': null,
+      },
+    ],
+    [
+      'queueName is missing',
+      'test-ns',
+      { 'InferenceService/my-model': makeStatus(KueueWorkloadStatus.Queued, undefined, 'wl-1') },
+    ],
+    [
+      'workloadName is missing',
+      'test-ns',
+      {
+        'InferenceService/my-model': makeStatus(
+          KueueWorkloadStatus.Queued,
+          'user-queue',
+          undefined,
+        ),
+      },
+    ],
+  ])('should return empty map and not fetch when %s', (_, ns, statusMap) => {
+    const renderResult = testHook(useQueuePositionsForDeployments)(ns, statusMap);
+    expect(renderResult).hookToStrictEqual({});
+    expect(getPendingWorkloadsMock).not.toHaveBeenCalled();
+  });
+
+  it('should fetch positions for Queued workloads', async () => {
+    getPendingWorkloadsMock.mockResolvedValue({
+      items: [mockPendingWorkload('wl-1', 'test-ns', 0)],
+    });
+
+    const statusMap = {
+      'InferenceService/my-model': makeStatus(KueueWorkloadStatus.Queued, 'user-queue', 'wl-1'),
+    };
+    const renderResult = testHook(useQueuePositionsForDeployments)('test-ns', statusMap);
+
+    await renderResult.waitForNextUpdate();
+
+    expect(getPendingWorkloadsMock).toHaveBeenCalledWith('test-ns', 'user-queue');
+    expect(renderResult).hookToStrictEqual({
+      'InferenceService/my-model': { queuePosition: 1, queueTotal: 1 },
+    });
+  });
+
+  it('should silently handle 403 and return empty map', async () => {
+    getPendingWorkloadsMock.mockRejectedValue(
+      Object.assign(new Error('Forbidden'), { statusObject: { code: 403 } }),
+    );
+    const statusMap = {
+      'InferenceService/my-model': makeStatus(KueueWorkloadStatus.Queued, 'user-queue', 'wl-1'),
+    };
+    const renderResult = testHook(useQueuePositionsForDeployments)('test-ns', statusMap);
+    await renderResult.waitForNextUpdate();
+    expect(renderResult).hookToStrictEqual({});
+  });
+});

--- a/frontend/src/pages/modelServing/__tests__/useQueuePositionsForDeployments.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useQueuePositionsForDeployments.spec.ts
@@ -92,6 +92,26 @@ describe('useQueuePositionsForDeployments', () => {
     });
   });
 
+  it('should skip malformed Visibility API responses without failing other queues', async () => {
+    getPendingWorkloadsMock.mockImplementation(async (_ns, queueName) => {
+      if (queueName === 'bad-queue') {
+        return { items: undefined } as unknown as { items: PendingWorkload[] };
+      }
+      return { items: [mockPendingWorkload('wl-2', 'test-ns', 1)] };
+    });
+
+    const statusMap = {
+      'InferenceService/bad': makeStatus(KueueWorkloadStatus.Queued, 'bad-queue', 'wl-1'),
+      'InferenceService/good': makeStatus(KueueWorkloadStatus.Queued, 'good-queue', 'wl-2'),
+    };
+    const renderResult = testHook(useQueuePositionsForDeployments)('test-ns', statusMap);
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult).hookToStrictEqual({
+      'InferenceService/good': { queuePosition: 2, queueTotal: 1 },
+    });
+  });
+
   it('should silently handle 403 and return empty map', async () => {
     getPendingWorkloadsMock.mockRejectedValue(
       Object.assign(new Error('Forbidden'), { statusObject: { code: 403 } }),

--- a/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
+++ b/frontend/src/pages/modelServing/useKueueStatusForDeployments.ts
@@ -6,6 +6,7 @@ import type { KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
 import {
   buildModelDeploymentKey,
   buildWorkloadMapForDeployments,
+  countActiveModelDeploymentPods,
   useWatchWorkloads,
   useWatchISPods,
   useWatchLLMISPods,
@@ -99,7 +100,9 @@ export const useKueueStatusForDeployments = (
       // Mirrors useKueueStatusForNotebooks: no matching Workload CR → null, full stop. No
       // queueName-based fallback — the queue label stays on the IS/LLMIS even while stopped, so
       // guessing a status here (e.g. "Queued") from label presence alone is unreliable.
-      const aggregated = aggregateKueueStatusForModel(isWorkloads);
+      const aggregated = aggregateKueueStatusForModel(isWorkloads, {
+        activePodCount: countActiveModelDeploymentPods(deploymentKey, allPods),
+      });
       if (!aggregated) {
         statusMap[deploymentKey] = null;
         continue;

--- a/frontend/src/pages/modelServing/useKueueStatusWithQueuePositions.ts
+++ b/frontend/src/pages/modelServing/useKueueStatusWithQueuePositions.ts
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
+import type { ProjectKind } from '@odh-dashboard/k8s-core';
+import { useKueueConfiguration } from '#~/concepts/hardwareProfiles/kueueUtils';
+import type { KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
+import {
+  useKueueStatusForDeployments,
+  type KueueStatusForDeploymentsResult,
+} from './useKueueStatusForDeployments';
+import { useQueuePositionsForDeployments } from './useQueuePositionsForDeployments';
+
+// Avoids importing @odh-dashboard/llmd-serving/types (not a frontend dep).
+type NamedModelResource = { metadata: { name: string; labels?: Record<string, string> } };
+
+/**
+ * Kueue status for model deployments with queue position merged from the Visibility API.
+ * Mirrors ProjectDetailsContext + useQueuePositions for workbenches.
+ */
+export const useKueueStatusWithQueuePositions = (
+  inferenceServices: InferenceServiceKind[],
+  project: ProjectKind | undefined,
+  llmInferenceServices: NamedModelResource[] = [],
+): KueueStatusForDeploymentsResult => {
+  const { isKueueFeatureEnabled, isProjectKueueEnabled } = useKueueConfiguration(project);
+  const useKueue = Boolean(isKueueFeatureEnabled && isProjectKueueEnabled);
+  const namespace = project == null ? undefined : project.metadata.name;
+
+  const {
+    kueueStatusByDeploymentKey: rawKueueStatusByDeploymentKey,
+    isLoading,
+    error,
+  } = useKueueStatusForDeployments(inferenceServices, project, llmInferenceServices);
+
+  const queuePositions = useQueuePositionsForDeployments(
+    useKueue ? namespace : undefined,
+    rawKueueStatusByDeploymentKey,
+  );
+
+  const kueueStatusByDeploymentKey = React.useMemo(() => {
+    if (Object.keys(queuePositions).length === 0) {
+      return rawKueueStatusByDeploymentKey;
+    }
+    const result: Record<string, KueueWorkloadStatusWithMessage | null> = {};
+    for (const [deploymentKey, status] of Object.entries(rawKueueStatusByDeploymentKey)) {
+      result[deploymentKey] =
+        status && deploymentKey in queuePositions
+          ? {
+              ...status,
+              queuePosition: queuePositions[deploymentKey].queuePosition,
+              queueTotal: queuePositions[deploymentKey].queueTotal,
+            }
+          : status;
+    }
+    return result;
+  }, [rawKueueStatusByDeploymentKey, queuePositions]);
+
+  return {
+    kueueStatusByDeploymentKey,
+    isLoading,
+    error,
+  };
+};

--- a/frontend/src/pages/modelServing/useQueuePositionsForDeployments.ts
+++ b/frontend/src/pages/modelServing/useQueuePositionsForDeployments.ts
@@ -81,10 +81,17 @@ export const useQueuePositionsForDeployments = (
         Array.from(byQueue.entries()).map(async ([queueName, entries]) => {
           try {
             const summary = await getPendingWorkloads(namespace, queueName);
+            if (!Array.isArray(summary.items)) {
+              return;
+            }
             const queueTotal = summary.items.length;
             for (const entry of entries) {
               const found = summary.items.find((pw) => pw.metadata.name === entry.workloadName);
-              if (found != null) {
+              if (
+                found != null &&
+                Number.isInteger(found.positionInLocalQueue) &&
+                found.positionInLocalQueue >= 0
+              ) {
                 newMetrics[entry.deploymentKey] = {
                   queuePosition: found.positionInLocalQueue + 1,
                   queueTotal,

--- a/frontend/src/pages/modelServing/useQueuePositionsForDeployments.ts
+++ b/frontend/src/pages/modelServing/useQueuePositionsForDeployments.ts
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { useDeepCompareMemoize } from '@odh-dashboard/ui-core/hooks';
+import { KueueWorkloadStatus, type KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
+import { getPendingWorkloads } from '#~/api/k8s/pendingWorkloads';
+
+const PENDING_STATUSES: KueueWorkloadStatus[] = [
+  KueueWorkloadStatus.Queued,
+  KueueWorkloadStatus.Inadmissible,
+];
+
+const REFRESH_INTERVAL = 30_000;
+
+type QueuedEntry = {
+  deploymentKey: string;
+  queueName: string;
+  workloadName: string;
+};
+
+export type DeploymentQueueMetrics = {
+  queuePosition: number;
+  queueTotal: number;
+};
+
+/**
+ * Fetches queue positions from the Kueue Visibility API for pending model deployments.
+ * Returns a map of deployment key → 1-indexed position and pending queue total.
+ *
+ * Keys match `buildModelDeploymentKey` (e.g. `InferenceService/my-model`).
+ *
+ * Handles 403 gracefully: when the user lacks RBAC for the Visibility API,
+ * metrics are silently omitted (no error, empty map).
+ */
+export const useQueuePositionsForDeployments = (
+  namespace: string | undefined,
+  kueueStatusByDeploymentKey: Record<string, KueueWorkloadStatusWithMessage | null>,
+): Record<string, DeploymentQueueMetrics> => {
+  const [metrics, setMetrics] = React.useState<Record<string, DeploymentQueueMetrics>>({});
+
+  const queuedEntries: QueuedEntry[] = React.useMemo(() => {
+    const entries: QueuedEntry[] = [];
+    for (const [deploymentKey, status] of Object.entries(kueueStatusByDeploymentKey)) {
+      if (
+        status &&
+        PENDING_STATUSES.includes(status.status) &&
+        status.queueName &&
+        status.workloadName
+      ) {
+        entries.push({
+          deploymentKey,
+          queueName: status.queueName,
+          workloadName: status.workloadName,
+        });
+      }
+    }
+    return entries;
+  }, [kueueStatusByDeploymentKey]);
+
+  const stableEntries = useDeepCompareMemoize(queuedEntries);
+
+  React.useEffect(() => {
+    if (!namespace || stableEntries.length === 0) {
+      setMetrics({});
+      return undefined;
+    }
+
+    let cancelled = false;
+    let latestRequestId = 0;
+
+    const fetchPositions = async (): Promise<void> => {
+      const requestId = ++latestRequestId;
+      const byQueue = new Map<string, QueuedEntry[]>();
+      for (const entry of stableEntries) {
+        const list = byQueue.get(entry.queueName) ?? [];
+        list.push(entry);
+        byQueue.set(entry.queueName, list);
+      }
+
+      const newMetrics: Record<string, DeploymentQueueMetrics> = {};
+
+      await Promise.all(
+        Array.from(byQueue.entries()).map(async ([queueName, entries]) => {
+          try {
+            const summary = await getPendingWorkloads(namespace, queueName);
+            const queueTotal = summary.items.length;
+            for (const entry of entries) {
+              const found = summary.items.find((pw) => pw.metadata.name === entry.workloadName);
+              if (found != null) {
+                newMetrics[entry.deploymentKey] = {
+                  queuePosition: found.positionInLocalQueue + 1,
+                  queueTotal,
+                };
+              }
+            }
+          } catch {
+            // Silently omit positions on any error (403 = no RBAC, others = optional data)
+          }
+        }),
+      );
+
+      if (!cancelled && requestId === latestRequestId) {
+        setMetrics(newMetrics);
+      }
+    };
+
+    fetchPositions();
+    const intervalId = setInterval(fetchPositions, REFRESH_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [namespace, stableEntries]);
+
+  return metrics;
+};

--- a/packages/kserve/src/__tests__/deploymentStatus.spec.ts
+++ b/packages/kserve/src/__tests__/deploymentStatus.spec.ts
@@ -2,7 +2,7 @@ import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__
 import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
 import type { InferenceServiceKind } from '@odh-dashboard/model-serving/shared';
 import { KueueWorkloadStatus } from '@odh-dashboard/internal/concepts/kueue/types';
-import { getKServeDeploymentConditions } from '../deploymentStatus';
+import { getKServeDeploymentConditions, getKServeDeploymentStatus } from '../deploymentStatus';
 
 describe('getKServeDeploymentConditions', () => {
   it('should include deployment requested from creationTimestamp', () => {
@@ -357,5 +357,16 @@ describe('getKServeDeploymentConditions', () => {
 
     const createPod = conditions.find((c) => c.type === 'CreatePod');
     expect(createPod?.status).not.toBe('True');
+  });
+
+  it('should set isStarting true and isRunning false when LOADED with Queued Kueue status', () => {
+    const isvc = mockInferenceServiceK8sResource({});
+    const status = getKServeDeploymentStatus(isvc, [], {
+      status: KueueWorkloadStatus.Queued,
+      queueName: 'test-queue',
+    });
+
+    expect(status.stoppedStates?.isStarting).toBe(true);
+    expect(status.stoppedStates?.isRunning).toBe(false);
   });
 });

--- a/packages/kserve/src/__tests__/deployments.spec.ts
+++ b/packages/kserve/src/__tests__/deployments.spec.ts
@@ -17,8 +17,8 @@ jest.mock('@odh-dashboard/plugin-core', () => ({
 }));
 
 // Mock Kueue status - not under test here, exercised by useKueueStatusForDeployments.spec.ts
-jest.mock('@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments', () => ({
-  useKueueStatusForDeployments: jest.fn(() => ({
+jest.mock('@odh-dashboard/internal/pages/modelServing/useKueueStatusWithQueuePositions', () => ({
+  useKueueStatusWithQueuePositions: jest.fn(() => ({
     kueueStatusByDeploymentKey: {},
     isLoading: false,
     error: null,
@@ -28,9 +28,9 @@ jest.mock('@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeploymen
 const mockUseWatchInferenceServices = watchModule.useWatchInferenceServices as jest.Mock;
 const mockUseWatchServingRuntimes = watchModule.useWatchServingRuntimes as jest.Mock;
 const mockUseWatchDeploymentPods = watchModule.useWatchDeploymentPods as jest.Mock;
-const mockUseKueueStatusForDeployments = jest.requireMock(
-  '@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments',
-).useKueueStatusForDeployments as jest.Mock;
+const mockUseKueueStatusWithQueuePositions = jest.requireMock(
+  '@odh-dashboard/internal/pages/modelServing/useKueueStatusWithQueuePositions',
+).useKueueStatusWithQueuePositions as jest.Mock;
 
 // Type helper for hook return value
 type DeploymentHookResult = [KServeDeployment[] | undefined, boolean, Error[] | undefined];
@@ -196,7 +196,7 @@ describe('useWatchDeployments', () => {
   });
 
   it('should surface Kueue watch errors (e.g. 403 for missing RBAC) instead of silently dropping them', () => {
-    mockUseKueueStatusForDeployments.mockReturnValue({
+    mockUseKueueStatusWithQueuePositions.mockReturnValue({
       kueueStatusByDeploymentKey: {},
       isLoading: false,
       error: 'Forbidden',
@@ -264,7 +264,7 @@ describe('useWatchDeployments', () => {
   });
 
   it('should default status.kueueStatus to null (not undefined) when the IS has no entry in kueueStatusByDeploymentKey', () => {
-    mockUseKueueStatusForDeployments.mockReturnValue({
+    mockUseKueueStatusWithQueuePositions.mockReturnValue({
       kueueStatusByDeploymentKey: {},
       isLoading: false,
       error: null,

--- a/packages/kserve/src/deploymentStatus.ts
+++ b/packages/kserve/src/deploymentStatus.ts
@@ -152,6 +152,7 @@ export const getKServeDeploymentStatus = (
     state,
     inferenceService.metadata.annotations,
     deploymentPod,
+    kueueStatus,
   );
 
   const conditions = getKServeDeploymentConditions(inferenceService, state, kueueStatus);

--- a/packages/kserve/src/deployments.ts
+++ b/packages/kserve/src/deployments.ts
@@ -15,9 +15,10 @@ import {
   deleteServingRuntime,
   getInferenceService,
   getInferenceServicePods,
+  resolveKueueStatusForInferenceService,
 } from '@odh-dashboard/internal/api/index';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
-import { useKueueStatusForDeployments } from '@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments';
+import { useKueueStatusWithQueuePositions } from '@odh-dashboard/internal/pages/modelServing/useKueueStatusWithQueuePositions';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { buildModelDeploymentKey } from '@odh-dashboard/internal/api/k8s/workloads';
 import {
@@ -79,7 +80,7 @@ export const useWatchDeployments = (
     kueueStatusByDeploymentKey,
     isLoading: kueueLoading,
     error: kueueError,
-  } = useKueueStatusForDeployments(filteredInferenceServices, project);
+  } = useKueueStatusWithQueuePositions(filteredInferenceServices, project);
 
   const deployments: KServeDeployment[] = React.useMemo(
     () =>
@@ -138,11 +139,15 @@ export const fetchDeploymentStatus = async (
     const inferenceService = await getInferenceService(name, namespace, opts);
 
     const deploymentPods = await getInferenceServicePods(name, namespace);
+    const kueueStatus = await resolveKueueStatusForInferenceService(
+      inferenceService,
+      deploymentPods,
+    );
 
     const deployment: KServeDeployment = {
       modelServingPlatformId: KSERVE_ID,
       model: inferenceService,
-      status: getKServeDeploymentStatus(inferenceService, deploymentPods),
+      status: getKServeDeploymentStatus(inferenceService, deploymentPods, kueueStatus),
     };
 
     return deployment;

--- a/packages/llmd-serving/src/deployments/status.ts
+++ b/packages/llmd-serving/src/deployments/status.ts
@@ -204,6 +204,7 @@ export const getLLMdDeploymentStatus = (
     state,
     inferenceService.metadata.annotations,
     deploymentPod,
+    kueueStatus,
   );
 
   const conditions = getLLMdDeploymentConditions(inferenceService, kueueStatus);

--- a/packages/llmd-serving/src/deployments/useWatchDeployments.ts
+++ b/packages/llmd-serving/src/deployments/useWatchDeployments.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { K8sAPIOptions, ProjectKind } from '@odh-dashboard/k8s-core';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
-import { useKueueStatusForDeployments } from '@odh-dashboard/internal/pages/modelServing/useKueueStatusForDeployments';
+import { useKueueStatusWithQueuePositions } from '@odh-dashboard/internal/pages/modelServing/useKueueStatusWithQueuePositions';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { buildModelDeploymentKey } from '@odh-dashboard/internal/api/k8s/workloads';
 import { getLLMdDeploymentEndpoints } from './endpoints';
@@ -40,7 +40,7 @@ export const useWatchDeployments = (
     kueueStatusByDeploymentKey,
     isLoading: kueueLoading,
     error: kueueError,
-  } = useKueueStatusForDeployments([], project, filteredLLMInferenceServices);
+  } = useKueueStatusWithQueuePositions([], project, filteredLLMInferenceServices);
 
   const deployments = React.useMemo(() => {
     return filteredLLMInferenceServices.map((llmInferenceService) => {

--- a/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
@@ -41,6 +41,7 @@ import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { useKueueConfiguration } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { KUEUE_QUEUE_LABEL } from '@odh-dashboard/internal/concepts/kueue/index';
+import { KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT } from '@odh-dashboard/internal/concepts/kueue/types';
 import {
   ModelStatusIcon,
   getDeploymentStatusSubtitleColor,
@@ -105,7 +106,11 @@ const getConditionMessageColor = (
   condition: DeploymentCondition,
   deploymentStatus?: DeploymentStatus | null,
 ): string | undefined => {
-  if (condition.type === 'CreatePod' && deploymentStatus?.kueueStatus) {
+  if (
+    condition.type === 'CreatePod' &&
+    deploymentStatus?.kueueStatus?.status &&
+    KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT.includes(deploymentStatus.kueueStatus.status)
+  ) {
     return getDeploymentStatusSubtitleColor(deploymentStatus);
   }
   const messageStatus = condition.messageStatus ?? condition.status;

--- a/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
@@ -5,6 +5,8 @@ import {
   ContentVariants,
   Flex,
   FlexItem,
+  HelperText,
+  HelperTextItem,
   Icon,
   // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- custom modal with ProgressStepper timeline and embedded status badge; ContentModal does not support this layout
   Modal,
@@ -28,18 +30,28 @@ import {
   Timestamp,
   TimestampTooltipVariant,
 } from '@patternfly/react-core';
-import { InProgressIcon } from '@patternfly/react-icons';
+import { InProgressIcon, InfoCircleIcon } from '@patternfly/react-icons';
+import {
+  t_global_text_color_status_danger_default as DangerColor,
+  t_global_color_status_warning_300 as WarningColor,
+  t_global_color_nonstatus_purple_400 as PurpleColor,
+  t_global_font_weight_body_bold as BoldWeight,
+} from '@patternfly/react-tokens';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { useKueueConfiguration } from '@odh-dashboard/hardware-profiles/shared/kueueUtils';
 import { ProjectsContext } from '@odh-dashboard/ui-core/context/ProjectsContext';
 import { KUEUE_QUEUE_LABEL } from '@odh-dashboard/internal/concepts/kueue/index';
-import { ModelStatusIcon } from '@odh-dashboard/model-serving/shared/components';
+import {
+  ModelStatusIcon,
+  getDeploymentStatusSubtitleColor,
+} from '@odh-dashboard/model-serving/shared/components';
 import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
 import DeploymentResourcesTab from './DeploymentResourcesTab';
 import type {
   Deployment,
   DeploymentCondition,
   DeploymentConditionStatus,
+  DeploymentStatus,
 } from '../../../extension-points';
 
 type DeploymentStatusModalProps = {
@@ -81,12 +93,23 @@ const ConditionTimestamp: React.FC<{ isoString?: string }> = ({ isoString }) => 
 const getMessageColor = (status: DeploymentConditionStatus | undefined): string | undefined => {
   switch (status) {
     case 'False':
-      return 'var(--pf-t--global--text--color--status--danger--default)';
+      return DangerColor.var;
     case 'Warning':
-      return 'var(--pf-t--global--text--color--status--warning--default)';
+      return WarningColor.var;
     default:
       return undefined;
   }
+};
+
+const getConditionMessageColor = (
+  condition: DeploymentCondition,
+  deploymentStatus?: DeploymentStatus | null,
+): string | undefined => {
+  if (condition.type === 'CreatePod' && deploymentStatus?.kueueStatus) {
+    return getDeploymentStatusSubtitleColor(deploymentStatus);
+  }
+  const messageStatus = condition.messageStatus ?? condition.status;
+  return getMessageColor(messageStatus);
 };
 
 /** In-progress steps (e.g. waiting on Kueue) render a spinner instead of the default variant icon. */
@@ -101,9 +124,10 @@ const InProgressStepIcon: React.FC = () => (
 
 const ConditionDescription: React.FC<{
   condition: DeploymentCondition;
-}> = ({ condition }) => {
+  deploymentStatus?: DeploymentStatus | null;
+}> = ({ condition, deploymentStatus }) => {
   const messageStatus = condition.messageStatus ?? condition.status;
-  const messageColor = getMessageColor(messageStatus);
+  const messageColor = getConditionMessageColor(condition, deploymentStatus);
   const showMessage =
     Boolean(condition.message) &&
     (messageStatus === 'False' || messageStatus === 'Warning' || messageStatus === 'Unknown');
@@ -124,7 +148,8 @@ const ConditionDescription: React.FC<{
 
 const ConditionChildren: React.FC<{
   children: DeploymentCondition[];
-}> = ({ children }) => (
+  deploymentStatus?: DeploymentStatus | null;
+}> = ({ children, deploymentStatus }) => (
   <ProgressStepper isVertical style={{ paddingTop: 'var(--pf-t--global--spacer--sm)' }}>
     {children.map((child) => (
       <ProgressStep
@@ -134,7 +159,7 @@ const ConditionChildren: React.FC<{
         aria-label={`${child.label}: ${child.status ?? 'pending'}`}
         id={`condition-child-${child.type}`}
         titleId={`condition-child-${child.type}-title`}
-        description={<ConditionDescription condition={child} />}
+        description={<ConditionDescription condition={child} deploymentStatus={deploymentStatus} />}
         data-testid={`deployment-condition-${child.type}`}
       >
         {child.label}
@@ -143,9 +168,10 @@ const ConditionChildren: React.FC<{
   </ProgressStepper>
 );
 
-const ConditionsProgressStepper: React.FC<{ conditions: DeploymentCondition[] }> = ({
-  conditions,
-}) => (
+const ConditionsProgressStepper: React.FC<{
+  conditions: DeploymentCondition[];
+  deploymentStatus?: DeploymentStatus | null;
+}> = ({ conditions, deploymentStatus }) => (
   <ProgressStepper isVertical data-testid="deployment-status-steps">
     {conditions.map((condition) => (
       <ProgressStep
@@ -157,9 +183,11 @@ const ConditionsProgressStepper: React.FC<{ conditions: DeploymentCondition[] }>
         titleId={`condition-${condition.type}-title`}
         description={
           <>
-            <ConditionDescription condition={condition} />
+            <ConditionDescription condition={condition} deploymentStatus={deploymentStatus} />
             {condition.children && condition.children.length > 0 && (
-              <ConditionChildren>{condition.children}</ConditionChildren>
+              <ConditionChildren deploymentStatus={deploymentStatus}>
+                {condition.children}
+              </ConditionChildren>
             )}
           </>
         }
@@ -173,6 +201,32 @@ const ConditionsProgressStepper: React.FC<{ conditions: DeploymentCondition[] }>
 
 const PROGRESS_TAB = 'progress';
 const RESOURCES_TAB = 'resources';
+
+const DeploymentProgressDisclaimer: React.FC = () => (
+  <HelperText data-testid="deployment-status-progress-disclaimer">
+    <HelperTextItem
+      variant="indeterminate"
+      icon={<InfoCircleIcon style={{ color: PurpleColor.var }} />}
+      style={{ fontWeight: BoldWeight.var }}
+    >
+      Steps may occur in any order, depending on the deployment type.
+    </HelperTextItem>
+  </HelperText>
+);
+
+const DeploymentProgressTab: React.FC<{
+  conditions: DeploymentCondition[];
+  deploymentStatus?: DeploymentStatus | null;
+}> = ({ conditions, deploymentStatus }) => (
+  <Stack hasGutter>
+    <StackItem>
+      <DeploymentProgressDisclaimer />
+    </StackItem>
+    <StackItem>
+      <ConditionsProgressStepper conditions={conditions} deploymentStatus={deploymentStatus} />
+    </StackItem>
+  </Stack>
+);
 
 const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
   deployment,
@@ -261,7 +315,7 @@ const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
                 deploymentName={deployment.model.metadata.name}
               />
             ) : (
-              <ConditionsProgressStepper conditions={conditions} />
+              <DeploymentProgressTab conditions={conditions} deploymentStatus={deployment.status} />
             )}
           </StackItem>
         </Stack>

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentStatusModal.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentStatusModal.spec.tsx
@@ -188,6 +188,24 @@ describe('DeploymentStatusModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('should show progress disclaimer on the Progress tab', () => {
+    const deployment = createMockDeployment([
+      {
+        type: 'DeploymentRequested',
+        label: 'Deployment requested',
+        status: 'True',
+        lastTransitionTime: '2026-04-22T15:44:32Z',
+      },
+    ]);
+
+    render(<DeploymentStatusModal deployment={deployment} onClose={jest.fn()} />);
+
+    expect(screen.getByTestId('deployment-status-progress-disclaimer')).toBeInTheDocument();
+    expect(
+      screen.getByText('Steps may occur in any order, depending on the deployment type.'),
+    ).toBeInTheDocument();
+  });
+
   it('should always show the tab strip with a Progress tab, even when Kueue/Resources is not available', () => {
     const deployment = createMockDeployment([]);
 

--- a/packages/model-serving/src/concepts/__tests__/utils.spec.ts
+++ b/packages/model-serving/src/concepts/__tests__/utils.spec.ts
@@ -1,0 +1,103 @@
+import {
+  KueueWorkloadStatus,
+  type KueueWorkloadStatusWithMessage,
+} from '@odh-dashboard/internal/concepts/kueue/types';
+import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
+import { getModelDeploymentStoppedStates } from '../utils';
+
+const kueueStatus = (
+  status: KueueWorkloadStatus,
+  overrides: Partial<KueueWorkloadStatusWithMessage> = {},
+): KueueWorkloadStatusWithMessage => ({
+  status,
+  queueName: 'test-queue',
+  ...overrides,
+});
+
+describe('getModelDeploymentStoppedStates', () => {
+  it('returns isStarting true when Workload is Queued during restart', () => {
+    const stoppedStates = getModelDeploymentStoppedStates(
+      ModelDeploymentState.UNKNOWN,
+      {},
+      undefined,
+      kueueStatus(KueueWorkloadStatus.Queued),
+    );
+    expect(stoppedStates.isStarting).toBe(true);
+    expect(stoppedStates.isRunning).toBe(false);
+  });
+
+  it('returns isStarting true when Workload is Inadmissible (quota pending UI)', () => {
+    const stoppedStates = getModelDeploymentStoppedStates(
+      ModelDeploymentState.PENDING,
+      {},
+      undefined,
+      kueueStatus(KueueWorkloadStatus.Inadmissible),
+    );
+    expect(stoppedStates.isStarting).toBe(true);
+    expect(stoppedStates.isRunning).toBe(false);
+  });
+
+  it('returns isStarting false and isRunning true when Workload is Admitted and IS is LOADED', () => {
+    const stoppedStates = getModelDeploymentStoppedStates(
+      ModelDeploymentState.LOADED,
+      {},
+      undefined,
+      kueueStatus(KueueWorkloadStatus.Admitted),
+    );
+    expect(stoppedStates.isStarting).toBe(false);
+    expect(stoppedStates.isRunning).toBe(true);
+  });
+
+  it('returns isStopped true and not isStarting when stop annotation is set with no pod', () => {
+    const stoppedStates = getModelDeploymentStoppedStates(
+      ModelDeploymentState.UNKNOWN,
+      { 'serving.kserve.io/stop': 'true' },
+      undefined,
+      kueueStatus(KueueWorkloadStatus.Queued),
+    );
+    expect(stoppedStates.isStopped).toBe(true);
+    expect(stoppedStates.isStarting).toBe(false);
+  });
+
+  it('returns isStarting true for UNKNOWN state with no Workload (existing logic)', () => {
+    const stoppedStates = getModelDeploymentStoppedStates(
+      ModelDeploymentState.UNKNOWN,
+      {},
+      undefined,
+      null,
+    );
+    expect(stoppedStates.isStarting).toBe(true);
+    expect(stoppedStates.isRunning).toBe(false);
+  });
+
+  it('slow admission: LOADED KServe state with Queued Workload keeps isStarting true and isRunning false', () => {
+    const stoppedStates = getModelDeploymentStoppedStates(
+      ModelDeploymentState.LOADED,
+      {},
+      undefined,
+      kueueStatus(KueueWorkloadStatus.Queued),
+    );
+    expect(stoppedStates.isStarting).toBe(true);
+    expect(stoppedStates.isRunning).toBe(false);
+  });
+
+  it('fast admission: transitions from Queued pre-admission to running when Admitted', () => {
+    const queued = getModelDeploymentStoppedStates(
+      ModelDeploymentState.LOADED,
+      {},
+      undefined,
+      kueueStatus(KueueWorkloadStatus.Queued),
+    );
+    expect(queued.isStarting).toBe(true);
+    expect(queued.isRunning).toBe(false);
+
+    const admitted = getModelDeploymentStoppedStates(
+      ModelDeploymentState.LOADED,
+      {},
+      undefined,
+      kueueStatus(KueueWorkloadStatus.Admitted),
+    );
+    expect(admitted.isStarting).toBe(false);
+    expect(admitted.isRunning).toBe(true);
+  });
+});

--- a/packages/model-serving/src/concepts/utils.ts
+++ b/packages/model-serving/src/concepts/utils.ts
@@ -1,31 +1,49 @@
 import type { ToggleState } from '@odh-dashboard/ui-core';
 import type { PodKind } from '@odh-dashboard/k8s-core';
+import {
+  KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT,
+  type KueueWorkloadStatusWithMessage,
+} from '@odh-dashboard/internal/concepts/kueue/types';
 import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
+
+const isKueuePreAdmissionBlocking = (
+  isStopAnnotated: boolean,
+  kueueStatus?: KueueWorkloadStatusWithMessage | null,
+): boolean =>
+  !isStopAnnotated &&
+  Boolean(
+    kueueStatus?.status && KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT.includes(kueueStatus.status),
+  );
 
 export const getModelDeploymentStoppedStates = (
   state: ModelDeploymentState,
   modelAnnotations?: Record<string, string>,
   deploymentPod?: PodKind,
+  kueueStatus?: KueueWorkloadStatusWithMessage | null,
 ): ToggleState => {
-  const isStopped = isModelServingStopped(modelAnnotations);
-  const stoppedStates = {
+  const isStopAnnotated = isModelServingStopped(modelAnnotations);
+  const isKueuePreAdmission = isKueuePreAdmissionBlocking(isStopAnnotated, kueueStatus);
+  const baseIsRunning =
+    (state === ModelDeploymentState.LOADED || state === ModelDeploymentState.FAILED_TO_LOAD) &&
+    !isStopAnnotated;
+  const baseIsStarting =
+    (state === ModelDeploymentState.PENDING ||
+      state === ModelDeploymentState.LOADING ||
+      state === ModelDeploymentState.STANDBY ||
+      state === ModelDeploymentState.UNKNOWN) &&
+    !isStopAnnotated;
+
+  return {
     // ISVC doesn't have annotation and state is LOADED
-    isRunning:
-      (state === ModelDeploymentState.LOADED || state === ModelDeploymentState.FAILED_TO_LOAD) &&
-      !isStopped,
+    isRunning: baseIsRunning && !isKueuePreAdmission,
     // ISVC has annotation and there are no pods
-    isStopped: isStopped && !deploymentPod,
-    // ISVC doesn't have annotation and state is PENDING, LOADING, STANDBY or UNKNOWN
-    isStarting:
-      (state === ModelDeploymentState.PENDING ||
-        state === ModelDeploymentState.LOADING ||
-        state === ModelDeploymentState.STANDBY ||
-        state === ModelDeploymentState.UNKNOWN) &&
-      !isStopped,
+    isStopped: isStopAnnotated && !deploymentPod,
+    // ISVC doesn't have annotation and state is PENDING, LOADING, STANDBY or UNKNOWN,
+    // or Kueue is still gating admission after a restart (stale LOADED + Queued Workload).
+    isStarting: baseIsStarting || isKueuePreAdmission,
     // ISVC has annotation and there are pods
-    isStopping: isStopped && !!deploymentPod,
+    isStopping: isStopAnnotated && !!deploymentPod,
   };
-  return stoppedStates;
 };
 
 export const isModelServingStopped = (modelAnnotations?: Record<string, string>): boolean =>

--- a/packages/model-serving/src/shared/components/__tests__/getDeploymentStatusSubtitle.spec.ts
+++ b/packages/model-serving/src/shared/components/__tests__/getDeploymentStatusSubtitle.spec.ts
@@ -1,0 +1,54 @@
+import { KueueWorkloadStatus } from '@odh-dashboard/internal/concepts/kueue/types';
+import { ModelDeploymentState } from '@odh-dashboard/model-serving/shared';
+import { getDeploymentStatusSubtitle } from '../getDeploymentStatusSubtitle';
+
+describe('getDeploymentStatusSubtitle', () => {
+  it('shows only queue position for Queued status when queuePosition is set', () => {
+    const subtitle = getDeploymentStatusSubtitle({
+      state: ModelDeploymentState.PENDING,
+      kueueStatus: {
+        status: KueueWorkloadStatus.Queued,
+        queueName: 'constrained-queue',
+        queuePosition: 2,
+      },
+    });
+    expect(subtitle).toBe('2nd in constrained-queue');
+    expect(subtitle).not.toContain('Waiting for quota');
+  });
+
+  it('does not show subtitle for Admitted status', () => {
+    const subtitle = getDeploymentStatusSubtitle({
+      state: ModelDeploymentState.LOADED,
+      kueueStatus: {
+        status: KueueWorkloadStatus.Admitted,
+        queueName: 'my-queue',
+        queuePosition: 3,
+      },
+    });
+    expect(subtitle).toBeNull();
+  });
+
+  it('shows Kueue message without position when queuePosition is absent', () => {
+    const subtitle = getDeploymentStatusSubtitle({
+      state: ModelDeploymentState.PENDING,
+      kueueStatus: {
+        status: KueueWorkloadStatus.Queued,
+        queueName: 'my-queue',
+      },
+    });
+    expect(subtitle).toBe('Waiting for quota in my-queue');
+  });
+
+  it('appends pod admission counts after queue position when both are present', () => {
+    const subtitle = getDeploymentStatusSubtitle({
+      state: ModelDeploymentState.PENDING,
+      kueueStatus: {
+        status: KueueWorkloadStatus.Queued,
+        queueName: 'my-queue',
+        queuePosition: 2,
+        podAdmissionCounts: { admitted: 3, total: 5 },
+      },
+    });
+    expect(subtitle).toBe('2nd in my-queue (3 of 5 pods admitted)');
+  });
+});

--- a/packages/model-serving/src/shared/components/getDeploymentStatusSubtitle.ts
+++ b/packages/model-serving/src/shared/components/getDeploymentStatusSubtitle.ts
@@ -5,14 +5,10 @@ import {
 } from '@patternfly/react-tokens';
 import { getKueueStatusInfo } from '@odh-dashboard/internal/concepts/kueue/index';
 import {
-  formatPodAdmissionCounts,
-  getHumanReadableKueueMessage,
-  getRequeuedMessage,
+  appendModelDeploymentPodAdmissionSuffix,
+  getModelDeploymentKueueDetailMessage,
 } from '@odh-dashboard/internal/concepts/kueue/messageUtils';
-import {
-  KueueWorkloadStatus,
-  KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT,
-} from '@odh-dashboard/internal/concepts/kueue/types';
+import { KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT } from '@odh-dashboard/internal/concepts/kueue/types';
 import { ModelDeploymentState } from '../types';
 import type { DeploymentStatus } from '../../../extension-points';
 
@@ -31,28 +27,10 @@ export const getDeploymentStatusSubtitle = (status?: DeploymentStatus | null): s
     kueueStatus?.status &&
     KUEUE_STATUSES_OVERRIDE_MODEL_DEPLOYMENT.includes(kueueStatus.status)
   ) {
-    if (kueueStatus.status === KueueWorkloadStatus.Requeued) {
-      return getRequeuedMessage(kueueStatus);
-    }
-    const humanMessage = getHumanReadableKueueMessage(
-      kueueStatus.status,
-      kueueStatus.message,
-      kueueStatus.queueName,
+    return appendModelDeploymentPodAdmissionSuffix(
+      getModelDeploymentKueueDetailMessage(kueueStatus),
+      kueueStatus,
     );
-
-    // Queue position isn't included here yet — queuePosition/queueTotal aren't populated for
-    // model deployments (only workbenches, via useQueuePositions). Tracked as a follow-up PR.
-    const suffixes: string[] = [];
-    if (kueueStatus.podAdmissionCounts && kueueStatus.podAdmissionCounts.total > 1) {
-      suffixes.push(
-        formatPodAdmissionCounts(
-          kueueStatus.podAdmissionCounts.admitted,
-          kueueStatus.podAdmissionCounts.total,
-        ),
-      );
-    }
-
-    return suffixes.length > 0 ? `${humanMessage} (${suffixes.join(', ')})` : humanMessage;
   }
 
   if (state === ModelDeploymentState.FAILED_TO_LOAD && message) {


### PR DESCRIPTION

Closes 

1. [RHOAIENG-79911](https://redhat.atlassian.net/browse/RHOAIENG-79911)
2. [RHOAIENG-79914](https://redhat.atlassian.net/browse/RHOAIENG-79914)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

https://github.com/user-attachments/assets/c843a7c6-709f-4ac1-b6fe-7af2ca780ec6


- Stop/start readmission: restarting a model with a Workload still Queued (or Inadmissible, etc.) keeps the row on **Starting** instead of Running when the ISVC is already LOADED. Same behavior on the Start button poll path, not only the table watch.
- Queue position: polls the Kueue Visibility API every 30s for pending deployments. Subtitle shows position only (e.g. `2nd in my-queue`) when we have it, not the full "Waiting for quota…" line. Queue name `default` displays as `default queue`.
- Multi-replica: partial admission suffix still works (`3 of 5 pods admitted`). Total can count live pods even when not every replica has a Workload CR yet (scale-up or watch lag).
- Status modal: Progress tab disclaimer (same idea as workbenches). Kueue sub-step under Create pod matches status column warning color. Requeued uses `Requeued:` prefix, not `Queued:`.
- Shared message helpers so table subtitle and modal stay aligned.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Verified it on a cluster with Kueue and Kueue positioning enabled on the deployment

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

1.  Unit tests: `messageUtils.spec`, `index.spec`, `utils.spec`, `getDeploymentStatusSubtitle.spec`, `useQueuePositionsForDeployments.spec`, `deploymentStatus.spec`
2. Will create a followup PR for cypress tests 


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ X Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-79911]: https://redhat.atlassian.net/browse/RHOAIENG-79911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-79914]: https://redhat.atlassian.net/browse/RHOAIENG-79914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added queue position and total-queue visibility for pending model deployments.
- Displayed active pod admission progress for multi-replica deployments.
- Improved Kueue messaging with queue names, positions, requeued states, and partial admission details.
- Enhanced deployment status indicators for Kueue-gated startup states.
- Added progress guidance noting that deployment steps may occur in any order.

## Bug Fixes
- Improved status handling when workloads and active pods are not fully correlated.
- Prevented queue-position lookup errors from disrupting deployment status display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->