### PR TITLE
feat(RHOAIENG-83620): keep catalog tool calling GA, wizard behind flag

### DIFF
--- a/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -188,7 +188,7 @@ spec:
                       description: 'When true, enables the Agents Catalog page.'
                     toolCalling:
                       type: boolean
-                      description: 'When true, enables tool-calling configuration for supported models in the model catalog and the deployment wizard.'
+                      description: 'When true, enables the tool-calling checkbox in the deployment wizard for catalog models that have validated tool-calling arguments. Catalog labels, filters, and details are always available. Tech Preview.'
                     modelCapabilities:
                       type: boolean
                       description: 'When true, enables model capabilities selection in the deployment wizard and the Capabilities column on the deployments table.'

--- a/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/base/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -188,7 +188,7 @@ spec:
                       description: 'When true, enables the Agents Catalog page.'
                     toolCalling:
                       type: boolean
-                      description: 'When true, enables the tool-calling checkbox in the deployment wizard for catalog models that have validated tool-calling arguments. Catalog labels, filters, and details are always available. Tech Preview.'
+                      description: 'When true, enables the tool-calling checkbox in the deployment wizard for catalog models that have validated tool-calling arguments.'
                     modelCapabilities:
                       type: boolean
                       description: 'When true, enables model capabilities selection in the deployment wizard and the Capabilities column on the deployments table.'

