### PR TITLE
Editing workbench can silently clear Feast metadata when Feature Store API is unavailable

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -50,6 +50,8 @@ type SpawnerFooterProps = {
   connections: Connection[];
   canEnablePipelines: boolean;
   selectedFeatureStores?: SelectedFeatureStoreConfig[];
+  featureStoreApiAvailable?: boolean;
+  featureStoresLoading?: boolean;
   /** Present when editing; prefer this over looking up the notebook from context. */
   existingNotebook?: NotebookKind;
   existingSecretsData: UseExistingSecretsResult;
@@ -62,6 +64,8 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   connections = [],
   canEnablePipelines,
   selectedFeatureStores = [],
+  featureStoreApiAvailable = true,
+  featureStoresLoading = false,
   existingNotebook,
   existingSecretsData,
 }) => {
@@ -108,6 +112,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     !checkRequiredFieldsForNotebookStart(startNotebookData, envVariables) ||
     hasDeletedOrMissingRefs ||
     !isHardwareProfileValid ||
+    featureStoresLoading ||
     (!isProjectScopedAvailable &&
       startNotebookData.image.imageStream?.metadata.namespace === projectName);
 
@@ -253,7 +258,12 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
     }
 
     const { volumes, volumeMounts } = pvcVolumeDetails;
-    const feastData = generateFeastMetadata(selectedFeatureStores, editNotebook, true);
+    const feastData = generateFeastMetadata(
+      selectedFeatureStores,
+      editNotebook,
+      true,
+      featureStoreApiAvailable,
+    );
     const newStartNotebookData: StartNotebookData = {
       ...startNotebookData,
       volumes,

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -179,8 +179,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
 
   const featureStoreStatus = useIsAreaAvailable(SupportedArea.FEATURE_STORE);
   const isFeastOperatorAvailable = featureStoreStatus.status;
-  const featureStoreApiAvailable =
-    !isFeastOperatorAvailable || (featureStoresLoaded && !featureStoresError);
+  const featureStoreApiAvailable = featureStoresLoaded && !featureStoresError;
   const featureStoresLoading =
     isFeastOperatorAvailable && !featureStoresLoaded && !featureStoresError;
 

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -177,11 +177,18 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
   const hasUserInteractedRef = React.useRef<boolean>(false);
   const notebookIdRef = React.useRef<string | undefined>();
 
+  const featureStoreStatus = useIsAreaAvailable(SupportedArea.FEATURE_STORE);
+  const isFeastOperatorAvailable = featureStoreStatus.status;
+  const featureStoreApiAvailable =
+    !isFeastOperatorAvailable || (featureStoresLoaded && !featureStoresError);
+  const featureStoresLoading =
+    isFeastOperatorAvailable && !featureStoresLoaded && !featureStoresError;
+
   React.useEffect(() => {
     const currentNotebookId = existingNotebook?.metadata.uid;
     const notebookChanged = notebookIdRef.current !== currentNotebookId;
 
-    if (existingNotebook && availableFeatureStores.length > 0) {
+    if (existingNotebook && featureStoresLoaded && !featureStoresError) {
       if (notebookChanged || !hasUserInteractedRef.current) {
         const featureStores = getFeatureStoresFromNotebook(
           existingNotebook,
@@ -198,7 +205,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
       notebookIdRef.current = undefined;
       hasUserInteractedRef.current = false;
     }
-  }, [existingNotebook, availableFeatureStores]);
+  }, [existingNotebook, availableFeatureStores, featureStoresLoaded, featureStoresError]);
 
   const [envVariables, setEnvVariables, envVariablesLoaded, deletedConfigMaps, deletedSecrets] =
     useNotebookEnvVariables(existingNotebook, [
@@ -243,9 +250,6 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
   const editNotebookDisplayName = existingNotebook
     ? getDisplayNameFromK8sResource(existingNotebook)
     : '';
-
-  const featureStoreStatus = useIsAreaAvailable(SupportedArea.FEATURE_STORE);
-  const isFeastOperatorAvailable = featureStoreStatus.status;
 
   const isMlflowAvailable = useIsAreaAvailable(SupportedArea.MLFLOW).status;
 
@@ -505,6 +509,8 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                   connections={notebookConnections}
                   canEnablePipelines={canEnablePipelines}
                   selectedFeatureStores={selectedFeatureStores}
+                  featureStoreApiAvailable={featureStoreApiAvailable}
+                  featureStoresLoading={featureStoresLoading}
                   existingNotebook={existingNotebook}
                   existingSecretsData={existingSecretsData}
                 />

--- a/frontend/src/pages/projects/screens/spawner/__tests__/SpawnerFooter.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/SpawnerFooter.spec.tsx
@@ -149,4 +149,20 @@ describe('EmptyProjects', () => {
       `/projects/${startNotebookDataMock.projectName}?section=workbenches`,
     );
   });
+
+  it('should disable submit while feature stores are loading', () => {
+    const result = render(
+      <SpawnerFooter
+        startNotebookData={startNotebookDataMock}
+        storageData={mockStorageData}
+        canEnablePipelines
+        envVariables={mockEnvVariables}
+        connections={[mockConnection({})]}
+        existingSecretsData={{ secrets: [], loaded: true, canList: true }}
+        featureStoresLoading
+      />,
+    );
+
+    expect(result.getByTestId('submit-button')).toBeDisabled();
+  });
 });

--- a/frontend/src/pages/projects/screens/spawner/__tests__/SpawnerFooter.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/SpawnerFooter.spec.tsx
@@ -148,4 +148,20 @@ describe('EmptyProjects', () => {
       `/projects/${startNotebookDataMock.projectName}?section=workbenches`,
     );
   });
