### PR TITLE
feat(feature-store): Add Cypress mocked and E2E tests for Feature Store admin UI

### DIFF
--- a/packages/cypress/cypress/pages/featureStore/featureStoreCreate.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureStoreCreate.ts
@@ -34,6 +34,60 @@ class FeatureStoreCreatePage {
   findStepByName(stepName: string) {
     return cy.findByRole('button', { name: stepName });
   }
+
+  findProjectNameInput() {
+    return cy.findByTestId('feast-project-name');
+  }
+
+  fillProjectName(name: string) {
+    this.findProjectNameInput().clear().type(name);
+    return this;
+  }
+
+  findNamespaceToggle() {
+    return cy.findByTestId('feast-namespace-toggle');
+  }
+
+  selectNamespace(ns: string) {
+    // SimpleSelect auto-selects and disables the toggle when only one option exists.
+    this.findNamespaceToggle().should(($el) => {
+      const disabled = $el.is(':disabled');
+      const text = $el.text();
+      const nsMatch = text === ns || text.endsWith(`(${ns})`);
+      expect(
+        !disabled || nsMatch,
+        `namespace toggle should be enabled or already show "${ns}" (disabled=${disabled}, text="${text}")`,
+      ).to.eq(true);
+    });
+    this.findNamespaceToggle().then(($el) => {
+      if (!$el.is(':disabled')) {
+        cy.wrap($el).click();
+        cy.findByRole('option', { name: new RegExp(`\\(${ns}\\)|^${ns}$`) }).click();
+      }
+    });
+    return this;
+  }
+
+  findProjectNameError() {
+    return cy.findByTestId('feast-project-name-error');
+  }
+
+  findRegistryTypeRadio(type: 'local' | 'remote') {
+    return cy.findByTestId(`feast-registry-${type}`);
+  }
+
+  findFeastRefNameInput() {
+    return cy.findByTestId('feast-ref-name');
+  }
+
+  findRestApiSwitch() {
+    return cy.findByTestId('feast-registry-rest-api');
+  }
+
+  clickNext() {
+    this.findNextButton().click();
+    return this;
+  }
 }
 
 export const featureStoreCreatePage = new FeatureStoreCreatePage();

