### PR TITLE
fix(RHOAIENG-82728): query DSC status for About dialog version validation

### DIFF
--- a/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
@@ -2,8 +2,8 @@ import { DataScienceStackComponentMap } from '@odh-dashboard/plugin-core/areas';
 import { aboutDialog } from '../../../pages/aboutDialog';
 import {
   getCsvByDisplayName,
+  getDscComponentVersions,
   getInstalledProductName,
-  getResourceVersionByName,
   getSubscriptionChannelFromCsv,
   getVersionFromCsv,
 } from '../../../utils/oc_commands/applications';
@@ -15,6 +15,7 @@ const dataScienceStackComponentMap = DataScienceStackComponentMap;
 describe('Verify RHODS About Dialog', () => {
   let odhCsv: Record<string, unknown>;
   let productName: string;
+  let dscVersions: Partial<Record<string, string[]>>;
 
   retryableBefore(async () => {
     cy.log('Auto-detecting installed product (RHOAI or ODH)...');
@@ -26,6 +27,9 @@ describe('Verify RHODS About Dialog', () => {
       getCsvByDisplayName(productName, 'default').then((csv) => {
         odhCsv = csv as Record<string, unknown>;
       });
+    });
+    getDscComponentVersions().then((versions) => {
+      dscVersions = versions;
     });
   });
 
@@ -75,19 +79,18 @@ describe('Verify RHODS About Dialog', () => {
       aboutDialog.isAdminAccessLevel();
 
       aboutDialog.findTable().then(() => {
-        Object.entries(dataScienceStackComponentMap).forEach(([, component]) => {
-          cy.step(`Verify versions in About dialog's table for component: ${component}`);
-          aboutDialog.getComponentReleasesText(component).then((texts) => {
-            getResourceVersionByName(component).then((version) => {
-              if (version.length === 0) {
-                return;
-              }
-              const text = texts.join(' ');
-              expect(version.some((v) => text.includes(v))).to.equal(
-                true,
-                `Version ${version} not found for component ${component}`,
-              );
-            });
+        Object.entries(dataScienceStackComponentMap).forEach(([componentKey, displayName]) => {
+          const versions = dscVersions[componentKey];
+          if (!versions) {
+            return;
+          }
+          cy.step(`Verify versions in About dialog's table for component: ${displayName}`);
+          aboutDialog.getComponentReleasesText(displayName).then((texts) => {
+            const text = texts.join(' ');
+            expect(versions.some((v) => text.includes(v))).to.equal(
+              true,
+              `Version ${versions} not found for component ${displayName}`,
+            );
           });
         });
       });

--- a/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
@@ -89,7 +89,7 @@ describe('Verify RHODS About Dialog', () => {
             const text = texts.join(' ');
             expect(versions.some((v) => text.includes(v))).to.equal(
               true,
-              `Version ${versions} not found for component ${displayName}`,
+              `Version ${versions.join(', ')} not found for component ${displayName}`,
             );
           });
         });

--- a/packages/cypress/cypress/utils/oc_commands/applications.ts
+++ b/packages/cypress/cypress/utils/oc_commands/applications.ts
@@ -30,27 +30,6 @@ export const getOcResourceNames = (
 };
 
 /**
- * Get the version of a resource by its name.
- *
- * @param resourceName - The name of the resource to retrieve the version for.
- * @returns A Cypress.Chainable that resolves to the version of the resource.
- */
-export const getResourceVersionByName = (resourceName: string): Cypress.Chainable<string[]> => {
-  const ocCommand = `oc get ${resourceName.replace(
-    /\s/g,
-    '',
-  )} -A -o jsonpath='{.items[*].status.releases[*].version}'`;
-  return execWithOutput(ocCommand).then(({ exitCode, stdout, stderr }) => {
-    if (exitCode !== 0) {
-      cy.log(`Failed to retrieve version of ${resourceName}:\n${stdout}\n${stderr}`);
-      return cy.wrap<string[]>([]);
-    }
-    cy.log(`Retrieved version of ${resourceName}:\n${stdout}\n${stderr}`);
-    return cy.wrap(stdout.trim().split(' '));
-  });
-};
-
-/**
  * Retrieve component release versions from the DataScienceCluster status.
  *
  * Queries the same source the UI uses (DSC .status.components), filters out
@@ -62,14 +41,23 @@ export const getDscComponentVersions = (): Cypress.Chainable<Record<string, stri
   const ocCommand = `oc get DataScienceCluster -A -o json`;
   return execWithOutput(ocCommand).then(({ exitCode, stdout, stderr }) => {
     if (exitCode !== 0 || !stdout.trim()) {
-      cy.log(`Failed to retrieve DSC component versions:\n${stderr}`);
-      return cy.wrap<Record<string, string[]>>({});
+      throw new Error(
+        `Failed to retrieve DSC component versions (exit code ${exitCode}): ${stderr}`,
+      );
     }
     const dsc = JSON.parse(stdout);
-    const components: Record<
-      string,
-      { managementState?: string; releases?: Array<{ version?: string }> }
-    > = dsc.items?.[0]?.status?.components ?? {};
+    const items: Array<{
+      status?: {
+        components?: Record<
+          string,
+          { managementState?: string; releases?: Array<{ version?: string }> }
+        >;
+      };
+    }> = dsc.items ?? [];
+    if (items.length === 0) {
+      throw new Error('No DataScienceCluster resources found on the cluster');
+    }
+    const components = items[0].status?.components ?? {};
     const result: Record<string, string[]> = {};
 
     Object.entries(components).forEach(([key, details]) => {

--- a/packages/cypress/cypress/utils/oc_commands/applications.ts
+++ b/packages/cypress/cypress/utils/oc_commands/applications.ts
@@ -51,6 +51,45 @@ export const getResourceVersionByName = (resourceName: string): Cypress.Chainabl
 };
 
 /**
+ * Retrieve component release versions from the DataScienceCluster status.
+ *
+ * Queries the same source the UI uses (DSC .status.components), filters out
+ * components with managementState 'Removed' and releases with version 'unknown'.
+ *
+ * @returns A map of component key to non-empty array of version strings.
+ */
+export const getDscComponentVersions = (): Cypress.Chainable<Record<string, string[]>> => {
+  const ocCommand = `oc get DataScienceCluster -A -o json`;
+  return execWithOutput(ocCommand).then(({ exitCode, stdout, stderr }) => {
+    if (exitCode !== 0 || !stdout.trim()) {
+      cy.log(`Failed to retrieve DSC component versions:\n${stderr}`);
+      return cy.wrap<Record<string, string[]>>({});
+    }
+    const dsc = JSON.parse(stdout);
+    const components: Record<
+      string,
+      { managementState?: string; releases?: Array<{ version?: string }> }
+    > = dsc.items?.[0]?.status?.components ?? {};
+    const result: Record<string, string[]> = {};
+
+    Object.entries(components).forEach(([key, details]) => {
+      if (details.managementState === 'Removed') {
+        return;
+      }
+      const versions = (details.releases ?? [])
+        .map((r) => r.version)
+        .filter((v): v is string => !!v && v !== 'unknown');
+      if (versions.length > 0) {
+        result[key] = versions;
+      }
+    });
+
+    cy.log(`Retrieved DSC component versions: ${JSON.stringify(result)}`);
+    return cy.wrap(result);
+  });
+};
+
+/**
  * Get CSV JSON by its display name, considering active subscriptions.
  *
  * @param displayName - The display name of the product to retrieve the CSV for.


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-82728

## Description

The `testAboutDialog.cy.ts` E2E test was false-failing when validating the "Installed components" table in the About dialog. Two root causes:

1. **Wrong data source** — The test ran `oc get <ComponentDisplayName>` (e.g., `oc get Dashboard`) to retrieve versions from individual CRD `.status.releases`, but the UI reads component versions from the **DataScienceCluster** resource's `.status.components` (via `/api/dsc/status`). These are different resources with different data.

2. **`unknown` included as a version** — The CRD query returned entries with `version: "unknown"` (components that haven't reported a version yet). The test then tried to match `"unknown"` in the UI table, which naturally failed.

### Changes

**`packages/cypress/cypress/utils/oc_commands/applications.ts`**
- Added `getDscComponentVersions()` — queries `DataScienceCluster -A -o json` (the same source the UI uses), extracts `.status.components`, filters out `managementState: 'Removed'` components and `version: 'unknown'` releases. Returns a map of component key → version strings.

**`packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts`**
- Replaced `getResourceVersionByName` (wrong source) with `getDscComponentVersions` (correct source)
- Fetches DSC component versions once in `retryableBefore` instead of per-component `oc get` calls
- Iterates `DataScienceStackComponentMap` entries using both `componentKey` (for DSC lookup) and `displayName` (for UI table lookup)

## How Has This Been Tested?

- Verified lint passes (`npm run lint -- --fix` in `packages/cypress/`)
- Verified type-check passes (`tsc --noEmit`)
- Verified the test logic aligns with the UI's data flow in `AboutDialog.tsx` (reads `dscStatus.components`, filters Removed, renders `releases[].version`)
- **Executed `testAboutDialog.cy.ts` on a live cluster** (ROSA cluster `liday-1`, ODH v3.5.0, DSC Ready) using:
  ```
  CY_TEST_CONFIG=test-variables.yml \
  npx cypress run \
    --spec "cypress/tests/e2e/applications/testAboutDialog.cy.ts" \
    --browser chrome --headless \
    --env grepTags="@Smoke",grepFilterSpecs=false,MOCK=false
  ```
  Result: **1 passing, 0 failing** (12s). The test successfully auto-detected ODH, logged in via OAuth, opened the About dialog, and verified product name, version, channel, and admin access level. Note: `getDscComponentVersions` returned `{}` on this cluster (no component versions reported yet in DSC status), and the test handled it gracefully by skipping component version assertions.

## Test Impact

This PR **is** the test fix — it corrects the data source and filtering logic in the existing `testAboutDialog.cy.ts` E2E test. No additional tests needed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component release validation by using detected component version information.
  * Components without available or valid version data are now skipped.
  * Component names are displayed more clearly in validation steps and results.
  * Improved handling of missing or empty release data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->