### PR TITLE
fix(RHOAIENG-80354): backport auto-detect Perses service for observability to v3.5.0

### DIFF
--- a/dashboard-operator/internal/controller/actions.go
+++ b/dashboard-operator/internal/controller/actions.go
@@ -10,8 +10,11 @@ import (
 	"strings"
 
 	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -37,6 +40,57 @@ const (
 	dataScienceGatewayNamespace   = "openshift-ingress"
 	rayDataScienceGatewayRBACName = "fetch-ray-data-science-gateway"
 )
+
+const (
+	persesServiceName              = "data-science-perses"
+	persesServicePort        int32 = 8080
+	rhoaiMonitoringNamespace       = "redhat-ods-monitoring"
+)
+
+func (r *DashboardReconciler) monitoringNamespace() string {
+	switch r.Platform {
+	case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
+		return rhoaiMonitoringNamespace
+	default:
+		return r.ApplicationsNamespace
+	}
+}
+
+// autoDetectObservability populates spec.observability in-memory when the Perses
+// service exists but the CR has no explicit observability config. This bridges
+// 3.5GA until the ODH Operator projects the config via BuildModuleCR (3.6ea1).
+func (r *DashboardReconciler) autoDetectObservability(ctx context.Context, dashboard *v1alpha1.Dashboard) error {
+	if dashboard.Spec.Observability != nil {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	monitoringNS := r.monitoringNamespace()
+
+	svc := &corev1.Service{}
+	key := types.NamespacedName{Name: persesServiceName, Namespace: monitoringNS}
+	if err := r.Get(ctx, key, svc); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("looking up Perses service %s/%s: %w", monitoringNS, persesServiceName, err)
+	}
+
+	logger.Info("Auto-detected Perses service, enabling observability",
+		"service", persesServiceName, "namespace", monitoringNS)
+
+	dashboard.Spec.Observability = &v1alpha1.ObservabilitySpec{
+		Enabled: true,
+		PersesService: &v1alpha1.ServiceTarget{
+			Name:      persesServiceName,
+			Namespace: monitoringNS,
+			Port:      persesServicePort,
+		},
+	}
+
+	return nil
+}
 
 // remapRayDashboardGatewayRBAC moves the named Gateway Role/RoleBinding into
 // openshift-ingress so authenticated users can get data-science-gateway there.

--- a/dashboard-operator/internal/controller/actions_test.go
+++ b/dashboard-operator/internal/controller/actions_test.go
@@ -9,10 +9,13 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
@@ -317,4 +320,200 @@ func TestRemapRayDashboardGatewayRBAC(t *testing.T) {
 	assert.Equal(t, dataScienceGatewayNamespace, resources[0].GetNamespace())
 	assert.Equal(t, dataScienceGatewayNamespace, resources[1].GetNamespace())
 	assert.Equal(t, "opendatahub", resources[2].GetNamespace())
+}
+
+func TestMonitoringNamespace(t *testing.T) {
+	tests := []struct {
+		name                  string
+		platform              cluster.Platform
+		applicationsNamespace string
+		want                  string
+	}{
+		{
+			name:                  "SelfManagedRhoai returns hardcoded monitoring namespace",
+			platform:              cluster.SelfManagedRhoai,
+			applicationsNamespace: "redhat-ods-applications",
+			want:                  "redhat-ods-monitoring",
+		},
+		{
+			name:                  "ManagedRhoai returns hardcoded monitoring namespace",
+			platform:              cluster.ManagedRhoai,
+			applicationsNamespace: "redhat-ods-applications",
+			want:                  "redhat-ods-monitoring",
+		},
+		{
+			name:                  "OpenDataHub returns applications namespace",
+			platform:              cluster.OpenDataHub,
+			applicationsNamespace: "opendatahub",
+			want:                  "opendatahub",
+		},
+		{
+			name:                  "XKS returns applications namespace",
+			platform:              cluster.XKS,
+			applicationsNamespace: "my-namespace",
+			want:                  "my-namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &DashboardReconciler{
+				Platform:              tt.platform,
+				ApplicationsNamespace: tt.applicationsNamespace,
+			}
+			assert.Equal(t, tt.want, r.monitoringNamespace())
+		})
+	}
+}
+
+func TestAutoDetectObservability(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	persesService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      persesServiceName,
+			Namespace: "redhat-ods-monitoring",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 8080}},
+		},
+	}
+
+	persesServiceODH := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      persesServiceName,
+			Namespace: "opendatahub",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 8080}},
+		},
+	}
+
+	tests := []struct {
+		name                  string
+		platform              cluster.Platform
+		applicationsNamespace string
+		existingObs           *v1alpha1.ObservabilitySpec
+		objects               []runtime.Object
+		wantObs               *v1alpha1.ObservabilitySpec
+		wantErr               bool
+	}{
+		{
+			name:                  "explicit config present — no change",
+			platform:              cluster.SelfManagedRhoai,
+			applicationsNamespace: "redhat-ods-applications",
+			existingObs: &v1alpha1.ObservabilitySpec{
+				Enabled: true,
+				PersesService: &v1alpha1.ServiceTarget{
+					Name:      "custom-perses",
+					Namespace: "custom-ns",
+					Port:      9090,
+				},
+			},
+			objects: []runtime.Object{persesService},
+			wantObs: &v1alpha1.ObservabilitySpec{
+				Enabled: true,
+				PersesService: &v1alpha1.ServiceTarget{
+					Name:      "custom-perses",
+					Namespace: "custom-ns",
+					Port:      9090,
+				},
+			},
+		},
+		{
+			name:                  "service found RHOAI — populates observability",
+			platform:              cluster.SelfManagedRhoai,
+			applicationsNamespace: "redhat-ods-applications",
+			objects:               []runtime.Object{persesService},
+			wantObs: &v1alpha1.ObservabilitySpec{
+				Enabled: true,
+				PersesService: &v1alpha1.ServiceTarget{
+					Name:      persesServiceName,
+					Namespace: "redhat-ods-monitoring",
+					Port:      persesServicePort,
+				},
+			},
+		},
+		{
+			name:                  "service found ODH — populates with applications namespace",
+			platform:              cluster.OpenDataHub,
+			applicationsNamespace: "opendatahub",
+			objects:               []runtime.Object{persesServiceODH},
+			wantObs: &v1alpha1.ObservabilitySpec{
+				Enabled: true,
+				PersesService: &v1alpha1.ServiceTarget{
+					Name:      persesServiceName,
+					Namespace: "opendatahub",
+					Port:      persesServicePort,
+				},
+			},
+		},
+		{
+			name:                  "service not found — observability remains nil",
+			platform:              cluster.SelfManagedRhoai,
+			applicationsNamespace: "redhat-ods-applications",
+			objects:               nil,
+			wantObs:               nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+
+			r := &DashboardReconciler{
+				Client:                cli,
+				Platform:              tt.platform,
+				ApplicationsNamespace: tt.applicationsNamespace,
+			}
+
+			dashboard := &v1alpha1.Dashboard{
+				Spec: v1alpha1.DashboardSpec{
+					Observability: tt.existingObs,
+				},
+			}
+
+			err := r.autoDetectObservability(context.Background(), dashboard)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantObs, dashboard.Spec.Observability)
+		})
+	}
+}
+
+func TestAutoDetectObservability_NonNotFoundError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	injectedErr := assert.AnError
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return injectedErr
+			},
+		}).
+		Build()
+
+	r := &DashboardReconciler{
+		Client:                cli,
+		Platform:              cluster.SelfManagedRhoai,
+		ApplicationsNamespace: "redhat-ods-applications",
+	}
+
+	dashboard := &v1alpha1.Dashboard{}
+	err := r.autoDetectObservability(context.Background(), dashboard)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, injectedErr)
+	assert.Nil(t, dashboard.Spec.Observability)
 }

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -222,17 +222,32 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return result, err
 }
 
