### PR TITLE
feat(dashboard-operator): add cross-namespace RBAC for notebooks and model-registry namespaces

### DIFF
--- a/dashboard-operator/api/v1alpha1/dashboard_types.go
+++ b/dashboard-operator/api/v1alpha1/dashboard_types.go
@@ -176,6 +176,25 @@ type DashboardSpec struct {
 	// +kubebuilder:default=Sidecar
 	// +optional
 	DeploymentMode DeploymentMode `json:"deploymentMode,omitempty"`
+
+	// NotebooksNamespace is the namespace where Workbenches (notebooks) run.
+	// When set, the dashboard-operator creates a Role and RoleBinding in this
+	// namespace granting the dashboard SA access to notebook-related resources.
+	// Absent means notebooks RBAC is skipped (component not enabled or standalone
+	// deployment where notebooks are not used).
+	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$`
+	NotebooksNamespace string `json:"notebooksNamespace,omitempty"`
+
+	// ModelRegistryNamespace is the namespace where the Model Registry runs.
+	// When set, the dashboard-operator creates a Role and RoleBinding in this
+	// namespace granting the dashboard SA access to model registry resources.
+	// Absent means model registry RBAC is skipped.
+	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$`
+	ModelRegistryNamespace string `json:"modelRegistryNamespace,omitempty"`
 }
 
 // +kubebuilder:object:generate=true

--- a/dashboard-operator/charts/dashboard/crds/components.platform.opendatahub.io_dashboards.yaml
+++ b/dashboard-operator/charts/dashboard/crds/components.platform.opendatahub.io_dashboards.yaml
@@ -113,6 +113,15 @@ spec:
                 - Managed
                 - Removed
                 type: string
+              modelRegistryNamespace:
+                description: |-
+                  ModelRegistryNamespace is the namespace where the Model Registry runs.
+                  When set, the dashboard-operator creates a Role and RoleBinding in this
+                  namespace granting the dashboard SA access to model registry resources.
+                  Absent means model registry RBAC is skipped.
+                maxLength: 63
+                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                type: string
               modules:
                 additionalProperties:
                   description: |-
@@ -132,6 +141,16 @@ spec:
                   Modules contains per-module override configuration. Map keys are
                   module names as defined in the controller's internal module registry.
                 type: object
+              notebooksNamespace:
+                description: |-
+                  NotebooksNamespace is the namespace where Workbenches (notebooks) run.
+                  When set, the dashboard-operator creates a Role and RoleBinding in this
+                  namespace granting the dashboard SA access to notebook-related resources.
+                  Absent means notebooks RBAC is skipped (component not enabled or standalone
+                  deployment where notebooks are not used).
+                maxLength: 63
+                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                type: string
               observability:
                 description: Observability configures the observability stack integration.
                 properties:

--- a/dashboard-operator/config/crd/bases/components.platform.opendatahub.io_dashboards.yaml
+++ b/dashboard-operator/config/crd/bases/components.platform.opendatahub.io_dashboards.yaml
@@ -113,6 +113,15 @@ spec:
                 - Managed
                 - Removed
                 type: string
+              modelRegistryNamespace:
+                description: |-
+                  ModelRegistryNamespace is the namespace where the Model Registry runs.
+                  When set, the dashboard-operator creates a Role and RoleBinding in this
+                  namespace granting the dashboard SA access to model registry resources.
+                  Absent means model registry RBAC is skipped.
+                maxLength: 63
+                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                type: string
               modules:
                 additionalProperties:
                   description: |-
@@ -132,6 +141,16 @@ spec:
                   Modules contains per-module override configuration. Map keys are
                   module names as defined in the controller's internal module registry.
                 type: object
+              notebooksNamespace:
+                description: |-
+                  NotebooksNamespace is the namespace where Workbenches (notebooks) run.
+                  When set, the dashboard-operator creates a Role and RoleBinding in this
+                  namespace granting the dashboard SA access to notebook-related resources.
+                  Absent means notebooks RBAC is skipped (component not enabled or standalone
+                  deployment where notebooks are not used).
+                maxLength: 63
+                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                type: string
               observability:
                 description: Observability configures the observability stack integration.
                 properties:

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -332,11 +332,26 @@ func (r *DashboardReconciler) reconcileSidecar(
 		conditions.WithReason("ResourcesApplied"),
 		conditions.WithMessage("Dashboard manifests applied successfully"))
 
+	rbacErr := r.reconcileNamespacedRBAC(ctx, dashboard)
+	if rbacErr != nil {
+		logger.Error(rbacErr, "Failed to reconcile namespaced RBAC")
+		cm.MarkTrue(string(common.ConditionTypeDegraded),
+			conditions.WithReason("NamespacedRBACFailed"),
+			conditions.WithError(rbacErr))
+	}
+
 	r.reconcileObservability(ctx, dashboard, cm)
 
 	url, requeueAfter, err := r.reconcileURL(ctx, dashboard, cm)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+	// reconcileURL overwrites Degraded on success; restore the RBAC failure so it
+	// is not silently cleared while cross-namespace grants are still broken.
+	if rbacErr != nil {
+		cm.MarkTrue(string(common.ConditionTypeDegraded),
+			conditions.WithReason("NamespacedRBACFailed"),
+			conditions.WithError(rbacErr))
 	}
 
 	nextStatuses := resolveModuleStatuses(&dashboard.Spec)