--- a/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreAdminLifecycle.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/featureStore/testFeatureStoreAdminLifecycle.cy.ts
@@ -1,0 +1,239 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
+import { deleteOpenShiftProject } from '../../../utils/oc_commands/project';
+import { createCleanProject } from '../../../utils/projectChecker';
+import { retryableBefore, wasSetupPerformed } from '../../../utils/retryableHooks';
+import { generateTestUUID } from '../../../utils/uuidGenerator';
+import { isRHOAI } from '../../../utils/oc_commands/applications';
+import { ensureAdminOcSession, pollUntilSuccess } from '../../../utils/oc_commands/baseCommands';
+import { featureStoreCreatePage } from '../../../pages/featureStore/featureStoreCreate';
+import {
+  featureStoreManagePage,
+  deleteFeatureStoreModal,
+} from '../../../pages/featureStore/featureStoreManage';
+
+const DEV_FLAGS = 'devFeatureFlags=Feature+store+plugin%3Dtrue';
+const APPLICATIONS_NAMESPACE = (): string => Cypress.env('APPLICATIONS_NAMESPACE') || 'opendatahub';
+const DASHBOARD_CONFIG = 'odhdashboardconfig odh-dashboard-config';
+
+const setFeatureStoreAdminFlag = (enabled: boolean): Cypress.Chainable<Cypress.Exec> => {
+  const ns = APPLICATIONS_NAMESPACE();
+  const patchJson = JSON.stringify({
+    spec: { dashboardConfig: { featureStoreAdmin: enabled } },
+  });
+  return cy
+    .exec(`oc patch ${DASHBOARD_CONFIG} -n ${ns} --type=merge -p '${patchJson}'`, {
+      failOnNonZeroExit: false,
+    })
+    .then((result) => {
+      if (result.exitCode !== 0) {
+        throw new Error(`Failed to set featureStoreAdmin to ${enabled}: ${result.stderr}`);
+      }
+      if (enabled) {
+        return pollUntilSuccess(
+          `oc get ${DASHBOARD_CONFIG} -n ${ns} -o json | jq -e '.spec.dashboardConfig.featureStoreAdmin == true'`,
+          'featureStoreAdmin flag to be true',
+          { maxAttempts: 30, pollIntervalMs: 2000 },
+        );
+      }
+      return pollUntilSuccess(
+        `oc get ${DASHBOARD_CONFIG} -n ${ns} -o json | jq -e '.spec.dashboardConfig.featureStoreAdmin == false'`,
+        'featureStoreAdmin flag to be false',
+        { maxAttempts: 30, pollIntervalMs: 2000 },
+      );
+    });
+};
+
+describe('Feature Store Admin Lifecycle (Create → Verify Ready → Delete)', () => {
+  const uuid = generateTestUUID();
+  const projectName = `fs-admin-e2e-${uuid}`;
+  let skipTest = false;
+  let adminFlagWasAlreadyEnabled = false;
+
+  const shouldSkip = () => {
+    if (skipTest) {
+      cy.log('Skipping — Feature Store is RHOAI-specific and not available on ODH.');
+      return true;
+    }
+    return false;
+  };
+
+  retryableBefore(() => {
+    ensureAdminOcSession();
+
+    cy.step('Check if the operator is RHOAI');
+    isRHOAI().then((rhoai) => {
+      if (!rhoai) {
+        skipTest = true;
+      }
+    });
+
+    cy.then(() => {
+      if (skipTest) {
+        return;
+      }
+
+      cy.step('Check if featureStoreAdmin flag is already enabled');
+      cy.exec(
+        `oc get ${DASHBOARD_CONFIG} -n ${APPLICATIONS_NAMESPACE()} -o json | jq -e '.spec.dashboardConfig.featureStoreAdmin == true'`,
+        { failOnNonZeroExit: false },
+      ).then((result) => {
+        if (result.exitCode === 0) {
+          adminFlagWasAlreadyEnabled = true;
+        } else if (result.exitCode !== 1) {
+          throw new Error(
+            `Unexpected error querying featureStoreAdmin flag (exit ${result.exitCode}): ${result.stderr}`,
+          );
+        }
+      });
+
+      cy.then(() => {
+        cy.step(`Create namespace: ${projectName}`);
+        createCleanProject(projectName);
+      });
+
+      cy.then(() => {
+        if (!adminFlagWasAlreadyEnabled) {
+          cy.step('Enable featureStoreAdmin flag');
+          setFeatureStoreAdminFlag(true);
+        }
+      });
+    });
+  });
+
+  after(() => {
+    if (!wasSetupPerformed() || shouldSkip()) {
+      cy.log('Skipping cleanup');
+      return;
+    }
+
+    ensureAdminOcSession();
+
+    cy.step(`Delete namespace: ${projectName}`);
+    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+
+    if (!adminFlagWasAlreadyEnabled) {
+      cy.step('Restore featureStoreAdmin flag to disabled');
+      setFeatureStoreAdminFlag(false);
+    }
+  });
+
+  it(
+    'Creates a feature store via the wizard, verifies it becomes Ready on the manage page, and deletes it',
+    {
+      tags: ['@Dashboard', '@FeatureStore', '@FeatureStoreCI', '@Sanity'],
+      retries: { runMode: 1, openMode: 0 },
+    },
+    () => {
+      if (shouldSkip()) {
+        return;
+      }
+
+      const storeName = `e2e-store-${generateTestUUID()}`;
+
+      // ── Step 1: Create via wizard ──────────────────────────────────────
+      cy.step('Navigate to the create page');
+      cy.visitWithLogin(
+        `/develop-train/feature-store/create?${DEV_FLAGS}`,
+        HTPASSWD_CLUSTER_ADMIN_USER,
+      );
+      cy.findByTestId('app-page-title').should('have.text', 'Create feature store');
+
+      cy.step('Fill in Details step');
+      featureStoreCreatePage.fillProjectName(storeName);
+      featureStoreCreatePage.selectNamespace(projectName);
+      featureStoreCreatePage.findNextButton().should('not.be.disabled');
+      featureStoreCreatePage.clickNext();
+
+      cy.step('Advance through Registry step');
+      featureStoreCreatePage.findStepByName('Registry').should('have.attr', 'aria-current', 'step');
+      featureStoreCreatePage.clickNext();
+
+      cy.step('Advance through Online & offline stores step');
+      featureStoreCreatePage
+        .findStepByName('Online & offline stores')
+        .should('have.attr', 'aria-current', 'step');
+      featureStoreCreatePage.clickNext();
+
+      cy.step('Advance through Advanced options step');
+      featureStoreCreatePage
+        .findStepByName('Advanced options')
+        .should('have.attr', 'aria-current', 'step');
+      featureStoreCreatePage.clickNext();
+
+      cy.step('Submit on Review step');
+      featureStoreCreatePage.findStepByName('Review').should('have.attr', 'aria-current', 'step');
+      featureStoreCreatePage.findSubmitButton().should('not.be.disabled');
+      featureStoreCreatePage.findSubmitButton().click();
+
+      cy.step('Verify redirect to deployment progress page');
+      cy.url({ timeout: 15000 }).should('include', '/create/deploy/');
+
+      // ── Step 2: Wait for FeatureStore CR to be Ready ───────────────────
+      cy.step('Wait for FeatureStore CR to reach Ready phase');
+      pollUntilSuccess(
+        `oc get featurestores.feast.dev ${storeName} -n ${projectName} -o jsonpath='{.status.phase}' | grep -q '^Ready$'`,
+        `FeatureStore/${storeName} to be Ready`,
+        { maxAttempts: 60, pollIntervalMs: 5000 },
+      );
+
+      // ── Step 3: Verify on the manage page ──────────────────────────────
+      cy.step('Navigate to the manage page');
+      cy.visitWithLogin(
+        `/settings/environment-setup/feature-stores?${DEV_FLAGS}`,
+        HTPASSWD_CLUSTER_ADMIN_USER,
+      );
+      cy.findByTestId('app-page-title', { timeout: 15000 }).should(
+        'contain.text',
+        'Feature stores',
+      );
+
+      cy.step('Verify the store appears in the table');
+      featureStoreManagePage.findTable().should('be.visible');
+      featureStoreManagePage.findRowByName(projectName, storeName).should('exist');
+
+      cy.step('Verify Ready status badge');
+      featureStoreManagePage
+        .findRowByName(projectName, storeName)
+        .findByTestId('status-badge-ready')
+        .should('have.text', 'Ready')
+        .and('have.class', 'pf-m-green');
+
+      cy.step('Verify namespace/project column');
+      featureStoreManagePage
+        .findRowByName(projectName, storeName)
+        .should('contain.text', projectName);
+
+      // ── Step 4: Expand row and verify details ──────────────────────────
+      cy.step('Expand the row and verify detail summary');
+      cy.findByTestId(`feature-store-row-${projectName}-${storeName}`)
+        .findByRole('button', { name: 'Details' })
+        .click();
+
+      cy.contains('Feast project').should('be.visible');
+      cy.contains(storeName).should('be.visible');
+      cy.contains('Conditions').should('be.visible');
+
+      // ── Step 5: Delete via the UI ──────────────────────────────────────
+      cy.step('Delete the feature store via kebab menu');
+      featureStoreManagePage.findKebabAction(projectName, storeName, 'Delete').click();
+      deleteFeatureStoreModal.shouldBeOpen(storeName);
+
+      deleteFeatureStoreModal.typeConfirmation(storeName);
+      deleteFeatureStoreModal.findDeleteButton().should('not.be.disabled');
+      deleteFeatureStoreModal.findDeleteButton().click();
+
+      cy.step('Verify the delete dialog closes and the row is removed from the table');
+      cy.findByRole('dialog', { timeout: 10000 }).should('not.exist');
+      cy.findByTestId(`feature-store-row-${projectName}-${storeName}`, { timeout: 15000 }).should(
+        'not.exist',
+      );
+
+      cy.step('Verify the FeatureStore CR is deleted from the cluster');
+      pollUntilSuccess(
+        `oc get featurestores.feast.dev ${storeName} -n ${projectName} 2>&1 | grep -q 'NotFound'`,
+        `FeatureStore/${storeName} to be deleted`,
+        { maxAttempts: 30, pollIntervalMs: 3000 },
+      );
+    },
+  );
+});

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureStoreCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureStoreCreate.cy.ts
@@ -2,26 +2,87 @@ import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashb
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { mockSelfSubjectAccessReview } from '@odh-dashboard/internal/__mocks__/mockSelfSubjectAccessReview';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
-import { FeatureStoreModel, ProjectModel } from '../../../utils/models';
+import {
+  FeatureStoreModel,
+  ProjectModel,
+  SelfSubjectAccessReviewModel,
+} from '../../../utils/models';
 import { asClusterAdminUser } from '../../../utils/mockUsers';
 import { featureStoreCreatePage } from '../../../pages/featureStore/featureStoreCreate';
 
 const NAMESPACE = 'test-ns';