+const observabilityRetryInterval = 5 * time.Minute
+
 func (r *DashboardReconciler) reconcile(
 	ctx context.Context,
 	dashboard *v1alpha1.Dashboard,
 	cm *conditions.Manager,
 	cfg OperatorConfig,
 ) (ctrl.Result, error) {
-	mode := dashboard.Spec.DeploymentMode
-	if mode == "" || mode == v1alpha1.DeploymentModeSidecar {
-		return r.reconcileSidecar(ctx, dashboard, cm, cfg)
+	if err := r.autoDetectObservability(ctx, dashboard); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to auto-detect observability, continuing without it")
 	}
-	return r.reconcileStandalone(ctx, dashboard, cm, cfg)
+
+	mode := dashboard.Spec.DeploymentMode
+	var result ctrl.Result
+	var err error
+	if mode == "" || mode == v1alpha1.DeploymentModeSidecar {
+		result, err = r.reconcileSidecar(ctx, dashboard, cm, cfg)
+	} else {
+		result, err = r.reconcileStandalone(ctx, dashboard, cm, cfg)
+	}
+
+	if dashboard.Spec.Observability == nil && err == nil && result.RequeueAfter == 0 {
+		result.RequeueAfter = observabilityRetryInterval
+	}
+
+	return result, err
 }
 
 func (r *DashboardReconciler) reconcileSidecar(
@@ -635,6 +650,10 @@ func (r *DashboardReconciler) cleanupCrossNamespaceResources(ctx context.Context
 	if dashboard.Spec.Observability != nil &&
 		dashboard.Spec.Observability.PersesService != nil {
 		obsNS = dashboard.Spec.Observability.PersesService.Namespace
+	}
+
+	if obsNS == "" {
+		obsNS = r.monitoringNamespace()
 	}
 
 	if obsNS == "" || obsNS == r.ApplicationsNamespace {

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -148,6 +148,7 @@ func TestReconcile(t *testing.T) {
 			wantProvisioned: boolPtr(true),
 			wantURL:         "https://dashboard.apps.example.com",
 			wantGeneration:  3,
+			wantRequeue:     ctrlpkg.ObservabilityRetryInterval,
 		},
 		{
 			name:       "kustomize failure",
@@ -200,6 +201,7 @@ func TestReconcile(t *testing.T) {
 			wantProvisioned: boolPtr(true),
 			wantURL:         "https://dashboard.apps.example.com",
 			wantGeneration:  1,
+			wantRequeue:     ctrlpkg.ObservabilityRetryInterval,
 			wantModuleCount: registrySize,
 			wantModulePhases: map[string]v1alpha1.ModulePhase{
 				"modelRegistry": v1alpha1.ModulePhaseDeployed,
@@ -826,7 +828,7 @@ data:
 	})
 
 	require.NoError(t, err)
-	assert.Zero(t, result.RequeueAfter)
+	assert.Equal(t, ctrlpkg.ObservabilityRetryInterval, result.RequeueAfter)
 
 	updated := &v1alpha1.Dashboard{}
 	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))

--- a/dashboard-operator/internal/controller/export_test.go
+++ b/dashboard-operator/internal/controller/export_test.go
@@ -25,3 +25,13 @@ func BuildFederationConfigMap(r *DashboardReconciler, statuses map[string]v1alph
 func (r *DashboardReconciler) PatchDeploymentFederationHash(ctx context.Context, configData string) error {
 	return r.patchDeploymentFederationHash(ctx, configData)
 }
+
+func (r *DashboardReconciler) AutoDetectObservability(ctx context.Context, dashboard *v1alpha1.Dashboard) error {
+	return r.autoDetectObservability(ctx, dashboard)
+}
+
+func (r *DashboardReconciler) MonitoringNamespace() string {
+	return r.monitoringNamespace()
+}
+
+const ObservabilityRetryInterval = observabilityRetryInterval


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-80354

## Description

Backport of #9269 to `v3.5.0-fixes`.

On RHOAI deployments, `spec.observability` is never set on the Dashboard CR, so the operator skips deploying observability manifests (NetworkPolicy + PersesDashboard CRDs) and omits the Perses proxy entry from the federation ConfigMap in standalone mode. This causes Perses dashboards to fail with "Unable to reach observability dashboards."

This cherry-pick adds `autoDetectObservability()` to the dashboard-operator, which looks up the `data-science-perses` Service in the platform-appropriate monitoring namespace during reconciliation:

- **RHOAI**: looks in `redhat-ods-monitoring`
- **ODH**: looks in the applications namespace (e.g., `opendatahub`)
- When found and `spec.observability` is nil, populates it **in-memory only** (not persisted to the CR)
- Explicit `spec.observability` always takes priority

**Conflict resolution**: removed the `DeleteSidecarResources` test export from `export_test.go` since `deleteSidecarResources` does not exist on the `v3.5.0-fixes` branch.

## How Has This Been Tested?

Cherry-pick of #9269 which was fully tested on a cluster. Go unit tests pass on this branch:

```
=== RUN   TestMonitoringNamespace (4 subtests) --- PASS
=== RUN   TestAutoDetectObservability (4 subtests) --- PASS
=== RUN   TestAutoDetectObservability_NonNotFoundError --- PASS
```

## Test Impact

Unit tests from the original PR are included:
- `TestMonitoringNamespace` — verifies namespace resolution per platform
- `TestAutoDetectObservability` — verifies auto-detection behavior for all scenarios
- `TestAutoDetectObservability_NonNotFoundError` — verifies non-NotFound errors are propagated

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`