### PR TITLE
fix: lazy-load Rsdoctor so Konflux s390x/ppc64le builds succeed

### DIFF
--- a/distributions/core-bff/frontend/config/rspack.prod.js
+++ b/distributions/core-bff/frontend/config/rspack.prod.js
@@ -2,8 +2,17 @@
 const path = require('path');
 const { merge } = require('rspack-merge');
 const { rspack } = require('@rspack/core');
-const { RsdoctorRspackPlugin } = require('@rsdoctor/rspack-plugin');
 const { setupWebpackDotenvFilesForEnv, setupDotenvFilesForEnv } = require('./dotenv');
+
+const getRsdoctorPlugin = () => {
+  if (process.env.RSDOCTOR !== 'true') {
+    return [];
+  }
+  // Lazy-require: @rsdoctor/rspack-plugin depends on @rspack/resolver, which has no
+  // native bindings for s390x/ppc64le. Container builds must not load it.
+  const { RsdoctorRspackPlugin } = require('@rsdoctor/rspack-plugin');
+  return [new RsdoctorRspackPlugin()];
+};
 
 setupDotenvFilesForEnv({ env: 'production' });
 const rspackCommon = require('./rspack.common.js');
@@ -51,8 +60,8 @@ module.exports = merge(
       }),
       // Only enable when analyzing — increases build time.
       // See https://rspack.rs/guide/optimization/use-rsdoctor
-      process.env.RSDOCTOR === 'true' && new RsdoctorRspackPlugin(),
-    ].filter(Boolean),
+      ...getRsdoctorPlugin(),
+    ],
     module: {
       rules: [
         {

--- a/frontend/config/rspack.prod.js
+++ b/frontend/config/rspack.prod.js
@@ -2,8 +2,17 @@
 const { merge } = require('rspack-merge');
 const { rspack } = require('@rspack/core');
 const { rimrafSync } = require('rimraf');
-const { RsdoctorRspackPlugin } = require('@rsdoctor/rspack-plugin');
 const { setupWebpackDotenvFilesForEnv, setupDotenvFilesForEnv } = require('./dotenv');
+
+const getRsdoctorPlugin = () => {
+  if (process.env.RSDOCTOR !== 'true') {
+    return [];
+  }
+  // Lazy-require: @rsdoctor/rspack-plugin depends on @rspack/resolver, which has no
+  // native bindings for s390x/ppc64le. Container builds must not load it.
+  const { RsdoctorRspackPlugin } = require('@rsdoctor/rspack-plugin');
+  return [new RsdoctorRspackPlugin()];
+};
 
 setupDotenvFilesForEnv({ env: 'production' });
 const rspackCommon = require('./rspack.common.js');
@@ -50,7 +59,7 @@ module.exports = merge(
       }),
       // Only enable when analyzing — increases build time.
       // See https://rspack.rs/guide/optimization/use-rsdoctor
-      process.env.RSDOCTOR === 'true' && new RsdoctorRspackPlugin(),
-    ].filter(Boolean),
+      ...getRsdoctorPlugin(),
+    ],
   },
 );


### PR DESCRIPTION
## Description
Konflux image builds for **linux/s390x** and **linux/ppc64le** failed after the Rspack architecture update.

Rspack 2.1.10 ships native bindings for those arches, but the production config still did a top-level `require('@rsdoctor/rspack-plugin')`. That plugin depends on `@rspack/resolver`, which has **no** `linux-s390x-gnu` or `linux-ppc64-gnu` bindings. The CLI evaluated the require while loading the config, even when `RSDOCTOR` was unset, so every container build crashed with:

```
Cannot find module '@rspack/resolver-binding-linux-s390x-gnu'
```

This lazy-loads Rsdoctor so it is only required when `RSDOCTOR=true` (`npm run build:analyze`). Normal Konflux/production builds no longer load `@rspack/resolver`.

## How Has This Been Tested?
- Confirmed the Konflux failure stack traces through `@rsdoctor/rspack-plugin` → `@rspack/resolver` on s390x (ppc64le has the same missing binding).
- Confirmed `@rspack/binding` 2.1.10 already includes `@rspack/binding-linux-s390x-gnu` and `@rspack/binding-linux-ppc64-gnu`.
- Did not yet re-run the Konflux multi-arch image build in this PR.

- Ran local build
- Ran local rsdoctor

## Test Impact
No new unit/Cypress tests. This is a prod-config load-order change; the failure only reproduces on s390x/ppc64le native bindings during container builds. `build:analyze` still constructs the plugin when `RSDOCTOR=true`.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved production builds by loading optional diagnostics only when explicitly enabled.
  - Prevented unsupported native components from being loaded during standard production builds.
  - Reduced build-time errors and unnecessary startup overhead when diagnostics are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->