### PR TITLE
Add confirmation dialog when changing or clearing the global project

### DIFF
--- a/frontend/src/pages/clusterSettings/GlobalProjectSettings.tsx
+++ b/frontend/src/pages/clusterSettings/GlobalProjectSettings.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import ProjectSelector from '#~/concepts/projects/ProjectSelector';
 import SettingSection from '#~/components/SettingSection';
 import { getDashboardMainContainer } from '#~/utilities/utils';
+import GlobalProjectWarningModal from './GlobalProjectWarningModal';
 
 type GlobalProjectSettingsProps = {
   selectedNamespace: string;
@@ -11,21 +12,54 @@ type GlobalProjectSettingsProps = {
 const GlobalProjectSettings: React.FC<GlobalProjectSettingsProps> = ({
   selectedNamespace,
   setSelectedNamespace,
-}) => (
-  <SettingSection
-    title="Global project"
-    testId="global-project-settings"
-    description="Select a project to store and share prompts globally."
-  >
-    <ProjectSelector
-      onSelection={setSelectedNamespace}
-      namespace={selectedNamespace}
-      clearLabel="None"
-      invalidDropdownPlaceholder="Select a project"
-      placeholder="Select a project"
-      appendTo={getDashboardMainContainer}
-    />
-  </SettingSection>
-);
+}) => {
+  const [pendingNamespace, setPendingNamespace] = React.useState<string | null>(null);
+
+  const warningVariant =
+    pendingNamespace === null ? null : pendingNamespace === '' ? 'clear' : 'switch';
+
+  const handleSelection = (ns: string) => {
+    if (!selectedNamespace || ns === selectedNamespace) {
+      setSelectedNamespace(ns);
+      return;
+    }
+    setPendingNamespace(ns);
+  };
+
+  const handleConfirm = () => {
+    if (pendingNamespace !== null) {
+      setSelectedNamespace(pendingNamespace);
+      setPendingNamespace(null);
+    }
+  };
+
+  const handleCancel = () => {
+    setPendingNamespace(null);
+  };
+
+  return (
+    <SettingSection
+      title="Global project"
+      testId="global-project-settings"
+      description="Select a project to store and share prompts globally."
+    >
+      <ProjectSelector
+        onSelection={handleSelection}
+        namespace={selectedNamespace}
+        clearLabel="Clear selection"
+        invalidDropdownPlaceholder="Select a project"
+        placeholder="Select a project"
+        appendTo={getDashboardMainContainer}
+      />
+      {warningVariant !== null && (
+        <GlobalProjectWarningModal
+          variant={warningVariant}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      )}
+    </SettingSection>
+  );
+};
 
 export default GlobalProjectSettings;

