### PR TITLE
fix(autorag): use link-style Close in Pattern Details modal

### DIFF
--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/AutomlModelDetailsModal.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/AutomlModelDetailsModal.tsx
@@ -237,7 +237,7 @@ const AutomlModelDetailsModal: React.FC<AutomlModelDetailsModalProps> = ({
           </Flex>
         </ModalBody>
         <ModalFooter>
-          <Button variant="primary" onClick={onClose} data-testid="model-details-close">
+          <Button variant="link" onClick={onClose} data-testid="model-details-close">
             Close
           </Button>
         </ModalFooter>

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/__tests__/AutomlModelDetailsModal.spec.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/__tests__/AutomlModelDetailsModal.spec.tsx
@@ -188,9 +188,7 @@ describe('AutomlModelDetailsModal', () => {
       </AutomlResultsContext.Provider>,
     );
 
-    // PF Modal renders a close button
-    const closeButton = screen.getByLabelText('Close');
-    await userEvent.click(closeButton);
+    await userEvent.click(screen.getByTestId('model-details-close'));
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternDetailsModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternDetailsModal.tsx
@@ -335,7 +335,7 @@ const PatternDetailsModal: React.FC<PatternDetailsModalProps> = ({
           </Flex>
         </ModalBody>
         <ModalFooter>
-          <Button variant="primary" onClick={onClose} data-testid="pattern-details-close">
+          <Button variant="link" onClick={onClose} data-testid="pattern-details-close">
             Close
           </Button>
         </ModalFooter>

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/PatternDetailsModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/PatternDetailsModal.spec.tsx
@@ -416,6 +416,12 @@ describe('PatternDetailsModal', () => {
   });
 
   describe('onClose callback', () => {
+    it('should render Close as a link-style footer button', () => {
+      render(<PatternDetailsModal {...defaultProps} />);
+      const closeButton = screen.getByTestId('pattern-details-close');
+      expect(closeButton).toHaveClass('pf-m-link');
+    });
+
     it('should call onClose when the modal close button is clicked', async () => {
       const user = userEvent.setup();
       const onClose = jest.fn();


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-78881

## Description
Pattern Details had two close affordances; the footer Close was primary and too heavy next to the header X. Per UX, footer Close is now variant="link" (text-only, same as other modal Cancel buttons). Header X unchanged

  Before | After
-- | --
<img width="1332" height="1029" alt="Before" src="https://github.com/user-attachments/assets/a8ad5fb8-a804-4639-972f-67a86e5e15ce" /> |   <img width="1312" height="1034" alt="after" src="https://github.com/user-attachments/assets/67b23000-9fac-4e33-b690-98ef3a076478" />

## How Has This Been Tested?
- npx jest PatternDetailsModal.spec (54 passed)
- Manual: open Pattern Details → footer Close closes modal and looks text-only


## Test Impact
- Unit test: footer Close has pf-m-link; existing onClose click test unchanged

## Request review criteria:


Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Close buttons in the Pattern Details and AutoML Model Details modals to use a link-style appearance instead of the primary button style.

* **Tests**
  * Added coverage confirming the Pattern Details modal uses link styling.
  * Updated AutoML Model Details modal coverage to target the Close button reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->