+const OTHER_NAMESPACE = 'other-ns';
 
-const mockProject = () => {
+const mockFeatureStoreCR = (
+  overrides: {
+    name?: string;
+    namespace?: string;
+    feastProject?: string;
+    phase?: string;
+    uiLabel?: boolean;
+  } = {},
+) => {
+  const name = overrides.name ?? 'existing-store';
+  const ns = overrides.namespace ?? NAMESPACE;
+  return {
+    apiVersion: 'feast.dev/v1',
+    kind: 'FeatureStore',
+    metadata: {
+      name,
+      namespace: ns,
+      uid: `uid-${name}`,
+      creationTimestamp: '2026-01-15T10:30:00Z',
+      labels: {
+        ...(overrides.uiLabel ? { 'feature-store-ui': 'enabled' } : {}),
+      },
+    },
+    spec: {
+      feastProject: overrides.feastProject ?? name,
+      services: {
+        registry: {
+          local: { persistence: { file: { path: '/tmp/registry.pb' } } },
+        },
+      },
+    },
+    status: {
+      phase: overrides.phase ?? 'Ready',
+      feastVersion: '0.41.0',
+      serviceHostnames: {
+        registry: `feast-${name}-${ns}-registry.${ns}.svc:6565`,
+      },
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          message: 'FeatureStore installation complete',
+          lastTransitionTime: '2026-01-15T10:31:00Z',
+        },
+      ],
+    },
+  };
+};
+
+const mockProject = (k8sName = NAMESPACE, displayName = 'Test Project', feastLabeled = true) => {
   const project = mockProjectK8sResource({
-    k8sName: NAMESPACE,
-    displayName: 'Test Project',
+    k8sName,
+    displayName,
   });
   project.metadata.labels = {
     ...project.metadata.labels,
-    'opendatahub.io/feast': 'true',
+    ...(feastLabeled ? { 'opendatahub.io/feast': 'true' } : {}),
   };
   return project;
 };
 
