### PR TITLE
fix: MLflow e2e test retry failure due to stale experiment names

### DIFF
--- a/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts
@@ -7,6 +7,7 @@ import {
   deleteMlflowExperimentViaAPI,
   getMlflowExperimentIdByName,
   logMlflowRunsViaAPI,
+  freeExperimentName,
 } from '../../../utils/oc_commands/mlflow';
 import { deleteOpenShiftProject, createOpenShiftProject } from '../../../utils/oc_commands/project';
 import { retryableBefore } from '../../../utils/retryableHooks';
@@ -46,7 +47,20 @@ describe('Verify MLflow Experiments page', () => {
       .then(() => {
         cy.step('Enable all features required for MLflow Experiments');
         return enableMlflowFeatures();
+      })
+      .then(() => {
+        const experimentName = `${testData.experiments[0].name}-${uuid}`;
+        const renamedName = `${testData.experiments[0].renamedName}-${uuid}`;
+        return freeExperimentName(projectName, experimentName).then(() =>
+          freeExperimentName(projectName, renamedName),
+        );
       });
+  });
+
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.clearAllLocalStorage();
+    cy.clearAllSessionStorage();
   });
 
   after(() => {

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -752,6 +752,56 @@ export const deleteMlflowExperimentViaAPI = (
   );
 
 /**
+ * Rename an MLflow experiment. Useful for freeing up a name before recreating,
+ * since MLflow's delete is only a soft-delete that retains the UNIQUE name constraint.
+ */
+export const renameMlflowExperimentViaAPI = (
+  workspace: string,
+  experimentId: string,
+  newName: string,
+): Cypress.Chainable<string> =>
+  execCurlInMlflowPod(
+    '/api/2.0/mlflow/experiments/update',
+    { experiment_id: experimentId, new_name: newName }, // eslint-disable-line camelcase
+    workspace,
+  );
+
+/**
+ * Restore a soft-deleted MLflow experiment so it can be renamed or reused.
+ */
+export const restoreMlflowExperimentViaAPI = (
+  workspace: string,
+  experimentId: string,
+): Cypress.Chainable<string> =>
+  execCurlInMlflowPod(
+    '/api/2.0/mlflow/experiments/restore',
+    { experiment_id: experimentId }, // eslint-disable-line camelcase
+    workspace,
+  );
+
+/**
+ * Free up an experiment name by renaming the existing experiment (active or deleted).
+ * MLflow soft-delete retains the UNIQUE name constraint, so this is needed to allow
+ * creating a new experiment with the same name after a test retry.
+ */
+export const freeExperimentName = (
+  workspace: string,
+  experimentName: string,
+): Cypress.Chainable<void> =>
+  getMlflowExperimentIdByName(workspace, experimentName).then((id) => {
+    if (!id) {
+      return;
+    }
+    const suffix = `-stale-${Date.now()}`;
+    cy.log(`Freeing experiment name: ${experimentName} (id=${id}) → ${experimentName}${suffix}`);
+    restoreMlflowExperimentViaAPI(workspace, id).then(() =>
+      renameMlflowExperimentViaAPI(workspace, id, `${experimentName}${suffix}`).then(() =>
+        deleteMlflowExperimentViaAPI(workspace, id),
+      ),
+    );
+  });
+
+/**
  * Look up an MLflow experiment by name and return its ID, or undefined if not found.
  */
 export const getMlflowExperimentIdByName = (


### PR DESCRIPTION
## Summary

- Fix `testMlflowExperiments` e2e test consistently failing on retry across builds #2272, #2290, #2299
- Root cause: MLflow's delete API only soft-deletes experiments, retaining the UNIQUE name constraint. On retry, creating an experiment with the same name returns `RESOURCE_ALREADY_EXISTS`, causing the embedded MLflow UI to show an error modal instead of navigating to the detail page
- Add `freeExperimentName()` utility (restore → rename → delete) to properly free experiment names between retries
- Clear browser state between retries to prevent stale module federation cache

## Changes

1. **`packages/cypress/cypress/utils/oc_commands/mlflow.ts`**:
   - `renameMlflowExperimentViaAPI()` — rename via `/experiments/update`
   - `restoreMlflowExperimentViaAPI()` — restore soft-deleted via `/experiments/restore`
   - `freeExperimentName()` — composite: lookup → restore → rename with timestamp suffix → delete

2. **`packages/cypress/cypress/tests/e2e/mlflowExperiments/testMlflowExperiments.cy.ts`**:
   - Add cleanup step in `retryableBefore` to free both experiment and renamed experiment names
   - Add `beforeEach` to clear cookies/localStorage/sessionStorage for clean module federation state

## Test plan

- [x] Verified on live cluster (`ag-gcp-34-pool-k6spq`): restore → rename → delete successfully frees experiment name, allowing create with same name to succeed
- [x] Confirmed MLflow soft-delete retains UNIQUE constraint — `RESOURCE_ALREADY_EXISTS` error reproduced and fixed
- [ ] Run full e2e suite on Jenkins to verify the fix resolves the retry failures