### PR TITLE
[v3.5.0-fixes] Cherry-pick #9336: scroll catalog sidebar filters into view

### DIFF
--- a/packages/cypress/cypress/tests/e2e/modelCatalog/testPerformanceFiltersAvailable.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelCatalog/testPerformanceFiltersAvailable.cy.ts
@@ -113,8 +113,8 @@ describe('Verify Performance Filters are available on RHOAI', () => {
       modelCatalog.findColdStartLoadTimeFilter().should('be.visible');
 
       cy.step('Verify performance sidebar slider filters appear');
-      modelCatalog.findMinimumVramFilter().should('be.visible');
-      modelCatalog.findContainerSizeFilter().should('be.visible');
+      modelCatalog.findMinimumVramFilter().scrollIntoView().should('be.visible');
+      modelCatalog.findContainerSizeFilter().scrollIntoView().should('be.visible');
 
       cy.step('Check if performance data is available on this cluster');
       checkPerformanceDataAvailable(15000).then((count) => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-84767

Cherry-pick of https://github.com/opendatahub-io/odh-dashboard/pull/9336 onto `v3.5.0-fixes`.

Needed after https://github.com/opendatahub-io/odh-dashboard/pull/9297 turned on the model catalog tool-calling flag on this branch. Validated arguments now sits in the fixed sidebar above the hardware sliders, so container size is clipped below the fold and Cypress `.should('be.visible')` times out.

## Description

E2E `testPerformanceFiltersAvailable` finds the container size MenuToggle (`data-testid="container-size-filter"`) but `.should('be.visible')` fails because the ancestor sidebar is `position: fixed` and overflowed.

This matches the existing mock catalog test: `scrollIntoView()` before the visibility assertion. Selectors are unchanged.

## How Has This Been Tested?

- Cherry-pick of `1779e1e16` applied cleanly onto `upstream/v3.5.0-fixes`.
- Confirmed the same two assertions exist on this branch and now call `scrollIntoView()`.
- Did not re-run the live-cluster E2E in this change.

To verify on a 3.5.0 cluster: run `testPerformanceFiltersAvailable.cy.ts` against RHOAI with model catalog available and confirm the sidebar slider step passes after scrolling.

## Test Impact

This is a Cypress E2E assertion fix only. No new coverage; existing test now scrolls the fixed sidebar before asserting visibility of min vRAM and container size filters.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`