### PR TITLE
feat(ui-core): expand AnalyticsAPI to cover all fire* tracking functions

### DIFF
--- a/frontend/src/concepts/analyticsTracking/AnalyticsProvider.tsx
+++ b/frontend/src/concepts/analyticsTracking/AnalyticsProvider.tsx
@@ -3,12 +3,24 @@ import {
   AnalyticsContext,
   type AnalyticsAPI,
 } from '@odh-dashboard/ui-core/contexts/AnalyticsContext';
-import { fireFormTrackingEvent } from './segmentIOUtils';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+  fireLinkTrackingEvent,
+  fireSimpleTrackingEvent,
+  firePageEvent,
+  fireIdentifyEvent,
+} from './segmentIOUtils';
 
 export const AnalyticsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const value = React.useMemo<AnalyticsAPI>(
     () => ({
       fireFormTrackingEvent,
+      fireMiscTrackingEvent,
+      fireLinkTrackingEvent,
+      fireSimpleTrackingEvent,
+      firePageEvent,
+      fireIdentifyEvent,
     }),
     [],
   );

--- a/frontend/src/concepts/analyticsTracking/trackingProperties.ts
+++ b/frontend/src/concepts/analyticsTracking/trackingProperties.ts
@@ -2,27 +2,13 @@ export type ODHSegmentKey = {
   segmentKey: string;
 };
 
-export type IdentifyEventProperties = {
-  isAdmin: boolean;
-  userID?: string;
-  canCreateProjects: boolean;
-};
+export type {
+  IdentifyEventProperties,
+  LinkTrackingEventProperties,
+  MiscTrackingEventProperties,
+} from '@odh-dashboard/ui-core/contexts/AnalyticsContext';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type BaseTrackingEventProperties = {
   // empty for the moment
 };
-
-export type LinkTrackingEventProperties = {
-  from?: string;
-  href?: string;
-  to?: string;
-  type?: string;
-  section?: string;
-  name?: string;
-  projectName?: string;
-} & BaseTrackingEventProperties;
-
-export type MiscTrackingEventProperties = {
-  [key: string]: string | number | boolean | undefined;
-} & BaseTrackingEventProperties;

--- a/packages/ui-core/src/contexts/AnalyticsContext.tsx
+++ b/packages/ui-core/src/contexts/AnalyticsContext.tsx
@@ -41,7 +41,7 @@ export type AnalyticsAPI = {
   fireIdentifyEvent: (properties: IdentifyEventProperties) => void;
 };
 