-const initIntercepts = ({ enableAdmin = true }: { enableAdmin?: boolean } = {}) => {
+const initIntercepts = ({
+  enableAdmin = true,
+  existingStores = [] as ReturnType<typeof mockFeatureStoreCR>[],
+}: {
+  enableAdmin?: boolean;
+  existingStores?: ReturnType<typeof mockFeatureStoreCR>[];
+} = {}) => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
@@ -39,9 +100,22 @@ const initIntercepts = ({ enableAdmin = true }: { enableAdmin?: boolean } = {}) 
     }),
   );
 
-  cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProject()]));
+  // Two projects so SimpleSelect does not auto-select and disable the namespace toggle.
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProject(), mockProject(OTHER_NAMESPACE, 'Other Project', false)]),
+  );
 
-  cy.interceptK8sList({ model: FeatureStoreModel, ns: NAMESPACE }, mockK8sResourceList([]));
+  cy.interceptK8sList(
+    { model: FeatureStoreModel, ns: NAMESPACE },
+    mockK8sResourceList(existingStores),
+  );
+  cy.interceptK8sList({ model: FeatureStoreModel, ns: OTHER_NAMESPACE }, mockK8sResourceList([]));
+
+  cy.interceptK8s('POST', SelfSubjectAccessReviewModel, (req) => {
+    const { resourceAttributes } = req.body.spec;
+    req.reply(mockSelfSubjectAccessReview({ ...resourceAttributes, allowed: true }));
+  });
 };
 
 describe('Feature Store Create Page', () => {
@@ -98,6 +172,120 @@ describe('Feature Store Create Page', () => {
       );
 
       cy.findByTestId('app-page-title').should('not.have.text', 'Create feature store');
+    });
+  });
+
+  describe('step validation gating', () => {
+    it('should disable Next when name is empty and enable it when a valid name and namespace are provided', () => {
+      featureStoreCreatePage.visit();
+
+      featureStoreCreatePage.findNextButton().should('be.disabled');
+
+      featureStoreCreatePage.fillProjectName('my-store');
+      featureStoreCreatePage.selectNamespace(NAMESPACE);
+
+      featureStoreCreatePage.findNextButton().should('not.be.disabled');
+    });
+
+    it('should disable Next when name contains invalid characters', () => {
+      featureStoreCreatePage.visit();
+
+      featureStoreCreatePage.fillProjectName('INVALID_NAME!');
+      featureStoreCreatePage.selectNamespace(NAMESPACE);
+
+      featureStoreCreatePage.findProjectNameError().should('exist');
+      featureStoreCreatePage.findNextButton().should('be.disabled');
+    });
+  });
+
+  describe('duplicate name detection', () => {
+    it('should show an error and disable Next when typing an existing feature store name', () => {
+      asClusterAdminUser();
+      initIntercepts({
+        existingStores: [
+          mockFeatureStoreCR({ name: 'existing-proj', feastProject: 'existing-proj' }),
+        ],
+      });
+
+      featureStoreCreatePage.visit();
+
+      featureStoreCreatePage.fillProjectName('existing-proj');
+      featureStoreCreatePage.selectNamespace(NAMESPACE);
+
+      featureStoreCreatePage.findProjectNameError().should('exist');
+      cy.contains('A feature store with this name already exists.').should('be.visible');
+      featureStoreCreatePage.findNextButton().should('be.disabled');
+    });
+  });
+
+  describe('secondary store auto-config', () => {
+    it('should auto-select remote registry and pre-fill feastRef when a primary store exists', () => {
+      const primaryStore = mockFeatureStoreCR({
+        name: 'primary-store',
+        feastProject: 'primary-project',
+        uiLabel: true,
+      });
+
+      asClusterAdminUser();
+      initIntercepts({ existingStores: [primaryStore] });
+
+      featureStoreCreatePage.visit();
+
+      featureStoreCreatePage.fillProjectName('secondary-store');
+      featureStoreCreatePage.selectNamespace(NAMESPACE);
+      featureStoreCreatePage.clickNext();
+
+      featureStoreCreatePage.findRegistryTypeRadio('remote').should('be.checked');
+      featureStoreCreatePage.findRegistryTypeRadio('local').should('be.disabled');
+
+      featureStoreCreatePage.findFeastRefNameInput().should('have.value', 'primary-store');
+    });
+  });
+
+  describe('happy path submit', () => {
+    it('should fill all steps and submit the form successfully', () => {
+      const createdCR = mockFeatureStoreCR({
+        name: 'my-new-store',
+        feastProject: 'my-new-store',
+      });
+
+      cy.interceptK8s('POST', { model: FeatureStoreModel, ns: NAMESPACE }, createdCR).as(
+        'createFeatureStore',
+      );
+
+      featureStoreCreatePage.visit();
+
+      featureStoreCreatePage.fillProjectName('my-new-store');
+      featureStoreCreatePage.selectNamespace(NAMESPACE);
+      featureStoreCreatePage.clickNext();
+
+      featureStoreCreatePage.findStepByName('Registry').should('have.attr', 'aria-current', 'step');
+      featureStoreCreatePage.clickNext();
+
+      featureStoreCreatePage
+        .findStepByName('Online & offline stores')
+        .should('have.attr', 'aria-current', 'step');
+      featureStoreCreatePage.clickNext();
+
+      featureStoreCreatePage
+        .findStepByName('Advanced options')
+        .should('have.attr', 'aria-current', 'step');
+      featureStoreCreatePage.clickNext();
+
+      featureStoreCreatePage.findStepByName('Review').should('have.attr', 'aria-current', 'step');
+
+      featureStoreCreatePage.findSubmitButton().should('not.be.disabled');
+      featureStoreCreatePage.findSubmitButton().click();
+
+      cy.wait('@createFeatureStore').then((interception) => {
+        expect(interception.request.body).to.have.nested.property(
+          'spec.feastProject',
+          'my-new-store',
+        );
+        expect(interception.request.body).to.have.nested.property('metadata.namespace', NAMESPACE);
+      });
+
+      cy.url().should('include', '/create/deploy/');
     });
   });
 });

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureStoreManage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureStoreManage.cy.ts
@@ -3,9 +3,14 @@ import { mockDashboardConfig } from '@odh-dashboard/k8s-core/__mocks__/mockDashb
 import { mockDscStatus } from '@odh-dashboard/plugin-core/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import { mockProjectK8sResource } from '@odh-dashboard/k8s-core/__mocks__/mockProjectK8sResource';
