### PR TITLE
Fix template missing label project scoped Templates

### DIFF
--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -376,7 +376,7 @@ export const getInferenceServiceStoppedStatus = (
 export const getServingRuntimeVersionStatus = (
   servingRuntimeVersion: string | undefined,
   templateVersion: string | undefined,
-): string | undefined => {
+): ServingRuntimeVersionStatusLabel | undefined => {
   if (!servingRuntimeVersion || !templateVersion) {
     return undefined;
   }

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -1,4 +1,6 @@
 // eslint-disable-next-line no-restricted-syntax
+import type { TemplateKind } from '@odh-dashboard/k8s-core';
+// eslint-disable-next-line no-restricted-syntax
 import { NamespaceApplicationCase } from '@odh-dashboard/k8s-core';
 // eslint-disable-next-line no-restricted-syntax
 import { ProjectObjectType } from '@odh-dashboard/ui-core';
@@ -28,6 +30,7 @@ import type {
 } from '@odh-dashboard/plugin-core/extension-points';
 import { DataScienceStackComponent, SupportedArea } from '@odh-dashboard/plugin-core/areas';
 import type { DeploymentMethodFieldData } from '@odh-dashboard/model-serving/shared/wizard-fields';
+import type { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import type { TimeoutFieldValue } from './src/wizardFields/timeout/TimeoutField';
 import type { KServeServingRuntimeFieldType } from './src/wizardFields/servingRuntime/KServeServingRuntimeField';
 import type { KServeDeployment } from './src/types';
@@ -114,7 +117,7 @@ const extensions: (
   | ModelServingAuthExtension<KServeDeployment>
   | ModelServingDeleteModal<KServeDeployment>
   | ModelServingMetricsExtension<KServeDeployment>
-  | DeployedModelServingDetails<KServeDeployment>
+  | DeployedModelServingDetails<KServeDeployment, FetchStateObject<TemplateKind[]>>
   | ModelServingStartStopAction<KServeDeployment>
   | ModelServingPlatformFetchDeploymentStatus<KServeDeployment>
   | ModelServingDeploy<KServeDeployment>
@@ -203,7 +206,12 @@ const extensions: (
     type: 'model-serving.deployed-model/serving-runtime',
     properties: {
       platform: KSERVE_ID,
-      ServingDetailsComponent: () => import('./src/components/deploymentServingDetails'),
+      dataHook: () =>
+        import('./src/components/deploymentServingDetails').then((m) => m.useServingDetailsData),
+      ServingDetailsComponent: () =>
+        import('./src/components/deploymentServingDetails').then((m) => ({
+          default: m.default,
+        })),
     },
     flags: {
       required: [SupportedArea.K_SERVE],

--- a/packages/kserve/src/api/template.ts
+++ b/packages/kserve/src/api/template.ts
@@ -29,6 +29,9 @@ export const useFetchTemplate = (
     if (!shouldFetch) {
       return Promise.reject(new NotReadyError('Project template fetch disabled'));
     }
+    if (!name) {
+      return Promise.reject(new NotReadyError('Name required to fetch template'));
+    }
     if (!namespace) {
       return Promise.reject(new NotReadyError('Namespace required to fetch template'));
     }

--- a/packages/kserve/src/api/template.ts
+++ b/packages/kserve/src/api/template.ts
@@ -1,0 +1,45 @@
+import React from 'react';
+import { TemplateModel } from '@odh-dashboard/internal/api/index';
+import { TemplateKind } from '@odh-dashboard/k8s-core';
+import useFetch, { FetchStateObject, NotReadyError } from '@odh-dashboard/ui-core/hooks/useFetch';
+import { k8sGetResource, k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
+
+export const useFetchTemplates = (namespace?: string): FetchStateObject<TemplateKind[]> => {
+  const fetchCallbackPromise = React.useCallback(async () => {
+    if (!namespace) {
+      return Promise.reject(new NotReadyError('Namespace required to fetch templates'));
+    }
+    return k8sListResourceItems<TemplateKind>({
+      model: TemplateModel,
+      queryOptions: {
+        ns: namespace,
+      },
+    });
+  }, [namespace]);
+
+  return useFetch(fetchCallbackPromise, []);
+};
+
+export const useFetchTemplate = (
+  name?: string,
+  namespace?: string,
+  shouldFetch?: boolean,
+): FetchStateObject<TemplateKind | undefined> => {
+  const fetchCallbackPromise = React.useCallback(async () => {
+    if (!shouldFetch) {
+      return Promise.reject(new NotReadyError('Project template fetch disabled'));
+    }
+    if (!namespace) {
+      return Promise.reject(new NotReadyError('Namespace required to fetch template'));
+    }
+    return k8sGetResource<TemplateKind>({
+      model: TemplateModel,
+      queryOptions: {
+        ns: namespace,
+        name,
+      },
+    });
+  }, [name, namespace, shouldFetch]);
+
+  return useFetch(fetchCallbackPromise, undefined);
+};

--- a/packages/kserve/src/components/__tests__/deploymentServingDetails.spec.tsx
+++ b/packages/kserve/src/components/__tests__/deploymentServingDetails.spec.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
+import type { TemplateKind } from '@odh-dashboard/k8s-core';
+import type { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
+import { mockServingRuntimeK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockServingRuntimeK8sResource';
+import { mockServingRuntimeTemplateK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockServingRuntimeTemplateK8sResource';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import { SERVING_RUNTIME_SCOPE } from '@odh-dashboard/internal/pages/modelServing/screens/const';
+import type { KServeDeployment } from '../../types';
+import DeploymentServingDetails from '../deploymentServingDetails';
+import { useFetchTemplate } from '../../api/template';
+
+// The project-scoped template fetch is the piece we drive per-test.
+jest.mock('../../api/template', () => ({
+  useFetchTemplate: jest.fn(),
+  useFetchTemplates: jest.fn(),
+}));
+
+// Project-scoped label gating is not under test here; keep the area off.
+jest.mock('@odh-dashboard/plugin-core/areas', () => ({
+  useIsAreaAvailable: jest.fn(() => ({ status: false })),
+  SupportedArea: { DS_PROJECT_SCOPED: 'ds-project-scoped' },
+}));
+
+// Version labels rendered from the serving runtime itself are noise for these assertions.
+jest.mock('@odh-dashboard/model-serving/shared/components', () => ({
+  renderDeploymentResourceVersionLabels: () => null,
+}));
+
+const mockUseFetchTemplate = jest.mocked(useFetchTemplate);
+
+const fetchState = <T,>(data: T, loaded = false, error?: Error): FetchStateObject<T> => ({
+  data,
+  loaded,
+  error,
+  refresh: jest.fn(),
+});
+
+// The component only reads `deployment.server`.
+const makeDeployment = (server: ServingRuntimeKind | undefined): KServeDeployment =>
+  ({ server } as unknown as KServeDeployment);
+
+const TEMPLATE_REMOVED = 'serving-runtime-template-status-label';
+const VERSION_STATUS = 'serving-runtime-version-status-label';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: project fetch disabled and idle.
+  mockUseFetchTemplate.mockReturnValue(fetchState<TemplateKind | undefined>(undefined));
+});
+
+describe('DeploymentServingDetails', () => {
+  it('should render "Unknown" when there is no serving runtime', () => {
+    render(<DeploymentServingDetails deployment={makeDeployment(undefined)} />);
+
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+    expect(screen.queryByTestId(TEMPLATE_REMOVED)).not.toBeInTheDocument();
+  });
+
+  it('should show the version status and no "template removed" label when the global template is found', () => {
+    const server = mockServingRuntimeK8sResource({ templateName: 'ovms', version: '1.0.0' });
+    const globalTemplate = mockServingRuntimeTemplateK8sResource({
+      name: 'ovms',
+      version: '1.0.0',
+    });
+
+    render(
+      <DeploymentServingDetails
+        deployment={makeDeployment(server)}
+        data={fetchState([globalTemplate], true)}
+      />,
+    );
+
+    expect(screen.queryByTestId(TEMPLATE_REMOVED)).not.toBeInTheDocument();
+    // Runtime version matches the template version -> "Latest".
+    expect(screen.getByTestId(VERSION_STATUS)).toHaveTextContent('Latest');
+  });
+
+  it('should show the "template removed" label when the template is not found anywhere', () => {
+    const server = mockServingRuntimeK8sResource({ templateName: 'ovms', version: '1.0.0' });
+    // Global list loaded but empty -> the component falls back to the project fetch, which also
+    // resolves with nothing.
+    mockUseFetchTemplate.mockReturnValue(fetchState<TemplateKind | undefined>(undefined, true));
+
+    render(
+      <DeploymentServingDetails deployment={makeDeployment(server)} data={fetchState([], true)} />,
+    );
+
+    expect(screen.getByTestId(TEMPLATE_REMOVED)).toHaveTextContent('Template removed');
+  });
+
+  // Regression guard for the flicker bug: while global templates are still loading (not loaded, no
+  // error) and the project fetch is disabled, the missing-template label must not appear.
+  it('should not show the "template removed" label while global templates are still loading', () => {
+    const server = mockServingRuntimeK8sResource({ templateName: 'ovms', version: '1.0.0' });
+
+    render(
+      <DeploymentServingDetails deployment={makeDeployment(server)} data={fetchState([], false)} />,
+    );
+
+    expect(screen.queryByTestId(TEMPLATE_REMOVED)).not.toBeInTheDocument();
+  });
+
+  it('should resolve a project-scoped template and use its version', () => {
+    const server = mockServingRuntimeK8sResource({
+      templateName: 'ovms',
+      version: '2.0.0',
+      scope: SERVING_RUNTIME_SCOPE.Project,
+    });
+    const projectTemplate = mockServingRuntimeTemplateK8sResource({
+      name: 'ovms',
+      version: '2.0.0',
+    });
+    mockUseFetchTemplate.mockReturnValue(
+      fetchState<TemplateKind | undefined>(projectTemplate, true),
+    );
+
+    render(
+      <DeploymentServingDetails deployment={makeDeployment(server)} data={fetchState([], true)} />,
+    );
+
+    expect(screen.queryByTestId(TEMPLATE_REMOVED)).not.toBeInTheDocument();
+    // Runtime version matches the project template version -> "Latest".
+    expect(screen.getByTestId(VERSION_STATUS)).toHaveTextContent('Latest');
+  });
+});

--- a/packages/kserve/src/components/__tests__/deploymentServingDetails.spec.tsx
+++ b/packages/kserve/src/components/__tests__/deploymentServingDetails.spec.tsx
@@ -77,6 +77,25 @@ describe('DeploymentServingDetails', () => {
     expect(screen.getByTestId(VERSION_STATUS)).toHaveTextContent('Latest');
   });
 
+  it('should not trigger the project-scoped fetch when the global template is found', () => {
+    const server = mockServingRuntimeK8sResource({ templateName: 'ovms', version: '1.0.0' });
+    const globalTemplate = mockServingRuntimeTemplateK8sResource({
+      name: 'ovms',
+      version: '1.0.0',
+    });
+
+    render(
+      <DeploymentServingDetails
+        deployment={makeDeployment(server)}
+        data={fetchState([globalTemplate], true)}
+      />,
+    );
+
+    // The project fetch is gated off (third arg false), so no project-scoped API call is made.
+    expect(mockUseFetchTemplate).toHaveBeenCalledWith('ovms', server.metadata.namespace, false);
+    expect(mockUseFetchTemplate).not.toHaveBeenCalledWith('ovms', server.metadata.namespace, true);
+  });
+
   it('should show the "template removed" label when the template is not found anywhere', () => {
     const server = mockServingRuntimeK8sResource({ templateName: 'ovms', version: '1.0.0' });
     // Global list loaded but empty -> the component falls back to the project fetch, which also

--- a/packages/kserve/src/components/deploymentServingDetails.tsx
+++ b/packages/kserve/src/components/deploymentServingDetails.tsx
@@ -23,6 +23,7 @@ import { getServingRuntimeVersionStatus } from '@odh-dashboard/internal/pages/mo
 import { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
 import { K8sResourceCommon, TemplateKind } from '@odh-dashboard/k8s-core';
 import { useDashboardNamespace } from '@odh-dashboard/plugin-core/host-api';
+import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
 import type { KServeDeployment } from '../types';
 import { useFetchTemplate, useFetchTemplates } from '../api/template';
 
@@ -85,7 +86,8 @@ const DeploymentServingDetails: React.FC<Props> = ({ deployment, data }) => {
     );
   }, [template, servingRuntime]);
 
-  const isTemplateRemoved = !!templateName && (allLoaded || error) && !template;
+  const isTemplateRemoved =
+    !!templateName && (allLoaded || getGenericErrorCode(error) === 404) && !template;
 
   return (
     <>

--- a/packages/kserve/src/components/deploymentServingDetails.tsx
+++ b/packages/kserve/src/components/deploymentServingDetails.tsx
@@ -4,6 +4,7 @@ import {
   getTemplateNameFromServingRuntime,
   getDisplayNameFromServingRuntimeTemplate,
   getServingRuntimeVersion,
+  findTemplateByName,
 } from '@odh-dashboard/model-serving/shared';
 import { LabelGroup, Stack, StackItem } from '@patternfly/react-core';
 import { renderDeploymentResourceVersionLabels } from '@odh-dashboard/model-serving/shared/components';
@@ -16,37 +17,75 @@ import {
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import ServingRuntimeTemplateStatus from '@odh-dashboard/internal/pages/modelServing/screens/ServingRuntimeTemplateStatus';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
-import { useTemplateByName } from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/useTemplateByName';
-// eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import ServingRuntimeVersionStatus from '@odh-dashboard/internal/pages/modelServing/screens/ServingRuntimeVersionStatus';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { getServingRuntimeVersionStatus } from '@odh-dashboard/internal/pages/modelServing/utils';
+import { FetchStateObject } from '@odh-dashboard/ui-core/hooks/useFetch';
+import { K8sResourceCommon, TemplateKind } from '@odh-dashboard/k8s-core';
+import { useDashboardNamespace } from '@odh-dashboard/plugin-core/host-api';
 import type { KServeDeployment } from '../types';
+import { useFetchTemplate, useFetchTemplates } from '../api/template';
+
+const isProjectScoped = (resource?: K8sResourceCommon) =>
+  resource &&
+  resource.metadata?.annotations?.['opendatahub.io/serving-runtime-scope'] ===
+    SERVING_RUNTIME_SCOPE.Project;
+
+export const useServingDetailsData = (): FetchStateObject<TemplateKind[]> => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  return useFetchTemplates(dashboardNamespace);
+};
 
 type Props = {
   deployment: KServeDeployment;
+  data?: ReturnType<typeof useServingDetailsData>;
 };
 
-const DeploymentServingDetails: React.FC<Props> = ({ deployment }) => {
-  const servingRuntime = deployment.server;
+const DeploymentServingDetails: React.FC<Props> = ({ deployment, data }) => {
   const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
+
+  const {
+    data: globalTemplates,
+    loaded: globalTemplatesLoaded,
+    error: globalTemplatesError,
+  } = data ?? {};
+
+  const servingRuntime = deployment.server;
 
   const templateName = servingRuntime
     ? getTemplateNameFromServingRuntime(servingRuntime)
     : undefined;
 
-  const [template, templateLoaded, templateError] = useTemplateByName(templateName);
+  const globalTemplate = React.useMemo(
+    () =>
+      !!globalTemplates && !!templateName
+        ? findTemplateByName(globalTemplates, templateName)
+        : undefined,
+    [templateName, globalTemplates],
+  );
+
+  const shouldCheckProject =
+    (!globalTemplate && (globalTemplatesLoaded || !!globalTemplatesError)) ||
+    isProjectScoped(servingRuntime);
+
+  const {
+    data: projectTemplate,
+    loaded: projectTemplateLoaded,
+    error: projectTemplateError,
+  } = useFetchTemplate(templateName, servingRuntime?.metadata.namespace, shouldCheckProject);
+
+  const template = globalTemplate ?? projectTemplate;
+  const allLoaded = shouldCheckProject ? projectTemplateLoaded : globalTemplatesLoaded;
+  const error = shouldCheckProject ? projectTemplateError : globalTemplatesError;
 
   const versionStatus = React.useMemo(() => {
-    if (templateLoaded && !templateError && servingRuntime) {
-      const servingRuntimeVersion = getServingRuntimeVersion(servingRuntime);
-      const templateVersion = getServingRuntimeVersion(template);
-      return getServingRuntimeVersionStatus(servingRuntimeVersion, templateVersion);
-    }
-    return undefined;
-  }, [template, templateLoaded, templateError, servingRuntime]);
+    return getServingRuntimeVersionStatus(
+      getServingRuntimeVersion(servingRuntime),
+      getServingRuntimeVersion(template),
+    );
+  }, [template, servingRuntime]);
 
-  const isTemplateRemoved = templateLoaded && !templateError && !template && !!templateName;
+  const isTemplateRemoved = !!templateName && (allLoaded || error) && !template;
 
   return (
     <>
@@ -64,13 +103,11 @@ const DeploymentServingDetails: React.FC<Props> = ({ deployment }) => {
                 />
               )}
               {isTemplateRemoved && <ServingRuntimeTemplateStatus />}
-              {isProjectScopedAvailable &&
-                servingRuntime.metadata.annotations?.['opendatahub.io/serving-runtime-scope'] ===
-                  SERVING_RUNTIME_SCOPE.Project && (
-                  <ScopedLabel isProject color="blue" isCompact>
-                    Project-scoped
-                  </ScopedLabel>
-                )}
+              {isProjectScopedAvailable && isProjectScoped(servingRuntime) && (
+                <ScopedLabel isProject color="blue" isCompact>
+                  Project-scoped
+                </ScopedLabel>
+              )}
             </LabelGroup>
           </StackItem>
         </Stack>

--- a/packages/kserve/src/components/deploymentServingDetails.tsx
+++ b/packages/kserve/src/components/deploymentServingDetails.tsx
@@ -1,13 +1,84 @@
 import React from 'react';
-import InferenceServiceServingRuntime from '@odh-dashboard/internal/pages/modelServing/screens/global/InferenceServiceServingRuntime';
+import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/plugin-core/areas';
+import {
+  getTemplateNameFromServingRuntime,
+  getDisplayNameFromServingRuntimeTemplate,
+  getServingRuntimeVersion,
+} from '@odh-dashboard/model-serving/shared';
+import { LabelGroup, Stack, StackItem } from '@patternfly/react-core';
+import { renderDeploymentResourceVersionLabels } from '@odh-dashboard/model-serving/shared/components';
+import ScopedLabel from '@odh-dashboard/ui-core/components/ScopedLabel';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import {
+  SERVING_RUNTIME_SCOPE,
+  ServingRuntimeVersionStatusLabel,
+} from '@odh-dashboard/internal/pages/modelServing/screens/const';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import ServingRuntimeTemplateStatus from '@odh-dashboard/internal/pages/modelServing/screens/ServingRuntimeTemplateStatus';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import { useTemplateByName } from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/useTemplateByName';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import ServingRuntimeVersionStatus from '@odh-dashboard/internal/pages/modelServing/screens/ServingRuntimeVersionStatus';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import { getServingRuntimeVersionStatus } from '@odh-dashboard/internal/pages/modelServing/utils';
 import type { KServeDeployment } from '../types';
 
 type Props = {
   deployment: KServeDeployment;
 };
 
-const DeploymentServingDetails: React.FC<Props> = ({ deployment }) => (
-  <InferenceServiceServingRuntime servingRuntime={deployment.server} />
-);
+const DeploymentServingDetails: React.FC<Props> = ({ deployment }) => {
+  const servingRuntime = deployment.server;
+  const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
+
+  const templateName = servingRuntime
+    ? getTemplateNameFromServingRuntime(servingRuntime)
+    : undefined;
+
+  const [template, templateLoaded, templateError] = useTemplateByName(templateName);
+
+  const versionStatus = React.useMemo(() => {
+    if (templateLoaded && !templateError && servingRuntime) {
+      const servingRuntimeVersion = getServingRuntimeVersion(servingRuntime);
+      const templateVersion = getServingRuntimeVersion(template);
+      return getServingRuntimeVersionStatus(servingRuntimeVersion, templateVersion);
+    }
+    return undefined;
+  }, [template, templateLoaded, templateError, servingRuntime]);
+
+  const isTemplateRemoved = templateLoaded && !templateError && !template && !!templateName;
+
+  return (
+    <>
+      {servingRuntime ? (
+        <Stack>
+          <StackItem>{getDisplayNameFromServingRuntimeTemplate(servingRuntime)}</StackItem>
+          <StackItem>
+            <LabelGroup numLabels={5}>
+              {renderDeploymentResourceVersionLabels(servingRuntime, { isCompact: true })}
+              {versionStatus && (
+                <ServingRuntimeVersionStatus
+                  isOutdated={versionStatus === ServingRuntimeVersionStatusLabel.OUTDATED}
+                  version={getServingRuntimeVersion(servingRuntime) || ''}
+                  templateVersion={getServingRuntimeVersion(template) || ''}
+                />
+              )}
+              {isTemplateRemoved && <ServingRuntimeTemplateStatus />}
+              {isProjectScopedAvailable &&
+                servingRuntime.metadata.annotations?.['opendatahub.io/serving-runtime-scope'] ===
+                  SERVING_RUNTIME_SCOPE.Project && (
+                  <ScopedLabel isProject color="blue" isCompact>
+                    Project-scoped
+                  </ScopedLabel>
+                )}
+            </LabelGroup>
+          </StackItem>
+        </Stack>
+      ) : (
+        'Unknown'
+      )}
+    </>
+  );
+};
 
 export default DeploymentServingDetails;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://redhat.atlassian.net/browse/RHOAIENG-82816

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The original code would not look inside the project for the Template. When the "Template removed" was added recently, this actually caused a regression for project scoped Templates. This also surfaced for the new NIM legacy wizard deployment flow, because it comes from the same project. (This also causes a regression for legacy nim modal deployments, because they get the template name wrong for some reason?)

The original code was also doing: 
list global `TemplateKind`s + fetch odhDashboardConfig for order + fetch odhDashboardConfig for disablement for EACH row

This PR makes it done only once per page load now

To fetch the project scoped Templates, it's hard to do when in the global models page, because there are mutliple projects. I just made it fall back to fetch for a single Template in the same project if the row couldn't find a global one

Before:
<img width="2944" height="1766" alt="image" src="https://github.com/user-attachments/assets/b8b1d70f-ecf0-4f5f-b95f-76e04a533ef6" />
After:
<img width="1496" height="892" alt="image" src="https://github.com/user-attachments/assets/ad11f53a-930a-40fb-af1e-b7e1c48ec81f" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
go to the zaffre emily2 project and toggle the NIM Wizard flag and you should see a kserve deployment with a project scoped runtime + the NIM deployments

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Jest tests added to cover the different component states

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Serving details now identify the runtime template used, including whether it is globally or project scoped.
  - Added runtime version status labels, resource details, and clearer indicators for removed templates.
  - Improved loading and error handling while template information is retrieved.

- **Bug Fixes**
  - Prevented temporary display flicker while serving-template data is loading.
  - Improved handling when serving runtimes or templates are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->