@@ -522,7 +537,7 @@ func (r *DashboardReconciler) reconcileStandalone(
 	// so the ConfigMap reflects actual deployment health, e.g. Degraded modules)
 	r.overlayStandaloneReadiness(ctx, nextStatuses)
 
-	// Persist module statuses now so early returns from steps 6-8 don't leave
+	// Persist module statuses now so early returns from steps 6-9 don't leave
 	// stale status on the CR (the outer Reconcile always calls Status().Update).
 	for name, next := range nextStatuses {
 		if prev, ok := dashboard.Status.ModuleStatuses[name]; ok &&
@@ -535,10 +550,19 @@ func (r *DashboardReconciler) reconcileStandalone(
 	}
 	dashboard.Status.ModuleStatuses = nextStatuses
 
-	// Step 6: Deploy observability
+	// Step 6: Reconcile cross-namespace RBAC (notebooks, model-registry)
+	rbacErr := r.reconcileNamespacedRBAC(ctx, dashboard)
+	if rbacErr != nil {
+		logger.Error(rbacErr, "Failed to reconcile namespaced RBAC")
+		cm.MarkTrue(string(common.ConditionTypeDegraded),
+			conditions.WithReason("NamespacedRBACFailed"),
+			conditions.WithError(rbacErr))
+	}
+
+	// Step 7: Deploy observability
 	r.reconcileObservability(ctx, dashboard, cm)
 
-	// Step 7: Build and deploy federation ConfigMap (critical for standalone routing)
+	// Step 8: Build and deploy federation ConfigMap (critical for standalone routing)
 	fedData, err := r.deployFederationConfigMap(ctx, nextStatuses, dashboard)
 	if err != nil {
 		cm.MarkTrue(string(common.ConditionTypeDegraded),
@@ -553,13 +577,21 @@ func (r *DashboardReconciler) reconcileStandalone(
 		return ctrl.Result{}, fmt.Errorf("patching federation hash: %w", err)
 	}
 
-	// Step 8: URL extraction + degraded condition
+	// Step 9: URL extraction + degraded condition
 	url, requeueAfter, urlErr := r.reconcileURL(ctx, dashboard, cm)
 	if urlErr != nil {
 		return ctrl.Result{}, urlErr
 	}
 	if requeueAfter == 0 {
 		r.reconcileDegradedCondition(cm, nextStatuses)
+	}
+	// reconcileURL and reconcileDegradedCondition overwrite Degraded on success;
+	// restore the RBAC failure so it is not silently cleared while cross-namespace
+	// grants are still broken.
+	if rbacErr != nil {
+		cm.MarkTrue(string(common.ConditionTypeDegraded),
+			conditions.WithReason("NamespacedRBACFailed"),
+			conditions.WithError(rbacErr))
 	}
 
 	if requeueAfter > 0 {
@@ -700,6 +732,10 @@ func (r *DashboardReconciler) cleanupRayDashboardGatewayRBAC(ctx context.Context
 // so resources deployed to a different namespace need explicit cleanup.
 func (r *DashboardReconciler) cleanupCrossNamespaceResources(ctx context.Context, dashboard *v1alpha1.Dashboard) error {
 	logger := log.FromContext(ctx)
+
+	if err := r.cleanupNamespacedRBAC(ctx); err != nil {
+		return fmt.Errorf("namespaced RBAC cleanup: %w", err)
+	}
 
 	if err := r.cleanupRayDashboardGatewayRBAC(ctx); err != nil {
 		return err

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -39,3 +39,17 @@ func (r *DashboardReconciler) MonitoringNamespace() string {
 }
 
 const ObservabilityRetryInterval = observabilityRetryInterval
+
+var DashboardSAName = dashboardSAName
+
+func (r *DashboardReconciler) ReconcileNamespacedRBAC(ctx context.Context, dashboard *v1alpha1.Dashboard) error {
+	return r.reconcileNamespacedRBAC(ctx, dashboard)
+}
+
+func (r *DashboardReconciler) CleanupNamespacedRBAC(ctx context.Context) error {
+	return r.cleanupNamespacedRBAC(ctx)
+}
+
+func (r *DashboardReconciler) GCStaleNamespacedRBAC(ctx context.Context, desired map[string]bool) error {
+	return r.gcStaleNamespacedRBAC(ctx, desired)
+}

--- a/dashboard-operator/internal/controller/namespaced_rbac.go
+++ b/dashboard-operator/internal/controller/namespaced_rbac.go
@@ -1,0 +1,337 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+const (
+	dashboardSANameODH   = "odh-dashboard"
+	dashboardSANameRHOAI = "rhods-dashboard"
+
+	namespacedRBACManagedLabel = "dashboard.opendatahub.io/namespaced-rbac"
+)
+
+// dashboardSAName returns the dashboard ServiceAccount name for the given platform.
+func dashboardSAName(platform cluster.Platform) string {
+	switch platform {
+	case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
+		return dashboardSANameRHOAI
+	default:
+		return dashboardSANameODH
+	}
+}
+
+// reconcileNamespacedRBAC creates or updates cross-namespace Roles and RoleBindings
+// for the dashboard SA in the notebooks and model-registry namespaces, then GCs
+// any resources left over in namespaces that are no longer in the desired set.
+func (r *DashboardReconciler) reconcileNamespacedRBAC(ctx context.Context, dashboard *v1alpha1.Dashboard) error {
+	saName := dashboardSAName(r.Platform)
+	saNamespace := r.ApplicationsNamespace
+
+	desired := map[string]bool{}
+
+	if ns := dashboard.Spec.NotebooksNamespace; ns != "" {
+		if err := r.applyNamespacedRBAC(ctx, saName, saNamespace, ns, "notebooks", notebooksRBACRules()); err != nil {
+			return fmt.Errorf("notebooks namespace RBAC in %s: %w", ns, err)
+		}
+		desired[namespacedRBACKey(ns, "notebooks")] = true
+	}
+
+	if ns := dashboard.Spec.ModelRegistryNamespace; ns != "" {
+		if err := r.applyNamespacedRBAC(ctx, saName, saNamespace, ns, "model-registry", modelRegistryRBACRules()); err != nil {
+			return fmt.Errorf("model-registry namespace RBAC in %s: %w", ns, err)
+		}
+		desired[namespacedRBACKey(ns, "model-registry")] = true
+	}
+
+	return r.gcStaleNamespacedRBAC(ctx, desired)
+}
+
+// cleanupNamespacedRBAC deletes all cross-namespace Roles and RoleBindings previously
+// created by reconcileNamespacedRBAC. Uses a cluster-wide label sweep so stale resources
+// are removed even when the namespace field changed since the last reconcile.
+// Called on Dashboard deletion and ManagementState=Removed.
+func (r *DashboardReconciler) cleanupNamespacedRBAC(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+
+	matchLabels := client.MatchingLabels{
+		namespacedRBACManagedLabel: "true",
+		labels.PlatformPartOf:      strings.ToLower(v1alpha1.DashboardKind),
+	}
+
+	var errs []error
+
+	var roleList rbacv1.RoleList
+	if err := r.List(ctx, &roleList, matchLabels); err != nil {
+		errs = append(errs, fmt.Errorf("listing namespaced RBAC Roles: %w", err))
+	} else {
+		for i := range roleList.Items {
+			logger.Info("Deleting namespaced RBAC Role", "name", roleList.Items[i].Name, "namespace", roleList.Items[i].Namespace)
+			if err := r.Delete(ctx, &roleList.Items[i]); client.IgnoreNotFound(err) != nil {
+				errs = append(errs, fmt.Errorf("deleting Role %s/%s: %w", roleList.Items[i].Namespace, roleList.Items[i].Name, err))
+			}
+		}
+	}
+
+	var rbList rbacv1.RoleBindingList
+	if err := r.List(ctx, &rbList, matchLabels); err != nil {
+		errs = append(errs, fmt.Errorf("listing namespaced RBAC RoleBindings: %w", err))
+	} else {
+		for i := range rbList.Items {
+			logger.Info("Deleting namespaced RBAC RoleBinding", "name", rbList.Items[i].Name, "namespace", rbList.Items[i].Namespace)
+			if err := r.Delete(ctx, &rbList.Items[i]); client.IgnoreNotFound(err) != nil {
+				errs = append(errs, fmt.Errorf("deleting RoleBinding %s/%s: %w", rbList.Items[i].Namespace, rbList.Items[i].Name, err))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// namespacedRBACKey returns the composite GC key for a (namespace, suffix) pair.
+// suffix is the component name used in role/rolebinding name generation (e.g. "notebooks").
+func namespacedRBACKey(namespace, suffix string) string {
+	return namespace + "/" + suffix
+}
+
+// gcStaleNamespacedRBAC removes managed Roles and RoleBindings whose (namespace, name)
+// identity is not in the desired set. Keying by identity (not just namespace) ensures
+// correct GC when two components share the same target namespace.
+func (r *DashboardReconciler) gcStaleNamespacedRBAC(ctx context.Context, desired map[string]bool) error {
+	logger := log.FromContext(ctx)
+
+	matchLabels := client.MatchingLabels{
+		namespacedRBACManagedLabel: "true",
+		labels.PlatformPartOf:      strings.ToLower(v1alpha1.DashboardKind),
+	}
+
+	var errs []error
+
+	var roleList rbacv1.RoleList
+	if err := r.List(ctx, &roleList, matchLabels); err != nil {
+		errs = append(errs, fmt.Errorf("listing namespaced RBAC Roles for GC: %w", err))
+	} else {
+		for i := range roleList.Items {
+			ns := roleList.Items[i].Namespace
+			name := roleList.Items[i].Name
+			// Role names are "dashboard-<suffix>-role"; extract suffix to match desired key.
+			suffix := roleNameSuffix(name)
+			if desired[namespacedRBACKey(ns, suffix)] {
+				continue
+			}
+			logger.Info("GC stale namespaced RBAC Role", "name", name, "namespace", ns)
+			if err := r.Delete(ctx, &roleList.Items[i]); client.IgnoreNotFound(err) != nil {
+				errs = append(errs, fmt.Errorf("deleting stale Role %s/%s: %w", ns, name, err))
+			}
+		}
+	}
+
+	var rbList rbacv1.RoleBindingList
+	if err := r.List(ctx, &rbList, matchLabels); err != nil {
+		errs = append(errs, fmt.Errorf("listing namespaced RBAC RoleBindings for GC: %w", err))
+	} else {
+		for i := range rbList.Items {
+			ns := rbList.Items[i].Namespace
+			name := rbList.Items[i].Name
+			suffix := roleBindingNameSuffix(name)
+			if desired[namespacedRBACKey(ns, suffix)] {
+				continue
+			}
+			logger.Info("GC stale namespaced RBAC RoleBinding", "name", name, "namespace", ns)
+			if err := r.Delete(ctx, &rbList.Items[i]); client.IgnoreNotFound(err) != nil {
+				errs = append(errs, fmt.Errorf("deleting stale RoleBinding %s/%s: %w", ns, name, err))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// roleNameSuffix extracts the component suffix from "dashboard-<suffix>-role".
+// Returns the full name unchanged for resources not following that convention.
+func roleNameSuffix(name string) string {
+	s := strings.TrimPrefix(name, "dashboard-")
+	s = strings.TrimSuffix(s, "-role")
+	return s
+}
+
+// roleBindingNameSuffix extracts the component suffix from "dashboard-<suffix>-rolebinding".
+func roleBindingNameSuffix(name string) string {
+	s := strings.TrimPrefix(name, "dashboard-")
+	s = strings.TrimSuffix(s, "-rolebinding")
+	return s
+}
+
+// applyNamespacedRBAC creates or updates a Role and RoleBinding in targetNamespace granting
+// saName/saNamespace the given rules.
+func (r *DashboardReconciler) applyNamespacedRBAC(
+	ctx context.Context,
+	saName, saNamespace, targetNamespace, suffix string,
+	rules []rbacv1.PolicyRule,
+) error {
+	roleName := fmt.Sprintf("dashboard-%s-role", suffix)
+	rbName := fmt.Sprintf("dashboard-%s-rolebinding", suffix)
+
+	roleLabels := map[string]string{
+		namespacedRBACManagedLabel: "true",
+		labels.PlatformPartOf:      strings.ToLower(v1alpha1.DashboardKind),
+	}
+	rbLabels := map[string]string{
+		namespacedRBACManagedLabel: "true",
+		labels.PlatformPartOf:      strings.ToLower(v1alpha1.DashboardKind),
+	}
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: targetNamespace,
+			Labels:    roleLabels,
+		},
+		Rules: rules,
+	}
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rbName,
+			Namespace: targetNamespace,
+			Labels:    rbLabels,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     roleName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      saName,
+			Namespace: saNamespace,
+		}},
+	}
+
+	if err := r.applyRole(ctx, role); err != nil {
+		return err
+	}
+	return r.applyRoleBinding(ctx, rb)
+}
+
+func (r *DashboardReconciler) applyRole(ctx context.Context, role *rbacv1.Role) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing := &rbacv1.Role{}
+		err := r.Get(ctx, client.ObjectKeyFromObject(role), existing)
+		if k8serrors.IsNotFound(err) {
+			if createErr := r.Create(ctx, role); createErr != nil && !k8serrors.IsAlreadyExists(createErr) {
+				return fmt.Errorf("creating Role %s/%s: %w", role.Namespace, role.Name, createErr)
+			}
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("getting Role %s/%s: %w", role.Namespace, role.Name, err)
+		}
+		mergedLabels := mergeLabels(existing.Labels, role.Labels)
+		if reflect.DeepEqual(existing.Rules, role.Rules) && reflect.DeepEqual(existing.Labels, mergedLabels) {
+			return nil
+		}
+		existing.Rules = role.Rules
+		existing.Labels = mergedLabels
+		return r.Update(ctx, existing)
+	})
+}
+
+func (r *DashboardReconciler) applyRoleBinding(ctx context.Context, rb *rbacv1.RoleBinding) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing := &rbacv1.RoleBinding{}
+		err := r.Get(ctx, client.ObjectKeyFromObject(rb), existing)
+		if k8serrors.IsNotFound(err) {
+			if createErr := r.Create(ctx, rb); createErr != nil && !k8serrors.IsAlreadyExists(createErr) {
+				return fmt.Errorf("creating RoleBinding %s/%s: %w", rb.Namespace, rb.Name, createErr)
+			}
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("getting RoleBinding %s/%s: %w", rb.Namespace, rb.Name, err)
+		}
+		// RoleRef is immutable — delete and recreate if it drifted.
+		if existing.RoleRef != rb.RoleRef {
+			if err := r.Delete(ctx, existing); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("deleting drifted RoleBinding %s/%s: %w", rb.Namespace, rb.Name, err)
+			}
+			fresh := rb.DeepCopy()
+			if createErr := r.Create(ctx, fresh); createErr != nil && !k8serrors.IsAlreadyExists(createErr) {
+				return fmt.Errorf("recreating RoleBinding %s/%s: %w", rb.Namespace, rb.Name, createErr)
+			}
+			return nil
+		}
+		mergedLabels := mergeLabels(existing.Labels, rb.Labels)
+		if reflect.DeepEqual(existing.Subjects, rb.Subjects) && reflect.DeepEqual(existing.Labels, mergedLabels) {
+			return nil
+		}
+		existing.Subjects = rb.Subjects
+		existing.Labels = mergedLabels
+		return r.Update(ctx, existing)
+	})
+}
+
+// mergeLabels merges additional into existing; additional wins on conflict.
+func mergeLabels(existing, additional map[string]string) map[string]string {
+	out := make(map[string]string, len(existing)+len(additional))
+	for k, v := range existing {
+		out[k] = v
+	}
+	for k, v := range additional {
+		out[k] = v
+	}
+	return out
+}
+
+// notebooksRBACRules returns the RBAC rules needed by the dashboard SA in the notebooks namespace.
+func notebooksRBACRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"persistentvolumeclaims"},
+			Verbs:     []string{"create", "get"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"create", "get", "update"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"create", "get", "update"},
+		},
+	}
+}
+
+// modelRegistryRBACRules returns the RBAC rules needed by the dashboard SA in the model-registry namespace.
+func modelRegistryRBACRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"create", "delete", "get", "list", "patch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"create", "list"},
+		},
+	}
+}

