### PR TITLE
feat(feature-store): Remove standalone CTA buttons from deployment progress page

### DIFF
--- a/packages/feature-store/src/FeatureStoreCoreLoader.tsx
+++ b/packages/feature-store/src/FeatureStoreCoreLoader.tsx
@@ -30,8 +30,8 @@ import SupportIcon from './icons/header-icons/SupportIcon';
 import FeatureStorePageTitle from './components/FeatureStorePageTitle';
 import FeatureStoreObjectIcon from './components/FeatureStoreObjectIcon';
 
-const CreateFeatureStoreLink = (props: React.ComponentProps<'a'>) => (
-  <Link {...props} to="/develop-train/feature-store/create" />
+const ManageFeatureStoresLink = (props: React.ComponentProps<'a'>) => (
+  <Link {...props} to="/settings/environment-setup/feature-stores" />
 );
 
 type ApplicationPageProps = React.ComponentProps<typeof ApplicationsPage>;
@@ -89,16 +89,16 @@ const FeatureStoreContent: React.FC<{
     let action: React.ReactNode;
 
     if (showAdminUI) {
-      title = 'No feature stores yet';
-      description = <>To get started, create a feature store.</>;
+      title = 'No feature stores';
+      description = <>Create a feature store to get started.</>;
       icon = () => <CogIcon />;
       action = (
         <Button
           variant="primary"
-          component={CreateFeatureStoreLink}
-          data-testid="create-feature-store-btn"
+          component={ManageFeatureStoresLink}
+          data-testid="go-to-feature-stores-btn"
         >
-          Create feature store
+          Go to Feature stores
         </Button>
       );
     } else if (isAdmin) {

--- a/packages/feature-store/src/hooks/__tests__/useExistingFeatureStores.spec.tsx
+++ b/packages/feature-store/src/hooks/__tests__/useExistingFeatureStores.spec.tsx
@@ -206,7 +206,29 @@ describe('useExistingFeatureStores', () => {
     expect(listFeatureStoresMock).not.toHaveBeenCalled();
   });
 
-  it('should poll for updates at regular intervals', async () => {
+  it('should poll for updates at regular intervals when poll is enabled', async () => {
+    listFeatureStoresMock.mockResolvedValue([makeStore('store-1', 'ns-1', 'proj-1')]);
+
+    const { result } = renderHook(() => useExistingFeatureStores({ poll: true }), {
+      wrapper: createWrapper([makeProject('ns-1')]),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(listFeatureStoresMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    await waitFor(() => {
+      expect(listFeatureStoresMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('should not poll when poll option is not set', async () => {
     listFeatureStoresMock.mockResolvedValue([makeStore('store-1', 'ns-1', 'proj-1')]);
 
     const { result } = renderHook(() => useExistingFeatureStores(), {
@@ -218,6 +240,41 @@ describe('useExistingFeatureStores', () => {
     });
 
     expect(listFeatureStoresMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    expect(listFeatureStoresMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not start a new poll while a request is still pending', async () => {
+    let resolveFirst: ((value: FeatureStoreKind[]) => void) | undefined;
+    listFeatureStoresMock.mockImplementationOnce(
+      () =>
+        new Promise<FeatureStoreKind[]>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    renderHook(() => useExistingFeatureStores({ poll: true }), {
+      wrapper: createWrapper([makeProject('ns-1')]),
+    });
+
+    expect(listFeatureStoresMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(90000);
+    });
+
+    expect(listFeatureStoresMock).toHaveBeenCalledTimes(1);
+    expect(resolveFirst).toBeDefined();
+
+    listFeatureStoresMock.mockResolvedValueOnce([makeStore('store-2', 'ns-1', 'proj-2')]);
+
+    await act(async () => {
+      resolveFirst?.([makeStore('store-1', 'ns-1', 'proj-1')]);
+    });
 
     act(() => {
       jest.advanceTimersByTime(30000);

--- a/packages/feature-store/src/hooks/useExistingFeatureStores.ts
+++ b/packages/feature-store/src/hooks/useExistingFeatureStores.ts
@@ -22,7 +22,14 @@ type UseExistingFeatureStoresReturn = {
   refresh: () => void;
 };
 
-const useExistingFeatureStores = (): UseExistingFeatureStoresReturn => {
+type UseExistingFeatureStoresOptions = {
+  poll?: boolean;
+};
+
+const useExistingFeatureStores = (
+  options?: UseExistingFeatureStoresOptions,
+): UseExistingFeatureStoresReturn => {
+  const enablePolling = options?.poll ?? false;
   const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
   const [featureStores, setFeatureStores] = React.useState<FeatureStoreKind[]>([]);
   const [loaded, setLoaded] = React.useState(false);
@@ -36,7 +43,7 @@ const useExistingFeatureStores = (): UseExistingFeatureStoresReturn => {
       return;
     }
     let cancelled = false;
-    setLoaded(false);
+    let pollTimeout: ReturnType<typeof setTimeout> | undefined;
     setError(undefined);
 
     const fetchAll = async () => {
@@ -79,16 +86,21 @@ const useExistingFeatureStores = (): UseExistingFeatureStoresReturn => {
           setError(e instanceof Error ? e : new Error(String(e)));
           setLoaded(true);
         }
+      } finally {
+        if (!cancelled && enablePolling) {
+          pollTimeout = setTimeout(() => setRefreshKey((k) => k + 1), POLL_INTERVAL);
+        }
       }
     };
 
     fetchAll();
-    const interval = setInterval(() => setRefreshKey((k) => k + 1), POLL_INTERVAL);
     return () => {
       cancelled = true;
-      clearInterval(interval);
+      if (pollTimeout) {
+        clearTimeout(pollTimeout);
+      }
     };
-  }, [projects, projectsLoaded, refreshKey]);
+  }, [projects, projectsLoaded, refreshKey, enablePolling]);
 
   const existingProjectNames = React.useMemo(
     () => featureStores.map((fs) => fs.spec.feastProject),

--- a/packages/feature-store/src/k8sTypes.ts
+++ b/packages/feature-store/src/k8sTypes.ts
@@ -211,6 +211,7 @@ export type FeastAuthzConfig = {
   oidc?: {
     secretRef?: { name: string };
   };
+  noAuth?: boolean;
 };
 
 export type FeastCronJobContainerConfigs = FeastContainerConfigs & {

--- a/packages/feature-store/src/screens/create/DeploymentProgressPage.tsx
+++ b/packages/feature-store/src/screens/create/DeploymentProgressPage.tsx
@@ -30,18 +30,21 @@ import {
   InProgressIcon,
   PendingIcon,
 } from '@patternfly/react-icons';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { ApplicationsPage } from '@odh-dashboard/ui-core';
 import useWatchFeatureStoreDeployment, {
   DeploymentPhase,
 } from '../../hooks/useWatchFeatureStoreDeployment';
-import { FeatureStoreObject } from '../../const';
-import { featureStoreRoute, featureStoreManageRoute } from '../../routes';
+import { featureStoreManageRoute } from '../../routes';
 import {
   hasConditionFailure,
   humanizeConditionType,
   resolveConditionDisplay,
 } from '../../statusUtils';
+
+const FeatureStoresLink = (props: React.ComponentProps<'a'>) => (
+  <Link {...props} to={featureStoreManageRoute()} />
+);
 
 const phaseConfig: Record<
   DeploymentPhase,
@@ -72,7 +75,6 @@ const computeProgress = (phase: DeploymentPhase, conditions: { status?: string }
 
 const DeploymentProgressPage: React.FC = () => {
   const { namespace = '', name = '' } = useParams<{ namespace: string; name: string }>();
-  const navigate = useNavigate();
   const deploymentStatus = useWatchFeatureStoreDeployment(namespace, name);
   const {
     featureStore,
@@ -320,8 +322,7 @@ const DeploymentProgressPage: React.FC = () => {
               title="Deployment failed"
               data-testid="deployment-failed-alert"
             >
-              The feature store deployment has failed. Review the conditions and pod logs for
-              details.
+              Review the conditions and pod logs. Delete this feature store, then create it again.
             </Alert>
           </StackItem>
         )}
@@ -334,7 +335,7 @@ const DeploymentProgressPage: React.FC = () => {
               title="Deployment complete"
               data-testid="deployment-success-alert"
             >
-              The feature store has been deployed successfully.
+              This feature store is ready. Open it from Feature stores.
             </Alert>
           </StackItem>
         )}
@@ -346,27 +347,15 @@ const DeploymentProgressPage: React.FC = () => {
             </Title>
           </StackItem>
         )}
+
         <StackItem>
-          <Split hasGutter>
-            <SplitItem>
-              <Button
-                variant="primary"
-                onClick={() => navigate(featureStoreRoute(FeatureStoreObject.OVERVIEW))}
-                data-testid="go-to-feature-store"
-              >
-                {isComplete ? 'Go to feature store' : 'Back to overview'}
-              </Button>
-            </SplitItem>
-            <SplitItem>
-              <Button
-                variant="secondary"
-                onClick={() => navigate(featureStoreManageRoute())}
-                data-testid="manage-feature-stores"
-              >
-                Manage feature stores
-              </Button>
-            </SplitItem>
-          </Split>
+          <Button
+            variant="primary"
+            component={FeatureStoresLink}
+            data-testid="go-to-feature-stores-btn"
+          >
+            Go to Feature stores
+          </Button>
         </StackItem>
       </Stack>
     </ApplicationsPage>

--- a/packages/feature-store/src/screens/create/__tests__/DeploymentProgressPage.spec.tsx
+++ b/packages/feature-store/src/screens/create/__tests__/DeploymentProgressPage.spec.tsx
@@ -4,10 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import DeploymentProgressPage from '../DeploymentProgressPage';
 
-const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
+jest.mock('../../../routes', () => ({
+  featureStoreManageRoute: () => '/settings/environment-setup/feature-stores',
 }));
 
 jest.mock('@odh-dashboard/ui-core', () => ({
@@ -65,20 +63,12 @@ describe('DeploymentProgressPage', () => {
     useWatchMock.mockReturnValue(mockDeploymentStatus);
   });
 
-  it('renders default state with status card, progress bar, and "Back to overview" button', () => {
+  it('renders default state with status card, progress bar, and in-progress text', () => {
     renderPage();
     expect(screen.getByTestId('deployment-status-card')).toBeInTheDocument();
     expect(screen.getByTestId('deployment-status-card')).toHaveTextContent('Pending');
     expect(screen.getByTestId('deployment-progress-bar')).toBeInTheDocument();
-    expect(screen.getByTestId('go-to-feature-store')).toHaveTextContent('Back to overview');
     expect(screen.getByText('Deployment in progress')).toBeInTheDocument();
-  });
-
-  it('navigates to overview on button click', async () => {
-    const user = userEvent.setup();
-    renderPage();
-    await user.click(screen.getByTestId('go-to-feature-store'));
-    expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('feature-store/overview'));
   });
 
   it.each([
@@ -92,7 +82,7 @@ describe('DeploymentProgressPage', () => {
     expect(screen.getByTestId('deployment-status-card')).toHaveTextContent(expectedLabel);
   });
 
-  it('shows success state with "Go to feature store" button and no progress text', () => {
+  it('shows success alert with ready message and no progress text', () => {
     const useWatchMock = jest.requireMock('../../../hooks/useWatchFeatureStoreDeployment').default;
     useWatchMock.mockReturnValue({
       ...mockDeploymentStatus,
@@ -102,11 +92,13 @@ describe('DeploymentProgressPage', () => {
     });
     renderPage();
     expect(screen.getByTestId('deployment-success-alert')).toBeInTheDocument();
-    expect(screen.getByTestId('go-to-feature-store')).toHaveTextContent('Go to feature store');
+    expect(screen.getByTestId('deployment-success-alert')).toHaveTextContent(
+      'This feature store is ready. Open it from Feature stores.',
+    );
     expect(screen.queryByText('Deployment in progress')).not.toBeInTheDocument();
   });
 
-  it('shows failed alert when deployment fails', () => {
+  it('shows failed alert with delete guidance when deployment fails', () => {
     const useWatchMock = jest.requireMock('../../../hooks/useWatchFeatureStoreDeployment').default;
     useWatchMock.mockReturnValue({
       ...mockDeploymentStatus,
@@ -116,6 +108,23 @@ describe('DeploymentProgressPage', () => {
     });
     renderPage();
     expect(screen.getByTestId('deployment-failed-alert')).toBeInTheDocument();
+    expect(screen.getByTestId('deployment-failed-alert')).toHaveTextContent(
+      'Delete this feature store, then create it again',
+    );
+  });
+
+  it.each([
+    ['default (pending)', {}],
+    ['success', { phase: 'Ready', isComplete: true, loaded: true }],
+    ['failed', { phase: 'Failed', isFailed: true, loaded: true }],
+  ])('shows "Go to Feature stores" secondary link in %s state', (_label, overrides) => {
+    const useWatchMock = jest.requireMock('../../../hooks/useWatchFeatureStoreDeployment').default;
+    useWatchMock.mockReturnValue({ ...mockDeploymentStatus, ...overrides });
+    renderPage();
+    const link = screen.getByTestId('go-to-feature-stores-btn');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveTextContent('Go to Feature stores');
+    expect(link.closest('a')).toHaveAttribute('href', '/settings/environment-setup/feature-stores');
   });
 
   it('shows Failed status when operator phase is Pending but conditions indicate failure', () => {

--- a/packages/feature-store/src/screens/create/__tests__/utils.spec.ts
+++ b/packages/feature-store/src/screens/create/__tests__/utils.spec.ts
@@ -377,14 +377,14 @@ describe('buildFormSpec', () => {
       expect(spec.authz).toEqual({ oidc: { secretRef: { name: 'oidc-secret' } } });
     });
 
-    it('should not include authz when AuthzType is NONE', () => {
+    it('should set noAuth when AuthzType is NONE', () => {
       const data = makeFormData({
         feastProject: 'test',
         namespace: 'ns',
         authzType: AuthzType.NONE,
       });
       const spec = buildFormSpec(data, false);
-      expect(spec.authz).toBeUndefined();
+      expect(spec.authz).toEqual({ noAuth: true });
     });
 
     it('should include cronJob when provided', () => {

--- a/packages/feature-store/src/screens/create/utils.ts
+++ b/packages/feature-store/src/screens/create/utils.ts
@@ -231,7 +231,7 @@ const buildServices = (data: FeatureStoreFormData): FeastServices | undefined =>
 
 const buildAuthz = (data: FeatureStoreFormData): FeastAuthzConfig | undefined => {
   if (data.authzType === AuthzType.NONE) {
-    return undefined;
+    return { noAuth: true };
   }
   return data.authz;
 };

--- a/packages/feature-store/src/screens/manage/FeatureStoreListPage.tsx
+++ b/packages/feature-store/src/screens/manage/FeatureStoreListPage.tsx
@@ -90,7 +90,7 @@ const CreateFeatureStoreButton: React.FC<{ 'data-testid'?: string }> = (props) =
 );
 
 const FeatureStoreListPage: React.FC = () => {
-  const { featureStores, loaded, error, refresh } = useExistingFeatureStores();
+  const { featureStores, loaded, error, refresh } = useExistingFeatureStores({ poll: true });
   const [canCreate] = useAccessAllowed(verbModelAccess('create', FeatureStoreModel));
   const [canDelete] = useAccessAllowed(verbModelAccess('delete', FeatureStoreModel));
   const [deleteTarget, setDeleteTarget] = React.useState<FeatureStoreKind | undefined>();

--- a/packages/feature-store/src/screens/manage/FeatureStoreTableRow.tsx
+++ b/packages/feature-store/src/screens/manage/FeatureStoreTableRow.tsx
@@ -16,6 +16,7 @@ import {
   OutlinedQuestionCircleIcon,
   PendingIcon,
 } from '@patternfly/react-icons';
+import { DashboardPopupIconButton } from '@odh-dashboard/ui-core';
 import { ActionsColumn, ExpandableRowContent, Td, Tr } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 import { FeatureStoreKind, FeastOnlineStore, FeastOfflineStore } from '../../k8sTypes';
@@ -182,10 +183,18 @@ const FeatureStoreTableRow: React.FC<FeatureStoreTableRowProps> = ({
           {isUILabeled && (
             <>
               {' '}
-              <Popover bodyContent="This is the primary feature store whose registry is shared with other feature stores. Additional feature stores should use a remote registry pointing to this store.">
-                <Label color="blue" isCompact isClickable icon={<OutlinedQuestionCircleIcon />}>
-                  Primary
-                </Label>
+              <Label color="blue" isCompact>
+                Primary
+              </Label>{' '}
+              <Popover
+                aria-label="Primary feature store help"
+                bodyContent="This is the primary feature store whose registry is shared with other feature stores. Additional feature stores should use a remote registry pointing to this store."
+              >
+                <DashboardPopupIconButton
+                  icon={<OutlinedQuestionCircleIcon />}
+                  aria-label="Primary feature store help"
+                  data-testid="primary-label-help"
+                />
               </Popover>
             </>
           )}

--- a/packages/feature-store/src/screens/manage/__tests__/FeatureStoreTableRow.spec.tsx
+++ b/packages/feature-store/src/screens/manage/__tests__/FeatureStoreTableRow.spec.tsx
@@ -125,6 +125,19 @@ describe('FeatureStoreTableRow', () => {
     expect(screen.queryByText('Primary')).not.toBeInTheDocument();
   });
 
+  it('should open Primary help popover on keyboard input', async () => {
+    renderRow({ isUILabeled: true });
+    const helpButton = screen.getByTestId('primary-label-help');
+    expect(helpButton).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    helpButton.focus();
+    await user.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(screen.getByText(/primary feature store whose registry/i)).toBeInTheDocument();
+    });
+  });
+
   it('should show version as dash when not available', () => {
     const fs: FeatureStoreKind = {
       ...baseFeatureStore,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-83820 

## Description

Addresses UX review feedback on the Feature Store deployment progress page and manage (settings) page from https://github.com/opendatahub-io/odh-dashboard/pull/9233#issuecomment-5294326064.

- Both standalone buttons removed. Success and failure alerts now include an inline secondary link: *"...go to **Feature stores**."* linking to the settings manage page.
- The manage page polls every 30 seconds via opt-in `useExistingFeatureStores({ poll: true })`. The create wizard and other consumers are unaffected (polling defaults to off).
- Moved the `OutlinedQuestionCircleIcon` from the Label `icon` prop (renders before text) to after the "Primary" text, so the (?) appears after the label.


<img width="1191" height="404" alt="Screenshot 2026-08-17 at 6 16 24 PM" src="https://github.com/user-attachments/assets/f6be1e01-9bf9-44e4-b8d9-00c825b0e4e6" />

<img width="1191" height="404" alt="Screenshot 2026-08-17 at 6 17 09 PM" src="https://github.com/user-attachments/assets/16e9fd47-0ed4-4ef1-96cb-afaec4c613e3" />

<img width="1614" height="292" alt="Screenshot 2026-08-18 at 5 19 53 PM" src="https://github.com/user-attachments/assets/19567e3e-e3a0-4b9e-a455-f20f8e13ff43" />

<img width="1614" height="210" alt="Screenshot 2026-08-18 at 5 23 34 PM" src="https://github.com/user-attachments/assets/a88243a4-fc75-45b4-9d54-d86146207321" />



## How Has This Been Tested?
- Deployed to dev cluster and verified:
  - Success alert shows inline "Feature stores" link navigating to settings page
  - Failed alert shows same inline "Feature stores" link
  - No standalone CTA buttons visible
  - Create wizard form does NOT refresh/re-render from polling
  - Primary label shows (?) after text

## Test Impact

- Updated `DeploymentProgressPage.spec.tsx`: removed old CTA button tests, added tests for inline links in both success and failed alerts (verifying text content and navigation), added test for stale progress label suppression.
- Updated `useExistingFeatureStores.spec.tsx`: added test for polling when `{ poll: true }`, added test confirming no polling when option is not set. Added `jest.useFakeTimers()` for all tests.


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional polling for feature-store listings, enabled on the management page.
  * Added accessible help for the Primary feature-store label.
  * Empty states now link to feature-store settings.
  * Disabled authorization can now be explicitly configured.

* **Bug Fixes**
  * Prevented unnecessary and overlapping polling requests.
  * Added guidance to delete and recreate a feature store after failed deployments.

* **UI Improvements**
  * Added Feature stores links to deployment messages.
  * Simplified deployment navigation with a single management link.
  * Updated successful deployment messaging to indicate readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->