+import { mockSelfSubjectAccessReview } from '@odh-dashboard/internal/__mocks__/mockSelfSubjectAccessReview';
 import { DataScienceStackComponent } from '@odh-dashboard/plugin-core/areas';
-import { FeatureStoreModel, ProjectModel } from '../../../utils/models';
-import { asClusterAdminUser } from '../../../utils/mockUsers';
+import {
+  FeatureStoreModel,
+  ProjectModel,
+  SelfSubjectAccessReviewModel,
+} from '../../../utils/models';
+import { asClusterAdminUser, asProjectEditUser } from '../../../utils/mockUsers';
 import {
   featureStoreManagePage,
   deleteFeatureStoreModal,
@@ -32,7 +37,7 @@ const mockFeatureStoreCR = (
     metadata: {
       name,
       namespace: ns,
-      uid: `uid-${name}`,
+      uid: `uid-${ns}-${name}`,
       creationTimestamp: overrides.creationTimestamp ?? '2026-01-15T10:30:00Z',
       labels: {
         ...(overrides.uiLabel !== false && { 'feature-store-ui': 'enabled' }),
@@ -322,6 +327,192 @@ describe('Feature Store Manage Page', () => {
         'contain.text',
         'and all of its associated resources will be permanently deleted',
       );
+    });
+  });
+
+  describe('status badge colors', () => {
+    it('should render correct badge colors for Ready, Failed, and Installing phases', () => {
+      const readyStore = mockFeatureStoreCR({
+        name: 'store-ready',
+        feastProject: 'ready_project',
+        phase: 'Ready',
+      });
+      const failedStore = mockFeatureStoreCR({
+        name: 'store-failed',
+        feastProject: 'failed_project',
+        phase: 'Failed',
+        uiLabel: false,
+      });
+      const installingStore = mockFeatureStoreCR({
+        name: 'store-installing',
+        feastProject: 'installing_project',
+        phase: 'Installing',
+        uiLabel: false,
+      });
+
+      asClusterAdminUser();
+      initIntercepts({
+        featureStores: [readyStore, failedStore, installingStore],
+      });
+
+      featureStoreManagePage.visit();
+
+      featureStoreManagePage
+        .findRowByName(NAMESPACE, 'store-ready')
+        .findByTestId('status-badge-ready')
+        .should('have.text', 'Ready')
+        .and('have.class', 'pf-m-green');
+
+      featureStoreManagePage
+        .findRowByName(NAMESPACE, 'store-failed')
+        .findByTestId('status-badge-failed')
+        .should('have.text', 'Failed')
+        .and('have.class', 'pf-m-red');
+
+      featureStoreManagePage
+        .findRowByName(NAMESPACE, 'store-installing')
+        .findByTestId('status-badge-installing')
+        .should('have.text', 'Installing')
+        .and('have.class', 'pf-m-blue');
+    });
+  });
+
+  describe('cross-namespace same name', () => {
+    it('should display two stores with the same name in different namespaces', () => {
+      const ns2 = 'other-ns';
+      const project2 = mockProjectK8sResource({
+        k8sName: ns2,
+        displayName: 'Other Project',
+      });
+      project2.metadata.labels = {
+        ...project2.metadata.labels,
+        'opendatahub.io/feast': 'true',
+      };
+
+      const store1 = mockFeatureStoreCR({
+        name: 'my-store',
+        namespace: NAMESPACE,
+        feastProject: 'my_store_ns1',
+      });
+      const store2 = mockFeatureStoreCR({
+        name: 'my-store',
+        namespace: ns2,
+        feastProject: 'my_store_ns2',
+        uiLabel: false,
+      });
+
+      asClusterAdminUser();
+
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+          },
+        }),
+      );
+
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          disableFeatureStore: false,
+          featureStoreAdmin: true,
+        }),
+      ).as('odh-config');
+
+      cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProject(), project2]));
+
+      cy.interceptK8sList(
+        { model: FeatureStoreModel, ns: NAMESPACE },
+        mockK8sResourceList([store1]),
+      );
+      cy.interceptK8sList({ model: FeatureStoreModel, ns: ns2 }, mockK8sResourceList([store2]));
+
+      featureStoreManagePage.visit();
+
+      featureStoreManagePage.findRowByName(NAMESPACE, 'my-store').should('exist');
+      featureStoreManagePage.findRowByName(ns2, 'my-store').should('exist');
+
+      featureStoreManagePage.findRowByName(NAMESPACE, 'my-store').should('contain.text', NAMESPACE);
+      featureStoreManagePage.findRowByName(ns2, 'my-store').should('contain.text', ns2);
+    });
+  });
+
+  describe('RBAC viewer', () => {
+    const viewerStores = [
+      mockFeatureStoreCR({
+        name: 'viewer-store',
+        feastProject: 'viewer_project',
+        phase: 'Ready',
+      }),
+    ];
+
+    const initViewerIntercepts = () => {
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+          },
+        }),
+      );
+
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({
+          disableFeatureStore: false,
+          featureStoreAdmin: true,
+        }),
+      ).as('odh-config');
+
+      cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProject()]));
+
+      cy.interceptK8sList(
+        { model: FeatureStoreModel, ns: NAMESPACE },
+        mockK8sResourceList(viewerStores),
+      );
+
+      // AccessReviewProvider defaults undefined namespace to dashboardNamespace
+      // (opendatahub). Allow list (needed by the route gate) but deny
+      // create/delete so the RBAC viewer assertions hold.
+      cy.interceptK8s('POST', SelfSubjectAccessReviewModel, (req) => {
+        const { resourceAttributes } = req.body.spec;
+        const allowed =
+          resourceAttributes.resource === 'featurestores' && resourceAttributes.verb === 'list';
+        req.reply(mockSelfSubjectAccessReview({ ...resourceAttributes, allowed }));
+      });
+    };
+
+    it('should hide Create button and disable Delete action when user lacks create/delete permissions', () => {
+      asProjectEditUser();
+      initViewerIntercepts();
+
+      featureStoreManagePage.visit();
+
+      featureStoreManagePage.findTable().should('be.visible');
+      featureStoreManagePage.findRowByName(NAMESPACE, 'viewer-store').should('exist');
+
+      cy.findByTestId('create-feature-store-toolbar-btn').should('not.exist');
+
+      featureStoreManagePage
+        .findRowByName(NAMESPACE, 'viewer-store')
+        .findByRole('button', { name: /kebab toggle/i })
+        .click();
+      cy.findByRole('menuitem', { name: 'Delete' }).should('have.attr', 'aria-disabled', 'true');
+    });
+
+    it('should allow expanding rows even without create/delete permissions', () => {
+      asProjectEditUser();
+      initViewerIntercepts();
+
+      featureStoreManagePage.visit();
+
+      cy.findByTestId(`feature-store-row-${NAMESPACE}-viewer-store`)
+        .findByRole('button', { name: 'Details' })
+        .click();
+
+      cy.contains('Feast project').should('be.visible');
+      cy.contains('viewer_project').should('be.visible');
     });
   });
 

