### PR TITLE
Remove hardcoded OSD example URL from deploy-python-model quickstart

### DIFF
--- a/frontend/src/__mocks__/mockQuickStarts.ts
+++ b/frontend/src/__mocks__/mockQuickStarts.ts
@@ -125,7 +125,7 @@ export const mockQuickStarts = (): OdhQuickStart[] => [
         },
         {
           description:
-            '### To test the sample Flask application:\n1. Click the application in the Topology view.\n2. In the panel that appears, copy the URL that appears under **Routes**.\n3. In a Jupyter notebook, navigate to a terminal view.\n4. Run this curl command, using the URL you copied in step 1.\n```\ncurl -X POST -d \'{"hello" ":" "world"}\' <URL>/prediction\n```\nFor example:\n```\ncurl -X POST -d \'{"hello" ":" "world"}\' http://example.apps.organization.abc3.p4.openshiftapps.com/prediction\n```\n\nThis should return `{"prediction":"not implemented"}` as output.',
+            '### To test the sample Flask application:\n1. Click the application in the Topology view.\n2. In the panel that appears, copy the URL that appears under **Routes**.\n3. In a Jupyter notebook, navigate to a terminal view.\n4. Run this curl command, using the URL you copied in step 1.\n```\ncurl -X POST -d \'{"hello" ":" "world"}\' <URL>/prediction\n```\n\nThis should return `{"prediction":"not implemented"}` as output.',
           review: {
             failedTaskHelp:
               'This task is not verified yet. Make sure your application built correctly. Make sure you remembered to add `/prediction` to the end of the application URL to get to the endpoint.',

--- a/manifests/base/apps/jupyter/deploy-python-model-quickstart.yaml
+++ b/manifests/base/apps/jupyter/deploy-python-model-quickstart.yaml
@@ -67,10 +67,6 @@ spec:
         ```
         curl -X POST -d '{"hello" ":" "world"}' <URL>/prediction
         ```
-        For example:
-        ```
-        curl -X POST -d '{"hello" ":" "world"}' http://example.apps.organization.abc3.p4.openshiftapps.com/prediction
-        ```
 
         This command should return `{"prediction":"not implemented"}` as output.
       review:


### PR DESCRIPTION
## Description

Disconnected readiness (`no-runtime-egress`) flags the Jupyter `deploy-python-model` quickstart as a blocker because the instructional `curl` example hardcodes `http://example.apps.organization.abc3.p4.openshiftapps.com/prediction`.

That curl is not runtime egress. It lives in `OdhQuickStart` text shown in the UI; the cluster never fetches the URL at install. Removing the example host keeps the `<URL>` placeholder so users still paste their own route.

Companion exception path fix: https://github.com/opendatahub-io/disconnected-readiness-scorer/pull/98

## How Has This Been Tested?

Reviewed the quickstart YAML and matching mock. No runtime behavior change. The remaining command is still `curl ... <URL>/prediction`.

## Test Impact

No new tests. Change is documentation text in a QuickStart CR plus the frontend mock that mirrors it.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`