--- a/dashboard-operator/internal/controller/namespaced_rbac_test.go
+++ b/dashboard-operator/internal/controller/namespaced_rbac_test.go
@@ -1,0 +1,490 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+)
+
+const (
+	testAppNamespace    = "redhat-ods-applications"
+	testNotebooksNS     = "rhods-notebooks"
+	testModelRegistryNS = "rhoai-model-registries"
+	managedLabel        = "dashboard.opendatahub.io/namespaced-rbac"
+)
+
+func newReconciler(t *testing.T, platform cluster.Platform, objects ...client.Object) (*ctrlpkg.DashboardReconciler, client.Client) {
+	t.Helper()
+	s := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).Build()
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		ManifestsBasePath:     t.TempDir(),
+		Platform:              platform,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testAppNamespace,
+	}
+	return r, cli
+}
+
+func newDashboard(notebooksNS, modelRegistryNS string) *v1alpha1.Dashboard {
+	return &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: v1alpha1.DashboardInstanceName,
+		},
+		Spec: v1alpha1.DashboardSpec{
+			NotebooksNamespace:     notebooksNS,
+			ModelRegistryNamespace: modelRegistryNS,
+		},
+	}
+}
+
+func managedRBACLabels() client.MatchingLabels {
+	return client.MatchingLabels{
+		managedLabel:          "true",
+		labels.PlatformPartOf: "dashboard",
+	}
+}
+
+func listRoles(t *testing.T, cli client.Client) []rbacv1.Role {
+	t.Helper()
+	var list rbacv1.RoleList
+	require.NoError(t, cli.List(context.Background(), &list, managedRBACLabels()))
+	return list.Items
+}
+
+func listRoleBindings(t *testing.T, cli client.Client) []rbacv1.RoleBinding {
+	t.Helper()
+	var list rbacv1.RoleBindingList
+	require.NoError(t, cli.List(context.Background(), &list, managedRBACLabels()))
+	return list.Items
+}
+
+func getRole(t *testing.T, cli client.Client, ns, name string) *rbacv1.Role {
+	t.Helper()
+	role := &rbacv1.Role{}
+	err := cli.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, role)
+	require.NoError(t, err)
+	return role
+}
+
+func getRoleBinding(t *testing.T, cli client.Client, ns, name string) *rbacv1.RoleBinding {
+	t.Helper()
+	rb := &rbacv1.RoleBinding{}
+	err := cli.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, rb)
+	require.NoError(t, err)
+	return rb
+}
+
+// TestDashboardSAName verifies platform-based SA name selection.
+func TestDashboardSAName(t *testing.T) {
+	tests := []struct {
+		platform cluster.Platform
+		want     string
+	}{
+		{cluster.SelfManagedRhoai, "rhods-dashboard"},
+		{cluster.ManagedRhoai, "rhods-dashboard"},
+		{cluster.OpenDataHub, "odh-dashboard"},
+		{cluster.XKS, "odh-dashboard"},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.platform), func(t *testing.T) {
+			assert.Equal(t, tc.want, ctrlpkg.DashboardSAName(tc.platform))
+		})
+	}
+}
+
+// TestReconcileNamespacedRBAC_BothNamespaces verifies that Roles and RoleBindings
+// are created in both target namespaces when both spec fields are set.
+func TestReconcileNamespacedRBAC_BothNamespaces(t *testing.T) {
+	r, cli := newReconciler(t, cluster.SelfManagedRhoai)
+	dashboard := newDashboard(testNotebooksNS, testModelRegistryNS)
+
+	err := r.ReconcileNamespacedRBAC(context.Background(), dashboard)
+	require.NoError(t, err)
+
+	// Expect 2 Roles and 2 RoleBindings
+	roles := listRoles(t, cli)
+	assert.Len(t, roles, 2)
+
+	rbs := listRoleBindings(t, cli)
+	assert.Len(t, rbs, 2)
+
+	// Verify notebooks Role is in the right namespace with the right rules
+	notebooksRole := getRole(t, cli, testNotebooksNS, "dashboard-notebooks-role")
+	assert.Equal(t, testNotebooksNS, notebooksRole.Namespace)
+	assert.Len(t, notebooksRole.Rules, 3)
+
+	// Verify notebooks RoleBinding points to rhods-dashboard SA
+	notebooksRB := getRoleBinding(t, cli, testNotebooksNS, "dashboard-notebooks-rolebinding")
+	require.Len(t, notebooksRB.Subjects, 1)
+	assert.Equal(t, "rhods-dashboard", notebooksRB.Subjects[0].Name)
+	assert.Equal(t, testAppNamespace, notebooksRB.Subjects[0].Namespace)
+	assert.Equal(t, "dashboard-notebooks-role", notebooksRB.RoleRef.Name)
+
+	// Verify model-registry Role is in the right namespace
+	mrRole := getRole(t, cli, testModelRegistryNS, "dashboard-model-registry-role")
+	assert.Equal(t, testModelRegistryNS, mrRole.Namespace)
+	assert.Len(t, mrRole.Rules, 2)
+
+	// Verify model-registry RoleBinding
+	mrRB := getRoleBinding(t, cli, testModelRegistryNS, "dashboard-model-registry-rolebinding")
+	require.Len(t, mrRB.Subjects, 1)
+	assert.Equal(t, "rhods-dashboard", mrRB.Subjects[0].Name)
+}
+
+// TestReconcileNamespacedRBAC_OnlyNotebooks verifies only notebooks RBAC is created
+// when ModelRegistryNamespace is empty.
+func TestReconcileNamespacedRBAC_OnlyNotebooks(t *testing.T) {
+	r, cli := newReconciler(t, cluster.OpenDataHub)
+	dashboard := newDashboard(testNotebooksNS, "")
+
+	err := r.ReconcileNamespacedRBAC(context.Background(), dashboard)
+	require.NoError(t, err)
+
+	roles := listRoles(t, cli)
+	assert.Len(t, roles, 1)
+	assert.Equal(t, testNotebooksNS, roles[0].Namespace)
+
+	rbs := listRoleBindings(t, cli)
+	assert.Len(t, rbs, 1)
+
+	// ODH platform uses odh-dashboard SA
+	rb := getRoleBinding(t, cli, testNotebooksNS, "dashboard-notebooks-rolebinding")
+	assert.Equal(t, "odh-dashboard", rb.Subjects[0].Name)
+}
+
+// TestReconcileNamespacedRBAC_OnlyModelRegistry verifies only model-registry RBAC
+// is created when NotebooksNamespace is empty.
+func TestReconcileNamespacedRBAC_OnlyModelRegistry(t *testing.T) {
+	r, cli := newReconciler(t, cluster.OpenDataHub)
+	dashboard := newDashboard("", testModelRegistryNS)
+
+	err := r.ReconcileNamespacedRBAC(context.Background(), dashboard)
+	require.NoError(t, err)
+
+	roles := listRoles(t, cli)
+	assert.Len(t, roles, 1)
+	assert.Equal(t, testModelRegistryNS, roles[0].Namespace)
+
+	rbs := listRoleBindings(t, cli)
+	assert.Len(t, rbs, 1)
+}
+
+// TestReconcileNamespacedRBAC_NoNamespaces verifies nothing is created when both
+// namespace fields are empty.
+func TestReconcileNamespacedRBAC_NoNamespaces(t *testing.T) {
+	r, cli := newReconciler(t, cluster.OpenDataHub)
+	dashboard := newDashboard("", "")
+
+	err := r.ReconcileNamespacedRBAC(context.Background(), dashboard)
+	require.NoError(t, err)
+
+	assert.Empty(t, listRoles(t, cli))
+	assert.Empty(t, listRoleBindings(t, cli))
+}
+
+// TestReconcileNamespacedRBAC_Idempotent verifies that reconciling twice produces
+// the same result (no duplicate resources, update path works).
+func TestReconcileNamespacedRBAC_Idempotent(t *testing.T) {
+	r, cli := newReconciler(t, cluster.SelfManagedRhoai)
+	dashboard := newDashboard(testNotebooksNS, testModelRegistryNS)
+
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+
+	// Should still be exactly 2 of each
+	assert.Len(t, listRoles(t, cli), 2)
+	assert.Len(t, listRoleBindings(t, cli), 2)
+}
+
+// TestReconcileNamespacedRBAC_UpdateExistingRole verifies that reconcile updates
+// an existing Role rather than failing on conflict.
+func TestReconcileNamespacedRBAC_UpdateExistingRole(t *testing.T) {
+	// Pre-create a Role with different rules
+	existingRole := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dashboard-notebooks-role",
+			Namespace: testNotebooksNS,
+			Labels: map[string]string{
+				managedLabel:          "true",
+				labels.PlatformPartOf: "dashboard",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}},
+		},
+	}
+
+	r, cli := newReconciler(t, cluster.OpenDataHub, existingRole)
+	dashboard := newDashboard(testNotebooksNS, "")
+
+	err := r.ReconcileNamespacedRBAC(context.Background(), dashboard)
+	require.NoError(t, err)
+
+	// Rules should be updated to the canonical notebooks rules
+	role := getRole(t, cli, testNotebooksNS, "dashboard-notebooks-role")
+	assert.Len(t, role.Rules, 3, "rules should be updated to the canonical notebooks set")
+
+	// Verify the specific resources are present
+	resources := make([]string, 0, 3)
+	for _, rule := range role.Rules {
+		resources = append(resources, rule.Resources...)
+	}
+	assert.Contains(t, resources, "persistentvolumeclaims")
+	assert.Contains(t, resources, "configmaps")
+	assert.Contains(t, resources, "secrets")
+}
+
+// TestReconcileNamespacedRBAC_GCStaleOnNamespaceChange verifies that when the
+// NotebooksNamespace changes from ns-a to ns-b, the old resources in ns-a are removed.
+func TestReconcileNamespacedRBAC_GCStaleOnNamespaceChange(t *testing.T) {
+	r, cli := newReconciler(t, cluster.SelfManagedRhoai)
+	oldNS := "old-notebooks-ns"
+	newNS := "new-notebooks-ns"
+
+	// First reconcile with old namespace
+	dashboard := newDashboard(oldNS, "")
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+
+	// Verify old resources exist
+	assert.Len(t, listRoles(t, cli), 1)
+	getRole(t, cli, oldNS, "dashboard-notebooks-role")
+
+	// Second reconcile with new namespace
+	dashboard.Spec.NotebooksNamespace = newNS
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+
+	// Old namespace resources should be gone
+	roles := listRoles(t, cli)
+	assert.Len(t, roles, 1, "should have exactly one role (in new namespace)")
+	assert.Equal(t, newNS, roles[0].Namespace)
+
+	rbs := listRoleBindings(t, cli)
+	assert.Len(t, rbs, 1)
+	assert.Equal(t, newNS, rbs[0].Namespace)
+}
+
+// TestReconcileNamespacedRBAC_GCStaleOnNamespaceRemoved verifies that when both
+// namespace fields are cleared, all managed resources are removed.
+func TestReconcileNamespacedRBAC_GCStaleOnNamespaceRemoved(t *testing.T) {
+	r, cli := newReconciler(t, cluster.OpenDataHub)
+	dashboard := newDashboard(testNotebooksNS, testModelRegistryNS)
+
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+	assert.Len(t, listRoles(t, cli), 2)
+
+	// Clear both namespaces
+	dashboard.Spec.NotebooksNamespace = ""
+	dashboard.Spec.ModelRegistryNamespace = ""
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+
+	assert.Empty(t, listRoles(t, cli))
+	assert.Empty(t, listRoleBindings(t, cli))
+}
+
+// TestCleanupNamespacedRBAC verifies that cleanup deletes all managed resources
+// cluster-wide, regardless of namespace.
+func TestCleanupNamespacedRBAC(t *testing.T) {
+	r, cli := newReconciler(t, cluster.SelfManagedRhoai)
+	dashboard := newDashboard(testNotebooksNS, testModelRegistryNS)
+
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+	assert.Len(t, listRoles(t, cli), 2)
+
+	err := r.CleanupNamespacedRBAC(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, listRoles(t, cli))
+	assert.Empty(t, listRoleBindings(t, cli))
+}
+
+// TestCleanupNamespacedRBAC_AlreadyGone verifies that cleanup is idempotent when
+// resources don't exist (NotFound is tolerated).
+func TestCleanupNamespacedRBAC_AlreadyGone(t *testing.T) {
+	r, _ := newReconciler(t, cluster.OpenDataHub)
+
+	err := r.CleanupNamespacedRBAC(context.Background())
+	require.NoError(t, err)
+}
+
+// TestGCStaleNamespacedRBAC_OnlyRemovesNonDesired verifies that GC leaves desired
+// namespaces untouched and only removes resources in non-desired namespaces.
+func TestGCStaleNamespacedRBAC_OnlyRemovesNonDesired(t *testing.T) {
+	r, cli := newReconciler(t, cluster.SelfManagedRhoai)
+	dashboard := newDashboard(testNotebooksNS, testModelRegistryNS)
+
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+	assert.Len(t, listRoles(t, cli), 2)
+
+	// GC keeping only model-registry namespace (key is "ns/suffix", matching namespacedRBACKey)
+	desired := map[string]bool{testModelRegistryNS + "/model-registry": true}
+	err := r.GCStaleNamespacedRBAC(context.Background(), desired)
+	require.NoError(t, err)
+
+	roles := listRoles(t, cli)
+	require.Len(t, roles, 1)
+	assert.Equal(t, testModelRegistryNS, roles[0].Namespace)
+
+	rbs := listRoleBindings(t, cli)
+	require.Len(t, rbs, 1)
+	assert.Equal(t, testModelRegistryNS, rbs[0].Namespace)
+}
+
+// TestGCStaleNamespacedRBAC_EmptyDesiredDeletesAll verifies that passing an empty
+// desired set removes all managed resources.
+func TestGCStaleNamespacedRBAC_EmptyDesiredDeletesAll(t *testing.T) {
+	r, cli := newReconciler(t, cluster.OpenDataHub)
+	dashboard := newDashboard(testNotebooksNS, testModelRegistryNS)
+
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+	assert.Len(t, listRoles(t, cli), 2)
+
+	err := r.GCStaleNamespacedRBAC(context.Background(), map[string]bool{})
+	require.NoError(t, err)
+
+	assert.Empty(t, listRoles(t, cli))
+	assert.Empty(t, listRoleBindings(t, cli))
+}
+
+// TestReconcileNamespacedRBAC_DoesNotTouchUnmanagedRoles verifies that Roles
+// without the managed label are not touched by GC or cleanup.
+func TestReconcileNamespacedRBAC_DoesNotTouchUnmanagedRoles(t *testing.T) {
+	// A pre-existing Role in testNotebooksNS that we do NOT own
+	foreignRole := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-other-role",
+			Namespace: testNotebooksNS,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}},
+		},
+	}
+
+	r, cli := newReconciler(t, cluster.OpenDataHub, foreignRole)
+
+	// GC with empty desired — should not delete the foreign role
+	err := r.GCStaleNamespacedRBAC(context.Background(), map[string]bool{})
+	require.NoError(t, err)
+
+	// Foreign role is still there
+	var remaining rbacv1.RoleList
+	require.NoError(t, cli.List(context.Background(), &remaining, client.InNamespace(testNotebooksNS)))
+	require.Len(t, remaining.Items, 1)
+	assert.Equal(t, "some-other-role", remaining.Items[0].Name)
+
+	// No managed RBAC was created
+	assert.Empty(t, listRoles(t, cli))
+}
+
+// TestReconcileNamespacedRBAC_Labels verifies that created resources carry the
+// expected managed label so future label-based GC can find them.
+func TestReconcileNamespacedRBAC_Labels(t *testing.T) {
+	r, cli := newReconciler(t, cluster.SelfManagedRhoai)
+	dashboard := newDashboard(testNotebooksNS, "")
+
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+
+	role := getRole(t, cli, testNotebooksNS, "dashboard-notebooks-role")
+	assert.Equal(t, "true", role.Labels[managedLabel])
+	assert.Equal(t, "dashboard", role.Labels[labels.PlatformPartOf])
+
+	rb := getRoleBinding(t, cli, testNotebooksNS, "dashboard-notebooks-rolebinding")
+	assert.Equal(t, "true", rb.Labels[managedLabel])
+	assert.Equal(t, "dashboard", rb.Labels[labels.PlatformPartOf])
+}
+
+// TestReconcileNamespacedRBAC_RoleRefIsRole verifies RoleBindings reference a Role
+// (not ClusterRole) in the same namespace.
+func TestReconcileNamespacedRBAC_RoleRefIsRole(t *testing.T) {
+	r, cli := newReconciler(t, cluster.OpenDataHub)
+	dashboard := newDashboard(testNotebooksNS, testModelRegistryNS)
+
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+
+	notebooksRB := getRoleBinding(t, cli, testNotebooksNS, "dashboard-notebooks-rolebinding")
+	assert.Equal(t, "Role", notebooksRB.RoleRef.Kind)
+	assert.Equal(t, "rbac.authorization.k8s.io", notebooksRB.RoleRef.APIGroup)
+
+	mrRB := getRoleBinding(t, cli, testModelRegistryNS, "dashboard-model-registry-rolebinding")
+	assert.Equal(t, "Role", mrRB.RoleRef.Kind)
+}
+
+// TestReconcileNamespacedRBAC_NotebooksRules verifies the exact RBAC rules for the
+// notebooks namespace match what the dashboard app needs.
+func TestReconcileNamespacedRBAC_NotebooksRules(t *testing.T) {
+	r, cli := newReconciler(t, cluster.OpenDataHub)
+	dashboard := newDashboard(testNotebooksNS, "")
+
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+
+	role := getRole(t, cli, testNotebooksNS, "dashboard-notebooks-role")
+	require.Len(t, role.Rules, 3)
+
+	// Build a map of resource → verbs for easy assertion
+	ruleMap := map[string][]string{}
+	for _, rule := range role.Rules {
+		for _, res := range rule.Resources {
+			ruleMap[res] = rule.Verbs
+		}
+	}
+
+	assert.ElementsMatch(t, []string{"create", "get"}, ruleMap["persistentvolumeclaims"])
+	assert.ElementsMatch(t, []string{"create", "get", "update"}, ruleMap["configmaps"])
+	assert.ElementsMatch(t, []string{"create", "get", "update"}, ruleMap["secrets"])
+}
+
+// TestReconcileNamespacedRBAC_ModelRegistryRules verifies the exact RBAC rules for
+// the model-registry namespace.
+func TestReconcileNamespacedRBAC_ModelRegistryRules(t *testing.T) {
+	r, cli := newReconciler(t, cluster.OpenDataHub)
+	dashboard := newDashboard("", testModelRegistryNS)
+
+	require.NoError(t, r.ReconcileNamespacedRBAC(context.Background(), dashboard))
+
+	role := getRole(t, cli, testModelRegistryNS, "dashboard-model-registry-role")
+	require.Len(t, role.Rules, 2)
+
+	ruleMap := map[string][]string{}
+	for _, rule := range role.Rules {
+		for _, res := range rule.Resources {
+			ruleMap[res] = rule.Verbs
+		}
+	}
+
+	assert.ElementsMatch(t, []string{"create", "delete", "get", "list", "patch"}, ruleMap["secrets"])
+	assert.ElementsMatch(t, []string{"create", "list"}, ruleMap["configmaps"])
+}
+
+// TestReconcileNamespacedRBAC_SameNamespaceBothComponents covers the edge case where
+// both namespace fields point to the same namespace. Should create 2 separate Role/RB pairs
+// both in that namespace (no collision since names differ).
+func TestReconcileNamespacedRBAC_SameNamespaceBothComponents(t *testing.T) {
+	r, cli := newReconciler(t, cluster.OpenDataHub)
+	sharedNS := "shared-namespace"
+	dashboard := newDashboard(sharedNS, sharedNS)
+
+	err := r.ReconcileNamespacedRBAC(context.Background(), dashboard)
+	require.NoError(t, err)
+
+	roles := listRoles(t, cli)
+	assert.Len(t, roles, 2)
+
+	// Both roles in the shared namespace
+	getRole(t, cli, sharedNS, "dashboard-notebooks-role")
+	getRole(t, cli, sharedNS, "dashboard-model-registry-role")
+}


