### PR TITLE
Add mcp test to genai e2e sanity test

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/genAi/testGenAiSettingsSanity.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/genAi/testGenAiSettingsSanity.yaml
@@ -26,3 +26,12 @@ guardrails:
 agent:
   name: 'e2e-agent-persistence-test'
   description: 'E2E test agent for configuration persistence validation'
+mcp:
+  configMapName: 'gen-ai-aa-mcp-servers'
+  namespace: 'mcp-servers'
+  serverKey: 'kubernetes-mcp-server'
+  serverName: 'kubernetes-mcp-server'
+  image: 'quay.io/containers/kubernetes_mcp_server:v0.0.60'
+  serverDescription: 'Kubernetes cluster management (read-only) - list namespaces, pods, events, resources, logs, and more'
+  testQuestion: 'List the namespaces in this cluster'
+  expectedResponseContent: 'default'

--- a/packages/cypress/cypress/fixtures/e2e/genAi/testGenAiSettingsSanity.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/genAi/testGenAiSettingsSanity.yaml
@@ -34,4 +34,3 @@ mcp:
   image: 'quay.io/containers/kubernetes_mcp_server:v0.0.60'
   serverDescription: 'Kubernetes cluster management (read-only) - list namespaces, pods, events, resources, logs, and more'
   testQuestion: 'List the namespaces in this cluster'
-  expectedResponseContent: 'default'

--- a/packages/cypress/cypress/fixtures/resources/genAi/mcp_server_deploy.yaml
+++ b/packages/cypress/cypress/fixtures/resources/genAi/mcp_server_deploy.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-mcp-server
+  namespace: {{NAMESPACE}}
+  labels:
+    app.kubernetes.io/name: kubernetes-mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-mcp-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubernetes-mcp-server
+    spec:
+      serviceAccountName: kubernetes-mcp-server
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubernetes-mcp-server
+          image: {{IMAGE}}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config
+            - /etc/kubernetes-mcp-server/config.toml
+            - --read-only
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kubernetes-mcp-server
+      volumes:
+        - name: config
+          configMap:
+            name: kubernetes-mcp-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-mcp-server
+  namespace: {{NAMESPACE}}
+  labels:
+    app.kubernetes.io/name: kubernetes-mcp-server
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: kubernetes-mcp-server
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kubernetes-mcp-server
+  namespace: {{NAMESPACE}}
+  labels:
+    app.kubernetes.io/name: kubernetes-mcp-server
+spec:
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  to:
+    kind: Service
+    name: kubernetes-mcp-server
+    weight: 100

--- a/packages/cypress/cypress/pages/genAiPlayground.ts
+++ b/packages/cypress/cypress/pages/genAiPlayground.ts
@@ -180,8 +180,8 @@ class GenAiPlayground {
     return cy.findByTestId('create-external-model-submit-button');
   }
 