--- a/packages/feature-store/src/screens/create/steps/ProjectBasicsStep.tsx
+++ b/packages/feature-store/src/screens/create/steps/ProjectBasicsStep.tsx
@@ -97,12 +97,12 @@ const ProjectBasicsStep: React.FC<ProjectBasicsStepProps> = ({
           <FormHelperText>
             <HelperText>
               {!nameValid ? (
-                <HelperTextItem variant="error">
+                <HelperTextItem variant="error" data-testid="feast-project-name-error">
                   Must consist of lowercase alphanumeric characters, &apos;-&apos; or &apos;.&apos;,
                   and must start and end with an alphanumeric character.
                 </HelperTextItem>
               ) : nameIsDuplicate ? (
-                <HelperTextItem variant="error">
+                <HelperTextItem variant="error" data-testid="feast-project-name-error">
                   A feature store with this name already exists.
                 </HelperTextItem>
               ) : (

--- a/packages/feature-store/src/screens/create/steps/RegistryStep.tsx
+++ b/packages/feature-store/src/screens/create/steps/RegistryStep.tsx
@@ -159,6 +159,7 @@ const RegistryStep: React.FC<RegistryStepProps> = ({
           <Stack hasGutter>
             <Radio
               id="registry-local"
+              data-testid="feast-registry-local"
               name="registry-type"
               label="Local registry"
               description={
@@ -172,6 +173,7 @@ const RegistryStep: React.FC<RegistryStepProps> = ({
             />
             <Radio
               id="registry-remote"
+              data-testid="feast-registry-remote"
               name="registry-type"
               label="Remote registry"
               description="Use a registry from another feature store or external hostname."

--- a/packages/feature-store/src/screens/manage/FeatureStoreTableRow.tsx
+++ b/packages/feature-store/src/screens/manage/FeatureStoreTableRow.tsx
@@ -50,15 +50,32 @@ const resolveEffectivePhase = (
 };
 
 const phaseLabel = (phase: string): React.ReactNode => {
+  const testId = `status-badge-${phase.toLowerCase()}`;
   switch (phase) {
     case 'Ready':
-      return <Label color="green">Ready</Label>;
+      return (
+        <Label color="green" data-testid={testId}>
+          Ready
+        </Label>
+      );
     case 'Failed':
-      return <Label color="red">Failed</Label>;
+      return (
+        <Label color="red" data-testid={testId}>
+          Failed
+        </Label>
+      );
     case 'Installing':
-      return <Label color="blue">Installing</Label>;
+      return (
+        <Label color="blue" data-testid={testId}>
+          Installing
+        </Label>
+      );
     default:
-      return <Label color="purple">{phase}</Label>;
+      return (
+        <Label color="purple" data-testid={testId}>
+          {phase}
+        </Label>
+      );
   }
 };
 
@@ -221,7 +238,7 @@ const FeatureStoreTableRow: React.FC<FeatureStoreTableRowProps> = ({
             items={[
               {
                 title: 'Delete',
-                isDisabled: !canDelete,
+                isAriaDisabled: !canDelete,
                 tooltipProps: !canDelete
                   ? { content: 'You do not have permission to delete feature stores.' }
                   : undefined,

--- a/packages/feature-store/src/screens/manage/__tests__/FeatureStoreTableRow.spec.tsx
+++ b/packages/feature-store/src/screens/manage/__tests__/FeatureStoreTableRow.spec.tsx
@@ -161,26 +161,15 @@ describe('FeatureStoreTableRow', () => {
       expect(onDeleteMock).toHaveBeenCalledWith(baseFeatureStore);
     });
 
-    it('should disable Delete action when canDelete is false', async () => {
-      const onDeleteMock = jest.fn();
-      const user = userEvent.setup();
-      renderRow({ canDelete: false, onDelete: onDeleteMock });
-
-      const kebab = screen.getByRole('button', { name: 'Kebab toggle' });
-      await user.click(kebab);
-      const deleteItem = await screen.findByRole('menuitem', { name: 'Delete' });
-      await user.click(deleteItem);
-
-      expect(onDeleteMock).not.toHaveBeenCalled();
-    });
-
-    it('should show tooltip on disabled Delete action explaining permission restriction', async () => {
+    it('should disable Delete and show permission tooltip when canDelete is false', async () => {
       const user = userEvent.setup();
       renderRow({ canDelete: false });
 
       const kebab = screen.getByRole('button', { name: 'Kebab toggle' });
       await user.click(kebab);
       const deleteItem = await screen.findByRole('menuitem', { name: 'Delete' });
+
+      expect(deleteItem).toHaveAttribute('aria-disabled', 'true');
       await user.hover(deleteItem);
 
       await waitFor(() => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-61270

## Description

Add comprehensive Cypress test coverage for the Feature Store creation wizard and management page (settings). This includes mocked tests for form validation, submission, RBAC gating, and status rendering, as well as a real E2E lifecycle test that creates a feature store via the wizard, waits for it to become Ready, verifies it on the manage page, and deletes it through the UI.


## How Has This Been Tested?
- All modified files pass `tsc --noEmit` (zero type errors) and `eslint --max-warnings 0` (zero lint errors).
- Mocked tests are validated through compilation and can be run with `npx cypress run --spec "packages/cypress/cypress/tests/mocked/featureStore/*.cy.ts"`.
- E2E test requires a RHOAI cluster with the Feast operator deployed.

## Test Impact

This PR is entirely test additions - 8 new mocked test cases and 1 new E2E lifecycle test covering previously untested scenarios (wizard validation, form submission, badge rendering, cross-namespace display, RBAC gating, and full admin CRUD lifecycle).

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Feature Store Improvements**
  - Enhanced the creation wizard with clearer validation for project names, namespaces, registry options, duplicate names, and secondary-store configuration.
  - Improved status indicators and accessibility for unavailable Delete actions.
  - Added support for managing stores with identical names across namespaces.
  - Strengthened permissions so viewers can inspect and expand stores but cannot create or delete Feature Stores.
- **Testing**
  - Expanded coverage for creating, monitoring, managing, and deleting Feature Stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->