### PR TITLE
Add color-coded node backgrounds to Feature Store lineage graph by object type

### DIFF
--- a/frontend/src/components/lineage/Lineage.tsx
+++ b/frontend/src/components/lineage/Lineage.tsx
@@ -31,6 +31,7 @@ const LineageInner: React.FC<LineageProps> = ({
   componentFactory,
   popoverComponent: PopoverComponent,
   toolbarComponent: ToolbarComponent,
+  legendComponent: LegendComponent,
   autoResetOnDataChange = false,
 }) => {
   const controller = useLineageController('lineage-graph', componentFactory);
@@ -233,6 +234,8 @@ const LineageInner: React.FC<LineageProps> = ({
             <VisualizationSurface state={{ selectedIds, highlightedIds }} />
           </VisualizationProvider>
         </TopologyView>
+
+        {LegendComponent && <LegendComponent />}
 
         {PopoverComponent && (
           <PopoverComponent

--- a/frontend/src/components/lineage/Lineage.tsx
+++ b/frontend/src/components/lineage/Lineage.tsx
@@ -19,6 +19,7 @@ import { createLineageTopologyControls } from './topologyControls';
 import { LineageClickProvider, useLineageClick } from './LineageClickContext';
 import { useLineageCenter } from './context/LineageCenterContext';
 import { useDebouncedCenter } from './useDebouncedCenter';
+import LineageNodeFocusOverlay from './LineageNodeFocusOverlay';
 
 const LineageInner: React.FC<LineageProps> = ({
   data,
@@ -31,6 +32,7 @@ const LineageInner: React.FC<LineageProps> = ({
   componentFactory,
   popoverComponent: PopoverComponent,
   toolbarComponent: ToolbarComponent,
+  legendComponent: LegendComponent,
   autoResetOnDataChange = false,
 }) => {
   const controller = useLineageController('lineage-graph', componentFactory);
@@ -233,6 +235,10 @@ const LineageInner: React.FC<LineageProps> = ({
             <VisualizationSurface state={{ selectedIds, highlightedIds }} />
           </VisualizationProvider>
         </TopologyView>
+
+        <LineageNodeFocusOverlay controller={controller} />
+
+        {LegendComponent && <LegendComponent />}
 
         {PopoverComponent && (
           <PopoverComponent

--- a/frontend/src/components/lineage/LineageNodeFocusOverlay.scss
+++ b/frontend/src/components/lineage/LineageNodeFocusOverlay.scss
@@ -1,0 +1,22 @@
+.lineage-node-focus-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.lineage-node-focus-button {
+  position: absolute;
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  pointer-events: auto;
+  outline: none;
+
+  &:focus-visible {
+    box-shadow: inset 0 0 0 2px var(--pf-t--global--border--color--clicked);
+  }
+}

--- a/frontend/src/components/lineage/LineageNodeFocusOverlay.tsx
+++ b/frontend/src/components/lineage/LineageNodeFocusOverlay.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {
+  Visualization,
+  GRAPH_LAYOUT_END_EVENT,
+  GRAPH_POSITION_CHANGE_EVENT,
+  SELECTION_EVENT,
+} from '@patternfly/react-topology';
+import {
+  activateLineageNode,
+  getLineageNodeSelector,
+  measureLineageNodeFocusTargets,
+} from './lineageNodeFocus';
+import './LineageNodeFocusOverlay.scss';
+
+type LineageNodeFocusOverlayProps = {
+  controller: Visualization;
+};
+
+const LineageNodeFocusOverlay: React.FC<LineageNodeFocusOverlayProps> = ({ controller }) => {
+  const overlayRef = React.useRef<HTMLDivElement>(null);
+  const [targets, setTargets] = React.useState<ReturnType<typeof measureLineageNodeFocusTargets>>(
+    [],
+  );
+
+  const refreshTargets = React.useCallback(() => {
+    const container = overlayRef.current?.parentElement;
+    if (!container) {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      setTargets(measureLineageNodeFocusTargets(controller, container));
+    });
+  }, [controller]);
+
+  React.useEffect(() => {
+    refreshTargets();
+
+    controller.addEventListener(GRAPH_LAYOUT_END_EVENT, refreshTargets);
+    controller.addEventListener(GRAPH_POSITION_CHANGE_EVENT, refreshTargets);
+    controller.addEventListener(SELECTION_EVENT, refreshTargets);
+
+    const container = overlayRef.current?.parentElement;
+    const resizeObserver = container ? new ResizeObserver(() => refreshTargets()) : undefined;
+    if (resizeObserver && container) {
+      resizeObserver.observe(container);
+    }
+
+    return () => {
+      controller.removeEventListener(GRAPH_LAYOUT_END_EVENT, refreshTargets);
+      controller.removeEventListener(GRAPH_POSITION_CHANGE_EVENT, refreshTargets);
+      controller.removeEventListener(SELECTION_EVENT, refreshTargets);
+      resizeObserver?.disconnect();
+    };
+  }, [controller, refreshTargets]);
+
+  return (
+    <div ref={overlayRef} className="lineage-node-focus-overlay">
+      {targets.map((target) => (
+        <button
+          key={target.id}
+          type="button"
+          tabIndex={0}
+          aria-label={target.label}
+          className="lineage-node-focus-button"
+          style={{
+            left: target.left,
+            top: target.top,
+            width: target.width,
+            height: target.height,
+            borderRadius: target.borderRadius,
+          }}
+          onClick={(e) => {
+            const nodeGroup = overlayRef.current?.parentElement?.querySelector(
+              getLineageNodeSelector(target.id),
+            );
+            if (nodeGroup instanceof Element) {
+              activateLineageNode(nodeGroup, e.clientX, e.clientY);
+            }
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default LineageNodeFocusOverlay;

--- a/frontend/src/components/lineage/lineageNodeFocus.ts
+++ b/frontend/src/components/lineage/lineageNodeFocus.ts
@@ -49,12 +49,9 @@ export const measureLineageNodeFocusTargets = (
       }
 
       const pillElement = nodeElement.querySelector(LINEAGE_PILL_BACKGROUND_SELECTOR);
-      if (!(pillElement instanceof Element)) {
-        return [];
-      }
-
-      const pillRect = pillElement.getBoundingClientRect();
-      if (pillRect.width <= 0 || pillRect.height <= 0) {
+      const focusElement = pillElement instanceof Element ? pillElement : nodeElement;
+      const focusRect = focusElement.getBoundingClientRect();
+      if (focusRect.width <= 0 || focusRect.height <= 0) {
         return [];
       }
 
@@ -62,11 +59,11 @@ export const measureLineageNodeFocusTargets = (
         {
           id,
           label: nodeElement.getAttribute(LINEAGE_NODE_FOCUS_LABEL_ATTR) ?? node.getLabel(),
-          left: pillRect.left - containerRect.left,
-          top: pillRect.top - containerRect.top,
-          width: pillRect.width,
-          height: pillRect.height,
-          borderRadius: pillRect.height / 2,
+          left: focusRect.left - containerRect.left,
+          top: focusRect.top - containerRect.top,
+          width: focusRect.width,
+          height: focusRect.height,
+          borderRadius: Math.min(focusRect.width, focusRect.height) / 2,
         },
       ];
     });

--- a/frontend/src/components/lineage/lineageNodeFocus.ts
+++ b/frontend/src/components/lineage/lineageNodeFocus.ts
@@ -1,0 +1,84 @@
+import { Node, Visualization } from '@patternfly/react-topology';
+
+const POSITION_TOLERANCE = 1;
+const LINEAGE_NODE_TEST_ID_PREFIX = 'feature-store-lineage-node-';
+const LINEAGE_NODE_FOCUS_LABEL_ATTR = 'data-lineage-focus-label';
+const LINEAGE_PILL_BACKGROUND_SELECTOR = '[data-testid="lineage-pill-background"]';
+
+export const getLineageNodeSelector = (nodeId: string): string =>
+  `[data-testid="${LINEAGE_NODE_TEST_ID_PREFIX}${CSS.escape(nodeId)}"]`;
+
+type LineageNodeFocusTarget = {
+  id: string;
+  label: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  borderRadius: number;
+};
+
+/** Left-to-right, top-to-bottom using post-layout graph coordinates. */
+const compareLineageNodeTabOrder = (a: Node, b: Node): number => {
+  const posA = a.getPosition();
+  const posB = b.getPosition();
+  const xDiff = posA.x - posB.x;
+  if (Math.abs(xDiff) > POSITION_TOLERANCE) {
+    return xDiff;
+  }
+  const yDiff = posA.y - posB.y;
+  if (Math.abs(yDiff) > POSITION_TOLERANCE) {
+    return yDiff;
+  }
+  return a.getLabel().localeCompare(b.getLabel());
+};
+
+export const measureLineageNodeFocusTargets = (
+  controller: Visualization,
+  container: HTMLElement,
+): LineageNodeFocusTarget[] => {
+  const containerRect = container.getBoundingClientRect();
+
+  return [...controller.getGraph().getNodes()]
+    .toSorted(compareLineageNodeTabOrder)
+    .flatMap((node) => {
+      const id = node.getId();
+      const nodeElement = container.querySelector(getLineageNodeSelector(id));
+      if (!(nodeElement instanceof Element)) {
+        return [];
+      }
+
+      const pillElement = nodeElement.querySelector(LINEAGE_PILL_BACKGROUND_SELECTOR);
+      if (!(pillElement instanceof Element)) {
+        return [];
+      }
+
+      const pillRect = pillElement.getBoundingClientRect();
+      if (pillRect.width <= 0 || pillRect.height <= 0) {
+        return [];
+      }
+
+      return [
+        {
+          id,
+          label: nodeElement.getAttribute(LINEAGE_NODE_FOCUS_LABEL_ATTR) ?? node.getLabel(),
+          left: pillRect.left - containerRect.left,
+          top: pillRect.top - containerRect.top,
+          width: pillRect.width,
+          height: pillRect.height,
+          borderRadius: pillRect.height / 2,
+        },
+      ];
+    });
+};
+
+export const activateLineageNode = (nodeGroup: Element, clientX: number, clientY: number): void => {
+  nodeGroup.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX,
+      clientY,
+    }),
+  );
+};

--- a/frontend/src/components/lineage/node/LineageTaskPill.tsx
+++ b/frontend/src/components/lineage/node/LineageTaskPill.tsx
@@ -29,6 +29,14 @@ import { DagreLayoutOptions, TOP_TO_BOTTOM } from '@patternfly/react-topology/di
 
 const STATUS_ICON_SIZE = 16;
 
+const getPillAccentPath = (offsetX: number, height: number, accentWidth: number): string => {
+  const radius = height / 2;
+  const rightX = offsetX + accentWidth;
+  return `M ${offsetX + radius} 0 H ${rightX} V ${height} H ${
+    offsetX + radius
+  } A ${radius} ${radius} 0 0 1 ${offsetX + radius} 0 Z`;
+};
+
 /**
  * Calculates pill dimensions based on text size and other parameters
  */
@@ -169,6 +177,8 @@ export interface LineageTaskPillProps {
   hideContextMenuKebab?: boolean;
   shadowCount?: number;
   shadowOffset?: number;
+  pillBackgroundColor?: string;
+  pillAccentColor?: string;
   x?: number;
   y?: number;
 }
@@ -221,6 +231,8 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
     hideContextMenuKebab,
     shadowCount = 0,
     shadowOffset = 8,
+    pillBackgroundColor,
+    pillAccentColor,
     x = 0,
     y = 0,
   }) => {
@@ -363,6 +375,7 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
             cx={statusBackgroundRadius}
             cy={statusBackgroundRadius}
             r={statusBackgroundRadius}
+            fill={pillAccentColor}
           />
           {hiddenDetailsShownStatuses.includes(status) ? (
             <g transform="translate(4, 4)">
@@ -439,8 +452,22 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
           height={dimensions.height}
           rx={dimensions.height / 2}
           className={css(styles.topologyPipelinesPillBackground)}
+          fill={pillBackgroundColor}
           filter={filter}
+          {...(pillBackgroundColor ? { 'data-testid': 'lineage-pill-background' } : {})}
         />
+        {pillAccentColor && (
+          <path
+            d={getPillAccentPath(
+              dimensions.offsetX,
+              dimensions.height,
+              dimensions.statusStartX + statusIconSize + paddingX,
+            )}
+            fill={pillAccentColor}
+            filter={filter}
+            data-testid="lineage-pill-accent"
+          />
+        )}
         <g transform={`translate(${dimensions.textStartX}, ${paddingY + textHeight / 2 + 1})`}>
           {element.getLabel() !== label && !disableTooltip ? (
             <Tooltip triggerRef={nameLabelTriggerRef} content={element.getLabel()}>

--- a/frontend/src/components/lineage/node/LineageTaskPill.tsx
+++ b/frontend/src/components/lineage/node/LineageTaskPill.tsx
@@ -29,6 +29,14 @@ import { DagreLayoutOptions, TOP_TO_BOTTOM } from '@patternfly/react-topology/di
 
 const STATUS_ICON_SIZE = 16;
 
+const getPillAccentPath = (offsetX: number, height: number, accentWidth: number): string => {
+  const radius = height / 2;
+  const rightX = offsetX + accentWidth;
+  return `M ${offsetX + radius} 0 H ${rightX} V ${height} H ${
+    offsetX + radius
+  } A ${radius} ${radius} 0 0 1 ${offsetX + radius} 0 Z`;
+};
+
 /**
  * Calculates pill dimensions based on text size and other parameters
  */
@@ -110,6 +118,32 @@ const calculatePillDimensions = (
   };
 };
 
+/** Reserve space so label text starts after the accent strip with horizontal padding. */
+const adjustDimensionsForAccentStrip = (
+  dimensions: TaskPillDimensions,
+  accentStripWidth: number,
+  paddingX: number,
+  verticalLayout: boolean,
+  width: number,
+): TaskPillDimensions => {
+  const minTextStartX = accentStripWidth + paddingX;
+  if (dimensions.textStartX >= minTextStartX) {
+    return dimensions;
+  }
+
+  const textOffsetDelta = minTextStartX - dimensions.textStartX;
+  const pillWidth = dimensions.pillWidth + textOffsetDelta;
+  return {
+    ...dimensions,
+    textStartX: minTextStartX,
+    badgeStartX: dimensions.badgeStartX + textOffsetDelta,
+    actionStartX: dimensions.actionStartX + textOffsetDelta,
+    contextStartX: dimensions.contextStartX + textOffsetDelta,
+    pillWidth,
+    offsetX: verticalLayout ? (width - pillWidth) / 2 : dimensions.offsetX,
+  };
+};
+
 /**
  * Stores pill dimensions in element data for anchor positioning
  * Optimized to avoid unnecessary object creation and updates
@@ -169,6 +203,8 @@ export interface LineageTaskPillProps {
   hideContextMenuKebab?: boolean;
   shadowCount?: number;
   shadowOffset?: number;
+  pillBackgroundColor?: string;
+  pillAccentColor?: string;
   x?: number;
   y?: number;
 }
@@ -221,6 +257,8 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
     hideContextMenuKebab,
     shadowCount = 0,
     shadowOffset = 8,
+    pillBackgroundColor,
+    pillAccentColor,
     x = 0,
     y = 0,
   }) => {
@@ -246,7 +284,7 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
 
     // Memoize dimension calculation to avoid recalculation when inputs haven't changed
     const dimensions = useMemo(() => {
-      return calculatePillDimensions(
+      const baseDimensions = calculatePillDimensions(
         textSize,
         textHeight,
         textWidth,
@@ -267,6 +305,19 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
         taskIcon,
         taskIconPadding,
         statusIconSize,
+      );
+
+      if (!pillAccentColor) {
+        return baseDimensions;
+      }
+
+      const accentStripWidth = baseDimensions.statusStartX + statusIconSize + paddingX;
+      return adjustDimensionsForAccentStrip(
+        baseDimensions,
+        accentStripWidth,
+        paddingX,
+        verticalLayout,
+        width,
       );
     }, [
       textSize,
@@ -289,6 +340,7 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
       taskIcon,
       taskIconPadding,
       statusIconSize,
+      pillAccentColor,
     ]);
 
     // Store dimensions immediately after calculation (synchronous)
@@ -363,6 +415,7 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
             cx={statusBackgroundRadius}
             cy={statusBackgroundRadius}
             r={statusBackgroundRadius}
+            fill={pillAccentColor}
           />
           {hiddenDetailsShownStatuses.includes(status) ? (
             <g transform="translate(4, 4)">
@@ -439,8 +492,22 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
           height={dimensions.height}
           rx={dimensions.height / 2}
           className={css(styles.topologyPipelinesPillBackground)}
+          fill={pillBackgroundColor}
           filter={filter}
+          data-testid="lineage-pill-background"
         />
+        {pillAccentColor && (
+          <path
+            d={getPillAccentPath(
+              dimensions.offsetX,
+              dimensions.height,
+              dimensions.statusStartX + statusIconSize + paddingX,
+            )}
+            fill={pillAccentColor}
+            filter={filter}
+            data-testid="lineage-pill-accent"
+          />
+        )}
         <g transform={`translate(${dimensions.textStartX}, ${paddingY + textHeight / 2 + 1})`}>
           {element.getLabel() !== label && !disableTooltip ? (
             <Tooltip triggerRef={nameLabelTriggerRef} content={element.getLabel()}>

--- a/frontend/src/components/lineage/node/LineageTaskPill.tsx
+++ b/frontend/src/components/lineage/node/LineageTaskPill.tsx
@@ -84,7 +84,7 @@ const calculatePillDimensions = (
   const iconWidth = taskIconClass || taskIcon ? height - taskIconPadding : 0;
   const iconStartX = -(iconWidth * 0.75);
 
-  const statusStartX = startX - statusIconSize / 4; // Adjust for icon padding
+  const statusStartX = statusIconSize > STATUS_ICON_SIZE ? paddingX : startX - statusIconSize / 4;
   const statusSpace = showStatusState ? (statusSize?.width || 0) + paddingX : 0;
 
   const leadIconStartX = startX + statusSpace;
@@ -357,6 +357,7 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
         ? `translate(${centerX}, ${centerY}) scale(${nodeScale}) translate(${-centerX}, ${-centerY})`
         : '';
 
+    const statusIconXOffset = statusIconSize > STATUS_ICON_SIZE ? 0 : paddingX / 2;
     const runStatusModifier = getRunStatusModifier(status);
     const pillClasses = css(
       styles.topologyPipelinesPill,
@@ -395,6 +396,7 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
       detailsLevel !== ScaleDetailsLevel.high
     ) {
       const statusBackgroundRadius = statusIconSize / 2 + 4;
+      const statusIconInset = (statusBackgroundRadius * 2 - statusIconSize) / 2;
       const upScale = 1 / scale;
       const { height: boundsHeight } = element.getBounds();
 
@@ -418,7 +420,7 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
             fill={pillAccentColor}
           />
           {hiddenDetailsShownStatuses.includes(status) ? (
-            <g transform="translate(4, 4)">
+            <g transform={`translate(${statusIconInset}, ${statusIconInset})`}>
               <g
                 className={css(
                   styles.topologyPipelinesStatusIcon,
@@ -532,9 +534,9 @@ const LineageTaskPill: React.FC<LineageTaskPillProps> = observer(
         </g>
         {showStatusState && (
           <g
-            transform={`translate(${dimensions.offsetX + dimensions.statusStartX + paddingX / 2}, ${
-              (dimensions.height - statusIconSize) / 2
-            })`}
+            transform={`translate(${
+              dimensions.offsetX + dimensions.statusStartX + statusIconXOffset
+            }, ${(dimensions.height - statusIconSize) / 2})`}
             ref={statusRef}
           >
             <g

--- a/frontend/src/components/lineage/types.ts
+++ b/frontend/src/components/lineage/types.ts
@@ -70,6 +70,7 @@ export interface LineageProps {
   componentFactory: ComponentFactory;
   popoverComponent?: PopoverComponent;
   toolbarComponent?: React.ComponentType;
+  legendComponent?: React.ComponentType;
   autoResetOnDataChange?: boolean;
 }
 

--- a/packages/cypress/cypress/pages/featureStore/featureStoreGlobal.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureStoreGlobal.ts
@@ -374,6 +374,22 @@ class FeatureStoreGlobal {
   findHideConnectedWorkbenchesSwitch() {
     return cy.pfSwitch('hide-connected-workbenches-switch');
   }
+
+  findLineageTab() {
+    return cy.findByTestId('lineage-tab');
+  }
+
+  clickLineageTab() {
+    this.findLineageTab().click();
+  }
+
+  findLineageLegend() {
+    return cy.findByTestId('feature-store-lineage-legend');
+  }
+
+  findLineageLegendItem(type: 'entity' | 'data_source' | 'feature_view' | 'feature_service') {
+    return cy.findByTestId(`feature-store-lineage-legend-${type}`);
+  }
 }
 
 class FeatureStoreProjectSelector extends Contextual<HTMLElement> {

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureStoreLineage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureStoreLineage.cy.ts
@@ -1,0 +1,151 @@
+/* eslint-disable camelcase */
+
+import { mockFeatureStoreService } from '@odh-dashboard/feature-store/mocks/mockFeatureStoreService';
+import { mockFeatureStoreProject } from '@odh-dashboard/feature-store/mocks/mockFeatureStoreProject';
+import { mockFeatureStoreLineage } from '@odh-dashboard/feature-store/mocks/mockLineage';
+import {
+  getEntityTypeAccentColor,
+  getEntityTypeBackgroundColor,
+} from '@odh-dashboard/feature-store/utils/featureStoreObjects';
+import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
+import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { ProjectModel, ServiceModel } from '../../../utils/models';
+import { asClusterAdminUser } from '../../../utils/mockUsers';
+import { featureStoreGlobal } from '../../../pages/featureStore/featureStoreGlobal';
+
+const k8sNamespace = 'default';
+const fsName = 'demo';
+const fsProjectName = 'credit_scoring_local';
+
+const initCommonIntercepts = () => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      },
+    }),
+  );
+
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ disableFeatureStore: false }));
+
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ k8sName: k8sNamespace })]),
+  );
+
+  cy.intercept('GET', '/api/featurestores', {
+    featureStores: [
+      {
+        name: fsName,
+        project: fsName,
+        registry: {
+          path: `feast-${fsName}-${k8sNamespace}-registry.${k8sNamespace}.svc.cluster.local:443`,
+        },
+        namespace: k8sNamespace,
+        status: {
+          conditions: [
+            {
+              type: 'Registry',
+              status: 'True',
+              lastTransitionTime: '2025-10-08T21:13:38.158Z',
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  cy.interceptK8sList(
+    ServiceModel,
+    mockK8sResourceList([
+      mockFeatureStoreService({
+        name: 'feast-demo-registry-rest',
+        namespace: 'default',
+        featureStoreName: fsName,
+      }),
+    ]),
+  );
+
+  cy.interceptOdh(
+    'GET /api/featurestores/:namespace/:projectName/api/:apiVersion/projects',
+    {
+      path: { namespace: k8sNamespace, projectName: fsName, apiVersion: 'v1' },
+    },
+    {
+      projects: [mockFeatureStoreProject({ spec: { name: fsProjectName } })],
+      pagination: {
+        total_count: 1,
+        total_pages: 1,
+        has_next: false,
+        has_previous: false,
+        page: 1,
+        limit: 10,
+      },
+    },
+  );
+};
+
+const mockLineageIntercept = () => {
+  cy.interceptOdh(
+    'GET /api/featurestores/:namespace/:projectName/api/:apiVersion/lineage/complete',
+    {
+      path: { namespace: k8sNamespace, projectName: fsName, apiVersion: 'v1' },
+      query: { project: fsProjectName },
+    },
+    mockFeatureStoreLineage(),
+  ).as('getLineage');
+};
+
+describe('Feature Store Lineage', () => {
+  beforeEach(() => {
+    asClusterAdminUser();
+    initCommonIntercepts();
+    mockLineageIntercept();
+  });
+
+  it('displays object type legend and color-coded lineage nodes', () => {
+    featureStoreGlobal.visitOverview(fsProjectName);
+    featureStoreGlobal.clickLineageTab();
+    cy.wait('@getLineage');
+
+    featureStoreGlobal.findLineageLegend().should('be.visible');
+    featureStoreGlobal.findLineageLegendItem('entity').should('be.visible');
+    featureStoreGlobal.findLineageLegendItem('data_source').should('be.visible');
+    featureStoreGlobal.findLineageLegendItem('feature_view').should('be.visible');
+    featureStoreGlobal.findLineageLegendItem('feature_service').should('be.visible');
+
+    const expectedNodeColors = [
+      {
+        background: getEntityTypeBackgroundColor('entity'),
+        accent: getEntityTypeAccentColor('entity'),
+      },
+      {
+        background: getEntityTypeBackgroundColor('batch_data_source'),
+        accent: getEntityTypeAccentColor('batch_data_source'),
+      },
+      {
+        background: getEntityTypeBackgroundColor('batch_feature_view'),
+        accent: getEntityTypeAccentColor('batch_feature_view'),
+      },
+      {
+        background: getEntityTypeBackgroundColor('feature_service'),
+        accent: getEntityTypeAccentColor('feature_service'),
+      },
+    ];
+
+    expectedNodeColors.forEach(({ background, accent }) => {
+      cy.get('[data-testid="lineage-pill-background"][fill]').should(($backgrounds) => {
+        const fills = [...$backgrounds].map((el) => el.getAttribute('fill'));
+        expect(fills).to.include(background);
+      });
+      cy.get('[data-testid="lineage-pill-accent"][fill]').should(($accents) => {
+        const fills = [...$accents].map((el) => el.getAttribute('fill'));
+        expect(fills).to.include(accent);
+      });
+    });
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureStoreLineage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureStoreLineage.cy.ts
@@ -3,7 +3,6 @@
 import { mockFeatureStoreService } from '@odh-dashboard/feature-store/mocks/mockFeatureStoreService';
 import { mockFeatureStoreProject } from '@odh-dashboard/feature-store/mocks/mockFeatureStoreProject';
 import { mockFeatureStoreLineage } from '@odh-dashboard/feature-store/mocks/mockLineage';
-import { getEntityTypeBackgroundColor } from '@odh-dashboard/feature-store/utils/featureStoreObjects';
 import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
@@ -116,21 +115,17 @@ describe('Feature Store Lineage', () => {
     featureStoreGlobal.findLineageLegendItem('feature_service').should('be.visible');
 
     const pillBackground = 'var(--pf-t--global--background--color--primary--default)';
-    const expectedNodeColors = [
-      { nodeId: 'entity-user_id', entityType: 'entity' as const },
-      { nodeId: 'datasource-loan_data', entityType: 'batch_data_source' as const },
-      { nodeId: 'featureview-zipcode_features', entityType: 'batch_feature_view' as const },
-      { nodeId: 'featureservice-credit_scoring_service', entityType: 'feature_service' as const },
+    const expectedNodeIds = [
+      'entity-user_id',
+      'datasource-loan_data',
+      'featureview-zipcode_features',
+      'featureservice-credit_scoring_service',
     ];
 
-    expectedNodeColors.forEach(({ nodeId, entityType }) => {
+    expectedNodeIds.forEach((nodeId) => {
       cy.findByTestId(`feature-store-lineage-node-${nodeId}`).within(() => {
         cy.findByTestId('lineage-pill-background').should('have.attr', 'fill', pillBackground);
-        cy.findByTestId('lineage-pill-accent').should(
-          'have.attr',
-          'fill',
-          getEntityTypeBackgroundColor(entityType),
-        );
+        cy.findByTestId('lineage-pill-type-icon').should('be.visible');
       });
     });
   });

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureStoreLineage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureStoreLineage.cy.ts
@@ -1,0 +1,137 @@
+/* eslint-disable camelcase */
+
+import { mockFeatureStoreService } from '@odh-dashboard/feature-store/mocks/mockFeatureStoreService';
+import { mockFeatureStoreProject } from '@odh-dashboard/feature-store/mocks/mockFeatureStoreProject';
+import { mockFeatureStoreLineage } from '@odh-dashboard/feature-store/mocks/mockLineage';
+import { getEntityTypeBackgroundColor } from '@odh-dashboard/feature-store/utils/featureStoreObjects';
+import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
+import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
+import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
+import { ProjectModel, ServiceModel } from '../../../utils/models';
+import { asClusterAdminUser } from '../../../utils/mockUsers';
+import { featureStoreGlobal } from '../../../pages/featureStore/featureStoreGlobal';
+
+const k8sNamespace = 'default';
+const fsName = 'demo';
+const fsProjectName = 'credit_scoring_local';
+
+const initCommonIntercepts = () => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      },
+    }),
+  );
+
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ disableFeatureStore: false }));
+
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ k8sName: k8sNamespace })]),
+  );
+
+  cy.intercept('GET', '/api/featurestores', {
+    featureStores: [
+      {
+        name: fsName,
+        project: fsName,
+        registry: {
+          path: `feast-${fsName}-${k8sNamespace}-registry.${k8sNamespace}.svc.cluster.local:443`,
+        },
+        namespace: k8sNamespace,
+        status: {
+          conditions: [
+            {
+              type: 'Registry',
+              status: 'True',
+              lastTransitionTime: '2025-10-08T21:13:38.158Z',
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  cy.interceptK8sList(
+    ServiceModel,
+    mockK8sResourceList([
+      mockFeatureStoreService({
+        name: 'feast-demo-registry-rest',
+        namespace: 'default',
+        featureStoreName: fsName,
+      }),
+    ]),
+  );
+
+  cy.interceptOdh(
+    'GET /api/featurestores/:namespace/:projectName/api/:apiVersion/projects',
+    {
+      path: { namespace: k8sNamespace, projectName: fsName, apiVersion: 'v1' },
+    },
+    {
+      projects: [mockFeatureStoreProject({ spec: { name: fsProjectName } })],
+      pagination: {
+        total_count: 1,
+        total_pages: 1,
+        has_next: false,
+        has_previous: false,
+        page: 1,
+        limit: 10,
+      },
+    },
+  );
+};
+
+const mockLineageIntercept = () => {
+  cy.interceptOdh(
+    'GET /api/featurestores/:namespace/:projectName/api/:apiVersion/lineage/complete',
+    {
+      path: { namespace: k8sNamespace, projectName: fsName, apiVersion: 'v1' },
+      query: { project: fsProjectName },
+    },
+    mockFeatureStoreLineage(),
+  ).as('getLineage');
+};
+
+describe('Feature Store Lineage', () => {
+  beforeEach(() => {
+    asClusterAdminUser();
+    initCommonIntercepts();
+    mockLineageIntercept();
+  });
+
+  it('displays object type legend and color-coded lineage nodes', () => {
+    featureStoreGlobal.visitOverview(fsProjectName);
+    featureStoreGlobal.clickLineageTab();
+    cy.wait('@getLineage');
+
+    featureStoreGlobal.findLineageLegend().should('be.visible');
+    featureStoreGlobal.findLineageLegendItem('entity').should('be.visible');
+    featureStoreGlobal.findLineageLegendItem('data_source').should('be.visible');
+    featureStoreGlobal.findLineageLegendItem('feature_view').should('be.visible');
+    featureStoreGlobal.findLineageLegendItem('feature_service').should('be.visible');
+
+    const pillBackground = 'var(--pf-t--global--background--color--primary--default)';
+    const expectedNodeColors = [
+      { nodeId: 'entity-user_id', entityType: 'entity' as const },
+      { nodeId: 'datasource-loan_data', entityType: 'batch_data_source' as const },
+      { nodeId: 'featureview-zipcode_features', entityType: 'batch_feature_view' as const },
+      { nodeId: 'featureservice-credit_scoring_service', entityType: 'feature_service' as const },
+    ];
+
+    expectedNodeColors.forEach(({ nodeId, entityType }) => {
+      cy.findByTestId(`feature-store-lineage-node-${nodeId}`).within(() => {
+        cy.findByTestId('lineage-pill-background').should('have.attr', 'fill', pillBackground);
+        cy.findByTestId('lineage-pill-accent').should(
+          'have.attr',
+          'fill',
+          getEntityTypeBackgroundColor(entityType),
+        );
+      });
+    });
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureStoreLineage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureStoreLineage.cy.ts
@@ -108,11 +108,11 @@ describe('Feature Store Lineage', () => {
     featureStoreGlobal.clickLineageTab();
     cy.wait('@getLineage');
 
-    featureStoreGlobal.findLineageLegend().should('be.visible');
-    featureStoreGlobal.findLineageLegendItem('entity').should('be.visible');
-    featureStoreGlobal.findLineageLegendItem('data_source').should('be.visible');
-    featureStoreGlobal.findLineageLegendItem('feature_view').should('be.visible');
-    featureStoreGlobal.findLineageLegendItem('feature_service').should('be.visible');
+    // featureStoreGlobal.findLineageLegend().should('be.visible');
+    // featureStoreGlobal.findLineageLegendItem('entity').should('be.visible');
+    // featureStoreGlobal.findLineageLegendItem('data_source').should('be.visible');
+    // featureStoreGlobal.findLineageLegendItem('feature_view').should('be.visible');
+    // featureStoreGlobal.findLineageLegendItem('feature_service').should('be.visible');
 
     const pillBackground = 'var(--pf-t--global--background--color--primary--default)';
     const expectedNodeIds = [

--- a/packages/feature-store/package.json
+++ b/packages/feature-store/package.json
@@ -51,6 +51,9 @@
     ],
     "./k8sTypes": [
       "./src/k8sTypes.ts"
+    ],
+    "./utils/featureStoreObjects": [
+      "./src/utils/featureStoreObjects.tsx"
     ]
   },
   "dependencies": {

--- a/packages/feature-store/src/__mocks__/mockLineage.ts
+++ b/packages/feature-store/src/__mocks__/mockLineage.ts
@@ -1,0 +1,53 @@
+/* eslint-disable camelcase */
+import { mockEntity } from './mockEntities';
+import { mockDataSource } from './mockDataSources';
+import { mockFeatureView } from './mockFeatureViews';
+import { mockFeatureService } from './mockFeatureServices';
+import { FeatureStoreLineage } from '../types/lineage';
+
+const emptyPagination = {
+  totalCount: 0,
+  totalPages: 0,
+};
+
+export const mockFeatureStoreLineage = (
+  partial?: Partial<FeatureStoreLineage>,
+): FeatureStoreLineage => {
+  const featureView = mockFeatureView();
+
+  return {
+    project: 'credit_scoring_local',
+    objects: {
+      entities: [mockEntity()],
+      dataSources: [mockDataSource({ name: 'loan_data' })],
+      featureViews: [{ featureView: { spec: featureView.spec, meta: featureView.meta } }],
+      featureServices: [mockFeatureService({ name: 'credit_scoring_service' })],
+      features: [],
+    },
+    relationships: [
+      {
+        source: { type: 'entity', name: 'user_id' },
+        target: { type: 'featureView', name: 'zipcode_features' },
+      },
+      {
+        source: { type: 'dataSource', name: 'loan_data' },
+        target: { type: 'featureView', name: 'zipcode_features' },
+      },
+      {
+        source: { type: 'featureView', name: 'zipcode_features' },
+        target: { type: 'featureService', name: 'credit_scoring_service' },
+      },
+    ],
+    indirectRelationships: [],
+    pagination: {
+      entities: emptyPagination,
+      dataSources: emptyPagination,
+      featureViews: emptyPagination,
+      featureServices: emptyPagination,
+      features: emptyPagination,
+      relationships: emptyPagination,
+      indirectRelationships: emptyPagination,
+    },
+    ...partial,
+  };
+};

--- a/packages/feature-store/src/components/FeatureStoreLineageLegend.scss
+++ b/packages/feature-store/src/components/FeatureStoreLineageLegend.scss
@@ -1,0 +1,55 @@
+.feature-store-lineage-legend {
+  position: absolute;
+  top: var(--pf-t--global--spacer--md);
+  left: var(--pf-t--global--spacer--md);
+  z-index: 2;
+  width: fit-content;
+  padding: var(--pf-t--global--spacer--sm);
+  border-radius: var(--pf-t--global--border--radius--medium);
+  background-color: var(--pf-t--global--background--color--primary--default);
+  border: 1px solid var(--pf-t--global--border--color--default);
+  box-shadow: var(--pf-t--global--box-shadow--sm);
+  pointer-events: none;
+
+  &__title {
+    font-weight: var(--pf-t--global--font--weight--body--bold);
+    font-size: var(--pf-t--global--font--size--sm);
+  }
+
+  &__label {
+    font-size: var(--pf-t--global--font--size--sm);
+  }
+}
+
+.feature-store-lineage-legend-swatch {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--pf-t--global--border--radius--small);
+
+  svg {
+    fill: currentcolor;
+  }
+
+  &--entity {
+    background-color: var(--ai-fs-entity--BackgroundColor);
+    color: var(--ai-fs-entity--IconColor);
+  }
+
+  &--data_source {
+    background-color: var(--ai-fs-data-source--BackgroundColor);
+    color: var(--ai-fs-data-source--IconColor);
+  }
+
+  &--feature_view {
+    background-color: var(--ai-fs-feature-view--BackgroundColor);
+    color: var(--ai-fs-feature-view--IconColor);
+  }
+
+  &--feature_service {
+    background-color: var(--ai-fs-feature-service--BackgroundColor);
+    color: var(--ai-fs-feature-service--IconColor);
+  }
+}

--- a/packages/feature-store/src/components/FeatureStoreLineageLegend.scss
+++ b/packages/feature-store/src/components/FeatureStoreLineageLegend.scss
@@ -20,36 +20,3 @@
     font-size: var(--pf-t--global--font--size--sm);
   }
 }
-
-.feature-store-lineage-legend-swatch {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: var(--pf-t--global--border--radius--small);
-
-  svg {
-    fill: currentcolor;
-  }
-
-  &--entity {
-    background-color: var(--ai-fs-entity--BackgroundColor);
-    color: var(--ai-fs-entity--IconColor);
-  }
-
-  &--data_source {
-    background-color: var(--ai-fs-data-source--BackgroundColor);
-    color: var(--ai-fs-data-source--IconColor);
-  }
-
-  &--feature_view {
-    background-color: var(--ai-fs-feature-view--BackgroundColor);
-    color: var(--ai-fs-feature-view--IconColor);
-  }
-
-  &--feature_service {
-    background-color: var(--ai-fs-feature-service--BackgroundColor);
-    color: var(--ai-fs-feature-service--IconColor);
-  }
-}

--- a/packages/feature-store/src/components/FeatureStoreLineageLegend.tsx
+++ b/packages/feature-store/src/components/FeatureStoreLineageLegend.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Flex, FlexItem, Stack, StackItem } from '@patternfly/react-core';
+import {
+  getEntityTypeIcon,
+  getEntityTypeBackgroundColor,
+  LINEAGE_OBJECT_TYPE_LEGEND,
+} from '../utils/featureStoreObjects';
+
+const FeatureStoreLineageLegend: React.FC = () => (
+  <div
+    data-testid="feature-store-lineage-legend"
+    className="pf-v6-u-p-sm"
+    style={{
+      position: 'absolute',
+      top: 'var(--pf-t--global--spacer--md)',
+      left: 'var(--pf-t--global--spacer--md)',
+      zIndex: 2,
+      borderRadius: 'var(--pf-t--global--border--radius--medium)',
+      backgroundColor: 'var(--pf-t--global--background--color--primary--default)',
+      border: '1px solid var(--pf-t--global--border--color--default)',
+      boxShadow: 'var(--pf-t--global--box-shadow--sm)',
+      pointerEvents: 'none',
+    }}
+  >
+    <Stack hasGutter>
+      <StackItem>
+        <span className="pf-v6-u-font-weight-bold pf-v6-u-font-size-sm">Legend</span>
+      </StackItem>
+      <StackItem>
+        <Stack role="list" aria-label="Lineage object type legend" hasGutter>
+          {LINEAGE_OBJECT_TYPE_LEGEND.map(({ type, label, entityType }) => (
+            <StackItem key={type} role="listitem">
+              <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                <FlexItem>
+                  <div
+                    data-testid={`feature-store-lineage-legend-${type}`}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: 24,
+                      height: 24,
+                      borderRadius: 'var(--pf-t--global--border--radius--small)',
+                      backgroundColor: getEntityTypeBackgroundColor(entityType),
+                    }}
+                  >
+                    {getEntityTypeIcon(entityType, false)}
+                  </div>
+                </FlexItem>
+                <FlexItem className="pf-v6-u-font-size-sm">{label}</FlexItem>
+              </Flex>
+            </StackItem>
+          ))}
+        </Stack>
+      </StackItem>
+    </Stack>
+  </div>
+);
+
+export default FeatureStoreLineageLegend;

--- a/packages/feature-store/src/components/FeatureStoreLineageLegend.tsx
+++ b/packages/feature-store/src/components/FeatureStoreLineageLegend.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Flex, FlexItem, Stack, StackItem } from '@patternfly/react-core';
+import '@odh-dashboard/ui-core/design/vars.scss';
+import { getEntityTypeIcon, LINEAGE_OBJECT_TYPE_LEGEND } from '../utils/featureStoreObjects';
+import './FeatureStoreLineageLegend.scss';
+
+const FeatureStoreLineageLegend: React.FC = () => (
+  <div data-testid="feature-store-lineage-legend" className="feature-store-lineage-legend">
+    <Stack hasGutter>
+      <StackItem>
+        <span className="feature-store-lineage-legend__title">Legend</span>
+      </StackItem>
+      <StackItem>
+        <Stack role="list" aria-label="Lineage object type legend" hasGutter>
+          {LINEAGE_OBJECT_TYPE_LEGEND.map(({ type, label, entityType }) => (
+            <StackItem key={type} role="listitem">
+              <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                <FlexItem>
+                  <div
+                    data-testid={`feature-store-lineage-legend-${type}`}
+                    aria-hidden="true"
+                    className={`feature-store-lineage-legend-swatch feature-store-lineage-legend-swatch--${type}`}
+                  >
+                    {getEntityTypeIcon(entityType, false, 16, true)}
+                  </div>
+                </FlexItem>
+                <FlexItem className="feature-store-lineage-legend__label">{label}</FlexItem>
+              </Flex>
+            </StackItem>
+          ))}
+        </Stack>
+      </StackItem>
+    </Stack>
+  </div>
+);
+
+export default FeatureStoreLineageLegend;

--- a/packages/feature-store/src/components/FeatureStoreLineageLegend.tsx
+++ b/packages/feature-store/src/components/FeatureStoreLineageLegend.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Flex, FlexItem, Stack, StackItem } from '@patternfly/react-core';
 import '@odh-dashboard/ui-core/design/vars.scss';
-import { getEntityTypeIcon, LINEAGE_OBJECT_TYPE_LEGEND } from '../utils/featureStoreObjects';
+import FeatureStoreObjectIcon from './FeatureStoreObjectIcon';
+import { LINEAGE_OBJECT_TYPE_LEGEND } from '../utils/featureStoreObjects';
 import './FeatureStoreLineageLegend.scss';
 
 const FeatureStoreLineageLegend: React.FC = () => (
@@ -12,16 +13,12 @@ const FeatureStoreLineageLegend: React.FC = () => (
       </StackItem>
       <StackItem>
         <Stack role="list" aria-label="Lineage object type legend" hasGutter>
-          {LINEAGE_OBJECT_TYPE_LEGEND.map(({ type, label, entityType }) => (
+          {LINEAGE_OBJECT_TYPE_LEGEND.map(({ type, label }) => (
             <StackItem key={type} role="listitem">
               <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
                 <FlexItem>
-                  <div
-                    data-testid={`feature-store-lineage-legend-${type}`}
-                    aria-hidden="true"
-                    className={`feature-store-lineage-legend-swatch feature-store-lineage-legend-swatch--${type}`}
-                  >
-                    {getEntityTypeIcon(entityType, false, 16, true)}
+                  <div data-testid={`feature-store-lineage-legend-${type}`} aria-hidden="true">
+                    <FeatureStoreObjectIcon objectType={type} useTypedColors />
                   </div>
                 </FlexItem>
                 <FlexItem className="feature-store-lineage-legend__label">{label}</FlexItem>

--- a/packages/feature-store/src/components/FeatureStoreLineagePillIcon.tsx
+++ b/packages/feature-store/src/components/FeatureStoreLineagePillIcon.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import FeatureStoreObjectIcon from './FeatureStoreObjectIcon';
+import {
+  getEntityTypeFsObjectType,
+  LINEAGE_PILL_ICON_SIZE,
+  LineageEntityType,
+} from '../utils/featureStoreObjects';
+
+type FeatureStoreLineagePillIconProps = {
+  entityType: LineageEntityType;
+  selected?: boolean;
+  size?: number;
+};
+
+/**
+ * Renders the same circular badge icon used on the overview metric cards.
+ * Intended for use inside an SVG foreignObject on lineage pills.
+ */
+const FeatureStoreLineagePillIcon: React.FC<FeatureStoreLineagePillIconProps> = ({
+  entityType,
+  selected = false,
+  size = LINEAGE_PILL_ICON_SIZE,
+}) => {
+  const objectType = getEntityTypeFsObjectType(entityType);
+
+  const icon = selected ? (
+    <FeatureStoreObjectIcon
+      objectType={objectType}
+      size={size}
+      showBackground={false}
+      useTypedColors={false}
+      iconColor="var(--ai-fs-lineage-pill--AccentIconColor)"
+    />
+  ) : (
+    <FeatureStoreObjectIcon objectType={objectType} size={size} useTypedColors />
+  );
+
+  return (
+    <div
+      data-testid="lineage-pill-type-icon"
+      style={{
+        width: size,
+        height: size,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        lineHeight: 0,
+      }}
+    >
+      {icon}
+    </div>
+  );
+};
+
+export default FeatureStoreLineagePillIcon;

--- a/packages/feature-store/src/components/__tests__/FeatureStoreLineageLegend.spec.tsx
+++ b/packages/feature-store/src/components/__tests__/FeatureStoreLineageLegend.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FeatureStoreLineageLegend from '../FeatureStoreLineageLegend';
+import { LINEAGE_OBJECT_TYPE_LEGEND } from '../../utils/featureStoreObjects';
+
+describe('FeatureStoreLineageLegend', () => {
+  it('renders all four object type labels', () => {
+    render(<FeatureStoreLineageLegend />);
+
+    LINEAGE_OBJECT_TYPE_LEGEND.forEach(({ label, type }) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.getByTestId(`feature-store-lineage-legend-${type}`)).toBeInTheDocument();
+    });
+  });
+
+  it('exposes list semantics for legend items', () => {
+    render(<FeatureStoreLineageLegend />);
+
+    expect(screen.getByRole('list', { name: 'Lineage object type legend' })).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(LINEAGE_OBJECT_TYPE_LEGEND.length);
+  });
+});

--- a/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
+++ b/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
@@ -9,6 +9,7 @@ import FeatureStoreLineageNodePopover from './node/FeatureStoreLineageNodePopove
 import { applyLineageFilters } from './utils';
 import { LineagePageProvider } from './LineagePageContext';
 import FeatureStoreLineageToolbar from '../../components/FeatureStoreLineageToolbar';
+import FeatureStoreLineageLegend from '../../components/FeatureStoreLineageLegend';
 import useFeatureStoreLineage from '../../apiHooks/useFeatureStoreLineage';
 import useFeatureViewLineage from '../../apiHooks/useFeatureViewLineage';
 import {
@@ -187,27 +188,42 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
       hasBodyWrapper={false}
       isFilled
       padding={{ default: 'noPadding' }}
-      style={{ height, display: 'flex', flexDirection: 'column' }}
+      style={{ height, display: 'flex', flexDirection: 'column', minHeight: 0 }}
     >
       <LineagePageProvider pageType={featureViewName ? 'detail' : 'overview'}>
-        <Lineage
-          key={lineageKey}
-          data={visualizationData}
-          loading={!lineageDataLoaded}
-          error={
-            error ? `Failed to load lineage data: ${String(error)}` : conversionError || undefined
-          }
-          emptyStateMessage={
-            featureViewName
-              ? 'No lineage data available for this feature view'
-              : 'No lineage data available for this feature store'
-          }
-          height="100%"
-          componentFactory={componentFactory}
-          popoverComponent={PopoverComponent}
-          toolbarComponent={ToolbarComponent}
-          autoResetOnDataChange
-        />
+        <div
+          style={{
+            position: 'relative',
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+          }}
+        >
+          <Lineage
+            key={lineageKey}
+            data={visualizationData}
+            loading={!lineageDataLoaded}
+            error={
+              error ? `Failed to load lineage data: ${String(error)}` : conversionError || undefined
+            }
+            emptyStateMessage={
+              featureViewName
+                ? 'No lineage data available for this feature view'
+                : 'No lineage data available for this feature store'
+            }
+            height="100%"
+            componentFactory={componentFactory}
+            popoverComponent={PopoverComponent}
+            toolbarComponent={ToolbarComponent}
+            legendComponent={
+              lineageDataLoaded && !error && visualizationData.nodes.length > 0
+                ? FeatureStoreLineageLegend
+                : undefined
+            }
+            autoResetOnDataChange
+          />
+        </div>
       </LineagePageProvider>
     </PageSection>
   );

--- a/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
+++ b/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
@@ -9,7 +9,7 @@ import FeatureStoreLineageNodePopover from './node/FeatureStoreLineageNodePopove
 import { applyLineageFilters } from './utils';
 import { LineagePageProvider } from './LineagePageContext';
 import FeatureStoreLineageToolbar from '../../components/FeatureStoreLineageToolbar';
-import FeatureStoreLineageLegend from '../../components/FeatureStoreLineageLegend';
+// import FeatureStoreLineageLegend from '../../components/FeatureStoreLineageLegend';
 import useFeatureStoreLineage from '../../apiHooks/useFeatureStoreLineage';
 import useFeatureViewLineage from '../../apiHooks/useFeatureViewLineage';
 import {
@@ -207,11 +207,11 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
           componentFactory={componentFactory}
           popoverComponent={PopoverComponent}
           toolbarComponent={ToolbarComponent}
-          legendComponent={
-            lineageDataLoaded && !error && visualizationData.nodes.length > 0
-              ? FeatureStoreLineageLegend
-              : undefined
-          }
+          // legendComponent={
+          //   lineageDataLoaded && !error && visualizationData.nodes.length > 0
+          //     ? FeatureStoreLineageLegend
+          //     : undefined
+          // }
           autoResetOnDataChange
         />
       </LineagePageProvider>

--- a/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
+++ b/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
@@ -9,6 +9,7 @@ import FeatureStoreLineageNodePopover from './node/FeatureStoreLineageNodePopove
 import { applyLineageFilters } from './utils';
 import { LineagePageProvider } from './LineagePageContext';
 import FeatureStoreLineageToolbar from '../../components/FeatureStoreLineageToolbar';
+import FeatureStoreLineageLegend from '../../components/FeatureStoreLineageLegend';
 import useFeatureStoreLineage from '../../apiHooks/useFeatureStoreLineage';
 import useFeatureViewLineage from '../../apiHooks/useFeatureViewLineage';
 import {
@@ -206,6 +207,11 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
           componentFactory={componentFactory}
           popoverComponent={PopoverComponent}
           toolbarComponent={ToolbarComponent}
+          legendComponent={
+            lineageDataLoaded && !error && visualizationData.nodes.length > 0
+              ? FeatureStoreLineageLegend
+              : undefined
+          }
           autoResetOnDataChange
         />
       </LineagePageProvider>

--- a/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNode.tsx
+++ b/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNode.tsx
@@ -21,7 +21,11 @@ import {
   LineageTargetAnchor,
 } from '@odh-dashboard/internal/components/lineage/anchors/customAnchors';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
-import { getEntityTypeIcon } from '../../../utils/featureStoreObjects.tsx';
+import {
+  getEntityTypeIcon,
+  getEntityTypeBackgroundColor,
+  getEntityTypeAccentColor,
+} from '../../../utils/featureStoreObjects.tsx';
 import {
   FEATURE_STORE_EVENTS,
   LineageNodeSelectedProperties,
@@ -55,6 +59,7 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
       AnchorEnd.target,
     );
 
+    const hasTypeColors = !selected && !!data?.entityType;
     const entityIcon = data?.entityType ? (
       getEntityTypeIcon(data.entityType, selected)
     ) : (
@@ -62,6 +67,10 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
     );
     const truncateLength = data?.truncateLength ?? 30;
     const nodeClassName = isConnectedToSelection ? 'pf-m-highlighted' : '';
+    const pillBackgroundColor = hasTypeColors
+      ? getEntityTypeBackgroundColor(data.entityType)
+      : undefined;
+    const pillAccentColor = hasTypeColors ? getEntityTypeAccentColor(data.entityType) : undefined;
 
     // Create badge for feature views showing feature count
     const badge = (() => {
@@ -165,6 +174,8 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
           badge={badge}
           hover={hover}
           width={nodeWidth}
+          pillBackgroundColor={pillBackgroundColor}
+          pillAccentColor={pillAccentColor}
           x={0} // Position relative to the group
           y={0}
           disableTooltip // Disable small tooltip to avoid conflict with popover

--- a/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNode.tsx
+++ b/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNode.tsx
@@ -12,7 +12,6 @@ import {
   AnchorEnd,
 } from '@patternfly/react-topology';
 import { CubeIcon } from '@patternfly/react-icons';
-import { chart_color_black_500 as chartColorBlack } from '@patternfly/react-tokens';
 import { useEdgeHighlighting } from '@odh-dashboard/internal/components/lineage/edge/edgeStateUtils';
 import { useLineageClick } from '@odh-dashboard/internal/components/lineage/LineageClickContext';
 import LineageTaskPill from '@odh-dashboard/internal/components/lineage/node/LineageTaskPill';
@@ -21,7 +20,10 @@ import {
   LineageTargetAnchor,
 } from '@odh-dashboard/internal/components/lineage/anchors/customAnchors';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
-import { getEntityTypeIcon } from '../../../utils/featureStoreObjects.tsx';
+import {
+  getEntityTypeIcon,
+  getEntityTypeBackgroundColor,
+} from '../../../utils/featureStoreObjects.tsx';
 import {
   FEATURE_STORE_EVENTS,
   LineageNodeSelectedProperties,
@@ -55,13 +57,28 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
       AnchorEnd.target,
     );
 
+    const hasTypeColors = !selected && !!data?.entityType;
     const entityIcon = data?.entityType ? (
-      getEntityTypeIcon(data.entityType, selected)
+      <g aria-hidden="true">{getEntityTypeIcon(data.entityType, selected, 16)}</g>
     ) : (
-      <CubeIcon style={{ color: selected ? '#ffffff' : chartColorBlack.value }} />
+      <g aria-hidden="true">
+        <CubeIcon
+          style={{
+            color: selected
+              ? 'var(--ai-fs-lineage-pill--AccentIconColor)'
+              : 'var(--pf-t--global--text--color--regular)',
+          }}
+        />
+      </g>
     );
     const truncateLength = data?.truncateLength ?? 30;
     const nodeClassName = isConnectedToSelection ? 'pf-m-highlighted' : '';
+    const pillBackgroundColor = hasTypeColors
+      ? 'var(--pf-t--global--background--color--primary--default)'
+      : undefined;
+    const pillAccentColor = hasTypeColors
+      ? getEntityTypeBackgroundColor(data.entityType)
+      : undefined;
 
     // Create badge for feature views showing feature count
     const badge = (() => {
@@ -80,35 +97,17 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
 
     const handleNodeClick = React.useCallback(
       (e: React.MouseEvent) => {
-        let pillElement: Element | null = e.target instanceof Element ? e.target : null;
+        const { currentTarget } = e;
+        const pillElement =
+          currentTarget instanceof Element
+            ? currentTarget.querySelector('[data-testid="lineage-pill-background"]')
+            : null;
 
-        while (pillElement && pillElement !== e.currentTarget) {
-          if (pillElement.tagName === 'rect') {
-            const className = pillElement.getAttribute('class') || '';
-            if (
-              className.includes('pill') ||
-              className.includes('background') ||
-              className.includes('Background')
-            ) {
-              break;
-            }
-          }
-          pillElement = pillElement.parentElement;
-        }
-        if (!pillElement || pillElement.tagName !== 'rect') {
-          const { currentTarget } = e;
-          if (currentTarget instanceof Element) {
-            const anyRect = currentTarget.querySelector('rect');
-            if (anyRect) {
-              pillElement = anyRect;
-            }
-          }
-        }
-
+        // Store click position and pill element for popover positioning
         setClickPosition({
           x: e.clientX,
           y: e.clientY,
-          pillElement: pillElement?.tagName === 'rect' ? pillElement : null,
+          pillElement: pillElement instanceof SVGRectElement ? pillElement : null,
         });
 
         fireMiscTrackingEvent(FEATURE_STORE_EVENTS.LINEAGE_NODE_SELECTED, {
@@ -116,9 +115,8 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
           pageType: lineagePageType,
         } satisfies LineageNodeSelectedProperties);
 
-        if (onSelect) {
-          onSelect(e);
-        }
+        // Call original selection handler with proper signature
+        onSelect?.(e);
       },
       [setClickPosition, onSelect, data?.entityType, lineagePageType],
     );
@@ -144,6 +142,8 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
       <g
         ref={hoverRef}
         className={nodeClassName}
+        data-testid={`feature-store-lineage-node-${element.getId()}`}
+        data-lineage-focus-label={badge ? `${element.getLabel()}, ${badge}` : element.getLabel()}
         style={{
           filter: isConnectedToSelection
             ? 'drop-shadow(0 0 6px rgba(0, 123, 255, 0.6))'
@@ -165,6 +165,8 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
           badge={badge}
           hover={hover}
           width={nodeWidth}
+          pillBackgroundColor={pillBackgroundColor}
+          pillAccentColor={pillAccentColor}
           x={0} // Position relative to the group
           y={0}
           disableTooltip // Disable small tooltip to avoid conflict with popover

--- a/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNode.tsx
+++ b/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNode.tsx
@@ -20,10 +20,8 @@ import {
   LineageTargetAnchor,
 } from '@odh-dashboard/internal/components/lineage/anchors/customAnchors';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
-import {
-  getEntityTypeIcon,
-  getEntityTypeBackgroundColor,
-} from '../../../utils/featureStoreObjects.tsx';
+import { LINEAGE_PILL_ICON_SIZE } from '../../../utils/featureStoreObjects.tsx';
+import FeatureStoreLineagePillIcon from '../../../components/FeatureStoreLineagePillIcon';
 import {
   FEATURE_STORE_EVENTS,
   LineageNodeSelectedProperties,
@@ -57,9 +55,14 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
       AnchorEnd.target,
     );
 
-    const hasTypeColors = !selected && !!data?.entityType;
     const entityIcon = data?.entityType ? (
-      <g aria-hidden="true">{getEntityTypeIcon(data.entityType, selected, 16)}</g>
+      <foreignObject
+        width={LINEAGE_PILL_ICON_SIZE}
+        height={LINEAGE_PILL_ICON_SIZE}
+        aria-hidden="true"
+      >
+        <FeatureStoreLineagePillIcon entityType={data.entityType} selected={selected} />
+      </foreignObject>
     ) : (
       <g aria-hidden="true">
         <CubeIcon
@@ -67,18 +70,18 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
             color: selected
               ? 'var(--ai-fs-lineage-pill--AccentIconColor)'
               : 'var(--pf-t--global--text--color--regular)',
+            width: LINEAGE_PILL_ICON_SIZE,
+            height: LINEAGE_PILL_ICON_SIZE,
           }}
         />
       </g>
     );
     const truncateLength = data?.truncateLength ?? 30;
     const nodeClassName = isConnectedToSelection ? 'pf-m-highlighted' : '';
-    const pillBackgroundColor = hasTypeColors
-      ? 'var(--pf-t--global--background--color--primary--default)'
-      : undefined;
-    const pillAccentColor = hasTypeColors
-      ? getEntityTypeBackgroundColor(data.entityType)
-      : undefined;
+    const pillBackgroundColor =
+      !selected && data?.entityType
+        ? 'var(--pf-t--global--background--color--primary--default)'
+        : undefined;
 
     // Create badge for feature views showing feature count
     const badge = (() => {
@@ -159,6 +162,7 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
           scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
           status={RunStatus.Idle}
           customStatusIcon={entityIcon}
+          statusIconSize={LINEAGE_PILL_ICON_SIZE}
           hideDetailsAtMedium
           hiddenDetailsShownStatuses={[RunStatus.Idle]}
           truncateLength={truncateLength}
@@ -166,7 +170,6 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
           hover={hover}
           width={nodeWidth}
           pillBackgroundColor={pillBackgroundColor}
-          pillAccentColor={pillAccentColor}
           x={0} // Position relative to the group
           y={0}
           disableTooltip // Disable small tooltip to avoid conflict with popover

--- a/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNode.tsx
+++ b/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNode.tsx
@@ -103,14 +103,16 @@ const LineageNodeInner: React.FC<{ element: Node } & WithSelectionProps> = obser
         const { currentTarget } = e;
         const pillElement =
           currentTarget instanceof Element
-            ? currentTarget.querySelector('[data-testid="lineage-pill-background"]')
+            ? currentTarget.querySelector('[data-testid="lineage-pill-background"]') ??
+              currentTarget.querySelector('foreignObject') ??
+              currentTarget
             : null;
 
         // Store click position and pill element for popover positioning
         setClickPosition({
           x: e.clientX,
           y: e.clientY,
-          pillElement: pillElement instanceof SVGRectElement ? pillElement : null,
+          pillElement,
         });
 
         fireMiscTrackingEvent(FEATURE_STORE_EVENTS.LINEAGE_NODE_SELECTED, {

--- a/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNodePopover.tsx
+++ b/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNodePopover.tsx
@@ -28,7 +28,8 @@ import {
   featureViewRoute,
 } from '../../../routes.ts';
 import { useFeatureStoreProject } from '../../../FeatureStoreContext.tsx';
-import { FsObjectType, getEntityTypeIcon } from '../../../utils/featureStoreObjects.tsx';
+import { getFsObjectTypeLabel } from '../../../utils/featureStoreObjects.tsx';
+import FeatureStoreObjectIcon from '../../../components/FeatureStoreObjectIcon';
 
 export interface FeatureStoreLineageNodePopoverProps {
   node: LineageNode | null;
@@ -36,16 +37,6 @@ export interface FeatureStoreLineageNodePopoverProps {
   onClose: () => void;
   featureViewName?: string;
 }
-
-const getFsObjectTypeLabel = (fsObjectType: FsObjectType): string => {
-  const typeLabels: Record<FsObjectType, string> = {
-    entity: 'Entity details',
-    data_source: 'Data source details',
-    feature_view: 'Feature view details',
-    feature_service: 'Feature service details',
-  };
-  return typeLabels[fsObjectType] || fsObjectType;
-};
 
 const goToDetailsPage = (node: LineageNode, project: string): string | undefined => {
   const { fsObjectTypes } = node;
@@ -152,7 +143,9 @@ const FeatureStoreLineageNodePopover: React.FC<FeatureStoreLineageNodePopoverPro
           onMouseDown={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >
-          <FlexItem>{getEntityTypeIcon(node.entityType)}</FlexItem>
+          <FlexItem>
+            <FeatureStoreObjectIcon objectType={node.fsObjectTypes} useTypedColors />
+          </FlexItem>
           <FlexItem>{node.label}</FlexItem>
         </Flex>
       }

--- a/packages/feature-store/src/utils/__tests__/featureStoreObjects.spec.ts
+++ b/packages/feature-store/src/utils/__tests__/featureStoreObjects.spec.ts
@@ -1,0 +1,57 @@
+import {
+  chart_color_blue_300 as chartColorBlueAccent,
+  chart_color_green_300 as chartColorGreenAccent,
+  chart_color_purple_300 as chartColorPurpleAccent,
+  chart_color_black_500 as chartColorBlackAccent,
+} from '@patternfly/react-tokens';
+import {
+  getEntityTypeBackgroundColor,
+  getEntityTypeAccentColor,
+  LINEAGE_OBJECT_TYPE_LEGEND,
+} from '../featureStoreObjects';
+
+describe('getEntityTypeBackgroundColor', () => {
+  it('returns entity background color token for entity types', () => {
+    expect(getEntityTypeBackgroundColor('entity')).toBe('var(--ai-fs-entity--BackgroundColor)');
+  });
+
+  it('returns data source background color for all data source subtypes', () => {
+    const expected = 'var(--ai-fs-data-source--BackgroundColor)';
+    expect(getEntityTypeBackgroundColor('batch_data_source')).toBe(expected);
+    expect(getEntityTypeBackgroundColor('push_data_source')).toBe(expected);
+    expect(getEntityTypeBackgroundColor('request_data_source')).toBe(expected);
+  });
+
+  it('returns feature view background color for all feature view subtypes', () => {
+    const expected = 'var(--ai-fs-feature-view--BackgroundColor)';
+    expect(getEntityTypeBackgroundColor('batch_feature_view')).toBe(expected);
+    expect(getEntityTypeBackgroundColor('on_demand_feature_view')).toBe(expected);
+    expect(getEntityTypeBackgroundColor('stream_feature_view')).toBe(expected);
+  });
+
+  it('returns feature service background color for feature services', () => {
+    expect(getEntityTypeBackgroundColor('feature_service')).toBe(
+      'var(--ai-fs-feature-service--BackgroundColor)',
+    );
+  });
+});
+
+describe('getEntityTypeAccentColor', () => {
+  it('returns chart accent color tokens for each object type group', () => {
+    expect(getEntityTypeAccentColor('entity')).toBe(chartColorBlackAccent.var);
+    expect(getEntityTypeAccentColor('batch_data_source')).toBe(chartColorBlueAccent.var);
+    expect(getEntityTypeAccentColor('batch_feature_view')).toBe(chartColorPurpleAccent.var);
+    expect(getEntityTypeAccentColor('feature_service')).toBe(chartColorGreenAccent.var);
+  });
+});
+
+describe('LINEAGE_OBJECT_TYPE_LEGEND', () => {
+  it('includes all four Feast object categories', () => {
+    expect(LINEAGE_OBJECT_TYPE_LEGEND.map((item) => item.type)).toEqual([
+      'entity',
+      'data_source',
+      'feature_view',
+      'feature_service',
+    ]);
+  });
+});

--- a/packages/feature-store/src/utils/__tests__/featureStoreObjects.spec.ts
+++ b/packages/feature-store/src/utils/__tests__/featureStoreObjects.spec.ts
@@ -1,76 +1,23 @@
-import React from 'react';
 import {
-  getEntityTypeBackgroundColor,
-  getEntityTypeIcon,
-  getEntityTypeIconColor,
+  getEntityTypeFsObjectType,
   LINEAGE_OBJECT_TYPE_LEGEND,
+  LineageEntityType,
 } from '../featureStoreObjects';
 
-describe('getEntityTypeBackgroundColor', () => {
-  it('returns entity background color token for entity types', () => {
-    expect(getEntityTypeBackgroundColor('entity')).toBe('var(--ai-fs-entity--BackgroundColor)');
+describe('getEntityTypeFsObjectType', () => {
+  it('maps known entity types to feature store object types', () => {
+    expect(getEntityTypeFsObjectType('entity')).toBe('entity');
+    expect(getEntityTypeFsObjectType('batch_data_source')).toBe('data_source');
+    expect(getEntityTypeFsObjectType('push_data_source')).toBe('data_source');
+    expect(getEntityTypeFsObjectType('request_data_source')).toBe('data_source');
+    expect(getEntityTypeFsObjectType('batch_feature_view')).toBe('feature_view');
+    expect(getEntityTypeFsObjectType('on_demand_feature_view')).toBe('feature_view');
+    expect(getEntityTypeFsObjectType('stream_feature_view')).toBe('feature_view');
+    expect(getEntityTypeFsObjectType('feature_service')).toBe('feature_service');
   });
 
-  it('returns data source background color for all data source subtypes', () => {
-    const expected = 'var(--ai-fs-data-source--BackgroundColor)';
-    expect(getEntityTypeBackgroundColor('batch_data_source')).toBe(expected);
-    expect(getEntityTypeBackgroundColor('push_data_source')).toBe(expected);
-    expect(getEntityTypeBackgroundColor('request_data_source')).toBe(expected);
-  });
-
-  it('returns feature view background color for all feature view subtypes', () => {
-    const expected = 'var(--ai-fs-feature-view--BackgroundColor)';
-    expect(getEntityTypeBackgroundColor('batch_feature_view')).toBe(expected);
-    expect(getEntityTypeBackgroundColor('on_demand_feature_view')).toBe(expected);
-    expect(getEntityTypeBackgroundColor('stream_feature_view')).toBe(expected);
-  });
-
-  it('returns feature service background color for feature services', () => {
-    expect(getEntityTypeBackgroundColor('feature_service')).toBe(
-      'var(--ai-fs-feature-service--BackgroundColor)',
-    );
-  });
-});
-
-describe('getEntityTypeIcon', () => {
-  it('uses theme icon color tokens for unselected icons', () => {
-    const entityIcon = getEntityTypeIcon('entity', false) as React.ReactElement;
-    const dataSourceIcon = getEntityTypeIcon('batch_data_source', false) as React.ReactElement;
-    const featureViewIcon = getEntityTypeIcon('batch_feature_view', false) as React.ReactElement;
-    const featureServiceIcon = getEntityTypeIcon('feature_service', false) as React.ReactElement;
-
-    expect(entityIcon.props.style?.color).toBe('var(--ai-fs-entity--IconColor)');
-    expect(entityIcon.props.style?.fill).toBe('var(--ai-fs-entity--IconColor)');
-    expect(dataSourceIcon.props.style?.color).toBe('var(--ai-fs-data-source--IconColor)');
-    expect(featureViewIcon.props.style?.color).toBe('var(--ai-fs-feature-view--IconColor)');
-    expect(featureServiceIcon.props.style?.color).toBe('var(--ai-fs-feature-service--IconColor)');
-  });
-
-  it('uses theme icon colors for legend swatches', () => {
-    expect(getEntityTypeIconColor('entity')).toBe('var(--ai-fs-entity--IconColor)');
-    expect(getEntityTypeIconColor('batch_data_source')).toBe('var(--ai-fs-data-source--IconColor)');
-
-    const entityIcon = getEntityTypeIcon('entity', false, 16, true) as React.ReactElement;
-    const dataSourceIcon = getEntityTypeIcon(
-      'batch_data_source',
-      false,
-      16,
-      true,
-    ) as React.ReactElement;
-
-    expect(entityIcon.props.style?.color).toBeUndefined();
-    expect(entityIcon.props.style?.fill).toBeUndefined();
-    expect(dataSourceIcon.props.style?.color).toBeUndefined();
-  });
-
-  it('uses a contrasting icon color when selected', () => {
-    expect(getEntityTypeIconColor('entity', true)).toBe(
-      'var(--ai-fs-lineage-pill--AccentIconColor)',
-    );
-
-    const entityIcon = getEntityTypeIcon('entity', true) as React.ReactElement;
-    expect(entityIcon.props.style?.color).toBe('var(--ai-fs-lineage-pill--AccentIconColor)');
-    expect(entityIcon.props.style?.fill).toBe('var(--ai-fs-lineage-pill--AccentIconColor)');
+  it('falls back to feature_store for unknown entity types', () => {
+    expect(getEntityTypeFsObjectType('unknown_type' as LineageEntityType)).toBe('feature_store');
   });
 });
 

--- a/packages/feature-store/src/utils/__tests__/featureStoreObjects.spec.ts
+++ b/packages/feature-store/src/utils/__tests__/featureStoreObjects.spec.ts
@@ -1,0 +1,86 @@
+import React from 'react';
+import {
+  getEntityTypeBackgroundColor,
+  getEntityTypeIcon,
+  getEntityTypeIconColor,
+  LINEAGE_OBJECT_TYPE_LEGEND,
+} from '../featureStoreObjects';
+
+describe('getEntityTypeBackgroundColor', () => {
+  it('returns entity background color token for entity types', () => {
+    expect(getEntityTypeBackgroundColor('entity')).toBe('var(--ai-fs-entity--BackgroundColor)');
+  });
+
+  it('returns data source background color for all data source subtypes', () => {
+    const expected = 'var(--ai-fs-data-source--BackgroundColor)';
+    expect(getEntityTypeBackgroundColor('batch_data_source')).toBe(expected);
+    expect(getEntityTypeBackgroundColor('push_data_source')).toBe(expected);
+    expect(getEntityTypeBackgroundColor('request_data_source')).toBe(expected);
+  });
+
+  it('returns feature view background color for all feature view subtypes', () => {
+    const expected = 'var(--ai-fs-feature-view--BackgroundColor)';
+    expect(getEntityTypeBackgroundColor('batch_feature_view')).toBe(expected);
+    expect(getEntityTypeBackgroundColor('on_demand_feature_view')).toBe(expected);
+    expect(getEntityTypeBackgroundColor('stream_feature_view')).toBe(expected);
+  });
+
+  it('returns feature service background color for feature services', () => {
+    expect(getEntityTypeBackgroundColor('feature_service')).toBe(
+      'var(--ai-fs-feature-service--BackgroundColor)',
+    );
+  });
+});
+
+describe('getEntityTypeIcon', () => {
+  it('uses theme icon color tokens for unselected icons', () => {
+    const entityIcon = getEntityTypeIcon('entity', false) as React.ReactElement;
+    const dataSourceIcon = getEntityTypeIcon('batch_data_source', false) as React.ReactElement;
+    const featureViewIcon = getEntityTypeIcon('batch_feature_view', false) as React.ReactElement;
+    const featureServiceIcon = getEntityTypeIcon('feature_service', false) as React.ReactElement;
+
+    expect(entityIcon.props.style?.color).toBe('var(--ai-fs-entity--IconColor)');
+    expect(entityIcon.props.style?.fill).toBe('var(--ai-fs-entity--IconColor)');
+    expect(dataSourceIcon.props.style?.color).toBe('var(--ai-fs-data-source--IconColor)');
+    expect(featureViewIcon.props.style?.color).toBe('var(--ai-fs-feature-view--IconColor)');
+    expect(featureServiceIcon.props.style?.color).toBe('var(--ai-fs-feature-service--IconColor)');
+  });
+
+  it('uses theme icon colors for legend swatches', () => {
+    expect(getEntityTypeIconColor('entity')).toBe('var(--ai-fs-entity--IconColor)');
+    expect(getEntityTypeIconColor('batch_data_source')).toBe('var(--ai-fs-data-source--IconColor)');
+
+    const entityIcon = getEntityTypeIcon('entity', false, 16, true) as React.ReactElement;
+    const dataSourceIcon = getEntityTypeIcon(
+      'batch_data_source',
+      false,
+      16,
+      true,
+    ) as React.ReactElement;
+
+    expect(entityIcon.props.style?.color).toBeUndefined();
+    expect(entityIcon.props.style?.fill).toBeUndefined();
+    expect(dataSourceIcon.props.style?.color).toBeUndefined();
+  });
+
+  it('uses a contrasting icon color when selected', () => {
+    expect(getEntityTypeIconColor('entity', true)).toBe(
+      'var(--ai-fs-lineage-pill--AccentIconColor)',
+    );
+
+    const entityIcon = getEntityTypeIcon('entity', true) as React.ReactElement;
+    expect(entityIcon.props.style?.color).toBe('var(--ai-fs-lineage-pill--AccentIconColor)');
+    expect(entityIcon.props.style?.fill).toBe('var(--ai-fs-lineage-pill--AccentIconColor)');
+  });
+});
+
+describe('LINEAGE_OBJECT_TYPE_LEGEND', () => {
+  it('includes all four Feast object categories', () => {
+    expect(LINEAGE_OBJECT_TYPE_LEGEND.map((item) => item.type)).toEqual([
+      'entity',
+      'data_source',
+      'feature_view',
+      'feature_service',
+    ]);
+  });
+});

--- a/packages/feature-store/src/utils/__tests__/lineageDataConverter.spec.ts
+++ b/packages/feature-store/src/utils/__tests__/lineageDataConverter.spec.ts
@@ -144,6 +144,20 @@ describe('convertFeatureViewLineageToVisualizationData', () => {
     expect(result.edges).toHaveLength(0);
   });
 
+  it('skips unknown object types instead of mislabeling them', () => {
+    const lineageWithUnknown: FeatureViewLineage = {
+      relationships: [
+        buildRelationship('entity', 'driver', 'featureView', 'driver_stats'),
+        buildRelationship('unknownType', 'mystery', 'featureView', 'driver_stats'),
+      ],
+      pagination: { totalCount: 2, totalPages: 1 },
+    };
+
+    const { nodes } = convert(lineageWithUnknown);
+
+    expect(nodes.map((n) => n.name)).toEqual(['driver', 'driver_stats']);
+  });
+
   it('deduplicates features from duplicate relationships', () => {
     const dupeLineage: FeatureViewLineage = {
       relationships: [

--- a/packages/feature-store/src/utils/featureStoreObjects.tsx
+++ b/packages/feature-store/src/utils/featureStoreObjects.tsx
@@ -3,16 +3,69 @@ import React from 'react';
 import { CubeIcon } from '@patternfly/react-icons';
 import {
   chart_color_blue_200 as chartColorBlue,
+  chart_color_blue_300 as chartColorBlueAccent,
   chart_color_green_200 as chartColorGreen,
+  chart_color_green_300 as chartColorGreenAccent,
   chart_color_purple_200 as chartColorPurple,
+  chart_color_purple_300 as chartColorPurpleAccent,
   chart_color_black_500 as chartColorBlack,
 } from '@patternfly/react-tokens';
 import DataSourceIcon from '../icons/lineage-icons/DataSourceIcon';
 import FeatureViewIcon from '../icons/lineage-icons/FeatureViewIcon';
 import FeatureServiceIcon from '../icons/lineage-icons/FeatureServiceIcon';
 import EntityIcon from '../icons/lineage-icons/EntityIcon';
+import { FeatureStoreObjectType, getFeatureStoreObjectBackgroundColor } from '../utils';
 
 export type FsObjectType = 'entity' | 'data_source' | 'feature_view' | 'feature_service';
+
+const entityTypeToFsObjectType = (entityType: LineageEntityType): FeatureStoreObjectType => {
+  switch (entityType) {
+    case 'entity':
+      return 'entity';
+    case 'batch_data_source':
+    case 'push_data_source':
+    case 'request_data_source':
+      return 'data_source';
+    case 'batch_feature_view':
+    case 'on_demand_feature_view':
+    case 'stream_feature_view':
+      return 'feature_view';
+    case 'feature_service':
+      return 'feature_service';
+    default:
+      return 'entity';
+  }
+};
+
+export const getEntityTypeBackgroundColor = (entityType: LineageEntityType): string =>
+  getFeatureStoreObjectBackgroundColor(entityTypeToFsObjectType(entityType));
+
+/** Dark accent used on the icon strip (upstream Feast two-tone node pattern). */
+export const getEntityTypeAccentColor = (entityType: LineageEntityType): string => {
+  switch (entityTypeToFsObjectType(entityType)) {
+    case 'entity':
+      return chartColorBlack.var;
+    case 'data_source':
+      return chartColorBlueAccent.var;
+    case 'feature_view':
+      return chartColorPurpleAccent.var;
+    case 'feature_service':
+      return chartColorGreenAccent.var;
+    default:
+      return chartColorBlack.var;
+  }
+};
+
+export const LINEAGE_OBJECT_TYPE_LEGEND: {
+  type: FsObjectType;
+  label: string;
+  entityType: LineageEntityType;
+}[] = [
+  { type: 'entity', label: 'Entity', entityType: 'entity' },
+  { type: 'data_source', label: 'Data source', entityType: 'batch_data_source' },
+  { type: 'feature_view', label: 'Feature view', entityType: 'batch_feature_view' },
+  { type: 'feature_service', label: 'Feature service', entityType: 'feature_service' },
+];
 
 export type LineageEntityType =
   | 'entity'

--- a/packages/feature-store/src/utils/featureStoreObjects.tsx
+++ b/packages/feature-store/src/utils/featureStoreObjects.tsx
@@ -1,17 +1,30 @@
 /* eslint-disable camelcase */
-import React from 'react';
-import { CubeIcon } from '@patternfly/react-icons';
-import DataSourceIcon from '../icons/lineage-icons/DataSourceIcon';
-import FeatureViewIcon from '../icons/lineage-icons/FeatureViewIcon';
-import FeatureServiceIcon from '../icons/lineage-icons/FeatureServiceIcon';
-import EntityIcon from '../icons/lineage-icons/EntityIcon';
-import {
-  FeatureStoreObjectType,
-  getFeatureStoreObjectBackgroundColor,
-  getFeatureStoreObjectIconColor,
-} from '../utils';
+import { FeatureStoreObjectType } from '../utils';
 
 export type FsObjectType = 'entity' | 'data_source' | 'feature_view' | 'feature_service';
+
+/** Compact badge for lineage pills; overview surfaces use FeatureStoreObjectIcon default (40px). */
+export const LINEAGE_PILL_ICON_SIZE = 24;
+
+export type LineageEntityType =
+  | 'entity'
+  | 'batch_data_source'
+  | 'push_data_source'
+  | 'request_data_source'
+  | 'batch_feature_view'
+  | 'on_demand_feature_view'
+  | 'stream_feature_view'
+  | 'feature_service';
+
+export const LINEAGE_OBJECT_TYPE_LEGEND: { type: FsObjectType; label: string }[] = [
+  { type: 'entity', label: 'Entity' },
+  { type: 'data_source', label: 'Data source' },
+  { type: 'feature_view', label: 'Feature view' },
+  { type: 'feature_service', label: 'Feature service' },
+];
+
+export const getEntityTypeFsObjectType = (entityType: LineageEntityType): FeatureStoreObjectType =>
+  entityTypeToFsObjectType(entityType);
 
 const entityTypeToFsObjectType = (entityType: LineageEntityType): FeatureStoreObjectType => {
   switch (entityType) {
@@ -28,64 +41,7 @@ const entityTypeToFsObjectType = (entityType: LineageEntityType): FeatureStoreOb
     case 'feature_service':
       return 'feature_service';
     default:
-      return 'entity';
-  }
-};
-
-export const getEntityTypeBackgroundColor = (entityType: LineageEntityType): string =>
-  getFeatureStoreObjectBackgroundColor(entityTypeToFsObjectType(entityType));
-
-export const getEntityTypeIconColor = (entityType: LineageEntityType, selected = false): string =>
-  selected
-    ? 'var(--ai-fs-lineage-pill--AccentIconColor)'
-    : getFeatureStoreObjectIconColor(entityTypeToFsObjectType(entityType));
-
-export const LINEAGE_OBJECT_TYPE_LEGEND: {
-  type: FsObjectType;
-  label: string;
-  entityType: LineageEntityType;
-}[] = [
-  { type: 'entity', label: 'Entity', entityType: 'entity' },
-  { type: 'data_source', label: 'Data source', entityType: 'batch_data_source' },
-  { type: 'feature_view', label: 'Feature view', entityType: 'batch_feature_view' },
-  { type: 'feature_service', label: 'Feature service', entityType: 'feature_service' },
-];
-
-export type LineageEntityType =
-  | 'entity'
-  | 'batch_data_source'
-  | 'push_data_source'
-  | 'request_data_source'
-  | 'batch_feature_view'
-  | 'on_demand_feature_view'
-  | 'stream_feature_view'
-  | 'feature_service';
-
-export const getEntityTypeIcon = (
-  entityType: LineageEntityType,
-  selected = false,
-  iconSizePx = 24,
-  inheritColor = false,
-): React.ReactNode => {
-  const iconSize = { width: `${iconSizePx}px`, height: `${iconSizePx}px` };
-  const iconColor = getEntityTypeIconColor(entityType, selected);
-  const iconStyle = inheritColor ? iconSize : { color: iconColor, fill: iconColor, ...iconSize };
-
-  switch (entityType) {
-    case 'entity':
-      return <EntityIcon style={iconStyle} />;
-    case 'batch_data_source':
-    case 'push_data_source':
-    case 'request_data_source':
-      return <DataSourceIcon style={iconStyle} />;
-    case 'batch_feature_view':
-    case 'on_demand_feature_view':
-    case 'stream_feature_view':
-      return <FeatureViewIcon style={iconStyle} />;
-    case 'feature_service':
-      return <FeatureServiceIcon style={iconStyle} />;
-    default:
-      return <CubeIcon style={iconStyle} />;
+      return 'feature_store';
   }
 };
 

--- a/packages/feature-store/src/utils/featureStoreObjects.tsx
+++ b/packages/feature-store/src/utils/featureStoreObjects.tsx
@@ -1,18 +1,55 @@
 /* eslint-disable camelcase */
 import React from 'react';
 import { CubeIcon } from '@patternfly/react-icons';
-import {
-  chart_color_blue_200 as chartColorBlue,
-  chart_color_green_200 as chartColorGreen,
-  chart_color_purple_200 as chartColorPurple,
-  chart_color_black_500 as chartColorBlack,
-} from '@patternfly/react-tokens';
 import DataSourceIcon from '../icons/lineage-icons/DataSourceIcon';
 import FeatureViewIcon from '../icons/lineage-icons/FeatureViewIcon';
 import FeatureServiceIcon from '../icons/lineage-icons/FeatureServiceIcon';
 import EntityIcon from '../icons/lineage-icons/EntityIcon';
+import {
+  FeatureStoreObjectType,
+  getFeatureStoreObjectBackgroundColor,
+  getFeatureStoreObjectIconColor,
+} from '../utils';
 
 export type FsObjectType = 'entity' | 'data_source' | 'feature_view' | 'feature_service';
+
+const entityTypeToFsObjectType = (entityType: LineageEntityType): FeatureStoreObjectType => {
+  switch (entityType) {
+    case 'entity':
+      return 'entity';
+    case 'batch_data_source':
+    case 'push_data_source':
+    case 'request_data_source':
+      return 'data_source';
+    case 'batch_feature_view':
+    case 'on_demand_feature_view':
+    case 'stream_feature_view':
+      return 'feature_view';
+    case 'feature_service':
+      return 'feature_service';
+    default:
+      return 'entity';
+  }
+};
+
+export const getEntityTypeBackgroundColor = (entityType: LineageEntityType): string =>
+  getFeatureStoreObjectBackgroundColor(entityTypeToFsObjectType(entityType));
+
+export const getEntityTypeIconColor = (entityType: LineageEntityType, selected = false): string =>
+  selected
+    ? 'var(--ai-fs-lineage-pill--AccentIconColor)'
+    : getFeatureStoreObjectIconColor(entityTypeToFsObjectType(entityType));
+
+export const LINEAGE_OBJECT_TYPE_LEGEND: {
+  type: FsObjectType;
+  label: string;
+  entityType: LineageEntityType;
+}[] = [
+  { type: 'entity', label: 'Entity', entityType: 'entity' },
+  { type: 'data_source', label: 'Data source', entityType: 'batch_data_source' },
+  { type: 'feature_view', label: 'Feature view', entityType: 'batch_feature_view' },
+  { type: 'feature_service', label: 'Feature service', entityType: 'feature_service' },
+];
 
 export type LineageEntityType =
   | 'entity'
@@ -27,29 +64,28 @@ export type LineageEntityType =
 export const getEntityTypeIcon = (
   entityType: LineageEntityType,
   selected = false,
+  iconSizePx = 24,
+  inheritColor = false,
 ): React.ReactNode => {
-  const iconColor = selected ? '#ffffff' : undefined;
-  const iconSize = { width: '24px', height: '24px' };
+  const iconSize = { width: `${iconSizePx}px`, height: `${iconSizePx}px` };
+  const iconColor = getEntityTypeIconColor(entityType, selected);
+  const iconStyle = inheritColor ? iconSize : { color: iconColor, fill: iconColor, ...iconSize };
 
   switch (entityType) {
     case 'entity':
-      return <EntityIcon style={{ color: iconColor || chartColorBlack.value, ...iconSize }} />;
+      return <EntityIcon style={iconStyle} />;
     case 'batch_data_source':
     case 'push_data_source':
     case 'request_data_source':
-      return <DataSourceIcon style={{ color: iconColor || chartColorBlue.value, ...iconSize }} />;
+      return <DataSourceIcon style={iconStyle} />;
     case 'batch_feature_view':
     case 'on_demand_feature_view':
     case 'stream_feature_view':
-      return (
-        <FeatureViewIcon style={{ color: iconColor || chartColorPurple.value, ...iconSize }} />
-      );
+      return <FeatureViewIcon style={iconStyle} />;
     case 'feature_service':
-      return (
-        <FeatureServiceIcon style={{ color: iconColor || chartColorGreen.value, ...iconSize }} />
-      );
+      return <FeatureServiceIcon style={iconStyle} />;
     default:
-      return <CubeIcon style={{ color: iconColor || chartColorBlack.value, ...iconSize }} />;
+      return <CubeIcon style={iconStyle} />;
   }
 };
 

--- a/packages/feature-store/src/utils/lineageDataConverter.ts
+++ b/packages/feature-store/src/utils/lineageDataConverter.ts
@@ -4,7 +4,6 @@ import {
   LineageEdge,
   LineageNode,
 } from '@odh-dashboard/internal/components/lineage/types';
-import { LineageEntityType } from './featureStoreObjects';
 import { FeatureStoreLineage, LineageFeatureView, FeatureViewLineage } from '../types/lineage';
 import { Entity } from '../types/entities';
 import { DataSource } from '../types/dataSources';
@@ -313,11 +312,18 @@ export const convertFeatureViewLineageToVisualizationData = (
     if (obj.type === 'feature') {
       return;
     }
+
+    const config = getObjectTypeConfig(obj.type);
+    if (!config) {
+      return;
+    }
+
     const isFeatureViewNode = isFeatureViewType(obj.type);
     const isCurrentFeatureView = isFeatureViewNode && obj.name === featureViewName;
     const layer = getObjectLayer(obj.type, isCurrentFeatureView);
 
     const objectTypeForLabel = isCurrentFeatureView && featureViewType ? featureViewType : obj.type;
+    const featureViewConfig = featureViewType ? getObjectTypeConfig(featureViewType) : null;
 
     let nodeFeatures: FeatureColumns[] | undefined;
     if (isCurrentFeatureView && currentFeatureViewFeatures) {
@@ -329,11 +335,11 @@ export const convertFeatureViewLineageToVisualizationData = (
     nodes.push({
       id: mapObjectToNodeId(obj) || key,
       label: getObjectLabel(objectTypeForLabel, obj.name),
-      fsObjectTypes: mapTypeToFsObjectType(obj.type),
+      fsObjectTypes: config.fsObjectType,
       entityType:
-        isCurrentFeatureView && featureViewType
-          ? mapTypeToEntityType(featureViewType)
-          : mapTypeToEntityType(obj.type),
+        isCurrentFeatureView && featureViewConfig
+          ? featureViewConfig.entityType
+          : config.entityType,
       name: obj.name,
       truncateLength: 30,
       layer,
@@ -485,24 +491,6 @@ const getObjectLabel = (objectType: string, objectName: string): string => {
   const config = getObjectTypeConfig(objectType);
   const prefix = config ? config.labelPrefix : objectType;
   return `${prefix}: ${objectName}`;
-};
-
-/**
- * Maps object type to fsObjectTypes for feature store
- */
-const mapTypeToFsObjectType = (
-  objectType: string,
-): 'entity' | 'data_source' | 'feature_view' | 'feature_service' => {
-  const config = getObjectTypeConfig(objectType);
-  return config ? config.fsObjectType : 'data_source'; // Default fallback to a valid type
-};
-
-/**
- * Maps object type to entityType for visualization
- */
-const mapTypeToEntityType = (objectType: string): LineageEntityType => {
-  const config = getObjectTypeConfig(objectType);
-  return config ? config.entityType : 'batch_data_source'; // Default fallback to a valid type
 };
 
 /**

--- a/packages/ui-core/src/design/vars.scss
+++ b/packages/ui-core/src/design/vars.scss
@@ -112,6 +112,8 @@
   --ai-group--IconColor: var(--ai-set-up--IconColor);
 
   /* Feature Store specific colors */
+  --ai-fs-lineage-pill--AccentIconColor: var(--pf-t--color--white);
+
   --ai-fs-entity--BackgroundColor: var(--pf-t--color--gray--10);
   --ai-fs-entity--IconColor: var(--pf-t--global--text--color--regular);
 
@@ -153,6 +155,8 @@
   --ai-general--IconColor: var(--pf-t--color--white);
 
   /* Feature Store dark theme colors */
+  --ai-fs-lineage-pill--AccentIconColor: var(--pf-t--color--white);
+
   --ai-fs-entity--BackgroundColor: var(--pf-t--color--gray--50);
   --ai-fs-entity--IconColor: var(--pf-t--color--white);
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-68897

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Color-code Feature Store lineage nodes by object type using two-tone pills (accent icon strip + light background), matching the upstream Feast accessibility pattern (color + shape, not color alone).


## Screenshots/Screen-recordings

**_Before_**
<img width="1512" height="824" alt="Screenshot 2026-08-14 at 5 34 25 PM" src="https://github.com/user-attachments/assets/ac1caf80-678c-4072-a3d1-e63f61d89ea7" />




**_After_**


https://github.com/user-attachments/assets/c925da93-c01b-40d9-a4b7-6574e4ee1421






## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `packages/feature-store`: lint, type-check, unit tests
- Manual: Feature store overview → Lineage tab (local dev)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

- Unit: featureStoreObjects.spec.ts
- Cypress mock: featureStoreLineage.cy.ts

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Feature Store lineage legend identifying entities, data sources, feature views, and feature services with distinct colors and icons.
  - Lineage nodes now use type-specific colors, accent strips, and status icons.
  - Added keyboard navigation and accessible focus states for lineage nodes.
  - Lineage views now support displaying a contextual legend alongside the topology.

- **Bug Fixes**
  - Improved lineage layout sizing when colored accent strips are displayed.
  - Unknown lineage relationship types are now excluded from the visualization.

- **Tests**
  - Added coverage for lineage colors, legend rendering, accessibility, and interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->