--- a/frontend/src/pages/clusterSettings/GlobalProjectWarningModal.tsx
+++ b/frontend/src/pages/clusterSettings/GlobalProjectWarningModal.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import ContentModal from '@odh-dashboard/ui-core/components/ContentModal';
+
+type GlobalProjectWarningModalVariant = 'clear' | 'switch';
+
+type GlobalProjectWarningModalProps = {
+  variant: GlobalProjectWarningModalVariant;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+const MODAL_CONTENT: Record<
+  GlobalProjectWarningModalVariant,
+  { title: string; body: string; confirmLabel: string }
+> = {
+  clear: {
+    title: 'Clear the global project?',
+    body: 'Clearing the global project selection will make shared prompt templates unavailable to users in this cluster. You can assign a global project again at any time.',
+    confirmLabel: 'Clear global project',
+  },
+  switch: {
+    title: 'Change the global project?',
+    body: 'Assigning a different project as the global project will change the prompt templates available to all users in this cluster.',
+    confirmLabel: 'Change global project',
+  },
+};
+
+const GlobalProjectWarningModal: React.FC<GlobalProjectWarningModalProps> = ({
+  variant,
+  onConfirm,
+  onCancel,
+}) => {
+  const { title, body, confirmLabel } = MODAL_CONTENT[variant];
+
+  return (
+    <ContentModal
+      title={title}
+      onClose={onCancel}
+      variant="small"
+      dataTestId="global-project-warning-modal"
+      contents={body}
+      buttonActions={[
+        {
+          label: confirmLabel,
+          onClick: onConfirm,
+          variant: 'primary',
+          dataTestId: 'global-project-warning-confirm',
+        },
+        {
+          label: 'Cancel',
+          onClick: onCancel,
+          variant: 'link',
+          dataTestId: 'global-project-warning-cancel',
+        },
+      ]}
+    />
+  );
+};
+
+export default GlobalProjectWarningModal;

--- a/frontend/src/pages/clusterSettings/__tests__/GlobalProjectSettings.spec.tsx
+++ b/frontend/src/pages/clusterSettings/__tests__/GlobalProjectSettings.spec.tsx
@@ -41,6 +41,10 @@ const renderComponent = (
 };
 
 describe('GlobalProjectSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render the section title and description', () => {
     renderComponent();
     expect(screen.getByText('Global project')).toBeInTheDocument();
@@ -59,25 +63,88 @@ describe('GlobalProjectSettings', () => {
     expect(screen.getByTestId('project-selector-toggle')).toHaveTextContent('MLflow NS');
   });
 
-  it('should call setSelectedNamespace when a project is selected', () => {
+  it('should call setSelectedNamespace directly for first-time selection (no modal)', () => {
     const setSelectedNamespace = jest.fn();
     renderComponent({ selectedNamespace: '', setSelectedNamespace });
     fireEvent.click(screen.getByTestId('project-selector-toggle'));
     fireEvent.click(screen.getByText('Project A'));
     expect(setSelectedNamespace).toHaveBeenCalledWith('project-a');
+    expect(screen.queryByTestId('global-project-warning-modal')).not.toBeInTheDocument();
   });
 
-  it('should call setSelectedNamespace with empty string when None is selected', () => {
-    const setSelectedNamespace = jest.fn();
-    renderComponent({ selectedNamespace: 'mlflow-ns', setSelectedNamespace });
-    fireEvent.click(screen.getByTestId('project-selector-toggle'));
-    fireEvent.click(screen.getByText('None'));
-    expect(setSelectedNamespace).toHaveBeenCalledWith('');
+  describe('warning modal on clear', () => {
+    it('should show the clear warning modal when clearing a selected project', () => {
+      renderComponent({ selectedNamespace: 'mlflow-ns' });
+      fireEvent.click(screen.getByTestId('project-selector-toggle'));
+      fireEvent.click(screen.getByText('Clear selection'));
+      expect(screen.getByTestId('global-project-warning-modal')).toBeInTheDocument();
+      expect(screen.getByText('Clear the global project?')).toBeInTheDocument();
+    });
+
+    it('should apply the clear when confirmed', () => {
+      const setSelectedNamespace = jest.fn();
+      renderComponent({ selectedNamespace: 'mlflow-ns', setSelectedNamespace });
+      fireEvent.click(screen.getByTestId('project-selector-toggle'));
+      fireEvent.click(screen.getByText('Clear selection'));
+      fireEvent.click(screen.getByTestId('global-project-warning-confirm'));
+      expect(setSelectedNamespace).toHaveBeenCalledWith('');
+      expect(screen.queryByTestId('global-project-warning-modal')).not.toBeInTheDocument();
+    });
+
+    it('should not apply the clear when cancelled', () => {
+      const setSelectedNamespace = jest.fn();
+      renderComponent({ selectedNamespace: 'mlflow-ns', setSelectedNamespace });
+      fireEvent.click(screen.getByTestId('project-selector-toggle'));
+      fireEvent.click(screen.getByText('Clear selection'));
+      fireEvent.click(screen.getByTestId('global-project-warning-cancel'));
+      expect(setSelectedNamespace).not.toHaveBeenCalled();
+      expect(screen.queryByTestId('global-project-warning-modal')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('warning modal on switch', () => {
+    it('should show the switch warning modal when changing to a different project', () => {
+      renderComponent({ selectedNamespace: 'mlflow-ns' });
+      fireEvent.click(screen.getByTestId('project-selector-toggle'));
+      fireEvent.click(screen.getByText('Project A'));
+      expect(screen.getByTestId('global-project-warning-modal')).toBeInTheDocument();
+      expect(screen.getByText('Change the global project?')).toBeInTheDocument();
+    });
+
+    it('should apply the switch when confirmed', () => {
+      const setSelectedNamespace = jest.fn();
+      renderComponent({ selectedNamespace: 'mlflow-ns', setSelectedNamespace });
+      fireEvent.click(screen.getByTestId('project-selector-toggle'));
+      fireEvent.click(screen.getByText('Project A'));
+      fireEvent.click(screen.getByTestId('global-project-warning-confirm'));
+      expect(setSelectedNamespace).toHaveBeenCalledWith('project-a');
+      expect(screen.queryByTestId('global-project-warning-modal')).not.toBeInTheDocument();
+    });
+
+    it('should not apply the switch when cancelled', () => {
+      const setSelectedNamespace = jest.fn();
+      renderComponent({ selectedNamespace: 'mlflow-ns', setSelectedNamespace });
+      fireEvent.click(screen.getByTestId('project-selector-toggle'));
+      fireEvent.click(screen.getByText('Project A'));
+      fireEvent.click(screen.getByTestId('global-project-warning-cancel'));
+      expect(setSelectedNamespace).not.toHaveBeenCalled();
+      expect(screen.queryByTestId('global-project-warning-modal')).not.toBeInTheDocument();
+    });
   });
 
   it('should not show an All projects option', () => {
     renderComponent({ selectedNamespace: '' });
     fireEvent.click(screen.getByTestId('project-selector-toggle'));
     expect(screen.queryByText('All projects')).not.toBeInTheDocument();
+  });
+
+  it('should not show modal when selecting the same project', () => {
+    const setSelectedNamespace = jest.fn();
+    renderComponent({ selectedNamespace: 'project-a', setSelectedNamespace });
+    fireEvent.click(screen.getByTestId('project-selector-toggle'));
+    const menuItems = screen.getAllByText('Project A');
+    fireEvent.click(menuItems[menuItems.length - 1]);
+    expect(screen.queryByTestId('global-project-warning-modal')).not.toBeInTheDocument();
+    expect(setSelectedNamespace).toHaveBeenCalledWith('project-a');
   });
 });

--- a/frontend/src/pages/clusterSettings/__tests__/GlobalProjectWarningModal.spec.tsx
+++ b/frontend/src/pages/clusterSettings/__tests__/GlobalProjectWarningModal.spec.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import GlobalProjectWarningModal from '#~/pages/clusterSettings/GlobalProjectWarningModal';
+
+describe('GlobalProjectWarningModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('clear variant', () => {
+    it('should render clear-specific title and body', () => {
+      render(
+        <GlobalProjectWarningModal variant="clear" onConfirm={jest.fn()} onCancel={jest.fn()} />,
+      );
+      expect(screen.getByText('Clear the global project?')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Clearing the global project selection will make shared prompt templates unavailable to users in this cluster. You can assign a global project again at any time.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should render "Clear global project" confirm button', () => {
+      render(
+        <GlobalProjectWarningModal variant="clear" onConfirm={jest.fn()} onCancel={jest.fn()} />,
+      );
+      expect(screen.getByTestId('global-project-warning-confirm')).toHaveTextContent(
+        'Clear global project',
+      );
+    });
+  });
+
+  describe('switch variant', () => {
+    it('should render switch-specific title and body', () => {
+      render(
+        <GlobalProjectWarningModal variant="switch" onConfirm={jest.fn()} onCancel={jest.fn()} />,
+      );
+      expect(screen.getByText('Change the global project?')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Assigning a different project as the global project will change the prompt templates available to all users in this cluster.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should render "Change global project" confirm button', () => {
+      render(
+        <GlobalProjectWarningModal variant="switch" onConfirm={jest.fn()} onCancel={jest.fn()} />,
+      );
+      expect(screen.getByTestId('global-project-warning-confirm')).toHaveTextContent(
+        'Change global project',
+      );
+    });
+  });
+
+  describe('interactions', () => {
+    it('should call onConfirm when confirm button is clicked', () => {
+      const onConfirm = jest.fn();
+      render(
+        <GlobalProjectWarningModal variant="clear" onConfirm={onConfirm} onCancel={jest.fn()} />,
+      );
+      fireEvent.click(screen.getByTestId('global-project-warning-confirm'));
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onCancel when cancel button is clicked', () => {
+      const onCancel = jest.fn();
+      render(
+        <GlobalProjectWarningModal variant="switch" onConfirm={jest.fn()} onCancel={onCancel} />,
+      );
+      fireEvent.click(screen.getByTestId('global-project-warning-cancel'));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onCancel when the modal close button is clicked', () => {
+      const onCancel = jest.fn();
+      render(
+        <GlobalProjectWarningModal variant="clear" onConfirm={jest.fn()} onCancel={onCancel} />,
+      );
+      fireEvent.click(screen.getByLabelText('Close'));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onCancel when Escape is pressed', () => {
+      const onCancel = jest.fn();
+      render(
+        <GlobalProjectWarningModal variant="clear" onConfirm={jest.fn()} onCancel={onCancel} />,
+      );
+      fireEvent.keyDown(screen.getByTestId('global-project-warning-modal'), {
+        key: 'Escape',
+        code: 'Escape',
+      });
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/pages/clusterSettings/__tests__/GlobalProjectWarningModal.spec.tsx
+++ b/frontend/src/pages/clusterSettings/__tests__/GlobalProjectWarningModal.spec.tsx
@@ -81,17 +81,5 @@ describe('GlobalProjectWarningModal', () => {
       fireEvent.click(screen.getByLabelText('Close'));
       expect(onCancel).toHaveBeenCalledTimes(1);
     });
-
-    it('should call onCancel when Escape is pressed', () => {
-      const onCancel = jest.fn();
-      render(
-        <GlobalProjectWarningModal variant="clear" onConfirm={jest.fn()} onCancel={onCancel} />,
-      );
-      fireEvent.keyDown(screen.getByTestId('global-project-warning-modal'), {
-        key: 'Escape',
-        code: 'Escape',
-      });
-      expect(onCancel).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/packages/cypress/cypress/pages/clusterSettings.ts
+++ b/packages/cypress/cypress/pages/clusterSettings.ts
@@ -129,8 +129,20 @@ class GlobalProjectSettingsPage extends ClusterSettings {
     cy.findByTestId('project-selector-menuList').contains(name).click();
   }
 
-  selectNone() {
-    this.selectProject('None');
+  selectClearSelection() {
+    this.selectProject('Clear selection');
+  }
+
+  findWarningModal() {
+    return cy.findByTestId('global-project-warning-modal');
+  }
+
+  findWarningConfirmButton() {
+    return cy.findByTestId('global-project-warning-confirm');
+  }
+
+  findWarningCancelButton() {
+    return cy.findByTestId('global-project-warning-cancel');
   }
 }
 

--- a/packages/cypress/cypress/tests/mocked/clusterSettings/globalProjectSettings.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/clusterSettings/globalProjectSettings.cy.ts
@@ -55,7 +55,7 @@ describe('Global Project Settings', () => {
     globalProjectSettings.findSelectorToggle().should('contain.text', 'MLflow Workspace');
   });
 
-  it('should enable page-level save and submit when a project is selected', () => {
+  it('should enable page-level save and submit when a project is selected for the first time', () => {
     cy.interceptOdh('GET /api/config', mockDashboardConfig({ globalProjectPrompts: true }));
     cy.interceptOdh('PUT /api/cluster-settings', { success: true, error: '' }).as(
       'saveClusterSettings',
@@ -63,6 +63,7 @@ describe('Global Project Settings', () => {
 
     clusterSettings.visit();
     globalProjectSettings.selectProject('Project Alpha');
+    globalProjectSettings.findWarningModal().should('not.exist');
     clusterSettings.findSubmitButton().should('be.enabled');
     clusterSettings.findSubmitButton().click();
 
@@ -71,29 +72,102 @@ describe('Global Project Settings', () => {
     });
   });
 
-  it('should send empty array when None is selected', () => {
-    cy.interceptOdh(
-      'GET /api/config',
-      mockDashboardConfig({
-        globalProjectPrompts: true,
-        globalMLflowNamespaces: ['mlflow-workspace'],
-      }),
-    );
-    cy.interceptOdh(
-      'GET /api/cluster-settings',
-      mockClusterSettings({ globalMLflowNamespaces: ['mlflow-workspace'] }),
-    );
-    cy.interceptOdh('PUT /api/cluster-settings', { success: true, error: '' }).as(
-      'saveClusterSettings',
-    );
+  describe('clear warning modal', () => {
+    beforeEach(() => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          globalProjectPrompts: true,
+          globalMLflowNamespaces: ['mlflow-workspace'],
+        }),
+      );
+      cy.interceptOdh(
+        'GET /api/cluster-settings',
+        mockClusterSettings({ globalMLflowNamespaces: ['mlflow-workspace'] }),
+      );
+    });
 
-    clusterSettings.visit();
-    globalProjectSettings.selectNone();
-    clusterSettings.findSubmitButton().should('be.enabled');
-    clusterSettings.findSubmitButton().click();
+    it('should show the clear warning modal when clearing a configured project', () => {
+      clusterSettings.visit();
+      globalProjectSettings.selectClearSelection();
+      globalProjectSettings.findWarningModal().should('exist');
+      globalProjectSettings.findWarningModal().should('contain.text', 'Clear the global project?');
+    });
 
-    cy.wait('@saveClusterSettings').then((interception) => {
-      expect(interception.request.body.globalMLflowNamespaces).to.eql([]);
+    it('should send empty array when clear is confirmed', () => {
+      cy.interceptOdh('PUT /api/cluster-settings', { success: true, error: '' }).as(
+        'saveClusterSettings',
+      );
+
+      clusterSettings.visit();
+      globalProjectSettings.selectClearSelection();
+      globalProjectSettings.findWarningConfirmButton().click();
+      globalProjectSettings.findWarningModal().should('not.exist');
+      clusterSettings.findSubmitButton().should('be.enabled');
+      clusterSettings.findSubmitButton().click();
+
+      cy.wait('@saveClusterSettings').then((interception) => {
+        expect(interception.request.body.globalMLflowNamespaces).to.eql([]);
+      });
+    });
+
+    it('should revert when clear is cancelled', () => {
+      clusterSettings.visit();
+      globalProjectSettings.selectClearSelection();
+      globalProjectSettings.findWarningCancelButton().click();
+      globalProjectSettings.findWarningModal().should('not.exist');
+      globalProjectSettings.findSelectorToggle().should('contain.text', 'MLflow Workspace');
+      clusterSettings.findSubmitButton().should('be.disabled');
+    });
+  });
+
+  describe('switch warning modal', () => {
+    beforeEach(() => {
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          globalProjectPrompts: true,
+          globalMLflowNamespaces: ['mlflow-workspace'],
+        }),
+      );
+      cy.interceptOdh(
+        'GET /api/cluster-settings',
+        mockClusterSettings({ globalMLflowNamespaces: ['mlflow-workspace'] }),
+      );
+    });
+
+    it('should show the switch warning modal when changing to a different project', () => {
+      clusterSettings.visit();
+      globalProjectSettings.selectProject('Project Alpha');
+      globalProjectSettings.findWarningModal().should('exist');
+      globalProjectSettings.findWarningModal().should('contain.text', 'Change the global project?');
+    });
+
+    it('should update the selection when switch is confirmed', () => {
+      cy.interceptOdh('PUT /api/cluster-settings', { success: true, error: '' }).as(
+        'saveClusterSettings',
+      );
+
+      clusterSettings.visit();
+      globalProjectSettings.selectProject('Project Alpha');
+      globalProjectSettings.findWarningConfirmButton().click();
+      globalProjectSettings.findWarningModal().should('not.exist');
+      globalProjectSettings.findSelectorToggle().should('contain.text', 'Project Alpha');
+      clusterSettings.findSubmitButton().should('be.enabled');
+      clusterSettings.findSubmitButton().click();
+
+      cy.wait('@saveClusterSettings').then((interception) => {
+        expect(interception.request.body.globalMLflowNamespaces).to.eql(['project-alpha']);
+      });
+    });
+
+    it('should revert when switch is cancelled', () => {
+      clusterSettings.visit();
+      globalProjectSettings.selectProject('Project Alpha');
+      globalProjectSettings.findWarningCancelButton().click();
+      globalProjectSettings.findWarningModal().should('not.exist');
+      globalProjectSettings.findSelectorToggle().should('contain.text', 'MLflow Workspace');
+      clusterSettings.findSubmitButton().should('be.disabled');
     });
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-78255

## Description

Cluster admins can set a global project on Cluster settings so prompt templates are shared cluster-wide. Changing or clearing that selection has a cluster-wide impact, but the previous UI applied changes immediately with no confirmation.

This PR adds a confirmation dialog before clearing or switching the global project:

- **First-time selection** — still applies immediately (no modal).
- **Clear selection** — shows a warning explaining that shared prompt templates will become unavailable.
- **Switch project** — shows a warning that prompt templates available to all users will change.


https://github.com/user-attachments/assets/b5a9428a-4b6c-420f-a90a-374d32412c73


Also renames the clear action label from **None** to **Clear selection** for clarity.

## How Has This Been Tested?

- Unit tests: `GlobalProjectSettings` and `GlobalProjectWarningModal` (confirm, cancel, close button, Escape).
- Cypress mock tests: clear/switch modal flows, including confirm, cancel, and save behavior.

Manual tested:

1. Enable `globalProjectPrompts` in OdhDashboardConfig.
2. Go to **Settings → Cluster settings → Global project**.
3. Select a project for the first time — should apply with no modal.
4. Switch to a different project — confirm modal appears; **Cancel** reverts; **Change global project** applies.
5. Use **Clear selection** — confirm modal appears; **Cancel** reverts; **Clear global project** clears the selection.

## Test Impact

- Added `GlobalProjectWarningModal.spec.tsx` (clear/switch copy, confirm, cancel, close, Escape).
- Updated `GlobalProjectSettings.spec.tsx` for modal gating on clear/switch vs first-time selection.
- Updated `globalProjectSettings.cy.ts` with clear/switch modal scenarios.
- Updated Cypress page object (`selectClearSelection`, modal helpers).

## Request review criteria:

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added confirmation prompts before clearing or switching an existing global project.
  - Added distinct messaging and actions for clearing versus switching projects.
  - Renamed the empty selection option from “None” to “Clear selection.”
  - Canceling or closing a prompt preserves the current project selection.

- **Bug Fixes**
  - Project selections now apply immediately when selecting a project for the first time or reselecting the current project.
  - Pending changes are applied only after explicit confirmation when replacing or clearing an existing project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->