-const noopAnalytics: AnalyticsAPI = {
+export const noopAnalytics: AnalyticsAPI = {
   fireFormTrackingEvent: () => undefined,
   fireMiscTrackingEvent: () => undefined,
   fireLinkTrackingEvent: () => undefined,

--- a/packages/ui-core/src/contexts/AnalyticsContext.tsx
+++ b/packages/ui-core/src/contexts/AnalyticsContext.tsx
@@ -12,12 +12,42 @@ export type FormTrackingEventProperties = {
   [key: string]: string | number | boolean | undefined;
 };
 
+export type MiscTrackingEventProperties = {
+  [key: string]: string | number | boolean | undefined;
+};
+
+export type LinkTrackingEventProperties = {
+  from?: string;
+  href?: string;
+  to?: string;
+  type?: string;
+  section?: string;
+  name?: string;
+  projectName?: string;
+};
+
+export type IdentifyEventProperties = {
+  isAdmin: boolean;
+  userID?: string;
+  canCreateProjects: boolean;
+};
+
 export type AnalyticsAPI = {
   fireFormTrackingEvent: (eventName: string, properties: FormTrackingEventProperties) => void;
+  fireMiscTrackingEvent: (eventName: string, properties: MiscTrackingEventProperties) => void;
+  fireLinkTrackingEvent: (eventName: string, properties: LinkTrackingEventProperties) => void;
+  fireSimpleTrackingEvent: (eventName: string) => void;
+  firePageEvent: () => void;
+  fireIdentifyEvent: (properties: IdentifyEventProperties) => void;
 };
 
 const noopAnalytics: AnalyticsAPI = {
   fireFormTrackingEvent: () => undefined,
+  fireMiscTrackingEvent: () => undefined,
+  fireLinkTrackingEvent: () => undefined,
+  fireSimpleTrackingEvent: () => undefined,
+  firePageEvent: () => undefined,
+  fireIdentifyEvent: () => undefined,
 };
 
 export const AnalyticsContext = React.createContext<AnalyticsAPI>(noopAnalytics);

--- a/packages/ui-core/src/contexts/__tests__/AnalyticsContext.spec.tsx
+++ b/packages/ui-core/src/contexts/__tests__/AnalyticsContext.spec.tsx
@@ -42,6 +42,10 @@ describe('AnalyticsContext', () => {
       return null;
     };
     render(<Capture />);
+    if (!analytics) {
+      throw new Error('AnalyticsContext did not provide an AnalyticsAPI');
+    }
+    const api = analytics;
 
     const formProperties: FormTrackingEventProperties = { outcome: TrackingOutcome.submit };
     const miscProperties: MiscTrackingEventProperties = { key: 'value' };
@@ -52,12 +56,12 @@ describe('AnalyticsContext', () => {
     };
 
     expect(() => {
-      expect(analytics?.fireFormTrackingEvent('event', formProperties)).toBeUndefined();
-      expect(analytics?.fireMiscTrackingEvent('event', miscProperties)).toBeUndefined();
-      expect(analytics?.fireLinkTrackingEvent('event', linkProperties)).toBeUndefined();
-      expect(analytics?.fireSimpleTrackingEvent('event')).toBeUndefined();
-      expect(analytics?.firePageEvent()).toBeUndefined();
-      expect(analytics?.fireIdentifyEvent(identifyProperties)).toBeUndefined();
+      expect(api.fireFormTrackingEvent('event', formProperties)).toBeUndefined();
+      expect(api.fireMiscTrackingEvent('event', miscProperties)).toBeUndefined();
+      expect(api.fireLinkTrackingEvent('event', linkProperties)).toBeUndefined();
+      expect(api.fireSimpleTrackingEvent('event')).toBeUndefined();
+      expect(api.firePageEvent()).toBeUndefined();
+      expect(api.fireIdentifyEvent(identifyProperties)).toBeUndefined();
     }).not.toThrow();
   });
 

--- a/packages/ui-core/src/contexts/__tests__/AnalyticsContext.spec.tsx
+++ b/packages/ui-core/src/contexts/__tests__/AnalyticsContext.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import {
   AnalyticsContext,
   useAnalytics,
+  noopAnalytics,
   type AnalyticsAPI,
   type FormTrackingEventProperties,
   type MiscTrackingEventProperties,
@@ -11,14 +12,7 @@ import {
   TrackingOutcome,
 } from '../AnalyticsContext';
 
-const ANALYTICS_API_KEYS: (keyof AnalyticsAPI)[] = [
-  'fireFormTrackingEvent',
-  'fireMiscTrackingEvent',
-  'fireLinkTrackingEvent',
-  'fireSimpleTrackingEvent',
-  'firePageEvent',
-  'fireIdentifyEvent',
-];
+const ANALYTICS_API_KEYS = Object.keys(noopAnalytics) as (keyof AnalyticsAPI)[];
 
 const TestConsumer: React.FC = () => {
   const analytics = useAnalytics();

--- a/packages/ui-core/src/contexts/__tests__/AnalyticsContext.spec.tsx
+++ b/packages/ui-core/src/contexts/__tests__/AnalyticsContext.spec.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  AnalyticsContext,
+  useAnalytics,
+  type AnalyticsAPI,
+  type FormTrackingEventProperties,
+  type MiscTrackingEventProperties,
+  type LinkTrackingEventProperties,
+  type IdentifyEventProperties,
+  TrackingOutcome,
+} from '../AnalyticsContext';
+
+const ANALYTICS_API_KEYS: (keyof AnalyticsAPI)[] = [
+  'fireFormTrackingEvent',
+  'fireMiscTrackingEvent',
+  'fireLinkTrackingEvent',
+  'fireSimpleTrackingEvent',
+  'firePageEvent',
+  'fireIdentifyEvent',
+];
+
+const TestConsumer: React.FC = () => {
+  const analytics = useAnalytics();
+  return (
+    <div data-testid="member-count">
+      {ANALYTICS_API_KEYS.filter((key) => typeof analytics[key] === 'function').length}
+    </div>
+  );
+};
+
+describe('AnalyticsContext', () => {
+  it('should default every AnalyticsAPI member to a callable no-op before a provider is mounted', () => {
+    render(<TestConsumer />);
+    expect(screen.getByTestId('member-count')).toHaveTextContent(String(ANALYTICS_API_KEYS.length));
+  });
+
+  it('should not throw and should return undefined when invoking any default (unmounted-provider) member', () => {
+    let analytics: AnalyticsAPI | undefined;
+    const Capture: React.FC = () => {
+      analytics = useAnalytics();
+      return null;
+    };
+    render(<Capture />);
+
+    const formProperties: FormTrackingEventProperties = { outcome: TrackingOutcome.submit };
+    const miscProperties: MiscTrackingEventProperties = { key: 'value' };
+    const linkProperties: LinkTrackingEventProperties = { href: '/somewhere' };
+    const identifyProperties: IdentifyEventProperties = {
+      isAdmin: false,
+      canCreateProjects: true,
+    };
+
+    expect(() => {
+      expect(analytics?.fireFormTrackingEvent('event', formProperties)).toBeUndefined();
+      expect(analytics?.fireMiscTrackingEvent('event', miscProperties)).toBeUndefined();
+      expect(analytics?.fireLinkTrackingEvent('event', linkProperties)).toBeUndefined();
+      expect(analytics?.fireSimpleTrackingEvent('event')).toBeUndefined();
+      expect(analytics?.firePageEvent()).toBeUndefined();
+      expect(analytics?.fireIdentifyEvent(identifyProperties)).toBeUndefined();
+    }).not.toThrow();
+  });
+
+  it('should let a mounted provider override the default no-op implementation', () => {
+    const fireSimpleTrackingEvent = jest.fn();
+    const providerValue: AnalyticsAPI = {
+      fireFormTrackingEvent: jest.fn(),
+      fireMiscTrackingEvent: jest.fn(),
+      fireLinkTrackingEvent: jest.fn(),
+      fireSimpleTrackingEvent,
+      firePageEvent: jest.fn(),
+      fireIdentifyEvent: jest.fn(),
+    };
+
+    const TriggerConsumer: React.FC = () => {
+      const analytics = useAnalytics();
+      React.useEffect(() => {
+        analytics.fireSimpleTrackingEvent('page-loaded');
+      }, [analytics]);
+      return null;
+    };
+
+    render(
+      <AnalyticsContext.Provider value={providerValue}>
+        <TriggerConsumer />
+      </AnalyticsContext.Provider>,
+    );
+
+    expect(fireSimpleTrackingEvent).toHaveBeenCalledWith('page-loaded');
+  });
+});

--- a/packages/ui-core/src/index.ts
+++ b/packages/ui-core/src/index.ts
@@ -3,7 +3,12 @@ export type { UpdateObjectAtPropAndValue } from './types';
 export { ThemeContext, useThemeContext } from './contexts/ThemeContext';
 export type { ThemeContextProps } from './contexts/ThemeContext';
 
-export { AnalyticsContext, useAnalytics, TrackingOutcome } from './contexts/AnalyticsContext';
+export {
+  AnalyticsContext,
+  useAnalytics,
+  noopAnalytics,
+  TrackingOutcome,
+} from './contexts/AnalyticsContext';
 export type {
   FormTrackingEventProperties,
   MiscTrackingEventProperties,

--- a/packages/ui-core/src/index.ts
+++ b/packages/ui-core/src/index.ts
@@ -4,7 +4,13 @@ export { ThemeContext, useThemeContext } from './contexts/ThemeContext';
 export type { ThemeContextProps } from './contexts/ThemeContext';
 
 export { AnalyticsContext, useAnalytics, TrackingOutcome } from './contexts/AnalyticsContext';
-export type { FormTrackingEventProperties, AnalyticsAPI } from './contexts/AnalyticsContext';
+export type {
+  FormTrackingEventProperties,
+  MiscTrackingEventProperties,
+  LinkTrackingEventProperties,
+  IdentifyEventProperties,
+  AnalyticsAPI,
+} from './contexts/AnalyticsContext';
 
 export { NotificationContext, useNotification } from './contexts/NotificationContext';
 export type { NotificationAction, NotificationAPI } from './contexts/NotificationContext';


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-84999

## Description

`AnalyticsAPI` in ui-core only exposes `fireFormTrackingEvent`. The other five tracking functions (`fireMiscTrackingEvent`, `fireLinkTrackingEvent`, `fireSimpleTrackingEvent`, `firePageEvent`, `fireIdentifyEvent`) live in `segmentIOUtils`, and 143 files across 12 packages import them from `@odh-dashboard/internal`. That couples every package to the main frontend.

This PR adds all five to `AnalyticsAPI` with no-op defaults, exports the matching property types, and wires the concrete implementations in `AnalyticsProvider`. First step in the analytics decoupling. Follow-up tasks will extract the Segment SDK to a shared `packages/analytics` package and migrate all 143 import sites to `useAnalytics()`.

| File | Change |
|------|--------|
| `packages/ui-core/src/contexts/AnalyticsContext.tsx` | 5 new methods on `AnalyticsAPI`, 3 property types, updated `noopAnalytics` |
| `packages/ui-core/src/index.ts` | Re-export new types |
| `frontend/src/concepts/analyticsTracking/AnalyticsProvider.tsx` | Provide all 6 implementations to context |
| `packages/ui-core/src/contexts/__tests__/AnalyticsContext.spec.tsx` | Tests for no-op defaults and provider override |

## How Has This Been Tested?

- `npm run type-check` passes
- `npm run lint` passes (lint-staged confirmed on commit)
- Unit tests in `AnalyticsContext.spec.tsx`:
  - No-op defaults are callable and return `undefined`
  - Provider overrides the defaults

## Test Impact

3 unit tests added in `AnalyticsContext.spec.tsx`. No UI changes, no Cypress tests needed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded analytics tracking to support miscellaneous, link, simple, page, and identify events alongside form events.
  * Added consistent event property definitions for improved tracking coverage and integration support.

* **Bug Fixes**
  * Improved behavior when analytics tracking is unavailable, preventing errors and allowing the application to continue operating normally.

* **Tests**
  * Added coverage for default analytics behavior and provider-based tracking overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->