--- a/packages/cypress/cypress/tests/e2e/modelCatalog/testCatalogToolCalling.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelCatalog/testCatalogToolCalling.cy.ts
@@ -29,15 +29,10 @@ describe('Verify tool calling configuration in Model Catalog', () => {
 
   it(
     'Tool calling labels, filter, and validated arguments card are displayed',
-    { tags: ['@Dashboard', '@ModelCatalog', '@Featureflagged'] },
+    { tags: ['@Dashboard', '@ModelCatalog'] },
     () => {
       cy.step('Login as admin');
       cy.visitWithLogin('/', LDAP_ADMIN_USER);
-
-      cy.step('Enable toolCalling feature flag');
-      cy.window().then((win) => {
-        win.sessionStorage.setItem('odh-feature-flags', '{"toolCalling":true}');
-      });
 
       cy.step('Navigate to Model Catalog');
       modelCatalog.visit();

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
@@ -26,7 +26,6 @@ import {
   MODEL_CATALOG_POPOVER_MESSAGES,
   CATALOG_VALUE_LABEL_KEYS,
 } from '~/concepts/modelCatalog/const';
-import useModelRegistryDashboardConfig from '~/app/hooks/useModelRegistryDashboardConfig';
 import { useUserInteraction } from '~/concepts/userInteraction';
 import { MODEL_CATALOG_EVENTS } from '~/app/pages/modelCatalog/tracking';
 import ModelCatalogLabels from './ModelCatalogLabels';
@@ -44,7 +43,6 @@ const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) =>
     : [];
   const isValidated = isModelValidated(model);
   const isRedHat = isRedHatModel(model);
-  const { toolCalling: isToolCallingEnabled } = useModelRegistryDashboardConfig();
   const { trackSimpleEvent } = useUserInteraction();
 
   const handleValidatedLabelClicked = React.useCallback(() => {
@@ -116,7 +114,7 @@ const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) =>
       <CardFooter>
         <ModelCatalogLabels
           tasks={model.tasks ?? []}
-          validatedTasks={isToolCallingEnabled ? model.validatedTasks : undefined}
+          validatedTasks={model.validatedTasks}
           provider={model.provider}
           labels={[...allLabels.filter((label) => label !== 'validated'), ...valueLabels]}
           numLabels={isValidated ? 2 : 3}

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
@@ -13,7 +13,6 @@ import {
   MODEL_CATALOG_MIDDLE_EASTERN_AND_OTHER_LANGUAGES_DETAILS,
   ModelCatalogTensorType,
 } from '~/concepts/modelCatalog/const';
-import useModelRegistryDashboardConfig from '~/app/hooks/useModelRegistryDashboardConfig';
 import { useUserInteraction } from '~/concepts/userInteraction';
 import {
   CatalogFilterPanel,
@@ -52,22 +51,7 @@ const LABEL_MAPPINGS: Record<string, Record<string, string>> = {
 const ModelCatalogFilters: React.FC = () => {
   const { filterOptions, filterOptionsLoaded, filterOptionsLoadError, filters, setFilters } =
     React.useContext(ModelCatalogContext);
-  const { toolCalling: toolCallingFeatureAvailable } = useModelRegistryDashboardConfig();
   const { trackSimpleEvent } = useUserInteraction();
-
-  React.useEffect(() => {
-    if (
-      !toolCallingFeatureAvailable &&
-      filters[ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION].length > 0
-    ) {
-      setFilters((prev) => ({
-        ...prev,
-        [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: [],
-      }));
-    }
-    // Only react to flag changes — including filters would cause an infinite loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [toolCallingFeatureAvailable]);
 
   const onFilterChange = React.useCallback(
     (key: string, values: string[]) => {
@@ -125,7 +109,6 @@ const ModelCatalogFilters: React.FC = () => {
         const hasSelection = item.selectedValues.length > 0;
         return {
           ...itemWithTestIds,
-          visible: toolCallingFeatureAvailable,
           footer:
             hasMultiple && hasSelection ? (
               <Content component={ContentVariants.small} className="pf-v6-u-mt-sm">
@@ -168,7 +151,7 @@ const ModelCatalogFilters: React.FC = () => {
 
     items.splice(insertIndex, 0, ...sliderItems);
     return items;
-  }, [baseFilterItems, toolCallingFeatureAvailable]);
+  }, [baseFilterItems]);
 
   return (
     <CatalogFilterPanel

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -57,7 +57,6 @@ import {
   MODEL_CATALOG_VALIDATED_CONFIGURATION_NAME_MAPPING,
   ValidatedConfiguration,
 } from '~/concepts/modelCatalog/const';
-import useModelRegistryDashboardConfig from '~/app/hooks/useModelRegistryDashboardConfig';
 import { useUserInteraction } from '~/concepts/userInteraction';
 import CodeBlockComponent from '~/app/shared/markdown/components/CodeBlockComponent';
 import { MODEL_CATALOG_EVENTS } from '~/app/pages/modelCatalog/tracking';
@@ -80,9 +79,8 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
     ? getValueLabels(model.customProperties, CATALOG_VALUE_LABEL_KEYS)
     : [];
   const isValidated = isModelValidated(model);
-  const { toolCalling: isToolCallingEnabled } = useModelRegistryDashboardConfig();
   const { trackSimpleEvent } = useUserInteraction();
-  const isToolCallingValidated = isToolCallingEnabled && hasValidatedToolCalling(model);
+  const isToolCallingValidated = hasValidatedToolCalling(model);
 
   const validatedOnPlatforms = getValidatedOnPlatforms(model.customProperties);
   const validatedDeploymentResources = getValidatedDeploymentResources(model.customProperties);
@@ -273,7 +271,7 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
                       <DescriptionListDescription>
                         <ModelCatalogLabels
                           tasks={model.tasks ?? []}
-                          validatedTasks={isToolCallingEnabled ? model.validatedTasks : undefined}
+                          validatedTasks={model.validatedTasks}
                           labels={[
                             ...allLabels.filter((label) => label !== 'validated'),
                             ...valueLabels,

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -225,9 +225,9 @@ export const getToolCallingArgs = (config?: ToolCallingConfig): string => {
 
 /**
  * Builds the `validatedConfigurations` entries to prefill into the deployment wizard for a
- * catalog model. Each supported validated configuration (currently just tool calling) is
- * responsible for its own gating here — the wizard itself renders whatever it receives, with
- * no knowledge of individual feature flags or model fields.
+ * catalog model. Catalog UI (labels, filters, details card) is always on. Wizard prefill is
+ * gated here — currently tool calling is included only when the `toolCalling` flag is on and
+ * the model has validated tool-calling args. The wizard renders whatever it receives.
  *
  * Returns both the available configurations and a pre-selection record so that validated
  * options are checked by default when the wizard opens.

--- a/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/preconfigureValidatedArguments.cy.ts
@@ -66,7 +66,7 @@ const catalogModel = {
 };
 /* eslint-enable camelcase */
 
-const initIntercepts = () => {
+const initIntercepts = ({ toolCalling = true }: { toolCalling?: boolean } = {}) => {
   asProductAdminUser();
 
   cy.interceptOdh(
@@ -88,7 +88,7 @@ const initIntercepts = () => {
       disableKServe: false,
       disableModelCatalog: false,
       disableModelRegistry: false,
-      toolCalling: true,
+      toolCalling,
       vLLMDeploymentOnMaaS: true,
     }),
   );
@@ -300,5 +300,14 @@ describe('Preconfigure deployment validated arguments', () => {
 
     modelServingWizard.findAdvancedOptionsStep().click();
     modelServingWizard.findRuntimeArgsTextBox().should('have.value', '--user-custom-arg');
+  });
+
+  it('should not show the tool calling checkbox when the toolCalling flag is off', () => {
+    initIntercepts({ toolCalling: false });
+    modelDetailsPage.visit(SOURCE_ID, MODEL_NAME);
+    modelCatalog.clickDeployModelButtonWithRetry();
+    modelServingWizard.findPreconfigureStep().should('be.enabled');
+    modelServingWizard.findValidatedConfigurationSection('args').should('not.exist');
+    modelServingWizard.findValidatedConfigurationOption('tool-calling').should('not.exist');
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-83620

## Description

Catalog tool calling is GA in 3.5. The same `toolCalling` flag also gated the deployment wizard checkbox, so turning the flag on for catalog leaked the wizard TP UI.

This change stops reading `toolCalling` in catalog UI (labels, Validated arguments filter, details card). Those surfaces always follow model data.

The wizard checkbox stays behind `toolCalling` (default false). Catalog deploy only prefills validated configs when **both** are true:

- `toolCalling` is on
- the catalog model has validated tool-calling args (`validatedTasks` includes `tool-calling` and `servingConfig.toolCalling.toolCallParser` is set)

If the flag is off, or the model has no catalog validated args, the checkbox is not shown.

CRD copy is updated so the flag describes wizard prefill only, not catalog.

## How Has This Been Tested?

- Lint on changed files
- Type-check for frontend, model-registry, and model-serving
- Unit tests: `@odh-dashboard/internal` (includes WhatsNew), `@odh-dashboard/model-serving` (454 tests, including preconfigure / validated configs), `modelCatalogUtils.spec.ts` (143 tests, including flag-off returning no wizard prefill)
- `npm run build` for backend + frontend

Not yet verified on a cluster with the PR image.

To verify locally:

1. Catalog (flag off): open Model Catalog. Models with validated tool calling still show the label, Validated arguments filter, and details card.
2. Wizard, flag off: deploy a catalog model that has validated tool-calling args. Preconfigure has no Tool calling checkbox.
3. Wizard, flag on (`toolCalling: true` in OdhDashboardConfig or session feature flags): same deploy path. Tool calling checkbox is present, checked by default, and writes runtime args.

## Test Impact

- E2E `testCatalogToolCalling.cy.ts`: dropped sessionStorage flag enable and `@Featureflagged` so catalog coverage runs without the flag
- Mocked Cypress `preconfigureValidatedArguments.cy.ts`: existing tests still set `toolCalling: true`; added a case that flag off hides the checkbox even when catalog has validated args
- Existing unit test still asserts `getValidatedConfigurationsForModel` returns `{}` when the flag is off

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Clarified that the **Tool Calling** dashboard setting controls the tool-calling checkbox in the deployment wizard for catalog models with validated tool-calling arguments.
  - Tool-calling catalog and model details remain available without requiring a separate feature flag.

- **Bug Fixes**
  - Ensured disabling Tool Calling hides the validated-arguments configuration section and checkbox as expected.
  - Added coverage confirming the setting’s disabled behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->