### PR TITLE
feat(RHOAIENG-79807): wire PVC selection into NIM KServe deployment wizard

### DIFF
--- a/packages/cypress/cypress/pages/modelServing/NIMWizardFields.ts
+++ b/packages/cypress/cypress/pages/modelServing/NIMWizardFields.ts
@@ -33,6 +33,12 @@ export class NIMWizardFields extends SubComponentBase {
     return this.findScope().findByTestId('nim-storage-size-input').find('input');
   }
 
+  /** PF NumberInput is controlled — use select-all instead of clear().type() to avoid stale values. */
+  setStorageSizeGi(sizeGi: number): void {
+    this.findStorageSizeInput().type(`{selectall}${sizeGi}`);
+    this.findStorageSizeInput().should('have.value', String(sizeGi));
+  }
+
   findExistingPVCSelect(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findScope().findByTestId('nim-existing-pvc-select');
   }

--- a/packages/cypress/cypress/utils/legacyNimUtils.ts
+++ b/packages/cypress/cypress/utils/legacyNimUtils.ts
@@ -159,6 +159,7 @@ export const initInterceptsToDeployNimInWizard = ({
   // NIM PVC caching field
   cy.interceptK8sList(StorageClassModel, mockStorageClassList());
   cy.interceptK8sList({ model: PVCModel, ns: namespace }, mockK8sResourceList([]));
+  cy.interceptK8s('POST', { model: PVCModel, ns: namespace }, mockNimModelPVC()).as('createPVC');
 
   cy.interceptK8s(
     'POST',

--- a/packages/llmd-serving/src/deployments/topology.ts
+++ b/packages/llmd-serving/src/deployments/topology.ts
@@ -1,4 +1,5 @@
 import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
+import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
 import {
   getDescriptionFromK8sResource,
   getDisplayNameFromK8sResource,
@@ -117,10 +118,13 @@ export const applyTopologyConfig = (
 export const preDeployTopologyConfig = async (
   fieldData: CustomTopologyConfigFieldData,
   wizardState: WizardFormData['state'],
-  deployment: LLMdDeployment,
+  deployment: DeploymentHookPayloadFor<LLMdDeployment>,
   existingDeployment?: LLMdDeployment,
   dryRun?: boolean,
-): Promise<LLMdDeployment> => {
+): Promise<DeploymentHookPayloadFor<LLMdDeployment>> => {
+  if (!deployment.model) {
+    return deployment;
+  }
   const { namespace } = deployment.model.metadata;
 
   const prevTopologyConfigName =

--- a/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maas-model-ref.ts
+++ b/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maas-model-ref.ts
@@ -1,5 +1,6 @@
 import type { LLMdDeployment } from '@odh-dashboard/llmd-serving/types';
 import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
+import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
 import { createMaaSModelRef, deleteMaaSModelRef, updateMaaSModelRef } from '~/app/api/maas-models';
 import type { MaaSFieldValue } from './MaaSEndpointCheckbox';
 
@@ -33,15 +34,18 @@ const parseModelCapabilities = (annotations?: Record<string, string>): string[] 
 export const preDeployMaaSModelRef = async (
   fieldData: MaaSFieldValue,
   wizardState: WizardFormData['state'],
-  deployment: LLMdDeployment,
+  deployment: DeploymentHookPayloadFor<LLMdDeployment>,
   existingDeployment?: LLMdDeployment,
   dryRun?: boolean,
-): Promise<LLMdDeployment> => {
+): Promise<DeploymentHookPayloadFor<LLMdDeployment>> => {
   if (typeof fieldData.isChecked !== 'boolean') {
     return deployment;
   }
   const { isChecked } = fieldData;
   const { model: modelResource } = deployment;
+  if (!modelResource) {
+    return deployment;
+  }
   const { name, namespace: modelNamespace } = modelResource.metadata;
   const namespace = wizardState.project.projectName ?? modelNamespace;
   if (!name || !namespace) {
@@ -116,10 +120,15 @@ export const preDeployMaaSModelRef = async (
  */
 export const postDeployMaaSModelRef = async (
   fieldData: MaaSFieldValue,
-  deployedModel: LLMdDeployment,
+  deployedModel: DeploymentHookPayloadFor<LLMdDeployment>,
   existingDeployment?: LLMdDeployment,
   dryRun?: boolean,
 ): Promise<void> => {
+  // Dryrun is done in preDeploy
+  if (dryRun || !deployedModel.model) {
+    return;
+  }
+
   const { name, namespace, uid } = deployedModel.model.metadata;
   if (typeof fieldData.isChecked !== 'boolean' || !name || !namespace) {
     return;
@@ -130,11 +139,6 @@ export const postDeployMaaSModelRef = async (
     deployedModel.model.metadata.annotations?.['openshift.io/display-name'] ?? name;
   const description = deployedModel.model.metadata.annotations?.['openshift.io/description'] ?? '';
   const modelCapabilities = parseModelCapabilities(deployedModel.model.metadata.annotations);
-
-  // Dryrun is done in preDeploy
-  if (dryRun) {
-    return;
-  }
 
   if (existingDeployment) {
     if (!isChecked) {

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -90,14 +90,14 @@ describe('NIM Models Deployments', () => {
     modelServingWizard.findNumReplicasPlusButton().click();
     modelServingWizard.findNumReplicasInputField().should('have.value', '2');
 
-    // PVC caching (not yet wired into the created resources)
+    // PVC caching storage
     modelServingWizard.nim.findPVCNameInput().type('nim-pvc');
     modelServingWizard.nim.findSubPathInput().type('arctic-embed-l');
     modelServingWizard.nim
       .findStorageClassSelect()
       .findSelectOption('openshift-default-sc')
       .click();
-    modelServingWizard.nim.findStorageSizeInput().clear().type('75');
+    modelServingWizard.nim.setStorageSizeGi(75);
     modelServingWizard.findNextButton().should('be.enabled').click();
 
     // Step 3: Advanced options
@@ -108,6 +108,37 @@ describe('NIM Models Deployments', () => {
 
     // Step 4: Summary
     modelServingWizard.findSubmitButton().should('be.enabled').click();
+
+    // PVC creation — dry-run validates the PVC can be created
+    cy.wait('@createPVC').then((interception) => {
+      expect(interception.request.url).to.include('?dryRun=All');
+      expect(interception.request.body.metadata).to.containSubset({
+        namespace: 'test-project',
+        annotations: {
+          'dashboard.opendatahub.io/nim-pvc': 'true',
+          'dashboard.opendatahub.io/nim-subpath': 'arctic-embed-l',
+        },
+        labels: {
+          'opendatahub.io/managed': 'true',
+        },
+      });
+      expect(interception.request.body.metadata.name).to.match(/^nim-pvc/);
+      expect(interception.request.body.spec).to.containSubset({
+        accessModes: ['ReadWriteOnce'],
+        resources: { requests: { storage: '75Gi' } },
+        storageClassName: 'openshift-default-sc',
+        volumeMode: 'Filesystem',
+      });
+    });
+
+    // PVC creation — real create
+    cy.wait('@createPVC').then((interception) => {
+      expect(interception.request.url).not.to.include('?dryRun=All');
+    });
+
+    cy.get('@createPVC.all').then((interceptions) => {
+      expect(interceptions).to.have.length(2);
+    });
 
     cy.wait('@createInferenceService').then((interception) => {
       expect(interception.request.url).to.include('?dryRun=All');
@@ -166,9 +197,16 @@ describe('NIM Models Deployments', () => {
         supportedModelFormats: [
           { name: 'arctic-embed-l', version: '1.0.1', autoSelect: false, priority: 1 },
         ],
-        // NIM mounts a shared memory volume for the runtime
+        // NIM mounts a shared memory volume and the PVC cache volume
         volumes: [{ name: 'shm', emptyDir: { medium: 'Memory', sizeLimit: '2Gi' } }],
       });
+      // Verify PVC volume is present on the ServingRuntime
+      const pvcVolume = interception.request.body.spec.volumes.find(
+        (v: { persistentVolumeClaim?: { claimName: string } }) => v.persistentVolumeClaim,
+      );
+      expect(pvcVolume).to.not.equal(undefined);
+      expect(pvcVolume.persistentVolumeClaim.claimName).to.match(/^nim-pvc/);
+
       const kserveContainer = interception.request.body.spec.containers.find(
         (container: { name: string }) => container.name === 'kserve-container',
       );
@@ -176,6 +214,16 @@ describe('NIM Models Deployments', () => {
         image: 'nvcr.io/nim/snowflake/arctic-embed-l:1.0.1',
         volumeMounts: [{ name: 'shm', mountPath: '/dev/shm' }],
       });
+      // Verify PVC volumeMount and NIM_CACHE_PATH env var on kserve-container
+      const cacheMount = kserveContainer.volumeMounts.find(
+        (vm: { mountPath: string }) => vm.mountPath === '/mnt/models/cache',
+      );
+      expect(cacheMount).to.not.equal(undefined);
+      expect(cacheMount.subPath).to.equal('arctic-embed-l');
+      const cachePath = kserveContainer.env.find(
+        (e: { name: string }) => e.name === 'NIM_CACHE_PATH',
+      );
+      expect(cachePath).to.containSubset({ value: '/mnt/models/cache' });
       // resources are sized by the InferenceService hardware profile, not the runtime container
       interception.request.body.spec.containers.forEach((container: { resources?: unknown }) => {
         expect(container).to.not.have.property('resources');

--- a/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
+++ b/packages/model-serving/cypress/tests/mocked/modelServing/modelServingNim.cy.ts
@@ -2,6 +2,7 @@ import {
   mockNimInferenceService,
   mockNimServingRuntime,
 } from '@odh-dashboard/model-serving/__mocks__/mockLegacyNimResource';
+import type { Volume } from '@odh-dashboard/k8s-core';
 import { mockK8sResourceList } from '@odh-dashboard/k8s-core/__mocks__/mockK8sResourceList';
 import {
   initInterceptsToDeployNimInWizard,
@@ -91,7 +92,7 @@ describe('NIM Models Deployments', () => {
     modelServingWizard.findNumReplicasInputField().should('have.value', '2');
 
     // PVC caching storage
-    modelServingWizard.nim.findPVCNameInput().type('nim-pvc');
+    modelServingWizard.nim.findPVCNameInput().type('pr pvc test');
     modelServingWizard.nim.findSubPathInput().type('arctic-embed-l');
     modelServingWizard.nim
       .findStorageClassSelect()
@@ -122,7 +123,7 @@ describe('NIM Models Deployments', () => {
           'opendatahub.io/managed': 'true',
         },
       });
-      expect(interception.request.body.metadata.name).to.match(/^nim-pvc/);
+      expect(interception.request.body.metadata.name).to.equal('pr-pvc-test');
       expect(interception.request.body.spec).to.containSubset({
         accessModes: ['ReadWriteOnce'],
         resources: { requests: { storage: '75Gi' } },
@@ -200,12 +201,13 @@ describe('NIM Models Deployments', () => {
         // NIM mounts a shared memory volume and the PVC cache volume
         volumes: [{ name: 'shm', emptyDir: { medium: 'Memory', sizeLimit: '2Gi' } }],
       });
-      // Verify PVC volume is present on the ServingRuntime
-      const pvcVolume = interception.request.body.spec.volumes.find(
-        (v: { persistentVolumeClaim?: { claimName: string } }) => v.persistentVolumeClaim,
+      // Verify the selected PVC replaced the template placeholder (no leftover nim-pvc)
+      const pvcVolumes = interception.request.body.spec.volumes.filter(
+        (v: Volume) => v.persistentVolumeClaim,
       );
-      expect(pvcVolume).to.not.equal(undefined);
-      expect(pvcVolume.persistentVolumeClaim.claimName).to.match(/^nim-pvc/);
+      expect(pvcVolumes).to.have.length(1);
+      expect(pvcVolumes[0].name).to.equal('pr-pvc-test');
+      expect(pvcVolumes[0].persistentVolumeClaim.claimName).to.equal('pr-pvc-test');
 
       const kserveContainer = interception.request.body.spec.containers.find(
         (container: { name: string }) => container.name === 'kserve-container',
@@ -219,6 +221,7 @@ describe('NIM Models Deployments', () => {
         (vm: { mountPath: string }) => vm.mountPath === '/mnt/models/cache',
       );
       expect(cacheMount).to.not.equal(undefined);
+      expect(cacheMount.name).to.equal('pr-pvc-test');
       expect(cacheMount.subPath).to.equal('arctic-embed-l');
       const cachePath = kserveContainer.env.find(
         (e: { name: string }) => e.name === 'NIM_CACHE_PATH',

--- a/packages/model-serving/extension-points/deployment-wizard.ts
+++ b/packages/model-serving/extension-points/deployment-wizard.ts
@@ -4,7 +4,7 @@ import type {
   useHardwareProfileConfig,
 } from '@odh-dashboard/hardware-profiles/shared';
 import type { SupportedModelFormats } from '@odh-dashboard/k8s-core';
-import type { Deployment, ExtractionResult } from './index';
+import type { Deployment, DeploymentHookPayloadFor, ExtractionResult } from './index';
 import type {
   InitialWizardFormData,
   WizardFormData,
@@ -257,10 +257,10 @@ export type WizardFieldDeploymentFunctionsExtension<
       (
         fieldData: T,
         wizardState: WizardFormData['state'],
-        deployment: D,
+        deployment: DeploymentHookPayloadFor<D>,
         existingDeployment?: D,
         dryRun?: boolean,
-      ) => Promise<D>
+      ) => Promise<DeploymentHookPayloadFor<D>>
     >;
     /**
      * Async function that runs after the deployment is saved.
@@ -276,7 +276,12 @@ export type WizardFieldDeploymentFunctionsExtension<
      * @param dryRun - True for the validation pass, falsy for the real pass
      */
     postDeploy: null | CodeRef<
-      (fieldData: T, deployedModel: D, existingDeployment?: D, dryRun?: boolean) => Promise<void>
+      (
+        fieldData: T,
+        deployedModel: DeploymentHookPayloadFor<D>,
+        existingDeployment?: D,
+        dryRun?: boolean,
+      ) => Promise<void>
     >;
   }
 >;

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -93,6 +93,25 @@ export type Deployment<
   resources?: ModelServingPodSpecOptionsState;
 };
 
+/**
+ * Deployment context passed to wizard pre/post-deploy hooks before the model resource
+ * is fully assembled (e.g. KServe NIM deploy). Hooks that require `model` must guard
+ * for its absence and no-op or throw as appropriate.
+ */
+export type DeploymentHookPayload<
+  ModelResource extends ModelResourceType = ModelResourceType,
+  ServerResource extends ServerResourceType = ServerResourceType,
+> = Omit<Deployment<ModelResource, ServerResource>, 'model'> & {
+  model?: ModelResource;
+};
+
+export type DeploymentHookPayloadFor<D extends Deployment> = DeploymentHookPayload<
+  D['model'],
+  D extends Deployment<ModelResourceType, infer ServerResource>
+    ? ServerResource
+    : ServerResourceType
+>;
+
 export type ModelServingPlatformExtension<D extends Deployment = Deployment> = Extension<
   'model-serving.platform',
   {

--- a/packages/model-serving/src/__mocks__/mockLegacyNimResource.ts
+++ b/packages/model-serving/src/__mocks__/mockLegacyNimResource.ts
@@ -118,6 +118,10 @@ export const mockNimServingRuntimeTemplate = ({
     namespace,
     // NIM writes the selected image and the shm mounts onto the `kserve-container`
     containerName: 'kserve-container',
+    // Real NIM operator templates ship a placeholder `nim-pvc` volume that must be
+    // replaced at deploy time — keep that shape so wizard tests catch leftovers.
+    volumes: [{ name: 'nim-pvc', persistentVolumeClaim: { claimName: 'nim-pvc' } }],
+    containerVolumeMounts: [{ name: 'nim-pvc', mountPath: '/mnt/models/cache' }],
   });
   if (templateMock.metadata.annotations != null) {
     templateMock.metadata.annotations['opendatahub.io/dashboard'] = 'true';

--- a/packages/model-serving/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/packages/model-serving/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -1,4 +1,10 @@
-import type { K8sDSGResource, SupportedModelFormats, TemplateKind } from '@odh-dashboard/k8s-core';
+import type {
+  K8sDSGResource,
+  SupportedModelFormats,
+  TemplateKind,
+  Volume,
+  VolumeMount,
+} from '@odh-dashboard/k8s-core';
 import {
   ServingRuntimeAPIProtocol,
   ServingRuntimeModelType,
@@ -16,6 +22,8 @@ type MockResourceConfigType = {
   apiProtocol?: ServingRuntimeAPIProtocol;
   containerName?: string;
   containerEnvVars?: { name: string; value: string }[];
+  containerVolumeMounts?: VolumeMount[];
+  volumes?: Volume[];
   supportedModelFormats?: SupportedModelFormats[];
   annotations?: Record<string, string>;
   objects?: K8sDSGResource[];
@@ -46,6 +54,8 @@ export const mockServingRuntimeTemplateK8sResource = ({
   ],
   annotations,
   objects,
+  containerVolumeMounts,
+  volumes,
   version = '1.0.0',
 }: MockResourceConfigType): TemplateKind => ({
   apiVersion: 'template.openshift.io/v1',
@@ -97,6 +107,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
               '--target_device=NVIDIA',
             ],
             ...(containerEnvVars && { env: containerEnvVars }),
+            ...(containerVolumeMounts && { volumeMounts: containerVolumeMounts }),
             image:
               'quay.io/modh/openvino-model-server@sha256:c89f76386bc8b59f0748cf173868e5beef21ac7d2f78dada69089c4d37c44116',
             name: containerName,
@@ -116,6 +127,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
         grpcEndpoint: 'port:8085',
         protocolVersions: ['grpc-v1'],
         supportedModelFormats,
+        ...(volumes && { volumes }),
       },
     },
   ],

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useWizardFieldPostDeploy.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useWizardFieldPostDeploy.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import type { WizardFormData } from '../../../shared/types/form-data';
-import { type Deployment } from '../../../../extension-points';
+import { type Deployment, type DeploymentHookPayload } from '../../../../extension-points';
 import { isWizardFieldDeploymentFunctionsExtension } from '../../../../extension-points/deployment-wizard';
 import { useActiveFields } from '../dynamicFormUtils';
 
 export type RunPostDeployFns = (
-  deployedModel: Deployment,
+  deployedModel: DeploymentHookPayload,
   existingDeployment?: Deployment,
   dryRun?: boolean,
 ) => Promise<void>;
@@ -45,7 +45,7 @@ export const useWizardFieldPostDeploy = (
 
   const runPostDeploy = React.useCallback<RunPostDeployFns>(
     async (
-      deployedModel: Deployment,
+      deployedModel: DeploymentHookPayload,
       existingDeployment?: Deployment,
       dryRun?: boolean,
     ): Promise<void> => {

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useWizardFieldPreDeploy.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useWizardFieldPreDeploy.ts
@@ -1,15 +1,15 @@
 import React from 'react';
 import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import type { WizardFormData } from '../../../shared/types/form-data';
-import { type Deployment } from '../../../../extension-points';
+import { type Deployment, type DeploymentHookPayload } from '../../../../extension-points';
 import { isWizardFieldDeploymentFunctionsExtension } from '../../../../extension-points/deployment-wizard';
 import { useActiveFields } from '../dynamicFormUtils';
 
 export type RunPreDeployFns = (
-  deployment: Deployment,
+  deployment: DeploymentHookPayload,
   existingDeployment?: Deployment,
   dryRun?: boolean,
-) => Promise<Deployment>;
+) => Promise<DeploymentHookPayload>;
 
 /**
  * Hook that returns an async function to dry-run all active pre-deploy extensions before
@@ -44,10 +44,10 @@ export const useWizardFieldPreDeploy = (
 
   const runPreDeploy = React.useCallback<RunPreDeployFns>(
     async (
-      deployment: Deployment,
+      deployment: DeploymentHookPayload,
       existingDeployment?: Deployment,
       dryRun?: boolean,
-    ): Promise<Deployment> => {
+    ): Promise<DeploymentHookPayload> => {
       let current = deployment;
       for (const ext of activePreDeployExtensions) {
         const { fieldId } = ext.properties;

--- a/packages/model-serving/src/components/deploymentWizard/utils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/utils.ts
@@ -30,7 +30,11 @@ import {
   handleConnectionCreation,
   handleSecretOwnerReferencePatch,
 } from '../../concepts/connectionUtils';
-import type { Deployment, DeploymentEndpoint } from '../../../extension-points';
+import type {
+  Deployment,
+  DeploymentEndpoint,
+  DeploymentHookPayload,
+} from '../../../extension-points';
 import { DeploymentAssemblyFn } from '../../../extension-points/deployment-wizard';
 import { isDeploymentAuthEnabled } from '../../concepts/auth';
 
@@ -72,12 +76,11 @@ export const getTokenAuthenticationFromDeployment = (
 // a pre-assembled model resource, so `model` may be undefined here. The
 // preDeploy/postDeploy hooks still need to run — they create side-effect
 // resources (PVCs, secrets, etc.) that don't depend on the model resource.
-const toDeployment = (
+const toDeploymentHookPayload = (
   platform: string,
   model?: Deployment['model'],
   server?: Deployment['server'],
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-): Deployment => ({ modelServingPlatformId: platform, model, server } as Deployment);
+): DeploymentHookPayload => ({ modelServingPlatformId: platform, model, server });
 
 export const deployModel = async (
   wizardState: WizardFormData['state'],
@@ -132,7 +135,7 @@ export const deployModel = async (
   if (runPreDeploy) {
     dryRuns.push(
       runPreDeploy(
-        toDeployment(deployMethod.platform, dryRunModelResource, serverResource),
+        toDeploymentHookPayload(deployMethod.platform, dryRunModelResource, serverResource),
         existingDeployment,
         true,
       ),
@@ -160,7 +163,7 @@ export const deployModel = async (
   if (runPostDeploy) {
     dryRuns.push(
       runPostDeploy(
-        toDeployment(deployMethod.platform, dryRunModelResource, serverResource),
+        toDeploymentHookPayload(deployMethod.platform, dryRunModelResource, serverResource),
         existingDeployment,
         true,
       ),
@@ -192,7 +195,7 @@ export const deployModel = async (
   }
   if (runPreDeploy) {
     await runPreDeploy(
-      toDeployment(deployMethod.platform, modelResourceWithConnection, serverResource),
+      toDeploymentHookPayload(deployMethod.platform, modelResourceWithConnection, serverResource),
       existingDeployment,
     );
   }

--- a/packages/model-serving/src/components/deploymentWizard/utils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/utils.ts
@@ -68,6 +68,17 @@ export const getTokenAuthenticationFromDeployment = (
   return [];
 };
 
+// Deploy paths that assemble the model internally (e.g. KServe) don't provide
+// a pre-assembled model resource, so `model` may be undefined here. The
+// preDeploy/postDeploy hooks still need to run — they create side-effect
+// resources (PVCs, secrets, etc.) that don't depend on the model resource.
+const toDeployment = (
+  platform: string,
+  model?: Deployment['model'],
+  server?: Deployment['server'],
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+): Deployment => ({ modelServingPlatformId: platform, model, server } as Deployment);
+
 export const deployModel = async (
   wizardState: WizardFormData['state'],
   externalData: ExternalDataMap,
@@ -118,14 +129,10 @@ export const deployModel = async (
       wizardState.modelLocationData.selectedConnection,
     ),
   );
-  if (runPreDeploy && dryRunModelResource) {
+  if (runPreDeploy) {
     dryRuns.push(
       runPreDeploy(
-        {
-          modelServingPlatformId: deployMethod.platform,
-          model: dryRunModelResource,
-          server: serverResource,
-        },
+        toDeployment(deployMethod.platform, dryRunModelResource, serverResource),
         existingDeployment,
         true,
       ),
@@ -150,14 +157,10 @@ export const deployModel = async (
       ),
     );
   }
-  if (runPostDeploy && dryRunModelResource) {
+  if (runPostDeploy) {
     dryRuns.push(
       runPostDeploy(
-        {
-          modelServingPlatformId: deployMethod.platform,
-          model: dryRunModelResource,
-          server: serverResource,
-        },
+        toDeployment(deployMethod.platform, dryRunModelResource, serverResource),
         existingDeployment,
         true,
       ),
@@ -187,13 +190,9 @@ export const deployModel = async (
     modelResourceWithConnection.metadata.annotations[MetadataAnnotation.ConnectionName] =
       createdSecretName;
   }
-  if (runPreDeploy && modelResourceWithConnection) {
+  if (runPreDeploy) {
     await runPreDeploy(
-      {
-        modelServingPlatformId: deployMethod.platform,
-        model: modelResourceWithConnection,
-        server: serverResource,
-      },
+      toDeployment(deployMethod.platform, modelResourceWithConnection, serverResource),
       existingDeployment,
     );
   }

--- a/packages/nim-serving/extensions/nim-kserve.ts
+++ b/packages/nim-serving/extensions/nim-kserve.ts
@@ -2,6 +2,7 @@ import type { KServeDeployment } from '@odh-dashboard/kserve/types';
 import type {
   ModelServingDeploy,
   WizardFieldApplyExtension,
+  WizardFieldDeploymentFunctionsExtension,
   WizardFieldExtractorExtension,
 } from '@odh-dashboard/model-serving/extension-points/deployment-wizard';
 // eslint-disable-next-line no-restricted-syntax
@@ -9,11 +10,72 @@ import { SupportedArea } from '@odh-dashboard/plugin-core/areas';
 // eslint-disable-next-line no-restricted-syntax
 import { NIM_LEGACY_ID } from '../src/constants';
 import type { NIMImageFieldValue } from '../src/pages/deploymentWizard/fields/NIMImageField';
+import type { NIMPVCFieldValue } from '../src/pages/deploymentWizard/fields/NIMPVCField';
+
+const nimPVCApplyExtension: WizardFieldApplyExtension<NIMPVCFieldValue, KServeDeployment> = {
+  type: 'model-serving.deployment/wizard-field-apply',
+  properties: {
+    fieldId: 'nim-serving/pvcStorage',
+    platform: NIM_LEGACY_ID,
+    apply: () =>
+      import('../src/nimKServe/fields/nimPVCApplyExtract').then((m) => m.applyNIMPVCFieldData),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
+
+const nimPVCExtractorExtension: WizardFieldExtractorExtension<NIMPVCFieldValue, KServeDeployment> =
+  {
+    type: 'model-serving.deployment/wizard-field-extractor',
+    properties: {
+      fieldId: 'nim-serving/pvcStorage',
+      platform: NIM_LEGACY_ID,
+      extract: () =>
+        import('../src/nimKServe/fields/nimPVCApplyExtract').then((m) => m.extractNIMPVCFieldData),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  };
+
+const nimPVCDeployFunctionsExtension: WizardFieldDeploymentFunctionsExtension<
+  NIMPVCFieldValue,
+  KServeDeployment
+> = {
+  type: 'model-serving.deployment/wizard-field-deployment-functions',
+  properties: {
+    fieldId: 'nim-serving/pvcStorage',
+    platform: NIM_LEGACY_ID,
+    preDeploy: () =>
+      import('../src/nimKServe/fields/nimPVCDeployFunctions').then((m) => m.nimPVCPreDeploy),
+    postDeploy: null,
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
+
+const nimImageApplyExtension: WizardFieldApplyExtension<NIMImageFieldValue, KServeDeployment> = {
+  type: 'model-serving.deployment/wizard-field-apply',
+  properties: {
+    fieldId: 'nim-serving/nimImage',
+    platform: NIM_LEGACY_ID,
+    apply: () =>
+      import('../src/nimKServe/fields/nimImageApplyExtract').then((m) => m.applyNIMImageFieldData),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
 
 const extensions: (
   | ModelServingDeploy<KServeDeployment>
   | WizardFieldExtractorExtension<NIMImageFieldValue, KServeDeployment>
+  | WizardFieldExtractorExtension<NIMPVCFieldValue, KServeDeployment>
   | WizardFieldApplyExtension<NIMImageFieldValue, KServeDeployment>
+  | WizardFieldApplyExtension<NIMPVCFieldValue, KServeDeployment>
+  | WizardFieldDeploymentFunctionsExtension<NIMPVCFieldValue, KServeDeployment>
 )[] = [
   {
     type: 'model-serving.deployment/deploy',
@@ -28,20 +90,10 @@ const extensions: (
       required: [SupportedArea.NIM_WIZARD],
     },
   },
-  {
-    type: 'model-serving.deployment/wizard-field-apply',
-    properties: {
-      fieldId: 'nim-serving/nimImage',
-      platform: NIM_LEGACY_ID,
-      apply: () =>
-        import('../src/nimKServe/fields/nimImageApplyExtract').then(
-          (m) => m.applyNIMImageFieldData,
-        ),
-    },
-    flags: {
-      required: [SupportedArea.NIM_WIZARD],
-    },
-  },
+  nimImageApplyExtension,
+  nimPVCApplyExtension,
+  nimPVCExtractorExtension,
+  nimPVCDeployFunctionsExtension,
 ];
 
 export default extensions;

--- a/packages/nim-serving/src/constants.ts
+++ b/packages/nim-serving/src/constants.ts
@@ -10,4 +10,6 @@ export const NIM_MODEL_TYPE = 'NVIDIA NIM';
 export const KSERVE_CONTAINER_NAME = 'kserve-container';
 export const NIM_CACHE_MOUNT_PATH = '/mnt/models/cache';
 export const NIM_CACHE_PATH_ENV = 'NIM_CACHE_PATH';
+/** Placeholder PVC volume baked into the NVIDIA NIM ServingRuntime template. */
+export const NIM_TEMPLATE_PVC_NAME = 'nim-pvc';
 export const DEFAULT_STORAGE_SIZE_GI = 50;

--- a/packages/nim-serving/src/constants.ts
+++ b/packages/nim-serving/src/constants.ts
@@ -6,3 +6,8 @@ export const NIM_LEGACY_ID = 'nvidia-nim';
 /** Platform id for NIMService deployments managed by the k8s-nim-operator. */
 export const NIM_SERVICE_ID = 'nvidia-nim-service';
 export const NIM_MODEL_TYPE = 'NVIDIA NIM';
+
+export const KSERVE_CONTAINER_NAME = 'kserve-container';
+export const NIM_CACHE_MOUNT_PATH = '/mnt/models/cache';
+export const NIM_CACHE_PATH_ENV = 'NIM_CACHE_PATH';
+export const DEFAULT_STORAGE_SIZE_GI = 50;

--- a/packages/nim-serving/src/nimKServe/fields/__tests__/nimPVCApplyExtract.spec.ts
+++ b/packages/nim-serving/src/nimKServe/fields/__tests__/nimPVCApplyExtract.spec.ts
@@ -5,7 +5,12 @@ import {
   NIMPVCStorageMode,
   type NIMPVCFieldValue,
 } from '../../../pages/deploymentWizard/fields/NIMPVCField';
-import { DEFAULT_STORAGE_SIZE_GI } from '../../../constants';
+import {
+  DEFAULT_STORAGE_SIZE_GI,
+  KSERVE_CONTAINER_NAME,
+  NIM_CACHE_MOUNT_PATH,
+  NIM_TEMPLATE_PVC_NAME,
+} from '../../../constants';
 import { applyNIMPVCFieldData, extractNIMPVCFieldData } from '../nimPVCApplyExtract';
 
 const makeServingRuntime = (
@@ -107,6 +112,24 @@ describe('applyNIMPVCFieldData', () => {
     expect(mount?.subPath).toBeUndefined();
   });
 
+  it('should translate display names with spaces into valid k8s names', () => {
+    const result = applyNIMPVCFieldData(
+      makeDeployment(makeServingRuntime()),
+      makeFieldValue({ pvcName: 'pr pvc test' }),
+    );
+    expect(result.server?.spec.volumes).toContainEqual({
+      name: 'pr-pvc-test',
+      persistentVolumeClaim: { claimName: 'pr-pvc-test' },
+    });
+    const container = result.server?.spec.containers.find((c) => c.name === 'kserve-container');
+    expect(container?.volumeMounts).toContainEqual(
+      expect.objectContaining({
+        name: 'pr-pvc-test',
+        mountPath: '/mnt/models/cache',
+      }),
+    );
+  });
+
   it('should preserve existing volumes', () => {
     const runtime = makeServingRuntime({
       volumes: [{ name: 'shm', emptyDir: {} }],
@@ -117,6 +140,36 @@ describe('applyNIMPVCFieldData', () => {
     );
     expect(result.server?.spec.volumes).toHaveLength(2);
     expect(result.server?.spec.volumes?.[0]).toEqual({ name: 'shm', emptyDir: {} });
+  });
+
+  it('should replace the template placeholder nim-pvc volume', () => {
+    const runtime = makeServingRuntime({
+      containers: [
+        {
+          name: KSERVE_CONTAINER_NAME,
+          volumeMounts: [{ name: NIM_TEMPLATE_PVC_NAME, mountPath: NIM_CACHE_MOUNT_PATH }],
+        },
+      ],
+      volumes: [
+        {
+          name: NIM_TEMPLATE_PVC_NAME,
+          persistentVolumeClaim: { claimName: NIM_TEMPLATE_PVC_NAME },
+        },
+        { name: 'shm', emptyDir: {} },
+      ],
+    });
+    const result = applyNIMPVCFieldData(
+      makeDeployment(runtime),
+      makeFieldValue({ pvcName: 'pr pvc test' }),
+    );
+    expect(result.server?.spec.volumes).toEqual([
+      { name: 'shm', emptyDir: {} },
+      { name: 'pr-pvc-test', persistentVolumeClaim: { claimName: 'pr-pvc-test' } },
+    ]);
+    const container = result.server?.spec.containers.find((c) => c.name === KSERVE_CONTAINER_NAME);
+    expect(container?.volumeMounts).toEqual([
+      { name: 'pr-pvc-test', mountPath: NIM_CACHE_MOUNT_PATH },
+    ]);
   });
 
   it('should replace an existing volume with the same PVC claim', () => {

--- a/packages/nim-serving/src/nimKServe/fields/__tests__/nimPVCApplyExtract.spec.ts
+++ b/packages/nim-serving/src/nimKServe/fields/__tests__/nimPVCApplyExtract.spec.ts
@@ -1,0 +1,213 @@
+import type { KServeDeployment } from '@odh-dashboard/kserve/types';
+import type { ServingRuntimeKind } from '@odh-dashboard/model-serving/shared';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
+import {
+  NIMPVCStorageMode,
+  type NIMPVCFieldValue,
+} from '../../../pages/deploymentWizard/fields/NIMPVCField';
+import { DEFAULT_STORAGE_SIZE_GI } from '../../../constants';
+import { applyNIMPVCFieldData, extractNIMPVCFieldData } from '../nimPVCApplyExtract';
+
+const makeServingRuntime = (
+  overrides?: Partial<ServingRuntimeKind['spec']>,
+): ServingRuntimeKind => ({
+  apiVersion: 'serving.kserve.io/v1alpha1',
+  kind: 'ServingRuntime',
+  metadata: { name: 'test-nim', namespace: 'test-project' },
+  spec: {
+    containers: [{ name: 'kserve-container' }],
+    supportedModelFormats: [{ name: 'test-model', version: '1' }],
+    ...overrides,
+  },
+});
+
+const makeDeployment = (server?: ServingRuntimeKind): KServeDeployment => ({
+  modelServingPlatformId: 'nvidia-nim',
+  model: mockInferenceServiceK8sResource({ name: 'test-nim' }),
+  server,
+});
+
+const makeFieldValue = (overrides?: Partial<NIMPVCFieldValue>): NIMPVCFieldValue => ({
+  storageMode: NIMPVCStorageMode.NEW,
+  pvcName: 'my-nim-pvc',
+  subPath: '',
+  storageClassName: 'gp3-csi',
+  storageSizeGi: DEFAULT_STORAGE_SIZE_GI,
+  ...overrides,
+});
+
+describe('applyNIMPVCFieldData', () => {
+  it('should return deployment unchanged when there is no server', () => {
+    const deployment = makeDeployment();
+    const result = applyNIMPVCFieldData(deployment, makeFieldValue());
+    expect(result.server).toBeUndefined();
+  });
+
+  it('should add a PVC volume to the serving runtime', () => {
+    const result = applyNIMPVCFieldData(
+      makeDeployment(makeServingRuntime()),
+      makeFieldValue({ pvcName: 'nim-cache' }),
+    );
+    expect(result.server?.spec.volumes).toContainEqual({
+      name: 'nim-cache',
+      persistentVolumeClaim: { claimName: 'nim-cache' },
+    });
+  });
+
+  it('should add a volume mount to the kserve-container', () => {
+    const result = applyNIMPVCFieldData(
+      makeDeployment(makeServingRuntime()),
+      makeFieldValue({ pvcName: 'nim-cache' }),
+    );
+    const container = result.server?.spec.containers.find((c) => c.name === 'kserve-container');
+    expect(container?.volumeMounts).toContainEqual(
+      expect.objectContaining({
+        name: 'nim-cache',
+        mountPath: '/mnt/models/cache',
+      }),
+    );
+  });
+
+  it('should set NIM_CACHE_PATH env var on the kserve-container', () => {
+    const result = applyNIMPVCFieldData(makeDeployment(makeServingRuntime()), makeFieldValue());
+    const container = result.server?.spec.containers.find((c) => c.name === 'kserve-container');
+    expect(container?.env).toContainEqual({
+      name: 'NIM_CACHE_PATH',
+      value: '/mnt/models/cache',
+    });
+  });
+
+  it('should omit subPath when it is empty', () => {
+    const result = applyNIMPVCFieldData(
+      makeDeployment(makeServingRuntime()),
+      makeFieldValue({ subPath: '' }),
+    );
+    const container = result.server?.spec.containers.find((c) => c.name === 'kserve-container');
+    const mount = container?.volumeMounts?.find((vm) => vm.mountPath === '/mnt/models/cache');
+    expect(mount?.subPath).toBeUndefined();
+  });
+
+  it('should strip leading slashes from subPath', () => {
+    const result = applyNIMPVCFieldData(
+      makeDeployment(makeServingRuntime()),
+      makeFieldValue({ subPath: '/models/llama' }),
+    );
+    const container = result.server?.spec.containers.find((c) => c.name === 'kserve-container');
+    const mount = container?.volumeMounts?.find((vm) => vm.mountPath === '/mnt/models/cache');
+    expect(mount?.subPath).toBe('models/llama');
+  });
+
+  it('should strip "/" to undefined (same as empty)', () => {
+    const result = applyNIMPVCFieldData(
+      makeDeployment(makeServingRuntime()),
+      makeFieldValue({ subPath: '/' }),
+    );
+    const container = result.server?.spec.containers.find((c) => c.name === 'kserve-container');
+    const mount = container?.volumeMounts?.find((vm) => vm.mountPath === '/mnt/models/cache');
+    expect(mount?.subPath).toBeUndefined();
+  });
+
+  it('should preserve existing volumes', () => {
+    const runtime = makeServingRuntime({
+      volumes: [{ name: 'shm', emptyDir: {} }],
+    });
+    const result = applyNIMPVCFieldData(
+      makeDeployment(runtime),
+      makeFieldValue({ pvcName: 'nim-cache' }),
+    );
+    expect(result.server?.spec.volumes).toHaveLength(2);
+    expect(result.server?.spec.volumes?.[0]).toEqual({ name: 'shm', emptyDir: {} });
+  });
+
+  it('should replace an existing volume with the same PVC claim', () => {
+    const runtime = makeServingRuntime({
+      volumes: [
+        { name: 'nim-cache', persistentVolumeClaim: { claimName: 'nim-cache' } },
+        { name: 'shm', emptyDir: {} },
+      ],
+    });
+    const result = applyNIMPVCFieldData(
+      makeDeployment(runtime),
+      makeFieldValue({ pvcName: 'nim-cache' }),
+    );
+    const pvcVolumes = result.server?.spec.volumes?.filter(
+      (v) => v.persistentVolumeClaim?.claimName === 'nim-cache',
+    );
+    expect(pvcVolumes).toHaveLength(1);
+  });
+
+  it('should not modify other containers', () => {
+    const runtime = makeServingRuntime({
+      containers: [{ name: 'sidecar' }, { name: 'kserve-container' }],
+    });
+    const result = applyNIMPVCFieldData(makeDeployment(runtime), makeFieldValue());
+    const sidecar = result.server?.spec.containers.find((c) => c.name === 'sidecar');
+    expect(sidecar?.volumeMounts).toBeUndefined();
+    expect(sidecar?.env).toBeUndefined();
+  });
+
+  it('should not mutate the original deployment', () => {
+    const runtime = makeServingRuntime();
+    const deployment = makeDeployment(runtime);
+    applyNIMPVCFieldData(deployment, makeFieldValue());
+    expect(runtime.spec.volumes).toBeUndefined();
+    expect(runtime.spec.containers[0].volumeMounts).toBeUndefined();
+  });
+});
+
+describe('extractNIMPVCFieldData', () => {
+  it('should return undefined when there is no server', () => {
+    expect(extractNIMPVCFieldData(makeDeployment())).toBeUndefined();
+  });
+
+  it('should return undefined when there is no cache volume mount', () => {
+    expect(extractNIMPVCFieldData(makeDeployment(makeServingRuntime()))).toBeUndefined();
+  });
+
+  it('should return undefined when volume mount has no matching PVC volume', () => {
+    const runtime = makeServingRuntime({
+      containers: [
+        {
+          name: 'kserve-container',
+          volumeMounts: [{ name: 'some-vol', mountPath: '/mnt/models/cache' }],
+        },
+      ],
+      volumes: [{ name: 'some-vol', emptyDir: {} }],
+    });
+    expect(extractNIMPVCFieldData(makeDeployment(runtime))).toBeUndefined();
+  });
+
+  it('should extract PVC data from a configured runtime', () => {
+    const runtime = makeServingRuntime({
+      containers: [
+        {
+          name: 'kserve-container',
+          volumeMounts: [{ name: 'nim-cache', mountPath: '/mnt/models/cache', subPath: 'models' }],
+        },
+      ],
+      volumes: [{ name: 'nim-cache', persistentVolumeClaim: { claimName: 'nim-cache' } }],
+    });
+    const result = extractNIMPVCFieldData(makeDeployment(runtime));
+    expect(result).toEqual({
+      storageMode: NIMPVCStorageMode.EXISTING,
+      pvcName: 'nim-cache',
+      subPath: 'models',
+      storageClassName: '',
+      storageSizeGi: DEFAULT_STORAGE_SIZE_GI,
+    });
+  });
+
+  it('should default subPath to empty string when not set', () => {
+    const runtime = makeServingRuntime({
+      containers: [
+        {
+          name: 'kserve-container',
+          volumeMounts: [{ name: 'nim-cache', mountPath: '/mnt/models/cache' }],
+        },
+      ],
+      volumes: [{ name: 'nim-cache', persistentVolumeClaim: { claimName: 'nim-cache' } }],
+    });
+    const result = extractNIMPVCFieldData(makeDeployment(runtime));
+    expect(result?.subPath).toBe('');
+  });
+});

--- a/packages/nim-serving/src/nimKServe/fields/__tests__/nimPVCDeployFunctions.spec.ts
+++ b/packages/nim-serving/src/nimKServe/fields/__tests__/nimPVCDeployFunctions.spec.ts
@@ -1,0 +1,128 @@
+import type { KServeDeployment } from '@odh-dashboard/kserve/types';
+import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/model-serving/__mocks__/mockInferenceServiceK8sResource';
+import { createPvc } from '@odh-dashboard/internal/api';
+import { AccessMode } from '@odh-dashboard/k8s-core';
+import {
+  NIMPVCStorageMode,
+  type NIMPVCFieldValue,
+} from '../../../pages/deploymentWizard/fields/NIMPVCField';
+import { DEFAULT_STORAGE_SIZE_GI } from '../../../constants';
+import { nimPVCPreDeploy } from '../nimPVCDeployFunctions';
+
+jest.mock('@odh-dashboard/internal/api', () => ({
+  createPvc: jest.fn(),
+}));
+
+const mockCreatePvc = jest.mocked(createPvc);
+
+const makeDeployment = (): KServeDeployment => ({
+  modelServingPlatformId: 'nvidia-nim',
+  model: mockInferenceServiceK8sResource({ name: 'test-nim' }),
+});
+
+const makeWizardState = (projectName = 'test-project'): WizardFormData['state'] =>
+  ({ project: { projectName } } as unknown as WizardFormData['state']);
+
+const makeFieldValue = (overrides?: Partial<NIMPVCFieldValue>): NIMPVCFieldValue => ({
+  storageMode: NIMPVCStorageMode.NEW,
+  pvcName: 'my-nim-pvc',
+  subPath: '',
+  storageClassName: 'gp3-csi',
+  storageSizeGi: DEFAULT_STORAGE_SIZE_GI,
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCreatePvc.mockResolvedValue({
+    apiVersion: 'v1',
+    kind: 'PersistentVolumeClaim',
+    metadata: { name: 'my-nim-pvc', namespace: 'test-project' },
+    spec: {
+      accessModes: [AccessMode.RWO],
+      resources: { requests: { storage: '50Gi' } },
+      volumeMode: 'Filesystem' as const,
+    },
+    status: { phase: 'Pending' },
+  });
+});
+
+describe('nimPVCPreDeploy', () => {
+  it('should throw when project is not set', async () => {
+    const wizardState = makeWizardState('');
+    await expect(nimPVCPreDeploy(makeFieldValue(), wizardState, makeDeployment())).rejects.toThrow(
+      'Project is required',
+    );
+  });
+
+  it('should skip PVC creation for EXISTING mode', async () => {
+    const deployment = makeDeployment();
+    const result = await nimPVCPreDeploy(
+      makeFieldValue({ storageMode: NIMPVCStorageMode.EXISTING }),
+      makeWizardState(),
+      deployment,
+    );
+    expect(mockCreatePvc).not.toHaveBeenCalled();
+    expect(result).toBe(deployment);
+  });
+
+  it('should create PVC for NEW mode', async () => {
+    await nimPVCPreDeploy(makeFieldValue(), makeWizardState(), makeDeployment());
+    expect(mockCreatePvc).toHaveBeenCalledTimes(1);
+    expect(mockCreatePvc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'my-nim-pvc',
+        size: '50Gi',
+        storageClassName: 'gp3-csi',
+      }),
+      'test-project',
+      { dryRun: false },
+      false,
+      expect.objectContaining({ 'dashboard.opendatahub.io/nim-pvc': 'true' }),
+      { 'opendatahub.io/managed': 'true' },
+    );
+  });
+
+  it('should pass dryRun flag to createPvc', async () => {
+    await nimPVCPreDeploy(makeFieldValue(), makeWizardState(), makeDeployment(), undefined, true);
+    expect(mockCreatePvc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { dryRun: true },
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('should include subPath annotation when subPath is set', async () => {
+    await nimPVCPreDeploy(
+      makeFieldValue({ subPath: 'models/llama' }),
+      makeWizardState(),
+      makeDeployment(),
+    );
+    expect(mockCreatePvc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        'dashboard.opendatahub.io/nim-subpath': 'models/llama',
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should not include subPath annotation when subPath is empty', async () => {
+    await nimPVCPreDeploy(makeFieldValue({ subPath: '' }), makeWizardState(), makeDeployment());
+    const annotations = mockCreatePvc.mock.calls[0][4];
+    expect(annotations).not.toHaveProperty('dashboard.opendatahub.io/nim-subpath');
+  });
+
+  it('should return the deployment unchanged', async () => {
+    const deployment = makeDeployment();
+    const result = await nimPVCPreDeploy(makeFieldValue(), makeWizardState(), deployment);
+    expect(result).toBe(deployment);
+  });
+});

--- a/packages/nim-serving/src/nimKServe/fields/nimImageApplyExtract.ts
+++ b/packages/nim-serving/src/nimKServe/fields/nimImageApplyExtract.ts
@@ -1,6 +1,7 @@
 import { KServeDeployment } from '@odh-dashboard/kserve/types';
 import type { NIMImageFieldValue } from '../../pages/deploymentWizard/fields/NIMImageField';
 import { getModelNameFromRepository } from '../../api/images/utils';
+import { KSERVE_CONTAINER_NAME } from '../../constants';
 
 const setNIMDeploymentModelFormat = (
   deployment: KServeDeployment,
@@ -47,7 +48,7 @@ const setNIMDeploymentImage = (
   }
   const newServingRuntime = structuredClone(deployment.server);
   newServingRuntime.spec.containers = newServingRuntime.spec.containers.map((c) => {
-    if (c.name === 'kserve-container') {
+    if (c.name === KSERVE_CONTAINER_NAME) {
       return {
         ...c,
         image: `${nimImage.repository}:${nimImage.tag}`,

--- a/packages/nim-serving/src/nimKServe/fields/nimPVCApplyExtract.ts
+++ b/packages/nim-serving/src/nimKServe/fields/nimPVCApplyExtract.ts
@@ -1,6 +1,6 @@
 import type { KServeDeployment } from '@odh-dashboard/kserve/types';
 import type { ServingContainer } from '@odh-dashboard/model-serving/shared';
-import type { Volume, VolumeMount } from '@odh-dashboard/k8s-core';
+import { translateDisplayNameForK8s, type Volume, type VolumeMount } from '@odh-dashboard/k8s-core';
 import {
   NIMPVCStorageMode,
   type NIMPVCFieldValue,
@@ -9,6 +9,7 @@ import {
   KSERVE_CONTAINER_NAME,
   NIM_CACHE_MOUNT_PATH,
   NIM_CACHE_PATH_ENV,
+  NIM_TEMPLATE_PVC_NAME,
   DEFAULT_STORAGE_SIZE_GI,
 } from '../../constants';
 
@@ -16,6 +17,11 @@ const normalizeSubPath = (subPath: string): string | undefined => {
   const stripped = subPath.replace(/^\/+/, '');
   return stripped || undefined;
 };
+
+const isTemplateOrCachePvcVolume = (volume: Volume, cacheVolumeNames: Set<string>): boolean =>
+  cacheVolumeNames.has(volume.name) ||
+  volume.name === NIM_TEMPLATE_PVC_NAME ||
+  volume.persistentVolumeClaim?.claimName === NIM_TEMPLATE_PVC_NAME;
 
 const addPVCVolumeToRuntime = (
   deployment: KServeDeployment,
@@ -26,19 +32,31 @@ const addPVCVolumeToRuntime = (
     return deployment;
   }
 
+  const k8sPvcName = translateDisplayNameForK8s(pvcName);
   const server = structuredClone(deployment.server);
+  const cacheVolumeNames = new Set(
+    server.spec.containers.flatMap((c) =>
+      (c.volumeMounts ?? [])
+        .filter((vm) => vm.mountPath === NIM_CACHE_MOUNT_PATH)
+        .map((vm) => vm.name),
+    ),
+  );
   const volume: Volume = {
-    name: pvcName,
-    persistentVolumeClaim: { claimName: pvcName },
+    name: k8sPvcName,
+    persistentVolumeClaim: { claimName: k8sPvcName },
   };
   const volumeMount: VolumeMount = {
-    name: pvcName,
+    name: k8sPvcName,
     mountPath: NIM_CACHE_MOUNT_PATH,
     subPath: normalizeSubPath(subPath),
   };
 
   server.spec.volumes = [
-    ...(server.spec.volumes ?? []).filter((v) => v.persistentVolumeClaim?.claimName !== pvcName),
+    ...(server.spec.volumes ?? []).filter(
+      (v) =>
+        !isTemplateOrCachePvcVolume(v, cacheVolumeNames) &&
+        v.persistentVolumeClaim?.claimName !== k8sPvcName,
+    ),
     volume,
   ];
 

--- a/packages/nim-serving/src/nimKServe/fields/nimPVCApplyExtract.ts
+++ b/packages/nim-serving/src/nimKServe/fields/nimPVCApplyExtract.ts
@@ -1,0 +1,112 @@
+import type { KServeDeployment } from '@odh-dashboard/kserve/types';
+import type { ServingContainer } from '@odh-dashboard/model-serving/shared';
+import type { Volume, VolumeMount } from '@odh-dashboard/k8s-core';
+import {
+  NIMPVCStorageMode,
+  type NIMPVCFieldValue,
+} from '../../pages/deploymentWizard/fields/NIMPVCField';
+import {
+  KSERVE_CONTAINER_NAME,
+  NIM_CACHE_MOUNT_PATH,
+  NIM_CACHE_PATH_ENV,
+  DEFAULT_STORAGE_SIZE_GI,
+} from '../../constants';
+
+const normalizeSubPath = (subPath: string): string | undefined => {
+  const stripped = subPath.replace(/^\/+/, '');
+  return stripped || undefined;
+};
+
+const addPVCVolumeToRuntime = (
+  deployment: KServeDeployment,
+  pvcName: string,
+  subPath: string,
+): KServeDeployment => {
+  if (!deployment.server) {
+    return deployment;
+  }
+
+  const server = structuredClone(deployment.server);
+  const volume: Volume = {
+    name: pvcName,
+    persistentVolumeClaim: { claimName: pvcName },
+  };
+  const volumeMount: VolumeMount = {
+    name: pvcName,
+    mountPath: NIM_CACHE_MOUNT_PATH,
+    subPath: normalizeSubPath(subPath),
+  };
+
+  server.spec.volumes = [
+    ...(server.spec.volumes ?? []).filter((v) => v.persistentVolumeClaim?.claimName !== pvcName),
+    volume,
+  ];
+
+  server.spec.containers = server.spec.containers.map((c): ServingContainer => {
+    if (c.name !== KSERVE_CONTAINER_NAME) {
+      return c;
+    }
+    const volumeMounts = (c.volumeMounts ?? []).filter(
+      (vm) => vm.mountPath !== NIM_CACHE_MOUNT_PATH,
+    );
+    const env = (c.env ?? []).filter((e) => e.name !== NIM_CACHE_PATH_ENV);
+    return {
+      ...c,
+      volumeMounts: [...volumeMounts, volumeMount],
+      env: [...env, { name: NIM_CACHE_PATH_ENV, value: NIM_CACHE_MOUNT_PATH }],
+    };
+  });
+
+  return { ...deployment, server };
+};
+
+/**
+ * Writes the PVC volume, volumeMount, and NIM_CACHE_PATH env var onto the
+ * KServe ServingRuntime so the NIM container can cache its model image.
+ */
+export const applyNIMPVCFieldData = (
+  deployment: KServeDeployment,
+  fieldData: NIMPVCFieldValue,
+): KServeDeployment => addPVCVolumeToRuntime(deployment, fieldData.pvcName, fieldData.subPath);
+
+/**
+ * Extracts PVC field data from an existing KServe deployment by inspecting
+ * the ServingRuntime's volumes for a persistentVolumeClaim whose mount path
+ * matches the NIM cache path.
+ */
+export const extractNIMPVCFieldData = (
+  deployment: KServeDeployment,
+): NIMPVCFieldValue | undefined => {
+  if (!deployment.server) {
+    return undefined;
+  }
+
+  const kserveContainer = deployment.server.spec.containers.find(
+    (c) => c.name === KSERVE_CONTAINER_NAME,
+  );
+  if (!kserveContainer) {
+    return undefined;
+  }
+
+  const cacheMount = kserveContainer.volumeMounts?.find(
+    (vm) => vm.mountPath === NIM_CACHE_MOUNT_PATH,
+  );
+  if (!cacheMount) {
+    return undefined;
+  }
+
+  const pvcVolume = deployment.server.spec.volumes?.find(
+    (v) => v.name === cacheMount.name && v.persistentVolumeClaim,
+  );
+  if (!pvcVolume?.persistentVolumeClaim) {
+    return undefined;
+  }
+
+  return {
+    storageMode: NIMPVCStorageMode.EXISTING,
+    pvcName: pvcVolume.persistentVolumeClaim.claimName,
+    subPath: cacheMount.subPath ?? '',
+    storageClassName: '',
+    storageSizeGi: DEFAULT_STORAGE_SIZE_GI,
+  };
+};

--- a/packages/nim-serving/src/nimKServe/fields/nimPVCDeployFunctions.ts
+++ b/packages/nim-serving/src/nimKServe/fields/nimPVCDeployFunctions.ts
@@ -1,4 +1,5 @@
 import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
+import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
 import type { KServeDeployment } from '@odh-dashboard/kserve/types';
 import { createPvc } from '@odh-dashboard/internal/api';
 import {
@@ -17,10 +18,10 @@ import {
 export const nimPVCPreDeploy = async (
   fieldData: NIMPVCFieldValue,
   wizardState: WizardFormData['state'],
-  deployment: KServeDeployment,
+  deployment: DeploymentHookPayloadFor<KServeDeployment>,
   _existingDeployment?: KServeDeployment,
   dryRun?: boolean,
-): Promise<KServeDeployment> => {
+): Promise<DeploymentHookPayloadFor<KServeDeployment>> => {
   const { projectName } = wizardState.project;
   if (!projectName) {
     throw new Error('Project is required to create PVC storage');

--- a/packages/nim-serving/src/nimKServe/fields/nimPVCDeployFunctions.ts
+++ b/packages/nim-serving/src/nimKServe/fields/nimPVCDeployFunctions.ts
@@ -1,0 +1,52 @@
+import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
+import type { KServeDeployment } from '@odh-dashboard/kserve/types';
+import { createPvc } from '@odh-dashboard/internal/api';
+import {
+  NIM_PVC_ANNOTATION,
+  NIM_PVC_SUBPATH_ANNOTATION,
+  NIMPVCStorageMode,
+  type NIMPVCFieldValue,
+} from '../../pages/deploymentWizard/fields/NIMPVCField';
+
+/**
+ * Creates the PVC (for NEW mode) before the InferenceService + ServingRuntime
+ * are saved. Skips PVC creation for EXISTING mode since the PVC already exists.
+ *
+ * Respects the `dryRun` flag so no real PVC is created during validation.
+ */
+export const nimPVCPreDeploy = async (
+  fieldData: NIMPVCFieldValue,
+  wizardState: WizardFormData['state'],
+  deployment: KServeDeployment,
+  _existingDeployment?: KServeDeployment,
+  dryRun?: boolean,
+): Promise<KServeDeployment> => {
+  const { projectName } = wizardState.project;
+  if (!projectName) {
+    throw new Error('Project is required to create PVC storage');
+  }
+
+  if (fieldData.storageMode !== NIMPVCStorageMode.NEW) {
+    return deployment;
+  }
+
+  await createPvc(
+    {
+      name: fieldData.pvcName,
+      description: '',
+      size: `${fieldData.storageSizeGi}Gi`,
+      storageClassName: fieldData.storageClassName,
+    },
+    projectName,
+    { dryRun: !!dryRun },
+    false,
+    {
+      [NIM_PVC_ANNOTATION]: 'true',
+      ...(fieldData.subPath &&
+        fieldData.subPath !== '/' && { [NIM_PVC_SUBPATH_ANNOTATION]: fieldData.subPath }),
+    },
+    { 'opendatahub.io/managed': 'true' },
+  );
+
+  return deployment;
+};

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCApplyExtract.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCApplyExtract.spec.ts
@@ -38,6 +38,14 @@ describe('applyNIMPVCFieldData', () => {
     expect(result.model.spec.storage?.pvc?.name).toBe('my-pvc');
   });
 
+  it('should translate display names with spaces into valid k8s names', () => {
+    const result = applyNIMPVCFieldData(
+      makeDeployment(),
+      makeFieldValue({ pvcName: 'pr pvc test' }),
+    );
+    expect(result.model.spec.storage?.pvc?.name).toBe('pr-pvc-test');
+  });
+
   it('should omit subPath when it is empty (default)', () => {
     const result = applyNIMPVCFieldData(makeDeployment(), makeFieldValue({ subPath: '' }));
     expect(result.model.spec.storage?.pvc?.subPath).toBeUndefined();

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
@@ -1,3 +1,4 @@
+import { translateDisplayNameForK8s } from '@odh-dashboard/k8s-core';
 import {
   convertToUnit,
   MEMORY_UNITS_FOR_PARSING,
@@ -35,7 +36,7 @@ export const applyNIMPVCFieldData = (
       ...deployment.model.spec,
       storage: {
         pvc: {
-          name: fieldData.pvcName,
+          name: translateDisplayNameForK8s(fieldData.pvcName),
           subPath: normalizeSubPath(fieldData.subPath),
         },
       },

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
@@ -1,4 +1,5 @@
 import type { WizardFormData } from '@odh-dashboard/model-serving/shared/types/form-data';
+import type { DeploymentHookPayloadFor } from '@odh-dashboard/model-serving/extension-points';
 import { createPvc } from '@odh-dashboard/internal/api';
 import {
   NIM_PVC_ANNOTATION,
@@ -11,14 +12,14 @@ import type { NIMDeployment } from '../../../api/nimservices/types';
 export const nimPVCPreDeploy = async (
   fieldData: NIMPVCFieldValue,
   wizardState: WizardFormData['state'],
-  deployment: NIMDeployment,
-): Promise<NIMDeployment> => {
+  deployment: DeploymentHookPayloadFor<NIMDeployment>,
+): Promise<DeploymentHookPayloadFor<NIMDeployment>> => {
   const { projectName } = wizardState.project;
   if (!projectName) {
     throw new Error('Project is required to create PVC storage');
   }
 
-  if (fieldData.storageMode !== NIMPVCStorageMode.NEW) {
+  if (fieldData.storageMode !== NIMPVCStorageMode.NEW || !deployment.model) {
     return deployment;
   }
 


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-79807

## Description

When deploying a NIM model via the KServe path (InferenceService + ServingRuntime), the PVC caching storage field in the deployment wizard was not applying to the deployment. The PVC was never created and the ServingRuntime was missing the volume/volumeMount/env configuration needed for NIM model caching.



## How Has This Been Tested?
<img width="1407" height="429" alt="Screenshot 2026-08-17 at 4 11 50 PM" src="https://github.com/user-attachments/assets/d4d80e63-fe50-4c6f-904c-1c7b5574e463" />


- **Unit tests**: 29 tests across 3 test suites (all passing):
  - `nimPVCApplyExtract.spec.ts` — 16 tests covering apply (volume/mount/env creation, subPath normalization, existing volume preservation, immutability) and extract (PVC detection, missing volume handling, defaults)
  - `nimPVCDeployFunctions.spec.ts` — 7 tests covering PVC creation, dryRun flag, EXISTING mode skip, subPath annotation, project validation
  - `nimImageApplyExtract.spec.ts` — 6 existing tests (unaffected, still passing)
- **Manual testing**: Deployed a NIM model through the wizard on a live cluster (namespace `emily2`) with `nimWizard` feature flag enabled. Verified:
  - PVC `pvc-deploy-test` was created with `Pending` status (expected for `gp3-csi` with `WaitForFirstConsumer`)
  - ServingRuntime was created with the correct volume and volumeMount configuration
- **Lint & type-check**: All 8 changed files pass ESLint and TypeScript strict mode

## Test Impact

- **Added**: `nimPVCApplyExtract.spec.ts` (16 tests) — covers apply/extract logic for KServe PVC field
- **Added**: `nimPVCDeployFunctions.spec.ts` (7 tests) — covers preDeploy PVC creation with dryRun support
- **Unchanged**: `nimImageApplyExtract.spec.ts` (6 tests) — existing tests still pass after constant extraction

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent storage configuration for NIM KServe deployments.
  * The deployment wizard can use existing storage or create new storage automatically.
  * NIM cache paths, mounts, subpaths, and storage sizes are configured during deployment setup.
  * Added storage validation during dry runs and actual deployment.

* **Bug Fixes**
  * Deployment hooks now run consistently, including deployments without model resources.
  * Improved handling of missing or incomplete deployment configuration.
  * Prevented unnecessary storage creation when deployment details are unavailable.
  * PVC display names with spaces are converted to valid Kubernetes names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->