### PR DESCRIPTION
## Description

Adds `NotebooksNamespace` and `ModelRegistryNamespace` fields to `DashboardSpec` and implements cross-namespace RBAC reconciliation in the dashboard-operator.

### Why

The dashboard SA needs access to resources in namespaces it doesn't live in:

- **Notebooks namespace** (`rhods-notebooks` / `opendatahub`): PVCs, ConfigMaps, Secrets for workbench lifecycle management
- **Model registry namespace** (`rhoai-model-registries` / `odh-model-registries`): Secrets, ConfigMaps for model registry integration

Previously this RBAC was managed by the platform operator (opendatahub-operator). That approach was incorrect: the platform operator should not create RBAC in namespaces owned by module operators. The dashboard-operator owns this responsibility.

### Architecture

The `DashboardSpec` fields are `// +optional`. Who sets them depends on the deployment model:

- **DSC-managed (OpenShift)**: the platform operator resolves the namespaces from DSC spec and projects them into the Dashboard CR via `BuildModuleCR`
- **Standalone (xKS / no DSC)**: admins set the fields directly in the Dashboard CR, or via GitOps overlay
- **Absent**: the corresponding namespace RBAC is skipped (component not enabled)

This design keeps the dashboard-operator decoupled from the DSC API, which is not guaranteed to exist in all deployment modes.

