### PR TITLE
fix(RHOAIENG-82728): query DSC status for About dialog version validation

### DIFF
--- a/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
@@ -3,8 +3,8 @@ import { DataScienceStackComponentMap } from '@odh-dashboard/internal/concepts/a
 import { aboutDialog } from '../../../pages/aboutDialog';
 import {
   getCsvByDisplayName,
+  getDscComponentVersions,
   getInstalledProductName,
-  getResourceVersionByName,
   getSubscriptionChannelFromCsv,
   getVersionFromCsv,
 } from '../../../utils/oc_commands/applications';
@@ -16,6 +16,7 @@ const dataScienceStackComponentMap = DataScienceStackComponentMap;
 describe('Verify RHODS About Dialog', () => {
   let odhCsv: Record<string, unknown>;
   let productName: string;
+  let dscVersions: Partial<Record<string, string[]>>;
 
   retryableBefore(async () => {
     cy.log('Auto-detecting installed product (RHOAI or ODH)...');
@@ -27,6 +28,9 @@ describe('Verify RHODS About Dialog', () => {
       getCsvByDisplayName(productName, 'default').then((csv) => {
         odhCsv = csv as Record<string, unknown>;
       });
+    });
+    getDscComponentVersions().then((versions) => {
+      dscVersions = versions;
     });
   });
 
@@ -76,19 +80,18 @@ describe('Verify RHODS About Dialog', () => {
       aboutDialog.isAdminAccessLevel();
 
       aboutDialog.findTable().then(() => {
-        Object.entries(dataScienceStackComponentMap).forEach(([, component]) => {
-          cy.step(`Verify versions in About dialog's table for component: ${component}`);
-          aboutDialog.getComponentReleasesText(component).then((texts) => {
-            getResourceVersionByName(component).then((version) => {
-              if (version.length === 0) {
-                return;
-              }
-              const text = texts.join(' ');
-              expect(version.some((v) => text.includes(v))).to.equal(
-                true,
-                `Version ${version} not found for component ${component}`,
-              );
-            });
+        Object.entries(dataScienceStackComponentMap).forEach(([componentKey, displayName]) => {
+          const versions = dscVersions[componentKey];
+          if (!versions) {
+            return;
+          }
+          cy.step(`Verify versions in About dialog's table for component: ${displayName}`);
+          aboutDialog.getComponentReleasesText(displayName).then((texts) => {
+            const text = texts.join(' ');
+            expect(versions.some((v) => text.includes(v))).to.equal(
+              true,
+              `Version ${versions.join(', ')} not found for component ${displayName}`,
+            );
           });
         });
       });

--- a/packages/cypress/cypress/utils/oc_commands/applications.ts
+++ b/packages/cypress/cypress/utils/oc_commands/applications.ts
@@ -30,23 +30,50 @@ export const getOcResourceNames = (
 };
 
 /**
- * Get the version of a resource by its name.
+ * Retrieve component release versions from the DataScienceCluster status.
  *
- * @param resourceName - The name of the resource to retrieve the version for.
- * @returns A Cypress.Chainable that resolves to the version of the resource.
+ * Queries the same source the UI uses (DSC .status.components), filters out
+ * components with managementState 'Removed' and releases with version 'unknown'.
+ *
+ * @returns A map of component key to non-empty array of version strings.
  */
-export const getResourceVersionByName = (resourceName: string): Cypress.Chainable<string[]> => {
-  const ocCommand = `oc get ${resourceName.replace(
-    /\s/g,
-    '',
-  )} -A -o jsonpath='{.items[*].status.releases[*].version}'`;
+export const getDscComponentVersions = (): Cypress.Chainable<Record<string, string[]>> => {
+  const ocCommand = `oc get DataScienceCluster -A -o json`;
   return execWithOutput(ocCommand).then(({ exitCode, stdout, stderr }) => {
-    if (exitCode !== 0) {
-      cy.log(`Failed to retrieve version of ${resourceName}:\n${stdout}\n${stderr}`);
-      return cy.wrap<string[]>([]);
+    if (exitCode !== 0 || !stdout.trim()) {
+      throw new Error(
+        `Failed to retrieve DSC component versions (exit code ${exitCode}): ${stderr}`,
+      );
     }
-    cy.log(`Retrieved version of ${resourceName}:\n${stdout}\n${stderr}`);
-    return cy.wrap(stdout.trim().split(' '));
+    const dsc = JSON.parse(stdout);
+    const items: Array<{
+      status?: {
+        components?: Record<
+          string,
+          { managementState?: string; releases?: Array<{ version?: string }> }
+        >;
+      };
+    }> = dsc.items ?? [];
+    if (items.length === 0) {
+      throw new Error('No DataScienceCluster resources found on the cluster');
+    }
+    const components = items[0].status?.components ?? {};
+    const result: Record<string, string[]> = {};
+
+    Object.entries(components).forEach(([key, details]) => {
+      if (details.managementState === 'Removed') {
+        return;
+      }
+      const versions = (details.releases ?? [])
+        .map((r) => r.version)
+        .filter((v): v is string => !!v && v !== 'unknown');
+      if (versions.length > 0) {
+        result[key] = versions;
+      }
+    });
+
+    cy.log(`Retrieved DSC component versions: ${JSON.stringify(result)}`);
+    return cy.wrap(result);
   });
 };
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-82728

Cherry-pick of #9332 to `v3.5.0-fixes`.

## Description

The `testAboutDialog.cy.ts` E2E test was false-failing when validating the "Installed components" table in the About dialog. Two root causes:

1. **Wrong data source** — The test ran `oc get <ComponentDisplayName>` to retrieve versions from individual CRD `.status.releases`, but the UI reads component versions from the **DataScienceCluster** resource's `.status.components` (via `/api/dsc/status`).

2. **`unknown` included as a version** — The CRD query returned entries with `version: "unknown"`. The test then tried to match `"unknown"` in the UI table, which naturally failed.

### Changes

- Added `getDscComponentVersions()` — queries `DataScienceCluster -A -o json` (the same source the UI uses), filters out `managementState: 'Removed'` and `version: 'unknown'`
- Replaced `getResourceVersionByName` with `getDscComponentVersions` in the test
- Fetches DSC component versions once in `retryableBefore` instead of per-component `oc get` calls

## How Has This Been Tested?

- Lint and type-check pass
- Executed `testAboutDialog.cy.ts` on a live ROSA cluster (ODH v3.5.0, DSC Ready): **1 passing, 0 failing** (12s)
- Merged to `main` via #9332

## Test Impact

This PR **is** the test fix — no product code changes.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`