### PR TITLE
RHOAIENG-84754: split package Cypress tests by file size to reduce CI time

### DIFF
--- a/scripts/generate-cypress-test-matrix.js
+++ b/scripts/generate-cypress-test-matrix.js
@@ -4,6 +4,7 @@
  * Automatically splits test directories based on file size:
  * - Files > 15KB get individual test groups
  * - Smaller files are grouped together
+ * - Package tests with large combined size are split the same way
  * - New test files are automatically picked up and will use the existing build mechanism
  */
 
@@ -195,7 +196,7 @@ function generateCentralTestGroups() {
 }
 
 /**
- * Discover package-based cypress tests using npm query
+ * Discover package-based cypress tests using npm query and split by file size
  */
 function generatePackageTestGroups() {
   try {
@@ -229,14 +230,109 @@ function generatePackageTestGroups() {
       }
 
       // Check for .cy.ts files
-      const hasTests = findTestFiles(testPath);
+      const testFilePaths = findTestFiles(testPath);
 
-      if (hasTests.length > 0) {
+      if (testFilePaths.length === 0) {
+        continue;
+      }
+
+      const pkgPrefix = `pkg-${pkgRelPath.replace(/\//g, '-')}`;
+      const mockedPattern = pkg.cypress.mocked;
+      // Extract test base dir from glob: "tests/mocked/**/*.cy.ts" -> "tests/mocked"
+      const testBaseDir = mockedPattern.replace(/\/?\*\*\/\*\.cy\.ts$/, '');
+      const fullTestBaseDir = path.join('packages', pkgRelPath, testBaseDir);
+
+      // Get file info with sizes
+      const allFiles = testFilePaths.map((filePath) => {
+        const stats = fs.statSync(filePath);
+        const relPath = path.relative(fullTestBaseDir, filePath);
+        return {
+          name: path.basename(filePath, '.cy.ts'),
+          size: stats.size,
+          relPath,
+          dir: path.dirname(relPath),
+        };
+      });
+
+      const totalSize = allFiles.reduce((sum, f) => sum + f.size, 0);
+
+      // Small packages: keep as a single group
+      if (totalSize <= GROUP_SIZE_THRESHOLD) {
         groups.push({
-          name: `pkg-${pkgRelPath.replace(/\//g, '-')}`,
-          spec: `${pkgRelPath}/${pkg.cypress.mocked}`,
+          name: pkgPrefix,
+          spec: `${pkgRelPath}/${mockedPattern}`,
+          size: totalSize,
+          count: allFiles.length,
           strategy: 'package',
         });
+        continue;
+      }
+
+      // Large packages: split by directory, then by file size (same as central tests)
+      const filesByDir = {};
+      for (const file of allFiles) {
+        if (!filesByDir[file.dir]) {
+          filesByDir[file.dir] = [];
+        }
+        filesByDir[file.dir].push(file);
+      }
+
+      for (const [dir, files] of Object.entries(filesByDir)) {
+        const sorted = [...files].toSorted((a, b) => b.size - a.size);
+        const largeFiles = sorted.filter((f) => f.size > SIZE_THRESHOLD);
+        const smallFiles = sorted.filter((f) => f.size <= SIZE_THRESHOLD);
+
+        for (const file of largeFiles) {
+          groups.push({
+            name: `${pkgPrefix}/${dir}/${file.name}`,
+            spec: `${pkgRelPath}/${testBaseDir}/${file.relPath}`,
+            size: file.size,
+            strategy: 'package-individual',
+          });
+        }
+
+        if (smallFiles.length > 0) {
+          const smallTotal = smallFiles.reduce((sum, f) => sum + f.size, 0);
+
+          if (smallTotal > GROUP_SIZE_THRESHOLD && smallFiles.length >= 2) {
+            const numBins = Math.ceil(smallTotal / GROUP_SIZE_THRESHOLD);
+            const bins = balancedSplit(smallFiles, numBins);
+
+            for (let i = 0; i < bins.length; i++) {
+              const suffix = bins.length === 1 ? 'other' : `other-${i + 1}`;
+              const binFiles = bins[i].files;
+              const spec =
+                binFiles.length === 1
+                  ? `${pkgRelPath}/${testBaseDir}/${binFiles[0].relPath}`
+                  : `${pkgRelPath}/${testBaseDir}/${dir}/{${binFiles
+                      .map((f) => f.name)
+                      .join(',')}}.cy.ts`;
+
+              groups.push({
+                name: `${pkgPrefix}/${dir}/${suffix}`,
+                spec,
+                size: bins[i].totalSize,
+                count: binFiles.length,
+                strategy: 'package-grouped',
+              });
+            }
+          } else {
+            const spec =
+              smallFiles.length === 1
+                ? `${pkgRelPath}/${testBaseDir}/${smallFiles[0].relPath}`
+                : `${pkgRelPath}/${testBaseDir}/${dir}/{${smallFiles
+                    .map((f) => f.name)
+                    .join(',')}}.cy.ts`;
+
+            groups.push({
+              name: `${pkgPrefix}/${dir}/other`,
+              spec,
+              size: smallTotal,
+              count: smallFiles.length,
+              strategy: 'package-grouped',
+            });
+          }
+        }
       }
     }
 
@@ -301,9 +397,13 @@ function main() {
   console.error(`\n📊 Test Matrix Summary:`);
   console.error(`   Total groups: ${allGroups.length}`);
 
-  const individual = allGroups.filter((g) => g.strategy === 'individual');
-  const grouped = allGroups.filter((g) => g.strategy === 'grouped');
-  const packages = allGroups.filter((g) => g.strategy === 'package');
+  const individual = allGroups.filter(
+    (g) => g.strategy === 'individual' || g.strategy === 'package-individual',
+  );
+  const grouped = allGroups.filter(
+    (g) => g.strategy === 'grouped' || g.strategy === 'package-grouped',
+  );
+  const unsplitPackages = allGroups.filter((g) => g.strategy === 'package');
 
   if (individual.length > 0) {
     console.error(`   Individual files (>${SIZE_THRESHOLD / 1024}KB): ${individual.length}`);
@@ -312,8 +412,8 @@ function main() {
     const totalFiles = grouped.reduce((sum, g) => sum + (g.count || 0), 0);
     console.error(`   Grouped files: ${totalFiles} files in ${grouped.length} groups`);
   }
-  if (packages.length > 0) {
-    console.error(`   Package tests: ${packages.length}`);
+  if (unsplitPackages.length > 0) {
+    console.error(`   Package tests (unsplit): ${unsplitPackages.length}`);
   }
 
   // Output JSON for GitHub Actions

--- a/scripts/generate-cypress-test-matrix.js
+++ b/scripts/generate-cypress-test-matrix.js
@@ -229,18 +229,17 @@ function generatePackageTestGroups() {
         continue;
       }
 
-      // Check for .cy.ts files
-      const testFilePaths = findTestFiles(testPath);
-
-      if (testFilePaths.length === 0) {
-        continue;
-      }
-
       const pkgPrefix = `pkg-${pkgRelPath.replace(/\//g, '-')}`;
       const mockedPattern = pkg.cypress.mocked;
       // Extract test base dir from glob: "tests/mocked/**/*.cy.ts" -> "tests/mocked"
       const testBaseDir = mockedPattern.replace(/\/?\*\*\/\*\.cy\.ts$/, '');
       const fullTestBaseDir = path.join('packages', pkgRelPath, testBaseDir);
+
+      const testFilePaths = findTestFiles(fullTestBaseDir);
+
+      if (testFilePaths.length === 0) {
+        continue;
+      }
 
       // Get file info with sizes
       const allFiles = testFilePaths.map((filePath) => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-84754

## Description

Package test groups (e.g., `model-serving`) were running all their Cypress mock test files in a single CI job, while central tests in `packages/cypress/` got file-size-based splitting. This caused the `pkg-model-serving-cypress` job to run for **~30 minutes** — 3x longer than any other job — holding up the entire CI pipeline.

**Root cause:** `generatePackageTestGroups()` in `scripts/generate-cypress-test-matrix.js` created one monolithic group per package using a wildcard glob (`tests/mocked/**/*.cy.ts`), with no size-based splitting.

**Fix:** Apply the same splitting logic already used by `generateCentralTestGroups()` to package tests:
- Files >15KB get individual CI jobs
- Smaller files are balanced into groups (≤40KB per group)
- Packages with total test size ≤40KB stay as a single group (e.g., observability at 6.5KB)

**Before:** 1 job for model-serving (14 files, 386KB total) → 30 min
**After:** 8 parallel jobs → longest individual file (`modelServingDeploy.cy.ts` at 121KB) estimated ~5-8 min

| Group | Strategy | Size |
|---|---|---|
| `modelServingDeploy` | individual | 121KB |
| `modelServingLlmd` | individual | 54KB |
| `modelMetrics` | individual | 36KB |
| `modelServingLlmdTopology` | individual | 35KB |
| `runtime/servingRuntimeList` | individual | 30KB |
| `modelServingGlobal` | individual | 28KB |
| `other-1` (4 files) | grouped | ~49KB |
| `other-2` (4 files) | grouped | ~40KB |

## How Has This Been Tested?

- Ran `node scripts/generate-cypress-test-matrix.js` locally and verified:
  - model-serving splits into 8 groups (6 individual + 2 grouped)
  - observability (6.5KB, 1 file) stays as a single unsplit group
  - All 70 central test groups unchanged
  - All generated group names and spec paths pass `validateSafePath` checks
- ESLint passes on the changed file

## Test Impact

No new tests needed — this is a CI matrix generation change. The existing test files and their execution are unchanged; only the parallelization strategy differs. Correctness is verified by the matrix generator output and by CI runs using the new matrix.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Cypress test discovery and grouping for package-based test suites.
  * Large packages are now split by directory, oversized test files, or balanced groups of smaller files.
  * Small packages remain grouped together for simpler execution.
  * Test summaries now include group size, file count, and grouping strategy.
* **Documentation**
  * Added guidance explaining how large package test suites are divided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->