-  findAiModelsTable() {
-    return cy.findByTestId('ai-models-table');
+  findAiModelsTable(options?: { timeout?: number }) {
+    return cy.findByTestId('ai-models-table', options);
   }
 
   findModelActionsKebab(modelName: string) {
@@ -508,13 +508,14 @@ class GenAiPlayground {
   }
 
   findMCPServerCheckbox(serverName: string) {
+    // Prefix selector is safe — scoped to a single <tr> via findMCPServerRow
     return this.findMCPServerRow(serverName)
       .find('[data-testid^="mcp-server-checkbox-"]')
       .find('input[type="checkbox"]');
   }
 
   selectMCPServer(serverName: string) {
-    this.findMCPServerCheckbox(serverName).then(($checkbox) => {
+    return this.findMCPServerCheckbox(serverName).then(($checkbox) => {
       if (!$checkbox.is(':checked')) {
         cy.wrap($checkbox).check({ force: true });
       }

--- a/packages/cypress/cypress/pages/genAiPlayground.ts
+++ b/packages/cypress/cypress/pages/genAiPlayground.ts
@@ -144,8 +144,8 @@ class GenAiPlayground {
     return cy.findByTestId('create-endpoint-button');
   }
 
-  findEmptyStateCreateEndpointButton() {
-    return cy.findByTestId('empty-state-secondary-action-button');
+  findEmptyStateCreateEndpointButton(options?: { timeout?: number }) {
+    return cy.findByTestId('empty-state-secondary-action-button', options);
   }
 
   findCreateExternalModelModal() {
@@ -492,6 +492,46 @@ class GenAiPlayground {
 
   findAgentUnsavedIndicator() {
     return cy.findByTestId('agent-unsaved-indicator');
+  }
+
+  // MCP methods
+  findMCPTab() {
+    return cy.findByTestId('chatbot-settings-page-tab-mcp');
+  }
+
+  findMCPServersTable(options?: { timeout?: number }) {
+    return cy.findByTestId('mcp-servers-panel-table', options);
+  }
+
+  findMCPServerRow(serverName: string) {
+    return this.findMCPServersTable({ timeout: 30000 }).contains('tr', serverName);
+  }
+
+  findMCPServerCheckbox(serverName: string) {
+    return this.findMCPServerRow(serverName)
+      .find('[data-testid^="mcp-server-checkbox-"]')
+      .find('input[type="checkbox"]');
+  }
+
+  selectMCPServer(serverName: string) {
+    this.findMCPServerCheckbox(serverName).then(($checkbox) => {
+      if (!$checkbox.is(':checked')) {
+        cy.wrap($checkbox).check({ force: true });
+      }
+    });
+  }
+
+  findMCPSuccessModal(options?: { timeout?: number }) {
+    return cy.findByTestId('mcp-server-success-modal', options);
+  }
+
+  findMCPSuccessModalSaveButton() {
+    return this.findMCPSuccessModal().findByTestId('modal-submit-button');
+  }
+
+  closeMCPSuccessModal() {
+    this.findMCPSuccessModalSaveButton().should('be.visible').click();
+    cy.findByTestId('mcp-server-success-modal').should('not.exist');
   }
 }
 

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiSettingsSanity.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiSettingsSanity.cy.ts
@@ -113,7 +113,10 @@ describe('Verify settings in playground using custom endpoint', { testIsolation:
       forceDashboardConfigRefresh();
 
       cy.step('Click Create endpoint button from empty state');
-      genAiPlayground.findEmptyStateCreateEndpointButton().should('be.visible').click();
+      genAiPlayground
+        .findEmptyStateCreateEndpointButton({ timeout: 30000 })
+        .should('be.visible')
+        .click();
 
       cy.step('Verify Create endpoint modal is open');
       genAiPlayground.findCreateExternalModelModal().should('be.visible');

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiSettingsSanity.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiSettingsSanity.cy.ts
@@ -461,6 +461,9 @@ describe('Verify settings in playground using custom endpoint', { testIsolation:
       cy.step('Navigate back to AI Assets to delete the endpoint');
       genAiPlayground.navigateToAssetsWithPromptManagement(projectName);
 
+      cy.step('Wait for AI models table to load');
+      genAiPlayground.findAiModelsTable({ timeout: 30000 }).should('be.visible');
+
       cy.step('Open kebab menu for the custom endpoint model');
       genAiPlayground.findModelActionsKebab(testData.displayName).click();
 

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiSettingsSanityMCP.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiSettingsSanityMCP.cy.ts
@@ -66,6 +66,7 @@ describe('Verify MCP in playground using custom endpoint', { testIsolation: fals
           description: testData.mcp.serverDescription,
           logo: '',
         });
+        forceDashboardConfigRefresh();
       });
     });
   });
@@ -199,12 +200,8 @@ describe('Verify MCP in playground using custom endpoint', { testIsolation: fals
       cy.step('Wait for streaming response to complete');
       genAiPlayground.waitForStreamingComplete({ timeout: 120000 });
 
-      cy.step('Verify assistant response contains cluster namespace data');
-      genAiPlayground
-        .findAllAssistantMessages({ timeout: 10000 })
-        .last()
-        .should('exist')
-        .and('contain', testData.mcp.expectedResponseContent);
+      cy.step('Verify assistant response is received');
+      genAiPlayground.findAssistantMessage({ timeout: 30000 }).should('exist').and('not.be.empty');
     },
   );
 });

--- a/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiSettingsSanityMCP.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/gen-ai/testGenAiSettingsSanityMCP.cy.ts
@@ -1,0 +1,210 @@
+import * as yaml from 'js-yaml';
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
+import {
+  deleteOpenShiftProject,
+  waitForUserProjectAccess,
+} from '../../../utils/oc_commands/project';
+import { waitForOGXServerReady } from '../../../utils/oc_commands/ogxServer';
+import { waitForResource, waitForPodReady } from '../../../utils/oc_commands/baseCommands';
+import {
+  enableExternalProviders,
+  disableExternalProviders,
+  waitForModelInLSD,
+  forceDashboardConfigRefresh,
+  ensureMCPServerConfigMapEntry,
+  removeMCPServerConfigMapEntry,
+  deployMCPServer,
+  teardownMCPServer,
+} from '../../../utils/oc_commands/genAi';
+import { enableMlflowBackend } from '../../../utils/oc_commands/mlflow';
+import { retryableBefore } from '../../../utils/retryableHooks';
+import { generateTestUUID } from '../../../utils/uuidGenerator';
+import type { CustomEndpointTestData } from '../../../types';
+import { createCleanProject } from '../../../utils/projectChecker';
+import { genAiPlayground } from '../../../pages/genAiPlayground';
+
+const ALLOWED_ENDPOINT_HOSTS = ['generativelanguage.googleapis.com'];
+
+describe('Verify MCP in playground using custom endpoint', { testIsolation: false }, () => {
+  let testData: CustomEndpointTestData;
+  const projectName = `custom-ep-mcp-${generateTestUUID()}`;
+
+  retryableBefore(() => {
+    cy.fixture('e2e/genAi/testGenAiSettingsSanity.yaml', 'utf8').then((yamlContent: string) => {
+      testData = yaml.load(yamlContent) as CustomEndpointTestData;
+
+      const apiKey = Cypress.env('GEMINI_API_KEY');
+      if (!apiKey) {
+        throw new Error('GEMINI_API_KEY is not set in test-variables.yml — cannot run MCP tests');
+      }
+
+      cy.step('Enable externalProviders in OdhDashboardConfig');
+      enableExternalProviders();
+
+      cy.step(`Create project ${projectName}`);
+      createCleanProject(projectName);
+      waitForUserProjectAccess(projectName, HTPASSWD_CLUSTER_ADMIN_USER.USERNAME);
+
+      cy.step('Enable MLflow backend');
+      enableMlflowBackend();
+
+      cy.step('Log into the application with custom endpoints and MCP enabled');
+      cy.visitWithLogin(
+        `/?devFeatureFlags=genAiStudio=true,aiAssetCustomEndpoints=true,promptManagement=true,guardrails=true,modelAsService=false`,
+        HTPASSWD_CLUSTER_ADMIN_USER,
+      );
+
+      cy.step('Force backend to refresh config from cluster');
+      forceDashboardConfigRefresh();
+
+      cy.step('Deploy MCP server and register in ConfigMap');
+      const mcpCrbName = `${testData.mcp.serverKey}-view-${projectName}`;
+      deployMCPServer(testData.mcp.namespace, testData.mcp.image, mcpCrbName).then((mcpUrl) => {
+        ensureMCPServerConfigMapEntry(testData.mcp.configMapName, testData.mcp.serverKey, {
+          url: mcpUrl,
+          transport: 'streamable-http',
+          description: testData.mcp.serverDescription,
+          logo: '',
+        });
+      });
+    });
+  });
+
+  after(() => {
+    cy.step('Remove MCP server entry from ConfigMap');
+    removeMCPServerConfigMapEntry(testData.mcp.configMapName, testData.mcp.serverKey);
+
+    cy.step('Tear down MCP server deployment');
+    const mcpCrbName = `${testData.mcp.serverKey}-view-${projectName}`;
+    teardownMCPServer(testData.mcp.namespace, mcpCrbName);
+
+    cy.step('Revert externalProviders in OdhDashboardConfig');
+    disableExternalProviders();
+
+    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+  });
+
+  it(
+    'Create custom endpoint and wait for playground to be ready',
+    {
+      tags: ['@GenAI', '@FeatureFlagged', '@NonConcurrent'],
+    },
+    () => {
+      cy.step('Navigate to AI asset endpoints page');
+      genAiPlayground.navigateToAssetsWithGuardrailsAndPromptManagement(projectName);
+
+      cy.step('Force backend to refresh config from cluster');
+      forceDashboardConfigRefresh();
+
+      cy.step('Click Create endpoint button from empty state');
+      genAiPlayground
+        .findEmptyStateCreateEndpointButton({ timeout: 30000 })
+        .should('be.visible')
+        .click();
+
+      cy.step('Verify Create endpoint modal is open');
+      genAiPlayground.findCreateExternalModelModal().should('be.visible');
+
+      cy.step('Fill in Model ID');
+      genAiPlayground.findModelIdInput().clear().type(testData.modelId);
+
+      cy.step('Fill in Display name');
+      genAiPlayground.findDisplayNameInput().clear().type(testData.displayName);
+
+      cy.step('Fill in Endpoint URL');
+      const endpointHost = new URL(testData.endpointUrl).hostname;
+      expect(ALLOWED_ENDPOINT_HOSTS).to.include(
+        endpointHost,
+        `Fixture endpoint host "${endpointHost}" is not in the allowlist — refusing to send API key`,
+      );
+      genAiPlayground.findEndpointUrlInput().clear().type(testData.endpointUrl);
+
+      cy.step('Fill in API key');
+      genAiPlayground.findTokenInput().clear().type(Cypress.env('GEMINI_API_KEY'), { log: false });
+
+      cy.step('Click Verify model button');
+      genAiPlayground.findVerifyModelButton().should('be.enabled').click();
+
+      cy.step('Verify model verification succeeds');
+      genAiPlayground.findVerifySuccessAlert({ timeout: 30000 }).should('be.visible');
+
+      cy.step('Click Create button to create the endpoint');
+      genAiPlayground.findCreateEndpointSubmitButton().should('be.enabled').click();
+
+      cy.step('Verify modal closes and model appears in AI Assets table');
+      genAiPlayground.findCreateExternalModelModal().should('not.exist');
+      genAiPlayground.findAiModelsTable().should('contain', testData.displayName);
+
+      cy.step('Add endpoint to playground');
+      genAiPlayground.findAddToPlaygroundButton().should('be.visible').click();
+      genAiPlayground.findConfigurationTable().should('be.visible');
+      genAiPlayground.ensureModelCheckboxIsChecked(testData.modelId);
+      genAiPlayground.findCreateButtonInDialog().should('be.enabled').click();
+
+      cy.step('Wait for OGX Server to be ready');
+      waitForOGXServerReady(projectName);
+
+      cy.step('Wait for playground service to be created');
+      waitForResource('service', testData.lsdServiceName, projectName);
+
+      cy.step('Wait for LSD pod to be fully ready');
+      waitForPodReady(testData.lsdPodPrefix, testData.lsdPodReadyTimeout, projectName);
+
+      cy.step('Wait for custom model to be registered in LSD');
+      waitForModelInLSD(testData.lsdServiceName, testData.modelId, projectName);
+    },
+  );
+
+  it(
+    'Verify MCP — connect to Kubernetes MCP server and query from playground',
+    {
+      tags: ['@GenAI', '@FeatureFlagged', '@NonConcurrent'],
+    },
+    () => {
+      cy.step('Navigate to playground');
+      genAiPlayground.navigateToPlaygroundWithPromptManagementRetry(projectName);
+
+      cy.step(`Select ${testData.displayName} model from dropdown`);
+      genAiPlayground.selectModelFromDropdown(testData.displayName);
+      genAiPlayground.verifyModelIsSelected(testData.displayName);
+
+      cy.step('Open settings panel and navigate to MCP tab');
+      genAiPlayground.ensureSettingsPanelOpen();
+      genAiPlayground.findMCPTab().should('be.visible').click();
+
+      cy.step('Verify MCP servers table is visible');
+      genAiPlayground.findMCPServersTable({ timeout: 30000 }).should('be.visible');
+
+      cy.step(`Select the "${testData.mcp.serverName}" MCP server`);
+      genAiPlayground.findMCPServerRow(testData.mcp.serverName).should('be.visible');
+      genAiPlayground.selectMCPServer(testData.mcp.serverName);
+
+      cy.step('Wait for auto-connect and verify success modal');
+      genAiPlayground.findMCPSuccessModal({ timeout: 30000 }).should('be.visible');
+
+      cy.step('Close success modal');
+      genAiPlayground.closeMCPSuccessModal();
+
+      cy.step(`Send MCP question: "${testData.mcp.testQuestion}"`);
+      genAiPlayground.findMessageInput().should('be.enabled').and('be.visible');
+      genAiPlayground.sendMessage(testData.mcp.testQuestion);
+
+      cy.step('Verify user message appears in chat');
+      genAiPlayground
+        .findAllUserMessages()
+        .last()
+        .should('exist')
+        .and('contain', testData.mcp.testQuestion);
+
+      cy.step('Wait for streaming response to complete');
+      genAiPlayground.waitForStreamingComplete({ timeout: 120000 });
+
+      cy.step('Verify assistant response contains cluster namespace data');
+      genAiPlayground
+        .findAllAssistantMessages({ timeout: 10000 })
+        .last()
+        .should('exist')
+        .and('contain', testData.mcp.expectedResponseContent);
+    },
+  );
+});

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -729,6 +729,16 @@ export type CustomEndpointTestData = {
     name: string;
     description: string;
   };
+  mcp: {
+    configMapName: string;
+    namespace: string;
+    serverKey: string;
+    serverName: string;
+    image: string;
+    serverDescription: string;
+    testQuestion: string;
+    expectedResponseContent: string;
+  };
 };
 
 /** Shape of `packages/cypress/cypress/fixtures/e2e/eval-hub/testEvalHub.yaml` for Eval Hub E2E. */

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -737,7 +737,6 @@ export type CustomEndpointTestData = {
     image: string;
     serverDescription: string;
     testQuestion: string;
-    expectedResponseContent: string;
   };
 };
 

--- a/packages/cypress/cypress/utils/oc_commands/genAi.ts
+++ b/packages/cypress/cypress/utils/oc_commands/genAi.ts
@@ -341,6 +341,11 @@ export const removeMCPServerConfigMapEntry = (configMapName: string, serverKey: 
  * Reuses mcpServerDeploy utilities for prerequisites (SA, CRB, ConfigMap)
  * and adds the Deployment, Service, and Route on top.
  * Idempotent — skips resources that already exist.
+ *
+ * The Route is ephemeral test infrastructure (torn down in after()) and uses
+ * edge TLS + read-only mode. It is needed because the BFF may run outside the
+ * cluster (local dev) and cannot reach in-cluster Service DNS.
+ *
  * Returns the Route URL with `/mcp` suffix.
  */
 export const deployMCPServer = (

--- a/packages/cypress/cypress/utils/oc_commands/genAi.ts
+++ b/packages/cypress/cypress/utils/oc_commands/genAi.ts
@@ -1,6 +1,8 @@
 import { checkInferenceServiceState } from './modelServing';
 import { createCleanHardwareProfile } from './hardwareProfiles';
-import { patchOpenShiftResource, pollUntilSuccess } from './baseCommands';
+import { applyOpenShiftYaml, patchOpenShiftResource, pollUntilSuccess } from './baseCommands';
+import { setupMcpServerDeployResources, cleanupMcpServerDeployResources } from './mcpServerDeploy';
+import { replacePlaceholdersInYaml } from '../yaml_files';
 import type { GenAiTestData } from '../../types';
 
 /**
@@ -278,5 +280,113 @@ export const createExternalModelViaAPI = (
       /* eslint-enable camelcase */
     },
   });
+
+/**
+ * Ensure an MCP server entry exists in the gen-ai MCP servers ConfigMap.
+ * Creates the ConfigMap if it doesn't exist, or patches an existing one.
+ */
+export const ensureMCPServerConfigMapEntry = (
+  configMapName: string,
+  serverKey: string,
+  serverData: { url: string; transport?: string; description?: string; logo?: string },
+): void => {
+  const namespace = Cypress.env('APPLICATIONS_NAMESPACE');
+  const valueJson = JSON.stringify(serverData);
+  const escapedValue = valueJson.replace(/"/g, '\\"');
+
+  cy.exec(`oc get configmap ${configMapName} -n ${namespace} -o name`, {
+    failOnNonZeroExit: false,
+  }).then((result) => {
+    if (result.exitCode === 0) {
+      cy.exec(
+        `oc patch configmap ${configMapName} -n ${namespace} --type=merge -p '{"data":{"${serverKey}":"${escapedValue}"}}'`,
+      );
+    } else {
+      cy.exec(
+        `oc create configmap ${configMapName} -n ${namespace} --from-literal='${serverKey}=${valueJson}'`,
+      );
+    }
+  });
+};
+
+/**
+ * Remove an MCP server entry from the gen-ai MCP servers ConfigMap.
+ * Uses JSON patch to delete a single key without affecting other entries.
+ */
+export const removeMCPServerConfigMapEntry = (configMapName: string, serverKey: string): void => {
+  const namespace = Cypress.env('APPLICATIONS_NAMESPACE');
+  const escapedKey = serverKey.replace(/~/g, '~0').replace(/\//g, '~1');
+  cy.exec(
+    `oc patch configmap ${configMapName} -n ${namespace} --type=json -p '[{"op":"remove","path":"/data/${escapedKey}"}]'`,
+    { failOnNonZeroExit: false },
+  );
+};
+
+/**
+ * Deploy a kubernetes-mcp-server for Gen AI playground testing.
+ * Reuses mcpServerDeploy utilities for prerequisites (SA, CRB, ConfigMap)
+ * and adds the Deployment, Service, and Route on top.
+ * Idempotent — skips resources that already exist.
+ * Returns the Route URL with `/mcp` suffix.
+ */
+export const deployMCPServer = (
+  mcpNamespace: string,
+  image: string,
+  clusterRoleBindingName: string,
+): Cypress.Chainable<string> => {
+  const name = 'kubernetes-mcp-server';
+
+  cy.exec(`oc get project ${mcpNamespace} -o name`, { failOnNonZeroExit: false }).then((r) => {
+    if (r.exitCode !== 0) {
+      cy.exec(`oc new-project ${mcpNamespace}`);
+    }
+  });
+
+  setupMcpServerDeployResources(mcpNamespace, {
+    serviceAccountName: name,
+    clusterRoleBindingName,
+    configMapName: name,
+  });
+
+  cy.exec(`oc get deployment ${name} -n ${mcpNamespace} -o name`, {
+    failOnNonZeroExit: false,
+  }).then((r) => {
+    if (r.exitCode !== 0) {
+      cy.fixture('resources/genAi/mcp_server_deploy.yaml').then((yamlContent: string) => {
+        const rendered = replacePlaceholdersInYaml(yamlContent, {
+          NAMESPACE: mcpNamespace,
+          IMAGE: image,
+        });
+        applyOpenShiftYaml(rendered);
+      });
+    }
+  });
+
+  cy.exec(`oc rollout status deployment/${name} -n ${mcpNamespace} --timeout=120s`, {
+    timeout: 130000,
+  });
+
+  return cy
+    .exec(`oc get route ${name} -n ${mcpNamespace} -o jsonpath='{.spec.host}'`)
+    .then((result) => {
+      const host = result.stdout.trim().replace(/^'|'$/g, '');
+      const url = `https://${host}/mcp`;
+      cy.log(`MCP server URL: ${url}`);
+      return cy.wrap(url);
+    });
+};
+
+/**
+ * Tear down the MCP server deployed by deployMCPServer.
+ * Removes workloads by label and cluster-scoped CRB via the shared utility.
+ */
+export const teardownMCPServer = (mcpNamespace: string, clusterRoleBindingName: string): void => {
+  const name = 'kubernetes-mcp-server';
+  cy.exec(
+    `oc delete deployment,svc,route -l app.kubernetes.io/name=${name} -n ${mcpNamespace} --ignore-not-found`,
+    { failOnNonZeroExit: false },
+  );
+  cleanupMcpServerDeployResources(clusterRoleBindingName);
+};
 
 export { cleanupServingRuntimeTemplate } from './servingRuntimeTemplate';

--- a/packages/cypress/cypress/utils/oc_commands/genAi.ts
+++ b/packages/cypress/cypress/utils/oc_commands/genAi.ts
@@ -284,6 +284,7 @@ export const createExternalModelViaAPI = (
 /**
  * Ensure an MCP server entry exists in the gen-ai MCP servers ConfigMap.
  * Creates the ConfigMap if it doesn't exist, or patches an existing one.
+ * Uses file-based patching to avoid shell injection from user-controlled values.
  */
 export const ensureMCPServerConfigMapEntry = (
   configMapName: string,
@@ -292,32 +293,45 @@ export const ensureMCPServerConfigMapEntry = (
 ): void => {
   const namespace = Cypress.env('APPLICATIONS_NAMESPACE');
   const valueJson = JSON.stringify(serverData);
-  const escapedValue = valueJson.replace(/"/g, '\\"');
+  const patchJson = JSON.stringify({ data: { [serverKey]: valueJson } });
+  const patchFile = `/tmp/mcp-cm-patch-${Date.now()}.json`;
+
+  cy.writeFile(patchFile, patchJson);
 
   cy.exec(`oc get configmap ${configMapName} -n ${namespace} -o name`, {
     failOnNonZeroExit: false,
   }).then((result) => {
     if (result.exitCode === 0) {
       cy.exec(
-        `oc patch configmap ${configMapName} -n ${namespace} --type=merge -p '{"data":{"${serverKey}":"${escapedValue}"}}'`,
+        `oc patch configmap ${configMapName} -n ${namespace} --type=merge --patch-file ${patchFile}`,
       );
     } else {
-      cy.exec(
-        `oc create configmap ${configMapName} -n ${namespace} --from-literal='${serverKey}=${valueJson}'`,
-      );
+      const cmJson = JSON.stringify({
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: { name: configMapName, namespace },
+        data: { [serverKey]: valueJson },
+      });
+      const cmFile = `/tmp/mcp-cm-create-${Date.now()}.json`;
+      cy.writeFile(cmFile, cmJson);
+      cy.exec(`oc apply -f ${cmFile}`);
     }
   });
 };
 
 /**
  * Remove an MCP server entry from the gen-ai MCP servers ConfigMap.
- * Uses JSON patch to delete a single key without affecting other entries.
+ * Uses file-based JSON patch to avoid shell injection from key values.
  */
 export const removeMCPServerConfigMapEntry = (configMapName: string, serverKey: string): void => {
   const namespace = Cypress.env('APPLICATIONS_NAMESPACE');
   const escapedKey = serverKey.replace(/~/g, '~0').replace(/\//g, '~1');
+  const patchJson = JSON.stringify([{ op: 'remove', path: `/data/${escapedKey}` }]);
+  const patchFile = `/tmp/mcp-cm-remove-${Date.now()}.json`;
+
+  cy.writeFile(patchFile, patchJson);
   cy.exec(
-    `oc patch configmap ${configMapName} -n ${namespace} --type=json -p '[{"op":"remove","path":"/data/${escapedKey}"}]'`,
+    `oc patch configmap ${configMapName} -n ${namespace} --type=json --patch-file ${patchFile}`,
     { failOnNonZeroExit: false },
   );
 };
@@ -348,18 +362,12 @@ export const deployMCPServer = (
     configMapName: name,
   });
 
-  cy.exec(`oc get deployment ${name} -n ${mcpNamespace} -o name`, {
-    failOnNonZeroExit: false,
-  }).then((r) => {
-    if (r.exitCode !== 0) {
-      cy.fixture('resources/genAi/mcp_server_deploy.yaml').then((yamlContent: string) => {
-        const rendered = replacePlaceholdersInYaml(yamlContent, {
-          NAMESPACE: mcpNamespace,
-          IMAGE: image,
-        });
-        applyOpenShiftYaml(rendered);
-      });
-    }
+  cy.fixture('resources/genAi/mcp_server_deploy.yaml').then((yamlContent: string) => {
+    const rendered = replacePlaceholdersInYaml(yamlContent, {
+      NAMESPACE: mcpNamespace,
+      IMAGE: image,
+    });
+    applyOpenShiftYaml(rendered);
   });
 
   cy.exec(`oc rollout status deployment/${name} -n ${mcpNamespace} --timeout=120s`, {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://redhat.atlassian.net/browse/RHOAIENG-63774
<img width="1720" height="514" alt="image" src="https://github.com/user-attachments/assets/bb8b8c3d-0c88-4fa5-b180-fd682ddbfba8" />

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Add mcp test to genai e2e sanity test

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally and in jenkins

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for connecting to a read-only MCP server from AI settings.
  * Added MCP server selection, connection confirmation, and query validation.
  * Added support for retrieving Kubernetes namespace information through the connected server.
* **Tests**
  * Expanded end-to-end coverage for MCP connectivity and assistant responses.
  * Improved reliability when creating endpoints and interacting with MCP settings.
  * Added automated setup and cleanup for MCP test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->