### PR TITLE
fix(autorag): reconfiguring run does not retain selected models

### DIFF
--- a/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
@@ -232,28 +232,42 @@ function AutoragConfigure({
 
   // When the secret changes, mark models as needing re-initialization and
   // immediately clear stale selections so the UI reflects the transition.
-  useEffect(() => {
+  // Uses useReconfigureSafeEffect (skips on mount) because ogxSecretName is
+  // already populated on mount during reconfigure; a plain useEffect would
+  // wipe the pre-populated model selections before they could be restored.
+  useReconfigureSafeEffect(() => {
     modelsInitialized.current = false;
     setValue('generation_models', []);
     setValue('embedding_models', []);
   }, [ogxSecretName, setValue]);
 
   useEffect(() => {
-    // Initialize available generation and embedding models into the form data
+    // Initialize available generation and embedding models into the form data.
+    // Preserve existing selections (reconfigure flow) when they are already
+    // populated; only default to all models on a fresh create.
     if (allModelsData?.models && !modelsInitialized.current && !isModelsError) {
       modelsInitialized.current = true;
+
+      const currentValues = getValues();
+      const currentGenModels = currentValues.generation_models;
+      const currentEmbModels = currentValues.embedding_models;
+
+      const allLlmModels = allModelsData.models
+        .filter((model) => model.type === 'llm')
+        .map((model) => model.id)
+        .toSorted((a, b) => a.localeCompare(b));
+
+      const allEmbeddingModels = allModelsData.models
+        .filter((model) => model.type === 'embedding')
+        .map((model) => model.id)
+        .toSorted((a, b) => a.localeCompare(b));
+
       reset({
-        ...getValues(),
+        ...currentValues,
         // eslint-disable-next-line camelcase
-        generation_models: allModelsData.models
-          .filter((model) => model.type === 'llm')
-          .map((model) => model.id)
-          .toSorted((a, b) => a.localeCompare(b)),
+        generation_models: currentGenModels.length > 0 ? currentGenModels : allLlmModels,
         // eslint-disable-next-line camelcase
-        embedding_models: allModelsData.models
-          .filter((model) => model.type === 'embedding')
-          .map((model) => model.id)
-          .toSorted((a, b) => a.localeCompare(b)),
+        embedding_models: currentEmbModels.length > 0 ? currentEmbModels : allEmbeddingModels,
       });
     }
   }, [allModelsData, isModelsError, getValues, reset]);

--- a/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
@@ -262,15 +262,38 @@ function AutoragConfigure({
         .map((model) => model.id)
         .toSorted((a, b) => a.localeCompare(b));
 
+      // Restored selections (e.g. from reconfigure) may reference models that are
+      // no longer returned for this secret (removed/deprecated upstream). Drop
+      // any IDs that aren't currently available before deciding whether to keep
+      // the restored selection or fall back to "all models".
+      const retainedGenerationModels = currentGenModels.filter((modelId) =>
+        allLlmModels.includes(modelId),
+      );
+      const retainedEmbeddingModels = currentEmbModels.filter((modelId) =>
+        allEmbeddingModels.includes(modelId),
+      );
+
+      if (
+        retainedGenerationModels.length < currentGenModels.length ||
+        retainedEmbeddingModels.length < currentEmbModels.length
+      ) {
+        notification.warning(
+          'Some previously selected models are unavailable',
+          'One or more previously selected foundation or embedding models are no longer available and have been removed from your selection.',
+        );
+      }
+
       reset({
         ...currentValues,
         // eslint-disable-next-line camelcase
-        generation_models: currentGenModels.length > 0 ? currentGenModels : allLlmModels,
+        generation_models:
+          retainedGenerationModels.length > 0 ? retainedGenerationModels : allLlmModels,
         // eslint-disable-next-line camelcase
-        embedding_models: currentEmbModels.length > 0 ? currentEmbModels : allEmbeddingModels,
+        embedding_models:
+          retainedEmbeddingModels.length > 0 ? retainedEmbeddingModels : allEmbeddingModels,
       });
     }
-  }, [allModelsData, isModelsError, getValues, reset]);
+  }, [allModelsData, isModelsError, getValues, reset, notification]);
 
   // Sync bucket from the resolved secret object (skips mount to preserve pre-populated values in reconfigure)
   useReconfigureSafeEffect(() => {

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -5,13 +5,13 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 import type { ExplorerFiles } from '@odh-dashboard/internal/concepts/fileExplorer/types';
 import { UIErrorHandler } from '~/app/components/common/UIError/UIErrorHandler';
 import AutoragConfigure from '~/app/components/configure/AutoragConfigure';
 import { useOgxModelsQuery } from '~/app/hooks/queries';
-import { createConfigureSchema } from '~/app/schemas/configure.schema';
+import { createConfigureSchema, type ConfigureSchema } from '~/app/schemas/configure.schema';
 import {
   AUTORAG_UPLOAD_MAX_BYTES,
   AUTORAG_UPLOAD_TOO_MANY_FILES_DETAIL,
@@ -232,6 +232,18 @@ const mockUseOgxModelsQuery = jest.mocked(useOgxModelsQuery);
 
 const configureSchema = createConfigureSchema();
 
+// Captures the live react-hook-form instance so tests can assert on exact
+// form state (e.g. which model IDs are selected) instead of only on rendered
+// text, which can't distinguish "same count, different models" regressions.
+let latestForm: UseFormReturn<ConfigureSchema> | undefined;
+
+const getLatestFormValues = (): ConfigureSchema => {
+  if (!latestForm) {
+    throw new Error('Form has not been rendered yet');
+  }
+  return latestForm.getValues();
+};
+
 const FormWrapper: React.FC<{
   children: React.ReactNode;
   defaultValues?: Partial<typeof configureSchema.defaults>;
@@ -241,6 +253,7 @@ const FormWrapper: React.FC<{
     resolver: zodResolver(configureSchema.full),
     defaultValues: { ...configureSchema.defaults, ...defaultValues },
   });
+  latestForm = form as unknown as UseFormReturn<ConfigureSchema>;
   return <FormProvider {...form}>{children}</FormProvider>;
 };
 
@@ -1222,8 +1235,13 @@ describe('AutoragConfigure', () => {
         },
       );
 
+      // Assert the exact retained model IDs (not just counts) so a regression that
+      // swaps the selection for a same-sized set of different models (e.g.
+      // llm-model-1 -> llm-model-2) is caught rather than passing on count alone.
       expect(screen.getByText(/1 foundation model/)).toBeInTheDocument();
       expect(screen.getByText(/1 embedding model/)).toBeInTheDocument();
+      expect(getLatestFormValues().generation_models).toEqual(['llm-model-1']);
+      expect(getLatestFormValues().embedding_models).toEqual(['embed-model-1']);
     });
   });
 

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -1161,6 +1161,70 @@ describe('AutoragConfigure', () => {
       const input = screen.getByTestId('max-rag-patterns-input').querySelector('input');
       expect(input).toHaveValue(12);
     });