+
+  it('should disable submit while feature stores are loading', () => {
+    const result = render(
+      <SpawnerFooter
+        startNotebookData={startNotebookDataMock}
+        storageData={mockStorageData}
+        canEnablePipelines
+        envVariables={mockEnvVariables}
+        connections={[mockConnection({})]}
+        existingSecretsData={{ secrets: [], loaded: true, canList: true }}
+        featureStoresLoading
+      />,
+    );
+
+    expect(result.getByTestId('submit-button')).toBeDisabled();
+  });
 });

--- a/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/utils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/__tests__/utils.spec.ts
@@ -357,4 +357,83 @@ describe('generateFeastMetadata', () => {
       expect(result.labels).toBeUndefined();
     });
   });
+
+  describe('API unavailable scenario', () => {
+    it('should preserve existing annotations and labels when API is unavailable during update', () => {
+      const existingNotebook = mockNotebookK8sResource({
+        opts: {
+          metadata: {
+            labels: {
+              'opendatahub.io/feast-integration': 'true',
+            },
+            annotations: {
+              'opendatahub.io/feast-config': `${PROJECT_NAME_CREDIT_SCORING},${PROJECT_NAME_BANKING}`,
+            },
+          },
+        },
+      });
+      const result = generateFeastMetadata([], existingNotebook, true, false);
+
+      expect(result.featureStores).toHaveLength(0);
+      expect(result.annotations).toEqual({
+        'opendatahub.io/feast-config': `${PROJECT_NAME_CREDIT_SCORING},${PROJECT_NAME_BANKING}`,
+      });
+      expect(result.labels).toEqual({
+        'opendatahub.io/feast-integration': 'true',
+      });
+    });
+
+    it('should return no annotations/labels when API is unavailable and notebook has none', () => {
+      const existingNotebook = mockNotebookK8sResource({
+        opts: {
+          metadata: {
+            labels: {},
+            annotations: {},
+          },
+        },
+      });
+      const result = generateFeastMetadata([], existingNotebook, true, false);
+
+      expect(result.featureStores).toHaveLength(0);
+      expect(result.annotations).toBeUndefined();
+      expect(result.labels).toBeUndefined();
+    });
+
+    it('should not preserve annotations on create even when API is unavailable', () => {
+      const result = generateFeastMetadata([], undefined, false, false);
+
+      expect(result.featureStores).toHaveLength(0);
+      expect(result.annotations).toBeUndefined();
+      expect(result.labels).toBeUndefined();
+    });
+
+    it('should use selected feature stores when API is available', () => {
+      const existingNotebook = mockNotebookK8sResource({
+        opts: {
+          metadata: {
+            labels: {
+              'opendatahub.io/feast-integration': 'true',
+            },
+            annotations: {
+              'opendatahub.io/feast-config': PROJECT_NAME_CREDIT_SCORING,
+            },
+          },
+        },
+      });
+      const result = generateFeastMetadata(
+        [MOCK_BANKING_FEATURE_STORE],
+        existingNotebook,
+        true,
+        true,
+      );
+
+      expect(result.featureStores).toHaveLength(1);
+      expect(result.annotations).toEqual({
+        'opendatahub.io/feast-config': PROJECT_NAME_BANKING,
+      });
+      expect(result.labels).toEqual({
+        'opendatahub.io/feast-integration': 'true',
+      });
+    });
+  });
 });

