### PR TITLE
feat(autorag): add segment event tracking

### DIFF
--- a/packages/autorag/frontend/src/app/components/AutoragRunsTable/AutoragRunsTableRow.tsx
+++ b/packages/autorag/frontend/src/app/components/AutoragRunsTable/AutoragRunsTableRow.tsx
@@ -58,7 +58,7 @@ const AutoragRunsTableRow: React.FC<AutoragRunsTableRowProps> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
   const [stopInitiated, setStopInitiated] = React.useState(false);
   const { handleRetry, handleConfirmStop, handleDelete, isRetrying, isTerminating, isDeleting } =
-    useAutoragRunActions(namespace, run.run_id, onActionComplete);
+    useAutoragRunActions(namespace, run.run_id, 'runsList', onActionComplete);
 
   const baseRunTerminatable = isRunTerminatable(run.state);
   const runTerminatable = baseRunTerminatable && !stopInitiated;
@@ -176,6 +176,7 @@ const AutoragRunsTableRow: React.FC<AutoragRunsTableRowProps> = ({
         onConfirm={handleStop}
         isTerminating={isTerminating}
         runName={run.display_name}
+        source="runsList"
       />
       <DeleteRunModal
         isOpen={isDeleteModalOpen}

--- a/packages/autorag/frontend/src/app/components/AutoragRunsTable/AutoragRunsTableRow.tsx
+++ b/packages/autorag/frontend/src/app/components/AutoragRunsTable/AutoragRunsTableRow.tsx
@@ -185,6 +185,7 @@ const AutoragRunsTableRow: React.FC<AutoragRunsTableRowProps> = ({
         onConfirm={handleConfirmDelete}
         isDeleting={isDeleting}
         runName={run.display_name}
+        source="runsList"
       />
     </>
   );

--- a/packages/autorag/frontend/src/app/components/AutoragRunsTable/AutoragRunsTableRow.tsx
+++ b/packages/autorag/frontend/src/app/components/AutoragRunsTable/AutoragRunsTableRow.tsx
@@ -150,6 +150,7 @@ const AutoragRunsTableRow: React.FC<AutoragRunsTableRowProps> = ({
         <Td dataLabel={autoragRunsColumns[0].label}>
           <Link
             to={`${autoragResultsPathname}/${namespace}/${run.run_id}`}
+            state={{ entrySource: 'experimentsList' }}
             data-testid={`run-name-${run.run_id}`}
           >
             {run.display_name}

--- a/packages/autorag/frontend/src/app/components/common/AutoragConnectionModal.scss
+++ b/packages/autorag/frontend/src/app/components/common/AutoragConnectionModal.scss
@@ -1,0 +1,11 @@
+// A plain <fieldset> is used to lock every field once the connection Secret has been created
+// (see AutoragConnectionModal.tsx), since PatternFly's ConnectionTypeForm only exposes an
+// `isPreview` mode that swaps displayed values for schema defaults rather than a true read-only
+// mode that preserves the current values. Reset the browser's default fieldset chrome so it's
+// visually transparent — PF has no equivalent "disable a form subtree, keep values" primitive.
+.autorag-connection-modal__fieldset {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-width: 0;
+}

--- a/packages/autorag/frontend/src/app/components/common/AutoragConnectionModal.tsx
+++ b/packages/autorag/frontend/src/app/components/common/AutoragConnectionModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Form, Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
+import { Alert, Form, Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
+import './AutoragConnectionModal.scss';
 import DashboardModalFooter from '@odh-dashboard/ui-core/components/DashboardModalFooter';
 import ConnectionTypeForm from '@odh-dashboard/internal/concepts/connectionTypes/ConnectionTypeForm';
 import {
@@ -157,34 +158,56 @@ const AutoragConnectionModal: React.FC<Props> = ({
     setConnectionValues(obj ? getDefaultValues(obj) : {});
   };
 
+  // Once the Secret has actually been created, the fields must be locked: assembleConnectionSecret
+  // captures a snapshot at submit time, and a retry after an onSubmit failure intentionally reuses
+  // that already-created connection (see the `submit` callback below) rather than re-creating the
+  // Secret. Leaving fields editable here would let a user change values that silently never reach
+  // the Secret or the retried onSubmit call.
+  const isLockedForRetry = !!createdConnectionRef.current;
+
   return (
     <Modal isOpen onClose={handleClose} variant="medium">
       <ModalHeader title="Add a connection" />
       <ModalBody>
-        <Form>
-          <ConnectionTypeForm
-            options={enabledConnectionTypes}
-            connectionType={selectedConnectionType}
-            setConnectionType={handleConnectionTypeChange}
-            connectionNameDesc={nameDescData}
-            setConnectionNameDesc={(key: keyof K8sNameDescriptionFieldData, value: string) => {
-              if (!isModified) {
-                setIsModified(true);
-              }
-              setNameDescData(key, value);
-            }}
-            connectionValues={connectionValues}
-            onChange={(field, value) => {
-              if (!isModified) {
-                setIsModified(true);
-              }
-              setConnectionValues((prev) => ({ ...prev, [field.envVar]: value }));
-            }}
-            onValidate={(field, error) =>
-              setConnectionErrors((prev) => ({ ...prev, [field.envVar]: !!error }))
-            }
-            connectionErrors={connectionErrors}
+        {isLockedForRetry && (
+          <Alert
+            variant="info"
+            isInline
+            isPlain
+            title="This connection was created. Retry saving it, or cancel to discard it."
+            data-testid="connection-locked-for-retry-alert"
           />
+        )}
+        <Form>
+          <fieldset
+            disabled={isLockedForRetry}
+            className="autorag-connection-modal__fieldset"
+            data-testid="connection-form-fieldset"
+          >
+            <ConnectionTypeForm
+              options={enabledConnectionTypes}
+              connectionType={selectedConnectionType}
+              setConnectionType={handleConnectionTypeChange}
+              connectionNameDesc={nameDescData}
+              setConnectionNameDesc={(key: keyof K8sNameDescriptionFieldData, value: string) => {
+                if (!isModified) {
+                  setIsModified(true);
+                }
+                setNameDescData(key, value);
+              }}
+              connectionValues={connectionValues}
+              onChange={(field, value) => {
+                if (!isModified) {
+                  setIsModified(true);
+                }
+                setConnectionValues((prev) => ({ ...prev, [field.envVar]: value }));
+              }}
+              onValidate={(field, error) =>
+                setConnectionErrors((prev) => ({ ...prev, [field.envVar]: !!error }))
+              }
+              connectionErrors={connectionErrors}
+            />
+          </fieldset>
         </Form>
       </ModalBody>
       <ModalFooter>

--- a/packages/autorag/frontend/src/app/components/common/AutoragConnectionModal.tsx
+++ b/packages/autorag/frontend/src/app/components/common/AutoragConnectionModal.tsx
@@ -280,10 +280,17 @@ const AutoragConnectionModal: React.FC<Props> = ({
               try {
                 await onSubmit(connectionToSubmit);
                 onClose(true);
-              } catch (e) {
+              } catch {
                 // The Secret was already created successfully, so this is not a creation
                 // failure. Surface it to the user, but don't emit a false S3_CONNECTION_CREATED.
-                setSubmitError(e instanceof Error ? e : new Error(String(e)));
+                // Don't render the raw error — onSubmit is caller-supplied and its failure
+                // could originate from a backend/proxy response we can't guarantee is safe
+                // to display verbatim.
+                setSubmitError(
+                  new Error(
+                    'The connection was created, but AutoRAG could not select it. Retry saving it.',
+                  ),
+                );
                 setIsSaving(false);
               }
             };

--- a/packages/autorag/frontend/src/app/components/common/AutoragConnectionModal.tsx
+++ b/packages/autorag/frontend/src/app/components/common/AutoragConnectionModal.tsx
@@ -20,6 +20,11 @@ import type {
 } from '@odh-dashboard/k8s-core';
 import { useK8sNameDescriptionFieldData } from '@odh-dashboard/ui-core/components/K8sNameDescriptionField';
 import { createSecret } from '@odh-dashboard/internal/api/k8s/secrets';
+import {
+  AUTORAG_FAILURE_CATEGORY,
+  fireAutoragS3ConnectionCreated,
+  TrackingOutcome,
+} from '~/app/utilities/tracking';
 
 const S3_REQUIRED_ENV_VARS = ['AWS_DEFAULT_REGION', 'AWS_S3_BUCKET'];
 
@@ -27,7 +32,7 @@ type Props = {
   connectionTypes: ConnectionTypeConfigMapObj[];
   project: string;
   onClose: (submitted?: boolean) => void;
-  onSubmit: (connection: Connection) => void;
+  onSubmit: (connection: Connection) => void | Promise<void>;
 };
 
 const AutoragConnectionModal: React.FC<Props> = ({
@@ -115,6 +120,24 @@ const AutoragConnectionModal: React.FC<Props> = ({
     ? getConnectionProtocolType(selectedConnectionType)
     : undefined;
 
+  // Tracks whether createSecret has already resolved for this modal instance, so a later
+  // close/cancel doesn't emit a conflicting cancel event once a success (or failure) outcome
+  // has already been reported for the creation attempt.
+  const hasCreatedSecretRef = React.useRef(false);
+
+  const handleClose = React.useCallback(() => {
+    // Block close requests (Escape, X button, Cancel button) while creation is in flight — the
+    // Secret may already exist by the time this resolves, so closing now would leave the parent
+    // unaware and could still race with the in-flight submit's own onClose(true) call.
+    if (isSaving) {
+      return;
+    }
+    if (!hasCreatedSecretRef.current) {
+      fireAutoragS3ConnectionCreated({ outcome: TrackingOutcome.cancel });
+    }
+    onClose();
+  }, [isSaving, onClose]);
+
   const handleConnectionTypeChange = (name: string) => {
     if (name === selectedConnectionType?.metadata.name) {
       return;
@@ -130,13 +153,7 @@ const AutoragConnectionModal: React.FC<Props> = ({
   };
 
   return (
-    <Modal
-      isOpen
-      onClose={() => {
-        onClose();
-      }}
-      variant="medium"
-    >
+    <Modal isOpen onClose={handleClose} variant="medium">
       <ModalHeader title="Add a connection" />
       <ModalBody>
         <Form>
@@ -168,7 +185,7 @@ const AutoragConnectionModal: React.FC<Props> = ({
       <ModalFooter>
         <DashboardModalFooter
           submitLabel="Add connection"
-          onCancel={onClose}
+          onCancel={handleClose}
           onSubmit={() => {
             setIsSaving(true);
             setSubmitError(undefined);
@@ -190,15 +207,40 @@ const AutoragConnectionModal: React.FC<Props> = ({
               ...(protocolType && { 'opendatahub.io/connection-type-protocol': protocolType }),
             };
 
-            createSecret(assembledConnection)
-              .then(() => {
-                onSubmit(assembledConnection);
-                onClose(true);
-              })
-              .catch((e) => {
-                setSubmitError(e);
+            const submit = async () => {
+              try {
+                await createSecret(assembledConnection);
+              } catch (e) {
+                // Secret creation itself failed — the resource does not exist.
+                setSubmitError(e instanceof Error ? e : new Error(String(e)));
                 setIsSaving(false);
-              });
+                fireAutoragS3ConnectionCreated({
+                  outcome: TrackingOutcome.submit,
+                  success: false,
+                  error: AUTORAG_FAILURE_CATEGORY,
+                });
+                return;
+              }
+
+              // The Secret now exists — report that outcome immediately, independent of
+              // whatever onSubmit does next, so a later onSubmit failure can't overwrite it.
+              // Also mark creation as complete so a later close/cancel doesn't emit a
+              // conflicting cancel event for the same creation attempt.
+              hasCreatedSecretRef.current = true;
+              fireAutoragS3ConnectionCreated({ outcome: TrackingOutcome.submit, success: true });
+
+              try {
+                await onSubmit(assembledConnection);
+                onClose(true);
+              } catch (e) {
+                // The Secret was already created successfully, so this is not a creation
+                // failure. Surface it to the user, but don't emit a false S3_CONNECTION_CREATED.
+                setSubmitError(e instanceof Error ? e : new Error(String(e)));
+                setIsSaving(false);
+              }
+            };
+
+            void submit();
           }}
           error={submitError}
           isSubmitDisabled={!isFormValid || !isModified || isSaving}

--- a/packages/autorag/frontend/src/app/components/common/AutoragConnectionModal.tsx
+++ b/packages/autorag/frontend/src/app/components/common/AutoragConnectionModal.tsx
@@ -120,10 +120,15 @@ const AutoragConnectionModal: React.FC<Props> = ({
     ? getConnectionProtocolType(selectedConnectionType)
     : undefined;
 
-  // Tracks whether createSecret has already resolved for this modal instance, so a later
-  // close/cancel doesn't emit a conflicting cancel event once a success (or failure) outcome
-  // has already been reported for the creation attempt.
-  const hasCreatedSecretRef = React.useRef(false);
+  // Holds the Connection object once createSecret has actually succeeded, so a later retry
+  // (after an onSubmit failure) can skip re-creating the already-existing Secret and simply
+  // retry onSubmit with the same connection.
+  const createdConnectionRef = React.useRef<Connection>();
+
+  // Tracks whether a creation outcome (success OR failure) has already been reported for this
+  // modal instance, so a later close/cancel doesn't emit a conflicting cancel event once that
+  // outcome has already been reported.
+  const hasReportedOutcomeRef = React.useRef(false);
 
   const handleClose = React.useCallback(() => {
     // Block close requests (Escape, X button, Cancel button) while creation is in flight — the
@@ -132,7 +137,7 @@ const AutoragConnectionModal: React.FC<Props> = ({
     if (isSaving) {
       return;
     }
-    if (!hasCreatedSecretRef.current) {
+    if (!hasReportedOutcomeRef.current) {
       fireAutoragS3ConnectionCreated({ outcome: TrackingOutcome.cancel });
     }
     onClose();
@@ -208,29 +213,49 @@ const AutoragConnectionModal: React.FC<Props> = ({
             };
 
             const submit = async () => {
-              try {
-                await createSecret(assembledConnection);
-              } catch (e) {
-                // Secret creation itself failed — the resource does not exist.
-                setSubmitError(e instanceof Error ? e : new Error(String(e)));
-                setIsSaving(false);
+              // If a previous attempt already created the Secret (and only onSubmit failed),
+              // don't re-create it on retry — reuse the already-created connection instead.
+              let connectionToSubmit = createdConnectionRef.current;
+
+              if (!connectionToSubmit) {
+                try {
+                  await createSecret(assembledConnection);
+                } catch {
+                  // Secret creation itself failed — the resource does not exist. Mark the
+                  // outcome as reported so a later close/cancel doesn't emit a conflicting
+                  // cancel event, but don't surface the raw error to the user — it may
+                  // contain credentials or internal endpoint details from the backend.
+                  hasReportedOutcomeRef.current = true;
+                  setSubmitError(
+                    new Error(
+                      'Failed to create the S3 connection. Please check your connection details and try again.',
+                    ),
+                  );
+                  setIsSaving(false);
+                  fireAutoragS3ConnectionCreated({
+                    outcome: TrackingOutcome.submit,
+                    success: false,
+                    error: AUTORAG_FAILURE_CATEGORY,
+                  });
+                  return;
+                }
+
+                // The Secret now exists — report that outcome immediately, independent of
+                // whatever onSubmit does next, so a later onSubmit failure can't overwrite it.
+                // Also remember the created connection and mark creation as complete so a
+                // later retry doesn't re-create the Secret and a later close/cancel doesn't
+                // emit a conflicting cancel event for the same creation attempt.
+                createdConnectionRef.current = assembledConnection;
+                hasReportedOutcomeRef.current = true;
                 fireAutoragS3ConnectionCreated({
                   outcome: TrackingOutcome.submit,
-                  success: false,
-                  error: AUTORAG_FAILURE_CATEGORY,
+                  success: true,
                 });
-                return;
+                connectionToSubmit = assembledConnection;
               }
 
-              // The Secret now exists — report that outcome immediately, independent of
-              // whatever onSubmit does next, so a later onSubmit failure can't overwrite it.
-              // Also mark creation as complete so a later close/cancel doesn't emit a
-              // conflicting cancel event for the same creation attempt.
-              hasCreatedSecretRef.current = true;
-              fireAutoragS3ConnectionCreated({ outcome: TrackingOutcome.submit, success: true });
-
               try {
-                await onSubmit(assembledConnection);
+                await onSubmit(connectionToSubmit);
                 onClose(true);
               } catch (e) {
                 // The Secret was already created successfully, so this is not a creation

--- a/packages/autorag/frontend/src/app/components/common/CodeSnippetModal.tsx
+++ b/packages/autorag/frontend/src/app/components/common/CodeSnippetModal.tsx
@@ -22,6 +22,8 @@ type CodeSnippetModalProps = {
   downloadText?: string;
   downloadFileName: string;
   onClose: () => void;
+  /** Called after the download has been triggered — use to fire download-completed analytics. */
+  onDownload?: () => void;
 };
 
 const CodeSnippetModal: React.FC<CodeSnippetModalProps> = ({
@@ -33,6 +35,7 @@ const CodeSnippetModal: React.FC<CodeSnippetModalProps> = ({
   downloadText = 'Download',
   downloadFileName,
   onClose,
+  onDownload,
 }) => {
   const [copied, setCopied] = useState(false);
 
@@ -48,6 +51,8 @@ const CodeSnippetModal: React.FC<CodeSnippetModalProps> = ({
     document.body.removeChild(link);
 
     URL.revokeObjectURL(url);
+
+    onDownload?.();
   };
 
   const modalHeaderLabelId = `${id}-modal-title`;

--- a/packages/autorag/frontend/src/app/components/common/ProjectSelectorNavigator.tsx
+++ b/packages/autorag/frontend/src/app/components/common/ProjectSelectorNavigator.tsx
@@ -1,8 +1,8 @@
-import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import ProjectSelector from '@odh-dashboard/ui-core/components/projectSelector/ProjectSelector';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useNamespaceSelectorWithPersistence } from '~/app/hooks/useNamespaceSelectorWithPersistence';
+import { fireAutoragProjectDropdownOptionSelected } from '~/app/utilities/tracking';
 
 type ProjectSelectorNavigatorProps = {
   namespace?: string;
@@ -25,9 +25,7 @@ const ProjectSelectorNavigator: React.FC<ProjectSelectorNavigatorProps> = ({
         const match = projectName
           ? (namespaces.find((n) => n.name === projectName) ?? undefined)
           : undefined;
-        fireMiscTrackingEvent('AutoRAG Project Dropdown Option Selected', {
-          selectedProject: projectName,
-        });
+        fireAutoragProjectDropdownOptionSelected(projectName);
         updatePreferredNamespace(match);
         navigate(getRedirectPath(projectName));
       }}

--- a/packages/autorag/frontend/src/app/components/common/__tests__/AutoragConnectionModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/common/__tests__/AutoragConnectionModal.spec.tsx
@@ -408,6 +408,120 @@ describe('AutoragConnectionModal', () => {
     const allCallArgs = JSON.stringify(fireAutoragS3ConnectionCreatedMock.mock.calls);
     expect(allCallArgs).not.toContain('super-secret-value');
     expect(allCallArgs).not.toContain('internal-proxy.svc');
+
+    // The raw backend error must never be rendered to the user either — only the fixed,
+    // user-facing message.
+    expect(screen.queryByText(/super-secret-value/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/internal-proxy\.svc/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Failed to create the S3 connection. Please check your connection details and try again.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should not re-create the Secret when retrying submit after onSubmit rejects', async () => {
+    onSubmitMock.mockRejectedValueOnce(new Error('onSubmit error'));
+
+    render(
+      <AutoragConnectionModal
+        project={TEST_PROJECT}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+        connectionTypes={[
+          mockConnectionTypeConfigMapObj({
+            name: 'the only type',
+            fields: [
+              {
+                type: 'short-text',
+                name: 'short text 1',
+                envVar: 'env',
+                properties: {},
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox', { name: 'Connection name' }), {
+        target: { value: 'my-conn' },
+      });
+    });
+
+    const addButton = screen.getByRole('button', { name: 'Add connection' });
+    await act(async () => {
+      addButton.click();
+    });
+
+    expect(await screen.findByText('onSubmit error')).toBeInTheDocument();
+    expect(createSecretMock).toHaveBeenCalledTimes(1);
+    expect(onSubmitMock).toHaveBeenCalledTimes(1);
+
+    // Retry: the Secret already exists from the first attempt, so createSecret must not be
+    // called again — only onSubmit is retried.
+    await act(async () => {
+      addButton.click();
+    });
+
+    await waitFor(() => expect(onCloseMock).toHaveBeenCalledWith(true));
+
+    expect(createSecretMock).toHaveBeenCalledTimes(1);
+    expect(onSubmitMock).toHaveBeenCalledTimes(2);
+    // Only the original creation success should have ever been reported — the retry must not
+    // emit a second, duplicate submit-success event.
+    expect(fireAutoragS3ConnectionCreatedMock).toHaveBeenCalledTimes(1);
+    expect(fireAutoragS3ConnectionCreatedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: tracking.TrackingOutcome.submit, success: true }),
+    );
+  });
+
+  it('should not emit a conflicting cancel event when Cancel is clicked after createSecret rejects', async () => {
+    createSecretMock.mockRejectedValueOnce(new Error('boom'));
+
+    render(
+      <AutoragConnectionModal
+        project={TEST_PROJECT}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+        connectionTypes={[
+          mockConnectionTypeConfigMapObj({
+            name: 'the only type',
+            fields: [
+              {
+                type: 'short-text',
+                name: 'short text 1',
+                envVar: 'env',
+                properties: {},
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox', { name: 'Connection name' }), {
+        target: { value: 'my-conn' },
+      });
+    });
+    await act(async () => {
+      screen.getByRole('button', { name: 'Add connection' }).click();
+    });
+
+    expect(createSecretMock).toHaveBeenCalled();
+    expect(fireAutoragS3ConnectionCreatedMock).toHaveBeenCalledTimes(1);
+
+    // The failure outcome was already reported above. Cancelling now must not emit a second,
+    // conflicting cancel event for the same (failed) creation attempt.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    });
+
+    expect(fireAutoragS3ConnectionCreatedMock).toHaveBeenCalledTimes(1);
+    expect(onCloseMock).toHaveBeenCalledWith();
+    expect(onCloseMock).not.toHaveBeenCalledWith(true);
   });
 
   it('should fire outcome: submit, success: true when createSecret resolves', async () => {

--- a/packages/autorag/frontend/src/app/components/common/__tests__/AutoragConnectionModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/common/__tests__/AutoragConnectionModal.spec.tsx
@@ -1,9 +1,10 @@
 import { mockConnectionTypeConfigMapObj } from '@odh-dashboard/k8s-core/__mocks__/mockConnectionType';
 import * as secretsApi from '@odh-dashboard/internal/api/k8s/secrets';
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React, { act } from 'react';
 import AutoragConnectionModal from '~/app/components/common/AutoragConnectionModal';
+import * as tracking from '~/app/utilities/tracking';
 
 const TEST_PROJECT = 'my-project';
 
@@ -11,7 +12,13 @@ jest.mock('@odh-dashboard/internal/api/k8s/secrets', () => ({
   createSecret: jest.fn(),
 }));
 
+jest.mock('~/app/utilities/tracking', () => ({
+  ...jest.requireActual('~/app/utilities/tracking'),
+  fireAutoragS3ConnectionCreated: jest.fn(),
+}));
+
 const createSecretMock = jest.mocked(secretsApi.createSecret);
+const fireAutoragS3ConnectionCreatedMock = jest.mocked(tracking.fireAutoragS3ConnectionCreated);
 
 describe('AutoragConnectionModal', () => {
   const onCloseMock = jest.fn();
@@ -353,7 +360,9 @@ describe('AutoragConnectionModal', () => {
   });
 
   it('should not call onClose with true when createSecret rejects', async () => {
-    createSecretMock.mockRejectedValueOnce(new Error('API error'));
+    createSecretMock.mockRejectedValueOnce(
+      new Error('AWS_SECRET_ACCESS_KEY=super-secret-value; endpoint=internal-proxy.svc:8443'),
+    );
 
     render(
       <AutoragConnectionModal
@@ -390,5 +399,236 @@ describe('AutoragConnectionModal', () => {
     expect(createSecretMock).toHaveBeenCalled();
     expect(onSubmitMock).not.toHaveBeenCalled();
     expect(onCloseMock).not.toHaveBeenCalledWith(true);
+    // Analytics must only ever see the fixed, allowlisted failure category — never the raw
+    // Error.message, which may contain credentials, tenant identifiers, or internal endpoints.
+    expect(fireAutoragS3ConnectionCreatedMock).toHaveBeenCalledTimes(1);
+    expect(fireAutoragS3ConnectionCreatedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, error: tracking.AUTORAG_FAILURE_CATEGORY }),
+    );
+    const allCallArgs = JSON.stringify(fireAutoragS3ConnectionCreatedMock.mock.calls);
+    expect(allCallArgs).not.toContain('super-secret-value');
+    expect(allCallArgs).not.toContain('internal-proxy.svc');
+  });
+
+  it('should fire outcome: submit, success: true when createSecret resolves', async () => {
+    render(
+      <AutoragConnectionModal
+        project={TEST_PROJECT}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+        connectionTypes={[
+          mockConnectionTypeConfigMapObj({
+            name: 'the only type',
+            fields: [
+              {
+                type: 'short-text',
+                name: 'short text 1',
+                envVar: 'env',
+                properties: {},
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox', { name: 'Connection name' }), {
+        target: { value: 'my-conn' },
+      });
+    });
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Add connection' }).click();
+    });
+
+    expect(fireAutoragS3ConnectionCreatedMock).toHaveBeenCalledWith({
+      outcome: tracking.TrackingOutcome.submit,
+      success: true,
+    });
+  });
+
+  it('should report success once createSecret resolves, even if onSubmit later rejects', async () => {
+    onSubmitMock.mockRejectedValueOnce(new Error('onSubmit error'));
+
+    render(
+      <AutoragConnectionModal
+        project={TEST_PROJECT}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+        connectionTypes={[
+          mockConnectionTypeConfigMapObj({
+            name: 'the only type',
+            fields: [
+              {
+                type: 'short-text',
+                name: 'short text 1',
+                envVar: 'env',
+                properties: {},
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox', { name: 'Connection name' }), {
+        target: { value: 'my-conn' },
+      });
+    });
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Add connection' }).click();
+    });
+
+    expect(await screen.findByText('onSubmit error')).toBeInTheDocument();
+
+    expect(createSecretMock).toHaveBeenCalled();
+    expect(onSubmitMock).toHaveBeenCalled();
+    // The Secret was created successfully, so the creation event must report success even
+    // though the later onSubmit call failed. It must not be called with success: false.
+    expect(fireAutoragS3ConnectionCreatedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true }),
+    );
+    expect(fireAutoragS3ConnectionCreatedMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+    expect(onCloseMock).not.toHaveBeenCalledWith(true);
+  });
+
+  it('should fire outcome: cancel when Cancel is clicked before creation', async () => {
+    render(
+      <AutoragConnectionModal
+        project={TEST_PROJECT}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+        connectionTypes={[
+          mockConnectionTypeConfigMapObj({
+            name: 'the only type',
+            fields: [],
+          }),
+        ]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    });
+
+    expect(fireAutoragS3ConnectionCreatedMock).toHaveBeenCalledWith({
+      outcome: tracking.TrackingOutcome.cancel,
+    });
+  });
+
+  it('should not emit a conflicting cancel event when Cancel is clicked after onSubmit rejects', async () => {
+    onSubmitMock.mockRejectedValueOnce(new Error('onSubmit error'));
+
+    render(
+      <AutoragConnectionModal
+        project={TEST_PROJECT}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+        connectionTypes={[
+          mockConnectionTypeConfigMapObj({
+            name: 'the only type',
+            fields: [
+              {
+                type: 'short-text',
+                name: 'short text 1',
+                envVar: 'env',
+                properties: {},
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox', { name: 'Connection name' }), {
+        target: { value: 'my-conn' },
+      });
+    });
+    await act(async () => {
+      screen.getByRole('button', { name: 'Add connection' }).click();
+    });
+
+    expect(await screen.findByText('onSubmit error')).toBeInTheDocument();
+    fireAutoragS3ConnectionCreatedMock.mockClear();
+
+    // The Secret was already reported as created (success: true) above. Cancelling now, after
+    // the async onSubmit failed, must not emit a second, conflicting cancel event for the same
+    // creation attempt.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    });
+
+    expect(fireAutoragS3ConnectionCreatedMock).not.toHaveBeenCalled();
+    expect(onCloseMock).toHaveBeenCalledWith();
+    expect(onCloseMock).not.toHaveBeenCalledWith(true);
+  });
+
+  it('should block close attempts (Cancel and Escape) while createSecret is still pending', async () => {
+    let resolveCreateSecret: (() => void) | undefined;
+    createSecretMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveCreateSecret = () => resolve({} as Awaited<ReturnType<typeof createSecretMock>>);
+      }),
+    );
+
+    render(
+      <AutoragConnectionModal
+        project={TEST_PROJECT}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+        connectionTypes={[
+          mockConnectionTypeConfigMapObj({
+            name: 'the only type',
+            fields: [
+              {
+                type: 'short-text',
+                name: 'short text 1',
+                envVar: 'env',
+                properties: {},
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox', { name: 'Connection name' }), {
+        target: { value: 'my-conn' },
+      });
+    });
+    await act(async () => {
+      screen.getByRole('button', { name: 'Add connection' }).click();
+    });
+
+    expect(createSecretMock).toHaveBeenCalled();
+    expect(onSubmitMock).not.toHaveBeenCalled();
+
+    // Creation is still pending — a Cancel click must not close the modal or fire a cancel
+    // event, since the Secret may still be created out from under a closed modal.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    });
+    expect(onCloseMock).not.toHaveBeenCalled();
+    expect(fireAutoragS3ConnectionCreatedMock).not.toHaveBeenCalled();
+
+    // Escape must be blocked the same way, since it reaches the same close handler.
+    await act(async () => {
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape', code: 'Escape' });
+    });
+    expect(onCloseMock).not.toHaveBeenCalled();
+    expect(fireAutoragS3ConnectionCreatedMock).not.toHaveBeenCalled();
+
+    // Once creation resolves, the normal flow proceeds and the modal is allowed to close.
+    await act(async () => {
+      resolveCreateSecret?.();
+    });
+    await waitFor(() => expect(onCloseMock).toHaveBeenCalledWith(true));
   });
 });

--- a/packages/autorag/frontend/src/app/components/common/__tests__/AutoragConnectionModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/common/__tests__/AutoragConnectionModal.spec.tsx
@@ -477,6 +477,76 @@ describe('AutoragConnectionModal', () => {
     );
   });
 
+  it('should lock all fields once the Secret has been created, so a retry cannot submit edited values', async () => {
+    onSubmitMock.mockRejectedValueOnce(new Error('onSubmit error'));
+
+    render(
+      <AutoragConnectionModal
+        project={TEST_PROJECT}
+        onClose={onCloseMock}
+        onSubmit={onSubmitMock}
+        connectionTypes={[
+          mockConnectionTypeConfigMapObj({
+            name: 'the only type',
+            fields: [
+              {
+                type: 'short-text',
+                name: 'short text 1',
+                envVar: 'env',
+                properties: {},
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox', { name: 'Connection name' }), {
+        target: { value: 'my-conn' },
+      });
+    });
+
+    const addButton = screen.getByRole('button', { name: 'Add connection' });
+    await act(async () => {
+      addButton.click();
+    });
+
+    expect(await screen.findByText('onSubmit error')).toBeInTheDocument();
+    expect(createSecretMock).toHaveBeenCalledTimes(1);
+
+    // The Secret already exists — every field must now be locked so a user can't change the
+    // connection type, name/description, or values before retrying, which would otherwise
+    // silently be discarded (the retry always resubmits the already-created connection).
+    expect(screen.getByRole('combobox')).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: 'Connection name' })).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: 'Connection description' })).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: 'short text 1' })).toBeDisabled();
+    expect(screen.getByTestId('connection-locked-for-retry-alert')).toBeInTheDocument();
+
+    // The retry itself must still be possible.
+    const addButtonAfterFailure = screen.getByRole('button', { name: 'Add connection' });
+    expect(addButtonAfterFailure).toBeEnabled();
+    await act(async () => {
+      addButtonAfterFailure.click();
+    });
+
+    await waitFor(() => expect(onCloseMock).toHaveBeenCalledWith(true));
+    expect(createSecretMock).toHaveBeenCalledTimes(1);
+    expect(onSubmitMock).toHaveBeenCalledTimes(2);
+    // The connection resubmitted on retry must be the one whose Secret actually exists — the
+    // (blocked) name field is still 'my-conn', matching what was actually created.
+    expect(onSubmitMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          annotations: expect.objectContaining({
+            'openshift.io/display-name': 'my-conn',
+          }),
+        }),
+      }),
+    );
+  });
+
   it('should not emit a conflicting cancel event when Cancel is clicked after createSecret rejects', async () => {
     createSecretMock.mockRejectedValueOnce(new Error('boom'));
 

--- a/packages/autorag/frontend/src/app/components/common/__tests__/AutoragConnectionModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/common/__tests__/AutoragConnectionModal.spec.tsx
@@ -455,7 +455,11 @@ describe('AutoragConnectionModal', () => {
       addButton.click();
     });
 
-    expect(await screen.findByText('onSubmit error')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'The connection was created, but AutoRAG could not select it. Retry saving it.',
+      ),
+    ).toBeInTheDocument();
     expect(createSecretMock).toHaveBeenCalledTimes(1);
     expect(onSubmitMock).toHaveBeenCalledTimes(1);
 
@@ -512,7 +516,11 @@ describe('AutoragConnectionModal', () => {
       addButton.click();
     });
 
-    expect(await screen.findByText('onSubmit error')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'The connection was created, but AutoRAG could not select it. Retry saving it.',
+      ),
+    ).toBeInTheDocument();
     expect(createSecretMock).toHaveBeenCalledTimes(1);
 
     // The Secret already exists — every field must now be locked so a user can't change the
@@ -666,7 +674,11 @@ describe('AutoragConnectionModal', () => {
       screen.getByRole('button', { name: 'Add connection' }).click();
     });
 
-    expect(await screen.findByText('onSubmit error')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'The connection was created, but AutoRAG could not select it. Retry saving it.',
+      ),
+    ).toBeInTheDocument();
 
     expect(createSecretMock).toHaveBeenCalled();
     expect(onSubmitMock).toHaveBeenCalled();
@@ -738,7 +750,11 @@ describe('AutoragConnectionModal', () => {
       screen.getByRole('button', { name: 'Add connection' }).click();
     });
 
-    expect(await screen.findByText('onSubmit error')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'The connection was created, but AutoRAG could not select it. Retry saving it.',
+      ),
+    ).toBeInTheDocument();
     fireAutoragS3ConnectionCreatedMock.mockClear();
 
     // The Secret was already reported as created (success: true) above. Cancelling now, after

--- a/packages/autorag/frontend/src/app/components/common/__tests__/CodeSnippetModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/common/__tests__/CodeSnippetModal.spec.tsx
@@ -125,6 +125,36 @@ describe('CodeSnippetModal', () => {
     expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-url');
   });
 
+  const mockDownloadUrlApis = () => {
+    Object.defineProperty(global.URL, 'createObjectURL', {
+      value: jest.fn().mockReturnValue('blob:mock-url'),
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(global.URL, 'revokeObjectURL', {
+      value: jest.fn(),
+      writable: true,
+      configurable: true,
+    });
+  };
+
+  it('should call onDownload after the download is triggered', () => {
+    mockDownloadUrlApis();
+    const mockOnDownload = jest.fn();
+    render(<CodeSnippetModal {...defaultProps} onDownload={mockOnDownload} />);
+
+    fireEvent.click(screen.getByTestId('test-snippet-download-button'));
+
+    expect(mockOnDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not throw when onDownload is not provided', () => {
+    mockDownloadUrlApis();
+    render(<CodeSnippetModal {...defaultProps} />);
+
+    expect(() => fireEvent.click(screen.getByTestId('test-snippet-download-button'))).not.toThrow();
+  });
+
   it('should copy code to clipboard when copy button is clicked', async () => {
     render(<CodeSnippetModal {...defaultProps} />);
 

--- a/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
@@ -1168,7 +1168,9 @@ function AutoragConfigure({
               knowledgeSourceType: 's3',
               countOfDocuments: 0,
               outcome: TrackingOutcome.cancel,
-              success: true,
+              // No file was ever selected/committed, so nothing was actually configured —
+              // `success: true` would misleadingly imply the milestone was completed.
+              success: false,
             });
           }
           inputDataS3SelectionCommittedRef.current = false;

--- a/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
@@ -96,6 +96,7 @@ import {
   AUTORAG_UPLOAD_TOO_LARGE_DETAIL,
   resolveSingleFileDropOutcome,
 } from '~/app/utilities/dropzoneFileUpload';
+import { fireAutoragKnowledgeSourceConfigured, TrackingOutcome } from '~/app/utilities/tracking';
 import {
   getInputDataDropRejectedNotification,
   INPUT_DATA_FILE_ACCEPT,
@@ -183,6 +184,10 @@ function AutoragConfigure({
   const [isInputDataDropdownOpen, setIsInputDataDropdownOpen] = useState(false);
   const inputDataUploadSeqRef = useRef(0);
   const inputDataNativeInputRef = useRef<HTMLInputElement>(null);
+  // Tracks whether the S3 file browser's "Select" primary action already fired the Knowledge
+  // Source Configured event for the current open/close cycle, so onClose doesn't also fire it
+  // as a cancel (onClose is invoked right after onSelectFiles when the user selects a file).
+  const inputDataS3SelectionCommittedRef = useRef(false);
   const secretsRefreshRef = useRef<(() => Promise<SecretListItem[] | undefined>) | null>(null);
   const modelsInitialized = useRef(false);
 
@@ -355,6 +360,12 @@ function AutoragConfigure({
           return;
         }
         setValue('input_data_key', uploadResult.key, { shouldValidate: true });
+        fireAutoragKnowledgeSourceConfigured({
+          knowledgeSourceType: 'upload',
+          countOfDocuments: 1,
+          outcome: TrackingOutcome.submit,
+          success: true,
+        });
       } catch (err) {
         if (uploadRequestId === inputDataUploadSeqRef.current) {
           if (isUIError(err)) {
@@ -370,6 +381,13 @@ function AutoragConfigure({
                 : errorMessage,
             );
           }
+          fireAutoragKnowledgeSourceConfigured({
+            knowledgeSourceType: 'upload',
+            countOfDocuments: 0,
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: errorMessage,
+          });
         }
       } finally {
         if (uploadRequestId === inputDataUploadSeqRef.current) {
@@ -1136,7 +1154,18 @@ function AutoragConfigure({
         namespace={namespace}
         s3SecretName={selectedSecret?.name}
         isOpen={Boolean(fileExplorerMode)}
-        onClose={() => setFileExplorerMode(false)}
+        onClose={() => {
+          if (fileExplorerMode === 'input_data' && !inputDataS3SelectionCommittedRef.current) {
+            fireAutoragKnowledgeSourceConfigured({
+              knowledgeSourceType: 's3',
+              countOfDocuments: 0,
+              outcome: TrackingOutcome.cancel,
+              success: true,
+            });
+          }
+          inputDataS3SelectionCommittedRef.current = false;
+          setFileExplorerMode(false);
+        }}
         onSelectFiles={(files) => {
           if (files.length > 0) {
             const file = files[0];
@@ -1144,6 +1173,13 @@ function AutoragConfigure({
             if (fileExplorerMode === 'input_data') {
               setValue('input_data_key', filePath, { shouldValidate: true });
               setSelectedInputDataFile(file);
+              inputDataS3SelectionCommittedRef.current = true;
+              fireAutoragKnowledgeSourceConfigured({
+                knowledgeSourceType: 's3',
+                countOfDocuments: files.length,
+                outcome: TrackingOutcome.submit,
+                success: true,
+              });
             }
             if (fileExplorerMode === 'test_data') {
               setValue('test_data_key', filePath, { shouldValidate: true });

--- a/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
@@ -1184,7 +1184,9 @@ function AutoragConfigure({
               inputDataS3SelectionCommittedRef.current = true;
               fireAutoragKnowledgeSourceConfigured({
                 knowledgeSourceType: 's3',
-                countOfDocuments: files.length,
+                // Only files[0] is ever committed to input_data_key, so report 1 committed
+                // document regardless of how many files the picker returned (e.g. a folder).
+                countOfDocuments: 1,
                 outcome: TrackingOutcome.submit,
                 success: true,
               });

--- a/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
@@ -69,6 +69,7 @@ import AutoragConnectionModal from '~/app/components/common/AutoragConnectionMod
 import ConfigureFormGroup from '~/app/components/common/ConfigureFormGroup';
 import SecretSelector, { SecretSelection } from '~/app/components/common/SecretSelector';
 import useReconfigureSafeEffect from '~/app/hooks/useReconfigureSafeEffect';
+import { useRunTriggeredTracking } from '~/app/context/RunTriggeredTrackingContext';
 import { useS3FileUploadMutation } from '~/app/hooks/mutations';
 import { useOgxModelsQuery } from '~/app/hooks/queries';
 import { useNotification } from '~/app/hooks/useNotification';
@@ -197,6 +198,7 @@ function AutoragConfigure({
 
   const notification = useNotification();
   const { showUIError } = useUIErrorHandler();
+  const { onKnowledgeSourceConfigured } = useRunTriggeredTracking();
 
   const form = useFormContext<ConfigureSchema>();
   const { getValues, reset, setValue, formState } = form;
@@ -370,6 +372,7 @@ function AutoragConfigure({
           outcome: TrackingOutcome.submit,
           success: true,
         });
+        onKnowledgeSourceConfigured('upload');
       } catch (err) {
         if (uploadRequestId === inputDataUploadSeqRef.current) {
           if (isUIError(err)) {
@@ -404,6 +407,7 @@ function AutoragConfigure({
       inputDataSecretName,
       namespace,
       notification,
+      onKnowledgeSourceConfigured,
       setValue,
       showUIError,
       uploadFileToS3,
@@ -1184,6 +1188,7 @@ function AutoragConfigure({
                 outcome: TrackingOutcome.submit,
                 success: true,
               });
+              onKnowledgeSourceConfigured('s3');
             }
             if (fileExplorerMode === 'test_data') {
               setValue('test_data_key', filePath, { shouldValidate: true });

--- a/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
@@ -96,7 +96,11 @@ import {
   AUTORAG_UPLOAD_TOO_LARGE_DETAIL,
   resolveSingleFileDropOutcome,
 } from '~/app/utilities/dropzoneFileUpload';
-import { fireAutoragKnowledgeSourceConfigured, TrackingOutcome } from '~/app/utilities/tracking';
+import {
+  AUTORAG_FAILURE_CATEGORY,
+  fireAutoragKnowledgeSourceConfigured,
+  TrackingOutcome,
+} from '~/app/utilities/tracking';
 import {
   getInputDataDropRejectedNotification,
   INPUT_DATA_FILE_ACCEPT,
@@ -386,7 +390,7 @@ function AutoragConfigure({
             countOfDocuments: 0,
             outcome: TrackingOutcome.submit,
             success: false,
-            error: errorMessage,
+            error: AUTORAG_FAILURE_CATEGORY,
           });
         }
       } finally {

--- a/packages/autorag/frontend/src/app/components/configure/AutoragEvaluationSelect.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragEvaluationSelect.tsx
@@ -9,6 +9,7 @@ import FileSelector from '~/app/components/common/FileSelector';
 import EvaluationFileCreator from '~/app/components/configure/EvaluationFileCreator';
 import { useUploadToStorageMutation } from '~/app/hooks/mutations';
 import { useNotification } from '~/app/hooks/useNotification';
+import { useRunTriggeredTracking } from '~/app/context/RunTriggeredTrackingContext';
 import { ConfigureSchema } from '~/app/schemas/configure.schema';
 import {
   AUTORAG_UPLOAD_MAX_BYTES,
@@ -30,6 +31,7 @@ function AutoragEvaluationSelect(): React.JSX.Element {
   const { namespace } = useParams();
 
   const notification = useNotification();
+  const { onEvaluationSourceConfigured } = useRunTriggeredTracking();
 
   const [fileExplorerOpen, setFileExplorerOpen] = useState(false);
   const [creatorOpen, setCreatorOpen] = useState(false);
@@ -116,6 +118,7 @@ function AutoragEvaluationSelect(): React.JSX.Element {
             outcome: TrackingOutcome.submit,
             success: true,
           });
+          onEvaluationSourceConfigured('upload');
         }}
         onClear={() => field.onChange('')}
         fileUploadProps={{
@@ -199,6 +202,7 @@ function AutoragEvaluationSelect(): React.JSX.Element {
                 outcome: TrackingOutcome.submit,
                 success: true,
               });
+              onEvaluationSourceConfigured('s3');
             }
           }}
           allowFolderSelection={false}

--- a/packages/autorag/frontend/src/app/components/configure/AutoragEvaluationSelect.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragEvaluationSelect.tsx
@@ -20,7 +20,11 @@ import {
   getEvaluationDropRejectedNotification,
   isAllowedEvaluationJsonFile,
 } from '~/app/utilities/autoragEvaluationFile';
-import { fireAutoragEvaluationSourceConfigured, TrackingOutcome } from '~/app/utilities/tracking';
+import {
+  AUTORAG_FAILURE_CATEGORY,
+  fireAutoragEvaluationSourceConfigured,
+  TrackingOutcome,
+} from '~/app/utilities/tracking';
 
 function AutoragEvaluationSelect(): React.JSX.Element {
   const { namespace } = useParams();
@@ -99,7 +103,7 @@ function AutoragEvaluationSelect(): React.JSX.Element {
               countOfDocuments: 0,
               outcome: TrackingOutcome.submit,
               success: false,
-              error: errorMessage,
+              error: AUTORAG_FAILURE_CATEGORY,
             });
             return;
           }

--- a/packages/autorag/frontend/src/app/components/configure/AutoragEvaluationSelect.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragEvaluationSelect.tsx
@@ -184,7 +184,9 @@ function AutoragEvaluationSelect(): React.JSX.Element {
                 evaluationSourceType: 's3',
                 countOfDocuments: 0,
                 outcome: TrackingOutcome.cancel,
-                success: true,
+                // No file was ever selected/committed, so nothing was actually configured —
+                // `success: true` would misleadingly imply the milestone was completed.
+                success: false,
               });
             }
             s3SelectionCommittedRef.current = false;

--- a/packages/autorag/frontend/src/app/components/configure/AutoragEvaluationSelect.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragEvaluationSelect.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@patternfly/react-core';
 import { DesktopIcon, PlusCircleIcon, StorageDomainIcon } from '@patternfly/react-icons';
 import type { FileRejection } from 'react-dropzone';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 import { useParams } from 'react-router';
 import S3FileExplorer from '@odh-dashboard/internal/concepts/fileExplorer/S3FileExplorer/S3FileExplorer';
@@ -20,6 +20,7 @@ import {
   getEvaluationDropRejectedNotification,
   isAllowedEvaluationJsonFile,
 } from '~/app/utilities/autoragEvaluationFile';
+import { fireAutoragEvaluationSourceConfigured, TrackingOutcome } from '~/app/utilities/tracking';
 
 function AutoragEvaluationSelect(): React.JSX.Element {
   const { namespace } = useParams();
@@ -28,6 +29,7 @@ function AutoragEvaluationSelect(): React.JSX.Element {
 
   const [fileExplorerOpen, setFileExplorerOpen] = useState(false);
   const [creatorOpen, setCreatorOpen] = useState(false);
+  const s3SelectionCommittedRef = useRef(false);
 
   const form = useFormContext<ConfigureSchema>();
   const {
@@ -92,11 +94,24 @@ function AutoragEvaluationSelect(): React.JSX.Element {
                 : errorMessage,
             );
             setStatus('danger');
+            fireAutoragEvaluationSourceConfigured({
+              evaluationSourceType: 'upload',
+              countOfDocuments: 0,
+              outcome: TrackingOutcome.submit,
+              success: false,
+              error: errorMessage,
+            });
             return;
           }
 
           field.onChange(response.key);
           setStatus('success');
+          fireAutoragEvaluationSourceConfigured({
+            evaluationSourceType: 'upload',
+            countOfDocuments: 1,
+            outcome: TrackingOutcome.submit,
+            success: true,
+          });
         }}
         onClear={() => field.onChange('')}
         fileUploadProps={{
@@ -156,12 +171,30 @@ function AutoragEvaluationSelect(): React.JSX.Element {
           namespace={namespace ?? ''}
           s3SecretName={testDataSecretName}
           isOpen
-          onClose={() => setFileExplorerOpen(false)}
+          onClose={() => {
+            if (!s3SelectionCommittedRef.current) {
+              fireAutoragEvaluationSourceConfigured({
+                evaluationSourceType: 's3',
+                countOfDocuments: 0,
+                outcome: TrackingOutcome.cancel,
+                success: true,
+              });
+            }
+            s3SelectionCommittedRef.current = false;
+            setFileExplorerOpen(false);
+          }}
           onSelectFiles={(files) => {
             if (files.length > 0) {
               const file = files[0];
               const filePath = file.path.replace(/^\//, '');
               field.onChange(filePath);
+              s3SelectionCommittedRef.current = true;
+              fireAutoragEvaluationSourceConfigured({
+                evaluationSourceType: 's3',
+                countOfDocuments: files.length,
+                outcome: TrackingOutcome.submit,
+                success: true,
+              });
             }
           }}
           allowFolderSelection={false}

--- a/packages/autorag/frontend/src/app/components/configure/AutoragExperimentSettings.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragExperimentSettings.tsx
@@ -9,6 +9,7 @@ import {
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { ConfigureSchema, EXPERIMENT_SETTINGS_FIELDS } from '~/app/schemas/configure.schema';
+import { useRunTriggeredTracking } from '~/app/context/RunTriggeredTrackingContext';
 import { fireAutoragModelsSelected, TrackingOutcome } from '~/app/utilities/tracking';
 import AutoragExperimentSettingsModelSelection from './AutoragExperimentSettingsModelSelection';
 
@@ -27,6 +28,7 @@ const AutoragExperimentSettings: React.FC<AutoragExperimentSettingsProps> = ({
     getValues,
     formState: { isDirty, errors },
   } = useFormContext<ConfigureSchema>();
+  const { onModelsConfigured } = useRunTriggeredTracking();
 
   const hasFieldErrors = EXPERIMENT_SETTINGS_FIELDS.some((field) => errors[field]);
 
@@ -38,6 +40,11 @@ const AutoragExperimentSettings: React.FC<AutoragExperimentSettingsProps> = ({
       outcome,
       success: true,
     });
+    // Only a completed (submit) selection counts toward "AutoRAG Flow Exited" funnel progress —
+    // a cancelled modal reverts to the prior selection, so it isn't a real milestone.
+    if (outcome === TrackingOutcome.submit) {
+      onModelsConfigured();
+    }
   };
 
   return (

--- a/packages/autorag/frontend/src/app/components/configure/AutoragExperimentSettings.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragExperimentSettings.tsx
@@ -47,6 +47,21 @@ const AutoragExperimentSettings: React.FC<AutoragExperimentSettingsProps> = ({
     }
   };
 
+  const handleSaveClick = () => {
+    const { generation_models: foundationModels, embedding_models: embeddingModels } = getValues();
+    // The Save button's `isDisabled` below is derived from formState.errors, which react-hook-form
+    // updates asynchronously (via a microtask) relative to the field values themselves, even for a
+    // synchronous zod resolver. Re-check the live values here so a click landing in that gap can't
+    // record a false "success" configuration event or close the modal with an actually-empty
+    // (invalid) model selection — Cancel remains unaffected, since discarding an invalid selection
+    // is always safe.
+    if (foundationModels.length === 0 || embeddingModels.length === 0) {
+      return;
+    }
+    fireModelsSelected(TrackingOutcome.submit);
+    onClose();
+  };
+
   return (
     <Modal
       variant={ModalVariant.medium}
@@ -65,10 +80,7 @@ const AutoragExperimentSettings: React.FC<AutoragExperimentSettingsProps> = ({
       <ModalFooter>
         <Button
           variant="primary"
-          onClick={() => {
-            fireModelsSelected(TrackingOutcome.submit);
-            onClose();
-          }}
+          onClick={handleSaveClick}
           isDisabled={!isDirty || hasFieldErrors}
           data-testid="experiment-settings-save"
         >

--- a/packages/autorag/frontend/src/app/components/configure/AutoragExperimentSettings.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragExperimentSettings.tsx
@@ -9,6 +9,7 @@ import {
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { ConfigureSchema, EXPERIMENT_SETTINGS_FIELDS } from '~/app/schemas/configure.schema';
+import { fireAutoragModelsSelected, TrackingOutcome } from '~/app/utilities/tracking';
 import AutoragExperimentSettingsModelSelection from './AutoragExperimentSettingsModelSelection';
 
 type AutoragExperimentSettingsProps = {
@@ -23,15 +24,28 @@ const AutoragExperimentSettings: React.FC<AutoragExperimentSettingsProps> = ({
   revertChanges,
 }) => {
   const {
+    getValues,
     formState: { isDirty, errors },
   } = useFormContext<ConfigureSchema>();
 
   const hasFieldErrors = EXPERIMENT_SETTINGS_FIELDS.some((field) => errors[field]);
+
+  const fireModelsSelected = (outcome: TrackingOutcome) => {
+    const { generation_models: foundationModels, embedding_models: embeddingModels } = getValues();
+    fireAutoragModelsSelected({
+      countOfFoundationModels: foundationModels.length,
+      countOfEmbeddingModels: embeddingModels.length,
+      outcome,
+      success: true,
+    });
+  };
+
   return (
     <Modal
       variant={ModalVariant.medium}
       isOpen={isOpen}
       onClose={() => {
+        fireModelsSelected(TrackingOutcome.cancel);
         revertChanges();
         onClose();
       }}
@@ -44,7 +58,10 @@ const AutoragExperimentSettings: React.FC<AutoragExperimentSettingsProps> = ({
       <ModalFooter>
         <Button
           variant="primary"
-          onClick={onClose}
+          onClick={() => {
+            fireModelsSelected(TrackingOutcome.submit);
+            onClose();
+          }}
           isDisabled={!isDirty || hasFieldErrors}
           data-testid="experiment-settings-save"
         >
@@ -53,6 +70,7 @@ const AutoragExperimentSettings: React.FC<AutoragExperimentSettingsProps> = ({
         <Button
           variant="link"
           onClick={() => {
+            fireModelsSelected(TrackingOutcome.cancel);
             revertChanges();
             onClose();
           }}

--- a/packages/autorag/frontend/src/app/components/configure/AutoragVectorStoreSelector.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragVectorStoreSelector.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 import { useParams } from 'react-router';
 import { useNotification } from '~/app/hooks/useNotification';
+import { useRunTriggeredTracking } from '~/app/context/RunTriggeredTrackingContext';
 import {
   SUPPORTED_VECTOR_STORE_PROVIDER_TYPES,
   // TODO: Re-enable in 3.5 when DEFAULT_IN_MEMORY_PROVIDER is available.
@@ -42,6 +43,7 @@ const AutoragVectorStoreSelector: React.FC = () => {
   const { namespace = '' } = useParams();
   const [isOpen, setIsOpen] = useState(false);
   const notification = useNotification();
+  const { onVectorStoreConfigured } = useRunTriggeredTracking();
 
   const {
     formState: { isSubmitting },
@@ -132,6 +134,7 @@ const AutoragVectorStoreSelector: React.FC = () => {
               outcome: TrackingOutcome.submit,
               success: true,
             });
+            onVectorStoreConfigured(providerType);
           }
         }
       }}

--- a/packages/autorag/frontend/src/app/components/configure/AutoragVectorStoreSelector.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragVectorStoreSelector.tsx
@@ -11,6 +11,11 @@ import {
 } from '~/app/schemas/configure.schema';
 import { useOgxVectorStoreProvidersQuery } from '~/app/hooks/queries';
 import { OgxVectorStoreProvider } from '~/app/types';
+import {
+  fireAutoragVectorStoreConfigured,
+  toVectorStoreProviderType,
+  TrackingOutcome,
+} from '~/app/utilities/tracking';
 
 /**
  * Formats a provider for display.
@@ -118,6 +123,17 @@ const AutoragVectorStoreSelector: React.FC = () => {
         const provider = providers.find((p) => p.provider_id === selectedProviderId);
         fieldOnChange(provider ? provider.provider_id : '');
         setIsOpen(false);
+        if (provider) {
+          const providerType = toVectorStoreProviderType(provider.provider_type);
+          if (providerType) {
+            fireAutoragVectorStoreConfigured({
+              providerType,
+              countOfCompatibleProviders: providers.length,
+              outcome: TrackingOutcome.submit,
+              success: true,
+            });
+          }
+        }
       }}
       selected={fieldValue}
       toggle={(toggleRef) => (

--- a/packages/autorag/frontend/src/app/components/configure/EvaluationTemplateModal.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/EvaluationTemplateModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import CodeSnippetModal from '~/app/components/common/CodeSnippetModal';
+import { fireAutoragEvaluationTemplateDownloaded } from '~/app/utilities/tracking';
 
 const EVALUATION_TEMPLATE = `[
   {
@@ -41,6 +42,7 @@ function EvaluationTemplateModal(props: EvaluationTemplateModalProps): React.JSX
       downloadText="Download template"
       downloadFileName="evaluation-template.json"
       onClose={props.onClose}
+      onDownload={fireAutoragEvaluationTemplateDownloaded}
     />
   );
 }

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -8,6 +8,7 @@ import * as React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 import type { ExplorerFiles } from '@odh-dashboard/internal/concepts/fileExplorer/types';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { UIErrorHandler } from '~/app/components/common/UIError/UIErrorHandler';
 import AutoragConfigure from '~/app/components/configure/AutoragConfigure';
 import { useOgxModelsQuery } from '~/app/hooks/queries';
@@ -18,6 +19,14 @@ import {
 } from '~/app/utilities/dropzoneFileUpload';
 import { INPUT_DATA_INVALID_FILE_TYPE_DESCRIPTION } from '~/app/utilities/autoragInputDataFile';
 import { DEFAULT_OPTIMIZATION_METRIC, OPTIMIZATION_METRIC_LABELS } from '~/app/utilities/const';
+import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
 
 const mockNotificationError = jest.fn();
 
@@ -221,6 +230,21 @@ jest.mock('@odh-dashboard/internal/concepts/fileExplorer/S3FileExplorer/S3FileEx
           }}
         >
           Select File
+        </button>
+        <button
+          data-testid="file-explorer-select-folder"
+          onClick={() => {
+            onSelectFiles([
+              { path: '/docs/a.txt', name: 'a.txt', type: 'txt' },
+              { path: '/docs/b.txt', name: 'b.txt', type: 'txt' },
+            ]);
+            onClose();
+          }}
+        >
+          Select Folder (2 files)
+        </button>
+        <button data-testid="file-explorer-cancel" onClick={() => onClose()}>
+          Cancel
         </button>
       </div>
     ) : null,
@@ -707,6 +731,126 @@ describe('AutoragConfigure', () => {
       expect(screen.getByText('Model configuration')).toBeInTheDocument();
       expect(screen.getByText('Optimization metric')).toBeInTheDocument();
       expect(screen.getByText('Maximum RAG patterns')).toBeInTheDocument();
+    });
+  });
+
+  describe('AutoRAG Knowledge Source Configured tracking', () => {
+    it('should fire with knowledgeSourceType: s3 and countOfDocuments: 1 when a single file is selected', () => {
+      renderComponent();
+      fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+      fireEvent.click(screen.getByRole('button', { name: 'Browse bucket' }));
+      fireEvent.click(screen.getByTestId('file-explorer-select-file'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
+        {
+          knowledgeSourceType: 's3',
+          countOfDocuments: 1,
+          outcome: TrackingOutcome.submit,
+          success: true,
+        },
+      );
+    });
+
+    it('should fire with countOfDocuments matching the number of files returned (e.g. a folder)', () => {
+      renderComponent();
+      fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+      fireEvent.click(screen.getByRole('button', { name: 'Browse bucket' }));
+      fireEvent.click(screen.getByTestId('file-explorer-select-folder'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
+        {
+          knowledgeSourceType: 's3',
+          countOfDocuments: 2,
+          outcome: TrackingOutcome.submit,
+          success: true,
+        },
+      );
+    });
+
+    it('should fire with outcome: cancel when the S3 file browser is dismissed without a selection', () => {
+      renderComponent();
+      fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+      fireEvent.click(screen.getByRole('button', { name: 'Browse bucket' }));
+      fireEvent.click(screen.getByTestId('file-explorer-cancel'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
+        {
+          knowledgeSourceType: 's3',
+          countOfDocuments: 0,
+          outcome: TrackingOutcome.cancel,
+          success: true,
+        },
+      );
+    });
+
+    it('should not fire a cancel event when the browser is closed immediately after a successful selection', () => {
+      renderComponent();
+      fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+      fireEvent.click(screen.getByRole('button', { name: 'Browse bucket' }));
+      fireFormTrackingEventMock.mockClear();
+      fireEvent.click(screen.getByTestId('file-explorer-select-file'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledTimes(1);
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
+        expect.objectContaining({ outcome: TrackingOutcome.submit }),
+      );
+    });
+
+    it('should fire with knowledgeSourceType: upload and success: true on a successful upload', async () => {
+      renderComponent();
+      fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+      fireEvent.click(screen.getByRole('button', { name: 'Upload file' }));
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement | null;
+      expect(fileInput).not.toBeNull();
+
+      const goodFile = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+      fireFormTrackingEventMock.mockClear();
+      fireEvent.change(fileInput!, { target: { files: [goodFile] } });
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
+          {
+            knowledgeSourceType: 'upload',
+            countOfDocuments: 1,
+            outcome: TrackingOutcome.submit,
+            success: true,
+          },
+        );
+      });
+    });
+
+    it('should fire with success: false and the error message on a failed upload', async () => {
+      renderComponent();
+      fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+      fireEvent.click(screen.getByRole('button', { name: 'Upload file' }));
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement | null;
+      expect(fileInput).not.toBeNull();
+
+      const file = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+      getMockS3MutateAsync().mockClear();
+      getMockS3MutateAsync().mockRejectedValueOnce(new Error('upload exploded'));
+      fireFormTrackingEventMock.mockClear();
+      fireEvent.change(fileInput!, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
+          {
+            knowledgeSourceType: 'upload',
+            countOfDocuments: 0,
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: 'upload exploded',
+          },
+        );
+      });
     });
   });
 

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -305,6 +305,7 @@ const renderWithQueryClient = (
           onKnowledgeSourceConfigured: options.onKnowledgeSourceConfigured,
           onEvaluationSourceConfigured: jest.fn(),
           onVectorStoreConfigured: jest.fn(),
+          onModelsConfigured: jest.fn(),
         }}
       >
         {tree}

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -19,7 +19,11 @@ import {
 } from '~/app/utilities/dropzoneFileUpload';
 import { INPUT_DATA_INVALID_FILE_TYPE_DESCRIPTION } from '~/app/utilities/autoragInputDataFile';
 import { DEFAULT_OPTIMIZATION_METRIC, OPTIMIZATION_METRIC_LABELS } from '~/app/utilities/const';
-import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
+import {
+  AUTORAG_EVENTS,
+  AUTORAG_FAILURE_CATEGORY,
+  TrackingOutcome,
+} from '~/app/utilities/tracking';
 
 jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
   fireFormTrackingEvent: jest.fn(),
@@ -825,7 +829,7 @@ describe('AutoragConfigure', () => {
       });
     });
 
-    it('should fire with success: false and the error message on a failed upload', async () => {
+    it('should fire with success: false and an allowlisted failure category (not the raw error message) on a failed upload', async () => {
       renderComponent();
       fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
       fireEvent.click(screen.getByRole('button', { name: 'Upload file' }));
@@ -835,7 +839,9 @@ describe('AutoragConfigure', () => {
 
       const file = new File(['hello'], 'notes.txt', { type: 'text/plain' });
       getMockS3MutateAsync().mockClear();
-      getMockS3MutateAsync().mockRejectedValueOnce(new Error('upload exploded'));
+      getMockS3MutateAsync().mockRejectedValueOnce(
+        new Error('upload exploded: s3://acme-secret-bucket'),
+      );
       fireFormTrackingEventMock.mockClear();
       fireEvent.change(fileInput!, { target: { files: [file] } });
 
@@ -847,10 +853,13 @@ describe('AutoragConfigure', () => {
             countOfDocuments: 0,
             outcome: TrackingOutcome.submit,
             success: false,
-            error: 'upload exploded',
+            error: AUTORAG_FAILURE_CATEGORY,
           },
         );
       });
+
+      const allTrackingCalls = JSON.stringify(fireFormTrackingEventMock.mock.calls);
+      expect(allTrackingCalls).not.toContain('acme-secret-bucket');
     });
   });
 

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -776,7 +776,7 @@ describe('AutoragConfigure', () => {
       );
     });
 
-    it('should fire with countOfDocuments matching the number of files returned (e.g. a folder)', () => {
+    it('should fire with countOfDocuments: 1 even when the picker returns multiple files (only the first is committed)', () => {
       renderComponent();
       fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
       fireEvent.click(screen.getByRole('button', { name: 'Browse bucket' }));
@@ -786,7 +786,7 @@ describe('AutoragConfigure', () => {
         AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
         {
           knowledgeSourceType: 's3',
-          countOfDocuments: 2,
+          countOfDocuments: 1,
           outcome: TrackingOutcome.submit,
           success: true,
         },

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -18,6 +18,7 @@ import {
   AUTORAG_UPLOAD_TOO_MANY_FILES_DETAIL,
 } from '~/app/utilities/dropzoneFileUpload';
 import { INPUT_DATA_INVALID_FILE_TYPE_DESCRIPTION } from '~/app/utilities/autoragInputDataFile';
+import { RunTriggeredTrackingContext } from '~/app/context/RunTriggeredTrackingContext';
 import { DEFAULT_OPTIMIZATION_METRIC, OPTIMIZATION_METRIC_LABELS } from '~/app/utilities/const';
 import {
   AUTORAG_EVENTS,
@@ -286,20 +287,38 @@ const createTestQueryClient = () =>
 const renderWithQueryClient = (
   component: React.ReactElement,
   defaultValues?: Partial<typeof configureSchema.defaults>,
+  options?: { onKnowledgeSourceConfigured?: (sourceType: string) => void },
 ) => {
   const queryClient = createTestQueryClient();
-  return render(
+  const tree = (
     <QueryClientProvider client={queryClient}>
       {/* UIError behavior is tested in UIErrorHandler's own spec */}
       <UIErrorHandler id="test-uierror" uiErrorMappings={{}}>
         <FormWrapper defaultValues={defaultValues}>{component}</FormWrapper>
       </UIErrorHandler>
-    </QueryClientProvider>,
+    </QueryClientProvider>
+  );
+  return render(
+    options?.onKnowledgeSourceConfigured ? (
+      <RunTriggeredTrackingContext.Provider
+        value={{
+          onKnowledgeSourceConfigured: options.onKnowledgeSourceConfigured,
+          onEvaluationSourceConfigured: jest.fn(),
+          onVectorStoreConfigured: jest.fn(),
+        }}
+      >
+        {tree}
+      </RunTriggeredTrackingContext.Provider>
+    ) : (
+      tree
+    ),
   );
 };
 
-const renderComponent = (defaultValues?: Partial<typeof configureSchema.defaults>) =>
-  renderWithQueryClient(<AutoragConfigure />, defaultValues);
+const renderComponent = (
+  defaultValues?: Partial<typeof configureSchema.defaults>,
+  options?: { onKnowledgeSourceConfigured?: (sourceType: string) => void },
+) => renderWithQueryClient(<AutoragConfigure />, defaultValues, options);
 
 const renderWithInitialValues = (
   initialValues: Parameters<typeof AutoragConfigure>[0]['initialValues'] & {
@@ -860,6 +879,45 @@ describe('AutoragConfigure', () => {
 
       const allTrackingCalls = JSON.stringify(fireFormTrackingEventMock.mock.calls);
       expect(allTrackingCalls).not.toContain('acme-secret-bucket');
+    });
+
+    it('should report a successful s3 selection to RunTriggeredTrackingContext for use by AutoRAG Run Triggered', () => {
+      const onKnowledgeSourceConfigured = jest.fn();
+      renderComponent(undefined, { onKnowledgeSourceConfigured });
+
+      fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+      fireEvent.click(screen.getByRole('button', { name: 'Browse bucket' }));
+      fireEvent.click(screen.getByTestId('file-explorer-select-file'));
+
+      expect(onKnowledgeSourceConfigured).toHaveBeenCalledWith('s3');
+    });
+
+    it('should not report a cancelled s3 selection to RunTriggeredTrackingContext', () => {
+      const onKnowledgeSourceConfigured = jest.fn();
+      renderComponent(undefined, { onKnowledgeSourceConfigured });
+
+      fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+      fireEvent.click(screen.getByRole('button', { name: 'Browse bucket' }));
+      fireEvent.click(screen.getByTestId('file-explorer-cancel'));
+
+      expect(onKnowledgeSourceConfigured).not.toHaveBeenCalled();
+    });
+
+    it('should report a successful upload to RunTriggeredTrackingContext for use by AutoRAG Run Triggered', async () => {
+      const onKnowledgeSourceConfigured = jest.fn();
+      renderComponent(undefined, { onKnowledgeSourceConfigured });
+
+      fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+      fireEvent.click(screen.getByRole('button', { name: 'Upload file' }));
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement | null;
+      expect(fileInput).not.toBeNull();
+      const goodFile = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+      fireEvent.change(fileInput!, { target: { files: [goodFile] } });
+
+      await waitFor(() => {
+        expect(onKnowledgeSourceConfigured).toHaveBeenCalledWith('upload');
+      });
     });
   });
 

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -793,7 +793,7 @@ describe('AutoragConfigure', () => {
       );
     });
 
-    it('should fire with outcome: cancel when the S3 file browser is dismissed without a selection', () => {
+    it('should fire with outcome: cancel and success: false when the S3 file browser is dismissed without a selection', () => {
       renderComponent();
       fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
       fireEvent.click(screen.getByRole('button', { name: 'Browse bucket' }));
@@ -805,7 +805,7 @@ describe('AutoragConfigure', () => {
           knowledgeSourceType: 's3',
           countOfDocuments: 0,
           outcome: TrackingOutcome.cancel,
-          success: true,
+          success: false,
         },
       );
     });

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
@@ -221,6 +221,7 @@ const renderWithProviders = (
           onKnowledgeSourceConfigured: jest.fn(),
           onEvaluationSourceConfigured: options.onEvaluationSourceConfigured,
           onVectorStoreConfigured: jest.fn(),
+          onModelsConfigured: jest.fn(),
         }}
       >
         {tree}

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
@@ -19,6 +19,7 @@ import {
   AUTORAG_FAILURE_CATEGORY,
   TrackingOutcome,
 } from '~/app/utilities/tracking';
+import { RunTriggeredTrackingContext } from '~/app/context/RunTriggeredTrackingContext';
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
@@ -200,17 +201,33 @@ const renderWithProviders = (
   options?: {
     onFormChange?: (values: unknown) => void;
     defaultValues?: Partial<typeof configureSchema.defaults>;
+    onEvaluationSourceConfigured?: (sourceType: string) => void;
   },
 ) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
+  const tree = (
     <QueryClientProvider client={queryClient}>
       <FormWrapper onFormChange={options?.onFormChange} defaultValues={options?.defaultValues}>
         {component}
       </FormWrapper>
-    </QueryClientProvider>,
+    </QueryClientProvider>
+  );
+  return render(
+    options?.onEvaluationSourceConfigured ? (
+      <RunTriggeredTrackingContext.Provider
+        value={{
+          onKnowledgeSourceConfigured: jest.fn(),
+          onEvaluationSourceConfigured: options.onEvaluationSourceConfigured,
+          onVectorStoreConfigured: jest.fn(),
+        }}
+      >
+        {tree}
+      </RunTriggeredTrackingContext.Provider>
+    ) : (
+      tree
+    ),
   );
 };
 
@@ -764,6 +781,30 @@ describe('AutoragEvaluationSelect', () => {
         AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED,
         expect.objectContaining({ outcome: TrackingOutcome.submit }),
       );
+    });
+
+    it('should report a successful s3 selection to RunTriggeredTrackingContext for use by AutoRAG Run Triggered', async () => {
+      const user = userEvent.setup();
+      const onEvaluationSourceConfigured = jest.fn();
+
+      renderWithProviders(<AutoragEvaluationSelect />, { onEvaluationSourceConfigured });
+
+      await user.click(screen.getByRole('button', { name: /s3/i }));
+      await user.click(screen.getByTestId('s3-select-file'));
+
+      expect(onEvaluationSourceConfigured).toHaveBeenCalledWith('s3');
+    });
+
+    it('should not report a cancelled s3 selection to RunTriggeredTrackingContext', async () => {
+      const user = userEvent.setup();
+      const onEvaluationSourceConfigured = jest.fn();
+
+      renderWithProviders(<AutoragEvaluationSelect />, { onEvaluationSourceConfigured });
+
+      await user.click(screen.getByRole('button', { name: /s3/i }));
+      await user.click(screen.getByTestId('s3-close'));
+
+      expect(onEvaluationSourceConfigured).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
@@ -704,7 +704,9 @@ describe('AutoragEvaluationSelect', () => {
     it('should fire with success: false and an allowlisted failure category (not the raw error message) on a failed upload', async () => {
       const user = userEvent.setup();
       const file = new File(['test content'], 'test.json', { type: 'application/json' });
-      mockUploadMutateAsync.mockRejectedValue(new Error('Upload failed: s3://acme-secret-bucket'));
+      mockUploadMutateAsync.mockRejectedValueOnce(
+        new Error('Upload failed: s3://acme-secret-bucket'),
+      );
 
       const { container } = renderWithProviders(<AutoragEvaluationSelect />);
 

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
@@ -14,7 +14,11 @@ import {
   AUTORAG_UPLOAD_MAX_BYTES,
   AUTORAG_UPLOAD_TOO_MANY_FILES_DETAIL,
 } from '~/app/utilities/dropzoneFileUpload';
-import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
+import {
+  AUTORAG_EVENTS,
+  AUTORAG_FAILURE_CATEGORY,
+  TrackingOutcome,
+} from '~/app/utilities/tracking';
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
@@ -679,10 +683,10 @@ describe('AutoragEvaluationSelect', () => {
       });
     });
 
-    it('should fire with success: false and the error message on a failed upload', async () => {
+    it('should fire with success: false and an allowlisted failure category (not the raw error message) on a failed upload', async () => {
       const user = userEvent.setup();
       const file = new File(['test content'], 'test.json', { type: 'application/json' });
-      mockUploadMutateAsync.mockRejectedValue(new Error('Upload failed'));
+      mockUploadMutateAsync.mockRejectedValue(new Error('Upload failed: s3://acme-secret-bucket'));
 
       const { container } = renderWithProviders(<AutoragEvaluationSelect />);
 
@@ -696,10 +700,13 @@ describe('AutoragEvaluationSelect', () => {
             countOfDocuments: 0,
             outcome: TrackingOutcome.submit,
             success: false,
-            error: 'Upload failed',
+            error: AUTORAG_FAILURE_CATEGORY,
           },
         );
       });
+
+      const allTrackingCalls = JSON.stringify(fireFormTrackingEventMock.mock.calls);
+      expect(allTrackingCalls).not.toContain('acme-secret-bucket');
     });
 
     it('should fire with evaluationSourceType: s3 and countOfDocuments: 1 when a file is selected', async () => {

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
@@ -748,7 +748,7 @@ describe('AutoragEvaluationSelect', () => {
       );
     });
 
-    it('should fire with outcome: cancel when the S3 file browser is closed without a selection', async () => {
+    it('should fire with outcome: cancel and success: false when the S3 file browser is closed without a selection', async () => {
       const user = userEvent.setup();
 
       renderWithProviders(<AutoragEvaluationSelect />);
@@ -762,7 +762,7 @@ describe('AutoragEvaluationSelect', () => {
           evaluationSourceType: 's3',
           countOfDocuments: 0,
           outcome: TrackingOutcome.cancel,
-          success: true,
+          success: false,
         },
       );
     });

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragEvaluationSelect.spec.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useParams } from 'react-router';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutoragEvaluationSelect from '~/app/components/configure/AutoragEvaluationSelect';
 import { useUploadToStorageMutation } from '~/app/hooks/mutations';
 import { createConfigureSchema } from '~/app/schemas/configure.schema';
@@ -13,10 +14,16 @@ import {
   AUTORAG_UPLOAD_MAX_BYTES,
   AUTORAG_UPLOAD_TOO_MANY_FILES_DETAIL,
 } from '~/app/utilities/dropzoneFileUpload';
+import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
   useParams: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
 }));
 
 jest.mock('~/app/hooks/mutations', () => ({
@@ -96,6 +103,7 @@ jest.mock('@odh-dashboard/internal/concepts/fileExplorer/S3FileExplorer/S3FileEx
 
 const mockUseParams = jest.mocked(useParams);
 const mockUseUploadToStorageMutation = jest.mocked(useUploadToStorageMutation);
+const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
 
 const configureSchema = createConfigureSchema();
 
@@ -645,6 +653,110 @@ describe('AutoragEvaluationSelect', () => {
       expect(formValues).toMatchObject({
         test_data_key: 'created-eval.json', // eslint-disable-line camelcase
       });
+    });
+  });
+
+  describe('AutoRAG Evaluation Source Configured tracking', () => {
+    it('should fire with evaluationSourceType: upload and success: true on successful upload', async () => {
+      const user = userEvent.setup();
+      const file = new File(['test content'], 'test.json', { type: 'application/json' });
+      mockUploadMutateAsync.mockResolvedValue({ key: 'test.json' });
+
+      const { container } = renderWithProviders(<AutoragEvaluationSelect />);
+
+      await user.upload(getEvaluationFileInput(container), file);
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED,
+          {
+            evaluationSourceType: 'upload',
+            countOfDocuments: 1,
+            outcome: TrackingOutcome.submit,
+            success: true,
+          },
+        );
+      });
+    });
+
+    it('should fire with success: false and the error message on a failed upload', async () => {
+      const user = userEvent.setup();
+      const file = new File(['test content'], 'test.json', { type: 'application/json' });
+      mockUploadMutateAsync.mockRejectedValue(new Error('Upload failed'));
+
+      const { container } = renderWithProviders(<AutoragEvaluationSelect />);
+
+      await user.upload(getEvaluationFileInput(container), file);
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED,
+          {
+            evaluationSourceType: 'upload',
+            countOfDocuments: 0,
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: 'Upload failed',
+          },
+        );
+      });
+    });
+
+    it('should fire with evaluationSourceType: s3 and countOfDocuments: 1 when a file is selected', async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(<AutoragEvaluationSelect />);
+
+      await user.click(screen.getByRole('button', { name: /s3/i }));
+      await user.click(screen.getByTestId('s3-select-file'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED,
+        {
+          evaluationSourceType: 's3',
+          countOfDocuments: 1,
+          outcome: TrackingOutcome.submit,
+          success: true,
+        },
+      );
+    });
+
+    it('should fire with outcome: cancel when the S3 file browser is closed without a selection', async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(<AutoragEvaluationSelect />);
+
+      await user.click(screen.getByRole('button', { name: /s3/i }));
+      await user.click(screen.getByTestId('s3-close'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED,
+        {
+          evaluationSourceType: 's3',
+          countOfDocuments: 0,
+          outcome: TrackingOutcome.cancel,
+          success: true,
+        },
+      );
+    });
+
+    it('should not fire a cancel event when the browser is closed right after a successful selection', async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(<AutoragEvaluationSelect />);
+
+      await user.click(screen.getByRole('button', { name: /s3/i }));
+      fireFormTrackingEventMock.mockClear();
+      // Real S3FileExplorer/FileExplorer calls onSelectFiles then onClose in sequence when the
+      // user clicks "Select" — simulate that ordering here to verify onClose doesn't re-fire.
+      await user.click(screen.getByTestId('s3-select-file'));
+      await user.click(screen.getByTestId('s3-close'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledTimes(1);
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED,
+        expect.objectContaining({ outcome: TrackingOutcome.submit }),
+      );
     });
   });
 });

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragExperimentSettings.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragExperimentSettings.spec.tsx
@@ -159,7 +159,7 @@ describe('AutoragExperimentSettings', () => {
       });
     });
 
-    it('should fire with countOfFoundationModels/countOfEmbeddingModels: 0 when no models are selected', async () => {
+    it('should not fire a submit event or close when Save is clicked with zero models selected', async () => {
       // Save is disabled unless the form is dirty; force it dirty with empty selections.
       renderComponent(
         {},
@@ -172,15 +172,16 @@ describe('AutoragExperimentSettings', () => {
       // Use fireEvent (synchronous) instead of userEvent here: clicking Save with zero models
       // selected races against the async zod validation that disables the button once it detects
       // the empty arrays are invalid, so a synchronous dispatch is needed to land the click before
-      // that validation resolves and flips isDisabled.
+      // that validation resolves and flips isDisabled. The click handler itself re-checks the live
+      // model counts (not just the — possibly stale — disabled state), so it must be a no-op here:
+      // no false "success" event, and the modal must not close on an invalid selection.
       fireEvent.click(screen.getByTestId('experiment-settings-save'));
 
-      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.MODELS_SELECTED, {
-        countOfFoundationModels: 0,
-        countOfEmbeddingModels: 0,
-        outcome: TrackingOutcome.submit,
-        success: true,
-      });
+      expect(fireFormTrackingEventMock).not.toHaveBeenCalledWith(
+        AUTORAG_EVENTS.MODELS_SELECTED,
+        expect.objectContaining({ outcome: TrackingOutcome.submit }),
+      );
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
 
       // Flush the async validation triggered on mount so its state update is captured within
       // act(), rather than resolving after the test completes.

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragExperimentSettings.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragExperimentSettings.spec.tsx
@@ -4,22 +4,55 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutoragExperimentSettings from '~/app/components/configure/AutoragExperimentSettings';
-import { createConfigureSchema } from '~/app/schemas/configure.schema';
+import { ConfigureSchema, createConfigureSchema } from '~/app/schemas/configure.schema';
+import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
 
 jest.mock('~/app/components/configure/AutoragExperimentSettingsModelSelection', () => {
   const MockModelSelection = () => <div data-testid="mock-model-selection">Model Selection</div>;
   return { __esModule: true, default: MockModelSelection };
 });
 
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
+
 const configureSchema = createConfigureSchema();
 
-const FormWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+type FormWrapperProps = {
+  children: React.ReactNode;
+  defaultValues?: Partial<ConfigureSchema>;
+  /** When set, marks generation_models/embedding_models dirty with these values post-mount. */
+  dirtyModels?: { generation_models?: string[]; embedding_models?: string[] };
+};
+
+const FormWrapper: React.FC<FormWrapperProps> = ({ children, defaultValues, dirtyModels }) => {
   const form = useForm({
     mode: 'onChange',
     resolver: zodResolver(configureSchema.full),
-    defaultValues: configureSchema.defaults,
+    defaultValues: { ...configureSchema.defaults, ...defaultValues },
   });
+
+  React.useEffect(() => {
+    if (dirtyModels?.generation_models) {
+      form.setValue('generation_models', dirtyModels.generation_models, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    }
+    if (dirtyModels?.embedding_models) {
+      form.setValue('embedding_models', dirtyModels.embedding_models, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return <FormProvider {...form}>{children}</FormProvider>;
 };
 
@@ -29,9 +62,12 @@ const defaultProps = {
   revertChanges: jest.fn(),
 };
 
-const renderComponent = (props = {}) =>
+const renderComponent = (
+  props: Partial<typeof defaultProps> = {},
+  formWrapperProps: Omit<FormWrapperProps, 'children'> = {},
+) =>
   render(
-    <FormWrapper>
+    <FormWrapper {...formWrapperProps}>
       <AutoragExperimentSettings {...defaultProps} {...props} />
     </FormWrapper>,
   );
@@ -78,5 +114,85 @@ describe('AutoragExperimentSettings', () => {
       expect(defaultProps.revertChanges).toHaveBeenCalledTimes(1);
       expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
     });
+  });
+
+  describe('AutoRAG Models Selected tracking', () => {
+    /* eslint-disable camelcase -- generation_models/embedding_models are schema field names */
+    it('should fire with outcome: submit and correct counts when Save is clicked', async () => {
+      const user = userEvent.setup();
+      renderComponent(
+        {},
+        {
+          dirtyModels: {
+            generation_models: ['gpt-4'],
+            embedding_models: ['text-embedding-3', 'minilm-v2'],
+          },
+        },
+      );
+
+      await user.click(screen.getByTestId('experiment-settings-save'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.MODELS_SELECTED, {
+        countOfFoundationModels: 1,
+        countOfEmbeddingModels: 2,
+        outcome: TrackingOutcome.submit,
+        success: true,
+      });
+    });
+
+    it('should fire with countOfFoundationModels/countOfEmbeddingModels: 0 when no models are selected', async () => {
+      const user = userEvent.setup();
+      // Save is disabled unless the form is dirty; force it dirty with empty selections.
+      renderComponent(
+        {},
+        {
+          dirtyModels: { generation_models: [], embedding_models: [] },
+          defaultValues: { generation_models: ['gpt-4'], embedding_models: ['minilm-v2'] },
+        },
+      );
+
+      await user.click(screen.getByTestId('experiment-settings-cancel'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.MODELS_SELECTED, {
+        countOfFoundationModels: 0,
+        countOfEmbeddingModels: 0,
+        outcome: TrackingOutcome.cancel,
+        success: true,
+      });
+    });
+
+    it('should fire with outcome: cancel when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      renderComponent(
+        {},
+        { dirtyModels: { generation_models: ['gpt-4'], embedding_models: ['minilm-v2'] } },
+      );
+
+      await user.click(screen.getByTestId('experiment-settings-cancel'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.MODELS_SELECTED,
+        expect.objectContaining({ outcome: TrackingOutcome.cancel }),
+      );
+      expect(defaultProps.revertChanges).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fire with outcome: cancel when the modal is closed via the X button', async () => {
+      const user = userEvent.setup();
+      renderComponent(
+        {},
+        { dirtyModels: { generation_models: ['gpt-4'], embedding_models: ['minilm-v2'] } },
+      );
+
+      await user.click(screen.getByLabelText('Close'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.MODELS_SELECTED,
+        expect.objectContaining({ outcome: TrackingOutcome.cancel }),
+      );
+      expect(defaultProps.revertChanges).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+    /* eslint-enable camelcase */
   });
 });

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragExperimentSettings.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragExperimentSettings.spec.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -160,7 +160,6 @@ describe('AutoragExperimentSettings', () => {
     });
 
     it('should fire with countOfFoundationModels/countOfEmbeddingModels: 0 when no models are selected', async () => {
-      const user = userEvent.setup();
       // Save is disabled unless the form is dirty; force it dirty with empty selections.
       renderComponent(
         {},
@@ -170,13 +169,23 @@ describe('AutoragExperimentSettings', () => {
         },
       );
 
-      await user.click(screen.getByTestId('experiment-settings-cancel'));
+      // Use fireEvent (synchronous) instead of userEvent here: clicking Save with zero models
+      // selected races against the async zod validation that disables the button once it detects
+      // the empty arrays are invalid, so a synchronous dispatch is needed to land the click before
+      // that validation resolves and flips isDisabled.
+      fireEvent.click(screen.getByTestId('experiment-settings-save'));
 
       expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.MODELS_SELECTED, {
         countOfFoundationModels: 0,
         countOfEmbeddingModels: 0,
-        outcome: TrackingOutcome.cancel,
+        outcome: TrackingOutcome.submit,
         success: true,
+      });
+
+      // Flush the async validation triggered on mount so its state update is captured within
+      // act(), rather than resolving after the test completes.
+      await waitFor(() => {
+        expect(screen.getByTestId('experiment-settings-save')).toBeDisabled();
       });
     });
 

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragExperimentSettings.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragExperimentSettings.spec.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutoragExperimentSettings from '~/app/components/configure/AutoragExperimentSettings';
+import { RunTriggeredTrackingContext } from '~/app/context/RunTriggeredTrackingContext';
 import { ConfigureSchema, createConfigureSchema } from '~/app/schemas/configure.schema';
 import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
 
@@ -65,12 +66,30 @@ const defaultProps = {
 const renderComponent = (
   props: Partial<typeof defaultProps> = {},
   formWrapperProps: Omit<FormWrapperProps, 'children'> = {},
-) =>
-  render(
+  options?: { onModelsConfigured?: () => void },
+) => {
+  const tree = (
     <FormWrapper {...formWrapperProps}>
       <AutoragExperimentSettings {...defaultProps} {...props} />
-    </FormWrapper>,
+    </FormWrapper>
   );
+  return render(
+    options?.onModelsConfigured ? (
+      <RunTriggeredTrackingContext.Provider
+        value={{
+          onKnowledgeSourceConfigured: jest.fn(),
+          onEvaluationSourceConfigured: jest.fn(),
+          onVectorStoreConfigured: jest.fn(),
+          onModelsConfigured: options.onModelsConfigured,
+        }}
+      >
+        {tree}
+      </RunTriggeredTrackingContext.Provider>
+    ) : (
+      tree
+    ),
+  );
+};
 
 describe('AutoragExperimentSettings', () => {
   beforeEach(() => {
@@ -192,6 +211,52 @@ describe('AutoragExperimentSettings', () => {
       );
       expect(defaultProps.revertChanges).toHaveBeenCalledTimes(1);
       expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+    /* eslint-enable camelcase */
+  });
+
+  describe('RunTriggeredTrackingContext reporting', () => {
+    /* eslint-disable camelcase -- generation_models/embedding_models are schema field names */
+    it('should report to RunTriggeredTrackingContext when Save is clicked', async () => {
+      const user = userEvent.setup();
+      const onModelsConfigured = jest.fn();
+      renderComponent(
+        {},
+        { dirtyModels: { generation_models: ['gpt-4'], embedding_models: ['minilm-v2'] } },
+        { onModelsConfigured },
+      );
+
+      await user.click(screen.getByTestId('experiment-settings-save'));
+
+      expect(onModelsConfigured).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT report to RunTriggeredTrackingContext when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      const onModelsConfigured = jest.fn();
+      renderComponent(
+        {},
+        { dirtyModels: { generation_models: ['gpt-4'], embedding_models: ['minilm-v2'] } },
+        { onModelsConfigured },
+      );
+
+      await user.click(screen.getByTestId('experiment-settings-cancel'));
+
+      expect(onModelsConfigured).not.toHaveBeenCalled();
+    });
+
+    it('should NOT report to RunTriggeredTrackingContext when the modal is closed via the X button', async () => {
+      const user = userEvent.setup();
+      const onModelsConfigured = jest.fn();
+      renderComponent(
+        {},
+        { dirtyModels: { generation_models: ['gpt-4'], embedding_models: ['minilm-v2'] } },
+        { onModelsConfigured },
+      );
+
+      await user.click(screen.getByLabelText('Close'));
+
+      expect(onModelsConfigured).not.toHaveBeenCalled();
     });
     /* eslint-enable camelcase */
   });

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
@@ -100,6 +100,7 @@ const renderWithProviders = (
           onKnowledgeSourceConfigured: jest.fn(),
           onEvaluationSourceConfigured: jest.fn(),
           onVectorStoreConfigured: options.onVectorStoreConfigured,
+          onModelsConfigured: jest.fn(),
         }}
       >
         {tree}

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
@@ -413,11 +413,16 @@ describe('AutoragVectorStoreSelector', () => {
       expect(fireFormTrackingEventMock).not.toHaveBeenCalled();
     });
 
-    it('should not fire when the auto-clear-stale-selection effect resets the field', () => {
-      const { rerender } = renderWithProviders(
-        <AutoragVectorStoreSelector />,
-        { defaultValues: { vector_io_provider_id: 'milvus' } }, // eslint-disable-line camelcase
-      );
+    it('should not fire when the auto-clear-stale-selection effect resets the field', async () => {
+      let formValues: unknown;
+      const onFormChange = (values: unknown) => {
+        formValues = values;
+      };
+
+      const { rerender } = renderWithProviders(<AutoragVectorStoreSelector />, {
+        defaultValues: { vector_io_provider_id: 'milvus' }, // eslint-disable-line camelcase
+        onFormChange,
+      });
 
       // Provider list refreshes and no longer includes the previously selected "milvus" —
       // this should silently clear the field via the effect, not fire a tracking event.
@@ -432,11 +437,17 @@ describe('AutoragVectorStoreSelector', () => {
       const preFilledDefaults = { vector_io_provider_id: 'milvus' }; // eslint-disable-line camelcase
       rerender(
         <QueryClientProvider client={queryClient}>
-          <FormWrapper defaultValues={preFilledDefaults}>
+          <FormWrapper defaultValues={preFilledDefaults} onFormChange={onFormChange}>
             <AutoragVectorStoreSelector />
           </FormWrapper>
         </QueryClientProvider>,
       );
+
+      await waitFor(() => {
+        expect(formValues).toMatchObject({
+          vector_io_provider_id: '', // eslint-disable-line camelcase
+        });
+      });
 
       expect(fireFormTrackingEventMock).not.toHaveBeenCalled();
     });

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
@@ -5,10 +5,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useParams } from 'react-router';
 import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutoragVectorStoreSelector from '~/app/components/configure/AutoragVectorStoreSelector';
 import { useOgxVectorStoreProvidersQuery } from '~/app/hooks/queries';
 import { mockVectorStoreProvidersResponse } from '~/__mocks__/mockVectorStore';
 import { createConfigureSchema } from '~/app/schemas/configure.schema';
+import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
@@ -19,6 +21,12 @@ jest.mock('~/app/hooks/queries', () => ({
   ...jest.requireActual('~/app/hooks/queries'),
   useOgxVectorStoreProvidersQuery: jest.fn(),
 }));
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+}));
+
+const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
 
 const mockNotificationError = jest.fn();
 const mockNotificationWarning = jest.fn();
@@ -40,13 +48,14 @@ const configureSchema = createConfigureSchema();
 type FormWrapperProps = {
   children: React.ReactNode;
   onFormChange?: (values: unknown) => void;
+  defaultValues?: Partial<typeof configureSchema.defaults>;
 };
 
-const FormWrapper: React.FC<FormWrapperProps> = ({ children, onFormChange }) => {
+const FormWrapper: React.FC<FormWrapperProps> = ({ children, onFormChange, defaultValues }) => {
   const form = useForm({
     mode: 'onChange',
     resolver: zodResolver(configureSchema.full),
-    defaultValues: configureSchema.defaults,
+    defaultValues: { ...configureSchema.defaults, ...defaultValues },
   });
 
   React.useEffect(() => {
@@ -67,14 +76,19 @@ const FormWrapper: React.FC<FormWrapperProps> = ({ children, onFormChange }) => 
 
 const renderWithProviders = (
   component: React.ReactElement,
-  options?: { onFormChange?: (values: unknown) => void },
+  options?: {
+    onFormChange?: (values: unknown) => void;
+    defaultValues?: Partial<typeof configureSchema.defaults>;
+  },
 ) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <FormWrapper onFormChange={options?.onFormChange}>{component}</FormWrapper>
+      <FormWrapper onFormChange={options?.onFormChange} defaultValues={options?.defaultValues}>
+        {component}
+      </FormWrapper>
     </QueryClientProvider>,
   );
 };
@@ -327,6 +341,86 @@ describe('AutoragVectorStoreSelector', () => {
       // Verify the display format shows provider_id with deployment and name
       expect(screen.getByText('milvus (remote Milvus)')).toBeInTheDocument();
       expect(screen.getByTestId('vector-store-option-milvus')).toBeInTheDocument();
+    });
+  });
+
+  describe('AutoRAG Vector Store Configured tracking', () => {
+    it('should fire with the categorized provider type and compatible provider count on selection', () => {
+      renderWithProviders(<AutoragVectorStoreSelector />);
+
+      fireEvent.click(screen.getByTestId('vector-store-select-toggle'));
+      fireEvent.click(screen.getByText('milvus (remote Milvus)'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.VECTOR_STORE_CONFIGURED,
+        {
+          providerType: 'milvus',
+          countOfCompatibleProviders: 2,
+          outcome: TrackingOutcome.submit,
+          success: true,
+        },
+      );
+    });
+
+    it('should fire again with pgvector when a different provider is selected afterward', () => {
+      renderWithProviders(<AutoragVectorStoreSelector />);
+
+      fireEvent.click(screen.getByTestId('vector-store-select-toggle'));
+      fireEvent.click(screen.getByText('milvus (remote Milvus)'));
+      fireFormTrackingEventMock.mockClear();
+
+      fireEvent.click(screen.getByTestId('vector-store-select-toggle'));
+      fireEvent.click(screen.getByText('pgvector (remote Pgvector)'));
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledTimes(1);
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.VECTOR_STORE_CONFIGURED,
+        {
+          providerType: 'pgvector',
+          countOfCompatibleProviders: 2,
+          outcome: TrackingOutcome.submit,
+          success: true,
+        },
+      );
+    });
+
+    it('should not fire on initial mount when a provider is pre-filled (reconfigure)', () => {
+      renderWithProviders(<AutoragVectorStoreSelector />, {
+        defaultValues: { vector_io_provider_id: 'milvus' }, // eslint-disable-line camelcase
+      });
+
+      expect(screen.getByTestId('vector-store-select-toggle')).toHaveTextContent(
+        'milvus (remote Milvus)',
+      );
+      expect(fireFormTrackingEventMock).not.toHaveBeenCalled();
+    });
+
+    it('should not fire when the auto-clear-stale-selection effect resets the field', () => {
+      const { rerender } = renderWithProviders(
+        <AutoragVectorStoreSelector />,
+        { defaultValues: { vector_io_provider_id: 'milvus' } }, // eslint-disable-line camelcase
+      );
+
+      // Provider list refreshes and no longer includes the previously selected "milvus" —
+      // this should silently clear the field via the effect, not fire a tracking event.
+      mockUseOgxVectorStoreProvidersQuery.mockReturnValue({
+        data: mockVectorStoreProvidersResponse([
+          { provider_id: 'pgvector', provider_type: 'remote::pgvector' }, // eslint-disable-line camelcase
+        ]),
+        isLoading: false,
+      } as unknown as ReturnType<typeof useOgxVectorStoreProvidersQuery>);
+
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const preFilledDefaults = { vector_io_provider_id: 'milvus' }; // eslint-disable-line camelcase
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <FormWrapper defaultValues={preFilledDefaults}>
+            <AutoragVectorStoreSelector />
+          </FormWrapper>
+        </QueryClientProvider>,
+      );
+
+      expect(fireFormTrackingEventMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
@@ -11,6 +11,7 @@ import { useOgxVectorStoreProvidersQuery } from '~/app/hooks/queries';
 import { mockVectorStoreProvidersResponse } from '~/__mocks__/mockVectorStore';
 import { createConfigureSchema } from '~/app/schemas/configure.schema';
 import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
+import { RunTriggeredTrackingContext } from '~/app/context/RunTriggeredTrackingContext';
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
@@ -79,17 +80,33 @@ const renderWithProviders = (
   options?: {
     onFormChange?: (values: unknown) => void;
     defaultValues?: Partial<typeof configureSchema.defaults>;
+    onVectorStoreConfigured?: (providerType: string) => void;
   },
 ) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
+  const tree = (
     <QueryClientProvider client={queryClient}>
       <FormWrapper onFormChange={options?.onFormChange} defaultValues={options?.defaultValues}>
         {component}
       </FormWrapper>
-    </QueryClientProvider>,
+    </QueryClientProvider>
+  );
+  return render(
+    options?.onVectorStoreConfigured ? (
+      <RunTriggeredTrackingContext.Provider
+        value={{
+          onKnowledgeSourceConfigured: jest.fn(),
+          onEvaluationSourceConfigured: jest.fn(),
+          onVectorStoreConfigured: options.onVectorStoreConfigured,
+        }}
+      >
+        {tree}
+      </RunTriggeredTrackingContext.Provider>
+    ) : (
+      tree
+    ),
   );
 };
 
@@ -421,6 +438,16 @@ describe('AutoragVectorStoreSelector', () => {
       );
 
       expect(fireFormTrackingEventMock).not.toHaveBeenCalled();
+    });
+
+    it('should report the selection to RunTriggeredTrackingContext for use by AutoRAG Run Triggered', () => {
+      const onVectorStoreConfigured = jest.fn();
+      renderWithProviders(<AutoragVectorStoreSelector />, { onVectorStoreConfigured });
+
+      fireEvent.click(screen.getByTestId('vector-store-select-toggle'));
+      fireEvent.click(screen.getByText('pgvector (remote Pgvector)'));
+
+      expect(onVectorStoreConfigured).toHaveBeenCalledWith('pgvector');
     });
   });
 });

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/EvaluationTemplateModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/EvaluationTemplateModal.spec.tsx
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import EvaluationTemplateModal from '~/app/components/configure/EvaluationTemplateModal';
+import * as tracking from '~/app/utilities/tracking';
+
+jest.mock('~/app/utilities/tracking', () => ({
+  ...jest.requireActual('~/app/utilities/tracking'),
+  fireAutoragEvaluationTemplateDownloaded: jest.fn(),
+}));
+
+const fireAutoragEvaluationTemplateDownloadedMock = jest.mocked(
+  tracking.fireAutoragEvaluationTemplateDownloaded,
+);
+
+describe('EvaluationTemplateModal', () => {
+  beforeEach(() => {
+    // jsdom does not implement these URL APIs; the download button's Blob-based download flow
+    // needs them to exist even though the resulting object URL is never asserted against here.
+    Object.defineProperty(global.URL, 'createObjectURL', {
+      value: jest.fn().mockReturnValue('blob:mock-url'),
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(global.URL, 'revokeObjectURL', {
+      value: jest.fn(),
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('should fire AutoRAG Evaluation Template Downloaded when the download button is clicked', () => {
+    render(<EvaluationTemplateModal onClose={jest.fn()} />);
+
+    fireEvent.click(screen.getByTestId('evaluation-template-download-button'));
+
+    expect(fireAutoragEvaluationTemplateDownloadedMock).toHaveBeenCalledTimes(1);
+    expect(fireAutoragEvaluationTemplateDownloadedMock).toHaveBeenCalledWith();
+  });
+
+  it('should not fire tracking when the modal is only closed', () => {
+    const onCloseMock = jest.fn();
+    render(<EvaluationTemplateModal onClose={onCloseMock} />);
+
+    fireEvent.click(screen.getByTestId('evaluation-template-close-button'));
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+    expect(fireAutoragEvaluationTemplateDownloadedMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragLeaderboard.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragLeaderboard.tsx
@@ -48,8 +48,10 @@ import { patternHasIndexingPipelineSpec } from '~/app/utilities/indexingPipeline
 import { METRIC_DESCRIPTIONS } from '~/app/utilities/const';
 import {
   fireAutoragResultsColumnToggled,
+  fireAutoragLeaderboardPresetApplied,
   mapOptimizationMetric,
   type ResultsColumnName,
+  type LeaderboardPresetType,
 } from '~/app/utilities/tracking';
 import ManageColumnsModal, { type ColumnPreset } from './ManageColumnsModal';
 import './AutoragLeaderboard.scss';
@@ -318,6 +320,18 @@ const getColumnAnalyticsName = (
   }
   return SETTINGS_COLUMN_ANALYTICS_NAMES[columnId] ?? 'other';
 };
+
+// Explicit allowlist mapping each "Manage columns" quick-select preset's display label to its
+// discrete analytics identity — mirrors `SETTINGS_COLUMN_ANALYTICS_NAMES` above so a label
+// rename doesn't silently break (or leak into) the analytics taxonomy.
+const PRESET_ANALYTICS_TYPES: Record<string, LeaderboardPresetType> = {
+  'Optimization metrics': 'optimizationMetrics',
+  'Optimization metrics and chunking': 'optimizationMetricsAndChunking',
+  'Full configuration': 'fullConfiguration',
+};
+
+const getPresetAnalyticsType = (presetLabel: string): LeaderboardPresetType =>
+  PRESET_ANALYTICS_TYPES[presetLabel] ?? 'other';
 
 const getColumnInfoProps = (
   columnId: string,
@@ -1158,6 +1172,9 @@ function AutoragLeaderboard({
         defaultColumns={defaultColumns}
         applyColumns={handleApplyColumns}
         presets={columnPresets}
+        onPresetSelect={(presetLabel) =>
+          fireAutoragLeaderboardPresetApplied(getPresetAnalyticsType(presetLabel))
+        }
       />
     </Card>
   );

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragLeaderboard.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragLeaderboard.tsx
@@ -46,6 +46,11 @@ import {
 } from '~/app/utilities/utils';
 import { patternHasIndexingPipelineSpec } from '~/app/utilities/indexingPipeline';
 import { METRIC_DESCRIPTIONS } from '~/app/utilities/const';
+import {
+  fireAutoragResultsColumnToggled,
+  mapOptimizationMetric,
+  type ResultsColumnName,
+} from '~/app/utilities/tracking';
 import ManageColumnsModal, { type ColumnPreset } from './ManageColumnsModal';
 import './AutoragLeaderboard.scss';
 
@@ -274,6 +279,46 @@ const SETTINGS_COLUMNS = Object.entries(COLUMN_META)
     testId: meta.testId!,
   }));
 
+// Explicit allowlist (rather than reusing COLUMN_META's ids directly) so the analytics taxonomy
+// doesn't silently grow every time a new settings column is added to COLUMN_META — new ids fall
+// back to `'other'` in `getColumnAnalyticsName` until deliberately added here.
+const SETTINGS_COLUMN_ANALYTICS_NAMES: Partial<Record<string, ResultsColumnName>> = {
+  chunkingMethod: 'chunkingMethod',
+  chunkingChunkSize: 'chunkingChunkSize',
+  chunkingChunkOverlap: 'chunkingChunkOverlap',
+  retrievalMethod: 'retrievalMethod',
+  retrievalSearchMode: 'retrievalSearchMode',
+  retrievalRankerStrategy: 'retrievalRankerStrategy',
+  retrievalNumberOfChunks: 'retrievalNumberOfChunks',
+};
+
+/**
+ * Maps an internal column id (as used in `columnDefs`/`ColumnManagementModalColumn.key`) to the
+ * discrete `ResultsColumnName` analytics taxonomy. `optimizedMetricKey` disambiguates the sticky
+ * `'optimized-metric'` column, whose underlying metric varies per run.
+ */
+const getColumnAnalyticsName = (
+  columnId: string,
+  optimizedMetricKey: string,
+): ResultsColumnName => {
+  if (columnId === 'rank') {
+    return 'rank';
+  }
+  if (columnId === 'pattern') {
+    return 'patternName';
+  }
+  if (columnId === 'modelNames') {
+    return 'modelNames';
+  }
+  if (columnId === 'optimized-metric') {
+    return mapOptimizationMetric(optimizedMetricKey) ?? 'otherMetric';
+  }
+  if (columnId.startsWith('metric:')) {
+    return mapOptimizationMetric(columnId.slice('metric:'.length)) ?? 'otherMetric';
+  }
+  return SETTINGS_COLUMN_ANALYTICS_NAMES[columnId] ?? 'other';
+};
+
 const getColumnInfoProps = (
   columnId: string,
   tooltipName?: string,
@@ -446,22 +491,39 @@ function AutoragLeaderboard({
     }));
   }, [columnDefs, visibleColumnIds, columnOrder, DEFAULT_VISIBLE_IDS]);
 
-  const handleApplyColumns = React.useCallback((newColumns: ColumnManagementModalColumn[]) => {
-    const newVisibleIds = new Set<string>();
-    newColumns.forEach((col) => {
-      if (col.isShown) {
-        newVisibleIds.add(col.key);
-      }
-    });
-    setVisibleColumnIds(newVisibleIds);
-    setColumnOrder(newColumns.map((col) => col.key));
+  const handleApplyColumns = React.useCallback(
+    (newColumns: ColumnManagementModalColumn[]) => {
+      const newVisibleIds = new Set<string>();
+      newColumns.forEach((col) => {
+        if (col.isShown) {
+          newVisibleIds.add(col.key);
+        }
+      });
 
-    // Reset sort to the first visible column if the currently sorted column is being hidden
-    const fallbackSortId = newColumns.find((col) => col.isShown)?.key ?? 'rank';
-    setActiveSort((prev) =>
-      newVisibleIds.has(prev.id) ? prev : { id: fallbackSortId, direction: 'asc' },
-    );
-  }, []);
+      // Track only columns whose visibility actually changed from the prior applied state —
+      // a reorder-only save (or a checkbox toggled back to its original state) fires nothing.
+      newColumns.forEach((col) => {
+        const wasVisible = visibleColumnIds.has(col.key);
+        const isShown = col.isShown ?? false;
+        if (wasVisible !== isShown) {
+          fireAutoragResultsColumnToggled(
+            getColumnAnalyticsName(col.key, optimizedMetric),
+            isShown,
+          );
+        }
+      });
+
+      setVisibleColumnIds(newVisibleIds);
+      setColumnOrder(newColumns.map((col) => col.key));
+
+      // Reset sort to the first visible column if the currently sorted column is being hidden
+      const fallbackSortId = newColumns.find((col) => col.isShown)?.key ?? 'rank';
+      setActiveSort((prev) =>
+        newVisibleIds.has(prev.id) ? prev : { id: fallbackSortId, direction: 'asc' },
+      );
+    },
+    [visibleColumnIds, optimizedMetric],
+  );
 
   // All visible columns in user order, used for both header and body rendering
   const visibleColumns = React.useMemo(() => {

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
@@ -24,6 +24,7 @@ import {
   fireAutoragNotebookDownloaded,
   fireAutoragPatternDetailsViewed,
   type PlaygroundOpenedSource,
+  type ViewCodeEntrySource,
 } from '~/app/utilities/tracking';
 import type { PipelineTreeLoadingMode } from './pipelineStatusLabels';
 import AutoragLeaderboard from './AutoragLeaderboard';
@@ -35,7 +36,7 @@ const PatternDetailsModal = React.lazy(() => import('./PatternDetailsModal/Patte
 
 type AutoragResultsProps = {
   onTryPattern?: (patternName: string, source: PlaygroundOpenedSource) => void;
-  onViewCode?: (patternName: string) => void;
+  onViewCode?: (patternName: string, source: ViewCodeEntrySource) => void;
 };
 
 function AutoragResults({ onTryPattern, onViewCode }: AutoragResultsProps): React.JSX.Element {
@@ -346,7 +347,9 @@ function AutoragResults({ onTryPattern, onViewCode }: AutoragResultsProps): Reac
             onTryPattern={
               onTryPattern ? (patternName) => onTryPattern(patternName, 'resultsTable') : undefined
             }
-            onViewCode={onViewCode}
+            onViewCode={
+              onViewCode ? (patternName) => onViewCode(patternName, 'resultsTable') : undefined
+            }
             onRunIndexingPipeline={runIndexingHandler}
           />
         </StackItem>
@@ -369,7 +372,9 @@ function AutoragResults({ onTryPattern, onViewCode }: AutoragResultsProps): Reac
                 ? (patternName) => onTryPattern(patternName, 'patternDetails')
                 : undefined
             }
-            onViewCode={onViewCode}
+            onViewCode={
+              onViewCode ? (patternName) => onViewCode(patternName, 'patternDetails') : undefined
+            }
             onRunIndexingPipeline={runIndexingHandler}
           />
         </React.Suspense>

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
@@ -22,6 +22,7 @@ import {
 import { buildIndexingPipelineRunRequest } from '~/app/utilities/indexingPipeline';
 import {
   fireAutoragNotebookDownloaded,
+  fireAutoragPatternDetailsViewed,
   type PlaygroundOpenedSource,
 } from '~/app/utilities/tracking';
 import type { PipelineTreeLoadingMode } from './pipelineStatusLabels';
@@ -209,6 +210,7 @@ function AutoragResults({ onTryPattern, onViewCode }: AutoragResultsProps): Reac
 
   const handleViewDetails = React.useCallback((patternName: string) => {
     setSelectedPatternName(patternName);
+    fireAutoragPatternDetailsViewed('resultsTable');
   }, []);
 
   const handleOpenRunIndexing = React.useCallback(

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
@@ -20,7 +20,10 @@ import {
   sanitizeFilename,
 } from '~/app/utilities/utils';
 import { buildIndexingPipelineRunRequest } from '~/app/utilities/indexingPipeline';
-import type { PlaygroundOpenedSource } from '~/app/utilities/tracking';
+import {
+  fireAutoragNotebookDownloaded,
+  type PlaygroundOpenedSource,
+} from '~/app/utilities/tracking';
 import type { PipelineTreeLoadingMode } from './pipelineStatusLabels';
 import AutoragLeaderboard from './AutoragLeaderboard';
 import AutoragPipelineVisualization from './AutoragPipelineVisualization';
@@ -293,6 +296,7 @@ function AutoragResults({ onTryPattern, onViewCode }: AutoragResultsProps): Reac
         const safePatternName = sanitizeFilename(patternName);
         const filename = `${displayName}_${safePatternName}_${notebookType}_notebook.ipynb`;
         downloadBlob(notebook, filename);
+        fireAutoragNotebookDownloaded(notebookType);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
         setDownloadError({

--- a/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/AutoragResults.tsx
@@ -20,6 +20,7 @@ import {
   sanitizeFilename,
 } from '~/app/utilities/utils';
 import { buildIndexingPipelineRunRequest } from '~/app/utilities/indexingPipeline';
+import type { PlaygroundOpenedSource } from '~/app/utilities/tracking';
 import type { PipelineTreeLoadingMode } from './pipelineStatusLabels';
 import AutoragLeaderboard from './AutoragLeaderboard';
 import AutoragPipelineVisualization from './AutoragPipelineVisualization';
@@ -29,7 +30,7 @@ import './AutoragResults.scss';
 const PatternDetailsModal = React.lazy(() => import('./PatternDetailsModal/PatternDetailsModal'));
 
 type AutoragResultsProps = {
-  onTryPattern?: (patternName: string) => void;
+  onTryPattern?: (patternName: string, source: PlaygroundOpenedSource) => void;
   onViewCode?: (patternName: string) => void;
 };
 
@@ -336,7 +337,9 @@ function AutoragResults({ onTryPattern, onViewCode }: AutoragResultsProps): Reac
           <AutoragLeaderboard
             onViewDetails={handleViewDetails}
             onSaveNotebook={handleSaveNotebook}
-            onTryPattern={onTryPattern}
+            onTryPattern={
+              onTryPattern ? (patternName) => onTryPattern(patternName, 'resultsTable') : undefined
+            }
             onViewCode={onViewCode}
             onRunIndexingPipeline={runIndexingHandler}
           />
@@ -355,7 +358,11 @@ function AutoragResults({ onTryPattern, onViewCode }: AutoragResultsProps): Reac
             namespace={namespace}
             ragPatternsBasePath={ragPatternsBasePath}
             onSaveNotebook={handleSaveNotebook}
-            onTryPattern={onTryPattern}
+            onTryPattern={
+              onTryPattern
+                ? (patternName) => onTryPattern(patternName, 'patternDetails')
+                : undefined
+            }
             onViewCode={onViewCode}
             onRunIndexingPipeline={runIndexingHandler}
           />

--- a/packages/autorag/frontend/src/app/components/run-results/DeleteRunModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/DeleteRunModal.tsx
@@ -12,7 +12,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
-import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
+import { AUTORAG_EVENTS, TrackingOutcome, type RunActionSource } from '~/app/utilities/tracking';
 
 type DeleteRunModalProps = {
   isOpen: boolean;
@@ -20,6 +20,7 @@ type DeleteRunModalProps = {
   onConfirm: () => void;
   isDeleting: boolean;
   runName?: string;
+  source: RunActionSource;
 };
 
 const DeleteRunModal: React.FC<DeleteRunModalProps> = ({
@@ -28,6 +29,7 @@ const DeleteRunModal: React.FC<DeleteRunModalProps> = ({
   onConfirm,
   isDeleting,
   runName,
+  source,
 }) => {
   const [confirmInputValue, setConfirmInputValue] = React.useState('');
   // Mirrors `isDeleting` but flips to `true` synchronously the instant the Delete button is
@@ -66,10 +68,10 @@ const DeleteRunModal: React.FC<DeleteRunModalProps> = ({
     setConfirmInputValue('');
     fireFormTrackingEvent(AUTORAG_EVENTS.EXPERIMENT_DELETED, {
       outcome: TrackingOutcome.cancel,
-      source: 'runsList',
+      source,
     });
     onClose();
-  }, [isBusy, onClose]);
+  }, [isBusy, onClose, source]);
 
   const handleDeleteClick = () => {
     // Set synchronously, before calling onConfirm(), so isBusy is already true by the time

--- a/packages/autorag/frontend/src/app/components/run-results/DeleteRunModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/DeleteRunModal.tsx
@@ -11,6 +11,8 @@ import {
   StackItem,
   TextInput,
 } from '@patternfly/react-core';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
 
 type DeleteRunModalProps = {
   isOpen: boolean;
@@ -32,9 +34,19 @@ const DeleteRunModal: React.FC<DeleteRunModalProps> = ({
   const isDisabled = !confirmMessage || confirmInputValue.trim() !== confirmMessage || isDeleting;
 
   const handleClose = React.useCallback(() => {
+    // Deletion is already in flight (e.g. triggered via Escape/backdrop, which PatternFly's
+    // Modal invokes regardless of the disabled Cancel button) — don't record a "cancel"
+    // outcome here, since handleDelete will record the real submit success/failure outcome.
+    if (isDeleting) {
+      return;
+    }
     setConfirmInputValue('');
+    fireFormTrackingEvent(AUTORAG_EVENTS.EXPERIMENT_DELETED, {
+      outcome: TrackingOutcome.cancel,
+      source: 'runsList',
+    });
     onClose();
-  }, [onClose]);
+  }, [isDeleting, onClose]);
 
   return (
     <Modal variant="small" isOpen={isOpen} onClose={handleClose} data-testid="delete-run-modal">

--- a/packages/autorag/frontend/src/app/components/run-results/DeleteRunModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/DeleteRunModal.tsx
@@ -30,14 +30,37 @@ const DeleteRunModal: React.FC<DeleteRunModalProps> = ({
   runName,
 }) => {
   const [confirmInputValue, setConfirmInputValue] = React.useState('');
+  // Mirrors `isDeleting` but flips to `true` synchronously the instant the Delete button is
+  // clicked, instead of waiting for the mutation library's (microtask-scheduled) notification
+  // to update the `isDeleting` prop. This closes the narrow race window between the click and
+  // the prop actually updating, during which Escape/backdrop-close could otherwise still see
+  // `isDeleting: false` and incorrectly fire a cancel event / close the modal.
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const isBusy = isSubmitting || isDeleting;
   const confirmMessage = runName ?? '';
-  const isDisabled = !confirmMessage || confirmInputValue.trim() !== confirmMessage || isDeleting;
+  const isDisabled = !confirmMessage || confirmInputValue.trim() !== confirmMessage || isBusy;
+
+  React.useEffect(() => {
+    // Reset once the real deletion is no longer in flight — covers both the success case
+    // (the modal will be closed/unmounted by the parent anyway) and the failure case (the
+    // modal stays open and the user needs to be able to retry or cancel again).
+    if (!isDeleting) {
+      setIsSubmitting(false);
+    }
+  }, [isDeleting]);
+
+  React.useEffect(() => {
+    // Avoid stale busy state if the modal is reopened for a different run.
+    if (!isOpen) {
+      setIsSubmitting(false);
+    }
+  }, [isOpen]);
 
   const handleClose = React.useCallback(() => {
     // Deletion is already in flight (e.g. triggered via Escape/backdrop, which PatternFly's
     // Modal invokes regardless of the disabled Cancel button) — don't record a "cancel"
     // outcome here, since handleDelete will record the real submit success/failure outcome.
-    if (isDeleting) {
+    if (isBusy) {
       return;
     }
     setConfirmInputValue('');
@@ -46,7 +69,15 @@ const DeleteRunModal: React.FC<DeleteRunModalProps> = ({
       source: 'runsList',
     });
     onClose();
-  }, [isDeleting, onClose]);
+  }, [isBusy, onClose]);
+
+  const handleDeleteClick = () => {
+    // Set synchronously, before calling onConfirm(), so isBusy is already true by the time
+    // any subsequent event (e.g. an Escape keydown) is processed — no need to wait for the
+    // async `isDeleting` prop update.
+    setIsSubmitting(true);
+    onConfirm();
+  };
 
   return (
     <Modal variant="small" isOpen={isOpen} onClose={handleClose} data-testid="delete-run-modal">
@@ -67,7 +98,7 @@ const DeleteRunModal: React.FC<DeleteRunModalProps> = ({
                 onChange={(_e, newValue) => setConfirmInputValue(newValue)}
                 onKeyDown={(event) => {
                   if (event.key === 'Enter' && !isDisabled) {
-                    onConfirm();
+                    handleDeleteClick();
                   }
                 }}
               />
@@ -78,15 +109,15 @@ const DeleteRunModal: React.FC<DeleteRunModalProps> = ({
       <ModalFooter>
         <Button
           variant="danger"
-          onClick={onConfirm}
+          onClick={handleDeleteClick}
           isDisabled={isDisabled}
-          isLoading={isDeleting}
+          isLoading={isBusy}
           spinnerAriaValueText="Deleting run"
           data-testid="confirm-delete-run-button"
         >
           Delete
         </Button>
-        <Button variant="link" onClick={handleClose} isDisabled={isDeleting}>
+        <Button variant="link" onClick={handleClose} isDisabled={isBusy}>
           Cancel
         </Button>
       </ModalFooter>

--- a/packages/autorag/frontend/src/app/components/run-results/ManageColumnsModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/ManageColumnsModal.tsx
@@ -40,6 +40,7 @@ type ManageColumnsModalProps = {
   defaultColumns: ColumnManagementModalColumn[];
   applyColumns: (columns: ColumnManagementModalColumn[]) => void;
   presets?: ColumnPreset[];
+  onPresetSelect?: (presetLabel: string) => void;
 };
 
 type ColumnState = ColumnManagementModalColumn & { isShown: boolean };
@@ -51,6 +52,7 @@ const ManageColumnsModal: React.FC<ManageColumnsModalProps> = ({
   defaultColumns,
   applyColumns,
   presets,
+  onPresetSelect,
 }) => {
   const [currentColumns, setCurrentColumns] = React.useState<ColumnState[]>(() =>
     appliedColumns.map((col) => ({
@@ -150,6 +152,7 @@ const ManageColumnsModal: React.FC<ManageColumnsModalProps> = ({
         isShown: preset.visibleColumnKeys.includes(col.key),
       })),
     );
+    onPresetSelect?.(preset.label);
   };
 
   const selectedCount = currentColumns.filter((c) => c.isShown).length;

--- a/packages/autorag/frontend/src/app/components/run-results/ManageColumnsModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/ManageColumnsModal.tsx
@@ -9,6 +9,8 @@ import {
   DataListCheck,
   DataListItemCells,
   DataListItemRow,
+  Flex,
+  FlexItem,
   MenuToggle,
   Modal,
   ModalBody,
@@ -233,13 +235,31 @@ const ManageColumnsModal: React.FC<ManageColumnsModalProps> = ({
                       value={preset.label}
                       data-testid={`organize-by-option-${preset.label}`}
                     >
-                      <Radio
-                        isChecked={selectedPreset === preset.label}
-                        name="organize-by-radio"
-                        label={preset.label}
-                        id={`preset-${preset.label}`}
-                        onChange={() => handlePresetSelect(preset.label)}
-                      />
+                      {/*
+                        The radio and its label are intentionally not wired together via
+                        PatternFly's `label` prop (which renders a native `<label htmlFor>`).
+                        Browsers forward a click on such a label to its associated input,
+                        producing a second click event that bubbles up to this SelectOption
+                        and would double-fire `onSelect`/`handlePresetSelect`. Rendering the
+                        radio (with an accessible name via `aria-label`) and the visible text
+                        as separate, unassociated elements keeps this as a single click target
+                        so `Select`'s `onSelect` remains the sole source of truth.
+                      */}
+                      <Flex
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                        alignItems={{ default: 'alignItemsCenter' }}
+                      >
+                        <FlexItem>
+                          <Radio
+                            isChecked={selectedPreset === preset.label}
+                            name="organize-by-radio"
+                            aria-label={preset.label}
+                            id={`preset-${preset.label}`}
+                            readOnly
+                          />
+                        </FlexItem>
+                        <FlexItem>{preset.label}</FlexItem>
+                      </Flex>
                     </SelectOption>
                   ))}
                 </SelectList>

--- a/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternDetailsModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternDetailsModal.tsx
@@ -27,6 +27,7 @@ import {
   getOptimizedScore,
   getMetricByName,
 } from '~/app/utilities/utils';
+import { fireAutoragPatternDetailsDownloadInitiated } from '~/app/utilities/tracking';
 import { getVisibleTabs, OVERVIEW_KEY, SAMPLE_QA_KEY } from './tabConfig';
 import PatternDetailsModalHeader from './PatternDetailsModalHeader';
 import PatternComparisonSelectModal from './PatternComparisonSelectModal';
@@ -207,7 +208,10 @@ const PatternDetailsModal: React.FC<PatternDetailsModalProps> = ({
             rank={rank}
             optimizedMetric={optimizedMetric}
             onPatternChange={onPatternChange}
-            onDownload={() => setIsPrinting(true)}
+            onDownload={() => {
+              fireAutoragPatternDetailsDownloadInitiated();
+              setIsPrinting(true);
+            }}
             onSaveNotebook={onSaveNotebook}
             onTryPattern={
               onTryPattern

--- a/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternDetailsModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/PatternDetailsModal/PatternDetailsModal.tsx
@@ -27,7 +27,10 @@ import {
   getOptimizedScore,
   getMetricByName,
 } from '~/app/utilities/utils';
-import { fireAutoragPatternDetailsDownloadInitiated } from '~/app/utilities/tracking';
+import {
+  fireAutoragPatternsCompared,
+  fireAutoragPatternDetailsDownloadInitiated,
+} from '~/app/utilities/tracking';
 import { getVisibleTabs, OVERVIEW_KEY, SAMPLE_QA_KEY } from './tabConfig';
 import PatternDetailsModalHeader from './PatternDetailsModalHeader';
 import PatternComparisonSelectModal from './PatternComparisonSelectModal';
@@ -356,6 +359,14 @@ const PatternDetailsModal: React.FC<PatternDetailsModalProps> = ({
         excludePatternIndex={selectedIndex}
         optimizedMetric={optimizedMetric ?? ''}
         onSelectPattern={(index) => {
+          const comparisonPattern = patterns[index];
+          const primaryRank = rankMap[data.name] ?? rank;
+          const comparisonRank = rankMap[comparisonPattern.name] ?? 0;
+          fireAutoragPatternsCompared(
+            comparisonEnabled ? 'changed' : 'initial',
+            comparisonRank - primaryRank,
+            getOptimizedScore(comparisonPattern) - getOptimizedScore(data),
+          );
           setComparisonPatternIndex(index);
           setComparisonEnabled(true);
         }}

--- a/packages/autorag/frontend/src/app/components/run-results/StopRunModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/StopRunModal.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { AUTORAG_EVENTS, TrackingOutcome, type RunActionSource } from '~/app/utilities/tracking';
 
 type StopRunModalProps = {
   isOpen: boolean;
@@ -7,6 +9,7 @@ type StopRunModalProps = {
   onConfirm: () => void | Promise<void>;
   isTerminating: boolean;
   runName?: string;
+  source: RunActionSource;
 };
 
 const StopRunModal: React.FC<StopRunModalProps> = ({
@@ -15,6 +18,7 @@ const StopRunModal: React.FC<StopRunModalProps> = ({
   onConfirm,
   isTerminating,
   runName,
+  source,
 }) => {
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
@@ -34,10 +38,22 @@ const StopRunModal: React.FC<StopRunModalProps> = ({
     }
   }, [onConfirm]);
 
+  const handleCancel = React.useCallback(() => {
+    // A stop request is already in flight (e.g. triggered via Escape/close-button, which
+    // PatternFly's Modal invokes regardless of the disabled Cancel button) — don't record a
+    // "cancel" outcome here, since handleStopClick's onConfirm will record the real submit
+    // success/failure outcome.
+    if (isSubmitting || isTerminating) {
+      return;
+    }
+    fireFormTrackingEvent(AUTORAG_EVENTS.RUN_STOPPED, { outcome: TrackingOutcome.cancel, source });
+    onClose();
+  }, [isSubmitting, isTerminating, onClose, source]);
+
   const isDisabled = isSubmitting || isTerminating;
 
   return (
-    <Modal variant="small" isOpen={isOpen} onClose={onClose} data-testid="stop-run-modal">
+    <Modal variant="small" isOpen={isOpen} onClose={handleCancel} data-testid="stop-run-modal">
       <ModalHeader title="Stop pipeline run?" />
       <ModalBody>
         Are you sure you want to stop {runName ? `"${runName}"` : 'this run'}? All running tasks
@@ -54,7 +70,7 @@ const StopRunModal: React.FC<StopRunModalProps> = ({
         >
           Stop
         </Button>
-        <Button variant="link" onClick={onClose} isDisabled={isDisabled}>
+        <Button variant="link" onClick={handleCancel} isDisabled={isDisabled}>
           Cancel
         </Button>
       </ModalFooter>

--- a/packages/autorag/frontend/src/app/components/run-results/ViewCodeModal.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/ViewCodeModal.tsx
@@ -20,6 +20,7 @@ import type { OgxCredentials } from '~/app/types';
 import type { ResponsesTemplate } from '~/app/types/autoragPattern';
 import { useAutoragResultsContext } from '~/app/context/AutoragResultsContext';
 import { useNotification } from '~/app/hooks/useNotification';
+import { fireAutoragCodeSnippetsExported } from '~/app/utilities/tracking';
 import { formatPatternName } from '~/app/utilities/utils';
 import {
   generateCurlSnippet,
@@ -121,6 +122,7 @@ const ViewCodeModal: React.FC<ViewCodeModalProps> = ({
       () => {
         setCopiedTab(tabIndex);
         setTimeout(() => setCopiedTab(null), 2000);
+        fireAutoragCodeSnippetsExported('copied');
       },
       () => {
         // clipboard access denied

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragLeaderboard.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragLeaderboard.spec.tsx
@@ -1619,6 +1619,7 @@ describe('AutoragLeaderboard component', () => {
         fireEvent.click(screen.getByTestId('organize-by-toggle'));
         fireEvent.click(screen.getByText('Optimization metrics and chunking'));
 
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledTimes(1);
         expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
           AUTORAG_EVENTS.LEADERBOARD_PRESET_APPLIED,
           { presetType: 'optimizationMetricsAndChunking' },
@@ -1637,6 +1638,7 @@ describe('AutoragLeaderboard component', () => {
         fireEvent.click(screen.getByText('Full configuration'));
         fireEvent.click(screen.getByText('Cancel'));
 
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledTimes(1);
         expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
           AUTORAG_EVENTS.LEADERBOARD_PRESET_APPLIED,
           { presetType: 'fullConfiguration' },

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragLeaderboard.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragLeaderboard.spec.tsx
@@ -3,11 +3,20 @@ import '@testing-library/jest-dom';
 import { render, screen, within, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutoragLeaderboard from '~/app/components/run-results/AutoragLeaderboard';
 import { AutoragResultsContext } from '~/app/context/AutoragResultsContext';
 import type { AutoragPattern } from '~/app/types/autoragPattern';
 import type { PipelineRun } from '~/app/types';
 import { RuntimeStateKF } from '~/app/types/pipeline';
+import { AUTORAG_EVENTS } from '~/app/utilities/tracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireMiscTrackingEventMock = jest.mocked(fireMiscTrackingEvent);
 
 // Mock empty state component
 jest.mock('~/app/components/empty-states/AutoragRunInProgress', () => ({
@@ -1492,6 +1501,110 @@ describe('AutoragLeaderboard component', () => {
       fireEvent.click(screen.getByText('Save'));
 
       expect(screen.queryByTestId('metric-header-faithfulness')).not.toBeInTheDocument();
+    });
+
+    describe('AutoRAG Results Column Toggled tracking', () => {
+      it('should fire with the mapped metric name when hiding a non-optimized metric column', () => {
+        renderWithContext({
+          patterns: mockStandardPatterns,
+          pipelineRun: createMockPipelineRun(RuntimeStateKF.SUCCEEDED, 'faithfulness'),
+        });
+        showAllColumns();
+        fireMiscTrackingEventMock.mockClear();
+
+        fireEvent.click(screen.getByTestId('manage-columns-button'));
+        fireEvent.click(screen.getByTestId('column-check-metric:answer_correctness'));
+        fireEvent.click(screen.getByText('Save'));
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RESULTS_COLUMN_TOGGLED,
+          { columnName: 'answerCorrectness', isVisible: false },
+        );
+      });
+
+      it('should fire with the settings column id when hiding a settings column', () => {
+        renderWithContext({
+          patterns: mockStandardPatterns,
+          pipelineRun: createMockPipelineRun(RuntimeStateKF.SUCCEEDED, 'faithfulness'),
+        });
+        showAllColumns();
+        fireMiscTrackingEventMock.mockClear();
+
+        fireEvent.click(screen.getByTestId('manage-columns-button'));
+        fireEvent.click(screen.getByTestId('column-check-chunkingMethod'));
+        fireEvent.click(screen.getByText('Save'));
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RESULTS_COLUMN_TOGGLED,
+          { columnName: 'chunkingMethod', isVisible: false },
+        );
+      });
+
+      it('should fire with the mapped metric name when hiding the sticky optimized metric column', () => {
+        renderWithContext({
+          patterns: mockStandardPatterns,
+          pipelineRun: createMockPipelineRun(RuntimeStateKF.SUCCEEDED, 'faithfulness'),
+        });
+
+        fireEvent.click(screen.getByTestId('manage-columns-button'));
+        fireEvent.click(screen.getByTestId('column-check-optimized-metric'));
+        fireEvent.click(screen.getByText('Save'));
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RESULTS_COLUMN_TOGGLED,
+          { columnName: 'answerFaithfulness', isVisible: false },
+        );
+      });
+
+      it('should fire with isVisible: true when showing a hidden column', () => {
+        renderWithContext({
+          patterns: mockStandardPatterns,
+          pipelineRun: createMockPipelineRun(RuntimeStateKF.SUCCEEDED, 'faithfulness'),
+        });
+
+        fireEvent.click(screen.getByTestId('manage-columns-button'));
+        fireEvent.click(screen.getByTestId('column-check-metric:answer_correctness'));
+        fireEvent.click(screen.getByText('Save'));
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RESULTS_COLUMN_TOGGLED,
+          { columnName: 'answerCorrectness', isVisible: true },
+        );
+      });
+
+      it('should not fire when the modal is cancelled', () => {
+        renderWithContext({
+          patterns: mockStandardPatterns,
+          pipelineRun: createMockPipelineRun(RuntimeStateKF.SUCCEEDED, 'faithfulness'),
+        });
+
+        fireEvent.click(screen.getByTestId('manage-columns-button'));
+        fireEvent.click(screen.getByTestId('column-check-optimized-metric'));
+        fireEvent.click(screen.getByText('Cancel'));
+
+        expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RESULTS_COLUMN_TOGGLED,
+          expect.anything(),
+        );
+      });
+
+      it('should not fire when a column is toggled back to its originally applied state before saving', () => {
+        renderWithContext({
+          patterns: mockStandardPatterns,
+          pipelineRun: createMockPipelineRun(RuntimeStateKF.SUCCEEDED, 'faithfulness'),
+        });
+
+        fireEvent.click(screen.getByTestId('manage-columns-button'));
+        const checkbox = screen.getByTestId('column-check-optimized-metric');
+        fireEvent.click(checkbox);
+        fireEvent.click(checkbox);
+        fireEvent.click(screen.getByText('Save'));
+
+        expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RESULTS_COLUMN_TOGGLED,
+          expect.anything(),
+        );
+      });
     });
 
     it('should display column count in toolbar', () => {

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragLeaderboard.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragLeaderboard.spec.tsx
@@ -1607,6 +1607,60 @@ describe('AutoragLeaderboard component', () => {
       });
     });
 
+    describe('AutoRAG Leaderboard Preset Applied tracking', () => {
+      it('should fire with the mapped presetType when a preset is selected', () => {
+        renderWithContext({
+          patterns: mockStandardPatterns,
+          pipelineRun: createMockPipelineRun(RuntimeStateKF.SUCCEEDED, 'faithfulness'),
+        });
+        fireMiscTrackingEventMock.mockClear();
+
+        fireEvent.click(screen.getByTestId('manage-columns-button'));
+        fireEvent.click(screen.getByTestId('organize-by-toggle'));
+        fireEvent.click(screen.getByText('Optimization metrics and chunking'));
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.LEADERBOARD_PRESET_APPLIED,
+          { presetType: 'optimizationMetricsAndChunking' },
+        );
+      });
+
+      it('should fire on selection even if the modal is subsequently cancelled', () => {
+        renderWithContext({
+          patterns: mockStandardPatterns,
+          pipelineRun: createMockPipelineRun(RuntimeStateKF.SUCCEEDED, 'faithfulness'),
+        });
+        fireMiscTrackingEventMock.mockClear();
+
+        fireEvent.click(screen.getByTestId('manage-columns-button'));
+        fireEvent.click(screen.getByTestId('organize-by-toggle'));
+        fireEvent.click(screen.getByText('Full configuration'));
+        fireEvent.click(screen.getByText('Cancel'));
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.LEADERBOARD_PRESET_APPLIED,
+          { presetType: 'fullConfiguration' },
+        );
+      });
+
+      it('should not fire when the modal is opened but no preset is selected', () => {
+        renderWithContext({
+          patterns: mockStandardPatterns,
+          pipelineRun: createMockPipelineRun(RuntimeStateKF.SUCCEEDED, 'faithfulness'),
+        });
+        fireMiscTrackingEventMock.mockClear();
+
+        fireEvent.click(screen.getByTestId('manage-columns-button'));
+        fireEvent.click(screen.getByTestId('column-check-optimized-metric'));
+        fireEvent.click(screen.getByText('Save'));
+
+        expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+          AUTORAG_EVENTS.LEADERBOARD_PRESET_APPLIED,
+          expect.anything(),
+        );
+      });
+    });
+
     it('should display column count in toolbar', () => {
       renderWithContext({
         patterns: mockStandardPatterns,

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragResults.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragResults.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import '@testing-library/jest-dom';
-import { render, screen, within, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -91,6 +91,14 @@ jest.mock('~/app/hooks/mutations', () => ({
     mutateAsync: jest.fn(),
     isPending: false,
     reset: jest.fn(),
+  }),
+}));
+
+jest.mock('~/app/hooks/usePatternEvaluationResults', () => ({
+  usePatternEvaluationResults: jest.fn().mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
   }),
 }));
 
@@ -208,6 +216,7 @@ describe('AutoragResults', () => {
     patterns: Record<string, AutoragPattern> = {},
     namespace = 'test-namespace',
     contextOverrides?: Partial<AutoragResultsContextProps>,
+    props?: React.ComponentProps<typeof AutoragResults>,
   ) =>
     render(
       <MemoryRouter initialEntries={[`/autorag/${namespace}/results`]}>
@@ -224,7 +233,7 @@ describe('AutoragResults', () => {
                   ...contextOverrides,
                 }}
               >
-                <AutoragResults />
+                <AutoragResults {...props} />
               </AutoragResultsContext.Provider>
             }
           />
@@ -765,6 +774,72 @@ describe('AutoragResults', () => {
 
       expect(getPipelineVisualization()).toHaveAttribute('data-tree-loading-mode', 'none');
       expect(getPipelineVisualization()).toHaveAttribute('data-run-state', 'SUCCEEDED');
+    });
+  });
+
+  describe('onTryPattern source', () => {
+    const patternWithTemplate: AutoragPattern = {
+      ...createMockPattern('Pattern1'),
+      inference: {
+        responses_template: {
+          model: 'vllm/llama-3',
+          stream: false,
+          store: true,
+          input: [
+            {
+              type: 'message',
+              role: 'user',
+              content: [{ type: 'input_text', text: '<user_query_placeholder>' }],
+            },
+          ],
+          metadata: { autorag_run_id: 'run-123', rag_pattern_name: 'Pattern1' },
+          instructions: 'Answer from file_search results.',
+          tools: [
+            {
+              type: 'file_search',
+              vector_store_ids: ['vs-1'],
+              max_num_results: 5,
+              ranking_options: {
+                search_mode: 'hybrid',
+                ranker_strategy: 'rrf',
+                ranker_k: 60,
+                ranker_alpha: 0.5,
+              },
+            },
+          ],
+          tool_choice: { type: 'file_search' },
+          include: ['file_search_call.results'],
+        },
+      },
+    };
+    const patterns = { Pattern1: patternWithTemplate };
+
+    it('should call onTryPattern with source: resultsTable from the leaderboard action', () => {
+      const onTryPattern = jest.fn();
+      renderWithContext(mockPipelineRun, patterns, 'test-namespace', undefined, { onTryPattern });
+
+      const row = screen.getByTestId('leaderboard-row-1');
+      fireEvent.click(within(row).getByRole('button', { name: /kebab toggle/i }));
+      fireEvent.click(screen.getByText('Try this pattern'));
+
+      expect(onTryPattern).toHaveBeenCalledWith('Pattern1', 'resultsTable');
+    });
+
+    it('should call onTryPattern with source: patternDetails from the pattern details modal action', async () => {
+      const user = userEvent.setup();
+      const onTryPattern = jest.fn();
+      renderWithContext(mockPipelineRun, patterns, 'test-namespace', undefined, { onTryPattern });
+
+      const row = screen.getByTestId('leaderboard-row-1');
+      fireEvent.click(within(row).getByRole('button', { name: /kebab toggle/i }));
+      fireEvent.click(screen.getByText('View details'));
+
+      const actionsToggle = await screen.findByTestId('pattern-details-actions-toggle');
+      await user.click(actionsToggle);
+      const tryPatternAction = await screen.findByText('Try this pattern');
+      await user.click(tryPatternAction);
+
+      expect(onTryPattern).toHaveBeenCalledWith('Pattern1', 'patternDetails');
     });
   });
 });

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragResults.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragResults.spec.tsx
@@ -884,4 +884,51 @@ describe('AutoragResults', () => {
       expect(onTryPattern).toHaveBeenCalledWith('Pattern1', 'patternDetails');
     });
   });
+
+  describe('AutoRAG Pattern Details Viewed tracking', () => {
+    const patterns = {
+      Pattern1: createMockPattern('Pattern1'),
+      Pattern2: createMockPattern('Pattern2'),
+    };
+
+    it('should fire with source: resultsTable when opening via the pattern name link', () => {
+      renderWithContext(mockPipelineRun, patterns);
+
+      fireEvent.click(screen.getByTestId('pattern-link-1'));
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.PATTERN_DETAILS_VIEWED,
+        { source: 'resultsTable' },
+      );
+    });
+
+    it('should fire with source: resultsTable when opening via the row kebab "View details" action', () => {
+      renderWithContext(mockPipelineRun, patterns);
+
+      const row = screen.getByTestId('leaderboard-row-1');
+      fireEvent.click(within(row).getByRole('button', { name: /kebab toggle/i }));
+      fireEvent.click(screen.getByText('View details'));
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.PATTERN_DETAILS_VIEWED,
+        { source: 'resultsTable' },
+      );
+    });
+
+    it('should not fire again when switching patterns via the in-modal pattern selector', () => {
+      renderWithContext(mockPipelineRun, patterns);
+
+      fireEvent.click(screen.getByTestId('pattern-link-1'));
+      fireMiscTrackingEventMock.mockClear();
+
+      fireEvent.change(screen.getByTestId('pattern-selector-dropdown'), {
+        target: { value: '1' },
+      });
+
+      expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+        AUTORAG_EVENTS.PATTERN_DETAILS_VIEWED,
+        expect.anything(),
+      );
+    });
+  });
 });

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragResults.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragResults.spec.tsx
@@ -885,6 +885,72 @@ describe('AutoragResults', () => {
     });
   });
 
+  describe('onViewCode source', () => {
+    const patternWithTemplate: AutoragPattern = {
+      ...createMockPattern('Pattern1'),
+      inference: {
+        responses_template: {
+          model: 'vllm/llama-3',
+          stream: false,
+          store: true,
+          input: [
+            {
+              type: 'message',
+              role: 'user',
+              content: [{ type: 'input_text', text: '<user_query_placeholder>' }],
+            },
+          ],
+          metadata: { autorag_run_id: 'run-123', rag_pattern_name: 'Pattern1' },
+          instructions: 'Answer from file_search results.',
+          tools: [
+            {
+              type: 'file_search',
+              vector_store_ids: ['vs-1'],
+              max_num_results: 5,
+              ranking_options: {
+                search_mode: 'hybrid',
+                ranker_strategy: 'rrf',
+                ranker_k: 60,
+                ranker_alpha: 0.5,
+              },
+            },
+          ],
+          tool_choice: { type: 'file_search' },
+          include: ['file_search_call.results'],
+        },
+      },
+    };
+    const patterns = { Pattern1: patternWithTemplate };
+
+    it('should call onViewCode with source: resultsTable from the leaderboard action', () => {
+      const onViewCode = jest.fn();
+      renderWithContext(mockPipelineRun, patterns, 'test-namespace', undefined, { onViewCode });
+
+      const row = screen.getByTestId('leaderboard-row-1');
+      fireEvent.click(within(row).getByRole('button', { name: /kebab toggle/i }));
+      fireEvent.click(screen.getByText('View code'));
+
+      expect(onViewCode).toHaveBeenCalledWith('Pattern1', 'resultsTable');
+    });
+
+    it('should call onViewCode with source: patternDetails from the pattern details modal action', async () => {
+      const user = userEvent.setup();
+      const onViewCode = jest.fn();
+      renderWithContext(mockPipelineRun, patterns, 'test-namespace', undefined, { onViewCode });
+
+      const row = screen.getByTestId('leaderboard-row-1');
+      fireEvent.click(within(row).getByRole('button', { name: /kebab toggle/i }));
+      fireEvent.click(screen.getByText('View details'));
+
+      const actionsToggle = await screen.findByTestId('pattern-details-actions-toggle');
+      await user.click(actionsToggle);
+      const viewCodeAction = await screen.findByText('View code');
+      await user.click(viewCodeAction);
+
+      expect(onViewCode).toHaveBeenCalledWith('Pattern1', 'patternDetails');
+    });
+  });
+
   describe('AutoRAG Pattern Details Viewed tracking', () => {
     const patterns = {
       Pattern1: createMockPattern('Pattern1'),

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragResults.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/AutoragResults.spec.tsx
@@ -4,7 +4,9 @@ import { fireEvent, render, screen, within, waitFor } from '@testing-library/rea
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutoragResults from '~/app/components/run-results/AutoragResults';
+import { AUTORAG_EVENTS } from '~/app/utilities/tracking';
 import {
   AutoragResultsContext,
   type AutoragResultsContextProps,
@@ -93,6 +95,13 @@ jest.mock('~/app/hooks/mutations', () => ({
     reset: jest.fn(),
   }),
 }));
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireMiscTrackingEventMock = jest.mocked(fireMiscTrackingEvent);
 
 jest.mock('~/app/hooks/usePatternEvaluationResults', () => ({
   usePatternEvaluationResults: jest.fn().mockReturnValue({
@@ -486,6 +495,9 @@ describe('AutoragResults', () => {
       });
 
       expect(screen.queryByText('Notebook download failed')).not.toBeInTheDocument();
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.NOTEBOOK_DOWNLOADED, {
+        notebookType: 'indexing',
+      });
     });
 
     it('should successfully download inference notebook when all data is valid', async () => {
@@ -516,6 +528,36 @@ describe('AutoragResults', () => {
           'My AutoRAG Run_Pattern1_inference_notebook.ipynb',
         );
       });
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.NOTEBOOK_DOWNLOADED, {
+        notebookType: 'inference',
+      });
+    });
+
+    it('should not fire AutoRAG Notebook Downloaded when the download fails', async () => {
+      const testPattern = createMockPattern('Pattern1');
+      const patterns = { Pattern1: testPattern };
+
+      fetchS3FileMock.mockRejectedValueOnce(new Error('boom'));
+
+      renderWithContext(mockPipelineRun, patterns);
+
+      const leaderboard = screen.getByTestId('leaderboard-table');
+      const firstRow = within(leaderboard).getByTestId('leaderboard-row-1');
+      const kebabButton = within(firstRow).getByRole('button', { name: 'Kebab toggle' });
+
+      await userEvent.click(kebabButton);
+
+      const saveNotebookAction = screen.getByText('Save as indexing notebook');
+      await userEvent.click(saveNotebookAction);
+
+      await waitFor(() => {
+        expect(screen.getByText('Notebook download failed')).toBeInTheDocument();
+      });
+
+      expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+        AUTORAG_EVENTS.NOTEBOOK_DOWNLOADED,
+        expect.anything(),
+      );
     });
   });
 

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/DeleteRunModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/DeleteRunModal.spec.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
@@ -149,5 +149,70 @@ describe('DeleteRunModal', () => {
     renderModal({ isOpen: false });
 
     expect(screen.queryByTestId('delete-run-modal')).not.toBeInTheDocument();
+  });
+
+  it('should not close or fire a cancel event if Escape is pressed synchronously right after clicking Delete, before the isDeleting prop updates', async () => {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    const user = userEvent.setup();
+    // isDeleting stays false throughout this test — it's externally controlled by the
+    // parent and won't auto-update just because the click handler ran. The fix relies on
+    // local `isSubmitting` state to close the gap instead.
+    renderModal({ onClose, onConfirm, isDeleting: false });
+
+    await user.type(screen.getByTestId('confirm-delete-input'), 'my-test-run');
+
+    // Click Delete and immediately fire Escape in the same synchronous step — no await in
+    // between — to reproduce the real race: by the time the very next line runs, the local
+    // `isSubmitting` state (set synchronously inside the click handler) must already be
+    // `true`, well before any microtask-scheduled `isDeleting` prop update could occur.
+    fireEvent.click(screen.getByTestId('confirm-delete-run-button'));
+    fireEvent.keyDown(document.body, { key: 'Escape', code: 'Escape' });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(fireFormTrackingEventMock).not.toHaveBeenCalledWith(
+      AUTORAG_EVENTS.EXPERIMENT_DELETED,
+      expect.objectContaining({ outcome: TrackingOutcome.cancel }),
+    );
+  });
+
+  it('should re-enable Cancel after a failed deletion (isDeleting cycles true -> false)', async () => {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    const user = userEvent.setup();
+    const { rerender } = renderModal({ onClose, onConfirm, isDeleting: false });
+
+    await user.type(screen.getByTestId('confirm-delete-input'), 'my-test-run');
+    await user.click(screen.getByTestId('confirm-delete-run-button'));
+
+    // The mutation starts: parent re-renders with isDeleting: true.
+    rerender(
+      <DeleteRunModal
+        isOpen
+        onClose={onClose}
+        onConfirm={onConfirm}
+        isDeleting
+        runName="my-test-run"
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+    // The mutation fails and settles: parent re-renders with isDeleting back to false, but
+    // the modal stays open so the user can retry or cancel.
+    rerender(
+      <DeleteRunModal
+        isOpen
+        onClose={onClose}
+        onConfirm={onConfirm}
+        isDeleting={false}
+        runName="my-test-run"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/DeleteRunModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/DeleteRunModal.spec.tsx
@@ -2,7 +2,16 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import DeleteRunModal from '~/app/components/run-results/DeleteRunModal';
+import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  ...jest.requireActual('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils'),
+  fireFormTrackingEvent: jest.fn(),
+}));
+
+const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
 
 const renderModal = (props: Partial<React.ComponentProps<typeof DeleteRunModal>> = {}) => {
   const defaultProps: React.ComponentProps<typeof DeleteRunModal> = {
@@ -77,7 +86,7 @@ describe('DeleteRunModal', () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
-  it('should call onClose when Cancel is clicked', async () => {
+  it('should call onClose and fire a cancel event when Cancel is clicked', async () => {
     const onClose = jest.fn();
     const user = userEvent.setup();
     renderModal({ onClose });
@@ -86,6 +95,36 @@ describe('DeleteRunModal', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_DELETED, {
+      outcome: TrackingOutcome.cancel,
+      source: 'runsList',
+    });
+  });
+
+  it('should close and fire a cancel event on Escape when no delete request is pending', async () => {
+    const onClose = jest.fn();
+    renderModal({ onClose });
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.EXPERIMENT_DELETED,
+      expect.objectContaining({ outcome: TrackingOutcome.cancel, source: 'runsList' }),
+    );
+  });
+
+  it('should not close or fire a cancel event on Escape while isDeleting is true', async () => {
+    const onClose = jest.fn();
+    renderModal({ onClose, isDeleting: true });
+
+    await userEvent.keyboard('{Escape}');
+
+    // PatternFly's Modal invokes onClose for Escape regardless of the disabled Cancel
+    // button — closing here would let a stray "cancel" event race with the submit
+    // success/failure event fired once the in-flight delete request resolves.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(fireFormTrackingEventMock).not.toHaveBeenCalled();
   });
 
   it('should disable buttons when isDeleting is true', async () => {

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/DeleteRunModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/DeleteRunModal.spec.tsx
@@ -20,6 +20,7 @@ const renderModal = (props: Partial<React.ComponentProps<typeof DeleteRunModal>>
     onConfirm: jest.fn(),
     isDeleting: false,
     runName: 'my-test-run',
+    source: 'runsList',
     ...props,
   };
   return render(<DeleteRunModal {...defaultProps} />);
@@ -99,6 +100,18 @@ describe('DeleteRunModal', () => {
       outcome: TrackingOutcome.cancel,
       source: 'runsList',
     });
+  });
+
+  it('should report the source it was opened from in the cancel event', async () => {
+    const user = userEvent.setup();
+    renderModal({ source: 'resultsPage' });
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.EXPERIMENT_DELETED,
+      expect.objectContaining({ source: 'resultsPage' }),
+    );
   });
 
   it('should close and fire a cancel event on Escape when no delete request is pending', async () => {
@@ -194,6 +207,7 @@ describe('DeleteRunModal', () => {
         onConfirm={onConfirm}
         isDeleting
         runName="my-test-run"
+        source="runsList"
       />,
     );
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
@@ -207,6 +221,7 @@ describe('DeleteRunModal', () => {
         onConfirm={onConfirm}
         isDeleting={false}
         runName="my-test-run"
+        source="runsList"
       />,
     );
 

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/ManageColumnsModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/ManageColumnsModal.spec.tsx
@@ -1,8 +1,11 @@
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import type { ColumnManagementModalColumn } from '@patternfly/react-component-groups';
-import ManageColumnsModal from '~/app/components/run-results/ManageColumnsModal';
+import ManageColumnsModal, {
+  type ColumnPreset,
+} from '~/app/components/run-results/ManageColumnsModal';
 
 let capturedOnDrop: ((event: unknown, newItems: { id: string }[]) => void) | undefined;
 
@@ -31,6 +34,11 @@ const columns: ColumnManagementModalColumn[] = [
   { key: 'col-a', title: 'Column A', isShownByDefault: true, isShown: true },
   { key: 'col-b', title: 'Column B', isShownByDefault: true, isShown: true },
   { key: 'col-c', title: 'Column C', isShownByDefault: true, isShown: true },
+];
+
+const presets: ColumnPreset[] = [
+  { label: 'Preset A', visibleColumnKeys: ['col-a'] },
+  { label: 'Preset B', visibleColumnKeys: ['col-a', 'col-b'] },
 ];
 
 describe('ManageColumnsModal', () => {
@@ -92,5 +100,32 @@ describe('ManageColumnsModal', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('should call onPresetSelect exactly once when a preset option is clicked', async () => {
+    const user = userEvent.setup();
+    const onPresetSelect = jest.fn();
+
+    render(
+      <ManageColumnsModal
+        isOpen
+        onClose={jest.fn()}
+        appliedColumns={columns}
+        defaultColumns={columns}
+        applyColumns={jest.fn()}
+        presets={presets}
+        onPresetSelect={onPresetSelect}
+      />,
+    );
+
+    await user.click(screen.getByTestId('organize-by-toggle'));
+    // Click the visible label text of the preset option, which is the most
+    // realistic user interaction and previously caused the handler to fire
+    // multiple times (once via the Select's onSelect, once via the Radio's
+    // onChange).
+    await user.click(screen.getByText('Preset B'));
+
+    expect(onPresetSelect).toHaveBeenCalledTimes(1);
+    expect(onPresetSelect).toHaveBeenCalledWith('Preset B');
   });
 });

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/PatternDetailsModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/PatternDetailsModal.spec.tsx
@@ -710,6 +710,128 @@ describe('PatternDetailsModal', () => {
       expect(screen.queryByTestId('comparison-column-header-comparison')).not.toBeInTheDocument();
     });
 
+    describe('AutoRAG Patterns Compared tracking', () => {
+      it('should fire with interactionType: initial, rankDifference: 1, scoreDifference: -0.21 for the first selection', async () => {
+        // mockPattern (primary, rank 1, score 0.66) vs comparisonPattern (rank 2, score 0.45):
+        // rankDifference = 2 - 1 = 1, scoreDifference = 0.45 - 0.66 = -0.21 (comparison scores
+        // lower).
+        const user = userEvent.setup();
+        render(<PatternDetailsModal {...twoPatternProps} />);
+        fireMiscTrackingEventMock.mockClear();
+
+        await user.click(screen.getByTestId('compare-patterns-toggle'));
+        await user.click(screen.getByTestId('comparison-pattern-row-1'));
+        await user.click(screen.getByTestId('compare-pattern-confirm'));
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.PATTERNS_COMPARED, {
+          interactionType: 'initial',
+          rankDifference: 1,
+          scoreDifference: -0.21,
+        });
+      });
+
+      it('should fire with interactionType: changed when swapping to a different comparison pattern', async () => {
+        // thirdPattern is a same-score clone of mockPattern (primary): scoreDifference = 0, and
+        // rankDifference is 1 (rank 2 - rank 1) once comparisonPattern (the lowest score) sorts
+        // to the bottom.
+        const user = userEvent.setup();
+        const thirdPattern: AutoragPattern = {
+          ...mockPattern,
+          name: 'pattern2',
+          iteration: 2,
+        };
+        const threePatternProps = {
+          ...defaultProps,
+          patterns: [mockPattern, comparisonPattern, thirdPattern],
+        };
+        render(<PatternDetailsModal {...threePatternProps} />);
+
+        await user.click(screen.getByTestId('compare-patterns-toggle'));
+        await user.click(screen.getByTestId('comparison-pattern-row-1'));
+        await user.click(screen.getByTestId('compare-pattern-confirm'));
+        fireMiscTrackingEventMock.mockClear();
+
+        await user.click(screen.getByTestId('change-comparison-pattern'));
+        await user.click(screen.getByTestId('comparison-pattern-row-2'));
+        await user.click(screen.getByTestId('compare-pattern-confirm'));
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledTimes(1);
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.PATTERNS_COMPARED, {
+          interactionType: 'changed',
+          rankDifference: 1,
+          scoreDifference: 0,
+        });
+      });
+
+      it('should fire with a negative rankDifference and a positive scoreDifference when comparing against a higher-ranked pattern', async () => {
+        // mockPattern (primary, score 0.66) ends up rank 4 once three higher-scoring patterns
+        // are added; comparing against the top-scoring one (rank 1, score 0.95) gives
+        // rankDifference = 1 - 4 = -3 (negative = comparison outranks primary) and
+        // scoreDifference = 0.95 - 0.66 = 0.29 (positive = comparison scores higher).
+        const withOptimizedScore = (name: string, score: number): AutoragPattern => ({
+          ...mockPattern,
+          name,
+          evaluation: {
+            metrics: mockPattern.evaluation.metrics.map((m) =>
+              m.optimization_metric ? { ...m, scores: { ...m.scores, mean: score } } : m,
+            ),
+          },
+        });
+        const higherA = withOptimizedScore('higherA', 0.75);
+        const higherB = withOptimizedScore('higherB', 0.85);
+        const topPattern = withOptimizedScore('topPattern', 0.95);
+        const fourPatternProps = {
+          ...defaultProps,
+          patterns: [mockPattern, higherA, higherB, topPattern],
+        };
+        const user = userEvent.setup();
+        render(<PatternDetailsModal {...fourPatternProps} />);
+        fireMiscTrackingEventMock.mockClear();
+
+        await user.click(screen.getByTestId('compare-patterns-toggle'));
+        await user.click(screen.getByTestId('comparison-pattern-row-3'));
+        await user.click(screen.getByTestId('compare-pattern-confirm'));
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.PATTERNS_COMPARED, {
+          interactionType: 'initial',
+          rankDifference: -3,
+          scoreDifference: 0.29,
+        });
+      });
+
+      it('should not fire when the comparison select modal is cancelled', async () => {
+        const user = userEvent.setup();
+        render(<PatternDetailsModal {...twoPatternProps} />);
+        fireMiscTrackingEventMock.mockClear();
+
+        await user.click(screen.getByTestId('compare-patterns-toggle'));
+        await user.click(screen.getByTestId('comparison-modal-cancel'));
+
+        expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+          AUTORAG_EVENTS.PATTERNS_COMPARED,
+          expect.anything(),
+        );
+      });
+
+      it('should not fire when comparison mode is turned off', async () => {
+        const user = userEvent.setup();
+        render(<PatternDetailsModal {...twoPatternProps} />);
+
+        await user.click(screen.getByTestId('compare-patterns-toggle'));
+        await user.click(screen.getByTestId('comparison-pattern-row-1'));
+        await user.click(screen.getByTestId('compare-pattern-confirm'));
+        fireMiscTrackingEventMock.mockClear();
+
+        // Disable comparison
+        await user.click(screen.getByTestId('compare-patterns-toggle'));
+
+        expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+          AUTORAG_EVENTS.PATTERNS_COMPARED,
+          expect.anything(),
+        );
+      });
+    });
+
     it('should reset comparison state when modal reopens', async () => {
       const user = userEvent.setup();
       const { rerender } = render(<PatternDetailsModal {...twoPatternProps} />);

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/PatternDetailsModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/PatternDetailsModal.spec.tsx
@@ -3,13 +3,22 @@ import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import type { AutoRAGEvaluationResult, AutoragPattern } from '~/app/types/autoragPattern';
 import PatternDetailsModal from '~/app/components/run-results/PatternDetailsModal/PatternDetailsModal';
+import { AUTORAG_EVENTS } from '~/app/utilities/tracking';
 
 const mockUsePatternEvaluationResults = jest.fn();
 jest.mock('~/app/hooks/usePatternEvaluationResults', () => ({
   usePatternEvaluationResults: (...args: unknown[]) => mockUsePatternEvaluationResults(...args),
 }));
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireMiscTrackingEventMock = jest.mocked(fireMiscTrackingEvent);
 
 const mockPattern: AutoragPattern = {
   name: 'pattern0',
@@ -442,6 +451,22 @@ describe('PatternDetailsModal', () => {
         render(<PatternDetailsModal {...defaultProps} />);
         await user.click(screen.getByTestId('pattern-details-download'));
         expect(printSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        printSpy.mockRestore();
+      }
+    });
+
+    it('should fire AutoRAG Pattern Details Download Initiated when Download is clicked', async () => {
+      const user = userEvent.setup();
+      const printSpy = jest.spyOn(window, 'print').mockImplementation(jest.fn());
+      try {
+        render(<PatternDetailsModal {...defaultProps} />);
+        await user.click(screen.getByTestId('pattern-details-download'));
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.PATTERN_DETAILS_DOWNLOAD_INITIATED,
+          { downloadType: 'patternDetails' },
+        );
       } finally {
         printSpy.mockRestore();
       }

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/StopRunModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/StopRunModal.spec.tsx
@@ -1,7 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import StopRunModal from '~/app/components/run-results/StopRunModal';
+import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  ...jest.requireActual('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils'),
+  fireFormTrackingEvent: jest.fn(),
+}));
+
+const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
 
 describe('StopRunModal', () => {
   const defaultProps = {
@@ -9,6 +18,7 @@ describe('StopRunModal', () => {
     onClose: jest.fn(),
     onConfirm: jest.fn(),
     isTerminating: false,
+    source: 'runsList' as const,
   };
 
   beforeEach(() => {
@@ -37,12 +47,16 @@ describe('StopRunModal', () => {
     expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
   });
 
-  it('should call onClose when Cancel button is clicked', async () => {
+  it('should call onClose and fire a cancel event when Cancel button is clicked', async () => {
     render(<StopRunModal {...defaultProps} />);
 
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_STOPPED, {
+      outcome: TrackingOutcome.cancel,
+      source: 'runsList',
+    });
   });
 
   it('should disable buttons when isTerminating is true', () => {
@@ -82,5 +96,59 @@ describe('StopRunModal', () => {
     render(<StopRunModal {...defaultProps} />);
 
     expect(screen.getByText(/the run will be marked as failed/)).toBeInTheDocument();
+  });
+
+  it('should report the source it was opened from in the cancel event', async () => {
+    render(<StopRunModal {...defaultProps} source="resultsPage" />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.RUN_STOPPED,
+      expect.objectContaining({ source: 'resultsPage' }),
+    );
+  });
+
+  it('should close and fire a cancel event on Escape when no stop request is pending', async () => {
+    render(<StopRunModal {...defaultProps} />);
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.RUN_STOPPED,
+      expect.objectContaining({ outcome: TrackingOutcome.cancel, source: 'runsList' }),
+    );
+  });
+
+  it('should not close or fire a cancel event on Escape while isTerminating is true', async () => {
+    render(<StopRunModal {...defaultProps} isTerminating />);
+
+    await userEvent.keyboard('{Escape}');
+
+    // PatternFly's Modal invokes onClose for Escape regardless of the disabled Cancel
+    // button — closing here would let a stray "cancel" event race with the submit
+    // success/failure event fired once the in-flight stop request resolves.
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+    expect(fireFormTrackingEventMock).not.toHaveBeenCalled();
+  });
+
+  it('should not close or fire a cancel event on Escape while a stop request is submitting', async () => {
+    let resolveConfirm: () => void = () => undefined;
+    const onConfirm = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+    render(<StopRunModal {...defaultProps} onConfirm={onConfirm} />);
+
+    await userEvent.click(screen.getByTestId('confirm-stop-run-button'));
+    await userEvent.keyboard('{Escape}');
+
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+    expect(fireFormTrackingEventMock).not.toHaveBeenCalled();
+
+    resolveConfirm();
   });
 });

--- a/packages/autorag/frontend/src/app/components/run-results/__tests__/ViewCodeModal.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/run-results/__tests__/ViewCodeModal.spec.tsx
@@ -1,9 +1,18 @@
 /* eslint-disable camelcase */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import ViewCodeModal from '~/app/components/run-results/ViewCodeModal';
 import type { ResponsesTemplate } from '~/app/types/autoragPattern';
+import { AUTORAG_EVENTS } from '~/app/utilities/tracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireMiscTrackingEventMock = jest.mocked(fireMiscTrackingEvent);
 
 const mockNotification = {
   success: jest.fn(),
@@ -230,6 +239,37 @@ describe('ViewCodeModal', () => {
       expect(copiedText).toContain('sk-test-key-123');
       expect(copiedText).not.toContain('<HOSTNAME>');
       expect(copiedText).not.toContain('<API_KEY>');
+    });
+
+    it('should fire AutoRAG Code Snippets Exported with action: copied when the clipboard write succeeds', async () => {
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      render(<ViewCodeModal {...propsWithCredentials} />);
+      fireEvent.click(screen.getByLabelText('Copy curl snippet'));
+
+      await waitFor(() => {
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.CODE_SNIPPETS_EXPORTED,
+          { action: 'copied' },
+        );
+      });
+    });
+
+    it('should not fire AutoRAG Code Snippets Exported when the clipboard write is rejected', async () => {
+      const writeText = jest.fn().mockRejectedValue(new Error('denied'));
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      render(<ViewCodeModal {...propsWithCredentials} />);
+      fireEvent.click(screen.getByLabelText('Copy curl snippet'));
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledTimes(1);
+      });
+      expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+        AUTORAG_EVENTS.CODE_SNIPPETS_EXPORTED,
+        expect.anything(),
+      );
     });
 
     it('should not show the credentials warning alert when toggle is off', () => {

--- a/packages/autorag/frontend/src/app/context/RunTriggeredTrackingContext.ts
+++ b/packages/autorag/frontend/src/app/context/RunTriggeredTrackingContext.ts
@@ -6,12 +6,14 @@ import type {
 } from '~/app/utilities/tracking';
 
 export type RunTriggeredTrackingContextProps = {
-  /** Records the most recent successful knowledge-source selection, for use at submit time on the "AutoRAG Run Triggered" event. */
+  /** Records the most recent successful knowledge-source selection, for use at submit time on the "AutoRAG Run Triggered" event, and advances the "AutoRAG Flow Exited" funnel step. */
   onKnowledgeSourceConfigured: (sourceType: KnowledgeSourceType) => void;
-  /** Records the most recent successful evaluation-source selection, for use at submit time on the "AutoRAG Run Triggered" event. */
+  /** Records the most recent successful evaluation-source selection, for use at submit time on the "AutoRAG Run Triggered" event, and advances the "AutoRAG Flow Exited" funnel step. */
   onEvaluationSourceConfigured: (sourceType: EvaluationSourceType) => void;
   /** Records the most recently selected vector store provider type, for use at submit time on the "AutoRAG Run Triggered" event. */
   onVectorStoreConfigured: (providerType: VectorStoreProviderType) => void;
+  /** Reports that the model configuration modal was saved, to advance the "AutoRAG Flow Exited" funnel step. Unlike the other callbacks, this carries no payload — model counts are read directly from form data at submit time. */
+  onModelsConfigured: () => void;
 };
 
 const noop = (): void => {
@@ -22,15 +24,18 @@ const defaultValue: RunTriggeredTrackingContextProps = {
   onKnowledgeSourceConfigured: noop,
   onEvaluationSourceConfigured: noop,
   onVectorStoreConfigured: noop,
+  onModelsConfigured: noop,
 };
 
 /**
- * Lets the Knowledge/Evaluation/Vector-store selectors (nested several levels below
- * `AutoragConfigurePage`) report the *category* of their last successful selection up to the
- * page, which needs it at submit time to build the "AutoRAG Run Triggered" event. This
- * category (s3 vs upload, provider type) is intentionally never stored in form state — only
- * the resulting file key/provider ID is — so this context is the only safe way to recover it
- * without re-deriving it (unsafely) from form data. Falls back to no-ops outside a provider.
+ * Lets the Knowledge/Evaluation/Vector-store/Models sections (nested several levels below
+ * `AutoragConfigurePage`) report their last successful selection up to the page. Two things are
+ * derived from these reports: the *category* of the selection (s3 vs upload, provider type),
+ * needed at submit time to build the "AutoRAG Run Triggered" event — this category is
+ * intentionally never stored in form state, only the resulting file key/provider ID is, so this
+ * context is the only safe way to recover it without re-deriving it (unsafely) from form data —
+ * and progress through the "AutoRAG Flow Exited" event's funnel steps. Falls back to no-ops
+ * outside a provider.
  */
 export const RunTriggeredTrackingContext =
   React.createContext<RunTriggeredTrackingContextProps>(defaultValue);

--- a/packages/autorag/frontend/src/app/context/RunTriggeredTrackingContext.ts
+++ b/packages/autorag/frontend/src/app/context/RunTriggeredTrackingContext.ts
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import type {
+  KnowledgeSourceType,
+  EvaluationSourceType,
+  VectorStoreProviderType,
+} from '~/app/utilities/tracking';
+
+export type RunTriggeredTrackingContextProps = {
+  /** Records the most recent successful knowledge-source selection, for use at submit time on the "AutoRAG Run Triggered" event. */
+  onKnowledgeSourceConfigured: (sourceType: KnowledgeSourceType) => void;
+  /** Records the most recent successful evaluation-source selection, for use at submit time on the "AutoRAG Run Triggered" event. */
+  onEvaluationSourceConfigured: (sourceType: EvaluationSourceType) => void;
+  /** Records the most recently selected vector store provider type, for use at submit time on the "AutoRAG Run Triggered" event. */
+  onVectorStoreConfigured: (providerType: VectorStoreProviderType) => void;
+};
+
+const noop = (): void => {
+  /* no-op default so consumers rendered outside a provider (e.g. isolated unit tests) don't need guards */
+};
+
+const defaultValue: RunTriggeredTrackingContextProps = {
+  onKnowledgeSourceConfigured: noop,
+  onEvaluationSourceConfigured: noop,
+  onVectorStoreConfigured: noop,
+};
+
+/**
+ * Lets the Knowledge/Evaluation/Vector-store selectors (nested several levels below
+ * `AutoragConfigurePage`) report the *category* of their last successful selection up to the
+ * page, which needs it at submit time to build the "AutoRAG Run Triggered" event. This
+ * category (s3 vs upload, provider type) is intentionally never stored in form state — only
+ * the resulting file key/provider ID is — so this context is the only safe way to recover it
+ * without re-deriving it (unsafely) from form data. Falls back to no-ops outside a provider.
+ */
+export const RunTriggeredTrackingContext =
+  React.createContext<RunTriggeredTrackingContextProps>(defaultValue);
+
+export const useRunTriggeredTracking = (): RunTriggeredTrackingContextProps =>
+  React.useContext(RunTriggeredTrackingContext);

--- a/packages/autorag/frontend/src/app/hooks/__tests__/useAutoragRunActions.spec.tsx
+++ b/packages/autorag/frontend/src/app/hooks/__tests__/useAutoragRunActions.spec.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useAutoragRunActions } from '~/app/hooks/useAutoragRunActions';
 import {
   AUTORAG_FAILURE_CATEGORY,
+  fireAutoragExperimentDeleted,
   fireAutoragRunRetried,
   fireAutoragRunStopped,
 } from '~/app/utilities/tracking';
@@ -37,10 +38,12 @@ jest.mock('~/app/utilities/tracking', () => ({
   ...jest.requireActual('~/app/utilities/tracking'),
   fireAutoragRunStopped: jest.fn(),
   fireAutoragRunRetried: jest.fn(),
+  fireAutoragExperimentDeleted: jest.fn(),
 }));
 
 const fireAutoragRunStoppedMock = jest.mocked(fireAutoragRunStopped);
 const fireAutoragRunRetriedMock = jest.mocked(fireAutoragRunRetried);
+const fireAutoragExperimentDeletedMock = jest.mocked(fireAutoragExperimentDeleted);
 
 const createTestQueryClient = () =>
   new QueryClient({
@@ -210,6 +213,63 @@ describe('useAutoragRunActions', () => {
         source: 'resultsPage',
       });
       const allTrackingCalls = JSON.stringify(fireAutoragRunRetriedMock.mock.calls);
+      expect(allTrackingCalls).not.toContain('acme-corp');
+      expect(allTrackingCalls).not.toContain('AKIAabc123');
+    });
+  });
+
+  describe('handleDelete', () => {
+    it('should show success notification and fire success: true on successful delete', async () => {
+      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123', 'runsList'), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.handleDelete();
+      });
+
+      expect(mockNotification.success).toHaveBeenCalledWith(
+        'Run deleted successfully',
+        'The pipeline run has been permanently removed',
+      );
+      expect(fireAutoragExperimentDeletedMock).toHaveBeenCalledWith({
+        outcome: 'submit',
+        success: true,
+        source: 'runsList',
+      });
+    });
+
+    it('should show error notification when delete fails, and fire the allowlisted failure category rather than the raw error message', async () => {
+      const errorMessage =
+        'Network error (403): AccessDenied for tenant acme-corp using key AKIAabc123';
+      const mockMutateAsync = jest.fn().mockRejectedValue(new Error(errorMessage));
+      const { useDeletePipelineRunMutation } = jest.requireMock('~/app/hooks/mutations');
+      useDeletePipelineRunMutation.mockReturnValue({
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+      });
+
+      const { result } = renderHook(
+        () => useAutoragRunActions('test-ns', 'run-123', 'resultsPage'),
+        {
+          wrapper,
+        },
+      );
+
+      await act(async () => {
+        await expect(result.current.handleDelete()).rejects.toThrow();
+      });
+
+      expect(mockNotification.error).toHaveBeenCalledWith('Failed to delete run', errorMessage);
+      // The in-product notification may keep the detailed message, but analytics must only
+      // ever see the fixed, allowlisted category.
+      expect(fireAutoragExperimentDeletedMock).toHaveBeenCalledWith({
+        outcome: 'submit',
+        success: false,
+        error: AUTORAG_FAILURE_CATEGORY,
+        source: 'resultsPage',
+      });
+      const allTrackingCalls = JSON.stringify(fireAutoragExperimentDeletedMock.mock.calls);
       expect(allTrackingCalls).not.toContain('acme-corp');
       expect(allTrackingCalls).not.toContain('AKIAabc123');
     });

--- a/packages/autorag/frontend/src/app/hooks/__tests__/useAutoragRunActions.spec.tsx
+++ b/packages/autorag/frontend/src/app/hooks/__tests__/useAutoragRunActions.spec.tsx
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { useAutoragRunActions } from '~/app/hooks/useAutoragRunActions';
+import { AUTORAG_FAILURE_CATEGORY, fireAutoragRunStopped } from '~/app/utilities/tracking';
 
 const mockNotification = {
   success: jest.fn(),
@@ -27,6 +28,13 @@ jest.mock('~/app/hooks/mutations', () => ({
 jest.mock('~/app/hooks/useNotification', () => ({
   useNotification: () => mockNotification,
 }));
+
+jest.mock('~/app/utilities/tracking', () => ({
+  ...jest.requireActual('~/app/utilities/tracking'),
+  fireAutoragRunStopped: jest.fn(),
+}));
+
+const fireAutoragRunStoppedMock = jest.mocked(fireAutoragRunStopped);
 
 const createTestQueryClient = () =>
   new QueryClient({
@@ -56,8 +64,8 @@ describe('useAutoragRunActions', () => {
   });
 
   describe('handleConfirmStop', () => {
-    it('should show success notification on successful stop', async () => {
-      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123'), {
+    it('should show success notification and fire success: true on successful stop', async () => {
+      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123', 'runsList'), {
         wrapper,
       });
 
@@ -69,9 +77,14 @@ describe('useAutoragRunActions', () => {
         'Stop submitted successfully',
         'The process is asynchronous and may take some time to take effect',
       );
+      expect(fireAutoragRunStoppedMock).toHaveBeenCalledWith({
+        outcome: 'submit',
+        success: true,
+        source: 'runsList',
+      });
     });
 
-    it('should show warning notification when run is already in terminal state', async () => {
+    it('should show warning notification when run is already in terminal state, but still fire success: false with the allowlisted category', async () => {
       const mockMutateAsync = jest
         .fn()
         .mockRejectedValue(new Error('run is in state FAILED and cannot be terminated'));
@@ -81,7 +94,7 @@ describe('useAutoragRunActions', () => {
         isPending: false,
       });
 
-      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123'), {
+      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123', 'runsList'), {
         wrapper,
       });
 
@@ -94,32 +107,54 @@ describe('useAutoragRunActions', () => {
         'The pipeline run has already completed or failed. The page will refresh to show the current state.',
       );
       expect(mockNotification.error).not.toHaveBeenCalled();
+      expect(fireAutoragRunStoppedMock).toHaveBeenCalledWith({
+        outcome: 'submit',
+        success: false,
+        error: AUTORAG_FAILURE_CATEGORY,
+        source: 'runsList',
+      });
     });
 
-    it('should show error notification for other errors', async () => {
-      const mockMutateAsync = jest.fn().mockRejectedValue(new Error('Network error'));
+    it('should show error notification for other errors, and fire the allowlisted failure category rather than the raw error message', async () => {
+      const errorMessage =
+        'Network error (403): AccessDenied for tenant acme-corp using key AKIAabc123';
+      const mockMutateAsync = jest.fn().mockRejectedValue(new Error(errorMessage));
       const { useTerminatePipelineRunMutation } = jest.requireMock('~/app/hooks/mutations');
       useTerminatePipelineRunMutation.mockReturnValue({
         mutateAsync: mockMutateAsync,
         isPending: false,
       });
 
-      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123'), {
-        wrapper,
-      });
+      const { result } = renderHook(
+        () => useAutoragRunActions('test-ns', 'run-123', 'resultsPage'),
+        {
+          wrapper,
+        },
+      );
 
       await act(async () => {
         await expect(result.current.handleConfirmStop()).rejects.toThrow();
       });
 
-      expect(mockNotification.error).toHaveBeenCalledWith('Failed to stop run', 'Network error');
+      expect(mockNotification.error).toHaveBeenCalledWith('Failed to stop run', errorMessage);
       expect(mockNotification.warning).not.toHaveBeenCalled();
+      // The in-product notification may keep the detailed message, but analytics must only
+      // ever see the fixed, allowlisted category.
+      expect(fireAutoragRunStoppedMock).toHaveBeenCalledWith({
+        outcome: 'submit',
+        success: false,
+        error: AUTORAG_FAILURE_CATEGORY,
+        source: 'resultsPage',
+      });
+      const allTrackingCalls = JSON.stringify(fireAutoragRunStoppedMock.mock.calls);
+      expect(allTrackingCalls).not.toContain('acme-corp');
+      expect(allTrackingCalls).not.toContain('AKIAabc123');
     });
   });
 
   describe('handleRetry', () => {
     it('should show success notification on successful retry', async () => {
-      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123'), {
+      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123', 'runsList'), {
         wrapper,
       });
 
@@ -141,7 +176,7 @@ describe('useAutoragRunActions', () => {
         isPending: false,
       });
 
-      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123'), {
+      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123', 'runsList'), {
         wrapper,
       });
 

--- a/packages/autorag/frontend/src/app/hooks/__tests__/useAutoragRunActions.spec.tsx
+++ b/packages/autorag/frontend/src/app/hooks/__tests__/useAutoragRunActions.spec.tsx
@@ -2,7 +2,11 @@ import { renderHook, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { useAutoragRunActions } from '~/app/hooks/useAutoragRunActions';
-import { AUTORAG_FAILURE_CATEGORY, fireAutoragRunStopped } from '~/app/utilities/tracking';
+import {
+  AUTORAG_FAILURE_CATEGORY,
+  fireAutoragRunRetried,
+  fireAutoragRunStopped,
+} from '~/app/utilities/tracking';
 
 const mockNotification = {
   success: jest.fn(),
@@ -32,9 +36,11 @@ jest.mock('~/app/hooks/useNotification', () => ({
 jest.mock('~/app/utilities/tracking', () => ({
   ...jest.requireActual('~/app/utilities/tracking'),
   fireAutoragRunStopped: jest.fn(),
+  fireAutoragRunRetried: jest.fn(),
 }));
 
 const fireAutoragRunStoppedMock = jest.mocked(fireAutoragRunStopped);
+const fireAutoragRunRetriedMock = jest.mocked(fireAutoragRunRetried);
 
 const createTestQueryClient = () =>
   new QueryClient({
@@ -153,7 +159,7 @@ describe('useAutoragRunActions', () => {
   });
 
   describe('handleRetry', () => {
-    it('should show success notification on successful retry', async () => {
+    it('should show success notification and fire success: true on successful retry', async () => {
       const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123', 'runsList'), {
         wrapper,
       });
@@ -166,25 +172,46 @@ describe('useAutoragRunActions', () => {
         'Retry submitted successfully',
         'The process is asynchronous and may take some time to take effect',
       );
+      expect(fireAutoragRunRetriedMock).toHaveBeenCalledWith({
+        outcome: 'submit',
+        success: true,
+        source: 'runsList',
+      });
     });
 
-    it('should show error notification when retry fails', async () => {
-      const mockMutateAsync = jest.fn().mockRejectedValue(new Error('Retry failed'));
+    it('should show error notification when retry fails, and fire the allowlisted failure category rather than the raw error message', async () => {
+      const errorMessage =
+        'Network error (403): AccessDenied for tenant acme-corp using key AKIAabc123';
+      const mockMutateAsync = jest.fn().mockRejectedValue(new Error(errorMessage));
       const { useRetryPipelineRunMutation } = jest.requireMock('~/app/hooks/mutations');
       useRetryPipelineRunMutation.mockReturnValue({
         mutateAsync: mockMutateAsync,
         isPending: false,
       });
 
-      const { result } = renderHook(() => useAutoragRunActions('test-ns', 'run-123', 'runsList'), {
-        wrapper,
-      });
+      const { result } = renderHook(
+        () => useAutoragRunActions('test-ns', 'run-123', 'resultsPage'),
+        {
+          wrapper,
+        },
+      );
 
       await act(async () => {
         await expect(result.current.handleRetry()).rejects.toThrow();
       });
 
-      expect(mockNotification.error).toHaveBeenCalledWith('Failed to retry run', 'Retry failed');
+      expect(mockNotification.error).toHaveBeenCalledWith('Failed to retry run', errorMessage);
+      // The in-product notification may keep the detailed message, but analytics must only
+      // ever see the fixed, allowlisted category.
+      expect(fireAutoragRunRetriedMock).toHaveBeenCalledWith({
+        outcome: 'submit',
+        success: false,
+        error: AUTORAG_FAILURE_CATEGORY,
+        source: 'resultsPage',
+      });
+      const allTrackingCalls = JSON.stringify(fireAutoragRunRetriedMock.mock.calls);
+      expect(allTrackingCalls).not.toContain('acme-corp');
+      expect(allTrackingCalls).not.toContain('AKIAabc123');
     });
   });
 });

--- a/packages/autorag/frontend/src/app/hooks/useAutoragRunActions.ts
+++ b/packages/autorag/frontend/src/app/hooks/useAutoragRunActions.ts
@@ -8,6 +8,7 @@ import {
 import { useNotification } from '~/app/hooks/useNotification';
 import {
   AUTORAG_FAILURE_CATEGORY,
+  fireAutoragRunRetried,
   fireAutoragRunStopped,
   TrackingOutcome,
   type RunActionSource,
@@ -48,11 +49,18 @@ export const useAutoragRunActions = (
         'Retry submitted successfully',
         'The process is asynchronous and may take some time to take effect',
       );
+      fireAutoragRunRetried({ outcome: TrackingOutcome.submit, success: true, source });
     } catch (error) {
       notification.error(
         'Failed to retry run',
         error instanceof Error ? error.message : 'An unknown error occurred',
       );
+      fireAutoragRunRetried({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: AUTORAG_FAILURE_CATEGORY,
+        source,
+      });
       throw error;
     }
     try {
@@ -60,7 +68,7 @@ export const useAutoragRunActions = (
     } catch {
       // Caller refresh failure should not mask a successful retry.
     }
-  }, [retryMutation, queryClient, runId, namespace, onActionComplete, notification]);
+  }, [retryMutation, queryClient, runId, namespace, onActionComplete, notification, source]);
 
   const handleConfirmStop = React.useCallback(async () => {
     try {

--- a/packages/autorag/frontend/src/app/hooks/useAutoragRunActions.ts
+++ b/packages/autorag/frontend/src/app/hooks/useAutoragRunActions.ts
@@ -6,6 +6,12 @@ import {
   useTerminatePipelineRunMutation,
 } from '~/app/hooks/mutations';
 import { useNotification } from '~/app/hooks/useNotification';
+import {
+  AUTORAG_FAILURE_CATEGORY,
+  fireAutoragRunStopped,
+  TrackingOutcome,
+  type RunActionSource,
+} from '~/app/utilities/tracking';
 
 type AutoragRunActions = {
   handleRetry: () => Promise<void>;
@@ -23,6 +29,7 @@ type AutoragRunActions = {
 export const useAutoragRunActions = (
   namespace: string,
   runId: string,
+  source: RunActionSource,
   onActionComplete?: () => void | Promise<void>,
 ): AutoragRunActions => {
   const queryClient = useQueryClient();
@@ -65,6 +72,7 @@ export const useAutoragRunActions = (
         'Stop submitted successfully',
         'The process is asynchronous and may take some time to take effect',
       );
+      fireAutoragRunStopped({ outcome: TrackingOutcome.submit, success: true, source });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
       // Check if the error is because the run is already in a terminal state (case-insensitive, whole words only)
@@ -79,6 +87,12 @@ export const useAutoragRunActions = (
       } else {
         notification.error('Failed to stop run', errorMessage);
       }
+      fireAutoragRunStopped({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: AUTORAG_FAILURE_CATEGORY,
+        source,
+      });
       // Refresh the state to update the UI (don't let refresh failure mask the original error)
       try {
         await queryClient.invalidateQueries({
@@ -94,7 +108,7 @@ export const useAutoragRunActions = (
     } catch {
       // Caller refresh failure should not mask a successful stop.
     }
-  }, [terminateMutation, queryClient, runId, namespace, onActionComplete, notification]);
+  }, [terminateMutation, queryClient, runId, namespace, onActionComplete, notification, source]);
 
   const handleDelete = React.useCallback(async () => {
     try {

--- a/packages/autorag/frontend/src/app/hooks/useAutoragRunActions.ts
+++ b/packages/autorag/frontend/src/app/hooks/useAutoragRunActions.ts
@@ -8,6 +8,7 @@ import {
 import { useNotification } from '~/app/hooks/useNotification';
 import {
   AUTORAG_FAILURE_CATEGORY,
+  fireAutoragExperimentDeleted,
   fireAutoragRunRetried,
   fireAutoragRunStopped,
   TrackingOutcome,
@@ -128,11 +129,18 @@ export const useAutoragRunActions = (
         'Run deleted successfully',
         'The pipeline run has been permanently removed',
       );
+      fireAutoragExperimentDeleted({ outcome: TrackingOutcome.submit, success: true, source });
     } catch (error) {
       notification.error(
         'Failed to delete run',
         error instanceof Error ? error.message : 'An unknown error occurred',
       );
+      fireAutoragExperimentDeleted({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: AUTORAG_FAILURE_CATEGORY,
+        source,
+      });
       throw error;
     }
     try {
@@ -140,7 +148,7 @@ export const useAutoragRunActions = (
     } catch {
       // Caller refresh failure should not mask a successful delete.
     }
-  }, [deleteMutation, queryClient, runId, namespace, onActionComplete, notification]);
+  }, [deleteMutation, queryClient, runId, namespace, onActionComplete, notification, source]);
 
   return {
     handleRetry,

--- a/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
@@ -235,14 +235,19 @@ function AutoragConfigurePage({
 
   // Catches a full page/tab close or refresh while the configure flow is in progress. Does not
   // catch in-app navigation away (e.g. the host dashboard's global nav) — see
-  // `fireAutoragFlowExited`'s doc comment for why that isn't covered.
+  // `fireAutoragFlowExited`'s doc comment for why that isn't covered. Skipped while a run
+  // submission is in flight or has already succeeded: the backend may have already accepted the
+  // run by the time the page unloads, so reporting 'abandon' here would be inaccurate.
   useEffect(() => {
     const handleBeforeUnload = () => {
+      if (form.formState.isSubmitting || form.formState.isSubmitSuccessful) {
+        return;
+      }
       fireAutoragFlowExited('abandon', funnelStepRef.current, 'none');
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, []);
+  }, [form.formState.isSubmitting, form.formState.isSubmitSuccessful]);
 
   const runTriggeredTrackingContextValue = useMemo<RunTriggeredTrackingContextProps>(
     () => ({

--- a/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import classNames from 'classnames';
 import { ApplicationsPage } from 'mod-arch-shared';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { FieldPath, FormProvider, useForm, useWatch } from 'react-hook-form';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import AutoragConfigure from '~/app/components/configure/AutoragConfigure';
@@ -27,7 +27,20 @@ import { useNotification } from '~/app/hooks/useNotification';
 import type { SecretSelection } from '~/app/components/common/SecretSelector';
 import { ConfigureSchema, createConfigureSchema } from '~/app/schemas/configure.schema';
 import { autoragExperimentsPathname, autoragResultsPathname } from '~/app/utilities/routes';
-import { fireAutoragExperimentCreated, TrackingOutcome } from '~/app/utilities/tracking';
+import {
+  AUTORAG_FAILURE_CATEGORY,
+  fireAutoragExperimentCreated,
+  fireAutoragRunTriggered,
+  mapOptimizationMetric,
+  TrackingOutcome,
+  type EvaluationSourceType,
+  type KnowledgeSourceType,
+  type VectorStoreProviderType,
+} from '~/app/utilities/tracking';
+import {
+  RunTriggeredTrackingContext,
+  type RunTriggeredTrackingContextProps,
+} from '~/app/context/RunTriggeredTrackingContext';
 import { useCatchUIError } from '~/app/components/common/UIError/UIErrorHandler.tsx';
 
 const configureSchema = createConfigureSchema();
@@ -88,6 +101,30 @@ function AutoragConfigurePage({
   });
 
   const [step, setStep] = useState<'create' | 'configure'>('create');
+
+  // Populated by the Knowledge/Evaluation/Vector-store selectors via RunTriggeredTrackingContext
+  // when the user actually (re)selects a source/provider in this session — see the context's
+  // doc comment for why this can't be safely derived from form data alone. Read at submit time
+  // to build the "AutoRAG Run Triggered" event; not reset between submits since a failed
+  // pipeline-run creation should still report the last known selection on retry.
+  const knowledgeSourceTypeRef = useRef<KnowledgeSourceType>();
+  const evaluationSourceTypeRef = useRef<EvaluationSourceType>();
+  const vectorDatabaseRef = useRef<VectorStoreProviderType>();
+
+  const runTriggeredTrackingContextValue = useMemo<RunTriggeredTrackingContextProps>(
+    () => ({
+      onKnowledgeSourceConfigured: (sourceType) => {
+        knowledgeSourceTypeRef.current = sourceType;
+      },
+      onEvaluationSourceConfigured: (sourceType) => {
+        evaluationSourceTypeRef.current = sourceType;
+      },
+      onVectorStoreConfigured: (providerType) => {
+        vectorDatabaseRef.current = providerType;
+      },
+    }),
+    [],
+  );
 
   const onCancel = useCallback(() => {
     if (step === 'create') {
@@ -232,73 +269,104 @@ function AutoragConfigurePage({
       loaded={namespacesLoaded}
     >
       <FormProvider {...form}>
-        <Stack
-          component="form"
-          className={classNames('pf-v6-u-h-0', 'pf-v6-u-flex-fill')}
-          hasGutter
-          noValidate
-          onSubmit={(event) => {
-            event.preventDefault();
+        <RunTriggeredTrackingContext.Provider value={runTriggeredTrackingContextValue}>
+          <Stack
+            component="form"
+            className={classNames('pf-v6-u-h-0', 'pf-v6-u-flex-fill')}
+            hasGutter
+            noValidate
+            onSubmit={(event) => {
+              event.preventDefault();
 
-            if (step === 'create') {
-              fireAutoragExperimentCreated({
-                outcome: TrackingOutcome.submit,
-                hasDescription: !!description,
-                success: true,
-              });
-              setStep('configure');
-              return;
-            }
+              if (step === 'create') {
+                fireAutoragExperimentCreated({
+                  outcome: TrackingOutcome.submit,
+                  hasDescription: !!description,
+                  success: true,
+                });
+                setStep('configure');
+                return;
+              }
 
-            form.handleSubmit(
-              async (data: ConfigureSchema) => {
-                try {
-                  const pipelineRun = await pipelineRunsMutation.mutateAsync(data);
-                  navigate(`${autoragResultsPathname}/${namespace}/${pipelineRun.run_id}`);
-                } catch (error) {
-                  catchUIError(error, () =>
-                    notification.error(
-                      'Failed to create pipeline run',
-                      error instanceof Error ? error.message : '',
-                    ),
-                  );
-                }
-              },
-              // this `onInvalid` case should be impossible to hit
-              // since we disable the button when the form is invalid
-              () => notification.error('Form is invalid'),
-            )();
-          }}
-        >
-          <StackItem className="pf-v6-u-h-0" isFilled>
-            <PageSection
-              className={classNames(
-                'pf-v6-c-form',
-                'pf-v6-u-py-0',
-                step === 'configure' && 'pf-v6-u-h-100',
-              )}
-              hasBodyWrapper={false}
-            >
-              {step === 'create' ? (
-                <AutoragCreate initialOgxSecret={initialOgxSecret} />
-              ) : (
-                <AutoragConfigure
-                  initialValues={initialValues}
-                  initialInputDataSecret={initialInputDataSecret}
-                />
-              )}
-            </PageSection>
-          </StackItem>
-          <StackItem>
-            <PageSection hasBodyWrapper={false} hasShadowTop>
-              <ActionList>
-                <ActionListGroup>
-                  {step === 'create' ? createActions : configureActions}
-                </ActionListGroup>
-              </ActionList>
-            </PageSection>
-          </StackItem>
-        </Stack>
+              form.handleSubmit(
+                async (data: ConfigureSchema) => {
+                  // Computed up front so it's available in both the success and failure branches
+                  // below — only the values that must come from `data` (not from the tracking
+                  // refs) live here, so a failed submission still reports accurate model/metric
+                  // counts even though the pipeline run itself never happened.
+                  const runTrackingProperties = {
+                    knowledgeSourceType: knowledgeSourceTypeRef.current,
+                    evaluationSourceType: evaluationSourceTypeRef.current,
+                    optimizationMetric: mapOptimizationMetric(data.optimization_metric),
+                    vectorDatabase: vectorDatabaseRef.current,
+                    countOfModels: data.generation_models.length + data.embedding_models.length,
+                    countOfKnowledgeDocuments: data.input_data_key ? 1 : 0,
+                    countOfEvaluationDocuments: data.test_data_key ? 1 : 0,
+                    countOfFoundationModels: data.generation_models.length,
+                    countOfEmbeddingModels: data.embedding_models.length,
+                    hasS3Connection:
+                      knowledgeSourceTypeRef.current === 's3' ||
+                      evaluationSourceTypeRef.current === 's3',
+                  };
+                  try {
+                    const pipelineRun = await pipelineRunsMutation.mutateAsync(data);
+                    fireAutoragRunTriggered({
+                      ...runTrackingProperties,
+                      outcome: TrackingOutcome.submit,
+                      success: true,
+                    });
+                    navigate(`${autoragResultsPathname}/${namespace}/${pipelineRun.run_id}`);
+                  } catch (error) {
+                    fireAutoragRunTriggered({
+                      ...runTrackingProperties,
+                      outcome: TrackingOutcome.submit,
+                      success: false,
+                      error: AUTORAG_FAILURE_CATEGORY,
+                    });
+                    catchUIError(error, () =>
+                      notification.error(
+                        'Failed to create pipeline run',
+                        error instanceof Error ? error.message : '',
+                      ),
+                    );
+                  }
+                },
+                // this `onInvalid` case should be impossible to hit
+                // since we disable the button when the form is invalid
+                () => notification.error('Form is invalid'),
+              )();
+            }}
+          >
+            <StackItem className="pf-v6-u-h-0" isFilled>
+              <PageSection
+                className={classNames(
+                  'pf-v6-c-form',
+                  'pf-v6-u-py-0',
+                  step === 'configure' && 'pf-v6-u-h-100',
+                )}
+                hasBodyWrapper={false}
+              >
+                {step === 'create' ? (
+                  <AutoragCreate initialOgxSecret={initialOgxSecret} />
+                ) : (
+                  <AutoragConfigure
+                    initialValues={initialValues}
+                    initialInputDataSecret={initialInputDataSecret}
+                  />
+                )}
+              </PageSection>
+            </StackItem>
+            <StackItem>
+              <PageSection hasBodyWrapper={false} hasShadowTop>
+                <ActionList>
+                  <ActionListGroup>
+                    {step === 'create' ? createActions : configureActions}
+                  </ActionListGroup>
+                </ActionList>
+              </PageSection>
+            </StackItem>
+          </Stack>
+        </RunTriggeredTrackingContext.Provider>
       </FormProvider>
     </ApplicationsPage>
   );

--- a/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
@@ -29,8 +29,10 @@ import { ConfigureSchema, createConfigureSchema } from '~/app/schemas/configure.
 import { autoragExperimentsPathname, autoragResultsPathname } from '~/app/utilities/routes';
 import {
   AUTORAG_FAILURE_CATEGORY,
+  buildRunReconfiguredChangedFields,
   fireAutoragExperimentCreated,
   fireAutoragFlowExited,
+  fireAutoragRunReconfigured,
   fireAutoragRunTriggered,
   mapOptimizationMetric,
   TrackingOutcome,
@@ -50,6 +52,16 @@ const configureSchema = createConfigureSchema();
 const createFields = ['display_name', 'description', 'ogx_secret_name'] as const satisfies Array<
   FieldPath<ConfigureSchema>
 >;
+
+/** Order-independent equality, used to diff model selections for "AutoRAG Run Reconfigured" without treating a same-set reordering as a change. */
+const arraysEqualUnordered = (a: string[], b: string[]): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  const sortedA = a.toSorted();
+  const sortedB = b.toSorted();
+  return sortedA.every((value, index) => value === sortedB[index]);
+};
 
 type AutoragConfigurePageProps = {
   initialValues?: Partial<ConfigureSchema>;
@@ -92,10 +104,20 @@ function AutoragConfigurePage({
 
   const pipelineRunsMutation = useCreatePipelineRunMutation(namespace ?? '');
 
+  // The actual baseline the form starts from — not just `initialValues`, which the reconfigure
+  // loader may leave partially populated (e.g. a field it couldn't parse from the source run's
+  // pipeline parameters). Diffing "AutoRAG Run Reconfigured"'s `changedFields` against raw
+  // `initialValues` would treat every such omitted field as "changed" the instant the schema
+  // default resolves to anything other than `undefined`, even with no user action at all.
+  const initialFormValues = useMemo(
+    () => ({ ...configureSchema.defaults, ...initialValues }),
+    [initialValues],
+  );
+
   const form = useForm({
     mode: 'onChange',
     resolver: zodResolver(configureSchema.full),
-    defaultValues: { ...configureSchema.defaults, ...initialValues },
+    defaultValues: initialFormValues,
   });
 
   const [displayName, description, ogxSecretName] = useWatch({
@@ -113,6 +135,44 @@ function AutoragConfigurePage({
   const knowledgeSourceTypeRef = useRef<KnowledgeSourceType>();
   const evaluationSourceTypeRef = useRef<EvaluationSourceType>();
   const vectorDatabaseRef = useRef<VectorStoreProviderType>();
+
+  // Builds the shared config summary + `changedFields` diff for "AutoRAG Run Reconfigured",
+  // from either `form.handleSubmit`'s `data` (submit) or `form.getValues()` (cancel) — both are
+  // the same `ConfigureSchema` shape. `knowledgeSourceType`/`evaluationSourceType`/
+  // `vectorDatabase` are flagged as changed the same way their value is populated at all: the
+  // user actually (re)selected that source/provider this session (see the refs' doc comment
+  // above for why this can't be a value comparison). `optimizationMetric` and `models` are
+  // diffed directly against `initialFormValues`.
+  const computeReconfigureTracking = useCallback(
+    (
+      values: Pick<
+        ConfigureSchema,
+        'optimization_metric' | 'generation_models' | 'embedding_models'
+      >,
+    ) => {
+      const runConfigSummary = {
+        knowledgeSourceType: knowledgeSourceTypeRef.current,
+        evaluationSourceType: evaluationSourceTypeRef.current,
+        optimizationMetric: mapOptimizationMetric(values.optimization_metric),
+        vectorDatabase: vectorDatabaseRef.current,
+        countOfFoundationModels: values.generation_models.length,
+        countOfEmbeddingModels: values.embedding_models.length,
+      };
+      const changedFields = buildRunReconfiguredChangedFields({
+        knowledgeSourceTypeChanged: knowledgeSourceTypeRef.current !== undefined,
+        evaluationSourceTypeChanged: evaluationSourceTypeRef.current !== undefined,
+        optimizationMetricChanged:
+          values.optimization_metric !== initialFormValues.optimization_metric,
+        vectorDatabaseChanged: vectorDatabaseRef.current !== undefined,
+        modelsChanged:
+          !arraysEqualUnordered(values.generation_models, initialFormValues.generation_models) ||
+          !arraysEqualUnordered(values.embedding_models, initialFormValues.embedding_models),
+      });
+      return { runConfigSummary, changedFields };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- knowledgeSourceTypeRef/evaluationSourceTypeRef/vectorDatabaseRef only ever touch refs, so they're safe to omit.
+    [initialFormValues],
+  );
 
   // How far the user has actually gotten in the configure flow, for "AutoRAG Flow Exited".
   // Advances monotonically (never regresses) as knowledge/evaluation/models milestones complete
@@ -212,10 +272,36 @@ function AutoragConfigurePage({
         hasDescription: !!description,
         success: true,
       });
+      // Cancel is only rendered on step 'create', so this is the only place a reconfigure
+      // attempt can be abandoned before ever submitting — no backend call has been made yet,
+      // hence no `success` on this outcome (see fireAutoragRunReconfigured's doc comment).
+      if (sourceRunId) {
+        // `getValues()`'s inferred type is loosened by `zodResolver`'s post-transform output
+        // type (a TS inference limitation, not a runtime gap — every field is always populated
+        // by `configureSchema.defaults`); the same widening is why `handleSubmit`'s callback
+        // below is explicitly annotated `(data: ConfigureSchema) => ...` rather than left
+        // inferred.
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const currentValues = form.getValues() as ConfigureSchema;
+        const { runConfigSummary, changedFields } = computeReconfigureTracking(currentValues);
+        fireAutoragRunReconfigured({
+          ...runConfigSummary,
+          changedFields,
+          outcome: TrackingOutcome.cancel,
+        });
+      }
     }
     fireAutoragFlowExited('navigate', funnelStepRef.current, cancelExitDestination);
     navigate(-1);
-  }, [navigate, step, description, cancelExitDestination]);
+  }, [
+    navigate,
+    step,
+    description,
+    cancelExitDestination,
+    sourceRunId,
+    form,
+    computeReconfigureTracking,
+  ]);
 
   const handleBackToCreate = useCallback(() => {
     // New runs only: clear configure-step values so Back → Next does not show stale S3/file UI.
@@ -400,6 +486,12 @@ function AutoragConfigurePage({
                       knowledgeSourceTypeRef.current === 's3' ||
                       evaluationSourceTypeRef.current === 's3',
                   };
+                  // Also computed up front, before the mutation, so a failed reconfigure
+                  // submission still reports what the user actually changed relative to the
+                  // source run, rather than an empty diff.
+                  const reconfigureTracking = sourceRunId
+                    ? computeReconfigureTracking(data)
+                    : undefined;
                   try {
                     const pipelineRun = await pipelineRunsMutation.mutateAsync(data);
                     fireAutoragRunTriggered({
@@ -407,6 +499,14 @@ function AutoragConfigurePage({
                       outcome: TrackingOutcome.submit,
                       success: true,
                     });
+                    if (reconfigureTracking) {
+                      fireAutoragRunReconfigured({
+                        ...reconfigureTracking.runConfigSummary,
+                        changedFields: reconfigureTracking.changedFields,
+                        outcome: TrackingOutcome.submit,
+                        success: true,
+                      });
+                    }
                     navigate(`${autoragResultsPathname}/${namespace}/${pipelineRun.run_id}`);
                   } catch (error) {
                     fireAutoragRunTriggered({
@@ -415,6 +515,15 @@ function AutoragConfigurePage({
                       success: false,
                       error: AUTORAG_FAILURE_CATEGORY,
                     });
+                    if (reconfigureTracking) {
+                      fireAutoragRunReconfigured({
+                        ...reconfigureTracking.runConfigSummary,
+                        changedFields: reconfigureTracking.changedFields,
+                        outcome: TrackingOutcome.submit,
+                        success: false,
+                        error: AUTORAG_FAILURE_CATEGORY,
+                      });
+                    }
                     catchUIError(error, () =>
                       notification.error(
                         'Failed to create pipeline run',

--- a/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import classNames from 'classnames';
 import { ApplicationsPage } from 'mod-arch-shared';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FieldPath, FormProvider, useForm, useWatch } from 'react-hook-form';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import AutoragConfigure from '~/app/components/configure/AutoragConfigure';
@@ -30,9 +30,12 @@ import { autoragExperimentsPathname, autoragResultsPathname } from '~/app/utilit
 import {
   AUTORAG_FAILURE_CATEGORY,
   fireAutoragExperimentCreated,
+  fireAutoragFlowExited,
   fireAutoragRunTriggered,
   mapOptimizationMetric,
   TrackingOutcome,
+  type AutoragExitDestination,
+  type AutoragFunnelStep,
   type EvaluationSourceType,
   type KnowledgeSourceType,
   type VectorStoreProviderType,
@@ -111,18 +114,94 @@ function AutoragConfigurePage({
   const evaluationSourceTypeRef = useRef<EvaluationSourceType>();
   const vectorDatabaseRef = useRef<VectorStoreProviderType>();
 
+  // How far the user has actually gotten in the configure flow, for "AutoRAG Flow Exited".
+  // Advances monotonically (never regresses) as knowledge/evaluation/models milestones complete
+  // — see `AutoragFunnelStep`'s doc comment for why these can complete in any order here, unlike
+  // automl's strictly-gated sections.
+  const funnelStepRef = useRef<AutoragFunnelStep>('defineDetails');
+  const completedMilestonesRef = useRef({ knowledge: false, evaluation: false, models: false });
+  const FUNNEL_STEP_RANK: Record<AutoragFunnelStep, number> = {
+    defineDetails: 0,
+    knowledge: 1,
+    evaluation: 2,
+    models: 3,
+    run: 4,
+  };
+  const advanceFunnelStep = (nextStep: AutoragFunnelStep) => {
+    if (FUNNEL_STEP_RANK[nextStep] > FUNNEL_STEP_RANK[funnelStepRef.current]) {
+      funnelStepRef.current = nextStep;
+    }
+  };
+  const markMilestoneComplete = (
+    milestone: 'knowledge' | 'evaluation' | 'models',
+    funnelStep: AutoragFunnelStep,
+  ) => {
+    completedMilestonesRef.current[milestone] = true;
+    advanceFunnelStep(funnelStep);
+    const { knowledge, evaluation, models } = completedMilestonesRef.current;
+    if (knowledge && evaluation && models) {
+      advanceFunnelStep('run');
+    }
+  };
+
+  // Cancel is only rendered on step 'create'. `sourceRunId` is set for every reconfigure flow
+  // (both results-page and runs-list origins), but `navigate(-1)` only lands back on the source
+  // run's results page (still part of this same package) when reconfigure was entered from
+  // there — from the runs list, Cancel returns to the experiments list. There's no dedicated
+  // "back to this package's own results page" bucket in the exitDestination taxonomy, so this
+  // is reported as 'otherGenAi' (elsewhere in Gen AI Studio, not the AutoRAG list) — the same
+  // bucket used for the source-run breadcrumb link below.
+  const cancelExitDestination: AutoragExitDestination = fromResultsPage
+    ? 'otherGenAi'
+    : 'experimentsList';
+
+  // Reconfigure's configure screen is fully populated on mount, so there's no equivalent to the
+  // create flow's progressive knowledge → evaluation → models milestones to observe — the form
+  // starts ready to submit, so report the deepest funnel step immediately. For the create flow,
+  // reset on every (re-)entry to 'configure': `handleBackToCreate` clears the knowledge/
+  // evaluation/models field values, so without this reset, a Back → Next round-trip after
+  // completing a milestone would leave funnel progress reporting a selection that no longer
+  // exists in the form.
+  useEffect(() => {
+    if (step === 'configure') {
+      if (sourceRunId) {
+        funnelStepRef.current = 'run';
+      } else {
+        funnelStepRef.current = 'defineDetails';
+        completedMilestonesRef.current = { knowledge: false, evaluation: false, models: false };
+      }
+    }
+  }, [step, sourceRunId]);
+
+  // Catches a full page/tab close or refresh while the configure flow is in progress. Does not
+  // catch in-app navigation away (e.g. the host dashboard's global nav) — see
+  // `fireAutoragFlowExited`'s doc comment for why that isn't covered.
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      fireAutoragFlowExited('abandon', funnelStepRef.current, 'none');
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, []);
+
   const runTriggeredTrackingContextValue = useMemo<RunTriggeredTrackingContextProps>(
     () => ({
       onKnowledgeSourceConfigured: (sourceType) => {
         knowledgeSourceTypeRef.current = sourceType;
+        markMilestoneComplete('knowledge', 'knowledge');
       },
       onEvaluationSourceConfigured: (sourceType) => {
         evaluationSourceTypeRef.current = sourceType;
+        markMilestoneComplete('evaluation', 'evaluation');
       },
       onVectorStoreConfigured: (providerType) => {
         vectorDatabaseRef.current = providerType;
       },
+      onModelsConfigured: () => {
+        markMilestoneComplete('models', 'models');
+      },
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- markMilestoneComplete/advanceFunnelStep only ever touch refs, so they're safe to omit; including them would recreate this context value (and downstream consumers) on every render.
     [],
   );
 
@@ -134,8 +213,9 @@ function AutoragConfigurePage({
         success: true,
       });
     }
+    fireAutoragFlowExited('navigate', funnelStepRef.current, cancelExitDestination);
     navigate(-1);
-  }, [navigate, step, description]);
+  }, [navigate, step, description, cancelExitDestination]);
 
   const handleBackToCreate = useCallback(() => {
     // New runs only: clear configure-step values so Back → Next does not show stale S3/file UI.
@@ -248,11 +328,23 @@ function AutoragConfigurePage({
         (step === 'configure' || sourceRunId) && (
           <Breadcrumb>
             <BreadcrumbItem>
-              <Link to={getRedirectPath(namespace!)}>AutoRAG: {namespace}</Link>
+              <Link
+                to={getRedirectPath(namespace!)}
+                onClick={() =>
+                  fireAutoragFlowExited('navigate', funnelStepRef.current, 'experimentsList')
+                }
+              >
+                AutoRAG: {namespace}
+              </Link>
             </BreadcrumbItem>
             {fromResultsPage && sourceRunId && sourceRunName && (
               <BreadcrumbItem data-testid="configure-breadcrumb-source-run">
-                <Link to={`${autoragResultsPathname}/${namespace}/${sourceRunId}`}>
+                <Link
+                  to={`${autoragResultsPathname}/${namespace}/${sourceRunId}`}
+                  onClick={() =>
+                    fireAutoragFlowExited('navigate', funnelStepRef.current, 'otherGenAi')
+                  }
+                >
                   <Truncate content={sourceRunName} />
                 </Link>
               </BreadcrumbItem>

--- a/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
@@ -507,7 +507,9 @@ function AutoragConfigurePage({
                         success: true,
                       });
                     }
-                    navigate(`${autoragResultsPathname}/${namespace}/${pipelineRun.run_id}`);
+                    navigate(`${autoragResultsPathname}/${namespace}/${pipelineRun.run_id}`, {
+                      state: { entrySource: 'direct' },
+                    });
                   } catch (error) {
                     fireAutoragRunTriggered({
                       ...runTrackingProperties,

--- a/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
@@ -27,6 +27,7 @@ import { useNotification } from '~/app/hooks/useNotification';
 import type { SecretSelection } from '~/app/components/common/SecretSelector';
 import { ConfigureSchema, createConfigureSchema } from '~/app/schemas/configure.schema';
 import { autoragExperimentsPathname, autoragResultsPathname } from '~/app/utilities/routes';
+import { fireAutoragExperimentCreated, TrackingOutcome } from '~/app/utilities/tracking';
 import { useCatchUIError } from '~/app/components/common/UIError/UIErrorHandler.tsx';
 
 const configureSchema = createConfigureSchema();
@@ -88,7 +89,16 @@ function AutoragConfigurePage({
 
   const [step, setStep] = useState<'create' | 'configure'>('create');
 
-  const onCancel = useCallback(() => navigate(-1), [navigate]);
+  const onCancel = useCallback(() => {
+    if (step === 'create') {
+      fireAutoragExperimentCreated({
+        outcome: TrackingOutcome.cancel,
+        hasDescription: !!description,
+        success: true,
+      });
+    }
+    navigate(-1);
+  }, [navigate, step, description]);
 
   const handleBackToCreate = useCallback(() => {
     // New runs only: clear configure-step values so Back → Next does not show stale S3/file UI.
@@ -231,6 +241,11 @@ function AutoragConfigurePage({
             event.preventDefault();
 
             if (step === 'create') {
+              fireAutoragExperimentCreated({
+                outcome: TrackingOutcome.submit,
+                hasDescription: !!description,
+                success: true,
+              });
               setStep('configure');
               return;
             }

--- a/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
@@ -85,6 +85,7 @@ function AutoragResultsPage(): React.JSX.Element {
   const { handleRetry, handleConfirmStop, isRetrying, isTerminating } = useAutoragRunActions(
     namespace ?? '',
     runId ?? '',
+    'resultsPage',
   );
 
   // Two-tier error strategy: polling errors (data already loaded) show a non-blocking
@@ -415,6 +416,7 @@ function AutoragResultsPage(): React.JSX.Element {
         onConfirm={handleStop}
         isTerminating={isTerminating}
         runName={pipelineRun?.display_name}
+        source="resultsPage"
       />
       {viewCodePattern && (
         <ViewCodeModal

--- a/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
@@ -41,11 +41,12 @@ import {
 import ViewCodeModal from '~/app/components/run-results/ViewCodeModal';
 import type { ResponsesTemplate } from '~/app/types/autoragPattern';
 import {
+  fireAutoragCodeSnippetsExported,
   fireAutoragPlaygroundOpened,
   fireAutoragResultsViewed,
   isAutoragResultsNavigationState,
 } from '~/app/utilities/tracking';
-import type { PlaygroundOpenedSource } from '~/app/utilities/tracking';
+import type { PlaygroundOpenedSource, ViewCodeEntrySource } from '~/app/utilities/tracking';
 
 type DrawerContentType =
   | { type: 'run-details' }
@@ -307,11 +308,12 @@ function AutoragResultsPage(): React.JSX.Element {
   } | null>(null);
 
   const handleViewCode = React.useCallback(
-    (patternName: string) => {
+    (patternName: string, source: ViewCodeEntrySource) => {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const responsesTemplate = patterns?.[patternName]?.inference?.responses_template;
       if (responsesTemplate) {
         setViewCodePattern({ patternName, responsesTemplate });
+        fireAutoragCodeSnippetsExported('viewed', source);
       }
     },
     [patterns],
@@ -335,7 +337,7 @@ function AutoragResultsPage(): React.JSX.Element {
                 patternInfo={drawerContent.patternInfo}
                 onClose={handleDrawerClose}
                 onSelectPattern={openPlaygroundForPattern}
-                onViewCode={handleViewCode}
+                onViewCode={(patternName) => handleViewCode(patternName, 'playground')}
               />
             ) : undefined
           }

--- a/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
@@ -41,9 +41,11 @@ import {
 import ViewCodeModal from '~/app/components/run-results/ViewCodeModal';
 import type { ResponsesTemplate } from '~/app/types/autoragPattern';
 import {
+  fireAutoragPlaygroundOpened,
   fireAutoragResultsViewed,
   isAutoragResultsNavigationState,
 } from '~/app/utilities/tracking';
+import type { PlaygroundOpenedSource } from '~/app/utilities/tracking';
 
 type DrawerContentType =
   | { type: 'run-details' }
@@ -252,15 +254,19 @@ function AutoragResultsPage(): React.JSX.Element {
   );
 
   /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-  const handleTryPattern = React.useCallback(
-    (patternName: string) => {
+  // Opens (or switches the pattern within) the playground drawer. Returns whether a pattern was
+  // actually opened, so callers can decide whether to fire tracking — this function itself never
+  // fires tracking, since it's also used to switch patterns from within an already-open drawer
+  // (see `onSelectPattern` below), which is not a new "open".
+  const openPlaygroundForPattern = React.useCallback(
+    (patternName: string): boolean => {
       const pattern = patterns?.[patternName];
       if (!pattern) {
-        return;
+        return false;
       }
       const responsesTemplate = pattern.inference?.responses_template;
       if (!responsesTemplate) {
-        return;
+        return false;
       }
 
       const optimizedMetric = getOptimizedMetricForRAG(pipelineRun);
@@ -280,10 +286,20 @@ function AutoragResultsPage(): React.JSX.Element {
           chunkMethod: pattern.settings?.chunking?.method || 'N/A',
         },
       });
+      return true;
     },
     [patterns, pipelineRun],
   );
   /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+
+  const handleTryPattern = React.useCallback(
+    (patternName: string, source: PlaygroundOpenedSource) => {
+      if (openPlaygroundForPattern(patternName)) {
+        fireAutoragPlaygroundOpened(source);
+      }
+    },
+    [openPlaygroundForPattern],
+  );
 
   const [viewCodePattern, setViewCodePattern] = React.useState<{
     patternName: string;
@@ -318,7 +334,7 @@ function AutoragResultsPage(): React.JSX.Element {
                 responsesTemplate={drawerContent.responsesTemplate}
                 patternInfo={drawerContent.patternInfo}
                 onClose={handleDrawerClose}
-                onSelectPattern={handleTryPattern}
+                onSelectPattern={openPlaygroundForPattern}
                 onViewCode={handleViewCode}
               />
             ) : undefined

--- a/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
@@ -40,6 +40,10 @@ import {
 } from '~/app/utilities/utils';
 import ViewCodeModal from '~/app/components/run-results/ViewCodeModal';
 import type { ResponsesTemplate } from '~/app/types/autoragPattern';
+import {
+  fireAutoragResultsViewed,
+  isAutoragResultsNavigationState,
+} from '~/app/utilities/tracking';
 
 type DrawerContentType =
   | { type: 'run-details' }
@@ -107,6 +111,17 @@ function AutoragResultsPage(): React.JSX.Element {
     isInitialLoadError &&
     pipelineRunLoadError instanceof Error &&
     parseErrorStatus(pipelineRunLoadError) === 404;
+
+  const resultsViewedTrackedRunId = React.useRef<string | undefined>(undefined);
+  React.useEffect(() => {
+    if (!pipelineRun?.run_id || resultsViewedTrackedRunId.current === pipelineRun.run_id) {
+      return;
+    }
+    resultsViewedTrackedRunId.current = pipelineRun.run_id;
+
+    const navState = isAutoragResultsNavigationState(location.state) ? location.state : undefined;
+    fireAutoragResultsViewed(navState?.entrySource ?? 'other');
+  }, [pipelineRun?.run_id, location.state]);
 
   // Fetch and process AutoRAG results using custom hook
   const {

--- a/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
+++ b/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
@@ -5,8 +5,17 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { BrowserRouter } from 'react-router';
+import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { UIErrorHandler } from '~/app/components/common/UIError/UIErrorHandler';
 import AutoragConfigurePage from '~/app/pages/AutoragConfigurePage';
+import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
 
 // Truncate relies on DOM measurement APIs (scrollWidth) unavailable in JSDOM.
 jest.mock('@patternfly/react-core', () => ({
@@ -443,6 +452,86 @@ describe('AutoragConfigurePage', () => {
       const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
       await user.click(cancelButton);
       expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+  });
+
+  describe('AutoRAG Experiment Created tracking', () => {
+    it('should fire with outcome: submit and hasDescription: false when Next is clicked without a description', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+
+      const selectSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectSecretButton);
+
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_CREATED, {
+        outcome: TrackingOutcome.submit,
+        hasDescription: false,
+        success: true,
+      });
+    });
+
+    it('should fire with hasDescription: true when Next is clicked with a description filled in', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+
+      const descriptionInput = await screen.findByLabelText(/Description/i);
+      await user.type(descriptionInput, 'Some description');
+
+      const selectSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectSecretButton);
+
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_CREATED, {
+        outcome: TrackingOutcome.submit,
+        hasDescription: true,
+        success: true,
+      });
+    });
+
+    it('should fire with outcome: cancel when Cancel is clicked in the create step', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+      await user.click(cancelButton);
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_CREATED, {
+        outcome: TrackingOutcome.cancel,
+        hasDescription: false,
+        success: true,
+      });
+    });
+
+    it('should NOT fire again when Cancel is clicked from the configure step', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+
+      const selectSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectSecretButton);
+
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      fireFormTrackingEventMock.mockClear();
+
+      // Configure step only shows Back/Create run, not Cancel, so navigate(-1) elsewhere
+      // (e.g. reconfigure Cancel) should not re-fire this event.
+      expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+      expect(fireFormTrackingEventMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
+++ b/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
@@ -929,6 +929,105 @@ describe('AutoragConfigurePage', () => {
     });
   });
 
+  describe('AutoRAG Run Triggered tracking', () => {
+    it('should fire with success: true and derived properties on successful run creation', async () => {
+      const user = userEvent.setup();
+      mockMutateAsync.mockResolvedValue({ run_id: 'new-run-123' });
+
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+
+      const selectOgxSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectOgxSecretButton);
+
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      // Select AWS connection and a file via the S3 browser (real AutoragConfigure component
+      // path), so knowledgeSourceType is reported as 's3' via RunTriggeredTrackingContext.
+      const selectAwsSecretButton = await screen.findByTestId('aws-secret-selector-select-secret');
+      await user.click(selectAwsSecretButton);
+      const selectFilesButton = await screen.findByRole('button', { name: 'Browse bucket' });
+      await user.click(selectFilesButton);
+      const fileSelectButton = await screen.findByTestId('file-explorer-select-file');
+      await user.click(fileSelectButton);
+
+      const runButton = await screen.findByRole('button', { name: 'Create run' });
+      await waitFor(() => {
+        expect(runButton).toBeEnabled();
+      });
+      fireFormTrackingEventMock.mockClear();
+      await user.click(runButton);
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_TRIGGERED, {
+          knowledgeSourceType: 's3',
+          // AutoragEvaluationSelect and AutoragVectorStoreSelector are mocked in this file
+          // (they auto-set their form field directly, bypassing RunTriggeredTrackingContext),
+          // so these two remain undefined here — covered for real in their own component specs.
+          evaluationSourceType: undefined,
+          vectorDatabase: undefined,
+          optimizationMetric: 'overallScore',
+          countOfModels: 3,
+          countOfKnowledgeDocuments: 1,
+          countOfEvaluationDocuments: 1,
+          countOfFoundationModels: 2,
+          countOfEmbeddingModels: 1,
+          hasS3Connection: true,
+          outcome: TrackingOutcome.submit,
+          success: true,
+        });
+      });
+    });
+
+    it('should fire with success: false and the allowlisted error category when run creation fails', async () => {
+      const user = userEvent.setup();
+      mockMutateAsync.mockRejectedValue(new Error('Pipeline creation failed'));
+
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+
+      const selectOgxSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectOgxSecretButton);
+
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      const selectAwsSecretButton = await screen.findByTestId('aws-secret-selector-select-secret');
+      await user.click(selectAwsSecretButton);
+      const selectFilesButton = await screen.findByRole('button', { name: 'Browse bucket' });
+      await user.click(selectFilesButton);
+      const fileSelectButton = await screen.findByTestId('file-explorer-select-file');
+      await user.click(fileSelectButton);
+
+      const runButton = await screen.findByRole('button', { name: 'Create run' });
+      await waitFor(() => {
+        expect(runButton).toBeEnabled();
+      });
+      fireFormTrackingEventMock.mockClear();
+      await user.click(runButton);
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RUN_TRIGGERED,
+          expect.objectContaining({
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: 'actionFailed',
+          }),
+        );
+      });
+      // The raw error message must never reach analytics.
+      expect(JSON.stringify(fireFormTrackingEventMock.mock.calls)).not.toContain(
+        'Pipeline creation failed',
+      );
+    });
+  });
+
   describe('Invalid namespace handling', () => {
     const { useNamespaceSelector } = require('mod-arch-core');
 

--- a/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
+++ b/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { BrowserRouter } from 'react-router';
@@ -1038,6 +1038,305 @@ describe('AutoragConfigurePage', () => {
       // The raw error message must never reach analytics.
       expect(JSON.stringify(fireFormTrackingEventMock.mock.calls)).not.toContain(
         'Pipeline creation failed',
+      );
+    });
+  });
+
+  describe('AutoRAG Run Reconfigured tracking', () => {
+    // Matches the models `useOgxModelsQuery` is mocked to return above — AutoragConfigure's own
+    // model-initialization effect always resets generation_models/embedding_models to "select
+    // all available models" on mount, overwriting whatever a reconfigure's initialValues
+    // provided, so this is the only way to get a genuine "no changes" baseline for `models`.
+    const noChangeReconfigureInitialValues = {
+      display_name: 'Original Run - 1',
+      ogx_secret_name: 'Test OGX Secret',
+      vector_io_provider_id: 'chromadb',
+      input_data_secret_name: 'Test AWS Secret',
+      input_data_bucket_name: 'test-bucket',
+      input_data_key: 'my-data/input.pdf',
+      test_data_secret_name: 'Test AWS Secret',
+      test_data_bucket_name: 'test-bucket',
+      test_data_key: 'eval.json',
+      optimization_metric: 'faithfulness' as const,
+      generation_models: ['llama-3-8b', 'llama-3-70b'],
+      embedding_models: ['text-embedding-ada-002'],
+    };
+    const reconfigureInitialOgxSecret = {
+      uuid: 'ogx-secret-1',
+      name: 'Test OGX Secret',
+      data: { OGX_CLIENT_BASE_URL: 'https://example.com', OGX_CLIENT_API_KEY: 'test-key' },
+      type: 'ogx',
+      invalid: false,
+    };
+    const reconfigureInitialSecret = {
+      uuid: 'aws-secret-1',
+      name: 'Test AWS Secret',
+      displayName: 'Test AWS Secret',
+      data: { AWS_S3_BUCKET: 'test-bucket', AWS_DEFAULT_REGION: 'us-east-1' },
+      type: 's3',
+      invalid: false,
+    };
+
+    const navigateToReconfigureConfigureStep = async () => {
+      const user = userEvent.setup();
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await waitFor(() => {
+        expect(nextButton).toBeEnabled();
+      });
+      await user.click(nextButton);
+      expect(await screen.findByText('Knowledge setup')).toBeInTheDocument();
+      return user;
+    };
+
+    it('should fire with success: true and an empty changedFields when nothing was changed', async () => {
+      mockMutateAsync.mockResolvedValue({ run_id: 'new-run-123' });
+      renderWithProviders(
+        <AutoragConfigurePage
+          initialValues={noChangeReconfigureInitialValues}
+          initialInputDataSecret={reconfigureInitialSecret}
+          initialOgxSecret={reconfigureInitialOgxSecret}
+          sourceRunId="prev-run-456"
+          sourceRunName="Original Run"
+        />,
+      );
+
+      const user = await navigateToReconfigureConfigureStep();
+
+      const runButton = await screen.findByRole('button', { name: 'Create new run' });
+      await waitFor(() => {
+        expect(runButton).toBeEnabled();
+      });
+      fireFormTrackingEventMock.mockClear();
+      await user.click(runButton);
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_RECONFIGURED, {
+          knowledgeSourceType: undefined,
+          evaluationSourceType: undefined,
+          optimizationMetric: 'answerFaithfulness',
+          vectorDatabase: undefined,
+          countOfFoundationModels: 2,
+          countOfEmbeddingModels: 1,
+          changedFields: '',
+          outcome: TrackingOutcome.submit,
+          success: true,
+        });
+      });
+    });
+
+    it('should not fire for a non-reconfigure (new run) submission', async () => {
+      mockMutateAsync.mockResolvedValue({ run_id: 'new-run-123' });
+      const user = userEvent.setup();
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+      const selectOgxSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectOgxSecretButton);
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      const selectAwsSecretButton = await screen.findByTestId('aws-secret-selector-select-secret');
+      await user.click(selectAwsSecretButton);
+      const selectFilesButton = await screen.findByRole('button', { name: 'Browse bucket' });
+      await user.click(selectFilesButton);
+      const fileSelectButton = await screen.findByTestId('file-explorer-select-file');
+      await user.click(fileSelectButton);
+
+      const runButton = await screen.findByRole('button', { name: 'Create run' });
+      await waitFor(() => {
+        expect(runButton).toBeEnabled();
+      });
+      fireFormTrackingEventMock.mockClear();
+      await user.click(runButton);
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RUN_TRIGGERED,
+          expect.anything(),
+        );
+      });
+      expect(fireFormTrackingEventMock).not.toHaveBeenCalledWith(
+        AUTORAG_EVENTS.RUN_RECONFIGURED,
+        expect.anything(),
+      );
+    });
+
+    it('should include optimizationMetric in changedFields when it is changed', async () => {
+      mockMutateAsync.mockResolvedValue({ run_id: 'new-run-123' });
+      renderWithProviders(
+        <AutoragConfigurePage
+          initialValues={noChangeReconfigureInitialValues}
+          initialInputDataSecret={reconfigureInitialSecret}
+          initialOgxSecret={reconfigureInitialOgxSecret}
+          sourceRunId="prev-run-456"
+          sourceRunName="Original Run"
+        />,
+      );
+
+      const user = await navigateToReconfigureConfigureStep();
+
+      fireEvent.click(screen.getByTestId('optimization-metric-select'));
+      await waitFor(() => {
+        expect(screen.getByText('Answer correctness')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Answer correctness'));
+
+      const runButton = await screen.findByRole('button', { name: 'Create new run' });
+      await waitFor(() => {
+        expect(runButton).toBeEnabled();
+      });
+      fireFormTrackingEventMock.mockClear();
+      await user.click(runButton);
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RUN_RECONFIGURED,
+          expect.objectContaining({
+            optimizationMetric: 'answerCorrectness',
+            changedFields: 'optimizationMetric',
+            outcome: TrackingOutcome.submit,
+            success: true,
+          }),
+        );
+      });
+    });
+
+    it('should include knowledgeSourceType in changedFields when the knowledge source is re-selected', async () => {
+      mockMutateAsync.mockResolvedValue({ run_id: 'new-run-123' });
+      renderWithProviders(
+        <AutoragConfigurePage
+          initialValues={noChangeReconfigureInitialValues}
+          initialInputDataSecret={reconfigureInitialSecret}
+          initialOgxSecret={reconfigureInitialOgxSecret}
+          sourceRunId="prev-run-456"
+          sourceRunName="Original Run"
+        />,
+      );
+
+      const user = await navigateToReconfigureConfigureStep();
+
+      // Re-select via the real S3 browser flow, so knowledgeSourceTypeRef is actually set.
+      const selectFilesButton = await screen.findByRole('button', { name: 'Browse bucket' });
+      await user.click(selectFilesButton);
+      const fileSelectButton = await screen.findByTestId('file-explorer-select-file');
+      await user.click(fileSelectButton);
+
+      const runButton = await screen.findByRole('button', { name: 'Create new run' });
+      await waitFor(() => {
+        expect(runButton).toBeEnabled();
+      });
+      fireFormTrackingEventMock.mockClear();
+      await user.click(runButton);
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RUN_RECONFIGURED,
+          expect.objectContaining({
+            knowledgeSourceType: 's3',
+            changedFields: 'knowledgeSourceType',
+            outcome: TrackingOutcome.submit,
+            success: true,
+          }),
+        );
+      });
+    });
+
+    it('should fire with success: false, the allowlisted error category, and a non-empty changedFields on failure', async () => {
+      mockMutateAsync.mockRejectedValue(new Error('Pipeline creation failed'));
+      renderWithProviders(
+        <AutoragConfigurePage
+          initialValues={noChangeReconfigureInitialValues}
+          initialInputDataSecret={reconfigureInitialSecret}
+          initialOgxSecret={reconfigureInitialOgxSecret}
+          sourceRunId="prev-run-456"
+          sourceRunName="Original Run"
+        />,
+      );
+
+      const user = await navigateToReconfigureConfigureStep();
+
+      fireEvent.click(screen.getByTestId('optimization-metric-select'));
+      await waitFor(() => {
+        expect(screen.getByText('Answer correctness')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Answer correctness'));
+
+      const runButton = await screen.findByRole('button', { name: 'Create new run' });
+      await waitFor(() => {
+        expect(runButton).toBeEnabled();
+      });
+      fireFormTrackingEventMock.mockClear();
+      await user.click(runButton);
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RUN_RECONFIGURED,
+          expect.objectContaining({
+            changedFields: 'optimizationMetric',
+            outcome: TrackingOutcome.submit,
+            success: false,
+            error: 'actionFailed',
+          }),
+        );
+      });
+      // The raw error message must never reach analytics.
+      expect(JSON.stringify(fireFormTrackingEventMock.mock.calls)).not.toContain(
+        'Pipeline creation failed',
+      );
+    });
+
+    it('should fire with outcome: cancel, no success field, and changedFields reflecting a change made before returning to the create step', async () => {
+      renderWithProviders(
+        <AutoragConfigurePage
+          initialValues={noChangeReconfigureInitialValues}
+          initialInputDataSecret={reconfigureInitialSecret}
+          initialOgxSecret={reconfigureInitialOgxSecret}
+          sourceRunId="prev-run-456"
+          sourceRunName="Original Run"
+        />,
+      );
+
+      const user = await navigateToReconfigureConfigureStep();
+
+      fireEvent.click(screen.getByTestId('optimization-metric-select'));
+      await waitFor(() => {
+        expect(screen.getByText('Answer correctness')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Answer correctness'));
+
+      await user.click(await screen.findByRole('button', { name: 'Back' }));
+
+      fireFormTrackingEventMock.mockClear();
+      const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+      await user.click(cancelButton);
+
+      expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.RUN_RECONFIGURED,
+        expect.objectContaining({
+          changedFields: 'optimizationMetric',
+          outcome: TrackingOutcome.cancel,
+        }),
+      );
+      // Cancel fires no backend call, so `success` must be omitted entirely.
+      const [, cancelProperties] = fireFormTrackingEventMock.mock.calls.find(
+        ([eventName]) => eventName === AUTORAG_EVENTS.RUN_RECONFIGURED,
+      )!;
+      expect(cancelProperties).not.toHaveProperty('success');
+      expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+
+    it('should not fire on cancel for a non-reconfigure (new run) submission', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+      fireFormTrackingEventMock.mockClear();
+      await user.click(cancelButton);
+
+      expect(fireFormTrackingEventMock).not.toHaveBeenCalledWith(
+        AUTORAG_EVENTS.RUN_RECONFIGURED,
+        expect.anything(),
       );
     });
   });

--- a/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
+++ b/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
@@ -5,7 +5,10 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { BrowserRouter } from 'react-router';
-import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { UIErrorHandler } from '~/app/components/common/UIError/UIErrorHandler';
 import AutoragConfigurePage from '~/app/pages/AutoragConfigurePage';
 import { AUTORAG_EVENTS, TrackingOutcome } from '~/app/utilities/tracking';
@@ -16,6 +19,7 @@ jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', (
 }));
 
 const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
+const fireMiscTrackingEventMock = jest.mocked(fireMiscTrackingEvent);
 
 // Truncate relies on DOM measurement APIs (scrollWidth) unavailable in JSDOM.
 jest.mock('@patternfly/react-core', () => ({
@@ -37,8 +41,18 @@ jest.mock('react-router', () => ({
   useNavigate: () => mockNavigate,
   useParams: () => mockUseParams(),
   useLocation: () => ({ state: mockLocationState, pathname: '', search: '', hash: '', key: '' }),
-  Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
-    <a href={to}>{children}</a>
+  Link: ({
+    to,
+    children,
+    onClick,
+  }: {
+    to: string;
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <a href={to} onClick={onClick}>
+      {children}
+    </a>
   ),
 }));
 
@@ -1025,6 +1039,272 @@ describe('AutoragConfigurePage', () => {
       expect(JSON.stringify(fireFormTrackingEventMock.mock.calls)).not.toContain(
         'Pipeline creation failed',
       );
+    });
+  });
+
+  describe('AutoRAG Flow Exited tracking', () => {
+    it('should fire with lastFunnelStep: defineDetails and exitDestination: experimentsList when Cancel is clicked on the create step', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+      await user.click(cancelButton);
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+        exitType: 'navigate',
+        lastFunnelStep: 'defineDetails',
+        exitDestination: 'experimentsList',
+      });
+    });
+
+    it('should fire with lastFunnelStep: defineDetails when the breadcrumb is clicked before any milestone is completed', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+      const selectOgxSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectOgxSecretButton);
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      const breadcrumbLink = await screen.findByText('AutoRAG: test-namespace');
+      await user.click(breadcrumbLink);
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+        exitType: 'navigate',
+        lastFunnelStep: 'defineDetails',
+        exitDestination: 'experimentsList',
+      });
+    });
+
+    it('should report lastFunnelStep: knowledge once a knowledge document has been selected', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+      const selectOgxSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectOgxSecretButton);
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      // Complete the "Knowledge setup" milestone via the real AutoragConfigure S3 flow.
+      const selectAwsSecretButton = await screen.findByTestId('aws-secret-selector-select-secret');
+      await user.click(selectAwsSecretButton);
+      const selectFilesButton = await screen.findByRole('button', { name: 'Browse bucket' });
+      await user.click(selectFilesButton);
+      const fileSelectButton = await screen.findByTestId('file-explorer-select-file');
+      await user.click(fileSelectButton);
+
+      const breadcrumbLink = await screen.findByText('AutoRAG: test-namespace');
+      await user.click(breadcrumbLink);
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+        exitType: 'navigate',
+        lastFunnelStep: 'knowledge',
+        exitDestination: 'experimentsList',
+      });
+    });
+
+    it('should reset lastFunnelStep to defineDetails after Back clears a completed milestone and the user returns to configure', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+      const selectOgxSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectOgxSecretButton);
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      // Complete the "Knowledge setup" milestone.
+      const selectAwsSecretButton = await screen.findByTestId('aws-secret-selector-select-secret');
+      await user.click(selectAwsSecretButton);
+      const selectFilesButton = await screen.findByRole('button', { name: 'Browse bucket' });
+      await user.click(selectFilesButton);
+      const fileSelectButton = await screen.findByTestId('file-explorer-select-file');
+      await user.click(fileSelectButton);
+
+      // Back clears the knowledge selection (new-run flow only) — returning to configure should
+      // not still report the milestone that was just cleared.
+      const backButton = await screen.findByRole('button', { name: 'Back' });
+      await user.click(backButton);
+      // AutoragCreate remounts on Back and resets ogx_secret_name to '' when no initialOgxSecret
+      // is provided (the SecretSelector can't visually reflect a pre-existing value), so it must
+      // be re-selected — via a freshly-queried button, since AutoragCreate's remount detaches the
+      // one captured above — before Next is enabled again.
+      const selectOgxSecretButtonAfterBack = await screen.findByTestId(
+        'ogx-secret-selector-select-secret',
+      );
+      await user.click(selectOgxSecretButtonAfterBack);
+      const nextButtonAgain = await screen.findByRole('button', { name: 'Next' });
+      await waitFor(() => {
+        expect(nextButtonAgain).toBeEnabled();
+      });
+      await user.click(nextButtonAgain);
+
+      const breadcrumbLink = await screen.findByText('AutoRAG: test-namespace');
+      await user.click(breadcrumbLink);
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+        exitType: 'navigate',
+        lastFunnelStep: 'defineDetails',
+        exitDestination: 'experimentsList',
+      });
+    });
+
+    it('should NOT fire when the run is created successfully', async () => {
+      const user = userEvent.setup();
+      mockMutateAsync.mockResolvedValue({ run_id: 'new-run-123' });
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+      const selectOgxSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectOgxSecretButton);
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      const selectAwsSecretButton = await screen.findByTestId('aws-secret-selector-select-secret');
+      await user.click(selectAwsSecretButton);
+      const selectFilesButton = await screen.findByRole('button', { name: 'Browse bucket' });
+      await user.click(selectFilesButton);
+      const fileSelectButton = await screen.findByTestId('file-explorer-select-file');
+      await user.click(fileSelectButton);
+
+      const runButton = await screen.findByRole('button', { name: 'Create run' });
+      await waitFor(() => {
+        expect(runButton).toBeEnabled();
+      });
+      await user.click(runButton);
+
+      await waitFor(() => {
+        expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+          AUTORAG_EVENTS.RUN_TRIGGERED,
+          expect.objectContaining({ success: true }),
+        );
+      });
+      expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+        AUTORAG_EVENTS.FLOW_EXITED,
+        expect.anything(),
+      );
+    });
+
+    it('should fire with exitType: abandon and exitDestination: none on a full page/tab close', async () => {
+      renderWithProviders(<AutoragConfigurePage />);
+      await screen.findByLabelText(/Name/i);
+
+      window.dispatchEvent(new Event('beforeunload'));
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+        exitType: 'abandon',
+        lastFunnelStep: 'defineDetails',
+        exitDestination: 'none',
+      });
+    });
+
+    describe('reconfigure flow', () => {
+      it('should report lastFunnelStep: run immediately upon reaching the configure step, since the form starts pre-populated', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+          <AutoragConfigurePage
+            initialValues={{
+              display_name: 'Original Run - 1',
+              ogx_secret_name: 'Test OGX Secret',
+            }}
+            initialOgxSecret={{
+              uuid: 'ogx-secret-1',
+              name: 'Test OGX Secret',
+              data: {
+                OGX_CLIENT_BASE_URL: 'https://example.com',
+                OGX_CLIENT_API_KEY: 'test-key',
+              },
+              type: 'ogx',
+              invalid: false,
+            }}
+            sourceRunId="prev-run-456"
+            sourceRunName="Original Run"
+          />,
+        );
+
+        const nextButton = await screen.findByRole('button', { name: 'Next' });
+        await waitFor(() => {
+          expect(nextButton).toBeEnabled();
+        });
+        await user.click(nextButton);
+
+        const breadcrumbLink = await screen.findByText('AutoRAG: test-namespace');
+        await user.click(breadcrumbLink);
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+          exitType: 'navigate',
+          lastFunnelStep: 'run',
+          exitDestination: 'experimentsList',
+        });
+      });
+
+      it('should fire with exitDestination: otherGenAi when the source-run breadcrumb is clicked', async () => {
+        const user = userEvent.setup();
+        mockLocationState = { from: 'results' };
+        renderWithProviders(
+          <AutoragConfigurePage
+            initialValues={{ display_name: 'Original Run - 1' }}
+            sourceRunId="prev-run-456"
+            sourceRunName="Original Run"
+          />,
+        );
+
+        const sourceRunBreadcrumb = await screen.findByTestId('configure-breadcrumb-source-run');
+        await user.click(sourceRunBreadcrumb.querySelector('a')!);
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+          exitType: 'navigate',
+          lastFunnelStep: 'defineDetails',
+          exitDestination: 'otherGenAi',
+        });
+      });
+
+      it('should fire with exitDestination: otherGenAi when Cancel is clicked after navigating from the results page', async () => {
+        const user = userEvent.setup();
+        mockLocationState = { from: 'results' };
+        renderWithProviders(
+          <AutoragConfigurePage
+            initialValues={{ display_name: 'Original Run - 1' }}
+            sourceRunId="prev-run-456"
+            sourceRunName="Original Run"
+          />,
+        );
+
+        const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+        await user.click(cancelButton);
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+          exitType: 'navigate',
+          lastFunnelStep: 'defineDetails',
+          exitDestination: 'otherGenAi',
+        });
+      });
+
+      it('should fire with exitDestination: experimentsList when Cancel is clicked without having navigated from the results page', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+          <AutoragConfigurePage
+            initialValues={{ display_name: 'Original Run - 1' }}
+            sourceRunId="prev-run-456"
+            sourceRunName="Original Run"
+          />,
+        );
+
+        const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+        await user.click(cancelButton);
+
+        expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+          exitType: 'navigate',
+          lastFunnelStep: 'defineDetails',
+          exitDestination: 'experimentsList',
+        });
+      });
     });
   });
 

--- a/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
+++ b/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
@@ -527,7 +527,7 @@ describe('AutoragConfigurePage', () => {
       });
     });
 
-    it('should NOT fire again when Cancel is clicked from the configure step', async () => {
+    it('should not render a Cancel button on the configure step', async () => {
       const user = userEvent.setup();
       renderWithProviders(<AutoragConfigurePage />);
 
@@ -540,12 +540,8 @@ describe('AutoragConfigurePage', () => {
       const nextButton = await screen.findByRole('button', { name: 'Next' });
       await user.click(nextButton);
 
-      fireFormTrackingEventMock.mockClear();
-
-      // Configure step only shows Back/Create run, not Cancel, so navigate(-1) elsewhere
-      // (e.g. reconfigure Cancel) should not re-fire this event.
+      // Configure step only shows Back/Create run, not Cancel.
       expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
-      expect(fireFormTrackingEventMock).not.toHaveBeenCalled();
     });
   });
 
@@ -1502,6 +1498,48 @@ describe('AutoragConfigurePage', () => {
         lastFunnelStep: 'defineDetails',
         exitDestination: 'none',
       });
+    });
+
+    it('should NOT fire abandon on a page/tab close while a run submission is still in flight', async () => {
+      const user = userEvent.setup();
+      // Never resolves within this test, simulating a submission that is still pending when
+      // beforeunload fires.
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      mockMutateAsync.mockReturnValue(new Promise(() => {}));
+
+      renderWithProviders(<AutoragConfigurePage />);
+
+      const nameInput = await screen.findByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Experiment');
+      const selectOgxSecretButton = await screen.findByTestId('ogx-secret-selector-select-secret');
+      await user.click(selectOgxSecretButton);
+      const nextButton = await screen.findByRole('button', { name: 'Next' });
+      await user.click(nextButton);
+
+      const selectAwsSecretButton = await screen.findByTestId('aws-secret-selector-select-secret');
+      await user.click(selectAwsSecretButton);
+      const selectFilesButton = await screen.findByRole('button', { name: 'Browse bucket' });
+      await user.click(selectFilesButton);
+      const fileSelectButton = await screen.findByTestId('file-explorer-select-file');
+      await user.click(fileSelectButton);
+
+      const runButton = await screen.findByRole('button', { name: 'Create run' });
+      await waitFor(() => {
+        expect(runButton).toBeEnabled();
+      });
+      await user.click(runButton);
+
+      // Confirm the submission is actually in flight before simulating the tab close.
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalled();
+      });
+
+      window.dispatchEvent(new Event('beforeunload'));
+
+      expect(fireMiscTrackingEventMock).not.toHaveBeenCalledWith(
+        AUTORAG_EVENTS.FLOW_EXITED,
+        expect.objectContaining({ exitType: 'abandon' }),
+      );
     });
 
     describe('reconfigure flow', () => {

--- a/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
+++ b/packages/autorag/frontend/src/app/pages/__tests__/AutoragConfigurePage.spec.tsx
@@ -791,6 +791,7 @@ describe('AutoragConfigurePage', () => {
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith(
           '/gen-ai-studio/autorag/results/test-namespace/new-run-123',
+          { state: { entrySource: 'direct' } },
         );
       });
     });

--- a/packages/autorag/frontend/src/app/pages/__tests__/AutoragResultsPage.spec.tsx
+++ b/packages/autorag/frontend/src/app/pages/__tests__/AutoragResultsPage.spec.tsx
@@ -5,20 +5,30 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import AutoragResultsPage from '~/app/pages/AutoragResultsPage';
 import type { AutoragPattern } from '~/app/types/autoragPattern';
 import type { PipelineRun } from '~/app/types';
 import type { ConfigureSchema } from '~/app/schemas/configure.schema';
+import { AUTORAG_EVENTS } from '~/app/utilities/tracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireMiscTrackingEventMock = jest.mocked(fireMiscTrackingEvent);
 
 // ============================================================================
 // Mocks
 // ============================================================================
 
 const mockUseParams = jest.fn();
+const mockUseLocation = jest.fn<{ state: unknown }, []>(() => ({ state: null }));
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
   useParams: () => mockUseParams(),
-  useLocation: () => ({ pathname: '/', search: '', hash: '', state: null, key: 'default' }),
+  useLocation: () => mockUseLocation(),
   Link: ({
     to,
     children,
@@ -289,6 +299,7 @@ describe('AutoragResultsPage', () => {
     jest.clearAllMocks();
     capturedContext = null;
     mockUseParams.mockReturnValue({ namespace: 'test-ns', runId: 'run-123' });
+    mockUseLocation.mockReturnValue({ state: null });
 
     // Reset useNamespaceSelector mock to default state
     const { useNamespaceSelector } = jest.requireMock('mod-arch-core');
@@ -1189,6 +1200,77 @@ describe('AutoragResultsPage', () => {
 
       expect(screen.getByTestId('retry-run-button')).toBeInTheDocument();
       expect(screen.getByTestId('reconfigure-run-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('AutoRAG Results Viewed tracking', () => {
+    it('should fire with entrySource from location state when navigated from the experiments list', () => {
+      mockUseLocation.mockReturnValue({ state: { entrySource: 'experimentsList' } });
+      mockUsePipelineRunQuery.mockReturnValue({
+        data: createMockPipelineRun(),
+        isPending: false,
+        isFetching: false,
+        isError: false,
+        error: null,
+      });
+
+      renderPage();
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RESULTS_VIEWED, {
+        entrySource: 'experimentsList',
+      });
+    });
+
+    it('should fall back to entrySource: other when location state is missing/invalid', () => {
+      mockUseLocation.mockReturnValue({ state: null });
+      mockUsePipelineRunQuery.mockReturnValue({
+        data: createMockPipelineRun(),
+        isPending: false,
+        isFetching: false,
+        isError: false,
+        error: null,
+      });
+
+      renderPage();
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RESULTS_VIEWED, {
+        entrySource: 'other',
+      });
+    });
+
+    it('should not fire again on re-renders for the same run', () => {
+      mockUsePipelineRunQuery.mockReturnValue({
+        data: createMockPipelineRun(),
+        isPending: false,
+        isFetching: false,
+        isError: false,
+        error: null,
+      });
+
+      const { rerender } = renderPage();
+      rerender(
+        <MemoryRouter>
+          <QueryClientProvider client={createTestQueryClient()}>
+            <AutoragResultsPage />
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fire while the pipeline run has not yet loaded', () => {
+      mockUsePipelineRunQuery.mockReturnValue({
+        data: undefined,
+        isPending: true,
+        isFetching: false,
+        isError: false,
+        error: null,
+      });
+
+      renderPage();
+
+      expect(fireMiscTrackingEventMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -13,6 +13,7 @@ import {
   fireAutoragKnowledgeSourceConfigured,
   fireAutoragLeaderboardPresetApplied,
   fireAutoragModelsSelected,
+  fireAutoragPatternsCompared,
   fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
   fireAutoragCodeSnippetsExported,
@@ -820,4 +821,36 @@ describe('fireAutoragLeaderboardPresetApplied', () => {
       );
     },
   );
+});
+
+describe('fireAutoragPatternsCompared', () => {
+  it('should fire AutoRAG Patterns Compared with the given interactionType, rankDifference, and scoreDifference', () => {
+    fireAutoragPatternsCompared('initial', 1, 0.4);
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.PATTERNS_COMPARED, {
+      interactionType: 'initial',
+      rankDifference: 1,
+      scoreDifference: 0.4,
+    });
+  });
+
+  it('should fire with interactionType: changed and negative rankDifference/scoreDifference', () => {
+    fireAutoragPatternsCompared('changed', -5, -0.15);
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.PATTERNS_COMPARED, {
+      interactionType: 'changed',
+      rankDifference: -5,
+      scoreDifference: -0.15,
+    });
+  });
+
+  it('should round scoreDifference to 4 decimal places to avoid floating-point noise', () => {
+    fireAutoragPatternsCompared('initial', 1, 0.45 - 0.66);
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.PATTERNS_COMPARED, {
+      interactionType: 'initial',
+      rankDifference: 1,
+      scoreDifference: -0.21,
+    });
+  });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -15,6 +15,7 @@ import {
   fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
   fireAutoragRunReconfigured,
+  fireAutoragRunRetried,
   fireAutoragRunStopped,
   fireAutoragRunTriggered,
   fireAutoragS3ConnectionCreated,
@@ -515,6 +516,34 @@ describe('fireAutoragRunStopped', () => {
     expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_STOPPED, {
       outcome: TrackingOutcome.cancel,
       source: 'runsList',
+    });
+  });
+});
+
+describe('fireAutoragRunRetried', () => {
+  it('should fire with outcome: submit and success: true, given a source', () => {
+    fireAutoragRunRetried({ outcome: TrackingOutcome.submit, success: true, source: 'runsList' });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_RETRIED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      source: 'runsList',
+    });
+  });
+
+  it('should fire with success: false and the allowlisted failure category on failure', () => {
+    fireAutoragRunRetried({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
+      source: 'resultsPage',
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_RETRIED, {
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
+      source: 'resultsPage',
     });
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -11,6 +11,7 @@ import {
   fireAutoragFlowExited,
   fireAutoragKnowledgeSourceConfigured,
   fireAutoragModelsSelected,
+  fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
   fireAutoragRunTriggered,
   fireAutoragS3ConnectionCreated,
@@ -417,5 +418,16 @@ describe('fireAutoragS3ConnectionCreated', () => {
     expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.S3_CONNECTION_CREATED, {
       outcome: TrackingOutcome.cancel,
     });
+  });
+});
+
+describe('fireAutoragEvaluationTemplateDownloaded', () => {
+  it('should fire with downloadType: evaluationTemplate', () => {
+    fireAutoragEvaluationTemplateDownloaded();
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.EVALUATION_TEMPLATE_DOWNLOADED,
+      { downloadType: 'evaluationTemplate' },
+    );
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -14,6 +14,7 @@ import {
   fireAutoragModelsSelected,
   fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
+  fireAutoragExperimentDeleted,
   fireAutoragRunReconfigured,
   fireAutoragRunRetried,
   fireAutoragRunStopped,
@@ -544,6 +545,47 @@ describe('fireAutoragRunRetried', () => {
       success: false,
       error: AUTORAG_FAILURE_CATEGORY,
       source: 'resultsPage',
+    });
+  });
+});
+
+describe('fireAutoragExperimentDeleted', () => {
+  it('should fire with outcome: submit and success: true, given a source', () => {
+    fireAutoragExperimentDeleted({
+      outcome: TrackingOutcome.submit,
+      success: true,
+      source: 'runsList',
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_DELETED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      source: 'runsList',
+    });
+  });
+
+  it('should fire with success: false and the allowlisted failure category on failure', () => {
+    fireAutoragExperimentDeleted({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
+      source: 'runsList',
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_DELETED, {
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
+      source: 'runsList',
+    });
+  });
+
+  it('should fire with outcome: cancel when the delete confirmation modal is dismissed', () => {
+    fireAutoragExperimentDeleted({ outcome: TrackingOutcome.cancel, source: 'runsList' });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_DELETED, {
+      outcome: TrackingOutcome.cancel,
+      source: 'runsList',
     });
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -15,6 +15,7 @@ import {
   fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
   fireAutoragExperimentDeleted,
+  fireAutoragNotebookDownloaded,
   fireAutoragPlaygroundOpened,
   fireAutoragResultsViewed,
   fireAutoragRunReconfigured,
@@ -710,6 +711,19 @@ describe('fireAutoragPlaygroundOpened', () => {
 
       expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.PLAYGROUND_OPENED, {
         source,
+      });
+    },
+  );
+});
+
+describe('fireAutoragNotebookDownloaded', () => {
+  it.each(['indexing', 'inference', 'other'] as const)(
+    'should fire AutoRAG Notebook Downloaded with notebookType: %s',
+    (notebookType) => {
+      fireAutoragNotebookDownloaded(notebookType);
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.NOTEBOOK_DOWNLOADED, {
+        notebookType,
       });
     },
   );

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -17,6 +17,7 @@ import {
   fireAutoragExperimentDeleted,
   fireAutoragNotebookDownloaded,
   fireAutoragPlaygroundOpened,
+  fireAutoragResultsColumnToggled,
   fireAutoragResultsViewed,
   fireAutoragRunReconfigured,
   fireAutoragRunRetried,
@@ -725,6 +726,28 @@ describe('fireAutoragNotebookDownloaded', () => {
       expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.NOTEBOOK_DOWNLOADED, {
         notebookType,
       });
+    },
+  );
+});
+
+describe('fireAutoragResultsColumnToggled', () => {
+  it.each([
+    ['rank', true],
+    ['patternName', false],
+    ['modelNames', true],
+    ['answerFaithfulness', false],
+    ['otherMetric', true],
+    ['chunkingMethod', false],
+    ['other', true],
+  ] as const)(
+    'should fire AutoRAG Results Column Toggled with columnName: %s, isVisible: %s',
+    (columnName, isVisible) => {
+      fireAutoragResultsColumnToggled(columnName, isVisible);
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.RESULTS_COLUMN_TOGGLED,
+        { columnName, isVisible },
+      );
     },
   );
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -8,6 +8,7 @@ import {
   AUTORAG_FAILURE_CATEGORY,
   fireAutoragEvaluationSourceConfigured,
   fireAutoragExperimentCreated,
+  fireAutoragFlowExited,
   fireAutoragKnowledgeSourceConfigured,
   fireAutoragModelsSelected,
   fireAutoragProjectDropdownOptionSelected,
@@ -349,6 +350,38 @@ describe('fireAutoragRunTriggered', () => {
       outcome: TrackingOutcome.submit,
       success: false,
       error: AUTORAG_FAILURE_CATEGORY,
+    });
+  });
+});
+
+describe('fireAutoragFlowExited', () => {
+  it('should fire AutoRAG Flow Exited with exitType, lastFunnelStep, and exitDestination', () => {
+    fireAutoragFlowExited('navigate', 'defineDetails', 'experimentsList');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+      exitType: 'navigate',
+      lastFunnelStep: 'defineDetails',
+      exitDestination: 'experimentsList',
+    });
+  });
+
+  it('should fire with exitType: abandon and exitDestination: none', () => {
+    fireAutoragFlowExited('abandon', 'knowledge', 'none');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+      exitType: 'abandon',
+      lastFunnelStep: 'knowledge',
+      exitDestination: 'none',
+    });
+  });
+
+  it('should fire with lastFunnelStep: run and exitDestination: otherGenAi', () => {
+    fireAutoragFlowExited('navigate', 'run', 'otherGenAi');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.FLOW_EXITED, {
+      exitType: 'navigate',
+      lastFunnelStep: 'run',
+      exitDestination: 'otherGenAi',
     });
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -16,6 +16,7 @@ import {
   fireAutoragProjectDropdownOptionSelected,
   fireAutoragExperimentDeleted,
   fireAutoragNotebookDownloaded,
+  fireAutoragPatternDetailsDownloadInitiated,
   fireAutoragPatternDetailsViewed,
   fireAutoragPlaygroundOpened,
   fireAutoragResultsColumnToggled,
@@ -765,4 +766,15 @@ describe('fireAutoragPatternDetailsViewed', () => {
       );
     },
   );
+});
+
+describe('fireAutoragPatternDetailsDownloadInitiated', () => {
+  it('should fire AutoRAG Pattern Details Download Initiated with downloadType: patternDetails', () => {
+    fireAutoragPatternDetailsDownloadInitiated();
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.PATTERN_DETAILS_DOWNLOAD_INITIATED,
+      { downloadType: 'patternDetails' },
+    );
+  });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -6,6 +6,7 @@ import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   AUTORAG_EVENTS,
   fireAutoragExperimentCreated,
+  fireAutoragKnowledgeSourceConfigured,
   fireAutoragProjectDropdownOptionSelected,
 } from '~/app/utilities/tracking';
 
@@ -71,5 +72,66 @@ describe('fireAutoragExperimentCreated', () => {
       success: false,
       error: 'boom',
     });
+  });
+});
+
+describe('fireAutoragKnowledgeSourceConfigured', () => {
+  it('should fire with knowledgeSourceType: s3 and outcome: submit', () => {
+    fireAutoragKnowledgeSourceConfigured({
+      knowledgeSourceType: 's3',
+      countOfDocuments: 3,
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
+      {
+        knowledgeSourceType: 's3',
+        countOfDocuments: 3,
+        outcome: TrackingOutcome.submit,
+        success: true,
+      },
+    );
+  });
+
+  it('should fire with outcome: cancel', () => {
+    fireAutoragKnowledgeSourceConfigured({
+      knowledgeSourceType: 's3',
+      countOfDocuments: 0,
+      outcome: TrackingOutcome.cancel,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
+      {
+        knowledgeSourceType: 's3',
+        countOfDocuments: 0,
+        outcome: TrackingOutcome.cancel,
+        success: true,
+      },
+    );
+  });
+
+  it('should fire with knowledgeSourceType: upload, success: false and an error message', () => {
+    fireAutoragKnowledgeSourceConfigured({
+      knowledgeSourceType: 'upload',
+      countOfDocuments: 0,
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: 'boom',
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
+      {
+        knowledgeSourceType: 'upload',
+        countOfDocuments: 0,
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: 'boom',
+      },
+    );
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -15,12 +15,14 @@ import {
   fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
   fireAutoragExperimentDeleted,
+  fireAutoragResultsViewed,
   fireAutoragRunReconfigured,
   fireAutoragRunRetried,
   fireAutoragRunStopped,
   fireAutoragRunTriggered,
   fireAutoragS3ConnectionCreated,
   fireAutoragVectorStoreConfigured,
+  isAutoragResultsNavigationState,
   mapOptimizationMetric,
   toVectorStoreProviderType,
 } from '~/app/utilities/tracking';
@@ -663,5 +665,38 @@ describe('fireAutoragEvaluationTemplateDownloaded', () => {
       AUTORAG_EVENTS.EVALUATION_TEMPLATE_DOWNLOADED,
       { downloadType: 'evaluationTemplate' },
     );
+  });
+});
+
+describe('fireAutoragResultsViewed', () => {
+  it('should fire AutoRAG Results Viewed with the given entrySource', () => {
+    fireAutoragResultsViewed('experimentsList');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RESULTS_VIEWED, {
+      entrySource: 'experimentsList',
+    });
+  });
+});
+
+describe('isAutoragResultsNavigationState', () => {
+  it.each(['experimentsList', 'notification', 'direct', 'other'] as const)(
+    'should accept entrySource: %s',
+    (entrySource) => {
+      expect(isAutoragResultsNavigationState({ entrySource })).toBe(true);
+    },
+  );
+
+  it('should reject an unknown entrySource', () => {
+    expect(isAutoragResultsNavigationState({ entrySource: 'somethingElse' })).toBe(false);
+  });
+
+  it('should reject state missing entrySource', () => {
+    expect(isAutoragResultsNavigationState({})).toBe(false);
+  });
+
+  it('should reject null/undefined/non-object state', () => {
+    expect(isAutoragResultsNavigationState(null)).toBe(false);
+    expect(isAutoragResultsNavigationState(undefined)).toBe(false);
+    expect(isAutoragResultsNavigationState('experimentsList')).toBe(false);
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -15,6 +15,7 @@ import {
   fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
   fireAutoragExperimentDeleted,
+  fireAutoragPlaygroundOpened,
   fireAutoragResultsViewed,
   fireAutoragRunReconfigured,
   fireAutoragRunRetried,
@@ -699,4 +700,17 @@ describe('isAutoragResultsNavigationState', () => {
     expect(isAutoragResultsNavigationState(undefined)).toBe(false);
     expect(isAutoragResultsNavigationState('experimentsList')).toBe(false);
   });
+});
+
+describe('fireAutoragPlaygroundOpened', () => {
+  it.each(['resultsTable', 'patternDetails', 'other'] as const)(
+    'should fire AutoRAG Playground Opened with source: %s',
+    (source) => {
+      fireAutoragPlaygroundOpened(source);
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.PLAYGROUND_OPENED, {
+        source,
+      });
+    },
+  );
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -8,6 +8,7 @@ import {
   fireAutoragEvaluationSourceConfigured,
   fireAutoragExperimentCreated,
   fireAutoragKnowledgeSourceConfigured,
+  fireAutoragModelsSelected,
   fireAutoragProjectDropdownOptionSelected,
 } from '~/app/utilities/tracking';
 
@@ -195,5 +196,39 @@ describe('fireAutoragEvaluationSourceConfigured', () => {
         error: 'boom',
       },
     );
+  });
+});
+
+describe('fireAutoragModelsSelected', () => {
+  it('should fire with outcome: submit and the selected model counts', () => {
+    fireAutoragModelsSelected({
+      countOfFoundationModels: 1,
+      countOfEmbeddingModels: 2,
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.MODELS_SELECTED, {
+      countOfFoundationModels: 1,
+      countOfEmbeddingModels: 2,
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+  });
+
+  it('should fire with outcome: cancel and zero counts when nothing is selected', () => {
+    fireAutoragModelsSelected({
+      countOfFoundationModels: 0,
+      countOfEmbeddingModels: 0,
+      outcome: TrackingOutcome.cancel,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.MODELS_SELECTED, {
+      countOfFoundationModels: 0,
+      countOfEmbeddingModels: 0,
+      outcome: TrackingOutcome.cancel,
+      success: true,
+    });
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -120,12 +120,12 @@ describe('fireAutoragKnowledgeSourceConfigured', () => {
     );
   });
 
-  it('should fire with outcome: cancel', () => {
+  it('should fire with outcome: cancel and success: false, since nothing was configured', () => {
     fireAutoragKnowledgeSourceConfigured({
       knowledgeSourceType: 's3',
       countOfDocuments: 0,
       outcome: TrackingOutcome.cancel,
-      success: true,
+      success: false,
     });
 
     expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
@@ -134,7 +134,7 @@ describe('fireAutoragKnowledgeSourceConfigured', () => {
         knowledgeSourceType: 's3',
         countOfDocuments: 0,
         outcome: TrackingOutcome.cancel,
-        success: true,
+        success: false,
       },
     );
   });
@@ -181,12 +181,12 @@ describe('fireAutoragEvaluationSourceConfigured', () => {
     );
   });
 
-  it('should fire with outcome: cancel', () => {
+  it('should fire with outcome: cancel and success: false, since nothing was configured', () => {
     fireAutoragEvaluationSourceConfigured({
       evaluationSourceType: 's3',
       countOfDocuments: 0,
       outcome: TrackingOutcome.cancel,
-      success: true,
+      success: false,
     });
 
     expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
@@ -195,7 +195,7 @@ describe('fireAutoragEvaluationSourceConfigured', () => {
         evaluationSourceType: 's3',
         countOfDocuments: 0,
         outcome: TrackingOutcome.cancel,
-        success: true,
+        success: false,
       },
     );
   });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -11,6 +11,7 @@ import {
   fireAutoragExperimentCreated,
   fireAutoragFlowExited,
   fireAutoragKnowledgeSourceConfigured,
+  fireAutoragLeaderboardPresetApplied,
   fireAutoragModelsSelected,
   fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
@@ -800,4 +801,23 @@ describe('fireAutoragCodeSnippetsExported', () => {
       action: 'copied',
     });
   });
+});
+
+describe('fireAutoragLeaderboardPresetApplied', () => {
+  it.each([
+    'optimizationMetrics',
+    'optimizationMetricsAndChunking',
+    'fullConfiguration',
+    'other',
+  ] as const)(
+    'should fire AutoRAG Leaderboard Preset Applied with presetType: %s',
+    (presetType) => {
+      fireAutoragLeaderboardPresetApplied(presetType);
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.LEADERBOARD_PRESET_APPLIED,
+        { presetType },
+      );
+    },
+  );
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -5,6 +5,7 @@ import {
 import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   AUTORAG_EVENTS,
+  fireAutoragEvaluationSourceConfigured,
   fireAutoragExperimentCreated,
   fireAutoragKnowledgeSourceConfigured,
   fireAutoragProjectDropdownOptionSelected,
@@ -127,6 +128,67 @@ describe('fireAutoragKnowledgeSourceConfigured', () => {
       AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED,
       {
         knowledgeSourceType: 'upload',
+        countOfDocuments: 0,
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: 'boom',
+      },
+    );
+  });
+});
+
+describe('fireAutoragEvaluationSourceConfigured', () => {
+  it('should fire with evaluationSourceType: s3 and outcome: submit', () => {
+    fireAutoragEvaluationSourceConfigured({
+      evaluationSourceType: 's3',
+      countOfDocuments: 1,
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED,
+      {
+        evaluationSourceType: 's3',
+        countOfDocuments: 1,
+        outcome: TrackingOutcome.submit,
+        success: true,
+      },
+    );
+  });
+
+  it('should fire with outcome: cancel', () => {
+    fireAutoragEvaluationSourceConfigured({
+      evaluationSourceType: 's3',
+      countOfDocuments: 0,
+      outcome: TrackingOutcome.cancel,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED,
+      {
+        evaluationSourceType: 's3',
+        countOfDocuments: 0,
+        outcome: TrackingOutcome.cancel,
+        success: true,
+      },
+    );
+  });
+
+  it('should fire with evaluationSourceType: upload, success: false and an error message', () => {
+    fireAutoragEvaluationSourceConfigured({
+      evaluationSourceType: 'upload',
+      countOfDocuments: 0,
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: 'boom',
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED,
+      {
+        evaluationSourceType: 'upload',
         countOfDocuments: 0,
         outcome: TrackingOutcome.submit,
         success: false,

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -11,6 +11,8 @@ import {
   fireAutoragKnowledgeSourceConfigured,
   fireAutoragModelsSelected,
   fireAutoragProjectDropdownOptionSelected,
+  fireAutoragVectorStoreConfigured,
+  toVectorStoreProviderType,
 } from '~/app/utilities/tracking';
 
 jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
@@ -229,6 +231,39 @@ describe('fireAutoragModelsSelected', () => {
       countOfFoundationModels: 0,
       countOfEmbeddingModels: 0,
       outcome: TrackingOutcome.cancel,
+      success: true,
+    });
+  });
+});
+
+describe('toVectorStoreProviderType', () => {
+  it('should map remote::milvus to milvus', () => {
+    expect(toVectorStoreProviderType('remote::milvus')).toBe('milvus');
+  });
+
+  it('should map remote::pgvector to pgvector', () => {
+    expect(toVectorStoreProviderType('remote::pgvector')).toBe('pgvector');
+  });
+
+  it('should return undefined for an unrecognized provider type', () => {
+    expect(toVectorStoreProviderType('inline::faiss')).toBeUndefined();
+    expect(toVectorStoreProviderType('')).toBeUndefined();
+  });
+});
+
+describe('fireAutoragVectorStoreConfigured', () => {
+  it('should fire with the categorized provider type and compatible provider count', () => {
+    fireAutoragVectorStoreConfigured({
+      providerType: 'milvus',
+      countOfCompatibleProviders: 2,
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.VECTOR_STORE_CONFIGURED, {
+      providerType: 'milvus',
+      countOfCompatibleProviders: 2,
+      outcome: TrackingOutcome.submit,
       success: true,
     });
   });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -14,6 +14,7 @@ import {
   fireAutoragModelsSelected,
   fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
+  fireAutoragCodeSnippetsExported,
   fireAutoragExperimentDeleted,
   fireAutoragNotebookDownloaded,
   fireAutoragPatternDetailsDownloadInitiated,
@@ -776,5 +777,27 @@ describe('fireAutoragPatternDetailsDownloadInitiated', () => {
       AUTORAG_EVENTS.PATTERN_DETAILS_DOWNLOAD_INITIATED,
       { downloadType: 'patternDetails' },
     );
+  });
+});
+
+describe('fireAutoragCodeSnippetsExported', () => {
+  it.each(['playground', 'resultsTable', 'patternDetails', 'other'] as const)(
+    'should fire AutoRAG Code Snippets Exported with action: viewed and entrySource: %s',
+    (entrySource) => {
+      fireAutoragCodeSnippetsExported('viewed', entrySource);
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.CODE_SNIPPETS_EXPORTED,
+        { action: 'viewed', entrySource },
+      );
+    },
+  );
+
+  it('should fire AutoRAG Code Snippets Exported with action: copied and no entrySource', () => {
+    fireAutoragCodeSnippetsExported('copied');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.CODE_SNIPPETS_EXPORTED, {
+      action: 'copied',
+    });
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -16,6 +16,7 @@ import {
   fireAutoragProjectDropdownOptionSelected,
   fireAutoragExperimentDeleted,
   fireAutoragNotebookDownloaded,
+  fireAutoragPatternDetailsViewed,
   fireAutoragPlaygroundOpened,
   fireAutoragResultsColumnToggled,
   fireAutoragResultsViewed,
@@ -747,6 +748,20 @@ describe('fireAutoragResultsColumnToggled', () => {
       expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
         AUTORAG_EVENTS.RESULTS_COLUMN_TOGGLED,
         { columnName, isVisible },
+      );
+    },
+  );
+});
+
+describe('fireAutoragPatternDetailsViewed', () => {
+  it.each(['resultsTable', 'pipelineVis', 'other'] as const)(
+    'should fire AutoRAG Pattern Details Viewed with source: %s',
+    (source) => {
+      fireAutoragPatternDetailsViewed(source);
+
+      expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+        AUTORAG_EVENTS.PATTERN_DETAILS_VIEWED,
+        { source },
       );
     },
   );

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -5,6 +5,7 @@ import {
 import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   AUTORAG_EVENTS,
+  AUTORAG_FAILURE_CATEGORY,
   fireAutoragEvaluationSourceConfigured,
   fireAutoragExperimentCreated,
   fireAutoragKnowledgeSourceConfigured,
@@ -60,19 +61,19 @@ describe('fireAutoragExperimentCreated', () => {
     });
   });
 
-  it('should pass through success: false and error when provided', () => {
+  it('should pass through success: false and an allowlisted failure category when provided', () => {
     fireAutoragExperimentCreated({
       outcome: TrackingOutcome.submit,
       hasDescription: false,
       success: false,
-      error: 'boom',
+      error: AUTORAG_FAILURE_CATEGORY,
     });
 
     expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_CREATED, {
       outcome: TrackingOutcome.submit,
       hasDescription: false,
       success: false,
-      error: 'boom',
+      error: AUTORAG_FAILURE_CATEGORY,
     });
   });
 });
@@ -116,13 +117,13 @@ describe('fireAutoragKnowledgeSourceConfigured', () => {
     );
   });
 
-  it('should fire with knowledgeSourceType: upload, success: false and an error message', () => {
+  it('should fire with knowledgeSourceType: upload, success: false and an allowlisted failure category', () => {
     fireAutoragKnowledgeSourceConfigured({
       knowledgeSourceType: 'upload',
       countOfDocuments: 0,
       outcome: TrackingOutcome.submit,
       success: false,
-      error: 'boom',
+      error: AUTORAG_FAILURE_CATEGORY,
     });
 
     expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
@@ -132,7 +133,7 @@ describe('fireAutoragKnowledgeSourceConfigured', () => {
         countOfDocuments: 0,
         outcome: TrackingOutcome.submit,
         success: false,
-        error: 'boom',
+        error: AUTORAG_FAILURE_CATEGORY,
       },
     );
   });
@@ -177,13 +178,13 @@ describe('fireAutoragEvaluationSourceConfigured', () => {
     );
   });
 
-  it('should fire with evaluationSourceType: upload, success: false and an error message', () => {
+  it('should fire with evaluationSourceType: upload, success: false and an allowlisted failure category', () => {
     fireAutoragEvaluationSourceConfigured({
       evaluationSourceType: 'upload',
       countOfDocuments: 0,
       outcome: TrackingOutcome.submit,
       success: false,
-      error: 'boom',
+      error: AUTORAG_FAILURE_CATEGORY,
     });
 
     expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
@@ -193,7 +194,7 @@ describe('fireAutoragEvaluationSourceConfigured', () => {
         countOfDocuments: 0,
         outcome: TrackingOutcome.submit,
         success: false,
-        error: 'boom',
+        error: AUTORAG_FAILURE_CATEGORY,
       },
     );
   });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -13,6 +13,7 @@ import {
   fireAutoragModelsSelected,
   fireAutoragProjectDropdownOptionSelected,
   fireAutoragRunTriggered,
+  fireAutoragS3ConnectionCreated,
   fireAutoragVectorStoreConfigured,
   mapOptimizationMetric,
   toVectorStoreProviderType,
@@ -382,6 +383,39 @@ describe('fireAutoragFlowExited', () => {
       exitType: 'navigate',
       lastFunnelStep: 'run',
       exitDestination: 'otherGenAi',
+    });
+  });
+});
+
+describe('fireAutoragS3ConnectionCreated', () => {
+  it('should fire with outcome: submit and success: true', () => {
+    fireAutoragS3ConnectionCreated({ outcome: TrackingOutcome.submit, success: true });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.S3_CONNECTION_CREATED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+  });
+
+  it('should fire with outcome: submit, success: false, and the allowlisted failure category', () => {
+    fireAutoragS3ConnectionCreated({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.S3_CONNECTION_CREATED, {
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
+    });
+  });
+
+  it('should fire with outcome: cancel and no success/error', () => {
+    fireAutoragS3ConnectionCreated({ outcome: TrackingOutcome.cancel });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.S3_CONNECTION_CREATED, {
+      outcome: TrackingOutcome.cancel,
     });
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -1,0 +1,75 @@
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import {
+  AUTORAG_EVENTS,
+  fireAutoragExperimentCreated,
+  fireAutoragProjectDropdownOptionSelected,
+} from '~/app/utilities/tracking';
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireFormTrackingEvent: jest.fn(),
+  fireMiscTrackingEvent: jest.fn(),
+}));
+
+const fireFormTrackingEventMock = jest.mocked(fireFormTrackingEvent);
+const fireMiscTrackingEventMock = jest.mocked(fireMiscTrackingEvent);
+
+describe('fireAutoragProjectDropdownOptionSelected', () => {
+  it('should fire AutoRAG Project Dropdown Option Selected with the selected project', () => {
+    fireAutoragProjectDropdownOptionSelected('test-namespace');
+
+    expect(fireMiscTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.PROJECT_DROPDOWN_OPTION_SELECTED,
+      { selectedProject: 'test-namespace' },
+    );
+  });
+});
+
+describe('fireAutoragExperimentCreated', () => {
+  it('should fire AutoRAG Experiment Created with outcome: submit and hasDescription: true', () => {
+    fireAutoragExperimentCreated({
+      outcome: TrackingOutcome.submit,
+      hasDescription: true,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_CREATED, {
+      outcome: TrackingOutcome.submit,
+      hasDescription: true,
+      success: true,
+    });
+  });
+
+  it('should fire AutoRAG Experiment Created with outcome: cancel and hasDescription: false', () => {
+    fireAutoragExperimentCreated({
+      outcome: TrackingOutcome.cancel,
+      hasDescription: false,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_CREATED, {
+      outcome: TrackingOutcome.cancel,
+      hasDescription: false,
+      success: true,
+    });
+  });
+
+  it('should pass through success: false and error when provided', () => {
+    fireAutoragExperimentCreated({
+      outcome: TrackingOutcome.submit,
+      hasDescription: false,
+      success: false,
+      error: 'boom',
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.EXPERIMENT_CREATED, {
+      outcome: TrackingOutcome.submit,
+      hasDescription: false,
+      success: false,
+      error: 'boom',
+    });
+  });
+});

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -6,6 +6,7 @@ import { TrackingOutcome } from '@odh-dashboard/ui-core';
 import {
   AUTORAG_EVENTS,
   AUTORAG_FAILURE_CATEGORY,
+  buildRunReconfiguredChangedFields,
   fireAutoragEvaluationSourceConfigured,
   fireAutoragExperimentCreated,
   fireAutoragFlowExited,
@@ -13,6 +14,7 @@ import {
   fireAutoragModelsSelected,
   fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
+  fireAutoragRunReconfigured,
   fireAutoragRunTriggered,
   fireAutoragS3ConnectionCreated,
   fireAutoragVectorStoreConfigured,
@@ -352,6 +354,129 @@ describe('fireAutoragRunTriggered', () => {
       outcome: TrackingOutcome.submit,
       success: false,
       error: AUTORAG_FAILURE_CATEGORY,
+    });
+  });
+});
+
+describe('buildRunReconfiguredChangedFields', () => {
+  it('should return an empty array when nothing changed', () => {
+    expect(
+      buildRunReconfiguredChangedFields({
+        knowledgeSourceTypeChanged: false,
+        evaluationSourceTypeChanged: false,
+        optimizationMetricChanged: false,
+        vectorDatabaseChanged: false,
+        modelsChanged: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it('should list every field that changed, in a fixed order', () => {
+    expect(
+      buildRunReconfiguredChangedFields({
+        knowledgeSourceTypeChanged: true,
+        evaluationSourceTypeChanged: true,
+        optimizationMetricChanged: true,
+        vectorDatabaseChanged: true,
+        modelsChanged: true,
+      }),
+    ).toEqual([
+      'knowledgeSourceType',
+      'evaluationSourceType',
+      'optimizationMetric',
+      'vectorDatabase',
+      'models',
+    ]);
+  });
+
+  it('should list only the fields that changed', () => {
+    expect(
+      buildRunReconfiguredChangedFields({
+        knowledgeSourceTypeChanged: false,
+        evaluationSourceTypeChanged: true,
+        optimizationMetricChanged: false,
+        vectorDatabaseChanged: false,
+        modelsChanged: true,
+      }),
+    ).toEqual(['evaluationSourceType', 'models']);
+  });
+});
+
+describe('fireAutoragRunReconfigured', () => {
+  it('should join changedFields with a comma and fire with success: true on submit', () => {
+    fireAutoragRunReconfigured({
+      knowledgeSourceType: 's3',
+      evaluationSourceType: undefined,
+      optimizationMetric: 'answerFaithfulness',
+      vectorDatabase: 'milvus',
+      countOfFoundationModels: 2,
+      countOfEmbeddingModels: 1,
+      changedFields: ['knowledgeSourceType', 'optimizationMetric'],
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_RECONFIGURED, {
+      knowledgeSourceType: 's3',
+      evaluationSourceType: undefined,
+      optimizationMetric: 'answerFaithfulness',
+      vectorDatabase: 'milvus',
+      countOfFoundationModels: 2,
+      countOfEmbeddingModels: 1,
+      changedFields: 'knowledgeSourceType,optimizationMetric',
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+  });
+
+  it('should fire an empty string for changedFields when nothing changed', () => {
+    fireAutoragRunReconfigured({
+      countOfFoundationModels: 1,
+      countOfEmbeddingModels: 1,
+      changedFields: [],
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.RUN_RECONFIGURED,
+      expect.objectContaining({ changedFields: '' }),
+    );
+  });
+
+  it('should fire with success: false and the allowlisted error category on failure', () => {
+    fireAutoragRunReconfigured({
+      countOfFoundationModels: 1,
+      countOfEmbeddingModels: 0,
+      changedFields: ['models'],
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(
+      AUTORAG_EVENTS.RUN_RECONFIGURED,
+      expect.objectContaining({
+        outcome: TrackingOutcome.submit,
+        success: false,
+        error: 'actionFailed',
+      }),
+    );
+  });
+
+  it('should fire with outcome: cancel and no success field', () => {
+    fireAutoragRunReconfigured({
+      countOfFoundationModels: 1,
+      countOfEmbeddingModels: 0,
+      changedFields: [],
+      outcome: TrackingOutcome.cancel,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_RECONFIGURED, {
+      countOfFoundationModels: 1,
+      countOfEmbeddingModels: 0,
+      changedFields: '',
+      outcome: TrackingOutcome.cancel,
     });
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -11,7 +11,9 @@ import {
   fireAutoragKnowledgeSourceConfigured,
   fireAutoragModelsSelected,
   fireAutoragProjectDropdownOptionSelected,
+  fireAutoragRunTriggered,
   fireAutoragVectorStoreConfigured,
+  mapOptimizationMetric,
   toVectorStoreProviderType,
 } from '~/app/utilities/tracking';
 
@@ -265,6 +267,88 @@ describe('fireAutoragVectorStoreConfigured', () => {
       countOfCompatibleProviders: 2,
       outcome: TrackingOutcome.submit,
       success: true,
+    });
+  });
+});
+
+describe('mapOptimizationMetric', () => {
+  it('should map all four schema values to their camelCase taxonomy', () => {
+    expect(mapOptimizationMetric('overall_score')).toBe('overallScore');
+    expect(mapOptimizationMetric('faithfulness')).toBe('answerFaithfulness');
+    expect(mapOptimizationMetric('answer_correctness')).toBe('answerCorrectness');
+    expect(mapOptimizationMetric('context_correctness')).toBe('contextCorrectness');
+  });
+
+  it('should return undefined for an unrecognized metric', () => {
+    expect(mapOptimizationMetric('answer_relevance')).toBeUndefined();
+    expect(mapOptimizationMetric('')).toBeUndefined();
+  });
+});
+
+describe('fireAutoragRunTriggered', () => {
+  it('should fire with success: true and the full derived run configuration', () => {
+    fireAutoragRunTriggered({
+      knowledgeSourceType: 's3',
+      evaluationSourceType: 'upload',
+      optimizationMetric: 'overallScore',
+      vectorDatabase: 'milvus',
+      countOfModels: 3,
+      countOfKnowledgeDocuments: 1,
+      countOfEvaluationDocuments: 1,
+      countOfFoundationModels: 2,
+      countOfEmbeddingModels: 1,
+      hasS3Connection: true,
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_TRIGGERED, {
+      knowledgeSourceType: 's3',
+      evaluationSourceType: 'upload',
+      optimizationMetric: 'overallScore',
+      vectorDatabase: 'milvus',
+      countOfModels: 3,
+      countOfKnowledgeDocuments: 1,
+      countOfEvaluationDocuments: 1,
+      countOfFoundationModels: 2,
+      countOfEmbeddingModels: 1,
+      hasS3Connection: true,
+      outcome: TrackingOutcome.submit,
+      success: true,
+    });
+  });
+
+  it('should pass through undefined source/vector properties and an allowlisted failure category on failure', () => {
+    fireAutoragRunTriggered({
+      knowledgeSourceType: undefined,
+      evaluationSourceType: undefined,
+      optimizationMetric: undefined,
+      vectorDatabase: undefined,
+      countOfModels: 0,
+      countOfKnowledgeDocuments: 0,
+      countOfEvaluationDocuments: 0,
+      countOfFoundationModels: 0,
+      countOfEmbeddingModels: 0,
+      hasS3Connection: false,
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_TRIGGERED, {
+      knowledgeSourceType: undefined,
+      evaluationSourceType: undefined,
+      optimizationMetric: undefined,
+      vectorDatabase: undefined,
+      countOfModels: 0,
+      countOfKnowledgeDocuments: 0,
+      countOfEvaluationDocuments: 0,
+      countOfFoundationModels: 0,
+      countOfEmbeddingModels: 0,
+      hasS3Connection: false,
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
     });
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
+++ b/packages/autorag/frontend/src/app/utilities/__tests__/tracking.spec.ts
@@ -15,6 +15,7 @@ import {
   fireAutoragEvaluationTemplateDownloaded,
   fireAutoragProjectDropdownOptionSelected,
   fireAutoragRunReconfigured,
+  fireAutoragRunStopped,
   fireAutoragRunTriggered,
   fireAutoragS3ConnectionCreated,
   fireAutoragVectorStoreConfigured,
@@ -477,6 +478,43 @@ describe('fireAutoragRunReconfigured', () => {
       countOfEmbeddingModels: 0,
       changedFields: '',
       outcome: TrackingOutcome.cancel,
+    });
+  });
+});
+
+describe('fireAutoragRunStopped', () => {
+  it('should fire with outcome: submit and success: true, given a source', () => {
+    fireAutoragRunStopped({ outcome: TrackingOutcome.submit, success: true, source: 'runsList' });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_STOPPED, {
+      outcome: TrackingOutcome.submit,
+      success: true,
+      source: 'runsList',
+    });
+  });
+
+  it('should fire with success: false and the allowlisted failure category on failure', () => {
+    fireAutoragRunStopped({
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
+      source: 'resultsPage',
+    });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_STOPPED, {
+      outcome: TrackingOutcome.submit,
+      success: false,
+      error: AUTORAG_FAILURE_CATEGORY,
+      source: 'resultsPage',
+    });
+  });
+
+  it('should fire with outcome: cancel and no success/error', () => {
+    fireAutoragRunStopped({ outcome: TrackingOutcome.cancel, source: 'runsList' });
+
+    expect(fireFormTrackingEventMock).toHaveBeenCalledWith(AUTORAG_EVENTS.RUN_STOPPED, {
+      outcome: TrackingOutcome.cancel,
+      source: 'runsList',
     });
   });
 });

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -9,6 +9,7 @@ export { TrackingOutcome };
 export const AUTORAG_EVENTS = {
   PROJECT_DROPDOWN_OPTION_SELECTED: 'AutoRAG Project Dropdown Option Selected',
   EXPERIMENT_CREATED: 'AutoRAG Experiment Created',
+  KNOWLEDGE_SOURCE_CONFIGURED: 'AutoRAG Knowledge Source Configured',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -33,4 +34,27 @@ export type ExperimentCreatedProperties = {
  */
 export const fireAutoragExperimentCreated = (properties: ExperimentCreatedProperties): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.EXPERIMENT_CREATED, properties);
+};
+
+export type KnowledgeSourceType = 's3' | 'upload';
+
+export type KnowledgeSourceConfiguredProperties = {
+  knowledgeSourceType: KnowledgeSourceType;
+  countOfDocuments: number;
+  outcome: TrackingOutcome;
+  success: boolean;
+  error?: string;
+};
+
+/**
+ * Fires when the user completes (or abandons) the "Knowledge setup" milestone on the configure
+ * step — selecting a file/folder from an S3 connection via the file browser, or uploading a file
+ * directly. `outcome: submit` covers both a successful selection/upload and a failed upload
+ * attempt (see `success`/`error`); `outcome: cancel` fires when the S3 browser is dismissed
+ * without a selection being made.
+ */
+export const fireAutoragKnowledgeSourceConfigured = (
+  properties: KnowledgeSourceConfiguredProperties,
+): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED, properties);
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -22,6 +22,7 @@ export const AUTORAG_EVENTS = {
   RUN_TRIGGERED: 'AutoRAG Run Triggered',
   RUN_RECONFIGURED: 'AutoRAG Run Reconfigured',
   RUN_STOPPED: 'AutoRAG Run Stopped',
+  RUN_RETRIED: 'AutoRAG Run Retried',
   FLOW_EXITED: 'AutoRAG Flow Exited',
   S3_CONNECTION_CREATED: 'AutoRAG S3 Connection Created',
   EVALUATION_TEMPLATE_DOWNLOADED: 'AutoRAG Evaluation Template Downloaded',
@@ -340,6 +341,16 @@ export type RunOutcomeTrackingProperties = {
  */
 export const fireAutoragRunStopped = (properties: RunOutcomeTrackingProperties): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.RUN_STOPPED, properties);
+};
+
+/**
+ * Fires when the user retries a run via the runs table's kebab menu (`source: 'runsList'`) or
+ * the results page's header button (`source: 'resultsPage'`). Unlike stop, retry has no
+ * confirmation modal — it's a direct action — so this always fires with `outcome: submit`,
+ * with `success`/`error` reflecting whether the retry request succeeded.
+ */
+export const fireAutoragRunRetried = (properties: RunOutcomeTrackingProperties): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.RUN_RETRIED, properties);
 };
 
 /**

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -27,6 +27,7 @@ export const AUTORAG_EVENTS = {
   FLOW_EXITED: 'AutoRAG Flow Exited',
   S3_CONNECTION_CREATED: 'AutoRAG S3 Connection Created',
   EVALUATION_TEMPLATE_DOWNLOADED: 'AutoRAG Evaluation Template Downloaded',
+  RESULTS_VIEWED: 'AutoRAG Results Viewed',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -363,6 +364,38 @@ export const fireAutoragRunRetried = (properties: RunOutcomeTrackingProperties):
  */
 export const fireAutoragExperimentDeleted = (properties: RunOutcomeTrackingProperties): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.EXPERIMENT_DELETED, properties);
+};
+
+/** Where the user came from when navigating to the results page. */
+export type AutoragResultsEntrySource = 'experimentsList' | 'notification' | 'direct' | 'other';
+
+/** Router `location.state` shape set by links/navigations that lead to the results page. */
+export type AutoragResultsNavigationState = {
+  entrySource: AutoragResultsEntrySource;
+};
+
+export const isAutoragResultsNavigationState = (
+  state: unknown,
+): state is AutoragResultsNavigationState => {
+  if (!state || typeof state !== 'object' || !('entrySource' in state)) {
+    return false;
+  }
+  const { entrySource } = state;
+  return (
+    entrySource === 'experimentsList' ||
+    entrySource === 'notification' ||
+    entrySource === 'direct' ||
+    entrySource === 'other'
+  );
+};
+
+/**
+ * Fires once per run when the results page finishes loading a run. `entrySource` is read from
+ * router state set by the link/navigation that brought the user here, falling back to `'other'`
+ * when the page was reached without that state (e.g. a bookmarked/pasted URL or a page refresh).
+ */
+export const fireAutoragResultsViewed = (entrySource: AutoragResultsEntrySource): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.RESULTS_VIEWED, { entrySource });
 };
 
 /**

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -18,11 +18,25 @@ export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string
   fireMiscTrackingEvent(AUTORAG_EVENTS.PROJECT_DROPDOWN_OPTION_SELECTED, { selectedProject });
 };
 
+/**
+ * Allowlisted, non-sensitive failure category for outcome-tracking `error` fields.
+ * `Error.message` from upload, selection, and configuration failures may originate from the
+ * backend, a proxy, or a dependency, and can embed credentials, tenant identifiers, resource
+ * details, user input, or internal endpoint information. Never forward a raw error message into
+ * analytics — detailed messages belong only in the in-product notification shown via
+ * `useNotification`. Callers must map caught errors to this fixed set before passing them to an
+ * outcome-tracking event.
+ */
+export type AutoragFailureCategory = 'actionFailed';
+
+/** The single allowlisted failure category currently in use — see {@link AutoragFailureCategory}. */
+export const AUTORAG_FAILURE_CATEGORY: AutoragFailureCategory = 'actionFailed';
+
 export type ExperimentCreatedProperties = {
   outcome: TrackingOutcome;
   hasDescription: boolean;
   success?: boolean;
-  error?: string;
+  error?: AutoragFailureCategory;
 };
 
 /**
@@ -45,7 +59,7 @@ export type KnowledgeSourceConfiguredProperties = {
   countOfDocuments: number;
   outcome: TrackingOutcome;
   success: boolean;
-  error?: string;
+  error?: AutoragFailureCategory;
 };
 
 /**
@@ -68,7 +82,7 @@ export type EvaluationSourceConfiguredProperties = {
   countOfDocuments: number;
   outcome: TrackingOutcome;
   success: boolean;
-  error?: string;
+  error?: AutoragFailureCategory;
 };
 
 /**
@@ -89,7 +103,7 @@ export type ModelsSelectedProperties = {
   countOfEmbeddingModels: number;
   outcome: TrackingOutcome;
   success: boolean;
-  error?: string;
+  error?: AutoragFailureCategory;
 };
 
 /**

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -23,6 +23,7 @@ export const AUTORAG_EVENTS = {
   RUN_RECONFIGURED: 'AutoRAG Run Reconfigured',
   RUN_STOPPED: 'AutoRAG Run Stopped',
   RUN_RETRIED: 'AutoRAG Run Retried',
+  EXPERIMENT_DELETED: 'AutoRAG Experiment Deleted',
   FLOW_EXITED: 'AutoRAG Flow Exited',
   S3_CONNECTION_CREATED: 'AutoRAG S3 Connection Created',
   EVALUATION_TEMPLATE_DOWNLOADED: 'AutoRAG Evaluation Template Downloaded',
@@ -351,6 +352,17 @@ export const fireAutoragRunStopped = (properties: RunOutcomeTrackingProperties):
  */
 export const fireAutoragRunRetried = (properties: RunOutcomeTrackingProperties): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.RUN_RETRIED, properties);
+};
+
+/**
+ * Fires from the "Delete AutoRAG optimization run?" confirmation modal, reachable from the
+ * experiments list's kebab menu (`source: 'runsList'`). `outcome: cancel` fires when the modal
+ * is dismissed (Cancel, X, Escape, backdrop) before the delete has been submitted — no backend
+ * call has been made yet, so `success` is omitted in that case. `outcome: submit` fires once the
+ * delete request resolves, with `success`/`error` reflecting whether it succeeded.
+ */
+export const fireAutoragExperimentDeleted = (properties: RunOutcomeTrackingProperties): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.EXPERIMENT_DELETED, properties);
 };
 
 /**

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -35,6 +35,7 @@ export const AUTORAG_EVENTS = {
   PATTERN_DETAILS_DOWNLOAD_INITIATED: 'AutoRAG Pattern Details Download Initiated',
   CODE_SNIPPETS_EXPORTED: 'AutoRAG Code Snippets Exported',
   LEADERBOARD_PRESET_APPLIED: 'AutoRAG Leaderboard Preset Applied',
+  PATTERNS_COMPARED: 'AutoRAG Patterns Compared',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -639,4 +640,46 @@ export type LeaderboardPresetType =
  */
 export const fireAutoragLeaderboardPresetApplied = (presetType: LeaderboardPresetType): void => {
   fireMiscTrackingEvent(AUTORAG_EVENTS.LEADERBOARD_PRESET_APPLIED, { presetType });
+};
+
+/**
+ * Whether this comparison selection was the first one made after enabling "Compare patterns"
+ * (`'initial'`), or a subsequent swap via "Change comparison" (`'changed'`) — surfaces whether
+ * users settle on one comparison or keep exploring different pairings.
+ */
+export type PatternComparedInteractionType = 'initial' | 'changed';
+
+/**
+ * Rounds a raw score delta to 4 decimal places to avoid floating-point noise (e.g.
+ * `0.45 - 0.66` producing `-0.21000000000000002`) leaking into analytics payloads.
+ */
+const roundScoreDifference = (value: number): number => Math.round(value * 10000) / 10000;
+
+/**
+ * Fires when the user confirms a pattern selection in the pattern details modal's comparison
+ * select modal — both for the initial "Compare patterns" selection and for a subsequent "Change
+ * comparison" swap to a different pattern. The comparison feature is a fixed 1-vs-1 pairing (a
+ * single `comparisonPatternIndex`, not a multi-select), so there is no meaningful
+ * "how many patterns at once" count to report — it is always exactly 2 (primary + comparison).
+ *
+ * `rankDifference` is signed: `comparisonRank - primaryRank`. Ranks are unique 1-based integers
+ * (see `computePatternRankMap`), so this is always well-defined and comparable across every run
+ * regardless of which metric is optimized.
+ *
+ * `scoreDifference` is signed: `comparisonScore - primaryScore` (each pattern's optimized-metric
+ * mean score). Left as a raw number (rather than a bucketed 'better'/'worse'/'tie' category) for
+ * full precision within a given run/metric — note that unlike `rankDifference`, raw score deltas
+ * from different runs aren't necessarily on the same scale if they optimize different metrics, so
+ * this field is best analyzed per-run/per-metric rather than aggregated wholesale across events.
+ */
+export const fireAutoragPatternsCompared = (
+  interactionType: PatternComparedInteractionType,
+  rankDifference: number,
+  scoreDifference: number,
+): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.PATTERNS_COMPARED, {
+    interactionType,
+    rankDifference,
+    scoreDifference: roundScoreDifference(scoreDifference),
+  });
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -34,6 +34,7 @@ export const AUTORAG_EVENTS = {
   PATTERN_DETAILS_VIEWED: 'AutoRAG Pattern Details Viewed',
   PATTERN_DETAILS_DOWNLOAD_INITIATED: 'AutoRAG Pattern Details Download Initiated',
   CODE_SNIPPETS_EXPORTED: 'AutoRAG Code Snippets Exported',
+  LEADERBOARD_PRESET_APPLIED: 'AutoRAG Leaderboard Preset Applied',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -615,4 +616,27 @@ export const fireAutoragCodeSnippetsExported = (
     action,
     ...(entrySource ? { entrySource } : {}),
   });
+};
+
+/**
+ * Discrete, bounded identity for a "Manage columns" quick-select preset, independent of its
+ * display label. `'other'` is a defensive catch-all for any future preset added before this
+ * taxonomy is updated.
+ */
+export type LeaderboardPresetType =
+  | 'optimizationMetrics'
+  | 'optimizationMetricsAndChunking'
+  | 'fullConfiguration'
+  | 'other';
+
+/**
+ * Fires when the user selects a preset from the "Manage columns" modal's "Quick select" control
+ * (applying that preset's column set to the current view). Does not fire for the underlying
+ * column visibility changes themselves — those are covered by
+ * {@link fireAutoragResultsColumnToggled} on Save. Fires on selection, not gated by whether the
+ * modal is subsequently saved or cancelled, since choosing the preset is itself the signal we
+ * care about.
+ */
+export const fireAutoragLeaderboardPresetApplied = (presetType: LeaderboardPresetType): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.LEADERBOARD_PRESET_APPLIED, { presetType });
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -1,0 +1,36 @@
+import { TrackingOutcome } from '@odh-dashboard/ui-core';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+
+export { TrackingOutcome };
+
+export const AUTORAG_EVENTS = {
+  PROJECT_DROPDOWN_OPTION_SELECTED: 'AutoRAG Project Dropdown Option Selected',
+  EXPERIMENT_CREATED: 'AutoRAG Experiment Created',
+} as const;
+
+export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.PROJECT_DROPDOWN_OPTION_SELECTED, { selectedProject });
+};
+
+export type ExperimentCreatedProperties = {
+  outcome: TrackingOutcome;
+  hasDescription: boolean;
+  success?: boolean;
+  error?: string;
+};
+
+/**
+ * Fires when the user leaves the "Define Details" (name/description/connection) step of the
+ * create-experiment flow — either moving forward (outcome: submit) or cancelling out
+ * (outcome: cancel). This is a pure local step transition with no backend call, so `success` is
+ * always `true` and `error` is omitted when submitting (the Next button is disabled until the
+ * step's fields are valid). Full run configuration metadata (optimization metric, source types,
+ * models, vector DB) is captured later, on AutoRAG Run Triggered, once the Knowledge/Eval/Models
+ * sections of the configure step are also complete.
+ */
+export const fireAutoragExperimentCreated = (properties: ExperimentCreatedProperties): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.EXPERIMENT_CREATED, properties);
+};

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -10,6 +10,7 @@ export const AUTORAG_EVENTS = {
   PROJECT_DROPDOWN_OPTION_SELECTED: 'AutoRAG Project Dropdown Option Selected',
   EXPERIMENT_CREATED: 'AutoRAG Experiment Created',
   KNOWLEDGE_SOURCE_CONFIGURED: 'AutoRAG Knowledge Source Configured',
+  EVALUATION_SOURCE_CONFIGURED: 'AutoRAG Evaluation Source Configured',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -57,4 +58,27 @@ export const fireAutoragKnowledgeSourceConfigured = (
   properties: KnowledgeSourceConfiguredProperties,
 ): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.KNOWLEDGE_SOURCE_CONFIGURED, properties);
+};
+
+export type EvaluationSourceType = 's3' | 'upload';
+
+export type EvaluationSourceConfiguredProperties = {
+  evaluationSourceType: EvaluationSourceType;
+  countOfDocuments: number;
+  outcome: TrackingOutcome;
+  success: boolean;
+  error?: string;
+};
+
+/**
+ * Fires when the user completes (or abandons) the "Evaluation source" milestone on the configure
+ * step — selecting a JSON file from an S3 connection via the file browser, or uploading one
+ * directly. `outcome: submit` covers both a successful selection/upload and a failed upload
+ * attempt (see `success`/`error`); `outcome: cancel` fires when the S3 browser is dismissed
+ * without a selection being made.
+ */
+export const fireAutoragEvaluationSourceConfigured = (
+  properties: EvaluationSourceConfiguredProperties,
+): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED, properties);
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -20,6 +20,7 @@ export const AUTORAG_EVENTS = {
   MODELS_SELECTED: 'AutoRAG Models Selected',
   VECTOR_STORE_CONFIGURED: 'AutoRAG Vector Store Configured',
   RUN_TRIGGERED: 'AutoRAG Run Triggered',
+  RUN_RECONFIGURED: 'AutoRAG Run Reconfigured',
   FLOW_EXITED: 'AutoRAG Flow Exited',
   S3_CONNECTION_CREATED: 'AutoRAG S3 Connection Created',
   EVALUATION_TEMPLATE_DOWNLOADED: 'AutoRAG Evaluation Template Downloaded',
@@ -235,6 +236,82 @@ export type RunTriggeredProperties = {
  */
 export const fireAutoragRunTriggered = (properties: RunTriggeredProperties): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.RUN_TRIGGERED, properties);
+};
+
+/**
+ * Converts the individual "did this section change vs. the source run" signals into the
+ * `changedFields` list used by {@link fireAutoragRunReconfigured}. Centralized so the field-name
+ * taxonomy — and the "actually reselected" vs. "value differs" distinction per field, see that
+ * function's doc comment — lives in one tested place instead of being duplicated at each call
+ * site.
+ */
+export const buildRunReconfiguredChangedFields = (signals: {
+  knowledgeSourceTypeChanged: boolean;
+  evaluationSourceTypeChanged: boolean;
+  optimizationMetricChanged: boolean;
+  vectorDatabaseChanged: boolean;
+  modelsChanged: boolean;
+}): string[] => {
+  const changedFields: string[] = [];
+  if (signals.knowledgeSourceTypeChanged) {
+    changedFields.push('knowledgeSourceType');
+  }
+  if (signals.evaluationSourceTypeChanged) {
+    changedFields.push('evaluationSourceType');
+  }
+  if (signals.optimizationMetricChanged) {
+    changedFields.push('optimizationMetric');
+  }
+  if (signals.vectorDatabaseChanged) {
+    changedFields.push('vectorDatabase');
+  }
+  if (signals.modelsChanged) {
+    changedFields.push('models');
+  }
+  return changedFields;
+};
+
+export type RunReconfiguredProperties = {
+  /**
+   * Flagged in `changedFields` when the user actually (re)selected a knowledge source this
+   * session — see {@link RunTriggeredProperties.knowledgeSourceType} for why this can't be a
+   * plain value comparison. Reports the current selection the same way {@link
+   * RunTriggeredProperties.knowledgeSourceType} does, so `undefined` here means the pre-filled
+   * source was never re-selected through the UI.
+   */
+  knowledgeSourceType?: KnowledgeSourceType;
+  /** See {@link RunReconfiguredProperties.knowledgeSourceType} — same caveat applies. */
+  evaluationSourceType?: EvaluationSourceType;
+  optimizationMetric?: RagOptimizationMetric;
+  /** See {@link RunReconfiguredProperties.knowledgeSourceType} — same caveat applies. */
+  vectorDatabase?: VectorStoreProviderType;
+  countOfFoundationModels: number;
+  countOfEmbeddingModels: number;
+  /**
+   * Which top-level sections differ from the source run's configuration at the time this event
+   * fires — comma-joined by {@link fireAutoragRunReconfigured} before sending, since analytics
+   * properties can't carry raw arrays. Built with {@link buildRunReconfiguredChangedFields}.
+   */
+  changedFields: string[];
+  outcome: TrackingOutcome;
+  /** Omitted on `outcome: cancel` — no backend call is made when the user cancels before submitting. */
+  success?: boolean;
+  error?: AutoragFailureCategory;
+};
+
+/**
+ * Fires from the reconfigure flow only (`sourceRunId` set) — never for a new-run create. Fires
+ * with `outcome: submit` when "Create new run" is clicked, alongside "AutoRAG Run Triggered"
+ * (which fires for every submission, reconfigure or not, but does not report what changed), with
+ * `success`/`error` reflecting the same pipeline-run creation result. Also fires with
+ * `outcome: cancel` when the user cancels out of the flow from the "Define details" step before
+ * ever submitting — before any backend call is made, so `success` is omitted in that case.
+ */
+export const fireAutoragRunReconfigured = (properties: RunReconfiguredProperties): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.RUN_RECONFIGURED, {
+    ...properties,
+    changedFields: properties.changedFields.join(','),
+  });
 };
 
 /**

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -21,6 +21,7 @@ export const AUTORAG_EVENTS = {
   VECTOR_STORE_CONFIGURED: 'AutoRAG Vector Store Configured',
   RUN_TRIGGERED: 'AutoRAG Run Triggered',
   FLOW_EXITED: 'AutoRAG Flow Exited',
+  S3_CONNECTION_CREATED: 'AutoRAG S3 Connection Created',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -284,4 +285,25 @@ export const fireAutoragFlowExited = (
     lastFunnelStep,
     exitDestination,
   });
+};
+
+export type S3ConnectionCreatedProperties = {
+  outcome: TrackingOutcome;
+  /** Omitted on `outcome: cancel` — no backend call is made when the modal is dismissed. */
+  success?: boolean;
+  error?: AutoragFailureCategory;
+};
+
+/**
+ * Fires from the "Add new connection" modal reached from the "Knowledge setup" S3 connection
+ * field on the configure step. `outcome: submit` fires as soon as the underlying Secret is
+ * created (success or failure) — independent of what the caller's `onSubmit` does with it
+ * afterward, so a later, unrelated failure there can't overwrite an already-successful creation.
+ * `outcome: cancel` fires when the modal is dismissed (Cancel, X, Escape, backdrop) before the
+ * Secret has been created; dismissal is blocked entirely while creation is in flight, and no
+ * cancel is fired once creation has already succeeded or failed, since that outcome was already
+ * reported.
+ */
+export const fireAutoragS3ConnectionCreated = (properties: S3ConnectionCreatedProperties): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.S3_CONNECTION_CREATED, properties);
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -31,6 +31,7 @@ export const AUTORAG_EVENTS = {
   PLAYGROUND_OPENED: 'AutoRAG Playground Opened',
   NOTEBOOK_DOWNLOADED: 'AutoRAG Notebook Downloaded',
   RESULTS_COLUMN_TOGGLED: 'AutoRAG Results Column Toggled',
+  PATTERN_DETAILS_VIEWED: 'AutoRAG Pattern Details Viewed',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -552,4 +553,22 @@ export const fireAutoragResultsColumnToggled = (
   isVisible: boolean,
 ): void => {
   fireMiscTrackingEvent(AUTORAG_EVENTS.RESULTS_COLUMN_TOGGLED, { columnName, isVisible });
+};
+
+/**
+ * Where the user drilled into a pattern's details modal from. `'pipelineVis'` is part of the
+ * taxonomy but is not currently fired — the pipeline topology view's step details drawer doesn't
+ * yet offer a way to open the pattern details modal. `'other'` is a defensive catch-all for any
+ * future entry point added before this taxonomy is updated.
+ */
+export type PatternDetailsEntrySource = 'resultsTable' | 'pipelineVis' | 'other';
+
+/**
+ * Fires when the pattern details modal is opened — from the results table/leaderboard's pattern
+ * name link or "View details" row action (`source: 'resultsTable'`). Does not fire when
+ * navigating between patterns (prev/next arrows or "Compare patterns") within an already-open
+ * modal — that's in-session navigation, not a new "drill into details".
+ */
+export const fireAutoragPatternDetailsViewed = (source: PatternDetailsEntrySource): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.PATTERN_DETAILS_VIEWED, { source });
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -21,6 +21,7 @@ export const AUTORAG_EVENTS = {
   VECTOR_STORE_CONFIGURED: 'AutoRAG Vector Store Configured',
   RUN_TRIGGERED: 'AutoRAG Run Triggered',
   RUN_RECONFIGURED: 'AutoRAG Run Reconfigured',
+  RUN_STOPPED: 'AutoRAG Run Stopped',
   FLOW_EXITED: 'AutoRAG Flow Exited',
   S3_CONNECTION_CREATED: 'AutoRAG S3 Connection Created',
   EVALUATION_TEMPLATE_DOWNLOADED: 'AutoRAG Evaluation Template Downloaded',
@@ -312,6 +313,33 @@ export const fireAutoragRunReconfigured = (properties: RunReconfiguredProperties
     ...properties,
     changedFields: properties.changedFields.join(','),
   });
+};
+
+/**
+ * Distinguishes which page/control a run action (stop, retry, delete, reconfigure) was
+ * triggered from — the runs table's per-row kebab (`ActionsColumn`) menu on the experiments
+ * list, or the standalone header button on the single-run results page.
+ */
+export type RunActionSource = 'runsList' | 'resultsPage';
+
+export type RunOutcomeTrackingProperties = {
+  outcome: TrackingOutcome;
+  /** Omitted on `outcome: cancel` — no backend call is made when the confirmation modal is dismissed. */
+  success?: boolean;
+  error?: AutoragFailureCategory;
+  source: RunActionSource;
+};
+
+/**
+ * Fires from the "Stop pipeline run?" confirmation modal, reachable from either the runs table's
+ * kebab menu (`source: 'runsList'`) or the results page's header button (`source: 'resultsPage'`).
+ * `outcome: cancel` fires when the modal is dismissed (Cancel, X, Escape, backdrop) before the
+ * stop request has been submitted — no backend call has been made yet, so `success` is omitted
+ * in that case. `outcome: submit` fires once the terminate request resolves, with `success`/
+ * `error` reflecting whether it succeeded.
+ */
+export const fireAutoragRunStopped = (properties: RunOutcomeTrackingProperties): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.RUN_STOPPED, properties);
 };
 
 /**

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -3,6 +3,12 @@ import {
   fireFormTrackingEvent,
   fireMiscTrackingEvent,
 } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  RAG_METRIC_FAITHFULNESS,
+  RAG_METRIC_ANSWER_CORRECTNESS,
+  RAG_METRIC_CONTEXT_CORRECTNESS,
+  RAG_METRIC_OVERALL_SCORE,
+} from '~/app/utilities/const';
 
 export { TrackingOutcome };
 
@@ -13,6 +19,7 @@ export const AUTORAG_EVENTS = {
   EVALUATION_SOURCE_CONFIGURED: 'AutoRAG Evaluation Source Configured',
   MODELS_SELECTED: 'AutoRAG Models Selected',
   VECTOR_STORE_CONFIGURED: 'AutoRAG Vector Store Configured',
+  RUN_TRIGGERED: 'AutoRAG Run Triggered',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -163,4 +170,66 @@ export const fireAutoragVectorStoreConfigured = (
   properties: VectorStoreConfiguredProperties,
 ): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.VECTOR_STORE_CONFIGURED, properties);
+};
+
+/** Product-wide, camelCase taxonomy for the RAG optimization metric, independent of the schema's snake_case values. */
+export type RagOptimizationMetric =
+  | 'overallScore'
+  | 'answerFaithfulness'
+  | 'answerCorrectness'
+  | 'contextCorrectness';
+
+/* eslint-disable camelcase -- keys mirror the schema's snake_case optimization_metric values */
+const RAG_OPTIMIZATION_METRIC_MAP: Record<string, RagOptimizationMetric> = {
+  [RAG_METRIC_OVERALL_SCORE]: 'overallScore',
+  [RAG_METRIC_FAITHFULNESS]: 'answerFaithfulness',
+  [RAG_METRIC_ANSWER_CORRECTNESS]: 'answerCorrectness',
+  [RAG_METRIC_CONTEXT_CORRECTNESS]: 'contextCorrectness',
+};
+/* eslint-enable camelcase */
+
+/**
+ * Maps the schema's `optimization_metric` value (e.g. `"answer_correctness"`) to the camelCase
+ * {@link RagOptimizationMetric} taxonomy used in analytics. Returns `undefined` for any value
+ * outside the current allowlist (defensive only — the schema's zod enum already restricts the
+ * field to these four values).
+ */
+export const mapOptimizationMetric = (metric: string): RagOptimizationMetric | undefined =>
+  Object.prototype.hasOwnProperty.call(RAG_OPTIMIZATION_METRIC_MAP, metric)
+    ? RAG_OPTIMIZATION_METRIC_MAP[metric]
+    : undefined;
+
+export type RunTriggeredProperties = {
+  /**
+   * Only known when the corresponding source was actually (re)selected in this session — see
+   * {@link RunTriggeredTrackingContext}. `undefined` on a reconfigure run submitted without
+   * touching that field (the pre-filled value was never re-selected through the UI).
+   */
+  knowledgeSourceType?: KnowledgeSourceType;
+  /** See {@link RunTriggeredProperties.knowledgeSourceType} — same caveat applies. */
+  evaluationSourceType?: EvaluationSourceType;
+  optimizationMetric?: RagOptimizationMetric;
+  /** See {@link RunTriggeredProperties.knowledgeSourceType} — same caveat applies. */
+  vectorDatabase?: VectorStoreProviderType;
+  countOfModels: number;
+  countOfKnowledgeDocuments: number;
+  countOfEvaluationDocuments: number;
+  countOfFoundationModels: number;
+  countOfEmbeddingModels: number;
+  /** True when at least one of the knowledge/evaluation sources was configured via an S3 connection (as opposed to a direct upload). */
+  hasS3Connection: boolean;
+  outcome: TrackingOutcome;
+  success: boolean;
+  error?: AutoragFailureCategory;
+};
+
+/**
+ * Fires when the user submits the "Create run"/"Create new run" button on the configure step,
+ * covering both new-run and reconfigure submissions. There is no cancel path for this specific
+ * action (the Back button returns to the previous step rather than abandoning the run), so
+ * `outcome` is always `submit`; `success`/`error` distinguish a successful pipeline-run creation
+ * from a failed one.
+ */
+export const fireAutoragRunTriggered = (properties: RunTriggeredProperties): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.RUN_TRIGGERED, properties);
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -28,6 +28,7 @@ export const AUTORAG_EVENTS = {
   S3_CONNECTION_CREATED: 'AutoRAG S3 Connection Created',
   EVALUATION_TEMPLATE_DOWNLOADED: 'AutoRAG Evaluation Template Downloaded',
   RESULTS_VIEWED: 'AutoRAG Results Viewed',
+  PLAYGROUND_OPENED: 'AutoRAG Playground Opened',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -480,4 +481,22 @@ export const fireAutoragEvaluationTemplateDownloaded = (): void => {
   fireMiscTrackingEvent(AUTORAG_EVENTS.EVALUATION_TEMPLATE_DOWNLOADED, {
     downloadType: 'evaluationTemplate',
   });
+};
+
+/**
+ * Where the user opened the pattern chat/playground drawer from. `'other'` is part of the
+ * taxonomy but is not currently fired by this package — every known "Try this pattern" entry
+ * point maps to one of the other two values.
+ */
+export type PlaygroundOpenedSource = 'resultsTable' | 'patternDetails' | 'other';
+
+/**
+ * Fires when the user opens the pattern chat/playground drawer to try a pattern — from the
+ * results table/leaderboard's "Try this pattern" action (`source: 'resultsTable'`) or from the
+ * pattern details modal's "Try this pattern" action (`source: 'patternDetails'`). Does not fire
+ * when the user switches patterns from the pattern select within an already-open playground
+ * drawer — that's a pattern swap, not a new "open".
+ */
+export const fireAutoragPlaygroundOpened = (source: PlaygroundOpenedSource): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.PLAYGROUND_OPENED, { source });
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -30,6 +30,7 @@ export const AUTORAG_EVENTS = {
   RESULTS_VIEWED: 'AutoRAG Results Viewed',
   PLAYGROUND_OPENED: 'AutoRAG Playground Opened',
   NOTEBOOK_DOWNLOADED: 'AutoRAG Notebook Downloaded',
+  RESULTS_COLUMN_TOGGLED: 'AutoRAG Results Column Toggled',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -517,4 +518,38 @@ export type NotebookDownloadedType = 'indexing' | 'inference' | 'other';
  */
 export const fireAutoragNotebookDownloaded = (notebookType: NotebookDownloadedType): void => {
   fireMiscTrackingEvent(AUTORAG_EVENTS.NOTEBOOK_DOWNLOADED, { notebookType });
+};
+
+/**
+ * Discrete, bounded identity for a results table column, independent of its (possibly dynamic
+ * or API-driven) display label. Metric columns reuse the {@link RagOptimizationMetric} taxonomy
+ * where possible; `'otherMetric'` covers metric columns outside that allowlist (e.g. a metric
+ * the API returns that isn't one of the four known optimization metrics), and `'other'` is a
+ * defensive catch-all for any future/unrecognized column — neither should leak a raw API value.
+ */
+export type ResultsColumnName =
+  | 'rank'
+  | 'patternName'
+  | 'modelNames'
+  | RagOptimizationMetric
+  | 'otherMetric'
+  | 'chunkingMethod'
+  | 'chunkingChunkSize'
+  | 'chunkingChunkOverlap'
+  | 'retrievalMethod'
+  | 'retrievalSearchMode'
+  | 'retrievalRankerStrategy'
+  | 'retrievalNumberOfChunks'
+  | 'other';
+
+/**
+ * Fires once per column whose visibility actually changed when the user saves the "Manage
+ * columns" modal — not on every checkbox click while the modal is open, so discarded edits
+ * (Cancel) don't get counted. Reordering-only saves fire nothing, since no `isShown` changed.
+ */
+export const fireAutoragResultsColumnToggled = (
+  columnName: ResultsColumnName,
+  isVisible: boolean,
+): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.RESULTS_COLUMN_TOGGLED, { columnName, isVisible });
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -32,6 +32,7 @@ export const AUTORAG_EVENTS = {
   NOTEBOOK_DOWNLOADED: 'AutoRAG Notebook Downloaded',
   RESULTS_COLUMN_TOGGLED: 'AutoRAG Results Column Toggled',
   PATTERN_DETAILS_VIEWED: 'AutoRAG Pattern Details Viewed',
+  PATTERN_DETAILS_DOWNLOAD_INITIATED: 'AutoRAG Pattern Details Download Initiated',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -571,4 +572,17 @@ export type PatternDetailsEntrySource = 'resultsTable' | 'pipelineVis' | 'other'
  */
 export const fireAutoragPatternDetailsViewed = (source: PatternDetailsEntrySource): void => {
   fireMiscTrackingEvent(AUTORAG_EVENTS.PATTERN_DETAILS_VIEWED, { source });
+};
+
+/**
+ * Fires when the user clicks "Download" in the pattern details modal header. That action opens
+ * the browser's native print dialog (`window.print()`) rather than a direct file download, and
+ * the dialog's `afterprint` event fires whether the user actually saves a PDF or cancels — so
+ * there is no reliable "completed" signal to wait for. This fires on the click itself, same as
+ * {@link fireAutoragEvaluationTemplateDownloaded}.
+ */
+export const fireAutoragPatternDetailsDownloadInitiated = (): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.PATTERN_DETAILS_DOWNLOAD_INITIATED, {
+    downloadType: 'patternDetails',
+  });
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -29,6 +29,7 @@ export const AUTORAG_EVENTS = {
   EVALUATION_TEMPLATE_DOWNLOADED: 'AutoRAG Evaluation Template Downloaded',
   RESULTS_VIEWED: 'AutoRAG Results Viewed',
   PLAYGROUND_OPENED: 'AutoRAG Playground Opened',
+  NOTEBOOK_DOWNLOADED: 'AutoRAG Notebook Downloaded',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -499,4 +500,21 @@ export type PlaygroundOpenedSource = 'resultsTable' | 'patternDetails' | 'other'
  */
 export const fireAutoragPlaygroundOpened = (source: PlaygroundOpenedSource): void => {
   fireMiscTrackingEvent(AUTORAG_EVENTS.PLAYGROUND_OPENED, { source });
+};
+
+/**
+ * Which artifact was downloaded from a pattern's "Save as notebook" actions. `'other'` is part
+ * of the taxonomy but is not currently fired — the only two notebook types produced today are
+ * `'indexing'` and `'inference'`.
+ */
+export type NotebookDownloadedType = 'indexing' | 'inference' | 'other';
+
+/**
+ * Fires when a pattern notebook has actually finished downloading (i.e. the S3 fetch succeeded
+ * and the browser download was triggered) — from either the results table/leaderboard or the
+ * pattern details modal's "Save as ... notebook" actions. Does not fire on a failed download
+ * attempt, since the signal we care about is completed engagement, not the click itself.
+ */
+export const fireAutoragNotebookDownloaded = (notebookType: NotebookDownloadedType): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.NOTEBOOK_DOWNLOADED, { notebookType });
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -20,6 +20,7 @@ export const AUTORAG_EVENTS = {
   MODELS_SELECTED: 'AutoRAG Models Selected',
   VECTOR_STORE_CONFIGURED: 'AutoRAG Vector Store Configured',
   RUN_TRIGGERED: 'AutoRAG Run Triggered',
+  FLOW_EXITED: 'AutoRAG Flow Exited',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -232,4 +233,55 @@ export type RunTriggeredProperties = {
  */
 export const fireAutoragRunTriggered = (properties: RunTriggeredProperties): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.RUN_TRIGGERED, properties);
+};
+
+/**
+ * Identifies where the user was in the configure flow when they exited without completing it.
+ * `'knowledge'`, `'evaluation'`, and `'models'` only apply to the create-run flow, where these
+ * milestones (see {@link fireAutoragKnowledgeSourceConfigured}, {@link
+ * fireAutoragEvaluationSourceConfigured}, {@link fireAutoragModelsSelected}) are reached
+ * progressively as the user actually completes each one — order-independent, since the configure
+ * screen doesn't gate these sections sequentially the way automl's did. `'run'` is reached once
+ * all three have been completed at least once this session. In the reconfigure flow the entire
+ * configure screen is already fully populated on mount, so there's no equivalent progression to
+ * observe — reconfigure reports `'run'` immediately upon reaching the configure screen, since the
+ * form starts ready to submit.
+ */
+export type AutoragFunnelStep = 'defineDetails' | 'knowledge' | 'evaluation' | 'models' | 'run';
+
+/**
+ * Where the user ended up after exiting the configure flow. `'none'` covers cases (e.g. tab
+ * close) where the destination can't be determined. `'home'` and `'projects'` are part of the
+ * taxonomy but are not currently fired by this package — see {@link fireAutoragFlowExited}.
+ */
+export type AutoragExitDestination =
+  | 'experimentsList'
+  | 'home'
+  | 'projects'
+  | 'otherGenAi'
+  | 'none';
+
+/**
+ * Fires when the user leaves the configure flow before creating a run — either via an explicit
+ * in-app action (Cancel, breadcrumb) or by abandoning the tab/browser entirely. Not fired on a
+ * successful run creation, nor when navigating between steps within the flow (e.g. Back).
+ *
+ * Only Cancel, the "AutoRAG: {namespace}" breadcrumb, the source-run breadcrumb (reconfigure from
+ * results), and a full page/tab close (`beforeunload`) are covered — these fire `exitDestination`
+ * values of `'experimentsList'`, `'otherGenAi'`, and `'none'` respectively. `'home'` and
+ * `'projects'` are not fired: detecting an in-app navigation to the host dashboard's global nav
+ * (Home, Projects, or another Gen AI Studio app) would require intercepting route changes, which
+ * isn't available here — this app uses a plain `<BrowserRouter>`, not a data router, so React
+ * Router's `useBlocker` can't be used.
+ */
+export const fireAutoragFlowExited = (
+  exitType: 'abandon' | 'navigate',
+  lastFunnelStep: AutoragFunnelStep,
+  exitDestination: AutoragExitDestination,
+): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.FLOW_EXITED, {
+    exitType,
+    lastFunnelStep,
+    exitDestination,
+  });
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -22,6 +22,7 @@ export const AUTORAG_EVENTS = {
   RUN_TRIGGERED: 'AutoRAG Run Triggered',
   FLOW_EXITED: 'AutoRAG Flow Exited',
   S3_CONNECTION_CREATED: 'AutoRAG S3 Connection Created',
+  EVALUATION_TEMPLATE_DOWNLOADED: 'AutoRAG Evaluation Template Downloaded',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -306,4 +307,16 @@ export type S3ConnectionCreatedProperties = {
  */
 export const fireAutoragS3ConnectionCreated = (properties: S3ConnectionCreatedProperties): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.S3_CONNECTION_CREATED, properties);
+};
+
+/**
+ * Fires when the user clicks "Download template" in the Evaluation data template modal. The
+ * download itself is a synchronous, client-side Blob creation with no network call or possible
+ * rejection, so this fires immediately after the download is triggered — there is no separate
+ * "completed" signal to wait for.
+ */
+export const fireAutoragEvaluationTemplateDownloaded = (): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.EVALUATION_TEMPLATE_DOWNLOADED, {
+    downloadType: 'evaluationTemplate',
+  });
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -12,6 +12,7 @@ export const AUTORAG_EVENTS = {
   KNOWLEDGE_SOURCE_CONFIGURED: 'AutoRAG Knowledge Source Configured',
   EVALUATION_SOURCE_CONFIGURED: 'AutoRAG Evaluation Source Configured',
   MODELS_SELECTED: 'AutoRAG Models Selected',
+  VECTOR_STORE_CONFIGURED: 'AutoRAG Vector Store Configured',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -117,4 +118,49 @@ export type ModelsSelectedProperties = {
  */
 export const fireAutoragModelsSelected = (properties: ModelsSelectedProperties): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.MODELS_SELECTED, properties);
+};
+
+/** Categorized vector I/O provider type, derived from the `SUPPORTED_VECTOR_STORE_PROVIDER_TYPES` allowlist. */
+export type VectorStoreProviderType = 'milvus' | 'pgvector';
+
+/**
+ * Maps a raw `OgxVectorStoreProvider.provider_type` (e.g. `"remote::milvus"`) to the categorized
+ * {@link VectorStoreProviderType} used in analytics. Returns `undefined` for any provider type
+ * outside the current allowlist — callers must skip firing the tracking event in that case rather
+ * than forwarding an uncategorized value. This keeps the tracked property to a fixed, non-sensitive
+ * set even though the underlying `provider_id` is a free-form, admin-assigned string that must
+ * never be sent to analytics.
+ */
+export const toVectorStoreProviderType = (
+  providerType: string,
+): VectorStoreProviderType | undefined => {
+  switch (providerType) {
+    case 'remote::milvus':
+      return 'milvus';
+    case 'remote::pgvector':
+      return 'pgvector';
+    default:
+      return undefined;
+  }
+};
+
+export type VectorStoreConfiguredProperties = {
+  providerType: VectorStoreProviderType;
+  countOfCompatibleProviders: number;
+  outcome: TrackingOutcome;
+  success: boolean;
+};
+
+/**
+ * Fires when the user selects a vector I/O provider in the "Configure details" step of the
+ * configure flow. Fires on every selection change (consistent with Knowledge/Evaluation Source,
+ * which re-fire on every upload/replace), from the Select's `onSelect` handler only — never from
+ * the effect that clears a stale selection when the provider list refreshes, and never from the
+ * initial/reconfigure pre-fill of `vector_io_provider_id`. This is a pure local field selection
+ * with no direct backend call, so `outcome` is always `submit` and `success` is always `true`.
+ */
+export const fireAutoragVectorStoreConfigured = (
+  properties: VectorStoreConfiguredProperties,
+): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.VECTOR_STORE_CONFIGURED, properties);
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -91,7 +91,8 @@ export type KnowledgeSourceConfiguredProperties = {
  * step — selecting a file/folder from an S3 connection via the file browser, or uploading a file
  * directly. `outcome: submit` covers both a successful selection/upload and a failed upload
  * attempt (see `success`/`error`); `outcome: cancel` fires when the S3 browser is dismissed
- * without a selection being made.
+ * without a selection being made, in which case `success` is always `false` since no document
+ * was actually configured.
  */
 export const fireAutoragKnowledgeSourceConfigured = (
   properties: KnowledgeSourceConfiguredProperties,
@@ -114,7 +115,8 @@ export type EvaluationSourceConfiguredProperties = {
  * step — selecting a JSON file from an S3 connection via the file browser, or uploading one
  * directly. `outcome: submit` covers both a successful selection/upload and a failed upload
  * attempt (see `success`/`error`); `outcome: cancel` fires when the S3 browser is dismissed
- * without a selection being made.
+ * without a selection being made, in which case `success` is always `false` since no document
+ * was actually configured.
  */
 export const fireAutoragEvaluationSourceConfigured = (
   properties: EvaluationSourceConfiguredProperties,

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -11,6 +11,7 @@ export const AUTORAG_EVENTS = {
   EXPERIMENT_CREATED: 'AutoRAG Experiment Created',
   KNOWLEDGE_SOURCE_CONFIGURED: 'AutoRAG Knowledge Source Configured',
   EVALUATION_SOURCE_CONFIGURED: 'AutoRAG Evaluation Source Configured',
+  MODELS_SELECTED: 'AutoRAG Models Selected',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -81,4 +82,25 @@ export const fireAutoragEvaluationSourceConfigured = (
   properties: EvaluationSourceConfiguredProperties,
 ): void => {
   fireFormTrackingEvent(AUTORAG_EVENTS.EVALUATION_SOURCE_CONFIGURED, properties);
+};
+
+export type ModelsSelectedProperties = {
+  countOfFoundationModels: number;
+  countOfEmbeddingModels: number;
+  outcome: TrackingOutcome;
+  success: boolean;
+  error?: string;
+};
+
+/**
+ * Fires when the user completes (or abandons) the "Model configuration" milestone — the
+ * foundation/embedding model selection modal reached from "Models to test" in the configure
+ * step. `outcome: submit` fires when Save is clicked (the modal is only dirty-enabled, so a
+ * submit always reflects a change to the selection); `outcome: cancel` fires when Cancel is
+ * clicked or the modal is dismissed (X/Escape/backdrop), in which case the in-progress selection
+ * is reverted. This is a pure local step with no backend call, so `success` is always `true` and
+ * `error` is omitted.
+ */
+export const fireAutoragModelsSelected = (properties: ModelsSelectedProperties): void => {
+  fireFormTrackingEvent(AUTORAG_EVENTS.MODELS_SELECTED, properties);
 };

--- a/packages/autorag/frontend/src/app/utilities/tracking.ts
+++ b/packages/autorag/frontend/src/app/utilities/tracking.ts
@@ -33,6 +33,7 @@ export const AUTORAG_EVENTS = {
   RESULTS_COLUMN_TOGGLED: 'AutoRAG Results Column Toggled',
   PATTERN_DETAILS_VIEWED: 'AutoRAG Pattern Details Viewed',
   PATTERN_DETAILS_DOWNLOAD_INITIATED: 'AutoRAG Pattern Details Download Initiated',
+  CODE_SNIPPETS_EXPORTED: 'AutoRAG Code Snippets Exported',
 } as const;
 
 export const fireAutoragProjectDropdownOptionSelected = (selectedProject: string): void => {
@@ -584,5 +585,34 @@ export const fireAutoragPatternDetailsViewed = (source: PatternDetailsEntrySourc
 export const fireAutoragPatternDetailsDownloadInitiated = (): void => {
   fireMiscTrackingEvent(AUTORAG_EVENTS.PATTERN_DETAILS_DOWNLOAD_INITIATED, {
     downloadType: 'patternDetails',
+  });
+};
+
+/** Whether the user viewed or copied a "View code" (curl/Node.js/Go/Python) snippet. */
+export type CodeSnippetAction = 'viewed' | 'copied';
+
+/**
+ * Where the "View code" modal was opened from: the Playground drawer's "View Code" button
+ * (`'playground'`), a results-table row's "View code" kebab action (`'resultsTable'`), or the
+ * pattern details modal's "View code" dropdown item (`'patternDetails'`). `'other'` is a
+ * defensive catch-all for any future entry point added before this taxonomy is updated.
+ */
+export type ViewCodeEntrySource = 'playground' | 'resultsTable' | 'patternDetails' | 'other';
+
+/**
+ * Fires with `action: 'viewed'` and an `entrySource` when the "View code" modal is opened. Fires
+ * once per open, regardless of which language tab is initially shown. Fires with
+ * `action: 'copied'` (no `entrySource`) when the user clicks a tab's "Copy" button and the
+ * clipboard write succeeds — not fired on a rejected clipboard write (e.g. denied permission);
+ * which tab/entry point was copied from isn't tracked separately from the "viewed" event for the
+ * same modal session.
+ */
+export const fireAutoragCodeSnippetsExported = (
+  action: CodeSnippetAction,
+  entrySource?: ViewCodeEntrySource,
+): void => {
+  fireMiscTrackingEvent(AUTORAG_EVENTS.CODE_SNIPPETS_EXPORTED, {
+    action,
+    ...(entrySource ? { entrySource } : {}),
   });
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAISTRAT-2206
https://redhat.atlassian.net/browse/RHOAIENG-82487

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds Segment analytics event tracking across the AutoRAG create/configure/results flows. No visual or behavioral changes — this PR only adds `fireFormTrackingEvent`/`fireMiscTrackingEvent` calls and the supporting `tracking.ts` utilities/types. All events live in `packages/autorag/frontend/src/app/utilities/tracking.ts`.

Events added:

| Event | Fires when |
| --- | --- |
| `AutoRAG Project Dropdown Option Selected` | User picks a project from the header dropdown |
| `AutoRAG Experiment Created` | Create-experiment flow completes (or fails) |
| `AutoRAG Knowledge Source Configured` | Knowledge source (S3/select/upload) step is completed |
| `AutoRAG Evaluation Source Configured` | Evaluation source step is completed |
| `AutoRAG Models Selected` | Embedding/generation model selections are made |
| `AutoRAG Vector Store Configured` | Vector store step is completed |
| `AutoRAG Run Triggered` | A run is submitted from the configure flow |
| `AutoRAG Run Reconfigured` | An existing run is edited and resubmitted (reports which fields changed) |
| `AutoRAG Run Stopped` | A run is stopped from the runs list or results page |
| `AutoRAG Run Retried` | A failed/stopped run is retried |
| `AutoRAG Experiment Deleted` | An experiment is deleted |
| `AutoRAG Flow Exited` | User abandons or navigates away from the configure flow before finishing |
| `AutoRAG S3 Connection Created` | A new S3 connection is created inline during configure |
| `AutoRAG Evaluation Template Downloaded` | The evaluation file template is downloaded |
| `AutoRAG Results Viewed` | The results page finishes loading a run |
| `AutoRAG Playground Opened` | User opens the playground from results |
| `AutoRAG Notebook Downloaded` | A pattern's notebook is downloaded |
| `AutoRAG Results Column Toggled` | A results-table column is shown/hidden via "Manage columns" |
| `AutoRAG Pattern Details Viewed` | The pattern details modal is opened |
| `AutoRAG Pattern Details Download Initiated` | "Download" is clicked in the pattern details modal |
| `AutoRAG Code Snippets Exported` | A code snippet is viewed or copied (playground, results table, or pattern details) |
| `AutoRAG Leaderboard Preset Applied` | A "Manage columns" preset is selected on the leaderboard |
| `AutoRAG Patterns Compared` | A comparison pattern is selected/changed in the pattern details modal |

Design principles followed throughout:
- No raw free-text (error messages, user input, resource names/IDs) is ever forwarded to analytics. Failures are mapped to a small allowlisted `AutoragFailureCategory` taxonomy (see `cbfc44ade`) instead of forwarding `Error.message`.
- Events fire only on genuine user-initiated actions/submissions — never from `useEffect`s, auto-clear timers, or form pre-fill.
- Categorical fields use small, explicit allowlists (e.g. `presetType`, `entrySource`) rather than passing raw UI copy through.
- Numeric deltas (e.g. `rankDifference`, `scoreDifference` on `AutoRAG Patterns Compared`) are left as raw signed numbers rather than bucketed into arbitrary categories, since bucketing would discard information without being justified by anything about the data itself.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified via automated checks only (lint, type-check, unit tests) — no manual/cluster testing was done for this PR, since it has no user-visible behavior or UI to exercise.

For each event added:
1. `npx eslint --fix` and `npx tsc --noEmit` on touched files.
2. Targeted `jest` runs for the touched spec files.
3. A revert-and-confirm regression check: temporarily broke/removed the new tracking call, confirmed the new test(s) actually fail, then restored the change and reconfirmed the tests pass. This guards against tests that pass regardless of whether the tracking call fires.
4. A full `packages/autorag/frontend` Jest run after each event to confirm no regressions elsewhere.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Added/extended unit tests for every event in `tracking.spec.ts` (payload shape, mapping helpers) plus the component/page spec for each fire site (asserting the event fires with the expected properties on the triggering action, and does not fire on cancel/dismiss or from incidental effects).

Current state: `packages/autorag/frontend` — 89/89 test suites, 1767/1767 tests passing.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved AutoRAG setup, source selection, and configuration flows with clearer handling of successful, failed, and cancelled actions.
  - Prevented connection, stop, and delete dialogs from closing during active operations and improved retry behavior.
  - Improved navigation context across run lists, results, pattern details, and code views.
  - Enhanced evaluation-template downloads, code-snippet copying, playground access, and result interactions.
  - Improved column preset selection and visibility management.
  - Added privacy-safe failure handling and more reliable cancellation and duplicate-action prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