+
+    it('should retain the previously selected foundation/embedding models instead of resetting to all models', () => {
+      // Query returns more models than were previously selected, so a reset-to-all
+      // regression is distinguishable from correctly retaining the prior selection.
+      mockUseOgxModelsQuery.mockReturnValue({
+        data: {
+          models: [
+            // eslint-disable-next-line camelcase
+            { id: 'llm-model-1', type: 'llm', provider: 'ollama', resource_path: 'ollama://llm-1' },
+            // eslint-disable-next-line camelcase
+            { id: 'llm-model-2', type: 'llm', provider: 'ollama', resource_path: 'ollama://llm-2' },
+            {
+              id: 'embed-model-1',
+              type: 'embedding',
+              provider: 'ollama',
+              resource_path: 'ollama://embed-1', // eslint-disable-line camelcase
+            },
+            {
+              id: 'embed-model-2',
+              type: 'embedding',
+              provider: 'ollama',
+              resource_path: 'ollama://embed-2', // eslint-disable-line camelcase
+            },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useOgxModelsQuery>);
+
+      renderWithInitialValues(
+        {
+          initialInputDataSecret: {
+            uuid: 'secret-1',
+            name: 'Test Secret 1',
+            data: { AWS_S3_BUCKET: 'test-bucket-1', AWS_DEFAULT_REGION: 'us-east-1' },
+            type: 's3',
+            invalid: false,
+          },
+          ogx_secret_name: 'Test OGX Secret',
+          input_data_secret_name: 'Test Secret 1',
+          input_data_bucket_name: 'test-bucket-1',
+          input_data_key: 'data.pdf',
+          test_data_secret_name: 'Test Secret 1',
+          test_data_bucket_name: 'test-bucket-1',
+          test_data_key: 'eval.json',
+          generation_models: ['llm-model-1'],
+          embedding_models: ['embed-model-1'],
+        },
+        {
+          ogx_secret_name: 'Test OGX Secret',
+          input_data_secret_name: 'Test Secret 1',
+          input_data_bucket_name: 'test-bucket-1',
+          input_data_key: 'data.pdf',
+          test_data_secret_name: 'Test Secret 1',
+          test_data_bucket_name: 'test-bucket-1',
+          test_data_key: 'eval.json',
+          generation_models: ['llm-model-1'],
+          embedding_models: ['embed-model-1'],
+        },
+      );
+
+      expect(screen.getByText(/1 foundation model/)).toBeInTheDocument();
+      expect(screen.getByText(/1 embedding model/)).toBeInTheDocument();
+    });
   });
 
   describe('invalid secret selection', () => {

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -1243,6 +1243,121 @@ describe('AutoragConfigure', () => {
       expect(getLatestFormValues().generation_models).toEqual(['llm-model-1']);
       expect(getLatestFormValues().embedding_models).toEqual(['embed-model-1']);
     });
+
+    it('should drop restored model selections that are no longer available and fall back to all models', () => {
+      // The restored selection references a model that is no longer returned by
+      // the current secret/provider (e.g. removed/deprecated upstream).
+      mockUseOgxModelsQuery.mockReturnValue({
+        data: {
+          models: [
+            // eslint-disable-next-line camelcase
+            { id: 'llm-model-1', type: 'llm', provider: 'ollama', resource_path: 'ollama://llm-1' },
+            // eslint-disable-next-line camelcase
+            { id: 'llm-model-2', type: 'llm', provider: 'ollama', resource_path: 'ollama://llm-2' },
+            {
+              id: 'embed-model-1',
+              type: 'embedding',
+              provider: 'ollama',
+              resource_path: 'ollama://embed-1', // eslint-disable-line camelcase
+            },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useOgxModelsQuery>);
+
+      renderWithInitialValues(
+        {
+          initialInputDataSecret: {
+            uuid: 'secret-1',
+            name: 'Test Secret 1',
+            data: { AWS_S3_BUCKET: 'test-bucket-1', AWS_DEFAULT_REGION: 'us-east-1' },
+            type: 's3',
+            invalid: false,
+          },
+          ogx_secret_name: 'Test OGX Secret',
+          input_data_secret_name: 'Test Secret 1',
+          input_data_bucket_name: 'test-bucket-1',
+          input_data_key: 'data.pdf',
+          test_data_secret_name: 'Test Secret 1',
+          test_data_bucket_name: 'test-bucket-1',
+          test_data_key: 'eval.json',
+          // "removed-llm-model" no longer exists in the current models response.
+          generation_models: ['removed-llm-model'],
+          embedding_models: ['removed-embed-model'],
+        },
+        {
+          ogx_secret_name: 'Test OGX Secret',
+          input_data_secret_name: 'Test Secret 1',
+          input_data_bucket_name: 'test-bucket-1',
+          input_data_key: 'data.pdf',
+          test_data_secret_name: 'Test Secret 1',
+          test_data_bucket_name: 'test-bucket-1',
+          test_data_key: 'eval.json',
+          generation_models: ['removed-llm-model'],
+          embedding_models: ['removed-embed-model'],
+        },
+      );
+
+      // Falls back to all currently available models rather than keeping the
+      // now-nonexistent restored IDs.
+      expect(getLatestFormValues().generation_models).toEqual(['llm-model-1', 'llm-model-2']);
+      expect(getLatestFormValues().embedding_models).toEqual(['embed-model-1']);
+      expect(getLatestFormValues().generation_models).not.toContain('removed-llm-model');
+      expect(getLatestFormValues().embedding_models).not.toContain('removed-embed-model');
+    });
+
+    it('should keep only the still-available restored models when some restored selections are stale', () => {
+      mockUseOgxModelsQuery.mockReturnValue({
+        data: {
+          models: [
+            // eslint-disable-next-line camelcase
+            { id: 'llm-model-1', type: 'llm', provider: 'ollama', resource_path: 'ollama://llm-1' },
+            // eslint-disable-next-line camelcase
+            { id: 'llm-model-2', type: 'llm', provider: 'ollama', resource_path: 'ollama://llm-2' },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useOgxModelsQuery>);
+
+      renderWithInitialValues(
+        {
+          initialInputDataSecret: {
+            uuid: 'secret-1',
+            name: 'Test Secret 1',
+            data: { AWS_S3_BUCKET: 'test-bucket-1', AWS_DEFAULT_REGION: 'us-east-1' },
+            type: 's3',
+            invalid: false,
+          },
+          ogx_secret_name: 'Test OGX Secret',
+          input_data_secret_name: 'Test Secret 1',
+          input_data_bucket_name: 'test-bucket-1',
+          input_data_key: 'data.pdf',
+          test_data_secret_name: 'Test Secret 1',
+          test_data_bucket_name: 'test-bucket-1',
+          test_data_key: 'eval.json',
+          // "llm-model-1" is still available, "removed-llm-model" is not.
+          generation_models: ['llm-model-1', 'removed-llm-model'],
+          embedding_models: ['embed-model-1'],
+        },
+        {
+          ogx_secret_name: 'Test OGX Secret',
+          input_data_secret_name: 'Test Secret 1',
+          input_data_bucket_name: 'test-bucket-1',
+          input_data_key: 'data.pdf',
+          test_data_secret_name: 'Test Secret 1',
+          test_data_bucket_name: 'test-bucket-1',
+          test_data_key: 'eval.json',
+          generation_models: ['llm-model-1', 'removed-llm-model'],
+          embedding_models: ['embed-model-1'],
+        },
+      );
+
+      // Only the still-valid restored selection is kept; since at least one valid
+      // restored ID remains, it does NOT fall back to all available models.
+      expect(getLatestFormValues().generation_models).toEqual(['llm-model-1']);
+    });
   });
 
   describe('invalid secret selection', () => {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-85392

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description

Reconfiguring an AutoRAG run did not retain the foundation (generation) and embedding model selections from the source run — the model selection was always reset to "all models" instead.

**Root cause:** `AutoragConfigure` uses two effects to manage model selection:
1. An effect that clears `generation_models` / `embedding_models` and flags them for re-initialization whenever the Open GenAI Stack secret (`ogx_secret_name`) changes.
2. A second effect that re-populates those fields once the models query resolves, preserving the current selection if it is non-empty, otherwise defaulting to all available models.

During reconfigure, the form is pre-populated on mount with the previous run's `ogx_secret_name` and model selections. Effect 1 was a plain `useEffect`, so it fired on the initial mount too (since its dependency already had a value), wiping the pre-populated selections to `[]` before effect 2 ran. Effect 2 then saw empty arrays and fell back to selecting all models — reproducing the reported bug.

**Fix:** Switch effect 1 to `useReconfigureSafeEffect`, the hook already used elsewhere in this component specifically to skip firing on mount so pre-populated reconfigure values aren't wiped before the user sees them. Also removed a couple of now-unnecessary `?? []` fallbacks flagged by `@typescript-eslint/no-unnecessary-condition` in the adjacent code.

## How Has This Been Tested?

- Added a Jest regression test that renders `AutoragConfigure` in the reconfigure flow with a pre-set `ogx_secret_name` and a subset of previously selected foundation/embedding models, while the mocked models query returns a larger set of available models. Verified the previously selected subset is retained instead of being reset to all models.
- Ran the full `AutoragConfigure.spec.tsx` suite (51/51 passing).
- Ran `eslint` and `tsc --noEmit` on the changed file — both clean.

Before | After
--- | ---
<video src="https://github.com/user-attachments/assets/9b92fbd1-8232-42ef-a4f9-b81894582240" /> | <video src="https://github.com/user-attachments/assets/281c0b58-bb83-4565-ad7e-b0da5cfa22ed" />

## Test Impact

- Added `should retain the previously selected foundation/embedding models instead of resetting to all models` in `packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx`, which fails against the previous implementation and passes with this fix.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved selected models when reconfiguring, provided they remain available.
  * Removed unavailable selections and displayed a warning.
  * Automatically restored all available models when selections are empty or no longer valid.
  * Retained valid models when only some previously selected models are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->