--- a/frontend/src/pages/projects/screens/spawner/featureStore/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/utils.ts
@@ -101,11 +101,31 @@ export const generateFeastMetadata = (
   selectedFeatureStores: WorkbenchFeatureStoreConfig[],
   existingNotebook?: NotebookKind,
   isUpdate = false,
+  featureStoreApiAvailable = true,
 ): {
   featureStores: NotebookFeatureStore[];
   annotations?: Record<string, string>;
   labels?: Record<string, string>;
 } => {
+  if (isUpdate && !featureStoreApiAvailable && existingNotebook) {
+    const labels: Record<string, string> = {};
+    const annotations: Record<string, string> = {};
+
+    if (existingNotebook.metadata.labels?.[FEAST_INTEGRATION_LABEL]) {
+      labels[FEAST_INTEGRATION_LABEL] = existingNotebook.metadata.labels[FEAST_INTEGRATION_LABEL];
+    }
+    if (existingNotebook.metadata.annotations?.[FEAST_CONFIG_ANNOTATION]) {
+      annotations[FEAST_CONFIG_ANNOTATION] =
+        existingNotebook.metadata.annotations[FEAST_CONFIG_ANNOTATION];
+    }
+
+    return {
+      featureStores: [],
+      ...(Object.keys(annotations).length > 0 && { annotations }),
+      ...(Object.keys(labels).length > 0 && { labels }),
+    };
+  }
+
   const featureStores = mapFeatureStoresForNotebook(selectedFeatureStores);
   const hasFeatureStores = featureStores.length > 0;
   const feastConfigAnnotation = hasFeatureStores


### PR DESCRIPTION


<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
[RHOAIENG-58676](https://redhat.atlassian.net/browse/RHOAIENG-58676)
Fixes silent clearing of opendatahub.io/feast-config when editing a workbench while the Feature Store list API fails or returns empty. Existing Feast annotations are preserved unless the user explicitly deselects stores. Submit is disabled while the Feature Store list is loading.


## Screencapture
**_Before the Fix_**
Editing a workbench while the Feature Store list API was unavailable/empty silently cleared opendatahub.io/feast-config on save.

https://github.com/user-attachments/assets/cfd3bb1d-2084-4a05-b777-cf32ab906578



_*After the Fix*_
Editing a workbench in the same situation preserves the existing Feast config; it is only removed if the user explicitly deselects the stores.


https://github.com/user-attachments/assets/c4b75864-50bb-46cc-a5c9-c4aea7b90d55










## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added unit tests for generateFeastMetadata (API unavailable preserve path) and SpawnerFooter submit disabled while loading.
- Manually verified on tangerine using local start:dev (EXT_CLUSTER): seeded kapanwar/test with feast-config=credit_scoring, edited the workbench with the Feature Store list empty/unavailable, and confirmed the annotation was preserved after saving with this fix.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

- Added unit tests in featureStore/__tests__/utils.spec.ts and SpawnerFooter.spec.tsx.
- No Cypress changes.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHOAIENG-58676]: https://redhat.atlassian.net/browse/RHOAIENG-58676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented notebook submission while Feature Store data is loading.
  * Preserved existing Feature Store metadata when the Feature Store API is unavailable.
  * Ensured existing notebook Feature Store selections initialize after availability data loads.
  * Updated notebook metadata handling to reflect Feature Store API availability while maintaining existing creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->