### PR TITLE
RHOAIENG-84757: exclude flaky elasticstack.slack.com link from manifest URL check

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/dashboardNavigation/testManifestLinks.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/dashboardNavigation/testManifestLinks.yaml
@@ -28,3 +28,6 @@ excludedSubstrings:
   - www3.
   - w3.org
   - serif.com
+  # Slack's edge/WAF intermittently 403s automated (non-browser) requests to this
+  # URL regardless of headers sent; the link itself works fine for real users.
+  - elasticstack.slack.com


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-84757

https://redhat.atlassian.net/browse/RHOAIENG-88299

## Description
`testManifestLinks.cy.ts` validates every external URL referenced in the manifest YAML files. `https://elasticstack.slack.com` (referenced from `manifests/rhoai/apps/elastic/elastic-app.yaml`) is intermittently returning `403 Forbidden` when hit by the test's automated HTTP requests.

Investigation showed:
- The link works fine in a real browser.
- Repeated `curl` requests to the same URL (varying headers, User-Agent, etc.) show a probabilistic ~403 rate, consistent with Slack's edge/WAF bot-detection flagging automated (non-browser) traffic rather than an actual broken/removed link.
- All other URLs in the manifest set (~82 links) validate consistently across repeated runs; only this one is flaky.

This adds `elasticstack.slack.com` to the `excludedSubstrings` list in the test fixture, the same mechanism already used to skip other known-problematic domains (e.g. `figma.com/figma/ns`, `scikit-learn.org/stable/getting_started.html`, tracker/localhost placeholders) that aren't real breakage but aren't reliably checkable by an automated request.

## How Has This Been Tested?
- Locally and via Jenkins
dashboard-e2e-tests/2296/Test_20Reports/

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`