### Changes

- `api/v1alpha1/dashboard_types.go`: adds `NotebooksNamespace` and `ModelRegistryNamespace` string fields to `DashboardSpec`
- `internal/controller/namespaced_rbac.go`: new file implementing `reconcileNamespacedRBAC` and `cleanupNamespacedRBAC`
- `internal/controller/dashboard_reconciler.go`: hooks both functions into the reconcile loop (both sidecar and standalone paths) and into `cleanupCrossNamespaceResources`

### RBAC rules

**Notebooks namespace:**
- `persistentvolumeclaims`: create, get
- `configmaps`: create, get, update
- `secrets`: create, get, update

**Model-registry namespace:**
- `secrets`: create, delete, get, list, patch
- `configmaps`: create, list

## How Has This Been Tested?

- `go build ./...` exits 0
- `go test ./...` passes (183 tests across 5 packages)

## Related

- Platform operator side (projects namespace values from DSC): opendatahub-io/opendatahub-operator#3982

## Merge criteria

- [ ] You have read the contributors guide.
- [x] Commit messages are meaningful.
- [x] Pull Request contains a description of the solution and links to related PRs.
- [x] Testing instructions have been added.
- [ ] The developer has run the integration test pipeline and verified that it passed successfully.

### E2E test suite update requirement

- [ ] Skip requirement to update E2E test suite for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for separate notebook and Model Registry namespaces.
  * Automatically manages the dashboard’s required permissions in configured namespaces.
  * Validates namespace names using Kubernetes-compatible naming rules.
  * Cleans up outdated permissions when namespace settings change or the dashboard is removed.
  * Supports safe, repeatable permission updates without affecting unrelated resources.

* **Bug Fixes**
  * Permission-management errors no longer prevent other dashboard resources from being processed.
  * Unrelated permissions and resources are preserved during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->